### PR TITLE
Fix(ci): jira automated message format for api v3

### DIFF
--- a/scripts/ci/_utils.mjs
+++ b/scripts/ci/_utils.mjs
@@ -163,3 +163,7 @@ export async function addJiraComment(issueKey, body) {
         throw error;
     }
 }
+
+export function jiraLink(text, url) {
+    return `[${text}|${url}]`;
+}

--- a/scripts/ci/create-jira-ticket.mjs
+++ b/scripts/ci/create-jira-ticket.mjs
@@ -133,11 +133,7 @@ async function createJiraIssue() {
         fields: {
             project: { key: PROJECT_ID },
             summary: summary,
-            description: {
-                content: [paragraph([txt(description)]), paragraph([txt('No QA needed')]), AUTOMATED_MESSAGE],
-                type: 'doc',
-                version: 1,
-            },
+            description: description + `\n\nNo QA needed\n\n${AUTOMATED_MESSAGE}`,
             issuetype: { name: 'Bug' },
             assignee: {
                 accountId:

--- a/scripts/ci/create-jira-ticket.mjs
+++ b/scripts/ci/create-jira-ticket.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { addJiraComment, commonFetch, transitionJiraIssue } from './_utils.mjs';
+import { addJiraComment, commonFetch, jiraLink, transitionJiraIssue } from './_utils.mjs';
 
 const TRANSITIONS = [
     { id: '21', name: 'TODO' },
@@ -51,7 +51,8 @@ const link = (text, url) => ({
     text: text,
     marks: [{ type: 'link', attrs: { href: url, title: text } }],
 });
-const AUTOMATED_MESSAGE = [
+const AUTOMATED_MESSAGE = `[This issue/comment was ${jiraLink('automatically created', ACTION_URL)} by the AG Grid CI workflow.]`;
+const AUTOMATED_MESSAGE_BLOCKS = [
     paragraph([
         txt(`[This issue/comment was `),
         link('automatically created', ACTION_URL),
@@ -75,7 +76,7 @@ if (isSuccess) {
             await addJiraComment(existingIssue.key, {
                 content: [
                     paragraph([txt(`Transitioned to ${TRANSITIONS_MAP['READY TO VERIFY'].name}.`)]),
-                    AUTOMATED_MESSAGE,
+                    AUTOMATED_MESSAGE_BLOCKS,
                 ],
                 type: 'doc',
                 version: 1,
@@ -107,7 +108,7 @@ if (isSuccess) {
                             `New failure detected${shouldAddComment ? ', reopening this issue' : ''}:\n\n${description}`
                         ),
                     ]),
-                    AUTOMATED_MESSAGE,
+                    AUTOMATED_MESSAGE_BLOCKS,
                 ],
                 type: 'doc',
                 version: 1,

--- a/scripts/ci/gen-jira-files.mjs
+++ b/scripts/ci/gen-jira-files.mjs
@@ -2,7 +2,7 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 
-import { getGitDiffLinks, getHeader, getStats, parseCtrfReport } from './_utils.mjs';
+import { getGitDiffLinks, getHeader, getStats, jiraLink, parseCtrfReport } from './_utils.mjs';
 
 const ctrfReportFile = process.env.CTRF_REPORT_FILE || '../../reports/performance.json';
 const workflowName = process.env.WORKFLOW_NAME || '';
@@ -60,10 +60,6 @@ function inlineCode(text) {
 function section(text) {
     const TAB = '  ';
     return `\n${TAB}${text.trim().replace(/\n+/g, `\n${TAB}`)}\n`;
-}
-
-function jiraLink(text, url) {
-    return `[${text}|${url}]`;
 }
 
 /**


### PR DESCRIPTION
Extract jiraLink to shared utility and use in JIRA scripts

- Add jiraLink to _utils.mjs for centralized link formatting
- Replace inline link creation with jiraLink in create-jira-ticket.mjs
- Remove redundant jiraLink implementation from gen-jira-files.mjs

Follow up for ag-grid/ag-grid#11446