### PR TITLE
RTI-2710-onclick-handler-in-status-bar-REVERT

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/component-instance/clickable-status-bar-component.component_angular.ts
+++ b/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/component-instance/clickable-status-bar-component.component_angular.ts
@@ -1,4 +1,4 @@
-import { Component, signal } from '@angular/core';
+import { Component } from '@angular/core';
 
 import type { IStatusPanelAngularComp } from 'ag-grid-angular';
 import type { IStatusPanelParams } from 'ag-grid-community';
@@ -9,10 +9,9 @@ import type { IStatusPanelParams } from 'ag-grid-community';
         @if (visible) {
             <div class="container">
                 <div>
-                    <span class="component">
-                        Status Bar Component <input type="button" (click)="onClick()" value="Click Me" />
-                        {{ text }}
-                    </span>
+                    <span class="component"
+                        >Status Bar Component <input type="button" (click)="onClick()" value="Click Me"
+                    /></span>
                 </div>
             </div>
         }
@@ -21,14 +20,13 @@ import type { IStatusPanelParams } from 'ag-grid-community';
 export class ClickableStatusBarComponent implements IStatusPanelAngularComp {
     public params!: IStatusPanelParams;
     public visible = true;
-    private text = signal<string>('');
 
     agInit(params: IStatusPanelParams): void {
         this.params = params;
     }
 
     onClick(): void {
-        this.text.set(this.params.api.getSelectedRows().length + ' selected');
+        console.log('Selected Row Count: ' + this.params.api.getSelectedRows().length);
     }
 
     setVisible(visible: boolean) {

--- a/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/component-instance/clickableStatusBarComponent_typescript.ts
+++ b/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/component-instance/clickableStatusBarComponent_typescript.ts
@@ -6,7 +6,6 @@ export class ClickableStatusBarComponent implements IStatusPanelComp {
     buttonListener: any;
     visible!: boolean;
     eButton!: HTMLButtonElement;
-    eText!: HTMLSpanElement;
 
     init(params: IStatusPanelParams) {
         this.params = params;
@@ -26,9 +25,6 @@ export class ClickableStatusBarComponent implements IStatusPanelComp {
         this.eButton.textContent = 'Click Me';
 
         this.eGui.appendChild(this.eButton);
-
-        this.eText = document.createElement('span');
-        this.eGui.appendChild(this.eText);
     }
 
     getGui() {
@@ -40,7 +36,7 @@ export class ClickableStatusBarComponent implements IStatusPanelComp {
     }
 
     onButtonClicked() {
-        this.eText.textContent = ' ' + this.params.api.getSelectedRows().length + ' selected';
+        console.log('Selected Row Count: ' + this.params.api.getSelectedRows().length);
     }
 
     setVisible(visible: boolean) {

--- a/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/component-instance/clickableStatusBarComponent_vue3.ts
+++ b/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/component-instance/clickableStatusBarComponent_vue3.ts
@@ -4,20 +4,18 @@ export default {
       <div>
           <span class="component">Status Bar Component&nbsp;
             <input type="button" v-on:click="onClick" value="Click Me"/>
-            {{ text }}
           </span>
       </div>
       </div>
     `,
     data: function () {
         return {
-            text: '',
             visible: true,
         };
     },
     methods: {
         onClick() {
-            this.text = this.params.api.getSelectedRows().length + ' selected';
+            console.log('Selected Row Count: ' + this.params.api.getSelectedRows().length);
         },
         setVisible(visible) {
             this.visible = visible;

--- a/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/component-instance/provided/reactFunctionalTs/clickableStatusBarComponent.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/component-instance/provided/reactFunctionalTs/clickableStatusBarComponent.tsx
@@ -4,10 +4,9 @@ import type { CustomStatusPanelProps } from 'ag-grid-react';
 
 export default forwardRef((props: CustomStatusPanelProps, ref) => {
     const [visible, setVisible] = useState(true);
-    const [text, setText] = useState('');
 
     const onClick = () => {
-        setText(props.api.getSelectedRows().length + ' selected');
+        console.log('Selected Row Count: ' + props.api.getSelectedRows().length);
     };
 
     useImperativeHandle(ref, () => {
@@ -28,7 +27,6 @@ export default forwardRef((props: CustomStatusPanelProps, ref) => {
                     <span className="component">
                         Status Bar Component&nbsp;
                         <input type="button" onClick={() => onClick()} value="Click Me" />
-                        <span> {text}</span>
                     </span>
                 </div>
             </div>

--- a/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/custom-component/clickable-status-bar-component.component_angular.ts
+++ b/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/custom-component/clickable-status-bar-component.component_angular.ts
@@ -1,4 +1,4 @@
-import { Component, signal } from '@angular/core';
+import { Component } from '@angular/core';
 
 import type { IStatusPanelAngularComp } from 'ag-grid-angular';
 import type { IStatusPanelParams } from 'ag-grid-community';
@@ -10,13 +10,11 @@ import type { IStatusPanelParams } from 'ag-grid-community';
             <span class="component">
                 Status Bar Component
                 <input class="status-bar-input" type="button" (click)="onClick()" value="Click Me" />
-                {{ text() }}
             </span>
         </div>
     `,
 })
 export class ClickableStatusBarComponent implements IStatusPanelAngularComp {
-    private text = signal<string>('');
     private params!: IStatusPanelParams;
 
     agInit(params: IStatusPanelParams): void {
@@ -24,6 +22,6 @@ export class ClickableStatusBarComponent implements IStatusPanelAngularComp {
     }
 
     onClick(): void {
-        this.text.set(this.params.api.getSelectedRows().length + ' selected');
+        console.log('Selected Row Count: ' + this.params.api.getSelectedRows().length);
     }
 }

--- a/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/custom-component/clickableStatusBarComponent_typescript.ts
+++ b/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/custom-component/clickableStatusBarComponent_typescript.ts
@@ -4,9 +4,7 @@ export class ClickableStatusBarComponent implements IStatusPanelComp {
     params!: IStatusPanelParams;
     eGui!: HTMLDivElement;
     eButton!: HTMLButtonElement;
-    eCounter!: HTMLSpanElement;
     buttonListener: any;
-    clickCount: number = 0;
 
     init(params: IStatusPanelParams) {
         this.params = params;
@@ -24,10 +22,7 @@ export class ClickableStatusBarComponent implements IStatusPanelComp {
         this.eButton.addEventListener('click', this.buttonListener);
         this.eButton.textContent = 'Click Me';
 
-        this.eCounter = document.createElement('span');
-
         this.eGui.appendChild(this.eButton);
-        this.eGui.appendChild(this.eCounter);
     }
 
     getGui() {
@@ -39,6 +34,6 @@ export class ClickableStatusBarComponent implements IStatusPanelComp {
     }
 
     onButtonClicked() {
-        this.eCounter.textContent = ` ${this.params.api.getSelectedRows().length} selected`;
+        console.log('Selected Row Count: ' + this.params.api.getSelectedRows().length);
     }
 }

--- a/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/custom-component/clickableStatusBarComponent_vue3.ts
+++ b/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/custom-component/clickableStatusBarComponent_vue3.ts
@@ -3,18 +3,15 @@ export default {
       <div class="ag-status-name-value">
           <span>Status Bar Component&nbsp; 
             <input type="button" class="status-bar-input" v-on:click="onClick" value="Click Me"/>
-            {{ text }}
           </span>
       </div>
     `,
     data: function () {
-        return {
-            text: '',
-        };
+        return {};
     },
     methods: {
         onClick() {
-            this.text = this.params.api.getSelectedRows().length + ' selected';
+            console.log('Selected Row Count: ' + this.params.api.getSelectedRows().length);
         },
     },
 };

--- a/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/custom-component/provided/reactFunctionalTs/clickableStatusBarComponent.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/custom-component/provided/reactFunctionalTs/clickableStatusBarComponent.tsx
@@ -3,10 +3,8 @@ import React from 'react';
 import type { CustomStatusPanelProps } from 'ag-grid-react';
 
 export default (props: CustomStatusPanelProps) => {
-    const [text, setText] = React.useState('');
-
     const onClick = () => {
-        setText(props.api.getSelectedRows().length + ' selected');
+        console.log('Selected Row Count: ' + props.api.getSelectedRows().length);
     };
 
     return (
@@ -14,7 +12,6 @@ export default (props: CustomStatusPanelProps) => {
             <span>
                 Status Bar Component&nbsp;
                 <input type="button" className="status-bar-input" onClick={() => onClick()} value="Click Me" />
-                <span> {text}</span>
             </span>
         </div>
     );


### PR DESCRIPTION
Reverts ag-grid/ag-grid#10489

We agreed that this will be handled separately with the console logger so we don't need to specify anything