### PR TITLE
removes unused `ag-background-2` variable

### DIFF
--- a/src/styles/theme-blue.styl
+++ b/src/styles/theme-blue.styl
@@ -12,7 +12,6 @@ ag-border-color-1 = #000
 ag-border-color-2 = #808080
 
 ag-background-1 = #f6f6f6
-ag-background-2 = #fafafa
 
 ag-foreground-1 = #222
 

--- a/src/styles/theme-bootstrap.styl
+++ b/src/styles/theme-bootstrap.styl
@@ -12,7 +12,6 @@ ag-border-color-1 = #000
 ag-border-color-2 = #808080
 
 ag-background-1 = #f6f6f6
-ag-background-2 = #fafafa
 
 ag-foreground-1 = #000
 

--- a/src/styles/theme-dark.styl
+++ b/src/styles/theme-dark.styl
@@ -12,7 +12,6 @@ ag-border-color-1 = #000
 ag-border-color-2 = #555
 
 ag-background-1 = #302E2E
-ag-background-2 = #f0f0f0
 
 ag-foreground-1 = #ccc
 

--- a/src/styles/theme-fresh.styl
+++ b/src/styles/theme-fresh.styl
@@ -12,7 +12,6 @@ ag-border-color-1 = #000
 ag-border-color-2 = #808080
 
 ag-background-1 = #f6f6f6
-ag-background-2 = #f0f0f0
 
 ag-foreground-1 = #222
 

--- a/src/styles/theme-material.styl
+++ b/src/styles/theme-material.styl
@@ -12,7 +12,6 @@ ag-border-color-1 = #000
 ag-border-color-2 = #808080
 
 ag-background-1 = #fff
-ag-background-2 = #fafafa
 
 ag-foreground-1 = #666
 


### PR DESCRIPTION
At least, it appears to be unused, if I'm not mistaken.