### PR TITLE
[AG-13490] Fix(row-sorting): abs sorting order and docs

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/absolute-sorting/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/absolute-sorting/main.ts
@@ -12,7 +12,6 @@ const columnDefs: ColDef[] = [
     {
         field: 'rankingChange',
         sort: { direction: 'asc', type: 'absolute' },
-        sortingOrder: [null, { direction: 'asc', type: 'absolute' }, { direction: 'desc', type: 'absolute' }],
     },
 ];
 

--- a/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/absolute-sorting/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/absolute-sorting/main.ts
@@ -38,7 +38,7 @@ document.addEventListener('DOMContentLoaded', function () {
             gridApi!.setGridOption(
                 'rowData',
                 data.map((item) => {
-                    return { ...item, rankingChange: Math.floor(window.agRandom() * 10 - 5) };
+                    return { ...item, rankingChange: Math.round(window.agRandom() * 10) - 5 };
                 })
             )
         );

--- a/documentation/ag-grid-docs/src/content/docs/row-sorting/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/row-sorting/index.mdoc
@@ -150,10 +150,6 @@ const gridOptions = {
 
 {% apiDocumentation source="column-properties/properties.json" section="sort" names=["sort"] /%}
 
-{% note %}
-The grid uses the `sortingOrder` property to determine if Absolute sort should be enabled for a column. Setting `sort` to `{ type: 'absolute', direction: '...' }` alone is not sufficient.
-{% /note %}
-
 ## Sorting API
 
 {% note %}

--- a/documentation/ag-grid-docs/src/content/docs/row-sorting/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/row-sorting/index.mdoc
@@ -139,12 +139,20 @@ In this example, the column `rankingChange` uses the following sort definition:
 const gridOptions = {
     columnDefs: [
         // ... other columns 
-        { field: 'rankingChange', sort: { type: 'absolute', direction: 'asc' } },
+        {
+            field: 'rankingChange',
+            sort: { direction: 'asc', type: 'absolute' },
+            sortingOrder: [null, { direction: 'asc', type: 'absolute' }, { direction: 'desc', type: 'absolute' }],
+        },
     ],
 };
 ```
 
 {% apiDocumentation source="column-properties/properties.json" section="sort" names=["sort"] /%}
+
+{% note %}
+The grid uses the `sortingOrder` property to determine if Absolute sort should be enabled for a column. Setting `sort` to `{ type: 'absolute', direction: '...' }` alone is not sufficient.
+{% /note %}
 
 ## Sorting API
 

--- a/packages/ag-grid-community/src/entities/agColumn.ts
+++ b/packages/ag-grid-community/src/entities/agColumn.ts
@@ -52,6 +52,11 @@ export function isColumn(col: Column | ColumnGroup | ProvidedColumnGroup): col i
 }
 
 const DEFAULT_SORTING_ORDER: SortDirection[] = ['asc', 'desc', null];
+const DEFAULT_ABSOLUTE_SORTING_ORDER: (SortDef | SortDirection)[] = [
+    ...DEFAULT_SORTING_ORDER,
+    { type: 'absolute', direction: 'asc' },
+    { type: 'absolute', direction: 'desc' },
+];
 
 // Wrapper around a user provide column definition. The grid treats the column definition as ready only.
 // This class contains all the runtime information about a column, plus some logic (the definition has no logic).
@@ -444,14 +449,26 @@ export class AgColumn<TValue = any>
         return this.sortDef;
     }
 
+    private getColDefAllowedSortTypes(): Set<SortType> {
+        const { sort, initialSort } = this.colDef;
+        const colDefSortType = _normalizeSortType((sort as SortDef)?.type);
+        const colDefInitialSortType = _normalizeSortType((initialSort as SortDef)?.type);
+
+        return new Set([colDefSortType, colDefInitialSortType]);
+    }
+
     public getSortingOrder() {
-        return (this.colDef.sortingOrder ?? this.gos.get('sortingOrder') ?? DEFAULT_SORTING_ORDER).map(
+        const defaultSortingOrder = this.getColDefAllowedSortTypes().has('absolute')
+            ? DEFAULT_ABSOLUTE_SORTING_ORDER
+            : DEFAULT_SORTING_ORDER;
+
+        return (this.colDef.sortingOrder ?? this.gos.get('sortingOrder') ?? defaultSortingOrder).map(
             (objOrDirection: unknown) => _getSortDefFromInput(objOrDirection)
         );
     }
 
     public getAvailableSortTypes() {
-        return new Set(this.getSortingOrder().map((so) => so.type));
+        return new Set([...this.getColDefAllowedSortTypes(), this.getSortingOrder().map((so) => so.type)]);
     }
 
     get wasSortExplicitlyRemoved(): boolean {

--- a/packages/ag-grid-community/src/entities/agColumn.ts
+++ b/packages/ag-grid-community/src/entities/agColumn.ts
@@ -53,9 +53,9 @@ export function isColumn(col: Column | ColumnGroup | ProvidedColumnGroup): col i
 
 const DEFAULT_SORTING_ORDER: SortDirection[] = ['asc', 'desc', null];
 const DEFAULT_ABSOLUTE_SORTING_ORDER: (SortDef | SortDirection)[] = [
-    ...DEFAULT_SORTING_ORDER,
     { type: 'absolute', direction: 'asc' },
     { type: 'absolute', direction: 'desc' },
+    null,
 ];
 
 // Wrapper around a user provide column definition. The grid treats the column definition as ready only.
@@ -449,16 +449,22 @@ export class AgColumn<TValue = any>
         return this.sortDef;
     }
 
-    private getColDefAllowedSortTypes(): Set<SortType> {
+    private getColDefAllowedSortTypes(): SortType[] {
+        const res: SortType[] = [];
         const { sort, initialSort } = this.colDef;
-        const colDefSortType = _normalizeSortType((sort as SortDef)?.type);
-        const colDefInitialSortType = _normalizeSortType((initialSort as SortDef)?.type);
-
-        return new Set([colDefSortType, colDefInitialSortType]);
+        const colDefSortType = (sort as SortDef)?.type;
+        const colDefInitialSortType = (initialSort as SortDef)?.type;
+        if (colDefSortType) {
+            res.push(colDefSortType);
+        }
+        if (colDefInitialSortType) {
+            res.push(colDefInitialSortType);
+        }
+        return res;
     }
 
     public getSortingOrder() {
-        const defaultSortingOrder = this.getColDefAllowedSortTypes().has('absolute')
+        const defaultSortingOrder = this.getColDefAllowedSortTypes().includes('absolute')
             ? DEFAULT_ABSOLUTE_SORTING_ORDER
             : DEFAULT_SORTING_ORDER;
 
@@ -468,7 +474,13 @@ export class AgColumn<TValue = any>
     }
 
     public getAvailableSortTypes() {
-        return new Set([...this.getColDefAllowedSortTypes(), this.getSortingOrder().map((so) => so.type)]);
+        const explicitSortTypesFromSortingOrder = this.getSortingOrder().reduce<string[]>((acc, so) => {
+            if (so.direction) {
+                acc.push(so.type);
+            }
+            return acc;
+        }, this.getColDefAllowedSortTypes());
+        return new Set(explicitSortTypesFromSortingOrder);
     }
 
     get wasSortExplicitlyRemoved(): boolean {

--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -818,8 +818,12 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
      */
     initialSortIndex?: number;
     /**
-     * Array defining the order in which sorting occurs (if sorting is enabled). An array with any of the following in any order `(SortDef | SortDirection)[]`.
-     * @default ['asc', 'desc', null]
+     * An array defining the order in which sorting occurs (if sorting is enabled) with any of the following in any order `(SortDef | SortDirection)[]`.
+     * <br /><br />
+     * Defaults:
+     *
+     * - `['asc', 'desc', null]` if no sort type is specified,
+     * - `['asc', 'desc', null, { type: 'absolute', direction: 'asc', }, { type: 'absolute', direction: 'desc' }]` if sort or initialSort have type: 'absolute'
      */
     sortingOrder?: (SortDirection | SortDef)[];
     /**

--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -823,7 +823,7 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
      * Defaults:
      *
      * - `['asc', 'desc', null]` if no sort type is specified,
-     * - `['asc', 'desc', null, { type: 'absolute', direction: 'asc', }, { type: 'absolute', direction: 'desc' }]` if sort or initialSort have type: 'absolute'
+     * - `[{ type: 'absolute', direction: 'asc', }, { type: 'absolute', direction: 'desc' }, null]` if sort or initialSort have type: 'absolute'
      */
     sortingOrder?: (SortDirection | SortDef)[];
     /**

--- a/packages/ag-grid-community/src/sort/rowNodeSorter.ts
+++ b/packages/ag-grid-community/src/sort/rowNodeSorter.ts
@@ -193,8 +193,8 @@ const defaultGetLeaf = (row: RowNode): RowNode | undefined => {
 };
 
 function _absoluteValueTransformer(value: any): number | null {
-    if (value == null) {
-        return null;
+    if (!value) {
+        return value;
     }
     const numberValue = Number(value);
     return isNaN(numberValue) ? value : Math.abs(numberValue);

--- a/packages/ag-grid-community/src/sort/sortService.ts
+++ b/packages/ag-grid-community/src/sort/sortService.ts
@@ -140,7 +140,7 @@ export class SortService extends BeanStub implements NamedBean {
         const currentSortDef = column.getSortDef();
         const currentIndex = sortingOrder.findIndex((e) => _areSortDefsEqual(e, currentSortDef));
 
-        let nextIndex = Math.max(0, currentIndex) + 1;
+        let nextIndex = currentIndex + 1;
         if (nextIndex >= sortingOrder.length) {
             nextIndex = 0;
         }

--- a/packages/ag-grid-enterprise/src/menu/columnMenuFactory.ts
+++ b/packages/ag-grid-enterprise/src/menu/columnMenuFactory.ts
@@ -1,4 +1,5 @@
 import type { AgColumn, AgProvidedColumnGroup, DefaultMenuItem, MenuItemDef, NamedBean } from 'ag-grid-community';
+import { _normalizeSortType } from 'ag-grid-community';
 import {
     BeanStub,
     _addGridCommonParams,
@@ -127,23 +128,26 @@ export class ColumnMenuFactory extends BeanStub implements NamedBean {
 
         if (sortSvc && !isLegacyMenuEnabled && column.isSortable()) {
             const sortDef = column.getSortDef();
+            const type = _normalizeSortType(sortDef?.type);
             const direction = _normalizeSortDirection(sortDef?.direction);
             const allowedSortTypes = column.getAvailableSortTypes();
             const isDefaultSortAllowed = allowedSortTypes.has('default');
             const isAbsoluteSortAllowed = allowedSortTypes.has('absolute');
+            const isAbsoluteSort = type === 'absolute';
+            const isDefaultSort = type === 'default';
             const isAscending = direction === 'asc';
             const isDescending = direction === 'desc';
 
-            if (isDefaultSortAllowed && !isAscending) {
+            if (isDefaultSortAllowed && !(isAscending && isDefaultSort)) {
                 result.push('sortAscending');
             }
-            if (isDefaultSortAllowed && !isDescending) {
+            if (isDefaultSortAllowed && !(isDescending && isDefaultSort)) {
                 result.push('sortDescending');
             }
-            if (isAbsoluteSortAllowed && !isAscending) {
+            if (isAbsoluteSortAllowed && !(isAscending && isAbsoluteSort)) {
                 result.push('sortAbsoluteAscending');
             }
-            if (isAbsoluteSortAllowed && !isDescending) {
+            if (isAbsoluteSortAllowed && !(isDescending && isAbsoluteSort)) {
                 result.push('sortAbsoluteDescending');
             }
             if (direction) {

--- a/packages/ag-grid-enterprise/src/menu/columnMenuFactory.ts
+++ b/packages/ag-grid-enterprise/src/menu/columnMenuFactory.ts
@@ -1,5 +1,4 @@
 import type { AgColumn, AgProvidedColumnGroup, DefaultMenuItem, MenuItemDef, NamedBean } from 'ag-grid-community';
-import { _normalizeSortType } from 'ag-grid-community';
 import {
     BeanStub,
     _addGridCommonParams,
@@ -7,6 +6,7 @@ import {
     _isClientSideRowModel,
     _isLegacyMenuEnabled,
     _normalizeSortDirection,
+    _normalizeSortType,
 } from 'ag-grid-community';
 
 import { isRowGroupColLocked } from '../rowGrouping/rowGroupingUtils';


### PR DESCRIPTION
addresses TC6, TC4, TC8 and others [AG-13490](https://ag-grid.atlassian.net/browse/AG-13490)
 
<img width="1021" height="255" alt="Screenshot 2025-12-01 at 17 34 11" src="https://github.com/user-attachments/assets/a7828276-7f46-4658-89c4-1ccda6cc4804" />
