### PR TITLE
Fix invalid template literal in AgProvidedColumnGroup ID

### DIFF
--- a/packages/ag-grid-community/src/columns/columnGroups/columnGroupService.ts
+++ b/packages/ag-grid-community/src/columns/columnGroups/columnGroupService.ts
@@ -469,7 +469,7 @@ export class ColumnGroupService extends BeanStub implements NamedBean {
             let nextChild: AgColumn | AgProvidedColumnGroup = col;
 
             for (let i = depth - 1; i >= 0; i--) {
-                const autoGroup = new AgProvidedColumnGroup(null, `FAKE_PATH_${col.getId()}}_${i}`, true, i);
+                const autoGroup = new AgProvidedColumnGroup(null, `FAKE_PATH_${col.getId()}_${i}`, true, i);
                 this.createBean(autoGroup);
                 autoGroup.setChildren([nextChild]);
                 nextChild.originalParent = autoGroup;


### PR DESCRIPTION
While reviewing the code that generates column group IDs, I noticed a small typo in the template literal:

```ts
FAKE_PATH_${col.getId()}}_${i}
```

While working with the Selection Row's checkbox column, I noticed that its generated col-id attribute was rendered as:

```ts
FAKE_PATH_ag-Grid-SelectionColumn}_0_0
```

An extra closing brace `}` was included, resulting in a malformed string.
This commit corrects the typo by removing the redundant brace:

```ts
FAKE_PATH_${col.getId()}_${i}
```

This ensures that the generated col-id values are properly formatted.
Please let me know if there's a preferred way to handle such changes — I'm happy to revise if needed.