### PR TITLE
[AG-14998] Fix(ag-grid): column filtering when single digit dates are used in set filter a zero is missing in the format padding

### DIFF
--- a/packages/ag-grid-community/src/utils/date.ts
+++ b/packages/ag-grid-community/src/utils/date.ts
@@ -51,14 +51,14 @@ export function _getDateParts(d: Date | null | undefined, includeTime: boolean =
         return [
             String(d.getFullYear()),
             String(d.getMonth() + 1),
-            String(d.getDate()),
+            _padStartWidthZeros(d.getDate(), 2),
             _padStartWidthZeros(d.getHours(), 2),
             `:${_padStartWidthZeros(d.getMinutes(), 2)}`,
             `:${_padStartWidthZeros(d.getSeconds(), 2)}`,
         ];
     }
 
-    return [d.getFullYear(), d.getMonth() + 1, d.getDate()].map(String);
+    return [d.getFullYear(), d.getMonth() + 1, _padStartWidthZeros(d.getDate(), 2)].map(String);
 }
 
 const calculateOrdinal = (value: number) => {


### PR DESCRIPTION
# Summary

Previously, we rendered non-padded day of the month number. MS Excel has it padded, so we are going to replicate that. This is only rendering thing, but still may be considered a breaking change. 

| Before | After |
|--------|--------|
| ![Screenshot 2025-05-29 at 11 05 16](https://github.com/user-attachments/assets/719343c4-643b-4ddf-a2db-20c7aa38bc7d) | ![Screenshot 2025-05-29 at 11 08 24](https://github.com/user-attachments/assets/37b7d3fc-edac-4795-8ce4-c84ed338e186) | 

## Notes

- Breaking change, to be included in the next major version
- Fixes https://ag-grid.atlassian.net/browse/AG-14998