### PR TITLE
AG-16383 row drag handle grayed out

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_widgets.scss
+++ b/community-modules/styles/src/internal/base/parts/_widgets.scss
@@ -167,12 +167,8 @@
     }
 
     .ag-drag-handle-disabled {
-        opacity: 0.5;
+        opacity: 0.35;
         pointer-events: none;
-
-        .ag-icon {
-            opacity: 0.5;
-        }
     }
 
     .ag-cell-wrapper > *:not(.ag-cell-value):not(.ag-group-value) {

--- a/community-modules/styles/src/internal/base/parts/_widgets.scss
+++ b/community-modules/styles/src/internal/base/parts/_widgets.scss
@@ -166,6 +166,15 @@
         color: var(--ag-secondary-foreground-color);
     }
 
+    .ag-drag-handle-disabled {
+        opacity: 0.5;
+        pointer-events: none;
+
+        .ag-icon {
+            opacity: 0.5;
+        }
+    }
+
     .ag-cell-wrapper > *:not(.ag-cell-value):not(.ag-group-value) {
         // assign internal variables to simplify the `height` value
         --ag-internal-calculated-line-height: var(

--- a/documentation/ag-grid-docs/src/content/docs/row-dragging-managed/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/row-dragging-managed/index.mdoc
@@ -53,7 +53,7 @@ The example below is almost identical to the [Managed Dragging](./row-dragging-m
 
 * The **Suppress** button will hide the drag icons.
 * The **Remove Suppress** button will un-hide the drag icons.
-* Applying a sort or a filter to the grid will also suppress the drag icons.
+* Applying a sort or a filter or entering pivot mode will disable the drag icons.
 
 {% gridExampleRunner title="Suppress Row Drag" name="suppress-row-drag" /%}
 

--- a/packages/ag-grid-community/src/agStack/core/baseDragAndDropService.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseDragAndDropService.ts
@@ -355,23 +355,24 @@ export abstract class BaseDragAndDropService<
     }
 
     public removeDropTarget(dropTarget: AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent>) {
-        let externalRemoved = 0;
         const container = dropTarget.getContainer();
-        for (let i = this.dropTargets.length - 1; i >= 0; --i) {
-            const target = this.dropTargets[i];
-            if (target.getContainer() !== container) {
-                continue;
+        const dropTargets = this.dropTargets;
+        let writeIndex = 0;
+        for (let readIndex = 0, len = dropTargets.length; readIndex < len; ++readIndex) {
+            const target = dropTargets[readIndex];
+            if (target.getContainer() === container) {
+                if (target.external) {
+                    --this.externalDropZoneCount;
+                }
+                continue; // removed
             }
 
-            if (target.external) {
-                externalRemoved++;
+            if (writeIndex !== readIndex) {
+                dropTargets[writeIndex] = target;
             }
-
-            this.dropTargets.splice(i, 1);
+            ++writeIndex;
         }
-        if (externalRemoved) {
-            this.externalDropZoneCount = Math.max(0, this.externalDropZoneCount - externalRemoved);
-        }
+        dropTargets.length = writeIndex;
     }
 
     public hasExternalDropZones(): boolean {

--- a/packages/ag-grid-community/src/agStack/core/baseDragAndDropService.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseDragAndDropService.ts
@@ -11,7 +11,6 @@ import type {
     IDragAndDropService,
 } from '../interfaces/iDragAndDrop';
 import type { IPropertiesService } from '../interfaces/iProperties';
-import { _removeFromArray } from '../utils/array';
 import { _getPageBody, _getRootNode } from '../utils/document';
 import { _anchorElementToMouseMoveEvent } from '../utils/event';
 import type { AgPromise } from '../utils/promise';
@@ -64,7 +63,8 @@ export abstract class BaseDragAndDropService<
     private dragImageLastIcon: TDragAndDropIcon | null | undefined = undefined;
     private dragImageLastLabel: string | null | undefined = undefined;
 
-    private dropTargets: AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent>[] = [];
+    private readonly dropTargets: AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent>[] = [];
+    private externalDropZoneCount = 0;
     private lastDropTarget: AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent> | null = null;
 
     protected abstract createEvent(
@@ -108,10 +108,13 @@ export abstract class BaseDragAndDropService<
 
     public removeDragSource(dragSource: TDragSource): void {
         const { dragSourceAndParamsList, beans } = this;
-        const sourceAndParams = dragSourceAndParamsList.find((item) => item.dragSource === dragSource);
-        if (sourceAndParams) {
-            beans.dragSvc?.removeDragSource(sourceAndParams);
-            _removeFromArray(dragSourceAndParamsList, sourceAndParams);
+        for (let i = 0, len = dragSourceAndParamsList.length; i < len; i++) {
+            if (dragSourceAndParamsList[i].dragSource === dragSource) {
+                const sourceAndParams = dragSourceAndParamsList[i];
+                beans.dragSvc?.removeDragSource(sourceAndParams);
+                dragSourceAndParamsList.splice(i, 1);
+                break;
+            }
         }
     }
 
@@ -123,6 +126,7 @@ export abstract class BaseDragAndDropService<
         }
         dragSourceAndParamsList.length = 0;
         dropTargets.length = 0;
+        this.externalDropZoneCount = 0;
         this.clearDragAndDropProperties();
         super.destroy();
     }
@@ -231,10 +235,19 @@ export abstract class BaseDragAndDropService<
     private getAllContainersFromDropTarget(
         dropTarget: AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent>
     ): HTMLElement[][] {
-        const secondaryContainers = dropTarget.getSecondaryContainers ? dropTarget.getSecondaryContainers() : null;
-        const containers: HTMLElement[][] = [[dropTarget.getContainer()]];
+        const primaryContainer = dropTarget.getContainer();
 
-        return secondaryContainers ? containers.concat(secondaryContainers) : containers;
+        const secondaryContainers = dropTarget.getSecondaryContainers?.();
+        const secondaryContainersLen = secondaryContainers?.length;
+        if (!secondaryContainersLen) {
+            return [[primaryContainer]];
+        }
+        const containers = new Array<HTMLElement[]>(secondaryContainersLen + 1);
+        containers[0] = [primaryContainer];
+        for (let i = 0; i < secondaryContainersLen; ++i) {
+            containers[i + 1] = secondaryContainers[i];
+        }
+        return containers;
     }
 
     // checks if the mouse is on the drop target. it checks eContainer and eSecondaryContainers
@@ -281,7 +294,14 @@ export abstract class BaseDragAndDropService<
     private findCurrentDropTarget(
         mouseEvent: MouseEvent
     ): AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent> | null {
-        const validDropTargets = this.dropTargets.filter((target) => this.isMouseOnDropTarget(mouseEvent, target));
+        const validDropTargets: AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent>[] = [];
+        for (let i = 0, len = this.dropTargets.length; i < len; ++i) {
+            const target = this.dropTargets[i];
+            if (this.isMouseOnDropTarget(mouseEvent, target)) {
+                validDropTargets.push(target);
+            }
+        }
+
         const len = validDropTargets.length;
 
         if (len === 0) {
@@ -298,10 +318,25 @@ export abstract class BaseDragAndDropService<
         const elementStack = rootNode.elementsFromPoint(mouseEvent.clientX, mouseEvent.clientY) as HTMLElement[];
 
         // loop over the sorted elementStack to find which dropTarget comes first
-        for (const el of elementStack) {
-            for (const dropTarget of validDropTargets) {
-                const containers = this.getAllContainersFromDropTarget(dropTarget).flatMap((a) => a);
-                if (containers.indexOf(el) !== -1) {
+        for (let i = 0, stackLen = elementStack.length; i < stackLen; ++i) {
+            const el = elementStack[i];
+
+            for (let targetIndex = 0, targetsLen = validDropTargets.length; targetIndex < targetsLen; targetIndex++) {
+                const dropTarget = validDropTargets[targetIndex];
+                const containerGroups = this.getAllContainersFromDropTarget(dropTarget);
+
+                let matched = false;
+                for (let groupIdx = 0, groupLen = containerGroups.length; groupIdx < groupLen && !matched; groupIdx++) {
+                    const group = containerGroups[groupIdx];
+                    for (let elIdx = 0, elLen = group.length; elIdx < elLen; elIdx++) {
+                        if (group[elIdx] === el) {
+                            matched = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (matched) {
                     return dropTarget;
                 }
             }
@@ -314,20 +349,45 @@ export abstract class BaseDragAndDropService<
 
     public addDropTarget(dropTarget: AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent>) {
         this.dropTargets.push(dropTarget);
+        if (dropTarget.external) {
+            this.externalDropZoneCount++;
+        }
     }
 
     public removeDropTarget(dropTarget: AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent>) {
-        this.dropTargets = this.dropTargets.filter((target) => target.getContainer() !== dropTarget.getContainer());
+        let externalRemoved = 0;
+        const container = dropTarget.getContainer();
+        for (let i = this.dropTargets.length - 1; i >= 0; --i) {
+            const target = this.dropTargets[i];
+            if (target.getContainer() !== container) {
+                continue;
+            }
+
+            if (target.external) {
+                externalRemoved++;
+            }
+
+            this.dropTargets.splice(i, 1);
+        }
+        if (externalRemoved) {
+            this.externalDropZoneCount = Math.max(0, this.externalDropZoneCount - externalRemoved);
+        }
     }
 
     public hasExternalDropZones(): boolean {
-        return this.dropTargets.some((zones) => zones.external);
+        return this.externalDropZoneCount > 0;
     }
 
     public findExternalZone(
         container: HTMLElement
     ): AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent> | null {
-        return this.dropTargets.find((zone) => zone.external && zone.getContainer() === container) || null;
+        for (let i = 0, len = this.dropTargets.length; i < len; ++i) {
+            const zone = this.dropTargets[i];
+            if (zone.external && zone.getContainer() === container) {
+                return zone;
+            }
+        }
+        return null;
     }
 
     private dropTargetEvent(

--- a/packages/ag-grid-community/src/agStack/core/baseDragAndDropService.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseDragAndDropService.ts
@@ -295,8 +295,9 @@ export abstract class BaseDragAndDropService<
         mouseEvent: MouseEvent
     ): AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent> | null {
         const validDropTargets: AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent>[] = [];
-        for (let i = 0, len = this.dropTargets.length; i < len; ++i) {
-            const target = this.dropTargets[i];
+        const dropTargets = this.dropTargets;
+        for (let i = 0, len = dropTargets.length; i < len; ++i) {
+            const target = dropTargets[i];
             if (this.isMouseOnDropTarget(mouseEvent, target)) {
                 validDropTargets.push(target);
             }
@@ -382,8 +383,9 @@ export abstract class BaseDragAndDropService<
     public findExternalZone(
         container: HTMLElement
     ): AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent> | null {
-        for (let i = 0, len = this.dropTargets.length; i < len; ++i) {
-            const zone = this.dropTargets[i];
+        const dropTargets = this.dropTargets;
+        for (let i = 0, len = dropTargets.length; i < len; ++i) {
+            const zone = dropTargets[i];
             if (zone.external && zone.getContainer() === container) {
                 return zone;
             }

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
@@ -1,7 +1,6 @@
 import type { LocaleTextFunc } from '../agStack/interfaces/iLocaleService';
 import type { AgColumn } from '../entities/agColumn';
 import type { RowNode } from '../entities/rowNode';
-import type { AgEventType } from '../eventTypes';
 import type { IRowDragItem } from '../interfaces/iRowDragItem';
 import type { ElementParams } from '../utils/element';
 import { _createIconNoSpan } from '../utils/icon';
@@ -16,9 +15,12 @@ const RowDragElement: ElementParams = {
     attrs: { 'aria-hidden': 'true' },
 };
 
+const SKIP_ARIA_HIDDEN = { skipAriaHidden: true };
+
 export class RowDragComp extends Component {
     private dragSource: GridDragSource<RowDraggingEvent> | null = null;
     private mouseDownListener: (() => void) | undefined;
+    private disabled = false;
 
     constructor(
         private readonly cellValueFn: () => string,
@@ -51,10 +53,12 @@ export class RowDragComp extends Component {
     }
 
     private initCellDrag(): void {
-        const { beans, gos, rowNode } = this;
+        const { beans, rowNode } = this;
         const refreshVisibility = this.refreshVisibility.bind(this);
 
-        this.addManagedPropertyListener('suppressRowDrag', refreshVisibility);
+        this.addManagedListeners(beans.eventSvc, {
+            rowDragVisibilityChanged: refreshVisibility,
+        });
 
         // in case data changes, then we need to update visibility of drag item
         this.addManagedListeners(rowNode, {
@@ -62,18 +66,7 @@ export class RowDragComp extends Component {
             cellChanged: refreshVisibility,
         });
 
-        this.addManagedListeners<AgEventType>(
-            beans.eventSvc,
-            // For managed row drag, we do not show the component if sort, filter or grouping is active
-            gos.get('rowDragManaged')
-                ? {
-                      sortChanged: refreshVisibility,
-                      filterChanged: refreshVisibility,
-                      columnRowGroupChanged: refreshVisibility,
-                      newColumnsLoaded: refreshVisibility,
-                  }
-                : { newColumnsLoaded: refreshVisibility }
-        );
+        this.refreshVisibility();
     }
 
     public setDragElement(dragElement: HTMLElement, dragStartPixels?: number) {
@@ -88,43 +81,59 @@ export class RowDragComp extends Component {
             return; // Always visible row draggers do not refresh visibility
         }
 
-        const displayedOptions = { skipAriaHidden: true };
-        if (this.isNeverDisplayed()) {
-            this.setDisplayed(false, displayedOptions);
-            return;
+        const { beans } = this;
+        const serviceVisibility = beans.rowDragSvc?.visibility;
+        const hideCompletely = serviceVisibility === 'hidden' && !beans.dragAndDrop?.hasExternalDropZones();
+
+        let displayed = !hideCompletely;
+        let visible = displayed;
+        let disabled = serviceVisibility === 'disabled';
+
+        if (displayed) {
+            const column = this.column;
+            const customGui = this.isCustomGui();
+
+            if (!customGui && column) {
+                const rowDragProp = column.getColDef().rowDrag;
+                if (rowDragProp === false) {
+                    displayed = false;
+                } else {
+                    const shownSometimes = typeof rowDragProp === 'function';
+                    visible = column.isRowDrag(this.rowNode);
+                    displayed = shownSometimes || visible;
+                }
+            }
+
+            if (displayed && visible && this.rowNode.footer && beans.gos.get('rowDragManaged')) {
+                visible = false; // Footer rows in managed mode never show drag handles
+                displayed = true;
+            }
         }
 
-        const column = this.column;
+        visible &&= displayed;
+        disabled ||= !visible;
 
-        // if shown sometimes, them some rows can have drag handle while other don't,
-        // so we use setVisible to keep the handles horizontally aligned (as _setVisible
-        // keeps the empty space, whereas setDisplayed looses the space)
-        let shownSometimes = typeof column?.getColDef().rowDrag === 'function';
-        let visible = !column || this.isCustomGui() || column.isRowDrag(this.rowNode);
-        if (visible && this.rowNode.footer && this.gos.get('rowDragManaged')) {
-            visible = false; // We hide footer rows in row drag managed mode
-            shownSometimes = true;
+        // Those calls are ordered to avoid flicker when changing state
+        if (!displayed) {
+            this.setDisplayed(displayed, SKIP_ARIA_HIDDEN);
         }
-
-        this.setDisplayed(shownSometimes || visible, displayedOptions);
-        this.setVisible(visible, displayedOptions);
+        if (!visible) {
+            this.setVisible(visible, SKIP_ARIA_HIDDEN);
+        }
+        this.setDisabled(disabled);
+        if (displayed) {
+            this.setDisplayed(displayed, SKIP_ARIA_HIDDEN);
+        }
+        if (visible) {
+            this.setVisible(visible, SKIP_ARIA_HIDDEN);
+        }
     }
 
-    private isNeverDisplayed(): boolean {
-        const { gos, beans } = this;
-        if (gos.get('suppressRowDrag')) {
-            return true; // Row dragging is suppressed
+    private setDisabled(disabled: boolean): void {
+        if (disabled !== this.disabled) {
+            this.disabled = disabled;
+            this.getGui()?.classList?.toggle('ag-drag-handle-disabled', disabled);
         }
-
-        if (
-            gos.get('rowDragManaged') &&
-            !!beans.rowDragSvc!.rowDragFeature?.shouldPreventRowMove() &&
-            !beans.dragAndDrop?.hasExternalDropZones()
-        ) {
-            return true; // Managed: only show if not prevented and not suppressed, or if there are external drop zones
-        }
-
-        return false;
     }
 
     private getSelectedNodes(): RowNode[] {

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
@@ -82,11 +82,11 @@ export class RowDragComp extends Component {
         }
 
         const { beans, column, rowNode } = this;
-        const visibility = beans.rowDragSvc!.visibility;
-        const hideCompletely =
-            visibility === 'suppress' || (visibility === 'hidden' && !beans.dragAndDrop?.hasExternalDropZones());
+        const { gos, dragAndDrop, rowDragSvc } = beans;
+        const visibility = rowDragSvc?.visibility;
+        const hide = visibility === 'suppress' || (visibility === 'hidden' && !dragAndDrop?.hasExternalDropZones());
 
-        let displayed = !hideCompletely;
+        let displayed = !hide;
         let visible = displayed;
 
         if (displayed && !this.isCustomGui() && column) {
@@ -100,7 +100,7 @@ export class RowDragComp extends Component {
             }
         }
 
-        if (displayed && visible && rowNode.footer && beans.gos.get('rowDragManaged')) {
+        if (displayed && visible && rowNode.footer && gos.get('rowDragManaged')) {
             visible = false; // Footer rows in managed mode never show drag handles
             displayed = true;
         }
@@ -116,7 +116,7 @@ export class RowDragComp extends Component {
             this.setVisible(visible, SKIP_ARIA_HIDDEN);
         }
 
-        this.setDisabled(!visible || (visibility === 'disabled' && !beans.dragAndDrop?.hasExternalDropZones()));
+        this.setDisabled(!visible || (visibility === 'disabled' && !dragAndDrop?.hasExternalDropZones()));
 
         if (displayed) {
             this.setDisplayed(displayed, SKIP_ARIA_HIDDEN);

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
@@ -81,7 +81,7 @@ export class RowDragComp extends Component {
             return; // Always visible row draggers do not refresh visibility
         }
 
-        const { beans } = this;
+        const { beans, column, rowNode } = this;
         const visibility = beans.rowDragSvc!.visibility;
         const hideCompletely =
             visibility === 'suppress' || (visibility === 'hidden' && !beans.dragAndDrop?.hasExternalDropZones());
@@ -89,30 +89,26 @@ export class RowDragComp extends Component {
         let displayed = !hideCompletely;
         let visible = displayed;
 
-        if (displayed) {
-            const column = this.column;
-            const customGui = this.isCustomGui();
-
-            if (!customGui && column) {
-                const rowDragProp = column.getColDef().rowDrag;
-                if (rowDragProp === false) {
-                    displayed = false;
-                } else {
-                    const shownSometimes = typeof rowDragProp === 'function';
-                    visible = column.isRowDrag(this.rowNode);
-                    displayed = shownSometimes || visible;
-                }
+        if (displayed && !this.isCustomGui() && column) {
+            const rowDragProp = column.getColDef().rowDrag;
+            if (rowDragProp === false) {
+                displayed = false;
+            } else {
+                const shownSometimes = typeof rowDragProp === 'function';
+                visible = column.isRowDrag(rowNode);
+                displayed = shownSometimes || visible;
             }
+        }
 
-            if (displayed && visible && this.rowNode.footer && beans.gos.get('rowDragManaged')) {
-                visible = false; // Footer rows in managed mode never show drag handles
-                displayed = true;
-            }
+        if (displayed && visible && rowNode.footer && beans.gos.get('rowDragManaged')) {
+            visible = false; // Footer rows in managed mode never show drag handles
+            displayed = true;
         }
 
         visible &&= displayed;
 
         // Those calls are ordered to avoid flicker when changing state
+
         if (!displayed) {
             this.setDisplayed(displayed, SKIP_ARIA_HIDDEN);
         }

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
@@ -82,12 +82,12 @@ export class RowDragComp extends Component {
         }
 
         const { beans } = this;
-        const serviceVisibility = beans.rowDragSvc?.visibility;
-        const hideCompletely = serviceVisibility === 'hidden' && !beans.dragAndDrop?.hasExternalDropZones();
+        const visibility = beans.rowDragSvc!.visibility;
+        const hideCompletely =
+            visibility === 'suppress' || (visibility === 'hidden' && !beans.dragAndDrop?.hasExternalDropZones());
 
         let displayed = !hideCompletely;
         let visible = displayed;
-        let disabled = serviceVisibility === 'disabled';
 
         if (displayed) {
             const column = this.column;
@@ -111,7 +111,6 @@ export class RowDragComp extends Component {
         }
 
         visible &&= displayed;
-        disabled ||= !visible;
 
         // Those calls are ordered to avoid flicker when changing state
         if (!displayed) {
@@ -120,7 +119,9 @@ export class RowDragComp extends Component {
         if (!visible) {
             this.setVisible(visible, SKIP_ARIA_HIDDEN);
         }
-        this.setDisabled(disabled);
+
+        this.setDisabled(!visible || (visibility === 'disabled' && !beans.dragAndDrop?.hasExternalDropZones()));
+
         if (displayed) {
             this.setDisplayed(displayed, SKIP_ARIA_HIDDEN);
         }

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
@@ -126,27 +126,11 @@ export class RowDragFeature extends BeanStub implements DropTarget {
             return 'notAllowed';
         }
 
-        if (this.gos.get('rowDragManaged') && this.shouldPreventRowMove()) {
+        if (this.beans.rowDragSvc!.visibility !== 'visible') {
             return 'notAllowed';
         }
 
         return 'move';
-    }
-
-    public shouldPreventRowMove(): boolean {
-        const { gos, rowGroupColsSvc, filterManager, sortSvc } = this.beans;
-        if (rowGroupColsSvc?.columns?.length && !gos.get('refreshAfterGroupEdit')) {
-            return true;
-        }
-        const isFilterPresent = filterManager?.isAnyFilterPresent();
-        if (isFilterPresent) {
-            return true;
-        }
-        const isSortActive = sortSvc?.isSortActive();
-        if (isSortActive) {
-            return true;
-        }
-        return false;
     }
 
     private getRowNodes(draggingEvent: RowDraggingEvent): RowNode[] {
@@ -297,7 +281,9 @@ export class RowDragFeature extends BeanStub implements DropTarget {
         let allowed = true;
         if (
             rowDragManaged &&
-            (!rows.length || this.shouldPreventRowMove() || ((suppressMoveWhenRowDragging || !sameGrid) && !withinGrid))
+            (!rows.length ||
+                beans.rowDragSvc!.visibility !== 'visible' ||
+                ((suppressMoveWhenRowDragging || !sameGrid) && !withinGrid))
         ) {
             allowed = false;
         }

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragService.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragService.ts
@@ -11,7 +11,7 @@ export class RowDragService extends BeanStub implements NamedBean {
     beanName = 'rowDragSvc' as const;
 
     public rowDragFeature: RowDragFeature | null = null;
-    public visibility: RowDragVisibility = 'hidden';
+    public visibility: RowDragVisibility = 'suppress';
 
     public setupRowDrag(element: HTMLElement, ctrl: BeanStub): void {
         const rowDragFeature = ctrl.createManagedBean(new RowDragFeature(element));
@@ -103,7 +103,7 @@ export class RowDragService extends BeanStub implements NamedBean {
         const gos = beans.gos;
 
         if (gos.get('suppressRowDrag')) {
-            return 'hidden';
+            return 'suppress';
         }
 
         const rowDragManaged = gos.get('rowDragManaged');

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragService.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragService.ts
@@ -5,11 +5,17 @@ import type { RowNode } from '../entities/rowNode';
 import { _isCellSelectionEnabled, _isClientSideRowModel } from '../gridOptionsUtils';
 import { RowDragComp } from './rowDragComp';
 import { RowDragFeature } from './rowDragFeature';
+import type { RowDragVisibility } from './rowDragTypes';
 
 export class RowDragService extends BeanStub implements NamedBean {
     beanName = 'rowDragSvc' as const;
 
-    public rowDragFeature?: RowDragFeature;
+    public rowDragFeature: RowDragFeature | null = null;
+    private _visibility: RowDragVisibility | undefined = undefined;
+
+    public get visibility(): RowDragVisibility {
+        return (this._visibility ??= this.computeVisibility());
+    }
 
     public setupRowDrag(element: HTMLElement, ctrl: BeanStub): void {
         const rowDragFeature = ctrl.createManagedBean(new RowDragFeature(element));
@@ -17,6 +23,22 @@ export class RowDragService extends BeanStub implements NamedBean {
         dragAndDrop.addDropTarget(rowDragFeature);
         ctrl.addDestroyFunc(() => dragAndDrop.removeDropTarget(rowDragFeature));
         this.rowDragFeature = rowDragFeature;
+
+        const refreshVisibility = () => this.refreshVisibility();
+
+        this.addManagedPropertyListeners(
+            ['rowDragManaged', 'suppressRowDrag', 'refreshAfterGroupEdit'],
+            refreshVisibility
+        );
+
+        this.addManagedEventListeners({
+            newColumnsLoaded: refreshVisibility,
+            columnRowGroupChanged: refreshVisibility,
+            columnPivotModeChanged: refreshVisibility,
+            columnPivotChanged: refreshVisibility,
+            sortChanged: refreshVisibility,
+            filterChanged: refreshVisibility,
+        });
     }
 
     public createRowDragComp(
@@ -61,7 +83,6 @@ export class RowDragService extends BeanStub implements NamedBean {
             }
         }
 
-        // otherwise (normal case) we are creating a RowDraggingComp for the first time
         const rowDragComp = this.createRowDragComp(
             cellValueFn,
             rowNode,
@@ -77,5 +98,54 @@ export class RowDragService extends BeanStub implements NamedBean {
         if (this.rowDragFeature?.lastDraggingEvent) {
             this.beans.dragSvc?.cancelDrag();
         }
+    }
+
+    private computeVisibility(): RowDragVisibility {
+        const beans = this.beans;
+        const gos = beans.gos;
+
+        if (gos.get('suppressRowDrag')) {
+            return 'hidden';
+        }
+
+        const rowDragManaged = gos.get('rowDragManaged');
+        if (!rowDragManaged) {
+            return 'visible';
+        }
+
+        const pivoting = beans.colModel.isPivotActive();
+
+        if ((pivoting || beans.rowGroupColsSvc?.columns?.length) && !gos.get('refreshAfterGroupEdit')) {
+            return 'hidden';
+        }
+
+        if (pivoting) {
+            return 'disabled';
+        }
+
+        if (beans.filterManager?.isAnyFilterPresent()) {
+            return 'disabled';
+        }
+
+        if (beans.sortSvc?.isSortActive()) {
+            return 'disabled';
+        }
+
+        return 'visible';
+    }
+
+    private refreshVisibility(): void {
+        const previousVisibility = this._visibility;
+        if (previousVisibility === undefined) {
+            return;
+        }
+        const newVisibility = this.computeVisibility();
+        if (previousVisibility === newVisibility) {
+            return;
+        }
+        this._visibility = newVisibility;
+        this.eventSvc?.dispatchEvent({
+            type: 'rowDragVisibilityChanged',
+        });
     }
 }

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragService.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragService.ts
@@ -11,11 +11,7 @@ export class RowDragService extends BeanStub implements NamedBean {
     beanName = 'rowDragSvc' as const;
 
     public rowDragFeature: RowDragFeature | null = null;
-    private _visibility: RowDragVisibility | undefined = undefined;
-
-    public get visibility(): RowDragVisibility {
-        return (this._visibility ??= this.computeVisibility());
-    }
+    public visibility: RowDragVisibility = 'hidden';
 
     public setupRowDrag(element: HTMLElement, ctrl: BeanStub): void {
         const rowDragFeature = ctrl.createManagedBean(new RowDragFeature(element));
@@ -39,6 +35,8 @@ export class RowDragService extends BeanStub implements NamedBean {
             sortChanged: refreshVisibility,
             filterChanged: refreshVisibility,
         });
+
+        this.visibility = this.computeVisibility();
     }
 
     public createRowDragComp(
@@ -135,17 +133,11 @@ export class RowDragService extends BeanStub implements NamedBean {
     }
 
     private refreshVisibility(): void {
-        const previousVisibility = this._visibility;
-        if (previousVisibility === undefined) {
-            return;
-        }
+        const previousVisibility = this.visibility;
         const newVisibility = this.computeVisibility();
-        if (previousVisibility === newVisibility) {
-            return;
+        if (previousVisibility !== newVisibility) {
+            this.visibility = newVisibility;
+            this.eventSvc?.dispatchEvent({ type: 'rowDragVisibilityChanged' });
         }
-        this._visibility = newVisibility;
-        this.eventSvc?.dispatchEvent({
-            type: 'rowDragVisibilityChanged',
-        });
     }
 }

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragTypes.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragTypes.ts
@@ -12,6 +12,8 @@ import type { DragItem } from '../interfaces/iDragItem';
 import type { IRowNode } from '../interfaces/iRowNode';
 import type { DragAndDropIcon, DragSourceType } from './dragAndDropService';
 
+export type RowDragVisibility = 'visible' | 'hidden' | 'disabled';
+
 export type RowDropTargetPosition = 'above' | 'inside' | 'below' | 'none';
 
 export interface IsRowValidDropPositionResult<TData = any> {

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragTypes.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragTypes.ts
@@ -12,7 +12,7 @@ import type { DragItem } from '../interfaces/iDragItem';
 import type { IRowNode } from '../interfaces/iRowNode';
 import type { DragAndDropIcon, DragSourceType } from './dragAndDropService';
 
-export type RowDragVisibility = 'visible' | 'hidden' | 'disabled';
+export type RowDragVisibility = 'suppress' | 'visible' | 'hidden' | 'disabled';
 
 export type RowDropTargetPosition = 'above' | 'inside' | 'below' | 'none';
 

--- a/packages/ag-grid-community/src/eventTypes.ts
+++ b/packages/ag-grid-community/src/eventTypes.ts
@@ -134,6 +134,7 @@ const _INTERNAL_EVENTS = [
     'scrollGapChanged',
     'columnHoverChanged',
     'flashCells',
+    'rowDragVisibilityChanged',
     'paginationPixelOffsetChanged',
     'displayedRowsChanged',
     'leftPinnedWidthChanged',

--- a/packages/ag-grid-community/src/events.ts
+++ b/packages/ag-grid-community/src/events.ts
@@ -190,6 +190,7 @@ export type AgEventTypeParams<TData = any, TContext = any> = BuildEventTypeMap<
         headerRowsChanged: AgEvent<'headerRowsChanged'>;
         rowExpansionStateChanged: AgEvent<'rowExpansionStateChanged'>;
         showRowGroupColsSetChanged: AgEvent<'showRowGroupColsSetChanged'>;
+        rowDragVisibilityChanged: AgEvent<'rowDragVisibilityChanged'>;
     }
 >;
 
@@ -543,6 +544,8 @@ export interface RowDragCancelEvent<TData = any, TContext = any>
 export interface RowDragMoveEvent<TData = any, TContext = any> extends RowDragEvent<TData, TContext, 'rowDragMove'> {}
 
 export interface RowDragLeaveEvent<TData = any, TContext = any> extends RowDragEvent<TData, TContext, 'rowDragLeave'> {}
+
+// rowDragVisibilityChanged uses the base AgGlobalEvent
 
 export interface CutStartEvent<TData = any, TContext = any> extends AgGlobalEvent<'cutStart', TData, TContext> {
     source: 'api' | 'ui' | 'contextMenu';

--- a/packages/ag-grid-community/src/theming/core/css/_grid-layout.css
+++ b/packages/ag-grid-community/src/theming/core/css/_grid-layout.css
@@ -70,7 +70,9 @@
             when there is a thick row border
           - subtract 2px to account for the 1px border around the cell
             */
-    --ag-internal-content-line-height: calc(min(var(--ag-row-height), var(--ag-line-height, 1000px)) - var(--ag-internal-row-border-width, 1px) - 2px);
+    --ag-internal-content-line-height: calc(
+        min(var(--ag-row-height), var(--ag-line-height, 1000px)) - var(--ag-internal-row-border-width, 1px) - 2px
+    );
 }
 
 .ag-row {
@@ -126,7 +128,7 @@
     position: absolute;
 }
 
-.ag-spanned-cell-wrapper>.ag-spanned-cell {
+.ag-spanned-cell-wrapper > .ag-spanned-cell {
     display: block;
     position: relative;
 }
@@ -141,7 +143,7 @@
     align-items: center;
     padding-left: calc(var(--ag-indentation-level) * var(--ag-row-group-indent-size));
 
-    >*:where(:not(.ag-cell-value, .ag-group-value)) {
+    > *:where(:not(.ag-cell-value, .ag-group-value)) {
         /* cell widgets like checkboxes don't respond to line-height, so set their
                height to vertically centre them */
         height: var(--ag-internal-content-line-height);
@@ -168,8 +170,10 @@
     }
 }
 
-.ag-row>.ag-cell-wrapper.ag-row-group {
-    padding-left: calc(var(--ag-cell-horizontal-padding) + var(--ag-row-group-indent-size) * var(--ag-indentation-level));
+.ag-row > .ag-cell-wrapper.ag-row-group {
+    padding-left: calc(
+        var(--ag-cell-horizontal-padding) + var(--ag-row-group-indent-size) * var(--ag-indentation-level)
+    );
 }
 
 .ag-cell-focus:not(.ag-cell-range-selected):focus-within,
@@ -234,7 +238,10 @@
 .ag-row-highlight-indent::after {
     display: block;
     width: auto;
-    left: calc(2 * (var(--ag-cell-widget-spacing) + var(--ag-icon-size)) + var(--ag-cell-horizontal-padding) + var(--ag-row-highlight-level) * var(--ag-row-group-indent-size));
+    left: calc(
+        2 * (var(--ag-cell-widget-spacing) + var(--ag-icon-size)) + var(--ag-cell-horizontal-padding) +
+            var(--ag-row-highlight-level) * var(--ag-row-group-indent-size)
+    );
     right: 1px;
 }
 
@@ -288,7 +295,7 @@
 }
 
 /* Default the content position to relative so that it doesn't appear under the background */
-.ag-row.ag-full-width-row.ag-row-group>* {
+.ag-row.ag-full-width-row.ag-row-group > * {
     position: relative;
 }
 
@@ -315,14 +322,16 @@
 .ag-cell:not(.ag-cell-inline-editing),
 /* stylelint-disable-next-line no-descending-specificity */
 .ag-full-width-row .ag-cell-wrapper.ag-row-group {
-    padding-left: calc(var(--ag-cell-horizontal-padding) - 1px + var(--ag-row-group-indent-size) * var(--ag-indentation-level));
+    padding-left: calc(
+        var(--ag-cell-horizontal-padding) - 1px + var(--ag-row-group-indent-size) * var(--ag-indentation-level)
+    );
     padding-right: calc(var(--ag-cell-horizontal-padding) - 1px);
 }
 
 /* in full width rows, a cell renderer is rendered directly into a row with no
       cell in between, in which case we need to apply the padding to the cell
       renderer's wrapper. */
-.ag-row>.ag-cell-wrapper {
+.ag-row > .ag-cell-wrapper {
     padding-left: calc(var(--ag-cell-horizontal-padding) - 1px);
     padding-right: calc(var(--ag-cell-horizontal-padding) - 1px);
 }
@@ -339,7 +348,6 @@
 
 .ag-layout-auto-height,
 .ag-layout-print {
-
     .ag-center-cols-viewport,
     .ag-center-cols-container {
         min-height: 150px;

--- a/packages/ag-grid-community/src/theming/core/css/_grid-layout.css
+++ b/packages/ag-grid-community/src/theming/core/css/_grid-layout.css
@@ -70,7 +70,9 @@
             when there is a thick row border
           - subtract 2px to account for the 1px border around the cell
             */
-    --ag-internal-content-line-height: calc(min(var(--ag-row-height), var(--ag-line-height, 1000px)) - var(--ag-internal-row-border-width, 1px) - 2px);
+    --ag-internal-content-line-height: calc(
+        min(var(--ag-row-height), var(--ag-line-height, 1000px)) - var(--ag-internal-row-border-width, 1px) - 2px
+    );
 }
 
 .ag-row {
@@ -126,7 +128,7 @@
     position: absolute;
 }
 
-.ag-spanned-cell-wrapper>.ag-spanned-cell {
+.ag-spanned-cell-wrapper > .ag-spanned-cell {
     display: block;
     position: relative;
 }
@@ -141,7 +143,7 @@
     align-items: center;
     padding-left: calc(var(--ag-indentation-level) * var(--ag-row-group-indent-size));
 
-    >*:where(:not(.ag-cell-value, .ag-group-value)) {
+    > *:where(:not(.ag-cell-value, .ag-group-value)) {
         /* cell widgets like checkboxes don't respond to line-height, so set their
                height to vertically centre them */
         height: var(--ag-internal-content-line-height);
@@ -168,8 +170,10 @@
     }
 }
 
-.ag-row>.ag-cell-wrapper.ag-row-group {
-    padding-left: calc(var(--ag-cell-horizontal-padding) + var(--ag-row-group-indent-size) * var(--ag-indentation-level));
+.ag-row > .ag-cell-wrapper.ag-row-group {
+    padding-left: calc(
+        var(--ag-cell-horizontal-padding) + var(--ag-row-group-indent-size) * var(--ag-indentation-level)
+    );
 }
 
 .ag-cell-focus:not(.ag-cell-range-selected):focus-within,
@@ -230,7 +234,10 @@
 .ag-row-highlight-indent::after {
     display: block;
     width: auto;
-    left: calc(2 * (var(--ag-cell-widget-spacing) + var(--ag-icon-size)) + var(--ag-cell-horizontal-padding) + var(--ag-row-highlight-level) * var(--ag-row-group-indent-size));
+    left: calc(
+        2 * (var(--ag-cell-widget-spacing) + var(--ag-icon-size)) + var(--ag-cell-horizontal-padding) +
+            var(--ag-row-highlight-level) * var(--ag-row-group-indent-size)
+    );
     right: 1px;
 }
 
@@ -284,7 +291,7 @@
 }
 
 /* Default the content position to relative so that it doesn't appear under the background */
-.ag-row.ag-full-width-row.ag-row-group>* {
+.ag-row.ag-full-width-row.ag-row-group > * {
     position: relative;
 }
 
@@ -311,14 +318,16 @@
 .ag-cell:not(.ag-cell-inline-editing),
 /* stylelint-disable-next-line no-descending-specificity */
 .ag-full-width-row .ag-cell-wrapper.ag-row-group {
-    padding-left: calc(var(--ag-cell-horizontal-padding) - 1px + var(--ag-row-group-indent-size) * var(--ag-indentation-level));
+    padding-left: calc(
+        var(--ag-cell-horizontal-padding) - 1px + var(--ag-row-group-indent-size) * var(--ag-indentation-level)
+    );
     padding-right: calc(var(--ag-cell-horizontal-padding) - 1px);
 }
 
 /* in full width rows, a cell renderer is rendered directly into a row with no
       cell in between, in which case we need to apply the padding to the cell
       renderer's wrapper. */
-.ag-row>.ag-cell-wrapper {
+.ag-row > .ag-cell-wrapper {
     padding-left: calc(var(--ag-cell-horizontal-padding) - 1px);
     padding-right: calc(var(--ag-cell-horizontal-padding) - 1px);
 }
@@ -335,7 +344,6 @@
 
 .ag-layout-auto-height,
 .ag-layout-print {
-
     .ag-center-cols-viewport,
     .ag-center-cols-container {
         min-height: 150px;

--- a/packages/ag-grid-community/src/theming/core/css/_grid-layout.css
+++ b/packages/ag-grid-community/src/theming/core/css/_grid-layout.css
@@ -70,9 +70,7 @@
             when there is a thick row border
           - subtract 2px to account for the 1px border around the cell
             */
-    --ag-internal-content-line-height: calc(
-        min(var(--ag-row-height), var(--ag-line-height, 1000px)) - var(--ag-internal-row-border-width, 1px) - 2px
-    );
+    --ag-internal-content-line-height: calc(min(var(--ag-row-height), var(--ag-line-height, 1000px)) - var(--ag-internal-row-border-width, 1px) - 2px);
 }
 
 .ag-row {
@@ -128,7 +126,7 @@
     position: absolute;
 }
 
-.ag-spanned-cell-wrapper > .ag-spanned-cell {
+.ag-spanned-cell-wrapper>.ag-spanned-cell {
     display: block;
     position: relative;
 }
@@ -143,7 +141,7 @@
     align-items: center;
     padding-left: calc(var(--ag-indentation-level) * var(--ag-row-group-indent-size));
 
-    > *:where(:not(.ag-cell-value, .ag-group-value)) {
+    >*:where(:not(.ag-cell-value, .ag-group-value)) {
         /* cell widgets like checkboxes don't respond to line-height, so set their
                height to vertically centre them */
         height: var(--ag-internal-content-line-height);
@@ -170,10 +168,8 @@
     }
 }
 
-.ag-row > .ag-cell-wrapper.ag-row-group {
-    padding-left: calc(
-        var(--ag-cell-horizontal-padding) + var(--ag-row-group-indent-size) * var(--ag-indentation-level)
-    );
+.ag-row>.ag-cell-wrapper.ag-row-group {
+    padding-left: calc(var(--ag-cell-horizontal-padding) + var(--ag-row-group-indent-size) * var(--ag-indentation-level));
 }
 
 .ag-cell-focus:not(.ag-cell-range-selected):focus-within,
@@ -202,12 +198,8 @@
 }
 
 .ag-drag-handle-disabled {
-    opacity: 0.5;
+    opacity: 0.35;
     pointer-events: none;
-}
-
-.ag-drag-handle-disabled .ag-icon {
-    opacity: 0.5;
 }
 
 .ag-group-child-count {
@@ -238,10 +230,7 @@
 .ag-row-highlight-indent::after {
     display: block;
     width: auto;
-    left: calc(
-        2 * (var(--ag-cell-widget-spacing) + var(--ag-icon-size)) + var(--ag-cell-horizontal-padding) +
-            var(--ag-row-highlight-level) * var(--ag-row-group-indent-size)
-    );
+    left: calc(2 * (var(--ag-cell-widget-spacing) + var(--ag-icon-size)) + var(--ag-cell-horizontal-padding) + var(--ag-row-highlight-level) * var(--ag-row-group-indent-size));
     right: 1px;
 }
 
@@ -295,7 +284,7 @@
 }
 
 /* Default the content position to relative so that it doesn't appear under the background */
-.ag-row.ag-full-width-row.ag-row-group > * {
+.ag-row.ag-full-width-row.ag-row-group>* {
     position: relative;
 }
 
@@ -322,16 +311,14 @@
 .ag-cell:not(.ag-cell-inline-editing),
 /* stylelint-disable-next-line no-descending-specificity */
 .ag-full-width-row .ag-cell-wrapper.ag-row-group {
-    padding-left: calc(
-        var(--ag-cell-horizontal-padding) - 1px + var(--ag-row-group-indent-size) * var(--ag-indentation-level)
-    );
+    padding-left: calc(var(--ag-cell-horizontal-padding) - 1px + var(--ag-row-group-indent-size) * var(--ag-indentation-level));
     padding-right: calc(var(--ag-cell-horizontal-padding) - 1px);
 }
 
 /* in full width rows, a cell renderer is rendered directly into a row with no
       cell in between, in which case we need to apply the padding to the cell
       renderer's wrapper. */
-.ag-row > .ag-cell-wrapper {
+.ag-row>.ag-cell-wrapper {
     padding-left: calc(var(--ag-cell-horizontal-padding) - 1px);
     padding-right: calc(var(--ag-cell-horizontal-padding) - 1px);
 }
@@ -348,6 +335,7 @@
 
 .ag-layout-auto-height,
 .ag-layout-print {
+
     .ag-center-cols-viewport,
     .ag-center-cols-container {
         min-height: 150px;

--- a/packages/ag-grid-community/src/theming/core/css/_grid-layout.css
+++ b/packages/ag-grid-community/src/theming/core/css/_grid-layout.css
@@ -70,9 +70,7 @@
             when there is a thick row border
           - subtract 2px to account for the 1px border around the cell
             */
-    --ag-internal-content-line-height: calc(
-        min(var(--ag-row-height), var(--ag-line-height, 1000px)) - var(--ag-internal-row-border-width, 1px) - 2px
-    );
+    --ag-internal-content-line-height: calc(min(var(--ag-row-height), var(--ag-line-height, 1000px)) - var(--ag-internal-row-border-width, 1px) - 2px);
 }
 
 .ag-row {
@@ -92,11 +90,11 @@
    is to ensure that the ag-body-vertical-content-no-gap class only hides the
    border of rows in the same grid, not in nested detail grids  */
 :where(
+
     /* there are either 3 or 4 elements between the body and the row as the
        center cols container has an extra layer of nesting than other containers */
     .ag-body-vertical-content-no-gap > div > div > div,
-    .ag-body-vertical-content-no-gap > div > div > div > div
-) > .ag-row-last {
+    .ag-body-vertical-content-no-gap > div > div > div > div)>.ag-row-last {
     border-bottom-color: transparent;
 }
 
@@ -128,7 +126,7 @@
     position: absolute;
 }
 
-.ag-spanned-cell-wrapper > .ag-spanned-cell {
+.ag-spanned-cell-wrapper>.ag-spanned-cell {
     display: block;
     position: relative;
 }
@@ -143,7 +141,7 @@
     align-items: center;
     padding-left: calc(var(--ag-indentation-level) * var(--ag-row-group-indent-size));
 
-    > *:where(:not(.ag-cell-value, .ag-group-value)) {
+    >*:where(:not(.ag-cell-value, .ag-group-value)) {
         /* cell widgets like checkboxes don't respond to line-height, so set their
                height to vertically centre them */
         height: var(--ag-internal-content-line-height);
@@ -170,10 +168,8 @@
     }
 }
 
-.ag-row > .ag-cell-wrapper.ag-row-group {
-    padding-left: calc(
-        var(--ag-cell-horizontal-padding) + var(--ag-row-group-indent-size) * var(--ag-indentation-level)
-    );
+.ag-row>.ag-cell-wrapper.ag-row-group {
+    padding-left: calc(var(--ag-cell-horizontal-padding) + var(--ag-row-group-indent-size) * var(--ag-indentation-level));
 }
 
 .ag-cell-focus:not(.ag-cell-range-selected):focus-within,
@@ -199,6 +195,15 @@
 .ag-group-expanded,
 .ag-group-contracted {
     margin-right: var(--ag-cell-widget-spacing);
+}
+
+.ag-drag-handle-disabled {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+.ag-drag-handle-disabled .ag-icon {
+    opacity: 0.5;
 }
 
 .ag-group-child-count {
@@ -229,10 +234,7 @@
 .ag-row-highlight-indent::after {
     display: block;
     width: auto;
-    left: calc(
-        2 * (var(--ag-cell-widget-spacing) + var(--ag-icon-size)) + var(--ag-cell-horizontal-padding) +
-            var(--ag-row-highlight-level) * var(--ag-row-group-indent-size)
-    );
+    left: calc(2 * (var(--ag-cell-widget-spacing) + var(--ag-icon-size)) + var(--ag-cell-horizontal-padding) + var(--ag-row-highlight-level) * var(--ag-row-group-indent-size));
     right: 1px;
 }
 
@@ -286,7 +288,7 @@
 }
 
 /* Default the content position to relative so that it doesn't appear under the background */
-.ag-row.ag-full-width-row.ag-row-group > * {
+.ag-row.ag-full-width-row.ag-row-group>* {
     position: relative;
 }
 
@@ -311,18 +313,16 @@
 }
 
 .ag-cell:not(.ag-cell-inline-editing),
-    /* stylelint-disable-next-line no-descending-specificity */
-    .ag-full-width-row .ag-cell-wrapper.ag-row-group {
-    padding-left: calc(
-        var(--ag-cell-horizontal-padding) - 1px + var(--ag-row-group-indent-size) * var(--ag-indentation-level)
-    );
+/* stylelint-disable-next-line no-descending-specificity */
+.ag-full-width-row .ag-cell-wrapper.ag-row-group {
+    padding-left: calc(var(--ag-cell-horizontal-padding) - 1px + var(--ag-row-group-indent-size) * var(--ag-indentation-level));
     padding-right: calc(var(--ag-cell-horizontal-padding) - 1px);
 }
 
 /* in full width rows, a cell renderer is rendered directly into a row with no
       cell in between, in which case we need to apply the padding to the cell
       renderer's wrapper. */
-.ag-row > .ag-cell-wrapper {
+.ag-row>.ag-cell-wrapper {
     padding-left: calc(var(--ag-cell-horizontal-padding) - 1px);
     padding-right: calc(var(--ag-cell-horizontal-padding) - 1px);
 }
@@ -339,6 +339,7 @@
 
 .ag-layout-auto-height,
 .ag-layout-print {
+
     .ag-center-cols-viewport,
     .ag-center-cols-container {
         min-height: 150px;

--- a/testing/behavioural/src/drag-n-drop/is-row-drag.test.ts
+++ b/testing/behavioural/src/drag-n-drop/is-row-drag.test.ts
@@ -1,17 +1,46 @@
 import { ClientSideRowModelModule, RowDragModule } from 'ag-grid-community';
 import type { GridOptions } from 'ag-grid-community';
+import { PivotModule } from 'ag-grid-enterprise';
 
 import { TestGridsManager, applyTransactionChecked, isAgHtmlElementVisible, setRowDataChecked } from '../test-utils';
 
-function isDragHandleVisible(element: Element): boolean {
-    return isAgHtmlElementVisible(element.querySelector('.ag-drag-handle'));
+type DragHandleState = {
+    displayed: boolean;
+    visible: boolean;
+    disabled: boolean;
+};
+
+const VisibleEnabledState: DragHandleState = { displayed: true, visible: true, disabled: false };
+const VisibleDisabledState: DragHandleState = { displayed: true, visible: true, disabled: true };
+const DisplayedHiddenState: DragHandleState = { displayed: true, visible: false, disabled: true };
+const FullyHiddenState: DragHandleState = { displayed: false, visible: false, disabled: true };
+
+function getDragHandle(element: Element): HTMLElement | null {
+    return element.querySelector('.ag-drag-handle');
+}
+
+function getDragHandleState(element: Element): DragHandleState {
+    const handle = getDragHandle(element);
+    if (!handle) {
+        return FullyHiddenState;
+    }
+
+    const classList = handle.classList;
+    const displayed = !classList.contains('ag-hidden');
+    const visible = displayed && !classList.contains('ag-invisible') && isAgHtmlElementVisible(handle);
+    const disabled = classList.contains('ag-drag-handle-disabled');
+    return { displayed, visible, disabled };
+}
+
+function expectHandleState(element: Element, expected: DragHandleState): void {
+    expect(getDragHandleState(element)).toEqual(expected);
 }
 
 describe('isRowDrag and drag handle refresh', () => {
     let gridsManager: TestGridsManager;
 
     beforeEach(() => {
-        gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, RowDragModule] });
+        gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, RowDragModule, PivotModule] });
     });
 
     afterEach(() => {
@@ -35,8 +64,8 @@ describe('isRowDrag and drag handle refresh', () => {
         };
         const api = gridsManager.createGrid('testGrid', gridOptions);
         const element = TestGridsManager.getHTMLElement(api)!;
-        expect(callCount).toBe(2);
-        expect(isDragHandleVisible(element)).toBe(true);
+        expect(callCount).toBeGreaterThanOrEqual(2);
+        expectHandleState(element, VisibleEnabledState);
 
         callCount = 0;
         returnValue = false;
@@ -48,7 +77,7 @@ describe('isRowDrag and drag handle refresh', () => {
         });
 
         expect(callCount).toBeGreaterThan(0);
-        expect(isDragHandleVisible(element)).toBe(false);
+        expectHandleState(element, DisplayedHiddenState);
 
         callCount = 0;
         returnValue = true;
@@ -58,7 +87,7 @@ describe('isRowDrag and drag handle refresh', () => {
         ]);
 
         expect(callCount).toBeGreaterThan(0);
-        expect(isDragHandleVisible(element)).toBe(true);
+        expectHandleState(element, VisibleEnabledState);
     });
 
     test('handle updates on suppressRowDrag property change', async () => {
@@ -82,12 +111,12 @@ describe('isRowDrag and drag handle refresh', () => {
         api.setGridOption('suppressRowDrag', true);
 
         expect(callCount).toBe(0);
-        expect(isDragHandleVisible(element)).toBe(false);
+        expectHandleState(element, FullyHiddenState);
 
         api.setGridOption('suppressRowDrag', false);
 
         expect(callCount).toBeGreaterThan(0);
-        expect(isDragHandleVisible(element)).toBe(true);
+        expectHandleState(element, VisibleEnabledState);
     });
 
     test('handle updates on sortChanged event', async () => {
@@ -112,13 +141,13 @@ describe('isRowDrag and drag handle refresh', () => {
 
         api.applyColumnState({ state: [{ colId: 'a', sort: 'desc' }], applyOrder: true });
 
-        expect(callCount).toBe(0);
-        expect(isDragHandleVisible(element)).toBe(false);
+        expect(callCount).toBeGreaterThan(0);
+        expectHandleState(element, VisibleDisabledState);
 
         api.applyColumnState({ state: [{ colId: 'a', sort: null }], applyOrder: true });
 
         expect(callCount).toBeGreaterThan(0);
-        expect(isDragHandleVisible(element)).toBe(true);
+        expectHandleState(element, VisibleEnabledState);
     });
 
     test('handle updates on filterChanged event', async () => {
@@ -142,12 +171,12 @@ describe('isRowDrag and drag handle refresh', () => {
 
         callCount = 0;
         api.setFilterModel({ a: { filterType: 'text', type: 'contains', filter: 'A' } });
-        expect(callCount).toBe(0);
-        expect(isDragHandleVisible(element)).toBe(false);
+        expect(callCount).toBeGreaterThan(0);
+        expectHandleState(element, VisibleDisabledState);
 
         api.setFilterModel(null);
         expect(callCount).toBeGreaterThan(0);
-        expect(isDragHandleVisible(element)).toBe(true);
+        expectHandleState(element, VisibleEnabledState);
     });
 
     test('handle updates on newColumnsLoaded event', async () => {
@@ -170,6 +199,44 @@ describe('isRowDrag and drag handle refresh', () => {
         api.setGridOption('columnDefs', [{ field: 'b', colId: 'b', rowDrag: isRowDrag }]);
 
         expect(callCount).toBeGreaterThan(0);
-        expect(isDragHandleVisible(element)).toBe(true);
+        expectHandleState(element, VisibleEnabledState);
+    });
+
+    test('handle updates on pivot events', async () => {
+        let callCount = 0;
+        const isRowDrag = () => {
+            callCount++;
+            return true;
+        };
+        const gridOptions: GridOptions = {
+            columnDefs: [
+                { field: 'a', colId: 'a', rowDrag: isRowDrag, enablePivot: true },
+                { field: 'b', colId: 'b', enablePivot: true },
+            ],
+            rowData: [
+                { id: 'r1', a: 'A', b: 'a' },
+                { id: 'r2', a: 'B', b: 'b' },
+            ],
+            getRowId: (params) => params.data.id,
+            rowDragManaged: true,
+            refreshAfterGroupEdit: true,
+        };
+        const api = gridsManager.createGrid('testGrid', gridOptions);
+        expect(callCount).toBeGreaterThan(0);
+        const element = TestGridsManager.getHTMLElement(api)!;
+        expectHandleState(element, VisibleEnabledState);
+
+        callCount = 0;
+        api.setGridOption('pivotMode', true);
+        api.applyColumnState({ state: [{ colId: 'b', pivot: true }], applyOrder: true });
+
+        expect(callCount).toBe(0);
+        expectHandleState(element, FullyHiddenState);
+
+        api.applyColumnState({ state: [{ colId: 'b', pivot: false }], applyOrder: true });
+        api.setGridOption('pivotMode', false);
+
+        expect(callCount).toBeGreaterThan(0);
+        expectHandleState(element, VisibleEnabledState);
     });
 });


### PR DESCRIPTION
- disable for pivoting
- add the new css class ag-drag-handle-disabled
- add a new type RowDragVisibility and computes it in RowDragService when relevant properties or events may change that state
- add a new event rowDragVisibilityChanged so the row drag handle register just to this handler instead of all the previous ones
- change the logic of the row drag comp to have a consistent css state after every update
- add test for pivoting

Tooltips not added in this PR and should be moved to a new ticket

Fix AG-16383