### PR TITLE
RTI-2729-tooltips-at-the-bottom-of-examples-do-not-point-directly-at-their-icons

### DIFF
--- a/external/ag-website-shared/src/components/open-in-cta/OpenInCTA.module.scss
+++ b/external/ag-website-shared/src/components/open-in-cta/OpenInCTA.module.scss
@@ -2,6 +2,7 @@
 
 .cta {
     position: relative;
+    display: inline-block;
 }
 
 a.cta,


### PR DESCRIPTION
The problem appears to be due to the fact that .cta is by default an inline element, and so it will have no width when it contains a block element.
Setting it to inline-block fix the problem. Checked places where cta is used (link buttons) and seems that all is fine