### PR TITLE
Fix calculation for sizeColumnsToFit

### DIFF
--- a/src/ts/gridPanel/gridPanel.ts
+++ b/src/ts/gridPanel/gridPanel.ts
@@ -847,8 +847,8 @@ export class GridPanel extends BeanStub {
         // if pinning right, then the scroll bar can show, however for some reason
         // it overlays the grid and doesn't take space. so we are only interested
         // in the body scroll showing.
-        var removeScrollWidth = this.isBodyVerticalScrollShowing();
-        if (removeScrollWidth) {
+        var removeVerticalScrollWidth = this.isVerticalScrollShowing();
+        if (removeVerticalScrollWidth) {
             availableWidth -= this.scrollWidth;
         }
         return availableWidth;


### PR DESCRIPTION
Fix for #1333 and #1386 

Hi @ceolter,
I had the issue described in 1333. When I debug through the `sizeColumnsToFit` function, I've noticed that, when having both a vertical and horizontal scrollbar, `this.isBodyVerticalScrollShowing();` is true and thus reduces the `availableWith`. When only having a vertical scrollbar, `this.isBodyVerticalScrollShowing();` is false and used the full client witdh. Using the below function seems to fix the problem. It also works correctly when having a column pinned right.

I was thinking about changing `this.isBodyVerticalScrollShowing()`, perhaps the `else` function should be changed.
Tested on chrome v 55.0.2883.87
