### PR TITLE
Add documentation for params.node

### DIFF
--- a/docs/angular-grid-cell-rendering/index.php
+++ b/docs/angular-grid-cell-rendering/index.php
@@ -133,6 +133,10 @@ var colDef = {
             <th>eGridCell</th>
             <td>A reference to the virtual cell (during the rendering process, virtual cells are used).</td>
         </tr>
+        <tr>
+            <th>node</th>
+            <td>The RowNode of the row beeing renderered.</td>
+        </tr>
     </table>
 
     <h4>Angular Compiling</h4>


### PR DESCRIPTION
I found out from angular-grid-angular-compiling/index.php example that params object exposes a node parameter that was not documented.
So this is a proposal to fix the documentation.