### PR TITLE
DisableBrowserDragging only if target is of type HTMLImageElement

### DIFF
--- a/src/ts/gridPanel/gridPanel.ts
+++ b/src/ts/gridPanel/gridPanel.ts
@@ -212,8 +212,10 @@ export class GridPanel {
     // and then that will start the browser native drag n' drop, which messes up with our own drag and drop.
     private disableBrowserDragging(): void {
         this.eRoot.addEventListener('dragstart', (event: MouseEvent)=> {
-            event.preventDefault();
-            return false;
+            if (event.target instanceof HTMLImageElement) {
+                event.preventDefault();
+                return false;
+            }
         });
     }
 


### PR DESCRIPTION
I have implemented dragging rows out of the grid for further use using the new processRowPostCreate callback.

This can only work if the 'dragstart' event is not prevented in all cases. Now 'dragstart' is only prevented for images.