### PR TITLE
AG-14482 updates

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/row-dragging/_examples/dragging-events/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-dragging/_examples/dragging-events/main.ts
@@ -55,18 +55,32 @@ function onRowDragEnter(e: RowDragEnterEvent) {
 
 function onRowDragEnd(e: RowDragEndEvent) {
     console.log('onRowDragEnd', e);
+    e.api.setRowDropPositionIndicator(null);
 }
 
 function onRowDragMove(e: RowDragMoveEvent) {
     console.log('onRowDragMove', e);
+
+    const overNodeTop = e.overNode?.rowTop ?? 0;
+    const overNodeHeight = e.overNode?.rowHeight ?? 0;
+
+    // yRatio is 0 if the mouse is in the center of the row, less than -0.5 if above, greater than 0.5 if below
+    const yRatio = (e.y - overNodeTop - overNodeHeight / 2) / overNodeHeight;
+
+    e.api.setRowDropPositionIndicator({
+        row: e.overNode,
+        dropIndicatorPosition: yRatio < 0 ? 'above' : 'below',
+    });
 }
 
 function onRowDragLeave(e: RowDragLeaveEvent) {
     console.log('onRowDragLeave', e);
+    e.api.setRowDropPositionIndicator(null);
 }
 
 function onRowDragCancel(e: RowDragCancelEvent) {
     console.log('onRowDragCancel', e);
+    e.api.setRowDropPositionIndicator(null);
 }
 
 // setup the grid after the page has finished loading

--- a/documentation/ag-grid-docs/src/content/docs/row-dragging/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/row-dragging/index.mdoc
@@ -134,6 +134,8 @@ From the example the following can be noted:
 
 * Because `rowDragManaged` is not set, the row dragging is left enabled even if sorting or filtering is applied. This is because your application should decide if dragging should be allowed or suppressed using the `suppressRowDrag` property.
 
+* While dragging the row, the `setRowDropPositionIndicator` API method is called to display the projected row drop location using a horizontal line indicator.
+
 {% gridExampleRunner title="Row Drag Events" name="dragging-events" /%}
 
 ### Simple Unmanaged Example

--- a/packages/ag-grid-community/src/api/gridApi.ts
+++ b/packages/ag-grid-community/src/api/gridApi.ts
@@ -24,7 +24,10 @@ import type {
     UpdateChartParams,
 } from '../interfaces/IChartService';
 import type { CellRange, CellRangeParams } from '../interfaces/IRangeService';
-import type { RowDropHighlight } from '../interfaces/IRowDropHighlightService';
+import type {
+    RowDropPositionIndicator,
+    SetRowDropPositionIndicatorParams,
+} from '../interfaces/IRowDropHighlightService';
 import type { ServerSideGroupLevelState } from '../interfaces/IServerSideStore';
 import type { AdvancedFilterModel } from '../interfaces/advancedFilterModel';
 import type {
@@ -824,17 +827,17 @@ export interface _DragGridApi<TData> {
     getRowDropZoneParams(events?: RowDropZoneEvents): RowDropZoneParams | undefined;
 
     /**
+     * Gets the currently highlighted drop target row, previously set by `setRowDropHighlight`.
+     * @agModule `RowDragModule`
+     */
+    getRowDropPositionIndicator(): RowDropPositionIndicator<TData>;
+
+    /**
      * Sets the current highlighted row drop target.
      * This is useful for implementing custom unmanaged row drag and drop logic, to highlight the target row.
      * @agModule `RowDragModule`
      */
-    setRowDropHighlight(highlight: RowDropHighlight<TData> | null | undefined): void;
-
-    /**
-     * Gets the currently highlighted drop target row, previously set by `setRowDropHighlight`.
-     * @agModule `RowDragModule`
-     */
-    getRowDropHighlight(): RowDropHighlight<TData>;
+    setRowDropPositionIndicator(highlight: SetRowDropPositionIndicatorParams<TData> | null | undefined): void;
 }
 
 export interface _EditGridApi<TData> {

--- a/packages/ag-grid-community/src/api/gridApiFunctions.ts
+++ b/packages/ag-grid-community/src/api/gridApiFunctions.ts
@@ -161,8 +161,8 @@ export const gridApiFunctionsMap: Record<keyof GridApi, ValidationModuleName> = 
         addRowDropZone: 0,
         removeRowDropZone: 0,
         getRowDropZoneParams: 0,
-        getRowDropHighlight: 0,
-        setRowDropHighlight: 0,
+        getRowDropPositionIndicator: 0,
+        setRowDropPositionIndicator: 0,
     }),
     ...mod<_ColumnGridApi<any>>('ColumnApi', {
         getColumnDefs: 0,

--- a/packages/ag-grid-community/src/dragAndDrop/dragApi.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/dragApi.ts
@@ -1,6 +1,9 @@
 import type { BeanCollection } from '../context/context';
 import type { RowNode } from '../entities/rowNode';
-import type { RowDropHighlight } from '../interfaces/IRowDropHighlightService';
+import type {
+    RowDropPositionIndicator,
+    SetRowDropPositionIndicatorParams,
+} from '../interfaces/IRowDropHighlightService';
 import type { RowDropZoneEvents, RowDropZoneParams } from './rowDragFeature';
 
 export function addRowDropZone(beans: BeanCollection, params: RowDropZoneParams): void {
@@ -19,24 +22,24 @@ export function getRowDropZoneParams(beans: BeanCollection, events?: RowDropZone
     return beans.rowDragSvc?.rowDragFeature?.getRowDropZone(events);
 }
 
-export function getRowDropHighlight(beans: BeanCollection): RowDropHighlight {
+export function getRowDropPositionIndicator(beans: BeanCollection): RowDropPositionIndicator {
     const rowDropHighlightSvc = beans.rowDropHighlightSvc;
     return rowDropHighlightSvc
-        ? { row: rowDropHighlightSvc.row, position: rowDropHighlightSvc.position }
-        : { row: null, position: 'none' };
+        ? { row: rowDropHighlightSvc.row, dropIndicatorPosition: rowDropHighlightSvc.position }
+        : { row: null, dropIndicatorPosition: 'none' };
 }
 
-export function setRowDropHighlight<TData>(
+export function setRowDropPositionIndicator<TData>(
     beans: BeanCollection,
-    highlight: RowDropHighlight<TData> | null | undefined
+    params: SetRowDropPositionIndicatorParams<TData>
 ): void {
     const rowDropHighlightSvc = beans.rowDropHighlightSvc;
     if (!rowDropHighlightSvc) {
         return;
     }
 
-    const rowNode = highlight?.row;
-    let position = highlight?.position;
+    const rowNode = params?.row;
+    let position = params?.dropIndicatorPosition;
 
     if (position !== 'above' && position !== 'below') {
         position = 'none';

--- a/packages/ag-grid-community/src/dragAndDrop/dragModule.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/dragModule.ts
@@ -5,7 +5,7 @@ import { VERSION } from '../version';
 import { DragAndDropImageComponent } from './dragAndDropImageComponent';
 import { DragAndDropService } from './dragAndDropService';
 import { addRowDropZone, getRowDropZoneParams, removeRowDropZone } from './dragApi';
-import { getRowDropHighlight, setRowDropHighlight } from './dragApi';
+import { getRowDropPositionIndicator, setRowDropPositionIndicator } from './dragApi';
 import { DragService } from './dragService';
 import { HorizontalResizeService } from './horizontalResizeService';
 import { RowDragService } from './rowDragService';
@@ -84,8 +84,8 @@ export const RowDragModule: _ModuleWithApi<_DragGridApi<any>> = {
         addRowDropZone,
         removeRowDropZone,
         getRowDropZoneParams,
-        getRowDropHighlight,
-        setRowDropHighlight,
+        getRowDropPositionIndicator,
+        setRowDropPositionIndicator,
     },
     dependsOn: [SharedDragAndDropModule],
 };

--- a/packages/ag-grid-community/src/dragAndDrop/rowDropHighlightService.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDropHighlightService.ts
@@ -1,13 +1,13 @@
 import type { NamedBean } from '../context/bean';
 import { BeanStub } from '../context/beanStub';
 import type { RowNode } from '../entities/rowNode';
-import type { IRowDropHighlightService, RowDropHighlightPosition } from '../interfaces/IRowDropHighlightService';
+import type { DropIndicatorPosition, IRowDropHighlightService } from '../interfaces/IRowDropHighlightService';
 
 export class RowDropHighlightService extends BeanStub implements NamedBean, IRowDropHighlightService {
     beanName = 'rowDropHighlightSvc' as const;
 
     public row: RowNode | null = null;
-    public position: RowDropHighlightPosition = 'none';
+    public position: DropIndicatorPosition = 'none';
 
     public postConstruct(): void {
         this.addManagedEventListeners({
@@ -29,21 +29,21 @@ export class RowDropHighlightService extends BeanStub implements NamedBean, IRow
     public clear(): void {
         const last = this.row;
         if (last) {
+            this.row = null;
             this.position = 'none';
             last.dispatchRowEvent('rowHighlightChanged');
-            this.row = null;
         }
     }
 
-    public set(row: RowNode, position: RowDropHighlightPosition): void {
+    public set(row: RowNode, dropIndicatorPosition: Exclude<DropIndicatorPosition, 'none'>): void {
         const nodeChanged = row !== this.row;
-        const highlightChanged = position !== this.position;
+        const highlightChanged = dropIndicatorPosition !== this.position;
         if (nodeChanged || highlightChanged) {
             if (nodeChanged) {
                 this.clear();
             }
-            this.position = position;
             this.row = row;
+            this.position = dropIndicatorPosition;
             row.dispatchRowEvent('rowHighlightChanged');
         }
     }

--- a/packages/ag-grid-community/src/interfaces/IRowDropHighlightService.ts
+++ b/packages/ag-grid-community/src/interfaces/IRowDropHighlightService.ts
@@ -1,17 +1,22 @@
 import type { RowNode } from '../entities/rowNode';
 import type { IRowNode } from './iRowNode';
 
-export type RowDropHighlightPosition = 'above' | 'below' | 'none';
+export type DropIndicatorPosition = 'above' | 'below' | 'none';
 
-export interface RowDropHighlight<TData = any> {
+export interface RowDropPositionIndicator<TData = any> {
     row: IRowNode<TData> | null;
-    position: RowDropHighlightPosition;
+    dropIndicatorPosition: DropIndicatorPosition;
+}
+
+export interface SetRowDropPositionIndicatorParams<TData = any> {
+    row: IRowNode<TData> | null | undefined;
+    dropIndicatorPosition: DropIndicatorPosition | null | false;
 }
 
 export interface IRowDropHighlightService {
     readonly row: RowNode | null;
-    readonly position: RowDropHighlightPosition;
+    readonly position: DropIndicatorPosition;
 
     clear(): void;
-    set(row: RowNode, position: Exclude<RowDropHighlightPosition, 'none'>): void;
+    set(row: RowNode, dropIndicatorPosition: Exclude<DropIndicatorPosition, 'none'>): void;
 }

--- a/packages/ag-grid-community/src/main.ts
+++ b/packages/ag-grid-community/src/main.ts
@@ -1158,7 +1158,11 @@ export {
     UndoRedoEditModule,
     CustomEditorModule,
 } from './edit/editModule';
-export type { RowDropHighlightPosition, RowDropHighlight } from './interfaces/IRowDropHighlightService';
+export type {
+    DropIndicatorPosition,
+    SetRowDropPositionIndicatorParams,
+    RowDropPositionIndicator,
+} from './interfaces/IRowDropHighlightService';
 export type { EditStrategyType } from './interfaces/editStrategyType';
 export {
     RowSelectionModule,

--- a/testing/behavioural/src/drag-n-drop/row-drop-highlight-api.test.ts
+++ b/testing/behavioural/src/drag-n-drop/row-drop-highlight-api.test.ts
@@ -35,8 +35,8 @@ describe('ag-grid row highlight', () => {
         const element = TestGridsManager.getHTMLElement(api)!;
 
         const getRowHighlight = () => {
-            const { row, position } = api.getRowDropHighlight();
-            return { id: row?.id, position };
+            const { row, dropIndicatorPosition } = api.getRowDropPositionIndicator();
+            return { id: row?.id, position: dropIndicatorPosition };
         };
 
         const node1 = api.getRowNode('1')!;
@@ -49,37 +49,39 @@ describe('ag-grid row highlight', () => {
 
         // Null or undefined params
 
-        api.setRowDropHighlight(null);
+        api.setRowDropPositionIndicator(null);
         expect(getRowHighlight()).toEqual({ id: undefined, position: 'none' });
         expect(getElementHighlight(element)).toEqual({ id: undefined, position: 'none' });
 
-        api.setRowDropHighlight(undefined);
+        api.setRowDropPositionIndicator(undefined);
         expect(getRowHighlight()).toEqual({ id: undefined, position: 'none' });
         expect(getElementHighlight(element)).toEqual({ id: undefined, position: 'none' });
 
         // clear
 
-        for (const position of ['none', 'above', 'below'] as const) {
-            api.setRowDropHighlight({ row: null, position });
-            expect(getRowHighlight()).toEqual({ id: undefined, position: 'none' });
-            expect(getElementHighlight(element)).toEqual({ id: undefined, position: 'none' });
+        for (const row of [null, undefined]) {
+            for (const position of ['none', 'above', 'below'] as const) {
+                api.setRowDropPositionIndicator({ row, dropIndicatorPosition: position });
+                expect(getRowHighlight()).toEqual({ id: undefined, position: 'none' });
+                expect(getElementHighlight(element)).toEqual({ id: undefined, position: 'none' });
+            }
         }
 
         // set
 
-        api.setRowDropHighlight({ row: node1, position: 'above' });
+        api.setRowDropPositionIndicator({ row: node1, dropIndicatorPosition: 'above' });
         expect(getRowHighlight()).toEqual({ id: '1', position: 'above' });
         expect(getElementHighlight(element)).toEqual({ id: '1', position: 'above' });
 
-        api.setRowDropHighlight({ row: node1, position: 'below' });
+        api.setRowDropPositionIndicator({ row: node1, dropIndicatorPosition: 'below' });
         expect(getRowHighlight()).toEqual({ id: '1', position: 'below' });
         expect(getElementHighlight(element)).toEqual({ id: '1', position: 'below' });
 
-        api.setRowDropHighlight({ row: node2, position: 'below' });
+        api.setRowDropPositionIndicator({ row: node2, dropIndicatorPosition: 'below' });
         expect(getRowHighlight()).toEqual({ id: '2', position: 'below' });
         expect(getElementHighlight(element)).toEqual({ id: '2', position: 'below' });
 
-        api.setRowDropHighlight({ row: node3, position: 'above' });
+        api.setRowDropPositionIndicator({ row: node3, dropIndicatorPosition: 'above' });
         expect(getRowHighlight()).toEqual({ id: '3', position: 'above' });
         expect(getElementHighlight(element)).toEqual({ id: '3', position: 'above' });
 
@@ -94,15 +96,15 @@ describe('ag-grid row highlight', () => {
         expect(getRowHighlight()).toEqual({ id: undefined, position: 'none' });
         expect(getElementHighlight(element)).toEqual({ id: undefined, position: 'none' });
 
-        api.setRowDropHighlight({ row: node3, position: 'below' });
+        api.setRowDropPositionIndicator({ row: node3, dropIndicatorPosition: 'below' });
         expect(getRowHighlight()).toEqual({ id: undefined, position: 'none' });
         expect(getElementHighlight(element)).toEqual({ id: undefined, position: 'none' });
 
         // set and clear
 
         for (const position of ['none', 'above', 'below'] as const) {
-            api.setRowDropHighlight({ row: node1, position: 'below' });
-            api.setRowDropHighlight({ row: null, position });
+            api.setRowDropPositionIndicator({ row: node1, dropIndicatorPosition: 'below' });
+            api.setRowDropPositionIndicator({ row: null, dropIndicatorPosition: position });
             expect(getRowHighlight()).toEqual({ id: undefined, position: 'none' });
             expect(getElementHighlight(element)).toEqual({ id: undefined, position: 'none' });
         }


### PR DESCRIPTION
After a review with Kiril, we decided to change the API names and their arguments.

- renamed methods and types to: 
    - getRowDropPositionIndicator() : {row, dropIndicatorPosition = "above" | "below" | "none"}
    - setRowDropPositionIndicator({row, dropIndicatorPosition = "above" | "below" | "none"})
- change the example documentation/ag-grid-docs/src/content/docs/row-dragging/_examples/dragging-events/main.ts to show how to use the new drop position api