### PR TITLE
RTI-2518 - Port sparkline styles to legacy common structural scss

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -851,6 +851,10 @@
         top: 0;
     }
 
+    .ag-sparkline-wrapper :where(canvas) {
+        position: absolute;
+    }
+
     .ag-full-width-row .ag-cell-wrapper.ag-row-group {
         height: 100%;
         align-items: center;


### PR DESCRIPTION
New sparkline styles worked for new theming API, but not for the legacy theme. This change fixes it for the legacy theme.