### PR TITLE
RTI-3136 prevent flickering while dragging auto scroll

### DIFF
--- a/packages/ag-grid-community/src/autoScrollService.ts
+++ b/packages/ag-grid-community/src/autoScrollService.ts
@@ -25,6 +25,11 @@ export class AutoScrollService {
 
     private tickCount: number;
 
+    /** True while auto-scrolling */
+    public get scrolling(): boolean {
+        return this.tickingInterval !== null;
+    }
+
     constructor(params: {
         scrollContainer: HTMLElement;
         scrollAxis: 'x' | 'y' | 'xy';

--- a/packages/ag-grid-community/src/autoScrollService.ts
+++ b/packages/ag-grid-community/src/autoScrollService.ts
@@ -25,11 +25,6 @@ export class AutoScrollService {
 
     private tickCount: number;
 
-    /** True while auto-scrolling */
-    public get scrolling(): boolean {
-        return this.tickingInterval !== null;
-    }
-
     constructor(params: {
         scrollContainer: HTMLElement;
         scrollAxis: 'x' | 'y' | 'xy';

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
@@ -147,13 +147,13 @@ export class RowDragFeature extends BeanStub implements DropTarget {
         this.dispatchGridEvent('rowDragMove', draggingEvent);
 
         if (
-            !fromNudge &&
             rowsDrop?.rowDragManaged &&
             rowsDrop.moved &&
             rowsDrop.allowed &&
             rowsDrop.sameGrid &&
             !rowsDrop.suppressMoveWhenRowDragging &&
-            !this.nudger?.autoScroll.scrolling // Prevent row move during auto-scroll to avoid flickering
+            // Avoid flickering by only dropping while auto-scrolling is not happening
+            ((!fromNudge && !this.nudger?.scrolling) || this.nudger?.scrollChanged)
         ) {
             this.dropRows(rowsDrop); // Drop the rows while dragging
         }
@@ -532,7 +532,7 @@ export class RowDragFeature extends BeanStub implements DropTarget {
         if (
             rowsDrop?.allowed &&
             rowsDrop.rowDragManaged &&
-            (rowsDrop.suppressMoveWhenRowDragging || !rowsDrop.sameGrid || this.nudger?.autoScroll.scrolling)
+            (rowsDrop.suppressMoveWhenRowDragging || !rowsDrop.sameGrid || this.nudger?.scrolling)
         ) {
             this.dropRows(rowsDrop); // Drop the rows after dragging
         }

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
@@ -153,7 +153,7 @@ export class RowDragFeature extends BeanStub implements DropTarget {
             rowsDrop.sameGrid &&
             !rowsDrop.suppressMoveWhenRowDragging &&
             // Avoid flickering by only dropping while auto-scrolling is not happening
-            ((!fromNudge && !this.nudger?.scrolling) || this.nudger?.scrollChanged)
+            ((!fromNudge && !this.nudger?.autoScroll.scrolling) || this.nudger?.scrollChanged)
         ) {
             this.dropRows(rowsDrop); // Drop the rows while dragging
         }
@@ -532,7 +532,7 @@ export class RowDragFeature extends BeanStub implements DropTarget {
         if (
             rowsDrop?.allowed &&
             rowsDrop.rowDragManaged &&
-            (rowsDrop.suppressMoveWhenRowDragging || !rowsDrop.sameGrid || this.nudger?.scrolling)
+            (rowsDrop.suppressMoveWhenRowDragging || !rowsDrop.sameGrid || this.nudger?.autoScroll.scrolling)
         ) {
             this.dropRows(rowsDrop); // Drop the rows after dragging
         }

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
@@ -152,7 +152,8 @@ export class RowDragFeature extends BeanStub implements DropTarget {
             rowsDrop.moved &&
             rowsDrop.allowed &&
             rowsDrop.sameGrid &&
-            !rowsDrop.suppressMoveWhenRowDragging
+            !rowsDrop.suppressMoveWhenRowDragging &&
+            !this.nudger?.autoScroll.scrolling // Prevent row move during auto-scroll to avoid flickering
         ) {
             this.dropRows(rowsDrop); // Drop the rows while dragging
         }
@@ -531,7 +532,7 @@ export class RowDragFeature extends BeanStub implements DropTarget {
         if (
             rowsDrop?.allowed &&
             rowsDrop.rowDragManaged &&
-            (rowsDrop.suppressMoveWhenRowDragging || !rowsDrop.sameGrid)
+            (rowsDrop.suppressMoveWhenRowDragging || !rowsDrop.sameGrid || this.nudger?.autoScroll.scrolling)
         ) {
             this.dropRows(rowsDrop); // Drop the rows after dragging
         }

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragFeatureNudger.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragFeatureNudger.ts
@@ -9,7 +9,6 @@ import type { IRowNode } from '../interfaces/iRowNode';
 export class RowDragFeatureNudger {
     public readonly autoScroll: AutoScrollService;
     public groupThrottled = false;
-    private oldVScroll: number | null = null;
     private groupTimer: number | null = null;
     private groupTarget: IRowNode | null = null;
     private readonly onGroupThrottle: () => void;
@@ -30,14 +29,6 @@ export class RowDragFeatureNudger {
             scrollAxis: 'y',
             getVerticalPosition: getScrollY,
             setVerticalPosition: (position) => gridBodyCtrl.scrollFeature.setVerticalScrollPosition(position),
-            onScrollCallback: () => {
-                const newVScroll = getScrollY();
-                const oldVScroll = this.oldVScroll;
-                this.oldVScroll = newVScroll;
-                if (oldVScroll !== null && oldVScroll !== newVScroll) {
-                    this.beans.dragAndDrop?.nudge();
-                }
-            },
         });
     }
 
@@ -83,6 +74,5 @@ export class RowDragFeatureNudger {
     public clear() {
         this.clearGroup();
         this.autoScroll.ensureCleared();
-        this.oldVScroll = null;
     }
 }

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragFeatureNudger.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragFeatureNudger.ts
@@ -9,6 +9,10 @@ import type { IRowNode } from '../interfaces/iRowNode';
 export class RowDragFeatureNudger {
     public readonly autoScroll: AutoScrollService;
     public groupThrottled = false;
+    public scrolling = false;
+    public scrollChanged = false;
+    private scrollChanging = false;
+    private oldVScroll: number | null = null;
     private groupTimer: number | null = null;
     private groupTarget: IRowNode | null = null;
     private readonly onGroupThrottle: () => void;
@@ -29,6 +33,21 @@ export class RowDragFeatureNudger {
             scrollAxis: 'y',
             getVerticalPosition: getScrollY,
             setVerticalPosition: (position) => gridBodyCtrl.scrollFeature.setVerticalScrollPosition(position),
+            onScrollCallback: () => {
+                const newVScroll = getScrollY();
+                if (this.oldVScroll !== newVScroll) {
+                    this.scrolling = true;
+                    this.oldVScroll = newVScroll;
+                    this.scrollChanging = true;
+                    return;
+                }
+                const scrollChanged = this.scrollChanging;
+                this.scrollChanged = scrollChanged;
+                this.scrollChanging = false;
+                if (scrollChanged) {
+                    this.beans.dragAndDrop?.nudge();
+                }
+            },
         });
     }
 
@@ -74,5 +93,9 @@ export class RowDragFeatureNudger {
     public clear() {
         this.clearGroup();
         this.autoScroll.ensureCleared();
+        this.oldVScroll = null;
+        this.scrollChanged = false;
+        this.scrollChanging = false;
+        this.scrolling = false;
     }
 }

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragFeatureNudger.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragFeatureNudger.ts
@@ -9,7 +9,6 @@ import type { IRowNode } from '../interfaces/iRowNode';
 export class RowDragFeatureNudger {
     public readonly autoScroll: AutoScrollService;
     public groupThrottled = false;
-    public scrolling = false;
     public scrollChanged = false;
     private scrollChanging = false;
     private oldVScroll: number | null = null;
@@ -36,7 +35,6 @@ export class RowDragFeatureNudger {
             onScrollCallback: () => {
                 const newVScroll = getScrollY();
                 if (this.oldVScroll !== newVScroll) {
-                    this.scrolling = true;
                     this.oldVScroll = newVScroll;
                     this.scrollChanging = true;
                     return;
@@ -46,6 +44,7 @@ export class RowDragFeatureNudger {
                 this.scrollChanging = false;
                 if (scrollChanged) {
                     this.beans.dragAndDrop?.nudge();
+                    this.scrollChanged = false;
                 }
             },
         });
@@ -96,6 +95,5 @@ export class RowDragFeatureNudger {
         this.oldVScroll = null;
         this.scrollChanged = false;
         this.scrollChanging = false;
-        this.scrolling = false;
     }
 }

--- a/testing/angular-package-tests/overrides/ColumnsToolPanelModule/expectedSize.json
+++ b/testing/angular-package-tests/overrides/ColumnsToolPanelModule/expectedSize.json
@@ -1,3 +1,3 @@
 {
-    "expectedSize": 146
+    "expectedSize": 150.41
 }

--- a/testing/module-size/moduleDefinitions.ts
+++ b/testing/module-size/moduleDefinitions.ts
@@ -57,7 +57,7 @@ export const AllEnterpriseModules: Record<`${EnterpriseModuleName}Module`, numbe
     CellSelectionModule: 55,
     ClipboardModule: 47.54,
     ColumnMenuModule: 153.19,
-    ColumnsToolPanelModule: 146,
+    ColumnsToolPanelModule: 150.41,
     ContextMenuModule: 72,
     ExcelExportModule: 84,
     FiltersToolPanelModule: 133.66,


### PR DESCRIPTION
There were few problems when suppressMoveWhenRowDragging is disabled: 

- now scroll event does cause the onDragging to be called, so invoking nudge on the auto scroll timer was not needed (double event processed)
- the only moment in which nudge should be called is when the timer fires but the scroll is not happening (end of scroll) only once
- change the logic of the nudger and the feature drag to apply row move only once while the auto-scroll is not happening or when mouse up happens

Fix RTI-3136