### PR TITLE
AG-15116 Deprecating advanced filter eval approach. Always use tree based filter

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-advanced/index.mdoc
@@ -254,12 +254,6 @@ When [Pivoting](./pivoting/), Pivot Result Columns will not appear in the Advanc
 
 In addition to the Client-Side Row Model, the Advanced Filter can be used with the [Server-Side Row Model](./row-models/). See the [SSRM Advanced Filter Example](./server-side-model-filtering/#advanced-filter) for more information.
 
-## Suppress Advanced Filter Function Evaluation
-
-To provide the best performance, Advanced Filter sanitises the filter input and passes it to `new Function()`. This requires the `unsafe-eval` policy in order to work.
-
-If this policy cannot be enabled, it is still possible to use Advanced Filter by setting the grid option `suppressAdvancedFilterEval = true`. This will use defined functions instead, and will result in the same functional behaviour, but filtering will be slightly slower.
-
 ## Localisation
 
 If providing custom [Localisation](./localisation/) values for the Advanced Filter, note that if the filter option values contain spaces, one option value cannot start with another option value.

--- a/documentation/ag-grid-docs/src/content/docs/security/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/security/index.mdoc
@@ -12,11 +12,9 @@ The basic information on Content Security Policy can be found on the [MDN web do
 
 Some optional grid features compile string expressions into code, and if you're using these then the `script-src 'unsafe-eval'` directive is required. However, it is possible to avoid this requirement as listed below:
 
-1. Many grid properties such as [Cell Class Rules](./cell-styles/#cell-class-rules) and [Value Getters](./value-getters/) allow using expressions. However, this requires `script-src 'unsafe-eval'`. In order to avoid this requirement, replace expressions with functions as shown in the example below for the cellClassRules property of a column definition:
+ * Many grid properties such as [Cell Class Rules](./cell-styles/#cell-class-rules) and [Value Getters](./value-getters/) allow using expressions. However, this requires `script-src 'unsafe-eval'`. In order to avoid this requirement, replace expressions with functions as shown in the example below for the cellClassRules property of a column definition:
     * `{ 'is-negative': 'value < 0' }` requires `script-src 'unsafe-eval'` so that `'value < 0'` can be compiled into a function.
     * `{ 'is-negative': params => params.value < 0 }` does not because you have provided a function.
-
-2. By default, [Advanced Filter](./filter-advanced) also requires `script-src 'unsafe-eval'`, but this can be avoided by [Suppressing Advanced Filter Function Evaluation](./filter-advanced/#suppress-advanced-filter-function-evaluation).
 
 ### style-src
 

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
@@ -795,7 +795,8 @@ export class AgGridAngular<TData = any, TColDef extends ColDef<TData> = ColDef<a
     /** When using AG Grid Enterprise, the Set Filter is used by default when `filter: true` is set on column definitions.
      * Set to `true` to prevent this and instead use the Text Filter, Number Filter or Date Filter based on the cell data type,
      * the same as when using AG Grid Community.
-     * @default false
+     * @deprecated As of v33.3, advanced filter evaluation is deprecated, and this option will default to true.
+     * @default true
      * @initial
      * @agModule TextFilterModule / NumberFilterModule / DateFilterModule / MultiFilterModule / CustomFilterModule
      */

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
@@ -796,6 +796,7 @@ export class AgGridAngular<TData = any, TColDef extends ColDef<TData> = ColDef<a
     /** When using AG Grid Enterprise, the Set Filter is used by default when `filter: true` is set on column definitions.
      * Set to `true` to prevent this and instead use the Text Filter, Number Filter or Date Filter based on the cell data type,
      * the same as when using AG Grid Community.
+     * @default false
      * @initial
      * @agModule TextFilterModule / NumberFilterModule / DateFilterModule / MultiFilterModule / CustomFilterModule
      */

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
@@ -785,10 +785,7 @@ export class AgGridAngular<TData = any, TColDef extends ColDef<TData> = ColDef<a
      * @agModule `AdvancedFilterModule`
      */
     @Input() public advancedFilterBuilderParams: IAdvancedFilterBuilderParams | undefined = undefined;
-    /** By default, Advanced Filter sanitises user input and passes it to `new Function()` to provide the best performance.
-     * Set to `true` to prevent this and use defined functions instead.
-     * This will result in slower filtering, but it enables Advanced Filter to work when `unsafe-eval` is disabled.
-     * @deprecated As of v34, advanced filter evaluation is deprecated, and this option will default to true.
+    /** @deprecated As of v34, advanced filter no longer uses function evaluation, so this option has no effect.
      * @default true
      * @agModule `AdvancedFilterModule`
      */

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
@@ -788,15 +788,14 @@ export class AgGridAngular<TData = any, TColDef extends ColDef<TData> = ColDef<a
     /** By default, Advanced Filter sanitises user input and passes it to `new Function()` to provide the best performance.
      * Set to `true` to prevent this and use defined functions instead.
      * This will result in slower filtering, but it enables Advanced Filter to work when `unsafe-eval` is disabled.
-     * @default false
+     * @deprecated As of v34, advanced filter evaluation is deprecated, and this option will default to true.
+     * @default true
      * @agModule `AdvancedFilterModule`
      */
     @Input({ transform: booleanAttribute }) public suppressAdvancedFilterEval: boolean | undefined = undefined;
     /** When using AG Grid Enterprise, the Set Filter is used by default when `filter: true` is set on column definitions.
      * Set to `true` to prevent this and instead use the Text Filter, Number Filter or Date Filter based on the cell data type,
      * the same as when using AG Grid Community.
-     * @deprecated As of v33.3, advanced filter evaluation is deprecated, and this option will default to true.
-     * @default true
      * @initial
      * @agModule TextFilterModule / NumberFilterModule / DateFilterModule / MultiFilterModule / CustomFilterModule
      */

--- a/packages/ag-grid-community/src/entities/gridOptions.ts
+++ b/packages/ag-grid-community/src/entities/gridOptions.ts
@@ -690,7 +690,7 @@ export interface GridOptions<TData = any> {
      */
     advancedFilterBuilderParams?: IAdvancedFilterBuilderParams;
     /**
-     * @deprecated As of v34, advanced filter evaluation is deprecated, and this option will default to true.
+     * @deprecated As of v34, advanced filter no longer uses function evaluation, so this option has no effect.
      * @default true
      * @agModule `AdvancedFilterModule`
      */

--- a/packages/ag-grid-community/src/entities/gridOptions.ts
+++ b/packages/ag-grid-community/src/entities/gridOptions.ts
@@ -699,6 +699,7 @@ export interface GridOptions<TData = any> {
      * When using AG Grid Enterprise, the Set Filter is used by default when `filter: true` is set on column definitions.
      * Set to `true` to prevent this and instead use the Text Filter, Number Filter or Date Filter based on the cell data type,
      * the same as when using AG Grid Community.
+     * @default false
      * @initial
      * @agModule TextFilterModule / NumberFilterModule / DateFilterModule / MultiFilterModule / CustomFilterModule
      */

--- a/packages/ag-grid-community/src/entities/gridOptions.ts
+++ b/packages/ag-grid-community/src/entities/gridOptions.ts
@@ -701,7 +701,8 @@ export interface GridOptions<TData = any> {
      * When using AG Grid Enterprise, the Set Filter is used by default when `filter: true` is set on column definitions.
      * Set to `true` to prevent this and instead use the Text Filter, Number Filter or Date Filter based on the cell data type,
      * the same as when using AG Grid Community.
-     * @default false
+     * @deprecated As of v33.3, advanced filter evaluation is deprecated, and this option will default to true.
+     * @default true
      * @initial
      * @agModule TextFilterModule / NumberFilterModule / DateFilterModule / MultiFilterModule / CustomFilterModule
      */

--- a/packages/ag-grid-community/src/entities/gridOptions.ts
+++ b/packages/ag-grid-community/src/entities/gridOptions.ts
@@ -690,10 +690,8 @@ export interface GridOptions<TData = any> {
      */
     advancedFilterBuilderParams?: IAdvancedFilterBuilderParams;
     /**
-     * By default, Advanced Filter sanitises user input and passes it to `new Function()` to provide the best performance.
-     * Set to `true` to prevent this and use defined functions instead.
-     * This will result in slower filtering, but it enables Advanced Filter to work when `unsafe-eval` is disabled.
-     * @default false
+     * @deprecated As of v34, advanced filter evaluation is deprecated, and this option will default to true.
+     * @default true
      * @agModule `AdvancedFilterModule`
      */
     suppressAdvancedFilterEval?: boolean;
@@ -701,8 +699,6 @@ export interface GridOptions<TData = any> {
      * When using AG Grid Enterprise, the Set Filter is used by default when `filter: true` is set on column definitions.
      * Set to `true` to prevent this and instead use the Text Filter, Number Filter or Date Filter based on the cell data type,
      * the same as when using AG Grid Community.
-     * @deprecated As of v33.3, advanced filter evaluation is deprecated, and this option will default to true.
-     * @default true
      * @initial
      * @agModule TextFilterModule / NumberFilterModule / DateFilterModule / MultiFilterModule / CustomFilterModule
      */

--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterService.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterService.ts
@@ -184,33 +184,11 @@ export class AdvancedFilterService extends BeanStub implements NamedBean, IAdvan
             return;
         }
 
-        const { expressionFunction, params } = this.getFunction(expressionParser);
+        const { expressionFunction, params } = expressionParser.getFunction();
 
         this.expressionFunction = expressionFunction;
         this.expressionParams = params;
         this.appliedExpression = this.expression;
-    }
-
-    private getFunction(expressionParser: FilterExpressionParser): {
-        expressionFunction: FilterExpressionFunction;
-        params: FilterExpressionFunctionParams;
-    } {
-        // `suppressAdvancedFilterEval` has been deprecated.
-        // For now assume only users who have explicitly set it to false wish to filter eval.
-        if (this.gos.get('suppressAdvancedFilterEval') !== false) {
-            return expressionParser.getFunctionParsed();
-        } else {
-            const { functionString, params } = expressionParser.getFunctionString();
-            return {
-                expressionFunction: new Function(
-                    'expressionProxy',
-                    'node',
-                    'params',
-                    functionString
-                ) as FilterExpressionFunction,
-                params,
-            };
-        }
     }
 
     public updateValidity(): boolean {

--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterService.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterService.ts
@@ -195,7 +195,9 @@ export class AdvancedFilterService extends BeanStub implements NamedBean, IAdvan
         expressionFunction: FilterExpressionFunction;
         params: FilterExpressionFunctionParams;
     } {
-        if (this.gos.get('suppressAdvancedFilterEval')) {
+        // `suppressAdvancedFilterEval` has been deprecated.
+        // For now assume only users who have explicitly set it to false wish to filter eval.
+        if (this.gos.get('suppressAdvancedFilterEval') !== false) {
             return expressionParser.getFunctionParsed();
         } else {
             const { functionString, params } = expressionParser.getFunctionString();

--- a/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
@@ -391,15 +391,7 @@ export class ColFilterExpressionParser {
         return null;
     }
 
-    public getFunctionString(params: FilterExpressionFunctionParams): string {
-        return this.getFunctionCommon(params, (operandIndex, operatorIndex, colId, evaluatorParamsIndex) => {
-            const escapedColId = escapeQuotes(colId);
-            const operand = operandIndex == null ? '' : `, params.operands[${operandIndex}]`;
-            return `params.operators[${operatorIndex}].evaluator(expressionProxy.getValue('${escapedColId}', node), node, params.evaluatorParams[${evaluatorParamsIndex}]${operand})`;
-        });
-    }
-
-    public getFunctionParsed(params: FilterExpressionFunctionParams): FilterExpressionFunction {
+    public getFunction(params: FilterExpressionFunctionParams): FilterExpressionFunction {
         return this.getFunctionCommon(params, (operandIndex, operatorIndex, colId, evaluatorParamsIndex) => {
             return (expressionProxy, node, p) =>
                 p.operators[operatorIndex].evaluator(

--- a/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/colFilterExpressionParser.ts
@@ -11,7 +11,6 @@ import type {
 } from './filterExpressionUtils';
 import {
     checkAndUpdateExpression,
-    escapeQuotes,
     findEndPosition,
     findStartPosition,
     getSearchString,

--- a/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionParser.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionParser.ts
@@ -46,7 +46,7 @@ export class FilterExpressionParser {
     } {
         const params = this.createFunctionParams();
         return {
-            expressionFunction: this.joinExpressionParser.getFunctionParsed(params),
+            expressionFunction: this.joinExpressionParser.getFunction(params),
             params,
         };
     }

--- a/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionParser.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionParser.ts
@@ -40,18 +40,7 @@ export class FilterExpressionParser {
             : this.params.advFilterExpSvc.translate('advancedFilterValidationMessageAtEnd', [message]);
     }
 
-    public getFunctionString(): {
-        functionString: string;
-        params: FilterExpressionFunctionParams;
-    } {
-        const params = this.createFunctionParams();
-        return {
-            functionString: `return ${this.joinExpressionParser.getFunctionString(params)};`,
-            params,
-        };
-    }
-
-    public getFunctionParsed(): {
+    public getFunction(): {
         expressionFunction: FilterExpressionFunction;
         params: FilterExpressionFunctionParams;
     } {

--- a/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionUtils.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/filterExpressionUtils.ts
@@ -127,7 +127,3 @@ export function checkAndUpdateExpression(
         ).updatedValue;
     }
 }
-
-export function escapeQuotes(value: string): string {
-    return value.replace(/(['"])/, '\\$1');
-}

--- a/packages/ag-grid-enterprise/src/advancedFilter/joinFilterExpressionParser.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/joinFilterExpressionParser.ts
@@ -269,17 +269,9 @@ export class JoinFilterExpressionParser {
         return null;
     }
 
-    public getFunctionString(params: FilterExpressionFunctionParams): string {
-        const hasMultipleExpressions = this.expressionParsers.length > 1;
-        const expression = this.expressionParsers
-            .map((expressionParser) => expressionParser.getFunctionString(params))
-            .join(` ${this.operatorParser.getFunction()} `);
-        return hasMultipleExpressions ? `(${expression})` : expression;
-    }
-
-    public getFunctionParsed(params: FilterExpressionFunctionParams): FilterExpressionFunction {
+    public getFunction(params: FilterExpressionFunctionParams): FilterExpressionFunction {
         const operator = this.operatorParser.getFunction();
-        const funcs = this.expressionParsers.map((expressionParser) => expressionParser.getFunctionParsed(params));
+        const funcs = this.expressionParsers.map((expressionParser) => expressionParser.getFunction(params));
         const arrayFunc = operator === '&&' ? 'every' : 'some';
         return (expressionProxy, node, p) => funcs[arrayFunc]((func) => func(expressionProxy, node, p));
     }

--- a/packages/ag-grid-vue3/src/components/utils.ts
+++ b/packages/ag-grid-vue3/src/components/utils.ts
@@ -614,6 +614,7 @@ export interface Props<TData> {
     /** When using AG Grid Enterprise, the Set Filter is used by default when `filter: true` is set on column definitions.
          * Set to `true` to prevent this and instead use the Text Filter, Number Filter or Date Filter based on the cell data type,
          * the same as when using AG Grid Community.
+         * @default false
          * @initial
          * @agModule TextFilterModule / NumberFilterModule / DateFilterModule / MultiFilterModule / CustomFilterModule
          */

--- a/packages/ag-grid-vue3/src/components/utils.ts
+++ b/packages/ag-grid-vue3/src/components/utils.ts
@@ -606,17 +606,14 @@ export interface Props<TData> {
          * @agModule `AdvancedFilterModule`
          */
     advancedFilterBuilderParams?: IAdvancedFilterBuilderParams | undefined,
-    /** By default, Advanced Filter sanitises user input and passes it to `new Function()` to provide the best performance.
-         * Set to `true` to prevent this and use defined functions instead.
-         * This will result in slower filtering, but it enables Advanced Filter to work when `unsafe-eval` is disabled.
-         * @default false
+    /** @deprecated As of v34, advanced filter evaluation is deprecated, and this option will default to true.
+         * @default true
          * @agModule `AdvancedFilterModule`
          */
     suppressAdvancedFilterEval?: boolean | undefined,
     /** When using AG Grid Enterprise, the Set Filter is used by default when `filter: true` is set on column definitions.
          * Set to `true` to prevent this and instead use the Text Filter, Number Filter or Date Filter based on the cell data type,
          * the same as when using AG Grid Community.
-         * @default false
          * @initial
          * @agModule TextFilterModule / NumberFilterModule / DateFilterModule / MultiFilterModule / CustomFilterModule
          */

--- a/packages/ag-grid-vue3/src/components/utils.ts
+++ b/packages/ag-grid-vue3/src/components/utils.ts
@@ -606,7 +606,7 @@ export interface Props<TData> {
          * @agModule `AdvancedFilterModule`
          */
     advancedFilterBuilderParams?: IAdvancedFilterBuilderParams | undefined,
-    /** @deprecated As of v34, advanced filter evaluation is deprecated, and this option will default to true.
+    /** @deprecated As of v34, advanced filter no longer uses function evaluation, so this option has no effect.
          * @default true
          * @agModule `AdvancedFilterModule`
          */


### PR DESCRIPTION
Deprecated the Advanced Filter function eval in favour of always using the tree based approach. This may cause minor perfromance issues for highly nested filters, but simplifies the approach and allows for more function types.

Documentation updated to reflect this. Unsure how to write relase note or mark deprecations in the docs.