### PR TITLE
fix: decimal and thousands separator for pt-PT

### DIFF
--- a/community-modules/locale/src/pt-PT.ts
+++ b/community-modules/locale/src/pt-PT.ts
@@ -560,8 +560,8 @@ export const AG_GRID_LOCALE_PT = {
     ariaFilterPanelList: 'Lista de Filtros',
 
     // Number Format (Status Bar, Pagination Panel)
-    thousandSeparator: ',',
-    decimalSeparator: '.',
+    thousandSeparator: '.',
+    decimalSeparator: ',',
 
     // Data types
     true: 'Verdadeiro',


### PR DESCRIPTION
Hello,

I noticed that I mistakenly imported `pt-PT` when I intended to use `pt-BR`. 

This lead me to find a strange behaviour on pt-PT. After reviewing it, I believe decimal and thousand separators may have been swapped.

Please verify with your "Portugal Portuguese" reviewer, but I am nearly certain that the formatting conventions for the numeric values are inverted. In Portugal, the correct format is `10.000.000,00` instead of the "American" format `10,000,000.00`.

This PR aims to fix this issue.

Thank you for your attention to this.