### PR TITLE
AG-12272 fix tree with children bugs found in tests

### DIFF
--- a/packages/ag-grid-community/src/clientSideRowModel/abstractClientSideNodeManager.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/abstractClientSideNodeManager.ts
@@ -164,7 +164,7 @@ export abstract class AbstractClientSideNodeManager<TData = any>
         this.executeUpdate(getRowIdFunc, rowDataTran, updateRowDataResult, nodesToUnselect);
         this.executeAdd(rowDataTran, updateRowDataResult);
 
-        this.updateSelection(nodesToUnselect, 'rowDataChanged');
+        this.deselectNodes(nodesToUnselect, 'rowDataChanged');
 
         return updateRowDataResult;
     }
@@ -409,7 +409,7 @@ export abstract class AbstractClientSideNodeManager<TData = any>
         });
     }
 
-    protected updateSelection(nodesToUnselect: RowNode<TData>[], source: SelectionEventSourceType): void {
+    protected deselectNodes(nodesToUnselect: RowNode<TData>[], source: SelectionEventSourceType): void {
         const selectionSvc = this.beans.selectionSvc;
         const selectionChanged = nodesToUnselect.length > 0;
         if (selectionChanged) {

--- a/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
@@ -291,6 +291,7 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
                 this.setGroupData(row, key);
             }
         } else {
+            row.groupData = null;
             row.parent = details.rootNode;
         }
     }
@@ -494,6 +495,8 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
         // this is important for transition, see rowComp removeFirstPassFuncs. when doing animation and
         // remove, if rowTop is still present, the rowComp thinks it's just moved position.
         row.clearRowTopAndRowIndex();
+
+        row.groupData = null;
     }
 
     /**

--- a/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
@@ -236,7 +236,7 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
                 break;
             }
             if (child.parent === parent) {
-                this.treeCommitChild(details, child, collapsed || !parent.row!.expanded);
+                this.treeCommitChild(details, child, collapsed || !(parent.row?.expanded ?? true));
             }
         }
 

--- a/testing/behavioural/src/tree-data/hierarchical/grouping-hierarchical-tree-data-reactive.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/grouping-hierarchical-tree-data-reactive.test.ts
@@ -18,8 +18,7 @@ describe('ag-grid grouping hierarchical treeData is reactive', () => {
         gridsManager.reset();
     });
 
-    // TODO: tree data with children bug: toggling grouping and tree data does not refresh properly the row grouping columns
-    test.skip('ag-grid grouping treeData is reactive', async () => {
+    test('ag-grid grouping treeData is reactive', async () => {
         const rowData = [
             { id: 'A', g: 0, v: 0, children: [{ id: 'B', g: 1, v: 1, children: [{ id: 'C', g: 1, v: 1 }] }] },
             {

--- a/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-reset.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-reset.test.ts
@@ -476,7 +476,7 @@ describe('ag-grid hierarchical tree data reset', () => {
                 children: [{ id: '5', x: 'S', label: '5-v2' }],
             },
             {
-                id: 'g1',
+                id: 'g4',
                 x: 'X',
                 label: 'g-X',
                 children: [
@@ -489,7 +489,7 @@ describe('ag-grid hierarchical tree data reset', () => {
                 ],
             },
             {
-                id: 'g2',
+                id: 'g5',
                 x: 'P',
                 label: 'g-P',
                 children: [{ id: '4', x: 'Q', label: '4-v2' }],
@@ -498,6 +498,16 @@ describe('ag-grid hierarchical tree data reset', () => {
         ];
 
         const rowData3 = [
+            { id: '100', x: 'a', label: '100-v3' },
+            {
+                id: 'g3',
+                x: 'C',
+                label: 'g-C',
+                children: [{ id: '3', x: 'D', label: '3-v3' }],
+            },
+        ];
+
+        const rowData4 = [
             { id: '100', x: 'a', label: '100-v3' },
             {
                 id: 'g0',
@@ -559,20 +569,30 @@ describe('ag-grid hierarchical tree data reset', () => {
             ├── 7 LEAF selected id:7 label:"7-v2" x:"N"
             ├─┬ g0 GROUP selected id:g0 label:"g-R" x:"R"
             │ └── 5 LEAF selected id:5 label:"5-v2" x:"S"
-            ├─┬ g1 GROUP selected id:g1 label:"g-X" x:"X"
+            ├─┬ g4 GROUP id:g4 label:"g-X" x:"X"
             │ └─┬ 2 GROUP id:2 label:"2-v2" x:"Y"
             │ · └── 1 LEAF selected id:1 label:"1-v2" x:"Z"
-            ├─┬ g2 GROUP selected collapsed id:g2 label:"g-P" x:"P"
-            │ └── 4 LEAF selected hidden id:4 label:"4-v2" x:"Q"
+            ├─┬ g5 GROUP id:g5 label:"g-P" x:"P"
+            │ └── 4 LEAF selected id:4 label:"4-v2" x:"Q"
             └── 6 LEAF selected id:6 label:"6-v2" x:"M"
         `);
 
+        console.log('BEGIN\n\n');
         api.setGridOption('rowData', rowData3);
 
         await new GridRows(api, 'update 2', gridRowsOptions).check(`
             ROOT id:ROOT_NODE_ID
             ├── 100 LEAF id:100 label:"100-v3" x:"a"
-            └─┬ g0 GROUP selected id:g0 label:"g-C" x:"C"
+            └─┬ g3 GROUP collapsed id:g3 label:"g-C" x:"C"
+            · └── 3 LEAF hidden id:3 label:"3-v3" x:"D"
+        `);
+
+        api.setGridOption('rowData', rowData4);
+
+        await new GridRows(api, 'update 3', gridRowsOptions).check(`
+            ROOT id:ROOT_NODE_ID
+            ├── 100 LEAF id:100 label:"100-v3" x:"a"
+            └─┬ g0 GROUP id:g0 label:"g-C" x:"C"
             · └── 3 LEAF id:3 label:"3-v3" x:"D"
         `);
 

--- a/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-reset.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-reset.test.ts
@@ -29,8 +29,7 @@ describe('ag-grid hierarchical tree data reset', () => {
         consoleWarnSpy?.mockRestore();
     });
 
-    // TODO: tree data with children bug: it seems the order is not maintained here, to investigate
-    test.skip('tree data with id is created in the right order, and order can be changed also if data references do not change', async () => {
+    test('tree data with id is created in the right order, and order can be changed also if data references do not change', async () => {
         const rowData = [
             { id: 'A', children: [{ id: 'B' }] },
             { id: 'C', children: [{ id: 'D' }, { id: 'E' }] },

--- a/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-reset.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-reset.test.ts
@@ -430,8 +430,7 @@ describe('ag-grid hierarchical tree data reset', () => {
         `);
     });
 
-    // TODO: tree data with children bug: selection is not cleared with setImmutableData for deleted nodes yet
-    test.skip('tree data setRowData with id maintains selection and expanded state, and follows order', async () => {
+    test('tree data setRowData with id maintains selection and expanded state, and follows order', async () => {
         const rowData1 = [
             {
                 id: 'g0',
@@ -557,24 +556,24 @@ describe('ag-grid hierarchical tree data reset', () => {
 
         await new GridRows(api, 'update 1', gridRowsOptions).check(`
             ROOT id:ROOT_NODE_ID
-            ├── N LEAF selected id:7 label:"7-v2"
-            ├─┬ R filler selected collapsed id:row-group-0-R
-            │ └── S LEAF selected hidden id:5 label:"5-v2"
-            ├─┬ X filler id:row-group-0-X
-            │ └─┬ Y GROUP id:2 label:"2-v2"
-            │ · └── Z LEAF selected id:1 label:"1-v2"
-            ├─┬ P filler selected collapsed id:row-group-0-P
-            │ └── Q LEAF selected hidden id:4 label:"4-v2"
-            └── M LEAF selected id:6 label:"6-v2"
+            ├── 7 LEAF selected id:7 label:"7-v2" x:"N"
+            ├─┬ g0 GROUP selected id:g0 label:"g-R" x:"R"
+            │ └── 5 LEAF selected id:5 label:"5-v2" x:"S"
+            ├─┬ g1 GROUP selected id:g1 label:"g-X" x:"X"
+            │ └─┬ 2 GROUP id:2 label:"2-v2" x:"Y"
+            │ · └── 1 LEAF selected id:1 label:"1-v2" x:"Z"
+            ├─┬ g2 GROUP selected collapsed id:g2 label:"g-P" x:"P"
+            │ └── 4 LEAF selected hidden id:4 label:"4-v2" x:"Q"
+            └── 6 LEAF selected id:6 label:"6-v2" x:"M"
         `);
 
         api.setGridOption('rowData', rowData3);
 
         await new GridRows(api, 'update 2', gridRowsOptions).check(`
             ROOT id:ROOT_NODE_ID
-            ├── a LEAF id:100 label:"100-v3"
-            └─┬ C filler id:row-group-0-C
-            · └── D LEAF id:3 label:"3-v3"
+            ├── 100 LEAF id:100 label:"100-v3" x:"a"
+            └─┬ g0 GROUP selected id:g0 label:"g-C" x:"C"
+            · └── 3 LEAF id:3 label:"3-v3" x:"D"
         `);
 
         api.setGridOption('rowData', []);

--- a/testing/behavioural/src/tree-data/hierarchical/stages/hierarchical-tree-selection.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/stages/hierarchical-tree-selection.test.ts
@@ -18,8 +18,7 @@ describe('ag-grid hierarchical tree selection', () => {
         gridsManager.reset();
     });
 
-    // TODO: tree data with children bug: selection is not cleared with setImmutableData for deleted nodes yet
-    test.skip('tree selection and update', async () => {
+    test('tree selection and update', async () => {
         const rowData = cachedJSONObjects.array([
             {
                 id: '1',


### PR DESCRIPTION
Writing and porting tests I identified few bugs with tree data with children:

1) the logic to invalidate the parent node if order was changed while setting immutable data was not correct, fixed here.
2) the deselection logic was not fully working for removed leaf nodes and tree data with children, fixed here and batching the node deselection as well.
3) the grouping data columns map needs to be cleared when switching between treeData on and off or else switching treeData and grouping was not working
4) ensures that row index is cleared if a row in the tree is a child of a collapsed row
5) fix a bug in ChangeDetectionService trying to access a null client side row model