### PR TITLE
AG-15753 is row drop valid position newParent type

### DIFF
--- a/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
@@ -34,7 +34,7 @@ export interface IsRowValidDropPositionResult<TData = any> {
     /** The position of the rows relative to the target row */
     position?: RowDropTargetPosition;
     /** The new parent row the rows will have after dropped */
-    newParent?: RowNode<TData> | null;
+    newParent?: IRowNode<TData> | null;
     /** The target row node where the row is being dropped. */
     target?: IRowNode<TData> | null;
 }


### PR DESCRIPTION
newParent shouldn't be of type RowNode but of type IRowNode as it is exposed to the end user

Fix AG-15753