### PR TITLE
angular tree data drag drop example not loading due to ts compile error

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/_examples/tree-managed-row-drag-filesystem/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/_examples/tree-managed-row-drag-filesystem/main.ts
@@ -8,7 +8,8 @@ import {
 } from 'ag-grid-community';
 import { TreeDataModule } from 'ag-grid-enterprise';
 
-import { type IFile, getData } from './data';
+import { getData } from './data';
+import type { IFile } from './data';
 
 ModuleRegistry.registerModules([
     ClientSideRowModelModule,

--- a/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/_examples/tree-unmanaged-row-drag/fileCellRenderer_typescript.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/_examples/tree-unmanaged-row-drag/fileCellRenderer_typescript.ts
@@ -1,6 +1,7 @@
 import type { ICellRendererParams } from 'ag-grid-community';
 
-import { type IFile, getFileCssIcon } from './fileUtils';
+import { getFileCssIcon } from './fileUtils';
+import type { IFile } from './fileUtils';
 
 export class FileCellRenderer {
     private eGui!: any;

--- a/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/_examples/tree-unmanaged-row-drag/provided/reactFunctionalTs/index.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/_examples/tree-unmanaged-row-drag/provided/reactFunctionalTs/index.tsx
@@ -16,7 +16,8 @@ import { AgGridReact } from 'ag-grid-react';
 
 import { getData } from './data';
 import FileCellRenderer from './fileCellRenderer';
-import { type IFile, moveFiles } from './fileUtils';
+import { moveFiles } from './fileUtils';
+import type { IFile } from './fileUtils';
 import './style.css';
 
 ModuleRegistry.registerModules([


### PR DESCRIPTION
examples should not have import { type ... } but import type { ... and angular does not like it