### PR TITLE
[AG-15660] Fix(sidebar): sidebar correct keyboard navigation when side buttons are hidden

### DIFF
--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
@@ -19,6 +19,7 @@ import {
     _focusInto,
     _focusNextGridCoreContainer,
     _getActiveDomElement,
+    _isVisible,
     _removeFromParent,
     _setAriaControlsAndLabel,
     _warn,
@@ -120,7 +121,7 @@ class AgSideBar extends Component implements ISideBar {
 
         if (!nextEl) {
             nextEl = sideBarGui.querySelector('.ag-selected button') as HTMLElement;
-            nextEl = nextEl.closest('.ag-hidden') ? null : nextEl;
+            nextEl = _isVisible(nextEl) ? nextEl : null;
         }
 
         if (nextEl && nextEl !== e.target) {

--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
@@ -120,6 +120,7 @@ class AgSideBar extends Component implements ISideBar {
 
         if (!nextEl) {
             nextEl = sideBarGui.querySelector('.ag-selected button') as HTMLElement;
+            nextEl = nextEl.closest('.ag-hidden') ? null : nextEl;
         }
 
         if (nextEl && nextEl !== e.target) {


### PR DESCRIPTION
Fix handling of hidden elements in sidebar navigation
 
 - Explicitly check for 'ag-hidden' class to prevent interaction with hidden elements
 - Adjust nextEl assignment to null when parent is marked as ag-hidden
 - Maintain existing logic while adding defensive checks for visibility state

Fix [AG-15660](https://ag-grid.atlassian.net/browse/AG-15660)
Fix [AG-4240](https://ag-grid.atlassian.net/browse/AG-4240)

Plnkr https://plnkr.co/edit/vaPmNJ6yXq9oHX3A