### PR TITLE
AG-14529 - Updates to example logger

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/example-logger-test/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/example-logger-test/index.mdoc
@@ -4,11 +4,25 @@ title: Example Logger Test
 
 This is an internal page that contains examples that can be used to test the example logger.
 
+## Usage
+
+The example logger is added to the bottom of the example runner, if any `console.log` is present in the example.
+
+Objects and arrays are shown as a collapsible component and are collapsed by default. It is recommended that you add a string as a label before logging any object or array, to give more context as to what is being logged eg,
+
+```
+// ❌
+console.log(rowObject);
+
+// ✅
+console.log('Row:', rowObject);
+```
+
+## Example Logger Demo
+
 {% gridExampleRunner title="Console logs" name="console-logs" /%}
 
-
-
-## Code Syntax Highlighting
+## A Comparison With Code Syntax Highlighting
 
 ```js
 console.log('string');

--- a/documentation/ag-grid-docs/src/content/docs/example-logger-test/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/example-logger-test/index.mdoc
@@ -24,9 +24,10 @@ console.log(['string', 23, null, undefined, true, false]);
 console.log([{ a: 'string', b: 23, c: null }, 23, null, undefined, true, false]);
 console.log([{}]);
 console.log({ a: 'string', b: 23, c: null });
-console.log({ a: undefined, b: NaN, c: null });
+console.log({ c: 'string', b: 23, a: null });
+console.log({ undefined: undefined, nan: NaN, null: null, infinity: Infinity, negativeInfinity: -Infinity });
 
-console.log({ a: 'more', b: 'here', c: 'now', d: 'more' });
+console.log({ a: 'more', b: 'here', c: undefined, d: 'more' });
 
 console.log(
     'string',

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.module.scss
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.module.scss
@@ -1,7 +1,10 @@
 @use 'design-system' as *;
 
 .loggerOuter {
+    min-height: 34px;
     height: 154px;
+    max-height: 700px;
+    resize: vertical;
     display: flex;
     flex-direction: column;
     margin-top: $spacing-size-4;

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.module.scss
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.module.scss
@@ -19,6 +19,13 @@
     font-size: var(--text-fs-xs);
     font-weight: var(--text-semibold);
     border-bottom: 1px solid var(--color-border-secondary);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    button {
+        padding: 0.08em 0.5em 0;
+    }
 }
 
 .loggerPre {

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.module.scss
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.module.scss
@@ -2,6 +2,7 @@
 
 .loggerOuter {
     min-height: 154px;
+    height: 154px;
     max-height: 700px;
     resize: vertical;
     display: flex;

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.module.scss
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.module.scss
@@ -122,3 +122,8 @@
         }
     }
 }
+
+.clearButton {
+    font-family: var(--text-monospace-font-family);
+    color: var(--color-button-secondary-fg);
+}

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.module.scss
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.module.scss
@@ -1,8 +1,7 @@
 @use 'design-system' as *;
 
 .loggerOuter {
-    min-height: 34px;
-    height: 154px;
+    min-height: 154px;
     max-height: 700px;
     resize: vertical;
     display: flex;

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
@@ -26,7 +26,7 @@ interface Props {
 }
 
 const REACT_JSON_VIEW_CONFIG = {
-    collapsed: 1,
+    collapsed: true,
     name: null,
     enableClipboard: false,
     displayDataTypes: false,

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
@@ -200,7 +200,7 @@ export const ExampleLogger: FunctionComponent<Props> = ({ exampleName, bufferSiz
         <div className={styles.loggerOuter}>
             <div className={styles.loggerHeader}>
                 <div>Console</div>
-                <button className="button-secondary" onClick={clearLogs}>
+                <button className={`button-secondary ${styles.clearButton}`} onClick={clearLogs}>
                     Clear
                 </button>
             </div>

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
@@ -1,6 +1,6 @@
 import { getType } from '@ag-website-shared/components/example-runner/utils/getType';
 import ReactJsonView from '@microlink/react-json-view';
-import { type FunctionComponent, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { type FunctionComponent, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import styles from './ExampleLogger.module.scss';
 
@@ -164,6 +164,10 @@ export const ExampleLogger: FunctionComponent<Props> = ({ exampleName, bufferSiz
     const containerRef = useRef<HTMLPreElement>(null);
     const [logs, setLogs] = useState<Log[]>([]);
 
+    const clearLogs = useCallback(() => {
+        setLogs([]);
+    }, []);
+
     useEffect(() => {
         const updateLogs = (event: MessageEvent) => {
             const log = event.data;
@@ -194,7 +198,12 @@ export const ExampleLogger: FunctionComponent<Props> = ({ exampleName, bufferSiz
 
     return (
         <div className={styles.loggerOuter}>
-            <div className={styles.loggerHeader}>Console</div>
+            <div className={styles.loggerHeader}>
+                <div>Console</div>
+                <button className="button-secondary" onClick={clearLogs}>
+                    Clear
+                </button>
+            </div>
             <pre ref={containerRef} className={styles.loggerPre}>
                 {logs.length === 0 && <div>Console logs from the example shown here...</div>}
                 {logs.map((log, i) => (

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
@@ -115,7 +115,14 @@ function updateWithTypeValues(value: any) {
         for (const key in value) {
             obj[key] = updateWithTypeValues(value[key]);
         }
-        return obj;
+
+        const sortedKeys = Object.keys(obj).sort();
+        const sortedObj = Object.fromEntries(
+            sortedKeys.map((key) => {
+                return [key, obj[key]];
+            })
+        );
+        return sortedObj;
     } else {
         return value;
     }

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
@@ -62,6 +62,14 @@ const JSON_VIEWER_THEME = {
     base0F: 'var(--color-code-symbol)',
 };
 
+const MATCH_TYPE_REGEXP = /\[TYPE:([^\]]+)]/g;
+const REPLACEMENT_TYPES_MAP: Record<string, any> = {
+    undefined: undefined,
+    nan: NaN,
+    infinity: Infinity,
+    negativeInfinity: -Infinity,
+};
+
 function containsIgnoredMessage(log: Log) {
     return log.data.some((message) =>
         IGNORED_MESSAGES.some((ignoredMessage) => typeof message === 'string' && message.includes(ignoredMessage))
@@ -72,11 +80,45 @@ function getLoggableData(data: LogData[]) {
     return data.map((logItem: LogData) => {
         const consoleLogObject = logItem as LogObject;
         if (logItem && consoleLogObject.__consoleLogObject) {
-            return JSON.parse(consoleLogObject.safeString);
+            const parsedObject = JSON.parse(consoleLogObject.safeString);
+            return updateWithTypeValues(parsedObject);
         } else {
             return logItem;
         }
     });
+}
+
+function getReplacementType(typeValue: string) {
+    const [replacementType] = Array.from(typeValue.matchAll(MATCH_TYPE_REGEXP), (m) => m[1]);
+    return replacementType;
+}
+
+/**
+ * Recursively update the values of an object or array with their replacement types.
+ *
+ * Due to the limitations of `JSON.stringify`, we need to store some values as special strings
+ * in the form `[TYPE:<type>]`, where `<type>` is a type that can't be deserialised. This
+ * needs to be extracted and converted back to the original value.
+ */
+function updateWithTypeValues(value: any) {
+    const valueType = getType(value);
+
+    if (valueType === 'string') {
+        const replacementType = getReplacementType(value);
+
+        const output = replacementType ? REPLACEMENT_TYPES_MAP[replacementType] : value;
+        return output;
+    } else if (valueType === 'array') {
+        return value.map((item: any) => updateWithTypeValues(item));
+    } else if (valueType === 'object') {
+        const obj = { ...value };
+        for (const key in value) {
+            obj[key] = updateWithTypeValues(value[key]);
+        }
+        return obj;
+    } else {
+        return value;
+    }
 }
 
 const SimpleValueDisplay = ({ value }: { value: SimpleValue }) => {

--- a/external/ag-website-shared/src/components/example-runner/utils/getType.ts
+++ b/external/ag-website-shared/src/components/example-runner/utils/getType.ts
@@ -2,6 +2,8 @@ export function getType(value: any) {
     if (value === null) return 'null';
     if (Number.isNaN(value)) return 'nan';
     if (Array.isArray(value)) return 'array';
+    if (value === Infinity) return 'infinity';
+    if (value === -Infinity) return 'negativeInfinity';
     if (value instanceof Date) return 'date';
     if (value instanceof RegExp) return 'regexp';
     if (value instanceof Map) return 'map';

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/getConsoleLogSnippet.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/getConsoleLogSnippet.ts
@@ -8,17 +8,31 @@ export const CONSOLE_LOG_END = '/** CONSOLE LOG END **/';
 
 /**
  * Override console log to send the log message to the parent window
+ *
+ * Values need to be serialised to be able to be passed through to the parent window using
+ * `window.parent.postMessage`. However, there are some extra processing steps required
+ * due to the limitations of `JSON.stringify`:
+ *
+ *   * Circular references are replaced with `[Circular]`
+ *   * Class instances are replaced with `ClassNameClass {}`
+ *   * `undefined`, `NaN`, `Infinity`, and `-Infinity` are replaced with `[TYPE:undefined]`, etc.
+ *     This is deserialised on the parent window to the correct value.
+ *
  */
 export const getConsoleLogSnippet = ({ pageName, exampleName }: Params) =>
     `${CONSOLE_LOG_START}
 
 function patchConsoleLog() {
     const PRIMITIVE_TYPES = ["string", "number", "boolean", "undefined", "null", "nan", "symbol"];
+    const REPLACEMENT_TYPES = ["undefined", "nan", "infinity", "negativeInfinity"];
+    const getReplacementTypeValue = (typeValue) => \`[TYPE:\${typeValue}]\`;
 
     function getType(value) {
         if (value === null) return "null";
         if (Number.isNaN(value)) return "nan";
         if (Array.isArray(value)) return "array";
+        if (value === Infinity) return "infinity";
+        if (value === -Infinity) return "negativeInfinity";
         if (value instanceof Date) return "date";
         if (value instanceof RegExp) return "regexp";
         if (value instanceof Map) return "map";
@@ -52,6 +66,29 @@ function patchConsoleLog() {
         }, space);
     }
 
+    function updateWithReplacements(value, replacementTypes) {
+        const valueType = getType(value);
+        
+        if (replacementTypes.includes(valueType)) {
+            return getReplacementTypeValue(valueType);
+        } else if (valueType === 'array') {
+            return value.map(item => updateWithReplacements(item, replacementTypes));
+        } else if (valueType === 'object') {
+            const obj = { ...value };
+            for (const key in value) {
+                const objValueType = getType(value[key]);
+                if (replacementTypes.includes(objValueType)) {
+                    obj[key] = getReplacementTypeValue(objValueType);
+                } else {
+                    obj[key] = updateWithReplacements(value[key], replacementTypes);
+                }
+            }
+            return obj;
+        } else {
+            return value;
+        }
+    }
+
     function isPrimitiveType(value) {
         return PRIMITIVE_TYPES.includes(getType(value));
     }
@@ -61,7 +98,7 @@ function patchConsoleLog() {
             __consoleLogObject: true,
             isLoggable: isPrimitiveType(value),
             argType: getType(value),
-            safeString: safeStringify(value)
+            safeString: safeStringify(updateWithReplacements(value, REPLACEMENT_TYPES)),
         }
     }
 


### PR DESCRIPTION
* Collapse logged object by default
* Make example logger resizable
* Allow `undefined` to be passed through to example logger
* Sort object keys alphabetically
* Add clear button to example logger