### PR TITLE
Read template from responseText also

### DIFF
--- a/dist/ag-grid.js
+++ b/dist/ag-grid.js
@@ -3449,7 +3449,8 @@ var ag;
                     return;
                 }
                 // response success, so process it
-                this.templateCache[url] = httpResult.response;
+                // in IE9 the response is under - responseText
+                this.templateCache[url] = httpResult.response || httpResult.responseText;
                 // inform all listeners that this is now in the cache
                 var callbacks = this.waitingCallbacks[url];
                 for (var i = 0; i < callbacks.length; i++) {


### PR DESCRIPTION
Read template from responseText in case response is undefined.
In IE9 the template is on responseTest, not on response.
As a result there was an infinite loop that would crash IE9

There are more details in this StackOverflow post: 
http://stackoverflow.com/questions/33295932/ag-grid-templateurl-crashes-in-ie9/33299054#33299054

And this issue:
https://github.com/ceolter/ag-grid/issues/521