### PR TITLE
RTI-2482 [R] Vue Grid Pre Destroy Example

### DIFF
--- a/packages/ag-grid-vue3/src/components/AgGridVue.vue
+++ b/packages/ag-grid-vue3/src/components/AgGridVue.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts" generic="TData = any, TColDef extends ColDef<TData> = ColDef<any>">
+
 // @START_IMPORTS@
 import type {
     AdvancedFilterBuilderVisibleChangedEvent,
@@ -56,6 +57,7 @@ import type {
     FirstDataRenderedEvent,
     FullWidthCellKeyDownEvent,
     GridColumnsChangedEvent,
+    GridPreDestroyedEvent,
     GridReadyEvent,
     GridSizeChangedEvent,
     HeaderFocusedEvent,
@@ -97,14 +99,15 @@ import type {
     ViewportChangedEvent,
     VirtualColumnsChangedEvent,
     VirtualRowRemovedEvent
-} from "ag-grid-community";
+} from 'ag-grid-community';
 // @END_IMPORTS@
+
 import { VueFrameworkComponentWrapper } from '@/components/VueFrameworkComponentWrapper';
 import { VueFrameworkOverrides } from '@/components/VueFrameworkOverrides';
 import type { Props } from '@/components/utils';
 import { debounce, deepToRaw, getProps } from '@/components/utils';
 import type { Ref } from 'vue';
-import { getCurrentInstance, markRaw, onMounted, ref, toRaw, toRefs, useTemplateRef, watch } from 'vue';
+import { getCurrentInstance, markRaw, onMounted, onUnmounted, ref, toRaw, toRefs, useTemplateRef, watch } from 'vue';
 
 import type { AgEventType, ColDef, GridApi, GridOptions, IRowNode } from 'ag-grid-community';
 import {
@@ -150,8 +153,6 @@ const ROW_DATA_EVENTS: Set<string> = new Set(['rowDataUpdated', 'cellValueChange
 const rowDataModel = defineModel<TData[]>();
 const rowDataUpdating: Ref<boolean> = ref(false);
 const emits = defineEmits<{
-    // @START_EVENTS@
-    // @END_EVENTS@
     'update:modelValue': [event: TData[]];
 }>();
 watch(
@@ -271,6 +272,13 @@ onMounted(() => {
 
     api.value = createGrid(rootRef.value!, gridOptions, gridParams);
     gridCreated.value = true;
+});
+
+onUnmounted(() => {
+  if (gridCreated.value) {
+    api?.value?.destroy();
+    isDestroyed.value = true;
+  }
 });
 
 defineExpose({

--- a/packages/ag-grid-vue3/src/components/utils.ts
+++ b/packages/ag-grid-vue3/src/components/utils.ts
@@ -80,8 +80,9 @@ import type {
     Theme,
     TreeDataDisplayType,
     UseGroupTotalRow
-} from "ag-grid-community";
+} from 'ag-grid-community';
 // @END_IMPORTS@
+
 // @START_EVENTS_IMPORTS@
 import type {
     AdvancedFilterBuilderVisibleChangedEvent,
@@ -139,6 +140,7 @@ import type {
     FirstDataRenderedEvent,
     FullWidthCellKeyDownEvent,
     GridColumnsChangedEvent,
+    GridPreDestroyedEvent,
     GridReadyEvent,
     GridSizeChangedEvent,
     HeaderFocusedEvent,
@@ -179,8 +181,10 @@ import type {
     UndoStartedEvent,
     ViewportChangedEvent,
     VirtualColumnsChangedEvent,
-    VirtualRowRemovedEvent,
+    VirtualRowRemovedEvent
 } from 'ag-grid-community';
+// @END_EVENTS_IMPORTS@
+
 import type { GridOptions, Module } from 'ag-grid-community';
 import type { AgChartTheme, AgChartThemeOverrides } from 'ag-charts-types';
 import { isProxy, isReactive, isRef, toRaw } from 'vue';
@@ -197,7 +201,7 @@ export interface Props<TData, TColDef> {
      * See [Providing Modules To Individual Grids](https://www.ag-grid.com/vue-data-grid/modules/#providing-modules-to-individual-grids) for more information.
      */
     modules?: Module[] | undefined;
-    // @START_PROPS@
+// @START_PROPS@
     /** Specifies the status bar components to use in the status bar.
          */
     statusBar?: { statusPanels: StatusPanelDef[] } | undefined,
@@ -1459,7 +1463,7 @@ export interface Props<TData, TColDef> {
 
     // @END_PROPS@
 
-    // @START_EVENT_PROP_TYPES@
+// @START_EVENT_PROP_TYPES@
    'onTool-panel-visible-changed': ToolPanelVisibleChangedEvent<TData>,
    'onTool-panel-size-changed': ToolPanelSizeChangedEvent<TData>,
    'onColumn-menu-visible-changed': ColumnMenuVisibleChangedEvent<TData>,
@@ -1513,6 +1517,7 @@ export interface Props<TData, TColDef> {
    'onChart-destroyed': ChartDestroyedEvent<TData>,
    'onCell-key-down': CellKeyDownEvent<TData> | FullWidthCellKeyDownEvent<TData>,
    'onGrid-ready': GridReadyEvent<TData>,
+   'onGrid-pre-destroyed': GridPreDestroyedEvent<TData>,
    'onFirst-data-rendered': FirstDataRenderedEvent<TData>,
    'onGrid-size-changed': GridSizeChangedEvent<TData>,
    'onModel-updated': ModelUpdatedEvent<TData>,
@@ -1564,7 +1569,8 @@ export function getProps() {
     return {
         gridOptions: {} as any,
         modules: [] as any,
-        // @START_DEFAULTS@
+
+// @START_DEFAULTS@
         statusBar: undefined,
         sideBar: undefined,
         suppressContextMenu: undefined,
@@ -1869,7 +1875,8 @@ export function getProps() {
         isFullWidthRow: undefined,
 
 // @END_DEFAULTS@
-        // @START_EVENT_PROPS@
+
+// @START_EVENT_PROPS@
         'onColumn-everything-changed': undefined,
         'onNew-columns-loaded': undefined,
         'onColumn-pivot-mode-changed': undefined,
@@ -1942,6 +1949,7 @@ export function getProps() {
         'onRow-clicked': undefined,
         'onRow-double-clicked': undefined,
         'onGrid-ready': undefined,
+        'onGrid-pre-destroyed': undefined,
         'onGrid-size-changed': undefined,
         'onViewport-changed': undefined,
         'onFirst-data-rendered': undefined,
@@ -1967,9 +1975,9 @@ export function getProps() {
         'onRow-drag-cancel': undefined
 // @END_EVENT_PROPS@
 
-        // _PUBLIC_EVENTS
     };
 }
+
 
 export const debounce = (func: () => void, delay: number) => {
     let timeout: number;

--- a/packages/ag-grid-vue3/updateGridAndColumnProperties.cjs
+++ b/packages/ag-grid-vue3/updateGridAndColumnProperties.cjs
@@ -11,8 +11,8 @@ const { formatNode, findNode, getFullJsDoc } = getFormatterForTS(ts);
 const AG_CHART_TYPES = ['AgChartTheme', 'AgChartThemeOverrides'];
 
 const skippableProperties = ['gridOptions', 'reactiveCustomComponents'];
-const skippableEvents = ['gridPreDestroyed'];
-const skippableEventTypes = ['GridPreDestroyedEvent'];
+const skippableEvents = [];
+const skippableEventTypes = [];
 
 function writeSortedLines(toWrite, result) {
     toWrite.sort((a, b) => {
@@ -251,8 +251,8 @@ const updateGridProperties = (getGridPropertiesAndEvents) => {
         eventNameAsProps,
         eventPropTypes,
     } = getGridPropertiesAndEvents();
-    const importsForProps = `import type {${EOL}    ${types.join(',' + EOL + '    ')}${EOL}} from "ag-grid-community";`;
-    const importsForEvents = `import type {${EOL}    ${eventTypes.join(',' + EOL + '    ')}${EOL}} from "ag-grid-community";`;
+    const importsForProps = `import type {${EOL}    ${types.join(',' + EOL + '    ')}${EOL}} from 'ag-grid-community';`;
+    const importsForEvents = `import type {${EOL}    ${eventTypes.join(',' + EOL + '    ')}${EOL}} from 'ag-grid-community';`;
 
     const optionsForUtils = {
         files: './src/components/utils.ts',
@@ -267,7 +267,7 @@ const updateGridProperties = (getGridPropertiesAndEvents) => {
         to: [
             `// @START_PROPS@${EOL}${gridPropertiesAndEvents}    // @END_PROPS@`,
             `// @START_IMPORTS@${EOL}${importsForProps}${EOL}// @END_IMPORTS@`,
-            `// @START_EVENTS_IMPORTS@${EOL}${importsForEvents}// @END_EVENTS_IMPORTS@`,
+            `// @START_EVENTS_IMPORTS@${EOL}${importsForEvents}${EOL}// @END_EVENTS_IMPORTS@`,
             `// @START_DEFAULTS@${EOL}${defaults}// @END_DEFAULTS@`,
             `// @START_EVENT_PROPS@${EOL}${eventNameAsProps.join(`,${EOL}`)}${EOL}// @END_EVENT_PROPS@`,
             `// @START_EVENT_PROP_TYPES@${EOL}${eventPropTypes}${EOL}// @END_EVENT_PROP_TYPES@`,
@@ -284,12 +284,10 @@ const updateGridProperties = (getGridPropertiesAndEvents) => {
     const optionsForVue = {
         files: './src/components/AgGridVue.vue',
         from: [
-            /(\/\/ @START_IMPORTS@)[^]*(\/\/ @END_IMPORTS@)/,
-            // /(\/\/ @START_EVENTS@)[^]*(\/\/ @END_EVENTS@)/,
+            /(\/\/ @START_IMPORTS@)[^]*(\/\/ @END_IMPORTS@)/
         ],
         to: [
-            `// @START_IMPORTS@${EOL}${importsForEvents}${EOL}// @END_IMPORTS@`,
-            // `// @START_EVENTS@${EOL}${events}${EOL}// @END_EVENTS@`
+            `// @START_IMPORTS@${EOL}${importsForEvents}${EOL}// @END_IMPORTS@`
         ],
     };
 


### PR DESCRIPTION
A regression - two missing bits:

- pre destroy method wasn't taken account of in the wrapper (as it was "skipped" in the property updater script)
- grid wasn't destroyed in the wrapper itself