### PR TITLE
Allow `CellStyleFunc`s to return `null` or `undefined`

### DIFF
--- a/community-modules/core/src/ts/entities/colDef.ts
+++ b/community-modules/core/src/ts/entities/colDef.ts
@@ -626,7 +626,7 @@ export interface CellClassFunc {
     (cellClassParams: CellClassParams): string | string[];
 }
 export interface CellStyleFunc {
-    (cellClassParams: CellClassParams): CellStyle;
+    (cellClassParams: CellClassParams): CellStyle | null | undefined;
 }
 
 export interface CellStyle { [cssProperty: string]: string | number; }


### PR DESCRIPTION
Currently `CellStyleFunc`s must return a style object, but sometimes users might want to return `null` or `undefined` in order to not style a cell. From empirical testing this works fine, and it also appears [the code allows it](https://github.com/ag-grid/ag-grid/blob/b1c2df07c4ee555621dcc4104afe8d898d3212f4/community-modules/core/src/ts/utils/dom.ts#L416) and in fact [the docs also do it in their example of cell styling](https://www.ag-grid.com/javascript-data-grid/cell-styles/#cell-style):

<img width="1024" alt="image" src="https://user-images.githubusercontent.com/1400151/138478137-3a9b76db-e37f-4ea8-983b-1ee1ad58f090.png">

This PR just updates the types to reflect that this is allowed. Not sure if there's other files to autogenerate or change after my change, feel free to modify this PR if useful!
