### PR TITLE
Implements selectionChanging callback as asked in issue #138

### DIFF
--- a/docs/angular-grid-grid-options/index.php
+++ b/docs/angular-grid-grid-options/index.php
@@ -138,6 +138,10 @@ include '../documentation_header.php';
             <td>Function callback, gets called when a selection is changed.</td>
         </tr>
         <tr>
+            <th>selectionChanging</th>
+            <td>Function callback, gets called when a selection is changing.</td>
+        </tr>
+        <tr>
             <th>cellValueChanged</th>
             <td>Function callback, gets called when a value has changed after editing.</td>
         </tr>

--- a/docs/angular-grid-selection/example3.html
+++ b/docs/angular-grid-selection/example3.html
@@ -10,5 +10,8 @@
 
 <div angular-grid="gridOptions" class="ag-fresh" style="height: 400px;"></div>
 
+<input type="button" ng-click="gridOptions.api.selectAll()" value="select all"/>
+<input type="button" ng-click="gridOptions.api.deselectAll()" value="deselect all"/>
+
 </body>
 </html>

--- a/docs/angular-grid-selection/example3.js
+++ b/docs/angular-grid-selection/example3.js
@@ -21,7 +21,8 @@ module.controller("exampleCtrl", function($scope, $http) {
         rowSelection: 'multiple',
         rowData: null,
         rowSelected: rowSelectedFunc,
-        selectionChanged: selectionChangedFunc
+        selectionChanged: selectionChangedFunc,
+        selectionChanging: selectionChangingFunc
     };
 
     function rowSelectedFunc(row) {
@@ -30,6 +31,18 @@ module.controller("exampleCtrl", function($scope, $http) {
 
     function selectionChangedFunc() {
         window.alert('selection changed, ' + $scope.gridOptions.selectedRows.length + ' rows selected');
+    }
+
+    function selectionChangingFunc(params) {
+        if (window.confirm('Change selection to ' + 
+                (!params.selectedRowsAfterChange.length ? 
+                    'nothing' :
+                    params.selectedRowsAfterChange.map(function(row) { return row.athlete; }).join(', ')) 
+                + '?')) {
+            params.ok();
+        } else {
+            params.cancel();
+        }
     }
 
     $http.get("../olympicWinners.json")

--- a/docs/angular-grid-selection/example3.js
+++ b/docs/angular-grid-selection/example3.js
@@ -21,8 +21,7 @@ module.controller("exampleCtrl", function($scope, $http) {
         rowSelection: 'multiple',
         rowData: null,
         rowSelected: rowSelectedFunc,
-        selectionChanged: selectionChangedFunc,
-        selectionChanging: selectionChangingFunc
+        selectionChanged: selectionChangedFunc        
     };
 
     function rowSelectedFunc(row) {
@@ -49,5 +48,6 @@ module.controller("exampleCtrl", function($scope, $http) {
         .then(function(res){
             $scope.gridOptions.rowData = res.data;
             $scope.gridOptions.api.onNewRows();
+            $scope.gridOptions.selectionChanging = selectionChangingFunc;
         });
 });

--- a/docs/angular-grid-selection/index.php
+++ b/docs/angular-grid-selection/index.php
@@ -81,9 +81,13 @@ include '../documentation_header.php';
     <h3>Selection Callbacks</h3>
 
     <p>
-        There are two callbacks with regards selection:<br/>
+        There are three callbacks with regards selection:<br/>
         rowSelected(row): Gets called when a row is selected and passes the selected row.<br/>
         selectionChanged(): Gets called when a row is selected or deselected.<br/>
+        selectionChanging(params): Gets called before row selection changes and allows to suppress the change. 
+          For this purpose params contains a function 'cancel()' to suppress the change and a function 'ok()' to 
+          allow it. To support the decision params offers the property 'selectedRowsAfterChange' containing the rows 
+          that would be selected when the change would be allowed.<br/>
     </p>
 
     <show-example example="example3" example-height="450px"></show-example>

--- a/src/js/gridOptionsWrapper.js
+++ b/src/js/gridOptionsWrapper.js
@@ -46,6 +46,7 @@ GridOptionsWrapper.prototype.getCellDoubleClicked = function() { return this.gri
 GridOptionsWrapper.prototype.getCellValueChanged = function() { return this.gridOptions.cellValueChanged; };
 GridOptionsWrapper.prototype.getRowSelected = function() { return this.gridOptions.rowSelected; };
 GridOptionsWrapper.prototype.getSelectionChanged = function() { return this.gridOptions.selectionChanged; };
+GridOptionsWrapper.prototype.getSelectionChanging = function() { return this.gridOptions.selectionChanging; };
 GridOptionsWrapper.prototype.getVirtualRowRemoved = function() { return this.gridOptions.virtualRowRemoved; };
 GridOptionsWrapper.prototype.getDatasource = function() { return this.gridOptions.datasource; };
 GridOptionsWrapper.prototype.getReady = function() { return this.gridOptions.ready; };


### PR DESCRIPTION
This pull request implements a selectionChanging callback as asked in issue #138.
The callback fires each time the selectedRows property would change (triggered in selectNode, selectAll, deselectAll). It passes the potentially new selectedRows and an ok() and a cancel() callback to allow/suppress the change. 