### PR TITLE
AG-9197 Use state of leaf row node instead of state of parent

### DIFF
--- a/grid-community-modules/core/src/ts/rendering/cellRenderers/groupCellRendererCtrl.ts
+++ b/grid-community-modules/core/src/ts/rendering/cellRenderers/groupCellRendererCtrl.ts
@@ -673,7 +673,7 @@ export class GroupCellRendererCtrl extends BeanStub {
             this.getContext().createBean(cbSelectionComponent);
 
             cbSelectionComponent.init({
-                rowNode: rowNode,
+                rowNode: this.params.node as RowNode, // when groupHideOpenParents = true and group expanded, we want the checkbox to refer to leaf node state (not group node state)
                 column: this.params.column,
                 overrides: {
                     isVisible: this.params.checkbox,


### PR DESCRIPTION
AG-9197 Use state of leaf row node instead of state of parent group row node in situation of groupHideOpenParents = true and group expanded.