### PR TITLE
AG-3390 - Ignore package test output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -590,10 +590,11 @@ jobs:
                     "e2e": "${{ needs.e2e.result }}",
                     "Docs": "${{ needs.docs.result }}",
                     "Bundle": "${{ needs.bundle_size.result }}",
-                    "FW_Pkg": "${{ needs.fw_pkg_test.result }}",
-                    "Angular_Pkg": "${{ needs.angular_fw_pkg_test.result }}"
                 }
             }
+# TODO: Add back into `jobStatuses` when package tests are enabled again
+#                    "FW_Pkg": "${{ needs.fw_pkg_test.result }}",
+#                    "Angular_Pkg": "${{ needs.angular_fw_pkg_test.result }}"
         run: |
           npx ts-node ./scripts/agBotSlackMessage.ts --auth-token "$SLACK_BOT_OAUTH_TOKEN" \
             --grid-channel "$CI_GRID_GATE_CHANNEL" \


### PR DESCRIPTION
So CI does not report error for `''` job status - based on https://github.com/ag-grid/ag-grid/actions/runs/16373498325/job/46268761767#step:12:43