### PR TITLE
eGui to afterGuiAttached as parameter

### DIFF
--- a/src/ts/rendering/cellEditors/iCellEditor.ts
+++ b/src/ts/rendering/cellEditors/iCellEditor.ts
@@ -21,7 +21,7 @@ export interface ICellEditor {
     init?(params: ICellEditorParams): void;
 
     /** Gets called once after GUI is attached to DOM. Useful if you want to focus or highlight a component (this is not possible when the element is not attached)*/
-    afterGuiAttached?(): void;
+    afterGuiAttached?(eGui? : HTMLElement): void;
 
     /** Return the DOM element of your editor, this is what the grid puts into the DOM */
     getGui(): HTMLElement;
@@ -61,4 +61,5 @@ export interface ICellEditorParams {
     context: any;
     onKeyDown: (event: KeyboardEvent)=>void;
     stopEditing: ()=>void;
+    eGridCell: HTMLElement;
 }

--- a/src/ts/rendering/cellEditors/popupEditorWrapper.ts
+++ b/src/ts/rendering/cellEditors/popupEditorWrapper.ts
@@ -49,7 +49,7 @@ export class PopupEditorWrapper extends Component implements ICellEditor {
 
     public afterGuiAttached(): void {
         if (this.cellEditor.afterGuiAttached) {
-            this.cellEditor.afterGuiAttached();
+            this.cellEditor.afterGuiAttached( super.getGui() );
         }
     }
 

--- a/src/ts/rendering/renderedCell.ts
+++ b/src/ts/rendering/renderedCell.ts
@@ -520,7 +520,8 @@ export class RenderedCell extends Component {
                 columnApi: this.gridOptionsWrapper.getColumnApi(),
                 context: this.gridOptionsWrapper.getContext(),
                 onKeyDown: this.onKeyDown.bind(this),
-                stopEditing: this.stopEditingAndFocus.bind(this)
+                stopEditing: this.stopEditingAndFocus.bind(this),
+                eGridCell: this.eGridCell
             };
 
             if (colDef.cellEditorParams) {


### PR DESCRIPTION
Sometimes it's required to set a position of popup editor relative to the cell. 
But the afterGuiAttached has no access to the cell DOM to get the bounding rect. 
I propose the changes to pass eGui to the afterGuiAttached function for that
