### PR TITLE
fix(gridOptions): set type of paginationAutoPageSize to boolean

### DIFF
--- a/src/ts/entities/gridOptions.ts
+++ b/src/ts/entities/gridOptions.ts
@@ -101,7 +101,7 @@ export interface GridOptions {
     infiniteInitialRowCount?: number;
     paginationPageSize?: number;
     infiniteBlockSize?: number;
-    paginationAutoPageSize?: number;
+    paginationAutoPageSize?: boolean;
     paginationStartPage?: number;
     suppressPaginationPanel?: boolean;
 


### PR DESCRIPTION
Please take the following issue as reference: https://github.com/ceolter/ag-grid/issues/1563

According to the documentation the paginationAutoPageSize field should be a boolean.
In the ComponentUtil Class it is already part of the BOOLEAN_PROPERTIES
Enum. Thats why this PR only consists of the gridOptions update.

