### PR TITLE
AG-13498 csrm column model prop change event order tactical fix

### DIFF
--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -1,9 +1,11 @@
+import { _getClientSideRowModel } from '../api/rowModelApiUtils';
 import { placeLockedColumns } from '../columnMove/columnMoveUtils';
 import type { NamedBean } from '../context/bean';
 import { BeanStub } from '../context/beanStub';
 import type { AgColumn } from '../entities/agColumn';
 import type { AgProvidedColumnGroup } from '../entities/agProvidedColumnGroup';
 import type { ColDef, ColGroupDef } from '../entities/colDef';
+import type { GridOptions } from '../entities/gridOptions';
 import type { ColumnEventType } from '../events';
 import { _shouldMaintainColumnOrder } from '../gridOptionsUtils';
 import type { Column } from '../interfaces/iColumn';
@@ -65,10 +67,49 @@ export class ColumnModel extends BeanStub implements NamedBean {
     public postConstruct(): void {
         this.pivotMode = this.gos.get('pivotMode');
 
+        // TODO: Due to https://ag-grid.atlassian.net/browse/AG-13089 - Order of grouped property listener changed is not deterministic
+        // and when properties that affect both columnModel and CSRM might be inverted.
+        // For this reason, we listen here to all properties listened by CSRM also.
+        //
+        // we need to listen to the rowData change here or else this event might fire AFTER clientSideRowModel calls refresh
+        // and this will cause the old grouping columns to be available in the row model
+        // We have also to ignore it if the change is not related to the columns
+        //
+        // The properties listened both by columnModel and clientSideRowModel are:
+        // - treeData
+        // - groupDisplayType
+        //
+        // See the test testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data.test.ts
+        // 'ag-grid hierarchical override tree data is insensitive to updateGridOptions object order'
+
+        const refreshProps = new Set<keyof GridOptions>([
+            'groupDisplayType',
+            'treeData',
+            'treeDataDisplayType',
+            'groupHideOpenParents',
+        ]);
+
         this.addManagedPropertyListeners(
-            ['groupDisplayType', 'treeData', 'treeDataDisplayType', 'groupHideOpenParents'],
-            (event) => this.refreshAll(_convertColumnEventSourceType(event.source))
+            [...refreshProps, ...(_getClientSideRowModel(this.beans)?.allRefreshProps ?? [])],
+            (event) => {
+                const properties = event.changeSet?.properties;
+                let refresh = true;
+                if (properties) {
+                    // Ignore the event if the change is not related to the columns
+                    refresh = false;
+                    for (let i = 0, len = properties.length; i < len; i++) {
+                        if (refreshProps.has(properties[i])) {
+                            refresh = true;
+                            break;
+                        }
+                    }
+                }
+                if (refresh) {
+                    this.refreshAll(_convertColumnEventSourceType(event.source));
+                }
+            }
         );
+
         this.addManagedPropertyListeners(
             ['defaultColDef', 'defaultColGroupDef', 'columnTypes', 'suppressFieldDotNotation'],
             (event) => this.recreateColumnDefs(_convertColumnEventSourceType(event.source))

--- a/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
+++ b/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
@@ -33,6 +33,14 @@ export interface IClientSideRowModel<TData = any> extends IRowModel {
     /** The root row containing all the rows */
     readonly rootNode: RowNode | null;
 
+    /**
+     * TODO: we are exporting here all the properties we listen to to start a refresh.
+     * This is a temporary fix for AG-13089 to ensure that the column model register to those events
+     * in such a way the order of execution of column model refresh and csrm refresh is always consistent.
+     * Remove this once AG-13089 is fixed
+     */
+    readonly allRefreshProps: (keyof GridOptions)[];
+
     onRowGroupOpened(): void;
     updateRowData(rowDataTran: RowDataTransaction<TData>): RowNodeTransaction<TData> | null;
     refreshModel(params: RefreshModelParams): void;

--- a/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data.test.ts
@@ -267,8 +267,9 @@ describe('ag-grid hierarchical tree data', () => {
             `);
     });
 
-    // TODO: this test is skipped because https://ag-grid.atlassian.net/browse/AG-13089 - Order of grouped property listener changed is not deterministic
-    test.skip('ag-grid hierarchical override tree data is insensitive to updateGridOptions object order', async () => {
+    test('ag-grid hierarchical override tree data is insensitive to updateGridOptions object order', async () => {
+        // see https://ag-grid.atlassian.net/browse/AG-13089 - Order of grouped property listener changed is not deterministic
+
         const rowData0 = [
             { x: 'A', children: [{ x: 'B' }] },
             { x: 'C', children: [{ x: 'D' }] },


### PR DESCRIPTION
When using CSRM and setting treeData and rowData together such that rowData is defined before treeData, group column isn't shown

This is a temporary fix to avoid users encountering this very hard to debug edge case, as it depends on the order of properties defined in react or in updateGridOptions

The solution here is to register the same properties used by CSRM in the columnModel, so that the events are executed in the right order (first columnModel than CSRM refresh) no matter in which the order of grouped properties is received.

This approach was already validated and approved by @StephenCooper 