### PR TITLE
fix(inMemoryRowController): skip add parents

### DIFF
--- a/src/ts/rowControllers/inMemoryRowController.ts
+++ b/src/ts/rowControllers/inMemoryRowController.ts
@@ -594,7 +594,7 @@ module ag.grid {
             }
             for (var i = 0; i < nodes.length; i++) {
                 var node = nodes[i];
-                if (parent) {
+                if (parent && !this.gridOptionsWrapper.isSuppressParentsInRowNodes()) {
                     node.parent = parent;
                 }
                 node.level = level;


### PR DESCRIPTION
while `recursivelyCheckUserProvidedNodes()`
when `suppressParentsInRowNode` is set to `true`
and `rowsAlreadyGrouped` is set to `true`

improves 8d83ff40e70cebe801025db9f629671b6627b64f