### PR TITLE
[RTI-2830] Fix(grid): datetime parsing order in datetime example

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/cell-data-types/_examples/overriding-pre-defined-cell-data-types/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/cell-data-types/_examples/overriding-pre-defined-cell-data-types/main.ts
@@ -102,7 +102,7 @@ const gridOptions: GridOptions<IOlympicDataTypes> = {
                 if (value == null) {
                     return;
                 }
-                let [_, HH, mm, ss, dd, MM, yyyy] = (value.match(dateTimeRegex) || Array(7).fill('0')).map(
+                let [_, dd, MM, yyyy, HH, mm, ss] = (value.match(dateTimeRegex) || Array(7).fill('0')).map(
                     (e) => e || '0'
                 );
                 return new Date(


### PR DESCRIPTION
 - Ensured that day, month, year, hour, minute, and second are correctly assigned.