### PR TITLE
Added option and functionality for comma separating

### DIFF
--- a/src/ts/csvCreator.ts
+++ b/src/ts/csvCreator.ts
@@ -1,12 +1,13 @@
 module ag.grid {
 
-    var LINE_SEPERATOR = '\r\n';
+    var LINE_SEPARATOR = '\r\n';
 
     export interface CsvExportParams {
         skipHeader?: boolean;
         skipFooters?: boolean;
         skipGroups?: boolean;
         fileName?: string;
+		forceCommaSeparator?: boolean;
     }
 
     export class CsvCreator {
@@ -19,7 +20,8 @@ module ag.grid {
         }
 
         public exportDataAsCsv(params?: CsvExportParams): void {
-            var csvString = this.getDataAsCsv(params);
+			var forceComma = params && params.forceCommaSeparator;
+            var csvString = (forceComma ? "sep=,\n" : "") + this.getDataAsCsv(params);
             var fileNamePresent = params && params.fileName && params.fileName.length !== 0;
             var fileName = fileNamePresent ? params.fileName : 'export.csv';
             // Internet Explorer
@@ -69,7 +71,7 @@ module ag.grid {
                     }
                     result += '"' + this.escape(nameForCol) + '"';
                 });
-                result += LINE_SEPERATOR;
+                result += LINE_SEPARATOR;
             }
 
             this.rowController.forEachNodeAfterFilterAndSort( (node: RowNode) => {
@@ -93,7 +95,7 @@ module ag.grid {
                     result += '"' + this.escape(valueForCell) + '"';
                 });
 
-                result += LINE_SEPERATOR;
+                result += LINE_SEPARATOR;
             });
 
             return result;


### PR DESCRIPTION
First of all, I don't know if this is worth a pull request, but I guess
you'll be the judge of that. I'll try to explain the 'why' behind my
(small) change:
It appears that Microsoft Excel sometimes doesn't open CSV files just
right. It appears it might have another character as a separator in the
default options (or if you change them). This is easily worked around
defining, in the first line of the file:
sep=<your_separator>
which in this case translates to:
sep=,

More info:
http://kb.paessler.com/en/topic/2293-i-have-trouble-opening-csv-files-with-microsoft-excel-is-there-a-quick-way-to-fix-this

I also checked on other spreadsheet software, but the few I checked
(OpenOffice and GoogleDocs) aren't suffering from this. Therefore I
added another option to params by which you can tell the generator if
the implicit declaration of the separator is needed or not. The option
is called `forceCommaSeparator`

Thanks for reading this and a million thanks for your awesome product.
We're including it as part of our software, and we will try to
contribute as much as we can.