### PR TITLE
Ag 13468 modules config design updates

### DIFF
--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleCellRenderer.module.scss
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleCellRenderer.module.scss
@@ -1,6 +1,13 @@
 .container {
-    svg {
-        margin-top: 8px;
-        padding-right: 2px;
+    --icon-color: var(--color-enterprise-icon);
+    --icon-size: 18px;
+
+    display: flex;
+    align-items: center;
+    gap: 6px;
+
+    :global(.icon) {
+        position: relative;
+        top: -2px;
     }
 }

--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleCellRenderer.tsx
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleCellRenderer.tsx
@@ -1,4 +1,4 @@
-import { EnterpriseIcon } from '@ag-website-shared/components/icon/EnterpriseIcon';
+import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { getFrameworkFromPath } from '@components/docs/utils/urlPaths';
 import { urlWithPrefix } from '@utils/urlWithPrefix';
 
@@ -24,9 +24,9 @@ export function ModuleCellRenderer({ data }: CustomCellRendererProps) {
 
     return isEnterprise ? (
         <span className={styles.container}>
-            {moduleValue} <EnterpriseIcon />
+            {moduleValue} <Icon name="enterprise" />
         </span>
     ) : (
-        moduleValue
+        <span className={styles.container}>{moduleValue}</span>
     );
 }

--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleCellRenderer.tsx
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleCellRenderer.tsx
@@ -9,6 +9,7 @@ import styles from './ModuleCellRenderer.module.scss';
 export function ModuleCellRenderer({ data }: CustomCellRendererProps) {
     const { isEnterprise, path, name } = data;
     const framework = getFrameworkFromPath(window.location.pathname);
+
     const moduleValue = path ? (
         <a
             href={urlWithPrefix({

--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleConfiguration.module.scss
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleConfiguration.module.scss
@@ -10,11 +10,17 @@
 .bundles,
 .charts {
     display: flex;
-    gap: $spacing-size-4;
+
+    > div {
+        display: flex;
+        gap: $spacing-size-8;
+        margin-left: $spacing-size-3;
+    }
 
     label {
         cursor: pointer;
         display: flex;
-        gap: $spacing-size-1;
+        align-items: center;
+        gap: 6px;
     }
 }

--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleConfiguration.module.scss
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleConfiguration.module.scss
@@ -11,6 +11,11 @@
 .charts {
     display: flex;
 
+    span {
+        min-width: 94px;
+        font-weight: var(--text-semibold);
+    }
+
     > div {
         display: flex;
         gap: $spacing-size-8;

--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleConfiguration.module.scss
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleConfiguration.module.scss
@@ -30,3 +30,8 @@
         gap: 6px;
     }
 }
+
+.enterpriseIcon {
+    --icon-size: var(--text-fs-lg);
+    --icon-color: var(--color-enterprise-icon);
+}

--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleConfiguration.module.scss
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleConfiguration.module.scss
@@ -10,9 +10,10 @@
 .bundles,
 .charts {
     display: flex;
+    align-items: center;
 
-    span {
-        min-width: 94px;
+    .label {
+        width: 100px;
         font-weight: var(--text-semibold);
     }
 

--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleConfiguration.tsx
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleConfiguration.tsx
@@ -21,7 +21,7 @@ export const ModuleConfiguration: FunctionComponent<Props> = ({ moduleConfig }) 
     return (
         <div className={styles.configuration}>
             <div className={styles.rowModel}>
-                <span>Row Model:</span>
+                <span className={styles.label}>Row Model:</span>
                 <div>
                     {ROW_MODEL_OPTIONS.map(({ name, moduleName, isEnterprise }) => {
                         return (
@@ -49,7 +49,7 @@ export const ModuleConfiguration: FunctionComponent<Props> = ({ moduleConfig }) 
             </div>
 
             <div className={styles.bundles}>
-                <span>Bundles:</span>
+                <span className={styles.label}>Bundles:</span>
                 <div>
                     {BUNDLE_OPTIONS.map(({ name, moduleName, isEnterprise }) => {
                         return (
@@ -77,7 +77,7 @@ export const ModuleConfiguration: FunctionComponent<Props> = ({ moduleConfig }) 
             </div>
 
             <div className={styles.charts}>
-                <span>Charts:</span>
+                <span className={styles.label}>Charts:</span>
                 <div>
                     {CHART_OPTIONS.map(({ name, moduleName, isEnterprise }) => {
                         return (

--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleConfiguration.tsx
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleConfiguration.tsx
@@ -21,79 +21,87 @@ export const ModuleConfiguration: FunctionComponent<Props> = ({ moduleConfig }) 
     return (
         <div className={styles.configuration}>
             <div className={styles.rowModel}>
-                Row Model:
-                {ROW_MODEL_OPTIONS.map(({ name, moduleName, isEnterprise }) => {
-                    return (
-                        <label key={name}>
-                            <input
-                                type="radio"
-                                name="rowModel"
-                                value={moduleName}
-                                checked={rowModelOption === moduleName}
-                                onChange={() => {
-                                    updateRowModelOption(moduleName);
-                                }}
-                            />{' '}
-                            {name}
-                            {isEnterprise && (
-                                <>
-                                    {' '}
-                                    <EnterpriseIcon />
-                                </>
-                            )}
-                        </label>
-                    );
-                })}
+                <span>Row Model:</span>
+                <div>
+                    {ROW_MODEL_OPTIONS.map(({ name, moduleName, isEnterprise }) => {
+                        return (
+                            <label key={name}>
+                                <input
+                                    type="radio"
+                                    name="rowModel"
+                                    value={moduleName}
+                                    checked={rowModelOption === moduleName}
+                                    onChange={() => {
+                                        updateRowModelOption(moduleName);
+                                    }}
+                                />{' '}
+                                {name}
+                                {isEnterprise && (
+                                    <>
+                                        {' '}
+                                        <EnterpriseIcon />
+                                    </>
+                                )}
+                            </label>
+                        );
+                    })}
+                </div>
             </div>
+
             <div className={styles.bundles}>
-                Bundles:
-                {BUNDLE_OPTIONS.map(({ name, moduleName, isEnterprise }) => {
-                    return (
-                        <label key={name}>
-                            <input
-                                type="radio"
-                                name="bundles"
-                                value={moduleName}
-                                checked={bundleOption === moduleName}
-                                onChange={() => {
-                                    updateBundleOption(moduleName as BundleOptionValue);
-                                }}
-                            />{' '}
-                            {name}
-                            {isEnterprise && (
-                                <>
-                                    {' '}
-                                    <EnterpriseIcon />
-                                </>
-                            )}
-                        </label>
-                    );
-                })}
+                <span>Bundles:</span>
+                <div>
+                    {BUNDLE_OPTIONS.map(({ name, moduleName, isEnterprise }) => {
+                        return (
+                            <label key={name}>
+                                <input
+                                    type="radio"
+                                    name="bundles"
+                                    value={moduleName}
+                                    checked={bundleOption === moduleName}
+                                    onChange={() => {
+                                        updateBundleOption(moduleName as BundleOptionValue);
+                                    }}
+                                />{' '}
+                                {name}
+                                {isEnterprise && (
+                                    <>
+                                        {' '}
+                                        <EnterpriseIcon />
+                                    </>
+                                )}
+                            </label>
+                        );
+                    })}
+                </div>
             </div>
+
             <div className={styles.charts}>
-                Charts:
-                {CHART_OPTIONS.map(({ name, moduleName, isEnterprise }) => {
-                    return (
-                        <label key={name}>
-                            <input
-                                type="checkbox"
-                                name="charts"
-                                value={moduleName}
-                                checked={chartOptions[name as ChartModuleName]}
-                                onChange={() => {
-                                    updateChartOption(name as ChartModuleName);
-                                }}
-                            />{' '}
-                            {name}
-                            {isEnterprise && (
-                                <>
-                                    {' '}
-                                    <EnterpriseIcon />
-                                </>
-                            )}
-                        </label>
-                    );
-                })}
+                <span>Charts:</span>
+                <div>
+                    {CHART_OPTIONS.map(({ name, moduleName, isEnterprise }) => {
+                        return (
+                            <label key={name}>
+                                <input
+                                    type="checkbox"
+                                    name="charts"
+                                    value={moduleName}
+                                    checked={chartOptions[name as ChartModuleName]}
+                                    onChange={() => {
+                                        updateChartOption(name as ChartModuleName);
+                                    }}
+                                />{' '}
+                                {name}
+                                {isEnterprise && (
+                                    <>
+                                        {' '}
+                                        <EnterpriseIcon />
+                                    </>
+                                )}
+                            </label>
+                        );
+                    })}
+                </div>
             </div>
         </div>
     );

--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleConfiguration.tsx
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleConfiguration.tsx
@@ -1,4 +1,4 @@
-import { EnterpriseIcon } from '@ag-website-shared/components/icon/EnterpriseIcon';
+import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { type FunctionComponent } from 'react';
 
 import styles from './ModuleConfiguration.module.scss';
@@ -36,12 +36,7 @@ export const ModuleConfiguration: FunctionComponent<Props> = ({ moduleConfig }) 
                                     }}
                                 />{' '}
                                 {name}
-                                {isEnterprise && (
-                                    <>
-                                        {' '}
-                                        <EnterpriseIcon />
-                                    </>
-                                )}
+                                {isEnterprise && <Icon name="enterprise" svgClasses={styles.enterpriseIcon} />}
                             </label>
                         );
                     })}
@@ -64,12 +59,7 @@ export const ModuleConfiguration: FunctionComponent<Props> = ({ moduleConfig }) 
                                     }}
                                 />{' '}
                                 {name}
-                                {isEnterprise && (
-                                    <>
-                                        {' '}
-                                        <EnterpriseIcon />
-                                    </>
-                                )}
+                                {isEnterprise && <Icon name="enterprise" svgClasses={styles.enterpriseIcon} />}
                             </label>
                         );
                     })}
@@ -92,12 +82,7 @@ export const ModuleConfiguration: FunctionComponent<Props> = ({ moduleConfig }) 
                                     }}
                                 />{' '}
                                 {name}
-                                {isEnterprise && (
-                                    <>
-                                        {' '}
-                                        <EnterpriseIcon />
-                                    </>
-                                )}
+                                {isEnterprise && <Icon name="enterprise" svgClasses={styles.enterpriseIcon} />}
                             </label>
                         );
                     })}

--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleMappings.module.scss
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleMappings.module.scss
@@ -5,8 +5,24 @@
     flex-direction: column;
     gap: $spacing-size-2;
 
+    :global(.ag-root-wrapper) {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+    }
+
     :global(.ag-group-child-count) {
         opacity: 0.6666;
         margin-left: 4px;
+    }
+}
+
+.moduleSnippet pre {
+    margin-top: -9px;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+
+    // Use same colour border as Quartz theme
+    #{$selector-darkmode} & {
+        border-color: color-mix(in srgb, var(--color-fg-primary) 15%, transparent);
     }
 }

--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleMappings.module.scss
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleMappings.module.scss
@@ -4,4 +4,9 @@
     display: flex;
     flex-direction: column;
     gap: $spacing-size-2;
+
+    :global(.ag-group-child-count) {
+        opacity: 0.6666;
+        margin-left: 4px;
+    }
 }

--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleMappings.tsx
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleMappings.tsx
@@ -135,7 +135,7 @@ export const ModuleMappings: FunctionComponent<Props> = ({ framework, modules })
         <div className={styles.container}>
             <ModuleConfiguration moduleConfig={moduleConfig} />
             <ModuleSearch gridRef={gridRef} />
-            <div style={{ height: '400px' }}>
+            <div style={{ height: '410px' }}>
                 <AgGridReact
                     ref={gridRef}
                     defaultColDef={defaultColDef}

--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleMappings.tsx
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleMappings.tsx
@@ -11,6 +11,7 @@ import { AgGridReact } from 'ag-grid-react';
 import { ModuleCellRenderer } from './ModuleCellRenderer';
 import { ModuleConfiguration } from './ModuleConfiguration';
 import styles from './ModuleMappings.module.scss';
+import { ModuleNameCellRenderer } from './ModuleNameCellRenderer';
 import { ModuleSearch } from './ModuleSearch';
 import { useModuleConfig } from './useModuleConfig';
 
@@ -39,7 +40,12 @@ export const ModuleMappings: FunctionComponent<Props> = ({ framework, modules })
         resizable: false,
         suppressMovable: true,
     });
-    const [columnDefs] = useState([{ field: 'moduleName' }]);
+    const [columnDefs] = useState([
+        {
+            field: 'moduleName',
+            cellRenderer: ModuleNameCellRenderer,
+        },
+    ]);
     const [autoGroupColumnDef] = useState({
         headerName: 'Feature',
         cellRendererParams: {

--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleMappings.tsx
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleMappings.tsx
@@ -158,7 +158,9 @@ export const ModuleMappings: FunctionComponent<Props> = ({ framework, modules })
                 />
             </div>
             {selectedDependenciesSnippet && (
-                <Snippet framework={framework} content={selectedDependenciesSnippet} copyToClipboard />
+                <div className={styles.moduleSnippet}>
+                    <Snippet framework={framework} content={selectedDependenciesSnippet} copyToClipboard />
+                </div>
             )}
         </div>
     );

--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleNameCellRenderer.module.scss
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleNameCellRenderer.module.scss
@@ -1,0 +1,3 @@
+.moduleName {
+    font-size: 13px;
+}

--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleNameCellRenderer.tsx
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleNameCellRenderer.tsx
@@ -1,13 +1,9 @@
-import { Icon } from '@ag-website-shared/components/icon/Icon';
-import { getFrameworkFromPath } from '@components/docs/utils/urlPaths';
-import { urlWithPrefix } from '@utils/urlWithPrefix';
-
 import type { CustomCellRendererProps } from 'ag-grid-react';
 
-import styles from './ModuleCellRenderer.module.scss';
+import styles from './ModuleNameCellRenderer.module.scss';
 
 export function ModuleNameCellRenderer({ data }: CustomCellRendererProps) {
     const moduleName = data.moduleName;
 
-    return moduleName ? <code>{moduleName}</code> : <span></span>;
+    return moduleName ? <code className={styles.moduleName}>{moduleName}</code> : null;
 }

--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleNameCellRenderer.tsx
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleNameCellRenderer.tsx
@@ -1,0 +1,13 @@
+import { Icon } from '@ag-website-shared/components/icon/Icon';
+import { getFrameworkFromPath } from '@components/docs/utils/urlPaths';
+import { urlWithPrefix } from '@utils/urlWithPrefix';
+
+import type { CustomCellRendererProps } from 'ag-grid-react';
+
+import styles from './ModuleCellRenderer.module.scss';
+
+export function ModuleNameCellRenderer({ data }: CustomCellRendererProps) {
+    const moduleName = data.moduleName;
+
+    return moduleName ? <code>{moduleName}</code> : <span></span>;
+}

--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleSearch.module.scss
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleSearch.module.scss
@@ -3,8 +3,10 @@
 .searchBox {
     position: relative;
     display: flex;
+    margin-top: $spacing-size-4;
     border-radius: var(--radius-md);
     cursor: text;
+
     #{$selector-darkmode} & {
         input {
             background: color-mix(in srgb, var(--color-bg-primary), var(--color-fg-primary) 6%);
@@ -22,12 +24,12 @@
 
     position: absolute;
     top: 10px;
-    left: $spacing-size-2;
+    left: $spacing-size-4;
 }
 
 input[type='search'].searchInput {
     width: 100%;
-    padding: $spacing-size-2 $spacing-size-2 $spacing-size-2 $spacing-size-8;
+    padding: $spacing-size-2 $spacing-size-2 $spacing-size-2 $spacing-size-10;
 
     &::placeholder {
         color: var(--color-fg-quinary);


### PR DESCRIPTION
Modules configurator design improvements

- Enterprise Ⓔ in cells vertical alignment
- Style module names as <code> without breaking single click copying
- Style (xx) number of modules display. De-emphasise compared to feature name? 
- Make grid height better match row height. Row is aligned so the middle is on the bottom of the grid (cut off the bottom half of the row). 