### PR TITLE
AG-12794 - step 1 - remove level from tree node

### DIFF
--- a/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
@@ -75,14 +75,18 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
 
     public override activate(rootNode: RowNode<TData>): void {
         super.activate(rootNode);
+        this.treeSetRootNode(rootNode);
+    }
 
+    protected treeSetRootNode(rootNode: RowNode<TData>): void {
         let treeRoot = this.treeRoot;
         if (!treeRoot) {
             treeRoot = new TreeNode(null, '', -1);
             treeRoot.childrenChanged = true;
             this.treeRoot = treeRoot;
         }
-        treeRoot.setRow(rootNode);
+        treeRoot.row = rootNode;
+        (rootNode as TreeRow).treeNode = treeRoot;
     }
 
     public override destroy(): void {

--- a/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/abstractClientSideTreeNodeManager.ts
@@ -81,7 +81,7 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
     protected treeSetRootNode(rootNode: RowNode<TData>): void {
         let treeRoot = this.treeRoot;
         if (!treeRoot) {
-            treeRoot = new TreeNode(null, '', -1);
+            treeRoot = new TreeNode(null, '');
             treeRoot.childrenChanged = true;
             this.treeRoot = treeRoot;
         }
@@ -118,8 +118,8 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
 
     /** Add or updates the row to a non-root node, preparing the tree correctly for the commit. */
     protected treeSetRow(node: TreeNode, newRow: RowNode, created: boolean): boolean {
-        const { level, row: oldRow } = node;
-        if (level < 0) {
+        const oldRow = node.row;
+        if (node === this.treeRoot) {
             return false; // Cannot overwrite the root row
         }
 
@@ -168,20 +168,19 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
      * @returns The previous row, if any, that was overwritten.
      */
     protected treeRemove(node: TreeNode, oldRow: RowNode): void {
-        const { parent, level } = node;
-
-        if (level < 0) {
+        if (node === this.treeRoot) {
             return; // Cannot overwrite a null node or the root row
         }
 
         let invalidate = false;
 
         if (node.removeRow(oldRow)) {
-            invalidate = true;
+            const parent = node.parent;
             if (parent) {
                 parent.childrenChanged = true;
             }
             this.destroyRow(oldRow, !oldRow.data);
+            invalidate = true;
         }
 
         if (invalidate) {
@@ -207,7 +206,7 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
             isGroupOpenByDefault: this.gos.getCallback('isGroupOpenByDefault'),
         };
 
-        this.treeCommitChildren(details, treeRoot, false);
+        this.treeCommitChildren(details, treeRoot, false, 0);
 
         const rootRow = treeRoot.row;
         if (rootRow) {
@@ -216,7 +215,7 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
             }
 
             if (treeRoot.childrenChanged) {
-                if (treeRoot.updateChildrenAfterGroup(treeData)) {
+                if (treeRoot.updateChildrenAfterGroup(treeData, true)) {
                     markTreeRowPathChanged(rootRow);
                 }
             }
@@ -242,14 +241,19 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
     }
 
     /** Calls commitChild for each invalidated child, recursively. We commit only the invalidated paths. */
-    private treeCommitChildren(details: TreeCommitDetails, parent: TreeNode, collapsed: boolean): void {
+    private treeCommitChildren(
+        details: TreeCommitDetails,
+        parent: TreeNode,
+        collapsed: boolean,
+        childrenLevel: number
+    ): void {
         while (true) {
             const child = parent.dequeueInvalidated();
             if (child === null) {
                 break;
             }
             if (child.parent === parent) {
-                this.treeCommitChild(details, child, collapsed || !(parent.row?.expanded ?? true));
+                this.treeCommitChild(details, child, collapsed || !(parent.row?.expanded ?? true), childrenLevel);
             }
         }
 
@@ -258,14 +262,14 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
     }
 
     /** Commit the changes performed to a node and its children */
-    private treeCommitChild(details: TreeCommitDetails, node: TreeNode, collapsed: boolean): void {
+    private treeCommitChild(details: TreeCommitDetails, node: TreeNode, collapsed: boolean, level: number): void {
         if (node.isEmptyFillerNode()) {
             this.treeClear(node);
             return; // Removed. No need to process children.
         }
 
-        this.treeCommitPreOrder(details, node);
-        this.treeCommitChildren(details, node, collapsed);
+        this.treeCommitPreOrder(details, node, level);
+        this.treeCommitChildren(details, node, collapsed, level + 1);
 
         if (node.isEmptyFillerNode()) {
             this.treeClear(node);
@@ -275,11 +279,11 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
         this.treeCommitPostOrder(details, node, collapsed);
     }
 
-    private treeCommitPreOrder(details: TreeCommitDetails, node: TreeNode): void {
+    private treeCommitPreOrder(details: TreeCommitDetails, node: TreeNode, level: number): void {
         let row = node.row;
 
         if (row === null) {
-            row = this.createFillerRow(node);
+            row = this.createFillerRow(node, level);
             node.setRow(row);
         } else {
             row = node.sortFirstDuplicateRow()!; // The main row must have the smallest sourceRowIndex of duplicates
@@ -290,7 +294,7 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
         }
 
         if (details.treeData) {
-            row.level = node.level;
+            row.level = level;
             row.parent = node.parent!.row;
             if (node.oldRow !== row) {
                 // We need to update children rows parents, as the row changed
@@ -324,7 +328,7 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
         const oldGroup = row.group;
 
         if (node.childrenChanged) {
-            if (node.updateChildrenAfterGroup(details.treeData)) {
+            if (node.updateChildrenAfterGroup(details.treeData, false)) {
                 markTreeRowPathChanged(row);
             }
         }
@@ -415,7 +419,7 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
         }
     }
 
-    private createFillerRow(node: TreeNode): RowNode {
+    private createFillerRow(node: TreeNode, level: number): RowNode {
         const row = new RowNode(this.beans); // Create a filler node
         row.key = node.key;
         row.group = true;
@@ -425,14 +429,15 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
         row.allChildrenCount = null;
 
         // Generate a unique id for the filler row
-        let id = node.level + '-' + node.key;
+        let id = level + '-' + node.key;
         let p = node.parent;
         while (p !== null) {
             const parent = p.parent;
             if (parent === null) {
                 break;
             }
-            id = `${p.level}-${p.key}-${id}`;
+            --level;
+            id = `${level}-${p.key}-${id}`;
             p = parent;
         }
         row.id = _ROW_ID_PREFIX_ROW_GROUP + id;
@@ -455,20 +460,18 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
 
     /** Called to clear a subtree. */
     public treeClear(node: TreeNode): void {
-        const { parent, oldRow, row, level } = node;
+        const { parent, oldRow } = node;
         if (parent !== null && oldRow !== null) {
             parent.childrenChanged = true;
             if (parent.row !== null) {
                 markTreeRowPathChanged(parent.row);
             }
         }
-        if (row !== null) {
-            if (level >= 0) {
-                let row = node.row;
-                while (row !== null && node.removeRow(row)) {
-                    this.destroyRow(row, !row.data);
-                    row = node.row;
-                }
+        if (node !== this.treeRoot) {
+            let row = node.row;
+            while (row !== null && node.removeRow(row)) {
+                this.destroyRow(row, !row.data);
+                row = node.row;
             }
         }
         for (const child of node.enumChildren()) {
@@ -479,9 +482,9 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
 
     /** Called by the deactivate, to destroy the whole tree. */
     private treeDestroy(node: TreeNode): void {
-        const { row, level, duplicateRows } = node;
+        const { row, duplicateRows } = node;
         if (row) {
-            if (level >= 0 && !row.data) {
+            if (node !== this.treeRoot && !row.data) {
                 this.destroyRow(row, true); // Delete the filler node
             } else {
                 clearTreeRowFlags(row); // Just clear the flags
@@ -489,7 +492,7 @@ export abstract class AbstractClientSideTreeNodeManager<TData> extends AbstractC
         }
         if (duplicateRows) {
             for (const row of duplicateRows) {
-                if (level >= 0 && !row.data) {
+                if (node !== this.treeRoot && !row.data) {
                     this.destroyRow(row, true); // Delete filler nodes
                 } else {
                     clearTreeRowFlags(row); // Just clear the flags

--- a/packages/ag-grid-enterprise/src/treeData/clientSideChildrenTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/clientSideChildrenTreeNodeManager.ts
@@ -111,18 +111,18 @@ export class ClientSideChildrenTreeNodeManager<TData>
         let orderChanged = false;
         let rowsChanged = false;
 
-        const processChildrenNoReorder = (node: TreeNode, children: TData[]): void => {
+        const processChildrenNoReorder = (node: TreeNode, children: TData[], childrenLevel: number): void => {
             for (let i = 0, len = children.length; i < len; ++i) {
-                processChild(node, children[i]);
+                processChild(node, children[i], childrenLevel);
             }
         };
 
-        const processChildrenReOrder = (node: TreeNode, children: TData[]): void => {
+        const processChildrenReOrder = (node: TreeNode, children: TData[], childrenLevel: number): void => {
             const childrenLen = children?.length;
             let inOrder = true;
             let prevIndex = -1;
             for (let i = 0; i < childrenLen; ++i) {
-                const oldSourceRowIndex = processChild(node, children[i]);
+                const oldSourceRowIndex = processChild(node, children[i], childrenLevel);
                 if (oldSourceRowIndex >= 0) {
                     if (oldSourceRowIndex < prevIndex) {
                         inOrder = false;
@@ -141,14 +141,14 @@ export class ClientSideChildrenTreeNodeManager<TData>
 
         const processChildren = canReorder ? processChildrenReOrder : processChildrenNoReorder;
 
-        const processChild = (parent: TreeNode, data: TData): number => {
+        const processChild = (parent: TreeNode, data: TData, level: number): number => {
             let row = processedData.get(data);
             if (row !== undefined) {
                 _warn(2, { nodeId: row.id }); // Duplicate node
                 return -1;
             }
 
-            const id = getRowIdFunc({ data, level: parent.level + 1 });
+            const id = getRowIdFunc({ data, level });
 
             let created = false;
             row = this.getRowNode(id) as TreeRow<TData> | undefined;
@@ -185,13 +185,13 @@ export class ClientSideChildrenTreeNodeManager<TData>
 
             const children = childrenGetter?.(data);
             if (children) {
-                processChildren(node, children);
+                processChildren(node, children, level + 1);
             }
 
             return oldSourceRowIndex;
         };
 
-        processChildren(treeRoot, rowData);
+        processChildren(treeRoot, rowData, 0);
 
         if (oldAllLeafChildren) {
             for (let i = 0, len = oldAllLeafChildren.length; i < len; ++i) {

--- a/packages/ag-grid-enterprise/src/treeData/clientSideChildrenTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/clientSideChildrenTreeNodeManager.ts
@@ -58,7 +58,7 @@ export class ClientSideChildrenTreeNodeManager<TData>
         rootNode.allLeafChildren = allLeafChildren;
 
         this.treeClear(treeRoot);
-        treeRoot.setRow(rootNode);
+        this.treeSetRootNode(rootNode);
 
         const processChild = (node: TreeNode, data: TData) => {
             let row = processedData.get(data);
@@ -242,15 +242,11 @@ export class ClientSideChildrenTreeNodeManager<TData>
     }
 
     public override refreshModel(params: RefreshModelParams<TData>): void {
-        const { rootNode, treeRoot } = this;
-        if (!treeRoot) {
-            return; // Not active, destroyed
-        }
-
-        if (params.changedProps?.has('treeData') && !params.newData) {
-            treeRoot.setRow(rootNode);
-            const allLeafChildren = rootNode?.allLeafChildren;
-            treeRoot.childrenChanged = true;
+        const rootNode = this.rootNode;
+        if (rootNode && params.changedProps?.has('treeData') && !params.newData) {
+            this.treeSetRootNode(rootNode);
+            const treeRoot = this.treeRoot!;
+            const allLeafChildren = rootNode.allLeafChildren;
             if (allLeafChildren) {
                 for (let i = 0, len = allLeafChildren.length; i < len; ++i) {
                     const row = allLeafChildren[i];
@@ -258,6 +254,7 @@ export class ClientSideChildrenTreeNodeManager<TData>
                     row.treeNode?.invalidate();
                 }
             }
+            treeRoot.childrenChanged = true;
             this.treeCommit();
         }
 

--- a/packages/ag-grid-enterprise/src/treeData/clientSidePathTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/clientSidePathTreeNodeManager.ts
@@ -22,7 +22,7 @@ export class ClientSidePathTreeNodeManager<TData>
         const treeRoot = this.treeRoot!;
 
         this.treeClear(treeRoot);
-        treeRoot.setRow(rootNode);
+        this.treeSetRootNode(rootNode);
 
         super.loadNewRowData(rowData);
 
@@ -59,7 +59,7 @@ export class ClientSidePathTreeNodeManager<TData>
             return; // Destroyed or not active
         }
 
-        treeRoot.setRow(this.rootNode);
+        this.treeSetRootNode(this.rootNode!);
 
         for (const row of changedRowNodes.removals) {
             const node = row.treeNode as TreeNode | null;

--- a/packages/ag-grid-enterprise/src/treeData/treeNode.ts
+++ b/packages/ag-grid-enterprise/src/treeData/treeNode.ts
@@ -155,18 +155,13 @@ export class TreeNode implements ITreeNode {
      * @returns True if the row changed
      */
     public setRow(newRow: TreeRow | null): boolean {
-        const { level, row: oldRow } = this;
-        if (level < 0) {
-            if (oldRow !== null && oldRow !== newRow) {
-                oldRow.treeNode = null;
-            }
-        } else {
-            if (oldRow === newRow) {
-                return false; // Already the same row
-            }
-            if (oldRow !== null) {
-                oldRow.treeNode = null;
-            }
+        const oldRow = this.row;
+
+        if (oldRow === newRow) {
+            return false; // Already the same row
+        }
+        if (oldRow !== null) {
+            oldRow.treeNode = null;
         }
         if (newRow !== null) {
             newRow.treeNode = this;

--- a/packages/ag-grid-enterprise/src/treeData/treeNode.ts
+++ b/packages/ag-grid-enterprise/src/treeData/treeNode.ts
@@ -81,10 +81,7 @@ export class TreeNode implements ITreeNode {
         public parent: TreeNode | null,
 
         /** The key of this node. */
-        public readonly key: string,
-
-        /** The level of this node. Root has level -1 */
-        public readonly level: number
+        public readonly key: string
     ) {}
 
     /** Returns the number of children in this node */
@@ -114,7 +111,7 @@ export class TreeNode implements ITreeNode {
         }
         let node = this.children?.get(key);
         if (!node) {
-            node = new TreeNode(this, key, this.level + 1);
+            node = new TreeNode(this, key);
             (this.children ??= new Map())?.set(node.key, node); // Add to the map
         }
         return node;
@@ -131,7 +128,7 @@ export class TreeNode implements ITreeNode {
             children!.delete(key); // Remove from the map
             children!.set(key, node); // Reinsert to the map
         } else {
-            node = new TreeNode(this, key, this.level + 1);
+            node = new TreeNode(this, key);
             (this.children ??= new Map())?.set(node.key, node); // Add to the map
         }
         return node;
@@ -316,7 +313,7 @@ export class TreeNode implements ITreeNode {
      * If the order changes, also the order in the children map will be updated,
      * so the next call to enumChildren() will return the children in the right order.
      */
-    public updateChildrenAfterGroup(treeData: boolean): boolean {
+    public updateChildrenAfterGroup(treeData: boolean, root: boolean): boolean {
         this.childrenChanged = false; // Reset the flag for this node
         const childrenCount = treeData && this.children?.size;
         if (!childrenCount) {
@@ -324,7 +321,7 @@ export class TreeNode implements ITreeNode {
                 return false; // Nothing changed
             }
 
-            this.childrenAfterGroup = this.level < 0 ? [] : _EmptyArray;
+            this.childrenAfterGroup = root ? [] : _EmptyArray;
             this.leafChildrenChanged = true;
             return true; // Children cleared
         }


### PR DESCRIPTION
We are implementing tree node manager by parentId.
To do that, the easiest option is to implement it by moving subtrees to the right parent, thing not currently supported by the tree node implementation.

As a first step, is good to remove the redundant property "level" that we do not need in the TreeNode and can be computed during commit in the rowNode.