### PR TITLE
AG-13994 do not use treeData as flatten flag

### DIFF
--- a/testing/behavioural/src/tree-data/hierarchical/grouping-hierarchical-tree-data-reactive.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/grouping-hierarchical-tree-data-reactive.test.ts
@@ -30,6 +30,76 @@ describe('ag-grid grouping hierarchical treeData is reactive', () => {
                     { id: 'F', g: 0, v: 3 },
                 ],
             },
+            { id: 'G', g: 1, v: 4 },
+        ];
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'g', rowGroup: true }, { field: 'v' }],
+            autoGroupColumnDef: {
+                headerName: 'group column',
+                valueGetter: (params) => {
+                    return 'X-' + params.node?.id;
+                },
+            },
+            ['treeDataChildrenField' as any]: 'children',
+            treeData: false,
+            animateRows: false,
+            groupDefaultExpanded: -1,
+            getRowId: ({ data }) => data.id,
+            rowData,
+        };
+
+        const api = gridsManager.createGrid('myGrid', gridOptions);
+
+        const gridRowsOptions: GridRowsOptions = {
+            checkDom: true,
+            columns: true,
+        };
+
+        for (let repeat = 0; repeat < 2; repeat++) {
+            api.setGridOption('treeData', false);
+
+            let gridRows = new GridRows(api, 'data 1 ' + repeat, gridRowsOptions);
+            await gridRows.check(`
+                ROOT id:ROOT_NODE_ID ag-Grid-AutoColumn:"X-ROOT_NODE_ID"
+                ├─┬ filler id:row-group-g-0 ag-Grid-AutoColumn:0
+                │ ├── LEAF id:A ag-Grid-AutoColumn:"X-A" g:0 v:0
+                │ └── LEAF id:D ag-Grid-AutoColumn:"X-D" g:0 v:1
+                └─┬ filler id:row-group-g-1 ag-Grid-AutoColumn:1
+                · └── LEAF id:G ag-Grid-AutoColumn:"X-G" g:1 v:4
+            `);
+
+            // Switch to treeData
+
+            api.setGridOption('treeData', true);
+
+            gridRows = new GridRows(api, 'data 2 ' + repeat, gridRowsOptions);
+            await gridRows.check(`
+                ROOT id:ROOT_NODE_ID ag-Grid-AutoColumn:"X-ROOT_NODE_ID"
+                ├─┬ A GROUP id:A ag-Grid-AutoColumn:"X-A" g:0 v:0
+                │ └─┬ B GROUP id:B ag-Grid-AutoColumn:"X-B" g:1 v:1
+                │ · └── C LEAF id:C ag-Grid-AutoColumn:"X-C" g:1 v:1
+                ├─┬ D GROUP id:D ag-Grid-AutoColumn:"X-D" g:0 v:1
+                │ ├── E LEAF id:E ag-Grid-AutoColumn:"X-E" g:0 v:2
+                │ └── F LEAF id:F ag-Grid-AutoColumn:"X-F" g:0 v:3
+                └── G LEAF id:G ag-Grid-AutoColumn:"X-G" g:1 v:4
+            `);
+        }
+    });
+
+    // TODO: disabled due to AG-13994 - Remove the treeData flattening behavior (from the API, not the codebase)
+    test.skip('ag-grid grouping treeData is reactive with flattening', async () => {
+        const rowData = [
+            { id: 'A', g: 0, v: 0, children: [{ id: 'B', g: 1, v: 1, children: [{ id: 'C', g: 1, v: 1 }] }] },
+            {
+                id: 'D',
+                g: 0,
+                v: 1,
+                children: [
+                    { id: 'E', g: 0, v: 2 },
+                    { id: 'F', g: 0, v: 3 },
+                ],
+            },
         ];
 
         const gridOptions: GridOptions = {

--- a/testing/behavioural/src/tree-data/hierarchical/grouping-hierarchical-with-immutable-row-data.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/grouping-hierarchical-with-immutable-row-data.test.ts
@@ -18,7 +18,8 @@ describe('ag-grid grouping treeDataChildrenField with set immutable data', () =>
         gridsManager.reset();
     });
 
-    test('grouping treeDataChildrenField with set immutable data', async () => {
+    // TODO: disabled due to AG-13994 - Remove the treeData flattening behavior (from the API, not the codebase)
+    test.skip('grouping treeDataChildrenField with set immutable data', async () => {
         const gridOptions: GridOptions = {
             columnDefs: [
                 { field: 'name' },
@@ -327,7 +328,8 @@ describe('ag-grid grouping treeDataChildrenField with set immutable data', () =>
         await gridRows.check('empty');
     });
 
-    test('expanded state is preserved correctly', async () => {
+    // TODO: disabled due to AG-13994 - Remove the treeData flattening behavior (from the API, not the codebase)
+    test.skip('expanded state is preserved correctly', async () => {
         const gridOptions: GridOptions = {
             columnDefs: [
                 { field: 'name' },

--- a/testing/behavioural/src/tree-data/hierarchical/hierarchical-immutable-tree-data.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/hierarchical-immutable-tree-data.test.ts
@@ -389,6 +389,426 @@ describe('ag-grid hierarchical immutable tree data', () => {
         expect(rows5[4] === rows6[5]).toBe(true);
         expect(rows5[6] === rows6[6]).toBe(true);
 
+        const rows7 = gridRows.displayedRows;
+        for (let i = 0; i < rows6.length; i++) {
+            expect(rows6[i] === rows7[i]).toBe(true);
+        }
+
+        const rowData8 = cachedJSONObjects.array([
+            {
+                id: 'E',
+                v: 5,
+                children: [{ id: 'D', v: 4 }],
+            },
+            {
+                id: 'C',
+                v: 3,
+                children: [
+                    {
+                        id: 'F',
+                        v: 6,
+                        children: [
+                            { id: 'N', v: 888, children: [{ id: 'G', v: 7 }] },
+                            { id: 'I', v: 9 },
+                        ],
+                    },
+                ],
+            },
+            { id: 'X', v: 100 },
+        ]);
+
+        api.setGridOption('rowData', rowData8);
+
+        const rows8 = gridRows.displayedRows;
+
+        gridRows = new GridRows(api, 'change a group and add a new node', gridRowsOptions);
+
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ E GROUP id:E ag-Grid-AutoColumn:"E" v:5
+            │ └── D LEAF id:D ag-Grid-AutoColumn:"D" v:4
+            ├─┬ C GROUP id:C ag-Grid-AutoColumn:"C" v:3
+            │ └─┬ F GROUP id:F ag-Grid-AutoColumn:"F" v:6
+            │ · ├─┬ N GROUP id:N ag-Grid-AutoColumn:"N" v:888
+            │ · │ └── G LEAF id:G ag-Grid-AutoColumn:"G" v:7
+            │ · └── I LEAF id:I ag-Grid-AutoColumn:"I" v:9
+            └── X LEAF id:X ag-Grid-AutoColumn:"X" v:100
+        `);
+
+        const rows9 = gridRows.displayedRows;
+
+        for (let i = 0; i < rows8.length; i++) {
+            expect(rows8[i] === rows9[i]).toBe(true);
+        }
+    });
+
+    // TODO: disabled due to AG-13994 - Remove the treeData flattening behavior (from the API, not the codebase)
+    test.skip('ag-grid hierarchical immutable tree data with flattening', async () => {
+        const rowData1 = cachedJSONObjects.array([
+            {
+                id: 'A',
+                v: 1,
+                children: [{ id: 'B', v: 2, children: [] }],
+            },
+            {
+                id: 'C',
+                v: 3,
+                children: [{ id: 'D', v: 4 }],
+            },
+
+            {
+                id: 'E',
+                v: 5,
+                children: [
+                    {
+                        id: 'F',
+                        v: 6,
+                        children: [
+                            { id: 'G', v: 7 },
+                            { id: 'H', v: 8 },
+                            { id: 'I', v: 9 },
+                        ],
+                    },
+                    { id: 'J', v: 10, children: [{ id: 'K', v: 11 }] },
+                ],
+            },
+        ]);
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'v' }],
+            treeData: true,
+            ['treeDataChildrenField' as any]: 'children',
+            animateRows: false,
+            groupDefaultExpanded: -1,
+            rowData: rowData1,
+            getRowId: ({ data }) => data.id,
+        };
+
+        const api = gridsManager.createGrid('myGrid', gridOptions);
+
+        const gridRowsOptions: GridRowsOptions = {
+            checkDom: true,
+            columns: true,
+        };
+
+        let gridRows = new GridRows(api, 'data', gridRowsOptions);
+
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ A GROUP id:A ag-Grid-AutoColumn:"A" v:1
+            │ └── B LEAF id:B ag-Grid-AutoColumn:"B" v:2
+            ├─┬ C GROUP id:C ag-Grid-AutoColumn:"C" v:3
+            │ └── D LEAF id:D ag-Grid-AutoColumn:"D" v:4
+            └─┬ E GROUP id:E ag-Grid-AutoColumn:"E" v:5
+            · ├─┬ F GROUP id:F ag-Grid-AutoColumn:"F" v:6
+            · │ ├── G LEAF id:G ag-Grid-AutoColumn:"G" v:7
+            · │ ├── H LEAF id:H ag-Grid-AutoColumn:"H" v:8
+            · │ └── I LEAF id:I ag-Grid-AutoColumn:"I" v:9
+            · └─┬ J GROUP id:J ag-Grid-AutoColumn:"J" v:10
+            · · └── K LEAF id:K ag-Grid-AutoColumn:"K" v:11
+        `);
+
+        // update some values
+
+        const rowData2 = cachedJSONObjects.array([
+            {
+                id: 'A',
+                v: 1,
+                children: [{ id: 'B', v: 20, children: [] }],
+            },
+            {
+                id: 'C',
+                v: 3,
+                children: [{ id: 'D', v: 4 }],
+            },
+
+            {
+                id: 'E',
+                v: 5,
+                children: [
+                    {
+                        id: 'F',
+                        v: 6,
+                        children: [
+                            { id: 'G', v: 7 },
+                            { id: 'H', v: 80 },
+                            { id: 'I', v: 9 },
+                        ],
+                    },
+                    { id: 'J', v: 10, children: [{ id: 'K', v: 110 }] },
+                ],
+            },
+        ]);
+
+        const rows1 = gridRows.displayedRows;
+
+        api.setGridOption('rowData', rowData2);
+
+        gridRows = new GridRows(api, 'update some values', gridRowsOptions);
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ A GROUP id:A ag-Grid-AutoColumn:"A" v:1
+            │ └── B LEAF id:B ag-Grid-AutoColumn:"B" v:20
+            ├─┬ C GROUP id:C ag-Grid-AutoColumn:"C" v:3
+            │ └── D LEAF id:D ag-Grid-AutoColumn:"D" v:4
+            └─┬ E GROUP id:E ag-Grid-AutoColumn:"E" v:5
+            · ├─┬ F GROUP id:F ag-Grid-AutoColumn:"F" v:6
+            · │ ├── G LEAF id:G ag-Grid-AutoColumn:"G" v:7
+            · │ ├── H LEAF id:H ag-Grid-AutoColumn:"H" v:80
+            · │ └── I LEAF id:I ag-Grid-AutoColumn:"I" v:9
+            · └─┬ J GROUP id:J ag-Grid-AutoColumn:"J" v:10
+            · · └── K LEAF id:K ag-Grid-AutoColumn:"K" v:110
+        `);
+
+        const rows2 = gridRows.displayedRows;
+
+        // Rows should be the same instances
+        for (let i = 0; i < rows1.length; i++) {
+            expect(rows1[i] === rows2[i]).toBe(true);
+        }
+
+        // add, remove, update nodes
+
+        const rowData3 = cachedJSONObjects.array([
+            {
+                id: 'A',
+                v: 1000,
+                children: [{ id: 'B', v: 20, children: [] }],
+            },
+            {
+                id: 'C',
+                v: 3,
+                children: [{ id: 'D', v: 4 }],
+            },
+
+            {
+                id: 'E',
+                v: 5,
+                children: [
+                    {
+                        id: 'F',
+                        v: 6,
+                        children: [
+                            { id: 'G', v: 7 },
+                            { id: 'I', v: 9 },
+                        ],
+                    },
+                    {
+                        id: 'J',
+                        v: 10,
+                        children: [
+                            { id: 'K', v: 110 },
+                            { id: 'L', v: 666 },
+                            { id: 'M', v: 777, children: [{ id: 'N', v: 888 }] },
+                        ],
+                    },
+                ],
+            },
+        ]);
+
+        api.setGridOption('rowData', rowData3);
+
+        gridRows = new GridRows(api, 'add, update nodes', gridRowsOptions);
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ A GROUP id:A ag-Grid-AutoColumn:"A" v:1000
+            │ └── B LEAF id:B ag-Grid-AutoColumn:"B" v:20
+            ├─┬ C GROUP id:C ag-Grid-AutoColumn:"C" v:3
+            │ └── D LEAF id:D ag-Grid-AutoColumn:"D" v:4
+            └─┬ E GROUP id:E ag-Grid-AutoColumn:"E" v:5
+            · ├─┬ F GROUP id:F ag-Grid-AutoColumn:"F" v:6
+            · │ ├── G LEAF id:G ag-Grid-AutoColumn:"G" v:7
+            · │ └── I LEAF id:I ag-Grid-AutoColumn:"I" v:9
+            · └─┬ J GROUP id:J ag-Grid-AutoColumn:"J" v:10
+            · · ├── K LEAF id:K ag-Grid-AutoColumn:"K" v:110
+            · · ├── L LEAF id:L ag-Grid-AutoColumn:"L" v:666
+            · · └─┬ M GROUP id:M ag-Grid-AutoColumn:"M" v:777
+            · · · └── N LEAF id:N ag-Grid-AutoColumn:"N" v:888
+        `);
+
+        const rows3 = gridRows.displayedRows;
+
+        expect(rows2[0] === rows3[0]).toBe(true);
+        expect(rows2[1] === rows3[1]).toBe(true);
+        expect(rows2[2] === rows3[2]).toBe(true);
+        expect(rows2[3] === rows3[3]).toBe(true);
+        expect(rows2[4] === rows3[4]).toBe(true);
+        expect(rows2[5] === rows3[5]).toBe(true);
+        expect(rows2[6] === rows3[6]).toBe(true);
+        expect(rows2[8] === rows3[7]).toBe(true); // removed row
+        expect(rows2[9] === rows3[8]).toBe(true);
+        expect(rows2[10] === rows3[9]).toBe(true);
+        expect(rows3[10].data.v).toBe(666); // added row
+        expect(rows3[11].data.v).toBe(777); // added row
+        expect(rows3[12].data.v).toBe(888); // added row
+        expect(rows2[11] === rows3[13]).toBe(true);
+
+        // add, remove, reorder, move some nodes
+
+        const rowData4 = cachedJSONObjects.array([
+            {
+                id: 'C',
+                v: 3,
+                children: [{ id: 'D', v: 4 }],
+            },
+            {
+                id: 'A',
+                v: 1000,
+                children: [{ id: 'B', v: 20, children: [{ id: 'Q', v: -100 }] }],
+            },
+            {
+                id: 'E',
+                v: 5,
+                children: [
+                    {
+                        id: 'F',
+                        v: 6,
+                        children: [
+                            { id: 'G', v: 7, children: [{ id: 'N', v: 888 }] },
+                            { id: 'I', v: 9 },
+                        ],
+                    },
+                    {
+                        id: 'J',
+                        v: 10,
+                        children: [
+                            { id: 'M', v: 777 },
+                            { id: 'L', v: 666 },
+                            { id: 'K', v: 110 },
+                        ],
+                    },
+                ],
+            },
+        ]);
+
+        api.setGridOption('rowData', rowData4);
+
+        gridRows = new GridRows(api, 'add, reorder, move some nodes', gridRowsOptions);
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ C GROUP id:C ag-Grid-AutoColumn:"C" v:3
+            │ └── D LEAF id:D ag-Grid-AutoColumn:"D" v:4
+            ├─┬ A GROUP id:A ag-Grid-AutoColumn:"A" v:1000
+            │ └─┬ B GROUP id:B ag-Grid-AutoColumn:"B" v:20
+            │ · └── Q LEAF id:Q ag-Grid-AutoColumn:"Q" v:-100
+            └─┬ E GROUP id:E ag-Grid-AutoColumn:"E" v:5
+            · ├─┬ F GROUP id:F ag-Grid-AutoColumn:"F" v:6
+            · │ ├─┬ G GROUP id:G ag-Grid-AutoColumn:"G" v:7
+            · │ │ └── N LEAF id:N ag-Grid-AutoColumn:"N" v:888
+            · │ └── I LEAF id:I ag-Grid-AutoColumn:"I" v:9
+            · └─┬ J GROUP id:J ag-Grid-AutoColumn:"J" v:10
+            · · ├── M LEAF id:M ag-Grid-AutoColumn:"M" v:777
+            · · ├── L LEAF id:L ag-Grid-AutoColumn:"L" v:666
+            · · └── K LEAF id:K ag-Grid-AutoColumn:"K" v:110
+        `);
+
+        const rows4 = gridRows.displayedRows;
+
+        expect(rows3[0] === rows4[2]).toBe(true); // C swapped with A
+        expect(rows3[1] === rows4[3]).toBe(true);
+        expect(rows3[2] === rows4[0]).toBe(true);
+        expect(rows3[3] === rows4[1]).toBe(true);
+        expect(rows4[4].data.v).toBe(-100); // Q added
+        expect(rows3[4] === rows4[5]).toBe(true);
+        expect(rows3[5] === rows4[6]).toBe(true);
+        expect(rows3[6] === rows4[7]).toBe(true);
+        expect(rows3[7] === rows4[9]).toBe(true);
+        expect(rows3[8] === rows4[10]).toBe(true);
+        expect(rows3[9] === rows4[13]).toBe(true); // K moved
+        expect(rows3[10] === rows4[12]).toBe(true); // L moved
+        expect(rows3[11] === rows4[11]).toBe(true); // M moved
+        expect(rows3[12] === rows4[8]).toBe(true); // N moved parent
+
+        // remove groups
+
+        const rowData5 = cachedJSONObjects.array([
+            {
+                id: 'C',
+                v: 3,
+                children: [{ id: 'D', v: 4 }],
+            },
+            {
+                id: 'E',
+                v: 5,
+                children: [
+                    {
+                        id: 'F',
+                        v: 6,
+                        children: [
+                            { id: 'G', v: 7, children: [{ id: 'N', v: 888 }] },
+                            { id: 'I', v: 9 },
+                        ],
+                    },
+                ],
+            },
+        ]);
+
+        api.setGridOption('rowData', rowData5);
+
+        gridRows = new GridRows(api, 'remove groups', gridRowsOptions);
+
+        const rows5 = gridRows.displayedRows;
+
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ C GROUP id:C ag-Grid-AutoColumn:"C" v:3
+            │ └── D LEAF id:D ag-Grid-AutoColumn:"D" v:4
+            └─┬ E GROUP id:E ag-Grid-AutoColumn:"E" v:5
+            · └─┬ F GROUP id:F ag-Grid-AutoColumn:"F" v:6
+            · · ├─┬ G GROUP id:G ag-Grid-AutoColumn:"G" v:7
+            · · │ └── N LEAF id:N ag-Grid-AutoColumn:"N" v:888
+            · · └── I LEAF id:I ag-Grid-AutoColumn:"I" v:9
+        `);
+
+        // swap groups children
+
+        const rowData6 = cachedJSONObjects.array([
+            {
+                id: 'E',
+                v: 5,
+                children: [{ id: 'D', v: 4 }],
+            },
+            {
+                id: 'C',
+                v: 3,
+                children: [
+                    {
+                        id: 'F',
+                        v: 6,
+                        children: [
+                            { id: 'N', v: 888, children: [{ id: 'G', v: 7 }] },
+                            { id: 'I', v: 9 },
+                        ],
+                    },
+                ],
+            },
+        ]);
+
+        api.setGridOption('rowData', rowData6);
+
+        gridRows = new GridRows(api, 'swap groups children', gridRowsOptions);
+
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ E GROUP id:E ag-Grid-AutoColumn:"E" v:5
+            │ └── D LEAF id:D ag-Grid-AutoColumn:"D" v:4
+            └─┬ C GROUP id:C ag-Grid-AutoColumn:"C" v:3
+            · └─┬ F GROUP id:F ag-Grid-AutoColumn:"F" v:6
+            · · ├─┬ N GROUP id:N ag-Grid-AutoColumn:"N" v:888
+            · · │ └── G LEAF id:G ag-Grid-AutoColumn:"G" v:7
+            · · └── I LEAF id:I ag-Grid-AutoColumn:"I" v:9
+        `);
+
+        const rows6 = gridRows.displayedRows;
+
+        expect(rows5[2] === rows6[0]).toBe(true);
+        expect(rows5[1] === rows6[1]).toBe(true);
+        expect(rows5[0] === rows6[2]).toBe(true);
+        expect(rows5[3] === rows6[3]).toBe(true);
+        expect(rows5[5] === rows6[4]).toBe(true);
+        expect(rows5[4] === rows6[5]).toBe(true);
+        expect(rows5[6] === rows6[6]).toBe(true);
+
         // disable treeData
 
         api.setGridOption('treeData', false);

--- a/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-excel-export.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-excel-export.test.ts
@@ -67,9 +67,46 @@ describe('ag-grid hierarchical tree excel export', () => {
             { Group: 'grp-3', value: 'value-400' },
             { Group: 'grp-4', value: 'value-500' },
         ]);
+    });
 
-        // Try to disable tree data now
-        api.setGridOption('treeData', false);
+    // TODO: disabled due to AG-13994 - Remove the treeData flattening behavior (from the API, not the codebase)
+    test.skip('excel exports calls value getter for groups and leafs with flattened tree data', async () => {
+        const rowData = [
+            {
+                uiId: '1',
+                value: 100,
+                children: [
+                    {
+                        uiId: '2',
+                        value: 200,
+                        children: [
+                            { uiId: '3', value: 300 },
+                            { uiId: '4', value: 400 },
+                        ],
+                    },
+                    { uiId: '5', value: 500 },
+                ],
+            },
+        ];
+
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                {
+                    headerName: 'value',
+                    valueGetter: ({ data }) => (data ? 'value-' + data.value : 'filler'),
+                },
+            ],
+            autoGroupColumnDef: {
+                valueGetter: (params) => {
+                    return 'grp-' + params.node?.rowIndex;
+                },
+            },
+            rowData,
+            treeData: false,
+            groupDefaultExpanded: -1,
+            ['treeDataChildrenField' as any]: 'children',
+            getRowId: (params) => params.data.uiId,
+        });
 
         api.exportDataAsExcel({ fileName: 'test.xlsx' });
 


### PR DESCRIPTION
Remove the flattening behavior
if treeData=false, treeDataChildrenField shouldn't be used

There's no way to see the hierarchical data in flat format

We’re not removing the code from the codebased, we’re only not surfacing it in the API