### PR TITLE
fix error in rowRenderer - prevent unbinding invalid row

### DIFF
--- a/src/ts/rendering/rowRenderer.ts
+++ b/src/ts/rendering/rowRenderer.ts
@@ -313,6 +313,9 @@ module ag.grid {
 
         private unbindVirtualRow(indexToRemove: any) {
             var renderedRow = this.renderedRows[indexToRemove];
+            if (!renderedRow) {
+                return;
+            }
             renderedRow.destroy();
 
             var event = {node: renderedRow.getRowNode(), rowIndex: indexToRemove};


### PR DESCRIPTION
Hey @ceolter I was hoping you could help me debug an error I was getting in `src/ts/rendering/rowRenderer.ts`.

I'm unable to reproduce this on the Virtual Paging / Infinite Scroll example page, but when I implemented virtual paging in my project I got an error any time I scrolled the grid quickly (for some reason scrolling very slowly prevented the error from occurring).

I traced where it was coming from:

`drawVirtualRows` makes 2 private method calls:
 * `workOutFirstAndLastRowsToRender` - uses `rowModel.getRowAtPixel` to find first/last rendered rows
 * `ensureRowsRendered` - uses first/last rendered rows as a range, then tries to remove some virtual rows by index by calling:
   * `removeVirtualRow` - gets an array of row indexes that are **not** in `renderedRows`! ends up calling:
     * `unbindVirtualRow` - error: "Cannot read property 'destroy' of undefined" (from `renderedRow.destroy()`)

I'm not sure if my solution is the right one, because it seems like `workOutFirstAndLastRowsToRender` is producing the wrong first/last row indexes. But I wasn't sure where to go next. I think the check I've added is reasonable, though.