### PR TITLE
AG-12272 - step 5 - simplify master detail initialization

### DIFF
--- a/community-modules/client-side-row-model/src/clientSideNodeManager/clientSideNodeManager.ts
+++ b/community-modules/client-side-row-model/src/clientSideNodeManager/clientSideNodeManager.ts
@@ -375,7 +375,16 @@ export class ClientSideNodeManager<TData>
         return node;
     }
 
-    protected setMasterForRow(rowNode: RowNode<TData>, data: TData, level: number, isNewRow: boolean): void {
+    public updateRowsMasterDetail(): void {
+        this.rootNode.allLeafChildren?.forEach((rowNode) => {
+            const data = rowNode.data;
+            if (data) {
+                this.setMasterForRow(rowNode, data, TOP_LEVEL, true);
+            }
+        });
+    }
+
+    protected setMasterForRow(rowNode: RowNode<TData>, data: TData, level: number, canExpand: boolean): void {
         const masterDetail = this.gos.get('masterDetail');
         // this is the default, for when doing grid data
         if (masterDetail) {
@@ -391,7 +400,7 @@ export class ClientSideNodeManager<TData>
             rowNode.setMaster(false);
         }
 
-        if (isNewRow) {
+        if (canExpand) {
             const rowGroupColumns = this.beans.funcColsService.getRowGroupColumns();
             const numRowGroupColumns = rowGroupColumns ? rowGroupColumns.length : 0;
 

--- a/community-modules/client-side-row-model/src/clientSideNodeManager/clientSideNodeManager.ts
+++ b/community-modules/client-side-row-model/src/clientSideNodeManager/clientSideNodeManager.ts
@@ -384,7 +384,7 @@ export class ClientSideNodeManager<TData>
         });
     }
 
-    private setMasterForRow(rowNode: RowNode<TData>, data: TData, level: number, canExpand: boolean): void {
+    private setMasterForRow(rowNode: RowNode<TData>, data: TData, level: number, canExpandOrCollapse: boolean): void {
         const masterDetail = this.gos.get('masterDetail');
         // this is the default, for when doing grid data
         if (masterDetail) {
@@ -400,7 +400,7 @@ export class ClientSideNodeManager<TData>
             rowNode.setMaster(false);
         }
 
-        if (canExpand) {
+        if (canExpandOrCollapse) {
             const rowGroupColumns = this.beans.funcColsService.getRowGroupColumns();
             const numRowGroupColumns = rowGroupColumns ? rowGroupColumns.length : 0;
 

--- a/community-modules/client-side-row-model/src/clientSideNodeManager/clientSideNodeManager.ts
+++ b/community-modules/client-side-row-model/src/clientSideNodeManager/clientSideNodeManager.ts
@@ -384,7 +384,7 @@ export class ClientSideNodeManager<TData>
         });
     }
 
-    protected setMasterForRow(rowNode: RowNode<TData>, data: TData, level: number, canExpand: boolean): void {
+    private setMasterForRow(rowNode: RowNode<TData>, data: TData, level: number, canExpand: boolean): void {
         const masterDetail = this.gos.get('masterDetail');
         // this is the default, for when doing grid data
         if (masterDetail) {

--- a/community-modules/client-side-row-model/src/clientSideRowModel/clientSideRowModel.ts
+++ b/community-modules/client-side-row-model/src/clientSideRowModel/clientSideRowModel.ts
@@ -190,8 +190,10 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         //
         // ** LIST OF NON REACTIVE, NO ARGUMENT
         //
-        // getDataPath, getRowId, isRowMaster -- these are called once for each Node when the Node is created.
-        //                                    -- these are immutable Node properties (ie a Node ID cannot be changed)
+        // getDataPath, getRowId -- these are called once for each Node when the Node is created.
+        //                       -- these are immutable Node properties (ie a Node ID cannot be changed)
+        //
+        // isRowMaster           -- called when masterDetail is true and the Node is created or the property was changed
         //
         // getRowHeight - this is called once when Node is created, if a new getRowHeight function is provided,
         //              - we do not revisit the heights of each node.

--- a/community-modules/client-side-row-model/src/clientSideRowModel/clientSideRowModel.ts
+++ b/community-modules/client-side-row-model/src/clientSideRowModel/clientSideRowModel.ts
@@ -211,10 +211,10 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         //                       - the application would change these functions, far more likely the functions were
         //                       - non memoised correctly.
 
-        const initRowManagerProps: Set<keyof GridOptions> = new Set(['treeData', 'treeDataChildrenField']);
+        const resetProps: Set<keyof GridOptions> = new Set(['treeData', 'treeDataChildrenField']);
 
-        const resetProps: Set<keyof GridOptions> = new Set(['masterDetail', ...initRowManagerProps]);
         const groupStageRefreshProps: Set<keyof GridOptions> = new Set([
+            'masterDetail',
             'groupDefaultExpanded',
             'groupAllowUnbalanced',
             'initialGroupOrderComparator',
@@ -278,9 +278,7 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
                 } else {
                     newRowData = this.rootNode.allLeafChildren?.map((child) => child.data);
                 }
-                if (arePropertiesImpacted(initRowManagerProps)) {
-                    this.initRowManager();
-                }
+                this.initRowManager();
                 this.setNewRowData(newRowData ?? []);
                 return;
             }
@@ -293,6 +291,10 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
             }
 
             if (arePropertiesImpacted(groupStageRefreshProps)) {
+                if (properties.includes('masterDetail')) {
+                    this.nodeManager.updateRowsMasterDetail?.();
+                }
+
                 this.refreshModel({ step: ClientSideRowModelSteps.EVERYTHING });
                 return;
             }

--- a/community-modules/core/src/interfaces/iClientSideNodeManager.ts
+++ b/community-modules/core/src/interfaces/iClientSideNodeManager.ts
@@ -28,4 +28,6 @@ export interface IClientSideNodeManager<TData = any> {
     setImmutableRowData(rowData: TData[]): ClientSideNodeManagerUpdateRowDataResult<TData> | null;
 
     updateRowData(rowDataTran: RowDataTransaction<TData>): ClientSideNodeManagerUpdateRowDataResult<TData>;
+
+    updateRowsMasterDetail?(): void;
 }


### PR DESCRIPTION
At the moment, CSRM recreates all the rowNodes when masterDetail is toggled.
However, this seems to not be necessary, we just need to update the master flag and rerun refreshModel