### PR TITLE
fix context

### DIFF
--- a/src/ts/filter/filterManager.ts
+++ b/src/ts/filter/filterManager.ts
@@ -335,7 +335,7 @@ export default class FilterManager {
             localeTextFunc: this.gridOptionsWrapper.getLocaleTextFunc(),
             valueGetter: this.createValueGetter(column),
             doesRowPassOtherFilter: doesRowPassOtherFilters,
-            context: this.gridOptionsWrapper.getContext,
+            context: this.gridOptionsWrapper.getContext(),
             $scope: filterWrapper.scope
         };
         if (!filterWrapper.filter.init) { // because users can do custom filters, give nice error message


### PR DESCRIPTION
filter instance doesn't have access to `gridOptionsWrapper`
so need save link to context object