### PR TITLE
AG-14757 regression fixes

### DIFF
--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
@@ -433,18 +433,25 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         recurse(this.rootNode);
     }
 
-    public highlightRow(rowNode: RowNode | null | undefined = null, highlight: RowHighlightPosition = 'Below'): void {
-        const old = this.lastHighlightedRow;
-        if (old !== rowNode || (rowNode && rowNode.highlighted !== highlight)) {
-            if (old && old !== rowNode) {
-                old.highlighted = null;
-                old.dispatchRowEvent('rowHighlightChanged');
+    public clearHighlight(): void {
+        const last = this.lastHighlightedRow;
+        if (last) {
+            last.highlighted = null;
+            last.dispatchRowEvent('rowHighlightChanged');
+            this.lastHighlightedRow = null;
+        }
+    }
+
+    public highlightRow(row: RowNode, highlight: RowHighlightPosition): void {
+        const nodeChanged = row !== this.lastHighlightedRow;
+        const highlightChanged = highlight !== row.highlighted;
+        if (nodeChanged || highlightChanged) {
+            if (nodeChanged) {
+                this.clearHighlight();
             }
-            if (rowNode) {
-                rowNode.highlighted = highlight;
-                rowNode.dispatchRowEvent('rowHighlightChanged');
-            }
-            this.lastHighlightedRow = rowNode;
+            row.highlighted = highlight;
+            row.dispatchRowEvent('rowHighlightChanged');
+            this.lastHighlightedRow = row;
         }
     }
 
@@ -1222,7 +1229,7 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         super.destroy();
 
         // Forcefully deallocate memory
-        this.highlightRow(null);
+        this.clearHighlight();
         this.started = false;
         this.rootNode = null;
         this.nodeManager = null!;

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
@@ -250,14 +250,14 @@ export class RowDragFeature extends BeanStub implements DropTarget {
         const targetRowIndex = clientSideRowModel.getRowIndexAtPixel(y);
         let target = clientSideRowModel.getRow(targetRowIndex);
         let delta = 0;
-        if (!source || target === source) {
+        if (!source) {
             return null; // Nothing to move
         }
         if (sameGrid) {
-            if (!target) {
+            if (!target || target === source) {
                 return null; // Nothing to move
             }
-            delta = targetRowIndex - (source.rowIndex ?? targetRowIndex);
+            delta = targetRowIndex - source.rowIndex!;
             if (rows.includes(target)) {
                 target = (delta < 0 ? this.getPrevOrNext(-1, rows[0]) : this.getPrevOrNext(1, _last(rows))) ?? target;
             }

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
@@ -281,8 +281,8 @@ export class RowDragFeature extends BeanStub implements DropTarget {
             if (!row || rowIndex < firstRow || rowIndex > lastRow) {
                 return undefined; // Out of bounds
             }
-            if (row.rowIndex !== null && row.sourceRowIndex >= 0) {
-                return row; // Valid row
+            if (row.sourceRowIndex >= 0) {
+                return row; // Valid leaf node
             }
         }
     }

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
@@ -217,8 +217,14 @@ export class RowDragFeature extends BeanStub implements DropTarget {
 
         if (gos.get('suppressMoveWhenRowDragging') || !isFromThisGrid) {
             if (dragAndDrop!.isDropZoneWithinThisGrid(draggingEvent)) {
+                const clientSideRowModel = this.clientSideRowModel;
                 const rowsDrop = this.getRowsDrop(draggingEvent);
-                this.clientSideRowModel.highlightRow(rowsDrop?.target, rowsDrop?.delta ?? 0 < 0 ? 'Above' : 'Below');
+                const target = rowsDrop?.target;
+                if (target) {
+                    clientSideRowModel.highlightRow(target, rowsDrop.delta < 0 ? 'Above' : 'Below');
+                } else {
+                    clientSideRowModel.clearHighlight();
+                }
             }
         } else {
             const rowsDrop = this.getRowsDrop(draggingEvent);
@@ -244,47 +250,41 @@ export class RowDragFeature extends BeanStub implements DropTarget {
         const targetRowIndex = clientSideRowModel.getRowIndexAtPixel(y);
         let target = clientSideRowModel.getRow(targetRowIndex);
         let delta = 0;
-        if (!source || !target || target === source) {
+        if (!source || target === source) {
             return null; // Nothing to move
         }
         if (sameGrid) {
+            if (!target) {
+                return null; // Nothing to move
+            }
             delta = targetRowIndex - (source.rowIndex ?? targetRowIndex);
             if (rows.includes(target)) {
-                target = this.getPrevOrNextTarget(rows, delta) ?? target;
+                target = (delta < 0 ? this.getPrevOrNext(-1, rows[0]) : this.getPrevOrNext(1, _last(rows))) ?? target;
             }
         }
-        if (!sameGrid || delta < -1 || delta > 1) {
+        if (target && (!sameGrid || delta < -1 || delta > 1)) {
             delta = y - target.rowTop! - target.rowHeight! / 2;
         }
         return { sameGrid, delta, target, rows };
     }
 
-    /** When dragging multiple rows, we want the user to be able to drag to the prev or next in the group if dragging on one of the selected rows */
-    private getPrevOrNextTarget(rows: IRowNode<any>[], delta: number): RowNode | undefined {
-        const allLeafChildren = this.clientSideRowModel.rootNode?.allLeafChildren;
-        const allLeafChildrenLen = allLeafChildren?.length;
-        if (!allLeafChildrenLen) {
-            return undefined;
-        }
-        let index = -1;
-        if (delta < 0) {
-            let min = allLeafChildrenLen;
-            for (const { sourceRowIndex } of rows) {
-                min = sourceRowIndex >= 0 && sourceRowIndex < min ? sourceRowIndex : min;
+    /** When dragging multiple rows, we want the user to be able to drag to the prev or next in the group if dragging on one of the selected rows. */
+    private getPrevOrNext(increment: -1 | 1, initialRow: IRowNode): RowNode | undefined {
+        const clientSideRowModel = this.clientSideRowModel;
+        const pageBounds = this.beans.pageBounds;
+        const firstRow = pageBounds.getFirstRow();
+        const lastRow = pageBounds.getLastRow();
+        let rowIndex = initialRow.rowIndex!;
+        while (true) {
+            rowIndex += increment;
+            const row = clientSideRowModel.getRow(rowIndex);
+            if (!row || rowIndex < firstRow || rowIndex > lastRow) {
+                return undefined; // Out of bounds
             }
-            if (min < allLeafChildrenLen) {
-                index = Math.max(min - 1, 0);
-            }
-        } else {
-            let max = -1;
-            for (const { sourceRowIndex } of rows) {
-                max = sourceRowIndex > max ? sourceRowIndex : max;
-            }
-            if (max >= 0) {
-                index = Math.min(max + 1, allLeafChildrenLen - 1);
+            if (row.rowIndex !== null && row.sourceRowIndex >= 0) {
+                return row; // Valid row
             }
         }
-        return index >= 0 ? (allLeafChildren[index] as RowNode) : undefined;
     }
 
     public addRowDropZone(params: RowDropZoneParams & { fromGrid?: boolean }): void {
@@ -441,7 +441,7 @@ export class RowDragFeature extends BeanStub implements DropTarget {
         this.stopDragging(draggingEvent);
 
         if (this.gos.get('rowDragManaged')) {
-            this.clientSideRowModel.highlightRow(null);
+            this.clientSideRowModel.clearHighlight();
         }
     }
 
@@ -459,7 +459,7 @@ export class RowDragFeature extends BeanStub implements DropTarget {
             if (rowsDrop) {
                 this.dropRows(rowsDrop);
             }
-            this.clientSideRowModel.highlightRow(null);
+            this.clientSideRowModel.clearHighlight();
         }
     }
 
@@ -473,7 +473,7 @@ export class RowDragFeature extends BeanStub implements DropTarget {
             (gos.get('suppressMoveWhenRowDragging') || !this.isFromThisGrid(draggingEvent)) &&
             dragAndDrop!.isDropZoneWithinThisGrid(draggingEvent)
         ) {
-            this.clientSideRowModel.highlightRow(null);
+            this.clientSideRowModel.clearHighlight();
         }
     }
 

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
@@ -271,20 +271,16 @@ export class RowDragFeature extends BeanStub implements DropTarget {
     /** When dragging multiple rows, we want the user to be able to drag to the prev or next in the group if dragging on one of the selected rows. */
     private getPrevOrNext(increment: -1 | 1, initialRow: IRowNode): RowNode | undefined {
         const clientSideRowModel = this.clientSideRowModel;
-        const pageBounds = this.beans.pageBounds;
-        const firstRow = pageBounds.getFirstRow();
-        const lastRow = pageBounds.getLastRow();
-        let rowIndex = initialRow.rowIndex!;
-        while (true) {
-            rowIndex += increment;
-            const row = clientSideRowModel.getRow(rowIndex);
-            if (!row || rowIndex < firstRow || rowIndex > lastRow) {
-                return undefined; // Out of bounds
-            }
+        const rowCount = clientSideRowModel.getRowCount();
+        let rowIndex = initialRow.rowIndex! + increment;
+        while (rowIndex >= 0 && rowIndex < rowCount) {
+            const row = clientSideRowModel.getRow(rowIndex)!;
             if (row.sourceRowIndex >= 0) {
                 return row; // Valid leaf node
             }
+            rowIndex += increment;
         }
+        return undefined; // Out of bounds
     }
 
     public addRowDropZone(params: RowDropZoneParams & { fromGrid?: boolean }): void {

--- a/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
+++ b/packages/ag-grid-community/src/interfaces/iClientSideRowModel.ts
@@ -53,7 +53,8 @@ export interface IClientSideRowModel<TData = any> extends IRowModel {
     flushAsyncTransactions(): void;
     doAggregate(changedPath?: ChangedPath): void;
     getTopLevelNodes(): RowNode[] | null;
-    highlightRow(rowNode: RowNode | null | undefined, highlight?: RowHighlightPosition): void;
+    clearHighlight(): void;
+    highlightRow(rowNode: RowNode, highlight: RowHighlightPosition): void;
     getLastHighlightedRowNode(): RowNode | null;
     isRowDataLoaded(): boolean;
 


### PR DESCRIPTION
There were two problems encountered with multi grid drag and drop.

- target can be null when dropping to an empty grid, and it should just add the row.
- the logic for highlight/dehighlight wasn't always working, simplified and cleaned up 
- the logic for getPrevOrNext was not fully correct, simplified it as well to look for the first displayed leaf row