### PR TITLE
AG-12272 csrm immutable row data refactor

### DIFF
--- a/packages/ag-grid-community/src/clientSideRowModel/abstractClientSideNodeManager.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/abstractClientSideNodeManager.ts
@@ -72,7 +72,7 @@ export abstract class AbstractClientSideNodeManager<TData = any>
 
     public deactivate(): void {
         if (this.rootNode) {
-            this.setNewRowData([]);
+            this.allNodesMap = {};
             this.rootNode = null!;
         }
     }

--- a/packages/ag-grid-community/src/clientSideRowModel/abstractClientSideNodeManager.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/abstractClientSideNodeManager.ts
@@ -6,6 +6,7 @@ import type {
     ClientSideNodeManagerUpdateRowDataResult,
     IClientSideNodeManager,
 } from '../interfaces/iClientSideNodeManager';
+import type { RefreshModelParams } from '../interfaces/iClientSideRowModel';
 import type { RowDataTransaction } from '../interfaces/rowDataTransaction';
 import { _exists } from '../utils/generic';
 import { _error, _warn } from '../validation/logging';
@@ -123,7 +124,7 @@ export abstract class AbstractClientSideNodeManager<TData = any>
         this.rootNode!.allLeafChildren = rowData?.map((dataItem, index) => this.createRowNode(dataItem, index)) ?? [];
     }
 
-    public setImmutableRowData(rowData: TData[]): ClientSideNodeManagerUpdateRowDataResult<TData> {
+    public setImmutableRowData(params: RefreshModelParams<TData>, rowData: TData[]): void {
         // convert the setRowData data into a transaction object by working out adds, removes and updates
 
         const rowDataTransaction = this.createTransactionForRowData(rowData);
@@ -131,14 +132,16 @@ export abstract class AbstractClientSideNodeManager<TData = any>
         // Apply the transaction
         const result = this.updateRowData(rowDataTransaction);
 
+        let rowsOrderChanged = false;
+
         // If true, we will not apply the new order specified in the rowData, but keep the old order.
-        const suppressSortOrder = this.gos.get('suppressMaintainUnsortedOrder');
-        if (!suppressSortOrder) {
+        if (!this.gos.get('suppressMaintainUnsortedOrder')) {
             // we need to reorder the nodes to match the new data order
-            result.rowsOrderChanged = this.updateRowOrderFromRowData(rowData);
+            rowsOrderChanged = this.updateRowOrderFromRowData(rowData);
         }
 
-        return result;
+        params.rowNodeTransactions = [result.rowNodeTransaction];
+        params.rowNodesOrderChanged = result.rowsInserted || rowsOrderChanged;
     }
 
     public updateRowData(rowDataTran: RowDataTransaction<TData>): ClientSideNodeManagerUpdateRowDataResult<TData> {
@@ -147,7 +150,6 @@ export abstract class AbstractClientSideNodeManager<TData = any>
         const updateRowDataResult: ClientSideNodeManagerUpdateRowDataResult<TData> = {
             rowNodeTransaction: { remove: [], update: [], add: [] },
             rowsInserted: false,
-            rowsOrderChanged: false,
         };
 
         const nodesToUnselect: RowNode[] = [];

--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
@@ -19,7 +19,6 @@ import {
 import type { IClientSideNodeManager } from '../interfaces/iClientSideNodeManager';
 import type {
     ClientSideRowModelStage,
-    ClientSideRowModelStep,
     IClientSideRowModel,
     RefreshModelParams,
 } from '../interfaces/iClientSideRowModel';
@@ -737,17 +736,6 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         // return true if we are only doing update transactions
         const transactionsContainUpdatesOnly = !transWithAddsOrDeletes;
         return transactionsContainUpdatesOnly;
-    }
-
-    public refreshModelApi(step: ClientSideRowModelStep | undefined): void {
-        if (!step || step === 'everything') {
-            step = 'group';
-        }
-        this.refreshModel({
-            step,
-            keepRenderedRows: true,
-            animate: !this.gos.get('suppressAnimationFrame'),
-        });
     }
 
     public refreshModel(params: RefreshModelParams): void {

--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
@@ -359,8 +359,6 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
                 params.animate = !this.gos.get('suppressAnimationFrame');
 
                 this.nodeManager.setImmutableRowData(params, newRowData);
-
-                params.changedPath ??= this.createChangePath(params.rowNodeTransactions);
             } else {
                 params.newData = true;
 

--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
@@ -297,6 +297,10 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
     }
 
     private onPropChange(properties: (keyof GridOptions)[]): void {
+        if (!this.rootNode) {
+            return; // Destroyed.
+        }
+
         const gos = this.gos;
 
         const changedProps = new Set(properties);
@@ -1394,6 +1398,7 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
 
         // Forcefully deallocate memory
         this.clearHighlightedRow();
+        this.hasStarted = false;
         this.rootNode = null;
         this.nodeManager = null!;
         this.rowDataTransactionBatch = null;

--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
@@ -342,6 +342,7 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
 
             const immutable =
                 !needFullReload &&
+                this.hasStarted &&
                 !this.isEmpty() &&
                 newRowData.length > 0 &&
                 gos.exists('getRowId') &&
@@ -350,14 +351,12 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
                 !gos.get('resetRowDataOnUpdate');
 
             if (immutable) {
-                const updateRowDataResult = this.nodeManager.setImmutableRowData(newRowData);
-
-                const { rowNodeTransaction, rowsInserted, rowsOrderChanged } = updateRowDataResult;
                 params.keepRenderedRows = true;
                 params.animate = !this.gos.get('suppressAnimationFrame');
-                params.rowNodeTransactions = [rowNodeTransaction];
-                params.rowNodesOrderChanged = rowsInserted || rowsOrderChanged;
-                params.changedPath = this.createChangePath(params.rowNodeTransactions);
+
+                this.nodeManager.setImmutableRowData(params, newRowData);
+
+                params.changedPath ??= this.createChangePath(params.rowNodeTransactions);
             } else {
                 params.newData = true;
 

--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
@@ -218,20 +218,19 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         //                       - the application would change these functions, far more likely the functions were
         //                       - non memoised correctly.
 
-        this.addManagedPropertyListeners(
-            [
-                'rowData',
-                'treeData',
-                'treeDataChildrenField',
-                ...this.orderedStages.flatMap(({ refreshProps }) => [...refreshProps]),
-            ],
-            (params) => {
-                const properties = params.changeSet?.properties;
-                if (properties) {
-                    this.onPropChange(properties);
-                }
+        const allProps: (keyof GridOptions)[] = [
+            'rowData',
+            'treeData',
+            'treeDataChildrenField',
+            ...this.orderedStages.flatMap(({ refreshProps }) => [...refreshProps]),
+        ];
+
+        this.addManagedPropertyListeners(allProps, (params) => {
+            const properties = params.changeSet?.properties;
+            if (properties) {
+                this.onPropChange(properties);
             }
-        );
+        });
 
         this.addManagedPropertyListener('rowHeight', () => this.resetRowHeights());
     }

--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModelApi.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModelApi.ts
@@ -11,7 +11,17 @@ export function onGroupExpandedOrCollapsed(beans: BeanCollection): void {
 }
 
 export function refreshClientSideRowModel(beans: BeanCollection, step?: ClientSideRowModelStep): void {
-    _getClientSideRowModel(beans)?.refreshModelApi(step);
+    const clientSideRowModel = _getClientSideRowModel(beans);
+    if (clientSideRowModel) {
+        if (!step || step === 'everything') {
+            step = 'group';
+        }
+        clientSideRowModel.refreshModel({
+            step,
+            keepRenderedRows: true,
+            animate: !beans.gos.get('suppressAnimationFrame'),
+        });
+    }
 }
 
 export function isRowDataEmpty(beans: BeanCollection): boolean {

--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModelApi.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModelApi.ts
@@ -11,7 +11,7 @@ export function onGroupExpandedOrCollapsed(beans: BeanCollection): void {
 }
 
 export function refreshClientSideRowModel(beans: BeanCollection, step?: ClientSideRowModelStep): void {
-    _getClientSideRowModel(beans)?.refreshModel(step === 'everything' ? 'group' : step);
+    _getClientSideRowModel(beans)?.refreshModelApi(step);
 }
 
 export function isRowDataEmpty(beans: BeanCollection): boolean {

--- a/packages/ag-grid-community/src/clientSideRowModel/flattenStage.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/flattenStage.ts
@@ -28,6 +28,7 @@ export class FlattenStage extends BeanStub implements IRowNodeStage, NamedBean {
         'groupRemoveSingleChildren',
         'groupRemoveLowestSingleChildren',
         'groupTotalRow',
+        'masterDetail',
     ]);
     public step: ClientSideRowModelStage = 'map';
 

--- a/packages/ag-grid-community/src/eventTypes.ts
+++ b/packages/ag-grid-community/src/eventTypes.ts
@@ -149,6 +149,7 @@ export const _INTERNAL_EVENTS = [
     'recalculateRowBounds',
     'stickyTopOffsetChanged',
     'overlayExclusiveChanged',
+    'beforeRefreshModel',
 ] as const;
 
 export const _ALL_EVENTS = [..._PUBLIC_EVENTS, ..._INTERNAL_EVENTS] as const;

--- a/packages/ag-grid-community/src/events.ts
+++ b/packages/ag-grid-community/src/events.ts
@@ -54,7 +54,6 @@ export type AgEventTypeParams<TData = any, TContext = any> = BuildEventTypeMap<
         toolPanelVisibleChanged: ToolPanelVisibleChangedEvent<TData, TContext>;
         toolPanelSizeChanged: ToolPanelSizeChangedEvent<TData, TContext>;
         modelUpdated: ModelUpdatedEvent<TData, TContext>;
-        beforeRefreshModel: BeforeRefreshModelEvent<TData, TContext>;
         cutStart: CutStartEvent<TData, TContext>;
         cutEnd: CutEndEvent<TData, TContext>;
         pasteStart: PasteStartEvent<TData, TContext>;
@@ -119,6 +118,7 @@ export type AgEventTypeParams<TData = any, TContext = any> = BuildEventTypeMap<
         rowDragEnd: RowDragEndEvent<TData, TContext>;
         rowDragCancel: RowDragCancelEvent<TData, TContext>;
         // Internal events
+        beforeRefreshModel: BeforeRefreshModelEvent<TData, TContext>;
         scrollbarWidthChanged: ScrollbarWidthChangedEvent<TData, TContext>;
         keyShortcutChangedCellStart: KeyShortcutChangedCellStartEvent<TData, TContext>;
         keyShortcutChangedCellEnd: KeyShortcutChangedCellEndEvent<TData, TContext>;

--- a/packages/ag-grid-community/src/events.ts
+++ b/packages/ag-grid-community/src/events.ts
@@ -7,6 +7,7 @@ import type { FilterRequestSource } from './filter/iColumnFilter';
 import type { CellRange, CellRangeParams } from './interfaces/IRangeService';
 import type { GridState } from './interfaces/gridState';
 import type { ChartType } from './interfaces/iChartOptions';
+import type { RefreshModelParams } from './interfaces/iClientSideRowModel';
 import type { Column, ColumnEventName, ColumnGroup, ColumnPinnedType, ProvidedColumnGroup } from './interfaces/iColumn';
 import type { AgGridCommon, WithoutGridCommon } from './interfaces/iCommon';
 import type { BuildEventTypeMap } from './interfaces/iEventEmitter';
@@ -53,6 +54,7 @@ export type AgEventTypeParams<TData = any, TContext = any> = BuildEventTypeMap<
         toolPanelVisibleChanged: ToolPanelVisibleChangedEvent<TData, TContext>;
         toolPanelSizeChanged: ToolPanelSizeChangedEvent<TData, TContext>;
         modelUpdated: ModelUpdatedEvent<TData, TContext>;
+        beforeRefreshModel: BeforeRefreshModelEvent<TData, TContext>;
         cutStart: CutStartEvent<TData, TContext>;
         cutEnd: CutEndEvent<TData, TContext>;
         pasteStart: PasteStartEvent<TData, TContext>;
@@ -270,8 +272,12 @@ export interface DisplayedColumnsChangedEvent<TData = any, TContext = any>
 }
 
 export interface RowDataUpdatedEvent<TData = any, TContext = any>
-    extends AgGlobalEvent<'rowDataUpdated', TData, TContext> {
-    transactions?: RowNodeTransaction[];
+    extends AgGlobalEvent<'rowDataUpdated', TData, TContext> {}
+
+/** Raised by ClientSideRowModel */
+export interface BeforeRefreshModelEvent<TData = any, TContext = any>
+    extends AgGlobalEvent<'beforeRefreshModel', TData, TContext> {
+    params: RefreshModelParams<TData>;
 }
 
 export interface RowDataUpdateStartedEvent<TData = any, TContext = any>

--- a/packages/ag-grid-community/src/interfaces/iClientSideNodeManager.ts
+++ b/packages/ag-grid-community/src/interfaces/iClientSideNodeManager.ts
@@ -1,5 +1,5 @@
 import type { RowNode } from '../entities/rowNode';
-import type { ChangedPath } from '../main-umd-noStyles';
+import type { RefreshModelParams } from './iClientSideRowModel';
 import type { RowDataTransaction } from './rowDataTransaction';
 import type { RowNodeTransaction } from './rowNodeTransaction';
 
@@ -30,17 +30,9 @@ export interface IClientSideNodeManager<TData = any> {
 
     setNewRowData(rowData: TData[]): void;
 
-    setImmutableRowData(rowData: TData[]): ClientSideNodeManagerUpdateRowDataResult<TData> | null;
+    setImmutableRowData(rowData: TData[]): ClientSideNodeManagerUpdateRowDataResult<TData>;
 
     updateRowData(rowDataTran: RowDataTransaction<TData>): ClientSideNodeManagerUpdateRowDataResult<TData>;
 
-    onTreeDataChanged?(): void;
-
-    afterColumnsChanged?(): void;
-
-    commitTransactions?(
-        transactions: RowNodeTransaction<TData>[],
-        changedPath: ChangedPath | undefined,
-        rowNodesOrderChanged: boolean
-    ): void;
+    refreshModel?(params: RefreshModelParams<TData>): void;
 }

--- a/packages/ag-grid-community/src/interfaces/iClientSideNodeManager.ts
+++ b/packages/ag-grid-community/src/interfaces/iClientSideNodeManager.ts
@@ -12,9 +12,6 @@ export interface ClientSideNodeManagerUpdateRowDataResult<TData = any> {
 
     /** True if at least one row was inserted (and not just appended) */
     rowsInserted: boolean;
-
-    /** True if the order of rows has changed */
-    rowsOrderChanged: boolean;
 }
 
 export interface IClientSideNodeManager<TData = any> {
@@ -30,7 +27,7 @@ export interface IClientSideNodeManager<TData = any> {
 
     setNewRowData(rowData: TData[]): void;
 
-    setImmutableRowData(rowData: TData[]): ClientSideNodeManagerUpdateRowDataResult<TData>;
+    setImmutableRowData(params: RefreshModelParams<TData>, rowData: TData[]): void;
 
     updateRowData(rowDataTran: RowDataTransaction<TData>): ClientSideNodeManagerUpdateRowDataResult<TData>;
 

--- a/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
+++ b/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
@@ -1,3 +1,4 @@
+import type { GridOptions } from '../entities/gridOptions';
 import type { RowHighlightPosition, RowNode } from '../entities/rowNode';
 import type { ChangedPath } from '../utils/changedPath';
 import type { IRowModel } from './iRowModel';
@@ -33,7 +34,8 @@ export interface IClientSideRowModel<TData = any> extends IRowModel {
 
     onRowGroupOpened(): void;
     updateRowData(rowDataTran: RowDataTransaction<TData>): RowNodeTransaction<TData> | null;
-    refreshModel(paramsOrStep: RefreshModelParams | ClientSideRowModelStage | undefined): void;
+    refreshModelApi(step: ClientSideRowModelStep | undefined): void;
+    refreshModel(params: RefreshModelParams): void;
     forEachLeafNode(callback: (node: RowNode, index: number) => void): void;
     forEachNodeAfterFilter(callback: (node: RowNode, index: number) => void, includeFooterNodes?: boolean): void;
     forEachNodeAfterFilterAndSort(callback: (node: RowNode, index: number) => void, includeFooterNodes?: boolean): void;
@@ -58,21 +60,37 @@ export interface IClientSideRowModel<TData = any> extends IRowModel {
 export interface RefreshModelParams<TData = any> {
     // how much of the pipeline to execute
     step: ClientSideRowModelStage;
+
+    // The set of changed grid options, if any
+    changedProps?: Set<keyof GridOptions<TData>>;
+
+    // The changedPath, if any
+    changedPath?: ChangedPath;
+
     // if NOT new data, then this flag tells grid to check if rows already
     // exist for the nodes (matching by node id) and reuses the row if it does.
     keepRenderedRows?: boolean;
+
     // if true, rows that are kept are animated to the new position
     animate?: boolean;
+
     // if doing delta updates, this has the changes that were done
     rowNodeTransactions?: RowNodeTransaction<TData>[];
+
     // true if the order of root.allLeafChildren has changed.
     // This can happen if order of root.allLeafChildren is updated or rows are inserted (and not just appended at the end)
     rowNodesOrderChanged?: boolean;
-    // true user called setRowData() (or a new page in pagination). the grid scrolls
+
+    // true if user called setRowData() (or a new page in pagination). the grid scrolls
     // back to the top when this is true.
     newData?: boolean;
+
+    // true if the row data changed, due to a setRowData, immutable row data or a transaction.
+    rowDataUpdated?: boolean;
+
     // true if this update is due to columns changing, ie no rows were changed
     afterColumnsChanged?: boolean;
+
     // true if all we did is changed row height, data still the same, no need to clear the undo/redo stacks
     keepUndoRedoStack?: boolean;
 }

--- a/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
+++ b/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
@@ -63,8 +63,6 @@ export interface RefreshModelParams<TData = any> {
     keepRenderedRows?: boolean;
     // if true, rows that are kept are animated to the new position
     animate?: boolean;
-    // if true, then rows we are editing will be kept
-    keepEditingRows?: boolean;
     // if doing delta updates, this has the changes that were done
     rowNodeTransactions?: RowNodeTransaction<TData>[];
     // true if the order of root.allLeafChildren has changed.

--- a/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
+++ b/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
@@ -34,7 +34,6 @@ export interface IClientSideRowModel<TData = any> extends IRowModel {
 
     onRowGroupOpened(): void;
     updateRowData(rowDataTran: RowDataTransaction<TData>): RowNodeTransaction<TData> | null;
-    refreshModelApi(step: ClientSideRowModelStep | undefined): void;
     refreshModel(params: RefreshModelParams): void;
     forEachLeafNode(callback: (node: RowNode, index: number) => void): void;
     forEachNodeAfterFilter(callback: (node: RowNode, index: number) => void, includeFooterNodes?: boolean): void;

--- a/packages/ag-grid-enterprise/src/masterDetail/masterDetailService.ts
+++ b/packages/ag-grid-enterprise/src/masterDetail/masterDetailService.ts
@@ -1,12 +1,12 @@
 import type {
     BeanCollection,
     BeanName,
+    BeforeRefreshModelEvent,
     IColsService,
     IMasterDetailService,
     IRowModel,
     NamedBean,
     RowCtrl,
-    RowDataUpdatedEvent,
     RowNodeTransaction,
 } from 'ag-grid-community';
 import { RowNode, _exists } from 'ag-grid-community';
@@ -42,32 +42,34 @@ export class MasterDetailService extends BeanStub implements NamedBean, IMasterD
     public postConstruct(): void {
         if (_isClientSideRowModel(this.gos)) {
             this.enabled = this.isEnabled();
-            this.addManagedPropertyListeners(['treeData', 'masterDetail'], this.enabledUpdated.bind(this));
-            this.addManagedEventListeners({ rowDataUpdated: this.rowDataUpdated.bind(this) });
+            this.addManagedEventListeners({ beforeRefreshModel: this.onRefreshModel.bind(this) });
         }
     }
 
-    private enabledUpdated() {
-        const enabled = this.isEnabled();
-        if (this.enabled !== enabled) {
-            if (this.setMasters(null)) {
-                _getClientSideRowModel(this.beans)?.refreshModel({ step: 'map' });
+    private onRefreshModel({ params }: BeforeRefreshModelEvent) {
+        const changedProps = params.changedProps;
+        if (changedProps) {
+            if (changedProps.has('masterDetail') || changedProps.has('treeData')) {
+                const enabled = this.isEnabled();
+                if (this.enabled !== enabled) {
+                    this.setMasters(null);
+                    return;
+                }
             }
         }
+
+        if (params.rowDataUpdated) {
+            this.setMasters(params.rowNodeTransactions);
+        }
     }
 
-    private rowDataUpdated({ transactions }: RowDataUpdatedEvent) {
-        this.setMasters(transactions);
-    }
-
-    private setMasters(transactions: RowNodeTransaction[] | null | undefined): boolean {
+    private setMasters(transactions: RowNodeTransaction[] | null | undefined): void {
         const enabled = this.isEnabled();
         this.enabled = enabled;
 
         const gos = this.gos;
         const isRowMaster = gos.get('isRowMaster');
         const groupDefaultExpanded = gos.get('groupDefaultExpanded');
-        let rowsChanged = false;
 
         const setMaster = (row: RowNode, created: boolean, updated: boolean) => {
             const oldMaster = row.master;
@@ -101,7 +103,6 @@ export class MasterDetailService extends BeanStub implements NamedBean, IMasterD
 
             if (newMaster !== oldMaster) {
                 row.master = newMaster;
-                rowsChanged ||= !newMaster !== !oldMaster;
 
                 row.dispatchRowEvent('masterChanged');
             }
@@ -125,8 +126,6 @@ export class MasterDetailService extends BeanStub implements NamedBean, IMasterD
                 }
             }
         }
-
-        return rowsChanged;
     }
 
     /** Used by flatten stage to get or create a detail node from a master node */

--- a/packages/ag-grid-enterprise/src/masterDetail/masterDetailService.ts
+++ b/packages/ag-grid-enterprise/src/masterDetail/masterDetailService.ts
@@ -42,19 +42,16 @@ export class MasterDetailService extends BeanStub implements NamedBean, IMasterD
     public postConstruct(): void {
         if (_isClientSideRowModel(this.gos)) {
             this.enabled = this.isEnabled();
-            this.addManagedEventListeners({ beforeRefreshModel: this.onRefreshModel.bind(this) });
+            this.addManagedEventListeners({ beforeRefreshModel: this.beforeRefreshModel.bind(this) });
         }
     }
 
-    private onRefreshModel({ params }: BeforeRefreshModelEvent) {
-        const changedProps = params.changedProps;
-        if (changedProps) {
-            if (changedProps.has('masterDetail') || changedProps.has('treeData')) {
-                const enabled = this.isEnabled();
-                if (this.enabled !== enabled) {
-                    this.setMasters(null);
-                    return;
-                }
+    private beforeRefreshModel({ params }: BeforeRefreshModelEvent) {
+        if (params.changedProps) {
+            const enabled = this.isEnabled();
+            if (this.enabled !== enabled) {
+                this.setMasters(null);
+                return;
             }
         }
 

--- a/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
@@ -85,9 +85,9 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
         super.destroy();
 
         // Forcefully deallocate memory
-        this.treeRoot = null!;
-        this.oldGroupDisplayColIds = null!;
-        this.rowsPendingDestruction = null!;
+        this.treeRoot = null;
+        this.rowsPendingDestruction = null;
+        this.oldGroupDisplayColIds = '';
     }
 
     public override deactivate(): void {
@@ -103,6 +103,7 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
         this.commitDestroyedRows();
 
         super.deactivate();
+        this.treeRoot = null;
     }
 
     /** Called by ClientSideRowModel if group data need to be recomputed due to group columns change */

--- a/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
@@ -519,7 +519,7 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
     }
 
     public refreshModel(params: RefreshModelParams<TData>): void {
-        if (params.afterColumnsChanged && !params.newData) {
+        if (params.afterColumnsChanged) {
             // Check if group data need to be recomputed due to group columns change
 
             if (this.gos.get('treeData')) {

--- a/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
@@ -108,16 +108,6 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
         this.oldGroupDisplayColIds = '';
     }
 
-    private checkAllGroupDataAfterColsChanged(rowNodes: RowNode[] | null | undefined) {
-        if (rowNodes) {
-            for (let i = 0, len = rowNodes.length ?? 0; i < len; ++i) {
-                const rowNode = rowNodes[i];
-                this.setGroupData(rowNode, rowNode.treeNode?.key ?? rowNode.key ?? rowNode.id!);
-                this.checkAllGroupDataAfterColsChanged(rowNode.childrenAfterGroup);
-            }
-        }
-    }
-
     /** Add or updates the row to a non-root node, preparing the tree correctly for the commit. */
     protected treeSetRow(node: TreeNode, newRow: RowNode, update: boolean): void {
         const { level, row: oldRow } = node;
@@ -532,8 +522,7 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
         if (params.afterColumnsChanged && !params.newData) {
             // Check if group data need to be recomputed due to group columns change
 
-            const rootNode = this.rootNode;
-            if (rootNode && this.gos.get('treeData')) {
+            if (this.gos.get('treeData')) {
                 const newGroupDisplayColIds =
                     this.beans.showRowGroupCols
                         ?.getShowRowGroupCols()
@@ -544,8 +533,13 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
                 // (regardless of tree data or row grouping)
                 if (this.oldGroupDisplayColIds !== newGroupDisplayColIds) {
                     this.oldGroupDisplayColIds = newGroupDisplayColIds;
-
-                    this.checkAllGroupDataAfterColsChanged(rootNode.childrenAfterGroup);
+                    const rowNodes = this.rootNode?.childrenAfterGroup;
+                    if (rowNodes) {
+                        for (let i = 0, len = rowNodes.length ?? 0; i < len; ++i) {
+                            const rowNode = rowNodes[i];
+                            this.setGroupData(rowNode, rowNode.treeNode?.key ?? rowNode.key ?? rowNode.id!);
+                        }
+                    }
                 }
             } else {
                 this.oldGroupDisplayColIds = '';

--- a/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
@@ -528,31 +528,28 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
         }
     }
 
-    /** Called by ClientSideRowModel if group data need to be recomputed due to group columns change */
-    private afterColumnsChanged(): void {
-        const rootNode = this.rootNode;
-        if (rootNode && this.gos.get('treeData')) {
-            const newGroupDisplayColIds =
-                this.beans.showRowGroupCols
-                    ?.getShowRowGroupCols()
-                    ?.map((c) => c.getId())
-                    .join('-') ?? '';
-
-            // if the group display cols have changed, then we need to update rowNode.groupData
-            // (regardless of tree data or row grouping)
-            if (this.oldGroupDisplayColIds !== newGroupDisplayColIds) {
-                this.oldGroupDisplayColIds = newGroupDisplayColIds;
-
-                this.checkAllGroupDataAfterColsChanged(rootNode.childrenAfterGroup);
-            }
-        } else {
-            this.oldGroupDisplayColIds = '';
-        }
-    }
-
     public refreshModel(params: RefreshModelParams<TData>): void {
         if (params.afterColumnsChanged && !params.newData) {
-            this.afterColumnsChanged();
+            // Check if group data need to be recomputed due to group columns change
+
+            const rootNode = this.rootNode;
+            if (rootNode && this.gos.get('treeData')) {
+                const newGroupDisplayColIds =
+                    this.beans.showRowGroupCols
+                        ?.getShowRowGroupCols()
+                        ?.map((c) => c.getId())
+                        .join('-') ?? '';
+
+                // if the group display cols have changed, then we need to update rowNode.groupData
+                // (regardless of tree data or row grouping)
+                if (this.oldGroupDisplayColIds !== newGroupDisplayColIds) {
+                    this.oldGroupDisplayColIds = newGroupDisplayColIds;
+
+                    this.checkAllGroupDataAfterColsChanged(rootNode.childrenAfterGroup);
+                }
+            } else {
+                this.oldGroupDisplayColIds = '';
+            }
         }
     }
 }

--- a/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
@@ -519,31 +519,33 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
     }
 
     public refreshModel(params: RefreshModelParams<TData>): void {
-        if (params.afterColumnsChanged) {
-            // Check if group data need to be recomputed due to group columns change
+        if (!params.afterColumnsChanged) {
+            return; // nothing to do
+        }
 
-            if (this.gos.get('treeData')) {
-                const newGroupDisplayColIds =
-                    this.beans.showRowGroupCols
-                        ?.getShowRowGroupCols()
-                        ?.map((c) => c.getId())
-                        .join('-') ?? '';
+        // Check if group data need to be recomputed due to group columns change
 
-                // if the group display cols have changed, then we need to update rowNode.groupData
-                // (regardless of tree data or row grouping)
-                if (this.oldGroupDisplayColIds !== newGroupDisplayColIds) {
-                    this.oldGroupDisplayColIds = newGroupDisplayColIds;
-                    const rowNodes = this.rootNode?.childrenAfterGroup;
-                    if (rowNodes) {
-                        for (let i = 0, len = rowNodes.length ?? 0; i < len; ++i) {
-                            const rowNode = rowNodes[i];
-                            this.setGroupData(rowNode, rowNode.treeNode?.key ?? rowNode.key ?? rowNode.id!);
-                        }
+        if (this.gos.get('treeData')) {
+            const newGroupDisplayColIds =
+                this.beans.showRowGroupCols
+                    ?.getShowRowGroupCols()
+                    ?.map((c) => c.getId())
+                    .join('-') ?? '';
+
+            // if the group display cols have changed, then we need to update rowNode.groupData
+            // (regardless of tree data or row grouping)
+            if (this.oldGroupDisplayColIds !== newGroupDisplayColIds) {
+                this.oldGroupDisplayColIds = newGroupDisplayColIds;
+                const rowNodes = this.rootNode?.childrenAfterGroup;
+                if (rowNodes) {
+                    for (let i = 0, len = rowNodes.length ?? 0; i < len; ++i) {
+                        const rowNode = rowNodes[i];
+                        this.setGroupData(rowNode, rowNode.treeNode?.key ?? rowNode.key ?? rowNode.id!);
                     }
                 }
-            } else {
-                this.oldGroupDisplayColIds = '';
             }
+        } else {
+            this.oldGroupDisplayColIds = '';
         }
     }
 }

--- a/packages/ag-grid-enterprise/src/treeData/clientSideChildrenTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/clientSideChildrenTreeNodeManager.ts
@@ -79,7 +79,7 @@ export class ClientSideChildrenTreeNodeManager<TData>
         this.treeCommit();
     }
 
-    public refreshModel(params: RefreshModelParams<TData>): void {
+    public override refreshModel(params: RefreshModelParams<TData>): void {
         const { rootNode, treeRoot } = this;
         if (!treeRoot) {
             return; // Not active, destroyed
@@ -95,5 +95,7 @@ export class ClientSideChildrenTreeNodeManager<TData>
             }
             this.treeCommit();
         }
+
+        super.refreshModel(params);
     }
 }

--- a/packages/ag-grid-enterprise/src/treeData/clientSideChildrenTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/clientSideChildrenTreeNodeManager.ts
@@ -1,4 +1,4 @@
-import type { IClientSideNodeManager, NamedBean, RowNode } from 'ag-grid-community';
+import type { IClientSideNodeManager, NamedBean, RefreshModelParams, RowNode } from 'ag-grid-community';
 import { _error } from 'ag-grid-community';
 
 import { AbstractClientSideTreeNodeManager } from './abstractClientSideTreeNodeManager';
@@ -79,15 +79,21 @@ export class ClientSideChildrenTreeNodeManager<TData>
         this.treeCommit();
     }
 
-    public onTreeDataChanged() {
+    public refreshModel(params: RefreshModelParams<TData>): void {
         const { rootNode, treeRoot } = this;
-        treeRoot?.setRow(rootNode);
-        const allLeafChildren = rootNode?.allLeafChildren;
-        if (allLeafChildren) {
-            for (let i = 0, len = allLeafChildren.length; i < len; ++i) {
-                allLeafChildren[i].treeNode?.invalidate();
-            }
+        if (!treeRoot) {
+            return; // Not active, destroyed
         }
-        this.treeCommit();
+
+        if (params.changedProps?.has('treeData') && !params.newData) {
+            treeRoot.setRow(rootNode);
+            const allLeafChildren = rootNode?.allLeafChildren;
+            if (allLeafChildren) {
+                for (let i = 0, len = allLeafChildren.length; i < len; ++i) {
+                    allLeafChildren[i].treeNode?.invalidate();
+                }
+            }
+            this.treeCommit();
+        }
     }
 }

--- a/packages/ag-grid-enterprise/src/treeData/clientSidePathTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/clientSidePathTreeNodeManager.ts
@@ -1,5 +1,5 @@
 import { _warn } from 'ag-grid-community';
-import type { ChangedPath, NamedBean, RowNode, RowNodeTransaction } from 'ag-grid-community';
+import type { NamedBean, RefreshModelParams, RowNode } from 'ag-grid-community';
 
 import { AbstractClientSideTreeNodeManager } from './abstractClientSideTreeNodeManager';
 import type { TreeNode } from './treeNode';
@@ -24,34 +24,33 @@ export class ClientSidePathTreeNodeManager<TData>
         this.treeCommit();
     }
 
-    public commitTransactions(
-        transactions: RowNodeTransaction<TData>[],
-        changedPath: ChangedPath | undefined,
-        rowNodesOrderChanged: boolean
-    ): void {
-        this.treeRoot?.setRow(this.rootNode);
+    public refreshModel(params: RefreshModelParams<TData>): void {
+        const transactions = params.rowNodeTransactions;
+        if (transactions?.length) {
+            this.treeRoot?.setRow(this.rootNode);
 
-        for (const { remove, update, add } of transactions) {
-            // the order of [add, remove, update] is the same as in ClientSideNodeManager.
-            // Order is important when a record with the same id is added and removed in the same transaction.
-            this.removeRows(remove as RowNode[] | null);
-            this.addOrUpdateRows(update as RowNode[] | null, true);
-            this.addOrUpdateRows(add as RowNode[] | null, false);
-        }
+            for (const { remove, update, add } of transactions) {
+                // the order of [add, remove, update] is the same as in ClientSideNodeManager.
+                // Order is important when a record with the same id is added and removed in the same transaction.
+                this.removeRows(remove as RowNode[] | null);
+                this.addOrUpdateRows(update as RowNode[] | null, true);
+                this.addOrUpdateRows(add as RowNode[] | null, false);
+            }
 
-        if (rowNodesOrderChanged) {
-            const rows = this.treeRoot?.row?.allLeafChildren;
-            if (rows) {
-                for (let rowIdx = 0, rowsLen = rows.length; rowIdx < rowsLen; ++rowIdx) {
-                    const node = rows[rowIdx].treeNode as TreeNode | null;
-                    if (node && node.oldSourceRowIndex !== rowIdx) {
-                        node.invalidateOrder(); // Order might have changed
+            if (transactions) {
+                const rows = this.treeRoot?.row?.allLeafChildren;
+                if (rows) {
+                    for (let rowIdx = 0, rowsLen = rows.length; rowIdx < rowsLen; ++rowIdx) {
+                        const node = rows[rowIdx].treeNode as TreeNode | null;
+                        if (node && node.oldSourceRowIndex !== rowIdx) {
+                            node.invalidateOrder(); // Order might have changed
+                        }
                     }
                 }
             }
-        }
 
-        this.treeCommit(changedPath); // One single commit for all the transactions
+            this.treeCommit(params.changedPath); // One single commit for all the transactions
+        }
     }
 
     /** Transactional removal */

--- a/packages/ag-grid-enterprise/src/treeData/clientSidePathTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/clientSidePathTreeNodeManager.ts
@@ -24,7 +24,7 @@ export class ClientSidePathTreeNodeManager<TData>
         this.treeCommit();
     }
 
-    public refreshModel(params: RefreshModelParams<TData>): void {
+    public override refreshModel(params: RefreshModelParams<TData>): void {
         const transactions = params.rowNodeTransactions;
         if (transactions?.length) {
             this.treeRoot?.setRow(this.rootNode);
@@ -51,6 +51,8 @@ export class ClientSidePathTreeNodeManager<TData>
 
             this.treeCommit(params.changedPath); // One single commit for all the transactions
         }
+
+        super.refreshModel(params);
     }
 
     /** Transactional removal */

--- a/testing/behavioural/src/hierarchical-tree/hierarchical-tree-data.test.ts
+++ b/testing/behavioural/src/hierarchical-tree/hierarchical-tree-data.test.ts
@@ -267,7 +267,6 @@ describe('ag-grid hierarchical tree data', () => {
             `);
     });
 
-    // TODO: this test is skipped because https://ag-grid.atlassian.net/browse/AG-13089 - Order of grouped property listener changed is not deterministic
     test.skip('ag-grid hierarchical override tree data is insensitive to updateGridOptions object order', async () => {
         const rowData0 = [
             { x: 'A', children: [{ x: 'B' }] },

--- a/testing/behavioural/src/hierarchical-tree/hierarchical-tree-data.test.ts
+++ b/testing/behavioural/src/hierarchical-tree/hierarchical-tree-data.test.ts
@@ -267,6 +267,7 @@ describe('ag-grid hierarchical tree data', () => {
             `);
     });
 
+    // TODO: this test is skipped because https://ag-grid.atlassian.net/browse/AG-13089 - Order of grouped property listener changed is not deterministic
     test.skip('ag-grid hierarchical override tree data is insensitive to updateGridOptions object order', async () => {
         const rowData0 = [
             { x: 'A', children: [{ x: 'B' }] },


### PR DESCRIPTION
To ensure the possibility to give to the node manager the ability to set immutable data without using transactions, as required by the new tree data with children node manager, we need to change the flow that CSRM uses to do refresh.

- remove the property `keepEditingRows` from RefreshModelParams as it was set but never read
- add more properties to RefreshModelParams so we can move some of the processing logic in different methods and in the client side node manager
- make setImmutableRowData able to update the RefreshModelParams if it has transactions to execute, and move some execution in the refresh method
- Split the parsing of refresh model step and the refreshModel method in two different methods (refreshModelApi and refreshModel)
- Simplify and linearize the logic to update rowData and refresh
- Added a new private event beforeRefreshModel, currently used only by MasterDetail. This simplifies the logic of master detail service