### PR TITLE
RTI-3020 - mark pending as unedited when _sync starts the edit

### DIFF
--- a/packages/ag-grid-community/src/edit/utils/editors.ts
+++ b/packages/ag-grid-community/src/edit/utils/editors.ts
@@ -336,6 +336,7 @@ export function _syncFromEditor(
         // sourceValue not set means sync called without corresponding startEdit - from API call
         edit = editModelSvc.setEdit(position, {
             sourceValue: valueSvc.getValue(column as AgColumn, rowNode, undefined, 'api'),
+            pendingValue: UNEDITED,
             state: hasEditor ? 'editing' : 'changed',
         });
     }


### PR DESCRIPTION
Fix RTI-3020