### PR TITLE
RTI-3013 custom detail grid example overflow fix

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/master-detail-custom-detail/_examples/custom-detail-with-grid/detail-cell-renderer.component_angular.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-custom-detail/_examples/custom-detail-with-grid/detail-cell-renderer.component_angular.ts
@@ -12,15 +12,16 @@ import type { ColDef, GridApi, GridReadyEvent, ICellRendererParams } from 'ag-gr
             <div class="full-width-detail"><b>Name: </b>{{ params.data.name }}</div>
             <div class="full-width-detail"><b>Account: </b>{{ params.data.account }}</div>
         </div>
-        <ag-grid-angular
-            #agGrid
-            style="height: 100%;"
-            class="full-width-grid"
-            [columnDefs]="colDefs"
-            [defaultColDef]="defaultColDef"
-            [rowData]="rowData"
-            (gridReady)="onGridReady($event)"
-        />
+        <div class="full-width-grid">
+            <ag-grid-angular
+                #agGrid
+                style="height: 100%;"
+                [columnDefs]="colDefs"
+                [defaultColDef]="defaultColDef"
+                [rowData]="rowData"
+                (gridReady)="onGridReady($event)"
+            />
+        </div>
     </div>`,
 })
 export class DetailCellRenderer implements ICellRendererAngularComp {

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-custom-detail/_examples/custom-detail-with-grid/detailCellRenderer_reactFunctionalTs.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-custom-detail/_examples/custom-detail-with-grid/detailCellRenderer_reactFunctionalTs.tsx
@@ -52,13 +52,14 @@ const DetailCellRenderer = ({ data, node, api }: CustomCellRendererProps) => {
                     {data.account}
                 </div>
             </div>
-            <AgGridReact
-                className="full-width-grid"
-                columnDefs={colDefs}
-                defaultColDef={defaultColDef}
-                rowData={data.callRecords}
-                onGridReady={onGridReady}
-            />
+            <div className="full-width-grid">
+                <AgGridReact
+                    columnDefs={colDefs}
+                    defaultColDef={defaultColDef}
+                    rowData={data.callRecords}
+                    onGridReady={onGridReady}
+                />
+            </div>
         </div>
     );
 };


### PR DESCRIPTION
The problem was in the template for react and angular

<img width="884" height="753" alt="image" src="https://github.com/user-attachments/assets/811a1170-3bf9-4b99-a903-d8f387559bed" />
