### PR TITLE
Fix(ci): reporting security conditions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,6 +33,7 @@ jobs:
               uses: actions/checkout@v4
               with:
                   fetch-depth: 1
+
             - name: Snyk scan workspaces
               id: snyk-scan-workspaces
               uses: ./external/ag-shared/github/actions/snyk-scan-workspaces
@@ -56,6 +57,7 @@ jobs:
               uses: actions/checkout@v4
               with:
                   fetch-depth: 1
+
             - name: Snyk code scan
               id: snyk-code-scan
               uses: ./external/ag-shared/github/actions/snyk-code-scan
@@ -73,6 +75,7 @@ jobs:
     combine-scan-results:
       needs: [code-dependency-scan, sast-code-scan]
       runs-on: ubuntu-latest
+      if: ${{ always() }}
       steps:
         - uses: actions/checkout@v4
           with:

--- a/external/ag-shared/github/actions/snyk-scan-workspaces/action.yml
+++ b/external/ag-shared/github/actions/snyk-scan-workspaces/action.yml
@@ -26,7 +26,7 @@ runs:
           env:
               SNYK_TOKEN: ${{ inputs.snyk_token }}
           with:
-              args: --yarn-workspaces --dev --strict-out-of-sync=false --severity-threshold=${{ inputs.severity_threshold }} --exclude=${{ inputs.exclude }} --remote-repo-url=${{ inputs.remote_repo_url }} --json-file-output=snyk.json
+              args: --yarn-workspaces --dev --strict-out-of-sync=false --severity-threshold=${{ inputs.severity_threshold }} --exclude=${{ inputs.exclude }} --remote-repo-url=${{ inputs.remote_repo_url }} --json > snyk.json
 
         - name: To CTRF format
           uses: actions/github-script@v7


### PR DESCRIPTION
Update Snyk scan workflows to ensure completion and correct output

- Add 'if: ${{ always() }}' to ensure combine-scan-results runs regardless of prior failures (per [docs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idneeds))
- Replace '--json-file-output' with '--json' in snyk-scan-workspaces args to direct output correctly
- should prevent failures [like this](https://github.com/ag-grid/ag-grid/actions/runs/16406000556/job/46352064177)