### PR TITLE
Fix(ci): update success condition for JIRA ticket creation

### DIFF
--- a/.github/actions/jira-integration/action.yml
+++ b/.github/actions/jira-integration/action.yml
@@ -67,7 +67,7 @@ runs:
         JIRA_API_AUTH: ${{ inputs.JIRA_API_AUTH }}
         WORKFLOW_NAME: ${{ github.workflow }}
         JIRA_SUMMARY: ${{ inputs.JIRA_SUMMARY }}
-        IS_SUCCESS: ${{ !steps.last-failed-step.outputs.failed_step }}
+        IS_SUCCESS: ${{ !steps.last-failed-step.outputs.failed_step || inputs.IS_SUCCESS }}
       shell: bash
       run: |
         node ./scripts/ci/create-jira-ticket.mjs


### PR DESCRIPTION
 - Ensure success condition accounts for both last-failed-step and input

Jira gh action still thinks [is success is true](https://github.com/ag-grid/ag-grid/actions/runs/16217647740/job/45793726550#step:8:60) even [if input says otherwise](https://github.com/ag-grid/ag-grid/actions/runs/16217647740/job/45793726550#step:8:17)