### PR TITLE
AG-14984-children-mapped-can-be-null

### DIFF
--- a/packages/ag-grid-community/src/entities/rowNode.ts
+++ b/packages/ag-grid-community/src/entities/rowNode.ts
@@ -193,16 +193,8 @@ export class RowNode<TData = any>
     /** Number of children and grand children. */
     public allChildrenCount: number | null;
 
-    /**
-     * Children mapped by the pivot columns.
-     *
-     * TODO: this field is currently used only by the GroupStrategy and Pivot.
-     * TreeStrategy does not use it, and pivot cannot be enabled with tree data.
-     * Creating a new object for every row when not pivoting and not grouping
-     * consumes memory unnecessarily. Setting it to null however currently breaks
-     * transactional updates in groups so this requires a deeper investigation on GroupStrategy.
-     */
-    public childrenMapped: { [key: string]: any } | null = {};
+    /** Children mapped by the pivot columns or group key */
+    public childrenMapped: { [key: string]: any } | null = null;
 
     /**
      * Used only by tree data internally.

--- a/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/groupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/groupStrategy.ts
@@ -383,14 +383,13 @@ export class GroupStrategy extends BeanStub implements IRowGroupingStrategy {
     /**
      * This is idempotent, but relies on the `key` field being the same throughout a RowNode's lifetime
      */
-    private addToParent(child: RowNode, parent: RowNode | null) {
+    private addToParent(child: RowNode, parent: RowNode) {
+        const childrenMapped = (parent.childrenMapped ??= {});
         const mapKey = this.getChildrenMappedKey(child.key!, child.rowGroupColumn);
-        if (parent?.childrenMapped) {
-            if (parent.childrenMapped[mapKey] !== child) {
-                parent.childrenMapped[mapKey] = child;
-                parent.childrenAfterGroup!.push(child);
-                setRowNodeGroup(parent, this.beans, true); // calls `.updateHasChildren` internally
-            }
+        if (childrenMapped[mapKey] !== child) {
+            childrenMapped[mapKey] = child;
+            parent.childrenAfterGroup!.push(child);
+            setRowNodeGroup(parent, this.beans, true); // calls `.updateHasChildren` internally
         }
     }
 

--- a/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/groupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/groupStrategy.ts
@@ -11,6 +11,7 @@ import type {
     InitialGroupOrderComparatorParams,
     IsGroupOpenByDefaultParams,
     KeyCreatorParams,
+    RowGroupingRowNode,
     StageExecuteParams,
     ValueService,
     WithoutGridCommon,
@@ -383,12 +384,12 @@ export class GroupStrategy extends BeanStub implements IRowGroupingStrategy {
     /**
      * This is idempotent, but relies on the `key` field being the same throughout a RowNode's lifetime
      */
-    private addToParent(child: RowNode, parent: RowNode) {
+    private addToParent(child: RowNode, parent: RowGroupingRowNode) {
         const childrenMapped = (parent.childrenMapped ??= {});
         const mapKey = this.getChildrenMappedKey(child.key!, child.rowGroupColumn);
         if (childrenMapped[mapKey] !== child) {
             childrenMapped[mapKey] = child;
-            parent.childrenAfterGroup!.push(child);
+            (parent.childrenAfterGroup ??= []).push(child);
             setRowNodeGroup(parent, this.beans, true); // calls `.updateHasChildren` internally
         }
     }


### PR DESCRIPTION
Currently, childrenMapped in the RowNode class is set to a new object on construction, for every row also when grouping, treeData and pivoting is not used.

This allocates a new object for every row that has a cost, also when is not used, and makes using this field for tree data in the future harder.

There was a simple check missing in the grouping stage, that made addToParent not work in case of transactional update if this field was null.

In pivoting handles this gracefully, and treeData does not use this field currently.

Verified (manually and also with unit tests) that this does not break existing grouping.