### PR TITLE
This PR adds the gridOptions.context to the angular scope as scope.co…

### DIFF
--- a/src/ts/filter/filterManager.ts
+++ b/src/ts/filter/filterManager.ts
@@ -326,6 +326,7 @@ export class FilterManager {
             // first up, create child scope if needed
             if (this.gridOptionsWrapper.isAngularCompileFilters()) {
                 filterWrapper.scope = this.$scope.$new();
+                filterWrapper.scope.context = this.gridOptionsWrapper.getContext();
             }
             // now create filter (had to cast to any to get 'new' working)
             this.assertMethodHasNoParameters(colDef.filter);

--- a/src/ts/headerRendering/renderedHeaderCell.ts
+++ b/src/ts/headerRendering/renderedHeaderCell.ts
@@ -154,6 +154,7 @@ export class RenderedHeaderCell implements IRenderedHeaderElement {
             this.childScope = parentScope.$new();
             this.childScope.colDef = this.column.getColDef();
             this.childScope.colDefWrapper = this.column;
+            this.childScope.context = this.gridOptionsWrapper.getContext();
 
             this.destroyFunctions.push( ()=> {
                 this.childScope.$destroy();

--- a/src/ts/rendering/renderedRow.ts
+++ b/src/ts/rendering/renderedRow.ts
@@ -454,6 +454,7 @@ export class RenderedRow {
         if (this.gridOptionsWrapper.isAngularCompileRows()) {
             var newChildScope = this.parentScope.$new();
             newChildScope.data = data;
+            newChildScope.context = this.gridOptionsWrapper.getContext();
             return newChildScope;
         } else {
             return null;


### PR DESCRIPTION
…ntext.

For small grids, using angular is super convenient.  I need the ability to reference my controller in the angular template.

With this PR, I can reference my controller in a template using context.myControllerReference.controllerFunction().