### PR TITLE
Fix Charts integration build.

### DIFF
--- a/packages/ag-grid-enterprise/src/agStack/iAgChartsExports.ts
+++ b/packages/ag-grid-enterprise/src/agStack/iAgChartsExports.ts
@@ -1,5 +1,6 @@
 import type { IntegratedModule } from 'ag-charts-types';
 
+/** MAKE SURE TO UPDATE THE SCRIPT scripts/ci/substituteAgChartsTypesScene.sh WHEN CHANGING THIS FILE */
 type ChartTypes = IntegratedModule;
 
 export interface IAgChartsExports {

--- a/packages/ag-grid-enterprise/src/charts/agChartsExports.ts
+++ b/packages/ag-grid-enterprise/src/charts/agChartsExports.ts
@@ -1,10 +1,11 @@
-import type { IntegratedModule } from 'ag-charts-types';
+import type { IntegratedModule } from 'ag-charts-community';
 
 import type { NamedBean } from 'ag-grid-community';
 import { BeanStub } from 'ag-grid-community';
 
 import type { IAgChartsExports } from '../agStack/iAgChartsExports';
 
+/** MAKE SURE TO UPDATE THE SCRIPT scripts/ci/substituteAgChartsTypesScene.sh WHEN CHANGING THIS FILE */
 type ChartTypes = IntegratedModule;
 
 /** Bean to expose the AG Charts apis from a single location and not require a code dependency on ag-charts-community */

--- a/packages/ag-grid-enterprise/src/charts/agChartsExports.ts
+++ b/packages/ag-grid-enterprise/src/charts/agChartsExports.ts
@@ -1,4 +1,4 @@
-import type { IntegratedModule } from 'ag-charts-community';
+import type { IntegratedModule } from 'ag-charts-types';
 
 import type { NamedBean } from 'ag-grid-community';
 import { BeanStub } from 'ag-grid-community';

--- a/scripts/ci/substituteAgChartsTypesScene.sh
+++ b/scripts/ci/substituteAgChartsTypesScene.sh
@@ -9,20 +9,18 @@ else
 fi
 
 git apply <<EOF
-diff --git a/packages/ag-grid-enterprise/src/charts/agChartsExports.ts b/packages/ag-grid-enterprise/src/charts/agChartsExports.ts
-index cfcd66b616..c35e75565e 100644
---- a/packages/ag-grid-enterprise/src/charts/agChartsExports.ts
-+++ b/packages/ag-grid-enterprise/src/charts/agChartsExports.ts
-@@ -1,9 +1,9 @@
+diff --git a/packages/ag-grid-enterprise/src/agStack/iAgChartsExports.ts b/packages/ag-grid-enterprise/src/agStack/iAgChartsExports.ts
+index e485b6842b4..bed022e8c00 100644
+--- a/packages/ag-grid-enterprise/src/agStack/iAgChartsExports.ts
++++ b/packages/ag-grid-enterprise/src/agStack/iAgChartsExports.ts
+@@ -1,7 +1,7 @@
 -import type { IntegratedModule } from 'ag-charts-types';
 +import type { AgChartsCommunityModule, IntegratedModule } from 'ag-charts-community';
  
- import type { NamedBean } from 'ag-grid-community';
- import { BeanStub } from 'ag-grid-community';
- 
+ /** MAKE SURE TO UPDATE THE SCRIPT scripts/ci/substituteAgChartsTypesScene.sh WHEN CHANGING THIS FILE */
 -type ChartTypes = IntegratedModule;
 +type ChartTypes = typeof AgChartsCommunityModule;
  
- /** Bean to expose the AG Charts apis from a single location and not require a code dependency on ag-charts-community */
- export class AgChartsExports extends BeanStub implements NamedBean {
- EOF
+ export interface IAgChartsExports {
+     readonly beanName: 'agChartsExports';
+EOF

--- a/scripts/ci/substituteAgChartsTypesScene.sh
+++ b/scripts/ci/substituteAgChartsTypesScene.sh
@@ -10,12 +10,12 @@ fi
 
 git apply <<EOF
 diff --git a/packages/ag-grid-enterprise/src/agStack/iAgChartsExports.ts b/packages/ag-grid-enterprise/src/agStack/iAgChartsExports.ts
-index e485b6842b4..bed022e8c00 100644
+index e485b6842b4..f1c404e68a6 100644
 --- a/packages/ag-grid-enterprise/src/agStack/iAgChartsExports.ts
 +++ b/packages/ag-grid-enterprise/src/agStack/iAgChartsExports.ts
 @@ -1,7 +1,7 @@
 -import type { IntegratedModule } from 'ag-charts-types';
-+import type { AgChartsCommunityModule, IntegratedModule } from 'ag-charts-community';
++import type { AgChartsCommunityModule } from 'ag-charts-community';
  
  /** MAKE SURE TO UPDATE THE SCRIPT scripts/ci/substituteAgChartsTypesScene.sh WHEN CHANGING THIS FILE */
 -type ChartTypes = IntegratedModule;
@@ -23,4 +23,23 @@ index e485b6842b4..bed022e8c00 100644
  
  export interface IAgChartsExports {
      readonly beanName: 'agChartsExports';
+diff --git a/packages/ag-grid-enterprise/src/charts/agChartsExports.ts b/packages/ag-grid-enterprise/src/charts/agChartsExports.ts
+index 915327e8ab8..493c5ac9697 100644
+--- a/packages/ag-grid-enterprise/src/charts/agChartsExports.ts
++++ b/packages/ag-grid-enterprise/src/charts/agChartsExports.ts
+@@ -1,4 +1,4 @@
+-import type { IntegratedModule } from 'ag-charts-community';
++import type { AgChartsCommunityModule, IntegratedModule } from 'ag-charts-community';
+ 
+ import type { NamedBean } from 'ag-grid-community';
+ import { BeanStub } from 'ag-grid-community';
+@@ -6,7 +6,7 @@ import { BeanStub } from 'ag-grid-community';
+ import type { IAgChartsExports } from '../agStack/iAgChartsExports';
+ 
+ /** MAKE SURE TO UPDATE THE SCRIPT scripts/ci/substituteAgChartsTypesScene.sh WHEN CHANGING THIS FILE */
+-type ChartTypes = IntegratedModule;
++type ChartTypes = typeof AgChartsCommunityModule;
+ 
+ /** Bean to expose the AG Charts apis from a single location and not require a code dependency on ag-charts-community */
+ export class AgChartsExports extends BeanStub implements NamedBean, IAgChartsExports {
 EOF

--- a/scripts/ci/substituteAgChartsTypesScene.sh
+++ b/scripts/ci/substituteAgChartsTypesScene.sh
@@ -28,7 +28,7 @@ index 915327e8ab8..493c5ac9697 100644
 --- a/packages/ag-grid-enterprise/src/charts/agChartsExports.ts
 +++ b/packages/ag-grid-enterprise/src/charts/agChartsExports.ts
 @@ -1,4 +1,4 @@
--import type { IntegratedModule } from 'ag-charts-community';
+-import type { IntegratedModule } from 'ag-charts-types';
 +import type { AgChartsCommunityModule, IntegratedModule } from 'ag-charts-community';
  
  import type { NamedBean } from 'ag-grid-community';


### PR DESCRIPTION
- **Add warning about build script dependency to iAgChartsExports.ts and agChartsExports.ts**
- **Fix iAgChartsExports.ts + agChartsExports.ts patching for Charts->Grid integration build.**
