### PR TITLE
RTI-2803 tree data group default expanded level bug

### DIFF
--- a/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
@@ -299,7 +299,7 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
         let flags = row.treeNodeFlags;
 
         row.treeNodeFlags = flags & FLAG_EXPANDED_INITIALIZED;
-        row.level = level++;
+        row.level = level;
 
         // Update group state and children markers
         if (row.group !== !!len) {
@@ -327,6 +327,7 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
         }
         collapsed ||= row.expanded === false;
 
+        ++level; // Increment level as it is passed down to children
         flags &= FLAG_CHILDREN_CHANGED;
         let leafsLen = 0;
         for (let i = 0; i < len; ++i) {

--- a/testing/behavioural/src/tree-data/parentid/parentid-tree-expanded-state.test.ts
+++ b/testing/behavioural/src/tree-data/parentid/parentid-tree-expanded-state.test.ts
@@ -1,3 +1,4 @@
+import type { IsGroupOpenByDefaultParams } from 'ag-grid-community';
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { TreeDataModule } from 'ag-grid-enterprise';
 
@@ -8,11 +9,6 @@ describe('ag-grid parentId tree expanded state', () => {
     const gridsManager = new TestGridsManager({
         modules: [ClientSideRowModelModule, TreeDataModule],
     });
-
-    const gridRowsOptions: GridRowsOptions = {
-        checkDom: true,
-        columns: ['ag-Grid-AutoColumn'],
-    };
 
     beforeEach(() => {
         gridsManager.reset();
@@ -55,6 +51,11 @@ describe('ag-grid parentId tree expanded state', () => {
         });
 
         await asyncSetTimeout(1);
+
+        const gridRowsOptions: GridRowsOptions = {
+            checkDom: true,
+            columns: ['ag-Grid-AutoColumn'],
+        };
 
         await new GridRows(api, '', gridRowsOptions).check(`
             ROOT id:ROOT_NODE_ID ag-Grid-AutoColumn:"unknown"
@@ -119,6 +120,108 @@ describe('ag-grid parentId tree expanded state', () => {
             · │ └── yoo-2 LEAF id:yoo-2 ag-Grid-AutoColumn:"Malcolm Barrett"
             · └── yoo-1 LEAF id:yoo-1 ag-Grid-AutoColumn:"Erica Rogers"
         `);
+    });
+
+    test('groupDefaultExpanded = 1', async () => {
+        const rowData = [
+            { x: 'A', parentId: null },
+            { x: 'B', parentId: 'A' },
+            { x: 'C', parentId: undefined },
+            { x: 'D', parentId: 'C' },
+            { x: 'E' },
+            { x: 'F', parentId: 'E' },
+            { x: 'G', parentId: 'F' },
+            { x: 'H', parentId: 'G' },
+        ];
+
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'x' }],
+            treeData: true,
+            treeDataParentIdField: 'parentId',
+            autoGroupColumnDef: { headerName: 'tree' },
+            animateRows: false,
+            groupDefaultExpanded: 1,
+            rowData,
+            getRowId: (params) => params.data.x,
+        });
+
+        const gridRowsOptions: GridRowsOptions = {
+            checkDom: true,
+        };
+
+        const gridRows = new GridRows(api, 'default expanded 1', gridRowsOptions);
+
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ A GROUP id:A
+            │ └── B LEAF id:B
+            ├─┬ C GROUP id:C
+            │ └── D LEAF id:D
+            └─┬ E GROUP id:E
+            · └─┬ F GROUP collapsed id:F
+            · · └─┬ G GROUP collapsed hidden id:G
+            · · · └── H LEAF hidden id:H
+        `);
+    });
+
+    test('groupDefaultExpanded callback', async () => {
+        const rowData = [
+            { x: 'A', parentId: null },
+            { x: 'B', parentId: 'A' },
+            { x: 'C', parentId: 'B' },
+            { x: 'D', parentId: 'C' },
+            { x: 'E' },
+            { x: 'F', parentId: 'E' },
+            { x: 'G', parentId: 'F' },
+            { x: 'H', parentId: 'G' },
+        ];
+
+        const calls: { key: string; level: number }[] = [];
+
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'x' }],
+            treeData: true,
+            treeDataParentIdField: 'parentId',
+            autoGroupColumnDef: { headerName: 'tree' },
+            animateRows: false,
+            isGroupOpenByDefault: (params) => {
+                calls.push({ key: params.key, level: params.level });
+                return params.level < 2;
+            },
+            rowData,
+            getRowId: (params) => params.data.x,
+        });
+
+        const gridRowsOptions: GridRowsOptions = {
+            checkDom: true,
+        };
+
+        const gridRows = new GridRows(api, 'default expanded 1', gridRowsOptions);
+
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ A GROUP id:A
+            │ └─┬ B GROUP id:B
+            │ · └─┬ C GROUP collapsed id:C
+            │ · · └── D LEAF hidden id:D
+            └─┬ E GROUP id:E
+            · └─┬ F GROUP id:F
+            · · └─┬ G GROUP collapsed id:G
+            · · · └── H LEAF hidden id:H
+        `);
+
+        calls.sort((a, b) => a.key.localeCompare(b.key));
+
+        const callsObj = Object.fromEntries(calls.map((call) => [call.key, call.level]));
+
+        expect(callsObj).toEqual({
+            A: 0,
+            B: 1,
+            C: 2,
+            E: 0,
+            F: 1,
+            G: 2,
+        });
     });
 });
 

--- a/testing/behavioural/src/tree-data/parentid/parentid-tree-expanded-state.test.ts
+++ b/testing/behavioural/src/tree-data/parentid/parentid-tree-expanded-state.test.ts
@@ -1,4 +1,3 @@
-import type { IsGroupOpenByDefaultParams } from 'ag-grid-community';
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { TreeDataModule } from 'ag-grid-enterprise';
 


### PR DESCRIPTION
During the new treeData construction post traversal, the level passed to the method used to determine if a row is expanded was using the wrong value, incremented by one

- Fix the implementation
- Add unit tests to check the level used is correct