### PR TITLE
Added a renderingContext field for valueGetter functions

### DIFF
--- a/docs/angular-grid-export/index.php
+++ b/docs/angular-grid-export/index.php
@@ -49,6 +49,7 @@ include '../documentation_header.php';
         <li>Value getters are used to work out the value to export (the 'Group' col in the example below uses a value getter to take the first letter of the country name)</li>
         <li>Aggregated values are exported.</li>
         <li>For groups, the first exported value (column) will always have the group key.</li>
+        <li>Rendering context for valueGetters will be 'csv'. Check <a href="../angular-grid-value-getters/index.php">value getters</a> section for more information.
     </ul>
 
     <show-example example="exampleExport"></show-example>

--- a/docs/angular-grid-value-getters/index.php
+++ b/docs/angular-grid-value-getters/index.php
@@ -31,6 +31,7 @@ include '../documentation_header.php';
         <li><b>api</b>: The API for the grid.</li>
         <li><b>context</b>: The grid context.</li>
         <li><b>getValue()</b>: A function, give it a column field name, and it returns the value for that column. Useful for chaining value getters.</li>
+        <li><b>renderingContext</b>: Optional rendering context under which this value is requested. Useful for returning HTML for displaying online or plain text for exporting to CSV or others.</li>
         </ul>
     </p>
 

--- a/src/ts/csvCreator.ts
+++ b/src/ts/csvCreator.ts
@@ -90,7 +90,7 @@ module ag.grid {
                     if (node.group && index === 0) {
                         valueForCell =  this.createValueForGroupNode(node);
                     } else {
-                        valueForCell =  this.valueService.getValue(column.colDef, node.data, node);
+                        valueForCell =  this.valueService.getValue(column.colDef, node.data, node, 'cvs');
                     }
                     if (valueForCell === null || valueForCell === undefined) {
                         valueForCell = '';
@@ -132,7 +132,7 @@ module ag.grid {
             } else if (typeof value.toString === 'function') {
                 stringValue = value.toString();
             } else {
-                console.warn('known value type during csv conversio');
+                console.warn('known value type during csv conversion');
                 stringValue = '';
             }
 

--- a/src/ts/valueService.ts
+++ b/src/ts/valueService.ts
@@ -16,7 +16,7 @@ module ag.grid {
             this.columnController = columnController;
         }
 
-        public getValue(colDef: ColDef, data: any, node: any):any {
+        public getValue(colDef: ColDef, data: any, node: any, renderingContext?: any):any {
 
             var cellExpressions = this.gridOptionsWrapper.isEnableCellExpressions();
             var field = colDef.field;
@@ -25,7 +25,7 @@ module ag.grid {
 
             // if there is a value getter, this gets precedence over a field
             if (colDef.valueGetter) {
-                result = this.executeValueGetter(colDef.valueGetter, data, colDef, node);
+                result = this.executeValueGetter(colDef.valueGetter, data, colDef, node, renderingContext);
             } else if (field && data) {
                 result = data[field];
             } else {
@@ -35,13 +35,13 @@ module ag.grid {
             // the result could be an expression itself, if we are allowing cell values to be expressions
             if (cellExpressions && (typeof result === 'string') && result.indexOf('=') === 0) {
                 var cellValueGetter = result.substring(1);
-                result = this.executeValueGetter(cellValueGetter, data, colDef, node);
+                result = this.executeValueGetter(cellValueGetter, data, colDef, node, renderingContext);
             }
 
             return result;
         }
 
-        private executeValueGetter(valueGetter: any, data: any, colDef: any, node: any): any {
+        private executeValueGetter(valueGetter: any, data: any, colDef: any, node: any, renderingContext?: any): any {
 
             var context = this.gridOptionsWrapper.getContext();
             var api = this.gridOptionsWrapper.getApi();
@@ -52,7 +52,8 @@ module ag.grid {
                 colDef: colDef,
                 api: api,
                 context: context,
-                getValue: this.getValueCallback.bind(this, data, node)
+                getValue: this.getValueCallback.bind(this, data, node),
+                renderingContext: renderingContext
             };
 
             if (typeof valueGetter === 'function') {


### PR DESCRIPTION
This allows different cell contents depending on where the value is rendered. As an example, I can render some HTML with a link displaying the table online and plain text for exporting to CSV.