### PR TITLE
[AG-12347] Maintenance(ag-grid): performance rowrenderer implement forall methods instead of creating copies

### DIFF
--- a/packages/ag-grid-community/src/edit/editService.ts
+++ b/packages/ag-grid-community/src/edit/editService.ts
@@ -155,12 +155,12 @@ export class EditService extends BeanStub implements NamedBean {
         rowCtrl.stoppingRowEdit = true;
 
         let fireRowEditEvent = false;
-        for (const ctrl of cellControls) {
+        cellControls.forEach((ctrl) => {
             const valueChanged = ctrl.stopEditing(cancel);
             if (isRowEdit && !cancel && !fireRowEditEvent && valueChanged) {
                 fireRowEditEvent = true;
             }
-        }
+        });
 
         if (fireRowEditEvent) {
             this.eventSvc.dispatchEvent(rowCtrl.createRowEvent('rowValueChanged'));

--- a/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
@@ -1337,7 +1337,7 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
             ...sharedProxyArrayMethods,
             forEach(callbackfn: (value: CellCtrl) => void) {
                 for (let i = 0; i < self.centerCellCtrls.list.length; i++) {
-                    callbackfn(self.leftCellCtrls.list[i]);
+                    callbackfn(self.centerCellCtrls.list[i]);
                 }
                 for (let i = 0; i < self.leftCellCtrls.list.length; i++) {
                     callbackfn(self.leftCellCtrls.list[i]);

--- a/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
@@ -1328,12 +1328,25 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         }
     }
 
-    public getAllCellCtrls(): CellCtrl[] {
-        if (this.leftCellCtrls.list.length === 0 && this.rightCellCtrls.list.length === 0) {
-            return this.centerCellCtrls.list;
-        }
-        const res = [...this.centerCellCtrls.list, ...this.leftCellCtrls.list, ...this.rightCellCtrls.list];
-        return res;
+    public getAllCellCtrls() {
+        const self = this;
+
+        // return a proxy object that allows us to iterate over all cellCtrls
+        // this optimization is here to avoid having to create a new array every time we want to iterate
+        return {
+            ...sharedProxyArrayMethods,
+            forEach(callbackfn: (value: CellCtrl) => void) {
+                for (let i = 0; i < self.centerCellCtrls.list.length; i++) {
+                    callbackfn(self.leftCellCtrls.list[i]);
+                }
+                for (let i = 0; i < self.leftCellCtrls.list.length; i++) {
+                    callbackfn(self.leftCellCtrls.list[i]);
+                }
+                for (let i = 0; i < self.rightCellCtrls.list.length; i++) {
+                    callbackfn(self.rightCellCtrls.list[i]);
+                }
+            },
+        };
     }
 
     private postProcessClassesFromGridOptions(): void {
@@ -1811,3 +1824,26 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         });
     }
 }
+
+/**
+ * This is an optimization effort to cut on array copying
+ * we checked this callback based approach is the fastest (compared to generators, iterators, and straight up array copy + forEach)
+ * see AG-12347
+ */
+export const sharedProxyArrayMethods = {
+    forEach<T extends CellCtrl>(_callbackfn: (value: T) => void) {}, // placeholder, meant to be overridden
+    find<T extends CellCtrl>(predicate: (value: T) => boolean): T | undefined {
+        let found: T | undefined;
+        this.forEach((value) => {
+            if (predicate(value as T)) {
+                found = value as T;
+            }
+        });
+        return found;
+    },
+    // careful, this is not the same as Array.prototype.some, as it doesn't support
+    // undefined values in the array, since that would require copying code from find()
+    some<T extends CellCtrl>(predicate: (value: T) => boolean): boolean {
+        return this.find(predicate) !== undefined;
+    },
+};

--- a/packages/ag-grid-community/src/rendering/rowRenderer.ts
+++ b/packages/ag-grid-community/src/rendering/rowRenderer.ts
@@ -32,7 +32,8 @@ import { _requestAnimationFrame } from '../utils/dom';
 import { _exists } from '../utils/generic';
 import { _errMsg } from '../validation/logging';
 import type { CellCtrl } from './cell/cellCtrl';
-import { RowCtrlInstanceId, sharedProxyArrayMethods } from './row/rowCtrl';
+import type { RowCtrlInstanceId } from './row/rowCtrl';
+import { sharedProxyArrayMethods } from './row/rowCtrl';
 import { RowCtrl } from './row/rowCtrl';
 import type { RowContainerHeightService } from './rowContainerHeightService';
 
@@ -893,7 +894,7 @@ export class RowRenderer extends BeanStub implements NamedBean {
         return {
             ...sharedProxyArrayMethods,
             forEach(callbackfn: (value: CellCtrl) => void) {
-                let rowCtrls = self.getRowCtrls(rowNodes);
+                const rowCtrls = self.getRowCtrls(rowNodes);
                 for (let i = 0; i < rowCtrls.length; i++) {
                     const rowCtrl = rowCtrls[i];
                     rowCtrl.getAllCellCtrls().forEach((cellCtrl) => {

--- a/packages/ag-grid-community/src/rendering/rowRenderer.ts
+++ b/packages/ag-grid-community/src/rendering/rowRenderer.ts
@@ -782,12 +782,11 @@ export class RowRenderer extends BeanStub implements NamedBean {
 
     public getAllCellCtrls() {
         const rowCtrls = this.getAllRowCtrls();
-        const rowCtrlsLength = rowCtrls.length;
 
         return {
             ...sharedProxyArrayMethods,
             forEach(callbackfn: (value: CellCtrl) => void) {
-                for (let i = 0; i < rowCtrlsLength; i++) {
+                for (let i = 0; i < rowCtrls.length; i++) {
                     rowCtrls[i].getAllCellCtrls().forEach(callbackfn);
                 }
             },

--- a/packages/ag-grid-community/src/rendering/rowRenderer.ts
+++ b/packages/ag-grid-community/src/rendering/rowRenderer.ts
@@ -32,7 +32,7 @@ import { _requestAnimationFrame } from '../utils/dom';
 import { _exists } from '../utils/generic';
 import { _errMsg } from '../validation/logging';
 import type { CellCtrl } from './cell/cellCtrl';
-import type { RowCtrlInstanceId } from './row/rowCtrl';
+import { RowCtrlInstanceId, sharedProxyArrayMethods } from './row/rowCtrl';
 import { RowCtrl } from './row/rowCtrl';
 import type { RowContainerHeightService } from './rowContainerHeightService';
 
@@ -780,21 +780,18 @@ export class RowRenderer extends BeanStub implements NamedBean {
         return null;
     }
 
-    public getAllCellCtrls(): CellCtrl[] {
-        const res: CellCtrl[] = [];
+    public getAllCellCtrls() {
         const rowCtrls = this.getAllRowCtrls();
         const rowCtrlsLength = rowCtrls.length;
 
-        for (let i = 0; i < rowCtrlsLength; i++) {
-            const cellCtrls = rowCtrls[i].getAllCellCtrls();
-            const cellCtrlsLength = cellCtrls.length;
-
-            for (let j = 0; j < cellCtrlsLength; j++) {
-                res.push(cellCtrls[j]);
-            }
-        }
-
-        return res;
+        return {
+            ...sharedProxyArrayMethods,
+            forEach(callbackfn: (value: CellCtrl) => void) {
+                for (let i = 0; i < rowCtrlsLength; i++) {
+                    rowCtrls[i].getAllCellCtrls().forEach(callbackfn);
+                }
+            },
+        };
     }
 
     public getAllRowCtrls(): RowCtrl[] {
@@ -832,9 +829,9 @@ export class RowRenderer extends BeanStub implements NamedBean {
             newData: false,
             suppressFlash: params.suppressFlash,
         };
-        for (const cellCtrl of this.getCellCtrls(params.rowNodes, params.columns as AgColumn[])) {
-            cellCtrl.refreshOrDestroyCell(refreshCellParams);
-        }
+        this.getCellCtrls(params.rowNodes, params.columns as AgColumn[]).forEach((cellCtrl) =>
+            cellCtrl.refreshOrDestroyCell(refreshCellParams)
+        );
 
         // refresh the full width rows too
         this.refreshFullWidth(params.rowNodes);
@@ -881,7 +878,7 @@ export class RowRenderer extends BeanStub implements NamedBean {
 
     // returns CellCtrl's that match the provided rowNodes and columns. eg if one row node
     // and two columns provided, that identifies 4 cells, so 4 CellCtrl's returned.
-    public getCellCtrls(rowNodes?: IRowNode[] | null, columns?: (string | AgColumn)[]): CellCtrl[] {
+    public getCellCtrls(rowNodes?: IRowNode[] | null, columns?: (string | AgColumn)[]) {
         let colIdsMap: any;
         if (_exists(columns)) {
             colIdsMap = {};
@@ -893,20 +890,26 @@ export class RowRenderer extends BeanStub implements NamedBean {
             });
         }
 
-        const res: CellCtrl[] = [];
-        this.getRowCtrls(rowNodes).forEach((rowCtrl) => {
-            rowCtrl.getAllCellCtrls().forEach((cellCtrl) => {
-                const colId: string = cellCtrl.column.getId();
-                const excludeColFromRefresh = colIdsMap && !colIdsMap[colId];
+        const self = this;
+        return {
+            ...sharedProxyArrayMethods,
+            forEach(callbackfn: (value: CellCtrl) => void) {
+                let rowCtrls = self.getRowCtrls(rowNodes);
+                for (let i = 0; i < rowCtrls.length; i++) {
+                    const rowCtrl = rowCtrls[i];
+                    rowCtrl.getAllCellCtrls().forEach((cellCtrl) => {
+                        const colId: string = cellCtrl.column.getId();
+                        const excludeColFromRefresh = colIdsMap && !colIdsMap[colId];
 
-                if (excludeColFromRefresh) {
-                    return;
+                        if (excludeColFromRefresh) {
+                            return;
+                        }
+
+                        callbackfn(cellCtrl);
+                    });
                 }
-
-                res.push(cellCtrl);
-            });
-        });
-        return res;
+            },
+        };
     }
 
     public override destroy(): void {


### PR DESCRIPTION
# Summary

Removes array copying in a loop. Replaces looping over array copy with a lazy-ish iteration. 

## Notes

Benchmark: https://jsbench.me/nkmalaqjfu/5 
Fixes: https://ag-grid.atlassian.net/browse/AG-12347 