### PR TITLE
AG-13902 update col def hides no loading overlay with ssr

### DIFF
--- a/packages/ag-grid-community/src/rendering/overlays/overlayService.ts
+++ b/packages/ag-grid-community/src/rendering/overlays/overlayService.ts
@@ -128,11 +128,14 @@ export class OverlayService extends BeanStub implements NamedBean {
             }
         } else {
             this.showInitialOverlay = false;
-            if (rowModel.isEmpty() && !gos.get('suppressNoRowsOverlay') && isClientSide) {
+            if (isClientSide && rowModel.isEmpty() && !gos.get('suppressNoRowsOverlay')) {
                 if (state !== OverlayServiceState.NoRows) {
                     this.doShowNoRowsOverlay();
                 }
-            } else if (state !== OverlayServiceState.Hidden) {
+            } else if (
+                state === OverlayServiceState.Loading ||
+                (isClientSide && state !== OverlayServiceState.Hidden)
+            ) {
                 this.doHideOverlay();
             }
         }

--- a/packages/ag-grid-community/src/rendering/overlays/overlayService.ts
+++ b/packages/ag-grid-community/src/rendering/overlays/overlayService.ts
@@ -2,7 +2,7 @@ import { _getLoadingOverlayCompDetails, _getNoRowsOverlayCompDetails } from '../
 import type { NamedBean } from '../../context/bean';
 import { BeanStub } from '../../context/beanStub';
 import type { GridOptions } from '../../entities/gridOptions';
-import { _isClientSideRowModel } from '../../gridOptionsUtils';
+import { _isClientSideRowModel, _isServerSideRowModel } from '../../gridOptionsUtils';
 import type { UserCompDetails } from '../../interfaces/iUserCompDetails';
 import { _warn } from '../../validation/logging';
 import type { ComponentSelector } from '../../widgets/component';
@@ -18,6 +18,7 @@ export class OverlayService extends BeanStub implements NamedBean {
     beanName = 'overlays' as const;
 
     private isClientSide: boolean;
+    private isServerSide: boolean;
     private state: OverlayServiceState = OverlayServiceState.Hidden;
     private showInitialOverlay: boolean = true;
     private exclusive?: boolean;
@@ -27,6 +28,7 @@ export class OverlayService extends BeanStub implements NamedBean {
 
     public postConstruct(): void {
         this.isClientSide = _isClientSideRowModel(this.gos);
+        this.isServerSide = !this.isClientSide && _isServerSideRowModel(this.gos);
         const updateOverlayVisibility = () => this.updateOverlayVisibility();
 
         this.addManagedEventListeners({
@@ -109,6 +111,7 @@ export class OverlayService extends BeanStub implements NamedBean {
         const {
             state,
             isClientSide,
+            isServerSide,
             beans: { gos, colModel, rowModel },
         } = this;
         let loading = this.gos.get('loading');
@@ -134,7 +137,7 @@ export class OverlayService extends BeanStub implements NamedBean {
                 }
             } else if (
                 state === OverlayServiceState.Loading ||
-                (isClientSide && state !== OverlayServiceState.Hidden)
+                (!isServerSide && state !== OverlayServiceState.Hidden)
             ) {
                 this.doHideOverlay();
             }

--- a/testing/behavioural/src/overlays/overlays-ssr.test.ts
+++ b/testing/behavioural/src/overlays/overlays-ssr.test.ts
@@ -1,5 +1,3 @@
-import type { MockInstance } from 'vitest';
-
 import { ServerSideRowModelModule } from 'ag-grid-enterprise';
 
 import { TestGridsManager } from '../test-utils';
@@ -8,7 +6,6 @@ describe('ag-grid overlays state', () => {
     const gridsManager = new TestGridsManager({
         modules: [ServerSideRowModelModule],
     });
-    let consoleWarnSpy: MockInstance;
 
     function hasLoadingIcon() {
         return !!document.querySelector('.ag-icon.ag-icon-loading');
@@ -19,13 +16,11 @@ describe('ag-grid overlays state', () => {
     }
 
     beforeEach(() => {
-        consoleWarnSpy = vitest.spyOn(console, 'warn').mockImplementation(() => {});
         gridsManager.reset();
     });
 
     afterEach(() => {
         gridsManager.reset();
-        consoleWarnSpy.mockRestore();
     });
 
     test('should show loading and no rows overlay, also when changing columns', async () => {
@@ -68,7 +63,6 @@ describe('ag-grid overlays state', () => {
         expect(hasNoRowsOverlay()).toBe(true);
         expect(hasLoadingIcon()).toBe(false);
 
-        console.log('HERE!');
         // Try to change columnDefs, row data still empty, we must still show the no overlay
         api.setGridOption('columnDefs', [{ field: 'athlete' }, { field: 'sport' }]);
         expect(hasLoadingIcon()).toBe(false);

--- a/testing/behavioural/src/overlays/overlays-ssr.test.ts
+++ b/testing/behavioural/src/overlays/overlays-ssr.test.ts
@@ -1,0 +1,91 @@
+import type { MockInstance } from 'vitest';
+
+import { ServerSideRowModelModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager } from '../test-utils';
+
+describe('ag-grid overlays state', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelModule],
+    });
+    let consoleWarnSpy: MockInstance;
+
+    function hasLoadingIcon() {
+        return !!document.querySelector('.ag-icon.ag-icon-loading');
+    }
+
+    function hasNoRowsOverlay() {
+        return !!document.querySelector('.ag-overlay-no-rows-center');
+    }
+
+    beforeEach(() => {
+        consoleWarnSpy = vitest.spyOn(console, 'warn').mockImplementation(() => {});
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+        consoleWarnSpy.mockRestore();
+    });
+
+    test('should show loading and no rows overlay, also when changing columns', async () => {
+        let finishLoadData: () => void;
+
+        let firstLoad: () => void;
+        const firstLoadPromise = new Promise<void>((resolve) => {
+            firstLoad = resolve;
+        });
+
+        const response = { rowData: [] as any[], rowCount: 0 };
+
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'athlete' }],
+            rowModelType: 'serverSide',
+            onGridReady: ({ api }) => {
+                api.setGridOption('serverSideDatasource', {
+                    getRows: async ({ success }) => {
+                        finishLoadData = () => {
+                            api.hideOverlay();
+                            response.rowCount = response.rowData.length;
+                            success(response);
+                            if (!response.rowData.length) {
+                                api.showNoRowsOverlay();
+                            }
+                        };
+                        firstLoad();
+                    },
+                });
+            },
+        });
+
+        await firstLoadPromise;
+
+        expect(hasNoRowsOverlay()).toBe(false);
+        expect(hasLoadingIcon()).toBe(true);
+
+        finishLoadData!();
+
+        expect(hasNoRowsOverlay()).toBe(true);
+        expect(hasLoadingIcon()).toBe(false);
+
+        console.log('HERE!');
+        // Try to change columnDefs, row data still empty, we must still show the no overlay
+        api.setGridOption('columnDefs', [{ field: 'athlete' }, { field: 'sport' }]);
+        expect(hasLoadingIcon()).toBe(false);
+        expect(hasNoRowsOverlay()).toBe(true);
+
+        response.rowData = [{ athlete: 'Michael Phelps' }, { athlete: 'Usain Bolt' }];
+
+        api.refreshServerSide({ route: [] });
+        expect(hasLoadingIcon()).toBe(true);
+        finishLoadData!();
+        expect(hasLoadingIcon()).toBe(false);
+        expect(hasNoRowsOverlay()).toBe(false);
+
+        response.rowData = [];
+        api.refreshServerSide({ route: [] });
+        finishLoadData!();
+        expect(hasLoadingIcon()).toBe(false);
+        expect(hasNoRowsOverlay()).toBe(true);
+    });
+});


### PR DESCRIPTION
updateOverlayVisibility was causing a call to doHideOverlay for SSR in case columns definitions are changed, but SSR is not supposed to causes automatically overlay changes and the responsibility is left to the user via API or grid options