### PR TITLE
AG-12272 changed row nodes, delta sorting and master detail service without transactions

### DIFF
--- a/packages/ag-grid-community/src/clientSideRowModel/changedRowNodes.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/changedRowNodes.ts
@@ -1,0 +1,34 @@
+import type { RowNode } from '../entities/rowNode';
+import type { ChangedRowNodesFlags, IChangedRowNodes } from '../interfaces/iClientSideRowModel';
+import type { IRowNode } from '../main-umd-noStyles';
+
+export class ChangedRowNodes<TData = any> implements IChangedRowNodes<TData> {
+    public readonly removed = new Set<RowNode<TData>>();
+    public readonly updated = new Map<RowNode<TData>, ChangedRowNodesFlags>();
+
+    /** Marks a row as removed. Order of operations is: remove, update, add */
+    public remove(node: IRowNode<TData>): void {
+        this.removed.add(node as RowNode<TData>);
+        this.updated.delete(node as RowNode<TData>);
+    }
+
+    /** Marks a row as updated. Order of operations is: remove, update, add */
+    public update(node: IRowNode<TData>): void {
+        const updated = this.updated;
+        const flags = updated.get(node as RowNode<TData>);
+        if (flags === undefined) {
+            updated.set(node as RowNode<TData>, this.removed.delete(node as RowNode<TData>) ? 1 : 2);
+        } else if (flags !== 1) {
+            updated.set(node as RowNode<TData>, 3);
+        }
+    }
+
+    /** Marks a row as added. Order of operation is: remove, update, add */
+    public add(node: IRowNode<TData>): void {
+        const updated = this.updated;
+        if (!updated.has(node as RowNode<TData>)) {
+            this.removed.delete(node as RowNode<TData>);
+            updated.set(node as RowNode<TData>, 1);
+        }
+    }
+}

--- a/packages/ag-grid-community/src/clientSideRowModel/changedRowNodes.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/changedRowNodes.ts
@@ -1,10 +1,10 @@
 import type { RowNode } from '../entities/rowNode';
-import type { ChangedRowNodesFlags, IChangedRowNodes } from '../interfaces/iClientSideRowModel';
+import type { IChangedRowNodes } from '../interfaces/iClientSideRowModel';
 import type { IRowNode } from '../main-umd-noStyles';
 
 export class ChangedRowNodes<TData = any> implements IChangedRowNodes<TData> {
     public readonly removals = new Set<RowNode<TData>>();
-    public readonly updates = new Map<RowNode<TData>, ChangedRowNodesFlags>();
+    public readonly updates = new Map<RowNode<TData>, boolean>();
 
     /** Marks a row as removed. Order of operations is: remove, update, add */
     public remove(node: IRowNode<TData>): void {
@@ -14,21 +14,16 @@ export class ChangedRowNodes<TData = any> implements IChangedRowNodes<TData> {
 
     /** Marks a row as updated. Order of operations is: remove, update, add */
     public update(node: IRowNode<TData>): void {
-        const updated = this.updates;
-        const flags = updated.get(node as RowNode<TData>);
-        if (flags === undefined) {
-            updated.set(node as RowNode<TData>, this.removals.delete(node as RowNode<TData>) ? 1 : 2);
-        } else if (flags !== 1) {
-            updated.set(node as RowNode<TData>, 3);
+        const updates = this.updates;
+        if (!updates.has(node as RowNode<TData>)) {
+            this.removals.delete(node as RowNode<TData>);
+            this.updates.set(node as RowNode<TData>, false);
         }
     }
 
     /** Marks a row as added. Order of operation is: remove, update, add */
     public add(node: IRowNode<TData>): void {
-        const updated = this.updates;
-        if (!updated.has(node as RowNode<TData>)) {
-            this.removals.delete(node as RowNode<TData>);
-            updated.set(node as RowNode<TData>, 1);
-        }
+        this.removals.delete(node as RowNode<TData>);
+        this.updates.set(node as RowNode<TData>, true);
     }
 }

--- a/packages/ag-grid-community/src/clientSideRowModel/changedRowNodes.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/changedRowNodes.ts
@@ -3,21 +3,21 @@ import type { ChangedRowNodesFlags, IChangedRowNodes } from '../interfaces/iClie
 import type { IRowNode } from '../main-umd-noStyles';
 
 export class ChangedRowNodes<TData = any> implements IChangedRowNodes<TData> {
-    public readonly removed = new Set<RowNode<TData>>();
-    public readonly updated = new Map<RowNode<TData>, ChangedRowNodesFlags>();
+    public readonly removals = new Set<RowNode<TData>>();
+    public readonly updates = new Map<RowNode<TData>, ChangedRowNodesFlags>();
 
     /** Marks a row as removed. Order of operations is: remove, update, add */
     public remove(node: IRowNode<TData>): void {
-        this.removed.add(node as RowNode<TData>);
-        this.updated.delete(node as RowNode<TData>);
+        this.removals.add(node as RowNode<TData>);
+        this.updates.delete(node as RowNode<TData>);
     }
 
     /** Marks a row as updated. Order of operations is: remove, update, add */
     public update(node: IRowNode<TData>): void {
-        const updated = this.updated;
+        const updated = this.updates;
         const flags = updated.get(node as RowNode<TData>);
         if (flags === undefined) {
-            updated.set(node as RowNode<TData>, this.removed.delete(node as RowNode<TData>) ? 1 : 2);
+            updated.set(node as RowNode<TData>, this.removals.delete(node as RowNode<TData>) ? 1 : 2);
         } else if (flags !== 1) {
             updated.set(node as RowNode<TData>, 3);
         }
@@ -25,9 +25,9 @@ export class ChangedRowNodes<TData = any> implements IChangedRowNodes<TData> {
 
     /** Marks a row as added. Order of operation is: remove, update, add */
     public add(node: IRowNode<TData>): void {
-        const updated = this.updated;
+        const updated = this.updates;
         if (!updated.has(node as RowNode<TData>)) {
-            this.removed.delete(node as RowNode<TData>);
+            this.removals.delete(node as RowNode<TData>);
             updated.set(node as RowNode<TData>, 1);
         }
     }

--- a/packages/ag-grid-community/src/clientSideRowModel/sortStage.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/sortStage.ts
@@ -197,7 +197,7 @@ export class SortStage extends BeanStub implements NamedBean, IRowNodeStage {
         const untouchedRows = new Set<string>();
         const touchedRows: SortedRowNode[] = [];
 
-        const { removals, updates } = changedRowNodes;
+        const updates = changedRowNodes.updates;
         for (let i = 0, len = unsortedRows.length; i < len; ++i) {
             const row = unsortedRows[i];
             if (updates.has(row) || (changedPath && !changedPath.canSkip(row))) {
@@ -205,7 +205,7 @@ export class SortStage extends BeanStub implements NamedBean, IRowNodeStage {
                     currentPos: touchedRows.length,
                     rowNode: row,
                 });
-            } else if (!removals.has(row)) {
+            } else {
                 untouchedRows.add(row.id!);
             }
         }

--- a/packages/ag-grid-community/src/clientSideRowModel/sortStage.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/sortStage.ts
@@ -197,9 +197,9 @@ export class SortStage extends BeanStub implements NamedBean, IRowNodeStage {
         const untouchedRows = new Set<RowNode>();
         const touchedRows: RowNode[] = [];
 
-        const updated = changedRowNodes.updated;
+        const updates = changedRowNodes.updates;
         unsortedRows.forEach((row) => {
-            if (updated.has(row) || (changedPath && !changedPath.canSkip(row))) {
+            if (updates.has(row) || (changedPath && !changedPath.canSkip(row))) {
                 touchedRows.push(row);
             } else {
                 untouchedRows.add(row);

--- a/packages/ag-grid-community/src/interfaces/iClientSideNodeManager.ts
+++ b/packages/ag-grid-community/src/interfaces/iClientSideNodeManager.ts
@@ -1,5 +1,5 @@
 import type { RowNode } from '../entities/rowNode';
-import type { RefreshModelParams } from './iClientSideRowModel';
+import type { IChangedRowNodes, RefreshModelParams } from './iClientSideRowModel';
 import type { RowDataTransaction } from './rowDataTransaction';
 import type { RowNodeTransaction } from './rowNodeTransaction';
 
@@ -7,6 +7,8 @@ export type RowDataChildrenGetter<TData = any> = (data: TData | null | undefined
 
 /** Result of IClientSideNodeManager.updateRowData method */
 export interface ClientSideNodeManagerUpdateRowDataResult<TData = any> {
+    changedRowNodes: IChangedRowNodes<TData>;
+
     /** The RowNodeTransaction containing all the removals, updates and additions */
     rowNodeTransaction: RowNodeTransaction<TData>;
 
@@ -29,7 +31,10 @@ export interface IClientSideNodeManager<TData = any> {
 
     setImmutableRowData(params: RefreshModelParams<TData>, rowData: TData[]): void;
 
-    updateRowData(rowDataTran: RowDataTransaction<TData>): ClientSideNodeManagerUpdateRowDataResult<TData>;
+    updateRowData(
+        rowDataTran: RowDataTransaction<TData>,
+        changedRowNodes: IChangedRowNodes<TData>
+    ): ClientSideNodeManagerUpdateRowDataResult<TData>;
 
     refreshModel?(params: RefreshModelParams<TData>): void;
 }

--- a/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
+++ b/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
@@ -66,8 +66,8 @@ export type ChangedRowNodesFlags =
     | 3;
 
 export interface IChangedRowNodes<TData = any> {
-    readonly removed: ReadonlySet<RowNode<TData>>;
-    readonly updated: ReadonlyMap<RowNode<TData>, ChangedRowNodesFlags>;
+    readonly removals: ReadonlySet<RowNode<TData>>;
+    readonly updates: ReadonlyMap<RowNode<TData>, ChangedRowNodesFlags>;
 
     /** Marks a row as removed. Order of operations is: remove, update, add */
     remove(node: IRowNode<TData>): void;

--- a/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
+++ b/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
@@ -57,17 +57,18 @@ export interface IClientSideRowModel<TData = any> extends IRowModel {
     isRowDataLoaded(): boolean;
 }
 
-export type ChangedRowNodesFlags =
-    // added
-    | 1
-    // updated
-    | 2
-    // added and updated
-    | 3;
-
 export interface IChangedRowNodes<TData = any> {
+    /**
+     * The set of removed nodes.
+     * Mutually exclusive, if a node is here, it cannot be in the updates map.
+     */
     readonly removals: ReadonlySet<RowNode<TData>>;
-    readonly updates: ReadonlyMap<RowNode<TData>, ChangedRowNodesFlags>;
+
+    /**
+     * Map of row nodes that have been updated.
+     * The value is true if the row node is a new node. is false if it was just updated.
+     */
+    readonly updates: ReadonlyMap<RowNode<TData>, boolean>;
 
     /** Marks a row as removed. Order of operations is: remove, update, add */
     remove(node: IRowNode<TData>): void;

--- a/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
+++ b/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
@@ -2,6 +2,7 @@ import type { GridOptions } from '../entities/gridOptions';
 import type { RowHighlightPosition, RowNode } from '../entities/rowNode';
 import type { ChangedPath } from '../utils/changedPath';
 import type { IRowModel } from './iRowModel';
+import type { IRowNode } from './iRowNode';
 import type { RowDataTransaction } from './rowDataTransaction';
 import type { RowNodeTransaction } from './rowNodeTransaction';
 
@@ -56,12 +57,36 @@ export interface IClientSideRowModel<TData = any> extends IRowModel {
     isRowDataLoaded(): boolean;
 }
 
+export type ChangedRowNodesFlags =
+    // added
+    | 1
+    // updated
+    | 2
+    // added and updated
+    | 3;
+
+export interface IChangedRowNodes<TData = any> {
+    readonly removed: ReadonlySet<RowNode<TData>>;
+    readonly updated: ReadonlyMap<RowNode<TData>, ChangedRowNodesFlags>;
+
+    /** Marks a row as removed. Order of operations is: remove, update, add */
+    remove(node: IRowNode<TData>): void;
+
+    /** Marks a row as updated. Order of operations is: remove, update, add */
+    update(node: IRowNode<TData>): void;
+
+    /** Marks a row as added. Order of operation is: remove, update, add */
+    add(node: IRowNode<TData>): void;
+}
+
 export interface RefreshModelParams<TData = any> {
     // how much of the pipeline to execute
     step: ClientSideRowModelStage;
 
     // The set of changed grid options, if any
     changedProps?: Set<keyof GridOptions<TData>>;
+
+    changedRowNodes?: IChangedRowNodes<TData>;
 
     // The changedPath, if any
     changedPath?: ChangedPath;

--- a/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
+++ b/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
@@ -81,41 +81,57 @@ export interface IChangedRowNodes<TData = any> {
 }
 
 export interface RefreshModelParams<TData = any> {
-    // how much of the pipeline to execute
+    /** how much of the pipeline to execute */
     step: ClientSideRowModelStage;
 
-    // The set of changed grid options, if any
+    /** The set of changed grid options, if any */
     changedProps?: Set<keyof GridOptions<TData>>;
 
-    changedRowNodes?: IChangedRowNodes<TData>;
-
-    // The changedPath, if any
-    changedPath?: ChangedPath;
-
-    // if NOT new data, then this flag tells grid to check if rows already
-    // exist for the nodes (matching by node id) and reuses the row if it does.
-    keepRenderedRows?: boolean;
-
-    // if true, rows that are kept are animated to the new position
-    animate?: boolean;
-
-    // if doing delta updates, this has the changes that were done
-    rowNodeTransactions?: RowNodeTransaction<TData>[];
-
-    // true if the order of root.allLeafChildren has changed.
-    // This can happen if order of root.allLeafChildren is updated or rows are inserted (and not just appended at the end)
-    rowNodesOrderChanged?: boolean;
-
-    // true if user called setRowData() (or a new page in pagination). the grid scrolls
-    // back to the top when this is true.
-    newData?: boolean;
-
-    // true if the row data changed, due to a setRowData, immutable row data or a transaction.
+    /**
+     * true if the row data changed, due to a setRowData, immutable row data or a transaction, or an update of the row data.
+     */
     rowDataUpdated?: boolean;
 
-    // true if this update is due to columns changing, ie no rows were changed
+    /**
+     * Indicates a completely new rowData array is loaded.
+     * Is true if user called setRowData() (or a new page in pagination). the grid scrolls back to the top when this is true.
+     */
+    newData?: boolean;
+
+    /**
+     * true if the order of root.allLeafChildren has changed.
+     * This can happen if order of root.allLeafChildren is updated or rows are inserted (and not just appended at the end)
+     */
+    rowNodesOrderChanged?: boolean;
+
+    /**
+     * A data structure that holds the affected row nodes, if this was an update and not a full reload.
+     */
+    changedRowNodes?: IChangedRowNodes<TData>;
+
+    /** The changedPath, if any */
+    changedPath?: ChangedPath;
+
+    /**
+     * List of transactions being executed for a delta update.
+     * To see the affected nodes for a delta update, use `changedRowNodes` instead.
+     */
+    rowNodeTransactions?: RowNodeTransaction<TData>[];
+
+    /**
+     * if NOT new data, then this flag tells grid to check if rows already
+     * exist for the nodes (matching by node id) and reuses the row if it does.
+     */
+    keepRenderedRows?: boolean;
+
+    /**
+     * if true, rows that are kept are animated to the new position
+     */
+    animate?: boolean;
+
+    /** true if this update is due to columns changing, ie no rows were changed */
     afterColumnsChanged?: boolean;
 
-    // true if all we did is changed row height, data still the same, no need to clear the undo/redo stacks
+    /** true if all we did is changed row height, data still the same, no need to clear the undo/redo stacks */
     keepUndoRedoStack?: boolean;
 }

--- a/packages/ag-grid-community/src/interfaces/iRowNodeStage.ts
+++ b/packages/ag-grid-community/src/interfaces/iRowNodeStage.ts
@@ -1,15 +1,18 @@
 import type { GridOptions } from '../entities/gridOptions';
 import type { RowNode } from '../entities/rowNode';
 import type { ChangedPath } from '../utils/changedPath';
-import type { ClientSideRowModelStage } from './iClientSideRowModel';
+import type { ClientSideRowModelStage, IChangedRowNodes } from './iClientSideRowModel';
 import type { RowNodeTransaction } from './rowNodeTransaction';
 
 export interface StageExecuteParams<TData = any> {
     rowNode: RowNode<TData>;
-    // used in group stage, as group stage does one transaction at a time
-    rowNodeTransaction?: RowNodeTransaction<TData> | null;
+
     // used in sort stage, as sort stage looks at all transactions in one go
+    changedRowNodes?: IChangedRowNodes<TData>;
+
+    // used in group stage
     rowNodeTransactions?: RowNodeTransaction<TData>[] | null;
+
     // true if the order of root.allLeafChildren has changed
     // This can happen if order of root.allLeafChildren is updated or rows are inserted (and not just appended at the end)
     rowNodesOrderChanged?: boolean;

--- a/packages/ag-grid-community/src/main.ts
+++ b/packages/ag-grid-community/src/main.ts
@@ -432,8 +432,14 @@ export {
     ClientSideRowModelStage,
     ClientSideRowModelStep,
     RefreshModelParams,
+    IChangedRowNodes,
+    ChangedRowNodesFlags,
 } from './interfaces/iClientSideRowModel';
-export { IClientSideNodeManager, ClientSideNodeManagerUpdateRowDataResult } from './interfaces/iClientSideNodeManager';
+export {
+    IClientSideNodeManager,
+    ClientSideNodeManagerUpdateRowDataResult,
+    SetImmutableRowDataRefreshModelParams,
+} from './interfaces/iClientSideNodeManager';
 export { AbstractClientSideNodeManager } from './clientSideRowModel/abstractClientSideNodeManager';
 export { IGroupHideOpenParentsService } from './interfaces/iGroupHideOpenParentsService';
 export type { RowAutoHeightService } from './rendering/row/rowAutoHeightService';

--- a/packages/ag-grid-community/src/main.ts
+++ b/packages/ag-grid-community/src/main.ts
@@ -433,13 +433,8 @@ export {
     ClientSideRowModelStep,
     RefreshModelParams,
     IChangedRowNodes,
-    ChangedRowNodesFlags,
 } from './interfaces/iClientSideRowModel';
-export {
-    IClientSideNodeManager,
-    ClientSideNodeManagerUpdateRowDataResult,
-    SetImmutableRowDataRefreshModelParams,
-} from './interfaces/iClientSideNodeManager';
+export { IClientSideNodeManager, ClientSideNodeManagerUpdateRowDataResult } from './interfaces/iClientSideNodeManager';
 export { AbstractClientSideNodeManager } from './clientSideRowModel/abstractClientSideNodeManager';
 export { IGroupHideOpenParentsService } from './interfaces/iGroupHideOpenParentsService';
 export type { RowAutoHeightService } from './rendering/row/rowAutoHeightService';

--- a/packages/ag-grid-community/src/utils/changedPath.ts
+++ b/packages/ag-grid-community/src/utils/changedPath.ts
@@ -57,12 +57,13 @@ export class ChangedPath {
     }
 
     private depthFirstSearchChangedPath(pathItem: PathItem, callback: (rowNode: RowNode) => void): void {
-        if (pathItem.children) {
-            for (let i = 0; i < pathItem.children.length; i++) {
-                this.depthFirstSearchChangedPath(pathItem.children[i], callback);
+        const { rowNode, children } = pathItem;
+        if (children) {
+            for (let i = 0; i < children.length; ++i) {
+                this.depthFirstSearchChangedPath(children[i], callback);
             }
         }
-        callback(pathItem.rowNode);
+        callback(rowNode);
     }
 
     private depthFirstSearchEverything(
@@ -70,11 +71,12 @@ export class ChangedPath {
         callback: (rowNode: RowNode) => void,
         traverseEverything: boolean
     ): void {
-        if (rowNode.childrenAfterGroup) {
-            for (let i = 0; i < rowNode.childrenAfterGroup.length; i++) {
-                const childNode = rowNode.childrenAfterGroup[i];
+        const childrenAfterGroup = rowNode.childrenAfterGroup;
+        if (childrenAfterGroup) {
+            for (let i = 0, len = childrenAfterGroup.length; i < len; ++i) {
+                const childNode = childrenAfterGroup[i];
                 if (childNode.childrenAfterGroup) {
-                    this.depthFirstSearchEverything(rowNode.childrenAfterGroup[i], callback, traverseEverything);
+                    this.depthFirstSearchEverything(childNode, callback, traverseEverything);
                 } else if (traverseEverything) {
                     callback(childNode);
                 }

--- a/packages/ag-grid-enterprise/src/masterDetail/masterDetailService.ts
+++ b/packages/ag-grid-enterprise/src/masterDetail/masterDetailService.ts
@@ -110,9 +110,9 @@ export class MasterDetailService extends BeanStub implements NamedBean, IMasterD
         };
 
         if (changedRowNodes) {
-            const updated = changedRowNodes.updated;
-            for (const node of updated.keys()) {
-                const flags = updated.get(node)!;
+            const updates = changedRowNodes.updates;
+            for (const node of updates.keys()) {
+                const flags = updates.get(node)!;
                 setMaster(node, (flags & 1) === 1, flags === 2);
             }
         } else {

--- a/packages/ag-grid-enterprise/src/masterDetail/masterDetailService.ts
+++ b/packages/ag-grid-enterprise/src/masterDetail/masterDetailService.ts
@@ -112,8 +112,8 @@ export class MasterDetailService extends BeanStub implements NamedBean, IMasterD
         if (changedRowNodes) {
             const updates = changedRowNodes.updates;
             for (const node of updates.keys()) {
-                const flags = updates.get(node)!;
-                setMaster(node, (flags & 1) === 1, flags === 2);
+                const created = updates.get(node)!;
+                setMaster(node, created, !created);
             }
         } else {
             const allLeafChildren = _getClientSideRowModel(this.beans)?.rootNode?.allLeafChildren;

--- a/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
@@ -105,7 +105,7 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
     }
 
     /** Add or updates the row to a non-root node, preparing the tree correctly for the commit. */
-    protected treeSetRow(node: TreeNode, newRow: RowNode, update: boolean): boolean {
+    protected treeSetRow(node: TreeNode, newRow: RowNode, created: boolean): boolean {
         const { level, row: oldRow } = node;
         if (level < 0) {
             return false; // Cannot overwrite the root row
@@ -137,7 +137,7 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
             }
         }
 
-        if (update && !isTreeRowUpdated(newRow)) {
+        if (!created && !isTreeRowUpdated(newRow)) {
             setTreeRowUpdated(newRow);
             invalidate = true;
         }

--- a/packages/ag-grid-enterprise/src/treeData/clientSideChildrenTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/clientSideChildrenTreeNodeManager.ts
@@ -72,7 +72,7 @@ export class ClientSideChildrenTreeNodeManager<TData>
             allLeafChildren.push(row);
 
             node = node.upsertKey(row.id!);
-            this.treeSetRow(node, row, false);
+            this.treeSetRow(node, row, true);
 
             const children = childrenGetter?.(data);
             if (children) {
@@ -154,7 +154,7 @@ export class ClientSideChildrenTreeNodeManager<TData>
 
             const id = getRowIdFunc({ data, level: parent.level + 1 });
 
-            let update = false;
+            let created = false;
             let row = this.getRowNode(id) as TreeRow<TData> | undefined;
             if (row) {
                 if (row.data !== data) {
@@ -163,11 +163,11 @@ export class ClientSideChildrenTreeNodeManager<TData>
                     if (!row.selectable && row.isSelected()) {
                         nodesToUnselect.push(row);
                     }
-                    update = true;
                 }
             } else {
                 row = this.createRowNode(data, -1);
                 changedRowNodes.add(row);
+                created = true;
             }
 
             let oldSourceRowIndex: number;
@@ -181,7 +181,7 @@ export class ClientSideChildrenTreeNodeManager<TData>
                 oldSourceRowIndex = -1;
             }
 
-            if (this.treeSetRow(node, row, update)) {
+            if (this.treeSetRow(node, row, created)) {
                 rowsChanged = true;
             }
 

--- a/packages/ag-grid-enterprise/src/treeData/clientSideChildrenTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/clientSideChildrenTreeNodeManager.ts
@@ -1,10 +1,4 @@
-import type {
-    IChangedRowNodes,
-    IClientSideNodeManager,
-    NamedBean,
-    RefreshModelParams,
-    RowNode,
-} from 'ag-grid-community';
+import type { IClientSideNodeManager, NamedBean, RefreshModelParams, RowNode } from 'ag-grid-community';
 import { ChangedPath, _error, _getRowIdCallback } from 'ag-grid-community';
 
 import { AbstractClientSideTreeNodeManager } from './abstractClientSideTreeNodeManager';
@@ -89,10 +83,7 @@ export class ClientSideChildrenTreeNodeManager<TData>
         this.treeCommit();
     }
 
-    public override setImmutableRowData(
-        params: RefreshModelParams<TData> & { changedRowNodes: IChangedRowNodes<TData> },
-        rowData: TData[]
-    ): void {
+    public override setImmutableRowData(params: RefreshModelParams<TData>, rowData: TData[]): void {
         const gos = this.gos;
         const treeRoot = this.treeRoot!;
         const rootNode = this.rootNode!;

--- a/packages/ag-grid-enterprise/src/treeData/clientSidePathTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/clientSidePathTreeNodeManager.ts
@@ -1,5 +1,5 @@
 import { _warn } from 'ag-grid-community';
-import type { ChangedPath, NamedBean, RefreshModelParams, RowNode, RowNodeTransaction } from 'ag-grid-community';
+import type { ChangedPath, IChangedRowNodes, NamedBean, RefreshModelParams, RowNode } from 'ag-grid-community';
 
 import { AbstractClientSideTreeNodeManager } from './abstractClientSideTreeNodeManager';
 import type { TreeNode } from './treeNode';
@@ -19,7 +19,10 @@ export class ClientSidePathTreeNodeManager<TData>
 
         super.loadNewRowData(rowData);
 
-        this.addOrUpdateRows(rootNode.allLeafChildren, false);
+        const allLeafChildren = rootNode.allLeafChildren!;
+        for (let i = 0, len = allLeafChildren.length; i < len; ++i) {
+            this.addOrUpdateRow(allLeafChildren[i], false);
+        }
 
         this.treeCommit();
     }
@@ -30,15 +33,19 @@ export class ClientSidePathTreeNodeManager<TData>
     }
 
     public override refreshModel(params: RefreshModelParams<TData>): void {
-        const transactions = params.rowNodeTransactions;
-        if (transactions?.length) {
-            this.executeTransactions(transactions, params.changedPath);
+        const changedRowNodes = params.changedRowNodes;
+        if (changedRowNodes) {
+            this.executeTransactions(changedRowNodes, params.changedPath, params.rowNodesOrderChanged);
         }
 
         super.refreshModel(params);
     }
 
-    private executeTransactions(transactions: RowNodeTransaction<TData>[], changedPath: ChangedPath | undefined): void {
+    private executeTransactions(
+        changedRowNodes: IChangedRowNodes,
+        changedPath: ChangedPath | undefined,
+        rowNodesOrderMaybeChanged: boolean | undefined
+    ): void {
         const treeRoot = this.treeRoot;
         if (!treeRoot) {
             return; // Destroyed or not active
@@ -46,22 +53,28 @@ export class ClientSidePathTreeNodeManager<TData>
 
         treeRoot.setRow(this.rootNode);
 
-        for (const { remove, update, add } of transactions) {
-            // the order of [add, remove, update] is the same as in ClientSideNodeManager.
-            // Order is important when a record with the same id is added and removed in the same transaction.
-            this.removeRows(remove as RowNode[] | null);
-            this.addOrUpdateRows(update as RowNode[] | null, true);
-            this.addOrUpdateRows(add as RowNode[] | null, false);
+        for (const row of changedRowNodes.removals) {
+            const node = row.treeNode as TreeNode | null;
+            if (node) {
+                this.treeRemove(node, row);
+            }
         }
 
-        if (transactions) {
-            const rows = this.treeRoot?.row?.allLeafChildren;
-            if (rows) {
-                for (let rowIdx = 0, rowsLen = rows.length; rowIdx < rowsLen; ++rowIdx) {
-                    const node = rows[rowIdx].treeNode as TreeNode | null;
-                    if (node && node.sourceIdx !== rowIdx) {
-                        node.invalidateOrder(); // Order might have changed
-                    }
+        const updates = changedRowNodes.updates;
+        for (const row of updates.keys()) {
+            const updated = updates.get(row) === 2;
+            if (updated) {
+                rowNodesOrderMaybeChanged = true; // Order might have changed
+            }
+            this.addOrUpdateRow(row, updated);
+        }
+
+        const rows = treeRoot.row?.allLeafChildren;
+        if (rowNodesOrderMaybeChanged && rows) {
+            for (let rowIdx = 0, rowsLen = rows.length; rowIdx < rowsLen; ++rowIdx) {
+                const node = rows[rowIdx].treeNode as TreeNode | null;
+                if (node && node.sourceIdx !== rowIdx) {
+                    node.invalidateOrder(); // Order might have changed
                 }
             }
         }
@@ -69,46 +82,28 @@ export class ClientSidePathTreeNodeManager<TData>
         this.treeCommit(changedPath); // One single commit for all the transactions
     }
 
-    /** Transactional removal */
-    private removeRows(rows: RowNode[] | null | undefined): void {
-        for (let i = 0, len = rows?.length ?? 0; i < len; ++i) {
-            const row = rows![i];
-            const node = row.treeNode as TreeNode | null;
-            if (node) {
-                this.treeRemove(node, row);
-            }
-        }
-    }
-
-    /** Transactional add/update */
-    private addOrUpdateRows(rows: RowNode[] | null, update: boolean): void {
+    private addOrUpdateRow(row: RowNode, update: boolean): void {
         const treeRoot = this.treeRoot!;
         if (!this.treeData) {
             // We assume that the data is flat and we use id as the key for the tree nodes.
             // This happens when treeData is false and getDataPath is undefined/null.
-            for (let i = 0, len = rows?.length ?? 0; i < len; ++i) {
-                const row = rows![i];
-                this.treeSetRow(treeRoot.upsertKey(row.id!), row, update);
-            }
+            this.treeSetRow(treeRoot.upsertKey(row.id!), row, update);
             return;
         }
 
         const getDataPath = this.gos.get('getDataPath');
-        for (let i = 0, len = rows?.length ?? 0; i < len; ++i) {
-            const row = rows![i];
-            const path = getDataPath?.(row.data);
-            const pathLength = path?.length;
-            if (!pathLength) {
-                _warn(185, { data: row.data });
-            } else {
-                // Gets the last node of a path. Inserts filler nodes where needed.
-                let level = 0;
-                let node = treeRoot;
-                do {
-                    node = node.upsertKey(path[level++]);
-                } while (level < pathLength);
-                this.treeSetRow(node, row, update);
-            }
+        const path = getDataPath?.(row.data);
+        const pathLength = path?.length;
+        if (!pathLength) {
+            _warn(185, { data: row.data });
+        } else {
+            // Gets the last node of a path. Inserts filler nodes where needed.
+            let level = 0;
+            let node = treeRoot;
+            do {
+                node = node.upsertKey(path[level++]);
+            } while (level < pathLength);
+            this.treeSetRow(node, row, update);
         }
     }
 }


### PR DESCRIPTION
- Add a new class ChangedRowNodes, and an interface IChangedRowNodes that holds information of what changed during a transactional update or a set immutable row data in a better way
- Changes CSRM transactions and immutable data handling to write in this new data structure
- Change the delta sorting algorithm to read this new data structure
- Change the master detail service to read this new data structure
- Change the clientSidePathTreeNodeManager to read this new data structure

This is required because the new client side node manager with children does NOT generate transactions for set immutable data, instead, it directly rebuild the structure correctly and now uses this class to notify of what's changed
