### PR TITLE
[AG-15325] Fix(ci): update CTRF report handling in Slack integration

### DIFF
--- a/.github/actions/slack-integration/ctrf-markdown-to-slack-blocks.mjs
+++ b/.github/actions/slack-integration/ctrf-markdown-to-slack-blocks.mjs
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 
-const rawReport = process.env.CTRF_REPORT || '';
+const rawReportFile = process.env.CTRF_REPORT_FILE || '';
 const jobID = process.env.JOB_ID || '';
 const jobName = process.env.JOB_NAME || '';
 const repoUrl = process.env.REPO_URL || '';
@@ -14,8 +14,15 @@ const slackFile = process.env.SLACK_FILE || './slack.json';
 
 const jobUrl = `${repoUrl}/actions/runs/${jobID}`
 
-if (!rawReport) {
-    console.log('CTRF_REPORT environment variable must be set.');
+let rawReport;
+
+try {
+    rawReport = fs.readFileSync(rawReportFile, 'utf8').trim();
+    if (!rawReport) {
+        throw new Error(`Report file ${rawReportFile} is empty.`);
+    }
+} catch (error) {
+    console.error(`Failed to read CTRF report from ${rawReportFile}:`, error);
     process.exit(1);
 }
 

--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -7,6 +7,7 @@ env:
     DEFAULT_RETENTION_DAYS: 30
     COMMIT_SHA_FILE: ./commit-sha.txt
     SLACK_FILE: ./slack.json
+    CTRF_FILE: ./ctrf-report.json
 on:
     workflow_dispatch:
         inputs:
@@ -218,6 +219,7 @@ jobs:
             failed-report: true
             flaky-report: true
             skipped-report: true
+            write-ctrf-to-file: ${{ env.CTRF_FILE }}
 
         - uses: actions/checkout@v4
           with:
@@ -234,7 +236,7 @@ jobs:
         - name: Convert ctrf output to Slack message blocks and write git sha
           if: ${{ github.event_name == 'schedule' || inputs.notify }}
           env:
-            CTRF_REPORT: ${{ steps.ctrf.outputs.report }}
+            CTRF_REPORT_FILE: ${{ env.CTRF_FILE }}
             JOB_NAME: 'Documentation Tests'
             JOB_ID: ${{ github.run_id }}
             BRANCH_NAME: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
 - Change environment variable from CTRF_REPORT to CTRF_REPORT_FILE.
 - Read CTRF report from a specified file and handle empty file errors.
 - Update workflow to pass CTRF report file path to the conversion step.