### PR TITLE
Check that index is integer in ensureIndexVisible

### DIFF
--- a/packages/ag-grid-community/src/gridBodyComp/gridBodyScrollFeature.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/gridBodyScrollFeature.ts
@@ -500,7 +500,7 @@ export class GridBodyScrollFeature extends BeanStub {
 
         const rowCount = this.rowModel.getRowCount();
 
-        if (typeof index !== 'number' || index < 0 || index >= rowCount) {
+        if (typeof index !== 'number' || !Number.isInteger(index) || index < 0 || index >= rowCount) {
             _warn(88, { index });
             return;
         }


### PR DESCRIPTION
Avoids an unsightly "TypeError: rowNode is undefined" from inside AG Grid code when called with nonsensical numbers like 2.5 or NaN.

I ran into this when passing accidentally passing on a NaN result from `parseInt(null, 10)`. That's of course a silly thing to do, but it took me a while to figure out what was actually wrong.

On second thought, at least the Type Error comes with a stack trace, which is great for finding the offending piece of code. Maybe for the best of both worlds you should consider logging a trace (`console.trace()`?) for these sorts of contract violations?

Anyway, here's how to reproduce:
https://plnkr.co/edit/Cn2df4fmKQGIi1g1?open=index.tsx
![image](https://github.com/user-attachments/assets/53a33f64-4b85-4fef-9d9e-27cdb9f68aff)

I haven't actually tried to run or even build this code, so proceed with caution.
