### PR TITLE
Fix to theme-common making theming more flexible

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -150,17 +150,22 @@ function webpackTask(minify, styles) {
 function stylusTask() {
     // Uncompressed
     gulp.src(['src/styles/*.styl', '!src/styles/theme-common.styl'])
-        .pipe(foreach(function(stream, file) {
-            var currentTheme = path.basename(file.path, '.styl');
-            var themeName = currentTheme.replace('theme-','');
-            return stream
-                .pipe(stylus({
-                    use: nib(),
-                    compress: false
-                }))
-                .pipe(gulpIf(currentTheme !== 'ag-grid', replace('ag-common','ag-' + themeName)))
-                .pipe(gulp.dest('dist/styles/'));
-        }));
+        .pipe(stylus({
+            use: nib(),
+            compress: false
+        }))
+        .pipe(gulp.dest('dist/styles'));
+        // .pipe(foreach(function(stream, file) {
+        //     var currentTheme = path.basename(file.path, '.styl');
+        //     var themeName = currentTheme.replace('theme-','');
+        //     return stream
+        //         .pipe(stylus({
+        //             use: nib(),
+        //             compress: false
+        //         }))
+        //         .pipe(gulpIf(currentTheme !== 'ag-grid', replace('ag-common','ag-' + themeName)))
+        //         .pipe(gulp.dest('dist/styles/'));
+        // }));
 }
 
 function watchTask() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -155,17 +155,6 @@ function stylusTask() {
             compress: false
         }))
         .pipe(gulp.dest('dist/styles'));
-        // .pipe(foreach(function(stream, file) {
-        //     var currentTheme = path.basename(file.path, '.styl');
-        //     var themeName = currentTheme.replace('theme-','');
-        //     return stream
-        //         .pipe(stylus({
-        //             use: nib(),
-        //             compress: false
-        //         }))
-        //         .pipe(gulpIf(currentTheme !== 'ag-grid', replace('ag-common','ag-' + themeName)))
-        //         .pipe(gulp.dest('dist/styles/'));
-        // }));
 }
 
 function watchTask() {

--- a/src/styles/theme-blue.styl
+++ b/src/styles/theme-blue.styl
@@ -1,5 +1,5 @@
 
-ag-style = blue
+ag-style = "blue"
 ag-root-font-family = Calibri, "Segoe UI", Thonburi, Arial, Verdana, sans-serif
 ag-root-font-size = 10pt
 

--- a/src/styles/theme-bootstrap.styl
+++ b/src/styles/theme-bootstrap.styl
@@ -1,5 +1,5 @@
 
-ag-style = bootstrap
+ag-style = "bootstrap"
 ag-root-font-family = "Helvetica Neue",Helvetica,Arial,sans-serif
 ag-root-font-size = 14px
 

--- a/src/styles/theme-common.styl
+++ b/src/styles/theme-common.styl
@@ -8,7 +8,7 @@ todo
 
 @import 'nib'
 
-.ag-common
+.ag-{ag-style}
   // copying bootstrap with line-height, sorts out alignment problems with images beside text
   line-height 1.4
   font-family ag-root-font-family

--- a/src/styles/theme-dark.styl
+++ b/src/styles/theme-dark.styl
@@ -1,5 +1,5 @@
 
-ag-style = dark
+ag-style = "dark"
 ag-root-font-family = "Helvetica Neue",Helvetica,Arial,sans-serif
 ag-root-font-size = 14px
 
@@ -69,7 +69,7 @@ ag-menu-option-shortcut-padding = 2px 2px 2px 20px
 
 // custom css for dark, we want to change the scrollbars
 
-.ag-common
+.ag-dark
 
   ::-webkit-scrollbar
     width 12px

--- a/src/styles/theme-fresh.styl
+++ b/src/styles/theme-fresh.styl
@@ -1,5 +1,5 @@
 
-ag-style = fresh
+ag-style = "fresh"
 ag-root-font-family = "Helvetica Neue",Helvetica,Arial,sans-serif
 ag-root-font-size = 14px
 

--- a/src/styles/theme-material.styl
+++ b/src/styles/theme-material.styl
@@ -1,5 +1,5 @@
 
-ag-style = material
+ag-style = "material"
 ag-root-font-family = Roboto
 ag-root-font-size = 14px
 
@@ -68,7 +68,7 @@ ag-menu-option-shortcut-padding = 10px 6px 10px 20px
 
 @import "theme-common"
 
-.ag-common
+.ag-material
   .ag-row-hover
     background-color #eeeeee !important
   .ag-cell-not-inline-editing


### PR DESCRIPTION
I would like to propose small change to make theming more flexible. 

Right now theming works as follow: 
- there is one file `theme-common.styl` that defines all common styles but requires some variables to be defined
- every theme defines all variables required by `theme-common.styl` and then includes this file
- as a result css file is generated with root class name `.ag-common`
- this magic class name is replaced on the fly by gulp task to match theme name eg. `.ag-blue`

This works fine but this is also a limitation. It is hard to create another theme by importing `theme-common.styl` one need to remember to replace this static class name.

As a solution to that problem I would like to propose dynamic class name generation. Every theme file has already variable named `ag-style` with theme name. To make it working all that need to be done is to define root class name in `theme-common.styl` as dynamic class name: `ag-${ag-style}` instead of giving it static name. Thanks to that workaround with replacing class name on the fly can be removed, and creating new themes is no longer problematic.

Thanks.

