### PR TITLE
AG-15449: Corrects selectedNodes type

### DIFF
--- a/packages/ag-grid-community/src/events.ts
+++ b/packages/ag-grid-community/src/events.ts
@@ -347,7 +347,7 @@ export interface SelectionChangedEvent<TData = any, TContext = any>
     /** The source that triggered the selection change event. */
     source: SelectionEventSourceType;
     /** The row nodes that are selected at the time the event is generated. When selecting all nodes in SSRM or when group selecting in SSRM, this will be `null`. */
-    selectedNodes: IRowNode[] | null;
+    selectedNodes: IRowNode<TData>[] | null;
     /** The SSRM selection state. This can be referred to when `selectedNodes` is `null`. This will be `null` when using a row model other than SSRM. */
     serverSideState: IServerSideSelectionState | IServerSideGroupSelectionState | null;
 }


### PR DESCRIPTION
- fixes: https://github.com/ag-grid/ag-grid/issues/10774
- explanation: passes `TData` generic to `selectedNode` `IRowNode[]` type for proper `selectedNode[0].data` typing
    - before: `IRowNode[]`
    - after:`IRowNode<TData>[]`