### PR TITLE
AG-15132 hide drag handle only when managed row dragging

### DIFF
--- a/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
@@ -170,18 +170,19 @@ class VisibilityStrategy extends BeanStub {
         super();
     }
 
-    protected setDisplayedOrVisible(neverDisplayed: boolean): void {
+    protected setDisplayedOrVisible(neverDisplayed: boolean, alwaysHidden: boolean = false): void {
         const displayedOptions = { skipAriaHidden: true };
         if (neverDisplayed) {
             this.parent.setDisplayed(false, displayedOptions);
         } else {
-            let shown: boolean = true;
+            let shown: boolean = !alwaysHidden;
             let isShownSometimes: boolean = false;
 
             const { column, rowNode, parent } = this;
             if (column) {
-                shown = column.isRowDrag(rowNode) || parent.isCustomGui();
-                isShownSometimes = typeof column.getColDef().rowDrag === 'function';
+                const rowDrag = column.getColDef().rowDrag;
+                isShownSometimes = typeof rowDrag === 'function';
+                shown = (alwaysHidden ? !!rowDrag : column.isRowDrag(rowNode)) || parent.isCustomGui();
             }
 
             // if shown sometimes, them some rows can have drag handle while other don't,
@@ -189,10 +190,10 @@ class VisibilityStrategy extends BeanStub {
             // keeps the empty space, whereas setDisplayed looses the space)
             if (isShownSometimes) {
                 parent.setDisplayed(true, displayedOptions);
-                parent.setVisible(shown, displayedOptions);
+                parent.setVisible(shown && !alwaysHidden, displayedOptions);
             } else {
                 parent.setDisplayed(shown, displayedOptions);
-                parent.setVisible(true, displayedOptions);
+                parent.setVisible(!alwaysHidden, displayedOptions);
             }
         }
     }
@@ -262,6 +263,6 @@ class ManagedVisibilityStrategy extends VisibilityStrategy {
         const hasExternalDropZones = dragAndDrop!.hasExternalDropZones();
         const neverDisplayed = (shouldPreventRowMove && !hasExternalDropZones) || suppressRowDrag;
 
-        this.setDisplayedOrVisible(neverDisplayed);
+        this.setDisplayedOrVisible(neverDisplayed, this.rowNode.footer);
     }
 }

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
@@ -98,6 +98,10 @@ export class RowDragComp extends Component {
             this.removeDragSource();
         }
 
+        if (this.gos.get('rowDragManaged') && this.rowNode.footer) {
+            return; // Footer nodes in row drag managed mode are not draggable
+        }
+
         const eGui = this.getGui();
 
         if (this.gos.get('enableCellTextSelection')) {

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragService.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragService.ts
@@ -30,16 +30,9 @@ export class RowDragService extends BeanStub implements NamedBean {
         return new RowDragComp(cellValueFn, rowNode, column, customGui, dragStartPixels, suppressVisibilityChange);
     }
 
-    private isRowDraggable(rowNode: RowNode): boolean {
-        return !rowNode.footer;
-    }
-
     public createRowDragCompForRow(rowNode: RowNode, element: HTMLElement): RowDragComp | undefined {
         if (_isCellSelectionEnabled(this.gos)) {
             return undefined;
-        }
-        if (!this.isRowDraggable(rowNode)) {
-            return undefined; // This type of row cannot be dragged
         }
         const translate = this.getLocaleTextFunc();
         return this.createRowDragComp(
@@ -66,10 +59,6 @@ export class RowDragService extends BeanStub implements NamedBean {
             if (!_isClientSideRowModel(gos) || gos.get('pagination')) {
                 return undefined;
             }
-        }
-
-        if (!this.isRowDraggable(rowNode)) {
-            return undefined; // This type of row cannot be dragged
         }
 
         // otherwise (normal case) we are creating a RowDraggingComp for the first time


### PR DESCRIPTION
To avoid any breaking changes, it is more correct to hide the total rows row handle and disable the ability to drag the full row only on managed drag, leaving it behaving as it was before for unmanaged row dragging.

Also, the indentation should behave the same as it would behave if hiding the handle with `isRowDrag:(n)=>!n.footer`, for consistency

![image](https://github.com/user-attachments/assets/bf6a3ca2-6f91-4624-9fa0-c332c258b54b)
