### PR TITLE
AG-13709 clean changed row nodes nodes added and removed in the same batch

### DIFF
--- a/packages/ag-grid-community/src/clientSideRowModel/changedRowNodes.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/changedRowNodes.ts
@@ -8,9 +8,9 @@ export class ChangedRowNodes<TData = any> {
 
     /** Marks a row as removed. Order of operations is: remove, update, add */
     public remove(node: IRowNode<TData>): void {
-        this.removals.add(node as RowNode<TData>);
-        if (!this.updates.delete(node as RowNode<TData>)) {
-            this.adds.delete(node as RowNode<TData>);
+        if (!this.adds.delete(node as RowNode<TData>)) {
+            this.updates.delete(node as RowNode<TData>);
+            this.removals.add(node as RowNode<TData>);
         }
     }
 

--- a/testing/behavioural/src/row-data/row-data.test.ts
+++ b/testing/behavioural/src/row-data/row-data.test.ts
@@ -167,8 +167,8 @@ describe('ag-grid rows-ordering', () => {
             └── LEAF id:3 value:300
         `);
         expect(rowDataUpdatedCount).toBe(4);
-        expect(modelUpdatedCount).toBe(3);
-        expect(compareCalled).toBe(true);
+        expect(modelUpdatedCount).toBe(2);
+        expect(compareCalled).toBe(false);
 
         compareCalled = false;
         api.updateGridOptions({ suppressModelUpdateAfterUpdateTransaction: false, rowData: rowData3 });
@@ -182,7 +182,7 @@ describe('ag-grid rows-ordering', () => {
             └── LEAF id:4 value:40
         `);
         expect(rowDataUpdatedCount).toBe(5);
-        expect(modelUpdatedCount).toBe(4);
+        expect(modelUpdatedCount).toBe(3);
         expect(compareCalled).toBe(true);
 
         compareCalled = false;
@@ -197,7 +197,7 @@ describe('ag-grid rows-ordering', () => {
             └── LEAF id:4 value:400
         `);
         expect(rowDataUpdatedCount).toBe(6);
-        expect(modelUpdatedCount).toBe(5);
+        expect(modelUpdatedCount).toBe(4);
         expect(compareCalled).toBe(true);
     });
 });


### PR DESCRIPTION
As noted in https://github.com/ag-grid/ag-grid/pull/9619#discussion_r1900847905 we can avoid to keep the removed nodes if they were just added and removed in the same transaction batch.
Note that this won't happen with immutable row data but just with asynchronous transaction batches

However - to consider - applying just this change causes a minor change in behaviour compared to latest (and previous ag-grid versions) as the previous version was still calling modelUpdate event for a node added and removed in the same batch - with this change it does not.

From a certain point of view seems more correct that modelUpdated is not called as the transaction batch in this case would result in no changes, but is a different behaviour from previous versions and is a different behaviour if transactions were to be executed one by one that can be a bit confusing.

Todo: decide if we want to maintain the old behaviour or move to this new behaviour.

If we do not want to change the behaviour for this edge case, and apply this change, we need another change to call modelUpdated, a flag for example.