### PR TITLE
bug fix - prevent exceptions when looking up columns

### DIFF
--- a/src/ts/columnController/columnController.ts
+++ b/src/ts/columnController/columnController.ts
@@ -557,7 +557,7 @@ module ag.grid {
                 }
             }
 
-            if (colMatches(this.groupAutoColumn)) {
+            if (this.groupAutoColumn && colMatches(this.groupAutoColumn)) {
                 return this.groupAutoColumn;
             }
 


### PR DESCRIPTION
Due to a bug in my application code (was trying to call `getValue` for a field that doesn't have a rendered column), I discovered that the column controller is attempting to look up a `null` column's colDef. 

Calling `getColumn` with a key that does not belong to any of the columns in `allColumns` results in dropping down to the next check: `colMatches(this.groupAutoColumn)`. There's no check whether `this.groupAutoColumn` is null, so an exception can be thrown when trying to then call `getColDef` on that object.

Obviously `getColumn` will return null when you call it with an invalid key, but I don't think throwing this exception is appropriate.