### PR TITLE
fix property for column definitions in documentation overview

### DIFF
--- a/docs/javascript-grid-interfacing-overview/index.php
+++ b/docs/javascript-grid-interfacing-overview/index.php
@@ -53,7 +53,7 @@ include '../documentation_header.php';
     <pre><code>var gridOptions = {
     // PROPERTIES - object properties, myRowData and myColDefs are created somewhere in your application
     rowData: myRowData,
-    colDef: myColDefs,
+    columnDefs: myColDefs,
 
     // PROPERTIES - simple boolean / string / number properties
     enableColResize: true,


### PR DESCRIPTION
Hi,

only a small adjustment because I was wondering why the columns didn't render. In the documentation overview `colDef` is used, which does not work for me in version 3.2.2. Using `columnDefs` however, does.