### PR TITLE
Fixed excel last cell calculation

### DIFF
--- a/enterprise-modules/excel-export/src/excelExport/files/ooxml/table.ts
+++ b/enterprise-modules/excel-export/src/excelExport/files/ooxml/table.ts
@@ -30,10 +30,21 @@ const tableFactory: ExcelOOXMLTemplate = {
             }
         }));
 
+        const getLastColumn = (columnLength: number) => {
+            let result = '';
+            let n = columnLength;
+            while (n > 0) {
+                let remainder = (n - 1) % 26;
+                result = String.fromCharCode(65 + remainder) + result;
+                n = Math.floor((n - 1) / 26);
+            }
+            return result;
+        }
+
         const firstRow = headerRowIndex + 1;
         const id: string = (idx + 1).toString();
         const firstCell = `A${firstRow}`;
-        const lastCell = `${String.fromCharCode(64 + columns.length)}${firstRow + rowCount}`;
+        const lastCell = `${getLastColumn(columns.length)}${firstRow + rowCount}`;
         const ref = `${firstCell}:${lastCell}`;
         const displayNameToUse = idx ? `${displayName}_${idx + 1}` : displayName;
 


### PR DESCRIPTION
Fixed bug where lastCell was not calculated correctly if column length > 26.

If columns.length == 27, firstRow == 1, rowCount == 4 then lastCell would be set to:
`[5`
Instead of:
`AA5`

Bug and fix shown [here](https://www.typescriptlang.org/play/?#code/MYewdgzgLgBA5gUygGQIbQMIgDYFcC2YAjDALwwAUoehyCYcUAFgFwxgEBGCATgJRkAfJQAGAEgDeAZSg8AlgwB0AMx4h8GJqh5YAJggoA2ACwwA1DGoEwdBsz4BfEXwDcAWABQn0JFiIU6FBYNGAATGSUVrT0jKzsXLwCpMISnjAw2EgwPAgQuNiw5ADkRe4e6ZmwYBFRNjHMZekA7kxymZTVwgAMAqnl6RlZOfioCvo8ERTVALQwRAIApDChho0DOXkFETLySqrqmtp6BoYArObZCCNjiRcb+VBr6dXkALKozCrYICA8FFMwWbzGAAemWhlcaRgDihOSguB41XuBTKMK8HgA2kQADTLXGhU74wz4gDs+IAHLiSV0cTBqaEqV0AMyM4wAXRUvwAoqhgEwKHIhDA+ukfBAcAhFN84BQirVbLEiri5JD+mKJVKQDKiv40JgcNYiEr4Eg9UEDYQiAK+KrReBxZlNdrdYFgtZQsaXfqQqFrbbLPaNdLZUVVQ4+EA)

This bug causes a corrupted excel file to be created (that excel can fix on open after prompting the user).