### PR TITLE
feat: implement textContentAsValue

### DIFF
--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -243,6 +243,12 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
     valueGetter?: string | ValueGetterFunc<TData, TValue>;
     /** A function or expression to format a value, should return a string. */
     valueFormatter?: string | ValueFormatterFunc<TData, TValue>;
+    /**
+     * Set to `true` to retrieve the DOM node's textContent as the cell value instead of using field/valueGetter.
+     * This is useful when you want to get the rendered text content from the cell's DOM element.
+     * @default false
+     */
+    textContentAsValue?: boolean;
     /** Provided a reference data map to be used to map column values to their respective value from the map. */
     refData?: { [key: string]: string };
     /**

--- a/packages/ag-grid-community/src/valueService/valueService.test.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.test.ts
@@ -112,3 +112,109 @@ describe('formatValue', () => {
         expect(formattedValue).toBe('1, 2, 3');
     });
 });
+
+describe('getValue with textContentAsValue', () => {
+    let valueService: ValueService;
+    let mockBeans: any;
+    let mockColumn: jest.Mocked<AgColumn>;
+    let mockRowNode: RowNode;
+    let colDef: ColDef;
+
+    beforeEach(() => {
+        valueService = new ValueService();
+
+        // Mock the beans collection
+        mockBeans = {
+            rowRenderer: {
+                getRowByPosition: jest.fn(),
+            },
+            spannedRowRenderer: null,
+        };
+
+        // Set up the value service with mocked beans
+        (valueService as any).beans = mockBeans;
+        (valueService as any).initialised = true;
+
+        colDef = {
+            field: 'testField',
+        };
+
+        mockColumn = mock<AgColumn>('getColDef', 'getColId', 'isFieldContainsDots');
+        mockColumn.getColDef.mockReturnValue(colDef);
+        mockColumn.getColId.mockReturnValue('testColumn');
+        mockColumn.isFieldContainsDots.mockReturnValue(false);
+
+        // Mock row node
+        mockRowNode = new RowNode(mockBeans as any);
+        mockRowNode.rowIndex = 0;
+        mockRowNode.rowPinned = null;
+        mockRowNode.data = { testField: 'Original Value' };
+    });
+
+    it('should return DOM textContent when textContentAsValue is true', () => {
+        colDef.textContentAsValue = true;
+
+        // Mock the row controller and cell controller to return DOM content
+        const mockCellCtrl = {
+            eGui: {
+                textContent: 'Test Cell Content',
+            },
+        };
+
+        const mockRowCtrl = {
+            getCellCtrl: jest.fn().mockReturnValue(mockCellCtrl),
+        };
+
+        mockBeans.rowRenderer.getRowByPosition.mockReturnValue(mockRowCtrl);
+
+        const result = valueService.getValue(mockColumn, mockRowNode);
+        expect(result).toBe('Test Cell Content');
+    });
+
+    it('should return normal field value when textContentAsValue is false', () => {
+        colDef.textContentAsValue = false;
+
+        const result = valueService.getValue(mockColumn, mockRowNode);
+        expect(result).toBe('Original Value');
+    });
+
+    it('should return undefined textContentAsValue is true but DOM element is not available', () => {
+        colDef.textContentAsValue = true;
+
+        // Mock beans to return null for row controller
+        mockBeans.rowRenderer.getRowByPosition.mockReturnValue(null);
+
+        const result = valueService.getValue(mockColumn, mockRowNode);
+        expect(result).toBe('Original Value');
+    });
+
+    it('should return undefined when textContentAsValue is true but cell controller is not available', () => {
+        colDef.textContentAsValue = true;
+
+        const mockRowCtrl = {
+            getCellCtrl: jest.fn().mockReturnValue(null),
+        };
+
+        mockBeans.rowRenderer.getRowByPosition.mockReturnValue(mockRowCtrl);
+
+        const result = valueService.getValue(mockColumn, mockRowNode);
+        expect(result).toBe('Original Value');
+    });
+
+    it('should return undefined when textContentAsValue is true but eGui is not available', () => {
+        colDef.textContentAsValue = true;
+
+        const mockCellCtrl = {
+            eGui: null,
+        };
+
+        const mockRowCtrl = {
+            getCellCtrl: jest.fn().mockReturnValue(mockCellCtrl),
+        };
+
+        mockBeans.rowRenderer.getRowByPosition.mockReturnValue(mockRowCtrl);
+
+        const result = valueService.getValue(mockColumn, mockRowNode);
+        expect(result).toBe('Original Value');
+    });
+});

--- a/packages/ag-grid-community/src/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.ts
@@ -13,10 +13,12 @@ import type {
     ValueParserParams,
     ValueSetterParams,
 } from '../entities/colDef';
+import { _getCellByPosition } from '../entities/positionUtils';
 import type { RowNode } from '../entities/rowNode';
 import type { CellValueChangedEvent } from '../events';
 import { _addGridCommonParams, _isServerSideRowModel } from '../gridOptionsUtils';
 import type { IEditService } from '../interfaces/iEditService';
+import type { CellPosition } from '../interfaces/iCellPosition';
 import type { IRowNode } from '../interfaces/iRowNode';
 import { _warn } from '../validation/logging';
 import type { ExpressionService } from './expressionService';
@@ -239,6 +241,17 @@ export class ValueService extends BeanStub implements NamedBean {
                 return result;
             }
             result = _getValueUsingField(data, field, column.isFieldContainsDots());
+        } else if (colDef.textContentAsValue && rowNode.rowIndex != null) {
+            const cellPosition: CellPosition = {
+                rowIndex: rowNode.rowIndex,
+                rowPinned: rowNode.rowPinned,
+                column: column,
+            };
+
+            const cellCtrl = _getCellByPosition(this.beans, cellPosition);
+            if (cellCtrl && cellCtrl.eGui && cellCtrl.eGui.textContent !== null) {
+                return cellCtrl.eGui.textContent;
+            }
         }
 
         // the result could be an expression itself, if we are allowing cell values to be expressions


### PR DESCRIPTION
Added a new `textContentAsValue` flag to `ColDef` that, when set to `true`, causes the value service to return the cell’s rendered DOM `textContent` when set.

This is useful when working with custom cell renderers