### PR TITLE
AG-4663-fix-tree-unmanaged-row-drag-with-parent-id-example

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/_examples/tree-unmanaged-row-drag-with-parent-id/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/_examples/tree-unmanaged-row-drag-with-parent-id/main.ts
@@ -54,11 +54,11 @@ function onRowDragEnd(event: RowDragEndEvent<IFile>) {
     event.api.setRowDropPositionIndicator(null);
 }
 
-function onRowDragLeave(event: RowDragLeaveEvent<IFile> | RowDragCancelEvent<IFile>) {
+function onRowDragLeave(event: RowDragLeaveEvent<IFile>) {
     event.api.setRowDropPositionIndicator(null);
 }
 
-function onRowDragCancel(event: RowDragLeaveEvent<IFile> | RowDragCancelEvent<IFile>) {
+function onRowDragCancel(event: RowDragCancelEvent<IFile>) {
     event.api.setRowDropPositionIndicator(null);
 }
 

--- a/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/_examples/tree-unmanaged-row-drag-with-parent-id/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/_examples/tree-unmanaged-row-drag-with-parent-id/main.ts
@@ -35,6 +35,30 @@ function getRowId(params: GetRowIdParams<IFile>) {
     return params.data.id;
 }
 
+function onRowDragMove(event: any) {
+    const source = event.node.data;
+    const target = event.overNode?.data;
+    const reorderOnly = event.event?.shiftKey;
+    const rowData = gridApi.getGridOption('rowData') ?? [];
+    const indicator = getFileDropPosition(rowData, source, target, !!reorderOnly);
+
+    if (indicator) {
+        // Find the row node by file reference
+        const rowNode = gridApi.getRowNode(indicator.target.id);
+        if (rowNode) {
+            // Update the position indicator
+            gridApi.setRowDropPositionIndicator({
+                row: rowNode,
+                dropIndicatorPosition: indicator.position,
+            });
+
+            return;
+        }
+    }
+
+    gridApi.setRowDropPositionIndicator(null);
+}
+
 function onRowDragEnd(event: RowDragEndEvent<IFile>) {
     const source = event.node.data;
     const target = event.overNode?.data;
@@ -60,30 +84,6 @@ function onRowDragLeave(event: RowDragLeaveEvent<IFile>) {
 
 function onRowDragCancel(event: RowDragCancelEvent<IFile>) {
     event.api.setRowDropPositionIndicator(null);
-}
-
-function onRowDragMove(event: any) {
-    const source = event.node.data;
-    const target = event.overNode?.data;
-    const reorderOnly = event.event?.shiftKey;
-    const rowData = gridApi.getGridOption('rowData') ?? [];
-    const indicator = getFileDropPosition(rowData, source, target, !!reorderOnly);
-
-    if (indicator) {
-        // Find the row node by file reference
-        const rowNode = gridApi.getRowNode(indicator.target.id);
-        if (rowNode) {
-            // Update the position indicator
-            gridApi.setRowDropPositionIndicator({
-                row: rowNode,
-                dropIndicatorPosition: indicator.position,
-            });
-
-            return;
-        }
-    }
-
-    gridApi.setRowDropPositionIndicator(null);
 }
 
 const gridOptions: GridOptions<IFile> = {
@@ -118,10 +118,10 @@ const gridOptions: GridOptions<IFile> = {
     treeDataParentIdField: 'parentId',
     rowData: getData(),
     animateRows: true,
-    onRowDragEnd,
     onRowDragMove,
-    onRowDragLeave: onRowDragLeave,
-    onRowDragCancel: onRowDragCancel,
+    onRowDragEnd,
+    onRowDragLeave,
+    onRowDragCancel,
     groupDefaultExpanded: -1,
 };
 

--- a/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/_examples/tree-unmanaged-row-drag-with-parent-id/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tree-data-row-dragging/_examples/tree-unmanaged-row-drag-with-parent-id/main.ts
@@ -54,7 +54,11 @@ function onRowDragEnd(event: RowDragEndEvent<IFile>) {
     event.api.setRowDropPositionIndicator(null);
 }
 
-function onRowDragLeaveOrCancel(event: RowDragLeaveEvent<IFile> | RowDragCancelEvent<IFile>) {
+function onRowDragLeave(event: RowDragLeaveEvent<IFile> | RowDragCancelEvent<IFile>) {
+    event.api.setRowDropPositionIndicator(null);
+}
+
+function onRowDragCancel(event: RowDragLeaveEvent<IFile> | RowDragCancelEvent<IFile>) {
     event.api.setRowDropPositionIndicator(null);
 }
 
@@ -116,8 +120,8 @@ const gridOptions: GridOptions<IFile> = {
     animateRows: true,
     onRowDragEnd,
     onRowDragMove,
-    onRowDragLeave: onRowDragLeaveOrCancel,
-    onRowDragCancel: onRowDragLeaveOrCancel,
+    onRowDragLeave: onRowDragLeave,
+    onRowDragCancel: onRowDragCancel,
     groupDefaultExpanded: -1,
 };
 


### PR DESCRIPTION
this example was broken in vue - the transpiler didn't recognise this pattern, replacing the common function with two separate functions for cancel and leave