### PR TITLE
AG-15626 - Use `app.component.ts` for adding console logger code for provided examples

### DIFF
--- a/plugins/ag-grid-generate-example-files/src/executors/generate/executor.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/executor.ts
@@ -411,8 +411,9 @@ async function processProvidedFiles(
     }
 
     // Transform entry file
-    provideFrameworkFiles[entryFileName] = transformEntryFile({
-        entryFile: provideFrameworkFiles[entryFileName],
+    const transformMainFile = internalFramework === 'angular' ? mainFileName : entryFileName;
+    provideFrameworkFiles[transformMainFile] = transformEntryFile({
+        entryFile: provideFrameworkFiles[transformMainFile],
     });
 
     return scriptFiles;


### PR DESCRIPTION
Fixes bug where angular provided examples were not logging.