### PR TITLE
AG-14481 - Prevent flash of nav for what's new page

### DIFF
--- a/documentation/ag-grid-docs/src/components/docs/utils/urlPaths.ts
+++ b/documentation/ag-grid-docs/src/components/docs/utils/urlPaths.ts
@@ -1,6 +1,6 @@
 import type { InternalFramework } from '@ag-grid-types';
 import type { Framework } from '@ag-grid-types';
-import { SITE_BASE_URL } from '@constants';
+import { FRAMEWORK_REDIRECT_PATH, SITE_BASE_URL } from '@constants';
 import { pathJoin } from '@utils/pathJoin';
 
 import { DOCS_FRAMEWORK_PATH_INDEX, DOCS_PAGE_NAME_PATH_INDEX } from '../constants';
@@ -19,8 +19,8 @@ export function getPageNameFromPath(path: string): string {
     return path.split('/')[DOCS_PAGE_NAME_PATH_INDEX];
 }
 
-export const getExamplePageUrl = ({ framework, path }: { framework: Framework; path: string }) => {
-    const frameworkPath = getFrameworkPath(framework);
+export const getExamplePageUrl = ({ framework, path }: { framework?: Framework; path: string }) => {
+    const frameworkPath = framework ? getFrameworkPath(framework) : FRAMEWORK_REDIRECT_PATH;
     return pathJoin(SITE_BASE_URL, frameworkPath, path) + '/';
 };
 

--- a/documentation/ag-grid-docs/src/constants.ts
+++ b/documentation/ag-grid-docs/src/constants.ts
@@ -109,6 +109,13 @@ export const SITE_BASE_URL_SEGMENTS = SITE_BASE_URL?.split('/').filter(Boolean).
 export const FILES_BASE_PATH = '/files';
 
 /**
+ * URL path used to redirect to the user selected framework
+ *
+ * Useful when the framework is not known eg, root pages
+ */
+export const FRAMEWORK_REDIRECT_PATH = 'data-grid';
+
+/**
  * Charts robots disallow json url for merging with grid
  */
 export const CHARTS_ROBOTS_DISALLOW_JSON_URL = import.meta.env?.CHARTS_ROBOTS_DISALLOW_JSON_URL;

--- a/external/ag-website-shared/src/components/docs-navigation/DocsNav.tsx
+++ b/external/ag-website-shared/src/components/docs-navigation/DocsNav.tsx
@@ -39,11 +39,11 @@ function getOpenGroup({ menuData, pageName }: { menuData?: any; pageName?: strin
     return openGroup;
 }
 
-function getLinkUrl({ framework, path, url }: { framework: Framework; path?: string; url?: string }) {
+function getLinkUrl({ framework, path, url }: { framework?: Framework; path?: string; url?: string }) {
     return url ? url : getExamplePageUrl({ framework, path: path! });
 }
 
-function Item({ itemData, framework, pageName }: { itemData?: any; framework: Framework; pageName?: string }) {
+function Item({ itemData, framework, pageName }: { itemData?: any; framework?: Framework; pageName?: string }) {
     const linkUrl = itemData.path ? getLinkUrl({ framework, path: itemData.path }) : itemData.url;
     const isExternalURL = itemData.url;
     const isCorrectFramework = !itemData.frameworks
@@ -98,7 +98,7 @@ function Group({
     setOpenGroup,
 }: {
     groupData?: any;
-    framework: Framework;
+    framework?: Framework;
     pageName?: string;
     openGroup?: any;
     setOpenGroup?: any;
@@ -148,7 +148,7 @@ function Section({
     setOpenGroup,
 }: {
     sectionData?: any;
-    framework: Framework;
+    framework?: Framework;
     pageName?: string;
     openGroup?: any;
     setOpenGroup?: any;
@@ -186,7 +186,7 @@ export function DocsNav({
     showWhatsNew = true,
 }: {
     menuData?: any;
-    framework: Framework;
+    framework?: Framework;
     pageName?: string;
     showWhatsNew?: boolean;
 }) {

--- a/external/ag-website-shared/src/components/docs-navigation/DocsNavFromLocalStorage.tsx
+++ b/external/ag-website-shared/src/components/docs-navigation/DocsNavFromLocalStorage.tsx
@@ -18,5 +18,5 @@ export function DocsNavFromLocalStorage({ menuData, pageName }: { menuData: any;
         }
     }, [internalFramework]);
 
-    return framework && <DocsNav menuData={menuData} framework={framework} pageName={pageName} />;
+    return <DocsNav menuData={menuData} framework={framework} pageName={pageName} />;
 }

--- a/external/ag-website-shared/src/components/whats-new/pages/whats-new.astro
+++ b/external/ag-website-shared/src/components/whats-new/pages/whats-new.astro
@@ -4,7 +4,7 @@ import Layout from '@layouts/Layout.astro';
 import { DocsNavFromLocalStorage } from '@ag-website-shared/components/docs-navigation/DocsNavFromLocalStorage';
 import { parseVersion } from '@ag-website-shared/utils/parseVersion';
 import { Version, type VersionProps } from '../components/Version';
-import type { Framework, Library } from '@ag-grid-types';
+import type { Library } from '@ag-grid-types';
 import styles from '../WhatsNew.module.scss';
 import whatsNewData from '@ag-website-shared/content/whats-new/data.json';
 


### PR DESCRIPTION
Allow docs nav framework to be undefined, and use redirect link if so.

Prevents flash of empty nav for pages like what's new, 404 etc.