### PR TITLE
deselectNode should pass down suppressEvents parameter

### DIFF
--- a/src/ts/gridApi.ts
+++ b/src/ts/gridApi.ts
@@ -166,8 +166,8 @@ module ag.grid {
             this.selectionController.selectNode(node, tryMulti, suppressEvents);
         }
 
-        public deselectNode(node:any) {
-            this.selectionController.deselectNode(node);
+        public deselectNode(node:any, suppressEvents: boolean = false) {
+            this.selectionController.deselectNode(node, suppressEvents);
         }
 
         public selectAll() {


### PR DESCRIPTION
The deselectNode function of the gridApi did not pass down the suppressEvents parameter to the selectionController.