### PR TITLE
fix issue when filter value is "0"

### DIFF
--- a/src/ts/filter/filterManager.ts
+++ b/src/ts/filter/filterManager.ts
@@ -98,7 +98,7 @@ export default class FilterManager {
                 return;
             }
             var model = filterApi.getModel();
-            if (model) {
+            if (model !== void 0) {
                 result[key] = model;
             }
         });


### PR DESCRIPTION
type coercion will lead to that this change will be ignored
I suppose that value could be also set to `null` so best way check only for `undefined` values

P.S. could you release only this fix in 3.3.4 ? 