### PR TITLE
fix(ag-grid-react): expose isFilterActive

### DIFF
--- a/packages/ag-grid-react/src/shared/customComp/filterComponentWrapper.ts
+++ b/packages/ag-grid-react/src/shared/customComp/filterComponentWrapper.ts
@@ -19,6 +19,9 @@ export class FilterComponentWrapper
     });
 
     public isFilterActive(): boolean {
+        if (this.providedMethods?.isFilterActive) {
+            return this.providedMethods.isFilterActive(this.model);
+        }
         return this.model != null;
     }
 

--- a/packages/ag-grid-react/src/shared/customComp/interfaces.ts
+++ b/packages/ag-grid-react/src/shared/customComp/interfaces.ts
@@ -157,7 +157,16 @@ export interface CustomCellEditorCallbacks extends BaseCellEditor {}
 export interface CustomDateCallbacks extends BaseDate {}
 
 /** Callbacks for custom filter components */
-export interface CustomFilterCallbacks extends BaseFilter {}
+export interface CustomFilterCallbacks extends BaseFilter {
+    /** enable to customize isFilterActive callback
+     *
+     * copied from IFilter
+     * Returns `true` if the filter is currently active, otherwise `false`.
+     * If active then 1) the grid will show the filter icon in the column header
+     * and 2) the filter will be included in the filtering of the data.
+     */
+    isFilterActive?: (model: any) => boolean;
+}
 
 /** Callbacks for custom floating filter components */
 export interface CustomFloatingFilterCallbacks extends BaseFloatingFilter {}


### PR DESCRIPTION
I have provided a fix for the issue I created:
https://github.com/ag-grid/ag-grid/issues/10558

Thanks to this fix `useGridFilter` now accepts `isFilterActive` which can be very helpful during creation of custom filters

Since I was unable to start your dev env, I have build the project and tested the change using my project.
If you guide me towards running local env & tests I am happy to add test cases for this.
