### PR TITLE
RTI-2710-onclick-handler-in-status-bar

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/component-instance/clickable-status-bar-component.component_angular.ts
+++ b/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/component-instance/clickable-status-bar-component.component_angular.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 
 import type { IStatusPanelAngularComp } from 'ag-grid-angular';
 import type { IStatusPanelParams } from 'ag-grid-community';
@@ -9,9 +9,10 @@ import type { IStatusPanelParams } from 'ag-grid-community';
         @if (visible) {
             <div class="container">
                 <div>
-                    <span class="component"
-                        >Status Bar Component <input type="button" (click)="onClick()" value="Click Me"
-                    /></span>
+                    <span class="component">
+                        Status Bar Component <input type="button" (click)="onClick()" value="Click Me" />
+                        {{ text }}
+                    </span>
                 </div>
             </div>
         }
@@ -20,13 +21,14 @@ import type { IStatusPanelParams } from 'ag-grid-community';
 export class ClickableStatusBarComponent implements IStatusPanelAngularComp {
     public params!: IStatusPanelParams;
     public visible = true;
+    private text = signal<string>('');
 
     agInit(params: IStatusPanelParams): void {
         this.params = params;
     }
 
     onClick(): void {
-        console.log('Selected Row Count: ' + this.params.api.getSelectedRows().length);
+        this.text.set(this.params.api.getSelectedRows().length + ' selected');
     }
 
     setVisible(visible: boolean) {

--- a/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/component-instance/clickableStatusBarComponent_typescript.ts
+++ b/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/component-instance/clickableStatusBarComponent_typescript.ts
@@ -6,6 +6,7 @@ export class ClickableStatusBarComponent implements IStatusPanelComp {
     buttonListener: any;
     visible!: boolean;
     eButton!: HTMLButtonElement;
+    eText!: HTMLSpanElement;
 
     init(params: IStatusPanelParams) {
         this.params = params;
@@ -25,6 +26,9 @@ export class ClickableStatusBarComponent implements IStatusPanelComp {
         this.eButton.textContent = 'Click Me';
 
         this.eGui.appendChild(this.eButton);
+
+        this.eText = document.createElement('span');
+        this.eGui.appendChild(this.eText);
     }
 
     getGui() {
@@ -36,7 +40,7 @@ export class ClickableStatusBarComponent implements IStatusPanelComp {
     }
 
     onButtonClicked() {
-        console.log('Selected Row Count: ' + this.params.api.getSelectedRows().length);
+        this.eText.textContent = ' ' + this.params.api.getSelectedRows().length + ' selected';
     }
 
     setVisible(visible: boolean) {

--- a/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/component-instance/clickableStatusBarComponent_vue3.ts
+++ b/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/component-instance/clickableStatusBarComponent_vue3.ts
@@ -4,18 +4,20 @@ export default {
       <div>
           <span class="component">Status Bar Component&nbsp;
             <input type="button" v-on:click="onClick" value="Click Me"/>
+            {{ text }}
           </span>
       </div>
       </div>
     `,
     data: function () {
         return {
+            text: '',
             visible: true,
         };
     },
     methods: {
         onClick() {
-            console.log('Selected Row Count: ' + this.params.api.getSelectedRows().length);
+            this.text = this.params.api.getSelectedRows().length + ' selected';
         },
         setVisible(visible) {
             this.visible = visible;

--- a/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/component-instance/provided/reactFunctionalTs/clickableStatusBarComponent.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/component-instance/provided/reactFunctionalTs/clickableStatusBarComponent.tsx
@@ -4,9 +4,10 @@ import type { CustomStatusPanelProps } from 'ag-grid-react';
 
 export default forwardRef((props: CustomStatusPanelProps, ref) => {
     const [visible, setVisible] = useState(true);
+    const [text, setText] = useState('');
 
     const onClick = () => {
-        console.log('Selected Row Count: ' + props.api.getSelectedRows().length);
+        setText(props.api.getSelectedRows().length + ' selected');
     };
 
     useImperativeHandle(ref, () => {
@@ -27,6 +28,7 @@ export default forwardRef((props: CustomStatusPanelProps, ref) => {
                     <span className="component">
                         Status Bar Component&nbsp;
                         <input type="button" onClick={() => onClick()} value="Click Me" />
+                        <span> {text}</span>
                     </span>
                 </div>
             </div>

--- a/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/custom-component/clickable-status-bar-component.component_angular.ts
+++ b/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/custom-component/clickable-status-bar-component.component_angular.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 
 import type { IStatusPanelAngularComp } from 'ag-grid-angular';
 import type { IStatusPanelParams } from 'ag-grid-community';
@@ -10,11 +10,13 @@ import type { IStatusPanelParams } from 'ag-grid-community';
             <span class="component">
                 Status Bar Component
                 <input class="status-bar-input" type="button" (click)="onClick()" value="Click Me" />
+                {{ text() }}
             </span>
         </div>
     `,
 })
 export class ClickableStatusBarComponent implements IStatusPanelAngularComp {
+    private text = signal<string>('');
     private params!: IStatusPanelParams;
 
     agInit(params: IStatusPanelParams): void {
@@ -22,6 +24,6 @@ export class ClickableStatusBarComponent implements IStatusPanelAngularComp {
     }
 
     onClick(): void {
-        console.log('Selected Row Count: ' + this.params.api.getSelectedRows().length);
+        this.text.set(this.params.api.getSelectedRows().length + ' selected');
     }
 }

--- a/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/custom-component/clickableStatusBarComponent_typescript.ts
+++ b/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/custom-component/clickableStatusBarComponent_typescript.ts
@@ -4,7 +4,9 @@ export class ClickableStatusBarComponent implements IStatusPanelComp {
     params!: IStatusPanelParams;
     eGui!: HTMLDivElement;
     eButton!: HTMLButtonElement;
+    eCounter!: HTMLSpanElement;
     buttonListener: any;
+    clickCount: number = 0;
 
     init(params: IStatusPanelParams) {
         this.params = params;
@@ -22,7 +24,10 @@ export class ClickableStatusBarComponent implements IStatusPanelComp {
         this.eButton.addEventListener('click', this.buttonListener);
         this.eButton.textContent = 'Click Me';
 
+        this.eCounter = document.createElement('span');
+
         this.eGui.appendChild(this.eButton);
+        this.eGui.appendChild(this.eCounter);
     }
 
     getGui() {
@@ -34,6 +39,6 @@ export class ClickableStatusBarComponent implements IStatusPanelComp {
     }
 
     onButtonClicked() {
-        console.log('Selected Row Count: ' + this.params.api.getSelectedRows().length);
+        this.eCounter.textContent = ` ${this.params.api.getSelectedRows().length} selected`;
     }
 }

--- a/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/custom-component/clickableStatusBarComponent_vue3.ts
+++ b/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/custom-component/clickableStatusBarComponent_vue3.ts
@@ -3,15 +3,18 @@ export default {
       <div class="ag-status-name-value">
           <span>Status Bar Component&nbsp; 
             <input type="button" class="status-bar-input" v-on:click="onClick" value="Click Me"/>
+            {{ text }}
           </span>
       </div>
     `,
     data: function () {
-        return {};
+        return {
+            text: '',
+        };
     },
     methods: {
         onClick() {
-            console.log('Selected Row Count: ' + this.params.api.getSelectedRows().length);
+            this.text = this.params.api.getSelectedRows().length + ' selected';
         },
     },
 };

--- a/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/custom-component/provided/reactFunctionalTs/clickableStatusBarComponent.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/custom-component/provided/reactFunctionalTs/clickableStatusBarComponent.tsx
@@ -3,8 +3,10 @@ import React from 'react';
 import type { CustomStatusPanelProps } from 'ag-grid-react';
 
 export default (props: CustomStatusPanelProps) => {
+    const [text, setText] = React.useState('');
+
     const onClick = () => {
-        console.log('Selected Row Count: ' + props.api.getSelectedRows().length);
+        setText(props.api.getSelectedRows().length + ' selected');
     };
 
     return (
@@ -12,6 +14,7 @@ export default (props: CustomStatusPanelProps) => {
             <span>
                 Status Bar Component&nbsp;
                 <input type="button" className="status-bar-input" onClick={() => onClick()} value="Click Me" />
+                <span> {text}</span>
             </span>
         </div>
     );


### PR DESCRIPTION
replace console.log and the old alert with a label that is changed to "x selected" in the status panel itself