### PR TITLE
fix(menuService): do not assume ColGroupDef when not a column

### DIFF
--- a/packages/ag-grid-community/src/misc/menu/menuService.ts
+++ b/packages/ag-grid-community/src/misc/menu/menuService.ts
@@ -94,8 +94,8 @@ export class MenuService extends BeanStub implements NamedBean {
     }
 
     public isHeaderContextMenuEnabled(column?: AgColumn | AgProvidedColumnGroup): boolean {
-        const colDef = column && isColumn(column) ? column.getColDef() : column?.getColGroupDef();
-        return !colDef?.suppressHeaderContextMenu && this.gos.get('columnMenu') === 'new';
+        const colDef = column && isColumn(column) ? column.getColDef() : column?.getColGroupDef?.();
+        return colDef && !colDef?.suppressHeaderContextMenu && this.gos.get('columnMenu') === 'new';
     }
 
     public isHeaderMenuButtonAlwaysShowEnabled(): boolean {


### PR DESCRIPTION
Trying to upgrade from an old version of ag-grid and running into a situation where the `isColumn` method is returning false and assuming that it's a `ColGroupDef` instance when it's not.