### PR TITLE
AG-13078 - Update JS/TS html with appropriate dark mode class

### DIFF
--- a/external/ag-website-shared/src/components/codeSandbox/components/OpenInCodeSandbox.tsx
+++ b/external/ag-website-shared/src/components/codeSandbox/components/OpenInCodeSandbox.tsx
@@ -1,9 +1,11 @@
 import type { InternalFramework } from '@ag-grid-types';
 import { OpenInCTA } from '@ag-website-shared/components/open-in-cta/OpenInCTA';
 import { cleanIndexHtml } from '@ag-website-shared/utils/cleanIndexHtml';
+import { updateHtmlWithDarkMode } from '@ag-website-shared/utils/updateHtmlWithDarkMode';
 import type { FileContents } from '@features/example-generator/types';
 import { stripOutDarkModeCode } from '@features/example-runner/components/CodeViewer';
 import { fetchTextFile } from '@utils/fetchTextFile';
+import { useDarkmode } from '@utils/hooks/useDarkmode';
 import type { FunctionComponent } from 'react';
 
 import { openCodeSandbox } from '../utils/codeSandbox';
@@ -27,12 +29,15 @@ export const OpenInCodeSandbox: FunctionComponent<Props> = ({
     packageJson,
     isDev,
 }) => {
+    const [isDarkMode] = useDarkmode();
+
     return (
         <OpenInCTA
             type="codesandbox"
             onClick={async () => {
                 const html = await fetchTextFile(htmlUrl);
-                const indexHtml = isDev ? cleanIndexHtml(html) : html;
+                const cleanedHtml = isDev ? cleanIndexHtml(html) : html;
+                const indexHtml = updateHtmlWithDarkMode({ html: cleanedHtml, isDarkMode });
                 const localFiles = { ...files };
                 stripOutDarkModeCode(localFiles);
                 const sandboxFiles = {

--- a/external/ag-website-shared/src/components/plunkr/components/OpenInPlunkr.tsx
+++ b/external/ag-website-shared/src/components/plunkr/components/OpenInPlunkr.tsx
@@ -1,8 +1,10 @@
 import { OpenInCTA } from '@ag-website-shared/components/open-in-cta/OpenInCTA';
 import { cleanIndexHtml } from '@ag-website-shared/utils/cleanIndexHtml';
+import { updateHtmlWithDarkMode } from '@ag-website-shared/utils/updateHtmlWithDarkMode';
 import type { FileContents } from '@features/example-generator/types';
 import { stripOutDarkModeCode } from '@features/example-runner/components/CodeViewer';
 import { fetchTextFile } from '@utils/fetchTextFile';
+import { useDarkmode } from '@utils/hooks/useDarkmode';
 import type { FunctionComponent } from 'react';
 
 import { openPlunker } from '../utils/plunkr';
@@ -26,12 +28,15 @@ export const OpenInPlunkr: FunctionComponent<Props> = ({
     fileToOpen,
     isDev,
 }) => {
+    const [isDarkMode] = useDarkmode();
+
     return (
         <OpenInCTA
             type="plunker"
             onClick={async () => {
                 const html = await fetchTextFile(htmlUrl);
-                const indexHtml = isDev ? cleanIndexHtml(html) : html;
+                const cleanedHtml = isDev ? cleanIndexHtml(html) : html;
+                const indexHtml = updateHtmlWithDarkMode({ html: cleanedHtml, isDarkMode });
                 const localFiles = { ...files };
                 stripOutDarkModeCode(localFiles);
                 const plunkrExampleFiles = {

--- a/external/ag-website-shared/src/utils/updateHtmlWithDarkMode.ts
+++ b/external/ag-website-shared/src/utils/updateHtmlWithDarkMode.ts
@@ -1,0 +1,22 @@
+interface Params {
+    html: string;
+    isDarkMode: boolean;
+}
+
+/*
+ * Update given html with appropriate dark mode class
+ *
+ * Useful for JavaScript and Typescript html files, where
+ * the ag-theme html class is in the html and not generated
+ * by JavaScript
+ */
+export const updateHtmlWithDarkMode = ({ html, isDarkMode }: Params) => {
+    if (!isDarkMode) {
+        return html;
+    }
+
+    const [, htmlClasses] = html.match(/class="(.*)"/) || [];
+    const agClass = htmlClasses?.split(' ').find((c) => c.startsWith('ag-theme'));
+
+    return agClass ? html.replace(agClass, `${agClass}-dark`) : html;
+};


### PR DESCRIPTION
Framework examples get dark mode class by injecting dark mode JS, but JS/TS can't use that because dark mode is determined by the class in the html