### PR TITLE
[AG-304] Fix(ag-grid): various follow ups

### DIFF
--- a/.idea/ag-grid.iml
+++ b/.idea/ag-grid.iml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/packages/ag-grid-community/styles" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/packages/ag-grid-enterprise/styles" isTestSource="false" generated="true" />
@@ -165,6 +166,7 @@
       <excludeFolder url="file://$MODULE_DIR$/packages/ag-grid-angular/.angular" />
       <excludeFolder url="file://$MODULE_DIR$/packages/ag-grid-react/dist" />
       <excludeFolder url="file://$MODULE_DIR$/packages/ag-grid-vue3/lib" />
+      <excludeFolder url="file://$MODULE_DIR$/testing/shared/packages/ag-grid-community/dist" />
     </content>
     <content url="file://$MODULE_DIR$/grid-packages/ag-grid-docs/node_modules" />
     <content url="file://$MODULE_DIR$/packages/ag-grid-angular/dist" />

--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -1797,10 +1797,13 @@
         flex: 1 1 auto;
     }
 
-    .ag-floating-filter-input .ag-input-field-input[type='date'] {
-        // Fix a bug in Blink rendering engine where date input will not shrink from its default size in a
-        // flex container, but it will grow. So we give it a very small width and it will grow to the right size
-        width: 1px;
+    .ag-floating-filter-input {
+        .ag-input-field-input[type='date'],
+        .ag-input-field-input[type='datetime-local'] {
+            // Fix a bug in Blink rendering engine where date input will not shrink from its default size in a
+            // flex container, but it will grow. So we give it a very small width and it will grow to the right size
+            width: 1px;
+        }
     }
 
     .ag-range-field {

--- a/documentation/ag-grid-docs/src/content/docs/cell-data-types/_examples/overriding-pre-defined-cell-data-types/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/cell-data-types/_examples/overriding-pre-defined-cell-data-types/main.ts
@@ -104,7 +104,9 @@ document.addEventListener('DOMContentLoaded', () => {
                     (d) =>
                         ({
                             ...d,
-                            date: dataTypeDefinitions.date.dateFormatter!(dataTypeDefinitions.date.dateParser!(d.date)),
+                            date: dataTypeDefinitions.date.dateFormatter!(
+                                new Date(dataTypeDefinitions.date.dateParser!(d.date)?.getTime()! + Math.random() * 1e7)
+                            ),
                         }) as IOlympicData
                 )
             );

--- a/documentation/ag-grid-docs/src/content/docs/cell-data-types/_examples/overriding-pre-defined-cell-data-types/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/cell-data-types/_examples/overriding-pre-defined-cell-data-types/main.ts
@@ -1,4 +1,10 @@
-import type { GridApi, GridOptions, ValueFormatterLiteParams, ValueParserLiteParams } from 'ag-grid-community';
+import type {
+    DateTimeStringDataTypeDefinition,
+    GridApi,
+    GridOptions,
+    ValueFormatterLiteParams,
+    ValueParserLiteParams,
+} from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     DateEditorModule,
@@ -24,42 +30,64 @@ ModuleRegistry.registerModules([
 ]);
 
 let gridApi: GridApi<IOlympicData>;
-
+const dataTypeDefinitions = {
+    date: {
+        baseDataType: 'dateTimeString',
+        extendsDataType: 'dateTimeString',
+        valueParser: (params: ValueParserLiteParams<IOlympicData, string>) => {
+            if (params.newValue != null && params.newValue.match('\\d{2}:\\d{2}:\\d{2} \\d{2}/\\d{2}/\\d{4}')) {
+                return params.newValue;
+            } else {
+                return null;
+            }
+        },
+        valueFormatter: (params: ValueFormatterLiteParams<IOlympicData, string>) => {
+            return params.value == null ? '' : params.value;
+        },
+        dataTypeMatcher: (value: any) => {
+            return typeof value === 'string' && !!value.match('\\d{2}:\\d{2}:\\d{2} \\d{2}/\\d{2}/\\d{4}');
+        },
+        dateParser: (value: string | undefined) => {
+            if (value == null) {
+                return;
+            }
+            // convert from `HH:mm:ss dd/MM/yyyy`
+            const [time, date] = value.split(' ');
+            const [HH, mm, ss] = date ? time.split(':') : ['0', '0', '0'];
+            const [dd, MM, yyyy] = (date ? date : time).split('/');
+            return new Date(parseInt(yyyy), parseInt(MM) - 1, parseInt(dd), parseInt(HH), parseInt(mm), parseInt(ss));
+        },
+        dateFormatter: (value: Date | undefined) => {
+            const pad = (n: number) => (n < 10 ? `0${n}` : n);
+            // convert to `HH:mm:ss dd/MM/yyyy`
+            return value == null
+                ? ''
+                : `${pad(value.getHours())}:${pad(value.getMinutes())}:${pad(value.getSeconds())}` +
+                      ` ${pad(value.getDate())}/${pad(value.getMonth() + 1)}/${value.getFullYear()}`;
+        },
+    } as DateTimeStringDataTypeDefinition,
+};
 const gridOptions: GridOptions<IOlympicData> = {
-    columnDefs: [{ field: 'athlete' }, { field: 'age' }, { field: 'date' }],
+    columnDefs: [
+        { field: 'athlete' },
+        { field: 'age' },
+        {
+            field: 'date',
+            cellDataType: 'date',
+            filterParams: {
+                includeTime: true,
+            },
+            cellEditorParams: {
+                includeTime: true,
+            },
+        },
+    ],
     defaultColDef: {
         filter: true,
         floatingFilter: true,
         editable: true,
     },
-    dataTypeDefinitions: {
-        dateString: {
-            baseDataType: 'dateString',
-            extendsDataType: 'dateString',
-            valueParser: (params: ValueParserLiteParams<IOlympicData, string>) =>
-                params.newValue != null && params.newValue.match('\\d{2}/\\d{2}/\\d{4}') ? params.newValue : null,
-            valueFormatter: (params: ValueFormatterLiteParams<IOlympicData, string>) =>
-                params.value == null ? '' : params.value,
-            dataTypeMatcher: (value: any) => typeof value === 'string' && !!value.match('\\d{2}/\\d{2}/\\d{4}'),
-            dateParser: (value: string | undefined) => {
-                if (value == null || value === '') {
-                    return undefined;
-                }
-                const dateParts = value.split('/');
-                return dateParts.length === 3
-                    ? new Date(parseInt(dateParts[2]), parseInt(dateParts[1]) - 1, parseInt(dateParts[0]))
-                    : undefined;
-            },
-            dateFormatter: (value: Date | undefined) => {
-                if (value == null) {
-                    return undefined;
-                }
-                const date = String(value.getDate());
-                const month = String(value.getMonth() + 1);
-                return `${date.length === 1 ? '0' + date : date}/${month.length === 1 ? '0' + month : month}/${value.getFullYear()}`;
-            },
-        },
-    },
+    dataTypeDefinitions,
 };
 
 // setup the grid after the page has finished loading
@@ -69,5 +97,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
     fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
         .then((response) => response.json())
-        .then((data: IOlympicData[]) => gridApi!.setGridOption('rowData', data));
+        .then((data: IOlympicData[]) => {
+            gridApi!.setGridOption(
+                'rowData',
+                data.map(
+                    (d) =>
+                        ({
+                            ...d,
+                            date: dataTypeDefinitions.date.dateFormatter!(dataTypeDefinitions.date.dateParser!(d.date)),
+                        }) as IOlympicData
+                )
+            );
+        });
 });

--- a/documentation/ag-grid-docs/src/content/docs/cell-data-types/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/cell-data-types/index.mdoc
@@ -234,27 +234,36 @@ This works in the same way as when [Providing Custom Cell Data Types](#providing
 ```{% frameworkTransform=true spaceBetweenProperties=true %}
 const gridOptions = {
     dataTypeDefinitions: {
-        // override `date` to handle custom date format `dd/mm/yyyy`
+        // override `date` to handle custom date format `HH:mm:ss dd/MM/yyyy`
         date: {
-            baseDataType: 'date',
-            extendsDataType: 'date',
+            baseDataType: 'dateTime',
+            extendsDataType: 'dateTime',
             valueParser: params => {
                 if (params.newValue == null) {
                     return null;
                 }
-                // convert from `dd/mm/yyyy`
-                const dateParts = params.newValue.split('/');
-                return dateParts.length === 3 ? new Date(
-                    parseInt(dateParts[2]),
-                    parseInt(dateParts[1]) - 1,
-                    parseInt(dateParts[0])
-                ) : null;
+                // convert from `HH:mm:ss dd/MM/yyyy`
+                const [time, date] = params.newValue.split(' ');
+                const [HH, mm, ss] = time.split(':');
+                const [dd, MM, yyyy] = date.split('/');
+                return new Date(
+                    parseInt(yyyy),
+                    parseInt(MM) - 1,
+                    parseInt(dd),
+                    parseInt(HH),
+                    parseInt(mm),
+                    parseInt(ss),
+                );
             },
             valueFormatter: params => {
-                // convert to `dd/mm/yyyy`
+                /** @type {Date} */
+                const date = params.value;
+                const pad = (n) => n < 10 ? `0${n}` : n;
+                // convert to `HH:mm:ss dd/MM/yyyy`
                 return params.value == null
                     ? ''
-                    : `${date.getDate()}/${date.getMonth() + 1}/${date.getFullYear}`;
+                    : `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}` 
+                        + ` ${pad(date.getDate())}/${pad(date.getMonth() + 1)}/${pad(date.getFullYear())}`;
             },
         }
     }

--- a/documentation/ag-grid-docs/src/content/docs/cell-data-types/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/cell-data-types/index.mdoc
@@ -109,7 +109,7 @@ The `'date'` cell data type is used for date values that are represented as `Dat
 The default Value Parser and Value Formatter use the ISO string format `'YYYY-MM-DD'`. If you wish to use a different date format, then you can [Override the Pre-Defined Cell Data Type Definition](#overriding-the-pre-defined-cell-data-type-definitions).
 
 {% note %}
-Please note that the `'date'` cell data type compares full Date objects, including the time portion. As a result, if a date includes a time other than midnight (`00:00:00`), filtering or editing might behave unexpectedly. For consistent results with built-in filters, it’s best to normalize all time values to the same value. If keeping the time component is important, consider using the `'dateTime'` cell data type instead or defining a custom comparator, as explained in the [Date Filter Comparator](./filter-date/#filter-comparator).
+Please note that the `'date'` cell data type compares full Date objects, including the time portion. As a result, if a date includes a time other than midnight (`00:00:00.000`), filtering or editing might behave unexpectedly. For consistent results with built-in filters, it’s best to normalize all time values to the same value. If keeping the time component is important, consider using the `'dateTime'` cell data type instead or defining a custom comparator, as explained in the [Date Filter Comparator](./filter-date/#filter-comparator).
 {% /note %}
 
 The following properties are set:

--- a/documentation/ag-grid-docs/src/content/docs/filter-date/_examples/date-filter/data.ts
+++ b/documentation/ag-grid-docs/src/content/docs/filter-date/_examples/date-filter/data.ts
@@ -6,6 +6,8 @@ export function getData(): any[] {
         rows.push({
             startDate: `20${i}-${pad(m, 2)}-${pad(getRandom(28), 2)}`,
             endDate: `20${i}-${pad(m + 1, 2)}-${pad(getRandom(28), 2)}`,
+            startDateTime: new Date(13e11 + getRandom(5e8) * 1e3),
+            endDateTime: new Date(13e11 + getRandom(5e8) * 1e3).toISOString(),
         });
     }
 

--- a/documentation/ag-grid-docs/src/content/docs/filter-date/_examples/date-filter/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/filter-date/_examples/date-filter/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
+import type { ColDef, GridApi, GridOptions, ValueFormatterParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     DateFilterModule,
@@ -14,7 +14,6 @@ ModuleRegistry.registerModules([
     DateFilterModule,
     ...(process.env.NODE_ENV !== 'production' ? [ValidationModule] : []),
 ]);
-
 const columnDefs: ColDef[] = [
     {
         field: 'startDate',
@@ -23,6 +22,18 @@ const columnDefs: ColDef[] = [
     {
         field: 'endDate',
         filter: 'agDateColumnFilter',
+    },
+    {
+        field: 'startDateTime',
+        filter: 'agDateColumnFilter',
+        cellDataType: 'dateTime',
+        valueFormatter: (params: ValueFormatterParams) =>
+            params.value.toISOString().replace(/[TZ]/g, ' ').trim().slice(0, -4),
+    },
+    {
+        field: 'endDateTime',
+        filter: 'agDateColumnFilter',
+        valueFormatter: (params: ValueFormatterParams) => params.value.replace(/[TZ]/g, ' ').trim().slice(0, -4),
     },
 ];
 

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-date/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-date/index.mdoc
@@ -29,7 +29,7 @@ columnDefs: [
 
 ### API Reference
 
-{% interfaceDocumentation interfaceName="IDateCellEditorParams" names=["min","max","step"] /%}
+{% interfaceDocumentation interfaceName="IDateCellEditorParams" names=["min","max","step","includeTime"] /%}
 
 ## Enabling Date as String Cell Editor
 
@@ -58,7 +58,7 @@ columnDefs: [
 
 ### API Reference
 
-{% interfaceDocumentation interfaceName="IDateStringCellEditorParams" names=["min","max","step"] /%}
+{% interfaceDocumentation interfaceName="IDateStringCellEditorParams" names=["min","max","step","includeTime"] /%}
 
 ## Next Up
 

--- a/packages/ag-grid-community/src/edit/cellEditors/dateCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/dateCellEditor.ts
@@ -16,6 +16,7 @@ const DateCellElement: ElementParams = {
 class DateCellEditorInput implements CellEditorInput<Date, IDateCellEditorParams, AgInputDateField> {
     private eInput: AgInputDateField;
     private params: IDateCellEditorParams;
+    private includeTime: boolean | undefined;
 
     constructor(private getDataTypeService: () => DataTypeService | undefined) {}
 
@@ -29,7 +30,7 @@ class DateCellEditorInput implements CellEditorInput<Date, IDateCellEditorParams
     public init(eInput: AgInputDateField, params: IDateCellEditorParams): void {
         this.eInput = eInput;
         this.params = params;
-        const { min, max, step, includeTime } = params;
+        const { min, max, step, colDef } = params;
         if (min != null) {
             eInput.setMin(min);
         }
@@ -39,8 +40,10 @@ class DateCellEditorInput implements CellEditorInput<Date, IDateCellEditorParams
         if (step != null) {
             eInput.setStep(step);
         }
-        if (includeTime != null) {
-            eInput.setIncludeTime(includeTime);
+        this.includeTime =
+            params.includeTime ?? this.getDataTypeService()?.getDateIncludesTimeFlag?.(colDef.cellDataType);
+        if (this.includeTime != null) {
+            eInput.setIncludeTime(this.includeTime);
         }
     }
 
@@ -58,11 +61,7 @@ class DateCellEditorInput implements CellEditorInput<Date, IDateCellEditorParams
         if (!(value instanceof Date)) {
             return undefined;
         }
-        const dataTypeSvc = this.getDataTypeService();
-        return _serialiseDate(
-            value,
-            this.params.includeTime ?? dataTypeSvc?.getDateIncludesTimeFlag?.(this.params.colDef.cellDataType) ?? false
-        );
+        return _serialiseDate(value, this.includeTime ?? false);
     }
 }
 

--- a/packages/ag-grid-community/src/edit/cellEditors/dateCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/dateCellEditor.ts
@@ -29,7 +29,7 @@ class DateCellEditorInput implements CellEditorInput<Date, IDateCellEditorParams
     public init(eInput: AgInputDateField, params: IDateCellEditorParams): void {
         this.eInput = eInput;
         this.params = params;
-        const { min, max, step } = params;
+        const { min, max, step, includeTime } = params;
         if (min != null) {
             eInput.setMin(min);
         }
@@ -38,6 +38,9 @@ class DateCellEditorInput implements CellEditorInput<Date, IDateCellEditorParams
         }
         if (step != null) {
             eInput.setStep(step);
+        }
+        if (includeTime != null) {
+            eInput.setIncludeTime(includeTime);
         }
     }
 
@@ -56,7 +59,10 @@ class DateCellEditorInput implements CellEditorInput<Date, IDateCellEditorParams
             return undefined;
         }
         const dataTypeSvc = this.getDataTypeService();
-        return _serialiseDate(value, dataTypeSvc?.getDateIncludesTimeFlag?.(this.params.colDef.cellDataType) ?? false);
+        return _serialiseDate(
+            value,
+            this.params.includeTime ?? dataTypeSvc?.getDateIncludesTimeFlag?.(this.params.colDef.cellDataType) ?? false
+        );
     }
 }
 

--- a/packages/ag-grid-community/src/edit/cellEditors/dateStringCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/dateStringCellEditor.ts
@@ -30,7 +30,7 @@ class DateStringCellEditorInput implements CellEditorInput<string, IDateStringCe
     public init(eInput: AgInputDateField, params: IDateStringCellEditorParams): void {
         this.eInput = eInput;
         this.params = params;
-        const { min, max, step } = params;
+        const { min, max, step, includeTime } = params;
         if (min != null) {
             eInput.setMin(min);
         }
@@ -39,6 +39,9 @@ class DateStringCellEditorInput implements CellEditorInput<string, IDateStringCe
         }
         if (step != null) {
             eInput.setStep(step);
+        }
+        if (includeTime != null) {
+            eInput.setIncludeTime(includeTime);
         }
     }
 
@@ -52,7 +55,7 @@ class DateStringCellEditorInput implements CellEditorInput<string, IDateStringCe
     }
 
     public getStartValue(): string | null | undefined {
-        return this.formatDate(this.parseDate(this.params.value ?? undefined));
+        return _serialiseDate(this.parseDate(this.params.value ?? undefined) ?? null, this.params.includeTime ?? false);
     }
 
     private parseDate(value: string | undefined): Date | undefined {
@@ -66,7 +69,7 @@ class DateStringCellEditorInput implements CellEditorInput<string, IDateStringCe
         const dataTypeSvc = this.getDataTypeService();
         return dataTypeSvc
             ? dataTypeSvc.getDateFormatterFunction(this.params.column as AgColumn)(value)
-            : _serialiseDate(value ?? null, false) ?? undefined;
+            : _serialiseDate(value ?? null, this.params.includeTime ?? false) ?? undefined;
     }
 }
 

--- a/packages/ag-grid-community/src/edit/cellEditors/dateStringCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/dateStringCellEditor.ts
@@ -17,6 +17,7 @@ const DateStringCellElement: ElementParams = {
 class DateStringCellEditorInput implements CellEditorInput<string, IDateStringCellEditorParams, AgInputDateField> {
     private eInput: AgInputDateField;
     private params: IDateStringCellEditorParams;
+    private includeTime: boolean | undefined;
 
     constructor(private getDataTypeService: () => DataTypeService | undefined) {}
 
@@ -30,7 +31,7 @@ class DateStringCellEditorInput implements CellEditorInput<string, IDateStringCe
     public init(eInput: AgInputDateField, params: IDateStringCellEditorParams): void {
         this.eInput = eInput;
         this.params = params;
-        const { min, max, step, includeTime } = params;
+        const { min, max, step, colDef } = params;
         if (min != null) {
             eInput.setMin(min);
         }
@@ -40,8 +41,10 @@ class DateStringCellEditorInput implements CellEditorInput<string, IDateStringCe
         if (step != null) {
             eInput.setStep(step);
         }
-        if (includeTime != null) {
-            eInput.setIncludeTime(includeTime);
+        this.includeTime =
+            params.includeTime ?? this.getDataTypeService()?.getDateIncludesTimeFlag?.(colDef.cellDataType);
+        if (this.includeTime != null) {
+            eInput.setIncludeTime(this.includeTime);
         }
     }
 
@@ -55,7 +58,7 @@ class DateStringCellEditorInput implements CellEditorInput<string, IDateStringCe
     }
 
     public getStartValue(): string | null | undefined {
-        return _serialiseDate(this.parseDate(this.params.value ?? undefined) ?? null, this.params.includeTime ?? false);
+        return _serialiseDate(this.parseDate(this.params.value ?? undefined) ?? null, this.includeTime ?? false);
     }
 
     private parseDate(value: string | undefined): Date | undefined {
@@ -69,7 +72,7 @@ class DateStringCellEditorInput implements CellEditorInput<string, IDateStringCe
         const dataTypeSvc = this.getDataTypeService();
         return dataTypeSvc
             ? dataTypeSvc.getDateFormatterFunction(this.params.column as AgColumn)(value)
-            : _serialiseDate(value ?? null, this.params.includeTime ?? false) ?? undefined;
+            : _serialiseDate(value ?? null, this.includeTime ?? false) ?? undefined;
     }
 }
 

--- a/packages/ag-grid-community/src/edit/cellEditors/iDateCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/iDateCellEditor.ts
@@ -15,8 +15,8 @@ export interface IDateCellEditorParams<TData = any, TContext = any> extends ICel
     /**
      * Defines whether time should be included when editing dates.
      *
-     * - `true`: Include the time component in date comparisons.
-     * - `false`: Only compare dates without considering the time component.
+     * - `true`: Date and time will be editable.
+     * - `false`: Only date portion will be editable.
      *
      * @default false
      */

--- a/packages/ag-grid-community/src/edit/cellEditors/iDateCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/iDateCellEditor.ts
@@ -13,7 +13,7 @@ export interface IDateCellEditorParams<TData = any, TContext = any> extends ICel
      */
     step?: number;
     /**
-     * Defines whether time should be included when filtering dates.
+     * Defines whether time should be included when editing dates.
      *
      * - `true`: Include the time component in date comparisons.
      * - `false`: Only compare dates without considering the time component.

--- a/packages/ag-grid-community/src/edit/cellEditors/iDateCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/iDateCellEditor.ts
@@ -12,4 +12,13 @@ export interface IDateCellEditorParams<TData = any, TContext = any> extends ICel
      * Defaults to any value allowed.
      */
     step?: number;
+    /**
+     * Defines whether time should be included when filtering dates.
+     *
+     * - `true`: Include the time component in date comparisons.
+     * - `false`: Only compare dates without considering the time component.
+     *
+     * @default false
+     */
+    includeTime?: boolean;
 }

--- a/packages/ag-grid-community/src/edit/cellEditors/iDateStringCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/iDateStringCellEditor.ts
@@ -14,10 +14,10 @@ export interface IDateStringCellEditorParams<TData = any, TContext = any>
      */
     step?: number;
     /**
-     * Defines whether time should be included when filtering dates.
+     * Defines whether time should be included when editing dates.
      *
-     * - `true`: Include the time component in date comparisons.
-     * - `false`: Only compare dates without considering the time component.
+     * - `true`: Date and time will be editable.
+     * - `false`: Only date portion will be editable.
      *
      * @default false
      */

--- a/packages/ag-grid-community/src/edit/cellEditors/iDateStringCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/iDateStringCellEditor.ts
@@ -13,4 +13,13 @@ export interface IDateStringCellEditorParams<TData = any, TContext = any>
      * Defaults to any value allowed.
      */
     step?: number;
+    /**
+     * Defines whether time should be included when filtering dates.
+     *
+     * - `true`: Include the time component in date comparisons.
+     * - `false`: Only compare dates without considering the time component.
+     *
+     * @default false
+     */
+    includeTime?: boolean;
 }

--- a/packages/ag-grid-community/src/edit/cellEditors/simpleCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/simpleCellEditor.ts
@@ -1,7 +1,6 @@
 import { KeyCode } from '../../constants/keyCode';
 import type { DefaultProvidedCellEditorParams, ICellEditorComp, ICellEditorParams } from '../../interfaces/iCellEditor';
 import { _isBrowserSafari } from '../../utils/browser';
-import type { AgInputDateFieldParams } from '../../widgets/agInputDateField';
 import type { AgInputTextField } from '../../widgets/agInputTextField';
 import { RefPlaceholder } from '../../widgets/component';
 import { PopupComponent } from '../../widgets/popupComponent';
@@ -25,11 +24,9 @@ export class SimpleCellEditor<
     }
 
     public init(params: P): void {
-        const includeTime = this.beans.dataTypeSvc?.getDateIncludesTimeFlag(params.colDef.cellDataType);
         this.setTemplate(
             { tag: 'div', cls: 'ag-cell-edit-wrapper', children: [this.cellEditorInput.getTemplate()] },
-            this.cellEditorInput.getAgComponents(),
-            { eInput: { includeTime } satisfies AgInputDateFieldParams }
+            this.cellEditorInput.getAgComponents()
         );
         this.params = params;
         const { cellStartedEdit, eventKey, suppressPreventDefault } = params;

--- a/packages/ag-grid-community/src/entities/dataType.ts
+++ b/packages/ag-grid-community/src/entities/dataType.ts
@@ -60,7 +60,7 @@ interface BaseDataTypeDefinition<TValueType extends BaseCellDataType, TData = an
     baseDataType: TValueType;
     /**
      * The data type that this extends. Either one of the pre-defined data types
-     * (`'text'`, `'number'`,  `'boolean'`,  `'date'`,  `'dateString'` or  `'object'`)
+     * (`'text'`, `'number'`,  `'boolean'`,  `'date'`,  `'dateString'`, `'dateTime'`, `'dateTimeString'` or  `'object'`)
      * or another custom data type.
      */
     extendsDataType: string;

--- a/packages/ag-grid-community/src/filter/column-filters.css
+++ b/packages/ag-grid-community/src/filter/column-filters.css
@@ -76,7 +76,8 @@
         flex: 1 1 auto;
     }
 
-    :where(.ag-input-field-input[type='date']) {
+    :where(.ag-input-field-input[type='date']),
+    :where(.ag-input-field-input[type='datetime-local']) {
         /* In Chrome the date input will not shrink from its default size in a flex
            container, but it will grow. So we give it a very small width and it will
            grow to the right size */

--- a/packages/ag-grid-community/src/filter/provided/date/defaultDateComponent.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/defaultDateComponent.ts
@@ -86,7 +86,10 @@ export class DefaultDateComponent extends Component implements IDateComp {
         const shouldUseBrowserDatePicker = this.shouldUseBrowserDatePicker(params);
         this.usingSafariDatePicker = shouldUseBrowserDatePicker && _isBrowserSafari();
         const dataTypeSvc = this.beans.dataTypeSvc;
-        const includeTime = dataTypeSvc?.getDateIncludesTimeFlag(params.filterParams?.colDef?.cellDataType) ?? false;
+        const includeTime =
+            params.filterParams.includeTime ??
+            dataTypeSvc?.getDateIncludesTimeFlag(params.filterParams?.colDef?.cellDataType) ??
+            false;
 
         if (shouldUseBrowserDatePicker) {
             if (includeTime) {

--- a/packages/ag-grid-community/src/filter/provided/date/defaultDateComponent.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/defaultDateComponent.ts
@@ -85,14 +85,16 @@ export class DefaultDateComponent extends Component implements IDateComp {
 
         const shouldUseBrowserDatePicker = this.shouldUseBrowserDatePicker(params);
         this.usingSafariDatePicker = shouldUseBrowserDatePicker && _isBrowserSafari();
+
+        const { minValidYear, maxValidYear, minValidDate, maxValidDate, buttons, includeTime, colDef } =
+            params.filterParams || {};
+
         const dataTypeSvc = this.beans.dataTypeSvc;
-        const includeTime =
-            params.filterParams.includeTime ??
-            dataTypeSvc?.getDateIncludesTimeFlag(params.filterParams?.colDef?.cellDataType) ??
-            false;
+        const shouldUseDateTimeLocal =
+            includeTime ?? dataTypeSvc?.getDateIncludesTimeFlag?.(colDef.cellDataType) ?? false;
 
         if (shouldUseBrowserDatePicker) {
-            if (includeTime) {
+            if (shouldUseDateTimeLocal) {
                 inputElement.type = 'datetime-local';
                 inputElement.step = '1'; // enforce seconds part to show up by default
             } else {
@@ -101,8 +103,6 @@ export class DefaultDateComponent extends Component implements IDateComp {
         } else {
             inputElement.type = 'text';
         }
-
-        const { minValidYear, maxValidYear, minValidDate, maxValidDate, buttons } = params.filterParams || {};
 
         if (minValidDate && minValidYear) {
             _warn(85);

--- a/packages/ag-grid-community/src/filter/provided/date/iDateFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/iDateFilter.ts
@@ -75,6 +75,15 @@ export interface IDateFilterParams extends IScalarFilterParams {
      * (as the comparator only allows for greater than, less than and equals).
      */
     isValidDate?: (value: any) => boolean;
+    /**
+     * Defines whether time should be included when filtering dates.
+     *
+     * - `true`: Include the time component in date comparisons.
+     * - `false`: Only compare dates without considering the time component.
+     *
+     * @default false
+     */
+    includeTime?: boolean;
 }
 
 export interface IDateComparatorFunc {

--- a/packages/ag-grid-community/src/widgets/agAbstractInputField.ts
+++ b/packages/ag-grid-community/src/widgets/agAbstractInputField.ts
@@ -37,7 +37,7 @@ export abstract class AgAbstractInputField<
     constructor(
         config?: TConfig,
         className?: string,
-        private readonly inputType: string | null = 'text',
+        private inputType: string | null | undefined = 'text',
         private readonly displayFieldTag: keyof HTMLElementTagNameMap = 'input'
     ) {
         super(config, config?.template ?? buildTemplate(displayFieldTag), [], className);
@@ -45,7 +45,7 @@ export abstract class AgAbstractInputField<
 
     public override postConstruct() {
         super.postConstruct();
-        this.setInputType();
+        this.setInputType(this.inputType!);
 
         const { eLabel, eWrapper, eInput, className } = this;
         eLabel.classList.add(`${className}-label`);
@@ -73,9 +73,10 @@ export abstract class AgAbstractInputField<
         });
     }
 
-    private setInputType() {
+    public setInputType(inputType?: string) {
         if (this.displayFieldTag === 'input') {
-            this.eInput.setAttribute('type', this.inputType!);
+            this.inputType = inputType;
+            _addOrRemoveAttribute(this.eInput, 'type', inputType);
         }
     }
 

--- a/packages/ag-grid-community/src/widgets/agInputDateField.ts
+++ b/packages/ag-grid-community/src/widgets/agInputDateField.ts
@@ -6,20 +6,14 @@ import type { AgInputTextFieldParams } from './agInputTextField';
 import { AgInputTextField } from './agInputTextField';
 import type { ComponentSelector } from './component';
 
-export interface AgInputDateFieldParams extends AgInputTextFieldParams {
-    includeTime?: boolean;
-}
 export class AgInputDateField extends AgInputTextField {
     private min?: string;
     private max?: string;
     private step?: number;
-    private readonly includeTime: boolean;
+    private includeTime?: boolean;
 
-    constructor(config?: AgInputDateFieldParams) {
-        const inputType = config?.includeTime ? 'datetime-local' : 'date';
-
-        super(config, 'ag-date-field', inputType);
-        this.includeTime = !!config?.includeTime;
+    constructor(config?: AgInputTextFieldParams) {
+        super(config, 'ag-date-field', 'date');
     }
 
     public override postConstruct() {
@@ -38,9 +32,6 @@ export class AgInputDateField extends AgInputTextField {
             },
         });
         this.eInput.step = 'any';
-        if (this.includeTime) {
-            this.setStep(1);
-        }
     }
 
     private onWheel(e: WheelEvent) {
@@ -84,6 +75,19 @@ export class AgInputDateField extends AgInputTextField {
         this.step = step;
 
         _addOrRemoveAttribute(this.eInput, 'step', step);
+
+        return this;
+    }
+
+    public setIncludeTime(includeTime?: boolean): this {
+        if (this.includeTime === includeTime) {
+            return this;
+        }
+
+        this.includeTime = includeTime;
+
+        super.setInputType(includeTime ? 'datetime-local' : 'date');
+        if (includeTime) this.setStep(1);
 
         return this;
     }

--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterCtrl.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterCtrl.ts
@@ -156,7 +156,7 @@ export class AdvancedFilterCtrl extends BeanStub<AdvancedFilterCtrlEvent> implem
         const maxWidth = Math.round(_getAbsoluteWidth(popupParent)) - 2; // assume 1 pixel border
         const maxHeight = Math.round(_getAbsoluteHeight(popupParent) * 0.75) - 2;
 
-        const width = Math.min(Math.max(600, minWidth), maxWidth);
+        const width = Math.min(Math.max(700, minWidth), maxWidth);
         const height = Math.min(600, maxHeight);
 
         return { width, height, minWidth };


### PR DESCRIPTION
Fixes TC3, TC7, TC8, TC9, TC10, TC11, TC12, TC13 from [#304](https://ag-grid.atlassian.net/browse/AG-304)
| Description                                                                                        | Before                                                                                                         | After                                                                                                          |
|----------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
| Fixed css issue where calendar icon was hidden                                                                                                  | ![Screenshot_20250609_162237](https://github.com/user-attachments/assets/f3d2c735-2b61-40cc-b09d-0e03ad7e13fd) | ![Screenshot_20250609_162315](https://github.com/user-attachments/assets/53f9e84c-3822-4ce8-906a-5212e1ef3728) | 
| with cellDataType: false and cellEditor: 'agDateCellEditor' it wasn't possible to edit/filter time | ![Screenshot_20250609_230309](https://github.com/user-attachments/assets/dfb93159-09fd-484f-b13c-b6d08a96949e) | ![Screenshot_20250609_230405](https://github.com/user-attachments/assets/22d771ed-e207-490e-9d98-347491d19528) |
| Added datetime to Overriding the Pre-Defined Cell Data Type Definitions example                    | ![Screenshot_20250609_230040](https://github.com/user-attachments/assets/da155c78-b510-4fbf-b921-3e3b7d74ecee) | ![Screenshot_20250609_230018](https://github.com/user-attachments/assets/ed8a87ac-78e3-4f67-ad18-864df8878862) |
| Fixed a syntax error and updated a code example | ![Screenshot_20250609_230604](https://github.com/user-attachments/assets/0169683c-8ebd-4dd2-a5d1-76df4a862afd) | ![Screenshot_20250609_230624](https://github.com/user-attachments/assets/8c488d41-131e-4614-884e-1039b61f3975) |
| Updated docs callout for precision | ![Screenshot_20250609_230859](https://github.com/user-attachments/assets/0b6deaa2-cbf6-4bdf-a667-01518055a42a) | ![Screenshot_20250609_230850](https://github.com/user-attachments/assets/ba8948e6-4f7f-48eb-9b10-6c72eba626bb) |
| Updated date filter docs to include new types | ![Screenshot_20250609_231050](https://github.com/user-attachments/assets/61ab03d3-8079-478b-bb8e-964c18f328da) | ![Screenshot_20250609_231037](https://github.com/user-attachments/assets/78a2781d-0528-4711-88f9-acf9efa13aca) |
| Added new filter/editor option: includeTime | - | ![Screenshot_20250609_231259](https://github.com/user-attachments/assets/607d89ee-e983-4144-a647-1b6609c68394) ![Screenshot_20250609_232511](https://github.com/user-attachments/assets/2d53f4c2-e8ec-4186-afcf-27c3cd447776) |
| Advanced filter builder wasn't wide enough to contain datetime editor | ![Screenshot_20250609_232710](https://github.com/user-attachments/assets/3ef9f5fc-12b8-4f4d-8ed2-694cafaed1ef) |  ![Screenshot_20250609_232733](https://github.com/user-attachments/assets/7c6fde1b-91e5-4389-9de2-46a1b35f2355) |
| Imprecise docs | ![Screenshot_20250609_233004](https://github.com/user-attachments/assets/d34d9303-8fa0-427c-8e7e-6be3ee830b7e) | ![Screenshot_20250609_233030](https://github.com/user-attachments/assets/901de4e3-c07e-43ab-bb2e-35d9af300d1b) |
| Cell editor component uses built-in date serializer instead of relying on user-defined date formatter | ![Screenshot_20250610_000018](https://github.com/user-attachments/assets/d80cc7ea-d2aa-4350-99ad-bc34e2b81df4) | ![Screenshot_20250610_000028](https://github.com/user-attachments/assets/a3d87d94-1156-462b-bffc-d61260ff5462) |