### PR TITLE
Enable Group Edit Option

### DIFF
--- a/src/ts/entities/gridOptions.ts
+++ b/src/ts/entities/gridOptions.ts
@@ -40,6 +40,7 @@ export interface GridOptions {
     maxColWidth?: number;
     suppressMenuHide?: boolean;
     singleClickEdit?: boolean;
+    enableGroupEdit?: boolean;
     debug?: boolean;
     icons?: any; // should be typed
     angularCompileRows?: boolean;

--- a/src/ts/gridOptionsWrapper.ts
+++ b/src/ts/gridOptionsWrapper.ts
@@ -113,6 +113,7 @@ export class GridOptionsWrapper {
     public getColumnApi(): ColumnApi { return this.gridOptions.columnApi; }
     public isEnableColResize() { return isTrue(this.gridOptions.enableColResize); }
     public isSingleClickEdit() { return isTrue(this.gridOptions.singleClickEdit); }
+    public isEnableGroupEdit() { return isTrue(this.gridOptions.enableGroupEdit); }
     public getGroupDefaultExpanded(): number { return this.gridOptions.groupDefaultExpanded; }
     public getRowData(): any[] { return this.gridOptions.rowData; }
     public isGroupUseEntireRow() { return isTrue(this.gridOptions.groupUseEntireRow); }

--- a/src/ts/rendering/cellRenderers/groupCellRenderer.ts
+++ b/src/ts/rendering/cellRenderers/groupCellRenderer.ts
@@ -213,7 +213,9 @@ export class GroupCellRenderer extends Component implements ICellRenderer {
 
         this.addDestroyableEventListener(this.eExpanded, 'click', this.onExpandOrContract.bind(this));
         this.addDestroyableEventListener(this.eContracted, 'click', this.onExpandOrContract.bind(this));
-        this.addDestroyableEventListener(eGroupCell, 'dblclick', this.onExpandOrContract.bind(this));
+        if(!this.gridOptionsWrapper.isEnableGroupEdit()){
+            this.addDestroyableEventListener(eGroupCell, 'dblclick', this.onExpandOrContract.bind(this));
+        }
 
         // expand / contract as the user hits enter
         this.addDestroyableEventListener(eGroupCell, 'keydown', this.onKeyDown.bind(this));

--- a/src/ts/rendering/renderedCell.ts
+++ b/src/ts/rendering/renderedCell.ts
@@ -696,8 +696,8 @@ export class RenderedCell extends Component {
             return false;
         }
 
-        // never allow editing of groups
-        if (this.node.group) {
+        // check whether node is group and group editing is allowed
+        if (this.node.group && !this.gridOptionsWrapper.isEnableGroupEdit()) {
             return false;
         }
 


### PR DESCRIPTION
Suggested new gridOptions flag for case when tree data is supplied as pre-grouped:
Add 'enableGroupEdit' option to GridOptions and expose through
gridOptionsWrapper, implement in groupCellRenderer and renderedCell.

Reference forum post: https://www.ag-grid.com/forum/showthread.php?tid=3868
