### PR TITLE
AG-5160 - Rename `characterLimit` property to `maxLength` and exclude…

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -288,8 +288,8 @@ export interface AgChartLegendMarkerOptions {
 }
 
 export interface AgChartLegendLabelOptions {
-    /** If the label text exceeds the character limit, it will be truncated and an ellipsis will be appended to indicate this. */
-    characterLimit?: number;
+    /** If the label text exceeds the maximum length, it will be truncated and an ellipsis will be appended to indicate this. */
+    maxLength?: number;
     /** The colour of the text. */
     color?: CssColor;
     /** The font style to use for the legend. */

--- a/charts-packages/ag-charts-community/src/chart/legend.ts
+++ b/charts-packages/ag-charts-community/src/chart/legend.ts
@@ -45,7 +45,7 @@ interface LegendLabelFormatterParams {
 }
 
 export class LegendLabel {
-    characterLimit = undefined;
+    maxLength = undefined;
     color = 'black';
     fontStyle?: FontStyle = undefined;
     fontWeight?: FontWeight = undefined;
@@ -219,7 +219,7 @@ export class Legend {
                 shape: markerShape
             },
             label: {
-                characterLimit = Infinity,
+                maxLength = Infinity,
                 fontStyle,
                 fontWeight,
                 fontSize,
@@ -261,8 +261,8 @@ export class Legend {
             const textChars = text.split('');
             let addEllipsis = false;
 
-            if (text.length > characterLimit) {
-                text = `${text.substring(0, characterLimit - ellipsis.length)}`;
+            if (text.length > maxLength) {
+                text = `${text.substring(0, maxLength)}`;
                 addEllipsis = true;
             }
 

--- a/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
+++ b/community-modules/core/src/ts/interfaces/iAgChartOptions.ts
@@ -288,8 +288,8 @@ export interface AgChartLegendMarkerOptions {
 }
 
 export interface AgChartLegendLabelOptions {
-    /** If the label text exceeds the character limit, it will be truncated and an ellipsis will be appended to indicate this. */
-    characterLimit?: number;
+    /** If the label text exceeds the maximum length, it will be truncated and an ellipsis will be appended to indicate this. */
+    maxLength?: number;
     /** The colour of the text. */
     color?: CssColor;
     /** The font style to use for the legend. */

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/index.md
@@ -91,7 +91,7 @@ Please refer to the example below to get a better idea of how the above configs 
 
 There are a number of configs that affect the `fontSize`, `fontStyle`, `fontWeight`, `fontFamily`, and `color` of the legend item labels.
 
-`characterLimit` can also be configured to constrain the length of legend item labels, if the label text exceeds the character limit, it will be truncated and an ellipsis will be appended.
+`maxLength` can also be configured to constrain the length of legend item labels, if the label text exceeds the maximum length, it will be truncated and an ellipsis will be appended.
 
 ```js
 legend: {
@@ -102,7 +102,7 @@ legend: {
             fontWeight: 'bold',
             fontFamily: 'Papyrus',
             color: 'red',
-            characterLimit: 25
+            maxLength: 25
         }
     }
 }


### PR DESCRIPTION
This PR is for https://ag-grid.atlassian.net/browse/AG-5160 and https://ag-grid.atlassian.net/browse/AG-6852.

It includes the following minor changes:
- Rename `characterLimit` to `maxLength`
- Exclude the ellipsis character count when truncating the legend item text. 