### PR TITLE
[AG-4640] Feature(tool-panel): allow tool panels built in and custom to render outside of the grid as a component in an external container

### DIFF
--- a/.idea/ag-grid.iml
+++ b/.idea/ag-grid.iml
@@ -167,6 +167,7 @@
       <excludeFolder url="file://$MODULE_DIR$/packages/ag-grid-react/dist" />
       <excludeFolder url="file://$MODULE_DIR$/packages/ag-grid-vue3/lib" />
       <excludeFolder url="file://$MODULE_DIR$/testing/shared/packages/ag-grid-community/dist" />
+      <excludeFolder url="file://$MODULE_DIR$/testing/performance/packages/ag-grid-community/dist" />
     </content>
     <content url="file://$MODULE_DIR$/grid-packages/ag-grid-docs/node_modules" />
     <content url="file://$MODULE_DIR$/packages/ag-grid-angular/dist" />

--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="JavaScriptLibraryMappings">
-    <file url="file://$PROJECT_DIR$" libraries="{@babel/preset-env, @babel/preset-react, @babel/preset-typescript, @babel/standalone, systemjs}" />
-    <file url="file://$PROJECT_DIR$/packages/ag-grid-angular/dist" libraries="{@babel/preset-env, @babel/preset-react, @babel/preset-typescript, @babel/standalone, systemjs}" />
     <excludedPredefinedLibrary name="HTML" />
   </component>
 </project>

--- a/community-modules/styles/src/internal/base/parts/_sidebar.scss
+++ b/community-modules/styles/src/internal/base/parts/_sidebar.scss
@@ -10,6 +10,15 @@
         background-color: var(--ag-control-panel-background-color);
     }
 
+    .ag-tool-panel-external {
+        display: flex;
+        flex-direction: row;
+    }
+
+    :where(.ag-tool-panel-external) .ag-tool-panel-wrapper {
+        flex-grow: 1;
+    }
+
     .ag-side-buttons {
         padding-top: calc(var(--ag-grid-size) * 4);
         width: calc(var(--ag-icon-size) + 4px);

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/index.html
@@ -1,0 +1,6 @@
+<div id="wrapper" class="example-wrapper">
+    <div id="advancedFilterParent" class="example-header">
+        <button onclick="passModal()">Open modal</button>
+    </div>
+    <div id="myGrid"></div>
+</div>

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/index.html
@@ -1,6 +1,6 @@
 <div id="wrapper" class="example-wrapper">
     <div id="advancedFilterParent" class="example-header">
-        <button onclick="passModal()">Open modal</button>
+        <button onclick="passModal('columns')">Open columns modal</button>
     </div>
     <div id="myGrid"></div>
 </div>

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/index.html
@@ -4,7 +4,7 @@
     </div>
     <div id="myGrid"></div>
 </div>
-<div id="modalDrawer" class="modal" onclick="toggleDrawer(e)">
+<div id="modalDrawer" class="modal">
     <div class="inner ag-theme-params-1">
         <div><button onclick="toggleDrawer()">Close</button></div>
         <div class="content"></div>

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/index.html
@@ -1,6 +1,6 @@
 <div id="wrapper" class="example-wrapper">
     <div id="advancedFilterParent" class="example-header">
-        <button onclick="passModal('columns')">Open columns modal</button>
+        <button onclick="passModal('columns')">Open tool panel modal</button>
     </div>
     <div id="myGrid"></div>
 </div>

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/index.html
@@ -4,3 +4,9 @@
     </div>
     <div id="myGrid"></div>
 </div>
+<div id="modalDrawer" class="modal" onclick="toggleDrawer(e)">
+    <div class="inner ag-theme-params-1">
+        <div><button onclick="toggleDrawer()">Close</button></div>
+        <div class="content"></div>
+    </div>
+</div>

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/main.ts
@@ -21,7 +21,7 @@ ModuleRegistry.registerModules([
 ]);
 
 let gridApi: GridApi<IOlympicData>;
-const toolPanel: ToolPanelDef = {
+const columnsToolPanel: ToolPanelDef = {
     id: 'columns',
     labelDefault: 'Modal',
     labelKey: 'columns',
@@ -30,10 +30,11 @@ const toolPanel: ToolPanelDef = {
     toolPanelParams: { suppressRowGroups: true, suppressValues: true, suppressPivotMode: true },
 };
 
-function passModal() {
+function passModal(toolPanelId: string = columnsToolPanel.id) {
     if (document.getElementById('modalDrawer')) {
         toggleDrawer();
-        gridApi.openToolPanel(toolPanel.id);
+        const drawer = document.getElementById('modalDrawer')!.querySelector('.content')!;
+        gridApi.openToolPanel(toolPanelId, drawer);
         return;
     }
     const modalDrawer = document.createElement('div');
@@ -47,15 +48,8 @@ function passModal() {
     modalDrawer.id = 'modalDrawer';
     modalDrawer.classList.add('modal', 'active');
     document.body.prepend(modalDrawer);
-    const drawer = document.querySelector('#modalDrawer .content')!;
-    gridApi.updateGridOptions({
-        sideBar: {
-            hideButtons: true,
-            hiddenByDefault: true,
-            toolPanels: [{ ...toolPanel, parent: drawer }] as ToolPanelDef[],
-        },
-    });
-    gridApi.openToolPanel(toolPanel.id);
+    const drawer = modalDrawer.querySelector('.content')!;
+    gridApi.openToolPanel(toolPanelId, drawer);
 }
 
 function toggleDrawer() {
@@ -78,7 +72,7 @@ const gridOptions: GridOptions<IOlympicData> = {
     ],
     defaultColDef: { flex: 1, minWidth: 100, filter: true },
     autoGroupColumnDef: { minWidth: 200 },
-    sideBar: { toolPanels: [toolPanel], hideButtons: true, hiddenByDefault: true },
+    sideBar: { toolPanels: [columnsToolPanel], hideButtons: true, hiddenByDefault: true },
 };
 
 // setup the grid after the page has finished loading

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/main.ts
@@ -1,0 +1,149 @@
+import type { GridApi, GridOptions } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    ModuleRegistry,
+    NumberFilterModule,
+    TextFilterModule,
+    ValidationModule,
+    createGrid,
+} from 'ag-grid-community';
+import { ColumnsToolPanelModule, FiltersToolPanelModule, PivotModule, SetFilterModule } from 'ag-grid-enterprise';
+
+ModuleRegistry.registerModules([
+    NumberFilterModule,
+    ClientSideRowModelModule,
+    ColumnsToolPanelModule,
+    FiltersToolPanelModule,
+    SetFilterModule,
+    PivotModule,
+    TextFilterModule,
+    ...(process.env.NODE_ENV !== 'production' ? [ValidationModule] : []),
+]);
+
+let gridApi: GridApi<IOlympicData>;
+const toolPanels = [
+    {
+        id: 'columns 1',
+        labelDefault: 'Inside grid',
+        labelKey: 'columns',
+        iconKey: 'columnsToolPanel',
+        toolPanel: 'agColumnsToolPanel',
+    },
+    {
+        id: 'filters 2',
+        labelDefault: 'Outside grid',
+        labelKey: 'filters',
+        iconKey: 'menu',
+        toolPanel: 'agFiltersToolPanel',
+        parent: document.getElementById('toolPanelParent'),
+    },
+    {
+        id: 'columns 3',
+        labelDefault: 'Popup/Modal/Drawer',
+        labelKey: 'columns',
+        iconKey: 'columnsToolPanel',
+        toolPanel: 'agColumnsToolPanel',
+    },
+];
+const sideBar = {
+    toolPanels,
+    defaultToolPanel: 'filters',
+};
+window.toggleMode = function toggleMode() {
+    const drawer = document.getElementById('modalDrawer')!;
+    const oldClass = drawer.classList.contains('modal')
+        ? 'modal'
+        : drawer.classList.contains('popup')
+          ? 'popup'
+          : 'drawer';
+    const nextClass = drawer.classList.contains('modal')
+        ? 'popup'
+        : drawer.classList.contains('popup')
+          ? 'drawer'
+          : 'modal';
+    drawer.classList.replace(oldClass, nextClass);
+};
+function createModal() {
+    if (document.getElementById('modalDrawer')) {
+        toggleDrawer();
+        return;
+    }
+    const modalDrawer = document.createElement('div');
+    modalDrawer.innerHTML = `
+        <div class="inner ag-theme-params-1">
+            <div>          
+                <p>Modal / Popup / Drawer Content</p>
+                <button onclick="toggleMode()">Toggle style</button>
+                <button onclick="toggleDrawer()">Close</button>
+            </div>
+            <div class="content"></div>
+        </div>
+    `;
+    modalDrawer.onclick = (e) => {
+        if (e.target === modalDrawer) toggleDrawer();
+    };
+    modalDrawer.id = 'modalDrawer';
+    modalDrawer.classList.add('modal', 'active');
+    document.body.prepend(modalDrawer);
+}
+window.passModal = function passModal() {
+    createModal();
+    const drawer = document.querySelector('#modalDrawer .content');
+    gridApi.updateGridOptions({
+        sideBar: {
+            ...sideBar,
+            toolPanels: Object.values({
+                ...toolPanels,
+                2: {
+                    ...toolPanels[2],
+                    parent: drawer,
+                },
+            }),
+        },
+    });
+    gridApi.openToolPanel(toolPanels[2].id);
+};
+window.toggleDrawer = function toggleDrawer() {
+    const drawer = document.getElementById('modalDrawer')!;
+    drawer.classList.toggle('active');
+    gridApi.closeToolPanel();
+};
+
+const gridOptions: GridOptions<IOlympicData> = {
+    columnDefs: [
+        { field: 'athlete', filter: 'agTextColumnFilter', minWidth: 200 },
+        { field: 'age' },
+        { field: 'country', minWidth: 180 },
+        { field: 'year' },
+        { field: 'date', minWidth: 150 },
+        { field: 'gold' },
+        { field: 'silver' },
+        { field: 'bronze' },
+        { field: 'total' },
+    ],
+    defaultColDef: {
+        flex: 1,
+        minWidth: 100,
+        // allow every column to be aggregated
+        enableValue: true,
+        // allow every column to be grouped
+        enableRowGroup: true,
+        // allow every column to be pivoted
+        enablePivot: true,
+        filter: true,
+    },
+    autoGroupColumnDef: {
+        minWidth: 200,
+    },
+    sideBar,
+};
+
+// setup the grid after the page has finished loading
+document.addEventListener('DOMContentLoaded', function () {
+    const gridDiv = document.querySelector<HTMLElement>('#myGrid')!;
+    gridApi = createGrid(gridDiv, gridOptions);
+
+    fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
+        .then((response) => response.json())
+        .then((data: IOlympicData[]) => gridApi!.setGridOption('rowData', data));
+});

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/main.ts
@@ -30,22 +30,6 @@ const columnsToolPanel: ToolPanelDef = {
     toolPanelParams: { suppressRowGroups: true, suppressValues: true, suppressPivotMode: true },
 };
 
-function passModal(toolPanelId: string = columnsToolPanel.id) {
-    toggleDrawer();
-    gridApi.openToolPanel(toolPanelId, document.querySelector<HTMLElement>('#modalDrawer .content'));
-}
-
-function toggleDrawer(e?: MouseEvent | TouchEvent) {
-    const drawer = document.getElementById('modalDrawer')!;
-    if (e && e.target !== drawer) return;
-    if (!drawer.classList.toggle('active')) {
-        gridApi.closeToolPanel();
-    }
-}
-
-window.passModal = passModal;
-window.toggleDrawer = toggleDrawer;
-
 const gridOptions: GridOptions<IOlympicData> = {
     popupParent: document.body,
     columnDefs: [
@@ -59,6 +43,21 @@ const gridOptions: GridOptions<IOlympicData> = {
     autoGroupColumnDef: { minWidth: 200 },
     sideBar: { toolPanels: [columnsToolPanel], hideButtons: true, hiddenByDefault: true },
 };
+
+function toggleDrawer() {
+    const drawer = document.getElementById('modalDrawer')!;
+    if (!drawer.classList.toggle('active')) {
+        gridApi.closeToolPanel();
+    }
+}
+
+function passModal(toolPanelId: string = columnsToolPanel.id) {
+    const drawer = document.getElementById('modalDrawer')!;
+    if (!drawer.classList.toggle('active')) {
+        gridApi.closeToolPanel();
+    }
+    gridApi.openToolPanel(toolPanelId, drawer.querySelector<HTMLElement>('.content'));
+}
 
 // setup the grid after the page has finished loading
 document.addEventListener('DOMContentLoaded', function () {

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/main.ts
@@ -31,31 +31,16 @@ const columnsToolPanel: ToolPanelDef = {
 };
 
 function passModal(toolPanelId: string = columnsToolPanel.id) {
-    if (document.getElementById('modalDrawer')) {
-        toggleDrawer();
-        const drawer = document.getElementById('modalDrawer')!.querySelector('.content')!;
-        gridApi.openToolPanel(toolPanelId, drawer);
-        return;
-    }
-    const modalDrawer = document.createElement('div');
-    modalDrawer.innerHTML = `
-        <div class="inner ag-theme-params-1">
-            <div><button onclick="toggleDrawer()">Close</button></div>
-            <div class="content"></div>
-        </div>
-    `;
-    modalDrawer.onclick = (e) => e.target === modalDrawer && toggleDrawer();
-    modalDrawer.id = 'modalDrawer';
-    modalDrawer.classList.add('modal', 'active');
-    document.body.prepend(modalDrawer);
-    const drawer = modalDrawer.querySelector('.content')!;
-    gridApi.openToolPanel(toolPanelId, drawer);
+    toggleDrawer();
+    gridApi.openToolPanel(toolPanelId, document.querySelector<HTMLElement>('#modalDrawer .content'));
 }
 
-function toggleDrawer() {
+function toggleDrawer(e?: MouseEvent | TouchEvent) {
     const drawer = document.getElementById('modalDrawer')!;
-    drawer.classList.toggle('active');
-    gridApi.closeToolPanel();
+    if (e && e.target !== drawer) return;
+    if (!drawer.classList.toggle('active')) {
+        gridApi.closeToolPanel();
+    }
 }
 
 window.passModal = passModal;

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/main.ts
@@ -1,4 +1,4 @@
-import type { GridApi, GridOptions } from 'ag-grid-community';
+import type { GridApi, GridOptions, ToolPanelDef } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ModuleRegistry,
@@ -21,105 +21,57 @@ ModuleRegistry.registerModules([
 ]);
 
 let gridApi: GridApi<IOlympicData>;
-const toolPanels = [
-    {
-        id: 'columns 1',
-        labelDefault: 'Inside grid',
-        labelKey: 'columns',
-        iconKey: 'columnsToolPanel',
-        toolPanel: 'agColumnsToolPanel',
-    },
-    {
-        id: 'filters 2',
-        labelDefault: 'Outside grid',
-        labelKey: 'filters',
-        iconKey: 'menu',
-        toolPanel: 'agFiltersToolPanel',
-        parent: document.getElementById('toolPanelParent'),
-    },
-    {
-        id: 'columns 3',
-        labelDefault: 'Popup/Modal/Drawer',
-        labelKey: 'columns',
-        iconKey: 'columnsToolPanel',
-        toolPanel: 'agColumnsToolPanel',
-    },
-];
-const sideBar = {
-    toolPanels,
-    defaultToolPanel: 'filters',
+const toolPanel: ToolPanelDef = {
+    id: 'columns',
+    labelDefault: 'Modal',
+    labelKey: 'columns',
+    iconKey: 'columnsToolPanel',
+    toolPanel: 'agColumnsToolPanel',
 };
-window.toggleMode = function toggleMode() {
-    const drawer = document.getElementById('modalDrawer')!;
-    const oldClass = drawer.classList.contains('modal')
-        ? 'modal'
-        : drawer.classList.contains('popup')
-          ? 'popup'
-          : 'drawer';
-    const nextClass = drawer.classList.contains('modal')
-        ? 'popup'
-        : drawer.classList.contains('popup')
-          ? 'drawer'
-          : 'modal';
-    drawer.classList.replace(oldClass, nextClass);
-};
-function createModal() {
+
+function passModal() {
     if (document.getElementById('modalDrawer')) {
         toggleDrawer();
+        gridApi.openToolPanel(toolPanel.id);
         return;
     }
     const modalDrawer = document.createElement('div');
     modalDrawer.innerHTML = `
         <div class="inner ag-theme-params-1">
-            <div>          
-                <p>Modal / Popup / Drawer Content</p>
-                <button onclick="toggleMode()">Toggle style</button>
-                <button onclick="toggleDrawer()">Close</button>
-            </div>
+            <div><button onclick="toggleDrawer()">Close</button></div>
             <div class="content"></div>
         </div>
     `;
-    modalDrawer.onclick = (e) => {
-        if (e.target === modalDrawer) toggleDrawer();
-    };
+    modalDrawer.onclick = (e) => e.target === modalDrawer && toggleDrawer();
     modalDrawer.id = 'modalDrawer';
     modalDrawer.classList.add('modal', 'active');
     document.body.prepend(modalDrawer);
-}
-window.passModal = function passModal() {
-    createModal();
-    const drawer = document.querySelector('#modalDrawer .content');
+    const drawer = document.querySelector('#modalDrawer .content')!;
     gridApi.updateGridOptions({
         sideBar: {
-            ...sideBar,
-            toolPanels: Object.values({
-                ...toolPanels,
-                2: {
-                    ...toolPanels[2],
-                    parent: drawer,
-                },
-            }),
+            hideButtons: true,
+            hiddenByDefault: true,
+            toolPanels: [{ ...toolPanel, parent: drawer }] as ToolPanelDef[],
         },
     });
-    gridApi.openToolPanel(toolPanels[2].id);
-};
-window.toggleDrawer = function toggleDrawer() {
+    gridApi.openToolPanel(toolPanel.id);
+}
+
+function toggleDrawer() {
     const drawer = document.getElementById('modalDrawer')!;
     drawer.classList.toggle('active');
     gridApi.closeToolPanel();
-};
+}
+
+window.passModal = passModal;
+window.toggleDrawer = toggleDrawer;
 
 const gridOptions: GridOptions<IOlympicData> = {
+    popupParent: document.body,
     columnDefs: [
         { field: 'athlete', filter: 'agTextColumnFilter', minWidth: 200 },
-        { field: 'age' },
         { field: 'country', minWidth: 180 },
-        { field: 'year' },
         { field: 'date', minWidth: 150 },
-        { field: 'gold' },
-        { field: 'silver' },
-        { field: 'bronze' },
-        { field: 'total' },
     ],
     defaultColDef: {
         flex: 1,
@@ -135,7 +87,7 @@ const gridOptions: GridOptions<IOlympicData> = {
     autoGroupColumnDef: {
         minWidth: 200,
     },
-    sideBar,
+    sideBar: { toolPanels: [toolPanel], hideButtons: true, hiddenByDefault: true },
 };
 
 // setup the grid after the page has finished loading

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/main.ts
@@ -27,6 +27,7 @@ const toolPanel: ToolPanelDef = {
     labelKey: 'columns',
     iconKey: 'columnsToolPanel',
     toolPanel: 'agColumnsToolPanel',
+    toolPanelParams: { suppressRowGroups: true, suppressValues: true, suppressPivotMode: true },
 };
 
 function passModal() {
@@ -72,21 +73,11 @@ const gridOptions: GridOptions<IOlympicData> = {
         { field: 'athlete', filter: 'agTextColumnFilter', minWidth: 200 },
         { field: 'country', minWidth: 180 },
         { field: 'date', minWidth: 150 },
+        { field: 'gold', minWidth: 150 },
+        { field: 'silver', minWidth: 150 },
     ],
-    defaultColDef: {
-        flex: 1,
-        minWidth: 100,
-        // allow every column to be aggregated
-        enableValue: true,
-        // allow every column to be grouped
-        enableRowGroup: true,
-        // allow every column to be pivoted
-        enablePivot: true,
-        filter: true,
-    },
-    autoGroupColumnDef: {
-        minWidth: 200,
-    },
+    defaultColDef: { flex: 1, minWidth: 100, filter: true },
+    autoGroupColumnDef: { minWidth: 200 },
     sideBar: { toolPanels: [toolPanel], hideButtons: true, hiddenByDefault: true },
 };
 

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/styles.css
@@ -49,8 +49,8 @@
     padding: 20px;
     border-radius: 10px;
     -webkit-font-smoothing: antialiased;
-    background-color: var(--ag-background-color, black);
-    color: var(--ag-text-color, white);
+    background-color: var(--ag-background-color, white);
+    color: var(--ag-text-color, black);
     color-scheme: var(--ag-browser-color-scheme);
     font-family: var(--ag-font-family, Arial), sans-serif;
     flex-direction: column;

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/styles.css
@@ -34,34 +34,14 @@
     align-items: center;
 }
 
-/* Popup style */
-#modalDrawer.popup {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-}
-
-#modalDrawer.modal,
-#modalDrawer.popup {
+#modalDrawer.modal {
     & .inner {
         min-width: 300px;
     }
 
     & .content {
-        min-height: 400px;
+        min-height: 200px;
     }
-}
-
-/* Side drawer style */
-#modalDrawer.drawer {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    width: 300px;
-    display: flex;
-    transform: translateX(-100%);
-    transition: transform 0.3s ease-in-out;
 }
 
 #modalDrawer .inner {
@@ -74,12 +54,4 @@
     color-scheme: var(--ag-browser-color-scheme);
     font-family: var(--ag-font-family, Arial), sans-serif;
     flex-direction: column;
-}
-
-#modalDrawer.drawer .content {
-    height: calc(100% - 90px);
-}
-
-#modalDrawer.drawer.active {
-    transform: translateX(0);
 }

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/styles.css
@@ -1,0 +1,85 @@
+.example-wrapper {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+#myGrid {
+    flex: 1 1 0;
+    width: 100%;
+}
+
+.example-header {
+    margin-bottom: 10px;
+}
+/* Base styles for the container */
+#modalDrawer {
+    display: none; /* Hidden by default */
+    z-index: 1000;
+}
+
+#modalDrawer.active {
+    display: flex;
+}
+
+/* Modal style */
+#modalDrawer.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    justify-content: center;
+    align-items: center;
+}
+
+/* Popup style */
+#modalDrawer.popup {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+#modalDrawer.modal,
+#modalDrawer.popup {
+    & .inner {
+        min-width: 300px;
+    }
+
+    & .content {
+        min-height: 400px;
+    }
+}
+
+/* Side drawer style */
+#modalDrawer.drawer {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    width: 300px;
+    display: flex;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease-in-out;
+}
+
+#modalDrawer .inner {
+    border: 1px solid;
+    padding: 20px;
+    border-radius: 10px;
+    -webkit-font-smoothing: antialiased;
+    background-color: var(--ag-background-color, black);
+    color: var(--ag-text-color, white);
+    color-scheme: var(--ag-browser-color-scheme);
+    font-family: var(--ag-font-family, Arial), sans-serif;
+    flex-direction: column;
+}
+
+#modalDrawer.drawer .content {
+    height: calc(100% - 90px);
+}
+
+#modalDrawer.drawer.active {
+    transform: translateX(0);
+}

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
@@ -198,7 +198,7 @@ If you are using the long form (providing a `SideBarDef` object) then it is poss
 
 ### Tool Panel Parent
 
-By default, Tool Panels are rendered inside the Side Bar. If you want to render Tool Panels in a different location, you can set the [parent](https://localhost:4610/javascript-data-grid/side-bar#reference-ToolPanelDef-parent) property in the `ToolPanelDef`. This is useful if you want to render Tool Panel in a different part of your application, such as a popup window or a separate section of your page.
+By default, Tool Panels are rendered inside the Side Bar. If you want to render Tool Panels in a different location, you can set the [parent](./side-bar#reference-ToolPanelDef-parent) property in the `ToolPanelDef`. This is useful if you want to render Tool Panel in a different part of your application, such as a popup window or a separate section of your page.
 
 It is also possible to call an api method `openToolPanel(toolPanelId, parent)` to open a Tool Panel in a different location. The `parent` parameter is the HTML element where the Tool Panel will be rendered.
 

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
@@ -196,6 +196,32 @@ If you are using the long form (providing a `SideBarDef` object) then it is poss
 
 {% gridExampleRunner title="Side Bar Fine Tuning" name="fine-tuning" /%}
 
+### Tool Panel Parent
+
+By default, Tool Panels are rendered inside the Side Bar. If you want to render Tool Panels in a different location, you can set the [parent](https://localhost:4610/javascript-data-grid/side-bar#reference-ToolPanelDef-parent) property in the `ToolPanelDef`. This is useful if you want to render Tool Panel in a different part of your application, such as a popup window or a separate section of your page.
+
+{% gridExampleRunner title="sadasd" name="tool-panel-parent" exampleHeight=600 /%}
+
+The example above demonstrates how to render the Columns Tool Panel in a different location by setting the `parent` property: 
+
+```{% frameworkTransform=true %}
+const gridOptions = {
+    sideBar: {
+        toolPanels: [
+            // ... other tool panels
+             {
+                id: 'filters',
+                labelDefault: 'Outside grid',
+                labelKey: 'filters',
+                iconKey: 'menu',
+                toolPanel: 'agFiltersToolPanel',
+                parent: document.getElementById('toolPanelParent'),
+            },
+        ]
+    }
+}
+```
+
 ## Providing Parameters to Tool Panels
 
 Parameters are passed to Tool Panels via the `toolPanelParams` object. For example, the following code snippet sets `suppressRowGroups: true` and `suppressValues: true` for the [Columns Tool Panel](./tool-panel-columns/).

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
@@ -86,6 +86,10 @@ The snippet above is demonstrated in the following example:
 Calling `setSideBarVisible(true)` when `sideBarDef.hideButtons` is set to true and no tool panel is open will not display anything.
 {% /note %}
 
+{% note %}
+Set `popupParent` to `document.body` (or a dedicated container) to ensure all popups (e.g., column tool panel menus) are fully visible when using a tool bar parent option.
+{% /note %}
+
 ## Configuration Shortcuts
 
 The `boolean` and `string` configurations are shortcuts for more detailed configurations. When you use a shortcut the grid replaces it with the equivalent long form of the configuration by building the equivalent `SideBarDef`.

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
@@ -204,7 +204,7 @@ The [Popup Parent](./context-menu/#popup-parent) must also be set to an element 
 
 {% gridExampleRunner title="Tool Panel Parent" name="tool-panel-parent" exampleHeight=600 /%}
 
-The example above demonstrates how to render the Columns Tool Panel in a different location by setting the `parent` property: 
+The example above demonstrates displaying the Columns Tool Panel in a modal. Popup Parent is set to the document body. Following configuration is used: 
 
 ```{% frameworkTransform=true %}
 const gridOptions = {

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
@@ -200,12 +200,15 @@ If you are using the long form (providing a `SideBarDef` object) then it is poss
 
 By default, Tool Panels are rendered inside the Side Bar. If you want to render Tool Panels in a different location, you can set the [parent](https://localhost:4610/javascript-data-grid/side-bar#reference-ToolPanelDef-parent) property in the `ToolPanelDef`. This is useful if you want to render Tool Panel in a different part of your application, such as a popup window or a separate section of your page.
 
-{% gridExampleRunner title="sadasd" name="tool-panel-parent" exampleHeight=600 /%}
+The [Popup Parent](./context-menu/#popup-parent) must also be set to an element that contains both the Tool Panel parent and the grid.
+
+{% gridExampleRunner title="Tool Panel Parent" name="tool-panel-parent" exampleHeight=600 /%}
 
 The example above demonstrates how to render the Columns Tool Panel in a different location by setting the `parent` property: 
 
 ```{% frameworkTransform=true %}
 const gridOptions = {
+    popupParent: document.body,
     sideBar: {
         toolPanels: [
             // ... other tool panels

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
@@ -200,30 +200,14 @@ If you are using the long form (providing a `SideBarDef` object) then it is poss
 
 By default, Tool Panels are rendered inside the Side Bar. If you want to render Tool Panels in a different location, you can set the [parent](https://localhost:4610/javascript-data-grid/side-bar#reference-ToolPanelDef-parent) property in the `ToolPanelDef`. This is useful if you want to render Tool Panel in a different part of your application, such as a popup window or a separate section of your page.
 
+It is also possible to call an api method `openToolPanel(toolPanelId, parent)` to open a Tool Panel in a different location. The `parent` parameter is the HTML element where the Tool Panel will be rendered.
+
 The [Popup Parent](./context-menu/#popup-parent) must also be set to an element that contains both the Tool Panel parent and the grid.
+
+The example below demonstrates how to use the `parent` property to render the Columns Tool Panel in a different location. The Side Bar is not visible, and the Columns Tool Panel is rendered in a modal dialog.
 
 {% gridExampleRunner title="Tool Panel Parent" name="tool-panel-parent" exampleHeight=600 /%}
 
-The example above demonstrates displaying the Columns Tool Panel in a modal. Popup Parent is set to the document body. Following configuration is used: 
-
-```{% frameworkTransform=true %}
-const gridOptions = {
-    popupParent: document.body,
-    sideBar: {
-        toolPanels: [
-            // ... other tool panels
-             {
-                id: 'filters',
-                labelDefault: 'Outside grid',
-                labelKey: 'filters',
-                iconKey: 'menu',
-                toolPanel: 'agFiltersToolPanel',
-                parent: document.getElementById('toolPanelParent'),
-            },
-        ]
-    }
-}
-```
 
 ## Providing Parameters to Tool Panels
 

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
@@ -87,7 +87,7 @@ Calling `setSideBarVisible(true)` when `sideBarDef.hideButtons` is set to true a
 {% /note %}
 
 {% note %}
-Set `popupParent` to `document.body` (or a dedicated container) to ensure all popups (e.g., column tool panel menus) are fully visible when using a tool bar parent option.
+The [Popup Parent](./context-menu/#popup-parent) must be set to an element that contains both the tool parent parent and the grid to ensure all popups (e.g., Columns Tool Panel context menus) are fully visible.
 {% /note %}
 
 ## Configuration Shortcuts

--- a/packages/ag-grid-community/project.json
+++ b/packages/ag-grid-community/project.json
@@ -28,7 +28,7 @@
       "dependsOn": ["@ag-grid-community/styles:build"],
       "inputs": ["{workspaceRoot}/community-modules/styles/*.*css"],
       "outputs": ["{projectRoot}/styles/**/*"],
-      "cache": true,
+      "cache": false,
       "command": "rsync -r ../../community-modules/styles/*.*css --delete styles",
       "options": {
         "cwd": "packages/ag-grid-community"

--- a/packages/ag-grid-community/src/agStack/core/baseEnvironment.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseEnvironment.ts
@@ -76,7 +76,7 @@ export abstract class BaseEnvironment<
         this.addDestroyFunc(() => this.mutationObserver.disconnect());
     }
 
-    public applyThemeClasses(el: HTMLElement) {
+    public applyThemeClasses(el: HTMLElement, extraClasses: string[] = []): void {
         const { theme } = this;
         let themeClass: string;
         if (theme) {
@@ -93,7 +93,7 @@ export abstract class BaseEnvironment<
         }
         if (themeClass) {
             const oldClass = el.className;
-            el.className = oldClass + (oldClass ? ' ' : '') + themeClass;
+            el.className = `${oldClass}${oldClass ? ' ' : ''}${themeClass}${extraClasses?.length ? ` ${extraClasses.join(' ')}` : ''}`;
         }
     }
 

--- a/packages/ag-grid-community/src/agStack/theming/shared/css/_reset.css
+++ b/packages/ag-grid-community/src/agStack/theming/shared/css/_reset.css
@@ -2,8 +2,8 @@
    one then don't forget the other */
 
 /* stylelint-disable-next-line selector-disallowed-list  */
-:where(.ag-root-wrapper, .ag-popup, .ag-dnd-ghost, .ag-chart),
-:where(.ag-root-wrapper, .ag-popup, .ag-dnd-ghost, .ag-chart) :where([class^='ag-']) {
+:where(.ag-root-wrapper, .ag-external, .ag-popup, .ag-dnd-ghost, .ag-chart),
+:where(.ag-root-wrapper, .ag-external, .ag-popup, .ag-dnd-ghost, .ag-chart) :where([class^='ag-']) {
     box-sizing: border-box;
 
     &::after,
@@ -33,6 +33,6 @@
    ::-ms-clear will ignore the whole block if it is placed in the above block */
 
 /* stylelint-disable-next-line selector-disallowed-list */
-:where(.ag-root-wrapper, .ag-popup, .ag-dnd-ghost, .ag-chart) :where([class^='ag-']) ::-ms-clear {
+:where(.ag-root-wrapper, ag-external, .ag-popup, .ag-dnd-ghost, .ag-chart) :where([class^='ag-']) ::-ms-clear {
     display: none;
 }

--- a/packages/ag-grid-community/src/agStack/theming/shared/css/_root.css
+++ b/packages/ag-grid-community/src/agStack/theming/shared/css/_root.css
@@ -3,6 +3,7 @@
 .ag-root-wrapper,
 .ag-popup,
 .ag-dnd-ghost,
+.ag-external,
 .ag-chart {
     line-height: normal;
     cursor: default;

--- a/packages/ag-grid-community/src/api/gridApi.ts
+++ b/packages/ag-grid-community/src/api/gridApi.ts
@@ -1310,7 +1310,7 @@ export interface _SideBarGridApi<TData> {
      * Optionally, provide a parent element to attach the tool panel to.
      * @agModule `SideBarModule`
      */
-    openToolPanel(key: string, parent?: Element | null): void;
+    openToolPanel(key: string, parent?: HTMLElement | null): void;
 
     /**
      * Closes the currently open tool panel (if any).

--- a/packages/ag-grid-community/src/api/gridApi.ts
+++ b/packages/ag-grid-community/src/api/gridApi.ts
@@ -1307,9 +1307,10 @@ export interface _SideBarGridApi<TData> {
 
     /**
      * Opens a particular tool panel. Provide the ID of the tool panel to open.
+     * Optionally, provide a parent element to attach the tool panel to.
      * @agModule `SideBarModule`
      */
-    openToolPanel(key: string): void;
+    openToolPanel(key: string, parent?: Element | null): void;
 
     /**
      * Closes the currently open tool panel (if any).

--- a/packages/ag-grid-community/src/interfaces/iSideBar.ts
+++ b/packages/ag-grid-community/src/interfaces/iSideBar.ts
@@ -12,7 +12,11 @@ export interface ISideBar {
     setDisplayed(show: boolean): void;
     setSideBarPosition(position?: 'left' | 'right'): void;
     isToolPanelShowing(): boolean;
-    openToolPanel(key: string, source?: 'sideBarButtonClicked' | 'sideBarInitializing' | 'api'): void;
+    openToolPanel(
+        key: string,
+        source?: 'sideBarButtonClicked' | 'sideBarInitializing' | 'api',
+        parent?: Element | null
+    ): void;
     getToolPanelInstance(key: string): IToolPanel | undefined;
     close(source?: 'sideBarButtonClicked' | 'sideBarInitializing' | 'api'): void;
     openedItem(): string | null;

--- a/packages/ag-grid-community/src/interfaces/iSideBar.ts
+++ b/packages/ag-grid-community/src/interfaces/iSideBar.ts
@@ -52,6 +52,12 @@ export interface ToolPanelDef {
     toolPanel?: any;
     /** Customise the parameters provided to the `toolPanel` component. */
     toolPanelParams?: any;
+
+    /**
+     * DOM element to use as the parent for the tool panel to allow it to appear outside the grid.
+     * Set to `null` or omit the property for tool panel to appear inside the grid.
+     */
+    parent?: HTMLElement | null;
 }
 
 export interface SideBarDef {

--- a/packages/ag-grid-community/src/interfaces/iSideBar.ts
+++ b/packages/ag-grid-community/src/interfaces/iSideBar.ts
@@ -15,7 +15,7 @@ export interface ISideBar {
     openToolPanel(
         key: string,
         source?: 'sideBarButtonClicked' | 'sideBarInitializing' | 'api',
-        parent?: Element | null
+        parent?: HTMLElement | null
     ): void;
     getToolPanelInstance(key: string): IToolPanel | undefined;
     close(source?: 'sideBarButtonClicked' | 'sideBarInitializing' | 'api'): void;

--- a/packages/ag-grid-enterprise/project.json
+++ b/packages/ag-grid-enterprise/project.json
@@ -36,7 +36,7 @@
       "dependsOn": ["@ag-grid-community/styles:build"],
       "inputs": ["{workspaceRoot}/community-modules/styles/*.*css"],
       "outputs": ["{projectRoot}/styles/**/*"],
-      "cache": true,
+      "cache": false,
       "command": "rsync -r ../../community-modules/styles/*.*css --delete styles",
       "options": {
         "cwd": "packages/ag-grid-enterprise"

--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.css
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.css
@@ -5,6 +5,15 @@
     width: var(--ag-side-bar-panel-width);
 }
 
+.ag-tool-panel-external {
+    display: flex;
+    flex-direction: row;
+}
+
+:where(.ag-tool-panel-external) .ag-tool-panel-wrapper {
+    flex-grow: 1;
+}
+
 .ag-select-agg-func-item {
     position: relative;
     align-items: center;

--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
@@ -1,7 +1,5 @@
 import type {
-    BeanCollection,
     ComponentSelector,
-    CtrlsService,
     ElementParams,
     ISideBar,
     IToolPanel,
@@ -47,7 +45,6 @@ const AgSideBarElement: ElementParams = {
 };
 class AgSideBar extends Component implements ISideBar {
     private readonly sideBarButtons: AgSideBarButtons = RefPlaceholder;
-    private ctrlsSvc: CtrlsService;
     private toolPanelWrappers: ToolPanelWrapper[] = [];
     private sideBar: SideBarDef | undefined;
     private position: 'left' | 'right';
@@ -57,15 +54,7 @@ class AgSideBar extends Component implements ISideBar {
         this.registerCSS(agSideBarCSS);
     }
 
-    wireBeans(beans: BeanCollection) {
-        this.ctrlsSvc = beans.ctrlsSvc;
-    }
-
     public postConstruct(): void {
-        this.ctrlsSvc.whenReady(this, () => this.setOutsideParent());
-        // todo basically have two routes: one sets the parent and the other stays as it is.
-        //   also need to subscribe to changes and redraw everything
-        //   look at advancedFilterCtrl.ts for clues
         this.sideBarButtons.addEventListener('sideBarButtonClicked', this.onToolPanelButtonClicked.bind(this));
         const { beans, gos } = this;
         const { sideBar: sideBarState } = gos.get('initialState') ?? {};
@@ -342,7 +331,11 @@ class AgSideBar extends Component implements ISideBar {
         wrapper.setDisplayed(false);
 
         const wrapperGui = wrapper.getGui();
-        this.appendChild(wrapperGui);
+        if (typeof def.parent?.appendChild === 'function') {
+            def.parent.appendChild(wrapperGui);
+        } else {
+            this.appendChild(wrapperGui);
+        }
 
         this.toolPanelWrappers.push(wrapper);
 

--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
@@ -29,7 +29,7 @@ import { findFocusableElementBeforeTabGuard, isTargetUnderManagedComponent } fro
 import { agSideBarCSS } from './agSideBar.css-GENERATED';
 import type { AgSideBarButtons, SideBarButtonClickedEvent } from './agSideBarButtons';
 import { AgSideBarButtonsSelector } from './agSideBarButtons';
-import { parseSideBarDef } from './sideBarDefParser';
+import { parseOneComponent, parseSideBarDef } from './sideBarDefParser';
 import type { SideBarService } from './sideBarService';
 import { ToolPanelWrapper } from './toolPanelWrapper';
 
@@ -349,24 +349,27 @@ class AgSideBar extends Component implements ISideBar {
         this.toolPanelWrappers.forEach((wrapper) => wrapper.refresh());
     }
 
+    private renderToolPanelUnderParent(key: string, parent: HTMLElement) {
+        const selfDefOrStr = this.sideBar?.toolPanels?.find((tp) => (typeof tp === 'string' ? tp : tp.id) === key);
+        // toolpanel def should exist, otherwise no way to find it by the key
+        if (selfDefOrStr) {
+            const panelDef = parseOneComponent(selfDefOrStr);
+            if (panelDef) {
+                const state = (this.gos.get('initialState') ?? {}).sideBar?.toolPanels?.[panelDef.id];
+                panelDef.parent = parent;
+                const wrapper = this.toolPanelWrappers.find((wrapper) => wrapper.getToolPanelId() === key);
+                this.createToolPanelAndSideButton(panelDef, state, wrapper);
+            }
+        }
+    }
+
     public openToolPanel(
         key: string | undefined,
         source: 'sideBarButtonClicked' | 'sideBarInitializing' | 'api' = 'api',
         parent?: HTMLElement | null
     ): void {
         if (parent && key) {
-            const selfDefOrStr = this.sideBar?.toolPanels?.find((tp) =>
-                typeof tp === 'string' ? tp === key : tp.id === key
-            );
-            const { sideBar: sideBarState } = this.gos.get('initialState') ?? {};
-            const selfDef = (
-                typeof selfDefOrStr === 'string' ? { id: selfDefOrStr, parent } : { ...(selfDefOrStr ?? {}), parent }
-            ) as ToolPanelDef;
-            this.createToolPanelAndSideButton(
-                selfDef,
-                sideBarState?.toolPanels?.[selfDef!.id],
-                this.toolPanelWrappers.find((wrapper) => wrapper.getToolPanelId() === key)
-            );
+            this.renderToolPanelUnderParent(key, parent);
         }
 
         const currentlyOpenedKey = this.openedItem();

--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
@@ -1,5 +1,7 @@
 import type {
+    BeanCollection,
     ComponentSelector,
+    CtrlsService,
     ElementParams,
     ISideBar,
     IToolPanel,
@@ -45,7 +47,7 @@ const AgSideBarElement: ElementParams = {
 };
 class AgSideBar extends Component implements ISideBar {
     private readonly sideBarButtons: AgSideBarButtons = RefPlaceholder;
-
+    private ctrlsSvc: CtrlsService;
     private toolPanelWrappers: ToolPanelWrapper[] = [];
     private sideBar: SideBarDef | undefined;
     private position: 'left' | 'right';
@@ -55,7 +57,15 @@ class AgSideBar extends Component implements ISideBar {
         this.registerCSS(agSideBarCSS);
     }
 
+    wireBeans(beans: BeanCollection) {
+        this.ctrlsSvc = beans.ctrlsSvc;
+    }
+
     public postConstruct(): void {
+        this.ctrlsSvc.whenReady(this, () => this.setOutsideParent());
+        // todo basically have two routes: one sets the parent and the other stays as it is.
+        //   also need to subscribe to changes and redraw everything
+        //   look at advancedFilterCtrl.ts for clues
         this.sideBarButtons.addEventListener('sideBarButtonClicked', this.onToolPanelButtonClicked.bind(this));
         const { beans, gos } = this;
         const { sideBar: sideBarState } = gos.get('initialState') ?? {};

--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
@@ -341,6 +341,9 @@ class AgSideBar extends Component implements ISideBar {
 
         if (def.parent instanceof HTMLElement) {
             this.environment.applyThemeClasses(def.parent);
+            wrapperGui.classList.add(this.gos.get('enableRtl') ? 'ag-rtl' : 'ag-ltr');
+            def.parent.classList.add('ag-external');
+            def.parent.classList.add('ag-tool-panel-external');
             def.parent.appendChild(wrapperGui);
         } else {
             this.appendChild(wrapperGui);

--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
@@ -351,8 +351,24 @@ class AgSideBar extends Component implements ISideBar {
 
     public openToolPanel(
         key: string | undefined,
-        source: 'sideBarButtonClicked' | 'sideBarInitializing' | 'api' = 'api'
+        source: 'sideBarButtonClicked' | 'sideBarInitializing' | 'api' = 'api',
+        parent?: Element | null
     ): void {
+        if (parent && key) {
+            const selfDefOrStr = this.sideBar?.toolPanels?.find((tp) =>
+                typeof tp === 'string' ? tp === key : tp.id === key
+            );
+            const { sideBar: sideBarState } = this.gos.get('initialState') ?? {};
+            const selfDef = (
+                typeof selfDefOrStr === 'string' ? { id: selfDefOrStr, parent } : { ...(selfDefOrStr ?? {}), parent }
+            ) as ToolPanelDef;
+            this.createToolPanelAndSideButton(
+                selfDef,
+                sideBarState?.toolPanels?.[selfDef!.id],
+                this.toolPanelWrappers.find((wrapper) => wrapper.getToolPanelId() === key)
+            );
+        }
+
         const currentlyOpenedKey = this.openedItem();
         if (currentlyOpenedKey === key) {
             return;

--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
@@ -1,6 +1,8 @@
 import type {
+    BeanCollection,
     ComponentSelector,
     ElementParams,
+    Environment,
     ISideBar,
     IToolPanel,
     IToolPanelParams,
@@ -48,10 +50,15 @@ class AgSideBar extends Component implements ISideBar {
     private toolPanelWrappers: ToolPanelWrapper[] = [];
     private sideBar: SideBarDef | undefined;
     private position: 'left' | 'right';
+    private environment: Environment;
 
     constructor() {
         super(AgSideBarElement, [AgSideBarButtonsSelector]);
         this.registerCSS(agSideBarCSS);
+    }
+
+    public wireBeans(beans: BeanCollection): void {
+        this.environment = beans.environment;
     }
 
     public postConstruct(): void {
@@ -114,7 +121,7 @@ class AgSideBar extends Component implements ISideBar {
 
         if (openPanel.contains(activeElement)) {
             nextEl = _findNextFocusableElement(beans, openPanel, undefined, true);
-        } else if (isTargetUnderManagedComponent(openPanel, target) && backwards) {
+        } else if (isTargetUnderManagedComponent(openPanel, target)) {
             nextEl = findFocusableElementBeforeTabGuard(openPanel, target);
         }
 
@@ -331,7 +338,9 @@ class AgSideBar extends Component implements ISideBar {
         wrapper.setDisplayed(false);
 
         const wrapperGui = wrapper.getGui();
-        if (typeof def.parent?.appendChild === 'function') {
+
+        if (def.parent instanceof HTMLElement) {
+            this.environment.applyThemeClasses(def.parent);
             def.parent.appendChild(wrapperGui);
         } else {
             this.appendChild(wrapperGui);

--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
@@ -352,7 +352,7 @@ class AgSideBar extends Component implements ISideBar {
     public openToolPanel(
         key: string | undefined,
         source: 'sideBarButtonClicked' | 'sideBarInitializing' | 'api' = 'api',
-        parent?: Element | null
+        parent?: HTMLElement | null
     ): void {
         if (parent && key) {
             const selfDefOrStr = this.sideBar?.toolPanels?.find((tp) =>

--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
@@ -1,8 +1,6 @@
 import type {
-    BeanCollection,
     ComponentSelector,
     ElementParams,
-    Environment,
     ISideBar,
     IToolPanel,
     IToolPanelParams,
@@ -50,15 +48,10 @@ class AgSideBar extends Component implements ISideBar {
     private toolPanelWrappers: ToolPanelWrapper[] = [];
     private sideBar: SideBarDef | undefined;
     private position: 'left' | 'right';
-    private environment: Environment;
 
     constructor() {
         super(AgSideBarElement, [AgSideBarButtonsSelector]);
         this.registerCSS(agSideBarCSS);
-    }
-
-    public wireBeans(beans: BeanCollection): void {
-        this.environment = beans.environment;
     }
 
     public postConstruct(): void {
@@ -338,16 +331,12 @@ class AgSideBar extends Component implements ISideBar {
         wrapper.setDisplayed(false);
 
         const wrapperGui = wrapper.getGui();
-
-        if (def.parent instanceof HTMLElement) {
-            this.environment.applyThemeClasses(def.parent);
+        const parent = def.parent instanceof HTMLElement ? def.parent : this;
+        if (parent === def.parent) {
+            this.beans.environment.applyThemeClasses(parent, ['ag-external', 'ag-tool-panel-external']);
             wrapperGui.classList.add(this.gos.get('enableRtl') ? 'ag-rtl' : 'ag-ltr');
-            def.parent.classList.add('ag-external');
-            def.parent.classList.add('ag-tool-panel-external');
-            def.parent.appendChild(wrapperGui);
-        } else {
-            this.appendChild(wrapperGui);
         }
+        parent.appendChild(wrapperGui);
 
         this.toolPanelWrappers.push(wrapper);
 

--- a/packages/ag-grid-enterprise/src/sideBar/sideBarApi.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/sideBarApi.ts
@@ -13,8 +13,8 @@ export function setSideBarPosition(beans: BeanCollection, position: 'left' | 'ri
     beans.sideBar?.comp.setSideBarPosition(position);
 }
 
-export function openToolPanel(beans: BeanCollection, key: string) {
-    beans.sideBar?.comp.openToolPanel(key, 'api');
+export function openToolPanel(beans: BeanCollection, key: string, parent?: Element | null) {
+    beans.sideBar?.comp.openToolPanel(key, 'api', parent);
 }
 
 export function closeToolPanel(beans: BeanCollection) {

--- a/packages/ag-grid-enterprise/src/sideBar/sideBarApi.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/sideBarApi.ts
@@ -13,7 +13,7 @@ export function setSideBarPosition(beans: BeanCollection, position: 'left' | 'ri
     beans.sideBar?.comp.setSideBarPosition(position);
 }
 
-export function openToolPanel(beans: BeanCollection, key: string, parent?: Element | null) {
+export function openToolPanel(beans: BeanCollection, key: string, parent?: HTMLElement | null) {
     beans.sideBar?.comp.openToolPanel(key, 'api', parent);
 }
 

--- a/packages/ag-grid-enterprise/src/sideBar/sideBarDefParser.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/sideBarDefParser.ts
@@ -87,21 +87,21 @@ function parseComponents(from?: (ToolPanelDef | string)[]): ToolPanelDef[] {
     }
 
     from.forEach((it: ToolPanelDef | string) => {
-        let toAdd: ToolPanelDef | null = null;
-        if (typeof it === 'string') {
-            const lookupResult = DEFAULT_BY_KEY[it];
-            if (!lookupResult) {
-                _warn(215, { key: it, defaultByKey: DEFAULT_BY_KEY });
-                return;
-            }
-
-            toAdd = lookupResult;
-        } else {
-            toAdd = it;
-        }
-
-        result.push(toAdd);
+        const parsed = parseOneComponent(it);
+        if (!parsed) return;
+        result.push(parsed);
     });
 
     return result;
+}
+
+export function parseOneComponent(it: ToolPanelDef | string): ToolPanelDef | null {
+    if (typeof it !== 'string') {
+        return it;
+    }
+    if (DEFAULT_BY_KEY[it]) {
+        return DEFAULT_BY_KEY[it];
+    }
+    _warn(215, { key: it, defaultByKey: DEFAULT_BY_KEY });
+    return null;
 }

--- a/testing/module-size/moduleDefinitions.ts
+++ b/testing/module-size/moduleDefinitions.ts
@@ -77,7 +77,7 @@ export const AllEnterpriseModules: Record<`${EnterpriseModuleName}Module`, numbe
     ServerSideRowModelApiModule: 19,
     ServerSideRowModelModule: 155.08,
     SetFilterModule: 152.16,
-    SideBarModule: 32,
+    SideBarModule: 33.16,
     SparklinesModule: 20,
     StatusBarModule: 27,
     TreeDataModule: 88.17,


### PR DESCRIPTION
Add external tool panel support and configuration options

 - Introduce `parent` property in SideBarDef to allow tool panels to render outside grid
 - Modify `openToolPanel()` api to accept second, optional `parent` parameter
 - Update docs
 - Disable cache for style synchronization in build configurations

Fixes [AG-4640](https://ag-grid.atlassian.net/browse/AG-4640)

Regular theme:
<img width="692" height="652" alt="Screenshot 2025-08-14 at 15 45 02" src="https://github.com/user-attachments/assets/b2cc69c0-3382-436f-91d9-116ab74eb022" />
As a modal window:
<img width="699" height="658" alt="Screenshot 2025-08-14 at 15 45 11" src="https://github.com/user-attachments/assets/bff2e153-fdf1-4ceb-9482-46dfadbfe39c" />
As a popup:
<img width="542" height="640" alt="Screenshot 2025-08-14 at 15 45 15" src="https://github.com/user-attachments/assets/73d23e20-a169-49af-9384-b166ad9e0235" />
As a sidedrawer:
<img width="427" height="708" alt="Screenshot 2025-08-14 at 15 45 18" src="https://github.com/user-attachments/assets/b0aab4c6-56c5-4364-a433-2ce12319ff6d" />
Legacy theme:
<img width="704" height="626" alt="Screenshot 2025-08-14 at 15 44 32" src="https://github.com/user-attachments/assets/f89ad9e6-4940-4b51-9ea4-5d16bd81f34a" />
Docs change:
<img width="870" height="793" alt="Screenshot 2025-08-19 at 11 52 50" src="https://github.com/user-attachments/assets/5d92347d-5db5-4204-b4f5-18e4910bf8cf" />
<img width="908" height="815" alt="Screenshot 2025-08-19 at 11 51 57" src="https://github.com/user-attachments/assets/acc6bc1a-d1b3-48fc-ae1a-05101d8fe9ef" />


