### PR TITLE
Fix(ci): include workflow name in JIRA fingerprint calculation

### DIFF
--- a/scripts/ci/gen-jira-files.mjs
+++ b/scripts/ci/gen-jira-files.mjs
@@ -77,7 +77,7 @@ function jiraLink(text, url) {
  *
  * @type {string}
  */
-const uniqueFingerprint = generateHash(JSON.stringify(diffLinks));
+const uniqueFingerprint = generateHash(`${JSON.stringify(diffLinks)}${workflowName}`);
 
 fs.writeFileSync(jiraDescriptionFile, content + '\n');
 fs.writeFileSync(jiraFingerprintFile, uniqueFingerprint + '\n');


### PR DESCRIPTION
 - Append workflow name to the unique fingerprint for JIRA integration

Otherwise all workflows that use jira integration comment on the same issue :)