### PR TITLE
AG-14155 Add param to ebable useTransition for cell renderers

### DIFF
--- a/packages/ag-grid-react/src/reactUi/cells/cellComp.tsx
+++ b/packages/ag-grid-react/src/reactUi/cells/cellComp.tsx
@@ -18,7 +18,7 @@ import { CustomContext } from '../../shared/customComp/customContext';
 import type { CustomCellEditorCallbacks } from '../../shared/customComp/interfaces';
 import { warnReactiveCustomComponents } from '../../shared/customComp/util';
 import { BeansContext } from '../beansContext';
-import { isComponentStateless } from '../utils';
+import { agStartTransition, isComponentStateless } from '../utils';
 import PopupEditorComp from './popupEditorComp';
 import useJsCellRenderer from './showJsRenderer';
 
@@ -403,17 +403,25 @@ const CellComp = ({
             getParentOfValue: () => eCellValue.current ?? eCellWrapper.current ?? eGui.current,
 
             setRenderDetails: (compDetails, value, force) => {
-                setRenderDetails((prev) => {
-                    if (prev?.compDetails !== compDetails || prev?.value !== value || prev?.force !== force) {
-                        return {
-                            value,
-                            compDetails,
-                            force,
-                        };
-                    } else {
-                        return prev;
-                    }
-                });
+                const updateRenderDetails = () => {
+                    setRenderDetails((prev) => {
+                        if (prev?.compDetails !== compDetails || prev?.value !== value || prev?.force !== force) {
+                            return {
+                                value,
+                                compDetails,
+                                force,
+                            };
+                        } else {
+                            return prev;
+                        }
+                    });
+                };
+
+                if (compDetails?.params?.useTransition) {
+                    agStartTransition(updateRenderDetails);
+                } else {
+                    updateRenderDetails();
+                }
             },
 
             setEditDetails: (compDetails, popup, popupPosition, reactiveCustomComponents) => {

--- a/packages/ag-grid-react/src/reactUi/utils.tsx
+++ b/packages/ag-grid-react/src/reactUi/utils.tsx
@@ -85,6 +85,17 @@ export const agFlushSync = (useFlushSync: boolean, fn: () => void) => {
 };
 
 /**
+ * Wrapper around startTransition to provide backwards compatibility with React 16-17 *
+ */
+export const agStartTransition = (fn: () => void) => {
+    if (!isReactVersion17Minus) {
+        (React as any).startTransition(fn);
+    } else {
+        fn();
+    }
+};
+
+/**
  * The aim of this function is to maintain references to prev or next values where possible.
  * If there are not real changes then return the prev value to avoid unnecessary renders.
  * @param maintainOrder If we want to maintain the order of the elements in the dom in line with the next array


### PR DESCRIPTION
This enables slow / problematic custom cell renderers to be removed from the blocking path of the rendering of rows.

This prevents slow renderers from blocking the rendering of other cells by making their rendering asynchronous. 

This also fixes the issues with some custom cell renderers triggering React's Maximum update depth error.

Enable as

```
cellRenderer: SlowRenderer,
cellRendererParams:{ useTransition: true }
```