### PR TITLE
AG-13990 Remove style that is now active

### DIFF
--- a/documentation/ag-grid-docs/src/components/demos/examples/hr/HRExample.module.css
+++ b/documentation/ag-grid-docs/src/components/demos/examples/hr/HRExample.module.css
@@ -80,11 +80,6 @@
     font-weight: 600;
 }
 
-:global(.ag-theme-quartz .ag-cell:not(:first-child)),
-:global(.ag-theme-quartz-dark .ag-cell:not(:first-child)) {
-    border-left: 1px solid var(--ag-border-color);
-}
-
 :global(.ag-theme-quartz .ag-group-expanded),
 :global(.ag-theme-quartz-dark .ag-group-expanded) {
     opacity: 1;

--- a/documentation/ag-grid-docs/src/components/demos/examples/hr/HRExample.module.css
+++ b/documentation/ag-grid-docs/src/components/demos/examples/hr/HRExample.module.css
@@ -80,6 +80,11 @@
     font-weight: 600;
 }
 
+:global(.ag-theme-quartz .ag-cell:not(:first-child, .ag-cell-focus)),
+:global(.ag-theme-quartz-dark .ag-cell:not(:first-child, .ag-cell-focus)) {
+    border-left: 1px solid var(--ag-border-color);
+}
+
 :global(.ag-theme-quartz .ag-group-expanded),
 :global(.ag-theme-quartz-dark .ag-group-expanded) {
     opacity: 1;


### PR DESCRIPTION
With this change.
<img width="290" height="112" alt="Screenshot 2025-09-03 at 11 54 11" src="https://github.com/user-attachments/assets/f245658a-e1b9-44e7-a43c-532722f8ca5c" />

Without this change.
<img width="348" height="98" alt="Screenshot 2025-09-03 at 11 54 23" src="https://github.com/user-attachments/assets/5c584314-4838-4ef2-ab56-dfc916012237" />

Looks like the changes I made to use the theming api / or maybe some other change in the website means that the styles applied in a file called `power-of-ag-charts.css` is no longer applying to this example. That was overriding this HR focus style meaning it was not visible.

Fix [AG-13990](https://ag-grid.atlassian.net/browse/AG-13990)