### PR TITLE
AG-12272 replace getDataPath with getRoute, and, verify and fix the aggregation test

### DIFF
--- a/packages/ag-grid-enterprise/src/setFilter/clientSideValueExtractor.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/clientSideValueExtractor.ts
@@ -1,7 +1,6 @@
 import type {
     AgColumn,
     AgEventType,
-    GetDataPath,
     IClientSideRowModel,
     IColsService,
     RowNode,
@@ -22,7 +21,6 @@ export class ClientSideValuesExtractor<V> {
         private readonly valueSvc: ValueService,
         private readonly treeDataOrGrouping: boolean,
         private readonly treeData: boolean,
-        private readonly getDataPath: GetDataPath | undefined,
         private readonly groupAllowUnbalanced: boolean,
         private readonly addManagedEventListeners: (
             handlers: Partial<Record<AgEventType, (event?: any) => void>>
@@ -55,7 +53,7 @@ export class ClientSideValuesExtractor<V> {
         const values: Map<string | null, V | null> = new Map();
         const existingFormattedKeys = this.extractExistingFormattedKeys(existingValues);
         const formattedKeys: Set<string | null> = new Set();
-        const treeData = this.treeData && !!this.getDataPath;
+        const treeData = this.treeData;
         const groupedCols = this.rowGroupColsSvc?.columns;
 
         const addValue = (unformattedKey: string | null, value: V | null | undefined) => {
@@ -113,7 +111,7 @@ export class ClientSideValuesExtractor<V> {
             if (node.childrenAfterGroup?.length) {
                 return;
             }
-            dataPath = this.getDataPath!(node.data);
+            dataPath = node.getRoute() ?? [node.key ?? node.id!];
         } else {
             dataPath = groupedCols.map((groupCol) => this.valueSvc.getKeyForNode(groupCol, node));
             dataPath.push(this.getValue(node) as any);

--- a/packages/ag-grid-enterprise/src/setFilter/setFilter.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilter.ts
@@ -4,13 +4,13 @@ import type {
     BeanCollection,
     ComponentSelector,
     DataTypeService,
-    GetDataPath,
     IAfterGuiAttachedParams,
     IColsService,
     IDoesFilterPassParams,
     IRowNode,
     ISetFilter,
     KeyCreatorParams,
+    RowNode,
     SetFilterModel,
     SetFilterModelValue,
     SetFilterParams,
@@ -73,7 +73,6 @@ export class SetFilter<V = string> extends ProvidedFilter<SetFilterModel, V> imp
     private virtualList: VirtualList<any>;
     private caseSensitive: boolean = false;
     private treeDataTreeList = false;
-    private getDataPath?: GetDataPath<any>;
     private groupingTreeList = false;
     private hardRefreshVirtualList = false;
     private noValueFormatterSupplied = false;
@@ -313,7 +312,6 @@ export class SetFilter<V = string> extends ProvidedFilter<SetFilterModel, V> imp
         this.setValueFormatter(newParams.valueFormatter, keyCreator, !!newParams.treeList, !!newParams.colDef.refData);
         const isGroupCol = newParams.column.getId().startsWith(GROUP_AUTO_COLUMN_ID);
         this.treeDataTreeList = this.gos.get('treeData') && !!newParams.treeList && isGroupCol;
-        this.getDataPath = this.gos.get('getDataPath');
         this.groupingTreeList = !!this.rowGroupColsSvc?.columns.length && !!newParams.treeList && isGroupCol;
         this.createKey = this.generateCreateKey(keyCreator, this.treeDataTreeList || this.groupingTreeList);
     };
@@ -874,7 +872,11 @@ export class SetFilter<V = string> extends ProvidedFilter<SetFilterModel, V> imp
         }
         return this.isInAppliedModel(
             this.createKey(
-                processDataPath(this.getDataPath!(data), true, this.gos.get('groupAllowUnbalanced')) as any
+                processDataPath(
+                    (node as RowNode).getRoute() ?? [node.key ?? node.id!],
+                    true,
+                    this.gos.get('groupAllowUnbalanced')
+                ) as any
             ) as any
         );
     }

--- a/packages/ag-grid-enterprise/src/setFilter/setValueModel.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setValueModel.ts
@@ -169,7 +169,6 @@ export class SetValueModel<V> implements IEventEmitter<SetValueModelEvent> {
         }
         this.keyComparator = (keyComparator as any) ?? _defaultComparator;
         this.caseSensitive = !!caseSensitive;
-        const getDataPath = gos.get('getDataPath');
         const groupAllowUnbalanced = gos.get('groupAllowUnbalanced');
 
         if (_isClientSideRowModel(gos, rowModel)) {
@@ -181,7 +180,6 @@ export class SetValueModel<V> implements IEventEmitter<SetValueModelEvent> {
                 valueSvc,
                 treeDataOrGrouping,
                 !!treeDataTreeList,
-                getDataPath,
                 groupAllowUnbalanced,
                 addManagedEventListeners,
                 rowGroupColsSvc

--- a/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
@@ -293,7 +293,7 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
                 this.setGroupData(row, key);
             }
         } else {
-            row.groupData = null;
+            row.key = node.key;
             row.parent = details.rootNode;
         }
     }
@@ -551,7 +551,10 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
                 if (rowNodes) {
                     for (let i = 0, len = rowNodes.length ?? 0; i < len; ++i) {
                         const rowNode = rowNodes[i];
-                        this.setGroupData(rowNode, rowNode.treeNode?.key ?? rowNode.key ?? rowNode.id!);
+                        const treeNode = rowNode.treeNode;
+                        if (treeNode) {
+                            this.setGroupData(rowNode, treeNode.key);
+                        }
                     }
                 }
             }

--- a/testing/behavioural/src/tree-data/hierarchical/stages/hierarchical-tree-filter-aggregation.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/stages/hierarchical-tree-filter-aggregation.test.ts
@@ -18,45 +18,51 @@ describe('ag-grid hierarchical tree aggregation and filter', () => {
         gridsManager.reset();
     });
 
-    // TODO: tree data with children bug: filter seems to not work properly and it fails as filter looks still for getDataPath
-    test.skip('aggregation and filter immutable', async () => {
+    test('aggregation and filter immutable', async () => {
         const rowData = cachedJSONObjects.array([
             {
+                id: '0',
                 y: 1,
                 n: 'A',
                 children: [
                     {
+                        id: '1',
                         y: 2,
                         n: 'B',
                         children: [
-                            { x: 14, y: 4, n: 'D' },
-                            { x: 15, y: 5, n: 'E' },
+                            { id: '3', x: 14, y: 4, n: 'D' },
+                            { id: '4', x: 15, y: 5, n: 'E' },
                         ],
                     },
                 ],
             },
             {
+                id: '2',
                 x: 13,
                 y: 3,
                 n: 'C',
                 children: [
-                    { x: 16, y: 1, n: 'F' },
-                    { x: 17, y: 2, n: 'G' },
+                    { id: '5', x: 16, y: 1, n: 'F' },
+                    { id: '6', x: 17, y: 2, n: 'G' },
                     {
+                        id: 'h',
                         n: 'H',
-                        children: [{ x: 18, y: 3, n: 'I' }],
+                        y: 0,
+                        children: [{ id: '7', x: 18, y: 3, n: 'I' }],
                     },
                 ],
             },
             {
+                id: '8',
                 n: 'J',
                 y: 4,
-                children: [{ x: 20, y: 5, n: 'K' }],
+                children: [{ id: '9', x: 20, y: 5, n: 'K' }],
             },
         ]);
 
         const api = gridsManager.createGrid('myGrid', {
             columnDefs: [
+                { field: 'n' },
                 { field: 'x', aggFunc: 'sum', filter: 'agNumberColumnFilter' },
                 { field: 'y', filter: 'agNumberColumnFilter' },
             ],
@@ -69,29 +75,29 @@ describe('ag-grid hierarchical tree aggregation and filter', () => {
             alwaysAggregateAtRootLevel: true,
             groupDefaultExpanded: -1,
             rowData,
-            getRowId: (params) => params.data.n,
+            getRowId: (params) => params.data.id,
             groupSuppressBlankHeader: true,
         });
 
         const gridRowsOptions: GridRowsOptions = {
-            columns: ['x', 'y'],
+            columns: ['n', 'x', 'y'],
             checkDom: true,
         };
 
         await new GridRows(api, 'initial', gridRowsOptions).check(`
             ROOT id:ROOT_NODE_ID x:100
             ├─ footer id:rowGroupFooter_ROOT_NODE_ID x:100
-            ├─┬ A GROUP id:A x:29 y:1
-            │ └─┬ B GROUP id:B x:29 y:2
-            │ · ├── D LEAF id:D x:14 y:4
-            │ · └── E LEAF id:E x:15 y:5
-            ├─┬ C GROUP id:C x:51 y:3
-            │ ├── F LEAF id:F x:16 y:1
-            │ ├── G LEAF id:G x:17 y:2
-            │ └─┬ H GROUP id:H x:18 y:undefined
-            │ · └── I LEAF id:I x:18 y:3
-            └─┬ J GROUP id:J x:20 y:4
-            · └── K LEAF id:K x:20 y:5
+            ├─┬ 0 GROUP id:0 n:"A" x:29 y:1
+            │ └─┬ 1 GROUP id:1 n:"B" x:29 y:2
+            │ · ├── 3 LEAF id:3 n:"D" x:14 y:4
+            │ · └── 4 LEAF id:4 n:"E" x:15 y:5
+            ├─┬ 2 GROUP id:2 n:"C" x:51 y:3
+            │ ├── 5 LEAF id:5 n:"F" x:16 y:1
+            │ ├── 6 LEAF id:6 n:"G" x:17 y:2
+            │ └─┬ h GROUP id:h n:"H" x:18 y:0
+            │ · └── 7 LEAF id:7 n:"I" x:18 y:3
+            └─┬ 8 GROUP id:8 n:"J" x:20 y:4
+            · └── 9 LEAF id:9 n:"K" x:20 y:5
         `);
 
         api.setFilterModel({
@@ -101,47 +107,53 @@ describe('ag-grid hierarchical tree aggregation and filter', () => {
         await new GridRows(api, 'filter greater than', gridRowsOptions).check(`
             ROOT id:ROOT_NODE_ID x:35
             ├─ footer id:rowGroupFooter_ROOT_NODE_ID x:35
-            ├─┬ A GROUP id:A x:15 y:1
-            │ └─┬ B GROUP id:B x:15 y:2
-            │ · └── E LEAF id:E x:15 y:5
-            └─┬ J GROUP id:J x:20 y:4
-            · └── K LEAF id:K x:20 y:5
+            ├─┬ 0 GROUP id:0 n:"A" x:15 y:1
+            │ └─┬ 1 GROUP id:1 n:"B" x:15 y:2
+            │ · └── 4 LEAF id:4 n:"E" x:15 y:5
+            └─┬ 8 GROUP id:8 n:"J" x:20 y:4
+            · └── 9 LEAF id:9 n:"K" x:20 y:5
         `);
 
         api.setGridOption(
             'rowData',
             cachedJSONObjects.array([
                 {
+                    id: '0',
                     y: 1,
                     n: 'A',
                     children: [
                         {
+                            id: '1',
                             y: 2,
                             n: 'B',
                             children: [
-                                { x: 14, y: 200, n: 'D' },
-                                { x: 15, y: 5, n: 'E' },
+                                { id: '3', x: 14, y: 200, n: 'D' },
+                                { id: '4', x: 15, y: 5, n: 'E' },
                             ],
                         },
                     ],
                 },
                 {
+                    id: '2',
                     x: 13,
                     y: 3,
                     n: 'C',
                     children: [
-                        { x: 16, y: 1, n: 'F' },
-                        { x: 17, y: 2, n: 'G' },
+                        { id: '5', x: 16, y: 1, n: 'F' },
+                        { id: '6', x: 17, y: 2, n: 'G' },
                         {
+                            id: 'h',
                             n: 'H',
-                            children: [{ x: 18, y: 3, n: 'I' }],
+                            y: 0,
+                            children: [{ id: '7', x: 18, y: 3, n: 'I' }],
                         },
                     ],
                 },
                 {
+                    id: '8',
                     n: 'J',
                     y: 4,
-                    children: [{ x: 20, y: 5, n: 'K' }],
+                    children: [{ id: '9', x: 20, y: 5, n: 'K' }],
                 },
             ])
         );
@@ -149,48 +161,54 @@ describe('ag-grid hierarchical tree aggregation and filter', () => {
         await new GridRows(api, 'filter greater than - update 1', gridRowsOptions).check(`
             ROOT id:ROOT_NODE_ID x:49
             ├─ footer id:rowGroupFooter_ROOT_NODE_ID x:49
-            ├─┬ A GROUP id:A x:29 y:1
-            │ └─┬ B GROUP id:B x:29 y:2
-            │ · ├── D LEAF id:D x:14 y:200
-            │ · └── E LEAF id:E x:15 y:5
-            └─┬ J GROUP id:J x:20 y:4
-            · └── K LEAF id:K x:20 y:5
+            ├─┬ 0 GROUP id:0 n:"A" x:29 y:1
+            │ └─┬ 1 GROUP id:1 n:"B" x:29 y:2
+            │ · ├── 3 LEAF id:3 n:"D" x:14 y:200
+            │ · └── 4 LEAF id:4 n:"E" x:15 y:5
+            └─┬ 8 GROUP id:8 n:"J" x:20 y:4
+            · └── 9 LEAF id:9 n:"K" x:20 y:5
         `);
 
         api.setGridOption(
             'rowData',
             cachedJSONObjects.array([
                 {
+                    id: '0',
                     y: 1,
                     n: 'A',
                     children: [
                         {
+                            id: '1',
                             y: 2,
                             n: 'B',
                             children: [
-                                { x: 14, y: 200, n: 'D' },
-                                { x: 15, y: 5, n: 'E' },
+                                { id: '3', x: 14, y: 200, n: 'D' },
+                                { id: '4', x: 15, y: 5, n: 'E' },
                             ],
                         },
                     ],
                 },
                 {
+                    id: '2',
                     x: 13,
                     y: 3,
                     n: 'C',
                     children: [
-                        { x: 16, y: 1, n: 'F' },
-                        { x: 17, y: 2, n: 'G' },
+                        { id: '5', x: 16, y: 1, n: 'F' },
+                        { id: '6', x: 17, y: 2, n: 'G' },
                         {
+                            id: 'h',
                             n: 'H',
-                            children: [{ x: 18, y: 3, n: 'I' }],
+                            y: 0,
+                            children: [{ id: '7', x: 18, y: 3, n: 'I' }],
                         },
                     ],
                 },
                 {
+                    id: '8',
                     n: 'J',
                     y: 4,
-                    children: [{ x: 20, y: 0, n: 'K' }],
+                    children: [{ id: '9', x: 20, y: 0, n: 'K' }],
                 },
             ])
         );
@@ -198,43 +216,49 @@ describe('ag-grid hierarchical tree aggregation and filter', () => {
         await new GridRows(api, 'filter greater than - update 2', gridRowsOptions).check(`
             ROOT id:ROOT_NODE_ID x:29
             ├─ footer id:rowGroupFooter_ROOT_NODE_ID x:29
-            └─┬ A GROUP id:A x:29 y:1
-            · └─┬ B GROUP id:B x:29 y:2
-            · · ├── D LEAF id:D x:14 y:200
-            · · └── E LEAF id:E x:15 y:5
+            └─┬ 0 GROUP id:0 n:"A" x:29 y:1
+            · └─┬ 1 GROUP id:1 n:"B" x:29 y:2
+            · · ├── 3 LEAF id:3 n:"D" x:14 y:200
+            · · └── 4 LEAF id:4 n:"E" x:15 y:5
         `);
 
         api.setGridOption(
             'rowData',
             cachedJSONObjects.array([
                 {
+                    id: '0',
                     y: 1,
                     n: 'A',
                     children: [
                         {
+                            id: '1',
                             y: 2,
                             n: 'B',
-                            children: [{ x: 15, y: 5, n: 'E' }],
+                            children: [{ id: '4', x: 15, y: 5, n: 'E' }],
                         },
                     ],
                 },
                 {
+                    id: '2',
                     x: 13,
                     y: 3,
                     n: 'C',
                     children: [
-                        { x: 16, y: 1, n: 'F' },
-                        { x: 17, y: 2, n: 'G' },
+                        { id: '5', x: 16, y: 1, n: 'F' },
+                        { id: '6', x: 17, y: 2, n: 'G' },
                         {
+                            id: 'h',
                             n: 'H',
-                            children: [{ x: 18, y: 3, n: 'I' }],
+                            y: 0,
+                            children: [{ id: '7', x: 18, y: 3, n: 'I' }],
                         },
                     ],
                 },
                 {
+                    id: '8',
                     n: 'J',
                     y: 4,
-                    children: [{ x: 20, y: 0, n: 'K' }],
+                    children: [{ id: '9', x: 20, y: 0, n: 'K' }],
                 },
             ])
         );
@@ -242,9 +266,9 @@ describe('ag-grid hierarchical tree aggregation and filter', () => {
         await new GridRows(api, 'filter greater than - remove', gridRowsOptions).check(`
             ROOT id:ROOT_NODE_ID x:15
             ├─ footer id:rowGroupFooter_ROOT_NODE_ID x:15
-            └─┬ A GROUP id:A x:15 y:1
-            · └─┬ B GROUP id:B x:15 y:2
-            · · └── E LEAF id:E x:15 y:5
+            └─┬ 0 GROUP id:0 n:"A" x:15 y:1
+            · └─┬ 1 GROUP id:1 n:"B" x:15 y:2
+            · · └── 4 LEAF id:4 n:"E" x:15 y:5
         `);
 
         api.setFilterModel({
@@ -252,18 +276,17 @@ describe('ag-grid hierarchical tree aggregation and filter', () => {
         });
 
         await new GridRows(api, 'filter less than', gridRowsOptions).check(`
-            ROOT id:ROOT_NODE_ID x:86
-            ├─ footer id:rowGroupFooter_ROOT_NODE_ID x:86
-            ├─┬ A GROUP id:0 x:66 y:1
-            │ ├─┬ B GROUP id:1 x:15 y:2
-            │ │ └── E LEAF id:4 x:15 y:5
-            │ └─┬ C GROUP id:2 x:51 y:3
-            │ · ├── F LEAF id:5 x:16 y:1
-            │ · ├── G LEAF id:6 x:17 y:2
-            │ · └─┬ H filler id:row-group-0-A-1-C-2-H x:18
-            │ · · └── I LEAF id:7 x:18 y:3
-            └─┬ J GROUP id:8 x:20 y:4
-            · └── K LEAF id:9 x:20 y:0
+            ROOT id:ROOT_NODE_ID x:69
+            ├─ footer id:rowGroupFooter_ROOT_NODE_ID x:69
+            ├─┬ 0 GROUP id:0 n:"A" x:15 y:1
+            │ └─┬ 1 GROUP id:1 n:"B" x:15 y:2
+            │ · └── 4 LEAF id:4 n:"E" x:15 y:5
+            ├─┬ 2 GROUP id:2 n:"C" x:34 y:3
+            │ ├── 5 LEAF id:5 n:"F" x:16 y:1
+            │ └─┬ h GROUP id:h n:"H" x:18 y:0
+            │ · └── 7 LEAF id:7 n:"I" x:18 y:3
+            └─┬ 8 GROUP id:8 n:"J" x:20 y:4
+            · └── 9 LEAF id:9 n:"K" x:20 y:0
         `);
 
         api.setGridOption('excludeChildrenWhenTreeDataFiltering', true);
@@ -271,11 +294,12 @@ describe('ag-grid hierarchical tree aggregation and filter', () => {
         await new GridRows(api, 'excludeChildrenWhenTreeDataFiltering=true', gridRowsOptions).check(`
             ROOT id:ROOT_NODE_ID x:36
             ├─ footer id:rowGroupFooter_ROOT_NODE_ID x:36
-            ├── A GROUP id:A x:null y:1
-            ├─┬ C GROUP id:C x:16 y:3
-            │ └── F LEAF id:F x:16 y:1
-            └─┬ J GROUP id:J x:20 y:4
-            · └── K LEAF id:K x:20 y:0
+            ├── 0 GROUP id:0 n:"A" x:null y:1
+            ├─┬ 2 GROUP id:2 n:"C" x:16 y:3
+            │ ├── 5 LEAF id:5 n:"F" x:16 y:1
+            │ └── h GROUP id:h n:"H" x:null y:0
+            └─┬ 8 GROUP id:8 n:"J" x:20 y:4
+            · └── 9 LEAF id:9 n:"K" x:20 y:0
         `);
 
         api.setGridOption('suppressAggFilteredOnly', true);
@@ -283,11 +307,12 @@ describe('ag-grid hierarchical tree aggregation and filter', () => {
         await new GridRows(api, 'suppressAggFilteredOnly=true', gridRowsOptions).check(`
             ROOT id:ROOT_NODE_ID x:86
             ├─ footer id:rowGroupFooter_ROOT_NODE_ID x:86
-            ├── A GROUP id:A x:15 y:1
-            ├─┬ C GROUP id:C x:51 y:3
-            │ └── F LEAF id:F x:16 y:1
-            └─┬ J GROUP id:J x:20 y:4
-            · └── K LEAF id:K x:20 y:0
+            ├── 0 GROUP id:0 n:"A" x:15 y:1
+            ├─┬ 2 GROUP id:2 n:"C" x:51 y:3
+            │ ├── 5 LEAF id:5 n:"F" x:16 y:1
+            │ └── h GROUP id:h n:"H" x:18 y:0
+            └─┬ 8 GROUP id:8 n:"J" x:20 y:4
+            · └── 9 LEAF id:9 n:"K" x:20 y:0
         `);
 
         api.setGridOption('suppressAggFilteredOnly', false);
@@ -295,11 +320,12 @@ describe('ag-grid hierarchical tree aggregation and filter', () => {
 
         await new GridRows(api, 'suppressAggFilteredOnly=false grandTotalRow=bottom', gridRowsOptions).check(`
             ROOT id:ROOT_NODE_ID x:36
-            ├── A GROUP id:A x:null y:1
-            ├─┬ C GROUP id:C x:16 y:3
-            │ └── F LEAF id:F x:16 y:1
-            ├─┬ J GROUP id:J x:20 y:4
-            │ └── K LEAF id:K x:20 y:0
+            ├── 0 GROUP id:0 n:"A" x:null y:1
+            ├─┬ 2 GROUP id:2 n:"C" x:16 y:3
+            │ ├── 5 LEAF id:5 n:"F" x:16 y:1
+            │ └── h GROUP id:h n:"H" x:null y:0
+            ├─┬ 8 GROUP id:8 n:"J" x:20 y:4
+            │ └── 9 LEAF id:9 n:"K" x:20 y:0
             └─ footer id:rowGroupFooter_ROOT_NODE_ID x:36
         `);
 
@@ -307,14 +333,16 @@ describe('ag-grid hierarchical tree aggregation and filter', () => {
 
         await new GridRows(api, 'groupTotalRow=top', gridRowsOptions).check(`
             ROOT id:ROOT_NODE_ID x:36
-            ├─┬ A GROUP id:A x:null y:1
-            │ └─ footer id:rowGroupFooter_A x:null y:1
-            ├─┬ C GROUP id:C x:16 y:3
-            │ ├── F LEAF id:F x:16 y:1
-            │ └─ footer id:rowGroupFooter_C x:16 y:3
-            ├─┬ J GROUP id:J x:20 y:4
-            │ ├── K LEAF id:K x:20 y:0
-            │ └─ footer id:rowGroupFooter_J x:20 y:4
+            ├─┬ 0 GROUP id:0 n:"A" x:null y:1
+            │ └─ footer id:rowGroupFooter_0 n:"A" x:null y:1
+            ├─┬ 2 GROUP id:2 n:"C" x:16 y:3
+            │ ├── 5 LEAF id:5 n:"F" x:16 y:1
+            │ ├─┬ h GROUP id:h n:"H" x:null y:0
+            │ │ └─ footer id:rowGroupFooter_h n:"H" x:null y:0
+            │ └─ footer id:rowGroupFooter_2 n:"C" x:16 y:3
+            ├─┬ 8 GROUP id:8 n:"J" x:20 y:4
+            │ ├── 9 LEAF id:9 n:"K" x:20 y:0
+            │ └─ footer id:rowGroupFooter_8 n:"J" x:20 y:4
             └─ footer id:rowGroupFooter_ROOT_NODE_ID x:36
         `);
     });

--- a/testing/behavioural/src/tree-data/tree-data-without-anything.test.ts
+++ b/testing/behavioural/src/tree-data/tree-data-without-anything.test.ts
@@ -58,8 +58,8 @@ describe('ag-grid tree data without hierarchical and without data path', () => {
         const gridRows = new GridRows(api, 'data', gridRowsOptions);
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├── LEAF id:0 ag-Grid-AutoColumn:undefined x:1
-            └── LEAF id:1 ag-Grid-AutoColumn:undefined x:2
+            ├── 0 LEAF id:0 ag-Grid-AutoColumn:undefined x:1
+            └── 1 LEAF id:1 ag-Grid-AutoColumn:undefined x:2
         `);
     });
 });


### PR DESCRIPTION
getDataPath was used where it should not be used, only CSRM should know how to handle data with children.
Filter and value extractor should just use getRoute

Also, verified that filter and tree data seems to work, and the problem was how undefined column values are treated as there was a filler node in the other example