### PR TITLE
AG-16204 - Do not include .swcrc file in packages

### DIFF
--- a/packages/ag-grid-community/.npmignore
+++ b/packages/ag-grid-community/.npmignore
@@ -25,3 +25,4 @@ jest.jsdom-env.cjs
 scripts
 coverage
 .dependency-cruiser.js
+.swcrc

--- a/packages/ag-grid-enterprise/.npmignore
+++ b/packages/ag-grid-enterprise/.npmignore
@@ -23,3 +23,4 @@ jest.setup.ts
 jest.setup.js
 jest.jsdom-env.cjs
 coverage
+.swcrc

--- a/scripts/package/sanity-check-package.js
+++ b/scripts/package/sanity-check-package.js
@@ -37,7 +37,7 @@ if (!packageJsonFile) {
     process.exit(1);
 }
 
-const packageContents = glob.sync('**/*', { cwd: dir, nodir: true });
+const packageContents = glob.sync('**/*', { cwd: dir, nodir: true, dot: true });
 const packageJson = JSON.parse(packageJsonFile.toString());
 
 let exitStatus = 0;


### PR DESCRIPTION
Allow the `sanity-check-package.js` to detect it during release by allowing dots in the glob options.