### PR TITLE
AG-15177 tree data drag and drop fixes regarding filler rows

### DIFF
--- a/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
@@ -286,6 +286,7 @@ export class RowDragFeature extends BeanStub implements DropTarget {
         const y = _getNormalisedMousePosition(beans, draggingEvent).y;
         let targetRowIndex = clientSideRowModel.getRowIndexAtPixel(y);
         let target = clientSideRowModel.getRow(targetRowIndex) ?? null;
+        const moved = source !== target;
 
         let yDelta = target ? (y - target.rowTop! - target.rowHeight! / 2) / target.rowHeight! || 0 : 1;
 
@@ -309,12 +310,12 @@ export class RowDragFeature extends BeanStub implements DropTarget {
         let above = yDelta < 0;
         let targetInRows = false;
         if (sameGrid && target) {
-            if (source === target) {
-                targetInRows = true;
+            if (!moved) {
                 if (Math.abs(yDelta) <= 0.5) {
                     this.makeGroupThrottleClear();
                     return null; // Nothing to move
                 }
+                targetInRows = true;
             } else {
                 targetInRows = rows.indexOf(target) >= 0;
                 if (targetInRows) {
@@ -368,6 +369,7 @@ export class RowDragFeature extends BeanStub implements DropTarget {
                 }
             }
 
+            console.log('target', target?.id, inside);
             if (target && !inside) {
                 // Set target to the first group that is not the root node or the new parent
                 let current: RowNode | null = target;

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
@@ -289,6 +289,10 @@ export class RowDragFeature extends BeanStub implements DropTarget {
 
         let yDelta = target ? (y - target.rowTop! - target.rowHeight! / 2) / target.rowHeight! || 0 : 1;
 
+        if (yDelta > 0.5 && targetRowIndex >= clientSideRowModel.getRowCount() - 1) {
+            target = null; // We want target null if we are past the last row
+        }
+
         const sameGrid = this.isFromThisGrid(draggingEvent);
         const groupingApproach = _getGroupingApproach(gos);
         const canSetParent =
@@ -351,9 +355,8 @@ export class RowDragFeature extends BeanStub implements DropTarget {
                     this.makeGroupThrottleTarget = target;
                     this.makeGroupThrottleStart();
                 }
-            } else {
-                newParent = target.parent ?? rootNode;
             }
+            newParent ??= target?.parent ?? rootNode;
         }
 
         let inside = false;
@@ -704,6 +707,7 @@ export class RowDragFeature extends BeanStub implements DropTarget {
 
         const clientSideRowModel = this.clientSideRowModel;
         const leafs = new Set<WritableRowNode>();
+        let lastFiller: WritableRowNode | null = null;
         for (const row of rows as WritableRowNode[]) {
             if (row.footer || (row.rowTop === null && row !== clientSideRowModel.getRowNode(row.id!))) {
                 continue; // This row cannot be dragged, not in allLeafChildren and not a filler
@@ -719,12 +723,25 @@ export class RowDragFeature extends BeanStub implements DropTarget {
 
             const leafRow = getLeafRow(row);
             if (leafRow) {
+                lastFiller = leafRow !== row ? row : null;
                 leafs.add(leafRow);
             }
         }
 
         if (!changed && leafs.size === 0) {
             return false; // Nothing to move
+        }
+
+        if (!target && lastFiller) {
+            // Special case, if the last moved row is a filler, we want to ensure
+            // the relative ordering is correct, as the order of a filler
+            // is determined by the first leaf. So we need to add all the remaining leaves to the dragged rows.
+            const fillerLeafChildren = lastFiller.allLeafChildren;
+            if (fillerLeafChildren) {
+                for (const fillerLeaf of fillerLeafChildren) {
+                    leafs.add(fillerLeaf);
+                }
+            }
         }
 
         // Get the focussed cell so we can ensure it remains focussed after the move
@@ -847,19 +864,18 @@ const getRowsPrevOrNext = (
 const getPrevOrNext = (
     clientSideRowModel: IClientSideRowModel,
     increment: -1 | 1,
-    initialRow: IRowNode
+    initialRow: IRowNode | null | undefined
 ): RowNode | undefined => {
-    const rowCount = clientSideRowModel.getRowCount();
-    let rowIndex = initialRow.rowIndex! + increment;
-    while (rowIndex >= 0 && rowIndex < rowCount) {
-        let row: RowNode | undefined = clientSideRowModel.getRow(rowIndex)!;
-        if (row?.footer) {
-            row = row.sibling; // Skip footer rows
+    if (initialRow) {
+        const rowCount = clientSideRowModel.getRowCount();
+        let rowIndex = initialRow.rowIndex! + increment;
+        while (rowIndex >= 0 && rowIndex < rowCount) {
+            const row: RowNode | undefined = clientSideRowModel.getRow(rowIndex)!;
+            if (!row || !row.footer) {
+                return row;
+            }
+            rowIndex += increment;
         }
-        if (row?.sourceRowIndex >= 0) {
-            return row; // Valid leaf node
-        }
-        rowIndex += increment;
     }
     return undefined; // Out of bounds
 };

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
@@ -289,10 +289,6 @@ export class RowDragFeature extends BeanStub implements DropTarget {
 
         let yDelta = target ? (y - target.rowTop! - target.rowHeight! / 2) / target.rowHeight! || 0 : 1;
 
-        if (yDelta > 0.5 && targetRowIndex >= clientSideRowModel.getRowCount() - 1) {
-            target = null; // We want target null if we are past the last row
-        }
-
         const sameGrid = this.isFromThisGrid(draggingEvent);
         const groupingApproach = _getGroupingApproach(gos);
         const canSetParent =
@@ -371,6 +367,16 @@ export class RowDragFeature extends BeanStub implements DropTarget {
                     above = true;
                 }
             }
+
+            if (target && !inside) {
+                // Set target to the first group that is not the root node or the new parent
+                let current: RowNode | null = target;
+                while (current && current !== rootNode && current !== newParent) {
+                    target = current;
+                    current = current.parent;
+                }
+            }
+
             if (rowsHaveSameParent(rows, newParent)) {
                 newParent = null; // No need to set parent if all rows have the same parent
             }
@@ -707,7 +713,6 @@ export class RowDragFeature extends BeanStub implements DropTarget {
 
         const clientSideRowModel = this.clientSideRowModel;
         const leafs = new Set<WritableRowNode>();
-        let lastFiller: WritableRowNode | null = null;
         for (const row of rows as WritableRowNode[]) {
             if (row.footer || (row.rowTop === null && row !== clientSideRowModel.getRowNode(row.id!))) {
                 continue; // This row cannot be dragged, not in allLeafChildren and not a filler
@@ -723,25 +728,12 @@ export class RowDragFeature extends BeanStub implements DropTarget {
 
             const leafRow = getLeafRow(row);
             if (leafRow) {
-                lastFiller = leafRow !== row ? row : null;
                 leafs.add(leafRow);
             }
         }
 
         if (!changed && leafs.size === 0) {
             return false; // Nothing to move
-        }
-
-        if (!target && lastFiller) {
-            // Special case, if the last moved row is a filler, we want to ensure
-            // the relative ordering is correct, as the order of a filler
-            // is determined by the first leaf. So we need to add all the remaining leaves to the dragged rows.
-            const fillerLeafChildren = lastFiller.allLeafChildren;
-            if (fillerLeafChildren) {
-                for (const fillerLeaf of fillerLeafChildren) {
-                    leafs.add(fillerLeaf);
-                }
-            }
         }
 
         // Get the focussed cell so we can ensure it remains focussed after the move

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
@@ -369,7 +369,6 @@ export class RowDragFeature extends BeanStub implements DropTarget {
                 }
             }
 
-            console.log('target', target?.id, inside);
             if (target && !inside) {
                 // Set target to the first group that is not the root node or the new parent
                 let current: RowNode | null = target;


### PR DESCRIPTION
This fixes some issues we found with tree data drag and drop with getDataPath and filler nodes.

- fix getPrevOrNext to ignore total rows properly
- fix the parent and target management so that the correct target is chosen when moving below the whole grid