### PR TITLE
[AG-15403] Chore(ci): switch test reporter from a fork to official release

### DIFF
--- a/.github/actions/slack-integration/ctrf-markdown-to-slack-blocks.mjs
+++ b/.github/actions/slack-integration/ctrf-markdown-to-slack-blocks.mjs
@@ -22,7 +22,7 @@ if (!rawReport) {
 console.log('Converting CTRF report to Slack blocks...');
 let parsedReport;
 try {
-    parsedReport = JSON.parse(rawReport);
+    parsedReport = JSON.parse(rawReport).results.summary;
 } catch (error) {
     console.error('Failed to parse CTRF report:', rawReport, error);
     process.exit(1);

--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -211,7 +211,7 @@ jobs:
 
         - name: Publish Combined Test Report
           id: ctrf
-          uses: sdwvit/github-test-reporter@v1.0.15report6
+          uses: ctrf-io/github-test-reporter@v1.0.17
           with:
             report-path: 'combined-reports/**/*.json'
             summary-report: true


### PR DESCRIPTION
 - Update GitHub Action for test reporting to version [1.0.17](https://github.com/ctrf-io/github-test-reporter/releases/tag/v1.0.17)
 - Change CTRF report parsing to access summary directly from results