### PR TITLE
Tweak naming of Chart options for better consistency.

### DIFF
--- a/charts-packages/ag-charts-community/src/axis.ts
+++ b/charts-packages/ag-charts-community/src/axis.ts
@@ -173,7 +173,7 @@ export class AxisLabel {
      * Avoid axis label collision by automatically reducing the number of ticks displayed. If set to `false`, axis labels may collide.
      */
     @Validate(BOOLEAN)
-    avoidCollision: boolean = true;
+    autoCollisionRemoval: boolean = true;
 
     /**
      * By default labels and ticks are positioned to the left of the axis line.
@@ -493,7 +493,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
             scale,
             gridLength,
             tick,
-            label: { parallel: parallelLabels, mirrored, avoidCollision, minGap },
+            label: { parallel: parallelLabels, mirrored, autoCollisionRemoval, minGap },
             requestedRange,
         } = this;
         const requestedRangeMin = Math.min(...requestedRange);
@@ -549,7 +549,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
                 const prevTicks = ticks;
 
                 const filteredTicks =
-                    !avoidCollision || (continuous && this.tick.count === undefined) || i === 0
+                    !autoCollisionRemoval || (continuous && this.tick.count === undefined) || i === 0
                         ? undefined
                         : ticks.filter((_, i) => i % 2 === 0);
 
@@ -578,7 +578,7 @@ export class Axis<S extends Scale<D, number>, D = any> {
                     primaryTickCount = ticks.length;
                 }
 
-                unchanged = avoidCollision ? ticks.every((t, i) => Number(t) === Number(prevTicks[i])) : false;
+                unchanged = autoCollisionRemoval ? ticks.every((t, i) => Number(t) === Number(prevTicks[i])) : false;
                 i++;
             }
 
@@ -599,8 +599,8 @@ export class Axis<S extends Scale<D, number>, D = any> {
 
             const labelPadding = minGap ?? (rotated ? 0 : 10);
 
-            // no need for further iterations if `avoidCollision` is false
-            labelOverlap = avoidCollision ? axisLabelsOverlap(labelData, labelPadding) : false;
+            // no need for further iterations if `autoCollisionRemoval` is false
+            labelOverlap = autoCollisionRemoval ? axisLabelsOverlap(labelData, labelPadding) : false;
         }
 
         this.updateGridLines({

--- a/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/charts-packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -345,6 +345,8 @@ export interface AgChartLegendItemOptions {
     paddingX?: PixelSize;
     /** The vertical spacing in pixels to use between legend items. */
     paddingY?: PixelSize;
+    /** Set to `false` to turn off toggling of the series visibility in the chart when the legend item is clicked. */
+    seriesToggleEnabled?: boolean;
 }
 
 export interface AgChartLegendClickEvent {
@@ -378,8 +380,6 @@ export interface AgChartLegendOptions {
     item?: AgChartLegendItemOptions;
     /** Reverse the display order of legend items if `true`. */
     reverseOrder?: boolean;
-    /** Set to `false` to turn off toggling of the series visibility in the chart when the legend item is clicked. */
-    seriesToggleEnabled?: boolean;
     /** Optional callbacks for specific legend-related events. */
     listeners?: AgChartLegendListeners;
     pagination?: AgChartLegendPaginationOptions;
@@ -590,7 +590,7 @@ export interface AgAxisLabelOptions {
     /** If autoRotate is enabled, specifies the rotation angle to use when autoRotate is activated. Defaults to an angle of 335 degrees if unspecified. */
     autoRotateAngle?: number;
     /** Avoid axis label collision by automatically reducing the number of ticks displayed. If set to `false`, axis labels may collide. */
-    avoidCollision?: boolean;
+    autoCollisionRemoval?: boolean;
     /** Minimum gap in pixels between the axis labels before being removed to avoid collisions. */
     minGap?: PixelSize;
     // mirrored?: boolean;

--- a/charts-packages/ag-charts-community/src/chart/legend.ts
+++ b/charts-packages/ag-charts-community/src/chart/legend.ts
@@ -141,6 +141,9 @@ class LegendItem {
      */
     @Validate(NUMBER(0))
     paddingY = 8;
+
+    @Validate(BOOLEAN)
+    seriesToggleEnabled: boolean = true;
 }
 
 const NO_OP_LISTENER = () => {
@@ -236,9 +239,6 @@ export class Legend {
 
     @Validate(OPT_ORIENTATION)
     orientation?: AgChartOrientation;
-
-    @Validate(BOOLEAN)
-    seriesToggleEnabled: boolean = true;
 
     constructor(
         private readonly chart: {
@@ -583,7 +583,7 @@ export class Legend {
             listeners: { legendItemClick },
             chart,
             highlightManager,
-            seriesToggleEnabled,
+            item: { seriesToggleEnabled },
         } = this;
         const datum = this.getDatumForPoint(event.offsetX, event.offsetY);
         if (!datum) {
@@ -619,7 +619,11 @@ export class Legend {
     }
 
     private handleLegendMouseMove(event: InteractionEvent<'hover'>) {
-        const { enabled, seriesToggleEnabled, listeners } = this;
+        const {
+            enabled,
+            item: { seriesToggleEnabled },
+            listeners,
+        } = this;
         if (!enabled) {
             return;
         }

--- a/charts-packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
+++ b/charts-packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
@@ -22,8 +22,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "#3f7cbf",
         "fontFamily": "Impact, Charcoal, Sans-Serif",
         "fontSize": 14,
@@ -71,8 +71,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "#3f7cbf",
         "fontFamily": "Impact, Charcoal, Sans-Serif",
         "fontSize": 14,
@@ -423,8 +423,8 @@ Object {
       ],
       "groupPaddingInner": 0.1,
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": true,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -471,8 +471,8 @@ Object {
         "female",
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -518,8 +518,8 @@ Object {
         "exportedTonnes",
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -835,8 +835,8 @@ Object {
       ],
       "groupPaddingInner": 0.1,
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": true,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -879,8 +879,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -1472,8 +1472,8 @@ Object {
       ],
       "groupPaddingInner": 0.1,
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": true,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -1516,8 +1516,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -1786,8 +1786,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -1830,8 +1830,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -2038,8 +2038,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -2083,8 +2083,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -2494,8 +2494,8 @@ Object {
       ],
       "groupPaddingInner": 0.1,
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": true,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -2538,8 +2538,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -3092,8 +3092,8 @@ Object {
       ],
       "groupPaddingInner": 0.1,
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": true,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -3136,8 +3136,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -3367,8 +3367,8 @@ Object {
       ],
       "groupPaddingInner": 0.1,
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": true,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -3411,8 +3411,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -3634,8 +3634,8 @@ Object {
       ],
       "groupPaddingInner": 0.1,
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": true,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -3673,8 +3673,8 @@ Object {
       "gridStyle": Array [],
       "groupPaddingInner": 0.1,
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": true,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -3883,8 +3883,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -3930,8 +3930,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -4142,8 +4142,8 @@ Object {
       ],
       "groupPaddingInner": 0.1,
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": true,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -4186,8 +4186,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -4441,8 +4441,8 @@ Object {
       ],
       "groupPaddingInner": 0.1,
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": true,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -4485,8 +4485,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -4743,8 +4743,8 @@ Object {
       ],
       "groupPaddingInner": 0.1,
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": true,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -4787,8 +4787,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -5059,8 +5059,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -5103,8 +5103,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -5328,8 +5328,8 @@ Object {
       ],
       "groupPaddingInner": 0.1,
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": true,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -5372,8 +5372,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -6501,8 +6501,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 10,
@@ -6546,8 +6546,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 10,
@@ -6953,8 +6953,8 @@ Object {
       ],
       "groupPaddingInner": 0.1,
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": true,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -6997,8 +6997,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -7273,8 +7273,8 @@ Object {
       ],
       "groupPaddingInner": 0.1,
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": true,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -7317,8 +7317,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -7580,8 +7580,8 @@ Object {
       ],
       "groupPaddingInner": 0.1,
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": true,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -7624,8 +7624,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -7905,8 +7905,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -7949,8 +7949,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -8392,8 +8392,8 @@ Object {
       ],
       "groupPaddingInner": 0.1,
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": true,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -8436,8 +8436,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -8864,8 +8864,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -8908,8 +8908,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -9119,8 +9119,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -9167,8 +9167,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -9637,8 +9637,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -9681,8 +9681,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -9889,8 +9889,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -9934,8 +9934,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -10215,8 +10215,8 @@ Object {
       ],
       "groupPaddingInner": 0.1,
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": true,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -10259,8 +10259,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -10514,8 +10514,8 @@ Object {
       ],
       "groupPaddingInner": 0.1,
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": true,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -10558,8 +10558,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -10833,8 +10833,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,
@@ -10877,8 +10877,8 @@ Object {
         },
       ],
       "label": Object {
+        "autoCollisionRemoval": true,
         "autoRotate": false,
-        "avoidCollision": true,
         "color": "rgb(87, 87, 87)",
         "fontFamily": "Verdana, sans-serif",
         "fontSize": 12,

--- a/charts-packages/ag-charts-community/src/chart/themes/chartTheme.ts
+++ b/charts-packages/ag-charts-community/src/chart/themes/chartTheme.ts
@@ -80,7 +80,7 @@ export class ChartTheme {
                 color: 'rgb(87, 87, 87)',
                 formatter: undefined,
                 autoRotate: false,
-                avoidCollision: true,
+                autoCollisionRemoval: true,
             },
             line: {
                 width: 1,

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/doc-interfaces.AUTO.json
@@ -1256,6 +1256,10 @@
     "paddingY": {
       "description": "/** The vertical spacing in pixels to use between legend items. */",
       "type": { "returnType": "PixelSize", "optional": true }
+    },
+    "seriesToggleEnabled": {
+      "description": "/** Set to `false` to turn off toggling of the series visibility in the chart when the legend item is clicked. */",
+      "type": { "returnType": "boolean", "optional": true }
     }
   },
   "AgChartLegendClickEvent": {
@@ -1313,10 +1317,6 @@
     },
     "reverseOrder": {
       "description": "/** Reverse the display order of legend items if `true`. */",
-      "type": { "returnType": "boolean", "optional": true }
-    },
-    "seriesToggleEnabled": {
-      "description": "/** Set to `false` to turn off toggling of the series visibility in the chart when the legend item is clicked. */",
       "type": { "returnType": "boolean", "optional": true }
     },
     "listeners": {
@@ -1691,7 +1691,7 @@
       "description": "/** If autoRotate is enabled, specifies the rotation angle to use when autoRotate is activated. Defaults to an angle of 335 degrees if unspecified. */",
       "type": { "returnType": "number", "optional": true }
     },
-    "avoidCollision": {
+    "autoCollisionRemoval": {
       "description": "/** Avoid axis label collision by automatically reducing the number of ticks displayed. If set to `false`, axis labels may collide. */",
       "type": { "returnType": "boolean", "optional": true }
     },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -781,14 +781,16 @@
       "label?": "AgChartLegendLabelOptions",
       "maxWidth?": "PixelSize",
       "paddingX?": "PixelSize",
-      "paddingY?": "PixelSize"
+      "paddingY?": "PixelSize",
+      "seriesToggleEnabled?": "boolean"
     },
     "docs": {
       "marker?": "/** Configuration for the legend markers. */",
       "label?": "/** Configuration for the legend labels. */",
       "maxWidth?": "/** Used to constrain the width of legend items. */",
       "paddingX?": "/** The horizontal spacing in pixels to use between legend items. */",
-      "paddingY?": "/** The vertical spacing in pixels to use between legend items. */"
+      "paddingY?": "/** The vertical spacing in pixels to use between legend items. */",
+      "seriesToggleEnabled?": "/** Set to `false` to turn off toggling of the series visibility in the chart when the legend item is clicked. */"
     }
   },
   "AgChartLegendClickEvent": {
@@ -818,7 +820,6 @@
       "spacing?": "PixelSize",
       "item?": "AgChartLegendItemOptions",
       "reverseOrder?": "boolean",
-      "seriesToggleEnabled?": "boolean",
       "listeners?": "AgChartLegendListeners",
       "pagination?": "AgChartLegendPaginationOptions"
     },
@@ -831,7 +832,6 @@
       "spacing?": "/** The spacing in pixels to use outside the legend. */",
       "item?": "/** Configuration for the legend items that consist of a marker and a label. */",
       "reverseOrder?": "/** Reverse the display order of legend items if `true`. */",
-      "seriesToggleEnabled?": "/** Set to `false` to turn off toggling of the series visibility in the chart when the legend item is clicked. */",
       "listeners?": "/** Optional callbacks for specific legend-related events. */"
     }
   },
@@ -1091,7 +1091,7 @@
       "rotation?": "number",
       "autoRotate?": "boolean",
       "autoRotateAngle?": "number",
-      "avoidCollision?": "boolean",
+      "autoCollisionRemoval?": "boolean",
       "minGap?": "PixelSize",
       "format?": "string",
       "formatter?": "(params: AgAxisLabelFormatterParams) => string | undefined"
@@ -1106,7 +1106,7 @@
       "rotation?": "/** The rotation of the axis labels in degrees. Note: for integrated charts the default is 335 degrees, unless the axis shows grouped or default categories (indexes). The first row of labels in a grouped category axis is rotated perpendicular to the axis line. */",
       "autoRotate?": "/** If specified and axis labels may collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category. If the `rotation` property is specified, it takes precedence. */",
       "autoRotateAngle?": "/** If autoRotate is enabled, specifies the rotation angle to use when autoRotate is activated. Defaults to an angle of 335 degrees if unspecified. */",
-      "avoidCollision?": "/** Avoid axis label collision by automatically reducing the number of ticks displayed. If set to `false`, axis labels may collide. */",
+      "autoCollisionRemoval?": "/** Avoid axis label collision by automatically reducing the number of ticks displayed. If set to `false`, axis labels may collide. */",
       "minGap?": "/** Minimum gap in pixels between the axis labels before being removed to avoid collisions. */",
       "format?": "/** Format string used when rendering labels for time axes. */",
       "formatter?": "/** Function used to render axis labels. If `value` is a number, `fractionDigits` will also be provided, which indicates the number of fractional digits used in the step between ticks; for example, a tick step of `0.0005` would have `fractionDigits` set to `4` */"

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-label-rotation/index.html
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-label-rotation/index.html
@@ -1,14 +1,19 @@
 <div class="wrapper">
     <div id="toolPanel">
-        Axis Label Rotation:
+        Rotation:
         <button onclick="disableRotation()">No rotation</button>
         <button onclick="fixedRotation()">Fixed rotation</button>
-        <button onclick="autoRotation()">Auto rotation</button>
+        <button onclick="autoRotation()">Auto rotation (default)</button>
     </div>
     <div id="toolPanel">
-        Axis Label Values:
+        Values:
         <button onclick="uniformLabels()">Uniform labels</button>
         <button onclick="irregularLabels()">Irregular labels</button>
+    </div>
+    <div id="toolPanel">
+        Collision Removal:
+        <button onclick="noCollisionDetection()">No removal</button>
+        <button onclick="autoCollisionDetection()">Auto removal (default)</button>
     </div>
     <div id="toolPanel" style="position: absolute; top: 0; right: 0">
         <button onclick="reset()">Reset</button>

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-label-rotation/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/examples/axis-label-rotation/main.ts
@@ -40,8 +40,10 @@ function reset() {
 
   delete options.axes![0].label!.rotation;
   delete options.axes![0].label!.autoRotate;
+  delete options.axes![0].label!.autoCollisionRemoval;
   delete options.axes![1].label!.rotation;
   delete options.axes![1].label!.autoRotate;
+  delete options.axes![1].label!.autoCollisionRemoval;
 
   options.series![0].xKey = 'year';
   agCharts.AgChart.update(chart, options);
@@ -81,5 +83,19 @@ function uniformLabels() {
 
 function irregularLabels() {
   options.series![0].xKey = 'country';
+  agCharts.AgChart.update(chart, options);
+}
+
+function noCollisionDetection() {
+  options.axes![0].label!.autoCollisionRemoval = false;
+  options.axes![1].label!.autoCollisionRemoval = false;
+
+  agCharts.AgChart.update(chart, options);
+}
+
+function autoCollisionDetection() {
+  options.axes![0].label!.autoCollisionRemoval = true;
+  options.axes![1].label!.autoCollisionRemoval = true;
+
   agCharts.AgChart.update(chart, options);
 }

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-axes/index.md
@@ -158,12 +158,12 @@ Three rotation approaches are available:
 - Enabling automatic rotation via the `autoRotate` property, and optionally specifying a rotation angle via the
   `autoRotateAngle` property. Rotation is applied if any label will be wider than the gap between ticks.
 
-Label skipping is performed automatically when there is a high likelihood of collisions. To disable this, set `label.avoidCollision` to false:
+Label skipping is performed automatically when there is a high likelihood of collisions. To disable this, set `label.autoCollisionRemoval` to false:
 
 ```js
 {
     label: {
-      avoidCollision: false
+      autoCollisionRemoval: false
     }
 }
 ```
@@ -171,7 +171,7 @@ Label skipping is performed automatically when there is a high likelihood of col
 If `autoRotate` is enabled, rotation will be attempted first to find a label fit, before label skipping applies.
 Category axes have `autoRotate` enabled by default with the default `autoRotateAngle` of `335`.
 
-When `label.avoidCollision` is `true`, the axis labels are dropped if they do not have a minimum of `10`px between them. This minimum gap between the axis labels can be configured using the `label.minGap` property:
+When `label.autoCollisionRemoval` is `true`, the axis labels are dropped if they do not have a minimum of `10`px between them. This minimum gap between the axis labels can be configured using the `label.minGap` property:
 
 ```js
 {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-click-series-toggle/main.ts
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/examples/legend-click-series-toggle/main.ts
@@ -155,7 +155,6 @@ const options: AgChartOptions = {
   ],
   legend: {
     position: "left",
-    seriesToggleEnabled: false,
     listeners: {
       legendItemClick: ({
         seriesId,
@@ -168,6 +167,7 @@ const options: AgChartOptions = {
       },
     },
     item: {
+      seriesToggleEnabled: false,
       marker: {
         strokeWidth: 2,
       },

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/index.md
@@ -201,7 +201,7 @@ legend: {
 
 By default, when a legend item is clicked, the visibility of the series associated with that legend item will be toggled. This allows the users to control which series are displayed in the chart by clicking on legend items.
 
-To disable series toggling on legend item click, the `legend.seriesToggleEnabled` property can be set to `false`:
+To disable series toggling on legend item click, the `legend.item.seriesToggleEnabled` property can be set to `false`:
 
 ```js
 legend: {

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/index.md
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-legend/index.md
@@ -205,7 +205,9 @@ To disable series toggling on legend item click, the `legend.seriesToggleEnabled
 
 ```js
 legend: {
-    seriesToggleEnabled: false
+    item: {
+        seriesToggleEnabled: false
+    }
 }
 ```
 


### PR DESCRIPTION
Renames `avoidCollision` to `autoCollisionRemoval` for better consistency with other automatic label-layout behaviour options.

Moves `seriesToggleEnabled` as a nested property of `item`, which better maps to its conceptual relationship.