### PR TITLE
AG-5316 - Allow customisation of mini-filter matching logic.

### DIFF
--- a/community-modules/core/src/ts/interfaces/iSetFilterParams.ts
+++ b/community-modules/core/src/ts/interfaces/iSetFilterParams.ts
@@ -62,6 +62,7 @@ export interface ISetFilterParams extends IProvidedFilterParams {
      */
     textFormatter?: (from: string) => string;
     valueFormatter?: (params: ValueFormatterParams) => string;
+    miniFilterMatcher?: (valuesToCheck: (string | null)[], formattedFilterText: string) => boolean;
     /** 
      * If `true`, hovering over a value in the Set Filter will show a tooltip containing the full, untruncated value.
      * Default: `false`


### PR DESCRIPTION
*DO NOT MERGE* - for approach discussion only at this stage.

Adds `ISetFilterParams.miniFilterMatcher` as an optional override for the `SetFilter`s mini-filter matching function.

TODO:
- [ ] Verify approach for matcher interface contract (there are tradeoffs).
- [ ] Add docs.
- [ ] Test.