### PR TITLE
[AG-15501] Fix(ci): previous commit sha is saved under the wrong cache key

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -206,7 +206,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ env.PREV_COMMIT_SHA_FILE }}
-          key: ${{ steps.prev-commit-sha.outputs.cache-primary-key }}-${{ github.sha }}
+          key: ${{ steps.prev-commit-sha.outputs.cache-primary-key }}
 
       - name: Output Report URL
         run: |

--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -338,4 +338,4 @@ jobs:
           uses: actions/cache/save@v4
           with:
             path: ${{ env.PREV_COMMIT_SHA_FILE }}
-            key: ${{ steps.prev-commit-sha.outputs.cache-primary-key }}-${{ github.sha }}
+            key: ${{ steps.prev-commit-sha.outputs.cache-primary-key }}

--- a/.github/workflows/full-clean-build.yml
+++ b/.github/workflows/full-clean-build.yml
@@ -256,7 +256,7 @@ jobs:
       - name: Save Current Commit Hash
         uses: actions/cache/save@v4
         with:
-          key: ${{ steps.prev-commit-sha.outputs.cache-primary-key }}-${{ github.sha }}
+          key: ${{ steps.prev-commit-sha.outputs.cache-primary-key }}
           path: ${{ env.PREV_COMMIT_SHA_FILE }}
 
         # only if run is successful

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -169,4 +169,4 @@ jobs:
           uses: actions/cache/save@v4
           with:
             path: ${{ env.PREV_COMMIT_SHA_FILE }}
-            key: ${{ steps.prev-commit-sha.outputs.cache-primary-key }}-${{ github.sha }}
+            key: ${{ steps.prev-commit-sha.outputs.cache-primary-key }}


### PR DESCRIPTION
Remove duplication of hash in a cache key.

Fixes [AG-15501](https://ag-grid.atlassian.net/browse/AG-15501) 