### PR TITLE
AG-11914 - Allow custom `head.html` to be added to examples

### DIFF
--- a/documentation/ag-grid-docs/src/components/example-runner/components/FrameworkTemplate.astro
+++ b/documentation/ag-grid-docs/src/components/example-runner/components/FrameworkTemplate.astro
@@ -53,7 +53,8 @@ const library = 'grid';
 
 const { entryFileName, files, scriptFiles, styleFiles, isEnterprise, isIntegratedCharts, isLocale, extras } =
     generatedContents || {};
-const indexFragment = files && files['index.html'];
+const indexFragment = files['index.html'] ?? '';
+const headFragment = files?.['head.html'] ?? '';
 const appLocation = relativePath ? '' : exampleUrl;
 const boilerPlateUrl = relativePath
     ? ''
@@ -107,6 +108,7 @@ const shouldShowTemplate = (framework: InternalFramework) => {
             appLocation={appLocation}
             extraStyles={extraStyles}
             extras={extras}
+            headFragment={headFragment}
             usesMathRandom={usesMathRandom}
         >
             {addInitMessageScript && <PostInitMessageScript pageName={pageName} exampleName={exampleName} />}
@@ -128,6 +130,7 @@ const shouldShowTemplate = (framework: InternalFramework) => {
             extraStyles={extraStyles}
             isEnterprise={isEnterprise}
             extras={extras}
+            headFragment={headFragment}
             usesMathRandom={usesMathRandom}
         >
             {addInitMessageScript && <PostInitMessageScript pageName={pageName} exampleName={exampleName} />}
@@ -151,6 +154,7 @@ const shouldShowTemplate = (framework: InternalFramework) => {
             isEnterprise={isEnterprise}
             internalFramework={internalFramework}
             extras={extras}
+            headFragment={headFragment}
             usesMathRandom={usesMathRandom}
         >
             {addInitMessageScript && <PostInitMessageScript pageName={pageName} exampleName={exampleName} />}
@@ -172,6 +176,7 @@ const shouldShowTemplate = (framework: InternalFramework) => {
             boilerplatePath={boilerPlateUrl}
             extraStyles={extraStyles}
             extras={extras}
+            headFragment={headFragment}
             usesMathRandom={usesMathRandom}
         >
             {addInitMessageScript && <PostInitMessageScript pageName={pageName} exampleName={exampleName} />}
@@ -193,6 +198,7 @@ const shouldShowTemplate = (framework: InternalFramework) => {
             boilerplatePath={boilerPlateUrl}
             extraStyles={extraStyles}
             extras={extras}
+            headFragment={headFragment}
             usesMathRandom={usesMathRandom}
         >
             {addInitMessageScript && <PostInitMessageScript pageName={pageName} exampleName={exampleName} />}

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/AngularTemplate.astro
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/AngularTemplate.astro
@@ -21,7 +21,7 @@ interface Props {
     appLocation: string;
     boilerplatePath: string;
     extraStyles?: string;
-    children?: any;
+    headFragment?: string;
     extras?: string[];
     usesMathRandom?: boolean;
 }
@@ -37,6 +37,7 @@ const {
     scriptFiles,
     boilerplatePath,
     extraStyles,
+    headFragment,
     extras,
     usesMathRandom,
 } = Astro.props as Props;
@@ -57,6 +58,7 @@ const startFile = pathJoin(appLocation, entryFileName);
                 : []}
         />
         <Extras extras={extras ?? []} />
+        <Fragment set:html={headFragment} />
     </head>
     <body>
         <my-app></my-app>

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/JavascriptTemplate.astro
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/JavascriptTemplate.astro
@@ -13,9 +13,9 @@ interface Props {
     scriptFiles?: string[];
     styleFiles?: string[];
     indexFragment: string;
+    headFragment?: string;
     appLocation: string;
     extraStyles?: string;
-    children?: any;
     extras?: string[];
     usesMathRandom?: boolean;
 }
@@ -30,6 +30,7 @@ const {
     styleFiles,
     scriptFiles,
     indexFragment,
+    headFragment,
     appLocation,
     extraStyles,
     extras,
@@ -73,6 +74,7 @@ const gridScriptLocalePath = getCacheBustingUrl(getGridLocaleScriptPath(siteUrl)
                 : []}
         />
         <Extras extras={extras ?? []} />
+        <Fragment set:html={headFragment} />
     </head>
     <body>
         <Fragment set:html={indexFragment} />

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/ReactTemplate.astro
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/ReactTemplate.astro
@@ -25,7 +25,7 @@ interface Props {
     boilerplatePath: string;
     ignoreSystemJs?: boolean;
     extraStyles?: string;
-    children?: any;
+    headFragment?: string;
     extras?: string[];
     usesMathRandom?: boolean;
 }
@@ -43,6 +43,7 @@ const {
     boilerplatePath,
     ignoreSystemJs,
     extraStyles,
+    headFragment,
     extras,
     usesMathRandom,
 } = Astro.props as Props;
@@ -56,6 +57,7 @@ const startFile = pathJoin(appLocation, entryFileName);
         <ExampleStyle rootSelector="#root" extraStyles={extraStyles} />
         <Styles baseUrl={appLocation} files={styleFiles} />
         <Extras extras={extras ?? []} />
+        <Fragment set:html={headFragment} />
     </head>
     <body>
         <div id="root"></div>

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/TypescriptTemplate.astro
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/TypescriptTemplate.astro
@@ -20,8 +20,8 @@ interface Props {
     appLocation: string;
     boilerplatePath: string;
     extraStyles?: string;
-    children?: any;
     extras?: string[];
+    headFragment?: string;
     usesMathRandom?: boolean;
 }
 
@@ -37,6 +37,7 @@ const {
     boilerplatePath,
     extraStyles,
     extras,
+    headFragment,
     usesMathRandom,
 } = Astro.props as Props;
 
@@ -56,6 +57,7 @@ const startFile = pathJoin(appLocation, entryFileName);
                 : []}
         />
         <Extras extras={extras ?? []} />
+        <Fragment set:html={headFragment} />
     </head>
     <body>
         <Fragment set:html={indexFragment} />

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/VueTemplate.astro
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/VueTemplate.astro
@@ -22,8 +22,8 @@ interface Props {
     appLocation: string;
     boilerplatePath: string;
     extraStyles?: string;
-    children?: any;
     extras?: string[];
+    headFragment?: string;
     usesMathRandom?: boolean;
 }
 
@@ -39,6 +39,7 @@ const {
     styleFiles = [],
     extraStyles,
     extras,
+    headFragment,
     usesMathRandom,
 } = Astro.props as Props;
 
@@ -51,6 +52,7 @@ const startFile = pathJoin(appLocation, entryFileName);
         <ExampleStyle rootSelector="#app" extraStyles={extraStyles} />
         <Styles baseUrl={appLocation} files={styleFiles} />
         <Extras extras={extras ?? []} />
+        <Fragment set:html={headFragment} />
     </head>
     <body>
         <div id="app"><my-component></my-component></div>

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/executor.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/executor.ts
@@ -30,6 +30,7 @@ import {
 import { frameworkFilesGenerator } from './generator/utils/frameworkFilesGenerator';
 import type { TransformEntryFile } from './generator/utils/frameworkFilesGenerator';
 import { getConsoleLogSnippet } from './generator/utils/getConsoleLogSnippet';
+import { getHtmlFiles } from './generator/utils/getHtmlFiles';
 import { getOtherScriptFiles, getUseFetchJsonFile } from './generator/utils/getOtherScriptFiles';
 import { getPackageJson } from './generator/utils/getPackageJson';
 import { getStyleFiles } from './generator/utils/getStyleFiles';
@@ -128,6 +129,7 @@ export async function generateFiles(options: ExecutorOptions, gridOptionsTypes: 
         readFile(path.join(folderPath, 'index.html')),
         getStyleFiles({ folderPath, sourceFileList }),
     ]);
+    const htmlFiles = await getHtmlFiles({ folderPath, sourceFileList });
 
     const isEnterprise = getIsEnterprise({ entryFile });
     const isLocale = getIsLocale({ entryFile });
@@ -245,7 +247,13 @@ export async function generateFiles(options: ExecutorOptions, gridOptionsTypes: 
         }
 
         let styleFilesKeys = [];
-        const mergedFiles = { ...mergedStyleFiles, ...files, ...provideFrameworkFiles, ...interfaceContents };
+        const mergedFiles = {
+            ...mergedStyleFiles,
+            ...htmlFiles,
+            ...files,
+            ...provideFrameworkFiles,
+            ...interfaceContents,
+        };
         if ((['typescript', 'vanilla'] as InternalFramework[]).includes(internalFramework)) {
             styleFilesKeys = Object.keys(mergedStyleFiles);
         }
@@ -267,6 +275,7 @@ export async function generateFiles(options: ExecutorOptions, gridOptionsTypes: 
             mainFileName,
             scriptFiles: scriptFiles!,
             styleFiles: styleFilesKeys,
+            htmlFiles: Object.keys(htmlFiles),
             files: mergedFiles,
             boilerPlateFiles,
             packageJson,

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/types.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/types.ts
@@ -99,6 +99,7 @@ export interface GeneratedContents extends ExampleConfig {
     files: FileContents;
     scriptFiles: string[];
     styleFiles: string[];
+    htmlFiles: string[];
     boilerPlateFiles: FileContents;
     packageJson: Record<string, any>;
 }

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/getHtmlFiles.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/getHtmlFiles.ts
@@ -1,0 +1,18 @@
+import { getFileList } from './fileUtils';
+
+export const getHtmlFiles = async ({
+    folderPath,
+    sourceFileList,
+}: {
+    folderPath: string;
+    sourceFileList: string[];
+}) => {
+    const htmlFiles = sourceFileList.filter((fileName) => fileName.endsWith('.html') && fileName !== 'index.html');
+
+    const htmlContents = await getFileList({
+        folderPath,
+        fileList: htmlFiles,
+    });
+
+    return htmlContents;
+};


### PR DESCRIPTION
Based off https://github.com/ag-grid/ag-charts/pull/1644