### PR TITLE
Add MouseEvent type to event property - BaseRowEvent

### DIFF
--- a/grid-community-modules/core/src/ts/events.ts
+++ b/grid-community-modules/core/src/ts/events.ts
@@ -509,7 +509,7 @@ interface BaseRowEvent<TData, TContext> extends AgGridEvent<TData, TContext> {
     /** Either 'top', 'bottom' or null / undefined (if not set) */
     rowPinned: RowPinnedType;
     /** If event was due to browser event (eg click), this is the browser event */
-    event?: Event | null;
+    event?: Event | MouseEvent | null;
     /** If the browser `event` is present the `eventPath` persists the `event.composedPath()` result for access within AG Grid event handlers.  */
     eventPath?: EventTarget[];
 }


### PR DESCRIPTION
This change tries to make available all Mouse events and properties to the  `BaseRowEvent - event` property.
