### PR TITLE
AG-13498 tactical fix by separating rowData listener

### DIFF
--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
@@ -209,7 +209,7 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
             ...this.orderedStages.flatMap(({ refreshProps }) => [...refreshProps]),
         ];
 
-        this.addManagedPropertyListeners(allProps, (params: PropertyChangedEvent): void => {
+        this.addManagedPropertyListeners(allProps, (params) => {
             const properties = params.changeSet?.properties;
             if (properties) {
                 this.onPropChange(properties);

--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
@@ -6,6 +6,7 @@ import type { GridOptions } from '../entities/gridOptions';
 import type { RowHighlightPosition } from '../entities/rowNode';
 import { ROW_ID_PREFIX_ROW_GROUP, RowNode } from '../entities/rowNode';
 import type { CssVariablesChanged, FilterChangedEvent } from '../events';
+import { PropertyChangedEvent } from '../gridOptionsService';
 import { _getGroupSelectsDescendants, _getRowHeightForNode, _isAnimateRows, _isDomLayout } from '../gridOptionsUtils';
 import type { IClientSideNodeManager } from '../interfaces/iClientSideNodeManager';
 import type {
@@ -203,18 +204,24 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         //                       - non memoised correctly.
 
         const allProps: (keyof GridOptions)[] = [
-            'rowData',
             'treeData',
             'treeDataChildrenField',
             ...this.orderedStages.flatMap(({ refreshProps }) => [...refreshProps]),
         ];
 
-        this.addManagedPropertyListeners(allProps, (params) => {
+        this.addManagedPropertyListeners(allProps, (params: PropertyChangedEvent): void => {
             const properties = params.changeSet?.properties;
             if (properties) {
                 this.onPropChange(properties);
             }
         });
+
+        // TODO: HACK: rowData should be in the list of allProps instead of being registered separately.
+        // but due to AG-13498, the columnModel will execute AFTER the previous listeners if properties
+        // the column model listen to together with the previous listener are changed together.
+        // So this is a temporary solution to make sure rowData is processed after the columnModel is ready.
+        // Unfortunately this can result in double refresh when multiple properties are changed together, as it was before version 33.
+        this.addManagedPropertyListener('rowData', () => this.onPropChange(['rowData']));
 
         this.addManagedPropertyListener('rowHeight', () => this.resetRowHeights());
     }

--- a/testing/behavioural/src/tree-data/datapath/tree-data.test.ts
+++ b/testing/behavioural/src/tree-data/datapath/tree-data.test.ts
@@ -197,8 +197,8 @@ describe('ag-grid tree data', () => {
         expect(rowsSnapshot).toMatchObject(expectedSnapshot);
     });
 
-    // TODO: this test is skipped because https://ag-grid.atlassian.net/browse/AG-13089 - Order of grouped property listener changed is not deterministic
-    test.skip('ag-grid override tree data is insensitive to updateGridOptions object order', async () => {
+    test('ag-grid override tree data is insensitive to updateGridOptions object order', async () => {
+        // see https://ag-grid.atlassian.net/browse/AG-13089 - Order of grouped property listener changed is not deterministic
         const rowData0 = [
             { orgHierarchy: ['A', 'B'], x: 'B' },
             { orgHierarchy: ['C', 'D', 'E'], x: 'E' },

--- a/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data.test.ts
@@ -267,8 +267,8 @@ describe('ag-grid hierarchical tree data', () => {
             `);
     });
 
-    // TODO: this test is skipped because https://ag-grid.atlassian.net/browse/AG-13089 - Order of grouped property listener changed is not deterministic
-    test.skip('ag-grid hierarchical override tree data is insensitive to updateGridOptions object order', async () => {
+    test('ag-grid hierarchical override tree data is insensitive to updateGridOptions object order', async () => {
+        // see https://ag-grid.atlassian.net/browse/AG-13089 - Order of grouped property listener changed is not deterministic
         const rowData0 = [
             { x: 'A', children: [{ x: 'B' }] },
             { x: 'C', children: [{ x: 'D' }] },


### PR DESCRIPTION
Due to the fact that we removed the immutable service and delegated the responsibility to CSRM, we merged the 'rowData' property to the list of properties.
Due to the bug https://ag-grid.atlassian.net/browse/AG-13089 - Order of grouped property listener changed is not deterministic - this may cause the columnModel to execute after the clientSideRowModel property change event handler causing a regression not happening in version 32 when properties are changed together with rowData.

To fix this, and maintain the exact behaviour of version 32, we are separating the property handler for rowData in its own change listener, removing it from the grouped property changes.