### PR TITLE
RTI-2761 RTI-2762 RTI-2763 RTI-2764 RTI-2767 RTI-2818 tree data drag drop docs

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/_examples/tree-managed-row-drag-filesystem/data.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/_examples/tree-managed-row-drag-filesystem/data.ts
@@ -1,7 +1,7 @@
 export interface IFile {
     id: string;
     name: string;
-    type: 'folder' | 'file';
+    type: 'folder' | 'file' | 'readonly-folder';
     dateModified?: string; // ISO date string
     size?: number; // Size in MB
     children?: IFile[];
@@ -16,66 +16,57 @@ export function getData(): IFile[] {
             children: [
                 {
                     id: '2',
-                    name: 'txt',
-                    type: 'folder',
-                    children: [
-                        {
-                            id: '3',
-                            name: 'notes.txt',
-                            type: 'file',
-                            dateModified: '2017-05-21',
-                            size: 14.7,
-                        },
-                    ],
+                    name: 'notes.txt',
+                    type: 'file',
+                    dateModified: '2017-05-21',
+                    size: 14.7,
+                },
+                {
+                    id: '3',
+                    name: 'accounts.xls',
+                    type: 'file',
+                    dateModified: '2016-08-12',
+                    size: 4.3,
                 },
                 {
                     id: '4',
-                    name: 'pdf',
-                    type: 'folder',
-                    children: [
-                        {
-                            id: '5',
-                            name: 'book.pdf',
-                            type: 'file',
-                            dateModified: '2017-05-20',
-                            size: 2.1,
-                        },
-                        {
-                            id: '6',
-                            name: 'cv.pdf',
-                            type: 'file',
-                            dateModified: '2016-05-20',
-                            size: 2.4,
-                        },
-                    ],
+                    name: 'xyz.txt',
+                    type: 'file',
+                    dateModified: '2016-01-17',
+                    size: 1.1,
                 },
                 {
-                    id: '7',
-                    name: 'xls',
+                    id: '5',
+                    name: 'var',
+                    type: 'folder',
+                },
+            ],
+        },
+        {
+            id: '100',
+            name: 'READONLY',
+            type: 'readonly-folder',
+            children: [
+                {
+                    id: '101',
+                    name: 'subfolder',
                     type: 'folder',
                     children: [
                         {
-                            id: '8',
-                            name: 'accounts.xls',
+                            id: '102',
+                            name: 'temp.txt',
                             type: 'file',
                             dateModified: '2016-08-12',
-                            size: 4.3,
+                            size: 101,
                         },
                     ],
                 },
                 {
-                    id: '9',
-                    name: 'stuff',
-                    type: 'folder',
-                    children: [
-                        {
-                            id: '10',
-                            name: 'xyz.txt',
-                            type: 'file',
-                            dateModified: '2016-01-17',
-                            size: 1.1,
-                        },
-                    ],
+                    id: '103',
+                    name: 'notes.txt',
+                    type: 'file',
+                    dateModified: '2016-08-12',
+                    size: 400,
                 },
             ],
         },
@@ -97,20 +88,6 @@ export function getData(): IFile[] {
                             size: 14.3,
                         },
                     ],
-                },
-            ],
-        },
-        {
-            id: '14',
-            name: 'Misc',
-            type: 'folder',
-            children: [
-                {
-                    id: '15',
-                    name: 'temp.txt',
-                    type: 'file',
-                    dateModified: '2016-08-12',
-                    size: 101,
                 },
             ],
         },

--- a/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/_examples/tree-managed-row-drag-filesystem/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/_examples/tree-managed-row-drag-filesystem/main.ts
@@ -1,4 +1,4 @@
-import type { GridApi, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { GridApi, GridOptions, IRowNode, ValueFormatterParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ModuleRegistry,
@@ -51,15 +51,48 @@ const gridOptions: GridOptions<IFile> = {
     rowDragManaged: true,
     suppressMoveWhenRowDragging: true,
     canDropOnRow: (params) => {
-        if (!params.newParent) {
-            return true; // Not changing parent, allow drop
+        let { newParent, position, rows } = params;
+
+        if (isReadonlyFolder(newParent) || isInsideReadonlyFolder(newParent)) {
+            return null; // Prevent dropping into a readonly folder
         }
-        if (params.newParent?.data?.type === 'folder') {
-            return true; // Allow dropping on folders
+
+        if (newParent) {
+            // Prevent moving a readonly folder into another folder
+            rows = rows.filter((row) => !isReadonlyFolder(row));
         }
-        return false; // Prevent dropping on anything else
+
+        // Filter out anything that is inside a readonly folder, it cannot be moved
+        rows = rows.filter((row) => !isInsideReadonlyFolder(row));
+
+        if (!rows.length) {
+            return null; // Nothing to drop
+        }
+
+        if (newParent && newParent.data && newParent.data?.type !== 'folder') {
+            // Block changing parents on anything that is not of type 'folder'
+            return { newParent: null, position: position === 'inside' ? 'below' : position, rows };
+        }
+
+        return { rows };
     },
 };
+
+/** Returns true if the row is a readonly folder, false if it is a file or a normal folder */
+function isReadonlyFolder(row: IRowNode<IFile> | null) {
+    return !!row && row.data?.type === 'readonly-folder';
+}
+
+/** Returns true if the row is a file or folder inside a readonly folder */
+function isInsideReadonlyFolder(row: IRowNode<IFile> | null): boolean {
+    if (!row || !row.parent) {
+        return false; // Root level
+    }
+    if (isReadonlyFolder(row.parent)) {
+        return true;
+    }
+    return isInsideReadonlyFolder(row.parent);
+}
 
 const eGridDiv = document.getElementById('myGrid');
 let gridApi: GridApi<IFile>;

--- a/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/index.mdoc
@@ -95,14 +95,18 @@ Returning an object allows instead to filter the rows to drop, or, change the pa
 
 {% apiDocumentation source="grid-options/properties.json" section="rowDragging" names=["canDropOnRow"] /%}
 
+In the example below, note that:
+* A file cannot be converted to a folder, dropping a file or a folder into a file is blocked.
+* The `READONLY` folder cannot be changed, not drag and drop allowed in or from it, but it can be reordered.
+
 {% gridExampleRunner title="Managed Row Drag with Tree Data and canDropOnRow" name="tree-managed-row-drag-filesystem"  /%}
 
 ## Unmanaged Row Dragging 
 
-To have full control, is possible to provide a customized implementation of row dragging using unmanaged row dragging.
-The application in this case is fully responsible to maintain the rowData state and handling the dragging events and updating the rowData based on the drag events fired by the grid.
+In order to have full control over row dragging, it is possible to provide a customized implementation of row dragging using unmanaged row dragging.
+In this case, the application is responsible for maintaining the rowData state, handling the dragging events and updating the rowData based on the drag events fired by the grid.
 
-### Example Tree Data Unmanaged Row Dragging
+### Tree Data with getDataPath
 
 The example below shows [Tree Data](./tree-data/) and row dragging with getDataPath where the following can be noted:
 
@@ -112,27 +116,24 @@ The example below shows [Tree Data](./tree-data/) and row dragging with getDataP
 * You can reorder a row only inside its current parent by holding the {% kbd "⇧ Shift" /%} key press and dragging it
 * The expanded/contracted state of a folder and all of its child folders is preserved when the folder is moved to a new parent.
 
-### Example Highlighted Tree Data Unmanaged Row Dragging
+{% gridExampleRunner title="Unmanaged Row Drag with Tree Data" name="tree-unmanaged-row-drag"  exampleHeight=545  /%}
+
+### Tree Data Highlighting the Drop Parent Row
 
 The example above works, however it is not intuitive as the user is given no visual hint what folder will be the destination folder. The example below continues with the example above by providing hints to the user while the drag is in progress. From the example the following can be observed:
 
 * The example registers for `onRowDragMove` events and works out what folder the mouse is over as the drag is happening.
-
 * While the row is dragging, the application highlights the folder that is currently selected as the destination folder (called `potentialParent` in the example code).
-
 * The application does NOT rearrange the rows as the drag is happening. As with the previous example, it waits for the `onRowDragEnd` event before updating the data.
-
 * The example uses [Cell Class Rules](./cell-styles/#cell-class-rules) to highlight the destination folder. The example adds a CSS class `hover-over` to all the cells of the destination folder.
-
 * The example uses [Refresh Cells](./view-refresh/#refresh-cells) to get the grid to execute the Cell Class Rules again over the destination folder when the destination folder changes.
 
 {% gridExampleRunner title="Highlighting Unmanaged Row Drag with Tree Data" name="tree-unmanaged-row-drag-highlight"  /%}
 
-### Example Tree Data with parentId Unmanaged Row Dragging
+### Tree Data with parentId
 
-{% gridExampleRunner title="Unmanaged Row Drag with Tree Data" name="tree-unmanaged-row-drag"  exampleHeight=545  /%}
-
-The following example shows how to implement unmanaged row dragging using the `parentId` approach, which is simpler and more direct than using `getDataPath`. The grid uses the `treeDataParentIdField` property, and utility functions are provided to move rows and update the tree structure. This approach is recommended for most use cases where your data is already structured with parent IDs.
+The following example shows how to implement unmanaged row dragging using the `parentId` approach, which is simpler and more direct than using `getDataPath`.
+The grid uses the `treeDataParentIdField` property, and utility functions are provided to move rows and update the tree structure. This approach is recommended for most use cases where your data is already structured with parent IDs.
 
 This example also demonstrates how to provide custom drop indicators using the [`setRowDropPositionIndicator`](https://www.ag-grid.com/javascript-data-grid/grid-api/#reference-setRowDropPositionIndicator) API.
 

--- a/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/index.mdoc
@@ -9,7 +9,7 @@ Configure the grid to display structured data by providing data paths.
 Row Dragging can be combined with Tree Data to let users reorder rows within a hierarchical structure. You can choose between two approaches:
 
 - [Managed Row Dragging](#enabling-managed-row-dragging): The grid handles row dragging automatically.
-- [Unmanaged Row Dragging](#unmanaged-row-dragging): Customized application specific logic for row dragging.
+- [Unmanaged Row Dragging](#unmanaged-row-dragging): Customized application-specific logic for row dragging.
 
 To enable row dragging, set `rowDrag: true` on the group column (usually via `autoGroupColumnDef`).
 
@@ -34,14 +34,26 @@ It supports reordering, moving parents and children, and converting a leaf node 
 
 To enable managed row dragging, set the following options:
 
-- `treeData: true` — Enables tree data mode, allowing hierarchical data structures.
-- `getRowId` — Provides a unique ID for each row, required for row movement.
-- `treeDataParentIdField: 'parentId'` — Specifies the field that defines parent-child relationships.
 - `rowDragManaged: true` — Enables managed row dragging, so the grid handles row movement automatically.
 - `rowDragInsertDelay` — Delay before expanding a collapsed group or converting a leaf to a group (see [Row Drag Insert Delay](#row-drag-insert-delay)).
 - `autoGroupColumnDef.rowDrag: true` — Enables the drag handle in the group column.
-- `groupDefaultExpanded: -1` — Expands all groups by default.
 - `suppressMoveWhenRowDragging: true` — Prevents the grid from moving rows while dragging, showing a highlight over the row instead.
+
+{% note %}
+It is recommended to enable `suppressMoveWhenRowDragging` when using managed row dragging with Tree Data.
+Without this option, moving subtrees can cause the grid to jump or scroll unexpectedly as rows are repositioned during the drag.
+Enabling it provides a smoother and more predictable user experience by only highlighting the drop target without moving rows until the drop is complete.
+{% /note %}
+
+{% gridExampleRunner title="Managed Row Drag with Tree Data" name="tree-managed-row-drag"  exampleHeight=545 /%}
+
+Other relevant options used in the example above include:
+
+- `getRowId` — Provides a unique ID for each row, required for row movement.
+- `treeData: true` — Enables tree data mode, allowing hierarchical data structures.
+- `treeDataParentIdField: 'parentId'` — Specifies the field that defines parent-child relationships.
+- `groupDefaultExpanded: -1` — Expands all groups by default.
+- `rowDragInsertDelay` — Optional delay before inserting a dragged row into a new parent node. Default is 500 milliseconds.
 
 ```{% frameworkTransform=true %}
 const gridOptions = {
@@ -60,14 +72,6 @@ const gridOptions = {
 };
 ```
 
-{% note %}
-It is recommended to enable `suppressMoveWhenRowDragging` when using managed row dragging with Tree Data.
-Without this option, moving subtrees can cause the grid to jump or scroll unexpectedly as rows are repositioned during the drag.
-Enabling it provides a smoother and more predictable user experience by only highlighting the drop target without moving rows until the drop is complete.
-{% /note %}
-
-{% gridExampleRunner title="Managed Row Drag with Tree Data" name="tree-managed-row-drag"  exampleHeight=545 /%}
-
 ### Managed Row Dragging with getDataPath
 
 This next examples shows how to use the `getDataPath` callback to define the hierarchical structure of the data.
@@ -76,7 +80,7 @@ This next examples shows how to use the `getDataPath` callback to define the hie
 This example uses filler nodes (where some intermediate path segments do not exist as explicit nodes in the data).
 Empty filler nodes cannot exist in the grid; if all their children are moved out, the filler node will be deleted and disappear.
 It is instead recommended to provide a full grid without filler nodes to avoid this.
-See the [Providing Data Paths](./tree-data-paths) for details about filler nodes ans `getDataPath`.
+See the [Providing Data Paths](./tree-data-paths) for details about filler nodes and `getDataPath`.
 {% /note %}
 
 {% gridExampleRunner title="Managed Row Drag with Tree Data (getDataPath)" name="tree-managed-row-drag-data-path" exampleHeight=500 /%}
@@ -90,14 +94,14 @@ This delay helps prevent accidental moves when hovering over potential drop targ
 ### Preventing dropping on certain rows
 
 The `canDropOnRow` callback allows you to control whether a row drop is allowed during managed row dragging, and optionally override the rows or parent or position for the drop.
-This is useful for restricting where rows can be dropped or customizing drop behaviour in tree data.
-Returning an object allows instead to filter the rows to drop, or, change the parent or the position of the drop.
+This is useful for restricting where rows can be dropped, or customizing drop behaviour in tree data.
+Returning an object instead allows the rows to drop to be filtered, or the parent or position of the drop to be changed
 
 {% apiDocumentation source="grid-options/properties.json" section="rowDragging" names=["canDropOnRow"] /%}
 
 In the example below, note that:
 * A file cannot be converted to a folder, dropping a file or a folder into a file is blocked.
-* The `READONLY` folder cannot be changed, not drag and drop allowed in or from it, but it can be reordered.
+* The `READONLY` folder cannot change parent, and drag and drop into or from it is not allowed.
 
 {% gridExampleRunner title="Managed Row Drag with Tree Data and canDropOnRow" name="tree-managed-row-drag-filesystem"  /%}
 
@@ -113,16 +117,16 @@ The example below shows [Tree Data](./tree-data/) and row dragging with getDataP
 * The [auto-group column](./grouping/) has row drag `true` for all rows.
 * The application moves the rows in the row data while the row drag is happening in the `onRowDragMove` event handler.
 * While row dragging the row move operation can be reverted by pressing {% kbd "⎋ Escape" /%} key.
-* You can reorder a row only inside its current parent by holding the {% kbd "⇧ Shift" /%} key press and dragging it
+* Is possible to reorder a row only inside its current parent by holding the {% kbd "⇧ Shift" /%} key and dragging it.  
 * The expanded/contracted state of a folder and all of its child folders is preserved when the folder is moved to a new parent.
 
 {% gridExampleRunner title="Unmanaged Row Drag with Tree Data" name="tree-unmanaged-row-drag"  exampleHeight=545  /%}
 
-### Tree Data Highlighting the Drop Parent Row
+### Tree Data with getDataPath, Highlighting the Drop Parent Row
 
 The example above works, however it is not intuitive as the user is given no visual hint what folder will be the destination folder. The example below continues with the example above by providing hints to the user while the drag is in progress. From the example the following can be observed:
 
-* The example registers for `onRowDragMove` events and works out what folder the mouse is over as the drag is happening.
+* The example registers for `onRowDragMove` events and works out which folder the mouse is over as the drag is happening.
 * While the row is dragging, the application highlights the folder that is currently selected as the destination folder (called `potentialParent` in the example code).
 * The application does NOT rearrange the rows as the drag is happening. As with the previous example, it waits for the `onRowDragEnd` event before updating the data.
 * The example uses [Cell Class Rules](./cell-styles/#cell-class-rules) to highlight the destination folder. The example adds a CSS class `hover-over` to all the cells of the destination folder.
@@ -130,7 +134,7 @@ The example above works, however it is not intuitive as the user is given no vis
 
 {% gridExampleRunner title="Highlighting Unmanaged Row Drag with Tree Data" name="tree-unmanaged-row-drag-highlight"  /%}
 
-### Tree Data with parentId
+### Tree Data with Parent ID
 
 The following example shows how to implement unmanaged row dragging using the `parentId` approach, which is simpler and more direct than using `getDataPath`.
 The grid uses the `treeDataParentIdField` property, and utility functions are provided to move rows and update the tree structure. This approach is recommended for most use cases where your data is already structured with parent IDs.


### PR DESCRIPTION
[RTI-2761 Move getDataPath in rowDrag example to correct location](https://ag-grid.atlassian.net/browse/RTI-2761)
[RTI-2762 Tree data rowDrag docs copy update](https://ag-grid.atlassian.net/browse/RTI-2762)
[RTI-2763 Tree data rowDrag section name updates](https://ag-grid.atlassian.net/browse/RTI-2763)
[RTI-2764 Tree data unmanaged rowDrag missing an example](https://ag-grid.atlassian.net/browse/RTI-2764)
[RTI-2767 Add explanation for the callback example canDropOnRow](https://ag-grid.atlassian.net/browse/RTI-2767)
[RTI-2818 Tree data row dragging docs updates](https://ag-grid.atlassian.net/browse/RTI-2818)

And improve the canDropOnRow example showing how to have a "readonly" folder