### PR TITLE
[AG-15526] Fix(ci): jira integration is_success calculation is wrong for docs tests workflow

### DIFF
--- a/.github/actions/jira-integration/action.yml
+++ b/.github/actions/jira-integration/action.yml
@@ -67,7 +67,7 @@ runs:
         JIRA_API_AUTH: ${{ inputs.JIRA_API_AUTH }}
         WORKFLOW_NAME: ${{ github.workflow }}
         JIRA_SUMMARY: ${{ inputs.JIRA_SUMMARY }}
-        IS_SUCCESS: ${{ !steps.last-failed-step.outputs.failed_step || inputs.IS_SUCCESS }}
+        IS_SUCCESS: ${{ inputs.IS_SUCCESS == 'true' && !steps.last-failed-step.outputs.failed_step }}
       shell: bash
       run: |
         node ./scripts/ci/create-jira-ticket.mjs


### PR DESCRIPTION
- Updated the `IS_SUCCESS` logic to require the input value to be `'true'` and verify that no failed steps exist, improving clarity and correctness in success determination.

Fixes [AG-15526](https://ag-grid.atlassian.net/browse/AG-15526)