### PR TITLE
AG-9704 Use relative assertions in doc tests

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/column-resizing/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/column-resizing/example.spec.ts
@@ -9,7 +9,7 @@ const COL_IDS = ['athlete', 'age', 'country', 'year', 'date'] as const;
 
 type ColIds = (typeof COL_IDS)[number];
 
-function getHeaders({ agIdFor }: AgGridFixtures): Record<ColIds, Locator> {
+function getHeaders(agIdFor: AgGridFixtures['agIdFor']): Record<ColIds, Locator> {
     return Object.fromEntries(COL_IDS.map((colId) => [colId, agIdFor.headerCell(colId)])) as Record<ColIds, Locator>;
 }
 
@@ -27,9 +27,8 @@ async function totalHeaderWidth(headers: Record<ColIds, Locator>): Promise<numbe
 }
 
 test.agExample(import.meta, () => {
-    test.eachFramework('fitCellToContents', async (fixtures) => {
-        const { page } = fixtures;
-        const headers = getHeaders(fixtures);
+    test.eachFramework('fitCellToContents', async ({ page, agIdFor }) => {
+        const headers = getHeaders(agIdFor);
         const headerRow = page.locator('.ag-header-row').filter({ has: headers.athlete });
         const baseHeaderWidths = await getHeaderWidths(headers);
 
@@ -93,17 +92,18 @@ test.agExample(import.meta, () => {
         await page.locator('#toggle-scale-up').click(); // on
         await page.locator('button.resize-button').click();
 
-        expect(await getWidth(page.locator('.ag-header-row').filter({ has: agIdFor.headerCell('athlete') }))).toEqual(
-            680
-        );
+        expect(
+            await getWidth(page.locator('.ag-header-row').filter({ has: agIdFor.headerCell('athlete') }))
+        ).toBeGreaterThan(600);
     });
 
     test.describe('Example modifications', () => {
         test.use({ agModules: ['RowSelectionModule'] });
 
         test.eachFramework('fitCellContents + pinned col + selection col', async ({ page, remoteGrid, agIdFor }) => {
-            const remoteApi = remoteGrid(page, '1');
+            const headers = getHeaders(agIdFor);
 
+            const remoteApi = remoteGrid(page, '1');
             await remoteApi.setGridOption('rowSelection', { mode: 'multiRow' });
             await remoteApi.setGridOption('columnDefs', [
                 { field: 'athlete', width: 150, pinned: 'left' },
@@ -116,23 +116,25 @@ test.agExample(import.meta, () => {
                 { field: 'year', width: 90 },
                 { field: 'date', width: 110 },
             ]);
+            const baseHeaderWidths = await getHeaderWidths(headers);
 
             await page.locator('#toggle-scale-up').click(); // on
             await page.locator('button.resize-button').click();
+            const apiResizedHeaderWidths = await getHeaderWidths(headers);
 
-            expect(await getWidth(agIdFor.headerCell('athlete'))).toEqual(185);
-            expect(await getWidth(agIdFor.headerCell('age'))).toEqual(222);
-            expect(await getWidth(agIdFor.headerCell('country'))).toEqual(296);
-            expect(await getWidth(agIdFor.headerCell('year'))).toEqual(222);
-            expect(await getWidth(agIdFor.headerCell('date'))).toEqual(271);
+            expect(apiResizedHeaderWidths.athlete).toBeGreaterThan(baseHeaderWidths.athlete);
+            expect(apiResizedHeaderWidths.age).toBeGreaterThan(baseHeaderWidths.age);
+            expect(apiResizedHeaderWidths.country).toBeGreaterThan(baseHeaderWidths.country);
+            expect(apiResizedHeaderWidths.year).toBeGreaterThan(baseHeaderWidths.year);
+            expect(apiResizedHeaderWidths.date).toBeGreaterThan(baseHeaderWidths.date);
 
             expect(await getWidth(agIdFor.headerCell('ag-Grid-SelectionColumn'))).toEqual(50);
 
-            const pinnedWidth =
-                (await getWidth(page.locator('.ag-header-row').filter({ has: agIdFor.headerCell('athlete') }))) ?? 0;
-            const mainWidth =
-                (await getWidth(page.locator('.ag-header-row').filter({ has: agIdFor.headerCell('age') }))) ?? 0;
-            expect(pinnedWidth + mainWidth).toEqual(1246);
+            const pinnedWidth = (await getWidth(page.locator('.ag-header-row').filter({ has: headers.athlete }))) ?? 0;
+            const mainWidth = (await getWidth(page.locator('.ag-header-row').filter({ has: headers.age }))) ?? 0;
+
+            // +50 for the selection column
+            expect(pinnedWidth + mainWidth).toEqual((await totalHeaderWidth(headers)) + 50);
         });
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/column-resizing/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/column-resizing/example.spec.ts
@@ -1,74 +1,90 @@
-import { expect, test } from '@utils/grid/test-utils';
+import { type AgGridFixtures, expect, test } from '@utils/grid/test-utils';
 import type { Locator } from 'playwright/test';
 
 async function getWidth(locator: Locator): Promise<number | undefined> {
     return (await locator.boundingBox())?.width;
 }
 
-test.agExample(import.meta, () => {
-    test.eachFramework('fitCellToContents', async ({ page, agIdFor }) => {
-        expect(await getWidth(agIdFor.headerCell('athlete'))).toEqual(150);
-        expect(await getWidth(agIdFor.headerCell('age'))).toEqual(142);
-        expect(await getWidth(agIdFor.headerCell('country'))).toEqual(137);
-        expect(await getWidth(agIdFor.headerCell('year'))).toEqual(86);
-        expect(await getWidth(agIdFor.headerCell('date'))).toEqual(130);
+const COL_IDS = ['athlete', 'age', 'country', 'year', 'date'] as const;
 
-        expect(await getWidth(page.locator('.ag-header-row').filter({ has: agIdFor.headerCell('athlete') }))).toEqual(
-            645
-        );
+type ColIds = (typeof COL_IDS)[number];
 
-        // API call doesn't use defaultMaxWidth so we expect a larger column
-        await page.locator('button.resize-button').click();
-        expect(await getWidth(agIdFor.headerCell('athlete'))).toEqual(185);
-        expect(await getWidth(page.locator('.ag-header-row').filter({ has: agIdFor.headerCell('athlete') }))).toEqual(
-            680
-        );
-    });
+function getHeaders({ agIdFor }: AgGridFixtures): Record<ColIds, Locator> {
+    return Object.fromEntries(COL_IDS.map((colId) => [colId, agIdFor.headerCell(colId)])) as Record<ColIds, Locator>;
+}
 
-    test.eachFramework(
-        'fitCellToContents combinations of skipHeaders and scaleUpToFitGridWidth',
-        async ({ page, agIdFor }) => {
-            // `skipHeaders`
-            await page.locator('#toggle-ignore-headers').click(); // on
-            await page.locator('button.resize-button').click();
-
-            expect(await getWidth(agIdFor.headerCell('athlete'))).toEqual(185);
-            expect(await getWidth(agIdFor.headerCell('age'))).toEqual(69);
-            expect(await getWidth(agIdFor.headerCell('country'))).toEqual(137);
-            expect(await getWidth(agIdFor.headerCell('year'))).toEqual(86);
-            expect(await getWidth(agIdFor.headerCell('date'))).toEqual(130);
-            expect(
-                await getWidth(page.locator('.ag-header-row').filter({ has: agIdFor.headerCell('athlete') }))
-            ).toEqual(607);
-
-            // `scaleUpToFitGridWidth`
-            await page.locator('#toggle-ignore-headers').click(); // off
-            await page.locator('#toggle-scale-up').click(); // on
-            await page.locator('button.resize-button').click();
-
-            expect(await getWidth(agIdFor.headerCell('athlete'))).toEqual(185);
-            expect(await getWidth(agIdFor.headerCell('age'))).toEqual(150);
-            expect(await getWidth(agIdFor.headerCell('country'))).toEqual(342);
-            expect(await getWidth(agIdFor.headerCell('year'))).toEqual(256);
-            expect(await getWidth(agIdFor.headerCell('date'))).toEqual(313);
-            expect(
-                await getWidth(page.locator('.ag-header-row').filter({ has: agIdFor.headerCell('athlete') }))
-            ).toEqual(1246);
-
-            // `skipHeaders` and `scaleUpToFitGridWidth`
-            await page.locator('#toggle-ignore-headers').click(); // on
-            await page.locator('button.resize-button').click();
-
-            expect(await getWidth(agIdFor.headerCell('athlete'))).toEqual(185);
-            expect(await getWidth(agIdFor.headerCell('age'))).toEqual(150);
-            expect(await getWidth(agIdFor.headerCell('country'))).toEqual(342);
-            expect(await getWidth(agIdFor.headerCell('year'))).toEqual(256);
-            expect(await getWidth(agIdFor.headerCell('date'))).toEqual(313);
-            expect(
-                await getWidth(page.locator('.ag-header-row').filter({ has: agIdFor.headerCell('athlete') }))
-            ).toEqual(1246);
-        }
+async function getHeaderWidths(headers: Record<ColIds, Locator>): Promise<Record<ColIds, number>> {
+    return Object.fromEntries(
+        await Promise.all(
+            Object.entries(headers).map(async ([colId, locator]) => [colId, (await getWidth(locator)) ?? 0])
+        )
     );
+}
+
+async function totalHeaderWidth(headers: Record<ColIds, Locator>): Promise<number> {
+    const widths = await Promise.all(Object.values(headers).map(getWidth));
+    return widths.reduce<number>((acc, w) => acc + (w ?? 0), 0);
+}
+
+test.agExample(import.meta, () => {
+    test.eachFramework('fitCellToContents', async (fixtures) => {
+        const { page } = fixtures;
+        const headers = getHeaders(fixtures);
+        const headerRow = page.locator('.ag-header-row').filter({ has: headers.athlete });
+        const baseHeaderWidths = await getHeaderWidths(headers);
+
+        expect(await getWidth(headerRow)).toEqual(await totalHeaderWidth(headers));
+
+        await page.locator('button.resize-button').click();
+        const apiResizedHeaderWidths = await getHeaderWidths(headers);
+        // API call doesn't use defaultMaxWidth so we expect a larger column
+        expect(apiResizedHeaderWidths.athlete).toBeGreaterThan(baseHeaderWidths.athlete);
+        expect(apiResizedHeaderWidths.age).toBe(baseHeaderWidths.age);
+        expect(apiResizedHeaderWidths.country).toBe(baseHeaderWidths.country);
+        expect(apiResizedHeaderWidths.year).toBe(baseHeaderWidths.year);
+        expect(apiResizedHeaderWidths.date).toBe(baseHeaderWidths.date);
+        expect(await getWidth(headerRow)).toEqual(await totalHeaderWidth(headers));
+
+        // `skipHeaders only`
+        await page.locator('#toggle-ignore-headers').click(); // on
+        await page.locator('button.resize-button').click();
+
+        // when we skip headers, we expect all widths to be the same except for the age column, which is narrower now
+        const headerSkippedWidths = await getHeaderWidths(headers);
+
+        expect(headerSkippedWidths.athlete).toBe(apiResizedHeaderWidths.athlete);
+        expect(headerSkippedWidths.age).toBeLessThan(apiResizedHeaderWidths.age);
+        expect(headerSkippedWidths.country).toBe(apiResizedHeaderWidths.country);
+        expect(headerSkippedWidths.year).toBe(apiResizedHeaderWidths.year);
+        expect(headerSkippedWidths.date).toBe(apiResizedHeaderWidths.date);
+        expect(await getWidth(headerRow)).toEqual(await totalHeaderWidth(headers));
+
+        // `scaleUpToFitGridWidth only`
+        await page.locator('#toggle-ignore-headers').click(); // off
+        await page.locator('#toggle-scale-up').click(); // on
+        await page.locator('button.resize-button').click();
+        const scaledUpHeaderWidths = await getHeaderWidths(headers);
+
+        expect(scaledUpHeaderWidths.athlete).toBe(apiResizedHeaderWidths.athlete);
+        // here the age column needs to be scaled up to fill the grid
+        expect(scaledUpHeaderWidths.age).toBeGreaterThan(baseHeaderWidths.age);
+        expect(scaledUpHeaderWidths.country).toBeGreaterThan(baseHeaderWidths.country);
+        expect(scaledUpHeaderWidths.year).toBeGreaterThan(baseHeaderWidths.year);
+        expect(scaledUpHeaderWidths.date).toBeGreaterThan(baseHeaderWidths.date);
+        expect(await getWidth(headerRow)).toEqual(await totalHeaderWidth(headers));
+
+        // `skipHeaders` and `scaleUpToFitGridWidth`
+        await page.locator('#toggle-ignore-headers').click(); // on
+        await page.locator('button.resize-button').click();
+        const headerSkippedAndScaledUpHeaderWidths = await getHeaderWidths(headers);
+
+        expect(headerSkippedAndScaledUpHeaderWidths.athlete).toBe(apiResizedHeaderWidths.athlete);
+        expect(headerSkippedAndScaledUpHeaderWidths.age).toBe(scaledUpHeaderWidths.age);
+        expect(headerSkippedAndScaledUpHeaderWidths.country).toBe(scaledUpHeaderWidths.country);
+        expect(headerSkippedAndScaledUpHeaderWidths.year).toBe(scaledUpHeaderWidths.year);
+        expect(headerSkippedAndScaledUpHeaderWidths.date).toBe(scaledUpHeaderWidths.date);
+        expect(await getWidth(headerRow)).toEqual(await totalHeaderWidth(headers));
+    });
 
     test.eachFramework('fitCellToContents + scaleUpToFitGridWidth does not scale down', async ({ agIdFor, page }) => {
         // need to set the viewport size to less than the column width to test the scale-down

--- a/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
@@ -25,7 +25,7 @@ type RemoteGrid = ((page: Page, gridId?: string) => AsyncGridApi) & {
     waitForEventlog: (timeoutMs: number) => Promise<EventLog>;
 };
 
-type AgGridFixtures = {
+export type AgGridFixtures = {
     agFramework: AgFramework;
     agExampleUrl?: AgExampleUrl;
     /**


### PR DESCRIPTION
Don't hardcode pixel assertions to avoid platform specific differences.