### PR TITLE
[AG-15659] Fix(celldatatypes): regression when columns contain guids they are incorrectly inferred as datestring cell data type

### DIFF
--- a/packages/ag-grid-community/src/utils/date.ts
+++ b/packages/ag-grid-community/src/utils/date.ts
@@ -139,7 +139,7 @@ export function _isValidDate(value?: string | null, bailIfInvalidTime = false): 
 
 // check if dateTime is a valid date and has time parts
 export function _isValidDateTime(value?: string | null): boolean {
-    return !!value && _isValidDate(value, true) && !!value.match(DATE_TIME_REGEXP)?.[1]; // matches the 'T14:22:19' part
+    return _isValidDate(value, true);
 }
 
 /**
@@ -152,6 +152,10 @@ export function _isValidDateTime(value?: string | null): boolean {
  */
 export function _parseDateTimeFromString(value?: string | null, bailIfInvalidTime = false): Date | null {
     if (!value) {
+        return null;
+    }
+
+    if (!DATE_TIME_REGEXP.test(value)) {
         return null;
     }
 

--- a/packages/ag-grid-community/src/utils/date.ts
+++ b/packages/ag-grid-community/src/utils/date.ts
@@ -179,6 +179,10 @@ export function _parseDateTimeFromString(value?: string | null, bailIfInvalidTim
         return null;
     }
 
+    if (!timeStr && bailIfInvalidTime) {
+        return null;
+    }
+
     if (!timeStr || timeStr === '00:00:00') {
         return date;
     }


### PR DESCRIPTION
- Added explicit DATE_TIME_REGEXP test in parseDateTime for stricter validation

Fixes [AG-15659](https://ag-grid.atlassian.net/browse/AG-15659)