### PR TITLE
AG-14059 - Add console log component

### DIFF
--- a/documentation/ag-grid-docs/markdoc.config.ts
+++ b/documentation/ag-grid-docs/markdoc.config.ts
@@ -107,6 +107,7 @@ export default defineMarkdocConfig({
                 typescriptOnly: { type: Boolean },
                 suppressDarkMode: { type: Boolean },
                 exampleHeight: { type: Number },
+                consoleBufferSize: { type: Number },
             },
         },
         apiDocumentation: {

--- a/documentation/ag-grid-docs/src/components/docs/components/DocsExampleRunner.astro
+++ b/documentation/ag-grid-docs/src/components/docs/components/DocsExampleRunner.astro
@@ -4,6 +4,7 @@ import ExampleRunnerContainer from '@components/example-runner/components/Exampl
 import { getIsDev } from '@utils/env';
 import { DocsExampleRunner } from './DocsExampleRunner';
 import { DISABLE_EXAMPLE_RUNNER } from '@constants';
+import { getGeneratedContents } from '@components/example-generator';
 
 interface Props {
     title: string;
@@ -11,17 +12,38 @@ interface Props {
     exampleHeight?: number;
     suppressDarkMode?: boolean;
     typescriptOnly?: boolean;
+    consoleBufferSize?: number;
 }
 
-const { title, name, exampleHeight, typescriptOnly, suppressDarkMode } = Astro.props as Props;
+const { title, name, exampleHeight, typescriptOnly, suppressDarkMode, consoleBufferSize } = Astro.props as Props;
 
 const pageName = getPageNameFromPath(Astro.url.pathname);
 const isDev = getIsDev();
+
+const generatedExampleParams = {
+    type: 'docs',
+    framework: 'vanilla', // Should be the same for all frameworks
+    pageName,
+    exampleName: name,
+};
+// NOTE: Even though we have the contents at build time, we are not passing
+// it into the component, so that we can load the contents at runtime.
+// This avoids the page being bigger than it needs to be, if the user does
+// not scroll to the example.
+const contents = await getGeneratedContents(generatedExampleParams);
+// Get whether example has console log component at build time, so that we
+// can show it on page load.
+const hasExampleConsoleLog = contents?.hasExampleConsoleLog;
 ---
 
 {
     !DISABLE_EXAMPLE_RUNNER && (
-        <ExampleRunnerContainer exampleHeight={exampleHeight} pageName={pageName} exampleName={name}>
+        <ExampleRunnerContainer
+            exampleHeight={exampleHeight}
+            pageName={pageName}
+            exampleName={name}
+            hasExampleConsoleLog={hasExampleConsoleLog}
+        >
             <DocsExampleRunner
                 client:only="react"
                 title={title}
@@ -31,6 +53,8 @@ const isDev = getIsDev();
                 suppressDarkMode={suppressDarkMode}
                 pageName={pageName}
                 isDev={isDev}
+                hasExampleConsoleLog={hasExampleConsoleLog}
+                consoleBufferSize={consoleBufferSize}
             />
         </ExampleRunnerContainer>
     )

--- a/documentation/ag-grid-docs/src/components/docs/components/DocsExampleRunner.astro
+++ b/documentation/ag-grid-docs/src/components/docs/components/DocsExampleRunner.astro
@@ -5,6 +5,7 @@ import { getIsDev } from '@utils/env';
 import { DocsExampleRunner } from './DocsExampleRunner';
 import { DISABLE_EXAMPLE_RUNNER } from '@constants';
 import { getGeneratedContents } from '@components/example-generator';
+import { getSupportedFrameworks } from '@components/docs/utils/filesData';
 
 interface Props {
     title: string;
@@ -20,9 +21,11 @@ const { title, name, exampleHeight, typescriptOnly, suppressDarkMode, consoleBuf
 const pageName = getPageNameFromPath(Astro.url.pathname);
 const isDev = getIsDev();
 
+const supportedFrameworks = await getSupportedFrameworks({ pageName, exampleName: name });
 const generatedExampleParams = {
     type: 'docs',
-    framework: 'vanilla', // Should be the same for all frameworks
+    // If there are supported frameworks, take the first one, otherwise the contents should be the same as vanilla
+    framework: supportedFrameworks?.values().next().value || 'vanilla',
     pageName,
     exampleName: name,
 };

--- a/documentation/ag-grid-docs/src/components/docs/components/DocsExampleRunner.tsx
+++ b/documentation/ag-grid-docs/src/components/docs/components/DocsExampleRunner.tsx
@@ -27,6 +27,8 @@ interface Props {
     isDev: boolean;
     typescriptOnly?: boolean;
     suppressDarkMode?: boolean;
+    hasExampleConsoleLog?: boolean;
+    consoleBufferSize?: number;
 }
 
 const getInternalFramework = (
@@ -63,6 +65,8 @@ const DocsExampleRunnerInner = ({
     suppressDarkMode,
     pageName,
     isDev,
+    hasExampleConsoleLog,
+    consoleBufferSize,
 }: Props) => {
     const exampleName = name;
     const id = `example-${name}`;
@@ -157,6 +161,7 @@ const DocsExampleRunnerInner = ({
         <ExampleRunner
             id={id}
             title={title}
+            exampleName={exampleName}
             exampleUrl={urls.exampleUrl}
             exampleRunnerExampleUrl={urls.exampleRunnerExampleUrl}
             exampleHeight={exampleHeight}
@@ -167,6 +172,8 @@ const DocsExampleRunnerInner = ({
             loadingIFrameId={loadingIFrameId}
             supportedFrameworks={supportedFrameworks}
             suppressDarkMode={suppressDarkMode}
+            hasExampleConsoleLog={hasExampleConsoleLog}
+            consoleBufferSize={consoleBufferSize}
         />
     ) : null;
 };

--- a/documentation/ag-grid-docs/src/components/example-runner/components/CodeViewer.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/components/CodeViewer.tsx
@@ -16,15 +16,32 @@ const ExtensionMap = {
     json: 'js',
 };
 
+export const CONSOLE_LOG_START = '/** CONSOLE LOG START **/';
+export const CONSOLE_LOG_END = '/** CONSOLE LOG END **/';
+
+function getSnippetRegex({ startDelimiter, endDelimiter }: { startDelimiter: string; endDelimiter: string }) {
+    const escapedStart = startDelimiter.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const escapedEnd = endDelimiter.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(`\\s*${escapedStart}[\\s\\S]*?${escapedEnd}\\s*`, 'g');
+
+    return regex;
+}
+
 export function stripOutExampleGeneratorCode(files: FileContents) {
     const mainFiles = ['main.js', 'main.ts', 'index.tsx', 'index.jsx', 'app.component.ts'];
+    const consoleLogRegex = getSnippetRegex({
+        startDelimiter: CONSOLE_LOG_START,
+        endDelimiter: CONSOLE_LOG_END,
+    });
+
     mainFiles.forEach((mainFile) => {
         if (files[mainFile]) {
             // hide integrated theme switcher
-            files[mainFile] = files[mainFile]?.replace(
-                /\/\*\* DARK INTEGRATED START \*\*\/([\s\S]*?)\/\*\* DARK INTEGRATED END \*\*\//g,
-                ''
-            );
+            files[mainFile] =
+                files[mainFile]
+                    ?.replace(/\/\*\* DARK INTEGRATED START \*\*\/([\s\S]*?)\/\*\* DARK INTEGRATED END \*\*\//g, '')
+                    .replace(consoleLogRegex, '')
+                    .trim() + '\n';
 
             // hide React tear down example code
             if (mainFile === 'index.tsx') {

--- a/documentation/ag-grid-docs/src/components/example-runner/components/ExampleRunner.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/components/ExampleRunner.tsx
@@ -1,4 +1,5 @@
 import type { InternalFramework } from '@ag-grid-types';
+import { ExampleLogger } from '@ag-website-shared/components/example-runner/components/ExampleLogger';
 import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { OpenInCTA } from '@ag-website-shared/components/open-in-cta/OpenInCTA';
 import type { FileContents } from '@components/example-generator/types';
@@ -12,6 +13,7 @@ import styles from './ExampleRunner.module.scss';
 interface Props {
     id: string;
     title: string;
+    exampleName: string;
     exampleUrl?: string;
     exampleRunnerExampleUrl?: string;
     externalLinks?: ReactElement;
@@ -23,6 +25,8 @@ interface Props {
     loadingIFrameId: string;
     supportedFrameworks: InternalFramework[];
     suppressDarkMode?: boolean;
+    hasExampleConsoleLog?: boolean;
+    consoleBufferSize?: number;
 }
 
 const DEFAULT_HEIGHT = 500;
@@ -30,6 +34,7 @@ const DEFAULT_HEIGHT = 500;
 export const ExampleRunner: FunctionComponent<Props> = ({
     id,
     title,
+    exampleName,
     exampleUrl,
     exampleRunnerExampleUrl,
     externalLinks,
@@ -41,6 +46,8 @@ export const ExampleRunner: FunctionComponent<Props> = ({
     loadingIFrameId,
     supportedFrameworks,
     suppressDarkMode,
+    hasExampleConsoleLog,
+    consoleBufferSize,
 }) => {
     const [showCode, setShowCode] = useState(false);
 
@@ -49,7 +56,9 @@ export const ExampleRunner: FunctionComponent<Props> = ({
         <div id={id} className={styles.exampleOuter}>
             <div className={styles.tabsContainer}>
                 <div
-                    className={styles.content}
+                    className={classnames(styles.content, {
+                        [styles.hasExampleConsoleLog]: hasExampleConsoleLog,
+                    })}
                     role="tabpanel"
                     aria-labelledby={`${showCode ? 'Preview' : 'Code'} tab`}
                     style={{ height: exampleHeight, width: '100%' }}
@@ -73,6 +82,7 @@ export const ExampleRunner: FunctionComponent<Props> = ({
                         />
                     )}
                 </div>
+                {hasExampleConsoleLog && <ExampleLogger exampleName={exampleName} bufferSize={consoleBufferSize} />}
                 <footer className={styles.footer}>
                     <button
                         className={classnames(styles.previewCodeToggle, 'button-secondary')}

--- a/documentation/ag-grid-docs/src/components/example-runner/components/ExampleRunnerContainer.astro
+++ b/documentation/ag-grid-docs/src/components/example-runner/components/ExampleRunnerContainer.astro
@@ -7,22 +7,37 @@ interface Props {
     exampleHeight?: number;
     pageName: string;
     exampleName: string;
+    hasExampleConsoleLog?: boolean;
 }
 
 const DEFAULT_HEIGHT = 500;
 const FRAME_WRAPPER_HEIGHT = 48 + 26;
 
-const { exampleHeight = DEFAULT_HEIGHT, pageName, exampleName } = Astro.props as Props;
-const minHeight = exampleHeight + FRAME_WRAPPER_HEIGHT;
+const { exampleHeight = DEFAULT_HEIGHT, pageName, exampleName, hasExampleConsoleLog } = Astro.props as Props;
+const EXAMPLE_CONSOLE_LOG_HEIGHT = hasExampleConsoleLog ? 100 : 0;
+const minHeight = exampleHeight + FRAME_WRAPPER_HEIGHT + EXAMPLE_CONSOLE_LOG_HEIGHT;
 const loadingLogoId = getLoadingLogoId({ pageName, exampleName });
 ---
 
-<div class="container example-runner-outer" style={{ minHeight: `${minHeight}px` }}>
+<div
+    class:list={[
+        'container',
+        'example-runner-outer',
+        {
+            hasExampleConsoleLog,
+        },
+    ]}
+    style={{ minHeight: `${minHeight}px` }}
+>
     <LoadingLogo id={loadingLogoId} />
     <slot />
 </div>
 
 <style lang="scss">
+    @use 'sass:math';
+
+    $half-logger-height: math.div(100px, 2);
+
     .container {
         position: relative;
 
@@ -31,6 +46,10 @@ const loadingLogoId = getLoadingLogoId({ pageName, exampleName });
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%) scale(2);
+        }
+
+        &:global(.hasExampleConsoleLog) :global(.logomark) {
+            transform: translate(-50%, calc(-100% - #{$half-logger-height})) scale(2);
         }
     }
 </style>

--- a/documentation/ag-grid-docs/src/content/docs/configuration/_examples/column-object/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/configuration/_examples/column-object/main.ts
@@ -22,7 +22,6 @@ const rowData = [
 
 function getAllColumns() {
     console.log(gridApi!.getColumns());
-    window.alert("Columns printed to developer's console");
 }
 
 function getAllColumnIds() {
@@ -30,7 +29,6 @@ function getAllColumnIds() {
     if (columns) {
         console.log(columns.map((col) => col.getColId()));
     }
-    window.alert("Column IDs printed to developer's console");
 }
 let gridApi: GridApi;
 

--- a/documentation/ag-grid-docs/src/content/docs/context-menu/_examples/context-menu/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/context-menu/_examples/context-menu/main.ts
@@ -56,9 +56,9 @@ function getContextMenuItems(
     const result: (DefaultMenuItem | MenuItemDef)[] = [
         {
             // custom item
-            name: 'Alert ' + params.value,
+            name: 'Log ' + params.value,
             action: () => {
-                window.alert('Alerting about ' + params.value);
+                console.log('Logging about ' + params.value);
             },
             cssClasses: ['red', 'bold'],
         },

--- a/documentation/ag-grid-docs/src/content/docs/row-ids/_examples/row-node/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-ids/_examples/row-node/main.ts
@@ -35,7 +35,6 @@ function getAllRows() {
         console.log(`height = ${rowNode.rowHeight}px`);
         console.log(`isSelected = ${rowNode.isSelected()}`);
     });
-    window.alert('Row details printed to developers console');
 }
 
 function getRowById() {
@@ -44,7 +43,6 @@ function getRowById() {
         console.log(`################ Got Row Node C2`);
         console.log(`data = ${JSON.stringify(rowNode.data)}`);
     }
-    window.alert('Row details printed to developers console');
 }
 
 let gridApi: GridApi;

--- a/documentation/ag-grid-docs/src/content/docs/rtl/_examples/rtl-complex/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/rtl/_examples/rtl-complex/main.ts
@@ -241,7 +241,7 @@ function getContextMenuItems(params: GetContextMenuItemsParams): (string | MenuI
         //shortcut: 'Alt + M',
         action: () => {
             const value = params.value ? params.value : '<empty>';
-            window.alert('You clicked a custom menu item on cell ' + value);
+            console.log('You clicked a custom menu item on cell ' + value);
         },
     });
 

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.module.scss
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.module.scss
@@ -1,19 +1,21 @@
 @use 'design-system' as *;
 
-$logger-height: 100px;
+$logger-height: 150px;
 
 .logger {
     height: $logger-height;
-    padding: $spacing-size-2;
-    margin: $spacing-size-1 0 0 0;
+    padding: 0;
+    margin: 0;
     overflow-y: auto;
     overflow-x: hidden;
     display: flex;
     flex-direction: column;
     color: var(--color-text-primary);
-    background-color: var(--color-bg-secondary);
+    background-color: var(--color-bg-primary);
     border: 1px solid var(--color-border-primary);
     border-radius: var(--radius-md);
+    font-size: 13px;
+    margin-top: $spacing-size-4;
 
     div {
         padding: $spacing-size-2;
@@ -29,7 +31,6 @@ $logger-height: 100px;
         }
 
         &::before {
-            content: '> ';
             color: var(--color-text-secondary);
         }
     }
@@ -40,6 +41,32 @@ $logger-height: 100px;
     }
 }
 
+.logger > div:nth-child(even) {
+    background-color: var(--color-bg-secondary);
+
+    #{$selector-darkmode} & {
+        background-color: color-mix(in srgb, var(--color-bg-secondary), var(--color-bg-primary) 90%);
+    }
+}
+
 .noLogs {
-    font-style: italic;
+    margin-top: $spacing-size-4;
+    margin-left: $spacing-size-2;
+}
+
+.consoleHeader {
+    top: 0;
+    position: sticky;
+    font-size: 12px;
+    background-color: var(--color-bg-primary);
+    padding-top: 8px !important;
+    border-bottom: 1px solid var(--color-border-secondary);
+    font-weight: 600;
+
+    span {
+        background: var(--color-bg-primary);
+        border-radius: var(--radius-lg);
+        padding: 0 $spacing-size-1;
+        color: var(--color-fg-secondary);
+    }
 }

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.module.scss
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.module.scss
@@ -26,8 +26,8 @@ $logger-height: 150px;
             padding-top: 0;
         }
 
-        &:last-child {
-            padding-bottom: 0;
+        &:nth-child(2) {
+            border-top: none;
         }
 
         &::before {

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.module.scss
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.module.scss
@@ -5,7 +5,7 @@ $logger-height: 100px;
 .logger {
     height: $logger-height;
     padding: $spacing-size-2;
-    margin: 0;
+    margin: $spacing-size-1 0 0 0;
     overflow-y: auto;
     overflow-x: hidden;
     display: flex;
@@ -13,8 +13,7 @@ $logger-height: 100px;
     color: var(--color-text-primary);
     background-color: var(--color-bg-secondary);
     border: 1px solid var(--color-border-primary);
-    border-top: none;
-    border-radius: 0 0 var(--radius-md) var(--radius-md);
+    border-radius: var(--radius-md);
 
     div {
         padding: $spacing-size-2;

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
@@ -17,7 +17,31 @@ interface Props {
 const IGNORED_MESSAGES = ['Angular is running in development mode.'];
 
 function containsIgnoredMessage(log: Log) {
-    return log.data.some((message) => IGNORED_MESSAGES.some((ignoredMessage) => message.includes(ignoredMessage)));
+    return log.data.some((message) =>
+        IGNORED_MESSAGES.some((ignoredMessage) => typeof message === 'string' && message.includes(ignoredMessage))
+    );
+}
+
+function safeStringify(obj: object, space: number = 2) {
+    const seen = new WeakSet();
+    return JSON.stringify(
+        obj,
+        (_, value) => {
+            if (typeof value === 'object' && value !== null) {
+                if (seen.has(value)) {
+                    return '[Circular]';
+                }
+                seen.add(value);
+            }
+            return value;
+        },
+        space
+    );
+}
+
+function safeLogData(data: unknown) {
+    if (typeof data === 'string' || typeof data === 'number') return data;
+    return safeStringify(data as object);
 }
 
 export const ExampleLogger: FunctionComponent<Props> = ({ exampleName, bufferSize = 10 }) => {
@@ -52,7 +76,7 @@ export const ExampleLogger: FunctionComponent<Props> = ({ exampleName, bufferSiz
         <pre ref={containerRef} className={styles.logger}>
             {logs.length === 0 && <div className={styles.noLogs}>Console logs from the example shown here...</div>}
             {logs.map((log, i) => (
-                <div key={i}>{log.data}</div>
+                <div key={i}>{safeLogData(log.data)}</div>
             ))}
         </pre>
     );

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
@@ -22,7 +22,7 @@ function containsIgnoredMessage(log: Log) {
     );
 }
 
-export const ExampleLogger: FunctionComponent<Props> = ({ exampleName, bufferSize = 10 }) => {
+export const ExampleLogger: FunctionComponent<Props> = ({ exampleName, bufferSize = 20 }) => {
     const containerRef = useRef<HTMLPreElement>(null);
     const [logs, setLogs] = useState<Log[]>([]);
 

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
@@ -2,11 +2,19 @@ import { type FunctionComponent, useEffect, useLayoutEffect, useRef, useState } 
 
 import styles from './ExampleLogger.module.scss';
 
+type LogObject = {
+    __consoleLogObject: true;
+    isLoggable: boolean;
+    argType: string;
+    safeString: string;
+};
+type LogData = string | number | undefined | null | LogObject;
+
 interface Log {
     type: 'console-log';
     pageName?: string;
     exampleName: string;
-    data: any[];
+    data: LogData[];
 }
 
 interface Props {
@@ -14,12 +22,35 @@ interface Props {
     bufferSize?: number;
 }
 
+const SEE_DEV_CONSOLE_MESSAGE = '[Object] - see developer console';
 const IGNORED_MESSAGES = ['Angular is running in development mode.'];
 
 function containsIgnoredMessage(log: Log) {
     return log.data.some((message) =>
         IGNORED_MESSAGES.some((ignoredMessage) => typeof message === 'string' && message.includes(ignoredMessage))
     );
+}
+
+function getLoggableData(data: LogData[]) {
+    const isLoggable = data.every((logItem: LogData) => {
+        const consoleLogObject = logItem as LogObject;
+        return consoleLogObject?.__consoleLogObject ? consoleLogObject.isLoggable : true;
+    });
+
+    return isLoggable
+        ? data.map((logItem: LogData) => {
+              const consoleLogObject = logItem as LogObject;
+              if (logItem && consoleLogObject.__consoleLogObject) {
+                  return consoleLogObject.safeString;
+              } else if (logItem === null) {
+                  return 'null';
+              } else if (logItem === undefined) {
+                  return 'undefined';
+              } else {
+                  return logItem;
+              }
+          })
+        : [SEE_DEV_CONSOLE_MESSAGE];
 }
 
 export const ExampleLogger: FunctionComponent<Props> = ({ exampleName, bufferSize = 20 }) => {
@@ -33,7 +64,11 @@ export const ExampleLogger: FunctionComponent<Props> = ({ exampleName, bufferSiz
                 setLogs((prevLogs) => {
                     const bufferedLogs = prevLogs.length >= bufferSize ? prevLogs.slice(1) : prevLogs;
 
-                    return [...bufferedLogs, log];
+                    const newLog = {
+                        ...log,
+                        data: getLoggableData(log.data),
+                    };
+                    return [...bufferedLogs, newLog];
                 });
             }
         };
@@ -55,7 +90,7 @@ export const ExampleLogger: FunctionComponent<Props> = ({ exampleName, bufferSiz
             {logs.length === 0 && <div className={styles.noLogs}>Console logs from the example shown here...</div>}
             {logs.length > 0 && <div className={styles.consoleHeader}>Console</div>}
             {logs.map((log, i) => (
-                <div key={i}>{log.data.join(', ')}</div>
+                <div key={i}>{log.data.join(' ')}</div>
             ))}
         </pre>
     );

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
@@ -22,28 +22,6 @@ function containsIgnoredMessage(log: Log) {
     );
 }
 
-function safeStringify(obj: object, space: number = 2) {
-    const seen = new WeakSet();
-    return JSON.stringify(
-        obj,
-        (_, value) => {
-            if (typeof value === 'object' && value !== null) {
-                if (seen.has(value)) {
-                    return '[Circular]';
-                }
-                seen.add(value);
-            }
-            return value;
-        },
-        space
-    );
-}
-
-function safeLogData(data: unknown) {
-    if (typeof data === 'string' || typeof data === 'number') return data;
-    return safeStringify(data as object);
-}
-
 export const ExampleLogger: FunctionComponent<Props> = ({ exampleName, bufferSize = 10 }) => {
     const containerRef = useRef<HTMLPreElement>(null);
     const [logs, setLogs] = useState<Log[]>([]);
@@ -76,7 +54,7 @@ export const ExampleLogger: FunctionComponent<Props> = ({ exampleName, bufferSiz
         <pre ref={containerRef} className={styles.logger}>
             {logs.length === 0 && <div className={styles.noLogs}>Console logs from the example shown here...</div>}
             {logs.map((log, i) => (
-                <div key={i}>{safeLogData(log.data)}</div>
+                <div key={i}>{log.data.join(', ')}</div>
             ))}
         </pre>
     );

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
@@ -53,6 +53,7 @@ export const ExampleLogger: FunctionComponent<Props> = ({ exampleName, bufferSiz
     return (
         <pre ref={containerRef} className={styles.logger}>
             {logs.length === 0 && <div className={styles.noLogs}>Console logs from the example shown here...</div>}
+            {logs.length > 0 && <div className={styles.consoleHeader}>Console</div>}
             {logs.map((log, i) => (
                 <div key={i}>{log.data.join(', ')}</div>
             ))}

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/executor.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/executor.ts
@@ -19,6 +19,7 @@ import {
     convertTsxToJsx,
     getBoilerPlateFiles,
     getEntryFileName,
+    getHasExampleConsoleLog,
     getIsEnterprise,
     getIsLocale,
     getMainFileName,
@@ -27,6 +28,8 @@ import {
     getTransformTsFileExt,
 } from './generator/utils/fileUtils';
 import { frameworkFilesGenerator } from './generator/utils/frameworkFilesGenerator';
+import type { TransformEntryFile } from './generator/utils/frameworkFilesGenerator';
+import { getConsoleLogSnippet } from './generator/utils/getConsoleLogSnippet';
 import { getOtherScriptFiles, getUseFetchJsonFile } from './generator/utils/getOtherScriptFiles';
 import { getPackageJson } from './generator/utils/getPackageJson';
 import { getStyleFiles } from './generator/utils/getStyleFiles';
@@ -92,6 +95,9 @@ async function getProvidedFiles(folderPath: string) {
 export async function generateFiles(options: ExecutorOptions, gridOptionsTypes: Record<string, GridOptionsType>) {
     const isDev = options.mode === 'dev';
     const folderPath = options.examplePath;
+    const folders = folderPath.split('/');
+    const pageName = folders[folders.length - 3];
+    const exampleName = folders[folders.length - 1];
 
     const sourceFileList = await getSourceFileList(folderPath);
     if (sourceFileList === undefined) {
@@ -112,6 +118,7 @@ export async function generateFiles(options: ExecutorOptions, gridOptionsTypes: 
 
     const isEnterprise = getIsEnterprise({ entryFile });
     const isLocale = getIsLocale({ entryFile });
+    const hasExampleConsoleLog = getHasExampleConsoleLog({ entryFile });
     const frameworkProvidedExamples = sourceFileList.includes('provided') ? await getProvidedFiles(folderPath) : {};
 
     const { bindings, typedBindings } = gridVanillaSrcParser(
@@ -162,6 +169,17 @@ export async function generateFiles(options: ExecutorOptions, gridOptionsTypes: 
             ...exampleConfig,
             ...(provideFrameworkFiles ? provideFrameworkFiles['exampleConfig.json'] : {}),
         };
+
+        const transformEntryFile: TransformEntryFile = ({ entryFile }) => {
+            let transformedEntryFile = entryFile;
+
+            if (hasExampleConsoleLog) {
+                transformedEntryFile = transformedEntryFile + '\n' + getConsoleLogSnippet({ pageName, exampleName });
+            }
+
+            return transformedEntryFile;
+        };
+
         const [otherScriptFiles, componentScriptFiles] = await getOtherScriptFiles({
             folderPath,
             sourceFileList,
@@ -183,6 +201,7 @@ export async function generateFiles(options: ExecutorOptions, gridOptionsTypes: 
                 otherScriptFiles,
                 styleFiles,
                 ignoreDarkMode: false,
+                transformEntryFile,
                 isDev,
                 exampleConfig: frameworkExampleConfig,
             });
@@ -195,6 +214,7 @@ export async function generateFiles(options: ExecutorOptions, gridOptionsTypes: 
                 entryFileName,
                 provideFrameworkFiles,
                 mergedStyleFiles,
+                transformEntryFile,
                 isDev,
                 isIntegratedCharts,
                 mainFileName,
@@ -220,6 +240,7 @@ export async function generateFiles(options: ExecutorOptions, gridOptionsTypes: 
             isEnterprise,
             isLocale,
             isIntegratedCharts,
+            hasExampleConsoleLog,
             entryFileName,
             mainFileName,
             scriptFiles: scriptFiles!,
@@ -249,6 +270,7 @@ async function processProvidedFiles(
     entryFileName: string,
     provideFrameworkFiles: any,
     mergedStyleFiles: { [x: string]: string },
+    transformEntryFile: TransformEntryFile,
     isDev: boolean,
     isIntegratedCharts: boolean,
     mainFileName: string,
@@ -335,6 +357,10 @@ async function processProvidedFiles(
                 code
             );
         }
+
+        provideFrameworkFiles[writeToFileName] = transformEntryFile({
+            entryFile: provideFrameworkFiles[writeToFileName],
+        });
     }
     return scriptFiles;
 }

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/executor.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/executor.ts
@@ -58,6 +58,17 @@ export default async function (
     }
 }
 
+const getExampleFolderParts = ({ exampleFolder }: { exampleFolder: string }) => {
+    const folders = exampleFolder.split('/');
+    const pageName = folders[folders.length - 3];
+    const exampleName = folders[folders.length - 1];
+
+    return {
+        pageName,
+        exampleName,
+    };
+};
+
 async function getSourceFileList(folderPath: string): Promise<string[]> {
     const sourceFileList = await fs.readdir(folderPath);
     if (!sourceFileList.includes(SOURCE_ENTRY_FILE_NAME)) {
@@ -95,9 +106,11 @@ async function getProvidedFiles(folderPath: string) {
 export async function generateFiles(options: ExecutorOptions, gridOptionsTypes: Record<string, GridOptionsType>) {
     const isDev = options.mode === 'dev';
     const folderPath = options.examplePath;
-    const folders = folderPath.split('/');
-    const pageName = folders[folders.length - 3];
-    const exampleName = folders[folders.length - 1];
+    const { pageName, exampleName } = getExampleFolderParts({ exampleFolder: folderPath });
+
+    if (!pageName || !exampleName) {
+        throw new Error('Invalid example folder path: ' + folderPath);
+    }
 
     const sourceFileList = await getSourceFileList(folderPath);
     if (sourceFileList === undefined) {

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/types.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/types.ts
@@ -92,6 +92,7 @@ export interface ParsedBindings {
 export interface GeneratedContents extends ExampleConfig {
     isEnterprise: boolean;
     isIntegratedCharts: boolean;
+    hasExampleConsoleLog: boolean;
     entryFileName: string;
     mainFileName: string;
     files: FileContents;

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/fileUtils.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/fileUtils.ts
@@ -174,3 +174,7 @@ export function convertTsxToJsx(fileStr: string): string {
     jsxFile = jsxFile.replaceAll('// empty line', '');
     return jsxFile;
 }
+
+export const getHasExampleConsoleLog = ({ entryFile }: { entryFile: string }) => {
+    return entryFile?.includes('console.log');
+};

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/getConsoleLogSnippet.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/getConsoleLogSnippet.ts
@@ -1,0 +1,28 @@
+interface Params {
+    pageName: string;
+    exampleName: string;
+}
+
+export const CONSOLE_LOG_START = '/** CONSOLE LOG START **/';
+export const CONSOLE_LOG_END = '/** CONSOLE LOG END **/';
+
+/**
+ * Override console log to send the log message to the parent window
+ */
+export const getConsoleLogSnippet = ({ pageName, exampleName }: Params) =>
+    `${CONSOLE_LOG_START}
+const originalConsoleLog = console.log;
+console.log = (...args) => {
+    try {
+        window.parent.postMessage({
+            type: 'console-log',
+            pageName: '${pageName}',
+            exampleName: '${exampleName}',
+            data: args
+        });
+    } catch {
+       // Posting is best-effort and shouldn't block normal console logging.
+    }
+    originalConsoleLog(...args);
+};
+${CONSOLE_LOG_END}`;

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/getConsoleLogSnippet.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/getConsoleLogSnippet.ts
@@ -11,31 +11,85 @@ export const CONSOLE_LOG_END = '/** CONSOLE LOG END **/';
  */
 export const getConsoleLogSnippet = ({ pageName, exampleName }: Params) =>
     `${CONSOLE_LOG_START}
+const PRIMITIVE_TYPES = ["string", "number", "boolean", "undefined", "null", "NaN", "symbol"];
+const OBJECT_PROPERTIES_LIMIT = 3;
+
+function getType(value) {
+    if (value === null) return "null";
+    if (Number.isNaN(value)) return "NaN";
+    if (Array.isArray(value)) return "array";
+    if (value instanceof Date) return "date";
+    if (value instanceof RegExp) return "regexp";
+    if (value instanceof Map) return "map";
+    if (value instanceof Set) return "set";
+    if (value instanceof WeakMap) return "weakmap";
+    if (value instanceof WeakSet) return "weakset";
+    if (value instanceof Promise) return "promise";
+    if (value instanceof Error) return "error";
+    if (typeof value === "object") return "object";
+    return typeof value;
+}
+
 function safeStringify(obj, space = 2) {
     const seen = new WeakSet();
-    return JSON.stringify(
+    const isLoggableArray = getType(obj) === "array" && obj.every(isLoggableType);
+    const getObjectValue = (value) => {
+        if (seen.has(value)) {
+            return '[Circular]';
+        } else if (value === undefined) {
+            return 'undefined';
+        }
+        seen.add(value);
+
+        // Include custom class names if available
+        if (value.constructor && value.constructor.name && getType(value) !== 'object') {
+            return \`\${value.constructor.name}Class { ... }\`;
+        }
+
+        return value;
+    };
+    return isLoggableArray ? JSON.stringify(obj) : JSON.stringify(
         obj,
         (_, value) => {
-            if (typeof value === 'object' && value !== null) {
-                if (seen.has(value)) {
-                    return '[Circular]';
-                }
-                seen.add(value);
-
-                // Include custom class names if available
-                if (value.constructor && value.constructor.name && value.constructor.name !== 'Object') {
-                    return \`\${value.constructor.name}Class { ... }\`;
-                }
+            const valueType = getType(value);
+            let newValue = value;
+            if (valueType === 'object') {
+                newValue = getObjectValue();
+            } else if (valueType === 'array') {
+                newValue = value.map((item) => {
+                    return getType(item === 'object') ? getObjectValue(item) : item;
+                });
             }
-            return value;
+
+            return newValue;
         },
         space
     );
 }
 
-function safeLogData(data) {
-    if (typeof data === 'string' || typeof data === 'number') return data;
-    return safeStringify(data);
+function isPrimitiveType(value) {
+    return PRIMITIVE_TYPES.includes(getType(value));
+}
+
+function isLoggableType(value) {
+    const valueType = getType(value);
+
+    return isPrimitiveType(value)
+        || (valueType === "array" && value.every(isPrimitiveType))
+        || (valueType === "object" && Object.values(value).every(isPrimitiveType) && Object.keys(value).length <= OBJECT_PROPERTIES_LIMIT);
+}
+
+function getConsoleValue(value) {
+    return isPrimitiveType(value) ? value : {
+        __consoleLogObject: true,
+        isLoggable: isLoggableType(value),
+        argType: getType(value),
+        safeString: safeStringify(value)
+    }
+}
+
+function getConsoleLogData(args) {
+    return args.map(getConsoleValue);
 }
 
 const originalConsoleLog = console.log;
@@ -45,7 +99,7 @@ console.log = (...args) => {
             type: 'console-log',
             pageName: '${pageName}',
             exampleName: '${exampleName}',
-            data: args.map(safeLogData),
+            data: getConsoleLogData(args),
         });
     } catch {
        // Posting is best-effort and shouldn't block normal console logging.

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/getConsoleLogSnippet.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/getConsoleLogSnippet.ts
@@ -11,6 +11,33 @@ export const CONSOLE_LOG_END = '/** CONSOLE LOG END **/';
  */
 export const getConsoleLogSnippet = ({ pageName, exampleName }: Params) =>
     `${CONSOLE_LOG_START}
+function safeStringify(obj, space = 2) {
+    const seen = new WeakSet();
+    return JSON.stringify(
+        obj,
+        (_, value) => {
+            if (typeof value === 'object' && value !== null) {
+                if (seen.has(value)) {
+                    return '[Circular]';
+                }
+                seen.add(value);
+
+                // Include custom class names if available
+                if (value.constructor && value.constructor.name && value.constructor.name !== 'Object') {
+                    return \`\${value.constructor.name}Class { ... }\`;
+                }
+            }
+            return value;
+        },
+        space
+    );
+}
+
+function safeLogData(data) {
+    if (typeof data === 'string' || typeof data === 'number') return data;
+    return safeStringify(data);
+}
+
 const originalConsoleLog = console.log;
 console.log = (...args) => {
     try {
@@ -18,7 +45,7 @@ console.log = (...args) => {
             type: 'console-log',
             pageName: '${pageName}',
             exampleName: '${exampleName}',
-            data: args
+            data: args.map(safeLogData),
         });
     } catch {
        // Posting is best-effort and shouldn't block normal console logging.


### PR DESCRIPTION
## Changes

* Add console log component based off https://github.com/ag-grid/ag-charts/pull/3759
  * Add support for `supportedFrameworks` (grid only)
  * Move `safeStringify` to the `postMessage` side and only allow simple objects/arrays to be logged
  * Increase buffer size to `20`
  * Update styles of log component
* Remove all `window.alert`s in examples