### PR TITLE
Refactor Chart.performLayout() 

### DIFF
--- a/charts-community-modules/ag-charts-community/src/chart/cartesianChart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/cartesianChart.ts
@@ -25,29 +25,7 @@ export class CartesianChart extends Chart {
     }
 
     async performLayout() {
-        this.scene.root!.visible = true;
-
-        const {
-            legend,
-            padding,
-            scene: { width, height },
-        } = this;
-
-        let shrinkRect = new BBox(0, 0, width, height);
-        shrinkRect.x += padding.left;
-        shrinkRect.y += padding.top;
-        shrinkRect.width -= padding.left + padding.right;
-        shrinkRect.height -= padding.top + padding.bottom;
-
-        shrinkRect = this.positionCaptions(shrinkRect);
-        shrinkRect = this.positionLegend(shrinkRect);
-
-        if (legend.visible && legend.enabled && legend.data.length) {
-            const legendPadding = legend.spacing;
-            shrinkRect.shrink(legendPadding, legend.position);
-        }
-
-        ({ shrinkRect } = this.layoutService.dispatchPerformLayout('before-series', { shrinkRect }));
+        const shrinkRect = await super.performLayout();
 
         const { seriesRect, visibility, clipSeries } = this.updateAxes(shrinkRect);
         this.seriesRoot.visible = visibility.series;
@@ -77,6 +55,8 @@ export class CartesianChart extends Chart {
         } else {
             seriesRoot.setClipRectInGroupCoordinateSpace();
         }
+
+        return shrinkRect;
     }
 
     private _lastAxisWidths: Partial<Record<AgCartesianAxisPosition, number>> = {

--- a/charts-community-modules/ag-charts-community/src/chart/hierarchyChart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/hierarchyChart.ts
@@ -15,28 +15,9 @@ export class HierarchyChart extends Chart {
     protected _data: any = {};
 
     async performLayout() {
-        this.scene.root!!.visible = true;
+        const shrinkRect = await super.performLayout();
 
-        const {
-            scene: { width, height },
-            legend,
-            padding,
-            seriesAreaPadding,
-        } = this;
-
-        let shrinkRect = new BBox(0, 0, width, height);
-        shrinkRect.shrink(padding.left, 'left');
-        shrinkRect.shrink(padding.top, 'top');
-        shrinkRect.shrink(padding.right, 'right');
-        shrinkRect.shrink(padding.bottom, 'bottom');
-
-        shrinkRect = this.positionCaptions(shrinkRect);
-        shrinkRect = this.positionLegend(shrinkRect);
-
-        if (legend.visible && legend.enabled && legend.data.length) {
-            const legendPadding = legend.spacing;
-            shrinkRect.shrink(legendPadding, legend.position);
-        }
+        const { seriesAreaPadding } = this;
 
         shrinkRect.shrink(seriesAreaPadding.left, 'left');
         shrinkRect.shrink(seriesAreaPadding.top, 'top');
@@ -54,5 +35,7 @@ export class HierarchyChart extends Chart {
         seriesRoot.setClipRectInGroupCoordinateSpace(
             new BBox(shrinkRect.x, shrinkRect.y, shrinkRect.width, shrinkRect.height)
         );
+
+        return shrinkRect;
     }
 }

--- a/charts-community-modules/ag-charts-community/src/chart/layout/layoutService.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/layout/layoutService.ts
@@ -1,7 +1,7 @@
 import { BBox } from '../../scene/bbox';
 import { Listeners } from '../../util/listeners';
 
-export type LayoutStage = 'before-series';
+export type LayoutStage = 'start-layout' | 'before-series';
 
 export type AxisLabelLayout = {
     baseline: 'hanging' | 'bottom' | 'middle';

--- a/charts-community-modules/ag-charts-community/src/chart/polarChart.ts
+++ b/charts-community-modules/ag-charts-community/src/chart/polarChart.ts
@@ -18,32 +18,16 @@ export class PolarChart extends Chart {
     }
 
     async performLayout() {
-        this.scene.root!.visible = true;
+        const shrinkRect = await super.performLayout();
 
-        const {
-            padding,
-            scene: { width, height },
-        } = this;
-
-        let shrinkRect = new BBox(0, 0, width, height);
-        shrinkRect.shrink(padding.left, 'left');
-        shrinkRect.shrink(padding.top, 'top');
-        shrinkRect.shrink(padding.right, 'right');
-        shrinkRect.shrink(padding.bottom, 'bottom');
-
-        shrinkRect = this.positionCaptions(shrinkRect);
-        shrinkRect = this.positionLegend(shrinkRect);
         this.computeSeriesRect(shrinkRect);
         this.computeCircle();
+
+        return shrinkRect;
     }
 
     private computeSeriesRect(shrinkRect: BBox) {
-        const { legend, seriesAreaPadding } = this;
-
-        if (legend.visible && legend.enabled && legend.data.length) {
-            const legendPadding = legend.spacing;
-            shrinkRect.shrink(legendPadding, legend.position);
-        }
+        const { seriesAreaPadding } = this;
 
         shrinkRect.shrink(seriesAreaPadding.left, 'left');
         shrinkRect.shrink(seriesAreaPadding.top, 'top');

--- a/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
+++ b/grid-packages/ag-grid-docs/documentation/doc-pages/charts-api/interfaces.AUTO.json
@@ -3535,7 +3535,10 @@
     ],
     "docs": [null, null, null, null, null, null, null, null]
   },
-  "LayoutStage": { "meta": { "isTypeAlias": true }, "type": "'before-series'" },
+  "LayoutStage": {
+    "meta": { "isTypeAlias": true },
+    "type": "'start-layout' | 'before-series'"
+  },
   "AxisLabelLayout": {
     "meta": { "isTypeAlias": true },
     "type": "{ baseline: 'hanging' | 'bottom' | 'middle'; align: 'start' | 'end' | 'center'; rotation: number; fractionDigits: number; padding: number; }"


### PR DESCRIPTION
Ad-hoc refactor to:
- reduce duplication between Chart sub-classes.
- declutter chart.ts by moving legend positioning to `legend.ts`.
