### PR TITLE
RTI-2366 - Fix framework selector in docs

### DIFF
--- a/documentation/ag-grid-docs/src/components/framework-selector-inside-doc/FrameworkSelectorInsideDocs.tsx
+++ b/documentation/ag-grid-docs/src/components/framework-selector-inside-doc/FrameworkSelectorInsideDocs.tsx
@@ -15,7 +15,12 @@ import styles from './FrameworkSelectorInsideDocs.module.scss';
 interface Props {
     path: string;
     currentFramework: Framework;
-    menuItems: MenuItem[];
+    /**
+     * Menu items used to check if the current page exists for the framework
+     * to be changed to. If not provided, will just go to the page without
+     * checks.
+     */
+    menuItems?: MenuItem[];
 }
 
 export const FrameworkSelectorInsideDocs = ({ path, currentFramework, menuItems }: Props) => {
@@ -33,7 +38,7 @@ export const FrameworkSelectorInsideDocs = ({ path, currentFramework, menuItems 
 
     const handleFrameworkChange = (selectedFramework: Framework) => {
         const pageName = getPageNameFromPath(path);
-        const menuItem = getMenuItemFromPageName({ menuItems: menuItems, pageName });
+        const menuItem = menuItems && getMenuItemFromPageName({ menuItems, pageName });
         let newUrl = getNewFrameworkPath({
             path,
             currentFramework,


### PR DESCRIPTION
Broke on license install page, because it wasn't passing in the menu items. Not required there since the page is generated for all frameworks

---

Cherry picked from https://github.com/ag-grid/ag-grid/commit/99276c4993500d6b9bef709627fac27c01ece821