### PR TITLE
Added rowDeSelected option and method for row deselection

### DIFF
--- a/dist/angular-grid.js
+++ b/dist/angular-grid.js
@@ -796,6 +796,9 @@ var awk;
             GridOptionsWrapper.prototype.getRowSelected = function () {
                 return this.gridOptions.rowSelected;
             };
+            GridOptionsWrapper.prototype.getRowDeSelected = function () {
+                return this.gridOptions.rowDeSelected;
+            };
             GridOptionsWrapper.prototype.getColumnResized = function () {
                 return this.gridOptions.columnResized;
             };
@@ -5541,6 +5544,7 @@ var awk;
                         this.recursivelyDeselectAllChildren(node);
                     }
                     else {
+                        this.gridOptionsWrapper.getRowDeSelected()(node.data,node);
                         this.deselectRealNode(node);
                     }
                 }


### PR DESCRIPTION
I have added a feature for getting the node of the row when a row gets deselected as per having my requirement. for this feature we have to provide a option  rowDeSelected in gridoption and a callback function so once user deselect any row that callback will get called and user can get object of that deselected row.