### PR TITLE
AG-3390 - Check last job status even if it's not on latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,7 +491,7 @@ jobs:
 
       - name: Check last job status
         id: lastJobStatus
-        if: always() && github.ref == 'refs/heads/latest'
+        if: always()
         run: |
           WORKFLOW_STATUS="success"
           if [[ "${{ needs.build_lint.result }}" == "failure" ]] ; then


### PR DESCRIPTION
eg, on PRs, want to fail further steps, so that auto merge is not accepted

Example of this working in https://github.com/ag-grid/ag-grid/actions/runs/15304809533