### PR TITLE
AG-2151 - Add column to FilterChangedEvent

### DIFF
--- a/community-modules/core/src/ts/events.ts
+++ b/community-modules/core/src/ts/events.ts
@@ -78,8 +78,8 @@ export interface FilterChangedEvent extends AgGridEvent {
     afterDataChange?: boolean;
     /** True if filter was changed via floating filter */
     afterFloatingFilter?: boolean;
-    /** Source column for the filter change, if a single Column can be attributed */
-    column?: Column;
+    /** Source column(s) for the filter change, if the change can be attributed */
+    columns: Column[];
 }
 
 export interface FilterModifiedEvent extends AgGridEvent {

--- a/community-modules/core/src/ts/filter/filterManager.ts
+++ b/community-modules/core/src/ts/filter/filterManager.ts
@@ -66,6 +66,7 @@ export class FilterManager extends BeanStub {
 
     public setFilterModel(model: { [key: string]: any; }): void {
         const allPromises: AgPromise<void>[] = [];
+        const columns: Column[] = [];
 
         if (model) {
             // mark the filters as we set them, so any active filters left over we stop
@@ -74,6 +75,7 @@ export class FilterManager extends BeanStub {
             this.allAdvancedFilters.forEach((filterWrapper, colId) => {
                 const newModel = model[colId];
 
+                columns.push(filterWrapper.column);
                 allPromises.push(this.setModelOnFilterWrapper(filterWrapper.filterPromise!, newModel));
                 modelKeys.delete(colId);
             });
@@ -88,16 +90,18 @@ export class FilterManager extends BeanStub {
                 }
 
                 const filterWrapper = this.getOrCreateFilterWrapper(column, 'NO_UI');
+                columns.push(filterWrapper.column);
 
                 allPromises.push(this.setModelOnFilterWrapper(filterWrapper.filterPromise!, model[colId]));
             });
         } else {
             this.allAdvancedFilters.forEach(filterWrapper => {
+                columns.push(filterWrapper.column);
                 allPromises.push(this.setModelOnFilterWrapper(filterWrapper.filterPromise!, null));
             });
         }
 
-        AgPromise.all(allPromises).then(() => this.onFilterChanged());
+        AgPromise.all(allPromises).then(() => this.onFilterChanged({ columns }));
     }
 
     private setModelOnFilterWrapper(filterPromise: AgPromise<IFilterComp>, newModel: any): AgPromise<void> {
@@ -213,8 +217,8 @@ export class FilterManager extends BeanStub {
         }
     }
 
-    public onFilterChanged(params: { filterInstance?: IFilterComp, additionalEventAttributes?: any, column?: Column} = {}): void {
-        const { filterInstance, additionalEventAttributes, column } = params;
+    public onFilterChanged(params: { filterInstance?: IFilterComp, additionalEventAttributes?: any, columns?: Column[]} = {}): void {
+        const { filterInstance, additionalEventAttributes, columns } = params;
 
         this.updateActiveFilters();
         this.updateFilterFlagInColumns('filterChanged', additionalEventAttributes);
@@ -232,7 +236,7 @@ export class FilterManager extends BeanStub {
             type: Events.EVENT_FILTER_CHANGED,
             api: this.gridApi,
             columnApi: this.columnApi,
-            column: column
+            columns: columns || [],
         };
 
         if (additionalEventAttributes) {
@@ -423,7 +427,7 @@ export class FilterManager extends BeanStub {
                 this.eventService.dispatchEvent(event);
             },
             filterChangedCallback: (additionalEventAttributes?: any) =>
-                this.onFilterChanged({filterInstance, additionalEventAttributes, column}),
+                this.onFilterChanged({filterInstance, additionalEventAttributes, columns: [column]}),
             doesRowPassOtherFilter: node => this.doesRowPassOtherFilters(filterInstance, node),
         };
 
@@ -522,18 +526,20 @@ export class FilterManager extends BeanStub {
 
     private onNewColumnsLoaded(): void {
         let atLeastOneFilterGone = false;
+        const columns: Column[] = [];
 
         this.allAdvancedFilters.forEach(filterWrapper => {
             const oldColumn = !this.columnModel.getPrimaryColumn(filterWrapper.column);
 
             if (oldColumn) {
                 atLeastOneFilterGone = true;
+                columns.push(filterWrapper.column);
                 this.disposeFilterWrapper(filterWrapper, 'filterDestroyed');
             }
         });
 
         if (atLeastOneFilterGone) {
-            this.onFilterChanged();
+            this.onFilterChanged({ columns });
         }
     }
 
@@ -543,7 +549,7 @@ export class FilterManager extends BeanStub {
 
         if (filterWrapper) {
             this.disposeFilterWrapper(filterWrapper, source);
-            this.onFilterChanged({column});
+            this.onFilterChanged({columns: [column]});
         }
     }
 

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/doc-interfaces.AUTO.json
@@ -5364,9 +5364,9 @@
       "description": "/** True if filter was changed via floating filter */",
       "type": { "returnType": "boolean", "optional": true }
     },
-    "column": {
-      "description": "/** Source column for the filter change, if a single Column can be attributed */",
-      "type": { "returnType": "Column", "optional": true }
+    "columns": {
+      "description": "/** Source column(s) for the filter change, if the change can be attributed */",
+      "type": { "returnType": "Column[]", "optional": false }
     },
     "api": { "type": { "returnType": "GridApi", "optional": false } },
     "columnApi": { "type": { "returnType": "ColumnApi", "optional": false } },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/grid-api/interfaces.AUTO.json
@@ -2677,7 +2677,7 @@
     "type": {
       "afterDataChange?": "boolean",
       "afterFloatingFilter?": "boolean",
-      "column?": "Column",
+      "columns": "Column[]",
       "api": "GridApi",
       "columnApi": "ColumnApi",
       "type": "string"
@@ -2685,7 +2685,7 @@
     "docs": {
       "afterDataChange?": "/** True if the filter was changed as a result of data changing */",
       "afterFloatingFilter?": "/** True if filter was changed via floating filter */",
-      "column?": "/** Source column for the filter change, if a single Column can be attributed */",
+      "columns": "/** Source column(s) for the filter change, if the change can be attributed */",
       "type": "/** Event identifier */"
     }
   },


### PR DESCRIPTION
Incorporates the following feedback from Rob & Gil:
- Removes determination of `Column` from the `Promise` chain in `FilterManager.onFilterChanged()`.
- Switches to parameter destructuring for `FilterManager.onFilterChanged()` for use-cases where we only have `columns` available.
- At `FilterManager.onFilterChanged()` call-sites where `columns` are available, pass them through.
- Switch from optional single `Column` to required `Column[]` in `FilterChangedEvent`.

NOTE:
- `GridApi.onFilterChanged()` calls will result in a `FilterChangedEvent` with `columns.length === 0`.

Bonus:
- Removes some potentially unsafe uses of `!`.

NOTE: I broke the change into a commit reverting the previous commit, and another with the full set of changes, depending on how you'd like to review (vs. baseline before any change, or vs. head of latest)