### PR TITLE
AG-15757 fix pill drop zone

### DIFF
--- a/packages/ag-grid-community/src/agStack/core/baseDragAndDropService.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseDragAndDropService.ts
@@ -1,3 +1,5 @@
+import type { MouseCapture } from '../events/mouseCapture';
+import { captureMouse, releaseMouseCapture } from '../events/mouseCapture';
 import type { AgCoreBeanCollection } from '../interfaces/agCoreBeanCollection';
 import type { BaseEvents } from '../interfaces/baseEvents';
 import type { BaseProperties } from '../interfaces/baseProperties';
@@ -53,8 +55,7 @@ export abstract class BaseDragAndDropService<
     private dragImageComp: (IComponent<any> & IDragAndDropImage) | null = null;
     private dragImageLastIcon: TDragAndDropIcon | null | undefined = undefined;
     private dragImageLastLabel: string | null | undefined = undefined;
-    private capturedPointerId: number | null = null;
-    private capturedTouchAction: string | null = null;
+    private mouseCapture: MouseCapture | null = null;
 
     private dropTargets: AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent>[] = [];
     private lastDropTarget: AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent> | null = null;
@@ -133,7 +134,7 @@ export abstract class BaseDragAndDropService<
         dragSource.onDragStarted?.();
 
         if (typeof PointerEvent !== 'undefined' && mouseEvent instanceof PointerEvent) {
-            this.capturePointer(mouseEvent);
+            this.mouseCapture = captureMouse(this.beans.eRootDiv, mouseEvent);
         }
 
         this.createAndUpdateDragImageComp(dragSource);
@@ -206,7 +207,7 @@ export abstract class BaseDragAndDropService<
     }
 
     private clearDragAndDropProperties(): void {
-        this.releasePointer();
+        this.mouseCapture = releaseMouseCapture(this.mouseCapture);
         this.removeDragImageComp(this.dragImageComp);
         this.dragImageCompPromise = null;
         this.dragImageParent = null;
@@ -217,41 +218,7 @@ export abstract class BaseDragAndDropService<
         this.lastDropTarget = null;
         this.dragItem = null;
         this.dragSource = null;
-        this.capturedPointerId = null;
-        this.capturedTouchAction = null;
-    }
-
-    private capturePointer(pointerEvent: PointerEvent): void {
-        const pointerId = pointerEvent.pointerId;
-        if (pointerId != null) {
-            const eRootDiv = this.beans.eRootDiv;
-            try {
-                eRootDiv.setPointerCapture(pointerId);
-                this.capturedPointerId = pointerId;
-                const style = eRootDiv.style;
-                this.capturedTouchAction = style.touchAction;
-                style.touchAction = 'none'; // stop touch scrolling while dragging
-            } catch {
-                // do nothing, just means pointer capture is not supported
-            }
-        }
-    }
-
-    private releasePointer(): void {
-        const pointerId = this.capturedPointerId;
-        if (pointerId != null) {
-            const eRootDiv = this.beans.eRootDiv;
-            if (eRootDiv) {
-                try {
-                    eRootDiv.releasePointerCapture(pointerId);
-                    if (this.capturedTouchAction != null) {
-                        eRootDiv.style.touchAction = this.capturedTouchAction;
-                    }
-                } catch {
-                    // do nothing, just means pointer capture is not supported
-                }
-            }
-        }
+        this.mouseCapture = null;
     }
 
     private getAllContainersFromDropTarget(
@@ -435,7 +402,7 @@ export abstract class BaseDragAndDropService<
 
         style.position = 'absolute';
         style.zIndex = '9999';
-        if (this.capturedPointerId != null) {
+        if (this.mouseCapture != null) {
             style.pointerEvents = 'none';
         }
 

--- a/packages/ag-grid-community/src/agStack/core/baseDragAndDropService.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseDragAndDropService.ts
@@ -53,6 +53,8 @@ export abstract class BaseDragAndDropService<
     private dragImageComp: (IComponent<any> & IDragAndDropImage) | null = null;
     private dragImageLastIcon: TDragAndDropIcon | null | undefined = undefined;
     private dragImageLastLabel: string | null | undefined = undefined;
+    private capturedPointerId: number | null = null;
+    private capturedTouchAction: string | null = null;
 
     private dropTargets: AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent>[] = [];
     private lastDropTarget: AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent> | null = null;
@@ -129,8 +131,12 @@ export abstract class BaseDragAndDropService<
         this.dragItem = dragSource.getDragItem();
 
         dragSource.onDragStarted?.();
-        const pointerCaptured = typeof PointerEvent !== 'undefined' && mouseEvent instanceof PointerEvent;
-        this.createAndUpdateDragImageComp(dragSource, pointerCaptured);
+
+        if (typeof PointerEvent !== 'undefined' && mouseEvent instanceof PointerEvent) {
+            this.capturePointer(mouseEvent);
+        }
+
+        this.createAndUpdateDragImageComp(dragSource);
     }
 
     private onDragStop(mouseEvent: MouseEvent): void {
@@ -200,6 +206,7 @@ export abstract class BaseDragAndDropService<
     }
 
     private clearDragAndDropProperties(): void {
+        this.releasePointer();
         this.removeDragImageComp(this.dragImageComp);
         this.dragImageCompPromise = null;
         this.dragImageParent = null;
@@ -210,6 +217,41 @@ export abstract class BaseDragAndDropService<
         this.lastDropTarget = null;
         this.dragItem = null;
         this.dragSource = null;
+        this.capturedPointerId = null;
+        this.capturedTouchAction = null;
+    }
+
+    private capturePointer(pointerEvent: PointerEvent): void {
+        const pointerId = pointerEvent.pointerId;
+        if (pointerId != null) {
+            const eRootDiv = this.beans.eRootDiv;
+            try {
+                eRootDiv.setPointerCapture(pointerId);
+                this.capturedPointerId = pointerId;
+                const style = eRootDiv.style;
+                this.capturedTouchAction = style.touchAction;
+                style.touchAction = 'none'; // stop touch scrolling while dragging
+            } catch {
+                // do nothing, just means pointer capture is not supported
+            }
+        }
+    }
+
+    private releasePointer(): void {
+        const pointerId = this.capturedPointerId;
+        if (pointerId != null) {
+            const eRootDiv = this.beans.eRootDiv;
+            if (eRootDiv) {
+                try {
+                    eRootDiv.releasePointerCapture(pointerId);
+                    if (this.capturedTouchAction != null) {
+                        eRootDiv.style.touchAction = this.capturedTouchAction;
+                    }
+                } catch {
+                    // do nothing, just means pointer capture is not supported
+                }
+            }
+        }
     }
 
     private getAllContainersFromDropTarget(
@@ -361,7 +403,7 @@ export abstract class BaseDragAndDropService<
         }
     }
 
-    private createAndUpdateDragImageComp(dragSource: TDragSource, pointerCaptured: boolean): void {
+    private createAndUpdateDragImageComp(dragSource: TDragSource): void {
         const promise = this.createDragImageComp(dragSource) ?? null;
 
         this.dragImageCompPromise = promise;
@@ -381,19 +423,19 @@ export abstract class BaseDragAndDropService<
             }
 
             if (dragImageComp) {
-                this.appendDragImageComp(dragImageComp, pointerCaptured);
+                this.appendDragImageComp(dragImageComp);
                 this.updateDragImageComp();
             }
         });
     }
 
-    private appendDragImageComp(component: IComponent<any> & IDragAndDropImage, pointerCaptured: boolean): void {
+    private appendDragImageComp(component: IComponent<any> & IDragAndDropImage): void {
         const eGui = component.getGui();
         const style = eGui.style;
 
         style.position = 'absolute';
         style.zIndex = '9999';
-        if (pointerCaptured) {
+        if (this.capturedPointerId != null) {
             style.pointerEvents = 'none';
         }
 

--- a/packages/ag-grid-community/src/agStack/core/baseDragService.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseDragService.ts
@@ -46,13 +46,16 @@ export class BaseDragService<
     }
 
     public override destroy(): void {
+        if (this.drag) {
+            this.cancelDrag();
+        }
         const dragSources = this.dragSources;
         for (const ds of dragSources) {
             removeTempEventHandlers(ds.handlers);
         }
         dragSources.length = 0;
-        this.destroyDrag();
         super.destroy();
+        this.handledEvents = null;
     }
 
     public removeDragSource(params: DragListenerParams): void {
@@ -68,6 +71,9 @@ export class BaseDragService<
     }
 
     public addDragSource(params: DragListenerParams): void {
+        if (!this.isAlive()) {
+            return; // Destroyed
+        }
         const { eElement, includeTouch } = params;
         const handlers: TempEventHandler[] = [];
         const dragSource = { handlers, params };
@@ -78,7 +84,7 @@ export class BaseDragService<
 
         // Fallback to legacy Mouse handler
         const mouseListener = (event: MouseEvent) => this.onMouseDown(params, event);
-
+        console.log('ADD DRAG SOURCExxxx', new Error());
         addTempEventHandlers(
             handlers,
             [eElement, 'pointerdown', pointerDownListener],
@@ -174,21 +180,18 @@ export class BaseDragService<
 
         this.destroyDrag();
 
-        const pointerDrag = new Dragging(params, pointerEvent);
-        if (!pointerDrag.capture(pointerEvent)) {
-            return; // capture failed, fallback to normal events
-        }
+        const eRootDiv = beans.eRootDiv;
+        const pointerDrag = new Dragging(params, pointerEvent, eRootDiv);
 
         const onMove = (ev: PointerEvent) => this.onMouseMove(ev);
         const onUp = (ev: PointerEvent) => this.onUp(ev);
         const onCancel = () => this.cancelDrag();
-        const eElement = pointerDrag.eElement;
         this.initDrag(
             pointerDrag,
-            [eElement, 'pointermove', onMove],
-            [eElement, 'pointerup', onUp],
-            [eElement, 'pointercancel', onCancel],
-            [eElement, 'lostpointercapture', onCancel]
+            [eRootDiv, 'pointermove', onMove],
+            [eRootDiv, 'pointerup', onUp],
+            [eRootDiv, 'pointercancel', onCancel],
+            [eRootDiv, 'lostpointercapture', onCancel]
         );
 
         // start immediately if threshold is zero
@@ -201,25 +204,37 @@ export class BaseDragService<
 
     // gets called whenever mouse down on any drag source
     private onTouchStart(params: DragListenerParams, touchEvent: TouchEvent): void {
-        const beans = this.beans;
-        if (!this.addHandledEvent(touchEvent)) {
-            return; // Already handled
+        const suppressTouch = this.gos.get('suppressTouch');
+        if (suppressTouch || !params.includeTouch) {
+            return;
         }
 
-        if (this.drag?.pointerId != null) {
-            return; // We are handling the pointer events, ignore this
+        if (!this.addHandledEvent(touchEvent)) {
+            return; // Already handled
         }
 
         if (_isFocusableFormField(getEventTargetElement(touchEvent))) {
             return;
         }
+
+        const drag = this.drag;
+        if (drag?.ePointer) {
+            drag.touchStart ||= touchEvent;
+            return; // We are handling the pointer events, ignore this
+        }
+
         if (params.stopPropagationForTouch) {
             touchEvent.stopPropagation();
         }
 
+        this.startTouch(params, touchEvent);
+    }
+
+    private startTouch(params: DragListenerParams, touchEvent: TouchEvent): void {
         this.destroyDrag();
 
-        const touchDrag = new Dragging(params, touchEvent.touches[0]);
+        const beans = this.beans;
+        const touchDrag = new Dragging(params, touchEvent.touches[0], null);
 
         const touchMoveEvent = (e: TouchEvent) => this.onTouchMove(e);
         const touchEndEvent = (e: TouchEvent) => this.onTouchUp(e);
@@ -246,7 +261,9 @@ export class BaseDragService<
 
     // gets called whenever mouse down on any drag source
     private onMouseDown(params: DragListenerParams, mouseEvent: MouseEvent): void {
-        const beans = this.beans;
+        if (mouseEvent.button !== 0) {
+            return; // only interested in left button clicks
+        }
         // if there are two elements with parent / child relationship, and both are draggable,
         // when we drag the child, we should NOT drag the parent. an example of this is row moving
         // and range selection - row moving should get preference when use drags the rowDrag component.
@@ -254,17 +271,20 @@ export class BaseDragService<
             return; // Already handled
         }
 
-        if (this.drag?.pointerId != null) {
+        const drag = this.drag;
+        if (drag?.ePointer) {
+            drag.mouseStart ||= mouseEvent;
             return; // We are handling the pointer events, ignore this
         }
 
-        if (mouseEvent.button !== 0) {
-            return; // only interested in left button clicks
-        }
+        this.startMouse(params, mouseEvent);
+    }
 
+    private startMouse(params: DragListenerParams, mouseEvent: MouseEvent): void {
+        const beans = this.beans;
         this.destroyDrag();
 
-        const mouseDrag = new Dragging(params, mouseEvent);
+        const mouseDrag = new Dragging(params, mouseEvent, null);
 
         const mouseMoveEvent = (event: MouseEvent) => this.onMouseMove(event);
         const mouseUpEvent = (event: MouseEvent) => this.onUp(event);
@@ -320,8 +340,22 @@ export class BaseDragService<
         }
     }
 
+    private fallbackCapture(drag: Dragging): void {
+        const params = drag.params;
+        // Pointer capture failed; try falling back to legacy handlers.
+        const touchStart = drag.touchStart;
+        if (touchStart) {
+            this.startTouch(params, touchStart);
+            return;
+        }
+        const mouseStart = drag.mouseStart;
+        if (mouseStart) {
+            this.startMouse(params, mouseStart);
+        }
+    }
+
     private onMove(currentEvent: PointerEvent | MouseEvent | Touch): void {
-        const drag = this.drag;
+        let drag = this.drag;
         if (!drag) {
             return;
         }
@@ -339,6 +373,16 @@ export class BaseDragService<
                 return;
             }
 
+            // // This is a pointer event, let's try to capture the pointer
+            // if (drag.ePointer && !drag.capture(currentEvent as PointerEvent)) {
+            //     this.fallbackCapture(drag); // Fallback to mouse or touch events
+            //     drag = this.drag;
+            // }
+
+            if (!drag) {
+                return;
+            }
+
             this.dragging = true;
             this.eventSvc.dispatchEvent({
                 type: 'dragStarted',
@@ -346,6 +390,8 @@ export class BaseDragService<
             });
 
             dragSource.onDragStart(start);
+
+            console.log('HAS DRAG 1', this.drag === drag);
 
             // we need ONE drag action at the start event, so that we are guaranteed the drop target
             // at the start gets notified. this is because the drag can start outside of the element
@@ -359,14 +405,20 @@ export class BaseDragService<
                 return; // drag has been cancelled.
             }
 
+            console.log('HAS DRAG 2', this.drag === drag);
+
             dragSource.onDragging(start);
 
             if (this.drag !== drag) {
                 return; // drag has been cancelled.
             }
+
+            console.log('HAS DRAG 3', this.drag === drag);
         }
 
         dragSource.onDragging(currentEvent);
+
+        console.log('HAS DRAG 4', this.drag === drag);
     }
 
     private onTouchUp(touchEvent: TouchEvent): void {
@@ -436,12 +488,15 @@ class Dragging {
     public readonly handlers: TempEventHandler[] = [];
     public readonly target: EventTarget | null;
     public lastDrag: PointerEvent | MouseEvent | Touch | null = null;
-    public pointerId: number | null = null;
+    public mouseStart: MouseEvent | null = null;
+    public touchStart: TouchEvent | null = null;
+    private pointerId: number | null = null;
     private oldTouchAction: string | undefined = undefined;
 
     public constructor(
         public readonly params: DragListenerParams,
-        public readonly start: PointerEvent | MouseEvent | Touch
+        public readonly start: PointerEvent | MouseEvent | Touch,
+        public readonly ePointer: (Element & Partial<HTMLElement>) | null
     ) {
         this.eElement = params.eElement;
         this.target = start.target;
@@ -454,41 +509,44 @@ class Dragging {
      * @returns True if the capture was successful, false otherwise.
      */
     public capture(pointerEvent: PointerEvent): boolean {
-        const eElement = this.eElement;
+        const ePointer = this.ePointer;
         const pointerId = pointerEvent.pointerId;
-        if (pointerId == null || !eElement.setPointerCapture) {
+        if (!ePointer || pointerId == null || !ePointer.setPointerCapture) {
             return false; // fallback to legacy handlers
         }
 
         try {
-            eElement.setPointerCapture(pointerId);
+            ePointer.setPointerCapture(pointerId);
         } catch {
             return false; // capture failed, fallback to normal events
         }
 
         this.pointerId = pointerId;
-        const style = eElement.style;
+        const style = ePointer.style;
         if (style) {
             this.oldTouchAction = style.touchAction;
             style.touchAction = 'none'; // disable touch actions while dragging with pointer events
         }
+
         return true;
     }
 
     public destroy(): void {
         removeTempEventHandlers(this.handlers);
-        const { pointerId, eElement, oldTouchAction } = this;
-        if (pointerId != null) {
-            try {
-                eElement.releasePointerCapture(pointerId);
-            } catch {
-                // ignore exception as releasePointerCapture can throw
+        const { pointerId, ePointer, oldTouchAction } = this;
+        if (ePointer) {
+            if (pointerId != null) {
+                try {
+                    ePointer.releasePointerCapture(pointerId);
+                } catch {
+                    // ignore exception as releasePointerCapture can throw
+                }
             }
-        }
-        if (oldTouchAction != null) {
-            const style = eElement.style;
-            if (style && style.touchAction === 'none') {
-                style.touchAction = oldTouchAction; // restore old touch action style
+            if (oldTouchAction != null) {
+                const style = ePointer.style;
+                if (style && style.touchAction === 'none') {
+                    style.touchAction = oldTouchAction; // restore old touch action style
+                }
             }
         }
     }

--- a/packages/ag-grid-community/src/agStack/core/baseDragService.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseDragService.ts
@@ -84,7 +84,6 @@ export class BaseDragService<
 
         // Fallback to legacy Mouse handler
         const mouseListener = (event: MouseEvent) => this.onMouseDown(params, event);
-        console.log('ADD DRAG SOURCExxxx', new Error());
         addTempEventHandlers(
             handlers,
             [eElement, 'pointerdown', pointerDownListener],
@@ -145,7 +144,7 @@ export class BaseDragService<
         const drag = this.drag;
         if (drag) {
             this.drag = null;
-            drag.destroy();
+            removeTempEventHandlers(drag.handlers);
         }
     }
 
@@ -181,17 +180,23 @@ export class BaseDragService<
         this.destroyDrag();
 
         const eRootDiv = beans.eRootDiv;
-        const pointerDrag = new Dragging(params, pointerEvent, eRootDiv);
+        const pointerDrag = new Dragging(params, pointerEvent, true);
 
         const onMove = (ev: PointerEvent) => this.onMouseMove(ev);
         const onUp = (ev: PointerEvent) => this.onUp(ev);
         const onCancel = () => this.cancelDrag();
+        const onMouseMove = (mouseEvent: MouseEvent) => {
+            if (this.shouldPreventMouseEvent(mouseEvent)) {
+                preventEventDefault(mouseEvent);
+            }
+        };
         this.initDrag(
             pointerDrag,
             [eRootDiv, 'pointermove', onMove],
             [eRootDiv, 'pointerup', onUp],
             [eRootDiv, 'pointercancel', onCancel],
-            [eRootDiv, 'lostpointercapture', onCancel]
+            [eRootDiv, 'lostpointercapture', onCancel],
+            [_getRootNode(beans), 'mousemove', onMouseMove]
         );
 
         // start immediately if threshold is zero
@@ -218,7 +223,7 @@ export class BaseDragService<
         }
 
         const drag = this.drag;
-        if (drag?.ePointer) {
+        if (drag?.pointer) {
             drag.touchStart ||= touchEvent;
             return; // We are handling the pointer events, ignore this
         }
@@ -227,14 +232,10 @@ export class BaseDragService<
             touchEvent.stopPropagation();
         }
 
-        this.startTouch(params, touchEvent);
-    }
-
-    private startTouch(params: DragListenerParams, touchEvent: TouchEvent): void {
         this.destroyDrag();
 
         const beans = this.beans;
-        const touchDrag = new Dragging(params, touchEvent.touches[0], null);
+        const touchDrag = new Dragging(params, touchEvent.touches[0], false);
 
         const touchMoveEvent = (e: TouchEvent) => this.onTouchMove(e);
         const touchEndEvent = (e: TouchEvent) => this.onTouchUp(e);
@@ -271,20 +272,14 @@ export class BaseDragService<
             return; // Already handled
         }
 
-        const drag = this.drag;
-        if (drag?.ePointer) {
-            drag.mouseStart ||= mouseEvent;
+        if (this.drag?.pointer) {
             return; // We are handling the pointer events, ignore this
         }
 
-        this.startMouse(params, mouseEvent);
-    }
-
-    private startMouse(params: DragListenerParams, mouseEvent: MouseEvent): void {
         const beans = this.beans;
         this.destroyDrag();
 
-        const mouseDrag = new Dragging(params, mouseEvent, null);
+        const mouseDrag = new Dragging(params, mouseEvent, false);
 
         const mouseMoveEvent = (event: MouseEvent) => this.onMouseMove(event);
         const mouseUpEvent = (event: MouseEvent) => this.onUp(event);
@@ -340,22 +335,8 @@ export class BaseDragService<
         }
     }
 
-    private fallbackCapture(drag: Dragging): void {
-        const params = drag.params;
-        // Pointer capture failed; try falling back to legacy handlers.
-        const touchStart = drag.touchStart;
-        if (touchStart) {
-            this.startTouch(params, touchStart);
-            return;
-        }
-        const mouseStart = drag.mouseStart;
-        if (mouseStart) {
-            this.startMouse(params, mouseStart);
-        }
-    }
-
     private onMove(currentEvent: PointerEvent | MouseEvent | Touch): void {
-        let drag = this.drag;
+        const drag = this.drag;
         if (!drag) {
             return;
         }
@@ -373,16 +354,6 @@ export class BaseDragService<
                 return;
             }
 
-            // // This is a pointer event, let's try to capture the pointer
-            // if (drag.ePointer && !drag.capture(currentEvent as PointerEvent)) {
-            //     this.fallbackCapture(drag); // Fallback to mouse or touch events
-            //     drag = this.drag;
-            // }
-
-            if (!drag) {
-                return;
-            }
-
             this.dragging = true;
             this.eventSvc.dispatchEvent({
                 type: 'dragStarted',
@@ -390,8 +361,6 @@ export class BaseDragService<
             });
 
             dragSource.onDragStart(start);
-
-            console.log('HAS DRAG 1', this.drag === drag);
 
             // we need ONE drag action at the start event, so that we are guaranteed the drop target
             // at the start gets notified. this is because the drag can start outside of the element
@@ -405,20 +374,14 @@ export class BaseDragService<
                 return; // drag has been cancelled.
             }
 
-            console.log('HAS DRAG 2', this.drag === drag);
-
             dragSource.onDragging(start);
 
             if (this.drag !== drag) {
                 return; // drag has been cancelled.
             }
-
-            console.log('HAS DRAG 3', this.drag === drag);
         }
 
         dragSource.onDragging(currentEvent);
-
-        console.log('HAS DRAG 4', this.drag === drag);
     }
 
     private onTouchUp(touchEvent: TouchEvent): void {
@@ -488,67 +451,15 @@ class Dragging {
     public readonly handlers: TempEventHandler[] = [];
     public readonly target: EventTarget | null;
     public lastDrag: PointerEvent | MouseEvent | Touch | null = null;
-    public mouseStart: MouseEvent | null = null;
     public touchStart: TouchEvent | null = null;
-    private pointerId: number | null = null;
-    private oldTouchAction: string | undefined = undefined;
 
     public constructor(
         public readonly params: DragListenerParams,
         public readonly start: PointerEvent | MouseEvent | Touch,
-        public readonly ePointer: (Element & Partial<HTMLElement>) | null
+        public readonly pointer: boolean
     ) {
         this.eElement = params.eElement;
         this.target = start.target;
-    }
-
-    /**
-     * Captures pointer events for the drag operation.
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/setPointerCapture)
-     * @param pointerEvent The pointer event to capture.
-     * @returns True if the capture was successful, false otherwise.
-     */
-    public capture(pointerEvent: PointerEvent): boolean {
-        const ePointer = this.ePointer;
-        const pointerId = pointerEvent.pointerId;
-        if (!ePointer || pointerId == null || !ePointer.setPointerCapture) {
-            return false; // fallback to legacy handlers
-        }
-
-        try {
-            ePointer.setPointerCapture(pointerId);
-        } catch {
-            return false; // capture failed, fallback to normal events
-        }
-
-        this.pointerId = pointerId;
-        const style = ePointer.style;
-        if (style) {
-            this.oldTouchAction = style.touchAction;
-            style.touchAction = 'none'; // disable touch actions while dragging with pointer events
-        }
-
-        return true;
-    }
-
-    public destroy(): void {
-        removeTempEventHandlers(this.handlers);
-        const { pointerId, ePointer, oldTouchAction } = this;
-        if (ePointer) {
-            if (pointerId != null) {
-                try {
-                    ePointer.releasePointerCapture(pointerId);
-                } catch {
-                    // ignore exception as releasePointerCapture can throw
-                }
-            }
-            if (oldTouchAction != null) {
-                const style = ePointer.style;
-                if (style && style.touchAction === 'none') {
-                    style.touchAction = oldTouchAction; // restore old touch action style
-                }
-            }
-        }
     }
 }
 

--- a/packages/ag-grid-community/src/agStack/core/baseDragService.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseDragService.ts
@@ -31,7 +31,7 @@ export class BaseDragService<
     private readonly dragSources: DragSourceEntry[] = [];
 
     public get startTarget(): EventTarget | null {
-        return this.drag?.target ?? null;
+        return this.drag?.start.target ?? null;
     }
 
     private addHandledEvent(event: Event): boolean {
@@ -224,7 +224,6 @@ export class BaseDragService<
 
         const drag = this.drag;
         if (drag?.pointer) {
-            drag.touchStart ||= touchEvent;
             return; // We are handling the pointer events, ignore this
         }
 
@@ -449,9 +448,7 @@ const removeTempEventHandlers = (list: TempEventHandler[]): void => {
 class Dragging {
     public readonly eElement: Element & Partial<HTMLElement>;
     public readonly handlers: TempEventHandler[] = [];
-    public readonly target: EventTarget | null;
     public lastDrag: PointerEvent | MouseEvent | Touch | null = null;
-    public touchStart: TouchEvent | null = null;
 
     public constructor(
         public readonly params: DragListenerParams,
@@ -459,7 +456,6 @@ class Dragging {
         public readonly pointer: boolean
     ) {
         this.eElement = params.eElement;
-        this.target = start.target;
     }
 }
 

--- a/packages/ag-grid-community/src/agStack/events/mouseCapture.ts
+++ b/packages/ag-grid-community/src/agStack/events/mouseCapture.ts
@@ -1,0 +1,43 @@
+export interface MouseCapture {
+    eRoot: HTMLElement;
+    pointerId: number;
+    touchAction: string;
+}
+
+export const captureMouse = (eRoot: HTMLElement, mouseEvent: MouseEvent): MouseCapture | null => {
+    if (typeof PointerEvent === 'undefined' || !(mouseEvent instanceof PointerEvent)) {
+        return null;
+    }
+
+    const pointerId = mouseEvent.pointerId;
+    if (pointerId == null) {
+        return null;
+    }
+
+    try {
+        eRoot.setPointerCapture(pointerId);
+        const style = eRoot.style;
+        const touchAction = style.touchAction;
+        style.touchAction = 'none'; // stop touch scrolling while dragging
+        return { eRoot: eRoot, pointerId, touchAction };
+    } catch {
+        return null; // Capture failed
+    }
+};
+
+export const releaseMouseCapture = (capture: MouseCapture | null): null => {
+    if (!capture) {
+        return null;
+    }
+
+    const { eRoot, pointerId, touchAction } = capture;
+    try {
+        eRoot.releasePointerCapture(pointerId);
+        if (touchAction != null) {
+            eRoot.style.touchAction = touchAction;
+        }
+    } catch {
+        // do nothing, just means pointer capture is not supported
+    }
+    return null;
+};


### PR DESCRIPTION
- eElement being dragged could be destroyed, like it happens in the drag and drop pill where refresh rebuilts the whole ui from scratch when dragging start - so we need to attach the pointer events to the grid root div
- move the mouse capture conservatively only when we have a drag ghost, so we don't cause problem with cell selection that still relies on mouse move