### PR TITLE
AG-7437 - Support tracking mouse/touch drags outside Chart canvas.

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/test/utils.ts
+++ b/charts-packages/ag-charts-community/src/chart/test/utils.ts
@@ -87,13 +87,13 @@ export async function waitForChartStability(chartOrProxy: Chart | AgChartInstanc
 }
 
 export function mouseMoveEvent({ offsetX, offsetY }: { offsetX: number; offsetY: number }): MouseEvent {
-    const event = new MouseEvent('mousemove');
+    const event = new MouseEvent('mousemove', { bubbles: true } as any);
     Object.assign(event, { offsetX, offsetY, pageX: offsetX, pageY: offsetY });
     return event;
 }
 
 export function clickEvent({ offsetX, offsetY }: { offsetX: number; offsetY: number }): MouseEvent {
-    const event = new MouseEvent('click');
+    const event = new MouseEvent('click', { bubbles: true } as any);
     Object.assign(event, { offsetX, offsetY, pageX: offsetX, pageY: offsetY });
     return event;
 }
@@ -135,9 +135,10 @@ export function hierarchyChartAssertions(params?: { seriesTypes?: string[] }) {
 export function hoverAction(x: number, y: number): (chart: Chart | AgChartInstance) => Promise<void> {
     return async (chartOrProxy) => {
         const chart = deproxy(chartOrProxy);
+        const target = chart.scene.canvas.element as HTMLElement;
         // Reveal tooltip.
-        chart.scene.container?.dispatchEvent(mouseMoveEvent({ offsetX: x - 1, offsetY: y - 1 }));
-        chart.scene.container?.dispatchEvent(mouseMoveEvent({ offsetX: x, offsetY: y }));
+        target?.dispatchEvent(mouseMoveEvent({ offsetX: x - 1, offsetY: y - 1 }));
+        target?.dispatchEvent(mouseMoveEvent({ offsetX: x, offsetY: y }));
 
         return new Promise((resolve) => {
             setTimeout(resolve, 50);
@@ -145,9 +146,11 @@ export function hoverAction(x: number, y: number): (chart: Chart | AgChartInstan
     };
 }
 
-export function clickAction(x: number, y: number): (chart: Chart) => Promise<void> {
-    return async (chart) => {
-        chart.scene.container?.dispatchEvent(clickEvent({ offsetX: x, offsetY: y }));
+export function clickAction(x: number, y: number): (chart: Chart | AgChartInstance) => Promise<void> {
+    return async (chartOrProxy) => {
+        const chart = deproxy(chartOrProxy);
+        const target = chart.scene.canvas.element;
+        target?.dispatchEvent(clickEvent({ offsetX: x, offsetY: y }));
         return new Promise((resolve) => {
             setTimeout(resolve, 50);
         });

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -4445,6 +4445,14 @@
   "InteractionEvent": {
     "meta": { "typeParams": ["T extends InteractionTypes"] }
   },
+  "Coords": {
+    "clientX": { "type": { "returnType": "number", "optional": false } },
+    "clientY": { "type": { "returnType": "number", "optional": false } },
+    "pageX": { "type": { "returnType": "number", "optional": false } },
+    "pageY": { "type": { "returnType": "number", "optional": false } },
+    "offsetX": { "type": { "returnType": "number", "optional": false } },
+    "offsetY": { "type": { "returnType": "number", "optional": false } }
+  },
   "Layers": {},
   "LegendDatum": {
     "id": { "type": { "returnType": "string", "optional": false } },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -2958,7 +2958,7 @@
   },
   "SUPPORTED_EVENTS": {
     "meta": { "isTypeAlias": true },
-    "type": "'click' | 'mousedown' | 'mousemove' | 'mouseup' | 'mouseout' | 'touchstart' | 'touchmove' | 'touchend' | 'touchcancel' | 'pagehide'"
+    "type": "'click' | 'mousedown' | 'mousemove' | 'mouseup' | 'mouseout' | 'mouseenter' | 'touchstart' | 'touchmove' | 'touchend' | 'touchcancel' | 'pagehide'"
   },
   "InteractionEvent": {
     "meta": {
@@ -2966,6 +2966,17 @@
       "typeParams": ["T extends InteractionTypes"]
     },
     "type": "{ type: T; offsetX: number; offsetY: number; pageX: number; pageY: number; sourceEvent: Event; consume(): void; } & (T extends 'drag' ? { startX: number; startY: number; } : {})"
+  },
+  "Coords": {
+    "meta": {},
+    "type": {
+      "clientX": "number",
+      "clientY": "number",
+      "pageX": "number",
+      "pageY": "number",
+      "offsetX": "number",
+      "offsetY": "number"
+    }
   },
   "Layers": {
     "meta": { "isEnum": true },


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7437
https://ag-grid.atlassian.net/browse/AG-7580

Attempts to address navigator drag not working as expected when leaving the bounds of the `<canvas>` - `InteractionManager` now tracks drags on the enclosing page, so that the navigator UI widget behaves much more like a regular HTML slider.