### PR TITLE
RTI-2376 fix next link in docs

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/grouping-custom-filtering/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/grouping-custom-filtering/index.mdoc
@@ -126,4 +126,4 @@ The following example demonstrates filtering with row groups. Note the following
 
 ## Next Up
 
-Continue to the next section to learn about [Opening Groups](./grouping-opening-groups/).
+Continue to the next section to learn about [Selecting Groups](./grouping-row-selection/).


### PR DESCRIPTION
Actual: Links to Opening Groups
Expected: Links to Selecting Groups