### PR TITLE
AG-14096 - Fix integrated charts automated example on mobile

### DIFF
--- a/external/ag-website-shared/src/components/automated-examples/AutomatedIntegratedCharts.module.scss
+++ b/external/ag-website-shared/src/components/automated-examples/AutomatedIntegratedCharts.module.scss
@@ -1,4 +1,5 @@
 @use 'sass:map';
+@use 'sass:math';
 @use 'design-system' as *;
 @use './AutomatedExamplesVars.module' as *;
 
@@ -9,7 +10,7 @@ $z-index-splash: $z-index-debug-canvas + 10;
 $z-index-debug-panel: $z-index-splash + 10;
 $z-index-splash-contents: 10;
 
-$aspect-ratio: 16 / 9;
+$aspect-ratio: math.div(16, 9);
 
 .automatedExampleWrapper {
     position: relative;

--- a/external/ag-website-shared/src/components/automated-examples/AutomatedIntegratedCharts.module.scss
+++ b/external/ag-website-shared/src/components/automated-examples/AutomatedIntegratedCharts.module.scss
@@ -16,7 +16,7 @@ $z-index-splash-contents: 10;
     width: 100%;
     z-index: $z-index-grid;
 
-    @media screen and (max-width: $breakpoint-automated-row-grouping-medium) {
+    @media screen and (max-width: $breakpoint-automated-integrated-charts-medium) {
         height: calc(var(--ic-grid-height) / 2);
         overflow: hidden;
     }
@@ -25,7 +25,7 @@ $z-index-splash-contents: 10;
         height: calc(var(--ic-grid-height) / 3);
     }
 
-    @media screen and (min-width: $breakpoint-automated-row-grouping-medium) {
+    @media screen and (min-width: $breakpoint-automated-integrated-charts-medium) {
         --ic-grid-height: 450px;
 
         height: var(--ic-grid-height);
@@ -49,7 +49,7 @@ $z-index-splash-contents: 10;
 
 :global(.automated-integrated-charts-grid.ag-theme-quartz),
 :global(.automated-integrated-charts-grid.ag-theme-quartz-dark) {
-    @media screen and (max-width: $breakpoint-automated-row-grouping-medium) {
+    @media screen and (max-width: $breakpoint-automated-integrated-charts-medium) {
         width: 200% !important;
         height: var(--ic-grid-height) !important;
         transform-origin: top left;
@@ -67,7 +67,7 @@ $z-index-splash-contents: 10;
         transform: scale(0.3333);
     }
 
-    @media screen and (min-width: $breakpoint-automated-row-grouping-medium) {
+    @media screen and (min-width: $breakpoint-automated-integrated-charts-medium) {
         height: var(--ic-grid-height);
     }
 
@@ -76,7 +76,7 @@ $z-index-splash-contents: 10;
         align-items: center;
         gap: $spacing-size-1;
 
-        @media screen and (max-width: $breakpoint-automated-row-grouping-medium) {
+        @media screen and (max-width: $breakpoint-automated-integrated-charts-medium) {
             gap: $spacing-size-2;
         }
     }
@@ -98,7 +98,7 @@ $z-index-splash-contents: 10;
     gap: $spacing-size-12;
     margin-top: $spacing-size-12;
 
-    @media screen and (min-width: $breakpoint-automated-row-grouping-medium) {
+    @media screen and (min-width: $breakpoint-automated-integrated-charts-medium) {
         display: flex;
     }
 
@@ -127,7 +127,7 @@ $z-index-splash-contents: 10;
         top: $mouse-offset-top;
         left: $mouse-offset-left;
 
-        @media screen and (max-width: $breakpoint-automated-row-grouping-medium) {
+        @media screen and (max-width: $breakpoint-automated-integrated-charts-medium) {
             top: calc(#{$mouse-offset-top} * var(--mobile-mouse-scale));
             left: calc(#{$mouse-offset-left} * var(--mobile-mouse-scale));
             width: calc(#{$mouse-base-width} * var(--mobile-mouse-scale));

--- a/external/ag-website-shared/src/components/automated-examples/AutomatedIntegratedCharts.module.scss
+++ b/external/ag-website-shared/src/components/automated-examples/AutomatedIntegratedCharts.module.scss
@@ -19,7 +19,6 @@ $z-index-splash-contents: 10;
     @media screen and (max-width: $breakpoint-automated-row-grouping-medium) {
         height: calc(var(--ic-grid-height) / 2);
         overflow: hidden;
-        pointer-events: none;
     }
 
     @media screen and (max-width: $breakpoint-automated-row-grouping-small) {

--- a/external/ag-website-shared/src/components/automated-examples/AutomatedIntegratedCharts.module.scss
+++ b/external/ag-website-shared/src/components/automated-examples/AutomatedIntegratedCharts.module.scss
@@ -9,31 +9,13 @@ $z-index-splash: $z-index-debug-canvas + 10;
 $z-index-debug-panel: $z-index-splash + 10;
 $z-index-splash-contents: 10;
 
+$aspect-ratio: 16 / 9;
+
 .automatedExampleWrapper {
-    --ic-grid-height: 550px;
-
     position: relative;
-    width: 100%;
     z-index: $z-index-grid;
-
-    @media screen and (max-width: $breakpoint-automated-integrated-charts-medium) {
-        height: calc(var(--ic-grid-height) / 2);
-        overflow: hidden;
-    }
-
-    @media screen and (max-width: $breakpoint-automated-row-grouping-small) {
-        height: calc(var(--ic-grid-height) / 3);
-    }
-
-    @media screen and (min-width: $breakpoint-automated-integrated-charts-medium) {
-        --ic-grid-height: 450px;
-
-        height: var(--ic-grid-height);
-    }
-
-    @media screen and (min-width: $breakpoint-automated-row-grouping-large) {
-        --ic-grid-height: 600px;
-    }
+    aspect-ratio: $aspect-ratio;
+    overflow: hidden;
 
     svg[class*='logo-mark'] {
         position: absolute;
@@ -49,12 +31,12 @@ $z-index-splash-contents: 10;
 
 :global(.automated-integrated-charts-grid.ag-theme-quartz),
 :global(.automated-integrated-charts-grid.ag-theme-quartz-dark) {
+    aspect-ratio: $aspect-ratio;
+
     @media screen and (max-width: $breakpoint-automated-integrated-charts-medium) {
         width: 200% !important;
-        height: var(--ic-grid-height) !important;
         transform-origin: top left;
         transform: scale(0.5);
-        overflow: hidden;
 
         :global(.overlay-button) {
             cursor: default;
@@ -63,12 +45,7 @@ $z-index-splash-contents: 10;
 
     @media screen and (max-width: $breakpoint-automated-row-grouping-small) {
         width: 300% !important;
-        height: var(--ic-grid-height) !important;
         transform: scale(0.3333);
-    }
-
-    @media screen and (min-width: $breakpoint-automated-integrated-charts-medium) {
-        height: var(--ic-grid-height);
     }
 
     :global(.country) {

--- a/external/ag-website-shared/src/components/automated-examples/AutomatedIntegratedCharts.module.scss
+++ b/external/ag-website-shared/src/components/automated-examples/AutomatedIntegratedCharts.module.scss
@@ -10,12 +10,10 @@ $z-index-splash: $z-index-debug-canvas + 10;
 $z-index-debug-panel: $z-index-splash + 10;
 $z-index-splash-contents: 10;
 
-$aspect-ratio: math.div(16, 9);
-
 .automatedExampleWrapper {
     position: relative;
     z-index: $z-index-grid;
-    aspect-ratio: $aspect-ratio;
+    aspect-ratio: 16 / 9;
     overflow: hidden;
 
     svg[class*='logo-mark'] {
@@ -32,7 +30,7 @@ $aspect-ratio: math.div(16, 9);
 
 :global(.automated-integrated-charts-grid.ag-theme-quartz),
 :global(.automated-integrated-charts-grid.ag-theme-quartz-dark) {
-    aspect-ratio: $aspect-ratio;
+    aspect-ratio: 16 / 9;
 
     @media screen and (max-width: $breakpoint-automated-integrated-charts-medium) {
         width: 200% !important;

--- a/external/ag-website-shared/src/components/automated-examples/AutomatedIntegratedChartsWithCreate.tsx
+++ b/external/ag-website-shared/src/components/automated-examples/AutomatedIntegratedChartsWithCreate.tsx
@@ -56,6 +56,7 @@ export function AutomatedIntegratedChartsWithCreate({
     const [darkMode] = useDarkmode();
     const debuggerManager = automatedExampleManager?.getDebuggerManager();
     const { isCI: useStaticData, runOnce } = getAutomatedExampleSearchParams();
+    const getIsMobileDevice = useCallback(() => isMobile('integratedCharts'), []);
 
     const setAllScriptEnabledVars = (isEnabled: boolean) => {
         setScriptIsEnabled(isEnabled);
@@ -100,7 +101,7 @@ export function AutomatedIntegratedChartsWithCreate({
                 return overlayRef.current;
             },
             getContainerScale: () => {
-                return isMobile() ? AUTOMATED_EXAMPLE_MOBILE_SCALE : 1;
+                return getIsMobileDevice() ? AUTOMATED_EXAMPLE_MOBILE_SCALE : 1;
             },
             mouseMaskClassname: styles.mouseMask,
             scriptDebuggerManager: debuggerManager,
@@ -118,7 +119,7 @@ export function AutomatedIntegratedChartsWithCreate({
                 },
             ],
             onStateChange(state: RunScriptState) {
-                if (state === 'errored' && !isMobile()) {
+                if (state === 'errored' && !getIsMobileDevice()) {
                     setAllScriptEnabledVars(false);
                     automatedExampleManager.errored(exampleId);
                 }
@@ -164,7 +165,7 @@ export function AutomatedIntegratedChartsWithCreate({
                             onPointerEnter={() => setGridIsHoveredOver(true)}
                             onPointerOut={() => setGridIsHoveredOver(false)}
                             onClick={() => {
-                                if (!isMobile()) {
+                                if (!getIsMobileDevice()) {
                                     setAllScriptEnabledVars(false);
                                     automatedExampleManager.stop(exampleId);
 

--- a/external/ag-website-shared/src/components/automated-examples/AutomatedRowGrouping.tsx
+++ b/external/ag-website-shared/src/components/automated-examples/AutomatedRowGrouping.tsx
@@ -90,7 +90,7 @@ export function AutomatedRowGrouping({ visibilityThreshold, darkMode }: Props) {
                 return overlayRef.current;
             },
             getContainerScale: () => {
-                return isMobile() ? AUTOMATED_EXAMPLE_MOBILE_SCALE : 1;
+                return isMobile('rowGrouping') ? AUTOMATED_EXAMPLE_MOBILE_SCALE : 1;
             },
             mouseMaskClassname: styles.mouseMask,
             scriptDebuggerManager: debuggerManager,

--- a/external/ag-website-shared/src/components/automated-examples/examples/integrated-charts/createScript.ts
+++ b/external/ag-website-shared/src/components/automated-examples/examples/integrated-charts/createScript.ts
@@ -335,7 +335,7 @@ export const createScript = ({
             actionParams: {
                 target: 'chartsLegendItem',
                 targetParams: {
-                    index: 3,
+                    index: 0,
                 },
             },
         },
@@ -357,7 +357,7 @@ export const createScript = ({
             actionParams: {
                 target: 'chartsLegendItem',
                 targetParams: {
-                    index: 3,
+                    index: 0,
                 },
             },
         },

--- a/external/ag-website-shared/src/components/automated-examples/examples/integrated-charts/createScript.ts
+++ b/external/ag-website-shared/src/components/automated-examples/examples/integrated-charts/createScript.ts
@@ -131,6 +131,10 @@ export const createScript = ({
                 scriptDebugger,
                 speed: 0.5,
             },
+            // A user clicking on the page when the context menu is open causes the context
+            // menu to close, and makes this action fail, but the script can recover in the
+            // next chart creation step
+            ignoreError: true,
         },
         {
             name: 'Create range chart',
@@ -224,6 +228,9 @@ export const createScript = ({
                     text: 'Country',
                 },
             },
+            // A user clicking or scrolling on the page when the dropdown is open causes the
+            // dropdown to close, and makes this action fail, but we can ignore this change
+            ignoreError: true,
         },
         { type: 'wait', duration: 600 },
 

--- a/external/ag-website-shared/src/components/automated-examples/lib/isMobile.ts
+++ b/external/ag-website-shared/src/components/automated-examples/lib/isMobile.ts
@@ -1,5 +1,12 @@
 import breakpoints from '@design-system/breakpoint.module.scss';
 
-const AUTOMATED_EXAMPLE_MEDIUM_WIDTH = parseInt(breakpoints['automated-row-grouping-medium'], 10);
+const AUTOMATED_ROW_GROUPING_MEDIUM_WIDTH = parseInt(breakpoints['automated-row-grouping-medium'], 10);
+const AUTOMATED_INTEGRATED_CHARTS_MEDIUM_WIDTH = parseInt(breakpoints['automated-integrated-charts-medium'], 10);
 
-export const isMobile = () => window.innerWidth <= AUTOMATED_EXAMPLE_MEDIUM_WIDTH;
+type ExampleType = 'rowGrouping' | 'integratedCharts';
+
+export const isMobile = (type: ExampleType) => {
+    const maxWidth =
+        type === 'rowGrouping' ? AUTOMATED_ROW_GROUPING_MEDIUM_WIDTH : AUTOMATED_INTEGRATED_CHARTS_MEDIUM_WIDTH;
+    return window.innerWidth <= maxWidth;
+};

--- a/external/ag-website-shared/src/components/automated-examples/lib/scriptRunner.ts
+++ b/external/ag-website-shared/src/components/automated-examples/lib/scriptRunner.ts
@@ -22,6 +22,7 @@ import type { EasingFunction } from './tween';
 export interface Action {
     name?: string;
     type: string;
+    ignoreError?: boolean;
 }
 
 export interface PathAction extends Action {
@@ -247,7 +248,9 @@ function createScriptActionSequence({
                     }),
                     error,
                 });
-                throw error;
+                if (!scriptAction.ignoreError) {
+                    throw error;
+                }
             }
         };
     });
@@ -323,7 +326,15 @@ export function createScriptRunner({
                                 } as CancelledPromise);
                             }
 
-                            onError?.({ error, index, action });
+                            const scriptAction = script[index];
+                            if (scriptAction.ignoreError) {
+                                scriptDebugger?.log('Action error (ignored)', {
+                                    index,
+                                    error,
+                                });
+                            } else {
+                                onError?.({ error, index, action });
+                            }
                         }) as Promise<void>;
                 }, Promise.resolve())
                 .then(resolve)

--- a/external/ag-website-shared/src/design-system/breakpoint.module.scss
+++ b/external/ag-website-shared/src/design-system/breakpoint.module.scss
@@ -4,4 +4,5 @@
 :export {
     site-header-small: $breakpoint-site-header-small;
     automated-row-grouping-medium: $breakpoint-automated-row-grouping-medium;
+    automated-integrated-charts-medium: $breakpoint-automated-integrated-charts-medium;
 }

--- a/external/ag-website-shared/src/design-system/core/_breakpoints.scss
+++ b/external/ag-website-shared/src/design-system/core/_breakpoints.scss
@@ -24,6 +24,8 @@ $automated-row-grouping-small: 480px;
 $automated-row-grouping-medium: 740px;
 $automated-row-grouping-large: 1200px;
 
+$automated-integrated-charts-medium: 1024px;
+
 $sponsorship-large: 840px;
 
 $fw-selector-full-width-medium: 740px;


### PR DESCRIPTION
* Remove `pointer-events: none` that was preventing the script from interacting with the example from https://github.com/ag-grid/ag-charts/pull/2415
* Add `ignoreError` action property to keep going if there is an error. Needed for when the context menu or dropdown menu is open and user interacts with the page