### PR TITLE
AG-15757 fix fill handle bug

### DIFF
--- a/packages/ag-grid-community/src/agStack/core/baseDragAndDropService.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseDragAndDropService.ts
@@ -1,5 +1,3 @@
-import type { MouseCapture } from '../events/mouseCapture';
-import { captureMouse, releaseMouseCapture } from '../events/mouseCapture';
 import type { AgCoreBeanCollection } from '../interfaces/agCoreBeanCollection';
 import type { BaseEvents } from '../interfaces/baseEvents';
 import type { BaseProperties } from '../interfaces/baseProperties';
@@ -57,7 +55,6 @@ export abstract class BaseDragAndDropService<
     private dragImageComp: (IComponent<any> & IDragAndDropImage) | null = null;
     private dragImageLastIcon: TDragAndDropIcon | null | undefined = undefined;
     private dragImageLastLabel: string | null | undefined = undefined;
-    private mouseCapture: MouseCapture | null = null;
 
     private dropTargets: AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent>[] = [];
     private lastDropTarget: AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent> | null = null;
@@ -78,6 +75,7 @@ export abstract class BaseDragAndDropService<
 
     public addDragSource(dragSource: TDragSource, allowTouch = false): void {
         const entry: DragSourceAndParams<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent, TDragSource> = {
+            capturePointer: true,
             dragSource,
             eElement: dragSource.eElement,
             dragStartPixels: dragSource.dragStartPixels,
@@ -138,10 +136,6 @@ export abstract class BaseDragAndDropService<
         this.dragInitialSourcePointerOffsetY = mouseEvent.clientY - rect.top;
 
         dragSource.onDragStarted?.();
-
-        if (typeof PointerEvent !== 'undefined' && mouseEvent instanceof PointerEvent) {
-            this.mouseCapture = captureMouse(this.beans.eRootDiv, mouseEvent);
-        }
 
         this.createAndUpdateDragImageComp(dragSource);
     }
@@ -213,7 +207,6 @@ export abstract class BaseDragAndDropService<
     }
 
     private clearDragAndDropProperties(): void {
-        this.mouseCapture = releaseMouseCapture(this.mouseCapture);
         this.removeDragImageComp(this.dragImageComp);
         this.dragImageCompPromise = null;
         this.dragImageParent = null;
@@ -226,7 +219,6 @@ export abstract class BaseDragAndDropService<
         this.dragInitialSourcePointerOffsetX = 0;
         this.dragInitialSourcePointerOffsetY = 0;
         this.dragSource = null;
-        this.mouseCapture = null;
     }
 
     private getAllContainersFromDropTarget(
@@ -419,8 +411,8 @@ export abstract class BaseDragAndDropService<
 
         style.position = 'absolute';
         style.zIndex = '9999';
-        if (this.mouseCapture != null) {
-            style.pointerEvents = 'none';
+        if (this.beans.dragSvc?.hasPointerCapture()) {
+            style.pointerEvents = 'none'; // stops the ghost image from interfering with scrolling
         }
 
         this.gos.setInstanceDomData(eGui);

--- a/packages/ag-grid-community/src/agStack/core/baseDragService.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseDragService.ts
@@ -375,7 +375,7 @@ export class BaseDragService<
         if (!this.dragging) {
             const start = drag.start;
             const dragStartPixels = dragSource.dragStartPixels;
-            const requiredPixelDiff = dragStartPixels != null ? dragStartPixels : 4;
+            const requiredPixelDiff = dragStartPixels ?? 4;
 
             // if pointer hasn't travelled from the start position enough, do nothing
             if (_areEventsNear(currentEvent, start, requiredPixelDiff)) {

--- a/packages/ag-grid-community/src/agStack/core/baseDragService.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseDragService.ts
@@ -1,4 +1,6 @@
 import { KeyCode } from '../constants/keyCode';
+import type { PointerCapture } from '../events/pointerCapture';
+import { capturePointer, releasePointerCapture } from '../events/pointerCapture';
 import type { AgCoreBeanCollection } from '../interfaces/agCoreBeanCollection';
 import type { BaseEvents } from '../interfaces/baseEvents';
 import type { BaseProperties } from '../interfaces/baseProperties';
@@ -16,7 +18,6 @@ import {
     clearTempEventHandlers,
     preventEventDefault,
 } from '../utils/event';
-import { _exists } from '../utils/generic';
 import { AgBeanStub } from './agBeanStub';
 
 let handledDragEvents: WeakSet<Event> | undefined;
@@ -45,11 +46,15 @@ export class BaseDragService<
 
     public dragging: boolean = false;
     private drag: Dragging | null = null;
-    private handledEvents: WeakSet<Event> | null = null;
     private readonly dragSources: DragSourceEntry[] = [];
 
     public get startTarget(): EventTarget | null {
         return this.drag?.start.target ?? null;
+    }
+
+    public hasPointerCapture(): boolean {
+        const capture = this.drag?.pointerCapture;
+        return !!(capture && this.beans.eRootDiv.hasPointerCapture?.(capture.pointerId));
     }
 
     public override destroy(): void {
@@ -62,7 +67,6 @@ export class BaseDragService<
         }
         dragSources.length = 0;
         super.destroy();
-        this.handledEvents = null;
     }
 
     public removeDragSource(params: DragListenerParams): void {
@@ -160,6 +164,7 @@ export class BaseDragService<
         const drag = this.drag;
         if (drag) {
             this.drag = null;
+            releasePointerCapture(drag.pointerCapture);
             clearTempEventHandlers(drag.handlers);
         }
     }
@@ -167,7 +172,7 @@ export class BaseDragService<
     // Pointer Events path (preferred when supported)
     private onPointerDown(params: DragListenerParams, pointerEvent: PointerEvent): void {
         const beans = this.beans;
-        if (this.handledEvents?.has(pointerEvent)) {
+        if (handledDragEvents?.has(pointerEvent)) {
             return; // Already handled
         }
 
@@ -208,12 +213,12 @@ export class BaseDragService<
 
         const onUp = (ev: PointerEvent) => {
             if (ev.pointerId === pointerId) {
-                this.onUp(ev);
+                this.onMouseOrPointerUp(ev);
             }
         };
 
         const onCancel = (ev: PointerEvent) => {
-            if (ev.pointerId === pointerId) {
+            if (ev.pointerId === pointerId && addHandledDragEvent(ev)) {
                 this.cancelDrag();
             }
         };
@@ -291,7 +296,7 @@ export class BaseDragService<
         // if there are two elements with parent / child relationship, and both are draggable,
         // when we drag the child, we should NOT drag the parent. an example of this is row moving
         // and range selection - row moving should get preference when use drags the rowDrag component.
-        if (this.handledEvents?.has(mouseEvent)) {
+        if (handledDragEvents?.has(mouseEvent)) {
             return; // Already handled
         }
 
@@ -305,7 +310,7 @@ export class BaseDragService<
         const mouseDrag = new Dragging(params, mouseEvent);
 
         const mouseMoveEvent = (event: MouseEvent) => this.onMouseOrPointerMove(event);
-        const mouseUpEvent = (event: MouseEvent) => this.onUp(event);
+        const mouseUpEvent = (event: MouseEvent) => this.onMouseOrPointerUp(event);
 
         const target = _getRootNode(beans);
         this.initDrag(mouseDrag, [target, 'mousemove', mouseMoveEvent], [target, 'mouseup', mouseUpEvent]);
@@ -364,18 +369,13 @@ export class BaseDragService<
             return;
         }
 
-        const pointerId = (currentEvent as Partial<PointerEvent>).pointerId;
-        if (pointerId != null && drag.pointerId != null && pointerId !== drag.pointerId) {
-            return; // Not the active pointer
-        }
-
         drag.lastDrag = currentEvent;
 
         const dragSource = drag.params;
         if (!this.dragging) {
             const start = drag.start;
             const dragStartPixels = dragSource.dragStartPixels;
-            const requiredPixelDiff = _exists(dragStartPixels) ? dragStartPixels : 4;
+            const requiredPixelDiff = dragStartPixels != null ? dragStartPixels : 4;
 
             // if pointer hasn't travelled from the start position enough, do nothing
             if (_areEventsNear(currentEvent, start, requiredPixelDiff)) {
@@ -383,6 +383,11 @@ export class BaseDragService<
             }
 
             this.dragging = true;
+
+            if (dragSource.capturePointer) {
+                drag.pointerCapture = capturePointer(this.beans.eRootDiv, currentEvent);
+            }
+
             this.eventSvc.dispatchEvent({
                 type: 'dragStarted',
                 target: dragSource.eElement,
@@ -414,8 +419,14 @@ export class BaseDragService<
 
     private onTouchUp(touchEvent: TouchEvent): void {
         const drag = this.drag;
-        if (drag) {
+        if (drag && addHandledDragEvent(touchEvent)) {
             this.onUp(_getFirstActiveTouch(drag.start as Touch, touchEvent.changedTouches));
+        }
+    }
+
+    private onMouseOrPointerUp(mouseEvent: MouseEvent | PointerEvent): void {
+        if (addHandledDragEvent(mouseEvent)) {
+            this.onUp(mouseEvent);
         }
     }
 
@@ -426,10 +437,6 @@ export class BaseDragService<
         }
         if (!eventOrTouch) {
             eventOrTouch = drag.lastDrag;
-        }
-        const pointerId = (eventOrTouch as Partial<PointerEvent>).pointerId;
-        if (pointerId != null && drag.pointerId != null && pointerId !== drag.pointerId) {
-            return; // Not the active pointer
         }
         if (eventOrTouch && this.dragging) {
             this.dragging = false;
@@ -471,6 +478,7 @@ class Dragging {
     public readonly eElement: Element & Partial<HTMLElement>;
     public readonly handlers: TempEventHandler[] = [];
     public lastDrag: PointerEvent | MouseEvent | Touch | null = null;
+    public pointerCapture: PointerCapture | null = null;
 
     constructor(
         readonly params: DragListenerParams,

--- a/packages/ag-grid-community/src/agStack/events/pointerCapture.ts
+++ b/packages/ag-grid-community/src/agStack/events/pointerCapture.ts
@@ -1,4 +1,4 @@
-export interface MouseCapture {
+export interface PointerCapture {
     eElement: HTMLElement | null;
     pointerId: number;
     onLost: ((event: PointerEvent) => void) | null;
@@ -16,7 +16,7 @@ const tryPointerCapture = (eElement: HTMLElement | null | undefined, pointerId: 
     return false;
 };
 
-export const captureMouse = (eElement: HTMLElement, mouseEvent: MouseEvent): MouseCapture | null => {
+export const capturePointer = (eElement: HTMLElement, mouseEvent: Event | Touch): PointerCapture | null => {
     if (typeof PointerEvent === 'undefined' || !(mouseEvent instanceof PointerEvent)) {
         return null;
     }
@@ -32,13 +32,13 @@ export const captureMouse = (eElement: HTMLElement, mouseEvent: MouseEvent): Mou
         onLost(pointerEvent: PointerEvent) {
             pointerLostHandler(capture, pointerEvent);
         },
-    } satisfies MouseCapture;
+    } satisfies PointerCapture;
 
     eElement.addEventListener('lostpointercapture', capture.onLost);
     return capture;
 };
 
-export const releaseMouseCapture = (capture: MouseCapture | null): null => {
+export const releasePointerCapture = (capture: PointerCapture | null): null => {
     if (!capture) {
         return null;
     }
@@ -58,7 +58,7 @@ export const releaseMouseCapture = (capture: MouseCapture | null): null => {
     return null;
 };
 
-const removeLostHandler = (capture: MouseCapture) => {
+const removeLostHandler = (capture: PointerCapture) => {
     const { eElement, onLost } = capture;
     if (eElement && onLost) {
         eElement.removeEventListener('lostpointercapture', onLost);
@@ -67,7 +67,7 @@ const removeLostHandler = (capture: MouseCapture) => {
 };
 
 /** When using touch, we might receive a lostpointercapture, try to recapture the pointer once */
-const pointerLostHandler = (capture: MouseCapture, pointerEvent: PointerEvent) => {
+const pointerLostHandler = (capture: PointerCapture, pointerEvent: PointerEvent) => {
     removeLostHandler(capture); // Only once
     const { eElement, pointerId } = capture;
     if (eElement && pointerEvent.pointerId === pointerId) {

--- a/packages/ag-grid-community/src/agStack/events/pointerCapture.ts
+++ b/packages/ag-grid-community/src/agStack/events/pointerCapture.ts
@@ -38,15 +38,15 @@ export const capturePointer = (eElement: HTMLElement, mouseEvent: Event | Touch)
     return capture;
 };
 
-export const releasePointerCapture = (capture: PointerCapture | null): null => {
+export const releasePointerCapture = (capture: PointerCapture | null): void => {
     if (!capture) {
-        return null;
+        return;
     }
     removeLostHandler(capture);
 
     const { eElement, pointerId } = capture;
     if (!eElement) {
-        return null;
+        return;
     }
 
     try {
@@ -55,7 +55,6 @@ export const releasePointerCapture = (capture: PointerCapture | null): null => {
         // do nothing, just means pointer capture is not supported
     }
     capture.eElement = null;
-    return null;
 };
 
 const removeLostHandler = (capture: PointerCapture) => {

--- a/packages/ag-grid-community/src/agStack/interfaces/iDrag.ts
+++ b/packages/ag-grid-community/src/agStack/interfaces/iDrag.ts
@@ -8,9 +8,14 @@ export interface IDragService {
     addDragSource(params: DragListenerParams): void;
 
     cancelDrag(el?: Element): void;
+
+    /** Returns true if the pointer is currently captured. See https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events */
+    hasPointerCapture(): boolean;
 }
 
 export interface DragListenerParams {
+    /** If true, the pointer will be captured, see https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events */
+    capturePointer?: boolean;
     /** After how many pixels of dragging should the drag operation start. Default is 4px. */
     dragStartPixels?: number;
     /** Dom element to add the drag handling to */


### PR DESCRIPTION
We introduced the use of pointer events because:
- they can capture the pointer avoiding events to bleed on underlying elements
- is a common interface for touch and mouse
- handle correctly cancellation on desktop and mobile (switch tab, popups)
- handle correctly scrolling in case of drag image component

We left also the compatibility with touch and mouse if pointer events are not available (typically in ours or user e2e tests)

**In this PR:**

Fixed mistakes in the previous PR with ignoring the previously handled events.

Also, improves the pointer capture mechanism:
- for correctness and reusability, moved the mouse capture logic to the base drag service, as it should be its responsibility to handle the pointer capture
- added the new property capturePointer to the drag source, so a drag source can specify it would like mouse to be captured
- added hasPointerCapture to baseDragAndDropService to know if the mouse is currently captured