### PR TITLE
fix(docs): resolves minor discrepancy in React inline cell renderer example

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/component-cell-renderer/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/component-cell-renderer/index.mdoc
@@ -144,7 +144,7 @@ const [columnDefs] = useState([
     // 3 - Inlined Component
     {
         field: 'year',
-        cellRenderer: props => {
+        cellRenderer: params => {
             // put the value in bold
             return <>Value is <b>{params.value}</b></>;
         }


### PR DESCRIPTION
- renames callback arg `props` -> `params` (matches function body)