### PR TITLE
[AG-16065] Fix(ssrm-groups): pivoting expansion state is preserved incorrectly

### DIFF
--- a/.run/Pivoting expansion state SSRM.run.xml
+++ b/.run/Pivoting expansion state SSRM.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Pivoting expansion state SSRM" type="JavascriptDebugType" uri="https://plnkr.co/edit/g5gCZoLwgnJvjVZa?open=main.js">
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/SSRM Grand Total Row .run.xml
+++ b/.run/SSRM Grand Total Row .run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="SSRM Grand Total Row " type="JavascriptDebugType" uri="https://plnkr.co/edit/ZhT2H7TRKcMLK6Vs?open=main.js">
+    <method v="2" />
+  </configuration>
+</component>

--- a/packages/ag-grid-enterprise/src/serverSideRowModel/services/serverSideExpansionService.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/services/serverSideExpansionService.ts
@@ -43,8 +43,10 @@ export class ServerSideExpansionService
         };
 
         this.addManagedEventListeners({
-            // when row grouping changes, the old expand all state is no longer valid as rows changed
+            // when row grouping / pivot changes, the old expand all state is no longer valid as rows changed
             columnRowGroupChanged: setDefaultExpand,
+            columnPivotChanged: setDefaultExpand,
+            columnPivotModeChanged: setDefaultExpand,
         });
 
         this.addManagedPropertyListener('ssrmExpandAllAffectsAllRows', (p) => {


### PR DESCRIPTION
Fix pivoting expansion state handling in SSRM
 - Added event listeners for columnPivotChanged and columnPivotModeChanged to reset expand state.

Relevant plunker has been added to the project

Fix [AG-16065](https://ag-grid.atlassian.net/browse/AG-16065)