### PR TITLE
AG-3390 - Return success value of generateFiles

### DIFF
--- a/plugins/ag-grid-generate-example-files/src/executors/generate/batch-instance.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/batch-instance.ts
@@ -16,8 +16,11 @@ export default async function processor(msg: Message) {
 
     let result: BatchExecutorTaskResult;
     try {
-        await generateFiles(options, {} as ExecutorContext, gridOptionsTypes);
-        result = { task: taskName, result: { success: true, terminalOutput: '' } };
+        const fileResults = await generateFiles(options, {} as ExecutorContext, gridOptionsTypes);
+        result = {
+            task: taskName,
+            result: { success: fileResults.success, terminalOutput: fileResults.terminalOutput ?? '' },
+        };
     } catch (e) {
         result = { task: taskName, result: { success: false, terminalOutput: `${e}` } };
     }


### PR DESCRIPTION
If `generateFiles` is not successful, it should pass that through the batch processing.

NOTE: `latest` with fail CI until https://github.com/ag-grid/ag-grid/pull/10116 is merged