### PR TITLE
RTI-2805 - Use `client:only` for community events to ensure that dark…

### DIFF
--- a/external/ag-website-shared/src/components/community/pages/events.astro
+++ b/external/ag-website-shared/src/components/community/pages/events.astro
@@ -12,6 +12,6 @@ import events from '@ag-website-shared/content/community/events.json';
     pageTitle="Global Event Participation"
 >
     <section>
-        <Events client:load images={eventImages} events={events} />
+        <Events client:only images={eventImages} events={events} />
     </section>
 </CommunityLayout>

--- a/external/ag-website-shared/src/components/community/pages/home.astro
+++ b/external/ag-website-shared/src/components/community/pages/home.astro
@@ -36,7 +36,7 @@ const { currentSite } = Astro.props;
                 <Icon name="arrowRight" />
             </a>
         </div>
-        <UpcomingEvents client:load enableFilters={false} images={eventImages} events={events} />
+        <UpcomingEvents client:only enableFilters={false} images={eventImages} events={events} />
     </section>
     <!-- Showcase -->
     <section>


### PR DESCRIPTION
 Use `client:only` for community events to ensure that darkmode images are used on page load