### PR TITLE
[AG-5088] Feature(tooltip): allow using tooltipComponentSelector

### DIFF
--- a/.github/workflows/beta-publish.yml
+++ b/.github/workflows/beta-publish.yml
@@ -33,12 +33,11 @@ jobs:
             - name: Fetch Refs
               run: git fetch origin --depth 1 latest-success latest
 
-            - name: Setup Node.js
-              id: setup_node
-              uses: actions/setup-node@v4
+            - name: Setup
+              id: setup
+              uses: ./.github/actions/setup-nx
               with:
-                  node-version: '20'
-                  cache: 'yarn'
+                cache_mode: ro
 
             - name: nx pack:verify
               id: pack-verify

--- a/.github/workflows/beta-publish.yml
+++ b/.github/workflows/beta-publish.yml
@@ -48,12 +48,5 @@ jobs:
               uses: EndBug/latest-tag@latest
               if: success()
               with:
-                ref: ${{ steps.next_version.outputs.tag }}
-                description: Latest commit to pass GitHub Actions workflow on latest branch.
-
-            - name: Tag Latest Successful Commit
-              uses: EndBug/latest-tag@latest
-              if: success()
-              with:
                   ref: latest-beta-version
                   description: Latest commit to pass GitHub Actions workflow on latest branch.

--- a/.github/workflows/beta-publish.yml
+++ b/.github/workflows/beta-publish.yml
@@ -40,32 +40,10 @@ jobs:
                   node-version: '20'
                   cache: 'yarn'
 
-            - name: Calculate Next Beta Version
-              id: next_version
+            - name: nx pack:verify
+              id: pack-verify
               run: |
-                  NEW_VERSION=$(node ./scripts/calculate-next-version.js)
-                  CHARTS_NEW_VERSION=$(node -e "console.log(require('./packages/ag-grid-enterprise/package.json').optionalDependencies['ag-charts-community'])")
-                  echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
-                  echo "CHARTS_NEW_VERSION=${CHARTS_NEW_VERSION}" >> $GITHUB_ENV
-                  echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
-                  echo "tag=b${NEW_VERSION}" >> $GITHUB_OUTPUT
-
-            - name: Bump Beta Package Version
-              run: node scripts/deployments/versionModules.js ${NEW_VERSION} ${CHARTS_NEW_VERSION} local
-
-            - name: Commit Changes
-              uses: EndBug/add-and-commit@v9
-              if: success()
-              with:
-                  default_author: github_actions
-                  message: Automated package version bump to ${{ steps.next_version.outputs.version }}.
-
-            - name: Tag Latest Successful Commit
-              uses: EndBug/latest-tag@latest
-              if: success()
-              with:
-                  ref: ${{ steps.next_version.outputs.tag }}
-                  description: Latest commit to pass GitHub Actions workflow on latest branch.
+                NODE_ENV=production yarn nx pack:verify -c staging
 
             - name: Tag Latest Successful Commit
               uses: EndBug/latest-tag@latest

--- a/.github/workflows/beta-publish.yml
+++ b/.github/workflows/beta-publish.yml
@@ -48,5 +48,12 @@ jobs:
               uses: EndBug/latest-tag@latest
               if: success()
               with:
+                ref: ${{ steps.next_version.outputs.tag }}
+                description: Latest commit to pass GitHub Actions workflow on latest branch.
+
+            - name: Tag Latest Successful Commit
+              uses: EndBug/latest-tag@latest
+              if: success()
+              with:
                   ref: latest-beta-version
                   description: Latest commit to pass GitHub Actions workflow on latest branch.

--- a/documentation/ag-grid-docs/src/content/api-documentation/column-properties/properties.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/column-properties/properties.json
@@ -114,6 +114,12 @@
                 "url": "./tooltips"
             }
         },
+        "tooltipComponentSelector": {
+            "more": {
+                "name": "Custom Tooltip Component",
+                "url": "./tooltips/#custom-component"
+            }
+        },
         "tooltipComponentParams": {}
     },
     "header": {

--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -274,6 +274,13 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
      * @agModule `TooltipModule`
      */
     tooltipValueGetter?: (params: ITooltipParams<TData, TValue>) => string | any;
+
+    /**
+     * Callback to select which tooltip component to be used for a given row within the same column.
+     * @agModule `TooltipModule`
+     */
+    tooltipComponentSelector?: CellEditorSelectorFunc | CellRendererSelectorFunc;
+
     /**
      * @deprecated v32.2 Use the new selection API instead. See `GridOptions.rowSelection`
      *

--- a/packages/ag-grid-community/src/entities/gridOptions.ts
+++ b/packages/ag-grid-community/src/entities/gridOptions.ts
@@ -3115,6 +3115,7 @@ export type SelectionColumnDef = Pick<
     | 'tooltipValueGetter'
     | 'tooltipComponent'
     | 'tooltipComponentParams'
+    | 'tooltipComponentSelector'
     | 'width'
     | 'initialWidth'
     | 'maxWidth'

--- a/packages/ag-grid-community/src/interfaces/rowNumbers.ts
+++ b/packages/ag-grid-community/src/interfaces/rowNumbers.ts
@@ -23,6 +23,7 @@ export interface RowNumbersOptions
             | 'tooltipValueGetter'
             | 'tooltipComponent'
             | 'tooltipComponentParams'
+            | 'tooltipComponentSelector'
             | 'valueGetter'
             | 'valueFormatter'
             | 'maxWidth'

--- a/packages/ag-grid-community/src/tooltip/tooltipModule.ts
+++ b/packages/ag-grid-community/src/tooltip/tooltipModule.ts
@@ -10,7 +10,7 @@ import { TooltipStateManager } from './tooltipStateManager';
 
 /**
  * @feature Tooltips
- * @colDef tooltipField, tooltipValueGetter, headerTooltip
+ * @colDef tooltipField, tooltipValueGetter, headerTooltip, tooltipComponentSelector
  */
 export const TooltipModule: _ModuleWithoutApi = {
     moduleName: 'Tooltip',

--- a/packages/ag-grid-community/src/validation/rules/colDefValidations.ts
+++ b/packages/ag-grid-community/src/validation/rules/colDefValidations.ts
@@ -95,6 +95,7 @@ export const COLUMN_DEFINITION_MOD_VALIDATIONS: ModuleValidation<ColDef | ColGro
     rowGroupIndex: 'SharedRowGrouping',
     tooltipField: 'Tooltip',
     tooltipValueGetter: 'Tooltip',
+    tooltipComponentSelector: 'Tooltip',
     spanRows: 'CellSpan',
     groupHierarchy: 'SharedRowGrouping',
 };
@@ -429,6 +430,7 @@ const colDefPropertyMap: Record<ColOrGroupKey, undefined> = {
     onCellContextMenu: undefined,
     rowDragText: undefined,
     tooltipValueGetter: undefined,
+    tooltipComponentSelector: undefined,
     cellRendererSelector: undefined,
     cellEditorSelector: undefined,
     suppressSpanHeaderHeight: undefined,

--- a/packages/ag-grid-enterprise/src/rowNumbers/rowNumbersService.ts
+++ b/packages/ag-grid-enterprise/src/rowNumbers/rowNumbersService.ts
@@ -226,6 +226,7 @@ export class RowNumbersService extends BeanStub implements NamedBean, IRowNumber
             'tooltipValueGetter',
             'tooltipComponent',
             'tooltipComponentParams',
+            'tooltipComponentSelector',
             'valueGetter',
             'valueFormatter',
             'width',


### PR DESCRIPTION
Add `tooltipComponentSelector` to api docs and remove warning about unrecognized grid option.

<img width="2307" height="1022" alt="Screenshot_20251013_095439" src="https://github.com/user-attachments/assets/6c02f78f-11d4-41f4-becf-515588a4f4f7" />

Fix [AG-5088](https://ag-grid.atlassian.net/browse/AG-5088)