### PR TITLE
[AG-11746] Fix(ssrm): missing warning for resetRowHeight + autoHeight combo

### DIFF
--- a/documentation/ag-grid-docs/src/content/api-documentation/grid-api/api.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/grid-api/api.json
@@ -1236,7 +1236,13 @@
                 "url": "./server-side-model-configuration/#debug-info"
             }
         },
-        "isLastRowIndexKnown": {}
+        "isLastRowIndexKnown": {},
+        "resetRowHeights": {
+            "more": {
+                "name": "Changing Row Height",
+                "url": "./row-height/#changing-row-height"
+            }
+        }
     },
     "find": {
         "meta": {

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/resetting-row-height/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/resetting-row-height/index.html
@@ -1,2 +1,2 @@
 Try clicking on rows and then hit <button onclick="resetRowHeights()">Reset Row Heights</button>
-<div id="myGrid" style="height: 100%"></div>
+<div id="myGrid" style="height: 90%"></div>

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/resetting-row-height/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/resetting-row-height/index.html
@@ -1,4 +1,4 @@
-<div style="height:100%">
+<div style="height: 100%">
     <button onclick="resetRowHeights()">Reset Row Heights</button>
     <div id="myGrid" style="height: 90%"></div>
 </div>

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/resetting-row-height/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/resetting-row-height/index.html
@@ -1,2 +1,4 @@
-Try clicking on rows and then hit <button onclick="resetRowHeights()">Reset Row Heights</button>
-<div id="myGrid" style="height: 90%"></div>
+<div style="height:100%">
+    <button onclick="resetRowHeights()">Reset Row Heights</button>
+    <div id="myGrid" style="height: 90%"></div>
+</div>

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/resetting-row-height/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/resetting-row-height/main.ts
@@ -25,9 +25,9 @@ ModuleRegistry.registerModules([
     ...(process.env.NODE_ENV !== 'production' ? [ValidationModule] : []),
 ]);
 
-let gridApi: GridApi<IOlympicData>;
+let gridApi: GridApi<IOlympicDataWithId>;
 
-const gridOptions: GridOptions<IOlympicData> = {
+const gridOptions: GridOptions<IOlympicDataWithId> = {
     columnDefs: [
         { field: 'athlete', minWidth: 200 },
         { field: 'age' },
@@ -47,7 +47,7 @@ const gridOptions: GridOptions<IOlympicData> = {
         enableValue: true,
         sortable: false,
     },
-    getRowId: (p) => p.data?.id,
+    getRowId: (p) => String(p.data?.id),
     getRowHeight: (p) => {
         return 50 + 30 * Math.sin((p.data?.id ?? 0) / 5 - Math.PI / 2);
     },

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/resetting-row-height/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/resetting-row-height/main.ts
@@ -120,21 +120,24 @@ function getLastRowIndex(request, results) {
     // if on or after the last block, work out the last row, otherwise return 'undefined'
     return currentLastRow < (request.endRow || 0) ? currentLastRow : undefined;
 }
-fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
-    .then((response) => response.json())
-    .then(function (data) {
-        // adding row id to data
-        let idSequence = 0;
-        data.forEach(function (item: { id: number }) {
-            item.id = idSequence++;
+
+document.addEventListener('DOMContentLoaded', function () {
+    fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
+        .then((response) => response.json())
+        .then(function (data) {
+            // adding row id to data
+            let idSequence = 0;
+            data.forEach(function (item: { id: number }) {
+                item.id = idSequence++;
+            });
+
+            // setup the fake server with entire dataset
+            const fakeServer = createFakeServer(data);
+
+            // create datasource with a reference to the fake server
+            const datasource = createServerSideDatasource(fakeServer);
+
+            // register the datasource with the grid
+            gridApi.setGridOption('serverSideDatasource', datasource);
         });
-
-        // setup the fake server with entire dataset
-        const fakeServer = createFakeServer(data);
-
-        // create datasource with a reference to the fake server
-        const datasource = createServerSideDatasource(fakeServer);
-
-        // register the datasource with the grid
-        gridApi.setGridOption('serverSideDatasource', datasource);
-    });
+});

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/index.mdoc
@@ -31,18 +31,18 @@ details on these properties.
 Ensure `maxBlocksInCache` is not set when using auto row height.
 {% /note %}
 
-## Setting and restoring Row Height
+## Changing Row Height
 
 To dynamically set or restore row heights in the Server-Side Row Model, use `setRowHeight()` to apply custom heights to specific rows and `resetRowHeights()` to revert all rows to the values calculated by the `getRowHeight()` in Grid Options. See [Changing Row Height](./row-height/#rownodesetrowheightheight-and-apionrowheightchanged) for more.
 
-The following example demonstrates how to set and reset row heights:
+{% apiDocumentation source="grid-api/api.json" section="serverSideRowModel" names=["resetRowHeights"] /%}
+
+The following example demonstrates this functionality:
+
+- Clicking on a row sets its height to `100px` using `setRowHeight()`.
+- Clicking the "Reset Row Heights" button resets all rows to their original heights using `resetRowHeights()`.
 
 {% gridExampleRunner title="Reset Row Height Example" name="resetting-row-height" exampleHeight=630 /%}
-
-Note the following:
-- `getRowHeight()` defines a function to dynamically calculate row heights based on data or conditions.
-- `resetRowHeights()` resets all rows to their original heights, as determined by getRowHeight or default values.
-- `onRowClicked()` and other table interactions can be set up to trigger height adjustments via `setRowHeight()` or resets.
 
 ## Next Up
 

--- a/packages/ag-grid-community/src/api/rowModelSharedApi.ts
+++ b/packages/ag-grid-community/src/api/rowModelSharedApi.ts
@@ -10,13 +10,13 @@ export function collapseAll(beans: BeanCollection) {
 }
 
 export function onRowHeightChanged(beans: BeanCollection) {
-    if (beans.rowAutoHeight?.active) {
-        _warn(3);
-        return;
-    }
     beans.rowModel?.onRowHeightChanged();
 }
 
 export function resetRowHeights(beans: BeanCollection) {
+    if (beans.rowAutoHeight?.active) {
+        _warn(3);
+        return;
+    }
     beans.rowModel?.resetRowHeights();
 }


### PR DESCRIPTION
Add a warning and update docs. 

Fix [AG-11746](https://ag-grid.atlassian.net/browse/AG-11746) TC5, TC8, TC9, and TC3

<img width="835" height="1092" alt="Screenshot 2025-09-02 at 15 28 07" src="https://github.com/user-attachments/assets/0b20ae1f-2c6f-4dc7-a5ab-292f235b9782" />

