### PR TITLE
fix https://github.com/ag-grid/ag-grid/issues/10745

### DIFF
--- a/packages/ag-grid-community/src/gridComp/gridCtrl.ts
+++ b/packages/ag-grid-community/src/gridComp/gridCtrl.ts
@@ -67,7 +67,7 @@ export class GridCtrl extends BeanStub {
         const beans = this.beans;
         return {
             paginationSelector: beans.pagination?.getPaginationSelector(),
-            gridHeaderDropZonesSelector: beans.registry.getSelector('AG-GRID-HEADER-DROP-ZONES'),
+            gridHeaderDropZonesSelector: beans.registry?.getSelector('AG-GRID-HEADER-DROP-ZONES'),
             sideBarSelector: beans.sideBar?.getSelector(),
             statusBarSelector: beans.registry?.getSelector('AG-STATUS-BAR'),
             watermarkSelector: (beans.licenseManager as IWatermark)?.getWatermarkSelector(),


### PR DESCRIPTION
This fix https://github.com/ag-grid/ag-grid/issues/10745
```diff
-            gridHeaderDropZonesSelector: beans.registry.getSelector('AG-GRID-HEADER-DROP-ZONES'),
+            gridHeaderDropZonesSelector: beans.registry?.getSelector('AG-GRID-HEADER-DROP-ZONES'),
```

The bug was introduced at https://github.com/ag-grid/ag-grid/commit/f31f90cf3917ec734f356b387bd3c3ab9214e7d3#diff-4931422f7b1bfbdec0e5616785313361d0b8a6613848004c70082119d335b64e where the optional chaining `?.` was removed

By  the way, can AG-GRID be built locally? I don't see a way as it is using a private registry and I cannot verify anything before submitting this PR.