### PR TITLE
AG-12915 - Truncate log url if parameters are too long

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,7 +11,7 @@
     "esModuleInterop": true,
     "target": "ES2020",
     "module": "commonjs",
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2022", "DOM", "dom.iterable"],
     "skipLibCheck": true,
     "strictBindCallApply": true,
     "skipDefaultLibCheck": true,


### PR DESCRIPTION
Update tsconfig.base.json to fix typescript error for `params.entries()`