### PR TITLE
[AG-15659] Fix(celldatatypes): regression when columns contain guids they are incorrectly inferred as datestring cell data type

### DIFF
--- a/packages/ag-grid-community/src/utils/date.ts
+++ b/packages/ag-grid-community/src/utils/date.ts
@@ -139,7 +139,7 @@ export function _isValidDate(value?: string | null, bailIfInvalidTime = false): 
 
 // check if dateTime is a valid date and has time parts
 export function _isValidDateTime(value?: string | null): boolean {
-    return !!value && _isValidDate(value, true) && !!value.match(DATE_TIME_REGEXP)?.[1]; // matches the 'T14:22:19' part
+    return _isValidDate(value, true);
 }
 
 /**
@@ -152,6 +152,10 @@ export function _isValidDateTime(value?: string | null): boolean {
  */
 export function _parseDateTimeFromString(value?: string | null, bailIfInvalidTime = false): Date | null {
     if (!value) {
+        return null;
+    }
+
+    if (!DATE_TIME_REGEXP.test(value)) {
         return null;
     }
 
@@ -172,6 +176,10 @@ export function _parseDateTimeFromString(value?: string | null, bailIfInvalidTim
 
     if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
         // date was not parsed as expected so must have been invalid
+        return null;
+    }
+
+    if (!timeStr && bailIfInvalidTime) {
         return null;
     }
 


### PR DESCRIPTION
- Removed redundant time part regex check in _isValidDateTime
- Added DATE_TIME_REGEXP validation in parseDateTime for format consistency
- Introduced explicit null return for invalid time strings when required
- Simplified date-time validation to rely solely on _isValidDate
- Ensured proper handling of time components during parsing

Fix AG-15659