### PR TITLE
AG-14020 - Add params and return value in api doc description

### DIFF
--- a/documentation/ag-grid-docs/src/components/reference-documentation/components/Property.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/components/Property.tsx
@@ -11,6 +11,7 @@ import { Fragment, type FunctionComponent, useCallback, useEffect, useRef, useSt
 import type { ChildDocEntry, Config, ICallSignature, InterfaceEntry } from '../types';
 import {
     convertMarkdown,
+    extractJSDocTags,
     formatJsDocString,
     getTypeUrl,
     inferType,
@@ -60,10 +61,20 @@ function getDescription({
     let description: string | undefined = '';
     let isObject: boolean = false;
     let propDescription: string | undefined =
-        definition.description || (gridOpProp && (gridOpProp.meta as ICallSignature['meta'])?.all) || undefined;
+        definition.description || (gridOpProp && (gridOpProp.meta as ICallSignature['meta'])?.comment) || undefined;
 
     if (propDescription) {
         propDescription = formatJsDocString(propDescription);
+        if (!definition.description && gridOpProp && (gridOpProp.meta as ICallSignature['meta'])?.all) {
+            const { params, returns } = extractJSDocTags(
+                definition.description || (gridOpProp && (gridOpProp.meta as ICallSignature['meta'])?.all)
+            );
+            const paramsStr = params?.map((p) => `<span class="param">\`${p.name}\`: ${p.value}</span>`).join('');
+            const returnsStr = returns ? `<strong>Returns:</strong> ${returns}` : '';
+
+            propDescription = [propDescription, paramsStr, returnsStr].filter(Boolean).join('\n');
+        }
+
         // process property object
         description = convertMarkdown(propDescription, framework);
     } else {

--- a/documentation/ag-grid-docs/src/components/reference-documentation/components/Property.tsx
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/components/Property.tsx
@@ -60,7 +60,7 @@ function getDescription({
     let description: string | undefined = '';
     let isObject: boolean = false;
     let propDescription: string | undefined =
-        definition.description || (gridOpProp && (gridOpProp.meta as ICallSignature['meta'])?.comment) || undefined;
+        definition.description || (gridOpProp && (gridOpProp.meta as ICallSignature['meta'])?.all) || undefined;
 
     if (propDescription) {
         propDescription = formatJsDocString(propDescription);

--- a/documentation/ag-grid-docs/src/components/reference-documentation/utils/documentation-helpers.ts
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/utils/documentation-helpers.ts
@@ -4,6 +4,12 @@ import { urlWithPrefix } from '@utils/urlWithPrefix';
 import type { InterfaceEntry, Properties, PropertyType } from '../types';
 import { getTypeLink } from './type-links';
 
+const paramReg = /\* @param (\w+) (.*)\n/g;
+const returnsReg = /\* (@returns) (.*)\n/g;
+const newLineReg = /\n\s+\*(?!\*)/g;
+// Turn option list, new line starting with - into bullet points
+const optionReg = /\n[\s]*[*]*[\s]*- (.*)/g;
+
 export const inferType = (value: any): string | null => {
     if (value == null) {
         return null;
@@ -221,13 +227,6 @@ export function formatJsDocString(docString: string) {
     if (!docString || docString.length === 0) {
         return;
     }
-    const paramReg = /\* @param (\w+) (.*)\n/g;
-    const returnsReg = /\* (@returns) (.*)\n/g;
-    const newLineReg = /\n\s+\*(?!\*)/g;
-
-    // Turn option list, new line starting with - into bullet points
-
-    const optionReg = /\n[\s]*[*]*[\s]*- (.*)/g;
 
     const formatted = docString
         .replace('/**', '')
@@ -238,6 +237,24 @@ export function formatJsDocString(docString: string) {
         .replace(newLineReg, ' ');
 
     return formatted;
+}
+
+export function extractJSDocTags(docString?: string) {
+    if (!docString || docString.length === 0) {
+        return {};
+    }
+
+    const params = [...docString.matchAll(paramReg)].map(([_, name, value]) => {
+        return {
+            name,
+            value,
+        };
+    });
+    const returns = [...docString.matchAll(returnsReg)].map(([_, _returns, value]) => {
+        return value;
+    })[0]; // Take first match only
+
+    return { params, returns };
 }
 
 export function appendCallSignature(name: string, interfaceType: any, framework: Framework, allLines: string[]) {

--- a/documentation/ag-grid-docs/src/components/reference-documentation/utils/documentation-helpers.ts
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/utils/documentation-helpers.ts
@@ -232,8 +232,8 @@ export function formatJsDocString(docString: string) {
     const formatted = docString
         .replace('/**', '')
         .replace('*/', '')
-        .replace(paramReg, '<br> `$1` $2 \n')
-        .replace(returnsReg, '<br> <strong>Returns: </strong> $2 \n')
+        .replace(paramReg, '<span class="param"> `$1` $2 </span>\n')
+        .replace(returnsReg, '<strong>Returns: </strong> $2 \n')
         .replace(optionReg, '<li style="margin-left:1rem"> $1 </li>')
         .replace(newLineReg, ' ');
 

--- a/external/ag-website-shared/src/components/reference-documentation/ApiReference.module.scss
+++ b/external/ag-website-shared/src/components/reference-documentation/ApiReference.module.scss
@@ -167,6 +167,11 @@
             padding-left: $spacing-size-6;
         }
     }
+
+    :global(.param) {
+        display: block;
+        margin: $spacing-size-2 0;
+    }
 }
 
 .name {


### PR DESCRIPTION
`comment` strips out params and return value, but `all` has everything