### PR TITLE
Maintenance(ci): expand jira ticket link

### DIFF
--- a/.github/workflows/gh-comment-hook.yml
+++ b/.github/workflows/gh-comment-hook.yml
@@ -2,10 +2,9 @@ name: Utility Comment Hook
 
 on:
   issue_comment:
-    types: [ created ]
-
-env:
-  ISSUE_ID: ${{ github.event.issue.number }}
+    types: [ created, edited ]
+  issues:
+    types: [ opened, edited ]
 
 permissions:
   contents: read
@@ -21,13 +20,23 @@ jobs:
         id: notify-start
         uses: actions/github-script@v7
         continue-on-error: true
-        if: ${{ env.ISSUE_ID }}
         env:
+          COMMENT_ID: ${{ github.event.comment.id }}
           COMMENT_BODY: ${{ github.event.comment.body }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_ID: ${{ github.event.issue.number }}
         with:
           result-encoding: string
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const comment_id = process.env.COMMENT_ID;
-            await github.rest.issues.updateComment({ owner, repo, comment_id, body: COMMENT_BODY.replace(/\#(AG-[\d]{3,})/g, `[$1](https://ag-grid.atlassian.net/browse/$1)`) });
+            const comment_body = process.env.COMMENT_BODY;
+            const issue_body = process.env.ISSUE_BODY;
+            const issue_number = process.env.ISSUE_ID;
+
+            if (comment_id && comment_body) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id, body: comment_body.replace(/\#(AG-[\d]{3,})/g, `[$1](https://ag-grid.atlassian.net/browse/$1)`) });
+            } else if (issue_body && issue_number) {
+              await github.rest.issues.update({ owner, repo, issue_number, body: issue_body.replace(/\#(AG-[\d]{3,})/g, `[$1](https://ag-grid.atlassian.net/browse/$1)`) });
+            }

--- a/.github/workflows/gh-comment-hook.yml
+++ b/.github/workflows/gh-comment-hook.yml
@@ -1,0 +1,33 @@
+name: Utility Comment Hook
+
+on:
+  issue_comment:
+    types: [ created ]
+
+env:
+  ISSUE_ID: ${{ github.event.issue.number }}
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Replace mention with jira link
+        id: notify-start
+        uses: actions/github-script@v7
+        continue-on-error: true
+        if: ${{ env.ISSUE_ID }}
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        with:
+          result-encoding: string
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const comment_id = process.env.COMMENT_ID;
+            await github.rest.issues.updateComment({ owner, repo, comment_id, body: COMMENT_BODY.replace(/\#(AG-[\d]{3,})/g, `[$1](https://ag-grid.atlassian.net/browse/$1)`) });


### PR DESCRIPTION
 - Create a new GitHub Action to replace JIRA ticket mentions in issue comments.
 - Trigger the action on issue comment creation events.
 - Use regex to format ticket links to point to JIRA.