### PR TITLE
Moved substraction of available pixels for the last column in sizeColumnsToFit to bottom of for loop

### DIFF
--- a/src/ts/columnController/columnController.ts
+++ b/src/ts/columnController/columnController.ts
@@ -1687,10 +1687,10 @@ export class ColumnController {
                         if (onLastCol) {
                             column.setActualWidth(pixelsForLastCol);
                         } else {
-                            pixelsForLastCol -= newWidth;
                             column.setActualWidth(newWidth);
                         }
                     }
+                    pixelsForLastCol -= newWidth;
                 }
             }
         }


### PR DESCRIPTION
I noticed when I called sizeColumnsToFit after autoSizeColumns, where, in our case, only the 3 left most columns aren't marked as suppressSIzeToFit, some columns would take up more width than necessary, and a column with a max-width & length content would not be getting as much as it could be.  What I did to fix this in our code was move the line `pixelsForLastCol -= newWidth;` outside of the if/else statements (so that it was the last line called in each iteration of the for loop), otherwise the pixelsForLastCol was too large because it wasn't subtracting available width in the case that the column was being set to either max or min width, and then being 'movedToNotSpread'

example plnkr:
[http://embed.plnkr.co/AcePXER70SerPXEsDgLi?p=info](http://embed.plnkr.co/AcePXER70SerPXEsDgLi?p=info)
