### PR TITLE
AG-7369 - Add tooltip animation

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -14,7 +14,7 @@ import { Marker } from '../../marker/marker';
 import { CartesianSeries, CartesianSeriesMarker, CartesianSeriesMarkerFormat } from './cartesianSeries';
 import { ChartAxisDirection } from '../../chartAxis';
 import { getMarker } from '../../marker/util';
-import { TooltipRendererResult, toTooltipHtml } from '../../chart';
+import { TooltipRendererResult, toTooltipHtml } from '../../tooltip/tooltip';
 import { extent } from '../../../util/array';
 import { equal } from '../../../util/equal';
 import { TypedEvent } from '../../../util/observable';

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -16,7 +16,7 @@ import { PointerEvents } from '../../../scene/node';
 import { LegendDatum } from '../../legend';
 import { CartesianSeries } from './cartesianSeries';
 import { ChartAxis, ChartAxisDirection, flipChartAxisDirection } from '../../chartAxis';
-import { TooltipRendererResult, toTooltipHtml } from '../../chart';
+import { TooltipRendererResult, toTooltipHtml } from '../../tooltip/tooltip';
 import { findMinMax } from '../../../util/array';
 import { equal } from '../../../util/equal';
 import { TypedEvent } from '../../../util/observable';

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -16,7 +16,7 @@ import { PointerEvents } from '../../../scene/node';
 import { LegendDatum } from '../../legend';
 import { CartesianSeries } from './cartesianSeries';
 import { ChartAxisDirection } from '../../chartAxis';
-import { TooltipRendererResult, toTooltipHtml } from '../../chart';
+import { TooltipRendererResult, toTooltipHtml } from '../../tooltip/tooltip';
 import { extent } from '../../../util/array';
 import { TypedEvent } from '../../../util/observable';
 import ticks, { tickStep } from '../../../util/ticks';

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -17,7 +17,7 @@ import { CartesianSeries, CartesianSeriesMarker, CartesianSeriesMarkerFormat } f
 import { ChartAxisDirection } from '../../chartAxis';
 import { getMarker } from '../../marker/util';
 import { TypedEvent } from '../../../util/observable';
-import { TooltipRendererResult, toTooltipHtml } from '../../chart';
+import { TooltipRendererResult, toTooltipHtml } from '../../tooltip/tooltip';
 import { interpolate } from '../../../util/string';
 import { Label } from '../../label';
 import { sanitizeHtml } from '../../../util/sanitize';

--- a/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -14,7 +14,7 @@ import { TypedEvent } from '../../../util/observable';
 import { CartesianSeries, CartesianSeriesMarker, CartesianSeriesMarkerFormat } from './cartesianSeries';
 import { ChartAxisDirection } from '../../chartAxis';
 import { getMarker } from '../../marker/util';
-import { TooltipRendererResult, toTooltipHtml } from '../../chart';
+import { TooltipRendererResult, toTooltipHtml } from '../../tooltip/tooltip';
 import { ContinuousScale } from '../../../scale/continuousScale';
 import { sanitizeHtml } from '../../../util/sanitize';
 import { Label } from '../../label';

--- a/charts-packages/ag-charts-community/src/chart/series/hierarchy/treemapSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/hierarchy/treemapSeries.ts
@@ -4,7 +4,7 @@ import { TypedEvent } from '../../../util/observable';
 import { Label } from '../../label';
 import { SeriesNodeDatum, SeriesTooltip, TooltipRendererParams } from '../series';
 import { HierarchySeries } from './hierarchySeries';
-import { TooltipRendererResult, toTooltipHtml } from '../../chart';
+import { TooltipRendererResult, toTooltipHtml } from '../../tooltip/tooltip';
 import { Group } from '../../../scene/group';
 import { Text } from '../../../scene/shape/text';
 import { Rect } from '../../../scene/shape/rect';

--- a/charts-packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/charts-packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -19,7 +19,7 @@ import { Caption } from '../../../caption';
 import { Observable, TypedEvent } from '../../../util/observable';
 import { PolarSeries } from './polarSeries';
 import { ChartAxisDirection } from '../../chartAxis';
-import { TooltipRendererResult, toTooltipHtml } from '../../chart';
+import { TooltipRendererResult, toTooltipHtml } from '../../tooltip/tooltip';
 import { DeprecatedAndRenamedTo } from '../../../util/deprecation';
 import {
     BOOLEAN,

--- a/charts-packages/ag-charts-community/src/chart/themes/chartTheme.ts
+++ b/charts-packages/ag-charts-community/src/chart/themes/chartTheme.ts
@@ -13,8 +13,8 @@ import {
     AgCartesianSeriesTheme,
     AgHierarchySeriesTheme,
 } from '../agChartOptions';
-import { Chart } from '../chart';
 import { TimeInterval } from '../../util/time/interval';
+import { DEFAULT_TOOLTIP_CLASS } from '../tooltip/tooltip';
 
 const palette: AgChartThemePalette = {
     fills: ['#f3622d', '#fba71b', '#57b757', '#41a9c9', '#4258c9', '#9a42c8', '#c84164', '#888888'],
@@ -247,7 +247,7 @@ export class ChartTheme {
                 enabled: true,
                 tracking: true,
                 delay: 0,
-                class: Chart.defaultTooltipClass,
+                class: DEFAULT_TOOLTIP_CLASS,
             },
         };
     }

--- a/charts-packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/charts-packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -20,8 +20,12 @@ const defaultTooltipCss = `
     box-shadow: 0 0 1px rgba(3, 3, 3, 0.7), 0.5vh 0.5vh 1vh rgba(3, 3, 3, 0.25);
 }
 
+.ag-chart-tooltip-no-animation {
+    transition: none !important;
+}
+
 .ag-chart-tooltip-hidden {
-    display: none;
+    visibility: hidden;
 }
 
 .ag-chart-tooltip-title {
@@ -214,16 +218,20 @@ export class Tooltip {
     updateClass(visible?: boolean, constrained?: boolean) {
         const { element, class: newClass, lastClass } = this;
 
-        if (visible === true) {
-            element.classList.remove(`${DEFAULT_TOOLTIP_CLASS}-hidden`);
-        } else {
-            element.classList.add(`${DEFAULT_TOOLTIP_CLASS}-hidden`);
-        }
-        if (constrained === true) {
-            element.classList.remove(`${DEFAULT_TOOLTIP_CLASS}-arrow`);
-        } else {
-            element.classList.add(`${DEFAULT_TOOLTIP_CLASS}-arrow`);
-        }
+        const wasVisible = !element.classList.contains(`${DEFAULT_TOOLTIP_CLASS}-hidden`);
+
+        const toggleClass = (name: string, include: boolean) => {
+            const className = `${DEFAULT_TOOLTIP_CLASS}-${name}`;
+            if (include) {
+                element.classList.add(className);
+            } else {
+                element.classList.remove(className);
+            }
+        };
+
+        toggleClass('no-animation', !wasVisible && !!visible); // No animation on first show.
+        toggleClass('hidden', !visible); // Hide if not visible.
+        toggleClass('arrow', !constrained); // Add arrow if tooltip is constrained.
 
         if (newClass !== lastClass) {
             if (lastClass) {
@@ -256,23 +264,20 @@ export class Tooltip {
 
         this.constrained = false;
         if (this.container()) {
-            const tooltipRect = el.getBoundingClientRect();
+            const tooltipWidth = el.getBoundingClientRect().width;
             const minLeft = 0;
-            const maxLeft = window.innerWidth - tooltipRect.width - 1;
+            const maxLeft = window.innerWidth - tooltipWidth - 1;
             if (left < minLeft) {
                 left = minLeft;
                 this.constrained = true;
-                this.updateClass(true, this.constrained);
             } else if (left > maxLeft) {
                 left = maxLeft;
                 this.constrained = true;
-                this.updateClass(true, this.constrained);
             }
 
             if (top < window.scrollY) {
                 top = meta.pageY + 20;
                 this.constrained = true;
-                this.updateClass(true, this.constrained);
             }
         }
 

--- a/charts-packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/charts-packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -1,0 +1,293 @@
+import { Validate, BOOLEAN, STRING, NUMBER } from '../../util/validation';
+
+export const DEFAULT_TOOLTIP_CLASS = 'ag-chart-tooltip';
+
+const defaultTooltipCss = `
+.ag-chart-tooltip {
+    display: table;
+    position: absolute;
+    user-select: none;
+    pointer-events: none;
+    white-space: nowrap;
+    z-index: 99999;
+    font: 12px Verdana, sans-serif;
+    color: black;
+    background: rgb(244, 244, 244);
+    border-radius: 5px;
+    box-shadow: 0 0 1px rgba(3, 3, 3, 0.7), 0.5vh 0.5vh 1vh rgba(3, 3, 3, 0.25);
+}
+
+.ag-chart-tooltip-hidden {
+    top: -10000px !important;
+}
+
+.ag-chart-tooltip-title {
+    font-weight: bold;
+    padding: 7px;
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+    color: white;
+    background-color: #888888;
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+}
+
+.ag-chart-tooltip-content {
+    padding: 7px;
+    line-height: 1.7em;
+    border-bottom-left-radius: 5px;
+    border-bottom-right-radius: 5px;
+    overflow: hidden;
+}
+
+.ag-chart-tooltip-content:empty {
+    padding: 0;
+    height: 7px;
+}
+
+.ag-chart-tooltip-arrow::before {
+    content: "";
+
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+
+    border: 6px solid #989898;
+
+    border-left-color: transparent;
+    border-right-color: transparent;
+    border-top-color: #989898;
+    border-bottom-color: transparent;
+
+    width: 0;
+    height: 0;
+
+    margin: 0 auto;
+}
+
+.ag-chart-tooltip-arrow::after {
+    content: "";
+
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+
+    border: 5px solid black;
+
+    border-left-color: transparent;
+    border-right-color: transparent;
+    border-top-color: rgb(244, 244, 244);
+    border-bottom-color: transparent;
+
+    width: 0;
+    height: 0;
+
+    margin: 0 auto;
+}
+
+.ag-chart-wrapper {
+    box-sizing: border-box;
+    overflow: hidden;
+}
+`;
+
+export interface TooltipMeta {
+    pageX: number;
+    pageY: number;
+    offsetX: number;
+    offsetY: number;
+    event: MouseEvent;
+}
+
+export interface TooltipRendererResult {
+    content?: string;
+    title?: string;
+    color?: string;
+    backgroundColor?: string;
+}
+
+export function toTooltipHtml(input: string | TooltipRendererResult, defaults?: TooltipRendererResult): string {
+    if (typeof input === 'string') {
+        return input;
+    }
+
+    defaults = defaults || {};
+
+    const {
+        content = defaults.content || '',
+        title = defaults.title || undefined,
+        color = defaults.color || 'white',
+        backgroundColor = defaults.backgroundColor || '#888',
+    } = input;
+
+    const titleHtml = title
+        ? `<div class="${DEFAULT_TOOLTIP_CLASS}-title"
+        style="color: ${color}; background-color: ${backgroundColor}">${title}</div>`
+        : '';
+
+    return `${titleHtml}<div class="${DEFAULT_TOOLTIP_CLASS}-content">${content}</div>`;
+}
+
+type OptionalHTMLElement = HTMLElement | undefined | null;
+
+export class Tooltip {
+    private static tooltipDocuments: Document[] = [];
+
+    element: HTMLDivElement;
+
+    private observer?: IntersectionObserver;
+    private observedElement: () => HTMLElement;
+    private container: () => OptionalHTMLElement;
+
+    @Validate(BOOLEAN)
+    enabled: boolean = true;
+
+    @Validate(STRING)
+    class: string = DEFAULT_TOOLTIP_CLASS;
+
+    @Validate(NUMBER(0))
+    delay: number = 0;
+
+    /**
+     * If `true`, the tooltip will be shown for the marker closest to the mouse cursor.
+     * Only has effect on series with markers.
+     */
+    @Validate(BOOLEAN)
+    tracking: boolean = true;
+
+    constructor(canvasElement: () => HTMLCanvasElement, document: Document, container: () => OptionalHTMLElement) {
+        this.class = '';
+
+        const tooltipRoot = document.body;
+        const element = document.createElement('div');
+        this.element = tooltipRoot.appendChild(element);
+        this.container = container;
+
+        // Detect when the chart becomes invisible and hide the tooltip as well.
+        if (window.IntersectionObserver) {
+            this.observedElement = canvasElement;
+            const observer = new IntersectionObserver(
+                (entries) => {
+                    for (const entry of entries) {
+                        if (entry.target === this.observedElement() && entry.intersectionRatio === 0) {
+                            this.toggle(false);
+                        }
+                    }
+                },
+                { root: tooltipRoot }
+            );
+            observer.observe(this.observedElement());
+            this.observer = observer;
+        }
+
+        if (Tooltip.tooltipDocuments.indexOf(document) < 0) {
+            const styleElement = document.createElement('style');
+            styleElement.innerHTML = defaultTooltipCss;
+            // Make sure the default tooltip style goes before other styles so it can be overridden.
+            document.head.insertBefore(styleElement, document.head.querySelector('style'));
+            Tooltip.tooltipDocuments.push(document);
+        }
+    }
+
+    destroy() {
+        const { parentNode } = this.element;
+        if (parentNode) {
+            parentNode.removeChild(this.element);
+        }
+
+        if (this.observer) {
+            this.observer.unobserve(this.observedElement());
+        }
+    }
+
+    isVisible(): boolean {
+        const { element } = this;
+        if (element.classList) {
+            // if not IE11
+            return !element.classList.contains(DEFAULT_TOOLTIP_CLASS + '-hidden');
+        }
+
+        // IE11 part.
+        const classes = element.getAttribute('class');
+        if (classes) {
+            return classes.split(' ').indexOf(DEFAULT_TOOLTIP_CLASS + '-hidden') < 0;
+        }
+        return false;
+    }
+
+    updateClass(visible?: boolean, constrained?: boolean) {
+        const classList = [DEFAULT_TOOLTIP_CLASS, this.class];
+
+        if (visible !== true) {
+            classList.push(`${DEFAULT_TOOLTIP_CLASS}-hidden`);
+        }
+        if (constrained !== true) {
+            classList.push(`${DEFAULT_TOOLTIP_CLASS}-arrow`);
+        }
+
+        this.element.setAttribute('class', classList.join(' '));
+    }
+
+    private showTimeout: number = 0;
+    private constrained = false;
+    /**
+     * Shows tooltip at the given event's coordinates.
+     * If the `html` parameter is missing, moves the existing tooltip to the new position.
+     */
+    show(meta: TooltipMeta, html?: string, instantly = false) {
+        const el = this.element;
+
+        if (html !== undefined) {
+            el.innerHTML = html;
+        } else if (!el.innerHTML) {
+            return;
+        }
+
+        let left = meta.pageX - el.clientWidth / 2;
+        let top = meta.pageY - el.clientHeight - 8;
+
+        this.constrained = false;
+        if (this.container()) {
+            const tooltipRect = el.getBoundingClientRect();
+            const minLeft = 0;
+            const maxLeft = window.innerWidth - tooltipRect.width - 1;
+            if (left < minLeft) {
+                left = minLeft;
+                this.constrained = true;
+                this.updateClass(true, this.constrained);
+            } else if (left > maxLeft) {
+                left = maxLeft;
+                this.constrained = true;
+                this.updateClass(true, this.constrained);
+            }
+
+            if (top < window.scrollY) {
+                top = meta.pageY + 20;
+                this.constrained = true;
+                this.updateClass(true, this.constrained);
+            }
+        }
+
+        el.style.left = `${Math.round(left)}px`;
+        el.style.top = `${Math.round(top)}px`;
+
+        if (this.delay > 0 && !instantly) {
+            this.toggle(false);
+            this.showTimeout = window.setTimeout(() => {
+                this.toggle(true);
+            }, this.delay);
+            return;
+        }
+
+        this.toggle(true);
+    }
+
+    toggle(visible?: boolean) {
+        if (!visible) {
+            window.clearTimeout(this.showTimeout);
+        }
+        this.updateClass(visible, this.constrained);
+    }
+}

--- a/charts-packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/charts-packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -1,4 +1,4 @@
-import { Validate, BOOLEAN, STRING, NUMBER } from '../../util/validation';
+import { Validate, BOOLEAN, NUMBER, OPT_STRING } from '../../util/validation';
 
 export const DEFAULT_TOOLTIP_CLASS = 'ag-chart-tooltip';
 
@@ -147,8 +147,9 @@ export class Tooltip {
     @Validate(BOOLEAN)
     enabled: boolean = true;
 
-    @Validate(STRING)
-    class: string = DEFAULT_TOOLTIP_CLASS;
+    @Validate(OPT_STRING)
+    class?: string = undefined;
+    lastClass?: string = undefined;
 
     @Validate(NUMBER(0))
     delay: number = 0;
@@ -211,7 +212,7 @@ export class Tooltip {
     }
 
     updateClass(visible?: boolean, constrained?: boolean) {
-        const { element } = this;
+        const { element, class: newClass, lastClass } = this;
 
         if (visible === true) {
             element.classList.remove(`${DEFAULT_TOOLTIP_CLASS}-hidden`);
@@ -222,6 +223,16 @@ export class Tooltip {
             element.classList.remove(`${DEFAULT_TOOLTIP_CLASS}-arrow`);
         } else {
             element.classList.add(`${DEFAULT_TOOLTIP_CLASS}-arrow`);
+        }
+
+        if (newClass !== lastClass) {
+            if (lastClass) {
+                element.classList.remove(lastClass);
+            }
+            if (newClass) {
+                element.classList.add(newClass);
+            }
+            this.lastClass = newClass;
         }
     }
 

--- a/charts-packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/charts-packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -4,8 +4,11 @@ export const DEFAULT_TOOLTIP_CLASS = 'ag-chart-tooltip';
 
 const defaultTooltipCss = `
 .ag-chart-tooltip {
+    transition: transform 0.05s ease;
     display: table;
     position: absolute;
+    left: 0px;
+    top: 0px;
     user-select: none;
     pointer-events: none;
     white-space: nowrap;
@@ -18,7 +21,7 @@ const defaultTooltipCss = `
 }
 
 .ag-chart-tooltip-hidden {
-    top: -10000px !important;
+    display: none;
 }
 
 .ag-chart-tooltip-title {
@@ -158,11 +161,10 @@ export class Tooltip {
     tracking: boolean = true;
 
     constructor(canvasElement: () => HTMLCanvasElement, document: Document, container: () => OptionalHTMLElement) {
-        this.class = '';
-
         const tooltipRoot = document.body;
         const element = document.createElement('div');
         this.element = tooltipRoot.appendChild(element);
+        this.element.classList.add(DEFAULT_TOOLTIP_CLASS);
         this.container = container;
 
         // Detect when the chart becomes invisible and hide the tooltip as well.
@@ -204,30 +206,23 @@ export class Tooltip {
 
     isVisible(): boolean {
         const { element } = this;
-        if (element.classList) {
-            // if not IE11
-            return !element.classList.contains(DEFAULT_TOOLTIP_CLASS + '-hidden');
-        }
 
-        // IE11 part.
-        const classes = element.getAttribute('class');
-        if (classes) {
-            return classes.split(' ').indexOf(DEFAULT_TOOLTIP_CLASS + '-hidden') < 0;
-        }
-        return false;
+        return !element.classList.contains(DEFAULT_TOOLTIP_CLASS + '-hidden');
     }
 
     updateClass(visible?: boolean, constrained?: boolean) {
-        const classList = [DEFAULT_TOOLTIP_CLASS, this.class];
+        const { element } = this;
 
-        if (visible !== true) {
-            classList.push(`${DEFAULT_TOOLTIP_CLASS}-hidden`);
+        if (visible === true) {
+            element.classList.remove(`${DEFAULT_TOOLTIP_CLASS}-hidden`);
+        } else {
+            element.classList.add(`${DEFAULT_TOOLTIP_CLASS}-hidden`);
         }
-        if (constrained !== true) {
-            classList.push(`${DEFAULT_TOOLTIP_CLASS}-arrow`);
+        if (constrained === true) {
+            element.classList.remove(`${DEFAULT_TOOLTIP_CLASS}-arrow`);
+        } else {
+            element.classList.add(`${DEFAULT_TOOLTIP_CLASS}-arrow`);
         }
-
-        this.element.setAttribute('class', classList.join(' '));
     }
 
     private showTimeout: number = 0;
@@ -270,8 +265,7 @@ export class Tooltip {
             }
         }
 
-        el.style.left = `${Math.round(left)}px`;
-        el.style.top = `${Math.round(top)}px`;
+        el.style.transform = `translate(${Math.round(left)}px, ${Math.round(top)}px)`;
 
         if (this.delay > 0 && !instantly) {
             this.toggle(false);

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -4186,19 +4186,6 @@
     "source": { "type": { "returnType": "Chart", "optional": false } },
     "type": { "type": { "returnType": "string", "optional": false } }
   },
-  "TooltipMeta": {
-    "pageX": { "type": { "returnType": "number", "optional": false } },
-    "pageY": { "type": { "returnType": "number", "optional": false } },
-    "offsetX": { "type": { "returnType": "number", "optional": false } },
-    "offsetY": { "type": { "returnType": "number", "optional": false } },
-    "event": { "type": { "returnType": "MouseEvent", "optional": false } }
-  },
-  "TooltipRendererResult": {
-    "content": { "type": { "returnType": "string", "optional": true } },
-    "title": { "type": { "returnType": "string", "optional": true } },
-    "color": { "type": { "returnType": "string", "optional": true } },
-    "backgroundColor": { "type": { "returnType": "string", "optional": true } }
-  },
   "ChartUpdateType": {},
   "OptionalHTMLElement": {},
   "ChartAxisDirection": {},
@@ -4874,6 +4861,19 @@
     }
   },
   "ChartThemeDefaults": {},
+  "TooltipMeta": {
+    "pageX": { "type": { "returnType": "number", "optional": false } },
+    "pageY": { "type": { "returnType": "number", "optional": false } },
+    "offsetX": { "type": { "returnType": "number", "optional": false } },
+    "offsetY": { "type": { "returnType": "number", "optional": false } },
+    "event": { "type": { "returnType": "MouseEvent", "optional": false } }
+  },
+  "TooltipRendererResult": {
+    "content": { "type": { "returnType": "string", "optional": true } },
+    "title": { "type": { "returnType": "string", "optional": true } },
+    "color": { "type": { "returnType": "string", "optional": true } },
+    "backgroundColor": { "type": { "returnType": "string", "optional": true } }
+  },
   "Tick": {
     "labels": { "type": { "returnType": "string[]", "optional": false } }
   },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -2708,25 +2708,6 @@
     "meta": {},
     "type": { "event": "MouseEvent", "source": "Chart", "type": "string" }
   },
-  "TooltipMeta": {
-    "meta": {},
-    "type": {
-      "pageX": "number",
-      "pageY": "number",
-      "offsetX": "number",
-      "offsetY": "number",
-      "event": "MouseEvent"
-    }
-  },
-  "TooltipRendererResult": {
-    "meta": {},
-    "type": {
-      "content?": "string",
-      "title?": "string",
-      "color?": "string",
-      "backgroundColor?": "string"
-    }
-  },
   "ChartUpdateType": {
     "meta": { "isEnum": true },
     "type": [
@@ -3546,6 +3527,25 @@
   "ChartThemeDefaults": {
     "meta": { "isTypeAlias": true },
     "type": "{ cartesian: AgCartesianThemeOptions; groupedCategory: AgCartesianThemeOptions; polar: AgPolarThemeOptions; hierarchy: AgHierarchyThemeOptions; } & { [key in keyof AgCartesianSeriesTheme]?: AgCartesianThemeOptions; } & { [key in keyof AgPolarSeriesTheme]?: AgPolarThemeOptions; } & { [key in keyof AgHierarchySeriesTheme]?: AgHierarchyThemeOptions; }"
+  },
+  "TooltipMeta": {
+    "meta": {},
+    "type": {
+      "pageX": "number",
+      "pageY": "number",
+      "offsetX": "number",
+      "offsetY": "number",
+      "event": "MouseEvent"
+    }
+  },
+  "TooltipRendererResult": {
+    "meta": {},
+    "type": {
+      "content?": "string",
+      "title?": "string",
+      "color?": "string",
+      "backgroundColor?": "string"
+    }
   },
   "Tick": { "meta": {}, "type": { "labels": "string[]" } },
   "Node": {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7369

Uses CSS `transition` and `transform` to animate tooltip position changes:
[Demo Video](https://user-images.githubusercontent.com/17544187/195855055-04eecb86-3631-4b16-8101-3cc216fa5bc4.mov)

Bonus:
- Refactors the `ChartTooltip` into its own module, and renames to `Tooltip` (see 64d765b5e032b86d4bba1956b103f3a4d2fda224).