### PR TITLE
chore: enable custom interval/setTimeout runner

### DIFF
--- a/src/ts/entities/gridOptions.ts
+++ b/src/ts/entities/gridOptions.ts
@@ -79,6 +79,7 @@ export interface GridOptions {
     aggFuncs?: {[key: string]: IAggFunc};
     suppressColumnVirtualisation?: boolean;
     layoutInterval?: number;
+    intervalRunner?: Function;
     functionsReadOnly?: boolean;
     functionsPassive?: boolean;
     maxConcurrentDatasourceRequests?: number;

--- a/src/ts/gridOptionsWrapper.ts
+++ b/src/ts/gridOptionsWrapper.ts
@@ -276,7 +276,21 @@ export class GridOptionsWrapper {
             return Constants.LAYOUT_INTERVAL;
         }
     }
-    
+
+    private defaultIntervalRunner(
+      intervalOrTimeout: Function, period: number, action: (...args: any[]) => any
+    ) {
+      return intervalOrTimeout.apply(window, [ action, period ])
+    }
+
+    public getIntervalRunner(): Function {
+        if (typeof this.gridOptions.intervalRunner === 'function') {
+            return this.gridOptions.intervalRunner;
+        } else {
+            return this.defaultIntervalRunner;
+        }
+    }
+
     public getMinColWidth() {
         if (this.gridOptions.minColWidth > GridOptionsWrapper.MIN_COL_WIDTH) {
             return this.gridOptions.minColWidth;


### PR DESCRIPTION
Related to ceolter/ag-grid-ng2#43.

Angular 2 requires that background timer-based functions not live
in the app's NgZone. The optional `intervalRunner` function allows
for this, and is used by ag-grid-ng2 to run the `setTimeout`s outside
the angular zone.
