### PR TITLE
AG-14681 - renderer setValue to use rowNode.setDataValue and trigger correct readOnlyEdit workflow

### DIFF
--- a/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
@@ -474,7 +474,7 @@ export class CellCtrl extends BeanStub {
             valueFormatted: valueFormatted,
             getValue: () => valueSvc.getValueForDisplay(column, rowNode).value,
             setValue: (value: any) =>
-                editSvc?.setDataValue({ rowNode, column }, value) || valueSvc.setValue(rowNode, column, value),
+                editSvc?.setDataValue({ rowNode, column }, value) || rowNode.setDataValue(column, value),
             formatValue: this.formatValue.bind(this),
             data: rowNode.data,
             node: rowNode,


### PR DESCRIPTION
Fix AG-14681