### PR TITLE
feat: enable configuration of `appRoot`

### DIFF
--- a/packages/ag-grid-community/src/dragAndDrop/dragAndDropService.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/dragAndDropService.ts
@@ -10,7 +10,7 @@ import type { BeanCollection } from '../context/context';
 import type { CtrlsService } from '../ctrlsService';
 import type { Environment } from '../environment';
 import { _stampTopLevelGridCompWithGridInstance } from '../gridBodyComp/mouseEventUtils';
-import { _addGridCommonParams, _anchorElementToMouseMoveEvent, _getPageBody } from '../gridOptionsUtils';
+import { _addGridCommonParams, _anchorElementToMouseMoveEvent, _getAppRoot } from '../gridOptionsUtils';
 import type { AgGridCommon } from '../interfaces/iCommon';
 import type { DragItem } from '../interfaces/iDragItem';
 import { _warn } from '../validation/logging';
@@ -589,7 +589,7 @@ export class DragAndDropService extends BeanStub implements NamedBean {
         eGui.style.top = '20px';
         eGui.style.left = '20px';
 
-        const targetEl = _getPageBody(this.beans);
+        const targetEl = _getAppRoot(this.beans);
 
         this.dragAndDropImageParent = targetEl;
 

--- a/packages/ag-grid-community/src/entities/gridOptions.ts
+++ b/packages/ag-grid-community/src/entities/gridOptions.ts
@@ -298,6 +298,11 @@ export interface GridOptions<TData = any> {
      * DOM element to use as the popup parent for grid popups (context menu, column menu etc).
      */
     popupParent?: HTMLElement | null;
+    /**
+     * DOM element that is used as the root of the application.
+     */
+    appRoot?: HTMLElement | null;
+
 
     // *** Clipboard *** //
     /**
@@ -506,9 +511,9 @@ export interface GridOptions<TData = any> {
      * @agModule `ColumnAutoSizeModule`
      */
     autoSizeStrategy?:
-        | SizeColumnsToFitGridStrategy
-        | SizeColumnsToFitProvidedWidthStrategy
-        | SizeColumnsToContentStrategy;
+    | SizeColumnsToFitGridStrategy
+    | SizeColumnsToFitProvidedWidthStrategy
+    | SizeColumnsToContentStrategy;
 
     // *** Components *** //
     /**
@@ -2889,7 +2894,7 @@ export interface ChartRef {
     setMaximized: (maximized: boolean) => void;
 }
 
-export interface ChartRefParams<TData = any, TContext = any> extends AgGridCommon<TData, TContext>, ChartRef {}
+export interface ChartRefParams<TData = any, TContext = any> extends AgGridCommon<TData, TContext>, ChartRef { }
 
 export interface ServerSideGroupLevelParams {
     /**
@@ -2908,7 +2913,7 @@ export interface ServerSideGroupLevelParams {
 
 /**
  * @deprecated use ServerSideGroupLevelParams instead */
-export interface ServerSideStoreParams extends ServerSideGroupLevelParams {}
+export interface ServerSideStoreParams extends ServerSideGroupLevelParams { }
 
 export interface LoadingCellRendererSelectorFunc<TData = any, TValue = any, TContext = any> {
     (params: ILoadingCellRendererParams<TData, TValue, TContext>): LoadingCellRendererSelectorResult | undefined;

--- a/packages/ag-grid-community/src/gridOptionsUtils.ts
+++ b/packages/ag-grid-community/src/gridOptionsUtils.ts
@@ -1,7 +1,7 @@
 import { _getDocument, _getRootNode } from './agStack/utils/document';
 import { _getElementRectWithOffset } from './agStack/utils/dom';
 import { _doOnce } from './agStack/utils/function';
-import { _missing } from './agStack/utils/generic';
+import { _exists, _missing } from './agStack/utils/generic';
 import type { GridApi } from './api/gridApi';
 import type { BeanCollection } from './context/context';
 import type {
@@ -175,9 +175,14 @@ export function _setDomData(gos: GridOptionsService, element: Element, key: stri
     domData[key] = value;
 }
 
-export function _getPageBody(beans: BeanCollection): HTMLElement | ShadowRoot {
+export function _getAppRoot(beans: BeanCollection): HTMLElement | ShadowRoot {
     let rootNode: Document | ShadowRoot | HTMLElement | null = null;
     let targetEl: HTMLElement | ShadowRoot | null = null;
+
+    const { appRoot } = beans.gridOptions
+    if (appRoot && _exists(appRoot)) {
+        return appRoot
+    }
 
     try {
         rootNode = _getDocument(beans).fullscreenElement as HTMLElement;
@@ -203,14 +208,14 @@ export function _getPageBody(beans: BeanCollection): HTMLElement | ShadowRoot {
     return targetEl;
 }
 
-function _getBodyWidth(beans: BeanCollection): number {
-    const body = _getPageBody(beans) as HTMLElement;
-    return body?.clientWidth ?? (window.innerWidth || -1);
+function _getAppRootWidth(beans: BeanCollection): number {
+    const appRoot = _getAppRoot(beans) as HTMLElement;
+    return appRoot?.clientWidth ?? (window.innerWidth || -1);
 }
 
-function _getBodyHeight(beans: BeanCollection): number {
-    const body = _getPageBody(beans) as HTMLElement;
-    return body?.clientHeight ?? (window.innerHeight || -1);
+function _getAppRootHeight(beans: BeanCollection): number {
+    const appRoot = _getAppRoot(beans) as HTMLElement;
+    return appRoot?.clientHeight ?? (window.innerHeight || -1);
 }
 
 export function _anchorElementToMouseMoveEvent(
@@ -221,8 +226,8 @@ export function _anchorElementToMouseMoveEvent(
     const eRect = element.getBoundingClientRect();
     const height = eRect.height;
 
-    const browserWidth = _getBodyWidth(beans) - 2; // 2px for 1px borderLeft and 1px borderRight
-    const browserHeight = _getBodyHeight(beans) - 2; // 2px for 1px borderTop and 1px borderBottom
+    const browserWidth = _getAppRootWidth(beans) - 2; // 2px for 1px borderLeft and 1px borderRight
+    const browserHeight = _getAppRootHeight(beans) - 2; // 2px for 1px borderTop and 1px borderBottom
 
     const offsetParent = element.offsetParent;
 
@@ -343,8 +348,8 @@ export function _getRowIdCallback<TData = any>(
     gos: GridOptionsService
 ):
     | ((
-          params: WithoutGridCommon<ExtractParamsFromCallback<GetRowIdFunc<TData>>>
-      ) => ExtractReturnTypeFromCallback<GetRowIdFunc<TData>>)
+        params: WithoutGridCommon<ExtractParamsFromCallback<GetRowIdFunc<TData>>>
+    ) => ExtractReturnTypeFromCallback<GetRowIdFunc<TData>>)
     | undefined {
     const getRowId = gos.getCallback('getRowId');
 

--- a/packages/ag-grid-community/src/main.ts
+++ b/packages/ag-grid-community/src/main.ts
@@ -889,7 +889,7 @@ export {
     _canSkipShowingRowGroup,
     _getRowHeightAsNumber,
     _shouldUpdateColVisibilityAfterGroup,
-    _getPageBody,
+    _getAppRoot,
     _anchorElementToMouseMoveEvent,
     _getGroupAggFiltering,
     _isRowSelection,

--- a/packages/ag-grid-enterprise/src/menu/contextMenu.ts
+++ b/packages/ag-grid-enterprise/src/menu/contextMenu.ts
@@ -24,7 +24,7 @@ import {
     _exists,
     _focusInto,
     _getGrandTotalRow,
-    _getPageBody,
+    _getAppRoot,
     _getRootNode,
     _isIOSUserAgent,
     _isKeyboardMode,
@@ -267,7 +267,7 @@ export class ContextMenuService extends BeanStub implements NamedBean, IContextM
         wrapperEl.appendChild(loadingIcon);
 
         const rootNode = _getRootNode(beans);
-        const targetEl = _getPageBody(beans);
+        const targetEl = _getAppRoot(beans);
 
         if (!targetEl) {
             _warn(54);


### PR DESCRIPTION
Some environments, e.g., MFEs, may not support attaching elements to `document.body`. For such environments, it may be necessary to configure an `appRoot` element that is used instead.