### PR TITLE
fix(docs): clarify filter types in server-side filtering example

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/index.mdoc
@@ -127,7 +127,8 @@ For more details on setting values, see [Supplying Filter Values](./filter-set-f
 
 The example below demonstrates Server-side Filtering using the Set Filter. Note the following:
 
-* The **Country** and **Sport** columns have Set Filters defined using `filter: 'agSetColumnFilter'`.
+* The **Country** column has a Set Filter defined using `filter: 'agSetColumnFilter'`.
+* The **Sport** column has a Multi Column Filter defined using `filter: 'agMultiColumnFilter'`, it combines a Set and a Text filters.
 * Set Filter values are fetched asynchronously and supplied via the `params.success(values)` callback.
 * The filter for the **Country** column is using [complex objects](./filter-set-filter-list/#complex-objects). The country name is shown in the Filter List, but the `filterModel` (and request) use the country code.
 * The filter for the **Sport** column only shows the values which are available for the selected countries.

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/index.mdoc
@@ -128,7 +128,7 @@ For more details on setting values, see [Supplying Filter Values](./filter-set-f
 The example below demonstrates Server-side Filtering using the Set Filter. Note the following:
 
 * The **Country** column has a Set Filter defined using `filter: 'agSetColumnFilter'`.
-* The **Sport** column has a Multi Column Filter defined using `filter: 'agMultiColumnFilter'`, it combines a Set and a Text filters.
+* The **Sport** column has a [Multi Filter](./filter-multi/) defined using `filter: 'agMultiColumnFilter'`, it combines a Set Filter and a [Text Filter](./filter-text/).
 * Set Filter values are fetched asynchronously and supplied via the `params.success(values)` callback.
 * The filter for the **Country** column is using [complex objects](./filter-set-filter-list/#complex-objects). The country name is shown in the Filter List, but the `filterModel` (and request) use the country code.
 * The filter for the **Sport** column only shows the values which are available for the selected countries.


### PR DESCRIPTION
 - Updated documentation to specify that  the **Sport** column employs a Multi Column Filter combining Set and Text filters.
 
<img width="932" height="948" alt="Screenshot 2025-08-21 at 17 03 50" src="https://github.com/user-attachments/assets/9b119b30-4b55-41bd-804f-d358ba4fb1e4" />
