### PR TITLE
textCellEditor now ignores case when initial value is undefined

### DIFF
--- a/src/ts/rendering/cellEditors/textCellEditor.ts
+++ b/src/ts/rendering/cellEditors/textCellEditor.ts
@@ -40,7 +40,9 @@ export class TextCellEditor extends Component implements ICellEditor {
             }
         }
 
-        eInput.value = startValue;
+	if (startValue !== undefined) {
+            eInput.value = startValue;
+	}
     }
 
     public afterGuiAttached(): void {


### PR DESCRIPTION
I noticed that if the underlying object for a row has no property to match the 'field', switching to edit mode for the cell using the default editor TextCellEditor initialises the displayed text to the word 'undefined.' This pull request skips assignment of the initial value to the <input> element if the underlying value is undefined.