### PR TITLE
RTI-2206 padding for cross filtering example2

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-api-cross-filter-chart/_examples/sales-dashboard2/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-api-cross-filter-chart/_examples/sales-dashboard2/main.ts
@@ -164,6 +164,7 @@ function createHandsetSalesChart(api: GridApi) {
                     enabled: true,
                     text: 'Handsets Sold (Units)',
                 },
+                padding: { left: 47, right: 80 },
             },
         },
         chartContainer: document.querySelector('#areaChart') as any,


### PR DESCRIPTION
Before:

![image](https://github.com/ag-grid/ag-grid/assets/6913178/d1f48fb0-c90b-4565-ad3e-a159dd0fbc80)


After:

![image](https://github.com/ag-grid/ag-grid/assets/6913178/26914901-1eb4-492e-a058-7c630c445a4a)


Notes:
- tested also using the longest string in every input, all renders fine.
- left and right padding are different but measured that there are exactly 80 pixels left and right from the graph in this way, so it looks centered.