### PR TITLE
Dispatch 'selectionChanged' on deselectAll

### DIFF
--- a/src/ts/selectionController.ts
+++ b/src/ts/selectionController.ts
@@ -183,6 +183,7 @@ export class SelectionController {
         // that we pick up, however it's good to clean it down, as we are still
         // left with entries pointing to 'undefined'
         this.selectedNodes = {};
+        this.eventService.dispatchEvent(Events.EVENT_SELECTION_CHANGED);
     }
 
     public selectAllRowNodes() {


### PR DESCRIPTION
When calling deselectAll 'selectionChanged' event is not triggered, documentation states it should. Issue noted in #822.