### PR TITLE
AG-13855 disable transactions for tree data with children

### DIFF
--- a/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
+++ b/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
@@ -609,6 +609,7 @@ export const AG_GRID_ERRORS = {
         'As of v33.1, using "keyCreator" with the Rich Select Editor has been deprecated. It now requires the "formatValue" callback to convert complex data to strings.' as const,
     267: () =>
         'Detail grids can not use a different theme to the master grid, the `theme` detail grid option will be ignored.' as const,
+    268: () => "Transactions aren't supported with tree data when providing hierarchical data" as const,
 };
 
 export type ErrorMap = typeof AG_GRID_ERRORS;

--- a/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
+++ b/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
@@ -609,8 +609,7 @@ export const AG_GRID_ERRORS = {
         'As of v33.1, using "keyCreator" with the Rich Select Editor has been deprecated. It now requires the "formatValue" callback to convert complex data to strings.' as const,
     267: () =>
         'Detail grids can not use a different theme to the master grid, the `theme` detail grid option will be ignored.' as const,
-    268: () =>
-        "Transactions aren't supported with tree data when providing hierarchical data setting treeDataChildrenField" as const,
+    268: () => "Transactions aren't supported with tree data when using treeDataChildrenField" as const,
 };
 
 export type ErrorMap = typeof AG_GRID_ERRORS;

--- a/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
+++ b/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
@@ -609,7 +609,8 @@ export const AG_GRID_ERRORS = {
         'As of v33.1, using "keyCreator" with the Rich Select Editor has been deprecated. It now requires the "formatValue" callback to convert complex data to strings.' as const,
     267: () =>
         'Detail grids can not use a different theme to the master grid, the `theme` detail grid option will be ignored.' as const,
-    268: () => "Transactions aren't supported with tree data when providing hierarchical data" as const,
+    268: () =>
+        "Transactions aren't supported with tree data when providing hierarchical data setting treeDataChildrenField" as const,
 };
 
 export type ErrorMap = typeof AG_GRID_ERRORS;

--- a/packages/ag-grid-enterprise/src/treeData/clientSideChildrenTreeNodeManager.ts
+++ b/packages/ag-grid-enterprise/src/treeData/clientSideChildrenTreeNodeManager.ts
@@ -1,8 +1,11 @@
 import type {
     AbstractClientSideNodeManager,
+    ClientSideNodeManagerUpdateRowDataResult,
+    IChangedRowNodes,
     IClientSideNodeManager,
     NamedBean,
     RefreshModelParams,
+    RowDataTransaction,
     RowNode,
 } from 'ag-grid-community';
 import { ChangedPath, _error, _getRowIdCallback, _warn } from 'ag-grid-community';
@@ -45,6 +48,18 @@ export class ClientSideChildrenTreeNodeManager<TData>
         }
 
         super.activate(rootNode);
+    }
+
+    public override updateRowData(
+        _rowDataTran: RowDataTransaction<TData>,
+        changedRowNodes: IChangedRowNodes<TData>
+    ): ClientSideNodeManagerUpdateRowDataResult<TData> {
+        _error(268);
+        return {
+            changedRowNodes,
+            rowNodeTransaction: { add: [], remove: [], update: [] },
+            rowsInserted: false,
+        };
     }
 
     protected override loadNewRowData(rowData: TData[]): void {

--- a/testing/behavioural/src/test-utils/grid-test-utils.ts
+++ b/testing/behavioural/src/test-utils/grid-test-utils.ts
@@ -1,4 +1,4 @@
-import type { GridApi, IRowNode, RowDataTransaction, RowNode } from 'ag-grid-community';
+import type { GridApi, IRowNode, RowDataTransaction, RowNode, RowNodeTransaction } from 'ag-grid-community';
 
 export function optionalEscapeString(s: string): string {
     return /^(?!\d)\w[._-\w]*$|^\d+$/.test(s) ? s : JSON.stringify(s);
@@ -32,21 +32,21 @@ export const getAllRows = (api: GridApi | null | undefined): RowNode[] => {
     return rows;
 };
 
-export async function executeTransactionsAsync(
+export function executeTransactionsAsync(
     transactions: RowDataTransaction<any>[] | RowDataTransaction<any>,
     api: GridApi<any>
-) {
+): Promise<RowNodeTransaction<any>[]> {
     if (!Array.isArray(transactions)) {
         transactions = [transactions];
     }
-    const promises: Promise<void>[] = [];
+    const promises: Promise<RowNodeTransaction<any>>[] = [];
     for (const transaction of transactions) {
         promises.push(
             new Promise((resolve) => {
-                api.applyTransactionAsync(transaction, () => resolve());
+                api.applyTransactionAsync(transaction, (x) => resolve(x));
             })
         );
     }
     api.flushAsyncTransactions();
-    await Promise.all(promises);
+    return Promise.all(promises);
 }

--- a/testing/behavioural/src/test-utils/grid-test-utils.ts
+++ b/testing/behavioural/src/test-utils/grid-test-utils.ts
@@ -32,17 +32,17 @@ export const getAllRows = (api: GridApi | null | undefined): RowNode[] => {
     return rows;
 };
 
-export function executeTransactionsAsync(
-    transactions: RowDataTransaction<any>[] | RowDataTransaction<any>,
+export function executeTransactionsAsync<TData = any>(
+    transactions: RowDataTransaction<TData>[] | RowDataTransaction<TData>,
     api: GridApi<any>
-): Promise<RowNodeTransaction<any>[]> {
+): Promise<RowNodeTransaction<TData>[]> {
     if (!Array.isArray(transactions)) {
         transactions = [transactions];
     }
-    const promises: Promise<RowNodeTransaction<any>>[] = [];
-    for (const transaction of transactions) {
-        promises.push(new Promise((resolve) => api.applyTransactionAsync(transaction, resolve)));
-    }
+    const promises = transactions.map(
+        (transaction) =>
+            new Promise<RowNodeTransaction<TData>>((resolve) => api.applyTransactionAsync(transaction, resolve))
+    );
     api.flushAsyncTransactions();
     return Promise.all(promises);
 }

--- a/testing/behavioural/src/test-utils/grid-test-utils.ts
+++ b/testing/behavioural/src/test-utils/grid-test-utils.ts
@@ -34,7 +34,7 @@ export const getAllRows = (api: GridApi | null | undefined): RowNode[] => {
 
 export function executeTransactionsAsync<TData = any>(
     transactions: RowDataTransaction<TData>[] | RowDataTransaction<TData>,
-    api: GridApi<any>
+    api: GridApi<TData>
 ): Promise<RowNodeTransaction<TData>[]> {
     if (!Array.isArray(transactions)) {
         transactions = [transactions];

--- a/testing/behavioural/src/test-utils/grid-test-utils.ts
+++ b/testing/behavioural/src/test-utils/grid-test-utils.ts
@@ -41,11 +41,7 @@ export function executeTransactionsAsync(
     }
     const promises: Promise<RowNodeTransaction<any>>[] = [];
     for (const transaction of transactions) {
-        promises.push(
-            new Promise((resolve) => {
-                api.applyTransactionAsync(transaction, (x) => resolve(x));
-            })
-        );
+        promises.push(new Promise((resolve) => api.applyTransactionAsync(transaction, resolve)));
     }
     api.flushAsyncTransactions();
     return Promise.all(promises);

--- a/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-transactions.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-transactions.test.ts
@@ -65,7 +65,7 @@ describe('ag-grid hierarchical tree data reset', () => {
 
         expect(consoleErrorSpy).toHaveBeenCalledWith(
             'AG Grid: error #268',
-            "Transactions aren't supported with tree data when providing hierarchical data",
+            "Transactions aren't supported with tree data when providing hierarchical data setting treeDataChildrenField",
             expect.anything()
         );
 

--- a/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-transactions.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-transactions.test.ts
@@ -1,0 +1,81 @@
+import type { MockInstance } from 'vitest';
+
+import { ClientSideRowModelModule } from 'ag-grid-community';
+import { TreeDataModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, executeTransactionsAsync } from '../../test-utils';
+import type { GridRowsOptions } from '../../test-utils';
+
+const defaultGridRowsOptions: GridRowsOptions = {
+    checkDom: true,
+};
+
+describe('ag-grid hierarchical tree data reset', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, TreeDataModule],
+    });
+
+    let consoleErrorSpy: MockInstance;
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+        consoleErrorSpy?.mockRestore();
+    });
+
+    test('transactions are no-ops and an error is generated', async () => {
+        const rowData = [
+            { id: 'A', children: [{ id: 'B' }] },
+            { id: 'C', children: [{ id: 'D' }, { id: 'E' }] },
+        ];
+
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [],
+            autoGroupColumnDef: { headerName: 'Organisation Hierarchy' },
+            treeData: true,
+            ['treeDataChildrenField' as any]: 'children',
+            animateRows: false,
+            groupDefaultExpanded: -1,
+            rowData: rowData,
+            getRowId: (params) => params.data.id,
+        });
+
+        consoleErrorSpy = vitest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const transactionResult = api.applyTransaction({
+            add: [{ id: 'F', children: [{ id: 'G' }] }],
+            remove: [{ id: 'A' }],
+            update: [{ id: 'C', children: [{ id: 'D' }] }],
+        });
+
+        expect(transactionResult).toEqual({ add: [], remove: [], update: [] });
+
+        const asyncTransactionResult = await executeTransactionsAsync(
+            [{ add: [{ id: 'F', children: [{ id: 'G' }] }] }, { update: [{ id: 'C', children: [{ id: 'D' }] }] }],
+            api
+        );
+
+        expect(asyncTransactionResult).toEqual([
+            { add: [], remove: [], update: [] },
+            { add: [], remove: [], update: [] },
+        ]);
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'AG Grid: error #268',
+            "Transactions aren't supported with tree data when providing hierarchical data",
+            expect.anything()
+        );
+
+        await new GridRows(api, 'tree', defaultGridRowsOptions).check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ A GROUP id:A
+            │ └── B LEAF id:B
+            └─┬ C GROUP id:C
+            · ├── D LEAF id:D
+            · └── E LEAF id:E
+        `);
+    });
+});

--- a/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-transactions.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-transactions.test.ts
@@ -65,7 +65,7 @@ describe('ag-grid hierarchical tree data reset', () => {
 
         expect(consoleErrorSpy).toHaveBeenCalledWith(
             'AG Grid: error #268',
-            "Transactions aren't supported with tree data when providing hierarchical data setting treeDataChildrenField",
+            "Transactions aren't supported with tree data when using treeDataChildrenField",
             expect.anything()
         );
 


### PR DESCRIPTION
Display a warning when executing a transaction against tree data with "children" hierarchical data

Tree data with hierarchical data cannot support transactions.