### PR TITLE
selectCellEditor stop mousedown propagation in IE

### DIFF
--- a/src/ts/rendering/cellEditors/selectCellEditor.ts
+++ b/src/ts/rendering/cellEditors/selectCellEditor.ts
@@ -9,32 +9,46 @@ export class SelectCellEditor extends Component implements ICellEditor {
     }
 
     public init(params: any) {
-        var eSelect = <HTMLSelectElement> this.getGui().querySelector('select');
+        var eSelect = <HTMLSelectElement>this.getGui().querySelector('select');
         if (_.missing(params.values)) {
             console.log('ag-Grid: no values found for select cellEditor');
             return;
         }
-        params.values.forEach( (value: any)=> {
+
+        if (this.isInternetExplorer()) {
+            this.addDestroyableEventListener(eSelect, 'mousedown', (event) => { event.stopPropagation(); });
+        }
+
+        params.values.forEach((value: any) => {
             var option = document.createElement('option');
-            option.value = value;
-            option.text = value;
+            if (params.valueField && params.textField) {
+                option.value = value[params.valueField];
+                option.text = value[params.textField];
+            } else {
+                option.value = value;
+                option.text = value;
+            }
             if (params.value === value) {
                 option.selected = true;
             }
             eSelect.appendChild(option);
         });
 
-        this.addDestroyableEventListener(eSelect, 'change', ()=> params.stopEditing() );
+        this.addDestroyableEventListener(eSelect, 'change', () => params.stopEditing());
     }
 
     public afterGuiAttached() {
-        var eSelect = <HTMLSelectElement> this.getGui().querySelector('select');
+        var eSelect = <HTMLSelectElement>this.getGui().querySelector('select');
         eSelect.focus();
     }
 
     public getValue(): any {
-        var eSelect = <HTMLSelectElement> this.getGui().querySelector('select');
+        var eSelect = <HTMLSelectElement>this.getGui().querySelector('select');
         return eSelect.value;
     }
 
+    private isInternetExplorer() {
+        var userAgent: string = window.navigator.userAgent;
+        return userAgent.indexOf("MSIE ") > 0 || !!userAgent.match(/Trident.*rv\:11\./);
+    }
 }


### PR DESCRIPTION
In Internet Explorer mousedown event on select editor is passed to the next sibbling cell, and triggers cellValueChanged() callback before selectEditor update his value.
Also the selectEditor should let developer set different fields for value and text in the cellEditorParams object.