### PR TITLE
AG-15757 drag and drop scroll and wheel

### DIFF
--- a/packages/ag-grid-community/src/dragAndDrop/dragAndDropService.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/dragAndDropService.ts
@@ -457,6 +457,9 @@ export class DragAndDropService extends BeanStub implements NamedBean {
         style.setProperty('position', 'absolute');
         style.setProperty('z-index', '9999');
 
+        // Do not intercept pointer events, so mouse wheel works as intended
+        style.setProperty('pointer-events', 'none');
+
         _stampTopLevelGridCompWithGridInstance(this.gos, eGui);
         this.beans.environment.applyThemeClasses(eGui);
 

--- a/packages/ag-grid-community/src/dragAndDrop/dragService.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/dragService.ts
@@ -15,17 +15,21 @@ export class DragService extends BeanStub implements NamedBean {
     beanName = 'dragSvc' as const;
 
     private currentDragParams: DragListenerParams | null;
-    public dragging: boolean;
-    public startTarget: EventTarget | null;
-    private mouseStartEvent: MouseEvent | null;
-    private touchLastTime: Touch | null;
-    private touchStart: Touch | null;
+    public dragging: boolean = false;
+    public startTarget: EventTarget | null = null;
+    private mouseStartEvent: MouseEvent | null = null;
+    private touchLastTime: Touch | null = null;
+    private touchStart: Touch | null = null;
+    private lastEventWasTouch: boolean = false;
+    private lastEventOrTouch: MouseEvent | Touch | null = null;
+    private nudgeTimer: number = 0;
 
     private dragEndFunctions: ((...args: any[]) => any)[] = [];
 
     private readonly dragSources: DragSourceAndListener[] = [];
 
     public override destroy(): void {
+        this.resetDragProperties();
         const { dragSources } = this;
         dragSources.forEach(this.removeListener.bind(this));
         dragSources.length = 0;
@@ -126,7 +130,7 @@ export class DragService extends BeanStub implements NamedBean {
 
         // see if we want to start dragging straight away
         if (params.dragStartPixels === 0) {
-            this.onCommonMove(touch, this.touchStart, params.eElement);
+            this.onCommonMove(touch, params.eElement, true);
         }
     }
 
@@ -226,14 +230,44 @@ export class DragService extends BeanStub implements NamedBean {
         return null;
     }
 
-    private onCommonMove(currentEvent: MouseEvent | Touch, startEvent: MouseEvent | Touch, el: Element): void {
+    private listenScroll(el: Element): void {
+        const nudge = (): void => {
+            this.nudgeTimer = 0;
+            const { dragging, lastEventWasTouch, lastEventOrTouch: lastMove } = this;
+            if (dragging && lastMove) {
+                this.onCommonMove(lastMove, el, lastEventWasTouch);
+            }
+        };
+
+        const scrollEvent = () => {
+            this.nudgeTimer ||= window.setTimeout(nudge, 5);
+        };
+
+        const eRoot = _getRootNode(this.beans);
+        const doc = _getDocument(this.beans);
+        const options = { capture: true };
+        this.addTemporaryEvents([
+            { target: eRoot, type: 'scroll', listener: scrollEvent, options },
+            { target: doc, type: 'scroll', listener: scrollEvent, options },
+            { target: window, type: 'resize', listener: scrollEvent },
+        ]);
+    }
+
+    private onCommonMove(eventOrTouch: MouseEvent | Touch, el: Element, touch: boolean): void {
+        this.clearNudgeTimer();
+        this.lastEventWasTouch = touch;
+        this.lastEventOrTouch = eventOrTouch;
+
         if (!this.dragging) {
+            const startEvent = touch ? this.touchStart! : this.mouseStartEvent!;
             // if mouse hasn't travelled from the start position enough, do nothing
-            if (this.isEventNearStartEvent(currentEvent, startEvent)) {
+            if (this.isEventNearStartEvent(eventOrTouch, startEvent)) {
                 return;
             }
 
             this.dragging = true;
+
+            this.listenScroll(el);
             this.eventSvc.dispatchEvent({
                 type: 'dragStarted',
                 target: el,
@@ -257,7 +291,9 @@ export class DragService extends BeanStub implements NamedBean {
             this.currentDragParams.onDragging(startEvent);
         }
 
-        this.currentDragParams?.onDragging(currentEvent);
+        if (this.dragging) {
+            this.currentDragParams?.onDragging(eventOrTouch);
+        }
     }
 
     private onTouchMove(touchEvent: TouchEvent, el: Element): void {
@@ -265,9 +301,8 @@ export class DragService extends BeanStub implements NamedBean {
         if (!touch) {
             return;
         }
-
-        // this.___statusPanel.setInfoText(Math.random() + ' onTouchMove preventDefault stopPropagation');
-        this.onCommonMove(touch, this.touchStart!, el);
+        this.touchLastTime = touch;
+        this.onCommonMove(touch, el, true);
     }
 
     // only gets called after a mouse down - as this is only added after mouseDown
@@ -282,7 +317,7 @@ export class DragService extends BeanStub implements NamedBean {
             mouseEvent.preventDefault();
         }
 
-        this.onCommonMove(mouseEvent, this.mouseStartEvent!, el);
+        this.onCommonMove(mouseEvent, el, false);
     }
 
     private shouldPreventMouseEvent(mouseEvent: MouseEvent): boolean {
@@ -360,15 +395,24 @@ export class DragService extends BeanStub implements NamedBean {
     }
 
     private resetDragProperties(): void {
+        this.clearNudgeTimer();
         this.mouseStartEvent = null;
         this.startTarget = null;
         this.touchStart = null;
         this.touchLastTime = null;
         this.currentDragParams = null;
+        this.lastEventOrTouch = null;
 
-        const { dragEndFunctions } = this;
-        dragEndFunctions.forEach((func) => func());
+        const dragEndFunctions = this.dragEndFunctions;
+        for (const func of dragEndFunctions) {
+            func();
+        }
         dragEndFunctions.length = 0;
+    }
+
+    private clearNudgeTimer(): void {
+        window.clearTimeout(this.nudgeTimer);
+        this.nudgeTimer = 0;
     }
 }
 

--- a/packages/ag-grid-community/src/dragAndDrop/dragService.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/dragService.ts
@@ -20,9 +20,10 @@ export class DragService extends BeanStub implements NamedBean {
     private mouseStartEvent: MouseEvent | null = null;
     private touchLastTime: Touch | null = null;
     private touchStart: Touch | null = null;
-    private lastEventWasTouch: boolean = false;
-    private lastEventOrTouch: MouseEvent | Touch | null = null;
+    private lastWasTouch: boolean = false;
+    private lastMove: MouseEvent | Touch | null = null;
     private nudgeTimer: number = 0;
+    private handledEvents: WeakSet<Event> | null = null;
 
     private dragEndFunctions: ((...args: any[]) => any)[] = [];
 
@@ -92,11 +93,26 @@ export class DragService extends BeanStub implements NamedBean {
         });
     }
 
+    private addHandledEvent(event: Event): boolean {
+        // if there are two elements with parent / child relationship, and both are draggable,
+        // when we drag the child, we should NOT drag the parent. an example of this is row moving
+        // and range selection - row moving should get preference when use drags the rowDrag component.
+        const set = (this.handledEvents ??= new WeakSet());
+        if (set.has(event)) {
+            return false;
+        }
+        set.add(event);
+        return true;
+    }
+
     // gets called whenever mouse down on any drag source
     private onTouchStart(params: DragListenerParams, touchEvent: TouchEvent): void {
         this.currentDragParams = params;
         this.dragging = false;
 
+        if (!this.addHandledEvent(touchEvent)) {
+            return; // Avoid double processing of the same event
+        }
         const touch = touchEvent.touches[0];
 
         this.touchLastTime = touch;
@@ -136,24 +152,16 @@ export class DragService extends BeanStub implements NamedBean {
 
     // gets called whenever mouse down on any drag source
     private onMouseDown(params: DragListenerParams, mouseEvent: MouseEvent): void {
-        const e = mouseEvent as any;
-
-        if (params.skipMouseEvent && params.skipMouseEvent(mouseEvent)) {
+        if (params.skipMouseEvent?.(mouseEvent)) {
             return;
         }
 
-        // if there are two elements with parent / child relationship, and both are draggable,
-        // when we drag the child, we should NOT drag the parent. an example of this is row moving
-        // and range selection - row moving should get preference when use drags the rowDrag component.
-        if (e._alreadyProcessedByDragService) {
-            return;
-        }
-
-        e._alreadyProcessedByDragService = true;
-
-        // only interested in left button clicks
         if (mouseEvent.button !== 0) {
-            return;
+            return; // only interested in left button clicks
+        }
+
+        if (!this.addHandledEvent(mouseEvent)) {
+            return; // Avoid double processing of the same event
         }
 
         if (this.shouldPreventMouseEvent(mouseEvent)) {
@@ -233,9 +241,9 @@ export class DragService extends BeanStub implements NamedBean {
     private listenScroll(el: Element): void {
         const nudge = (): void => {
             this.nudgeTimer = 0;
-            const { dragging, lastEventWasTouch, lastEventOrTouch: lastMove } = this;
+            const { dragging, lastWasTouch, lastMove } = this;
             if (dragging && lastMove) {
-                this.onCommonMove(lastMove, el, lastEventWasTouch);
+                this.onCommonMove(lastMove, el, lastWasTouch);
             }
         };
 
@@ -255,8 +263,8 @@ export class DragService extends BeanStub implements NamedBean {
 
     private onCommonMove(eventOrTouch: MouseEvent | Touch, el: Element, touch: boolean): void {
         this.clearNudgeTimer();
-        this.lastEventWasTouch = touch;
-        this.lastEventOrTouch = eventOrTouch;
+        this.lastWasTouch = touch;
+        this.lastMove = eventOrTouch;
 
         if (!this.dragging) {
             const startEvent = touch ? this.touchStart! : this.mouseStartEvent!;
@@ -401,7 +409,7 @@ export class DragService extends BeanStub implements NamedBean {
         this.touchStart = null;
         this.touchLastTime = null;
         this.currentDragParams = null;
-        this.lastEventOrTouch = null;
+        this.lastMove = null;
 
         const dragEndFunctions = this.dragEndFunctions;
         for (const func of dragEndFunctions) {

--- a/testing/module-size/moduleDefinitions.ts
+++ b/testing/module-size/moduleDefinitions.ts
@@ -134,7 +134,7 @@ const chartModules: ModuleTest[] = [
     },
 ];
 
-export const baseModule = { modules: [], expectedSize: 490.37 };
+export const baseModule = { modules: [], expectedSize: 496.04 };
 
 export const moduleCombinations: ModuleTest[] = [
     ...commonFeatureSets,

--- a/testing/shared/moduleDefinitions.ts
+++ b/testing/shared/moduleDefinitions.ts
@@ -134,7 +134,7 @@ const chartModules: ModuleTest[] = [
     },
 ];
 
-export const baseModule = { modules: [], expectedSize: 490.37 };
+export const baseModule = { modules: [], expectedSize: 496.04 };
 
 export const moduleCombinations: ModuleTest[] = [
     ...commonFeatureSets,


### PR DESCRIPTION
- add `pointer-events: none` to the wrapper of the ghost element, so the mouse wheel events pass through the element underneath it
- properly handle grid scroll, document scroll, window resize to update the current target and move the ghost when the page or the grid is scrolled

Refactoring:

- clean the old `_alreadyProcessedByDragService` added to the event object and replace it with a WeakSet, to not modify native objects