### PR TITLE
[AG-13490] Fix(row-sorting): duplicate icons header while using abs sort

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/absolute-sorting/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/absolute-sorting/main.ts
@@ -11,7 +11,6 @@ const columnDefs: ColDef[] = [
     { field: 'year', maxWidth: 90 },
     {
         field: 'rankingChange',
-        sortable: true,
         sort: { direction: 'asc', type: 'absolute' },
         sortingOrder: [null, { direction: 'asc', type: 'absolute' }, { direction: 'desc', type: 'absolute' }],
     },
@@ -23,7 +22,6 @@ const gridOptions: GridOptions<any> = {
     defaultColDef: {
         flex: 1,
         minWidth: 100,
-        unSortIcon: true,
     },
 
     columnDefs: columnDefs,
@@ -40,7 +38,7 @@ document.addEventListener('DOMContentLoaded', function () {
             gridApi!.setGridOption(
                 'rowData',
                 data.map((item) => {
-                    return { ...item, rankingChange: Math.floor(Math.random() * 201) - 100 };
+                    return { ...item, rankingChange: Math.floor(window.agRandom() * 10 - 5) };
                 })
             )
         );

--- a/documentation/ag-grid-docs/src/content/docs/row-sorting/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/row-sorting/index.mdoc
@@ -139,7 +139,7 @@ In this example, the column `rankingChange` uses the following sort definition:
 const gridOptions = {
     columnDefs: [
         // ... other columns 
-        { field: 'rankingChange', sortable: true, sort: { type: 'absolute', direction: 'asc' } },
+        { field: 'rankingChange', sort: { type: 'absolute', direction: 'asc' } },
     ],
 };
 ```

--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -787,7 +787,7 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
      */
     sortable?: boolean;
 
-    /** If sorting by default, set it here. Set to `SortDef | SortDirection`. */
+    /** Set the default sort. */
     sort?: SortDirection | SortDef;
 
     /**

--- a/packages/ag-grid-community/src/sort/sortIndicatorComp.ts
+++ b/packages/ag-grid-community/src/sort/sortIndicatorComp.ts
@@ -1,8 +1,7 @@
 import { RefPlaceholder } from '../agStack/interfaces/agComponent';
 import { _clearElement, _setDisplayed } from '../agStack/utils/dom';
 import type { AgColumn } from '../entities/agColumn';
-import { _normalizeSortType } from '../entities/agColumn';
-import { _normalizeSortDirection } from '../entities/agColumn';
+import { _normalizeSortDirection, _normalizeSortType } from '../entities/agColumn';
 import { _isColumnsSortingCoupledToGroup } from '../gridOptionsUtils';
 import type { ElementParams } from '../utils/element';
 import type { IconName } from '../utils/icon';

--- a/packages/ag-grid-community/src/sort/sortIndicatorComp.ts
+++ b/packages/ag-grid-community/src/sort/sortIndicatorComp.ts
@@ -1,6 +1,7 @@
 import { RefPlaceholder } from '../agStack/interfaces/agComponent';
 import { _clearElement, _setDisplayed } from '../agStack/utils/dom';
 import type { AgColumn } from '../entities/agColumn';
+import { _normalizeSortType } from '../entities/agColumn';
 import { _normalizeSortDirection } from '../entities/agColumn';
 import { _isColumnsSortingCoupledToGroup } from '../gridOptionsUtils';
 import type { ElementParams } from '../utils/element';
@@ -119,19 +120,22 @@ export class SortIndicatorComp extends Component {
         const { eSortAsc, eSortDesc, eSortAbsoluteAsc, eSortAbsoluteDesc, eSortNone, column, gos, beans } = this;
 
         const sortDef = beans.sortSvc!.getDisplaySortForColumn(column);
+        const type = _normalizeSortType(sortDef?.type);
         const direction = _normalizeSortDirection(sortDef?.direction);
         const allowedSortTypes = column.getAvailableSortTypes();
         const isDefaultSortAllowed = allowedSortTypes.has('default');
         const isAbsoluteSortAllowed = allowedSortTypes.has('absolute');
+        const isAbsoluteSort = type === 'absolute';
+        const isDefaultSort = type === 'default';
         const isAscending = direction === 'asc';
         const isDescending = direction === 'desc';
 
         if (eSortAsc) {
-            _setDisplayed(eSortAsc, isAscending && isDefaultSortAllowed, { skipAriaHidden: true });
+            _setDisplayed(eSortAsc, isAscending && isDefaultSort && isDefaultSortAllowed, { skipAriaHidden: true });
         }
 
         if (eSortDesc) {
-            _setDisplayed(eSortDesc, isDescending && isDefaultSortAllowed, { skipAriaHidden: true });
+            _setDisplayed(eSortDesc, isDescending && isDefaultSort && isDefaultSortAllowed, { skipAriaHidden: true });
         }
 
         if (eSortNone) {
@@ -140,11 +144,15 @@ export class SortIndicatorComp extends Component {
         }
 
         if (eSortAbsoluteAsc) {
-            _setDisplayed(eSortAbsoluteAsc, isAscending && isAbsoluteSortAllowed, { skipAriaHidden: true });
+            _setDisplayed(eSortAbsoluteAsc, isAscending && isAbsoluteSort && isAbsoluteSortAllowed, {
+                skipAriaHidden: true,
+            });
         }
 
         if (eSortAbsoluteDesc) {
-            _setDisplayed(eSortAbsoluteDesc, isDescending && isAbsoluteSortAllowed, { skipAriaHidden: true });
+            _setDisplayed(eSortAbsoluteDesc, isDescending && isAbsoluteSort && isAbsoluteSortAllowed, {
+                skipAriaHidden: true,
+            });
         }
     }
 

--- a/testing/behavioural/src/grouping-data/grouping-sorting.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-sorting.test.ts
@@ -77,7 +77,7 @@ describe('ag-grid grouping sorting', () => {
             state: [{ colId: 'gold', sort: 'desc' }],
         });
 
-        await new GridRows(api, 'sort by gold desc', gridRowsOptions).check(`
+        await new GridRows(api, 'sort by sport asc + gold desc', gridRowsOptions).check(`
             ROOT
             ├─┬ LEAF_GROUP
             │ ├── LEAF athlete:"Bob Johnson" sport:"Football" gold:3
@@ -91,20 +91,20 @@ describe('ag-grid grouping sorting', () => {
         // Multi-column sort: sport asc, then gold desc
         api.applyColumnState({
             state: [
-                { colId: 'sport', sort: 'asc' },
-                { colId: 'gold', sort: 'desc' },
+                { colId: 'gold', sort: 'asc' },
+                { colId: 'sport', sort: 'desc' },
             ],
         });
 
         await new GridRows(api, 'multi-column sort', gridRowsOptions).check(`
             ROOT
             ├─┬ LEAF_GROUP
-            │ ├── LEAF athlete:"Bob Johnson" sport:"Football" gold:3
+            │ ├── LEAF athlete:"Jane Doe" sport:"Soccer" gold:2
             │ ├── LEAF athlete:"John Smith" sport:"Sailing" gold:1
-            │ └── LEAF athlete:"Jane Doe" sport:"Soccer" gold:2
+            │ └── LEAF athlete:"Bob Johnson" sport:"Football" gold:3
             └─┬ LEAF_GROUP
-            · ├── LEAF athlete:"Luigi Verdi" sport:"Football" gold:5
-            · └── LEAF athlete:"Mario Rossi" sport:"Soccer" gold:4
+            · ├── LEAF athlete:"Mario Rossi" sport:"Soccer" gold:4
+            · └── LEAF athlete:"Luigi Verdi" sport:"Football" gold:5
         `);
     });
 


### PR DESCRIPTION
Update sort indicator logic to respect sort type

- Use `_normalizeSortType` to determine sort type and ensure correct sort indicator display
- Adjust sort indicator display logic to only show absolute sort indicators when the sort type is absolute
- Update grouping test case to make more sense

Addresses TC10 and TC5 in [AG-13490](https://ag-grid.atlassian.net/browse/AG-13490)