### PR TITLE
AG-14577 synchronous set loading overlay text

### DIFF
--- a/packages/ag-grid-community/src/rendering/overlays/loadingOverlayComponent.ts
+++ b/packages/ag-grid-community/src/rendering/overlays/loadingOverlayComponent.ts
@@ -14,8 +14,9 @@ export interface ILoadingOverlayComp<TData = any, TContext = any>
 const LoadingOverlayElement: ElementParams = {
     tag: 'span',
     cls: 'ag-overlay-loading-center',
-    attrs: { 'aria-live': 'polite', 'aria-atomic': 'true' },
+    attrs: { 'aria-live': 'polite', 'aria-atomic': 'true', 'aria-hidden': 'true' },
 };
+
 export class LoadingOverlayComponent
     extends OverlayComponent<any, any, ILoadingOverlayParams>
     implements ILoadingOverlayComp<any, any>
@@ -23,15 +24,25 @@ export class LoadingOverlayComponent
     public init(): void {
         const customTemplate = _makeNull(this.gos.get('overlayLoadingTemplate')?.trim());
 
-        this.setTemplate(customTemplate ?? LoadingOverlayElement);
-
-        if (!customTemplate) {
-            const localeTextFunc = this.getLocaleTextFunc();
-            // setTimeout is used because some screen readers only announce `aria-live` text when
-            // there is a "text change", so we force a change from empty.
-            setTimeout(() => {
-                this.getGui().textContent = localeTextFunc('loadingOoo', 'Loading...');
-            });
+        if (customTemplate) {
+            this.setTemplate(customTemplate);
+            return;
         }
+
+        this.setTemplate(LoadingOverlayElement);
+
+        const localeTextFunc = this.getLocaleTextFunc();
+        const eGui = this.getGui();
+
+        // This need to be set synchronously to ensure the loading screen is visible immediately
+        eGui.textContent = localeTextFunc('loadingOoo', 'Loading...');
+
+        // we set aria-hidden = true and clear it with a setTimeout
+        // because some screen readers only announce `aria-live` text when
+        // there is a "text change", so we force a change.
+        setTimeout(() => {
+            eGui.removeAttribute('aria-hidden');
+            eGui.textContent += ' ';
+        }, 0);
     }
 }


### PR DESCRIPTION
The loading text should not be set asynchronously as it would prevent the loading screen to appear if there is some sync processing going on that would block the main thread after setting loading=true.
There was a setTimeout added to force screen readers to announce the grid is loading, so, here there is another proposal of a solution to handle both cases.

This relates also to https://ag-grid.atlassian.net/browse/AG-15086 