### PR TITLE
Vitest benchmarks treedata

### DIFF
--- a/testing/behavioural/README.md
+++ b/testing/behavioural/README.md
@@ -26,6 +26,12 @@ To run in watch mode
 nx test ag-behavioural-testing -- -w
 ```
 
+To execute benchmarks
+
+```sh
+nx benchmark ag-behavioural-testing
+```
+
 ## References:
 
 -   https://www.youtube.com/watch?v=EZ05e7EMOLM

--- a/testing/behavioural/package.json
+++ b/testing/behavioural/package.json
@@ -20,7 +20,7 @@
     "@testing-library/user-event": "^14.6.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "typescript": "^5.5.4",
+    "typescript": "~5.6.2",
     "vitest": "2.1.6",
     "xlsx": "^0.18.5"
   },

--- a/testing/behavioural/package.json
+++ b/testing/behavioural/package.json
@@ -4,16 +4,16 @@
   "private": true,
   "description": "Behavioural unit testing for ag-Grid",
   "dependencies": {
-    "tslib": "^2.7.0"
+    "tslib": "^2.8.1"
   },
   "type": "module",
   "devDependencies": {
     "ag-grid-community": "33.3.0",
     "ag-grid-enterprise": "33.3.0",
     "ag-grid-react": "33.3.0",
-    "@vitejs/plugin-react": "^4.4.1",
-    "@types/react": "^18.3.20",
-    "@types/react-dom": "^18.3.6",
+    "@vitejs/plugin-react": "^4.5.1",
+    "@types/react": "^18.3.23",
+    "@types/react-dom": "^18.3.7",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
@@ -21,7 +21,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "typescript": "~5.6.2",
-    "vitest": "2.1.6",
+    "vitest": "2.1.9",
     "xlsx": "^0.18.5"
   },
   "repository": {

--- a/testing/behavioural/project.json
+++ b/testing/behavioural/project.json
@@ -30,6 +30,21 @@
           "update": true
         }
       }
+    },
+    "benchmark": {
+      "command": "vitest bench --run",
+      "dependsOn": ["ag-grid-community:build:css", "ag-grid-enterprise:build:css"],
+      "options": {
+        "cwd": "{projectRoot}"
+      },
+      "configurations": {
+        "watch": {
+          "watch": true
+        },
+        "update": {
+          "update": true
+        }
+      }
     }
   },
   "tags": ["test", "module"]

--- a/testing/behavioural/src/test-utils/index.ts
+++ b/testing/behavioural/src/test-utils/index.ts
@@ -8,3 +8,4 @@ export * from './grid-test-utils';
 export * from './testGridsManager';
 export * from './rows-snapshot';
 export * from './drag-n-drop-utils';
+export * from './prng';

--- a/testing/behavioural/src/test-utils/prng.ts
+++ b/testing/behavioural/src/test-utils/prng.ts
@@ -1,0 +1,57 @@
+/** A simple non cryptographic seeded pseudorandom random number generator */
+export class SimplePRNG {
+    private a: number;
+    private b: number;
+
+    constructor(private readonly seed: number = 0x13d24a75) {
+        this.reset(seed);
+    }
+
+    reset(seed: number = this.seed): this {
+        this.a = seed >>> 0;
+        this.b = 0x6d2b79f5;
+        return this;
+    }
+
+    next(): number {
+        let b = this.b;
+        let x = (this.a += 0x6d2b79f5);
+        b = Math.imul((b << 5) | (b >>> 27), 16807) + 4093;
+        x = Math.imul(x ^ (x >>> 15), x | 1);
+        x ^= x + Math.imul(x ^ (x >>> 7), x | 61);
+        const r = (b ^ x ^ (x >>> 14)) >>> 0;
+        this.b = b + (((r * 2957946851) ^ (x * 139)) >>> (r >>> 27));
+        return r * 2.3283064365386963e-10;
+    }
+
+    nextInt(min: number, max: number): number {
+        return Math.floor(this.next() * (max - min + 1)) + min;
+    }
+
+    nextFloat(min: number, max: number): number {
+        return this.next() * (max - min) + min;
+    }
+
+    nextString(length: number, characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'): string {
+        let result = '';
+        for (let i = 0; i < length; i++) {
+            result += characters.charAt(this.nextInt(0, characters.length - 1));
+        }
+        return result;
+    }
+
+    /** Shuffle an array in place */
+    shuffle<T>(array: T[], start: number = 0, end: number = array.length - 1): T[] {
+        const len = array.length;
+        if (start < 0) start = 0;
+        if (end >= len) end = len - 1;
+        if (end < 0 || start >= end) return array;
+        for (let i = end; i > start; --i) {
+            const j = this.nextInt(start, i);
+            const tmp = array[i];
+            array[i] = array[j];
+            array[j] = tmp;
+        }
+        return array;
+    }
+}

--- a/testing/behavioural/src/tree-data/datapath/benchmarks/tree-data-path.bench.ts
+++ b/testing/behavioural/src/tree-data/datapath/benchmarks/tree-data-path.bench.ts
@@ -1,0 +1,153 @@
+import type { BenchOptions } from 'vitest';
+import { bench, suite } from 'vitest';
+
+import type { GridOptions } from 'ag-grid-community';
+import { ClientSideRowModelApiModule, ClientSideRowModelModule } from 'ag-grid-community';
+import { TreeDataModule } from 'ag-grid-enterprise';
+
+import { SimplePRNG, TestGridsManager } from '../../../test-utils';
+
+suite('treeData with getDataPath', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, ClientSideRowModelApiModule, TreeDataModule],
+    });
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    const rowData = buildRandomTreeDataPath(20000);
+    const rowData1 = buildUpdatedRowData(rowData);
+
+    const getRowId = ({ data }: { data: { id: string } }) => data.id;
+    const getDataPath = (data: { path: string[] }) => data.path;
+
+    const gridOptions: GridOptions = {
+        columnDefs: [],
+        autoGroupColumnDef: { headerName: 'Path' },
+        rowData,
+        treeData: true,
+        groupDefaultExpanded: -1,
+        getDataPath,
+        getRowId,
+    };
+
+    const benchOptions: BenchOptions = { throws: true };
+
+    bench(
+        'build from scratch',
+        () => {
+            gridsManager.reset();
+            gridsManager.createGrid('G', gridOptions);
+        },
+        benchOptions
+    );
+
+    bench('update row data', () => {
+        gridsManager.reset();
+        const api = gridsManager.createGrid('G', gridOptions);
+        api.setGridOption('rowData', rowData1);
+    });
+});
+
+interface TreeDataPathData {
+    id: string;
+    path: string[];
+}
+
+/** Generate a random ag-grid tree getDataPath paths */
+function buildRandomTreeDataPath(
+    numberOfRows: number,
+    maxDepth: number = 100,
+    prng = new SimplePRNG(0x13d24a75)
+): TreeDataPathData[] {
+    const rows: TreeDataPathData[] = [];
+    let keyCounter = 0;
+
+    const newKey = () => keyCounter++ + '$' + prng.nextString(prng.nextInt(2, 30));
+    const newFillerKey = () => prng.nextString(prng.nextInt(15, 30));
+
+    const currentPath: string[] = [];
+
+    const addRow = () => {
+        for (let pop = 0; pop < 5; ++pop) {
+            if (prng.nextFloat(0, 1) < 0.5) {
+                break;
+            }
+            currentPath.pop();
+        }
+
+        const currentMaxDepth = prng.nextInt(1, maxDepth);
+
+        if (prng.nextFloat(0, 1) < 0.5 && currentPath.length < currentMaxDepth) {
+            currentPath.push(newKey());
+            rows.push({ id: rows.length.toString(), path: currentPath.slice() });
+        }
+
+        const newPath = [...currentPath, newKey()];
+        rows.push({ id: rows.length.toString(), path: newPath });
+
+        if (prng.nextFloat(0, 1) < 0.5 && currentPath.length < currentMaxDepth - 1) {
+            currentPath.push(newFillerKey());
+            if (prng.nextFloat(0, 1) < 0.5 && currentPath.length < currentMaxDepth - 1) {
+                currentPath.push(newFillerKey());
+            }
+        }
+    };
+
+    for (let i = 0; i < numberOfRows; i++) {
+        addRow();
+    }
+
+    prng.shuffle(rows);
+    return rows;
+}
+
+/** This adds some delete, add, update operations that affect the tree structure */
+function buildUpdatedRowData(rows: TreeDataPathData[], prng = new SimplePRNG(0x3d24a75)) {
+    rows = rows.slice();
+    prng.shuffle(rows);
+
+    let rowCount = rows.length;
+    const maxDeletes = Math.floor(rowCount * 0.1);
+    for (let i = 0; i < maxDeletes; i++) {
+        rows.splice(prng.nextInt(0, rowCount - 1), 1);
+    }
+    rowCount = rows.length;
+
+    const maxMove = Math.floor(rowCount * 0.1);
+    for (let i = 0; i < maxMove; i++) {
+        const indexToMove = prng.nextInt(0, rowCount - 1);
+        const newParentRow = prng.nextInt(0, rowCount - 1);
+
+        const rowToMove = rows[indexToMove];
+
+        let key = rowToMove.path[rowToMove.path.length - 1];
+        if (prng.nextFloat(0, 1) < 0.5) {
+            key += '+' + i;
+        }
+
+        rows[indexToMove] = {
+            ...rowToMove,
+            path: [...rows[newParentRow].path, key],
+        };
+    }
+
+    const maxAdds = Math.floor(rowCount * 0.1);
+    for (let i = 0; i < maxAdds; i++) {
+        const newParentRow = prng.nextInt(0, rowCount - 1);
+
+        const path = rows[newParentRow].path;
+        const newRow: TreeDataPathData = {
+            id: rows.length.toString(),
+            path: [...path, prng.nextString(12) + '+'],
+        };
+        rows.push(newRow);
+    }
+
+    return rows;
+}

--- a/testing/behavioural/src/tree-data/datapath/benchmarks/tree-data-path.bench.ts
+++ b/testing/behavioural/src/tree-data/datapath/benchmarks/tree-data-path.bench.ts
@@ -20,7 +20,7 @@ suite('treeData with getDataPath', () => {
     const benchOptions: BenchOptions = {
         throws: true,
         setup: () => {
-            api = gridsManager.createGrid('G', {
+            api ??= gridsManager.createGrid('G', {
                 columnDefs: [],
                 autoGroupColumnDef: { headerName: 'Path' },
                 rowData: [],
@@ -39,6 +39,7 @@ suite('treeData with getDataPath', () => {
     bench(
         'build from scratch',
         () => {
+            console.error('build from scratch');
             api.setGridOption('rowData', []);
             api.setGridOption('rowData', rowData);
         },
@@ -48,6 +49,7 @@ suite('treeData with getDataPath', () => {
     bench(
         'update rowData',
         () => {
+            console.error('updt');
             api.setGridOption('rowData', rowData);
             api.setGridOption('rowData', rowData1);
         },

--- a/testing/behavioural/src/tree-data/datapath/benchmarks/tree-data-path.bench.ts
+++ b/testing/behavioural/src/tree-data/datapath/benchmarks/tree-data-path.bench.ts
@@ -1,7 +1,7 @@
 import type { BenchOptions } from 'vitest';
 import { bench, suite } from 'vitest';
 
-import type { GridOptions } from 'ag-grid-community';
+import type { GridApi } from 'ag-grid-community';
 import { ClientSideRowModelApiModule, ClientSideRowModelModule } from 'ag-grid-community';
 import { TreeDataModule } from 'ag-grid-enterprise';
 
@@ -12,46 +12,47 @@ suite('treeData with getDataPath', () => {
         modules: [ClientSideRowModelModule, ClientSideRowModelApiModule, TreeDataModule],
     });
 
-    beforeEach(() => {
-        gridsManager.reset();
-    });
-
-    afterEach(() => {
-        gridsManager.reset();
-    });
+    let api!: GridApi<TreeDataPathData>;
 
     const rowData = buildRandomTreeDataPath(20000);
     const rowData1 = buildUpdatedRowData(rowData);
 
-    const getRowId = ({ data }: { data: { id: string } }) => data.id;
-    const getDataPath = (data: { path: string[] }) => data.path;
-
-    const gridOptions: GridOptions = {
-        columnDefs: [],
-        autoGroupColumnDef: { headerName: 'Path' },
-        rowData,
-        treeData: true,
-        groupDefaultExpanded: -1,
-        getDataPath,
-        getRowId,
+    const benchOptions: BenchOptions = {
+        throws: true,
+        setup: () => {
+            api = gridsManager.createGrid('G', {
+                columnDefs: [],
+                autoGroupColumnDef: { headerName: 'Path' },
+                rowData: [],
+                treeData: true,
+                groupDefaultExpanded: -1,
+                getDataPath: (data: { path: string[] }) => data.path,
+                getRowId: ({ data }: { data: { id: string } }) => data.id,
+            });
+        },
+        teardown: () => {
+            gridsManager.reset();
+            api = undefined!;
+        },
     };
-
-    const benchOptions: BenchOptions = { throws: true };
 
     bench(
         'build from scratch',
         () => {
-            gridsManager.reset();
-            gridsManager.createGrid('G', gridOptions);
+            api.setGridOption('rowData', []);
+            api.setGridOption('rowData', rowData);
         },
         benchOptions
     );
 
-    bench('update row data', () => {
-        gridsManager.reset();
-        const api = gridsManager.createGrid('G', gridOptions);
-        api.setGridOption('rowData', rowData1);
-    });
+    bench(
+        'update rowData',
+        () => {
+            api.setGridOption('rowData', rowData);
+            api.setGridOption('rowData', rowData1);
+        },
+        benchOptions
+    );
 });
 
 interface TreeDataPathData {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6433,6 +6433,11 @@
   resolved "http://52.50.158.57:4873/@radix-ui/rect/-/rect-1.1.0.tgz#f817d1d3265ac5415dadc67edab30ae196696438"
   integrity sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==
 
+"@rolldown/pluginutils@1.0.0-beta.9":
+  version "1.0.0-beta.9"
+  resolved "http://52.50.158.57:4873/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.9.tgz#68ef9fff5a9791a642cea0dc4380ce6cb487a84a"
+  integrity sha512-e9MeMtVWo186sgvFFJOPGy7/d2j2mZhLJIdVW0C/xDluuOvymEATqz6zKsP0ZmXGzQtqlyjz5sC1sYQUoJG98w==
+
 "@rollup/plugin-babel@^6.0.4":
   version "6.0.4"
   resolved "http://52.50.158.57:4873/@rollup/plugin-babel/-/plugin-babel-6.0.4.tgz#bd698e351fa9aa9619fcae780aea2a603d98e4c4"
@@ -8149,10 +8154,10 @@
   resolved "http://52.50.158.57:4873/@types/react-dom/-/react-dom-18.3.5.tgz#45f9f87398c5dcea085b715c58ddcf1faf65f716"
   integrity sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==
 
-"@types/react-dom@^18.3.6":
-  version "18.3.6"
-  resolved "http://52.50.158.57:4873/@types/react-dom/-/react-dom-18.3.6.tgz#fa59a5e9a33499a792af6c1130f55921ef49d268"
-  integrity sha512-nf22//wEbKXusP6E9pfOCDwFdHAX4u172eaJI4YkDRQEZiorm6KfYnSC2SWLDMVWUOWPERmJnN0ujeAfTBLvrw==
+"@types/react-dom@^18.3.7":
+  version "18.3.7"
+  resolved "http://52.50.158.57:4873/@types/react-dom/-/react-dom-18.3.7.tgz#b89ddf2cd83b4feafcc4e2ea41afdfb95a0d194f"
+  integrity sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==
 
 "@types/react-dom@~18.2.0":
   version "18.2.25"
@@ -8176,10 +8181,10 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
-"@types/react@^18.3.20":
-  version "18.3.20"
-  resolved "http://52.50.158.57:4873/@types/react/-/react-18.3.20.tgz#b0dccda9d2f1bc24d2a04b1d0cb5d0b9a3576ad3"
-  integrity sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==
+"@types/react@^18.3.23":
+  version "18.3.23"
+  resolved "http://52.50.158.57:4873/@types/react/-/react-18.3.23.tgz#86ae6f6b95a48c418fecdaccc8069e0fbb63696a"
+  integrity sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -8571,14 +8576,15 @@
     "@types/babel__core" "^7.20.5"
     react-refresh "^0.14.2"
 
-"@vitejs/plugin-react@^4.4.1":
-  version "4.4.1"
-  resolved "http://52.50.158.57:4873/@vitejs/plugin-react/-/plugin-react-4.4.1.tgz#d7d1e9c9616d7536b0953637edfee7c6cbe2fe0f"
-  integrity sha512-IpEm5ZmeXAP/osiBXVVP5KjFMzbWOonMs0NaQQl+xYnUAcq4oHUBsF2+p4MgKWG4YMmFYJU8A6sxRPuowllm6w==
+"@vitejs/plugin-react@^4.5.1":
+  version "4.5.1"
+  resolved "http://52.50.158.57:4873/@vitejs/plugin-react/-/plugin-react-4.5.1.tgz#19432712467ad3b81f24c85d695a6febf8d4cc11"
+  integrity sha512-uPZBqSI0YD4lpkIru6M35sIfylLGTyhGHvDZbNLuMA73lMlwJKz5xweH7FajfcCAc2HnINciejA9qTz0dr0M7A==
   dependencies:
     "@babel/core" "^7.26.10"
     "@babel/plugin-transform-react-jsx-self" "^7.25.9"
     "@babel/plugin-transform-react-jsx-source" "^7.25.9"
+    "@rolldown/pluginutils" "1.0.0-beta.9"
     "@types/babel__core" "^7.20.5"
     react-refresh "^0.17.0"
 
@@ -8615,12 +8621,31 @@
     chai "^5.1.2"
     tinyrainbow "^1.2.0"
 
+"@vitest/expect@2.1.9":
+  version "2.1.9"
+  resolved "http://52.50.158.57:4873/@vitest/expect/-/expect-2.1.9.tgz#b566ea20d58ea6578d8dc37040d6c1a47ebe5ff8"
+  integrity sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==
+  dependencies:
+    "@vitest/spy" "2.1.9"
+    "@vitest/utils" "2.1.9"
+    chai "^5.1.2"
+    tinyrainbow "^1.2.0"
+
 "@vitest/mocker@2.1.6":
   version "2.1.6"
   resolved "http://52.50.158.57:4873/@vitest/mocker/-/mocker-2.1.6.tgz#d13c5a7bd0abf432e1030f68acb43f51c4b3692e"
   integrity sha512-MHZp2Z+Q/A3am5oD4WSH04f9B0T7UvwEb+v5W0kCYMhtXGYbdyl2NUk1wdSMqGthmhpiThPDp/hEoVwu16+u1A==
   dependencies:
     "@vitest/spy" "2.1.6"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.12"
+
+"@vitest/mocker@2.1.9":
+  version "2.1.9"
+  resolved "http://52.50.158.57:4873/@vitest/mocker/-/mocker-2.1.9.tgz#36243b27351ca8f4d0bbc4ef91594ffd2dc25ef5"
+  integrity sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==
+  dependencies:
+    "@vitest/spy" "2.1.9"
     estree-walker "^3.0.3"
     magic-string "^0.30.12"
 
@@ -8631,7 +8656,7 @@
   dependencies:
     tinyrainbow "^1.2.0"
 
-"@vitest/pretty-format@^2.1.6":
+"@vitest/pretty-format@2.1.9", "@vitest/pretty-format@^2.1.6", "@vitest/pretty-format@^2.1.9":
   version "2.1.9"
   resolved "http://52.50.158.57:4873/@vitest/pretty-format/-/pretty-format-2.1.9.tgz#434ff2f7611689f9ce70cd7d567eceb883653fdf"
   integrity sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==
@@ -8655,6 +8680,14 @@
     "@vitest/utils" "2.1.6"
     pathe "^1.1.2"
 
+"@vitest/runner@2.1.9":
+  version "2.1.9"
+  resolved "http://52.50.158.57:4873/@vitest/runner/-/runner-2.1.9.tgz#cc18148d2d797fd1fd5908d1f1851d01459be2f6"
+  integrity sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==
+  dependencies:
+    "@vitest/utils" "2.1.9"
+    pathe "^1.1.2"
+
 "@vitest/snapshot@1.6.0":
   version "1.6.0"
   resolved "http://52.50.158.57:4873/@vitest/snapshot/-/snapshot-1.6.0.tgz#deb7e4498a5299c1198136f56e6e0f692e6af470"
@@ -8673,6 +8706,15 @@
     magic-string "^0.30.12"
     pathe "^1.1.2"
 
+"@vitest/snapshot@2.1.9":
+  version "2.1.9"
+  resolved "http://52.50.158.57:4873/@vitest/snapshot/-/snapshot-2.1.9.tgz#24260b93f798afb102e2dcbd7e61c6dfa118df91"
+  integrity sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==
+  dependencies:
+    "@vitest/pretty-format" "2.1.9"
+    magic-string "^0.30.12"
+    pathe "^1.1.2"
+
 "@vitest/spy@1.6.0":
   version "1.6.0"
   resolved "http://52.50.158.57:4873/@vitest/spy/-/spy-1.6.0.tgz#362cbd42ccdb03f1613798fde99799649516906d"
@@ -8684,6 +8726,13 @@
   version "2.1.6"
   resolved "http://52.50.158.57:4873/@vitest/spy/-/spy-2.1.6.tgz#229f9d48b90b8bdd6573723bdec0699915598080"
   integrity sha512-oTFObV8bd4SDdRka5O+mSh5w9irgx5IetrD5i+OsUUsk/shsBoHifwCzy45SAORzAhtNiprUVaK3hSCCzZh1jQ==
+  dependencies:
+    tinyspy "^3.0.2"
+
+"@vitest/spy@2.1.9":
+  version "2.1.9"
+  resolved "http://52.50.158.57:4873/@vitest/spy/-/spy-2.1.9.tgz#cb28538c5039d09818b8bfa8edb4043c94727c60"
+  integrity sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==
   dependencies:
     tinyspy "^3.0.2"
 
@@ -8716,6 +8765,15 @@
   integrity sha512-ixNkFy3k4vokOUTU2blIUvOgKq/N2PW8vKIjZZYsGJCMX69MRa9J2sKqX5hY/k5O5Gty3YJChepkqZ3KM9LyIQ==
   dependencies:
     "@vitest/pretty-format" "2.1.6"
+    loupe "^3.1.2"
+    tinyrainbow "^1.2.0"
+
+"@vitest/utils@2.1.9":
+  version "2.1.9"
+  resolved "http://52.50.158.57:4873/@vitest/utils/-/utils-2.1.9.tgz#4f2486de8a54acf7ecbf2c5c24ad7994a680a6c1"
+  integrity sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==
+  dependencies:
+    "@vitest/pretty-format" "2.1.9"
     loupe "^3.1.2"
     tinyrainbow "^1.2.0"
 
@@ -26279,7 +26337,7 @@ tslib@2.6.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
   integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
 
-tslib@2.8.1, tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.6.2, tslib@^2.6.3, tslib@^2.7.0, tslib@^2.8.0:
+tslib@2.8.1, tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.6.2, tslib@^2.6.3, tslib@^2.8.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "http://52.50.158.57:4873/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -27268,6 +27326,17 @@ vite-node@2.1.6:
     pathe "^1.1.2"
     vite "^5.0.0 || ^6.0.0"
 
+vite-node@2.1.9:
+  version "2.1.9"
+  resolved "http://52.50.158.57:4873/vite-node/-/vite-node-2.1.9.tgz#549710f76a643f1c39ef34bdb5493a944e4f895f"
+  integrity sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.3.7"
+    es-module-lexer "^1.5.4"
+    pathe "^1.1.2"
+    vite "^5.0.0"
+
 vite-plugin-inspect@0.8.9:
   version "0.8.9"
   resolved "http://52.50.158.57:4873/vite-plugin-inspect/-/vite-plugin-inspect-0.8.9.tgz#01a7e484ccbc12a8c86ee8bc90efe13aeb0fed1b"
@@ -27403,6 +27472,32 @@ vitest@2.1.6:
     tinyrainbow "^1.2.0"
     vite "^5.0.0 || ^6.0.0"
     vite-node "2.1.6"
+    why-is-node-running "^2.3.0"
+
+vitest@2.1.9:
+  version "2.1.9"
+  resolved "http://52.50.158.57:4873/vitest/-/vitest-2.1.9.tgz#7d01ffd07a553a51c87170b5e80fea3da7fb41e7"
+  integrity sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==
+  dependencies:
+    "@vitest/expect" "2.1.9"
+    "@vitest/mocker" "2.1.9"
+    "@vitest/pretty-format" "^2.1.9"
+    "@vitest/runner" "2.1.9"
+    "@vitest/snapshot" "2.1.9"
+    "@vitest/spy" "2.1.9"
+    "@vitest/utils" "2.1.9"
+    chai "^5.1.2"
+    debug "^4.3.7"
+    expect-type "^1.1.0"
+    magic-string "^0.30.12"
+    pathe "^1.1.2"
+    std-env "^3.8.0"
+    tinybench "^2.9.0"
+    tinyexec "^0.3.1"
+    tinypool "^1.0.1"
+    tinyrainbow "^1.2.0"
+    vite "^5.0.0"
+    vite-node "2.1.9"
     why-is-node-running "^2.3.0"
 
 vitest@^1.6.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -26516,7 +26516,7 @@ typescript-eslint@^8.0.1:
     "@typescript-eslint/parser" "8.20.0"
     "@typescript-eslint/utils" "8.20.0"
 
-typescript@^5.4.5, typescript@^5.5.3, typescript@^5.5.4:
+typescript@^5.4.5, typescript@^5.5.3:
   version "5.7.3"
   resolved "http://52.50.158.57:4873/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
   integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==


### PR DESCRIPTION
Add vitest capability to the project and write a simple benchmark for tree data with path
The tests are currently meant to be executed manually and just for developer benefit in the local machine

The version we currently use for vitest says is an experimental feature, is not experimental anymore in the new vitest, when we upgrade.

Also updates behavioural tests ts version

![image](https://github.com/user-attachments/assets/ae4efe0a-0ee9-4d55-8bd6-59e98e650601)
