### PR TITLE
AG-14751 - Clean up build generators in postinstall task 2

### DIFF
--- a/community-modules/styles/project.json
+++ b/community-modules/styles/project.json
@@ -84,6 +84,7 @@
     },
     "test": {
       "executor": "nx:run-commands",
+      "dependsOn": ["build"],
       "inputs": [],
       "outputs": [],
       "options": {

--- a/community-modules/styles/project.json
+++ b/community-modules/styles/project.json
@@ -51,7 +51,7 @@
         "!{projectRoot}/_css-content.scss"
       ],
       "options": {
-        "cwd": "community-modules/styles",
+        "cwd": "{projectRoot}",
         "command": "sass --silence-deprecation=mixed-decls --no-source-map --load-path src/internal src:."
       },
       "cache": true
@@ -68,7 +68,7 @@
       "inputs": [],
       "outputs": [],
       "options": {
-        "cwd": "community-modules/styles",
+        "cwd": "{projectRoot}",
         "commands": [
           "stylelint --formatter unix --config stylelint-config-scss.js 'src/**/*.scss' '*.scss'",
           "stylelint --formatter unix --config stylelint-config-css.js '*.css'"
@@ -87,7 +87,7 @@
       "inputs": [],
       "outputs": [],
       "options": {
-        "cwd": "community-modules/styles",
+        "cwd": "{projectRoot}",
         "commands": ["sass test/test.scss"]
       }
     }

--- a/documentation/ag-grid-docs/project.json
+++ b/documentation/ag-grid-docs/project.json
@@ -66,6 +66,8 @@
     "dev": {
       "dependsOn": [
         "^build",
+        "generate-doc-references",
+        "generate-examples",
         "^docs-resolved-interfaces",
         "elapsedBuildTime",
         "ag-grid-react:build",
@@ -120,7 +122,7 @@
     "test:vitest": {
       "command": "npx vitest",
       "outputs": ["{workspaceRoot}/reports/ag-grid-website.xml"],
-      "dependsOn": [],
+      "dependsOn": ["ag-grid-community:build:css", "ag-grid-enterprise:build:css", "generate-doc-references"],
       "options": {
         "cwd": "{projectRoot}",
         "config": "vitest.config.mjs",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "compressVideo": "tsx external/ag-website-shared/scripts/compress-video",
-    "build-generators": "nx run-many -p ag-grid-generate-code-reference-files,ag-grid-task-autogen,ag-grid-generate-example-files -t build && nx run-many -t build:css",
+    "build-generators": "nx run-many -p ag-grid-task-autogen -t build",
     "subrepo": "tsx external/ag-shared/scripts/subrepo",
     "postinstall": "patch-package && yarn run build-generators",
     "bootstrap": "SHARP_IGNORE_GLOBAL_LIBVIPS=true YARN_REGISTRY=\"http://52.50.158.57:4873\" yarn"

--- a/packages/ag-grid-community/project.json
+++ b/packages/ag-grid-community/project.json
@@ -124,6 +124,7 @@
     },
     "test": {
       "executor": "@nx/jest:jest",
+      "dependsOn": ["build:css"],
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}", "{workspaceRoot}/reports/ag-grid-community.xml"],
       "parallelism": false,
       "options": {

--- a/plugins/ag-grid-generate-example-files/project.json
+++ b/plugins/ag-grid-generate-example-files/project.json
@@ -57,6 +57,7 @@
     },
     "test": {
       "executor": "@nx/jest:jest",
+      "dependsOn": ["copySrcFilesForGeneration"],
       "outputs": [
         "{workspaceRoot}/coverage/{projectRoot}",
         "{workspaceRoot}/reports/ag-grid-generate-example-files.xml"

--- a/testing/module-size/project.json
+++ b/testing/module-size/project.json
@@ -16,7 +16,8 @@
         "ag-grid-community:build:package",
         "ag-grid-enterprise:build:types",
         "ag-grid-enterprise:build:package",
-        "ag-grid-react:build"
+        "ag-grid-react:build",
+        "ag-shared:build"
       ],
       "options": {
         "script": "test:e2e"


### PR DESCRIPTION
2nd attempt at https://github.com/ag-grid/ag-grid/pull/10370

## Changes

* Move `generate-doc-references` and `generate-examples` deps to `nx dev` (`nx build` already had them)
* Removed `build:css` from `postinstall` as `nx dev` and `nx build` already had them in their deps (although, missing in `ag-grid-docs:test:vitest`)
* Add `build:css` to `vitest` deps - required for theme builder tests
* Add `generate-doc-references` to `vitest` deps - fails to build with error `[vite] (ssr) Error when evaluating SSR module /home/runner/work/ag-grid/ag-grid/documentation/ag-grid-docs/astro.config.mjs: Cannot find module 'ag-shared/processor' imported from '/home/runner/work/ag-grid/ag-grid/external/ag-website-shared/plugins/agLinkChecker.ts'`
* Add `copySrcFilesForGeneration` to `ag-grid-generate-example-files:test`
* Add `build:css` for `ag-grid-community:test`
* Add `build` to `@ag-grid-community/styles:build:styles` - fails from clean run of `nx test`
* Add `ag-shared:build` to module size test deps - needed for generating `junit-processor/src/processor.js`