### PR TITLE
AG-14751 - Clean up build generators in postinstall task

### DIFF
--- a/documentation/ag-grid-docs/project.json
+++ b/documentation/ag-grid-docs/project.json
@@ -66,6 +66,8 @@
     "dev": {
       "dependsOn": [
         "^build",
+        "generate-doc-references",
+        "generate-examples",
         "^docs-resolved-interfaces",
         "elapsedBuildTime",
         "ag-grid-react:build",
@@ -120,7 +122,7 @@
     "test:vitest": {
       "command": "npx vitest",
       "outputs": ["{workspaceRoot}/reports/ag-grid-website.xml"],
-      "dependsOn": [],
+      "dependsOn": ["ag-grid-community:build:css", "ag-grid-enterprise:build:css", "generate-doc-references"],
       "options": {
         "cwd": "{projectRoot}",
         "config": "vitest.config.mjs",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "compressVideo": "tsx external/ag-website-shared/scripts/compress-video",
-    "build-generators": "nx run-many -p ag-grid-generate-code-reference-files,ag-grid-task-autogen,ag-grid-generate-example-files -t build && nx run-many -t build:css",
+    "build-generators": "nx run-many -p ag-grid-task-autogen -t build",
     "subrepo": "tsx external/ag-shared/scripts/subrepo",
     "postinstall": "patch-package && yarn run build-generators",
     "bootstrap": "SHARP_IGNORE_GLOBAL_LIBVIPS=true YARN_REGISTRY=\"http://52.50.158.57:4873\" yarn"


### PR DESCRIPTION
* Move `generate-doc-references` and `generate-examples` deps to `nx dev` (`nx build` already had them)
* Removed `build:css` from `postinstall` as `nx dev` and `nx build` already had them in their deps (although, missing in `ag-grid-docs:test:vitest`)
* Add `build:css` to `vitest` deps - required for theme builder tests
* Add `generate-doc-references` to `vitest` deps - fails to build with error `[vite] (ssr) Error when evaluating SSR module /home/runner/work/ag-grid/ag-grid/documentation/ag-grid-docs/astro.config.mjs: Cannot find module 'ag-shared/processor' imported from '/home/runner/work/ag-grid/ag-grid/external/ag-website-shared/plugins/agLinkChecker.ts'`