### PR TITLE
RTI-2770 isRowValidDropPosition fired many times over unnecessarily

### DIFF
--- a/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
@@ -136,17 +136,18 @@ export class RowDragFeature extends BeanStub implements DropTarget {
 
         ctrlsSvc.whenReady(this, (p) => {
             const gridBodyCon = p.gridBodyCtrl;
-            const oldVerticalPosition = 0;
-            const getVerticalPosition = () => gridBodyCon.scrollFeature.getVScrollPosition().top;
+            let oldVScroll = 0;
+            const getVScroll = () => gridBodyCon.scrollFeature.getVScrollPosition().top;
 
             this.autoScrollService = new AutoScrollService({
                 scrollContainer: gridBodyCon.eBodyViewport,
                 scrollAxis: 'y',
-                getVerticalPosition,
+                getVerticalPosition: getVScroll,
                 setVerticalPosition: (position) => gridBodyCon.scrollFeature.setVerticalScrollPosition(position),
                 onScrollCallback: () => {
-                    const newVerticalScrollPosition = getVerticalPosition();
-                    if (oldVerticalPosition !== newVerticalScrollPosition) {
+                    const newVScroll = getVScroll();
+                    if (oldVScroll !== newVScroll) {
+                        oldVScroll = newVScroll;
                         const lastDraggingEvent = this.lastDraggingEvent;
                         if (lastDraggingEvent) {
                             this.onDragging(lastDraggingEvent);

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
@@ -136,15 +136,21 @@ export class RowDragFeature extends BeanStub implements DropTarget {
 
         ctrlsSvc.whenReady(this, (p) => {
             const gridBodyCon = p.gridBodyCtrl;
+            const oldVerticalPosition = 0;
+            const getVerticalPosition = () => gridBodyCon.scrollFeature.getVScrollPosition().top;
+
             this.autoScrollService = new AutoScrollService({
                 scrollContainer: gridBodyCon.eBodyViewport,
                 scrollAxis: 'y',
-                getVerticalPosition: () => gridBodyCon.scrollFeature.getVScrollPosition().top,
+                getVerticalPosition,
                 setVerticalPosition: (position) => gridBodyCon.scrollFeature.setVerticalScrollPosition(position),
                 onScrollCallback: () => {
-                    const lastDraggingEvent = this.lastDraggingEvent;
-                    if (lastDraggingEvent) {
-                        this.onDragging(lastDraggingEvent);
+                    const newVerticalScrollPosition = getVerticalPosition();
+                    if (oldVerticalPosition !== newVerticalScrollPosition) {
+                        const lastDraggingEvent = this.lastDraggingEvent;
+                        if (lastDraggingEvent) {
+                            this.onDragging(lastDraggingEvent);
+                        }
                     }
                 },
             });


### PR DESCRIPTION
The issue is with the autoScrollService that is firing the callback also when there is no scroll position change.
The solution here is to check if the position changed or not when handling the onScrollCallback

So, the problem happens only in the top of the grid or the bottom of the grid if there is nothing to scroll