### PR TITLE
Add null check for focusedHeader in horizontal header navigation

### DIFF
--- a/packages/ag-grid-community/src/navigation/headerNavigationService.ts
+++ b/packages/ag-grid-community/src/navigation/headerNavigationService.ts
@@ -174,6 +174,9 @@ export class HeaderNavigationService extends BeanStub implements NamedBean {
         event: KeyboardEvent
     ): boolean {
         const { focusSvc, gos } = this.beans;
+        if (!focusSvc.focusedHeader) {
+            return false;
+        }
         const focusedHeader = { ...focusSvc.focusedHeader! };
         let nextHeader: HeaderPosition;
         let normalisedDirection: 'Before' | 'After';


### PR DESCRIPTION
While investigating a header navigation issue, I noticed that the method `navigateHorizontally` assumes `focusSvc.focusedHeader` is always defined.
However, there are scenarios (such as initial keyboard navigation or after a blur event) where `focusedHeader` may be null or undefined.

This patch adds a defensive null check before attempting to spread `focusedHeader`, preventing potential runtime errors.

Please let me know if this should be handled differently or if there's a preferred internal utility for guarding this access.
I'm happy to revise the approach based on your feedback.

I’ve attached both a screen and a Chrome DevTools recording to demonstrate the issue I encountered.

You can reproduce the error by following these steps:

1. Click on an empty space in the header area, or on the Selection Column header (which has no group).

2. Press the left or right arrow key.

3. An error occurs.

Thank you for your time and consideration. I appreciate your review of this patch.

Now I'm using below version of ag-grid

ag-grid-community: ^33.3.2
ag-grid-enterprise: ^33.3.2
ag-grid-react": ^33.3.2


https://github.com/user-attachments/assets/69851069-4858-4c9f-be01-ef5268810fa5


https://github.com/user-attachments/assets/9f017910-47c8-4614-93e7-8a7557147849

