### PR TITLE
NOT_EQUALS text filter type should include empty strings

### DIFF
--- a/src/ts/filter/textFilter.ts
+++ b/src/ts/filter/textFilter.ts
@@ -54,7 +54,7 @@ export class TextFilter implements IFilter {
         }
         var value = this.filterParams.valueGetter(params.node);
         if (!value) {
-            return false;
+            return this.filterType === TextFilter.NOT_EQUALS;
         }
         var valueLowerCase = value.toString().toLowerCase();
         switch (this.filterType) {


### PR DESCRIPTION
TextFilter.prototype.doesFilterPass returns false if !value. This means that empty strings never pass a filter. However, when using TextFilter.NOT_EQUALS, empty strings should satisfy any non-empty filter text. As filterText is tested for empty values prior to the node value check, we are guaranteed at this point that the filterText is non-empty, so an empty node value should return true.