### PR TITLE
AG-16006 update that creates filler row does not honour collapsed state

### DIFF
--- a/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
@@ -156,11 +156,11 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
                     if (oldParent) {
                         const oldParentFlags = oldParent.treeNodeFlags;
                         if (
-                            removedNodes?.has(oldParent) &&
                             (oldParentFlags & FLAG_EXPANDED_INITIALIZED) !== 0 &&
                             (parentFlags & FLAG_EXPANDED_INITIALIZED) === 0 &&
                             parent.treeParent !== null &&
-                            parent.sourceRowIndex < 0
+                            parent.sourceRowIndex < 0 &&
+                            removedNodes?.has(oldParent)
                         ) {
                             // If parent is a new filler node, copy the expanded flag from old removed parent
                             parent.expanded = oldParent.expanded;

--- a/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
@@ -702,17 +702,15 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
             const end = segments[level];
             const subPath = pathKey.slice(0, end);
             let current = nodesByPath.get(subPath);
-            if (current !== undefined) {
-                if (current.sourceRowIndex < 0) {
-                    fillerId = current.id!;
-                    fillerLevel = level + 1; // current filler includes segment at 'level'
-                }
-            } else {
+            if (current === undefined) {
                 const fillerKey = start === 0 ? subPath : pathKey.slice(start, end);
                 fillerId = this.makeFillerIdBase(pathKey, segments, level, fillerId, fillerLevel) + fillerKey;
                 current = this.getOrCreateFiller(fillerKey, fillerId);
                 nodesByPath.set(subPath, current);
                 fillerLevel = level + 1;
+            } else if (current.sourceRowIndex < 0) {
+                fillerId = current.id!;
+                fillerLevel = level + 1; // current filler includes segment at 'level'
             }
             current.treeParent = treeParent;
             treeParent = current;

--- a/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
@@ -171,9 +171,7 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
             }
 
             if (parentChanged && oldParent) {
-                const removedOldParent = !!removedNodes?.has(oldParent);
-                const shouldInitExpand = removedOldParent && maybeExpandFromRemovedParent(parent, oldParent);
-                if (shouldInitExpand) {
+                if (removedNodes?.has(oldParent) && maybeExpandFromRemovedParent(parent, oldParent)) {
                     parentFlags |= FLAG_EXPANDED_INITIALIZED;
                 }
                 oldParent.treeNodeFlags |= FLAG_CHANGED;

--- a/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
@@ -35,13 +35,11 @@ const FLAG_EXPANDED_INITIALIZED = 0x10000000;
 /** Mask used to keep track of the number of children in a node */
 const MASK_CHILDREN_LEN = 0x0fffffff; // This equates to 268,435,455 maximum children per parent, more than enough
 
+const random = Math.random;
+
 /** Path key separator used to flatten hierarchical paths. Includes uncommon and randomized characters to avoid collisions and abuse. */
-const PATH_KEY_SEPARATOR = String.fromCodePoint(
-    31,
-    4096 + Math.floor(Math.random() * 61440),
-    4096 + Math.floor(Math.random() * 61440),
-    8291
-);
+const PATH_KEY_SEPARATOR = String.fromCodePoint(31, (4096 + random() * 61440) | 0, (4096 + random() * 61440) | 0, 8291);
+
 const PATH_KEY_SEPARATOR_LEN = 4;
 
 export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGroupingStrategy<TData> {

--- a/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
@@ -35,12 +35,9 @@ const FLAG_EXPANDED_INITIALIZED = 0x10000000;
 /** Mask used to keep track of the number of children in a node */
 const MASK_CHILDREN_LEN = 0x0fffffff; // This equates to 268,435,455 maximum children per parent, more than enough
 
-const random = Math.random;
-
-/** Path key separator used to flatten hierarchical paths. Includes uncommon and randomized characters to avoid collisions and abuse. */
-const PATH_KEY_SEPARATOR = String.fromCodePoint(31, (4096 + random() * 61440) | 0, (4096 + random() * 61440) | 0, 8291);
-
-const PATH_KEY_SEPARATOR_LEN = 4;
+/** Path key separator used to flatten hierarchical paths. Includes uncommon characters to reduce the risk of collisions. */
+const PATH_KEY_SEPARATOR = String.fromCodePoint(31, 41150, 8291);
+const PATH_KEY_SEPARATOR_LEN = 3;
 
 export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGroupingStrategy<TData> {
     private groupColsIds: string = '';
@@ -136,23 +133,23 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
         }
         const rootAllLeafChildren = rootNode.allLeafChildren!;
         const allLeafChildrenLen = rootAllLeafChildren.length;
-        let treeChanged = false;
+        let parentsChanged = false;
         for (let i = 0; i < allLeafChildrenLen; ++i) {
             if (this.initRowParent(rootAllLeafChildren[i], removedNodes)) {
-                treeChanged = true;
+                parentsChanged = true;
             }
         }
-        return treeChanged;
+        return parentsChanged;
     }
 
     private initRowParent(current: GroupingRowNode<TData>, removedNodes: Set<RowNode> | undefined): boolean {
-        let treeChanged = false;
+        let parentsChanged = false;
         while (true) {
             const oldParent = current.parent;
             const parent = current.treeParent;
             if (parent === null) {
                 if (oldParent) {
-                    treeChanged = true;
+                    parentsChanged = true;
                     this.hideRow(current); // Hide the row if it has no parent
                 }
                 break; // No more parents to process, we are at the root
@@ -163,7 +160,7 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
 
             const parentChanged = oldParent !== parent;
             if (parentChanged) {
-                treeChanged = true;
+                parentsChanged = true;
                 parentFlags |= FLAG_CHANGED;
                 current.parent = parent;
             }
@@ -184,7 +181,7 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
             parent.treeNodeFlags = parentFlags | FLAG_MARKED_FILLER | (current.treeNodeFlags & FLAG_CHANGED);
             current = parent;
         }
-        return treeChanged;
+        return parentsChanged;
     }
 
     private destroyFillerRows(): void {

--- a/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
@@ -36,8 +36,12 @@ const FLAG_EXPANDED_INITIALIZED = 0x10000000;
 const MASK_CHILDREN_LEN = 0x0fffffff; // This equates to 268,435,455 maximum children per parent, more than enough
 
 /** Path key separator used to flatten hierarchical paths. Includes uncommon and randomized characters to avoid collisions and abuse. */
-const PATH_KEY_SEPARATOR = String.fromCharCode(31, 4096 + Math.random() * 61440, 4096 + Math.random() * 61440, 8291);
-
+const PATH_KEY_SEPARATOR = String.fromCodePoint(
+    31,
+    4096 + Math.floor(Math.random() * 61440),
+    4096 + Math.floor(Math.random() * 61440),
+    8291
+);
 const PATH_KEY_SEPARATOR_LEN = 4;
 
 export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGroupingStrategy<TData> {
@@ -129,54 +133,60 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
     }
 
     private initRowsParents(rootNode: GroupingRowNode<TData>, removedNodes: Set<RowNode> | undefined): boolean {
-        if (!removedNodes?.size) {
-            removedNodes = undefined;
+        if (removedNodes?.size === 0) {
+            removedNodes = undefined; // Avoid checking for emptiness later
         }
         const rootAllLeafChildren = rootNode.allLeafChildren!;
         const allLeafChildrenLen = rootAllLeafChildren.length;
         let treeChanged = false;
         for (let i = 0; i < allLeafChildrenLen; ++i) {
-            let current = rootAllLeafChildren[i];
-            while (true) {
-                const oldParent = current.parent;
-                const parent = current.treeParent;
-                if (parent === null) {
-                    if (oldParent) {
-                        treeChanged = true;
-                        this.hideRow(current); // Hide the row if it has no parent
-                    }
-                    break; // No more parents to process, we are at the root
-                }
-
-                let parentFlags = parent.treeNodeFlags + 1; // Increment the number of children in the parent
-                if (oldParent !== parent) {
-                    treeChanged = true;
-                    parentFlags |= FLAG_CHANGED;
-                    current.parent = parent;
-                    if (oldParent) {
-                        const oldParentFlags = oldParent.treeNodeFlags;
-                        if (
-                            (oldParentFlags & FLAG_EXPANDED_INITIALIZED) !== 0 &&
-                            (parentFlags & FLAG_EXPANDED_INITIALIZED) === 0 &&
-                            parent.treeParent !== null &&
-                            parent.sourceRowIndex < 0 &&
-                            removedNodes?.has(oldParent)
-                        ) {
-                            // If parent is a new filler node, copy the expanded flag from old removed parent
-                            parent.expanded = oldParent.expanded;
-                            parentFlags |= FLAG_EXPANDED_INITIALIZED;
-                        }
-                        oldParent.treeNodeFlags = oldParentFlags | FLAG_CHANGED;
-                    }
-                }
-
-                if (parent.data || (parent.treeNodeFlags & FLAG_MARKED_FILLER) !== 0 || parent.treeParent === null) {
-                    parent.treeNodeFlags = parentFlags;
-                    break; // Continue up only if parent is a non-processed filler
-                }
-                parent.treeNodeFlags = parentFlags | FLAG_MARKED_FILLER | (current.treeNodeFlags & FLAG_CHANGED); // Mark filler as processed
-                current = parent;
+            if (this.initRowParent(rootAllLeafChildren[i], removedNodes)) {
+                treeChanged = true;
             }
+        }
+        return treeChanged;
+    }
+
+    private initRowParent(current: GroupingRowNode<TData>, removedNodes: Set<RowNode> | undefined): boolean {
+        let treeChanged = false;
+        while (true) {
+            const oldParent = current.parent;
+            const parent = current.treeParent;
+            if (parent === null) {
+                if (oldParent) {
+                    treeChanged = true;
+                    this.hideRow(current); // Hide the row if it has no parent
+                }
+                break; // No more parents to process, we are at the root
+            }
+
+            // Increment the number of children in the parent
+            let parentFlags = parent.treeNodeFlags + 1;
+
+            const parentChanged = oldParent !== parent;
+            if (parentChanged) {
+                treeChanged = true;
+                parentFlags |= FLAG_CHANGED;
+                current.parent = parent;
+            }
+
+            if (parentChanged && oldParent) {
+                const removedOldParent = !!removedNodes?.has(oldParent);
+                const shouldInitExpand = removedOldParent && maybeExpandFromRemovedParent(parent, oldParent);
+                if (shouldInitExpand) {
+                    parentFlags |= FLAG_EXPANDED_INITIALIZED;
+                }
+                oldParent.treeNodeFlags |= FLAG_CHANGED;
+            }
+
+            if (parent.sourceRowIndex >= 0 || parent.treeNodeFlags & FLAG_MARKED_FILLER || parent.treeParent === null) {
+                parent.treeNodeFlags = parentFlags;
+                break; // Continue up only if parent is a non-processed filler
+            }
+
+            // Mark filler as processed
+            parent.treeNodeFlags = parentFlags | FLAG_MARKED_FILLER | (current.treeNodeFlags & FLAG_CHANGED);
+            current = parent;
         }
         return treeChanged;
     }
@@ -216,7 +226,7 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
         let { childrenAfterGroup, allLeafChildren, treeNodeFlags } = row;
         const oldLen = childrenAfterGroup?.length;
         const len = treeNodeFlags & MASK_CHILDREN_LEN;
-        row.treeNodeFlags = (treeNodeFlags & ~MASK_CHILDREN_LEN) | ((oldLen || 0) !== len ? FLAG_CHILDREN_CHANGED : 0);
+        row.treeNodeFlags = (treeNodeFlags & ~MASK_CHILDREN_LEN) | ((oldLen || 0) === len ? 0 : FLAG_CHILDREN_CHANGED);
         if (len === 0 && row.level >= 0) {
             if (childrenAfterGroup !== _EmptyArray) {
                 row.childrenAfterGroup = _EmptyArray;
@@ -392,7 +402,9 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
         const mark = (row: GroupingRowNode<TData>): boolean => {
             if (marked.has(row)) return false;
             marked.add(row);
-            row.childrenAfterGroup!.forEach(mark);
+            for (const child of row.childrenAfterGroup!) {
+                mark(child);
+            }
             return true;
         };
         mark(rootNode);
@@ -832,3 +844,23 @@ const compareSourceRowIndex = <TData>(a: RowNode<TData>, b: RowNode<TData>): num
     a.sourceRowIndex - b.sourceRowIndex;
 
 type DuplicatePathsMap<TData> = Map<string, GroupingRowNode<TData>[]>;
+
+/**
+ * If parent is a new filler node, copy the expanded flag from old removed parent.
+ * Returns true if the expanded flag was copied.
+ */
+const maybeExpandFromRemovedParent = <TData>(
+    parent: GroupingRowNode<TData>,
+    oldParent: GroupingRowNode<TData>
+): boolean => {
+    if (
+        (oldParent.treeNodeFlags & FLAG_EXPANDED_INITIALIZED) !== 0 &&
+        (parent.treeNodeFlags & FLAG_EXPANDED_INITIALIZED) === 0 &&
+        parent.treeParent !== null &&
+        parent.sourceRowIndex < 0
+    ) {
+        parent.expanded = oldParent.expanded;
+        return true;
+    }
+    return false;
+};

--- a/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
@@ -87,7 +87,7 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
             }
         }
 
-        const parentsChanged = this.initRowsParents(rootNode);
+        const parentsChanged = this.initRowsParents(rootNode, changedRowNodes?.removals);
 
         this.destroyFillerRows();
 
@@ -128,7 +128,10 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
         return hasUpdates;
     }
 
-    private initRowsParents(rootNode: GroupingRowNode<TData>): boolean {
+    private initRowsParents(rootNode: GroupingRowNode<TData>, removedNodes: Set<RowNode> | undefined): boolean {
+        if (!removedNodes?.size) {
+            removedNodes = undefined;
+        }
         const rootAllLeafChildren = rootNode.allLeafChildren!;
         const allLeafChildrenLen = rootAllLeafChildren.length;
         let treeChanged = false;
@@ -153,12 +156,14 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
                     if (oldParent) {
                         const oldParentFlags = oldParent.treeNodeFlags;
                         if (
+                            removedNodes?.has(oldParent) &&
                             (oldParentFlags & FLAG_EXPANDED_INITIALIZED) !== 0 &&
                             (parentFlags & FLAG_EXPANDED_INITIALIZED) === 0 &&
                             parent.treeParent !== null &&
-                            !parent.data
+                            parent.sourceRowIndex < 0
                         ) {
-                            parent.expanded = oldParent.expanded; // If parent is a new filler node, copy the expanded flag from old parent
+                            // If parent is a new filler node, copy the expanded flag from old removed parent
+                            parent.expanded = oldParent.expanded;
                             parentFlags |= FLAG_EXPANDED_INITIALIZED;
                         }
                         oldParent.treeNodeFlags = oldParentFlags | FLAG_CHANGED;

--- a/testing/behavioural/src/tree-data/datapath/tree-expanded-state.test.ts
+++ b/testing/behavioural/src/tree-data/datapath/tree-expanded-state.test.ts
@@ -125,6 +125,81 @@ describe('ag-grid tree expanded state', () => {
             · └── yoo-1 LEAF id:yoo-1
         `);
     });
+
+    test('updated node that creates filler starts collapsed', async () => {
+        const node1 = {
+            path: ['Desktop', 'ProjectAlpha', 'Proposal.docx'],
+            key: '1',
+        };
+
+        const node2 = {
+            path: ['Desktop', 'ProjectAlpha', 'Timeline.xlsx'],
+            key: '2',
+        };
+
+        const rowData = [node1, node2];
+
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [],
+            rowData,
+            treeData: true,
+            groupDefaultExpanded: 0,
+            getDataPath: (data) => data.path,
+            getRowId: (params) => params.data.key,
+        });
+
+        let gridRows = new GridRows(api, 'initial', gridRowsOptions);
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ Desktop filler collapsed id:row-group-0-Desktop
+            · └─┬ ProjectAlpha filler collapsed hidden id:row-group-0-Desktop-1-ProjectAlpha
+            · · ├── Proposal.docx LEAF hidden id:1
+            · · └── Timeline.xlsx LEAF hidden id:2
+        `);
+
+        // Expand Desktop and ProjectAlpha
+        api.getRowNode('row-group-0-Desktop')!.setExpanded(true, undefined, true);
+        api.getRowNode('row-group-0-Desktop-1-ProjectAlpha')!.setExpanded(true, undefined, true);
+
+        gridRows = new GridRows(api, 'expanded', gridRowsOptions);
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ Desktop filler id:row-group-0-Desktop
+            · └─┬ ProjectAlpha filler id:row-group-0-Desktop-1-ProjectAlpha
+            · · ├── Proposal.docx LEAF id:1
+            · · └── Timeline.xlsx LEAF id:2
+        `);
+
+        const update = () => {
+            const last_node = node2.path[node2.path.length - 1];
+
+            // Create the update node
+            const updateNode = { ...node2 };
+            updateNode.path = [
+                ...updateNode.path.slice(0, updateNode.path.length - 1),
+                last_node + '-virtual',
+                last_node,
+            ];
+            const newNode = { ...node2, key: '3' };
+
+            newNode.path = [...newNode.path.slice(0, newNode.path.length - 1), last_node + '-virtual', 'newNode'];
+
+            api.applyTransaction({ update: [updateNode], add: [newNode] });
+        };
+
+        update();
+
+        gridRows = new GridRows(api, 'updated', gridRowsOptions);
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ Desktop filler id:row-group-0-Desktop
+            · └─┬ ProjectAlpha filler id:row-group-0-Desktop-1-ProjectAlpha
+            · · ├── Proposal.docx LEAF id:1
+            · · └─┬ Timeline.xlsx-virtual filler collapsed id:row-group-0-Desktop-1-ProjectAlpha-2-Timeline.xlsx-virtual
+            · · · ├── Timeline.xlsx LEAF hidden id:2
+            · · · └── newNode LEAF hidden id:3
+        `);
+    });
 });
 
 function getOrgHierarchyData() {

--- a/testing/module-size/moduleDefinitions.ts
+++ b/testing/module-size/moduleDefinitions.ts
@@ -51,7 +51,7 @@ export const AllGridCommunityModules: Record<`${CommunityModuleName}Module`, num
 };
 export const AllEnterpriseModules: Record<`${EnterpriseModuleName}Module`, number> = {
     AdvancedFilterModule: 217.72,
-    AllEnterpriseModule: 1493.76,
+    AllEnterpriseModule: 1498.82,
     BatchEditModule: 81.15,
     CellSelectionModule: 55,
     ClipboardModule: 46.04,


### PR DESCRIPTION
The was a specific logic that was used to solve a user request of when a parent node is removed, the expanded state is maintained on the newly created filler node.
The implementation was not however checking that the parent was effectively removed and so was applying the logic also on newly created filler nodes when updating a path.

- fix the logic in initRowsParents to check that the parent node was effectively deleted before copying the expanded state
- add a unit test to verify this situation