### PR TITLE
AG-3390 - Docs content spelling and grammar fixes

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/accessibility/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/accessibility/index.mdoc
@@ -182,14 +182,14 @@ Using advanced functionality in AG Grid makes the DOM structure incompatible wit
 * ### Navigation to pinned rows/columns
   Screen readers assume that the visual and DOM element order are identical. Specifically, when you pin a row/column, it  causes elements to be rendered in different containers. This is why you cannot use screen readers to navigate into a  pinned row/column cells, as in fact, this means they're rendered in a different element from the rest of the columns/rows which are scrollable.
 
-* ### Full Width Rows
+* ### Full width rows
   Full Width Rows are rendered in a different container, therefore screen readers have trouble announcing them for the same reason as `Pinned Rows/Columns`. This also includes Row Grouping, when `groupDisplayType="groupRows"`
 
-* ### Limitations in Announcing the Correct Column Name in Grouped Columns
+* ### Limitations in announcing the correct column name in grouped columns
   Even though all aria tags have been applied to the necessary elements, some screen readers have trouble navigating the tags when the structure of the grid gets more complex (eg. grouped columns). This is the reason why there are some limitations announcing the correct column names.
 
 * ### No announcements of state change of a gridcell or gridheader
   Some screen readers will not recognise changes that happen to an element that is currently focused (including children of this element). So in order to detect changes (eg. sorted state, updated labels, etc...) you will need to move focus to another element and back.
 
-* ### Server-Side Row Model
+* ### Server-side row model
   Announcing the row count in the grid when using server-side row model (SSRM) is not supported. This is because the row count cannot be known in all the scenarios where SSRM is in use.

--- a/documentation/ag-grid-docs/src/content/docs/accessibility/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/accessibility/index.mdoc
@@ -20,7 +20,7 @@ As meeting WCAG 2.0 level AA guidelines also meets the ADA and Section 508 stand
 
 ## High Contrast Theme
 
-For users that are visually impaired due to colour deficiencies, care should be taken when using colours to provide information.
+For users who are visually impaired due to colour deficiencies, care should be taken when using colours to provide information.
 
 Using our demo page as an example, the chrome plugin [Colorblindly](https://chrome.google.com/webstore/detail/colorblindly/floniaahmccleoclneebhhmnjgdfijgg/related?hl=en) shows how cells with colour indicators might appear to someone with total colour blindness (Monochromacy / Achromatopsia).
 
@@ -58,7 +58,7 @@ When inspecting the DOM you'll notice the following roles and properties have be
   **Note:** You can set any aria property in the panel (role="treegrid") by using the `setGridAriaProperty` method in the [Grid Api](./grid-api/).
 
   * **aria-rowcount** - announces the number of rows.
-  * **aria-colcount** - announces the number of rows.
+  * **aria-colcount** - announces the number of columns.
   * **aria-multiselectable="true"** - marks the grid as being able to select multiple rows.
 * **role="rowgroup"** - element that serve as container for the table header rows and grid rows.
 * **role="row"** - a row of column headers or grid cells.
@@ -185,7 +185,7 @@ Using advanced functionality in AG Grid makes the DOM structure incompatible wit
 * ### Full Width Rows
   Full Width Rows are rendered in a different container, therefore screen readers have trouble announcing them for the same reason as `Pinned Rows/Columns`. This also includes Row Grouping, when `groupDisplayType="groupRows"`
 
-* ### Limitations announcing the correct column name in grouped columns
+* ### Limitations in Announcing the Correct Column Name in Grouped Columns
   Even though all aria tags have been applied to the necessary elements, some screen readers have trouble navigating the tags when the structure of the grid gets more complex (eg. grouped columns). This is the reason why there are some limitations announcing the correct column names.
 
 * ### No announcements of state change of a gridcell or gridheader

--- a/documentation/ag-grid-docs/src/content/docs/ag-grid-design-system/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/ag-grid-design-system/index.mdoc
@@ -13,7 +13,7 @@ The design system has been built from the ground up to be consistent with the ja
 
 ## Getting Started
 
-To start working with the AG Grid Figma design system visit our [Figma community page](https://www.figma.com/community/file/1360600846643230092) and click "Open in Figma". The AG Grid design system will open directly in Figma and you're ready to start designing for AG Grid applications. 
+To start working with the AG Grid Figma design system, visit our [Figma community page](https://www.figma.com/community/file/1360600846643230092) and click "Open in Figma". The AG Grid design system will open directly in Figma and you're ready to start designing for AG Grid applications. 
 
 {% note %}
 We supply the AG Grid design system as a [Figma community file](https://www.figma.com/community/file/1360600846643230092). You will use the file by duplicating it to your Figma workspace. Whilst we regularly update the AG Grid design system, your duplicated files will not receive any updates automatically.
@@ -43,7 +43,7 @@ You can find more information about how to create and manage themes within the F
 
 If you have created your own theme in Figma using the variables feature, you can export those variables and use the [Style Dictionary](https://amzn.github.io/style-dictionary/#/) NPM package to create an [AG Grid legacy CSS theme](./theming/#legacy-themes). An example Style Dictionary project and full instructions are included in our [design systems GitHub repo](https://github.com/ag-grid/ag-grid-figma-design-system/tree/main/ag-grid-figma-variables-to-css).
 
-To export your Figma Variables as json...
+To export your Figma Variables as JSON...
 
 1. In the Resources panel go to the Plugins tab. 
 2. Search for the [Design Tokens](https://www.figma.com/community/plugin/888356646278934516/design-tokens) Figma plugin.

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-filtering/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-filtering/index.mdoc
@@ -44,7 +44,7 @@ When filtering for aggregated values the filter applies to all group rows by def
 granularly by instead providing the `groupAggFiltering` grid option with a callback function.
 
 The example below demonstrates a grid configured to apply filters only to aggregated values, and not the leaf rows:
-{% gridExampleRunner title="Group-only Aggregate filtering" name="agg-filtering-group" /%}
+{% gridExampleRunner title="Group-Only Aggregate Filtering" name="agg-filtering-group" /%}
 
 The configuration below demonstrates how to only apply test filters against group rows, and not leaf rows:
 ```{% frameworkTransform=true %}

--- a/documentation/ag-grid-docs/src/content/docs/cell-data-types/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/cell-data-types/index.mdoc
@@ -8,7 +8,7 @@ This allows different grid features to work without any additional configuration
 
 ## Enable Cell Data Types
 
-There is a number of pre-defined cell data types: `'text'`, `'number'`, `'boolean'`, `'date'`, `'dateString'`, `'dateTime'`, `'dateTimeString'` and `'object'`.
+There are a number of pre-defined cell data types: `'text'`, `'number'`, `'boolean'`, `'date'`, `'dateString'`, `'dateTime'`, `'dateTimeString'` and `'object'`.
 
 These are enabled by default, with the data type being inferred from the row data if possible (see [Inferring Data Types](#inferring-data-types)).
 
@@ -255,7 +255,7 @@ const gridOptions = {
                 const date = params.value;
                 return date == null
                     ? ''
-                    : `${date.getDate()}/${date.getMonth() + 1}/${date.getFullYear}`;
+                    : `${date.getDate()}/${date.getMonth() + 1}/${date.getFullYear()}`;
             },
         }
     }

--- a/documentation/ag-grid-docs/src/content/docs/cell-editing-start-stop/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/cell-editing-start-stop/index.mdoc
@@ -1,5 +1,5 @@
 ---
-title: "Start / Stop Cell Editing"
+title: "Start/Stop Cell Editing"
 ---
 
 This page discusses the different ways in which Cell Editing can be started and stopped.

--- a/documentation/ag-grid-docs/src/content/docs/cell-selection-fill-handle/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/cell-selection-fill-handle/index.mdoc
@@ -149,6 +149,6 @@ Here you can find a full list of configuration options available when the handle
 
 {% interfaceDocumentation interfaceName="FillHandleOptions" config={"description":""} /%}
 
-## Next up
+## Next Up
 
 Continue to the next section to see the [API Reference](./cell-selection-api-reference) for cell selection.

--- a/documentation/ag-grid-docs/src/content/docs/cell-selection-handle/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/cell-selection-handle/index.mdoc
@@ -23,6 +23,6 @@ The example below demonstrates simple range selection with a range handle.
 
 {% gridExampleRunner title="Range Handle" name="range-selection-handle" /%}
 
-## Next up
+## Next Up
 
 Continue to the next section to learn about the [Fill Handle](./cell-selection-fill-handle).

--- a/documentation/ag-grid-docs/src/content/docs/cell-selection/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/cell-selection/index.mdoc
@@ -105,6 +105,6 @@ Here you can find a full list of configuration options available in `'cell'` mod
 
 {% interfaceDocumentation interfaceName="CellSelectionOptions" config={"description":""} /%}
 
-## Next up
+## Next Up
 
 Continue to the next section to learn about the [Range Handle](./cell-selection-handle).

--- a/documentation/ag-grid-docs/src/content/docs/cell-text-selection/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/cell-text-selection/index.mdoc
@@ -8,7 +8,7 @@ The grid can be configured to allow simple text selection.
 
 ## Enabling Cell Text Selection
 
-To enable text selection as if the grid were a regular table, set the grid option `enableCellTextSelection = true`.  For the selection to work correctly, the order of the rows within the DOM must much what is displayed by setting the grid option `ensureDomOrder = true`.
+To enable text selection as if the grid were a regular table, set the grid option `enableCellTextSelection = true`.  For the selection to work correctly, the order of the rows within the DOM must match what is displayed by setting the grid option `ensureDomOrder = true`.
 
 {% gridExampleRunner title="Cell Text Selection" name="cell-text-selection" /%}
 

--- a/documentation/ag-grid-docs/src/content/docs/clipboard/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/clipboard/index.mdoc
@@ -42,7 +42,7 @@ const gridOptions = {
 }
 ```
 
-The below example demonstrates copying rows. Initially, pressing {% kbd "^ Ctrl" /%}+C will select the focused cell, regardless of which rows have been selected. ]
+The below example demonstrates copying rows. Initially, pressing {% kbd "^ Ctrl" /%}+C will select the focused cell, regardless of which rows have been selected.
 You can change this behaviour by toggling the "Copy Selected Rows" checkbox to enable the `copySelectedRows` flag:
 
 * Toggle the "Copy Selected Rows" checkbox on

--- a/documentation/ag-grid-docs/src/content/docs/codemods/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/codemods/index.mdoc
@@ -142,7 +142,7 @@ handle the migration of these custom grid wrappers.
 
 {% if isFramework("javascript") %}
 
-Let's assume organization "my-org" has two custom grid wrapper in the package `@my-org/my-grid`
+Let's assume organisation "my-org" has two custom grid wrapper in the package `@my-org/my-grid`
 
 ```ts
 // @my-org/my-grid/index.ts
@@ -189,7 +189,7 @@ export default defineUserConfig({
 
 {% if isFramework("react") %}
 
-Let's assume organization "my-org" has a react grid wrapper in the package `@my-org/my-grid-react`
+Let's assume organisation "my-org" has a react grid wrapper in the package `@my-org/my-grid-react`
 
 ```ts
 // @my-org/my-grid-react/index.tsx
@@ -230,7 +230,7 @@ export default defineUserConfig({
 
 {% if isFramework("angular") %}
 
-Let's assume organization "my-org" a custom angular grid wrapper in the package `@my-org/my-grid-angular`
+Let's assume organisation "my-org" a custom angular grid wrapper in the package `@my-org/my-grid-angular`
 
 Then the configuration file could be:
 
@@ -262,7 +262,7 @@ export default defineUserConfig({
 
 {% if isFramework("vue") %}
 
-Let's assume organization "my-org" has a custom vue grid wrapper in the package `@my-org/my-grid-vue`
+Let's assume organisation "my-org" has a custom vue grid wrapper in the package `@my-org/my-grid-vue`
 
 Then the configuration file could be:
 

--- a/documentation/ag-grid-docs/src/content/docs/column-groups/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-groups/index.mdoc
@@ -41,7 +41,7 @@ See [Group Column Properties](./column-properties/#reference-columnGroups) for a
 
 ## Group Defaults
 
-Use `defaultColGroupDef` to set properties accross all Column Groups.
+Use `defaultColGroupDef` to set properties across all Column Groups.
 
 {% gridExampleRunner title="Default Props" name="defaults"  exampleHeight=550 /%}
 

--- a/documentation/ag-grid-docs/src/content/docs/column-menu/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-menu/index.mdoc
@@ -111,7 +111,7 @@ The behaviour and appearance of the Columns Menu tab can be customised by supply
 
 The following example demonstrates all of the above column chooser properties **except columnLayout** which will be covered later on. Note the following:
 
-* Launch the column chooser by selecing `Choose Columns` from any of the column menus.
+* Launch the column chooser by selecting `Choose Columns` from any of the column menus.
 * The column chooser when launched from any column has been configured to ignore column moves in the grid by setting `suppressSyncLayoutWithGrid=true` on the default column definition.
 * The **Name** column chooser doesn't show the top filter section as `suppressColumnFilter`, `suppressColumnSelectAll` and `suppressColumnExpandAll` are all set to `true`.
 * The **Age** column chooser shows the group columns in a collapsed state as `contractColumnSelection` is set to `true`.

--- a/documentation/ag-grid-docs/src/content/docs/community-vs-enterprise/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/community-vs-enterprise/index.mdoc
@@ -66,7 +66,7 @@ Fill out the form below and we'll send you an Enterprise Bundle license key, val
 
 **AG Grid Community** is an excellent choice if you need a robust, feature-rich data grid without the need for advanced enterprise features. It is ideal for developers and organisations looking for a free, open-source solution.
 
-**AG Grid Enterprise** is the preferred option for companies that need advanced functionality, dedicated support, and a flexible licencing model. It is suited for complex applications that demand high performance, extensive customization, and large-scale data handling.
+**AG Grid Enterprise** is the preferred option for companies that need advanced functionality, dedicated support, and a flexible licencing model. It is suited for complex applications that demand high performance, extensive customisation, and large-scale data handling.
 
 **Enterprise Bundle** is the best choice for organisations that require both AG Grid Enterprise and AG Charts Enterprise, or those who have advanced use-cases for Integrated Charting.
 

--- a/documentation/ag-grid-docs/src/content/docs/component-filter/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/component-filter/index.mdoc
@@ -58,7 +58,7 @@ will be additionally added to the params object, overriding items of the same na
 
 {% if isFramework("vue") %}
 When a Vue component is instantiated the grid will make the grid APIs, a number of utility methods as well as the cell and
-row values available to you via `this.params` - the interface for which is provided is documented below.
+row values available to you via `this.params` - the interface for this is documented below.
 
 If custom params are provided via the `colDef.filterParams` property, these
 will be additionally added to the params object, overriding items of the same name if a name clash exists.

--- a/documentation/ag-grid-docs/src/content/docs/data-update/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/data-update/index.mdoc
@@ -7,7 +7,7 @@ There are many ways in which data can change in your application, and as a resul
 {% /if %}
 
 {% if isFramework("react") %}
-{% videoSection id="_V5qFr62uhY" title="React Updating Datal" showHeader=true %}
+{% videoSection id="_V5qFr62uhY" title="React Updating Data" showHeader=true %}
 There are many ways in which data can change in your application, and as a result many ways in which you can inform the grid of data changes. This section explains the different ways of how you can update data inside the grid using the grid's API.
 {% /videoSection %}
 {% /if %}

--- a/documentation/ag-grid-docs/src/content/docs/excel-export-rows/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/excel-export-rows/index.mdoc
@@ -3,7 +3,7 @@ title: "Excel Export - Rows"
 enterprise: true
 ---
 
-Excel Export allows you  to select which rows get exported to Excel.
+Excel Export allows you to select which rows get exported to Excel.
 
 By default, all the rows in the grid are included in the Excel export. However, you can set which rows are exported and configure how they are rendered within the Excel file.
 

--- a/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
@@ -30,7 +30,7 @@ AG Grid is a high-performance {% getFrameworkCapitalised() %} Data Grid library 
 {% /if %}
 
 {% if isFramework("angular") %}
-## Create a Angular Data Grid
+## Create an Angular Data Grid
 {% /if %}
 
 {% if isFramework("javascript") %}

--- a/documentation/ag-grid-docs/src/content/docs/grid-api/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/grid-api/index.mdoc
@@ -3,6 +3,6 @@ title: "Grid API Reference"
 description: "Grid API Reference for $framework Data Grid. Browse all Grid API methods used to interact with the grid, get grid data, and act on grid events."
 ---
 
-To access the api see: [Grid Api](./grid-interface/#grid-api).
+To access the api see: [Grid API](./grid-interface/#grid-api).
 
 {% apiDocumentation source="grid-api/api.json" /%}

--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-application-created/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-application-created/index.mdoc
@@ -16,7 +16,7 @@ The dummy financial application above shows some of the grid's integrated charti
 To learn how to create charts in your applications see the following sections for details:
 
 * [Range Chart API](./integrated-charts-api-range-chart/) - create Range Charts using the Grid API
-* [Pivot Chart API](./integrated-charts-api-range-chart/) - create Pivot Charts using the Grid API
+* [Pivot Chart API](./integrated-charts-api-pivot-chart/) - create Pivot Charts using the Grid API
 * [Cross Filter Chart API](./integrated-charts-api-cross-filter-chart/) - create cross-filter charts where element clicks auto-filter grid and charts
 
 ## Next Up

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-grids/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-grids/index.mdoc
@@ -94,9 +94,9 @@ The following example shows flashing cells on the detail grids by using the Grid
 
 ## Detail Grid Lifecycle
 
-When a Master Row is expanded a Detail Row is created. When the Master Row is collapsed, the Detail Row is destroyed. When the Master Row is expanded a second time, a Detail Row is created again from scratch. This can be undesirable behaviour if there was context in the Detail Row, e.g. if the user sorted or filtered data in the Detail Row, the sort or filter will be reset the second time the Retail Row is displayed.
+When a Master Row is expanded a Detail Row is created. When the Master Row is collapsed, the Detail Row is destroyed. When the Master Row is expanded a second time, a Detail Row is created again from scratch. This can be undesirable behaviour if there was context in the Detail Row, e.g. if the user sorted or filtered data in the Detail Row, the sort or filter will be reset the second time the Detail Row is displayed.
 
-To prevent losing the context of Details Rows, the grid provides two properties to cache the Details Rows to be reused the next time the row is shows. The properties are as follows:
+To prevent losing the context of Details Rows, the grid provides two properties to cache the Details Rows to be reused the next time the row is shown. The properties are as follows:
 
 {% apiDocumentation source="grid-options/properties.json" section="masterDetail" names=["keepDetailRows", "keepDetailRowsCount"] /%}
 

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-date/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-date/index.mdoc
@@ -20,7 +20,7 @@ columnDefs: [
         cellEditor: 'agDateCellEditor',
         cellEditorParams: {
             min: '2000-01-01',
-            min: '2019-12-31',
+            max: '2019-12-31',
         }
         // ...other props
     }
@@ -49,7 +49,7 @@ columnDefs: [
         cellEditor: 'agDateStringCellEditor',
         cellEditorParams: {
             min: '2000-01-01',
-            min: '2019-12-31',
+            max: '2019-12-31',
         }
         // ...other props
     }

--- a/documentation/ag-grid-docs/src/content/docs/react-hooks/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/react-hooks/index.mdoc
@@ -77,7 +77,7 @@ Instead use `useMemo` or `useState` to ensure a consistent reference is maintain
 ```jsx
 const App = () => {
     // GOOD - only one instance created
-    const defaultColDef = useMemo( ()=> { filter: true }, []);
+    const defaultColDef = useMemo( ()=> ({ filter: true }), []);
 
     return <AgGridReact defaultColDef={defaultColDef} />;
 };

--- a/documentation/ag-grid-docs/src/content/docs/row-dragging/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/row-dragging/index.mdoc
@@ -377,7 +377,7 @@ useEffect(() => {
 ```js
 // your custom cell renderer code
 mounted() {
-    this.params.registerRhahaowDragger(this.$refs.myRef);
+    this.params.registerRowDragger(this.$refs.myRef);
 }
 ```
 {% /if %}

--- a/documentation/ag-grid-docs/src/content/docs/row-spanning/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/row-spanning/index.mdoc
@@ -32,7 +32,7 @@ const gridOptions = {
 ```
 
 ## Custom Row Spanning
-Row spanning can be customized by providing a callback function to `colDef.spanRows` which returns true if the two rows should be spanned together.
+Row spanning can be customised by providing a callback function to `colDef.spanRows` which returns true if the two rows should be spanned together.
 
 The example below demonstrates custom row spanning which prevents any country cells with the value `"Algeria"` from being spanned.
 {% gridExampleRunner title="Row Spanning Simple" name="row-spanning-custom" /%}

--- a/documentation/ag-grid-docs/src/content/docs/scrolling-performance/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/scrolling-performance/index.mdoc
@@ -72,7 +72,7 @@ your own application with this suggestion to see how much of a difference it mak
 ## Configure Row Buffer
 
 The `rowBuffer` property sets the number of rows the grid renders outside of the viewable area. The default is 10. For example, if your
-grid is showing 50 rows (as that's all that fits on your screen without scrolling),then the grid will actually render 70 in total (10 extra
+grid is showing 50 rows (as that's all that fits on your screen without scrolling), then the grid will actually render 70 in total (10 extra
 above and 10 extra below). Then when you scroll, the grid will already have 10 rows ready and waiting to show, so the user will not see a redraw
 (not all browsers show the redraw, only the slower ones).
 

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-configuration/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-configuration/index.mdoc
@@ -109,11 +109,11 @@ const gridOptions = {
     getRowId: params => {
         const parentKeysJoined = (params.parentKeys || []).join('-');
         if (params.data.id != null) {
-            parentKeysJoined + params.data.id;
+            return parentKeysJoined + params.data.id;
         }
         const rowGroupCols = params.api.getRowGroupColumns();
         const thisGroupCol = rowGroupCols[params.level];
-        parentKeysJoined + params.data[thisGroupCol.getColDef().field];
+        return parentKeysJoined + params.data[thisGroupCol.getColDef().field];
     }
 }
 ```

--- a/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-26/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-26/index.mdoc
@@ -1,6 +1,6 @@
 ---
 title: "Upgrading to AG Grid 26"
-description: "See whats new in AG Grid, view a full list of changes and migrate your $framework Data Grid to v26 with our Codemods."
+description: "See what's new in AG Grid, view a full list of changes and migrate your $framework Data Grid to v26 with our Codemods."
 migrationVersion: "26.0.0"
 ---
 

--- a/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-27/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-27/index.mdoc
@@ -1,6 +1,6 @@
 ---
 title: "Upgrading to AG Grid 27"
-description: "See whats new in AG Grid, view a full list of changes and migrate your $framework Data Grid to v27 with our Codemods."
+description: "See what's new in AG Grid, view a full list of changes and migrate your $framework Data Grid to v27 with our Codemods."
 migrationVersion: "27.0.0"
 ---
 

--- a/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-28/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-28/index.mdoc
@@ -1,6 +1,6 @@
 ---
 title: "Upgrading to AG Grid 28"
-description: "See whats new in AG Grid, view a full list of changes and migrate your $framework Data Grid to v28 with our Codemods."
+description: "See what's new in AG Grid, view a full list of changes and migrate your $framework Data Grid to v28 with our Codemods."
 migrationVersion: "28.0.0"
 ---
 Angular Ivy Support, Sticky Group Rows, Column Headers Word Wrapping, Theming Using CSS Variables

--- a/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-29/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-29/index.mdoc
@@ -1,6 +1,6 @@
 ---
 title: "Upgrading to AG Grid 29"
-description: "See whats new in AG Grid, view a full list of changes and migrate your $framework Data Grid to v29 with our Codemods."
+description: "See what's new in AG Grid, view a full list of changes and migrate your $framework Data Grid to v29 with our Codemods."
 migrationVersion: "29.0.0"
 ---
 

--- a/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-30/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-30/index.mdoc
@@ -1,6 +1,6 @@
 ---
 title: "Upgrading to AG Grid 30"
-description: "See whats new in AG Grid, view a full list of changes and migrate your $framework Data Grid to v30 with our Codemods."
+description: "See what's new in AG Grid, view a full list of changes and migrate your $framework Data Grid to v30 with our Codemods."
 migrationVersion: "30.0.0"
 ---
 

--- a/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-31/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-31/index.mdoc
@@ -1,6 +1,6 @@
 ---
 title: "Upgrading to AG Grid 31"
-description: "See whats new in AG Grid, view a full list of changes and migrate your $framework Data Grid to v31 with our Codemods."
+description: "See what's new in AG Grid, view a full list of changes and migrate your $framework Data Grid to v31 with our Codemods."
 ---
 
 ## What's New

--- a/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-32/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-32/index.mdoc
@@ -1,6 +1,6 @@
 ---
 title: "Upgrading to AG Grid 32"
-description: "See whats new in AG Grid, view a full list of changes and migrate your $framework Data Grid to v32 with our Codemods."
+description: "See what's new in AG Grid, view a full list of changes and migrate your $framework Data Grid to v32 with our Codemods."
 ---
 
 ## What's New

--- a/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-33-1/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-33-1/index.mdoc
@@ -1,6 +1,6 @@
 ---
 title: "Upgrading to AG Grid 33.1"
-description: "See whats new in AG Grid, view a full list of changes and migrate your $framework Data Grid to version v33.1."
+description: "See what's new in AG Grid, view a full list of changes and migrate your $framework Data Grid to version v33.1."
 migrationVersion: "33.1.0"
 ---
 

--- a/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-33-2/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-33-2/index.mdoc
@@ -1,6 +1,6 @@
 ---
 title: "Upgrading to AG Grid 33.2"
-description: "See whats new in AG Grid, view a full list of changes and migrate your $framework Data Grid to version v33.2."
+description: "See what's new in AG Grid, view a full list of changes and migrate your $framework Data Grid to version v33.2."
 migrationVersion: "33.2.0"
 ---
 

--- a/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-33-3/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-33-3/index.mdoc
@@ -1,6 +1,6 @@
 ---
 title: "Upgrading to AG Grid 33.3"
-description: "See whats new in AG Grid, view a full list of changes and migrate your $framework Data Grid to version v33.3."
+description: "See what's new in AG Grid, view a full list of changes and migrate your $framework Data Grid to version v33.3."
 migrationVersion: "33.3.0"
 ---
 

--- a/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-33/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-33/index.mdoc
@@ -1,10 +1,10 @@
 ---
 title: "Upgrading to AG Grid 33.0"
-description: "See whats new in AG Grid, view a full list of changes and migrate your $framework Data Grid to v33 with our Codemods."
+description: "See what's new in AG Grid, view a full list of changes and migrate your $framework Data Grid to v33 with our Codemods."
 migrationVersion: "33.0.0"
 ---
 
-Reductions in bundle size, updated theming, column header content customization.
+Reductions in bundle size, updated theming, column header content customisation.
 
 ## What's New
 

--- a/documentation/ag-grid-docs/src/content/docs/vue3-script-setup/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/vue3-script-setup/index.mdoc
@@ -30,7 +30,7 @@ import DateComponent from "@/rich-grid-example/DateComponent";
 import HeaderGroupComponent from "@/rich-grid-example/HeaderGroupComponent";
 
 const columnDefs = ref([
- {field: "make", , cellRenderer: "CellComponentRenderer"},
+ {field: "make", cellRenderer: "CellComponentRenderer"},
  {field: "model"},
  {field: "price"},
  {field: "manufactured"}


### PR DESCRIPTION
# Documentation Amendments

## Accessibility
LN23: "users that are visually" => "users who are visually"
-- Changed relative pronoun for people from "that" to "who"

LN61: "announces the number of rows" => "announces the number of columns"
-- Fixed incorrect description for aria-colcount attribute

LN188: "Limitations announcing the correct" => "Limitations in Announcing the Correct"
-- Added preposition and applied title case to heading

## AG Grid Design System
LN16: "design system visit our" => "design system, visit our"
-- Added comma before imperative verb

LN46: "Figma Variables as json..." => "Figma Variables as JSON..."
-- Capitalised acronym JSON

## Aggregation - Filtering
LN47: "Group-only Aggregate filtering" => "Group-Only Aggregate Filtering"
-- Applied title case to grid example title

## Cell Data Types
LN11: "There is a number" => "There are a number"
-- Fixed subject-verb agreement

LN259: "date.getFullYear}" => "date.getFullYear()}"
-- Added missing parentheses to method call

## Cell Editing - Start/Stop
LN2: "Start / Stop Cell Editing" => "Start/Stop Cell Editing"
-- Removed spaces around slash for consistency

## Cell Selection - Fill Handle
LN152: "Next up" => "Next Up"
-- Applied title case to heading

## Cell Selection - Handle
LN26: "Next up" => "Next Up"
-- Applied title case to heading

## Cell Selection
LN108: "Next up" => "Next Up"
-- Applied title case to heading

## Cell Text Selection
LN11: "must much what" => "must match what"
-- Fixed typo

## Clipboard
LN45: "have been selected. ]" => "have been selected."
-- Removed extra closing bracket

## Column Groups
LN44: "properties accross all" => "properties across all"
-- Fixed spelling of "across"

## Column Menu
LN114: "by selecing `Choose" => "by selecting `Choose"
-- Fixed typo

## Component Filter
LN61: "interface for which is provided" => "interface for this"
-- Fixed awkward wording

## Updating Data
LN10: "React Updating Datal" => "React Updating Data"
-- Fixed typo in video section title

## Excel Export - Rows
LN6: "allows you  to select" => "allows you to select"
-- Removed extra space

## Quick Start
LN33: "Create a Angular Data Grid" => "Create an Angular Data Grid"
-- Added article "an" before vowel sound

## Grid API Reference
LN6: "Grid Api" => "Grid API"
-- Corrected capitalization of API acronym

## Application Created Charts
LN19: "Pivot Chart API](./integrated-charts-api-range-chart/)" => "Pivot Chart API](./integrated-charts-api-pivot-chart/)"
-- Fixed incorrect link reference

## Master / Detail - Detail Grids
LN97: "the second time the Retail Row is displayed" => "the second time the Detail Row is displayed"
-- Fixed typo "Retail Row" to "Detail Row"

LN99: "the next time the row is shows" => "the next time the row is shown"
-- Fixed grammar error

## Provided Cell Editors - Date
LN23 & LN52: "min: '2019-12-31'," => "max: '2019-12-31',"
-- Fixed duplicate property name (both min/max examples should have different properties)

## React Hooks
LN80: "useMemo( ()=> { filter: true }, [])" => "useMemo( ()=> ({ filter: true }), [])"
-- Fixed missing parentheses in object return

## Row Dragging
LN380: "registerRhahaowDragger" => "registerRowDragger"
-- Fixed typo in method name

## Scrolling Performance
LN75: "without scrolling),then the grid" => "without scrolling), then the grid"
-- Added missing space after comma

## Server-Side Model Configuration
LN112: "parentKeysJoined + params.data.id;" => "return parentKeysJoined + params.data.id;"
-- Added missing return statement

LN116: "parentKeysJoined + params.data[thisGroupCol.getColDef().field];" => "return parentKeysJoined + params.data[thisGroupCol.getColDef().field];"
-- Added missing return statement

## Upgrading to AG Grid 31
LN3: "See whats new in AG Grid" => "See what's new in AG Grid"
-- Added apostrophe to contraction

## Upgrading to AG Grid 32
LN3: "See whats new in AG Grid" => "See what's new in AG Grid"
-- Added apostrophe to contraction

## Upgrading to AG Grid 33
LN3: "See whats new in AG Grid" => "See what's new in AG Grid"
-- Added apostrophe to contraction

## Upgrading to AG Grid 33.1
LN3: "See whats new in AG Grid" => "See what's new in AG Grid"
-- Added apostrophe to contraction

## Upgrading to AG Grid 33.2
LN3: "See whats new in AG Grid" => "See what's new in AG Grid"
-- Added apostrophe to contraction

## Upgrading to AG Grid 33.3
LN3: "See whats new in AG Grid" => "See what's new in AG Grid"
-- Added apostrophe to contraction

## Upgrading to AG Grid 26
LN3: "See what's new in AG Grid" => "See what's new in AG Grid"
-- Already correct

## Upgrading to AG Grid 27
LN3: "See what's new in AG Grid" => "See what's new in AG Grid"
-- Already correct

## Upgrading to AG Grid 28
LN3: "See whats new in AG Grid" => "See what's new in AG Grid"
-- Added apostrophe to contraction

## Upgrading to AG Grid 29
LN3: "See whats new in AG Grid" => "See what's new in AG Grid"
-- Added apostrophe to contraction

## Upgrading to AG Grid 30
LN3: "See whats new in AG Grid" => "See what's new in AG Grid"
-- Added apostrophe to contraction

## Vue 3 SFC with script/setup
LN33: "{field: \"make\", , cellRenderer:" => "{field: \"make\", cellRenderer:"
-- Removed extra comma syntax error

## Row Spanning
LN35: "Row spanning can be customized" => "Row spanning can be customised"
-- Changed American spelling to British spelling

## Upgrading to AG Grid 33
LN7: "column header content customization" => "column header content customisation"
-- Changed American spelling to British spelling

## Community vs Enterprise
LN69: "extensive customization" => "extensive customisation"
-- Changed American spelling to British spelling

## Codemods
LN145, 192, 233, 265: "organization" => "organisation"
-- Changed American spelling to British spelling (4 instances)