### PR TITLE
AG-14411 fix grouping batch remover to use rownodes instances instead of idsgit 

### DIFF
--- a/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/batchRemover.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/batchRemover.ts
@@ -13,67 +13,82 @@ import type { GroupRow } from './groupRow';
 // it took about 20 seconds to delete. with the BathRemoved, the reduced to less than 1 second.
 
 interface RemoveDetails {
-    removeFromChildrenAfterGroup: { [id: string]: boolean };
-    removeFromAllLeafChildren: { [id: string]: boolean };
+    fromChildrenAfterGroup: Set<GroupRow> | null;
+    fromAllLeafChildren: Set<GroupRow> | null;
 }
 
 export class BatchRemover {
-    private allSets: { [parentId: string]: RemoveDetails } = {};
-    private allParents: RowNode[] = [];
+    private allSets = new Map<GroupRow, RemoveDetails>();
 
     public removeFromChildrenAfterGroup(parent: RowNode, child: RowNode): void {
         const set = this.getSet(parent);
-        set.removeFromChildrenAfterGroup[child.id!] = true;
+        (set.fromChildrenAfterGroup ??= new Set()).add(child);
     }
 
     public isRemoveFromAllLeafChildren(parent: RowNode, child: RowNode): boolean {
-        const set = this.getSet(parent);
-        return !!set.removeFromAllLeafChildren[child.id!];
+        return !!this.allSets.get(parent)?.fromAllLeafChildren?.has(child);
     }
 
     public preventRemoveFromAllLeafChildren(parent: RowNode, child: RowNode): void {
-        const set = this.getSet(parent);
-        delete set.removeFromAllLeafChildren[child.id!];
+        this.allSets.get(parent)?.fromAllLeafChildren?.delete(child);
     }
 
     public removeFromAllLeafChildren(parent: RowNode, child: RowNode): void {
         const set = this.getSet(parent);
-        set.removeFromAllLeafChildren[child.id!] = true;
+        (set.fromAllLeafChildren ??= new Set()).add(child);
     }
 
     private getSet(parent: RowNode): RemoveDetails {
-        if (!this.allSets[parent.id!]) {
-            this.allSets[parent.id!] = {
-                removeFromAllLeafChildren: {},
-                removeFromChildrenAfterGroup: {},
+        let set = this.allSets.get(parent);
+        if (!set) {
+            set = {
+                fromChildrenAfterGroup: null,
+                fromAllLeafChildren: null,
             };
-            this.allParents.push(parent);
+            this.allSets.set(parent, set);
         }
-        return this.allSets[parent.id!];
+        return set;
     }
 
     public getAllParents(): RowNode[] {
-        return this.allParents;
+        return Array.from(this.allSets.keys());
     }
 
     public flush(): void {
-        this.allParents.forEach((parent: GroupRow) => {
-            const nodeDetails = this.allSets[parent.id!];
+        const allSets = this.allSets;
 
-            parent.childrenAfterGroup = parent.childrenAfterGroup!.filter(
-                (child) => !nodeDetails.removeFromChildrenAfterGroup[child.id!]
-            );
-            parent.allLeafChildren =
-                parent.allLeafChildren?.filter((child) => !nodeDetails.removeFromAllLeafChildren[child.id!]) ?? null;
-            parent.updateHasChildren();
+        for (const parent of allSets.keys()) {
+            const nodeDetails = allSets.get(parent);
+            if (nodeDetails) {
+                const { childrenAfterGroup, allLeafChildren } = parent;
+                const { fromChildrenAfterGroup, fromAllLeafChildren } = nodeDetails;
 
-            const sibling: GroupRow = parent.sibling;
-            if (sibling) {
-                sibling.childrenAfterGroup = parent.childrenAfterGroup;
-                sibling.allLeafChildren = parent.allLeafChildren;
+                if (fromChildrenAfterGroup && childrenAfterGroup) {
+                    let writeIdx = 0;
+                    for (let i = 0, len = childrenAfterGroup.length; i < len; ++i) {
+                        const child = childrenAfterGroup[i];
+                        if (!fromChildrenAfterGroup.has(child)) {
+                            childrenAfterGroup[writeIdx++] = child;
+                        }
+                    }
+                    childrenAfterGroup.length = writeIdx;
+                }
+
+                if (fromAllLeafChildren && allLeafChildren) {
+                    let writeIdx = 0;
+                    for (let i = 0, len = allLeafChildren.length; i < len; ++i) {
+                        const child = allLeafChildren[i];
+                        if (!fromAllLeafChildren.has(child)) {
+                            allLeafChildren[writeIdx++] = child;
+                        }
+                    }
+                    allLeafChildren.length = writeIdx;
+                }
+
+                parent.updateHasChildren();
             }
-        });
-        this.allSets = {};
-        this.allParents.length = 0;
+        }
+
+        allSets.clear();
     }
 }

--- a/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/batchRemover.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/batchRemover.ts
@@ -56,24 +56,20 @@ export class BatchRemover {
 
     public flush(): void {
         const allSets = this.allSets;
-
         for (const parent of allSets.keys()) {
             const nodeDetails = allSets.get(parent);
             if (nodeDetails) {
                 const { fromChildrenAfterGroup, fromAllLeafChildren } = nodeDetails;
                 const { childrenAfterGroup, allLeafChildren } = parent;
-
                 if (childrenAfterGroup && fromChildrenAfterGroup) {
                     filterRowNodesInPlace(childrenAfterGroup, fromChildrenAfterGroup);
                     parent.updateHasChildren();
                 }
-
                 if (allLeafChildren && fromAllLeafChildren) {
                     filterRowNodesInPlace(allLeafChildren, fromAllLeafChildren);
                 }
             }
         }
-
         allSets.clear();
     }
 }

--- a/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/batchRemover.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/batchRemover.ts
@@ -60,35 +60,31 @@ export class BatchRemover {
         for (const parent of allSets.keys()) {
             const nodeDetails = allSets.get(parent);
             if (nodeDetails) {
-                const { childrenAfterGroup, allLeafChildren } = parent;
                 const { fromChildrenAfterGroup, fromAllLeafChildren } = nodeDetails;
+                const { childrenAfterGroup, allLeafChildren } = parent;
 
-                if (fromChildrenAfterGroup && childrenAfterGroup) {
-                    let writeIdx = 0;
-                    for (let i = 0, len = childrenAfterGroup.length; i < len; ++i) {
-                        const child = childrenAfterGroup[i];
-                        if (!fromChildrenAfterGroup.has(child)) {
-                            childrenAfterGroup[writeIdx++] = child;
-                        }
-                    }
-                    childrenAfterGroup.length = writeIdx;
+                if (childrenAfterGroup && fromChildrenAfterGroup) {
+                    filterRowNodesInPlace(childrenAfterGroup, fromChildrenAfterGroup);
+                    parent.updateHasChildren();
                 }
 
-                if (fromAllLeafChildren && allLeafChildren) {
-                    let writeIdx = 0;
-                    for (let i = 0, len = allLeafChildren.length; i < len; ++i) {
-                        const child = allLeafChildren[i];
-                        if (!fromAllLeafChildren.has(child)) {
-                            allLeafChildren[writeIdx++] = child;
-                        }
-                    }
-                    allLeafChildren.length = writeIdx;
+                if (allLeafChildren && fromAllLeafChildren) {
+                    filterRowNodesInPlace(allLeafChildren, fromAllLeafChildren);
                 }
-
-                parent.updateHasChildren();
             }
         }
 
         allSets.clear();
     }
+}
+
+function filterRowNodesInPlace(array: GroupRow[], removals: ReadonlySet<GroupRow>): void {
+    let writeIdx = 0;
+    for (let i = 0, len = array.length; i < len; ++i) {
+        const item = array[i];
+        if (!removals.has(item)) {
+            array[writeIdx++] = item;
+        }
+    }
+    array.length = writeIdx;
 }

--- a/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/groupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/groupStrategy.ts
@@ -165,7 +165,7 @@ export class GroupStrategy extends BeanStub implements IRowGroupingStrategy {
             }
         }
 
-        const parentsWithChildrenRemoved = batchRemover.getAllParents().slice();
+        const parentsWithChildrenRemoved = batchRemover.getAllParents();
         batchRemover.flush();
         this.removeEmptyGroups(parentsWithChildrenRemoved, details);
 

--- a/testing/behavioural/src/grouping-data/grouping-with-transactions.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-with-transactions.test.ts
@@ -111,11 +111,10 @@ describe('ag-grid grouping with transactions', () => {
 
         await executeTransactionsAsync(
             [
-                // TODO: AG-14411 - fix this, removing and adding in the same transaction results in an invalid allLeafChildren with the row missing
-                // {
-                //     remove: [{ id: '6' }],
-                //     add: [{ id: '6', country: 'Italy', year: 1900, name: 'unknown 2' }],
-                // },
+                {
+                    remove: [{ id: '6' }],
+                    add: [{ id: '6', country: 'Italy', year: 1900, name: 'unknown 2' }],
+                },
                 {
                     update: [{ id: '6', country: 'Italy', year: 1901, name: 'unknown 3' }],
                 },


### PR DESCRIPTION
Batch remover was using string IDs instead of row node instances to check if a node needed to be removed.
When executing a set of transactions that remove a rownode with a given id and adds a new rownode with the same given id, it can happen that the computation of allLeafChildren and childrenAfterGroup for a group to be wrong.

The solution is to replace the use of objects with string keys with maps and sets
Also, filtering the arrays in place makes the logic simpler and less complicated by not having to update the siblings