### PR TITLE
Refresh tooltip on chart data change.

### DIFF
--- a/charts-packages/ag-charts-community/src/chart/chartUpdateType.ts
+++ b/charts-packages/ag-charts-community/src/chart/chartUpdateType.ts
@@ -4,6 +4,7 @@ export enum ChartUpdateType {
     PROCESS_DATA,
     PERFORM_LAYOUT,
     SERIES_UPDATE,
+    TOOLTIP_RECALCULATION,
     SCENE_RENDER,
     NONE,
 }

--- a/charts-packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
+++ b/charts-packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
@@ -32,6 +32,10 @@ export class TooltipManager {
         this.applyStates();
     }
 
+    public getTooltipMeta(callerId: string): TooltipMeta | undefined {
+        return this.states[callerId]?.meta;
+    }
+
     private applyStates() {
         let contentToApply: string | undefined = undefined;
         let metaToApply: TooltipMeta | undefined = undefined;

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -3087,10 +3087,11 @@
       "PROCESS_DATA",
       "PERFORM_LAYOUT",
       "SERIES_UPDATE",
+      "TOOLTIP_RECALCULATION",
       "SCENE_RENDER",
       "NONE"
     ],
-    "docs": [null, null, null, null, null, null]
+    "docs": [null, null, null, null, null, null, null]
   },
   "NodeData": { "meta": { "isTypeAlias": true }, "type": "number[]" },
   "CrossLineType": {


### PR DESCRIPTION
Fixes the tooltip handling for this example: https://build.ag-grid.com/javascript-data-grid/integrated-charts-application-created/

(Tooltip is currently cleared on every data update).