### PR TITLE
AG-15950 span rows grouping toggle error

### DIFF
--- a/packages/ag-grid-community/src/rendering/spanning/spannedCellCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/spanning/spannedCellCtrl.ts
@@ -51,10 +51,11 @@ export class SpannedCellCtrl extends CellCtrl {
      * When cell is spanning, ensure row index is also available on the cell
      */
     public override refreshAriaRowIndex(): void {
-        if (this.rowNode.rowIndex == null) {
+        const { eGui, rowNode } = this;
+        if (!eGui || rowNode.rowIndex == null) {
             return;
         }
-        _setAriaRowIndex(this.eGui, this.rowNode.rowIndex);
+        _setAriaRowIndex(eGui, rowNode.rowIndex);
     }
 
     /**

--- a/packages/ag-grid-community/src/rendering/spanning/spannedRowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/spanning/spannedRowCtrl.ts
@@ -7,13 +7,7 @@ import { SpannedCellCtrl } from './spannedCellCtrl';
 export class SpannedRowCtrl extends RowCtrl {
     protected override onRowIndexChanged(): void {
         super.onRowIndexChanged();
-        for (const cellCtrl of this.getAllCellCtrls()) {
-            // eGui can be null in react as this event might be called before the cell is rendered
-            // setComp in any case calls refreshAriaRowIndex after the cell is rendered
-            if (cellCtrl.eGui) {
-                cellCtrl.refreshAriaRowIndex();
-            }
-        }
+        this.getAllCellCtrls().forEach((c) => c.refreshAriaRowIndex());
     }
 
     protected override getInitialRowClasses(_rowContainerType: RowContainerType): string[] {

--- a/packages/ag-grid-community/src/rendering/spanning/spannedRowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/spanning/spannedRowCtrl.ts
@@ -7,7 +7,13 @@ import { SpannedCellCtrl } from './spannedCellCtrl';
 export class SpannedRowCtrl extends RowCtrl {
     protected override onRowIndexChanged(): void {
         super.onRowIndexChanged();
-        this.getAllCellCtrls().forEach((c) => c.refreshAriaRowIndex());
+        for (const cellCtrl of this.getAllCellCtrls()) {
+            // eGui can be null in react as this event might be called before the cell is rendered
+            // setComp in any case calls refreshAriaRowIndex after the cell is rendered
+            if (cellCtrl.eGui) {
+                cellCtrl.refreshAriaRowIndex();
+            }
+        }
     }
 
     protected override getInitialRowClasses(_rowContainerType: RowContainerType): string[] {


### PR DESCRIPTION
rowIndexChanged could be invoked before the cell is rendered as react might render asynchronously
In this case, we need to check for eGui not null if this happens