### PR TITLE
Mark Copy / Paste as an Enterprise feature in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Here are some of the features that make AG Grid stand out:
 * Data Export to CSV
 * Data Export to Excel *
 * Excel-like Pivoting *
-* Row Reordering
+* Row Reordering *
 * Copy / Paste
 * Column Spanning
 * Pinned Rows


### PR DESCRIPTION
Marked Copy / Paste as an enterprise feature for README since it is not supported for the community version.