### PR TITLE
Maintenance(ci): follow up on performance workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -132,7 +132,7 @@ jobs:
         if: ${{ steps.setup.outcome == 'success' || steps.setup.outcome == 'skipped' }}
         run: |
           echo "Building UMD packages..."
-          npx nx run-many -t build --projects=ag-grid-{enterprise,community,angular,react,vue3}
+          npx nx run-many -t build --projects=ag-grid-{enterprise,community}
 
       - name: Notify Progress
         uses: actions/github-script@v7
@@ -209,14 +209,12 @@ jobs:
           retention-days: ${{ env.DEFAULT_RETENTION_DAYS }}
 
       - name: Attach snippet
-        uses: actions/github-script@v7
         id: attach-snippet
         if: ${{ steps.upload-snippet.outputs.artifact-url }}
         env:
           SNIPPET_URL: ${{ steps.upload-snippet.outputs.artifact-url }}
-        with:
-          script: |
-            node ./testing/shared/scripts/attach-snippet.mjs
+        run: |
+          node ./testing/shared/scripts/attach-snippet.mjs
 
       - name: Slack Notification
         continue-on-error: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -218,7 +218,7 @@ jobs:
 
       - name: Slack Notification
         continue-on-error: true
-        if: ${{ steps.upload-snippet.outputs.artifact-url }}
+        if: ${{ steps.upload-snippet.outputs.artifact-url && (github.event_name == 'schedule' || inputs.notify) }}
         env:
           SLACK_WEBHOOK: ${{ secrets.CI_GATE_WEBHOOK }}
           SNIPPET_URL: ${{ steps.upload-snippet.outputs.artifact-url }}

--- a/testing/performance/benchmarking.ts
+++ b/testing/performance/benchmarking.ts
@@ -138,7 +138,7 @@ async function getGitHash(version: Version): Promise<string> {
 /**
  * Taken from ag-grid-enterprise package.json git history
  */
-const gridToChartsMap = {
+const gridToChartsMap: Record<Version, Version> = {
     local: 'v11.3.0',
     prod: 'v11.3.0',
     staging: 'v11.3.0',
@@ -188,7 +188,6 @@ type Stats = {
     average: number;
     stdDev: number;
     marginOfError: number;
-    newBase: number[];
     filteredCount: number;
     originalCount: number;
 };
@@ -296,7 +295,6 @@ const computeStats = (times: number[]): Stats => {
         average: avg,
         stdDev,
         marginOfError: totalMarginOfError,
-        newBase: base,
         filteredCount: base.length,
         originalCount: times.length,
     };
@@ -386,7 +384,7 @@ function benchError(message: string, e: any, testCase: InternalTestCase) {
 }
 
 async function attachScripts(page: Page, version: Version, testCase: InternalTestCase) {
-    const chartsVersion = gridToChartsMap[version as keyof typeof gridToChartsMap] || gridToChartsMap.prod;
+    const chartsVersion = gridToChartsMap[version] || gridToChartsMap.prod;
 
     const urls = [getCdnUrl('ag-grid-community', version), getCdnUrl('ag-grid-enterprise', version)];
     if (chartsVersion) {
@@ -493,6 +491,7 @@ const testBody = async (testCase: InternalTestCase, { page, context }: Playwrigh
             if (testCase.preSetup) await testCase.preSetup(page);
             for (let i = 0; i < minIter; i++) {
                 if (testCase.setupPreActions) await testCase.setupPreActions(page);
+                if (i % 50 === 0) await page.requestGC();
                 const noiseSize = (await metricsGetter(page, testCase)).length;
                 if (testCase.actions) await testCase.actions(page);
                 if (i > warmupIter) {
@@ -505,7 +504,6 @@ const testBody = async (testCase: InternalTestCase, { page, context }: Playwrigh
             if (testCase.expectsPostActions) await testCase.expectsPostActions(page, lastCommunications);
         }
         [s1, s2] = [computeStats(measurements.control), computeStats(measurements.variant)];
-        [measurements.control, measurements.variant] = [s1.newBase, s2.newBase]; // update the result with filtered data
         const { percentDiff, avgMoEPercent, isSignificant } = computeCommonStats(s1, s2, testCase);
         significant = isSignificant;
         needToContinue = !significant && totalIterations < maxIter;

--- a/testing/performance/benchmarking.ts
+++ b/testing/performance/benchmarking.ts
@@ -157,7 +157,7 @@ const gridToChartsMap = {
     'v31.2.0': 'v9.2.0',
 } as const;
 
-const getCdnUrl = (pkg: string, version: Version, path: `/${string}` = `/dist/${pkg}.js`) => {
+const getCdnUrl = (pkg: string, version: Version, path: `/${string}` = `/dist/${pkg}.min.js`) => {
     return `${knownUrlsProxy[version]}/files/${pkg}${path}`;
 };
 
@@ -194,6 +194,68 @@ type Stats = {
 };
 
 /**
+ * Helper function to calculate drift rate and its margin of error
+ */
+function calculateDriftWithMargin(data: number[]): { driftRate: number; driftMarginOfError: number } {
+    if (data.length < 2) return { driftRate: 0, driftMarginOfError: 0 };
+
+    let sumX = 0,
+        sumY = 0,
+        sumXY = 0,
+        sumX2 = 0;
+    for (let i = 0; i < data.length; i++) {
+        const x = i;
+        const y = data[i];
+        sumX += x;
+        sumY += y;
+        sumXY += x * y;
+        sumX2 += x * x;
+    }
+
+    // Compute slope
+    const numerator = data.length * sumXY - sumX * sumY;
+    const denominator = data.length * sumX2 - sumX * sumX;
+
+    if (denominator === 0) return { driftRate: 0, driftMarginOfError: 0 };
+
+    const slope = numerator / denominator;
+
+    // Compute intercept
+    const intercept = (sumY - slope * sumX) / data.length;
+
+    // Compute residuals
+    let SSE = 0;
+    for (let i = 0; i < data.length; i++) {
+        const predicted = slope * i + intercept;
+        const residual = data[i] - predicted;
+        SSE += Math.pow(residual, 2);
+    }
+
+    // Degrees of freedom
+    const df = data.length - 2;
+
+    if (df <= 0) return { driftRate: slope, driftMarginOfError: 0 };
+
+    // Standard error of the regression (MSE)
+    const MSE = SSE / df;
+
+    // Compute Sxx (sum of squared deviations from mean x)
+    const xBar = sumX / data.length;
+    let Sxx = 0;
+    for (let i = 0; i < data.length; i++) {
+        Sxx += Math.pow(i - xBar, 2);
+    }
+
+    // Standard error of the slope
+    const SE_slope = Math.sqrt(MSE / Sxx);
+
+    // Compute margin of error using critical value
+    const driftMarginOfError = SE_slope * CRITICAL_VALUE;
+
+    return { driftRate: slope, driftMarginOfError };
+}
+
+/**
  * Calculates:
  * - Average time
  * - Standard deviation
@@ -212,23 +274,28 @@ const computeStats = (times: number[]): Stats => {
         return sorted[lower] * (1 - weight) + sorted[upper] * weight;
     }
 
-    const sorted = times.sort((a, b) => a - b);
+    const sorted = [...times].sort((a, b) => a - b);
     const q1 = getPercentile(sorted, 0.25);
     const q3 = getPercentile(sorted, 0.75);
     const iqr = q3 - q1;
     const lower = q1 - 1.5 * iqr;
     const upper = q3 + 1.5 * iqr;
+    const { driftRate, driftMarginOfError } = calculateDriftWithMargin([...times]);
     const filtered = sorted.filter((t) => t >= lower && t <= upper);
     const base = filtered.length >= 5 ? filtered : sorted;
 
     const avg = base.reduce((sum, v) => sum + v, 0) / base.length;
     const stdDev = Math.sqrt(base.reduce((sum, v) => sum + Math.pow(v - avg, 2), 0) / (base.length - 1));
     const marginOfError = (CRITICAL_VALUE * stdDev) / Math.sqrt(base.length);
-
+    const isDriftSignificant = Math.abs(driftRate) > driftMarginOfError;
+    if (isDriftSignificant && !process.env['CI']) {
+        console.log(`${yellow('Drift detected:')} ${renderNumbersDiffString(driftRate, driftMarginOfError)};`);
+    }
+    const totalMarginOfError = Math.sqrt(Math.pow(driftMarginOfError, 2) + Math.pow(marginOfError, 2));
     return {
         average: avg,
         stdDev,
-        marginOfError,
+        marginOfError: totalMarginOfError,
         newBase: base,
         filteredCount: base.length,
         originalCount: times.length,
@@ -283,7 +350,7 @@ function isDiffSignificant(diff: number, moe1: number, moe2: number) {
 function reportStats(s1: Stats, s2: Stats, testCase: InternalTestCase) {
     const { percentDiff, avgMoEPercent, slower, faster, diff, avgMoE, practicalConfidence, isSignificant } =
         computeCommonStats(s1, s2, testCase);
-    const numbersDiffString = `${Math.abs(diff).toFixed(2)} ± ${avgMoE.toFixed(2)}`;
+    const numbersDiffString = renderNumbersDiffString(diff, avgMoE);
     const percentDiffString = renderPercentDiffString(percentDiff, avgMoEPercent);
     const resultMessage =
         isSignificant || practicalConfidence
@@ -324,7 +391,7 @@ async function attachScripts(page: Page, version: Version, testCase: InternalTes
     const urls = [getCdnUrl('ag-grid-community', version), getCdnUrl('ag-grid-enterprise', version)];
     if (chartsVersion) {
         urls.push(
-            `https://cdn.jsdelivr.net/npm/ag-charts-community@${chartsVersion.slice(1)}/dist/umd/ag-charts-community.js`
+            `https://cdn.jsdelivr.net/npm/ag-charts-community@${chartsVersion.slice(1)}/dist/umd/ag-charts-community.min.js`
         );
     }
 
@@ -349,8 +416,8 @@ function updatePageTitle(page: Page, testCase: TestCase, variant: Variant) {
 function metricsGetter(page: Page, testCase: TestCase) {
     return waitFor(
         testCase.metrics
-            ? (metrics: TestCase['metrics']) => performance.getEntriesByType(metrics!)
-            : () => performance.getEntries(),
+            ? (metrics: TestCase['metrics']) => performance.getEntriesByName(metrics!)
+            : () => performance.getEntriesByName('long-animation-frame'),
         page,
         { args: [testCase.metrics] }
     );
@@ -390,12 +457,17 @@ function renderPercentDiffString(percentDiff: number, avgMoEPercent: number) {
     return `${percentDiff.toFixed(1)}% ± ${avgMoEPercent.toFixed(1)}%`;
 }
 
+function renderNumbersDiffString(diff: number, avgMoE: number, unit = 'ms') {
+    return `${Math.abs(diff).toFixed(2)}${unit} ± ${avgMoE.toFixed(2)}${unit}`;
+}
+
 const testBody = async (testCase: InternalTestCase, { page, context }: PlaywrightTestArgs, ..._: any[]) => {
-    const result = { control: [] as number[], variant: [] as number[] };
+    const measurements = { control: [] as number[], variant: [] as number[] };
     let s1: Stats, s2: Stats;
     const { minIter, maxIter, warmupIter, setLastCommunications } = testCase.__hidden!;
     let significant = false;
     let needToContinue = true;
+    let totalIterations = 0;
     test.info().annotations.push({
         type: 'info',
         description: {
@@ -425,17 +497,18 @@ const testBody = async (testCase: InternalTestCase, { page, context }: Playwrigh
                 if (testCase.actions) await testCase.actions(page);
                 if (i > warmupIter) {
                     const usefulEntries = (await metricsGetter(page, testCase)).slice(noiseSize);
-                    const duration = usefulEntries.reduce((acc, pe) => acc + pe.duration, 0);
-                    result[variantName].push(duration);
+                    const duration = usefulEntries.pop()!.duration || 0;
+                    measurements[variantName].push(duration);
+                    totalIterations++;
                 }
             }
             if (testCase.expectsPostActions) await testCase.expectsPostActions(page, lastCommunications);
         }
-        [s1, s2] = [computeStats(result.control), computeStats(result.variant)];
-        [result.control, result.variant] = [s1.newBase, s2.newBase]; // update the result with filtered data
+        [s1, s2] = [computeStats(measurements.control), computeStats(measurements.variant)];
+        [measurements.control, measurements.variant] = [s1.newBase, s2.newBase]; // update the result with filtered data
         const { percentDiff, avgMoEPercent, isSignificant } = computeCommonStats(s1, s2, testCase);
         significant = isSignificant;
-        needToContinue = !significant && result['control'].length < maxIter;
+        needToContinue = !significant && totalIterations < maxIter;
         if (!process.env['CI']) {
             if (significant) reportStats(s1, s2, testCase);
             if (needToContinue) {

--- a/testing/performance/benchmarking.ts
+++ b/testing/performance/benchmarking.ts
@@ -157,7 +157,7 @@ const gridToChartsMap: Record<Version, Version> = {
     'v31.2.0': 'v9.2.0',
 } as const;
 
-const getCdnUrl = (pkg: string, version: Version, path: `/${string}` = `/dist/${pkg}.min.js`) => {
+const getCdnUrl = (pkg: string, version: Version, path: `/${string}` = `/dist/${pkg}.js`) => {
     return `${knownUrlsProxy[version]}/files/${pkg}${path}`;
 };
 
@@ -389,7 +389,7 @@ async function attachScripts(page: Page, version: Version, testCase: InternalTes
     const urls = [getCdnUrl('ag-grid-community', version), getCdnUrl('ag-grid-enterprise', version)];
     if (chartsVersion) {
         urls.push(
-            `https://cdn.jsdelivr.net/npm/ag-charts-community@${chartsVersion.slice(1)}/dist/umd/ag-charts-community.min.js`
+            `https://cdn.jsdelivr.net/npm/ag-charts-community@${chartsVersion.slice(1)}/dist/umd/ag-charts-community.js`
         );
     }
 

--- a/testing/performance/e2e/cron.spec.ts
+++ b/testing/performance/e2e/cron.spec.ts
@@ -11,7 +11,7 @@ const frameworks = ['typescript', 'reactFunctionalTs', 'angular', 'vue3'];
 
 test(`Performance Test - Compare performance of setting data`, {
     timeout: frameworks.length * 20 * 60_000, // takes about 10 mins per framework, but allow for some overhead
-    minIterations: 200,
+    minIterations: 300,
     testCases: frameworks.map(
         (framework) =>
             ({
@@ -30,7 +30,7 @@ test(`Performance Test - Compare performance of setting data`, {
                     await page.getByText('Set Data').click({ force: true });
                     await waitFor(athleteCheck, page);
                 },
-                metrics: 'long-animation-frame',
+                metrics: 'set-data',
             }) as TestCase
     ),
 });

--- a/testing/performance/e2e/cron.spec.ts
+++ b/testing/performance/e2e/cron.spec.ts
@@ -10,8 +10,10 @@ const localLotsOfCells = `file://${path.join(__dirname, './lots-of-cells.html')}
 const frameworks = ['typescript', 'reactFunctionalTs', 'angular', 'vue3'];
 
 test(`Performance Test - Compare performance of setting data`, {
-    timeout: frameworks.length * 20 * 60_000, // takes about 10 mins per framework, but allow for some overhead
-    minIterations: 300,
+    timeout: frameworks.length * 10 * 60_000,
+    minIterations: 50,
+    maxIterations: 150,
+    warmupIterations: 5,
     testCases: frameworks.map(
         (framework) =>
             ({

--- a/testing/performance/e2e/lots-of-cells.html
+++ b/testing/performance/e2e/lots-of-cells.html
@@ -106,7 +106,7 @@
                     columnDefs: repeat(cols, 4), // 20
                     rowData: repeat(data, 200), // 1_000
                 },
-              /*  lots: {
+                /*  lots: {
                     rowData: repeat(data, 100000), // 500_000
                     columnDefs: repeat(cols, 4), // 20
                 },*/

--- a/testing/performance/e2e/lots-of-cells.html
+++ b/testing/performance/e2e/lots-of-cells.html
@@ -30,44 +30,12 @@
                 });
             }
 
-            function onSetData() {
-                gridApi.updateGridOptions({
-                    columnDefs: repeat(cols, 10),
-                    rowData: repeat(data, 100),
-                });
-            }
-
-            function onScroll() {
-                const eBodyViewport = document.querySelector('.ag-body-viewport');
-                const currScroll = eBodyViewport.scrollTop;
-                eBodyViewport.scroll(0, currScroll + 5000);
-            }
-
-            function run() {
-                const gridOptions = {
-                    columnDefs: [],
-                    suppressColumnVirtualisation: true,
-                    rowBuffer: 300,
-                    defaultColDef: {
-                        initialWidth: 100,
-                    },
-                    rowData: [],
-                };
-                const myGridElement = document.querySelector('#myGrid');
-                gridApi = agGrid.createGrid(myGridElement, gridOptions);
-            }
-
             const cols = [
                 { field: 'athlete' },
                 { field: 'gold' },
                 { field: 'silver' },
                 { field: 'bronze' },
                 { field: 'total' },
-                { field: 'age' },
-                { field: 'country' },
-                { field: 'sport' },
-                { field: 'year' },
-                { field: 'date' },
             ];
 
             const data = [
@@ -131,55 +99,41 @@
                     bronze: 3,
                     total: 6,
                 },
-                {
-                    athlete: 'Alicia Coutts',
-                    age: 24,
-                    country: 'Australia',
-                    sport: 'Swimming',
-                    year: 2012,
-                    date: '12/08/2012',
-                    gold: 1,
-                    silver: 3,
-                    bronze: 1,
-                    total: 5,
-                },
-                {
-                    athlete: 'Missy Franklin',
-                    age: 17,
-                    country: 'United States',
-                    sport: 'Swimming',
-                    year: 2012,
-                    date: '12/08/2012',
-                    gold: 4,
-                    silver: 0,
-                    bronze: 1,
-                    total: 5,
-                },
-                {
-                    athlete: 'Ryan Lochte',
-                    age: 27,
-                    country: 'United States',
-                    sport: 'Swimming',
-                    year: 2012,
-                    date: '12/08/2012',
-                    gold: 2,
-                    silver: 2,
-                    bronze: 1,
-                    total: 5,
-                },
-                {
-                    athlete: 'Allison Schmitt',
-                    age: 22,
-                    country: 'United States',
-                    sport: 'Swimming',
-                    year: 2012,
-                    date: '12/08/2012',
-                    gold: 3,
-                    silver: 1,
-                    bronze: 1,
-                    total: 5,
-                },
             ];
+
+            const preAllocatedData = {
+                init: {
+                    columnDefs: repeat(cols, 4), // 20
+                    rowData: repeat(data, 200), // 1_000
+                },
+              /*  lots: {
+                    rowData: repeat(data, 100000), // 500_000
+                    columnDefs: repeat(cols, 4), // 20
+                },*/
+            };
+
+            function onSetData() {
+                performance.mark('set-data-started');
+                gridApi.updateGridOptions(preAllocatedData.init);
+            }
+
+            function onScroll() {
+                const eBodyViewport = document.querySelector('.ag-body-viewport');
+                const currScroll = eBodyViewport.scrollTop;
+                eBodyViewport.scroll(0, currScroll + 5000);
+            }
+
+            function run() {
+                const gridOptions = {
+                    columnDefs: [],
+                    rowData: [],
+                };
+                const myGridElement = document.querySelector('#myGrid');
+                gridApi = agGrid.createGrid(myGridElement, gridOptions);
+                gridApi.addEventListener('displayedRowsChanged', () =>
+                    performance.measure('set-data', 'set-data-started')
+                );
+            }
         </script>
     </body>
 </html>

--- a/testing/performance/e2e/lots-of-cells.html
+++ b/testing/performance/e2e/lots-of-cells.html
@@ -35,76 +35,15 @@
                 { field: 'gold' },
                 { field: 'silver' },
                 { field: 'bronze' },
-                { field: 'total' },
+                { field: 'date' },
             ];
 
-            const data = [
-                {
-                    athlete: 'Michael Phelps',
-                    age: 23,
-                    country: 'United States',
-                    sport: 'Swimming',
-                    year: 2008,
-                    date: '24/08/2008',
-                    gold: 8,
-                    silver: 0,
-                    bronze: 0,
-                    total: 8,
-                },
-                {
-                    athlete: 'Michael Phelps',
-                    age: 19,
-                    country: 'United States',
-                    sport: 'Swimming',
-                    year: 2004,
-                    date: '29/08/2004',
-                    gold: 6,
-                    silver: 0,
-                    bronze: 2,
-                    total: 8,
-                },
-                {
-                    athlete: 'Michael Phelps',
-                    age: 27,
-                    country: 'United States',
-                    sport: 'Swimming',
-                    year: 2012,
-                    date: '12/08/2012',
-                    gold: 4,
-                    silver: 2,
-                    bronze: 0,
-                    total: 6,
-                },
-                {
-                    athlete: 'Natalie Coughlin',
-                    age: 25,
-                    country: 'United States',
-                    sport: 'Swimming',
-                    year: 2008,
-                    date: '24/08/2008',
-                    gold: 1,
-                    silver: 2,
-                    bronze: 3,
-                    total: 6,
-                },
-                {
-                    athlete: 'Aleksey Nemov',
-                    age: 24,
-                    country: 'Russia',
-                    sport: 'Gymnastics',
-                    year: 2000,
-                    date: '01/10/2000',
-                    gold: 2,
-                    silver: 1,
-                    bronze: 3,
-                    total: 6,
-                },
-            ];
+            const data = { athlete: 'Michael Phelps', date: '24/08/2008', gold: 8, silver: 0, bronze: 0 };
 
             const preAllocatedData = {
                 init: {
-                    columnDefs: repeat(cols, 4), // 20
-                    rowData: repeat(data, 200), // 1_000
+                    columnDefs: repeat(cols, 4),
+                    rowData: repeat(data, 300),
                 },
                 /*  lots: {
                     rowData: repeat(data, 100000), // 500_000
@@ -127,6 +66,8 @@
                 const gridOptions = {
                     columnDefs: [],
                     rowData: [],
+                    suppressColumnVirtualisation: true,
+                    rowBuffer: 300,
                 };
                 const myGridElement = document.querySelector('#myGrid');
                 gridApi = agGrid.createGrid(myGridElement, gridOptions);

--- a/testing/performance/e2e/setData.spec.ts
+++ b/testing/performance/e2e/setData.spec.ts
@@ -9,7 +9,9 @@ const localLotsOfCells = `file://${path.join(__dirname, './lots-of-cells.html')}
 
 test(`Performance Test - Compare performance of setting data`, {
     timeout: 40 * 60_000,
-    minIterations: 300,
+    minIterations: 50,
+    maxIterations: 150,
+    warmupIterations: 5,
     testCases: [
         {
             name: 'Set data (lots): staging vs local',

--- a/testing/performance/e2e/setData.spec.ts
+++ b/testing/performance/e2e/setData.spec.ts
@@ -9,7 +9,7 @@ const localLotsOfCells = `file://${path.join(__dirname, './lots-of-cells.html')}
 
 test(`Performance Test - Compare performance of setting data`, {
     timeout: 40 * 60_000,
-    minIterations: 100,
+    minIterations: 300,
     testCases: [
         {
             name: 'Set data (lots): staging vs local',
@@ -27,7 +27,7 @@ test(`Performance Test - Compare performance of setting data`, {
                 await page.getByText('Set Data').click({ force: true });
                 await waitFor(athleteCheck, page);
             },
-            metrics: 'long-animation-frame',
+            metrics: 'set-data',
         },
     ],
 });

--- a/testing/performance/playwright.utils.ts
+++ b/testing/performance/playwright.utils.ts
@@ -74,6 +74,7 @@ export const waitFor = async <T>(
     const { timeout } = options;
     if (page) {
         const handle = await page.waitForFunction(getterOrTimeout, options.args ?? [], { timeout: timeout ?? 5000 });
+        setTimeout(() => handle.dispose(), timeout ?? 5000 + 1000);
         if (options.smart) {
             return handle as T; // todo this type assertion is a workaround, ideally we should handle the type more gracefully
         } else {

--- a/testing/shared/scripts/attach-snippet.mjs
+++ b/testing/shared/scripts/attach-snippet.mjs
@@ -1,30 +1,25 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 
-try {
-    const snippetUrl = process.env.SNIPPET_URL || 'https://example.com/snippet.md';
+const snippetUrl = process.env.SNIPPET_URL || 'https://example.com/snippet.md';
 
-    if (!snippetUrl) {
-        console.error('SNIPPET_URL environment variable must be set.');
-        process.exit(1);
-    }
-
-    const slackFileName = process.env.SLACK_FILE || './slack.json';
-    const commentFileName = process.env.COMMENT_FILE || './comment.md';
-    const jiraFileName = process.env.JIRA_FILE || './jira.md';
-
-    const slackMsg = JSON.parse(fs.readFileSync(slackFileName, 'utf8'));
-    let ghMsg = fs.readFileSync(commentFileName, 'utf8');
-    let jiraMsg = fs.readFileSync(jiraFileName, 'utf8');
-
-    slackMsg.blocks.push({ type: 'section', text: { type: 'mrkdwn', text: `<${snippetUrl}|Full stdout>` } });
-    ghMsg += `\n\n[Full stdout](${snippetUrl})`;
-    jiraMsg += `\n\n[Full stdout|${snippetUrl}]`;
-
-    fs.writeFileSync(slackFileName, JSON.stringify(slackMsg));
-    fs.writeFileSync(commentFileName, ghMsg);
-    fs.writeFileSync(jiraFileName, jiraMsg);
-} catch (error) {
-    console.error('Error processing snippet:', error);
+if (!snippetUrl) {
+    console.error('SNIPPET_URL environment variable must be set.');
     process.exit(1);
 }
+
+const slackFileName = process.env.SLACK_FILE || './slack.json';
+const commentFileName = process.env.COMMENT_FILE || './comment.md';
+const jiraFileName = process.env.JIRA_FILE || './jira.md';
+
+const slackMsg = JSON.parse(fs.readFileSync(slackFileName, 'utf8'));
+let ghMsg = fs.readFileSync(commentFileName, 'utf8');
+let jiraMsg = fs.readFileSync(jiraFileName, 'utf8');
+
+slackMsg.blocks.push({ type: 'section', text: { type: 'mrkdwn', text: `<${snippetUrl}|Full stdout>` } });
+ghMsg += `\n\n[Full stdout](${snippetUrl})`;
+jiraMsg += `\n\n[Full stdout|${snippetUrl}]`;
+
+fs.writeFileSync(slackFileName, JSON.stringify(slackMsg));
+fs.writeFileSync(commentFileName, ghMsg);
+fs.writeFileSync(jiraFileName, jiraMsg);

--- a/testing/shared/scripts/attach-snippet.mjs
+++ b/testing/shared/scripts/attach-snippet.mjs
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import fs from 'fs';
 
 const snippetUrl = process.env.SNIPPET_URL || 'https://example.com/snippet.md';

--- a/testing/shared/scripts/attach-snippet.mjs
+++ b/testing/shared/scripts/attach-snippet.mjs
@@ -1,25 +1,30 @@
 #!/usr/bin/env node
-import fs from 'fs';
+import fs from 'node:fs';
 
-const snippetUrl = process.env.SNIPPET_URL || 'https://example.com/snippet.md';
+try {
+    const snippetUrl = process.env.SNIPPET_URL || 'https://example.com/snippet.md';
 
-if (!snippetUrl) {
-    console.error('SNIPPET_URL environment variable must be set.');
+    if (!snippetUrl) {
+        console.error('SNIPPET_URL environment variable must be set.');
+        process.exit(1);
+    }
+
+    const slackFileName = process.env.SLACK_FILE || './slack.json';
+    const commentFileName = process.env.COMMENT_FILE || './comment.md';
+    const jiraFileName = process.env.JIRA_FILE || './jira.md';
+
+    const slackMsg = JSON.parse(fs.readFileSync(slackFileName, 'utf8'));
+    let ghMsg = fs.readFileSync(commentFileName, 'utf8');
+    let jiraMsg = fs.readFileSync(jiraFileName, 'utf8');
+
+    slackMsg.blocks.push({ type: 'section', text: { type: 'mrkdwn', text: `<${snippetUrl}|Full stdout>` } });
+    ghMsg += `\n\n[Full stdout](${snippetUrl})`;
+    jiraMsg += `\n\n[Full stdout|${snippetUrl}]`;
+
+    fs.writeFileSync(slackFileName, JSON.stringify(slackMsg));
+    fs.writeFileSync(commentFileName, ghMsg);
+    fs.writeFileSync(jiraFileName, jiraMsg);
+} catch (error) {
+    console.error('Error processing snippet:', error);
     process.exit(1);
 }
-
-const slackFileName = process.env.SLACK_FILE || './slack.json';
-const commentFileName = process.env.COMMENT_FILE || './comment.md';
-const jiraFileName = process.env.JIRA_FILE || './jira.md';
-
-const slackMsg = JSON.parse(fs.readFileSync(slackFileName, 'utf8'));
-let ghMsg = fs.readFileSync(commentFileName, 'utf8');
-let jiraMsg = fs.readFileSync(jiraFileName, 'utf8');
-
-slackMsg.blocks.push({ type: 'section', text: { type: 'mrkdwn', text: `<${snippetUrl}|Full stdout>` } });
-ghMsg += `\n\n[Full stdout](${snippetUrl})`;
-jiraMsg += `\n\n[Full stdout|${snippetUrl}]`;
-
-fs.writeFileSync(slackFileName, JSON.stringify(slackMsg));
-fs.writeFileSync(commentFileName, ghMsg);
-fs.writeFileSync(jiraFileName, jiraMsg);


### PR DESCRIPTION
 - Remove unused frameworks from build
 - Fix Attach snippet action
 - Call page.requestGC() every 50 iterations, so we get a bit more control when it runs
 - Adjust test settings/iterations
 - Call dispose of handler to help memory pressure
 - Add calculateDriftWithMargin function for drift rate analysis
 - Adjust margin of error calculations in performance metrics
 - Rely on performance.mark and events from the grid to measure click-to-render accurately
 - preallocate data for the grid to speed up the tests