### PR TITLE
[AG-10043] Feature(tooltip): allow setting headerTooltipValueGetter

### DIFF
--- a/.run/Header Group Tooltip Value Getter feat.run.xml
+++ b/.run/Header Group Tooltip Value Getter feat.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Header Group Tooltip Value Getter feat" type="JavascriptDebugType" uri="https://plnkr.co/edit/NPMeY8YQqrX18I1c?open=main.js">
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Header Tooltip Value Getter feat.run.xml
+++ b/.run/Header Tooltip Value Getter feat.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Header Tooltip Value Getter feat" type="JavascriptDebugType" uri="https://plnkr.co/edit/riwX9Rc6ecKCH9d5?open=main.js">
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Nx dev.run.xml
+++ b/.run/Nx dev.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Nx dev" type="NxRunConfigurationType">
+    <option name="nx-projects" value="dev" />
+    <option name="nx-targets" value="" />
+    <option name="nx-target-configuration" value="" />
+    <envs />
+    <option name="arguments" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/documentation/ag-grid-docs/src/content/api-documentation/column-properties/properties.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/column-properties/properties.json
@@ -128,9 +128,7 @@
         "headerValueGetter": {
             "description": "Function or [expression](./cell-expressions/#column-definition-expressions). Gets the value for display in the header."
         },
-        "headerTooltipValueGetter": {
-            "description": "Callback that gets the string to use for a tooltip."
-        },
+        "headerTooltipValueGetter": {},
         "headerTooltip": {},
         "headerStyle": {},
         "headerClass": {},
@@ -612,6 +610,7 @@
         },
         "headerName": {},
         "headerClass": {},
+        "headerTooltipValueGetter": {},
         "headerTooltip": {},
         "autoHeaderHeight": {
             "more": {

--- a/documentation/ag-grid-docs/src/content/api-documentation/column-properties/properties.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/column-properties/properties.json
@@ -128,6 +128,9 @@
         "headerValueGetter": {
             "description": "Function or [expression](./cell-expressions/#column-definition-expressions). Gets the value for display in the header."
         },
+        "headerTooltipValueGetter": {
+            "description": "Callback that gets the string to use for a tooltip."
+        },
         "headerTooltip": {},
         "headerStyle": {},
         "headerClass": {},

--- a/documentation/ag-grid-docs/src/content/docs/column-headers/_examples/header-tooltip/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-headers/_examples/header-tooltip/main.ts
@@ -18,9 +18,9 @@ const columnDefs: ColDef[] = [
     { field: 'age', headerTooltip: "The athlete's age" },
     { field: 'date', headerTooltip: 'The date of the Olympics' },
     { field: 'sport', headerTooltip: 'The sport the medal was for' },
-    { field: 'gold', headerTooltip: 'How many gold medals' },
-    { field: 'silver', headerTooltip: 'How many silver medals' },
-    { field: 'bronze', headerTooltip: 'How many bronze medals' },
+    { field: 'gold', headerTooltipValueGetter: (p) => `How many ${p.colDef.field} medals` },
+    { field: 'silver', headerTooltipValueGetter: (p) => `How many ${p.colDef.field} medals` },
+    { field: 'bronze', headerTooltipValueGetter: (p) => `How many ${p.colDef.field} medals` },
     { field: 'total', headerTooltip: 'The total number of medals' },
 ];
 

--- a/documentation/ag-grid-docs/src/content/docs/column-headers/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-headers/index.mdoc
@@ -613,9 +613,11 @@ See the [Touch](./touch/) documentation for how the grid will handle touch suppo
 
 ## Tooltips
 
-Tooltips can be added to the Column Header by using the `headerTooltip` property of the `ColDef`.
+Tooltips can be added to the Column Header by using either  the `headerTooltip` property of the `ColDef`.
 
-The example below demonstrates using the `headerTooltip` property in the grid columns.
+{% apiDocumentation source="column-properties/properties.json" section="header" names=["headerTooltipValueGetter", "headerTooltip"] /%}
+
+The example below demonstrates using both `headerTooltipValueGetter` and `headerTooltip` properties to set tooltips in the grid columns.
 
 {% gridExampleRunner title="Header Tooltip" name="header-tooltip" /%}
 

--- a/documentation/ag-grid-docs/src/content/docs/column-headers/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-headers/index.mdoc
@@ -613,7 +613,7 @@ See the [Touch](./touch/) documentation for how the grid will handle touch suppo
 
 ## Tooltips
 
-Tooltips can be added to the Column Header by using either  the `headerTooltip` property of the `ColDef`.
+Tooltips can be added to the Column Header by using either the `headerTooltipValueGetter`, or `headerTooltip` property of the `ColDef`.
 
 {% apiDocumentation source="column-properties/properties.json" section="header" names=["headerTooltipValueGetter", "headerTooltip"] /%}
 

--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -18,10 +18,18 @@ export interface AbstractColDef<TData = any, TValue = any> {
     /** Function or expression. Gets the value for display in the header. */
     headerValueGetter?: string | HeaderValueGetterFunc<TData, TValue>;
     /**
-     * Tooltip for the column header
+     * Tooltip for the column header, `headerTooltipValueGetter` takes precedence if set
      * @agModule `TooltipModule`
      */
     headerTooltip?: string;
+
+    /**
+     * Callback that should return the string to use for a tooltip, `headerTooltip` takes precedence if set.
+     * If using a custom `tooltipComponent` you may return any custom value to be passed to your tooltip component.
+     * @agModule `TooltipModule`
+     */
+    headerTooltipValueGetter?: (params: ITooltipParams<TData, TValue>) => string | any;
+
     /** An object of CSS values / or function returning an object of CSS values for a particular header. */
     headerStyle?: HeaderStyle | HeaderStyleFunc<TData, TValue>;
     /** CSS class to use for the header cell. Can be a string, array of strings, or function. */

--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -18,14 +18,13 @@ export interface AbstractColDef<TData = any, TValue = any> {
     /** Function or expression. Gets the value for display in the header. */
     headerValueGetter?: string | HeaderValueGetterFunc<TData, TValue>;
     /**
-     * Tooltip for the column header, `headerTooltipValueGetter` takes precedence if set
+     * Tooltip for the column header, `headerTooltipValueGetter` takes precedence if set.
      * @agModule `TooltipModule`
      */
     headerTooltip?: string;
 
     /**
-     * Callback that should return the string to use for a tooltip, `headerTooltip` takes precedence if set.
-     * If using a custom `tooltipComponent` you may return any custom value to be passed to your tooltip component.
+     * Callback that should return the string to use for a tooltip.
      * @agModule `TooltipModule`
      */
     headerTooltipValueGetter?: (params: ITooltipParams<TData, TValue>) => string | any;

--- a/packages/ag-grid-community/src/entities/gridOptions.ts
+++ b/packages/ag-grid-community/src/entities/gridOptions.ts
@@ -3079,6 +3079,7 @@ export type SelectionColumnDef = Pick<
     | 'onCellDoubleClicked'
     | 'onCellValueChanged'
     | 'headerTooltip'
+    | 'headerTooltipValueGetter'
     | 'headerStyle'
     | 'headerClass'
     | 'headerComponent'

--- a/packages/ag-grid-community/src/tooltip/tooltipService.ts
+++ b/packages/ag-grid-community/src/tooltip/tooltipService.ts
@@ -12,6 +12,7 @@ import type { HeaderGroupCellCtrl } from '../headerRendering/cells/columnGroup/h
 import type { ICellEditor } from '../interfaces/iCellEditor';
 import type { CellCtrl } from '../rendering/cell/cellCtrl';
 import type { RowCtrl } from '../rendering/row/rowCtrl';
+import type { ColDef } from '../entities/colDef';
 import type { ITooltipCtrl, ITooltipCtrlParams, TooltipFeature } from './tooltipFeature';
 import { _isShowTooltipWhenTruncated } from './tooltipFeature';
 
@@ -36,7 +37,7 @@ export class TooltipService extends BeanStub implements NamedBean {
     public setupHeaderTooltip(
         existingTooltipFeature: TooltipFeature | undefined,
         ctrl: HeaderCellCtrl,
-        value?: string,
+        passedValue?: string,
         shouldDisplayTooltip?: () => boolean
     ): TooltipFeature | undefined {
         if (existingTooltipFeature) {
@@ -53,13 +54,17 @@ export class TooltipService extends BeanStub implements NamedBean {
                 () => eGui.querySelector('.ag-header-cell-text') as HTMLElement | undefined
             );
         }
-
+        const location = 'header';
+        const value = passedValue ?? colDef.headerName ?? colDef.field;
+        const valueFormatted = this.beans.colNames.getDisplayNameForColumn(column, 'header', true);
         const tooltipCtrl: ITooltipCtrl = {
             getGui: () => eGui,
-            getLocation: () => 'header',
+            getLocation: () => location,
             getTooltipValue: () =>
-                value ??
-                colDef?.headerTooltipValueGetter?.(_addGridCommonParams(gos, { location: 'cell', colDef, column })) ??
+                passedValue ??
+                colDef?.headerTooltipValueGetter?.(
+                    _addGridCommonParams(gos, { location, colDef, column, value, valueFormatted })
+                ) ??
                 colDef?.headerTooltip,
             shouldDisplayTooltip,
             getAdditionalParams: () => ({
@@ -79,7 +84,7 @@ export class TooltipService extends BeanStub implements NamedBean {
     public setupHeaderGroupTooltip(
         existingTooltipFeature: TooltipFeature | undefined,
         ctrl: HeaderGroupCellCtrl,
-        value?: string,
+        passedValue?: string,
         shouldDisplayTooltip?: () => boolean
     ): TooltipFeature | undefined {
         if (existingTooltipFeature) {
@@ -96,12 +101,18 @@ export class TooltipService extends BeanStub implements NamedBean {
             );
         }
 
+        const location = 'headerGroup';
+        const value = passedValue ?? colDef?.headerName ?? (colDef as ColDef)?.field;
+        const valueFormatted = this.beans.colNames.getDisplayNameForColumnGroup(column, 'header');
+
         const tooltipCtrl: ITooltipCtrl = {
             getGui: () => eGui,
-            getLocation: () => 'headerGroup',
+            getLocation: () => location,
             getTooltipValue: () =>
-                value ??
-                colDef?.headerTooltipValueGetter?.(_addGridCommonParams(gos, { location: 'cell', colDef, column })) ??
+                passedValue ??
+                colDef?.headerTooltipValueGetter?.(
+                    _addGridCommonParams(gos, { location, colDef, column, value, valueFormatted })
+                ) ??
                 colDef?.headerTooltip,
             shouldDisplayTooltip,
             getAdditionalParams: () => {

--- a/packages/ag-grid-community/src/tooltip/tooltipService.ts
+++ b/packages/ag-grid-community/src/tooltip/tooltipService.ts
@@ -6,13 +6,13 @@ import type { NamedBean } from '../context/bean';
 import { BeanStub } from '../context/beanStub';
 import type { BeanCollection } from '../context/context';
 import type { AgColumn } from '../entities/agColumn';
+import type { ColDef } from '../entities/colDef';
 import { _addGridCommonParams } from '../gridOptionsUtils';
 import type { HeaderCellCtrl } from '../headerRendering/cells/column/headerCellCtrl';
 import type { HeaderGroupCellCtrl } from '../headerRendering/cells/columnGroup/headerGroupCellCtrl';
 import type { ICellEditor } from '../interfaces/iCellEditor';
 import type { CellCtrl } from '../rendering/cell/cellCtrl';
 import type { RowCtrl } from '../rendering/row/rowCtrl';
-import type { ColDef } from '../entities/colDef';
 import type { ITooltipCtrl, ITooltipCtrlParams, TooltipFeature } from './tooltipFeature';
 import { _isShowTooltipWhenTruncated } from './tooltipFeature';
 

--- a/packages/ag-grid-community/src/tooltip/tooltipService.ts
+++ b/packages/ag-grid-community/src/tooltip/tooltipService.ts
@@ -43,7 +43,8 @@ export class TooltipService extends BeanStub implements NamedBean {
             ctrl.destroyBean(existingTooltipFeature);
         }
 
-        const isTooltipWhenTruncated = _isShowTooltipWhenTruncated(this.gos);
+        const gos = this.gos;
+        const isTooltipWhenTruncated = _isShowTooltipWhenTruncated(gos);
         const { column, eGui } = ctrl;
         const colDef = column.getColDef();
 
@@ -61,8 +62,21 @@ export class TooltipService extends BeanStub implements NamedBean {
                     return value;
                 }
 
-                const res = column.getColDef().headerTooltip;
-                return res;
+                const res = colDef.headerTooltip;
+
+                if (res != null) {
+                    return res;
+                }
+
+                if (colDef.headerTooltipValueGetter) {
+                    return colDef.headerTooltipValueGetter(
+                        _addGridCommonParams(gos, {
+                            location: 'cell',
+                            colDef: column.getColDef(),
+                            column: column,
+                        })
+                    );
+                }
             },
             shouldDisplayTooltip,
             getAdditionalParams: () => ({

--- a/packages/ag-grid-community/src/tooltip/tooltipService.ts
+++ b/packages/ag-grid-community/src/tooltip/tooltipService.ts
@@ -55,8 +55,9 @@ export class TooltipService extends BeanStub implements NamedBean {
             );
         }
         const location = 'header';
-        const value = passedValue ?? colDef.headerName ?? colDef.field;
-        const valueFormatted = this.beans.colNames.getDisplayNameForColumn(column, 'header', true);
+        const headerLocation = 'header';
+        const valueFormatted = this.beans.colNames.getDisplayNameForColumn(column, headerLocation, true);
+        const value = passedValue ?? valueFormatted;
         const tooltipCtrl: ITooltipCtrl = {
             getGui: () => eGui,
             getLocation: () => location,
@@ -102,8 +103,9 @@ export class TooltipService extends BeanStub implements NamedBean {
         }
 
         const location = 'headerGroup';
-        const value = passedValue ?? colDef?.headerName ?? (colDef as ColDef)?.field;
-        const valueFormatted = this.beans.colNames.getDisplayNameForColumnGroup(column, 'header');
+        const headerLocation = 'header';
+        const valueFormatted = this.beans.colNames.getDisplayNameForColumnGroup(column, headerLocation);
+        const value = passedValue ?? valueFormatted;
 
         const tooltipCtrl: ITooltipCtrl = {
             getGui: () => eGui,

--- a/packages/ag-grid-community/src/tooltip/tooltipService.ts
+++ b/packages/ag-grid-community/src/tooltip/tooltipService.ts
@@ -6,7 +6,6 @@ import type { NamedBean } from '../context/bean';
 import { BeanStub } from '../context/beanStub';
 import type { BeanCollection } from '../context/context';
 import type { AgColumn } from '../entities/agColumn';
-import type { ColDef } from '../entities/colDef';
 import { _addGridCommonParams } from '../gridOptionsUtils';
 import type { HeaderCellCtrl } from '../headerRendering/cells/column/headerCellCtrl';
 import type { HeaderGroupCellCtrl } from '../headerRendering/cells/columnGroup/headerGroupCellCtrl';

--- a/packages/ag-grid-community/src/tooltip/tooltipService.ts
+++ b/packages/ag-grid-community/src/tooltip/tooltipService.ts
@@ -57,27 +57,10 @@ export class TooltipService extends BeanStub implements NamedBean {
         const tooltipCtrl: ITooltipCtrl = {
             getGui: () => eGui,
             getLocation: () => 'header',
-            getTooltipValue: () => {
-                if (value != null) {
-                    return value;
-                }
-
-                const res = colDef.headerTooltip;
-
-                if (res != null) {
-                    return res;
-                }
-
-                if (colDef.headerTooltipValueGetter) {
-                    return colDef.headerTooltipValueGetter(
-                        _addGridCommonParams(gos, {
-                            location: 'cell',
-                            colDef: column.getColDef(),
-                            column: column,
-                        })
-                    );
-                }
-            },
+            getTooltipValue: () =>
+                value ??
+                colDef?.headerTooltipValueGetter?.(_addGridCommonParams(gos, { location: 'cell', colDef, column })) ??
+                colDef?.headerTooltip,
             shouldDisplayTooltip,
             getAdditionalParams: () => ({
                 column,
@@ -102,12 +85,12 @@ export class TooltipService extends BeanStub implements NamedBean {
         if (existingTooltipFeature) {
             ctrl.destroyBean(existingTooltipFeature);
         }
-
-        const isTooltipWhenTruncated = _isShowTooltipWhenTruncated(this.gos);
+        const gos = this.gos;
+        const isTooltipWhenTruncated = _isShowTooltipWhenTruncated(gos);
         const { column, eGui } = ctrl;
-        const colGroupDef = column.getColGroupDef();
+        const colDef = column.getColGroupDef();
 
-        if (!shouldDisplayTooltip && isTooltipWhenTruncated && !colGroupDef?.headerGroupComponent) {
+        if (!shouldDisplayTooltip && isTooltipWhenTruncated && !colDef?.headerGroupComponent) {
             shouldDisplayTooltip = _isElementOverflowingCallback(
                 () => eGui.querySelector('.ag-header-group-text') as HTMLElement | undefined
             );
@@ -116,14 +99,17 @@ export class TooltipService extends BeanStub implements NamedBean {
         const tooltipCtrl: ITooltipCtrl = {
             getGui: () => eGui,
             getLocation: () => 'headerGroup',
-            getTooltipValue: () => value ?? colGroupDef?.headerTooltip,
+            getTooltipValue: () =>
+                value ??
+                colDef?.headerTooltipValueGetter?.(_addGridCommonParams(gos, { location: 'cell', colDef, column })) ??
+                colDef?.headerTooltip,
             shouldDisplayTooltip,
             getAdditionalParams: () => {
                 const additionalParams: ITooltipCtrlParams = {
                     column,
                 };
-                if (colGroupDef) {
-                    additionalParams.colDef = colGroupDef;
+                if (colDef) {
+                    additionalParams.colDef = colDef;
                 }
                 return additionalParams;
             },

--- a/packages/ag-grid-community/src/validation/rules/colDefValidations.ts
+++ b/packages/ag-grid-community/src/validation/rules/colDefValidations.ts
@@ -80,6 +80,7 @@ export const COLUMN_DEFINITION_MOD_VALIDATIONS: ModuleValidation<ColDef | ColGro
     floatingFilter: 'ColumnFilter',
     getQuickFilterText: 'QuickFilter',
     headerTooltip: 'Tooltip',
+    headerTooltipValueGetter: 'Tooltip',
     mainMenuItems: 'ColumnMenu',
     menuTabs: (options: ColDef) => {
         const enterpriseMenuTabs: ColumnMenuTab[] = ['columnsMenuTab', 'generalMenuTab'];
@@ -318,6 +319,7 @@ const colDefPropertyMap: Record<ColOrGroupKey, undefined> = {
     tooltipComponent: undefined,
     tooltipField: undefined,
     headerTooltip: undefined,
+    headerTooltipValueGetter: undefined,
     cellClass: undefined,
     showRowGroup: undefined,
     filter: undefined,


### PR DESCRIPTION
Feature(tooltip): add headerTooltipValueGetter for customizable tooltips 
- Introduced headerTooltipValueGetter to allow dynamic tooltip content.
 - Updated colDef, colDefValidations, gridOptions, and properties.json.
 - Enhanced tooltipService to prioritize headerTooltipValueGetter over headerTooltip.

local plnkr: https://plnkr.co/edit/riwX9Rc6ecKCH9d5?open=main.js
same but with column groups: https://plnkr.co/edit/NPMeY8YQqrX18I1c?open=main.js

<img width="1346" height="1532" alt="Screenshot_20251013_163649" src="https://github.com/user-attachments/assets/7b461ff6-e455-4dfc-b4d3-67f313a3a9f4" />


Fix [AG-10043](https://ag-grid.atlassian.net/browse/AG-10043)