### PR TITLE
AG - column auto size edge case

### DIFF
--- a/grid-community-modules/core/src/ts/rendering/autoWidthCalculator.ts
+++ b/grid-community-modules/core/src/ts/rendering/autoWidthCalculator.ts
@@ -69,7 +69,7 @@ export class AutoWidthCalculator extends BeanStub {
 
         // at this point, all the clones are lined up vertically with natural widths. the dummy
         // container will have a width wide enough just to fit the largest.
-        const dummyContainerWidth = eDummyContainer.offsetWidth;
+        const dummyContainerWidth = Math.ceil(eDummyContainer.getBoundingClientRect().width);
 
         // we are finished with the dummy container, so get rid of it
         eBodyContainer.removeChild(eDummyContainer);


### PR DESCRIPTION
width for autosize column greater or equal to eDummyContainer width.

edge case: 
![ag-grid-column-auto-size](https://github.com/ag-grid/ag-grid/assets/5861876/db2418bd-aada-46cc-94e7-12d2aa644634)
