### PR TITLE
Fix stringification of RowIndex to prevent grid hard crashing

### DIFF
--- a/community-modules/core/src/ts/entities/rowNode.ts
+++ b/community-modules/core/src/ts/entities/rowNode.ts
@@ -325,7 +325,7 @@ export class RowNode<TData = any> implements IEventEmitter {
             return 'b-' + this.rowIndex;
         }
 
-        return this.rowIndex!.toString();
+        return String(this.rowIndex);
     }
 
     private createDaemonNode(): RowNode {


### PR DESCRIPTION
There have been several GitHub issues referencing this problem:

https://github.com/ag-grid/ag-grid/issues/5068
https://github.com/ag-grid/ag-grid/issues/4767

It is difficult to reproduce in a sandbox environment, but in real-world applications we are seeing this problem manifest throughout the grid.

![Screen Shot 2022-07-29 at 12 15 40 PM](https://user-images.githubusercontent.com/79478569/181829089-c4605187-00c9-483c-bb55-bb6e98aacda4.png)

Essentially, In certain circumstances, `rowIndex` will briefly be null. If the row attempts to re-render while `rowIndex` is null, the grid hard crashes.

This often seems linked to filtering the grid in rapid succession, or updating rows when a filter is applied.

This simple fix prevents a hard crash and filtering works as intended. 
