### PR TITLE
Fix(ci): don't move already done tickets

### DIFF
--- a/.github/workflows/update-jira-ticket.yml
+++ b/.github/workflows/update-jira-ticket.yml
@@ -86,9 +86,7 @@ jobs:
                 if (process.env.DEBUG_JIRA_TICKET) {
                     issue_keys.push(process.env.DEBUG_JIRA_TICKET);
                 }
-                const pr = pull_number ? (await github.rest.pulls.get({ owner,
-                    repo,
-                    pull_number: pull_number })).data : {};
+                const pr = pull_number ? (await github.rest.pulls.get({ owner, repo, pull_number })).data : {};
                 const is_merged = !!pr.merged_at;
                 if (!is_merged) {
                     console.log(`PR #${pull_number} is not merged, skipping JIRA ticket update.`);

--- a/.github/workflows/update-jira-ticket.yml
+++ b/.github/workflows/update-jira-ticket.yml
@@ -42,31 +42,23 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const {
-                addJiraComment,
-                getJiraTransitions,
-                getJiraIssue,
-                transitionJiraIssue
-            } = require('./scripts/ci/_utils.mjs');
-            
-            const paragraph = content => ({
-                "type": "paragraph",
-                "content": Array.isArray(content) ? content : [content]
-            });
-            const txt = (text, marks = []) => {
-                if (marks.length) {
-                    return {text, type: 'text', marks};
-                }
-                return {text, type: 'text'};
-            };
-            const link = (text, url) => ({
-                type: 'text',
-                text: text,
-                marks: [{type: 'link', attrs: {href: url, title: text}}]
-            });
-            const mention = (gh_user) => {
+            async function exec() {
+                const {
+                    addJiraComment,
+                    getJiraTransitions,
+                    getJiraIssue,
+                    transitionJiraIssue
+                } = require('./scripts/ci/_utils.mjs');
+                
                 const gh_user_jira_mapping = JSON.parse(process.env.GH_USER_JIRA_MAPPING || '{}');
-                return ({
+                const regex = /fix(es)? \[?((AG|RTI)-\d{3,})/gi;
+                const paragraph = content => ({ "type": "paragraph",
+                    "content": Array.isArray(content) ? content : [content] });
+                const txt = (text) => ({ text, type: 'text' });
+                const link = (text, url) => ({ type: 'text',
+                    text: text,
+                    marks: [{ type: 'link', attrs: { href: url, title: text } }] });
+                const mention = (gh_user) => ({
                     "type": "mention",
                     "attrs": {
                         "id": gh_user_jira_mapping[gh_user][0],
@@ -74,110 +66,113 @@ jobs:
                         "userType": "APP"
                     }
                 });
-            };
-            const owner = context.repo.owner; 
-            const repo = context.repo.repo;
-            const pr_number = process.env.PR_ID || '';
-            const issue_keys = [process.env.DEBUG_JIRA_TICKET || ''].filter(Boolean);
-            const runUrl = process.env.JOB_URL || '#';
-            if (!pr_number && !issue_keys) {
-                throw new Error('Must provide a PR ID or a JIRA ticket.');
-            }
-            const pr = (await github.rest.pulls.get({ owner, repo, pull_number: pr_number })).data;
-            if (!issue_keys.length) {
+                const getReviewers = async (pr) => {
+                    const reviewers = (await github.rest.pulls.listReviews({ owner,
+                        repo,
+                        pull_number })).data?.map(r => r.user.login) || [];
+                    const mergedBy = pr.merged_by?.login || '';
+                    return { reviewers, mergedBy }
+                };
+                const owner = context.repo.owner;
+                const repo = context.repo.repo;
+                const pull_number = process.env.PR_ID;
+                const runUrl = process.env.JOB_URL || '#';
+                const issue_keys = [];
+                const knownQaColumns = new Set(['QA', 'REVIEWED']);
+                const readOnlyTransitions = new Set(['DONE', 'PENDING RC', 'POST RELEASE', 'READY TO VERIFY', 'ARCHIVE', 'TESTS PASSED', ...knownQaColumns]);
+                if (!pull_number && !process.env.DEBUG_JIRA_TICKET) {
+                    throw new Error('Must provide a PR ID or a JIRA ticket.');
+                }
+                if (process.env.DEBUG_JIRA_TICKET) {
+                    issue_keys.push(process.env.DEBUG_JIRA_TICKET);
+                }
+                const pr = pull_number ? (await github.rest.pulls.get({ owner,
+                    repo,
+                    pull_number: pull_number })).data : {};
                 const is_merged = !!pr.merged_at;
                 if (!is_merged) {
-                    console.log(`PR #${pr_number} is not merged, skipping JIRA ticket update.`);
+                    console.log(`PR #${pull_number} is not merged, skipping JIRA ticket update.`);
                     return;
                 }
-                if (!pr.body && !pr.title) {
-                    console.log('PR title and body are empty, cannot find JIRA ticket.');
-                } else {
-                    const regex = /fix(es)? \[?((AG|RTI)-\d{3,})/gi;
-                    const matches = pr.body?.match(regex);
-                    if (matches) {
-                        issue_keys.push(...matches.map(m => m.match(/(AG|RTI)-\d{3,}/i)[0].toUpperCase()));
+                if (!pr.body) {
+                    console.log(`PR #${pull_number} body is empty, cannot find JIRA ticket.`);
+                    return;
+                }
+                const matches = pr.body?.match(regex);
+                if (matches) {
+                    issue_keys.push(...matches.map(m => m.match(/(AG|RTI)-\d{3,}/i)[0].toUpperCase()));
+                }
+                if (!issue_keys.length) {
+                    throw new Error('No JIRA ticket found in PR body.');
+                }
+                let ghCommentBody = '';
+                await Promise.all([...new Set(issue_keys)].map(async (issue_key) => {
+                    // Move the JIRA ticket to 'the next column' if the PR is merged
+                    const availableTransitions = await getJiraTransitions(issue_key);
+                    if (!availableTransitions || availableTransitions.length === 0) {
+                        console.warn(`No available transitions found for JIRA ticket ${issue_key}.`);
+                        return;
                     }
+                    const nextTransition = availableTransitions.find(tr => knownQaColumns.has(tr.name.toUpperCase()));
+                    const issue = await getJiraIssue(issue_key);
+                    if (!issue) {
+                        console.warn(`JIRA ticket ${issue_key} not found.`);
+                        return;
+                    }
+                    const isTransitioning = !readOnlyTransitions.has(issue.fields.status.name.toUpperCase());
+                    
+                    // blocks section
+                    const content = [];
+                    if (pull_number) {
+                        const { reviewers, mergedBy } = await getReviewers(pr);
+                        
+                        const samePerson = reviewers.length === 1 && reviewers[0] === mergedBy;
+                        const reviewedByText = samePerson ? 'Reviewed and merged by ' : 'Reviewed by ';
+                        
+                        const blocks = [];
+                        if (reviewers.length) {
+                            blocks.push(txt(reviewedByText));
+                            blocks.push(
+                                ...reviewers
+                                    .map(r => mention(r))
+                                    .filter(r => r.attrs.id && r.attrs.text)
+                                    .join(', ')
+                            );
+                            blocks.push(txt(`. `));
+                        }
+                        if (mergedBy && !samePerson) {
+                            blocks.push(txt(`Merged by `));
+                            blocks.push(mention(mergedBy));
+                            blocks.push(txt(`. `));
+                        }
+                        if (blocks.length) {
+                            content.push(paragraph(blocks));
+                        }
+                    }
+                    if (isTransitioning) {
+                        const from = issue.fields.status.name;
+                        const to = nextTransition.name;
+                        content.push(paragraph([
+                            txt(`[This issue was `),
+                            link('transitioned', `https://github.com/${owner}/${repo}/pull/${pull_number}`),
+                            txt(` from '${from}' to '${to}' column by `),
+                            link('the AG Grid CI workflow', runUrl),
+                            txt('.]')
+                        ]));
+                        await transitionJiraIssue(issue, nextTransition.id);
+                        ghCommentBody ||= `[Transitioned](${runUrl}) JIRA ticket(s): `;
+                        ghCommentBody += `- [${issue_key}](https://ag-grid.atlassian.net/browse/${issue_key}) to ${to}\n`
+                    }
+                    await addJiraComment(issue_key, { content, "type": "doc", "version": 1 });
+                }));
+                if (ghCommentBody) {
+                    ghCommentBody += `\n\nThis comment was added by the [AG Grid CI workflow](${runUrl}).`;
+                    await github.rest.issues.createComment({
+                        issue_number: pull_number,
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        body: ghCommentBody
+                    })
                 }
             }
-            if (!issue_keys.length) {
-                throw new Error('No JIRA ticket found in PR body.');
-            }
-            const known_transitions = {
-                131: 'QA',
-                3: 'REVIEWED',
-                'QA': 131,
-                'REVIEWED': 3
-            };
-            let transitioned_at_least_one = false;
-            const transitions = {};
-            [...new Set(issue_keys)].forEach(async (issue_key) => {
-                // Move the JIRA ticket to 'the next column' if the PR is merged
-                const availableTransitions = await getJiraTransitions(issue_key);
-                if (!availableTransitions || availableTransitions.length === 0) {
-                    throw new Error(`No available transitions found for JIRA ticket ${issue_key}.`);
-                }
-                const nextTransition = Object
-                    .keys(known_transitions)
-                    .find(key => availableTransitions
-                        .find(tr =>
-                            tr.id === key &&
-                            tr.name.toLowerCase() === known_transitions[key].toLowerCase()
-                        )
-                    );
-                const issue = await getJiraIssue(issue_key);
-                if (!issue) {
-                    throw new Error(`JIRA ticket ${issue_key} not found.`);
-                }
-                transitioned_at_least_one ||= !known_transitions[issue.fields.status.name.toUpperCase()];
-                transitions[issue_key] = { from: issue.fields.status.name, to: known_transitions[nextTransition] };
-
-            
-                // blocks section
-                const blocks = [];
-            
-                if (pr_number) {
-                    // Reviewers
-                    const reviews = await github.rest.pulls.listReviews({ owner, repo, pull_number: pr_number});
-                    if (reviews.data.length) {
-                        blocks.push(txt(`Reviewed by `));
-                        reviews.data
-                            .map(r => mention(r.user.login))
-                            .filter(r => r.attrs.id && r.attrs.text)
-                            .forEach((m, i, arr) => {
-                                if (i > 0 && i < arr.length - 1) {
-                                    blocks.push(txt(`, `));
-                                }
-                                blocks.push(m);
-                            });
-                        blocks.push(txt(`. `));
-                    }
-            
-                    const mergedBy = pr.merged_by?.login;
-                    if (mergedBy) {
-                        blocks.push(txt(`Merged by `));
-                        blocks.push(mention(mergedBy));
-                        blocks.push(txt(`. `));
-                    }
-                }
-                const content = [paragraph(blocks), paragraph([
-                    txt(`[This issue was `),
-                    link('transitioned', `https://github.com/${owner}/${repo}/pull/${pr_number}`),
-                    txt(` from '${transitions[issue_key].from}' to '${transitions[issue_key].to}' column by `),
-                    link('the AG Grid CI workflow', runUrl),
-                    txt('.]')
-                ])];
-                if (!known_transitions[issue.fields.status.name.toUpperCase()]) {
-                    await transitionJiraIssue(issue, nextTransition);
-                    await addJiraComment(issue_key, {content, "type": "doc", "version": 1});
-                }
-            });
-            
-            if (transitioned_at_least_one) {
-                await github.rest.issues.createComment({
-                    issue_number: pr_number,
-                    owner, 
-                    repo,
-                    body: `[Transitioned](${runUrl}) JIRA ticket(s): ${issue_keys.map((issue_key) => `- [${issue_key}](https://ag-grid.atlassian.net/browse/${issue_key}) to ${transitions[issue_key]}`).join(',\n')}.`
-                });
-            }
+            await exec();


### PR DESCRIPTION
Update Jira ticket script with async handling and improved reviewer logic

- Wrap script in async exec() function for better control flow
- Refactor reviewer/mergedBy logic using getReviewers helper
- Use knownQaColumns instead of hard-coded transitions
- Dynamic content building for Jira comments with proper formatting
- Add warnings for missing Jira tickets instead of throwing errors
- Improve error handling for untransitioned tickets
- Update comment structure to include reviewer attribution
- Add progress tracking for Jira transition status