### PR TITLE
[RTI-3095] Fix(docs): nr master detail docs section are incorrect for react

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/master-detail-grids/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-grids/index.mdoc
@@ -13,10 +13,6 @@ The Detail Grid fits inside one row of the Master Grid without using any of the 
 
 The Detail Grid is a fully fledged independent grid instance. This means that the Detail Grid has access to the full range of grid features.
 
-{% if isFramework("javascript", "angular", "vue") %}
-The instance of the grid is instantiated using native JavaScript and not any particular framework. This means properties are provided via a plain JavaScript object called Grid Options and not bound by any framework or HTML tags or bindings.
-{% /if %}
-
 The Grid Options object is provided to the Detail Grid using the parameter `detailGridOptions`.
 
 The example below shows configuring a Detail Grid with some additional Grid Options set. Note the following:

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-grids/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-grids/index.mdoc
@@ -13,7 +13,9 @@ The Detail Grid fits inside one row of the Master Grid without using any of the 
 
 The Detail Grid is a fully fledged independent grid instance. This means that the Detail Grid has access to the full range of grid features.
 
+{% if isFramework("javascript", "angular", "vue") %}
 The instance of the grid is instantiated using native JavaScript and not any particular framework. This means properties are provided via a plain JavaScript object called Grid Options and not bound by any framework or HTML tags or bindings.
+{% /if %}
 
 The Grid Options object is provided to the Detail Grid using the parameter `detailGridOptions`.
 


### PR DESCRIPTION
Corrects Detail Grid documentation

<img width="982" height="194" alt="Screenshot 2025-10-20 at 15 44 30" src="https://github.com/user-attachments/assets/f3f473df-e382-446f-90f0-0b1d9582e56a" />

Fix [RTI-3095](https://ag-grid.atlassian.net/browse/RTI-3095)
