### PR TITLE
Fix ag-row-selected. 

### DIFF
--- a/grid-community-modules/styles/src/internal/base/parts/_grid-layout.scss
+++ b/grid-community-modules/styles/src/internal/base/parts/_grid-layout.scss
@@ -117,6 +117,7 @@
         left: 0;
         right: 0;
         bottom: 0;
+        z-index: -1;
     }
 
     .ag-row-hover:not(.ag-full-width-row)::before,


### PR DESCRIPTION
If a header of a group is selected, it is hidden after the mouse cursor is moved away from that header.

https://tinyurl.com/274okj88