### PR TITLE
[AG-9792] Fix(editing): minor api tweaks for rich select

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select/_examples/rich-select-full-async-values/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select/_examples/rich-select-full-async-values/main.ts
@@ -40,14 +40,13 @@ function getValueFromServer(params: RichCellEditorValuesCallbackParams): Promise
 
 const columnDefs: ColDef[] = [
     {
-        headerName: 'Server-Side Filtering',
+        headerName: 'Async Filtering',
         field: 'language',
         cellEditor: 'agRichSelectCellEditor',
         width: 300,
         cellEditorParams: {
             allowTyping: true,
             values: getValueFromServer,
-            filterList: true,
             filterListAsync: true,
         } as IRichCellEditorParams,
     },

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select/index.mdoc
@@ -217,11 +217,11 @@ columnDefs: [
 ]
 ```
 
-### Server-Side Filtering
+### Async Filtering
 
-For advanced filtering scenarios, combine async `values` callback, `allowTyping`, `filterList`, and `filterListAsync` to enable server-side filtering. This is shown in the example below:
+For advanced filtering scenarios, combine async `values` callback, `allowTyping`, and `filterListAsync` to enable Async filtering. This is shown in the example below:
 
-{% gridExampleRunner title="Rich Select Server-Side Filtering" name="rich-select-full-async-values" /%}
+{% gridExampleRunner title="Rich Select Async Filtering" name="rich-select-full-async-values" /%}
 
 When `filterListAsync` is `true`, the cell editor:
 

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select/index.mdoc
@@ -219,7 +219,7 @@ columnDefs: [
 
 ### Async Filtering
 
-For advanced filtering scenarios, combine async `values` callback, `allowTyping`, and `filterListAsync` to enable Async filtering. This is shown in the example below:
+For advanced filtering scenarios, combine async `values` callback, `allowTyping`, and `filterListAsync` to enable async filtering. This is shown in the example below:
 
 {% gridExampleRunner title="Rich Select Async Filtering" name="rich-select-full-async-values" /%}
 

--- a/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
+++ b/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
@@ -722,7 +722,7 @@ export const AG_GRID_ERRORS = {
     293: () =>
         `The grid was initialised detached from the DOM and was then inserted into a Shadow Root. Theme styles are probably broken. Pass the themeStyleContainer grid option to let the grid know where in the document to insert theme CSS.` as const,
     294: () =>
-        `When using the \`agRichSelectCellEditor\` setting \`filterListAsync = true\` requires \`filterList = true\`, \`allowTyping = true\` and the \`values()\` callback must return a Promise of filtered values.` as const,
+        `When using the \`agRichSelectCellEditor\` setting \`filterListAsync = true\` requires \`allowTyping = true\` and the \`values()\` callback must return a Promise of filtered values.` as const,
     295: () =>
         `'rowDragManaged' requires 'refreshAfterGroupEdit' to be true when row grouping columns are enabled.` as const,
     296: ({ blockedService }: { blockedService: string }) =>

--- a/packages/ag-grid-enterprise/src/richSelect/richSelectCellEditor.ts
+++ b/packages/ag-grid-enterprise/src/richSelect/richSelectCellEditor.ts
@@ -78,8 +78,8 @@ export class RichSelectCellEditor<TData = any, TValue = any, TContext = any> ext
     }
 
     private isFullAsync(): boolean {
-        const { allowTyping, filterList, filterListAsync } = this.params;
-        return !!(filterListAsync && filterList && allowTyping);
+        const { allowTyping, filterListAsync } = this.params;
+        return !!(filterListAsync && allowTyping);
     }
 
     private buildRichSelectParams(): {
@@ -142,6 +142,7 @@ export class RichSelectCellEditor<TData = any, TValue = any, TContext = any> ext
 
         if (typeof values === 'function') {
             if (fullAsync) {
+                params.filterList = ret.filterList = true; // force filterList when doing full async
                 params.search = formatValue?.(value);
                 ret.onSearch = this.onSearchCallback;
                 ret.allowNoResultsCopy = true;


### PR DESCRIPTION
Fix `filterList` requirement in `agRichSelectCellEditor` with `filterListAsync`

- Remove unnecessary `filterList` requirement when `filterListAsync` is enabled
- Update documentation to reflect that `filterListAsync` only requires `allowTyping` and async `values`
- Correct example title and description to use "Async Filtering" instead of "Server-Side Filtering"
- Update error message to reflect the simplified requirements for `filterListAsync`

Fixes [AG-9792](https://ag-grid.atlassian.net/browse/AG-9792)