### PR TITLE
Enable support for `TValue` typing of `ValueFormatterParams` when using `ValueFormatterFunc`

### DIFF
--- a/community-modules/core/src/ts/entities/colDef.ts
+++ b/community-modules/core/src/ts/entities/colDef.ts
@@ -637,8 +637,8 @@ export interface ValueFormatterParams<TData = any, TValue = any> extends BaseCol
     value: TValue;
 }
 
-export interface ValueFormatterFunc<TData = any> {
-    (params: ValueFormatterParams<TData>): string;
+export interface ValueFormatterFunc<TData = any, TValue = any> {
+    (params: ValueFormatterParams<TData, TValue>): string;
 }
 
 export interface KeyCreatorParams<TData = any, TValue = any> extends BaseColDefParams<TData> {


### PR DESCRIPTION
At the moment, we use something like this:

```tsx
const numericFormatter = ({
  value,
}: ValueFormatterParams<TData, number | undefined>) =>
  value === undefined ? '' : round(value, 2).toFixed(2);
```

This is great, but type safety can be improved a little further with this change:

```tsx
const numericFormatter = ({
  value
}): ValueFormatterFunc<TData, number | undefined> =>
  value === undefined ? '' : round(value, 2).toFixed(2);
```
