### PR TITLE
AG-12915 - Redirect to archive version of website if version of the error is different to the deployed website grid version

### DIFF
--- a/documentation/ag-grid-docs/src/constants.ts
+++ b/documentation/ag-grid-docs/src/constants.ts
@@ -133,6 +133,7 @@ function getChartsUrl() {
 export const CHARTS_SITE_URL = getChartsUrl();
 
 export const PRODUCTION_GRID_SITE_URL = 'https://ag-grid.com';
+export const GRID_ARCHIVE_BASE_URL = `${PRODUCTION_GRID_SITE_URL}/archive`;
 function calculateGridUrl() {
     if (SITE_URL == null) return;
 

--- a/documentation/ag-grid-docs/src/pages/[framework]-data-grid/errors/[code].astro
+++ b/documentation/ag-grid-docs/src/pages/[framework]-data-grid/errors/[code].astro
@@ -95,16 +95,24 @@ const headings = errorPage
 <script>
     import { getErrorText } from '@utils/getErrorText';
     import type { ErrorId } from '../../../../../../packages/ag-grid-community/src/validation/errorMessages/errorText';
+    import { VERSION } from '../../../../../../packages/ag-grid-community/src/version';
+    import { getErrorRedirectBaseUrl } from '@utils/getErrorRedirectBaseUrl';
+    import { pathJoin } from '@utils/pathJoin';
 
     // Get errorCode from url, so it doesn't need to be passed
     // in from Astro and we can import in this script
     const errorCode = parseInt(window.location.pathname.split('/').filter(Boolean).slice(-1)[0], 10) as ErrorId;
     const searchParams = new URLSearchParams(window.location.search);
-    const params = Object.fromEntries(searchParams.entries());
+    const { _version_, ...params } = Object.fromEntries(searchParams.entries());
     const errorText = getErrorText({ errorCode, params });
+    const errorRedirectBaseUrl = getErrorRedirectBaseUrl({ errorVersion: _version_, pageVersion: VERSION });
+
+    if (errorRedirectBaseUrl) {
+        const redirectUrl = pathJoin(errorRedirectBaseUrl, window.location.pathname, window.location.search);
+        window.location.replace(redirectUrl);
+    }
 
     const errorCodeTextEl = document.getElementById('errorCodeText');
-
     if (errorCodeTextEl) {
         errorCodeTextEl.textContent = errorText;
     }

--- a/documentation/ag-grid-docs/src/pages/[framework]-data-grid/errors/[code].astro
+++ b/documentation/ag-grid-docs/src/pages/[framework]-data-grid/errors/[code].astro
@@ -1,8 +1,8 @@
 ---
 import Layout from '@layouts/Layout.astro';
 import { getCollection, getEntry, type CollectionEntry } from 'astro:content';
-import type { Framework, MenuItem, MenuSection } from '@ag-grid-types';
-import { FRAMEWORKS } from '@constants';
+import type { Framework } from '@ag-grid-types';
+import { FRAMEWORKS, PRODUCTION_GRID_SITE_URL } from '@constants';
 import styles from '@ag-website-shared/components/page-styles/docs.module.scss';
 import { DocsNav } from '@ag-website-shared/components/docs-navigation/DocsNav';
 import { Header } from '@features/docs/components/Header';
@@ -15,6 +15,8 @@ import {
     type ErrorId,
 } from '../../../../../../packages/ag-grid-community/src/validation/errorMessages/errorText';
 import Note from '@ag-website-shared/components/alert/Note';
+import { getIsArchive } from '@utils/env';
+import Warning from '@ag-website-shared/components/alert/Warning';
 
 interface Params {
     framework: Framework;
@@ -71,6 +73,9 @@ const headings = errorPage
           })
       ).concat(fullErrorTextHeading)
     : [topHeading, fullErrorTextHeading];
+const isArchive = getIsArchive();
+// TODO: Update this when we have a migration page
+const migrationUrl = PRODUCTION_GRID_SITE_URL;
 ---
 
 <Layout title={title} description={description} showSearchBar={true} showDocsNav={true}>
@@ -79,6 +84,14 @@ const headings = errorPage
 
         <div id="doc-content" class:list={[styles.docPage, styles.errorPage]}>
             <Header client:load title={title} framework={framework} path={path} menuItems={docsNavData.sections} />
+            {
+                isArchive && (
+                    <Warning>
+                        You are using an older version of AG Grid. To upgrade, please see the{' '}
+                        <a href={migrationUrl}>migration guide</a>.
+                    </Warning>
+                )
+            }
             <div class={styles.pageSections}>
                 {Content ? <Content framework={framework} /> : undefined}
 

--- a/documentation/ag-grid-docs/src/utils/getErrorRedirectBaseUrl.test.ts
+++ b/documentation/ag-grid-docs/src/utils/getErrorRedirectBaseUrl.test.ts
@@ -1,0 +1,10 @@
+import { getErrorRedirectBaseUrl } from './getErrorRedirectBaseUrl';
+
+describe.each([
+    { errorVersion: '32.2.0', pageVersion: '32.2.0', output: undefined },
+    { errorVersion: '32.2.0', pageVersion: '33.0.0', output: 'https://ag-grid.com/archive/32.2.0' },
+])('getErrorRedirectBaseUrl', ({ errorVersion, pageVersion, output }) => {
+    it(`errorVersion: ${errorVersion} and pageVersion: ${pageVersion}, outputs ${output}`, () => {
+        expect(getErrorRedirectBaseUrl({ errorVersion, pageVersion })).toEqual(output);
+    });
+});

--- a/documentation/ag-grid-docs/src/utils/getErrorRedirectBaseUrl.ts
+++ b/documentation/ag-grid-docs/src/utils/getErrorRedirectBaseUrl.ts
@@ -1,0 +1,14 @@
+import { GRID_ARCHIVE_BASE_URL } from '@constants';
+
+interface Params {
+    errorVersion: string;
+    pageVersion: string;
+}
+
+export function getErrorRedirectBaseUrl({ errorVersion, pageVersion }: Params) {
+    if (errorVersion === pageVersion) {
+        return;
+    }
+
+    return `${GRID_ARCHIVE_BASE_URL}/${errorVersion}`;
+}


### PR DESCRIPTION
From the next major release v33.0.0 onwards, an error will link to the production website, and if it isn't the same version as production, it will redirect to the archive version of the website.