### PR TITLE
[AG-15479] Fix(ci): previous commit sha is not always saved resulting in missing git diffs

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -155,8 +155,11 @@ jobs:
         id: prev-commit-sha
         uses: actions/cache/restore@v4
         with:
+          restore-keys: |
+            - accessibility-prev-commit-
+            - accessibility-prev-commit-${{ github.ref }}
           path: ${{ env.PREV_COMMIT_SHA_FILE }}
-          key: aceessibility-prev-commit-${{ github.ref }}
+          key: accessibility-prev-commit-${{ github.ref }}-${{ github.sha }}
 
       - name: Load files into environment
         continue-on-error: true
@@ -202,8 +205,8 @@ jobs:
       - name: Save Current Commit Hash
         uses: actions/cache/save@v4
         with:
-          key: ${{ steps.prev-commit-sha.outputs.cache-primary-key }}
           path: ${{ env.PREV_COMMIT_SHA_FILE }}
+          key: ${{ steps.prev-commit-sha.outputs.cache-primary-key }}-${{ github.sha }}
 
       - name: Output Report URL
         run: |

--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -287,8 +287,11 @@ jobs:
           id: prev-commit-sha
           uses: actions/cache/restore@v4
           with:
+            restore-keys: |
+              - doc-tests-prev-commit-
+              - doc-tests-prev-commit-${{ github.ref }}
             path: ${{ env.PREV_COMMIT_SHA_FILE }}
-            key: doc-tests-prev-commit-${{ github.ref }}
+            key: doc-tests-prev-commit-${{ github.ref }}-${{ github.sha }}
 
         - name: Load files into environment
           continue-on-error: true
@@ -331,8 +334,8 @@ jobs:
           run: |
             echo ${{ github.sha }} > ${{ env.PREV_COMMIT_SHA_FILE }}
 
-        - name: Save this run commit SHA
+        - name: Save Current Commit Hash
           uses: actions/cache/save@v4
           with:
             path: ${{ env.PREV_COMMIT_SHA_FILE }}
-            key: ${{ steps.prev-commit-sha.outputs.cache-primary-key }}
+            key: ${{ steps.prev-commit-sha.outputs.cache-primary-key }}-${{ github.sha }}

--- a/.github/workflows/full-clean-build.yml
+++ b/.github/workflows/full-clean-build.yml
@@ -209,8 +209,11 @@ jobs:
         id: prev-commit-sha
         uses: actions/cache/restore@v4
         with:
+          restore-keys: |
+            - full-clean-build-prev-commit-
+            - full-clean-build-prev-commit-${{ github.ref }}
           path: ${{ env.PREV_COMMIT_SHA_FILE }}
-          key: full-build-prev-commit-${{ github.ref }}
+          key: full-clean-build-prev-commit-${{ github.ref }}-${{ github.sha }}
 
       - name: Load files into environment
         continue-on-error: true
@@ -253,7 +256,7 @@ jobs:
       - name: Save Current Commit Hash
         uses: actions/cache/save@v4
         with:
-          key: ${{ steps.prev-commit-sha.outputs.cache-primary-key }}
+          key: ${{ steps.prev-commit-sha.outputs.cache-primary-key }}-${{ github.sha }}
           path: ${{ env.PREV_COMMIT_SHA_FILE }}
 
         # only if run is successful

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -126,8 +126,11 @@ jobs:
           id: prev-commit-sha
           uses: actions/cache/restore@v4
           with:
+            restore-keys: |
+              - security-prev-commit-
+              - security-prev-commit-${{ github.ref }}
             path: ${{ env.PREV_COMMIT_SHA_FILE }}
-            key: security-prev-commit-${{ github.ref }}
+            key: security-prev-commit-${{ github.ref }}-${{ github.sha }}
 
         - name: Load files into environment
           continue-on-error: true
@@ -169,8 +172,8 @@ jobs:
           id: set-commit-sha
           run: echo ${{ github.sha }} > ${{ env.PREV_COMMIT_SHA_FILE }}
 
-        - name: Save this run commit SHA
+        - name: Save Current Commit Hash
           uses: actions/cache/save@v4
           with:
             path: ${{ env.PREV_COMMIT_SHA_FILE }}
-            key: ${{ steps.prev-commit-sha.outputs.cache-primary-key }}
+            key: ${{ steps.prev-commit-sha.outputs.cache-primary-key }}-${{ github.sha }}


### PR DESCRIPTION
 - Update key for saving current commit hash to include the GitHub SHA
 - Add restore keys to improve cache retrieval for different branches