### PR TITLE
RTI-2769 - Spelling & grammar fixes

### DIFF
--- a/documentation/ag-grid-docs/src/components/framework-landing-pages/react/sections/features/tabs/customfeatures/CustomFeatures.tsx
+++ b/documentation/ag-grid-docs/src/components/framework-landing-pages/react/sections/features/tabs/customfeatures/CustomFeatures.tsx
@@ -31,7 +31,7 @@ return (
                         <span className={styles.featureDetail}>
                             Customise our <a href="./react-data-grid/themes/">Built-in Themes</a> with the{' '}
                             <a href="./react-data-grid/theming/">Theming API</a>. Define a{' '}
-                            <a href="./react-data-grid/theming-colors/#color-schemes">Color Scheme</a>, modify{' '}
+                            <a href="./react-data-grid/theming-colors/#colour-schemes">Color Scheme</a>, modify{' '}
                             <a href="/react-data-grid/theming-parameters/">Theme Parameters</a>, mix and match{' '}
                             <a href=".react-data-grid/theming-parts/">Theme Parts</a>, and use{' '}
                             <a href="./react-data-grid/theming-css/">CSS</a> for unlimited control.

--- a/documentation/ag-grid-docs/src/content/docs/accessibility/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/accessibility/index.mdoc
@@ -137,7 +137,7 @@ Animations won't work properly when the DOM order is forced, so ensure they are 
 
 In order to ensure all grid elements are loaded, you need to disable column and row virtualization. The best way to do this is to use [pagination](./row-pagination/). This way you can reduce the initial loading time and memory footprint while ensuring all elements for these rows are loaded for screen readers.
 
-If your requirement is to use scrolling instead of pagination, you can disable row virtualisation at the expense  of increasing the memory footprint. Please test the performance of this and if it's not satisfactory, switch to  using pagination instead.
+If your requirement is to use scrolling instead of pagination, you can disable row virtualisation at the expense of increasing the memory footprint. Please test the performance of this and if it's not satisfactory, switch to using pagination instead.
 
 Column virtualisation can be disabled as follows:
 

--- a/documentation/ag-grid-docs/src/content/docs/aligned-grids/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/aligned-grids/index.mdoc
@@ -141,7 +141,7 @@ So why would you want to align grids like this? It's great for aligning grids th
 
 This example is a bit more useful. In the bottom grid, we show a summary row. Also note the following:
 
-* The top grid has no horizontal scroll bar, suppressed via a grid option\*.
+* The top grid has no horizontal scroll bar, suppressed via a grid option.
 * The bottom grid has no header, suppressed via a grid option.
 * `autoSizeStrategy` is only passed to the top grid, the bottom grid receives the new column widths from the top grid.
 

--- a/documentation/ag-grid-docs/src/content/docs/cell-editing-batch/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/cell-editing-batch/index.mdoc
@@ -29,7 +29,7 @@ The following example demonstrates basic batch editing functionality.
 Batch Edit is only compatible with the [Client-Side Row Model](./row-models/).
 {% /note %}
 
-## Using API methods to batch edit data
+## Using API Methods to Batch Edit Data
 
 Using the following API calls, you can build your own experience around the batch editing functionality.
 

--- a/documentation/ag-grid-docs/src/content/docs/cell-selection/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/cell-selection/index.mdoc
@@ -59,9 +59,9 @@ The following example demonstrates single range cell selection:
 
 ## Ranges with Pinning and Floating
 
-It is possible to select a cell range that spans pinned and non-pinned sections of the grid. If you do this, the selected range will not have any gaps with regards to the column order. For example, if you start the drag on the left pinned area and drag to the right pinned area, then all of the columns in the center area will also be part of the range.
+It is possible to select a cell range that spans pinned and non-pinned sections of the grid. If you do this, the selected range will not have any gaps with regards to the column order. For example, if you start the drag on the left pinned area and drag to the right pinned area, then all of the columns in the centre area will also be part of the range.
 
-Likewise with floating, no row gaps will occur if a range spans into pinned rows. A range will be continuous between the floating top rows, the center, and the floating bottom rows.
+Likewise with floating, no row gaps will occur if a range spans into pinned rows. A range will be continuous between the floating top rows, the centre, and the floating bottom rows.
 
 The above two (pinning and floating) can be thought of as follows: if you have a grid with pinning and / or floating, then 'flatten out' the grid in your head so that all rows and columns are visible, then the cell selection will work as you would expect in the flattened out version where only full rectangles can be selectable.
 

--- a/documentation/ag-grid-docs/src/content/docs/column-groups/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-groups/index.mdoc
@@ -104,7 +104,7 @@ The example below demonstrates using the `autoHeaderHeight` property in conjunct
 
 ## Colouring Groups
 
-The grid does not automatically color the groups for you. However, you can achieve this by using the `headerClass` or `headerStyle` properties in the column definitions. These attributes can be applied to both individual columns and column groups.
+The grid does not automatically colour the groups for you. However, you can achieve this by using the `headerClass` or `headerStyle` properties in the column definitions. These attributes can be applied to both individual columns and column groups.
 
 ```{% frameworkTransform=true suppressFrameworkContext=true %}
 const gridOptions = {

--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-customisation/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-customisation/index.mdoc
@@ -16,7 +16,7 @@ The following themes are provided to Integrated Charts by default.
 These themes correspond to [AG Charts Base Themes](https://www.ag-grid.com/charts/themes-api/#reference-AgChartTheme-baseTheme).
 
 {% note %}
-When using a dark color scheme for the grid, the application must provide the dark equivalents of the chart themes. If a default AG Chart theme is used, the dark themes are named with a `-dark` suffix, e.g. `'ag-vivid-dark'`.
+When using a dark colour scheme for the grid, the application must provide the dark equivalents of the chart themes. If a default AG Chart theme is used, the dark themes are named with a `-dark` suffix, e.g. `'ag-vivid-dark'`.
 {% /note %}
 
 The selected theme can be changed by the user via the [Chart Tool Panel](./integrated-charts-chart-tool-panels/) or

--- a/documentation/ag-grid-docs/src/content/docs/key-features/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/key-features/index.mdoc
@@ -290,7 +290,7 @@ This example demonstrates filtering, editing, sorting, row selection, and pagina
 
 ### Themes
 
-[Grid Themes](./theming/) define how the grid looks (colors, font, spacing etc). The default theme is called Quartz. You can choose a [different theme](./themes/), or customise a built-in theme by changing parameters. Here we create a new theme based on Quartz:
+[Grid Themes](./theming/) define how the grid looks (colours, font, spacing etc). The default theme is called Quartz. You can choose a [different theme](./themes/), or customise a built-in theme by changing parameters. Here we create a new theme based on Quartz:
 
 ```js
 import { themeQuartz } from "ag-grid-community"; // or themeBalham, themeAlpine
@@ -298,13 +298,13 @@ import { themeQuartz } from "ag-grid-community"; // or themeBalham, themeAlpine
 const myTheme = themeQuartz.withParams({
     /* Low spacing = very compact */
     spacing: 2,
-    /* Changes the color of the grid text */
+    /* Changes the colour of the grid text */
     foregroundColor: 'rgb(14, 68, 145)',
-    /* Changes the color of the grid background */
+    /* Changes the colour of the grid background */
     backgroundColor: 'rgb(241, 247, 255)',
-    /* Changes the header color of the top row */
+    /* Changes the header colour of the top row */
     headerBackgroundColor: 'rgb(228, 237, 250)',
-    /* Changes the hover color of the row*/
+    /* Changes the hover colour of the row*/
     rowHoverColor: 'rgb(216, 226, 255)',
 });
 

--- a/documentation/ag-grid-docs/src/content/docs/row-interface/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/row-interface/index.mdoc
@@ -20,7 +20,7 @@ Most users will not need to use Row Events but they are made available for advan
 
 ### Row Event Guidance
 
-All events fired by the `rowNode` are synchronous (events are normally asynchronous). The grid is also listening for these events internally. This means that when you receive an event, the grid  may still have some work to do (e.g. if `rowTop` changed, the grid UI may still have to update to reflect this change).
+All events fired by the `rowNode` are synchronous (events are normally asynchronous). The grid is also listening for these events internally. This means that when you receive an event, the grid may still have some work to do (e.g. if `rowTop` changed, the grid UI may still have to update to reflect this change).
 
 It is recommended to **not** call any grid API functions while receiving events from the `rowNode`. Instead, it is best to put your logic into a timeout and call the grid in another VM tick.
 

--- a/documentation/ag-grid-docs/src/content/docs/themes/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/themes/index.mdoc
@@ -61,7 +61,7 @@ public theme = themeBalham;
 
 Themes are simply preset configurations of parts and parameters. After choosing a theme as a starting point, you can:
 
-1. Choose a different [Color Scheme](./theming-colors/#color-schemes) if required.
+1. Choose a different [Color Scheme](./theming-colors/#colour-schemes) if required.
 2. Use [Theme Parameters](./theming-parameters/) to customise borders, compactness, fonts and more.
 3. Use [Theme Parts](./theming-parts/) mix and match elements from different themes, for example the icons from Quartz with the text inputs from Material.
 4. [Write your own CSS](./theming-css/) for unlimited control over grid appearance.

--- a/documentation/ag-grid-docs/src/content/docs/theming-colors/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-colors/index.mdoc
@@ -1,19 +1,19 @@
 ---
-title: "Theming: Colors & Dark Mode"
+title: "Theming: Colours & Dark Mode"
 ---
 
-Control the overall color scheme and color of individual elements
+Control the overall colour scheme and colour of individual elements
 
 ## Overview
 
 * Change individual [colour parameters](#color-parameters)
-* Switch between [light and dark color schemes](#color-schemes) using parts
+* Switch between [light and dark colour schemes](#colour-schemes) using parts
 * Integrate with a website that has a dark mode toggle using [theme modes](#theme-modes)
 * Make unrestricted [customisations using CSS](./theming-css/#custom-css-rules)
 
-## Color Parameters
+## Colour Parameters
 
-The grid has a few key color parameters that most applications will set custom values for, and many more specific color parameters that can be used for fine tuning. Appropriate default values for many parameters are automatically generated based on the key parameters:
+The grid has a few key colour parameters that most applications will set custom values for, and many more specific colour parameters that can be used for fine tuning. Appropriate default values for many parameters are automatically generated based on the key parameters:
 
 * `backgroundColor` - typically your application page background (must be opaque)
 * `foregroundColor` - typically your application text colour
@@ -44,18 +44,18 @@ const myTheme = themeQuartz.withParams({
 
 {% gridExampleRunner title="Colour Customisation" name="color-customisation" exampleHeight=400 suppressDarkMode=true /%}
 
-## Extended Syntax for Color Values
+## Extended Syntax for Colour Values
 
-All theme parameters with the suffix `Color` are color values, and can accept the following values:
+All theme parameters with the suffix `Color` are colour values, and can accept the following values:
 
 | Syntax | Description |
 |-|-|
-| `string` | A [CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value), such as `'red'`, `'rgb(255, 0, 0)'`, or variable expression `'var(--myColorVar)'`. |
+| `string` | A [CSS colour value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value), such as `'red'`, `'rgb(255, 0, 0)'`, or variable expression `'var(--myColorVar)'`. |
 | `{ ref: 'accentColor' }` | Use the same value as the `accentColor` parameter |
 | `{ ref: 'accentColor', mix: 0.25 }` | A mix of 25%, `accentColor` 75% transparent |
 | `{ ref: 'accentColor', mix: 0.25, onto: 'backgroundColor' }` | A mix of 25%, `accentColor` 75% `backgroundColor` |
 
-## Color Schemes
+## Colour Schemes
 
 The grid defines a number of dark and light colour schemes that you can apply.
 

--- a/documentation/ag-grid-docs/src/content/docs/theming/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming/index.mdoc
@@ -7,7 +7,7 @@ Theming refers to the process of adjusting design elements such as colours, bord
 We provide a range of methods for customising the appearance of the grid so that you can create any look that your designer can imagine. From the quick and easy to the most advanced, they are:
 
 1. Select a [Built-in Theme](./themes/) as a starting point.
-2. Choose a different [Color Scheme](./theming-colors/#color-schemes) if required.
+2. Choose a different [Color Scheme](./theming-colors/#colour-schemes) if required.
 3. Use [Theme Parameters](./theming-parameters/) to customise borders, compactness, fonts and more.
 4. Use [Theme Parts](./theming-parts/) to change the appearance of components like the icon set and text inputs.
 5. [Write your own CSS](./theming-css/) for unlimited control over grid appearance.

--- a/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-31/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-31/index.mdoc
@@ -101,7 +101,7 @@ module.exports = {
 ### ColumnDefs
 
 * Grid columns are now sortable and resizable by default. Also, the grid animates rows by default. In order to avoid this, please set `defaultColDef.resizable = false`, `defaultColDef.sortable = false` and `gridOptions.animateRows = false`.
-* When not providing column definitions or setting `columnDefs = undefined`, a loading overlay will be displayed until column definitions are set. To go back to the earlier behavior of showing a grid without any columns, please set `columnDefs = []`.
+* When not providing column definitions or setting `columnDefs = undefined`, a loading overlay will be displayed until column definitions are set. To go back to the earlier behaviour of showing a grid without any columns, please set `columnDefs = []`.
 * Setting `columnDefs` to `null`/`undefined` via a call to `api.setColumnDefs` or via a state variable no longer clears the columns shown in the grid. Instead, set `columnDefs` to `[]` to clear the columns shown in the grid.
 * `useValueFormatterForExport` is now true by default. This means that cell values are formatted using the column's valueFormatter when exporting data from the grid. This applies to CSV and Excel export, as well as clipboard operations and the fill handle. 
 
@@ -135,7 +135,7 @@ Setting `rowData` to `null`/`undefined` via a call to `api.setRowData` or via a 
 ### Row Grouping
 
 * Group values will no longer be typeless, and will be inferred from the first row when they were created.
-* When using row grouping with `groupDisplayType=singleColumn` (which is the default behavior) and displaying checkboxes in the auto-group column, checkboxes in leaf rows are only displayed if `autoGroupColumnDef` provides a field or a valueGetter to show values in leaf row cells. If you'd like to show checkboxes in the group columns for leaf rows, provide a field or valueGetter in the `autoGroupColumnDef`.
+* When using row grouping with `groupDisplayType=singleColumn` (which is the default behaviour) and displaying checkboxes in the auto-group column, checkboxes in leaf rows are only displayed if `autoGroupColumnDef` provides a field or a valueGetter to show values in leaf row cells. If you'd like to show checkboxes in the group columns for leaf rows, provide a field or valueGetter in the `autoGroupColumnDef`.
 
 ### Pagination
 

--- a/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-34/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-34/index.mdoc
@@ -34,7 +34,7 @@ There are no deprecated API removals in AG Grid version {% migrationVersion() %}
 
 ### Filters
 
-- `suppressAdvancedFilterEval` is deprecated without replacement. No longer using eval at all in advanced filters so this is now default behavior. This improves security by not requiring `script-src 'unsafe-eval'` for advanced filters.
+- `suppressAdvancedFilterEval` is deprecated without replacement. No longer using eval at all in advanced filters so this is now default behaviour. This improves security by not requiring `script-src 'unsafe-eval'` for advanced filters.
 
 - `ISetFilter` interface is deprecated. When retrieving via `api.getColumnFilterInstance(column)`, use `SetFilterUi`. To access the methods that were previously available on `ISetFilter` (but not on `SetFilterUi`), instead retrieve the filter handler via `api.getColumnFilterHandler(column)` and use the `SetFilterHandler` interface.
 


### PR DESCRIPTION
# AG Grid Documentation Amendments

This file documents all spelling and grammar corrections made to the AG Grid documentation.

## Upgrading to AG Grid 34
LN37: "this is now default behavior" => "this is now default behaviour"
-- Changed American spelling to British spelling

## Theming: Colours & Dark Mode
LN2: "Colors & Dark Mode" => "Colours & Dark Mode"
-- Changed American spelling to British spelling

LN5: "overall color scheme and color of" => "overall colour scheme and colour of"
-- Changed American spelling to British spelling

LN10: "dark color schemes](#color-schemes)" => "dark colour schemes](#colour-schemes)"
-- Changed American spelling to British spelling

LN14: "## Color Parameters" => "## Colour Parameters"
-- Changed American spelling to British spelling

LN16: "few key color parameters" => "few key colour parameters"
-- Changed American spelling to British spelling

LN16: "specific color parameters" => "specific colour parameters"
-- Changed American spelling to British spelling

LN47: "## Extended Syntax for Color Values" => "## Extended Syntax for Colour Values"
-- Changed American spelling to British spelling

LN49: "suffix `Color` are color values" => "suffix `Color` are colour values"
-- Changed American spelling to British spelling

LN53: "[CSS color value]" => "[CSS colour value]"
-- Changed American spelling to British spelling

LN59: "## Color Schemes" => "## Colour Schemes"
-- Changed American spelling to British spelling

## Cell Selection
LN62: "columns in the center area" => "columns in the centre area"
-- Changed American spelling to British spelling

LN64: "floating top rows, the center, and" => "floating top rows, the centre, and"
-- Changed American spelling to British spelling

## Upgrading to AG Grid 31
LN104: "go back to the earlier behavior of" => "go back to the earlier behaviour of"
-- Changed American spelling to British spelling

LN138: "(which is the default behavior) and" => "(which is the default behaviour) and"
-- Changed American spelling to British spelling

## Row Overview
LN23: "when you receive an event, the grid  may still" => "when you receive an event, the grid may still"
-- Removed double space

## Chart Customisation
LN19: "When using a dark color scheme" => "When using a dark colour scheme"
-- Changed American spelling to British spelling

## Batch Editing
LN32: "## Using API methods to batch edit data" => "## Using API Methods to Batch Edit Data"
-- Converted heading to title case

## Key Features
LN293: "how the grid looks (colors, font" => "how the grid looks (colours, font"
-- Changed American spelling to British spelling

LN301: "/* Changes the color of the" => "/* Changes the colour of the"
-- Changed American spelling to British spelling

LN303: "/* Changes the color of the" => "/* Changes the colour of the"
-- Changed American spelling to British spelling

LN305: "/* Changes the header color of" => "/* Changes the header colour of"
-- Changed American spelling to British spelling

LN307: "/* Changes the hover color of" => "/* Changes the hover colour of"
-- Changed American spelling to British spelling

## Column Groups
LN107: "does not automatically color the groups" => "does not automatically colour the groups"
-- Changed American spelling to British spelling

## Accessibility
LN140: "virtualisation at the expense  of increasing" => "virtualisation at the expense of increasing"
-- Removed double space

LN140: "it's not satisfactory, switch to  using" => "it's not satisfactory, switch to using"
-- Removed double space
