### PR TITLE
(angular) : Lazy load modules ag-grid-angular

### DIFF
--- a/packages/ag-grid-angular/projects/ag-grid-angular/README.md
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/README.md
@@ -211,8 +211,8 @@ ModuleRegistry.registerModules([AllCommunityModule]);
 To take advantage of Angular’s lazy provider loading and reduce bundle size, use the `provideAgGrid` helper as shown below.
 
 ```ts
-import { provideAgGrid, AgGridService } from 'ag-grid-angular';
-import { ApplicationConfig, provideAppInitializer, inject } from '@angular/core';
+import { provideAgGrid } from 'ag-grid-angular';
+import { ApplicationConfig } from '@angular/core';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -226,18 +226,6 @@ export const appConfig: ApplicationConfig = {
       options: () => Promise.resolve({ domLayout: 'autoHeight' }),
       licenseKey: '-----' // Add your license key for enterprise
     }),
-    // angular 18+ uses `provideAppInitializer` to load the grid service
-    provideAppInitializer(async () => {
-      const agGridService = inject(AgGridService);
-      await agGridService.load();
-    }),
-    // Angular < 18 (Traditional APP_INITIALIZER)
-    {
-      provide: APP_INITIALIZER,
-      useFactory: (agGridService: AgGridService) => async () => await agGridService.load(),
-      deps: [AgGridService],
-      multi: true
-    }
   ]
 };
 ```

--- a/packages/ag-grid-angular/projects/ag-grid-angular/README.md
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/README.md
@@ -206,6 +206,41 @@ ModuleRegistry.registerModules([AllCommunityModule]);
     <p>To minimize bundle size, only register the modules you want to use. See the <a href="https://www.ag-grid.com/angular-data-grid/modules/">Modules</a> page for more information.</p>
 </blockquote>
 
+---
+
+**1.1 Register Modules (Lazy Loading)**
+
+To take advantage of Angular’s lazy provider loading and reduce bundle size, use the `provideAgGrid` helper as shown below.
+
+```ts
+import { provideAgGrid, AgGridService } from 'ag-grid-angular';
+import { ApplicationConfig, provideAppInitializer, inject } from '@angular/core';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideAgGrid({
+      modules: () => import('ag-grid-community').then(m => [m.AllCommunityModule]),
+      // or only specific modules
+      // modules: () => import('ag-grid-community').then(m => [m.ClientSideRowModelModule, m.CsvExportModule]),
+      options: () => Promise.resolve({ domLayout: 'autoHeight' }),
+      licenseKey: '-----' // Add your license key for enterprise
+    }),
+    // angular 18+ uses `provideAppInitializer` to load the grid service
+    provideAppInitializer(() => {
+      const agGridService = inject(AgGridService);
+      agGridService.load();
+    }),
+    // Angular < 18 (Traditional APP_INITIALIZER)
+    {
+      provide: APP_INITIALIZER,
+      useFactory: (agGridService: AgGridService) => () => agGridService.load(),
+      deps: [AgGridService],
+      multi: true
+    }
+  ]
+};
+```
+
 **2. Import the Angular Data Grid**
 
 ```js

--- a/packages/ag-grid-angular/projects/ag-grid-angular/README.md
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/README.md
@@ -219,21 +219,24 @@ import { ApplicationConfig, provideAppInitializer, inject } from '@angular/core'
 export const appConfig: ApplicationConfig = {
   providers: [
     provideAgGrid({
-      modules: () => import('ag-grid-community').then(m => [m.AllCommunityModule]),
-      // or only specific modules
-      // modules: () => import('ag-grid-community').then(m => [m.ClientSideRowModelModule, m.CsvExportModule]),
+      modules: async () => {
+        const { AllCommunityModule } = await import('ag-grid-community');
+        // or only specific modules
+        // const { ClientSideRowModelModule, CsvExportModule} = await import('ag-grid-community');
+        return [AllCommunityModule]
+      },
       options: () => Promise.resolve({ domLayout: 'autoHeight' }),
       licenseKey: '-----' // Add your license key for enterprise
     }),
     // angular 18+ uses `provideAppInitializer` to load the grid service
-    provideAppInitializer(() => {
+    provideAppInitializer(async () => {
       const agGridService = inject(AgGridService);
-      agGridService.load();
+      await agGridService.load();
     }),
     // Angular < 18 (Traditional APP_INITIALIZER)
     {
       provide: APP_INITIALIZER,
-      useFactory: (agGridService: AgGridService) => () => agGridService.load(),
+      useFactory: (agGridService: AgGridService) => async () => await agGridService.load(),
       deps: [AgGridService],
       multi: true
     }

--- a/packages/ag-grid-angular/projects/ag-grid-angular/README.md
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/README.md
@@ -206,8 +206,6 @@ ModuleRegistry.registerModules([AllCommunityModule]);
     <p>To minimize bundle size, only register the modules you want to use. See the <a href="https://www.ag-grid.com/angular-data-grid/modules/">Modules</a> page for more information.</p>
 </blockquote>
 
----
-
 **1.1 Register Modules (Lazy Loading)**
 
 To take advantage of Angular’s lazy provider loading and reduce bundle size, use the `provideAgGrid` helper as shown below.

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.provider.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.provider.ts
@@ -1,9 +1,29 @@
-import { EnvironmentProviders, InjectionToken, makeEnvironmentProviders } from '@angular/core';
+import { APP_INITIALIZER, EnvironmentProviders, InjectionToken, makeEnvironmentProviders } from '@angular/core';
 
+import { AgGridService } from './ag-grid-angular.service';
 import type { AgGridProviderConfig } from './interfaces';
 
 export const AG_GRID_PROVIDER_CONFIG = new InjectionToken<AgGridProviderConfig>('AG_GRID_PROVIDER_CONFIG');
 
 export function provideAgGrid(config: AgGridProviderConfig = {}): EnvironmentProviders {
-    return makeEnvironmentProviders([{provide: AG_GRID_PROVIDER_CONFIG, useValue: config }]);
+    return makeEnvironmentProviders([
+      {
+        provide: AG_GRID_PROVIDER_CONFIG,
+        useValue: config
+      },
+      /**
+       * TODO: for angular 18+ we should use `provideAppInitializer`
+       * instead of `APP_INITIALIZER` to avoid the warning
+       *     provideAppInitializer(async () => {
+       *       const agGridService = inject(AgGridService);
+       *       await agGridService.load();
+       *     }),
+       */
+      {
+        provide: APP_INITIALIZER,
+        useFactory: (agGridService: AgGridService) => async () => await agGridService.load(),
+        deps: [AgGridService],
+        multi: true
+      }
+    ]);
 }

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.provider.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.provider.ts
@@ -1,0 +1,9 @@
+import { EnvironmentProviders, InjectionToken, makeEnvironmentProviders } from '@angular/core';
+
+import type { AgGridProviderConfig } from './interfaces';
+
+export const AG_GRID_PROVIDER_CONFIG = new InjectionToken<AgGridProviderConfig>('AG_GRID_PROVIDER_CONFIG');
+
+export function provideAgGrid(config: AgGridProviderConfig = {}): EnvironmentProviders {
+    return makeEnvironmentProviders([{provide: AG_GRID_PROVIDER_CONFIG, useValue: config }]);
+}

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.provider.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.provider.ts
@@ -10,7 +10,7 @@ export function provideAgGrid(config: AgGridProviderConfig = {}): EnvironmentPro
         useValue: config
       },
       /**
-       * TODO: for angular 18+ we should use `provideAppInitializer`
+       * TODO: for angular 19+ we should use `provideAppInitializer`
        * instead of `APP_INITIALIZER` to avoid the warning
        *     provideAppInitializer(async () => {
        *       const agGridService = inject(AgGridService);

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.provider.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.provider.ts
@@ -1,9 +1,7 @@
-import { APP_INITIALIZER, EnvironmentProviders, InjectionToken, makeEnvironmentProviders } from '@angular/core';
+import { APP_INITIALIZER, EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
 
-import { AgGridService } from './ag-grid-angular.service';
+import { AgGridService, AG_GRID_PROVIDER_CONFIG } from './ag-grid-angular.service';
 import type { AgGridProviderConfig } from './interfaces';
-
-export const AG_GRID_PROVIDER_CONFIG = new InjectionToken<AgGridProviderConfig>('AG_GRID_PROVIDER_CONFIG');
 
 export function provideAgGrid(config: AgGridProviderConfig = {}): EnvironmentProviders {
     return makeEnvironmentProviders([

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.service.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.service.ts
@@ -9,20 +9,20 @@ export class AgGridService {
 
     private async loadAgGridWithModules() {
         const config = this.config;
-        const agGridCommunity = await import('ag-grid-community');
+        const { ModuleRegistry, provideGlobalGridOptions } = await import('ag-grid-community');
         if (config.modules){
           const modules = await Promise.all(config.modules());
-          agGridCommunity.ModuleRegistry.registerModules(modules);
+          ModuleRegistry.registerModules(modules);
         }
         // If a global grid options function is provided, set it for ag-Grid Community
         if (config.options){
           const options = await config.options();
-          agGridCommunity.provideGlobalGridOptions(options);
+          provideGlobalGridOptions(options);
         }
         // If a license key is provided, set it for ag-Grid Enterprise
         if (config.licenseKey){
-          const agGridEnterprise = await import('ag-grid-enterprise');
-          agGridEnterprise.LicenseManager.setLicenseKey(config.licenseKey);
+          const { LicenseManager } = await import('ag-grid-enterprise');
+          LicenseManager.setLicenseKey(config.licenseKey);
         }
     }
 

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.service.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.service.ts
@@ -26,7 +26,7 @@ export class AgGridService {
         }
     }
 
-    public load(): void {
-        this.loadAgGridWithModules().then();
+    public async load() {
+        await this.loadAgGridWithModules();
     }
 }

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.service.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.service.ts
@@ -1,7 +1,8 @@
-import { inject, Injectable } from '@angular/core';
+import { inject, Injectable, InjectionToken } from '@angular/core';
 
-import { AG_GRID_PROVIDER_CONFIG } from './ag-grid-angular.provider';
 import { AgGridProviderConfig } from './interfaces';
+
+export const AG_GRID_PROVIDER_CONFIG = new InjectionToken<AgGridProviderConfig>('AG_GRID_PROVIDER_CONFIG');
 
 @Injectable({ providedIn: 'root' })
 export class AgGridService {

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.service.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.service.ts
@@ -11,7 +11,7 @@ export class AgGridService {
         const config = this.config;
         const { ModuleRegistry, provideGlobalGridOptions } = await import('ag-grid-community');
         if (config.modules){
-          const modules = await Promise.all(config.modules());
+          const modules = await config.modules();
           ModuleRegistry.registerModules(modules);
         }
         // If a global grid options function is provided, set it for ag-Grid Community

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.service.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.service.ts
@@ -1,0 +1,32 @@
+import { inject, Injectable } from '@angular/core';
+
+import { AG_GRID_PROVIDER_CONFIG } from './ag-grid-angular.provider';
+import { AgGridProviderConfig } from './interfaces';
+
+@Injectable({ providedIn: 'root' })
+export class AgGridService {
+    private readonly config = inject<AgGridProviderConfig>(AG_GRID_PROVIDER_CONFIG);
+
+    private async loadAgGridWithModules() {
+        const config = this.config;
+        const agGridCommunity = await import('ag-grid-community');
+        if (config.modules){
+          const modules = await Promise.all(config.modules());
+          agGridCommunity.ModuleRegistry.registerModules(modules);
+        }
+        // If a global grid options function is provided, set it for ag-Grid Community
+        if (config.options){
+          const options = await config.options();
+          agGridCommunity.provideGlobalGridOptions(options);
+        }
+        // If a license key is provided, set it for ag-Grid Enterprise
+        if (config.licenseKey){
+          const agGridEnterprise = await import('ag-grid-enterprise');
+          agGridEnterprise.LicenseManager.setLicenseKey(config.licenseKey);
+        }
+    }
+
+    public load(): void {
+        this.loadAgGridWithModules().then();
+    }
+}

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/interfaces.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/interfaces.ts
@@ -3,6 +3,7 @@ import type {
     FilterDisplayParams,
     FloatingFilterDisplay,
     FloatingFilterDisplayParams,
+    GridOptions,
     ICellEditor,
     ICellEditorParams,
     ICellEditorRendererParams,
@@ -32,6 +33,7 @@ import type {
     IToolPanel,
     IToolPanelParams,
     ITooltipParams,
+    Module,
 } from 'ag-grid-community';
 
 export interface AgFrameworkComponent<T> {
@@ -94,3 +96,9 @@ export interface IToolPanelAngularComp extends AgFrameworkComponent<IToolPanelPa
 export interface ITooltipAngularComp extends AgFrameworkComponent<ITooltipParams> {}
 
 export interface IMenuItemAngularComp extends AgFrameworkComponent<IMenuItemParams>, IMenuItem {}
+
+export interface AgGridProviderConfig {
+    modules?: () => Promise<Module>[],
+    options?: () => Promise<GridOptions>;
+    licenseKey?: string;
+}

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/interfaces.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/interfaces.ts
@@ -98,7 +98,7 @@ export interface ITooltipAngularComp extends AgFrameworkComponent<ITooltipParams
 export interface IMenuItemAngularComp extends AgFrameworkComponent<IMenuItemParams>, IMenuItem {}
 
 export interface AgGridProviderConfig {
-    modules?: () => Promise<Module>[],
+    modules?: () => Promise<Module[]>;
     options?: () => Promise<GridOptions>;
     licenseKey?: string;
 }

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/public-api.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/public-api.ts
@@ -1,5 +1,7 @@
 export * from './lib/ag-grid-angular.component';
 export * from './lib/ag-grid-angular.module';
+export * from './lib/ag-grid-angular.service';
+export * from './lib/ag-grid-angular.provider';
 export * from './lib/interfaces';
 export * from './lib/angularFrameworkComponentWrapper';
 export * from './lib/angularFrameworkOverrides';

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/public-api.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/public-api.ts
@@ -1,6 +1,5 @@
 export * from './lib/ag-grid-angular.component';
 export * from './lib/ag-grid-angular.module';
-export * from './lib/ag-grid-angular.service';
 export * from './lib/ag-grid-angular.provider';
 export * from './lib/interfaces';
 export * from './lib/angularFrameworkComponentWrapper';


### PR DESCRIPTION
💡 Why This Change?

This PR updates the documentation to demonstrate how to lazy load **Ag Grid modules in Angular 17+** using the new provideAgGrid` API.

🆕 What's Included

  - Example using modules and options as lazy-loaded promises with import().
  - Initialization via provideAppInitializer (Angular 18+) or APP_INITIALIZER (<18).

✅ Benefits

  - Smarter lazy-loading: theme selection can affect which assets are included.
  - Smaller initial bundle size: no need to eagerly include all themes or configuration up front.
  - Aligns with Angular 17+ best practices.
  - Encourages module-level tree-shaking and performance optimization.
  
  
Here is the link to the full example on StackBlitz: 🔗 https://stackblitz.com/edit/stackblitz-starters-esfzg2pw?file=src%2Fmain.ts

Without lazy loading, the compiled main.js file exceeds 1 MB and includes all Ag Grid modules

<img width="761" height="183" alt="Screenshot 2025-08-02 at 01 29 32" src="https://github.com/user-attachments/assets/1776ddb5-cf21-44b0-b3eb-10a72497fd54" />

With lazy loading enabled, we can clearly observe that the Ag Grid modules are split into a separate chunk, which helps reduce the initial bundle size and improves load performance.

<img width="798" height="376" alt="Screenshot 2025-08-02 at 01 28 16" src="https://github.com/user-attachments/assets/6414b348-3b61-45e9-8c41-3e41f812de18" />

