### PR TITLE
RTI-2198 fix ssrm showcase css showing double scrollbar

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-showcase/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-showcase/index.html
@@ -1,5 +1,5 @@
 <div class="grid-container">
-    <div style="margin-bottom: 5px">
+    <div>
         <button id="startUpdates" onclick="startUpdates()">Start Updates</button>
         <button id="stopUpdates" onclick="stopUpdates()">Stop Updates</button>
     </div>

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-showcase/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-showcase/styles.css
@@ -1,7 +1,10 @@
 .grid-container {
+    display: flex;
+    flex-direction: column;
     height: 100%;
+    row-gap: 5px;
 }
 
 #myGrid {
-    height: calc(100% - 35px);
+    flex: 1 1 0px;
 }


### PR DESCRIPTION
Fix the CSS, simplify the HTML, use display flex instead with row gap

before: 
<img width="927" alt="image" src="https://github.com/ag-grid/ag-grid/assets/6913178/53346f44-9f4c-4a15-9860-cc6a4f9d779b">

after:

<img width="915" alt="image" src="https://github.com/ag-grid/ag-grid/assets/6913178/f7c6abf4-ee2c-4345-a113-5b715595fa63">

<img width="710" alt="image" src="https://github.com/ag-grid/ag-grid/assets/6913178/3fb2009a-5760-42b7-8c23-7d8d66c8a60e">
