### PR TITLE
AG-15709 allow indeterminate checkboxes on tree groups

### DIFF
--- a/packages/ag-grid-community/src/rendering/cellRenderers/checkboxCellRenderer.ts
+++ b/packages/ag-grid-community/src/rendering/cellRenderers/checkboxCellRenderer.ts
@@ -95,9 +95,11 @@ export class CheckboxCellRenderer extends Component implements ICellRenderer {
                     // if we're grouping by this column then the value is a string and we need to parse it
                     isSelected = value == null || (value as any) === '' ? undefined : (value as any) === 'true';
                 } else if (node.aggData && node.aggData[colId] !== undefined) {
-                    isSelected = value ?? undefined;
+                    isSelected = value ?? undefined; // group with aggregation
+                } else if (node.sourceRowIndex >= 0) {
+                    isSelected = value ?? undefined; // tree group with data
                 } else {
-                    displayed = false;
+                    displayed = false; // group without aggregation or tree filler node without aggregation
                 }
             }
         } else {


### PR DESCRIPTION
Fix the condition to allow checkboxes to be indeterminate when using tree data groups that are not filler nodes

Fix AG-15709