### PR TITLE
AG-5867 ensure refresh cells invokes row drag callback

### DIFF
--- a/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
@@ -88,14 +88,19 @@ export class RowDragComp extends Component {
             return;
         }
 
+        const column = this.column;
+
         // if shown sometimes, them some rows can have drag handle while other don't,
         // so we use setVisible to keep the handles horizontally aligned (as _setVisible
         // keeps the empty space, whereas setDisplayed looses the space)
-        const shownSometimes = typeof this.column?.getColDef().rowDrag === 'function';
+        let shownSometimes = typeof column?.getColDef().rowDrag === 'function';
+        let visible = !column || this.isCustomGui() || column.isRowDrag(this.rowNode);
+        if (visible && this.rowNode.footer && this.gos.get('rowDragManaged')) {
+            visible = false; // We hide footer rows in row drag managed mode
+            shownSometimes = true;
+        }
 
-        const visible = this.isVisible();
-        const displayed = shownSometimes || visible;
-        this.setDisplayed(displayed, displayedOptions);
+        this.setDisplayed(shownSometimes || visible, displayedOptions);
         this.setVisible(visible, displayedOptions);
     }
 
@@ -114,17 +119,6 @@ export class RowDragComp extends Component {
         }
 
         return false;
-    }
-
-    private isVisible(): boolean {
-        const { column, rowNode } = this;
-        if (rowNode.footer && this.gos.get('rowDragManaged')) {
-            return false; // Footer nodes in row drag managed mode are not visible
-        }
-        if (column) {
-            return this.isCustomGui() || column.isRowDrag(rowNode);
-        }
-        return true;
     }
 
     private getSelectedNodes(): RowNode[] {

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
@@ -24,7 +24,7 @@ export class RowDragComp extends Component {
         private readonly column?: AgColumn,
         private readonly customGui?: HTMLElement,
         private readonly dragStartPixels?: number,
-        private readonly suppressVisibilityChange?: boolean
+        private readonly rowDragEntireRow?: boolean
     ) {
         super();
     }
@@ -34,34 +34,44 @@ export class RowDragComp extends Component {
     }
 
     public postConstruct(): void {
-        const { beans, rowNode } = this;
-        if (!this.customGui) {
+        const { beans, customGui } = this;
+        if (customGui) {
+            this.setDragElement(customGui, this.dragStartPixels);
+        } else {
             this.setTemplate(RowDragElement);
             this.getGui().appendChild(_createIconNoSpan('rowDrag', beans, null)!);
             this.addDragSource();
-        } else {
-            this.setDragElement(this.customGui, this.dragStartPixels);
         }
 
-        if (!this.suppressVisibilityChange) {
-            const refresh = this.refresh.bind(this);
+        if (!this.rowDragEntireRow) {
+            this.initCellDrag();
+        }
+    }
 
-            this.addManagedPropertyListener('suppressRowDrag', refresh);
+    private initCellDrag(): void {
+        const { beans, gos, rowNode } = this;
+        const refresh = this.refresh.bind(this);
 
-            // in case data changes, then we need to update visibility of drag item
-            this.addManagedListeners(rowNode, {
-                dataChanged: refresh,
-                cellChanged: refresh,
-            });
+        this.addManagedPropertyListener('suppressRowDrag', refresh);
 
+        // in case data changes, then we need to update visibility of drag item
+        this.addManagedListeners(rowNode, {
+            dataChanged: refresh,
+            cellChanged: refresh,
+        });
+
+        this.addManagedListeners<AgEventType>(
+            beans.eventSvc,
             // For managed row drag, we do not show the component if sort, filter or grouping is active
-            this.addManagedListeners<AgEventType>(beans.eventSvc, {
-                sortChanged: refresh,
-                filterChanged: refresh,
-                columnRowGroupChanged: refresh,
-                newColumnsLoaded: refresh,
-            });
-        }
+            gos.get('rowDragManaged')
+                ? {
+                      sortChanged: refresh,
+                      filterChanged: refresh,
+                      columnRowGroupChanged: refresh,
+                      newColumnsLoaded: refresh,
+                  }
+                : { newColumnsLoaded: refresh }
+        );
     }
 
     public setDragElement(dragElement: HTMLElement, dragStartPixels?: number) {
@@ -72,50 +82,49 @@ export class RowDragComp extends Component {
     }
 
     public refresh(): void {
-        if (this.suppressVisibilityChange) {
-            return;
-        }
-
-        const { rowDragSvc, dragAndDrop, gos } = this.beans;
-        const isManaged = gos.get('rowDragManaged');
-        const suppressRowDrag = gos.get('suppressRowDrag');
-        let neverDisplayed = false;
-        let alwaysHidden = false;
-
-        if (isManaged) {
-            // Managed: only show if not prevented and not suppressed, or if there are external drop zones
-            const shouldPreventRowMove = rowDragSvc!.rowDragFeature?.shouldPreventRowMove();
-            const hasExternalDropZones = dragAndDrop?.hasExternalDropZones();
-            neverDisplayed = (shouldPreventRowMove && !hasExternalDropZones) || suppressRowDrag;
-            alwaysHidden = !!this.rowNode.footer;
-        } else {
-            // Non-managed: only show if not suppressed
-            neverDisplayed = suppressRowDrag;
-        }
-
-        // Now, match the old setDisplayedOrVisible logic
         const displayedOptions = { skipAriaHidden: true };
-        if (neverDisplayed) {
+        if (this.isNeverDisplayed()) {
             this.setDisplayed(false, displayedOptions);
             return;
         }
 
-        let shown = !alwaysHidden;
-        let isShownSometimes = false;
-        const column = this.column;
-        if (column) {
-            const rowDrag = column.getColDef().rowDrag;
-            isShownSometimes = typeof rowDrag === 'function';
-            shown = (alwaysHidden ? !!rowDrag : column.isRowDrag(this.rowNode)) || this.isCustomGui();
+        // if shown sometimes, them some rows can have drag handle while other don't,
+        // so we use setVisible to keep the handles horizontally aligned (as _setVisible
+        // keeps the empty space, whereas setDisplayed looses the space)
+        const shownSometimes = typeof this.column?.getColDef().rowDrag === 'function';
+
+        const visible = this.isVisible();
+        const displayed = shownSometimes || visible;
+        this.setDisplayed(displayed, displayedOptions);
+        this.setVisible(visible, displayedOptions);
+    }
+
+    private isNeverDisplayed(): boolean {
+        const { gos, beans } = this;
+        if (gos.get('suppressRowDrag')) {
+            return true; // Row dragging is suppressed
         }
 
-        if (isShownSometimes) {
-            this.setDisplayed(true, displayedOptions);
-            this.setVisible(shown && !alwaysHidden, displayedOptions);
-        } else {
-            this.setDisplayed(shown, displayedOptions);
-            this.setVisible(!alwaysHidden, displayedOptions);
+        if (
+            gos.get('rowDragManaged') &&
+            !!beans.rowDragSvc!.rowDragFeature?.shouldPreventRowMove() &&
+            !beans.dragAndDrop?.hasExternalDropZones()
+        ) {
+            return true; // Managed: only show if not prevented and not suppressed, or if there are external drop zones
         }
+
+        return false;
+    }
+
+    private isVisible(): boolean {
+        const { column, rowNode } = this;
+        if (rowNode.footer && this.gos.get('rowDragManaged')) {
+            return false; // Footer nodes in row drag managed mode are not visible
+        }
+        if (column) {
+            return this.isCustomGui() || column.isRowDrag(rowNode);
+        }
+        return true;
     }
 
     private getSelectedNodes(): RowNode[] {

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
@@ -24,7 +24,7 @@ export class RowDragComp extends Component {
         private readonly column?: AgColumn,
         private readonly customGui?: HTMLElement,
         private readonly dragStartPixels?: number,
-        private readonly rowDragEntireRow?: boolean
+        private readonly alwaysVisible: boolean = false
     ) {
         super();
     }
@@ -43,7 +43,7 @@ export class RowDragComp extends Component {
             this.addDragSource();
         }
 
-        if (!this.rowDragEntireRow) {
+        if (!this.alwaysVisible) {
             this.initCellDrag();
         }
     }
@@ -82,6 +82,10 @@ export class RowDragComp extends Component {
     }
 
     public refresh(): void {
+        if (this.alwaysVisible) {
+            return; // Always visible row draggers do not refresh visibility
+        }
+
         const displayedOptions = { skipAriaHidden: true };
         if (this.isNeverDisplayed()) {
             this.setDisplayed(false, displayedOptions);

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
@@ -1,4 +1,3 @@
-import { BeanStub } from '../context/beanStub';
 import type { AgColumn } from '../entities/agColumn';
 import type { RowNode } from '../entities/rowNode';
 import type { AgEventType } from '../eventTypes';
@@ -35,7 +34,7 @@ export class RowDragComp extends Component {
     }
 
     public postConstruct(): void {
-        const { beans, rowNode, column, gos } = this;
+        const { beans, rowNode } = this;
         if (!this.customGui) {
             this.setTemplate(RowDragElement);
             this.getGui().appendChild(_createIconNoSpan('rowDrag', beans, null)!);
@@ -45,11 +44,23 @@ export class RowDragComp extends Component {
         }
 
         if (!this.suppressVisibilityChange) {
-            const strategy = gos.get('rowDragManaged')
-                ? new ManagedVisibilityStrategy(this, rowNode, column)
-                : new NonManagedVisibilityStrategy(this, rowNode, column);
+            const refresh = this.refresh.bind(this);
 
-            this.createManagedBean(strategy, this.beans.context);
+            this.addManagedPropertyListener('suppressRowDrag', refresh);
+
+            // in case data changes, then we need to update visibility of drag item
+            this.addManagedListeners(rowNode, {
+                dataChanged: refresh,
+                cellChanged: refresh,
+            });
+
+            // For managed row drag, we do not show the component if sort, filter or grouping is active
+            this.addManagedListeners<AgEventType>(beans.eventSvc, {
+                sortChanged: refresh,
+                filterChanged: refresh,
+                columnRowGroupChanged: refresh,
+                newColumnsLoaded: refresh,
+            });
         }
     }
 
@@ -58,6 +69,53 @@ export class RowDragComp extends Component {
         // that are not part of this row dragger's context. Maybe this should just setGui and not setTemplateFromElement?
         this.setTemplateFromElement(dragElement, undefined, undefined, true);
         this.addDragSource(dragStartPixels);
+    }
+
+    public refresh(): void {
+        if (this.suppressVisibilityChange) {
+            return;
+        }
+
+        const { rowDragSvc, dragAndDrop, gos } = this.beans;
+        const isManaged = gos.get('rowDragManaged');
+        const suppressRowDrag = gos.get('suppressRowDrag');
+        let neverDisplayed = false;
+        let alwaysHidden = false;
+
+        if (isManaged) {
+            // Managed: only show if not prevented and not suppressed, or if there are external drop zones
+            const shouldPreventRowMove = rowDragSvc!.rowDragFeature?.shouldPreventRowMove();
+            const hasExternalDropZones = dragAndDrop?.hasExternalDropZones();
+            neverDisplayed = (shouldPreventRowMove && !hasExternalDropZones) || suppressRowDrag;
+            alwaysHidden = !!this.rowNode.footer;
+        } else {
+            // Non-managed: only show if not suppressed
+            neverDisplayed = suppressRowDrag;
+        }
+
+        // Now, match the old setDisplayedOrVisible logic
+        const displayedOptions = { skipAriaHidden: true };
+        if (neverDisplayed) {
+            this.setDisplayed(false, displayedOptions);
+            return;
+        }
+
+        let shown = !alwaysHidden;
+        let isShownSometimes = false;
+        const column = this.column;
+        if (column) {
+            const rowDrag = column.getColDef().rowDrag;
+            isShownSometimes = typeof rowDrag === 'function';
+            shown = (alwaysHidden ? !!rowDrag : column.isRowDrag(this.rowNode)) || this.isCustomGui();
+        }
+
+        if (isShownSometimes) {
+            this.setDisplayed(true, displayedOptions);
+            this.setVisible(shown && !alwaysHidden, displayedOptions);
+        } else {
+            this.setDisplayed(shown, displayedOptions);
+            this.setVisible(!alwaysHidden, displayedOptions);
+        }
     }
 
     private getSelectedNodes(): RowNode[] {
@@ -162,111 +220,5 @@ export class RowDragComp extends Component {
 
         this.mouseDownListener();
         this.mouseDownListener = undefined;
-    }
-}
-
-class VisibilityStrategy extends BeanStub {
-    constructor(
-        private readonly parent: RowDragComp,
-        protected readonly rowNode: RowNode,
-        private readonly column?: AgColumn
-    ) {
-        super();
-    }
-
-    protected setDisplayedOrVisible(neverDisplayed: boolean, alwaysHidden: boolean = false): void {
-        const displayedOptions = { skipAriaHidden: true };
-        if (neverDisplayed) {
-            this.parent.setDisplayed(false, displayedOptions);
-        } else {
-            let shown: boolean = !alwaysHidden;
-            let isShownSometimes: boolean = false;
-
-            const { column, rowNode, parent } = this;
-            if (column) {
-                const rowDrag = column.getColDef().rowDrag;
-                isShownSometimes = typeof rowDrag === 'function';
-                shown = (alwaysHidden ? !!rowDrag : column.isRowDrag(rowNode)) || parent.isCustomGui();
-            }
-
-            // if shown sometimes, them some rows can have drag handle while other don't,
-            // so we use setVisible to keep the handles horizontally aligned (as _setVisible
-            // keeps the empty space, whereas setDisplayed looses the space)
-            if (isShownSometimes) {
-                parent.setDisplayed(true, displayedOptions);
-                parent.setVisible(shown && !alwaysHidden, displayedOptions);
-            } else {
-                parent.setDisplayed(shown, displayedOptions);
-                parent.setVisible(!alwaysHidden, displayedOptions);
-            }
-        }
-    }
-}
-
-// when non managed, the visibility depends on suppressRowDrag property only
-class NonManagedVisibilityStrategy extends VisibilityStrategy {
-    public postConstruct(): void {
-        this.addManagedPropertyListener('suppressRowDrag', this.onSuppressRowDrag.bind(this));
-
-        // in case data changes, then we need to update visibility of drag item
-        const listener = this.workOutVisibility.bind(this);
-        this.addManagedListeners(this.rowNode, {
-            dataChanged: listener,
-            cellChanged: listener,
-        });
-
-        this.addManagedListeners(this.beans.eventSvc, { newColumnsLoaded: listener });
-
-        this.workOutVisibility();
-    }
-
-    private onSuppressRowDrag(): void {
-        this.workOutVisibility();
-    }
-
-    private workOutVisibility(): void {
-        // only show the drag if both sort and filter are not present
-        const neverDisplayed = this.gos.get('suppressRowDrag');
-        this.setDisplayedOrVisible(neverDisplayed);
-    }
-}
-
-// when managed, the visibility depends on sort, filter and row group, as well as suppressRowDrag property
-class ManagedVisibilityStrategy extends VisibilityStrategy {
-    public postConstruct(): void {
-        const listener = this.workOutVisibility.bind(this);
-        // we do not show the component if sort, filter or grouping is active
-        this.addManagedListeners<AgEventType>(this.beans.eventSvc, {
-            sortChanged: listener,
-            filterChanged: listener,
-            columnRowGroupChanged: listener,
-            newColumnsLoaded: listener,
-        });
-
-        // in case data changes, then we need to update visibility of drag item
-        this.addManagedListeners(this.rowNode, {
-            dataChanged: listener,
-            cellChanged: listener,
-        });
-
-        this.addManagedPropertyListener('suppressRowDrag', this.onSuppressRowDrag.bind(this));
-
-        this.workOutVisibility();
-    }
-
-    private onSuppressRowDrag(): void {
-        this.workOutVisibility();
-    }
-
-    private workOutVisibility(): void {
-        const { rowDragSvc, dragAndDrop, gos } = this.beans;
-        // only show the drag if both sort and filter are not present
-        const rowDragFeature = rowDragSvc!.rowDragFeature;
-        const shouldPreventRowMove = rowDragFeature && rowDragFeature.shouldPreventRowMove();
-        const suppressRowDrag = gos.get('suppressRowDrag');
-        const hasExternalDropZones = dragAndDrop!.hasExternalDropZones();
-        const neverDisplayed = (shouldPreventRowMove && !hasExternalDropZones) || suppressRowDrag;
-
-        this.setDisplayedOrVisible(neverDisplayed, this.rowNode.footer);
     }
 }

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragService.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragService.ts
@@ -25,9 +25,9 @@ export class RowDragService extends BeanStub implements NamedBean {
         column?: AgColumn,
         customGui?: HTMLElement,
         dragStartPixels?: number,
-        suppressVisibilityChange?: boolean
+        rowDragEntireRow?: boolean
     ): RowDragComp {
-        return new RowDragComp(cellValueFn, rowNode, column, customGui, dragStartPixels, suppressVisibilityChange);
+        return new RowDragComp(cellValueFn, rowNode, column, customGui, dragStartPixels, rowDragEntireRow);
     }
 
     public createRowDragCompForRow(rowNode: RowNode, element: HTMLElement): RowDragComp | undefined {

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragService.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragService.ts
@@ -25,9 +25,9 @@ export class RowDragService extends BeanStub implements NamedBean {
         column?: AgColumn,
         customGui?: HTMLElement,
         dragStartPixels?: number,
-        rowDragEntireRow?: boolean
+        alwaysVisible?: boolean
     ): RowDragComp {
-        return new RowDragComp(cellValueFn, rowNode, column, customGui, dragStartPixels, rowDragEntireRow);
+        return new RowDragComp(cellValueFn, rowNode, column, customGui, dragStartPixels, alwaysVisible);
     }
 
     public createRowDragCompForRow(rowNode: RowNode, element: HTMLElement): RowDragComp | undefined {
@@ -51,7 +51,7 @@ export class RowDragService extends BeanStub implements NamedBean {
         cellValueFn: () => string,
         element?: HTMLElement,
         dragStartPixels?: number,
-        suppressVisibilityChange?: boolean
+        alwaysVisible?: boolean
     ): RowDragComp | undefined {
         const gos = this.gos;
         if (gos.get('rowDragManaged')) {
@@ -68,7 +68,7 @@ export class RowDragService extends BeanStub implements NamedBean {
             column,
             element,
             dragStartPixels,
-            suppressVisibilityChange
+            alwaysVisible
         );
         return rowDragComp;
     }

--- a/packages/ag-grid-community/src/rendering/cell/cellComp.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellComp.ts
@@ -144,26 +144,28 @@ export class CellComp extends Component {
     ): void {
         // this can happen if the users asks for the cell to refresh, but we are not showing the vale as we are editing
         const isInlineEditing = this.cellEditor && !this.cellEditorPopupWrapper;
-        if (!isInlineEditing) {
-            // this means firstRender will be true for one pass only, as it's initialised to undefined
-            this.firstRender = this.firstRender == null;
+        if (isInlineEditing) {
+            return;
+        }
 
-            // if display template has changed, means any previous Cell Renderer is in the wrong location
-            const controlWrapperChanged = this.refreshWrapper(false);
-            this.refreshEditStyles(false);
+        // this means firstRender will be true for one pass only, as it's initialised to undefined
+        this.firstRender = this.firstRender == null;
 
-            // all of these have dependencies on the eGui, so only do them after eGui is set
-            if (compDetails) {
-                const neverRefresh = forceNewCellRendererInstance || controlWrapperChanged;
-                const cellRendererRefreshSuccessful = neverRefresh ? false : this.refreshCellRenderer(compDetails);
-                if (!cellRendererRefreshSuccessful) {
-                    this.destroyRenderer();
-                    this.createCellRendererInstance(compDetails);
-                }
-            } else {
+        // if display template has changed, means any previous Cell Renderer is in the wrong location
+        const controlWrapperChanged = this.refreshWrapper(false);
+        this.refreshEditStyles(false);
+
+        // all of these have dependencies on the eGui, so only do them after eGui is set
+        if (compDetails) {
+            const neverRefresh = forceNewCellRendererInstance || controlWrapperChanged;
+            const cellRendererRefreshSuccessful = neverRefresh ? false : this.refreshCellRenderer(compDetails);
+            if (!cellRendererRefreshSuccessful) {
                 this.destroyRenderer();
-                this.insertValueWithoutCellRenderer(valueToDisplay);
+                this.createCellRendererInstance(compDetails);
             }
+        } else {
+            this.destroyRenderer();
+            this.insertValueWithoutCellRenderer(valueToDisplay);
         }
 
         this.rowDraggingComp?.refresh();

--- a/packages/ag-grid-community/src/rendering/cell/cellComp.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellComp.ts
@@ -1,4 +1,5 @@
 import type { BeanCollection } from '../../context/context';
+import type { RowDragComp } from '../../dragAndDrop/rowDragComp';
 import type { PopupEditorWrapper } from '../../edit/cellEditors/popupEditorWrapper';
 import type { AgColumn } from '../../entities/agColumn';
 import type { CellStyle } from '../../entities/colDef';
@@ -37,7 +38,7 @@ export class CellComp extends Component {
 
     private checkboxSelectionComp: CheckboxSelectionComponent | undefined;
     private dndSourceComp: DndSourceComp | undefined;
-    private rowDraggingComp: Component | undefined;
+    private rowDraggingComp: RowDragComp | undefined;
 
     private hideEditorPopup: ((...args: any[]) => any) | null | undefined;
     private cellEditorPopupWrapper: PopupEditorWrapper | undefined;
@@ -143,29 +144,29 @@ export class CellComp extends Component {
     ): void {
         // this can happen if the users asks for the cell to refresh, but we are not showing the vale as we are editing
         const isInlineEditing = this.cellEditor && !this.cellEditorPopupWrapper;
-        if (isInlineEditing) {
-            return;
-        }
+        if (!isInlineEditing) {
+            // this means firstRender will be true for one pass only, as it's initialised to undefined
+            this.firstRender = this.firstRender == null;
 
-        // this means firstRender will be true for one pass only, as it's initialised to undefined
-        this.firstRender = this.firstRender == null;
+            // if display template has changed, means any previous Cell Renderer is in the wrong location
+            const controlWrapperChanged = this.refreshWrapper(false);
+            this.refreshEditStyles(false);
 
-        // if display template has changed, means any previous Cell Renderer is in the wrong location
-        const controlWrapperChanged = this.refreshWrapper(false);
-        this.refreshEditStyles(false);
-
-        // all of these have dependencies on the eGui, so only do them after eGui is set
-        if (compDetails) {
-            const neverRefresh = forceNewCellRendererInstance || controlWrapperChanged;
-            const cellRendererRefreshSuccessful = neverRefresh ? false : this.refreshCellRenderer(compDetails);
-            if (!cellRendererRefreshSuccessful) {
+            // all of these have dependencies on the eGui, so only do them after eGui is set
+            if (compDetails) {
+                const neverRefresh = forceNewCellRendererInstance || controlWrapperChanged;
+                const cellRendererRefreshSuccessful = neverRefresh ? false : this.refreshCellRenderer(compDetails);
+                if (!cellRendererRefreshSuccessful) {
+                    this.destroyRenderer();
+                    this.createCellRendererInstance(compDetails);
+                }
+            } else {
                 this.destroyRenderer();
-                this.createCellRendererInstance(compDetails);
+                this.insertValueWithoutCellRenderer(valueToDisplay);
             }
-        } else {
-            this.destroyRenderer();
-            this.insertValueWithoutCellRenderer(valueToDisplay);
         }
+
+        this.rowDraggingComp?.refresh();
     }
 
     private setEditDetails(

--- a/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
@@ -964,18 +964,14 @@ export class CellCtrl extends BeanStub {
         return dndSourceComp;
     }
 
-    public registerRowDragger(
-        customElement: HTMLElement,
-        dragStartPixels?: number,
-        suppressVisibilityChange?: boolean
-    ): void {
+    public registerRowDragger(customElement: HTMLElement, dragStartPixels?: number, alwaysVisible?: boolean): void {
         // if previously existed, then we are only updating
         if (this.customRowDragComp) {
             this.customRowDragComp.setDragElement(customElement, dragStartPixels);
             return;
         }
 
-        const newComp = this.createRowDragComp(customElement, dragStartPixels, suppressVisibilityChange);
+        const newComp = this.createRowDragComp(customElement, dragStartPixels, alwaysVisible);
 
         if (newComp) {
             this.customRowDragComp = newComp;
@@ -989,7 +985,7 @@ export class CellCtrl extends BeanStub {
     public createRowDragComp(
         customElement?: HTMLElement,
         dragStartPixels?: number,
-        suppressVisibilityChange?: boolean
+        alwaysVisible?: boolean
     ): RowDragComp | undefined {
         const rowDragComp = this.beans.rowDragSvc?.createRowDragCompForCell(
             this.rowNode,
@@ -997,7 +993,7 @@ export class CellCtrl extends BeanStub {
             () => this.value,
             customElement,
             dragStartPixels,
-            suppressVisibilityChange
+            alwaysVisible
         );
         if (!rowDragComp) {
             return undefined;

--- a/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
@@ -1246,8 +1246,8 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
             eParentOfValue: eRow,
             pinned: pinned as any,
             addRenderedRowListener: this.addEventListener.bind(this) as any, // This is not on the type of ICellRendererParams
-            registerRowDragger: (rowDraggerElement, dragStartPixels, value, suppressVisibilityChange) =>
-                this.addFullWidthRowDragging(rowDraggerElement, dragStartPixels, value, suppressVisibilityChange),
+            registerRowDragger: (rowDraggerElement, dragStartPixels, value, rowDragEntireRow) =>
+                this.addFullWidthRowDragging(rowDraggerElement, dragStartPixels, value, rowDragEntireRow),
             setTooltip: (value, shouldDisplayTooltip) => {
                 gos.assertModuleRegistered('Tooltip', 3);
                 this.setupFullWidthRowTooltip(value, shouldDisplayTooltip);
@@ -1288,7 +1288,7 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         rowDraggerElement?: HTMLElement,
         dragStartPixels?: number,
         value: string = '',
-        suppressVisibilityChange?: boolean
+        rowDragEntireRow?: boolean
     ): void {
         const { rowDragSvc, context } = this.beans;
         if (!rowDragSvc || !this.isFullWidth()) {
@@ -1301,7 +1301,7 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
             undefined,
             rowDraggerElement,
             dragStartPixels,
-            suppressVisibilityChange
+            rowDragEntireRow
         );
         this.createBean(rowDragComp, context);
 

--- a/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
@@ -1288,7 +1288,7 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         rowDraggerElement?: HTMLElement,
         dragStartPixels?: number,
         value: string = '',
-        rowDragEntireRow?: boolean
+        alwaysVisible?: boolean
     ): void {
         const { rowDragSvc, context } = this.beans;
         if (!rowDragSvc || !this.isFullWidth()) {
@@ -1301,7 +1301,7 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
             undefined,
             rowDraggerElement,
             dragStartPixels,
-            rowDragEntireRow
+            alwaysVisible
         );
         this.createBean(rowDragComp, context);
 

--- a/testing/behavioural/src/drag-n-drop/is-row-drag.test.ts
+++ b/testing/behavioural/src/drag-n-drop/is-row-drag.test.ts
@@ -109,7 +109,6 @@ describe('isRowDrag and drag handle refresh', () => {
         expect(callCount).toBeGreaterThan(0);
         const element = TestGridsManager.getHTMLElement(api)!;
         callCount = 0;
-        console.log('UPDATE!');
 
         api.applyColumnState({ state: [{ colId: 'a', sort: 'desc' }], applyOrder: true });
 
@@ -122,7 +121,7 @@ describe('isRowDrag and drag handle refresh', () => {
         expect(isDragHandleVisible(element)).toBe(true);
     });
 
-    test.only('handle updates on filterChanged event', async () => {
+    test('handle updates on filterChanged event', async () => {
         let callCount = 0;
         const isRowDrag = () => {
             callCount++;

--- a/testing/behavioural/src/drag-n-drop/is-row-drag.test.ts
+++ b/testing/behavioural/src/drag-n-drop/is-row-drag.test.ts
@@ -1,0 +1,161 @@
+import { ClientSideRowModelModule, RowDragModule } from 'ag-grid-community';
+import type { GridOptions } from 'ag-grid-community';
+
+import { TestGridsManager, asyncSetTimeout, isAgHtmlElementVisible } from '../test-utils';
+
+function isDragHandleVisible(element: Element): boolean {
+    return isAgHtmlElementVisible(element.querySelector('.ag-drag-handle'));
+}
+
+describe('isRowDrag and drag handle refresh', () => {
+    let gridsManager: TestGridsManager;
+
+    beforeEach(() => {
+        gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, RowDragModule] });
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    test('isRowDrag is called on refresh and handle updates', async () => {
+        let callCount = 0;
+        let returnValue = true;
+        const isRowDrag = () => {
+            callCount++;
+            return returnValue;
+        };
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'a', colId: 'a', rowDrag: isRowDrag }],
+            rowData: [
+                { id: 'r1', a: 'A', b: 'a' },
+                { id: 'r2', a: 'B', b: 'b' },
+            ],
+            getRowId: (params) => params.data.id,
+        };
+        const api = gridsManager.createGrid('testGrid', gridOptions);
+        const element = TestGridsManager.getHTMLElement(api)!;
+        expect(callCount).toBe(2);
+        expect(isDragHandleVisible(element)).toBe(true);
+
+        callCount = 0;
+        returnValue = false;
+        api.applyTransaction({
+            update: [
+                { id: 'r1', a: 'X', b: 'x' },
+                { id: 'r2', a: 'Y', b: 'y' },
+            ],
+        });
+        await asyncSetTimeout(1);
+        expect(callCount).toBeGreaterThan(0);
+        expect(isDragHandleVisible(element)).toBe(false);
+
+        callCount = 0;
+        returnValue = true;
+        api.setGridOption('rowData', [
+            { id: 'r1', a: 'A', b: 'a' },
+            { id: 'r2', a: 'B', b: 'b' },
+        ]);
+        await asyncSetTimeout(1);
+        expect(callCount).toBeGreaterThan(0);
+        expect(isDragHandleVisible(element)).toBe(true);
+    });
+
+    test('handle updates on suppressRowDrag property change', async () => {
+        let callCount = 0;
+        const isRowDrag = () => {
+            callCount++;
+            return true;
+        };
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'a', colId: 'a', rowDrag: isRowDrag }],
+            rowData: [
+                { id: 'r1', a: 'A', b: 'a' },
+                { id: 'r2', a: 'B', b: 'b' },
+            ],
+            getRowId: (params) => params.data.id,
+        };
+        const api = gridsManager.createGrid('testGrid', gridOptions);
+        const element = TestGridsManager.getHTMLElement(api)!;
+
+        callCount = 0;
+        api.setGridOption('suppressRowDrag', true);
+        await asyncSetTimeout(1);
+        expect(callCount).toBe(0);
+        expect(isDragHandleVisible(element)).toBe(false);
+
+        api.setGridOption('suppressRowDrag', false);
+        await asyncSetTimeout(1);
+        expect(callCount).toBeGreaterThan(0);
+        expect(isDragHandleVisible(element)).toBe(true);
+    });
+
+    test('handle updates on sortChanged event', async () => {
+        let callCount = 0;
+        const isRowDrag = () => {
+            callCount++;
+            return true;
+        };
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'a', colId: 'a', rowDrag: isRowDrag }],
+            rowData: [
+                { id: 'r1', a: 'A', b: 'a' },
+                { id: 'r2', a: 'B', b: 'b' },
+            ],
+            getRowId: (params) => params.data.id,
+        };
+        const api = gridsManager.createGrid('testGrid', gridOptions);
+        const element = TestGridsManager.getHTMLElement(api)!;
+        callCount = 0;
+        api.applyColumnState({ state: [{ colId: 'a', sort: 'desc' }], applyOrder: true });
+        await asyncSetTimeout(1);
+        expect(callCount).toBeGreaterThan(0);
+        expect(isDragHandleVisible(element)).toBe(true);
+    });
+
+    test('handle updates on filterChanged event', async () => {
+        let callCount = 0;
+        const isRowDrag = () => {
+            callCount++;
+            return true;
+        };
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'a', colId: 'a', rowDrag: isRowDrag }],
+            rowData: [
+                { id: 'r1', a: 'A', b: 'a' },
+                { id: 'r2', a: 'B', b: 'b' },
+            ],
+            getRowId: (params) => params.data.id,
+        };
+        const api = gridsManager.createGrid('testGrid', gridOptions);
+        const element = TestGridsManager.getHTMLElement(api)!;
+        callCount = 0;
+        api.onFilterChanged();
+        await asyncSetTimeout(1);
+        expect(callCount).toBeGreaterThan(0);
+        expect(isDragHandleVisible(element)).toBe(true);
+    });
+
+    test('handle updates on newColumnsLoaded event', async () => {
+        let callCount = 0;
+        const isRowDrag = () => {
+            callCount++;
+            return true;
+        };
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'a', colId: 'a', rowDrag: isRowDrag }],
+            rowData: [
+                { id: 'r1', a: 'A', b: 'a' },
+                { id: 'r2', a: 'B', b: 'b' },
+            ],
+            getRowId: (params) => params.data.id,
+        };
+        const api = gridsManager.createGrid('testGrid', gridOptions);
+        const element = TestGridsManager.getHTMLElement(api)!;
+        callCount = 0;
+        api.setGridOption('columnDefs', [{ field: 'b', colId: 'b', rowDrag: isRowDrag }]);
+        await asyncSetTimeout(1);
+        expect(callCount).toBeGreaterThan(0);
+        expect(isDragHandleVisible(element)).toBe(true);
+    });
+});

--- a/testing/behavioural/src/drag-n-drop/is-row-drag.test.ts
+++ b/testing/behavioural/src/drag-n-drop/is-row-drag.test.ts
@@ -1,7 +1,7 @@
 import { ClientSideRowModelModule, RowDragModule } from 'ag-grid-community';
 import type { GridOptions } from 'ag-grid-community';
 
-import { TestGridsManager, asyncSetTimeout, isAgHtmlElementVisible } from '../test-utils';
+import { TestGridsManager, isAgHtmlElementVisible } from '../test-utils';
 
 function isDragHandleVisible(element: Element): boolean {
     return isAgHtmlElementVisible(element.querySelector('.ag-drag-handle'));
@@ -46,7 +46,7 @@ describe('isRowDrag and drag handle refresh', () => {
                 { id: 'r2', a: 'Y', b: 'y' },
             ],
         });
-        await asyncSetTimeout(1);
+
         expect(callCount).toBeGreaterThan(0);
         expect(isDragHandleVisible(element)).toBe(false);
 
@@ -56,7 +56,7 @@ describe('isRowDrag and drag handle refresh', () => {
             { id: 'r1', a: 'A', b: 'a' },
             { id: 'r2', a: 'B', b: 'b' },
         ]);
-        await asyncSetTimeout(1);
+
         expect(callCount).toBeGreaterThan(0);
         expect(isDragHandleVisible(element)).toBe(true);
     });
@@ -80,12 +80,12 @@ describe('isRowDrag and drag handle refresh', () => {
 
         callCount = 0;
         api.setGridOption('suppressRowDrag', true);
-        await asyncSetTimeout(1);
+
         expect(callCount).toBe(0);
         expect(isDragHandleVisible(element)).toBe(false);
 
         api.setGridOption('suppressRowDrag', false);
-        await asyncSetTimeout(1);
+
         expect(callCount).toBeGreaterThan(0);
         expect(isDragHandleVisible(element)).toBe(true);
     });
@@ -103,35 +103,50 @@ describe('isRowDrag and drag handle refresh', () => {
                 { id: 'r2', a: 'B', b: 'b' },
             ],
             getRowId: (params) => params.data.id,
+            rowDragManaged: true,
         };
         const api = gridsManager.createGrid('testGrid', gridOptions);
+        expect(callCount).toBeGreaterThan(0);
         const element = TestGridsManager.getHTMLElement(api)!;
         callCount = 0;
+        console.log('UPDATE!');
+
         api.applyColumnState({ state: [{ colId: 'a', sort: 'desc' }], applyOrder: true });
-        await asyncSetTimeout(1);
+
+        expect(callCount).toBe(0);
+        expect(isDragHandleVisible(element)).toBe(false);
+
+        api.applyColumnState({ state: [{ colId: 'a', sort: null }], applyOrder: true });
+
         expect(callCount).toBeGreaterThan(0);
         expect(isDragHandleVisible(element)).toBe(true);
     });
 
-    test('handle updates on filterChanged event', async () => {
+    test.only('handle updates on filterChanged event', async () => {
         let callCount = 0;
         const isRowDrag = () => {
             callCount++;
             return true;
         };
         const gridOptions: GridOptions = {
-            columnDefs: [{ field: 'a', colId: 'a', rowDrag: isRowDrag }],
+            columnDefs: [{ field: 'a', colId: 'a', rowDrag: isRowDrag, filter: true }],
             rowData: [
                 { id: 'r1', a: 'A', b: 'a' },
                 { id: 'r2', a: 'B', b: 'b' },
             ],
             getRowId: (params) => params.data.id,
+            rowDragManaged: true,
         };
         const api = gridsManager.createGrid('testGrid', gridOptions);
+        expect(callCount).toBeGreaterThan(0);
         const element = TestGridsManager.getHTMLElement(api)!;
+
         callCount = 0;
-        api.onFilterChanged();
-        await asyncSetTimeout(1);
+        api.setFilterModel({ a: { filterType: 'text', type: 'contains', filter: 'A' } });
+        expect(callCount).toBe(0);
+        expect(isDragHandleVisible(element)).toBe(false);
+
+        api.setFilterModel(null);
         expect(callCount).toBeGreaterThan(0);
         expect(isDragHandleVisible(element)).toBe(true);
     });
@@ -154,7 +169,7 @@ describe('isRowDrag and drag handle refresh', () => {
         const element = TestGridsManager.getHTMLElement(api)!;
         callCount = 0;
         api.setGridOption('columnDefs', [{ field: 'b', colId: 'b', rowDrag: isRowDrag }]);
-        await asyncSetTimeout(1);
+
         expect(callCount).toBeGreaterThan(0);
         expect(isDragHandleVisible(element)).toBe(true);
     });

--- a/testing/behavioural/src/test-utils/grid-test-utils.ts
+++ b/testing/behavioural/src/test-utils/grid-test-utils.ts
@@ -46,3 +46,19 @@ export function executeTransactionsAsync<TData = any>(
     api.flushAsyncTransactions();
     return Promise.all(promises);
 }
+
+export function isAgHtmlElementVisible(element: Element | null | undefined): boolean {
+    let current = element;
+    while (current && current.role !== 'row') {
+        const classList = current.classList;
+        if (classList.contains('ag-hidden') || classList.contains('ag-invisible')) {
+            return false;
+        }
+        const computedStyle = getComputedStyle(current);
+        if (computedStyle.display === 'none' || computedStyle.visibility === 'hidden') {
+            return false;
+        }
+        current = current.parentElement;
+    }
+    return true;
+}


### PR DESCRIPTION
- add a new method `refresh` in rowDragComp that is invoked by cellComp to update the visibility of the drag handle
- simplify the rowDragComp logic and complexity by removing the two strategies classes and implement the logic in a centralised refresh method
- remove the call to workoutVisibility from postConstruct as is in any case called by refresh cells
- add unit tests to verify rowDrag is called and works as intended