### PR TITLE
[AG-15001] Fix(ag-grid): advanced filter allow advanced filter to support date time filtering 

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/cell-data-types/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/cell-data-types/index.mdoc
@@ -261,7 +261,7 @@ const gridOptions = {
 The following example demonstrates overriding pre-defined cell data types:
 
 * The **Date** column is of type `'dateString'` which has been overridden to use a different date format (`dd/mm/yyyy`).
-* The data type definition for `'dateString'` provides a `dateParser` and `dateFormatter` as it is a [Date as String Data Type Definition](#date-as-string-data-type-definition).
+* The data type definition for `'dateString'` provides a `dateParser` and `dateFormatter` as it is a [Date as String Data Type Definition](#date-as-string).
 
 {% gridExampleRunner title="Overriding Pre-Defined Cell Data Types" name="overriding-pre-defined-cell-data-types" /%}
 

--- a/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
@@ -103,28 +103,28 @@ For all [Cell Data Types](./cell-data-types/), the available filter options can 
 
 The available options are as follows:
 
-| Option Name             | Option Key            | Cell Data Type                                              |
-| ----------------------- | --------------------- | ----------------------------------------------------------- |
-| contains                | `contains`            | `text`, `object`                                            |
-| does not contain        | `notContains`         | `text`, `object`                                            |
-| equals                  | `equals`              | `text`, `object`                                            |
-| =                       | `equals`              | `number`, `date`, `dateString`                              |
-| not equal               | `notEqual`            | `text`, `object`                                            |
-| !=                      | `notEqual`            | `number`, `date`, `dateString`                              |
-| begins with             | `startsWith`          | `text`, `object`                                            |
-| ends with               | `endsWith`            | `text`, `object`                                            |
-| is blank                | `blank`               | `text`, `number`, `boolean`, `date`, `dateString`, `object` |
-| is not blank            | `notBlank`            | `text`, `number`, `boolean`, `date`, `dateString`, `object` |
-| >                       | `greaterThan`         | `number`, `date`, `dateString`                              |
-| >=                      | `greaterThanOrEqual`  | `number`, `date`, `dateString`                              |
-| <                       | `lessThan`            | `number`, `date`, `dateString`                              |
-| <=                      | `lessThanOrEqual`     | `number`, `date`, `dateString`                              |
-| is true                 | `true`                | `boolean`                                                   |
-| is false                | `false`               | `boolean`                                                   |
+| Option Name      | Option Key           | Cell Data Type                                                                            |
+|------------------|----------------------|-------------------------------------------------------------------------------------------|
+| contains         | `contains`           | `text`, `object`                                                                          |
+| does not contain | `notContains`        | `text`, `object`                                                                          |
+| equals           | `equals`             | `text`, `object`                                                                          |
+| =                | `equals`             | `number`, `date`, `dateString`, `dateTime`, `dateTimeString`                              |
+| not equal        | `notEqual`           | `text`, `object`                                                                          |
+| !=               | `notEqual`           | `number`, `date`, `dateString`, `dateTime`, `dateTimeString`                              |
+| begins with      | `startsWith`         | `text`, `object`                                                                          |
+| ends with        | `endsWith`           | `text`, `object`                                                                          |
+| is blank         | `blank`              | `text`, `number`, `boolean`, `date`, `dateString`, `dateTime`, `dateTimeString`, `object` |
+| is not blank     | `notBlank`           | `text`, `number`, `boolean`, `date`, `dateString`, `dateTime`, `dateTimeString`, `object` |
+| >                | `greaterThan`        | `number`, `date`, `dateString`, `dateTime`, `dateTimeString`                              |
+| >=               | `greaterThanOrEqual` | `number`, `date`, `dateString`, `dateTime`, `dateTimeString`                              |
+| <                | `lessThan`           | `number`, `date`, `dateString`, `dateTime`, `dateTimeString`                              |
+| <=               | `lessThanOrEqual`    | `number`, `date`, `dateString`, `dateTime`, `dateTimeString`                              |
+| is true          | `true`               | `boolean`                                                                                 |
+| is false         | `false`              | `boolean`                                                                                 |
 
 For `text` and `object` Cell Data Types, `caseSensitive = true` can be set to enable case sensitivity.
 
-For `number`, `date` and `dateString` Cell Data Types, the following properties can be set to include blank values for the relevant options:
+For `number`, `date`, `dateString`, `dateTime` and `dateTimeString` Cell Data Types, the following properties can be set to include blank values for the relevant options:
 
 * `includeBlanksInEquals = true`
 * `includeBlanksInLessThan = true`

--- a/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
@@ -240,8 +240,8 @@ All of the [Cell Data Types](./cell-data-types) are supported in the Advanced Fi
 * **Text** - The value in the input is compared against the cell value before any [Value Formatters](./value-formatters/) are applied (similar to the [Text Filter](./filter-text/)). To change the value being compared against, a [Filter Value Getter](./filter-text/#text-filter-values) can be used.
 * **Number** - The value in the input is compared against the cell value (like in the [Number Filter](./filter-number/)).
 * **Boolean** - No values are displayed for booleans as the filter option is used instead.
-* **Date** - The value in the input is converted to a `Date` via the [Value Parser](./value-parsers/#value-parser).
-* **Date String** - The value in the input is converted to a `Date` using the [Value Parser](./value-parsers/#value-parser) and the [Date Parser](./cell-data-types/#date-as-string-data-type-definition). This is compared against the cell values, which are also converted using the Date Parser.
+* **Date** and **Date Time** - The value in the input is converted to a `Date` via the [Value Parser](./value-parsers/#value-parser).
+* **Date String** and **Date Time String** - The value in the input is converted to a `Date` using the [Value Parser](./value-parsers/#value-parser) and the [Date Parser](./cell-data-types/#date-as-string). This is compared against the cell values, which are also converted using the Date Parser.
 * **Object** - The value in the input is compared against the values returned by the [Filter Value Getter](./column-properties/#reference-filtering-filterValueGetter) if one is provided. Otherwise, the cell values are converted using the [Value Formatter](./value-formatters/).
 
 ## Aggregation / Pivoting

--- a/documentation/ag-grid-docs/src/content/docs/filter-date/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-date/index.mdoc
@@ -59,10 +59,10 @@ The example below demonstrates configuring date range filtering in the Date Filt
 
 Dates can be represented in your data in many ways e.g. as a JavaScript `Date` object, as a string in a particular format such as `'26-MAR-2020'`, or something else. How you represent dates will be particular to your application.
 
-The Date Filter will automatically be configured to work correctly if the [Cell Data Type](./cell-data-types/) is `date` or `dateString`.
+The Date Filter will automatically be configured to work correctly if the [Cell Data Type](./cell-data-types/) is `date`, `dateString`, `dateTime` or `dateTimeString`.
 
 {% note %}
-If using `Date` objects, the default date comparator assumes that the `Date`s do not have a time (e.g. they are at midnight local time). If your dates have times, then you will either need to override the [Filter Values](#filter-values) to remove the time, or provide a `comparator` that can handle the time.
+If using `Date` objects, the default date comparator assumes that the `Date`s do not have a time (e.g. they are at midnight local time). If your dates have times, then you will either need to override the [Filter Values](#filter-values) to remove the time, to switch cell data type to `dateTime`, or provide a `comparator` that can handle the time.
 {% /note %}
 
 If you are not using Cell Data Types (and the cell value is not a `Date` object, which will also work automatically), then a `comparator` needs to be configured to allow the Date Filter to perform the date comparisons.

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-date/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-date/index.mdoc
@@ -39,7 +39,7 @@ Edit any of the cells in the grid below to see the Date as String Cell Editor.
 
 The Date as String Cell Editor is a simple date editor that uses the standard HTML date input. It's similar to the Date Cell Editor, but works off of cell values with type [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String).
 
-The date format is controlled via [Cell Data Types](./cell-data-types/) and the [Date as String Data Type Definition](./cell-data-types/#date-as-string-data-type-definition). The default is `'yyyy-mm-dd'`.
+The date format is controlled via [Cell Data Types](./cell-data-types/) and the [Date as String Data Type Definition](./cell-data-types/#date-as-string). The default is `'YYYY-MM-DD'` (or `'YYYY-MM-DDTHH:mm:ss'` for `dateTimeString`).
 
 Enabled with `agDateStringCellEditor` and configured with `IDateStringCellEditorParams`.
 

--- a/packages/ag-grid-community/src/columns/dataTypeService.ts
+++ b/packages/ag-grid-community/src/columns/dataTypeService.ts
@@ -437,7 +437,7 @@ export class DataTypeService extends BeanStub implements NamedBean {
         return this.getDateStringTypeDefinition(column).dateFormatter!;
     }
 
-    public getDateIncludesTimeFlag(cellDataType?: any): cellDataType is 'dateTime' | 'dateTimeString' {
+    public getDateIncludesTimeFlag(cellDataType?: any): boolean {
         return cellDataType === 'dateTime' || cellDataType === 'dateTimeString';
     }
 

--- a/packages/ag-grid-community/src/interfaces/advancedFilterModel.ts
+++ b/packages/ag-grid-community/src/interfaces/advancedFilterModel.ts
@@ -103,7 +103,7 @@ export interface DateTimeAdvancedFilterModel {
     colId: string;
     /** The filter option that is being applied. */
     type: ScalarAdvancedFilterModelType;
-    /** The value to filter on. This is in format `YYYY-MM-DD HH:mm:ss`. */
+    /** The value to filter on. This is in format `YYYY-MM-DDTHH:mm:ss`. */
     filter?: string;
 }
 

--- a/packages/ag-grid-enterprise/src/advancedFilter/builder/advancedFilterBuilderItemComp.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/builder/advancedFilterBuilderItemComp.ts
@@ -1,5 +1,4 @@
 import type {
-    BaseCellDataType,
     BeanCollection,
     DragAndDropService,
     DragSource,
@@ -423,7 +422,7 @@ export class AdvancedFilterBuilderItemComp extends TabGuardComp<AdvancedFilterBu
                     value: key,
                     valueFormatter,
                     cssClass,
-                    type: this.inputType[baseCellDataType],
+                    type: baseCellDataType,
                     ariaLabel,
                 })
             );
@@ -431,17 +430,6 @@ export class AdvancedFilterBuilderItemComp extends TabGuardComp<AdvancedFilterBu
             return comp;
         }
     }
-
-    private inputType: Record<BaseCellDataType, 'number' | 'text' | 'date'> = {
-        number: 'number',
-        boolean: 'text',
-        object: 'text',
-        text: 'text',
-        date: 'date',
-        dateString: 'date',
-        dateTime: 'date',
-        dateTimeString: 'date',
-    };
 
     private setupDragging(): void {
         const dragSource: DragSource = {

--- a/packages/ag-grid-enterprise/src/advancedFilter/builder/inputPillComp.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/builder/inputPillComp.ts
@@ -1,4 +1,10 @@
-import type { BeanCollection, ElementParams, FieldValueEvent, WithoutGridCommon } from 'ag-grid-community';
+import type {
+    BaseCellDataType,
+    BeanCollection,
+    ElementParams,
+    FieldValueEvent,
+    WithoutGridCommon,
+} from 'ag-grid-community';
 import {
     AgInputDateField,
     AgInputNumberField,
@@ -16,6 +22,20 @@ import {
 import type { AdvancedFilterExpressionService } from '../advancedFilterExpressionService';
 
 export type InputPillCompEvent = 'fieldValueChanged';
+
+type SupportedComponent = typeof AgInputTextField | typeof AgInputNumberField | typeof AgInputDateField;
+const inputComponentDescriptors: {
+    [S in BaseCellDataType]: [SupportedComponent] | [SupportedComponent, ConstructorParameters<SupportedComponent>];
+} = {
+    number: [AgInputNumberField],
+    boolean: [AgInputTextField],
+    object: [AgInputTextField],
+    text: [AgInputTextField],
+    date: [AgInputDateField],
+    dateString: [AgInputDateField],
+    dateTime: [AgInputDateField, [{ includeTime: true }]],
+    dateTimeString: [AgInputDateField, [{ includeTime: true }]],
+};
 
 const InputPillElement: ElementParams = {
     tag: 'div',
@@ -56,7 +76,7 @@ export class InputPillComp extends Component<InputPillCompEvent> {
             value: string;
             valueFormatter: (value: string) => string;
             cssClass: string;
-            type: 'text' | 'number' | 'date';
+            type: BaseCellDataType;
             ariaLabel: string;
         }
     ) {
@@ -129,22 +149,9 @@ export class InputPillComp extends Component<InputPillCompEvent> {
         this.eEditor.getFocusableElement().focus();
     }
 
-    private createEditorComp(
-        type: 'text' | 'number' | 'date'
-    ): AgInputTextField | AgInputNumberField | AgInputDateField {
-        let comp;
-        switch (type) {
-            case 'text':
-                comp = new AgInputTextField();
-                break;
-            case 'number':
-                comp = new AgInputNumberField();
-                break;
-            case 'date':
-                comp = new AgInputDateField();
-                break;
-        }
-        return this.createBean(comp);
+    private createEditorComp(type: BaseCellDataType): AgInputTextField {
+        const [Comp, args] = inputComponentDescriptors[type];
+        return this.createBean(new Comp(...(args ?? [])));
     }
 
     private hideEditor(keepFocus: boolean): void {


### PR DESCRIPTION
Earlier today we merged support for 2 new data types. However, I missed a few places where data types are handled separately. This PR addresses that miss. 

QA plnkr: https://plnkr.co/edit/rjW7EA8gvCneaSqU?open=main.ts&preview (freeform filter should work; filter builder should allow date time input, not only date)

Fixes: https://ag-grid.atlassian.net/browse/AG-15001