### PR TITLE
AG-13089 partial fix for csrm and column model

### DIFF
--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
@@ -62,6 +62,14 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
     private pivotStage?: IRowNodeStage;
     private filterAggStage?: IRowNodeStage;
 
+    /**
+     * TODO: we are exporting here all the properties we listen to to start a refresh.
+     * This is a temporary fix for AG-13089 to ensure that the column model register to those events
+     * in such a way the order of execution of column model refresh and csrm refresh is always consistent.
+     * Remove this once AG-13089 is fixed
+     */
+    public allRefreshProps: (keyof GridOptions)[];
+
     public wireBeans(beans: BeanCollection): void {
         this.colModel = beans.colModel;
         this.valueCache = beans.valueCache;
@@ -74,6 +82,23 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         this.aggStage = beans.aggStage;
         this.pivotStage = beans.pivotStage;
         this.filterAggStage = beans.filterAggStage;
+
+        this.orderedStages = [
+            this.groupStage,
+            this.filterStage,
+            this.pivotStage,
+            this.aggStage,
+            this.sortStage,
+            this.filterAggStage,
+            this.flattenStage,
+        ].filter((stage) => !!stage) as IRowNodeStage[];
+
+        this.allRefreshProps = [
+            'rowData',
+            'treeData',
+            'treeDataChildrenField',
+            ...this.orderedStages.flatMap(({ refreshProps }) => Array.from(refreshProps ?? _EmptyArray)),
+        ];
     }
 
     private onRowHeightChanged_debounced = _debounce(this, this.onRowHeightChanged.bind(this), 100);
@@ -108,16 +133,6 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
     private orderedStages: IRowNodeStage[];
 
     public postConstruct(): void {
-        this.orderedStages = [
-            this.groupStage,
-            this.filterStage,
-            this.pivotStage,
-            this.aggStage,
-            this.sortStage,
-            this.filterAggStage,
-            this.flattenStage,
-        ].filter((stage) => !!stage) as IRowNodeStage[];
-
         const rootNode = new RowNode(this.beans);
         this.rootNode = rootNode;
         this.nodeManager = this.getNodeManagerToUse();
@@ -211,14 +226,7 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         //                       - the application would change these functions, far more likely the functions were
         //                       - non memoised correctly.
 
-        const allProps: (keyof GridOptions)[] = [
-            'rowData',
-            'treeData',
-            'treeDataChildrenField',
-            ...this.orderedStages.flatMap(({ refreshProps }) => Array.from(refreshProps ?? _EmptyArray)),
-        ];
-
-        this.addManagedPropertyListeners(allProps, (params) => {
+        this.addManagedPropertyListeners(this.allRefreshProps, (params) => {
             const changedProps = params.changeSet?.properties;
             if (changedProps) {
                 this.refreshModel({ step: 'nothing', changedProps, allowChangedPath: true });

--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -67,11 +67,18 @@ export class ColumnModel extends BeanStub implements NamedBean {
         this.pivotMode = this.gos.get('pivotMode');
 
         // TODO: Due to https://ag-grid.atlassian.net/browse/AG-13089 - Order of grouped property listener changed is not deterministic
-        // and when both rowData and treeData are changed in the same batch, the order of the events is CSRM and ColumnModel is inverted.
+        // and when both rowData and treeData are changed in the same batch, the order of the events is CSRM and ColumnModel might be inverted.
         //
         // we need to listen to the rowData change here or else this event might fire AFTER clientSideRowModel calls refresh
         // and this will cause the old grouping columns to be available in the row model
         // We have also to ignore it if the change is not related to the columns
+        //
+        // The properties listened both by columnModel and clientSideRowModel are:
+        // - treeData
+        // - groupDisplayType
+        //
+        // See the test testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data.test.ts
+        // 'ag-grid hierarchical override tree data is insensitive to updateGridOptions object order'
 
         const refreshProps = new Set<keyof GridOptions>([
             'groupDisplayType',

--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -67,7 +67,7 @@ export class ColumnModel extends BeanStub implements NamedBean {
         this.pivotMode = this.gos.get('pivotMode');
 
         // TODO: Due to https://ag-grid.atlassian.net/browse/AG-13089 - Order of grouped property listener changed is not deterministic
-        // and when both rowData and treeData are changed in the same batch, the order of the events is CSRM and ColumnModel.
+        // and when both rowData and treeData are changed in the same batch, the order of the events is CSRM and ColumnModel is inverted.
         //
         // we need to listen to the rowData change here or else this event might fire AFTER clientSideRowModel calls refresh
         // and this will cause the old grouping columns to be available in the row model

--- a/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
+++ b/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
@@ -1,4 +1,5 @@
 import type { RefreshModelParams } from '../clientSideRowModel/refreshModelState';
+import type { GridOptions } from '../entities/gridOptions';
 import type { RowHighlightPosition, RowNode } from '../entities/rowNode';
 import type { ChangedPath } from '../utils/changedPath';
 import type { IRowModel } from './iRowModel';
@@ -31,6 +32,14 @@ export type ClientSideRowModelStage =
 export interface IClientSideRowModel<TData = any> extends IRowModel {
     /** The root row containing all the rows */
     readonly rootNode: RowNode | null;
+
+    /**
+     * TODO: we are exporting here all the properties we listen to to start a refresh.
+     * This is a temporary fix for AG-13089 to ensure that the column model register to those events
+     * in such a way the order of execution of column model refresh and csrm refresh is always consistent.
+     * Remove this once AG-13089 is fixed
+     */
+    readonly allRefreshProps: (keyof GridOptions)[];
 
     refreshAfterRowGroupOpened(keepRenderedRows: boolean): void;
     refreshModel(params: RefreshModelParams): void;

--- a/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data.test.ts
@@ -267,8 +267,8 @@ describe('ag-grid hierarchical tree data', () => {
             `);
     });
 
-    // TODO: this test is skipped because https://ag-grid.atlassian.net/browse/AG-13089 - Order of grouped property listener changed is not deterministic
-    test.skip('ag-grid hierarchical override tree data is insensitive to updateGridOptions object order', async () => {
+    test('ag-grid hierarchical override tree data is insensitive to updateGridOptions object order', async () => {
+        // see https://ag-grid.atlassian.net/browse/AG-13089 - Order of grouped property listener changed is not deterministic
         const rowData0 = [
             { x: 'A', children: [{ x: 'B' }] },
             { x: 'C', children: [{ x: 'D' }] },


### PR DESCRIPTION
Due to the bug https://ag-grid.atlassian.net/browse/AG-13089 - Order of grouped property listener changed is not deterministic and when both rowData and treeData are changed in the same batch, the order of the events is CSRM and ColumnModel.

One way to fix the issue is to listen to the rowData change in column model too, or else this event might fire AFTER clientSideRowModel calls refresh and this will cause the old grouping columns to be available in the row model
We have also to ignore it if the change is not related to the columns, so if only rowData changed.
