### PR TITLE
AG-15192 Run System calls from one file

### DIFF
--- a/documentation/ag-grid-docs/public/example-runner/grid-angular-boilerplate/systemjs.config.dev.js
+++ b/documentation/ag-grid-docs/public/example-runner/grid-angular-boilerplate/systemjs.config.dev.js
@@ -106,4 +106,14 @@
             },
         },
     });
+
+    window.addEventListener('error', (e) => {
+        console.error('ERROR', e.message, e.filename);
+    });
+
+    System.import('main.ts').catch(function (err) {
+        document.body.innerHTML =
+            '<div class="example-error" style="background:#fdb022;padding:1rem;">' + 'Example Error: ' + err + '</div>';
+        console.error(err);
+    });
 })(this);

--- a/documentation/ag-grid-docs/public/example-runner/grid-angular-boilerplate/systemjs.config.js
+++ b/documentation/ag-grid-docs/public/example-runner/grid-angular-boilerplate/systemjs.config.js
@@ -97,8 +97,14 @@
             },
         },
     });
-})(this);
 
-window.addEventListener('error', (e) => {
-    console.error('ERROR', e.message, e.filename);
-});
+    window.addEventListener('error', (e) => {
+        console.error('ERROR', e.message, e.filename);
+    });
+
+    System.import('main.ts').catch(function (err) {
+        document.body.innerHTML =
+            '<div class="example-error" style="background:#fdb022;padding:1rem;">' + 'Example Error: ' + err + '</div>';
+        console.error(err);
+    });
+})(this);

--- a/documentation/ag-grid-docs/public/example-runner/grid-react-boilerplate/systemjs.config.dev.js
+++ b/documentation/ag-grid-docs/public/example-runner/grid-react-boilerplate/systemjs.config.dev.js
@@ -125,8 +125,14 @@
             '*.css': { loader: 'css' },
         },
     });
-})(this);
 
-window.addEventListener('error', (e) => {
-    console.error('ERROR', e.message, e.filename);
-});
+    window.addEventListener('error', (e) => {
+        console.error('ERROR', e.message, e.filename);
+    });
+
+    System.import('index.jsx').catch(function (err) {
+        document.body.innerHTML =
+            '<div class="example-error" style="background:#fdb022;padding:1rem;">' + 'Example Error: ' + err + '</div>';
+        console.error(err);
+    });
+})(this);

--- a/documentation/ag-grid-docs/public/example-runner/grid-react-boilerplate/systemjs.config.js
+++ b/documentation/ag-grid-docs/public/example-runner/grid-react-boilerplate/systemjs.config.js
@@ -114,8 +114,14 @@
             '*.css': { loader: 'css' },
         },
     });
-})(this);
 
-window.addEventListener('error', (e) => {
-    console.error('ERROR', e.message, e.filename);
-});
+    window.addEventListener('error', (e) => {
+        console.error('ERROR', e.message, e.filename);
+    });
+
+    System.import('index.jsx').catch(function (err) {
+        document.body.innerHTML =
+            '<div class="example-error" style="background:#fdb022;padding:1rem;">' + 'Example Error: ' + err + '</div>';
+        console.error(err);
+    });
+})(this);

--- a/documentation/ag-grid-docs/public/example-runner/grid-react-ts-boilerplate/systemjs.config.dev.js
+++ b/documentation/ag-grid-docs/public/example-runner/grid-react-ts-boilerplate/systemjs.config.dev.js
@@ -126,8 +126,14 @@
             '*.css': { loader: 'css' },
         },
     });
-})(this);
 
-window.addEventListener('error', (e) => {
-    console.error('ERROR', e.message, e.filename);
-});
+    window.addEventListener('error', (e) => {
+        console.error('ERROR', e.message, e.filename);
+    });
+
+    System.import('index.tsx').catch(function (err) {
+        document.body.innerHTML =
+            '<div class="example-error" style="background:#fdb022;padding:1rem;">' + 'Example Error: ' + err + '</div>';
+        console.error(err);
+    });
+})(this);

--- a/documentation/ag-grid-docs/public/example-runner/grid-react-ts-boilerplate/systemjs.config.js
+++ b/documentation/ag-grid-docs/public/example-runner/grid-react-ts-boilerplate/systemjs.config.js
@@ -114,8 +114,14 @@
             '*.css': { loader: 'css' },
         },
     });
-})(this);
 
-window.addEventListener('error', (e) => {
-    console.error('ERROR', e.message, e.filename);
-});
+    window.addEventListener('error', (e) => {
+        console.error('ERROR', e.message, e.filename);
+    });
+
+    System.import('index.tsx').catch(function (err) {
+        document.body.innerHTML =
+            '<div class="example-error" style="background:#fdb022;padding:1rem;">' + 'Example Error: ' + err + '</div>';
+        console.error(err);
+    });
+})(this);

--- a/documentation/ag-grid-docs/public/example-runner/grid-typescript-boilerplate/systemjs.config.dev.js
+++ b/documentation/ag-grid-docs/public/example-runner/grid-typescript-boilerplate/systemjs.config.dev.js
@@ -76,8 +76,14 @@
             },
         },
     });
-})(this);
 
-window.addEventListener('error', (e) => {
-    console.error('ERROR', e.message, e.filename);
-});
+    window.addEventListener('error', (e) => {
+        console.error('ERROR', e.message, e.filename);
+    });
+
+    System.import('main.ts').catch(function (err) {
+        document.body.innerHTML =
+            '<div class="example-error" style="background:#fdb022;padding:1rem;">' + 'Example Error: ' + err + '</div>';
+        console.error(err);
+    });
+})(this);

--- a/documentation/ag-grid-docs/public/example-runner/grid-typescript-boilerplate/systemjs.config.js
+++ b/documentation/ag-grid-docs/public/example-runner/grid-typescript-boilerplate/systemjs.config.js
@@ -65,8 +65,14 @@
             },
         },
     });
-})(this);
 
-window.addEventListener('error', (e) => {
-    console.error('ERROR', e.message, e.filename);
-});
+    window.addEventListener('error', (e) => {
+        console.error('ERROR', e.message, e.filename);
+    });
+
+    System.import('main.ts').catch(function (err) {
+        document.body.innerHTML =
+            '<div class="example-error" style="background:#fdb022;padding:1rem;">' + 'Example Error: ' + err + '</div>';
+        console.error(err);
+    });
+})(this);

--- a/documentation/ag-grid-docs/public/example-runner/grid-vue3-boilerplate/systemjs.config.dev.js
+++ b/documentation/ag-grid-docs/public/example-runner/grid-vue3-boilerplate/systemjs.config.dev.js
@@ -89,8 +89,14 @@
             },
         },
     });
-})(this);
 
-window.addEventListener('error', (e) => {
-    console.error('ERROR', e.message, e.filename);
-});
+    window.addEventListener('error', (e) => {
+        console.error('ERROR', e.message, e.filename);
+    });
+
+    System.import('main.ts').catch(function (err) {
+        document.body.innerHTML =
+            '<div class="example-error" style="background:#fdb022;padding:1rem;">' + 'Example Error: ' + err + '</div>';
+        console.error(err);
+    });
+})(this);

--- a/documentation/ag-grid-docs/public/example-runner/grid-vue3-boilerplate/systemjs.config.js
+++ b/documentation/ag-grid-docs/public/example-runner/grid-vue3-boilerplate/systemjs.config.js
@@ -81,8 +81,14 @@
             },
         },
     });
-})(this);
 
-window.addEventListener('error', (e) => {
-    console.error('ERROR', e.message, e.filename);
-});
+    window.addEventListener('error', (e) => {
+        console.error('ERROR', e.message, e.filename);
+    });
+
+    System.import('main.ts').catch(function (err) {
+        document.body.innerHTML =
+            '<div class="example-error" style="background:#fdb022;padding:1rem;">' + 'Example Error: ' + err + '</div>';
+        console.error(err);
+    });
+})(this);

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/AngularTemplate.astro
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/AngularTemplate.astro
@@ -32,7 +32,6 @@ const {
     isEnterprise,
     modifiedTimeMs,
     appLocation,
-    entryFileName,
     styleFiles,
     scriptFiles,
     boilerplatePath,
@@ -41,8 +40,6 @@ const {
     extras,
     usesMathRandom,
 } = Astro.props as Props;
-
-const startFile = pathJoin(appLocation, entryFileName);
 ---
 
 <html lang="en">
@@ -74,7 +71,6 @@ const startFile = pathJoin(appLocation, entryFileName);
             isDev={isDev}
             boilerplatePath={boilerplatePath}
             appLocation={appLocation}
-            startFile={startFile}
             internalFramework={'angular'}
             isEnterprise={isEnterprise}
             usesMathRandom={usesMathRandom}

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/ReactTemplate.astro
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/ReactTemplate.astro
@@ -37,7 +37,6 @@ const {
     internalFramework,
     modifiedTimeMs,
     appLocation,
-    entryFileName,
     scriptFiles = [],
     styleFiles = [],
     boilerplatePath,
@@ -47,8 +46,6 @@ const {
     extras,
     usesMathRandom,
 } = Astro.props as Props;
-
-const startFile = pathJoin(appLocation, entryFileName);
 ---
 
 <html lang="en">
@@ -68,7 +65,6 @@ const startFile = pathJoin(appLocation, entryFileName);
                     isDev={isDev}
                     boilerplatePath={boilerplatePath}
                     appLocation={appLocation}
-                    startFile={startFile}
                     internalFramework={internalFramework}
                     isEnterprise={isEnterprise}
                     usesMathRandom={usesMathRandom}

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/TypescriptTemplate.astro
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/TypescriptTemplate.astro
@@ -31,7 +31,6 @@ const {
     isEnterprise,
     modifiedTimeMs,
     appLocation,
-    entryFileName,
     styleFiles,
     indexFragment,
     boilerplatePath,
@@ -40,8 +39,6 @@ const {
     headFragment,
     usesMathRandom,
 } = Astro.props as Props;
-
-const startFile = pathJoin(appLocation, entryFileName);
 ---
 
 <html lang="en">
@@ -75,7 +72,6 @@ const startFile = pathJoin(appLocation, entryFileName);
             isDev={isDev}
             boilerplatePath={boilerplatePath}
             appLocation={appLocation}
-            startFile={startFile}
             internalFramework={'typescript'}
             isEnterprise={isEnterprise}
             usesMathRandom={usesMathRandom}

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/VueTemplate.astro
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/VueTemplate.astro
@@ -34,7 +34,6 @@ const {
     modifiedTimeMs,
     boilerplatePath,
     appLocation,
-    entryFileName,
     scriptFiles = [],
     styleFiles = [],
     extraStyles,
@@ -42,8 +41,6 @@ const {
     headFragment,
     usesMathRandom,
 } = Astro.props as Props;
-
-const startFile = pathJoin(appLocation, entryFileName);
 ---
 
 <html lang="en">
@@ -62,7 +59,6 @@ const startFile = pathJoin(appLocation, entryFileName);
             isDev={isDev}
             boilerplatePath={boilerplatePath}
             appLocation={appLocation}
-            startFile={startFile}
             internalFramework={'vue3'}
             isEnterprise={isEnterprise}
             usesMathRandom={usesMathRandom}

--- a/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/SystemJs.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/framework-templates/lib/SystemJs.tsx
@@ -15,7 +15,6 @@ import { SeedRandom } from './SeedRandom';
 interface Props {
     boilerplatePath: string;
     appLocation: string;
-    startFile: string;
     internalFramework: InternalFramework;
     isEnterprise: boolean;
     isDev: boolean;
@@ -121,7 +120,6 @@ function getRelevantConfig(configuration: Configuration, framework: InternalFram
 export const SystemJs = ({
     boilerplatePath,
     appLocation,
-    startFile,
     internalFramework,
     isEnterprise,
     isDev,
@@ -165,16 +163,10 @@ export const SystemJs = ({
         `,
                 }}
             />
-            <script src={systemJsVersion} />
-            <script src={systemJsPath} />
-
             {usesMathRandom && <SeedRandom />}
 
-            <script
-                dangerouslySetInnerHTML={{
-                    __html: `System.import('${startFile}').catch(function(err) { document.body.innerHTML = '<div class="example-error" style="background:#fdb022;padding:1rem;">' + 'Example Error: ' + err + '</div>'; console.error(err); });`,
-                }}
-            />
+            <script src={systemJsVersion} />
+            <script src={systemJsPath} />
         </>
     );
 };


### PR DESCRIPTION
The following error leads to flakey tests.

```
   Received: "Example Error: Error: (SystemJS) XHR error (404 Not Found) loading https://grid-staging.ag-grid.com/examples/find/find-full-width/typescript/traceur
            Error loading https://grid-staging.ag-grid.com/examples/find/find-full-width/typescript/traceur
```

This happens when we call `System.import()` before we have called `System.config`. At the moment these are run in separate scripts so I believe there is a race condition. 

This change inlines both into the same file. 