### PR TITLE
[AG-11746] Fix(ssrm): row height allow calling api resetrowheights when using ssrm to reset row heights

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/resetting-row-height/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/resetting-row-height/index.html
@@ -1,2 +1,2 @@
 Try clicking on rows and then hit <button onclick="resetRowHeights()">Reset Row Heights</button>
-<div id="myGrid" style="height: 100%"></div>
+<div id="myGrid" style="height: 90%"></div>

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/resetting-row-height/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/resetting-row-height/main.ts
@@ -120,21 +120,24 @@ function getLastRowIndex(request, results) {
     // if on or after the last block, work out the last row, otherwise return 'undefined'
     return currentLastRow < (request.endRow || 0) ? currentLastRow : undefined;
 }
-fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
-    .then((response) => response.json())
-    .then(function (data) {
-        // adding row id to data
-        let idSequence = 0;
-        data.forEach(function (item: { id: number }) {
-            item.id = idSequence++;
+
+document.addEventListener('DOMContentLoaded', function () {
+    fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
+        .then((response) => response.json())
+        .then(function (data) {
+            // adding row id to data
+            let idSequence = 0;
+            data.forEach(function (item: { id: number }) {
+                item.id = idSequence++;
+            });
+
+            // setup the fake server with entire dataset
+            const fakeServer = createFakeServer(data);
+
+            // create datasource with a reference to the fake server
+            const datasource = createServerSideDatasource(fakeServer);
+
+            // register the datasource with the grid
+            gridApi.setGridOption('serverSideDatasource', datasource);
         });
-
-        // setup the fake server with entire dataset
-        const fakeServer = createFakeServer(data);
-
-        // create datasource with a reference to the fake server
-        const datasource = createServerSideDatasource(fakeServer);
-
-        // register the datasource with the grid
-        gridApi.setGridOption('serverSideDatasource', datasource);
-    });
+});


### PR DESCRIPTION
Wrap fetch and data setup in DOMContentLoaded event
 - Added DOMContentLoaded event listener to ensure grid is initialized before fetching data
 - Moved fetch and data processing inside event handler to avoid timing issues
 - Wrapped server setup code in event listener for proper execution order

Fixes [AG-11746](https://ag-grid.atlassian.net/browse/AG-11746) TC1