### PR TITLE
Add missing safe-navigation operator in getOptionalSelectors

### DIFF
--- a/packages/ag-grid-community/src/gridComp/gridCtrl.ts
+++ b/packages/ag-grid-community/src/gridComp/gridCtrl.ts
@@ -67,7 +67,7 @@ export class GridCtrl extends BeanStub {
         const beans = this.beans;
         return {
             paginationSelector: beans.pagination?.getPaginationSelector(),
-            gridHeaderDropZonesSelector: beans.registry.getSelector('AG-GRID-HEADER-DROP-ZONES'),
+            gridHeaderDropZonesSelector: beans.registry?.getSelector('AG-GRID-HEADER-DROP-ZONES'),
             sideBarSelector: beans.sideBar?.getSelector(),
             statusBarSelector: beans.registry?.getSelector('AG-STATUS-BAR'),
             watermarkSelector: (beans.licenseManager as IWatermark)?.getWatermarkSelector(),


### PR DESCRIPTION
Hi!

We're not sure how we triggered this code in our usages, but we found it explodes and upon inspection line 72 assumes that `beans.registry` can be undefined, but line 70 doesn't.

Since one already assumes it could be undefined, I figure it's safe to add it to the other.

Thank you! 🙂

--------

For others hitting this, we RCA'd this to nested [lazy](https://react.dev/reference/react/lazy) React components. [Nesting lazy components does not appear to currently be supported](https://github.com/facebook/react/issues/29235) in any fashion, even with proper caching.

When we attempted to load a lazy component in a tree with a lazy grandparent that also contained our grid, React unmounted and remounted the AgGridReact component, leaving the grid in a useless partially loaded state.

Additionally, while merging this MR makes the immediate error go away, it doesn't solve the grid state issue. Our workaround was to skip lazy for the nested component and directly await a function returning an `import()` call then caching the result.

**ag-grid devs:** Even though our problem has been solved, this is still a potentially useful fix to have. Thanks!