### PR TITLE
[AG-4240] Feature(sidebar): allow hiding the sidebar containing the buttons and keeping the tool panel visible

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/api/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/api/main.ts
@@ -73,6 +73,7 @@ const gridOptions: GridOptions<IOlympicData> = {
         ],
         defaultToolPanel: 'filters',
         hiddenByDefault: true,
+        hideButtons: false,
     },
     onToolPanelVisibleChanged: (event: ToolPanelVisibleChangedEvent) => {
         console.log('toolPanelVisibleChanged', event);

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/api/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/api/main.ts
@@ -73,7 +73,6 @@ const gridOptions: GridOptions<IOlympicData> = {
         ],
         defaultToolPanel: 'filters',
         hiddenByDefault: true,
-        hideButtons: false,
     },
     onToolPanelVisibleChanged: (event: ToolPanelVisibleChangedEvent) => {
         console.log('toolPanelVisibleChanged', event);

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
@@ -73,7 +73,8 @@ const gridOptions = {
             }
         ],
         position: 'left',
-        defaultToolPanel: 'filters'
+        defaultToolPanel: 'filters',
+        hideButtons: false,
     }
 }
 ```
@@ -223,6 +224,10 @@ The Side Bar state can be saved and restored as part of [Grid State](./grid-stat
 The list below details all the API methods relevant to the Tool Panel.
 
 {% apiDocumentation source="grid-api/api.json" section="accessories" names=["getSideBar","setSideBarVisible","isSideBarVisible","setSideBarPosition","openToolPanel","closeToolPanel","getOpenedToolPanel","isToolPanelShowing","refreshToolPanel", "getToolPanelInstance"] /%}
+
+{% warning %}
+Calling `setSideBarVisible(true)` when `sideBarDef.hideButtons` is set to true and no tool panel is open will not display anything. This is useful if you want to show a tool panel without showing the buttons.
+{% /warning %}
 
 The example below demonstrates different usages of the Tool Panel API methods. The following can be noted:
 

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
@@ -9,12 +9,12 @@ This section covers how to configure the Side Bar which contains Tool Panels.
 
 The Side Bar is configured using the grid property `sideBar`. The property takes multiple forms to allow easy configuration or more advanced configuration. The different forms for the `sideBar` property are as follows:
 
-| Type                         | Description                                                                                        |
-| ---------------------------- | -------------------------------------------------------------------------------------------------- |
-| `undefined` / `null`         | No Side Bar provided.                                                                              |
-| `boolean`                    | Set to `true` to display the Side Bar with default configuration.                       |
-| `string` / `string[]`        | Set to `'columns'`, `'filters'` or `'filters-new'` to display the Side Bar with just one of [Columns](./tool-panel-columns/), [Filters](./tool-panel-filters/) or [New Filters](./tool-panel-filters-new) Tool Panels or an array of some or all of these values. |
-| `SideBarDef`{% br /%}(long form) | An object of type `SideBarDef` (explained below) to allow detailed configuration of the Side Bar. Use this to configure the provided Tool Panels (e.g. pass parameters to the columns or filters panel) or to include custom Tool Panels. |
+| Type                             | Description                                                                                                                                                                                                                                                       |
+|----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `undefined` / `null`             | No Side Bar provided.                                                                                                                                                                                                                                             |
+| `boolean`                        | Set to `true` to display the Side Bar with default configuration.                                                                                                                                                                                                 |
+| `string` / `string[]`            | Set to `'columns'`, `'filters'` or `'filters-new'` to display the Side Bar with just one of [Columns](./tool-panel-columns/), [Filters](./tool-panel-filters/) or [New Filters](./tool-panel-filters-new) Tool Panels or an array of some or all of these values. |
+| `SideBarDef`{% br /%}(long form) | An object of type `SideBarDef` (explained below) to allow detailed configuration of the Side Bar. Use this to configure the provided Tool Panels (e.g. pass parameters to the columns or filters panel) or to include custom Tool Panels.                         |
 
 ### Boolean Configuration
 
@@ -74,7 +74,6 @@ const gridOptions = {
         ],
         position: 'left',
         defaultToolPanel: 'filters',
-        hideButtons: false,
     }
 }
 ```
@@ -225,9 +224,9 @@ The list below details all the API methods relevant to the Tool Panel.
 
 {% apiDocumentation source="grid-api/api.json" section="accessories" names=["getSideBar","setSideBarVisible","isSideBarVisible","setSideBarPosition","openToolPanel","closeToolPanel","getOpenedToolPanel","isToolPanelShowing","refreshToolPanel", "getToolPanelInstance"] /%}
 
-{% warning %}
+{% note %}
 Calling `setSideBarVisible(true)` when `sideBarDef.hideButtons` is set to true and no tool panel is open will not display anything. This is useful if you want to show a tool panel without showing the buttons.
-{% /warning %}
+{% /note %}
 
 The example below demonstrates different usages of the Tool Panel API methods. The following can be noted:
 

--- a/packages/ag-grid-community/src/interfaces/iSideBar.ts
+++ b/packages/ag-grid-community/src/interfaces/iSideBar.ts
@@ -66,5 +66,5 @@ export interface SideBarDef {
     /** Sets the side bar position relative to the grid. */
     position?: 'left' | 'right';
     /** Allows granular control over the visibility of the side buttons. */
-    hideSideButtons?: boolean;
+    hideButtons?: boolean;
 }

--- a/packages/ag-grid-community/src/interfaces/iSideBar.ts
+++ b/packages/ag-grid-community/src/interfaces/iSideBar.ts
@@ -65,4 +65,6 @@ export interface SideBarDef {
     hiddenByDefault?: boolean;
     /** Sets the side bar position relative to the grid. */
     position?: 'left' | 'right';
+    /** Allows granular control over the visibility of the side buttons. */
+    hideSideButtons?: boolean;
 }

--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
@@ -197,7 +197,7 @@ class AgSideBar extends Component implements ISideBar {
         this.sideBar = sideBarDef;
 
         if (sideBarDef) {
-            this.sideBarButtons.setDisplayed(!sideBarDef.hideSideButtons);
+            this.sideBarButtons.setDisplayed(!sideBarDef.hideButtons);
         }
         if (sideBarDef?.toolPanels) {
             const toolPanelDefs = sideBarDef.toolPanels as ToolPanelDef[];

--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
@@ -255,6 +255,14 @@ class AgSideBar extends Component implements ISideBar {
         this.dispatchSideBarUpdated();
     }
 
+    public setSideButtonsDisplayed(
+        show: boolean,
+        options?: { skipAriaHidden?: boolean | undefined } | undefined
+    ): void {
+        this.sideBarButtons.setDisplayed(show, options);
+        this.dispatchSideBarUpdated();
+    }
+
     public getState(): SideBarState {
         const toolPanels: { [id: string]: any } = {};
         this.toolPanelWrappers.forEach((wrapper) => {

--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
@@ -197,8 +197,7 @@ class AgSideBar extends Component implements ISideBar {
         this.sideBar = sideBarDef;
 
         if (sideBarDef) {
-            const shouldHideSideButtons = sideBarDef.hideSideButtons ?? !this.sideBarButtons.isDisplayed();
-            this.sideBarButtons.setDisplayed(!shouldHideSideButtons);
+            this.sideBarButtons.setDisplayed(!sideBarDef.hideSideButtons);
         }
         if (sideBarDef?.toolPanels) {
             const toolPanelDefs = sideBarDef.toolPanels as ToolPanelDef[];

--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
@@ -196,7 +196,11 @@ class AgSideBar extends Component implements ISideBar {
 
         this.sideBar = sideBarDef;
 
-        if (!!sideBarDef && !!sideBarDef.toolPanels) {
+        if (sideBarDef) {
+            const shouldHideSideButtons = sideBarDef.hideSideButtons ?? !this.sideBarButtons.isDisplayed();
+            this.sideBarButtons.setDisplayed(!shouldHideSideButtons);
+        }
+        if (sideBarDef?.toolPanels) {
             const toolPanelDefs = sideBarDef.toolPanels as ToolPanelDef[];
             this.createToolPanelsAndSideButtons(toolPanelDefs, sideBarState, existingToolPanelWrappers);
             if (!this.toolPanelWrappers.length) {
@@ -252,14 +256,6 @@ class AgSideBar extends Component implements ISideBar {
         options?: { skipAriaHidden?: boolean | undefined } | undefined
     ): void {
         super.setDisplayed(displayed, options);
-        this.dispatchSideBarUpdated();
-    }
-
-    public setSideButtonsDisplayed(
-        show: boolean,
-        options?: { skipAriaHidden?: boolean | undefined } | undefined
-    ): void {
-        this.sideBarButtons.setDisplayed(show, options);
         this.dispatchSideBarUpdated();
     }
 

--- a/packages/ag-grid-enterprise/src/sideBar/sideBarDefParser.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/sideBarDefParser.ts
@@ -70,14 +70,13 @@ export function parseSideBarDef(
         };
     }
 
-    const result: SideBarDef = {
+    return {
         toolPanels: parseComponents(toParse.toolPanels),
         defaultToolPanel: toParse.defaultToolPanel,
         hiddenByDefault: toParse.hiddenByDefault,
         position: toParse.position,
+        hideSideButtons: toParse.hideSideButtons,
     };
-
-    return result;
 }
 
 function parseComponents(from?: (ToolPanelDef | string)[]): ToolPanelDef[] {

--- a/packages/ag-grid-enterprise/src/sideBar/sideBarDefParser.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/sideBarDefParser.ts
@@ -75,7 +75,7 @@ export function parseSideBarDef(
         defaultToolPanel: toParse.defaultToolPanel,
         hiddenByDefault: toParse.hiddenByDefault,
         position: toParse.position,
-        hideSideButtons: toParse.hideSideButtons,
+        hideButtons: toParse.hideButtons,
     };
 }
 


### PR DESCRIPTION
Add hideSideButtons option to side bar configuration

 - Add `hideSideButtons` boolean property to iSideBar interface
 - Update sideBarDefParser to include `hideSideButtons` in parsed config
 - Modify agSideBar logic to respect `hideSideButtons` for button visibility

Fixes AG-4240