### PR TITLE
Ag 14210 filter tool panel icons

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_filter-tool-panel.scss
+++ b/community-modules/styles/src/internal/base/parts/_filter-tool-panel.scss
@@ -78,6 +78,15 @@
         &:not(.ag-filter-active) {
             display: none;
         }
+
+        &.ag-filter-active {
+            background-image: unset;
+            outline: unset;
+        }
+
+        &.ag-filter-active .ag-icon-filter {
+            color: var(--ag-icon-color);
+        }
     }
 
     .ag-set-filter-group-icons {

--- a/community-modules/styles/src/internal/base/parts/_filter-tool-panel.scss
+++ b/community-modules/styles/src/internal/base/parts/_filter-tool-panel.scss
@@ -10,13 +10,6 @@
         padding: 0 var(--ag-grid-size);
     }
 
-    @include ag.keyboard-focus((ag-filter-toolpanel-header), 4px);
-    .ag-filter-toolpanel-group:not(.ag-has-filter)
-        > .ag-group-title-bar
-        .ag-filter-toolpanel-group-instance-header-icon {
-        display: none;
-    }
-
     .ag-filter-toolpanel-group-level-0-header {
         height: calc(var(--ag-grid-size) * 8);
     }

--- a/community-modules/styles/src/internal/base/parts/_filter-tool-panel.scss
+++ b/community-modules/styles/src/internal/base/parts/_filter-tool-panel.scss
@@ -74,6 +74,10 @@
                 margin-left: var(--ag-grid-size),
             )
         );
+
+        &:not(.ag-filter-active) {
+            display: none;
+        }
     }
 
     .ag-set-filter-group-icons {

--- a/packages/ag-grid-enterprise/src/filterToolPanel/filtersToolPanel.css
+++ b/packages/ag-grid-enterprise/src/filterToolPanel/filtersToolPanel.css
@@ -39,11 +39,6 @@
     min-height: var(--ag-header-height);
 }
 
-:where(.ag-filter-toolpanel-group:not(.ag-has-filter) > .ag-group-title-bar)
-    .ag-filter-toolpanel-group-instance-header-icon {
-    display: none;
-}
-
 .ag-filter-toolpanel-search-input {
     flex-grow: 1;
     height: calc(var(--ag-spacing) * 4);

--- a/packages/ag-grid-enterprise/src/filterToolPanel/filtersToolPanel.css
+++ b/packages/ag-grid-enterprise/src/filterToolPanel/filtersToolPanel.css
@@ -31,6 +31,19 @@
 .ag-filter-toolpanel-group-instance-header-icon,
 .ag-filter-toolpanel-instance-header-icon {
     margin-left: var(--ag-spacing);
+
+    &:not(.ag-filter-active) {
+        display: none;
+    }
+
+    &.ag-filter-active {
+        background-image: unset;
+        outline: unset;
+    }
+
+    &.ag-filter-active .ag-icon-filter {
+        color: var(--ag-icon-color);
+    }
 }
 
 .ag-filter-toolpanel-search {

--- a/packages/ag-grid-enterprise/src/filterToolPanel/toolPanelFilterComp.ts
+++ b/packages/ag-grid-enterprise/src/filterToolPanel/toolPanelFilterComp.ts
@@ -30,7 +30,6 @@ const ToolPanelFilterElement: ElementParams = {
                     tag: 'span',
                     ref: 'eFilterIcon',
                     cls: 'ag-header-icon ag-filter-icon ag-filter-toolpanel-instance-header-icon',
-                    attrs: { 'aria-hidden': 'true' },
                 },
             ],
         },
@@ -80,7 +79,7 @@ export class ToolPanelFilterComp extends Component<ToolPanelFilterCompEvent> {
         this.addManagedEventListeners({ filterOpened: this.onFilterOpened.bind(this) });
         this.addInIcon('filterActive', eFilterIcon, column);
 
-        _setDisplayed(eFilterIcon, this.isFilterActive(), { skipAriaHidden: true });
+        eFilterIcon.classList.toggle('ag-filter-active', this.isFilterActive());
         _setDisplayed(eExpandChecked, false);
 
         if (hideHeader) {
@@ -138,7 +137,8 @@ export class ToolPanelFilterComp extends Component<ToolPanelFilterCompEvent> {
     }
 
     private onFilterChanged(): void {
-        _setDisplayed(this.eFilterIcon, this.isFilterActive(), { skipAriaHidden: true });
+        this.eFilterIcon.classList.toggle('ag-filter-active', this.isFilterActive());
+
         this.dispatchLocalEvent({ type: 'filterChanged' });
     }
 

--- a/packages/ag-grid-enterprise/src/filterToolPanel/toolPanelFilterGroupComp.ts
+++ b/packages/ag-grid-enterprise/src/filterToolPanel/toolPanelFilterGroupComp.ts
@@ -10,6 +10,7 @@ import {
     Component,
     RefPlaceholder,
     _clearElement,
+    _createElement,
     _createIconNoSpan,
     _getShouldDisplayTooltip,
     isProvidedColumnGroup,
@@ -146,11 +147,13 @@ export class ToolPanelFilterGroupComp extends Component {
     }
 
     private addInIcon(iconName: IconName): void {
+        const iconOuter = _createElement({ tag: 'span' });
         const eIcon = _createIconNoSpan(iconName, this.beans)!;
         if (eIcon) {
-            eIcon.classList.add('ag-filter-toolpanel-group-instance-header-icon');
+            iconOuter.classList.add('ag-filter-toolpanel-group-instance-header-icon');
+            iconOuter.appendChild(eIcon);
         }
-        this.filterGroupComp.addTitleBarWidget(eIcon);
+        this.filterGroupComp.addTitleBarWidget(iconOuter);
     }
 
     private forEachToolPanelFilterChild(action: (filterComp: ToolPanelFilterItem) => void) {
@@ -198,7 +201,14 @@ export class ToolPanelFilterGroupComp extends Component {
         const columns = this.getColumns();
 
         const anyChildFiltersActive = () => columns.some((col) => col.isFilterActive());
-        this.filterGroupComp.toggleCss('ag-has-filter', anyChildFiltersActive());
+
+        const iconOuter = this.filterGroupComp
+            .getGui()
+            .querySelector('.ag-filter-toolpanel-group-instance-header-icon') as HTMLElement;
+
+        if (iconOuter) {
+            iconOuter.classList.toggle('ag-filter-active', anyChildFiltersActive());
+        }
     }
 
     private onFilterOpened(event: FilterOpenedEvent): void {


### PR DESCRIPTION
Updates filters tool panel (old) to show filter icons next to all column names. Shows active filters using same highlight styles as column header filter buttons/icons. 