### PR TITLE
RTI-2981 setfilter show blanks with transactions and refresh model

### DIFF
--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
@@ -78,7 +78,10 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
     private rowsToDisplay: RowNode[] = []; // the rows mapped to rows to display
     private nodeManager: IClientSideNodeManager<any>;
     private rowDataTransactionBatch: BatchTransactionItem[] | null;
-    private lastHighlightedRow: RowNode | null = null;
+
+    /** Keep track if row data was updated. Important with suppressModelUpdateAfterUpdateTransaction and refreshModel api is called  */
+    private rowDataUpdatedPending: boolean = false;
+
     private applyAsyncTransactionsTimeout: number | undefined;
     /** Has the start method been called */
     private started: boolean = false;
@@ -625,11 +628,15 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         // console.log('======= start =======');
 
         const beans = this.beans;
-        const changedPath = (params.changedPath ??= this.createChangePath(!params.newData && !!params.rowDataUpdated));
 
-        if (this.started && params.rowDataUpdated) {
+        let rowDataUpdated = !!params.rowDataUpdated;
+        const changedPath = (params.changedPath ??= this.createChangePath(!params.newData && rowDataUpdated));
+
+        if (this.started && rowDataUpdated) {
             this.eventSvc.dispatchEvent({ type: 'rowDataUpdated' });
         }
+
+        this.rowDataUpdatedPending ||= rowDataUpdated;
 
         if (
             !this.started ||
@@ -640,11 +647,16 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
             return;
         }
 
+        if (this.rowDataUpdatedPending) {
+            this.rowDataUpdatedPending = false;
+            params.rowDataUpdated = rowDataUpdated = true;
+        }
+
         this.isRefreshingModel = true;
 
         beans.masterDetailSvc?.refreshModel(params);
 
-        if (params.rowDataUpdated && params.step !== 'group') {
+        if (rowDataUpdated && params.step !== 'group') {
             beans.colFilter?.refreshModel();
         }
 
@@ -652,10 +664,10 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         switch (params.step) {
             case 'group': {
                 const groupingChanged = this.doRowGrouping(params);
-                if (groupingChanged || params.rowDataUpdated) {
+                if (groupingChanged || rowDataUpdated) {
                     beans.colFilter?.refreshModel();
                 }
-                if (params.step === 'group' && this.rowNodesCountReady) {
+                if (!this.rowCountReady && this.rowNodesCountReady) {
                     this.rowCountReady = true; // only if row data has been set
                     this.eventSvc.dispatchEventOnce({ type: 'rowCountReady' });
                 }


### PR DESCRIPTION
As a result of a change made in https://github.com/ag-grid/ag-grid/pull/11354 the column refresh was not invoked correctly when suppressing transaction refresh and invoking refresh manually.
This is because we were losing the information that row data was updated.
The columns filters needs to be refreshed if there is a row data change, and after grouping because the set filter uses tree data need to have the correct parents set as it uses getRoute

- removed the leftover unused lastHighlightedRow field
- add a new field rowDataUpdatedPending to keep track if row data was changed but grouping wasn't executed
- fix the logic in refreshModel to use rowDataUpdatedPending