### PR TITLE
[RTI-2784] Maintenance(grid): allow all console methods (except for console.error) in example generator

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/pivoting-result-columns/_examples/extreme-pivot/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-result-columns/_examples/extreme-pivot/main.ts
@@ -34,7 +34,7 @@ const gridOptions: GridOptions<IOlympicData> = {
     sideBar: 'columns',
     pivotMaxGeneratedColumns: 1000,
     onPivotMaxColumnsExceeded: () => {
-        console.error(
+        console.warn(
             'The limit of 1000 generated columns has been exceeded. Either remove pivot or aggregations from some columns or increase the limit.'
         );
     },

--- a/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
+++ b/external/ag-website-shared/src/components/example-runner/components/ExampleLogger.tsx
@@ -37,7 +37,10 @@ const REACT_JSON_VIEW_CONFIG = {
     displayArrayKey: false,
     quotesOnKeys: false,
 };
-const IGNORED_MESSAGES = ['Angular is running in development mode.'];
+const IGNORED_MESSAGES = [
+    'Angular is running in development mode.',
+    '[vite] server connection lost. Polling for restart...',
+];
 
 // Styles using base16: https://github.com/chriskempson/base16/blob/main/styling.md
 const JSON_VIEWER_THEME = {
@@ -191,7 +194,7 @@ export const ExampleLogger: FunctionComponent<Props> = ({ exampleName, bufferSiz
     useEffect(() => {
         const updateLogs = (event: MessageEvent) => {
             const log = event.data;
-            if (log?.type === 'console-log' && log.exampleName === exampleName && !containsIgnoredMessage(log)) {
+            if (log?.type.startsWith('console-') && log.exampleName === exampleName && !containsIgnoredMessage(log)) {
                 setLogs((prevLogs) => {
                     if (isRepeatedLog({ prevLogs, log })) {
                         const lastLog = prevLogs[prevLogs.length - 1];

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/fileUtils.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/fileUtils.ts
@@ -174,9 +174,13 @@ export function convertTsxToJsx(fileStr: string): string {
     jsxFile = jsxFile.replaceAll('// empty line', '');
     return jsxFile;
 }
+const consoleMethods = Object.getOwnPropertyNames(console);
+const consoleRegexp = new RegExp(`console\.(${consoleMethods.join('|')})`, 'g');
 
 export const getHasExampleConsoleLog = ({ contents }: { contents?: string }) => {
-    return contents?.includes('console.log');
+    const res = consoleRegexp.test(contents || '');
+    consoleRegexp.lastIndex = 0; // reset lastIndex to ensure it can be reused
+    return res;
 };
 
 export const getHasSimpleHtml = ({ contents }: { contents?: string }) => {

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/fileUtils.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/fileUtils.ts
@@ -175,7 +175,7 @@ export function convertTsxToJsx(fileStr: string): string {
     return jsxFile;
 }
 const consoleMethods = Object.getOwnPropertyNames(console);
-const consoleRegexp = new RegExp(`console\.(${consoleMethods.join('|')})`, 'g');
+const consoleRegexp = new RegExp(`console.(${consoleMethods.join('|')})`, 'g');
 
 export const getHasExampleConsoleLog = ({ contents }: { contents?: string }) => {
     const res = consoleRegexp.test(contents || '');

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/fileUtils.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/fileUtils.ts
@@ -174,7 +174,7 @@ export function convertTsxToJsx(fileStr: string): string {
     jsxFile = jsxFile.replaceAll('// empty line', '');
     return jsxFile;
 }
-const consoleMethods = Object.getOwnPropertyNames(console);
+const consoleMethods = ['log', 'warn', 'table', 'info', 'debug'] as const;
 const consoleRegexp = new RegExp(`console.(${consoleMethods.join('|')})`, 'g');
 
 export const getHasExampleConsoleLog = ({ contents }: { contents?: string }) => {

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/getConsoleLogSnippet.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/getConsoleLogSnippet.ts
@@ -161,8 +161,8 @@ function patchConsoleLog() {
         return args.map(getConsoleValue);
     }
 
-    // we ignore console.error to avoid printing license messages
-    Object.getOwnPropertyNames(console).filter(name => name !== 'error').map(name => [name, console[name]]).forEach(([name, originalMethod]) => {
+    // we ignore console.error to avoid printing license messages, as well as infinite try catch loop below
+    ['log', 'info', 'warn', 'table', 'debug'].map(name => [name, console[name]]).forEach(([name, originalMethod]) => {
         console[name] = (...args) => {
             try {
                 window.parent.postMessage({
@@ -177,6 +177,7 @@ function patchConsoleLog() {
             }
             originalMethod(...args);
         };
+        console[name]._original = originalMethod;
     });
 }
 patchConsoleLog();

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/getConsoleLogSnippet.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/getConsoleLogSnippet.ts
@@ -161,21 +161,23 @@ function patchConsoleLog() {
         return args.map(getConsoleValue);
     }
 
-    const originalConsoleLog = console.log;
-    console.log = (...args) => {
-        try {
-            window.parent.postMessage({
-                type: 'console-log',
-                pageName: '${pageName}',
-                exampleName: '${exampleName}',
-                data: getConsoleLogData(args),
-            });
-        } catch(error) {
-            // Posting is best-effort and shouldn't block normal console logging.
-            ${logError ? 'console.error(error);' : undefined}
-        }
-        originalConsoleLog(...args);
-    };
+    // we ignore console.error to avoid printing license messages
+    Object.getOwnPropertyNames(console).filter(name => name !== 'error').map(name => [name, console[name]]).forEach(([name, originalMethod]) => {
+        console[name] = (...args) => {
+            try {
+                window.parent.postMessage({
+                    type: 'console-' + name,
+                    pageName: '${pageName}',
+                    exampleName: '${exampleName}',
+                    data: getConsoleLogData(args)
+                });
+            } catch(error) {
+                // Posting is best-effort and shouldn't block normal console logging.
+                ${logError ? 'console.error(error);' : undefined}
+            }
+            originalMethod(...args);
+        };
+    });
 }
 patchConsoleLog();
 


### PR DESCRIPTION
 - Introduced an array to match more console methods for better detection in example gen.
 - Updated getHasExampleConsoleLog to utilize the new logic.
 - Still do not allow console.error, as it is reserved for service messages like absent licence error
 - Update extreme pivot example to use console.warn

| Was | Now |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/f19b81ef-efd0-4faf-9b16-6111f24bbd84)  | ![Screenshot 2025-06-23 at 16 08 49](https://github.com/user-attachments/assets/2c46facc-a3d0-4a14-af1c-baa8f7520755)  | 

Also fixes 
https://ag-grid.atlassian.net/jira/software/projects/RTI/boards/23?selectedIssue=RTI-2824

| Was | Now |
|--------|--------|
| ![Screenshot 2025-06-23 at 16 24 10](https://github.com/user-attachments/assets/25e5bd0c-3b63-4a3e-8d65-773fdc4d7a80) | ![Screenshot 2025-06-23 at 16 22 47](https://github.com/user-attachments/assets/1375591e-00a9-4dbf-880f-c043448d4b1f)  | 
