### PR TITLE
AG-12915 - Add error codes page to the website

### DIFF
--- a/documentation/ag-grid-docs/src/components/pages-navigation/components/SideNavigation.tsx
+++ b/documentation/ag-grid-docs/src/components/pages-navigation/components/SideNavigation.tsx
@@ -29,7 +29,7 @@ export function SideNavigation({ headings, delayedScrollSpy }: Props) {
                                 onClick={(event) => {
                                     event.preventDefault();
                                     scrollIntoViewById(slug);
-                                    navigate({ hash: slug });
+                                    navigate({ search: window.location.search, hash: slug });
                                 }}
                             >
                                 {addNonBreakingSpaceBetweenLastWords(text)}

--- a/documentation/ag-grid-docs/src/content/config.ts
+++ b/documentation/ag-grid-docs/src/content/config.ts
@@ -99,7 +99,6 @@ const matrixTable = defineCollection({
 
 const errors = defineCollection({
     schema: z.object({
-        title: z.string().optional(),
         description: z.string().optional(),
     }),
 });

--- a/documentation/ag-grid-docs/src/content/config.ts
+++ b/documentation/ag-grid-docs/src/content/config.ts
@@ -97,8 +97,16 @@ const matrixTable = defineCollection({
     schema: z.array(z.record(z.string(), z.any())),
 });
 
+const errors = defineCollection({
+    schema: z.object({
+        title: z.string().optional(),
+        description: z.string().optional(),
+    }),
+});
+
 export const collections = {
     docs,
     menu,
     'matrix-table': matrixTable,
+    errors,
 };

--- a/documentation/ag-grid-docs/src/content/errors/1.mdoc
+++ b/documentation/ag-grid-docs/src/content/errors/1.mdoc
@@ -1,0 +1,1 @@
+This is an error about row data. See [Row Data docs](./row-ids/).

--- a/documentation/ag-grid-docs/src/content/errors/2.mdoc
+++ b/documentation/ag-grid-docs/src/content/errors/2.mdoc
@@ -1,0 +1,12 @@
+---
+title: "Row data error #2"
+description: Row data description
+---
+
+This is an error about duplicate node ids. See [Row IDs docs](./row-ids/#row-ids).
+
+## Why is this error happening?
+
+Because you have a duplicate node id
+
+

--- a/documentation/ag-grid-docs/src/content/errors/2.mdoc
+++ b/documentation/ag-grid-docs/src/content/errors/2.mdoc
@@ -1,5 +1,4 @@
 ---
-title: "Row data error #2"
 description: Row data description
 ---
 

--- a/documentation/ag-grid-docs/src/pages/[framework]-data-grid/errors/[code].astro
+++ b/documentation/ag-grid-docs/src/pages/[framework]-data-grid/errors/[code].astro
@@ -12,6 +12,7 @@ import { SideNavigation } from '@components/pages-navigation/components/SideNavi
 import { getHeadings, getTopHeading } from '@utils/markdoc/getHeadings';
 import { DOCS_TAB_ITEM_ID_PREFIX } from '@ag-website-shared/constants';
 import { AG_GRID_ERRORS } from '../../../../../../packages/ag-grid-community/src/validation/errorMessages/errorText';
+import Note from '@ag-website-shared/components/alert/Note';
 
 interface Params {
     framework: Framework;
@@ -97,6 +98,7 @@ const headings = errorPage
 
                 <h2 id={fullErrorTextHeading.slug}>{fullErrorTextHeading.text}</h2>
                 <pre id="errorCodeText">{defaultErrorText}</pre>
+                <Note>To show this error text in the dev console, import the <code>ValidationModule</code>.</Note>
             </div>
         </div>
 

--- a/documentation/ag-grid-docs/src/pages/[framework]-data-grid/errors/[code].astro
+++ b/documentation/ag-grid-docs/src/pages/[framework]-data-grid/errors/[code].astro
@@ -76,16 +76,7 @@ const headings = errorPage
 <Layout title={title} description={description} showSearchBar={true} showDocsNav={true}>
     <div class:list={[styles.contentViewport, 'layout-grid']}>
         <PagesNavigation client:load menuSections={menuSections} framework={framework} pageName={pageName} />
-        <div
-            id="doc-content"
-            class:list={[
-                styles.docPage,
-                styles.errorPage,
-                {
-                    noSideMenu: styles.hideSideMenu,
-                },
-            ]}
-        >
+        <div id="doc-content" class:list={[styles.docPage, styles.errorPage]}>
             <Header
                 client:load
                 title={title}

--- a/documentation/ag-grid-docs/src/pages/[framework]-data-grid/errors/[code].astro
+++ b/documentation/ag-grid-docs/src/pages/[framework]-data-grid/errors/[code].astro
@@ -1,0 +1,121 @@
+---
+import Layout from '@layouts/Layout.astro';
+import { getCollection, getEntry, type CollectionEntry } from 'astro:content';
+import type { Framework, MenuItem, MenuSection } from '@ag-grid-types';
+import { FRAMEWORKS } from '@constants';
+import { getFilteredMenuSections } from '@components/pages-navigation/utils/getFilteredMenuSections';
+import styles from '@ag-website-shared/components/page-styles/docs.module.scss';
+import { PagesNavigation } from '@components/pages-navigation/components/PagesNavigation';
+import { Header } from '@features/docs/components/Header';
+import { getErrorText } from '@utils/getErrorText';
+import { SideNavigation } from '@components/pages-navigation/components/SideNavigation';
+import { getHeadings } from '@utils/markdoc/getHeadings';
+import { DOCS_TAB_ITEM_ID_PREFIX } from '@ag-website-shared/constants';
+import { AG_GRID_ERRORS } from '../../../../../../packages/ag-grid-community/src/validation/errorMessages/errorText';
+
+interface Params {
+    framework: Framework;
+    code: string;
+}
+interface Props {
+    errorPage?: CollectionEntry<'errors'>;
+}
+
+export async function getStaticPaths() {
+    const errors = await getCollection('errors');
+    return FRAMEWORKS.flatMap((framework: Framework) => {
+        return Object.keys(AG_GRID_ERRORS).map((codeNum) => {
+            const code = codeNum.toString();
+            const errorPage = errors.find(({ slug }) => slug === code);
+            return {
+                params: {
+                    framework,
+                    code,
+                },
+                props: {
+                    errorPage,
+                },
+            };
+        });
+    });
+}
+
+const { framework, code } = Astro.params as Params;
+const { errorPage } = Astro.props as Props;
+const title = errorPage?.data.title ? errorPage?.data.title : `AG Grid Error #${code}`;
+const description = errorPage?.data.description ? errorPage?.data.description : '';
+
+const { Content } = errorPage ? await errorPage.render() : { Content: undefined };
+
+const { data: menu } = await getEntry('menu', 'data');
+const menuSections: MenuSection[] = getFilteredMenuSections({
+    menuSections: menu.main.sections,
+    framework,
+});
+const path = Astro.url.pathname;
+const pageName = `errors/${code}`;
+const defaultErrorText = getErrorText({ errorCode: code });
+
+const getTabItemSlug = (id: string) => `${DOCS_TAB_ITEM_ID_PREFIX}${id}`;
+const fullErrorTextHeading = { slug: getTabItemSlug('full-error-text'), depth: 2, text: 'Full Error Text' };
+const headings = errorPage
+    ? (
+          await getHeadings({
+              title,
+              pageName,
+              markdocContent: errorPage.body,
+              framework,
+              getTabItemSlug,
+          })
+      ).concat(fullErrorTextHeading)
+    : [fullErrorTextHeading];
+---
+
+<Layout title={title} description={description} showSearchBar={true} showDocsNav={true}>
+    <div class:list={[styles.contentViewport, 'layout-grid']}>
+        <PagesNavigation client:load menuSections={menuSections} framework={framework} pageName={pageName} />
+        <div
+            id="doc-content"
+            class:list={[
+                styles.docPage,
+                styles.errorPage,
+                {
+                    noSideMenu: styles.hideSideMenu,
+                },
+            ]}
+        >
+            <Header
+                client:load
+                title={title}
+                framework={framework}
+                path={path}
+                menuItems={menuSections as MenuItem[]}
+            />
+            <div class={styles.pageSections}>
+                {Content ? <Content framework={framework} /> : undefined}
+
+                <h2 id={fullErrorTextHeading.slug}>{fullErrorTextHeading.text}</h2>
+                <pre id="errorCodeText">{defaultErrorText}</pre>
+            </div>
+        </div>
+
+        <SideNavigation client:load headings={headings} />
+    </div>
+</Layout>
+
+<script>
+    import { getErrorText } from '@utils/getErrorText';
+
+    // Get errorCode from url, so it doesn't need to be passed
+    // in from Astro and we can import in this script
+    const errorCode = window.location.pathname.split('/').filter(Boolean).slice(-1)[0];
+    const searchParams = new URLSearchParams(window.location.search);
+    const params = Object.fromEntries(searchParams.entries());
+    const errorText = getErrorText({ errorCode, params });
+
+    const errorCodeTextEl = document.getElementById('errorCodeText');
+
+    if (errorCodeTextEl) {
+        errorCodeTextEl.textContent = errorText;
+    }
+</script>

--- a/documentation/ag-grid-docs/src/pages/[framework]-data-grid/errors/[code].astro
+++ b/documentation/ag-grid-docs/src/pages/[framework]-data-grid/errors/[code].astro
@@ -11,7 +11,10 @@ import { getErrorText } from '@utils/getErrorText';
 import { SideNavigation } from '@components/pages-navigation/components/SideNavigation';
 import { getHeadings, getTopHeading } from '@utils/markdoc/getHeadings';
 import { DOCS_TAB_ITEM_ID_PREFIX } from '@ag-website-shared/constants';
-import { AG_GRID_ERRORS } from '../../../../../../packages/ag-grid-community/src/validation/errorMessages/errorText';
+import {
+    AG_GRID_ERRORS,
+    type ErrorId,
+} from '../../../../../../packages/ag-grid-community/src/validation/errorMessages/errorText';
 import Note from '@ag-website-shared/components/alert/Note';
 
 interface Params {
@@ -43,7 +46,8 @@ export async function getStaticPaths() {
 
 const { framework, code } = Astro.params as Params;
 const { errorPage } = Astro.props as Props;
-const title = errorPage?.data.title ? errorPage?.data.title : `AG Grid Error #${code}`;
+const errorCode = parseInt(code, 10) as ErrorId;
+const title = `AG Grid Error #${code}`;
 const description = errorPage?.data.description ? errorPage?.data.description : '';
 
 const { Content } = errorPage ? await errorPage.render() : { Content: undefined };
@@ -55,7 +59,7 @@ const menuSections: MenuSection[] = getFilteredMenuSections({
 });
 const path = Astro.url.pathname;
 const pageName = `errors/${code}`;
-const defaultErrorText = getErrorText({ errorCode: code });
+const defaultErrorText = getErrorText({ errorCode });
 
 const getTabItemSlug = (id: string) => `${DOCS_TAB_ITEM_ID_PREFIX}${id}`;
 const topHeading = getTopHeading(title);
@@ -93,16 +97,17 @@ const headings = errorPage
             </div>
         </div>
 
-        <SideNavigation client:load headings={headings} alwaysShow />
+        <SideNavigation client:load headings={headings} />
     </div>
 </Layout>
 
 <script>
     import { getErrorText } from '@utils/getErrorText';
+    import type { ErrorId } from '../../../../../../packages/ag-grid-community/src/validation/errorMessages/errorText';
 
     // Get errorCode from url, so it doesn't need to be passed
     // in from Astro and we can import in this script
-    const errorCode = window.location.pathname.split('/').filter(Boolean).slice(-1)[0];
+    const errorCode = parseInt(window.location.pathname.split('/').filter(Boolean).slice(-1)[0], 10) as ErrorId;
     const searchParams = new URLSearchParams(window.location.search);
     const params = Object.fromEntries(searchParams.entries());
     const errorText = getErrorText({ errorCode, params });

--- a/documentation/ag-grid-docs/src/pages/[framework]-data-grid/errors/[code].astro
+++ b/documentation/ag-grid-docs/src/pages/[framework]-data-grid/errors/[code].astro
@@ -9,7 +9,7 @@ import { PagesNavigation } from '@components/pages-navigation/components/PagesNa
 import { Header } from '@features/docs/components/Header';
 import { getErrorText } from '@utils/getErrorText';
 import { SideNavigation } from '@components/pages-navigation/components/SideNavigation';
-import { getHeadings } from '@utils/markdoc/getHeadings';
+import { getHeadings, getTopHeading } from '@utils/markdoc/getHeadings';
 import { DOCS_TAB_ITEM_ID_PREFIX } from '@ag-website-shared/constants';
 import { AG_GRID_ERRORS } from '../../../../../../packages/ag-grid-community/src/validation/errorMessages/errorText';
 
@@ -57,6 +57,7 @@ const pageName = `errors/${code}`;
 const defaultErrorText = getErrorText({ errorCode: code });
 
 const getTabItemSlug = (id: string) => `${DOCS_TAB_ITEM_ID_PREFIX}${id}`;
+const topHeading = getTopHeading(title);
 const fullErrorTextHeading = { slug: getTabItemSlug('full-error-text'), depth: 2, text: 'Full Error Text' };
 const headings = errorPage
     ? (
@@ -68,7 +69,7 @@ const headings = errorPage
               getTabItemSlug,
           })
       ).concat(fullErrorTextHeading)
-    : [fullErrorTextHeading];
+    : [topHeading, fullErrorTextHeading];
 ---
 
 <Layout title={title} description={description} showSearchBar={true} showDocsNav={true}>
@@ -99,7 +100,7 @@ const headings = errorPage
             </div>
         </div>
 
-        <SideNavigation client:load headings={headings} />
+        <SideNavigation client:load headings={headings} alwaysShow />
     </div>
 </Layout>
 

--- a/documentation/ag-grid-docs/src/utils/getErrorText.ts
+++ b/documentation/ag-grid-docs/src/utils/getErrorText.ts
@@ -5,20 +5,31 @@ import {
     type ErrorId,
 } from '../../../../packages/ag-grid-community/src/validation/errorMessages/errorText';
 
-export function getErrorText({
-    errorCode,
-    params = {},
-}: {
-    errorCode: ErrorId;
-    params?: Record<string, string>;
-}): string {
+type Params = Record<string, string>;
+
+function cleanParams(params: Params) {
+    return Object.fromEntries(
+        Object.entries(params).map(([key, value]) => {
+            let cleanParam = value;
+
+            // Clean up serialised strings
+            if (cleanParam.startsWith('"') && cleanParam.endsWith('"')) {
+                cleanParam = cleanParam.slice(1, cleanParam.length - 1).replaceAll('\\"', '"');
+            }
+
+            return [key, cleanParam];
+        })
+    );
+}
+
+export function getErrorText({ errorCode, params = {} }: { errorCode: ErrorId; params?: Params }): string {
     const errorTextFn = AG_GRID_ERRORS[errorCode];
 
     if (!errorTextFn) {
         throwDevWarning({ message: `Error code #${errorCode} not found` });
     }
 
-    const textOutput = errorTextFn(params);
+    const textOutput = errorTextFn(cleanParams(params) as any);
     const textOutputArray = typeof textOutput === 'string' ? [textOutput] : textOutput;
 
     return textOutputArray.filter(Boolean).join('\n');

--- a/documentation/ag-grid-docs/src/utils/getErrorText.ts
+++ b/documentation/ag-grid-docs/src/utils/getErrorText.ts
@@ -1,0 +1,25 @@
+import { throwDevWarning } from '@ag-website-shared/utils/throwDevWarning';
+
+import {
+    AG_GRID_ERRORS,
+    type ErrorId,
+} from '../../../../packages/ag-grid-community/src/validation/errorMessages/errorText';
+
+export function getErrorText({
+    errorCode,
+    params = {},
+}: {
+    errorCode: ErrorId;
+    params?: Record<string, string>;
+}): string {
+    const errorTextFn = AG_GRID_ERRORS[errorCode];
+
+    if (!errorTextFn) {
+        throwDevWarning({ message: `Error code #${errorCode} not found` });
+    }
+
+    const textOutput = errorTextFn(params);
+    const textOutputArray = typeof textOutput === 'string' ? [textOutput] : textOutput;
+
+    return textOutputArray.filter(Boolean).join('\n');
+}

--- a/documentation/ag-grid-docs/src/utils/markdoc/getHeadings.ts
+++ b/documentation/ag-grid-docs/src/utils/markdoc/getHeadings.ts
@@ -198,6 +198,10 @@ async function resolvePartials({ pageName, ast, framework }: { pageName: string;
         .flat();
 }
 
+export function getTopHeading(title: string) {
+    return { slug: 'top', depth: 1, text: title };
+}
+
 /**
  * Get headings within markdoc content, resolving headings shown based on framework and adding
  * tab headings
@@ -243,7 +247,7 @@ export async function getHeadings({
         };
     });
 
-    const topHeading = { slug: 'top', depth: 1, text: title };
+    const topHeading = getTopHeading(title);
 
     const headingsWithTabs = addTabsToHeadings({ headings: renderTreeHeadings, markdocAst: ast, getTabItemSlug });
 

--- a/external/ag-website-shared/src/components/page-styles/docs.module.scss
+++ b/external/ag-website-shared/src/components/page-styles/docs.module.scss
@@ -201,3 +201,9 @@ blockquote:where(:not(:last-child)) {
 .sideMenu {
     padding-top: $spacing-size-8 + $spacing-size-1;
 }
+
+.errorPage {
+    pre {
+        background-color: rgb(254 226 226); // TODO: Find better color
+    }
+}

--- a/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
+++ b/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
@@ -1,5 +1,6 @@
 import type { ClientSideRowModelStep } from '../../interfaces/iClientSideRowModel';
 import type { Column } from '../../interfaces/iColumn';
+import { getErrorLink } from '../logging';
 
 /**
  * NOTES on setting console messages:
@@ -63,5 +64,7 @@ export function getError<TId extends ErrorId, TParams extends GetErrorParams<TId
     }
 
     const errorBody = msgOrFunc(args as any);
-    return Array.isArray(errorBody) ? errorBody : [errorBody];
+    const errorLink = getErrorLink(errorId, args);
+    const errorSuffix = `\nSee ${errorLink}`;
+    return Array.isArray(errorBody) ? (errorBody.concat(errorSuffix) as string[]) : [errorBody, errorSuffix];
 }

--- a/packages/ag-grid-community/src/validation/logging.ts
+++ b/packages/ag-grid-community/src/validation/logging.ts
@@ -55,13 +55,18 @@ function stringifyValue(value: any) {
     return output;
 }
 
-const minifiedLog = (errorNum: number, args: GetErrorParams<any>) => {
+export function getErrorLink(errorNum: ErrorId, args: GetErrorParams<any>) {
     const params = new URLSearchParams();
     Object.entries(args as any).forEach(([key, value]) => {
         params.append(key, stringifyValue(value));
     });
 
-    return `Visit ${baseDocLink}/errors/${errorNum}?${params.toString()} \n  Alternatively register the ValidationModule to see the full message in the console.`;
+    return `${baseDocLink}/errors/${errorNum}?${params.toString()}`;
+}
+
+const minifiedLog = (errorNum: ErrorId, args: GetErrorParams<any>) => {
+    const errorLink = getErrorLink(errorNum, args);
+    return `Visit ${errorLink} \n  Alternatively register the ValidationModule to see the full message in the console.`;
 };
 
 export function _logWarn<

--- a/packages/ag-grid-community/src/validation/logging.ts
+++ b/packages/ag-grid-community/src/validation/logging.ts
@@ -33,12 +33,8 @@ function getMsgOrDefault<TId extends ErrorId>(logger: LogFn, id: TId, args: GetE
 function stringifyObject(inputObj: any) {
     const object: Record<string, any> = {};
 
-    for (const prop in inputObj) {
-        if (
-            Object.prototype.hasOwnProperty.call(inputObj, prop) &&
-            typeof inputObj[prop] !== 'object' &&
-            typeof inputObj[prop] !== 'function'
-        ) {
+    for (const prop in Object.entries(inputObj)) {
+        if (typeof inputObj[prop] !== 'object' && typeof inputObj[prop] !== 'function') {
             object[prop] = inputObj[prop];
         }
     }

--- a/testing/behavioural/src/row-data-order/row-data-order.test.ts
+++ b/testing/behavioural/src/row-data-order/row-data-order.test.ts
@@ -177,7 +177,8 @@ describe('ag-grid rows-ordering', () => {
 
         expect(consoleWarnSpy).toHaveBeenCalledWith(
             'AG Grid: error #2',
-            "Duplicate node id '9' detected from getRowId callback, this could cause issues in your grid."
+            "Duplicate node id '9' detected from getRowId callback, this could cause issues in your grid.",
+            '\nSee https://www.ag-grid.com/javascript-data-grid/errors/2?nodeId=9'
         );
 
         consoleWarnSpy.mockRestore();
@@ -643,14 +644,16 @@ describe('ag-grid rows-ordering', () => {
 
             expect(consoleErrorSpy).toHaveBeenCalledWith(
                 'AG Grid: error #4',
-                'Could not find row id=jhDjSi3Ec-3, data item was not found for this id'
+                'Could not find row id=jhDjSi3Ec-3, data item was not found for this id',
+                '\nSee https://www.ag-grid.com/javascript-data-grid/errors/4?id=jhDjSi3Ec-3'
             );
 
             await executeTransactionsAsync({ update: [{ id: 'jhDjSi3Ec-4', x: 4 }] }, api);
 
             expect(consoleErrorSpy).toHaveBeenCalledWith(
                 'AG Grid: error #4',
-                'Could not find row id=jhDjSi3Ec-4, data item was not found for this id'
+                'Could not find row id=jhDjSi3Ec-4, data item was not found for this id',
+                '\nSee https://www.ag-grid.com/javascript-data-grid/errors/4?id=jhDjSi3Ec-4'
             );
 
             consoleErrorSpy.mockRestore();


### PR DESCRIPTION
## Changes

* Generate error pages on website at: `/[framework]-data-grid/errors/[code]?[params?]`
* Get errors from export of `ag-grid-community`
* Allow error pages to be extended with markdoc content in `content/errors/[code].mdoc`
* Do some transformation of objects when logging and showing the errors
* Integrate with https://github.com/ag-grid/ag-grid/pull/8705

## References

Previous work https://github.com/ag-grid/ag-grid/pull/8830