### PR TITLE
AG-13497 csrm does not always update root sibling array

### DIFF
--- a/packages/ag-grid-community/src/clientSideRowModel/abstractClientSideNodeManager.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/abstractClientSideNodeManager.ts
@@ -69,6 +69,8 @@ export abstract class AbstractClientSideNodeManager<TData = any>
         rootNode.childrenAfterSort = [];
         rootNode.childrenAfterAggFilter = [];
         rootNode.childrenAfterFilter = [];
+
+        this.updateRootSiblingArrays(rootNode);
     }
 
     public deactivate(): void {
@@ -94,8 +96,6 @@ export abstract class AbstractClientSideNodeManager<TData = any>
 
         this.dispatchRowDataUpdateStartedEvent(rowData);
 
-        const sibling = rootNode.sibling;
-
         rootNode.childrenAfterFilter = null;
         rootNode.childrenAfterGroup = null;
         rootNode.childrenAfterAggFilter = null;
@@ -110,6 +110,11 @@ export abstract class AbstractClientSideNodeManager<TData = any>
 
         this.loadNewRowData(rowData);
 
+        this.updateRootSiblingArrays(rootNode);
+    }
+
+    private updateRootSiblingArrays(rootNode: AbstractClientSideNodeManager.RootNode<TData>): void {
+        const sibling = rootNode.sibling;
         if (sibling) {
             sibling.childrenAfterFilter = rootNode.childrenAfterFilter;
             sibling.childrenAfterGroup = rootNode.childrenAfterGroup;
@@ -267,7 +272,7 @@ export abstract class AbstractClientSideNodeManager<TData = any>
             return;
         }
 
-        const allLeafChildren = this.rootNode!.allLeafChildren!;
+        let allLeafChildren = this.rootNode!.allLeafChildren!;
         let addIndex = allLeafChildren.length;
 
         if (typeof rowDataTran.addIndex === 'number') {
@@ -315,15 +320,16 @@ export abstract class AbstractClientSideNodeManager<TData = any>
                 nodesAfterIndex[index].sourceRowIndex = nodesAfterIndexFirstIndex + index;
             }
 
-            rootNode!.allLeafChildren = [...nodesBeforeIndex, ...newNodes, ...nodesAfterIndex];
+            allLeafChildren = [...nodesBeforeIndex, ...newNodes, ...nodesAfterIndex];
 
             // Mark the result as rows inserted
             result.rowsInserted = true;
         } else {
             // Just append at the end
-            rootNode.allLeafChildren = allLeafChildren.concat(newNodes);
+            allLeafChildren = allLeafChildren.concat(newNodes);
         }
 
+        rootNode.allLeafChildren = allLeafChildren;
         const sibling = rootNode.sibling;
         if (sibling) {
             sibling.allLeafChildren = allLeafChildren;

--- a/packages/ag-grid-enterprise/src/treeData/clientSideChildrenTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/clientSideChildrenTreeNodeManager.ts
@@ -220,6 +220,11 @@ export class ClientSideChildrenTreeNodeManager<TData>
 
         this.treeCommit(changedPath);
 
+        const sibling = rootNode.sibling;
+        if (sibling) {
+            sibling.allLeafChildren = allLeafChildren;
+        }
+
         if (rowsChanged || orderChanged) {
             params.step = 'group';
             params.rowDataUpdated = true;

--- a/testing/behavioural/src/test-utils/gridRows/validation/gridRowsValidator.ts
+++ b/testing/behavioural/src/test-utils/gridRows/validation/gridRowsValidator.ts
@@ -157,6 +157,8 @@ export class GridRowsValidator {
             );
         }
 
+        this.validateSiblingArrays(row);
+
         const childrenAfterGroupSet = this.validateChildren(gridRows, row, 'childrenAfterGroup', null);
         const childrenAfterFilterSet = this.validateChildren(
             gridRows,
@@ -194,6 +196,26 @@ export class GridRowsValidator {
         const detailGrid = gridRows.getDetailGridRows(row);
         if (detailGrid) {
             this.validate(detailGrid);
+        }
+    }
+
+    private validateSiblingArrays(row: RowNode<any>) {
+        if (row.sibling) {
+            if (row.sibling.childrenAfterGroup !== row.childrenAfterGroup) {
+                this.errors.get(row).add('Sibling childrenAfterGroup is different');
+            }
+            if (row.sibling.childrenAfterFilter !== row.childrenAfterFilter) {
+                this.errors.get(row).add('Sibling childrenAfterFilter is different');
+            }
+            if (row.sibling.childrenAfterAggFilter !== row.childrenAfterAggFilter) {
+                this.errors.get(row).add('Sibling childrenAfterAggFilter is different');
+            }
+            if (row.sibling.childrenAfterSort !== row.childrenAfterSort) {
+                this.errors.get(row).add('Sibling childrenAfterSort is different');
+            }
+            if (row.sibling.allLeafChildren !== row.allLeafChildren) {
+                this.errors.get(row).add('Sibling allLeafChildren is different');
+            }
         }
     }
 


### PR DESCRIPTION
root.sibling.allLeafChildren is not always updated to be root.allLeafChildren
This was happening in transaction add and insert, when switching node manager for treeData, when using treeDataChildrenField