### PR TITLE
AG-12272 - step 6 - separate get data path and children managers

### DIFF
--- a/community-modules/client-side-row-model/src/clientSideRowModel/clientSideRowModel.ts
+++ b/community-modules/client-side-row-model/src/clientSideRowModel/clientSideRowModel.ts
@@ -160,14 +160,17 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
     private initRowManager(): void {
         const { gos, beans, nodeManager: oldNodeManager } = this;
 
-        const childrenField = gos.get('treeDataChildrenField');
         const treeData = gos.get('treeData');
+        const childrenField = gos.get('treeDataChildrenField');
 
-        const mustUseClientSideTreeNodeManager = childrenField || treeData;
+        const isTree = childrenField || treeData;
 
         let nodeManager: IClientSideNodeManager<any> | undefined;
-        if (mustUseClientSideTreeNodeManager) {
-            nodeManager = beans.clientSideTreeNodeManager;
+        if (isTree) {
+            nodeManager = childrenField ? beans.clientSideChildrenTreeNodeManager : beans.clientSidePathTreeNodeManager;
+            if (!nodeManager) {
+                _warnOnce('Tree data requires tree enterprise module to be loaded'); // TODO: improve this warning
+            }
         }
 
         if (!nodeManager) {

--- a/community-modules/client-side-row-model/src/treeData/abstractClientSideTreeNodeManager.ts
+++ b/community-modules/client-side-row-model/src/treeData/abstractClientSideTreeNodeManager.ts
@@ -1,0 +1,3 @@
+import { AbstractClientSideNodeManager } from '../clientSideNodeManager/abstractClientSideNodeManager';
+
+export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractClientSideNodeManager<TData> {}

--- a/community-modules/client-side-row-model/src/treeData/clientSideChildrenTreeNodeManager.ts
+++ b/community-modules/client-side-row-model/src/treeData/clientSideChildrenTreeNodeManager.ts
@@ -25,11 +25,11 @@ import type { DataFieldGetter } from './fieldAccess';
 
 const TOP_LEVEL = 0;
 
-export class ClientSideTreeNodeManager<TData>
+export class ClientSideChildrenTreeNodeManager<TData>
     extends AbstractClientSideNodeManager<TData>
     implements IClientSideNodeManager<TData>, NamedBean
 {
-    beanName = 'clientSideTreeNodeManager' as const;
+    beanName = 'clientSideChildrenTreeNodeManager' as const;
 
     private allNodesMap: { [id: string]: RowNode } = {};
 

--- a/community-modules/client-side-row-model/src/treeData/clientSidePathTreeNodeManager.ts
+++ b/community-modules/client-side-row-model/src/treeData/clientSidePathTreeNodeManager.ts
@@ -15,8 +15,6 @@ import type {
     ClientSideNodeManagerRowNode,
 } from '../clientSideNodeManager/abstractClientSideNodeManager';
 import { AbstractClientSideTreeNodeManager } from './abstractClientSideTreeNodeManager';
-import { makeFieldPathGetter } from './fieldAccess';
-import type { DataFieldGetter } from './fieldAccess';
 
 const TOP_LEVEL = 0;
 
@@ -28,19 +26,8 @@ export class ClientSidePathTreeNodeManager<TData>
 
     private allNodesMap: { [id: string]: RowNode } = {};
 
-    private childrenGetter: DataFieldGetter | null = null;
-
     // when user is provide the id's, we also keep a map of ids to row nodes for convenience
     private nextId = 0;
-
-    public override initRootNode(rootRowNode: RowNode<TData>): void {
-        const childrenField = this.gos.get('treeDataChildrenField');
-        if (this.childrenGetter?.path !== childrenField) {
-            this.childrenGetter = makeFieldPathGetter(childrenField);
-        }
-
-        super.initRootNode(rootRowNode);
-    }
 
     public getRowNode(id: string): RowNode | undefined {
         return this.allNodesMap[id];

--- a/community-modules/client-side-row-model/src/treeData/clientSidePathTreeNodeManager.ts
+++ b/community-modules/client-side-row-model/src/treeData/clientSidePathTreeNodeManager.ts
@@ -10,17 +10,37 @@ import {
     _warnOnce,
 } from '@ag-grid-community/core';
 
-import type { ClientSideNodeManagerRootNode, ClientSideNodeManagerRowNode } from './abstractClientSideNodeManager';
-import { AbstractClientSideNodeManager } from './abstractClientSideNodeManager';
+import type {
+    ClientSideNodeManagerRootNode,
+    ClientSideNodeManagerRowNode,
+} from '../clientSideNodeManager/abstractClientSideNodeManager';
+import { AbstractClientSideTreeNodeManager } from './abstractClientSideTreeNodeManager';
+import { makeFieldPathGetter } from './fieldAccess';
+import type { DataFieldGetter } from './fieldAccess';
 
 const TOP_LEVEL = 0;
 
-export class ClientSideNodeManager<TData> extends AbstractClientSideNodeManager<TData> implements NamedBean {
-    beanName = 'clientSideNodeManager' as const;
+export class ClientSidePathTreeNodeManager<TData>
+    extends AbstractClientSideTreeNodeManager<TData>
+    implements NamedBean
+{
+    beanName = 'clientSidePathTreeNodeManager' as const;
+
+    private allNodesMap: { [id: string]: RowNode } = {};
+
+    private childrenGetter: DataFieldGetter | null = null;
 
     // when user is provide the id's, we also keep a map of ids to row nodes for convenience
-    private allNodesMap: { [id: string]: RowNode } = {};
     private nextId = 0;
+
+    public override initRootNode(rootRowNode: RowNode<TData>): void {
+        const childrenField = this.gos.get('treeDataChildrenField');
+        if (this.childrenGetter?.path !== childrenField) {
+            this.childrenGetter = makeFieldPathGetter(childrenField);
+        }
+
+        super.initRootNode(rootRowNode);
+    }
 
     public getRowNode(id: string): RowNode | undefined {
         return this.allNodesMap[id];
@@ -200,6 +220,22 @@ export class ClientSideNodeManager<TData> extends AbstractClientSideNodeManager<
 
         if (typeof rowDataTran.addIndex === 'number') {
             addIndex = this.sanitizeAddIndex(rowDataTran.addIndex);
+
+            if (addIndex > 0) {
+                // TODO: this code should not be here, see AG-12602
+                // This was a fix for AG-6231, but is not the correct fix
+                // We enable it only for trees that use getDataPath and not the new children field
+                const getDataPath = !!this.gos.get('getDataPath');
+                if (getDataPath) {
+                    for (let i = 0; i < allLeafChildren.length; i++) {
+                        const node = allLeafChildren[i];
+                        if (node?.rowIndex == addIndex - 1) {
+                            addIndex = i + 1;
+                            break;
+                        }
+                    }
+                }
+            }
         }
 
         // create new row nodes for each data item
@@ -311,8 +347,6 @@ export class ClientSideNodeManager<TData> extends AbstractClientSideNodeManager<
                 nodesToUnselect.push(rowNode);
             }
 
-            this.setMasterForRow(rowNode, item, TOP_LEVEL, false);
-
             rowNodeTransaction.update.push(rowNode);
         });
     }
@@ -347,7 +381,8 @@ export class ClientSideNodeManager<TData> extends AbstractClientSideNodeManager<
         node.sourceRowIndex = sourceRowIndex;
 
         node.group = false;
-        this.setMasterForRow(node, dataItem, level, true);
+        node.master = false;
+        node.expanded = false;
 
         if (parent) {
             node.parent = parent;
@@ -365,41 +400,5 @@ export class ClientSideNodeManager<TData> extends AbstractClientSideNodeManager<
         this.nextId++;
 
         return node;
-    }
-
-    public updateRowsMasterDetail(): void {
-        this.rootNode.allLeafChildren?.forEach((rowNode) => {
-            const data = rowNode.data;
-            if (data) {
-                this.setMasterForRow(rowNode, data, TOP_LEVEL, true);
-            }
-        });
-    }
-
-    private setMasterForRow(rowNode: RowNode<TData>, data: TData, level: number, canExpandOrCollapse: boolean): void {
-        const masterDetail = this.gos.get('masterDetail');
-        // this is the default, for when doing grid data
-        if (masterDetail) {
-            // if we are doing master detail, then the
-            // default is that everything can be a Master Row.
-            const isRowMasterFunc = this.gos.get('isRowMaster');
-            if (isRowMasterFunc) {
-                rowNode.setMaster(isRowMasterFunc(data));
-            } else {
-                rowNode.setMaster(true);
-            }
-        } else {
-            rowNode.setMaster(false);
-        }
-
-        if (canExpandOrCollapse) {
-            const rowGroupColumns = this.beans.funcColsService.getRowGroupColumns();
-            const numRowGroupColumns = rowGroupColumns ? rowGroupColumns.length : 0;
-
-            // need to take row group into account when determining level
-            const masterRowLevel = level + numRowGroupColumns;
-
-            rowNode.expanded = rowNode.master ? this.isExpanded(masterRowLevel) : false;
-        }
     }
 }

--- a/community-modules/client-side-row-model/src/treeData/treeDataModule.ts
+++ b/community-modules/client-side-row-model/src/treeData/treeDataModule.ts
@@ -1,12 +1,13 @@
 import { ModuleNames, _defineModule } from '@ag-grid-community/core';
 
 import { ClientSideRowModelModule } from '../clientSideRowModelModule';
-import { ClientSideTreeNodeManager } from '../treeData/clientSideTreeNodeManager';
 import { VERSION } from '../version';
+import { ClientSideChildrenTreeNodeManager } from './clientSideChildrenTreeNodeManager';
+import { ClientSidePathTreeNodeManager } from './clientSidePathTreeNodeManager';
 
 export const TreeDataModule = _defineModule({
     version: VERSION,
     moduleName: ModuleNames.ClientSideRowModelModule,
-    beans: [ClientSideTreeNodeManager],
+    beans: [ClientSidePathTreeNodeManager, ClientSideChildrenTreeNodeManager],
     dependantModules: [ClientSideRowModelModule],
 });

--- a/community-modules/core/src/context/context.ts
+++ b/community-modules/core/src/context/context.ts
@@ -295,7 +295,8 @@ export interface CoreBeanCollection {
     chartService?: IChartService;
     selectableService: SelectableService;
     clientSideNodeManager?: IClientSideNodeManager;
-    clientSideTreeNodeManager?: IClientSideNodeManager;
+    clientSidePathTreeNodeManager?: IClientSideNodeManager;
+    clientSideChildrenTreeNodeManager?: IClientSideNodeManager;
 }
 
 export type BeanCollection = CoreBeanCollection & {
@@ -485,4 +486,5 @@ export type BeanName =
     | 'validationLogger'
     | 'validationService'
     | 'clientSideNodeManager'
-    | 'clientSideTreeNodeManager';
+    | 'clientSidePathTreeNodeManager'
+    | 'clientSideChildrenTreeNodeManager';

--- a/testing/behavioural/src/grouping-data/trees/grouping-tree-data-reactive.test.ts
+++ b/testing/behavioural/src/grouping-data/trees/grouping-tree-data-reactive.test.ts
@@ -1,4 +1,4 @@
-import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import { ClientSideRowModelModule, TreeDataModule } from '@ag-grid-community/client-side-row-model';
 import type { GridOptions } from '@ag-grid-community/core';
 import { RowGroupingModule } from '@ag-grid-enterprise/row-grouping';
 
@@ -8,7 +8,9 @@ import { getRowsSnapshot } from '../row-snapshot-test-utils';
 import type { RowSnapshot } from '../row-snapshot-test-utils';
 
 describe('ag-grid grouping treeData is reactive', () => {
-    const gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, RowGroupingModule] });
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule, TreeDataModule],
+    });
 
     beforeEach(() => {
         gridsManager.reset();

--- a/testing/behavioural/src/grouping-data/trees/stages/tree-aggregation.test.ts
+++ b/testing/behavioural/src/grouping-data/trees/stages/tree-aggregation.test.ts
@@ -1,11 +1,13 @@
-import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import { ClientSideRowModelModule, TreeDataModule } from '@ag-grid-community/client-side-row-model';
 import { RowGroupingModule } from '@ag-grid-enterprise/row-grouping';
 
 import type { GridRowsOptions } from '../../../test-utils';
 import { GridRows, TestGridsManager, cachedJSONObjects, executeTransactionsAsync } from '../../../test-utils';
 
 describe('ag-grid tree aggregation', () => {
-    const gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, RowGroupingModule] });
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule, TreeDataModule],
+    });
 
     beforeEach(() => {
         vitest.useRealTimers();

--- a/testing/behavioural/src/grouping-data/trees/stages/tree-filter-aggregation.test.ts
+++ b/testing/behavioural/src/grouping-data/trees/stages/tree-filter-aggregation.test.ts
@@ -1,11 +1,13 @@
-import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import { ClientSideRowModelModule, TreeDataModule } from '@ag-grid-community/client-side-row-model';
 import { RowGroupingModule } from '@ag-grid-enterprise/row-grouping';
 
 import type { GridRowsOptions } from '../../../test-utils';
 import { GridRows, TestGridsManager, cachedJSONObjects } from '../../../test-utils';
 
 describe('ag-grid tree aggregation and filter', () => {
-    const gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, RowGroupingModule] });
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule, TreeDataModule],
+    });
 
     beforeEach(() => {
         vitest.useRealTimers();

--- a/testing/behavioural/src/grouping-data/trees/stages/tree-filter-sort.test.ts
+++ b/testing/behavioural/src/grouping-data/trees/stages/tree-filter-sort.test.ts
@@ -1,11 +1,13 @@
-import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import { ClientSideRowModelModule, TreeDataModule } from '@ag-grid-community/client-side-row-model';
 import { RowGroupingModule } from '@ag-grid-enterprise/row-grouping';
 
 import type { GridRowsOptions } from '../../../test-utils';
 import { GridRows, TestGridsManager, cachedJSONObjects } from '../../../test-utils';
 
 describe('ag-grid tree filter', () => {
-    const gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, RowGroupingModule] });
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule, TreeDataModule],
+    });
 
     beforeEach(() => {
         vitest.useRealTimers();

--- a/testing/behavioural/src/grouping-data/trees/stages/tree-selection.test.ts
+++ b/testing/behavioural/src/grouping-data/trees/stages/tree-selection.test.ts
@@ -1,11 +1,13 @@
-import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import { ClientSideRowModelModule, TreeDataModule } from '@ag-grid-community/client-side-row-model';
 import { RowGroupingModule } from '@ag-grid-enterprise/row-grouping';
 
 import type { GridRowsOptions } from '../../../test-utils';
 import { GridRows, TestGridsManager, cachedJSONObjects } from '../../../test-utils';
 
 describe('ag-grid tree selection', () => {
-    const gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, RowGroupingModule] });
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule, TreeDataModule],
+    });
 
     beforeEach(() => {
         vitest.useRealTimers();

--- a/testing/behavioural/src/grouping-data/trees/tree-data-reset.test.ts
+++ b/testing/behavioural/src/grouping-data/trees/tree-data-reset.test.ts
@@ -1,4 +1,4 @@
-import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import { ClientSideRowModelModule, TreeDataModule } from '@ag-grid-community/client-side-row-model';
 import { RowGroupingModule } from '@ag-grid-enterprise/row-grouping';
 import { setTimeout as asyncSetTimeout } from 'timers/promises';
 import type { MockInstance } from 'vitest';
@@ -13,7 +13,9 @@ const defaultGridRowsOptions: GridRowsOptions = {
 const getDataPath = (data: any) => data.orgHierarchy;
 
 describe('ag-grid tree data', () => {
-    const gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, RowGroupingModule] });
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule, TreeDataModule],
+    });
 
     let consoleWarnSpy: MockInstance;
 

--- a/testing/behavioural/src/grouping-data/trees/tree-data.test.ts
+++ b/testing/behavioural/src/grouping-data/trees/tree-data.test.ts
@@ -1,4 +1,4 @@
-import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import { ClientSideRowModelModule, TreeDataModule } from '@ag-grid-community/client-side-row-model';
 import type { GridOptions } from '@ag-grid-community/core';
 import { RowGroupingModule } from '@ag-grid-enterprise/row-grouping';
 import type { MockInstance } from 'vitest';
@@ -11,7 +11,9 @@ import type { RowSnapshot } from '../row-snapshot-test-utils';
 const getDataPath = (data: any) => data.orgHierarchy;
 
 describe('ag-grid tree data', () => {
-    const gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, RowGroupingModule] });
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule, TreeDataModule],
+    });
 
     let consoleWarnSpy: MockInstance;
 

--- a/testing/behavioural/src/grouping-data/trees/tree-duplicate-keys.test.ts
+++ b/testing/behavioural/src/grouping-data/trees/tree-duplicate-keys.test.ts
@@ -1,4 +1,4 @@
-import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import { ClientSideRowModelModule, TreeDataModule } from '@ag-grid-community/client-side-row-model';
 import { RowGroupingModule } from '@ag-grid-enterprise/row-grouping';
 import type { MockInstance } from 'vitest';
 
@@ -7,7 +7,9 @@ import { GridRows, TestGridsManager } from '../../test-utils';
 const getDataPath = (data: any) => data.orgHierarchy;
 
 describe('ag-grid tree duplicate keys', () => {
-    const gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, RowGroupingModule] });
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule, TreeDataModule],
+    });
 
     const gridRowsOptions = {
         checkDom: 'myGrid',

--- a/testing/behavioural/src/grouping-data/trees/tree-expanded-state.test.ts
+++ b/testing/behavioural/src/grouping-data/trees/tree-expanded-state.test.ts
@@ -1,4 +1,4 @@
-import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import { ClientSideRowModelModule, TreeDataModule } from '@ag-grid-community/client-side-row-model';
 import { RowGroupingModule } from '@ag-grid-enterprise/row-grouping';
 
 import { GridRows, TestGridsManager, asyncSetTimeout } from '../../test-utils';
@@ -7,7 +7,9 @@ import type { GridRowsOptions } from '../../test-utils';
 const getDataPath = (data: any) => data.orgHierarchy;
 
 describe('ag-grid tree expanded state', () => {
-    const gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, RowGroupingModule] });
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule, TreeDataModule],
+    });
 
     const gridRowsOptions: GridRowsOptions = {
         checkDom: 'myGrid',

--- a/testing/behavioural/src/grouping-data/trees/tree-file-manager.test.ts
+++ b/testing/behavioural/src/grouping-data/trees/tree-file-manager.test.ts
@@ -1,4 +1,4 @@
-import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import { ClientSideRowModelModule, TreeDataModule } from '@ag-grid-community/client-side-row-model';
 import type { GridOptions, IRowNode } from '@ag-grid-community/core';
 import { RowGroupingModule } from '@ag-grid-enterprise/row-grouping';
 
@@ -6,7 +6,9 @@ import { GridRows, TestGridsManager } from '../../test-utils';
 import type { GridRowsOptions } from '../../test-utils';
 
 describe('ag-grid tree transactions', () => {
-    const gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, RowGroupingModule] });
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule, TreeDataModule],
+    });
 
     beforeEach(() => {
         gridsManager.reset();

--- a/testing/behavioural/src/grouping-data/trees/tree-group-rows.test.ts
+++ b/testing/behavioural/src/grouping-data/trees/tree-group-rows.test.ts
@@ -1,4 +1,4 @@
-import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import { ClientSideRowModelModule, TreeDataModule } from '@ag-grid-community/client-side-row-model';
 import { RowGroupingModule } from '@ag-grid-enterprise/row-grouping';
 
 import { GridRows, TestGridsManager } from '../../test-utils';
@@ -6,7 +6,9 @@ import type { GridRowsOptions } from '../../test-utils';
 import { getRowsSnapshot, simpleHierarchyRowSnapshot } from '../row-snapshot-test-utils';
 
 describe('ag-grid grouping tree data with groupRows', () => {
-    const gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, RowGroupingModule] });
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule, TreeDataModule],
+    });
 
     beforeEach(() => {
         gridsManager.reset();

--- a/testing/behavioural/src/grouping-data/trees/tree-remove.test.ts
+++ b/testing/behavioural/src/grouping-data/trees/tree-remove.test.ts
@@ -1,4 +1,4 @@
-import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import { ClientSideRowModelModule, TreeDataModule } from '@ag-grid-community/client-side-row-model';
 import type { RowDataTransaction } from '@ag-grid-community/core';
 import { RowGroupingModule } from '@ag-grid-enterprise/row-grouping';
 
@@ -10,7 +10,9 @@ const gridRowsOptions: GridRowsOptions = {
 };
 
 describe('ag-grid tree transactions', () => {
-    const gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, RowGroupingModule] });
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule, TreeDataModule],
+    });
 
     beforeEach(() => {
         vitest.useRealTimers();

--- a/testing/behavioural/src/grouping-data/trees/tree-transactions.test.ts
+++ b/testing/behavioural/src/grouping-data/trees/tree-transactions.test.ts
@@ -1,4 +1,4 @@
-import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import { ClientSideRowModelModule, TreeDataModule } from '@ag-grid-community/client-side-row-model';
 import type { RowDataTransaction } from '@ag-grid-community/core';
 import { RowGroupingModule } from '@ag-grid-enterprise/row-grouping';
 
@@ -10,7 +10,9 @@ const gridRowsOptions: GridRowsOptions = {
 };
 
 describe('ag-grid tree transactions', () => {
-    const gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, RowGroupingModule] });
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule, TreeDataModule],
+    });
 
     beforeEach(() => {
         gridsManager.reset();


### PR DESCRIPTION
As the logic for implementing the new node managers for getDataPath and treeDataChildrenField are going to be deeply different we decided to split them in two different classes and select the right one as needed.