### PR TITLE
Performance improvements

### DIFF
--- a/community-modules/core/src/ts/utils/string.ts
+++ b/community-modules/core/src/ts/utils/string.ts
@@ -172,6 +172,10 @@ export function capitalise(str: string): string {
     return str[0].toUpperCase() + str.substr(1).toLowerCase();
 }
 
+export function stringOrNull(value: number | string | null) {
+  return value == null ? null : value.toString().toString();
+}
+
 export function escapeString(toEscape?: string | null): string | null {
     // we call toString() twice, in case value is an object, where user provides
     // a toString() method, and first call to toString() returns back something other

--- a/community-modules/core/src/ts/widgets/component.ts
+++ b/community-modules/core/src/ts/widgets/component.ts
@@ -204,6 +204,10 @@ export class Component extends BeanStub {
         }
     }
 
+    public setElement(eGui: any, paramsMap?: any) {
+        this.setTemplateFromElement(eGui, paramsMap);
+    }
+
     public setTemplate(template: string | null, paramsMap?: { [key: string]: any; }): void {
         const eGui = loadTemplate(template as string);
         this.setTemplateFromElement(eGui, paramsMap);


### PR DESCRIPTION
Hi!

This is a preview PR of changes requested in #20514 Zendesk request.
I believe that the code will explain our intentions better than words 🙂
Just please keep in mind that this is just a preview of our intentions. Surely it needs some typing improvements, probably better structure and a rebase to the current master.

The content below is just a copy-paste from Zendesk request.

---

We use the viewport row model and at some point, we call `params.setRowData` function. This call takes ~200ms to complete, which causes glitches.

It turns out that the majority of this time is spent on parsing HTML. It comes mostly from the method [`getCreateTemplate`](https://github.com/ag-grid/ag-grid/blob/v25.3.0/community-modules/core/src/ts/rendering/cellComp.ts#L215). After changing this piece of code from assembling string template and calling [`loadTemplate`](https://github.com/ag-grid/ag-grid/blob/v25.3.0/community-modules/core/src/ts/utils/dom.ts#L314) to create the DOM manually using methods like `document.createElement`, `element.setAttribute` etc. we experienced 5 to 10 times faster execution of `params.setRowData` function.

We checked also the DEMO on the main ag-grid page and it seems that parsing HTML in function [`redrawAfterScroll`](https://github.com/ag-grid/ag-grid/blob/f11be0faec6d82e306e955dbafd1f4c0c218dd1d/community-modules/core/src/ts/gridBodyComp/gridBodyScrollFeature.ts#L250) takes around 18% of the time, so it seems that the issue is not case-specific.

With that being said, we request to switch from parsing HTML strings to creating the DOM with DOM API.

Please note, that we use ag-grid in version: 25.3.0, but the same method for creating the DOM i is present in the latest master branch on Github.

I'm attaching screens from the performance inspection.


Before the change:
![image](https://user-images.githubusercontent.com/6236664/153178118-9e47cea1-b4e1-4cbc-9070-4be44933a036.png)


After the change:
![image](https://user-images.githubusercontent.com/6236664/153178167-7aa1a187-1b70-4517-8aa9-d1aad4cbdee6.png)



----

I created a plunker for that purpose - https://plnkr.co/edit/Tisqid5a4Im7lkQx?

To reproduce this issue, try to resize the screen to have many columns and rows visible at once, and then just scroll down the grid. Every hundred items scrolled, you should see a blank grid for a while. It's the time that takes javascript to populate the grid with the data.
