### PR TITLE
AG-14147 update and reorder installation docs

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
@@ -145,12 +145,6 @@ const gridOptions = {
 {% metaTag tags=["aggridreact"] /%}
 <!-- Create React -->
 
-### Import the React Data Grid
-
-```js
-import { AgGridReact } from 'ag-grid-react'; // React Data Grid Component
-```
-
 ### Register Modules
 
 Register the `AllCommunityModule` to access all Community features:
@@ -165,6 +159,12 @@ ModuleRegistry.registerModules([AllCommunityModule]);
 {% note %}
 To minimize bundle size, only register the modules you want to use. See the [Modules](./modules/) docs for more information.
 {% /note %}
+
+### Import the React Data Grid
+
+```js
+import { AgGridReact } from 'ag-grid-react'; // React Data Grid Component
+```
 
 ### Define Rows and Columns
 
@@ -208,14 +208,6 @@ return (
 
 {% if isFramework("angular") %}
 
-### Import the Angular Data Grid
-
-```js
-import { Component } from '@angular/core';
-import { AgGridAngular } from 'ag-grid-angular'; // Angular Data Grid Component
-import type { ColDef } from 'ag-grid-community'; // Column Definition Type Interface
-```
-
 ### Register Modules
 
 Register the `AllCommunityModule` to access all Community features:
@@ -231,12 +223,16 @@ ModuleRegistry.registerModules([AllCommunityModule]);
 To minimize bundle size, only register the modules you want to use. See the [Modules](./modules/) page for more information.
 {% /note %}
 
+### Import the Angular Data Grid
+
+```js
+import { AgGridAngular } from 'ag-grid-angular'; // Angular Data Grid Component
+import type { ColDef } from 'ag-grid-community'; // Column Definition Type Interface
+```
+
 ### Define Rows and Columns
 
 ```jsx
-// Register all community features
-ModuleRegistry.registerModules([AllCommunityModule]);
-
 @Component({
     selector: 'app-root',
     standalone: true,
@@ -281,25 +277,6 @@ template:
 
 {% if isFramework("vue") %}
 
-### Import the Vue Data Grid
-
-```html
-<template></template>
-
-<script>
-import { ref } from 'vue';
-import { AgGridVue } from "ag-grid-vue3"; // Vue Data Grid Component
-
-export default {
-    name: "App",
-    components: {
-        AgGridVue, // Add Vue Data Grid component
-    },
-    setup() {},
-};
-</script>
-```
-
 ### Register Modules
 
 Register the `AllCommunityModule` to access all Community features:
@@ -314,6 +291,22 @@ ModuleRegistry.registerModules([AllCommunityModule]);
 {% note %}
 To minimize bundle size, only register the modules you want to use. See the [Modules](./modules/) page for more information.
 {% /note %}
+
+### Import the Vue Data Grid
+
+```html
+<script>
+import { AgGridVue } from "ag-grid-vue3"; // Vue Data Grid Component
+
+export default {
+    name: "App",
+    components: {
+        AgGridVue, // Add Vue Data Grid component
+    },
+    setup() {},
+};
+</script>
+```
 
 ### Define Rows and Columns
 

--- a/documentation/ag-grid-docs/src/content/docs/installation/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/installation/index.mdoc
@@ -80,6 +80,37 @@ You can test AG Grid Enterprise locally without a licence. To test in production
 {% /if %}
 
 {% if isFramework("react", "angular", "vue") %}
+## Registering Modules
+{% /if %}
+
+{% if isFramework("javascript") %}
+### Registering Modules
+{% /if %}
+
+Register the `AllCommunityModule` to access all Community features:
+
+```js
+import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community'; 
+
+// Register all Community features
+ModuleRegistry.registerModules([AllCommunityModule]);
+```
+
+Register the `AllEnterpriseBundle` to access all Community ***and*** Enterprise features:
+
+```js
+import { ModuleRegistry } from 'ag-grid-community'; 
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
+
+// Register all Community and Enterprise features
+ModuleRegistry.registerModules([AllEnterpriseModule]);
+```
+
+{% note %}
+To minimize bundle size, only register the modules you want to use. See the [Selecting Modules](./modules/) docs for more information.
+{% /note %}
+
+{% if isFramework("react", "angular", "vue") %}
 ## Importing
 {% /if %}
 
@@ -112,49 +143,12 @@ import { AgGridVue } from "ag-grid-vue3";
 {% /if %}
 
 {% if isFramework("javascript") %}
-To use AG Grid Community features, import them from the `ag-grid-community` package, e.g:
+Import `createGrid` from the `ag-grid-community` package to create a new data grid:
 
 ```js
 import { createGrid } from 'ag-grid-community';
 ```
-
-To use AG Grid Enterprise features, import the `ag-grid-enterprise` package:
-
-```js
-import 'ag-grid-enterprise';
-```
 {% /if %}
-
-{% if isFramework("react", "angular", "vue") %}
-## Registering Modules
-{% /if %}
-
-{% if isFramework("javascript") %}
-### Registering Modules
-{% /if %}
-
-Register the `AllCommunityModule` to access all Community features:
-
-```js
-import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community'; 
-
-// Register all Community features
-ModuleRegistry.registerModules([AllCommunityModule]);
-```
-
-Register the `AllEnterpriseBundle` to access all Community ***and*** Enterprise features:
-
-```js
-import { ModuleRegistry } from 'ag-grid-community'; 
-import { AllEnterpriseModule } from 'ag-grid-enterprise';
-
-// Register all Community and Enterprise features
-ModuleRegistry.registerModules([AllEnterpriseModule]);
-```
-
-{% note %}
-To minimize bundle size, only register the modules you want to use. See the [Selecting Modules](./modules/) docs for more information.
-{% /note %}
 
 {% if isFramework("javascript") %}
 ## CDN Installation

--- a/packages/ag-grid-angular/README.md
+++ b/packages/ag-grid-angular/README.md
@@ -190,18 +190,7 @@ $ npm install --save ag-grid-angular
 
 <!-- START SETUP -->
 
-**1. Import the Angular Data Grid**
-
-```js
-import { Component } from '@angular/core';
-
-// Angular Data Grid Component
-import { AgGridAngular } from 'ag-grid-angular';
-// Column Definition Type Interface
-import { ColDef } from 'ag-grid-community';
-```
-
-**2. Register Modules**
+**1. Register Modules**
 
 Register the `AllCommunityModule` to access all Community features:
 
@@ -216,6 +205,17 @@ ModuleRegistry.registerModules([AllCommunityModule]);
     <p>ℹ️ <b>Note:</b></p>
     <p>To minimize bundle size, only register the modules you want to use. See the <a href="https://www.ag-grid.com/angular-data-grid/modules/">Modules</a> page for more information.</p>
 </blockquote>
+
+**2. Import the Angular Data Grid**
+
+```js
+import { Component } from '@angular/core';
+
+// Angular Data Grid Component
+import { AgGridAngular } from 'ag-grid-angular';
+// Column Definition Type Interface
+import { ColDef } from 'ag-grid-community';
+```
 
 **3. Define Rows and Columns**
 

--- a/packages/ag-grid-angular/projects/ag-grid-angular/README.md
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/README.md
@@ -190,18 +190,7 @@ $ npm install --save ag-grid-angular
 
 <!-- START SETUP -->
 
-**1. Import the Angular Data Grid**
-
-```js
-import { Component } from '@angular/core';
-
-// Angular Data Grid Component
-import { AgGridAngular } from 'ag-grid-angular';
-// Column Definition Type Interface
-import { ColDef } from 'ag-grid-community';
-```
-
-**2. Register Modules**
+**1. Register Modules**
 
 Register the `AllCommunityModule` to access all Community features:
 
@@ -216,6 +205,17 @@ ModuleRegistry.registerModules([AllCommunityModule]);
     <p>ℹ️ <b>Note:</b></p>
     <p>To minimize bundle size, only register the modules you want to use. See the <a href="https://www.ag-grid.com/angular-data-grid/modules/">Modules</a> page for more information.</p>
 </blockquote>
+
+**2. Import the Angular Data Grid**
+
+```js
+import { Component } from '@angular/core';
+
+// Angular Data Grid Component
+import { AgGridAngular } from 'ag-grid-angular';
+// Column Definition Type Interface
+import { ColDef } from 'ag-grid-community';
+```
 
 **3. Define Rows and Columns**
 

--- a/packages/ag-grid-react/README.md
+++ b/packages/ag-grid-react/README.md
@@ -190,14 +190,7 @@ $ npm install --save ag-grid-react
 
 <!-- START SETUP -->
 
-**1. Import the React Data Grid**
-
-```js
-// React Data Grid Component
-import { AgGridReact } from 'ag-grid-react';
-```
-
-**2. Register Modules**
+**1. Register Modules**
 
 Register the `AllCommunityModule` to access all Community features:
 
@@ -212,6 +205,13 @@ ModuleRegistry.registerModules([AllCommunityModule]);
     <p>ℹ️ <b>Note:</b></p>
     <p>To minimize bundle size, only register the modules you want to use. See the <a href="https://www.ag-grid.com/react-data-grid/modules/">Modules</a> page for more information.</p>
 </blockquote>
+
+**2. Import the React Data Grid**
+
+```js
+// React Data Grid Component
+import { AgGridReact } from 'ag-grid-react';
+```
 
 **3. Define Rows and Columns**
 

--- a/packages/ag-grid-vue3/README.md
+++ b/packages/ag-grid-vue3/README.md
@@ -190,7 +190,23 @@ $ npm install --save ag-grid-vue3
 
 <!-- START SETUP -->
 
-**1. Import the Vue Data Grid**
+**1. Register Modules**
+
+Register the `AllCommunityModule` to access all Community features:
+
+```js
+import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community';
+
+// Register all Community features
+ModuleRegistry.registerModules([AllCommunityModule]);
+```
+
+<blockquote>
+    <p>ℹ️ <b>Note:</b></p>
+    <p>To minimize bundle size, only register the modules you want to use. See the <a href="https://www.ag-grid.com/vue-data-grid/modules/">Modules</a> page for more information.</p>
+</blockquote>
+
+**2. Import the Vue Data Grid**
 
 ```js
 <template></template>
@@ -208,22 +224,6 @@ export default {
 };
 </script>
 ```
-
-**2. Register Modules**
-
-Register the `AllCommunityModule` to access all Community features:
-
-```js
-import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community';
-
-// Register all Community features
-ModuleRegistry.registerModules([AllCommunityModule]);
-```
-
-<blockquote>
-    <p>ℹ️ <b>Note:</b></p>
-    <p>To minimize bundle size, only register the modules you want to use. See the <a href="https://www.ag-grid.com/vue-data-grid/modules/">Modules</a> page for more information.</p>
-</blockquote>
 
 **3. Define Rows and Columns**
 

--- a/scripts/readme/readme-framework-content.js
+++ b/scripts/readme/readme-framework-content.js
@@ -1,12 +1,5 @@
 const quickStartReact = `
-**1. Import the React Data Grid**
-
-\`\`\`js
-// React Data Grid Component
-import { AgGridReact } from 'ag-grid-react'; 
-\`\`\`
-
-**2. Register Modules**
+**1. Register Modules**
 
 Register the \`AllCommunityModule\` to access all Community features:
 
@@ -21,6 +14,13 @@ ModuleRegistry.registerModules([AllCommunityModule]);
     <p>ℹ️ <b>Note:</b></p>
     <p>To minimize bundle size, only register the modules you want to use. See the <a href="https://www.ag-grid.com/react-data-grid/modules/">Modules</a> page for more information.</p>
 </blockquote>
+
+**2. Import the React Data Grid**
+
+\`\`\`js
+// React Data Grid Component
+import { AgGridReact } from 'ag-grid-react'; 
+\`\`\`
 
 **3. Define Rows and Columns**
 
@@ -62,18 +62,7 @@ return (
 `;
 
 const quickStartAngular = `
-**1. Import the Angular Data Grid**
-
-\`\`\`js
-import { Component } from '@angular/core';
-
-// Angular Data Grid Component
-import { AgGridAngular } from 'ag-grid-angular'; 
-// Column Definition Type Interface
-import { ColDef } from 'ag-grid-community'; 
-\`\`\`
-
-**2. Register Modules**
+**1. Register Modules**
 
 Register the \`AllCommunityModule\` to access all Community features:
 
@@ -88,6 +77,17 @@ ModuleRegistry.registerModules([AllCommunityModule]);
     <p>ℹ️ <b>Note:</b></p>
     <p>To minimize bundle size, only register the modules you want to use. See the <a href="https://www.ag-grid.com/angular-data-grid/modules/">Modules</a> page for more information.</p>
 </blockquote>
+
+**2. Import the Angular Data Grid**
+
+\`\`\`js
+import { Component } from '@angular/core';
+
+// Angular Data Grid Component
+import { AgGridAngular } from 'ag-grid-angular'; 
+// Column Definition Type Interface
+import { ColDef } from 'ag-grid-community'; 
+\`\`\`
 
 **3. Define Rows and Columns**
 
@@ -133,7 +133,23 @@ template:
 `;
 
 const quickStartVue3 = `
-**1. Import the Vue Data Grid**
+**1. Register Modules**
+
+Register the \`AllCommunityModule\` to access all Community features:
+
+\`\`\`js
+import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community'; 
+
+// Register all Community features
+ModuleRegistry.registerModules([AllCommunityModule]);
+\`\`\`
+
+<blockquote>
+    <p>ℹ️ <b>Note:</b></p>
+    <p>To minimize bundle size, only register the modules you want to use. See the <a href="https://www.ag-grid.com/vue-data-grid/modules/">Modules</a> page for more information.</p>
+</blockquote>
+
+**2. Import the Vue Data Grid**
 
 \`\`\`js
 <template></template>
@@ -151,22 +167,6 @@ export default {
 };
 </script>
 \`\`\`
-
-**2. Register Modules**
-
-Register the \`AllCommunityModule\` to access all Community features:
-
-\`\`\`js
-import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community'; 
-
-// Register all Community features
-ModuleRegistry.registerModules([AllCommunityModule]);
-\`\`\`
-
-<blockquote>
-    <p>ℹ️ <b>Note:</b></p>
-    <p>To minimize bundle size, only register the modules you want to use. See the <a href="https://www.ag-grid.com/vue-data-grid/modules/">Modules</a> page for more information.</p>
-</blockquote>
 
 **3. Define Rows and Columns**
 


### PR DESCRIPTION
Remove `ag-grid-enterprise` import from JS Installation docs

Reorder Installation, Getting Started and README docs so that registering modules comes before importing.