### PR TITLE
Add IViewportDatasourceParams to main exported type definitions

### DIFF
--- a/main.d.ts
+++ b/main.d.ts
@@ -136,7 +136,7 @@ export { ColDef } from "./dist/lib/entities/colDef";
 export { ProcessCellForExportParams, ProcessHeaderForExportParams } from "./dist/lib/exportParams";
 export { GridOptions, GetContextMenuItemsParams, GetContextMenuItems, MenuItemDef } from "./dist/lib/entities/gridOptions";
 export { OriginalColumnGroupChild } from "./dist/lib/entities/originalColumnGroupChild";
-export { IViewportDatasource } from "./dist/lib/interfaces/iViewportDatasource";
+export { IViewportDatasource, IViewportDatasourceParams } from "./dist/lib/interfaces/iViewportDatasource";
 export { IContextMenuFactory } from "./dist/lib/interfaces/iContextMenuFactory";
 export { ICompFactory } from "./dist/lib/interfaces/iCompFactory";
 export { IRowNodeStage, StageExecuteParams } from "./dist/lib/interfaces/iRowNodeStage";


### PR DESCRIPTION
https://github.com/ceolter/ag-grid/issues/1713

**I'm submitting a ...**  (check one with "x")
```
[ ] bug report => search github for a similar issue or PR before submitting
[x] feature request
[ ] support request => Please do not submit support request here, instead see https://github.com/ceolter/ag-grid/blob/master/CONTRIBUTING.md#question
```

**What is the motivation / use case for changing the behavior?**

I would like to see ```IViewportDatasourceParams``` added to the exported types in ```main.d.ts``` so that I can easily import and use this type in my code. With the recent restructuring of the exported types list I now have to import ```IViewportDatasourceParams``` directly from ```ag-grid/dist/lib/interfaces/iViewportDatasource``` in order to use the interface.

**ag-Grid version:** 10.1.0

