### PR TITLE
Added custom selection checkbox id provider feature

### DIFF
--- a/docs/angular-grid-column-definitions/index.php
+++ b/docs/angular-grid-column-definitions/index.php
@@ -110,6 +110,10 @@ include '../documentation_header.php';
             <td>Set to true to render a selection checkbox in the column.</td>
         </tr>
         <tr>
+            <th>checkboxSelectionIdGetter</th>
+            <td>Function callback, sets the id attribute of the rendered checkbox. Provides rowIndex, and the node in it's parameter.</td>
+        </tr>
+        <tr>
             <th>suppressMenu</th>
             <td>Set to true if no menu should be shown for this column header.</td>
         </tr>

--- a/docs/angular-grid-selection/example5.html
+++ b/docs/angular-grid-selection/example5.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.8/angular.min.js"></script>
+    <!-- you don't need ignore=notused in your code, this is just here to trick the cache -->
+    <script src="../dist/ag-grid.js?ignore=notused12"></script>
+    <link rel="stylesheet" type="text/css" href="../dist/ag-grid.css?ignore=notused12">
+    <link rel="stylesheet" type="text/css" href="../dist/theme-fresh.css?ignore=notused12">
+    <script src="example5.js"></script>
+</head>
+<body ng-app="example" ng-controller="exampleCtrl">
+
+<div ag-grid="gridOptions" class="ag-fresh" style="height: 370px;"></div>
+
+</body>
+</html>

--- a/docs/angular-grid-selection/example5.js
+++ b/docs/angular-grid-selection/example5.js
@@ -1,0 +1,29 @@
+
+var module = angular.module("example", ["agGrid"]);
+
+module.controller("exampleCtrl", function($scope, $http) {
+
+    var columnDefs = [
+        {
+            headerName: "SelectionWithID",
+            checkboxSelection: true,
+            checkboxSelectionIdGetter: function (data) {
+                return 'customID_' + data.node.data.make + '_' + data.rowIndex;
+            }
+        },
+        {headerName: "Make", field: "make"},
+        {headerName: "Model", field: "model"}
+    ];
+
+    var rowData = [
+        {make: "Toyota", model: "Celica", price: 35000},
+        {make: "Ford", model: "Mondeo", price: 32000},
+        {make: "Porsche", model: "Boxter", price: 72000}
+    ];
+
+    $scope.gridOptions = {
+        columnDefs: columnDefs,
+        rowSelection: 'multiple',
+        rowData: rowData
+    };
+});

--- a/docs/angular-grid-selection/index.php
+++ b/docs/angular-grid-selection/index.php
@@ -116,6 +116,15 @@ include '../documentation_header.php';
 
     <show-example example="example3" example-height="450px"></show-example>
 
+    <h3>Selection Checkbox with custom id</h3>
+
+    <p>
+        Testing user interfaces could be simplified by e.g.: assigning custom, unique id-s for each selection checkbox.<br/>
+        The checkboxSelectionIdGetter attribute could be used to generate a custom id for the rendered checkbox.<br/>
+    </p>
+
+    <show-example example="example5" example-height="450px"></show-example>
+
 </div>
 
 <?php include '../documentation_footer.php';?>

--- a/src/ts/entities/colDef.ts
+++ b/src/ts/entities/colDef.ts
@@ -69,6 +69,9 @@ module ag.grid {
         /** Set to true to render a selection checkbox in the column. */
         checkboxSelection?: boolean;
 
+        /** Function callback which will populate the id attribute of all checkboxes */
+        checkboxSelectionIdGetter?: Function;
+
         /** Set to true if no menu should be shown for this column header. */
         suppressMenu?: boolean;
 

--- a/src/ts/rendering/renderedCell.ts
+++ b/src/ts/rendering/renderedCell.ts
@@ -508,10 +508,19 @@ module ag.grid {
 
         public createSelectionCheckbox() {
 
+            var paramsForCallbacks = {
+                rowIndex: this.rowIndex,
+                node: this.node
+            };
+
             this.eCheckbox = document.createElement('input');
             this.eCheckbox.type = "checkbox";
             this.eCheckbox.name = "name";
             this.eCheckbox.className = 'ag-selection-checkbox';
+
+            if (this.column.colDef.checkboxSelectionIdGetter) {
+                this.eCheckbox.id = this.column.colDef.checkboxSelectionIdGetter(paramsForCallbacks)
+            }
 
             this.eCheckbox.addEventListener('click', function (event) {
                 event.stopPropagation();


### PR DESCRIPTION
Automated UI tests could be simplified by this. Since if the grid is configured with:
rowSelection: 'simple'

then ag-grid provides a built in way how to manage checkbox toggling mechanics. We previously used a custom cell renderer, but the above example gave us too big of a deal to handle manually.

Hope you'll like this! :)