### PR TITLE
Properly remove outdated styles from DOM on theme change

### DIFF
--- a/packages/ag-grid-community/src/agStack/theming/inject.ts
+++ b/packages/ag-grid-community/src/agStack/theming/inject.ts
@@ -84,7 +84,7 @@ export const _unregisterInstanceUsingThemingAPI = (environment: IEnvironment) =>
     injectionState.grids.delete(environment);
     if (injectionState.grids.size === 0) {
         injectionState.map = new WeakMap();
-        for (const style of document.head.querySelectorAll('style[data-ag-global-css]')) {
+        for (const style of document.querySelectorAll('style[data-ag-global-css]')) {
             style.remove();
         }
     }


### PR DESCRIPTION
By querying from `document.head`, outdated injected styles are left behind in the DOM when using a `themeStyleContainer` that is outside of `document.head` (like `document.body`, for example). The impetus to use such selectors could come from a desire to avoid layer collisions, such as were run into in #12035 . This proposed change simply widens the search to the entire document, ensuring that the stylesheets are found. Alternatively, the query could be made from `environment.eStyleContainer.querySelectorAll(...)`, which defaults to `document.head`, but if for some reason that container identifier changed, the query would fail (weird hypothetical...but I do like just using `document` regardless).