### PR TITLE
[AG-15693] Fix(ssrm): reapplies default group row expansion state after row is reloaded

### DIFF
--- a/packages/ag-grid-enterprise/src/serverSideRowModel/services/serverSideExpansionService.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/services/serverSideExpansionService.ts
@@ -16,6 +16,12 @@ interface IServerSideRowExpansionState {
     toggledNodes: string[];
 }
 
+/**
+ * Service for managing row expansion in the server-side row model.
+ * Contains declarative states for interacted with nodes and toggled nodes.
+ * Nodes still maintain their own expanded state, and also there is a user-defined lazy initial state.
+ * This service manages all these states and provides an API for expanding/collapsing rows.
+ */
 export class ServerSideExpansionService extends BaseExpansionService implements NamedBean, IExpansionService {
     beanName = 'expansionSvc' as const;
     private readonly interactedWith = new Set<string>();
@@ -125,6 +131,7 @@ export class ServerSideExpansionService extends BaseExpansionService implements 
     }
 
     /**
+     * Internal method for checking service internal state only.
      * expandAll XOR isToggled, since toggleNodes signifies a diff from expandAll.
      */
     private isExpanded = (rowId: string) => !!this.expandAllStatus !== this.toggledNodes.has(rowId);

--- a/packages/ag-grid-enterprise/src/serverSideRowModel/services/serverSideExpansionService.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/services/serverSideExpansionService.ts
@@ -59,7 +59,12 @@ export class ServerSideExpansionService extends BaseExpansionService implements 
             rowNode,
         };
 
-        return userFunc(params);
+        const userState = userFunc(params);
+        if (this.isExpanded(rowNode.id!) !== userState) {
+            // sync with user defined state
+            this.toggleNode(rowNode.id!);
+        }
+        return userState;
     }
 
     public expandRows(rowIdsToExpand: string[], rowIdsToCollapse?: string[]): void {
@@ -122,7 +127,7 @@ export class ServerSideExpansionService extends BaseExpansionService implements 
     /**
      * expandAll XOR isToggled, since toggleNodes signifies a diff from expandAll.
      */
-    private isExpanded = (rowId: string) => this.expandAllStatus !== this.toggledNodes.has(rowId);
+    private isExpanded = (rowId: string) => !!this.expandAllStatus !== this.toggledNodes.has(rowId);
 
     /**
      * Cleans up sets and sets the expandAll state if provided, otherwise resets it too.

--- a/testing/behavioural/src/services/server-side-expansion-service.test.ts
+++ b/testing/behavioural/src/services/server-side-expansion-service.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, vi, vitest } from 'vitest';
+
+import { RowNode } from 'ag-grid-community';
+
+import { ServerSideExpansionService } from '../../../../packages/ag-grid-enterprise/src/serverSideRowModel/services/serverSideExpansionService';
+
+describe('ServerSideExpansionService', () => {
+    let expansionService: ServerSideExpansionService;
+    let beans: any;
+    let rowNode: RowNode;
+    beforeEach(() => {
+        beans = {
+            rowRenderer: { refreshCells: vi.fn() },
+            eventSvc: { dispatchEvent: vitest.fn() },
+            gos: {
+                get: (key: string) => {
+                    switch (key) {
+                        case 'ssrmExpandAllAffectsAllRows':
+                            return true;
+                    }
+                },
+                addCommon: (params) => params,
+            },
+            serverSideRowModel: {
+                forEachNodeTransactional: (cb) => cb(rowNode),
+            },
+        };
+        expansionService = new ServerSideExpansionService();
+        expansionService['gos'] = beans.gos as any;
+        expansionService['serverSideRowModel'] = beans.serverSideRowModel as any;
+        expansionService['eventSvc'] = beans.eventSvc;
+        expansionService['beans'] = beans;
+    });
+
+    describe('isRowExpanded()', () => {
+        beforeEach(() => {
+            rowNode = new RowNode(beans);
+            rowNode.id = '1';
+            vitest.spyOn(rowNode, 'isExpandable').mockReturnValue(true);
+        });
+
+        it('should return false for non-expandable nodes', () => {
+            vitest.spyOn(rowNode, 'isExpandable').mockReturnValue(false);
+            expect(expansionService.isRowExpanded(rowNode)).toBe(false);
+        });
+
+        describe('when collapsed by default', () => {
+            beforeEach(() => {
+                expansionService['gos'].getCallback = () => () => false;
+                expect(expansionService.isRowExpanded(rowNode)).toBe(false);
+            });
+
+            it('should stay collapsed', () => {
+                expect(expansionService.isRowExpanded(rowNode)).toBe(false);
+            });
+            it('should stay expanded, when toggled by user', () => {
+                expansionService.setExpanded(rowNode, true);
+                expect(expansionService.isRowExpanded(rowNode)).toBe(true);
+            });
+            it('should stay expanded, when expand all clicked', () => {
+                expansionService.expandAll(true);
+                expect(expansionService.isRowExpanded(rowNode)).toBe(true);
+            });
+            it('should stay collapsed, when collapse all clicked', () => {
+                expect(expansionService.isRowExpanded(rowNode)).toBe(false);
+            });
+        });
+
+        describe('when expanded by default', () => {
+            beforeEach(() => {
+                expansionService['gos'].getCallback = () => () => true;
+                expect(expansionService.isRowExpanded(rowNode)).toBe(true);
+            });
+            it('should stay expanded', () => {
+                expect(expansionService.isRowExpanded(rowNode)).toBe(true);
+            });
+            it('should stay collapsed, when toggled by user', () => {
+                expansionService.setExpanded(rowNode, false);
+                expect(expansionService.isRowExpanded(rowNode)).toBe(false);
+            });
+            it('should stay expanded, when expand all clicked', () => {
+                expansionService.expandAll(true);
+                expect(expansionService.isRowExpanded(rowNode)).toBe(true);
+            });
+            it('should stay collapsed, when collapse all clicked', () => {
+                expansionService.expandAll(false);
+                expect(expansionService.isRowExpanded(rowNode)).toBe(false);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Improve server-side expansion service functionality and add tests

 - Fix isExpanded logic to use boolean conversion for expandAllStatus
 - Introduce test suite covering expansion states and interactions
 - Sync user-defined state with node toggle in expandRow method
 - Add service documentation for row expansion management

Fix [AG-15693](https://ag-grid.atlassian.net/browse/AG-15693)