### PR TITLE
Fix for issue #10338: Unable to customize drag handle icon

### DIFF
--- a/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
@@ -38,7 +38,7 @@ export class RowDragComp extends Component {
         const { beans, rowNode, column, gos } = this;
         if (!this.customGui) {
             this.setTemplate(RowDragElement);
-            this.getGui().appendChild(_createIconNoSpan('rowDrag', beans, null)!);
+            this.getGui().appendChild(_createIconNoSpan('rowDrag', beans, column)!);
             this.addDragSource();
         } else {
             this.setDragElement(this.customGui, this.dragStartPixels);


### PR DESCRIPTION
Component should include column definition when creating the icon, in case the column def includes any icon customizations.