### PR TITLE
[AG-16338] Fix(performance): safari slowdown calculating fuzzy matches

### DIFF
--- a/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
+++ b/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
@@ -46,65 +46,99 @@ export function _fuzzySuggestions(params: {
 /**
  * This uses Levenshtein Distance to match strings.
  * Lower values mean more similar strings.
+ *
+ * This function is often being called, so it must be performant.
+ * {@link|https://github.com/ag-grid/ag-grid/issues/12473}
  */
-export function _getLevenshteinSimilarityDistance(inputText: string, suggestion: string): number {
-    const inputTextLower = inputText.toLocaleLowerCase();
-    const suggestionLower = suggestion.toLocaleLowerCase();
-    // Always use the shorter string for columns to reduce space
-    if (inputText.length < suggestion.length) {
-        [inputText, suggestion] = [suggestion, inputText];
+export function _getLevenshteinSimilarityDistance(source: string, target: string): number {
+    let inputLower = source.toLocaleLowerCase();
+    let targetLower = target.toLocaleLowerCase();
+    let tmp;
+
+    const sourceLength = source.length;
+    const targetLength = target.length;
+
+    if (targetLength === 0) {
+        return sourceLength ? sourceLength : 0;
     }
 
-    let previousRow: number[] = [];
-    let currentRow: number[] = [];
+    // Always use the shorter string for columns to reduce space
+    if (source.length < target.length) {
+        tmp = targetLower;
+        targetLower = inputLower;
+        inputLower = tmp;
+        tmp = target;
+        target = source;
+        source = tmp;
+    }
 
-    const sourceLength = inputText.length;
-    const targetLength = suggestion.length;
+    // Typed arrays → faster and avoid realloc
+    let previousRow = new Uint16Array(targetLength + 1);
+    let currentRow = new Uint16Array(targetLength + 1);
 
-    // Initialize previousRow with 0..targetLength
+    // Initialize first row
     for (let j = 0; j <= targetLength; j++) {
         previousRow[j] = j;
     }
 
     let secondaryScore = 0;
 
+    const earlyMatchLimit = sourceLength / 2 - 10;
+
     for (let i = 1; i <= sourceLength; i++) {
+        const inputChar = source[i - 1];
+        const inputCharLower = inputLower[i - 1];
+
         currentRow[0] = i;
 
         for (let j = 1; j <= targetLength; j++) {
-            const sourceChar = inputText[i - 1];
-            const targetChar = suggestion[j - 1];
-            const sourceCharLower = inputTextLower[i - 1];
-            const targetCharLower = suggestionLower[j - 1];
+            const targetChar = target[j - 1];
+            const targetCharLower = targetLower[j - 1];
 
-            if (sourceCharLower === targetCharLower) {
-                ++secondaryScore; // Favor case-insensitive matches;
-                if (sourceChar === targetChar) {
-                    ++secondaryScore; // Favor exact matches
-                }
-                if (i > 1 && j > 1) {
-                    if (inputTextLower[i - 2] === suggestionLower[j - 2]) {
-                        ++secondaryScore; // Favor case-insensitive consecutive matches
-                        if (inputText[i - 2] === suggestion[j - 2]) {
-                            ++secondaryScore; // Favor case-sensitive consecutive matches
-                        }
-                    }
-                }
-                if (i < sourceLength / 2 - 10) {
-                    ++secondaryScore;
-                } // Favor matches at the start of the string
-                currentRow[j] = previousRow[j - 1]; // No cost
-            } else {
+            // Fast mismatch branch (most common)
+            if (inputCharLower !== targetCharLower) {
                 const insertCost = currentRow[j - 1];
                 const deleteCost = previousRow[j];
                 const replaceCost = previousRow[j - 1];
 
-                currentRow[j] = 1 + Math.min(insertCost, deleteCost, replaceCost);
+                let cost = insertCost < deleteCost ? insertCost : deleteCost;
+                if (replaceCost < cost) {
+                    cost = replaceCost;
+                }
+
+                currentRow[j] = (cost + 1) | 0;
+                continue;
             }
+
+            secondaryScore++; // Favor case-insensitive matches;
+            if (inputChar === targetChar) {
+                secondaryScore++; // Favor exact matches
+            }
+
+            if (i > 1 && j > 1) {
+                const prevSourceChar = source[i - 2];
+                const prevSourceCharLower = inputLower[i - 2];
+                const prevTargetChar = target[j - 2];
+                const prevTargetCharLower = targetLower[j - 2];
+
+                if (prevSourceCharLower === prevTargetCharLower) {
+                    secondaryScore++; // Favor case-insensitive consecutive matches
+                    if (prevSourceChar === prevTargetChar) {
+                        secondaryScore++; // Favor case-sensitive consecutive matches
+                    }
+                }
+            }
+
+            if (i < earlyMatchLimit) {
+                secondaryScore++; // Favor matches at the start of the string
+            }
+
+            currentRow[j] = previousRow[j - 1]; // No cost
         }
 
-        // Swap rows for next iteration
-        [previousRow, currentRow] = [currentRow, previousRow];
+        tmp = previousRow;
+        previousRow = currentRow;
+        currentRow = tmp;
     }
 
     return previousRow[targetLength] / (secondaryScore + 1); // negatives divided by positives, ensure no division by zero

--- a/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
+++ b/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
@@ -53,7 +53,7 @@ export function _fuzzySuggestions(params: {
 export function _getLevenshteinSimilarityDistance(source: string, target: string): number {
     let inputLower = source.toLocaleLowerCase();
     let targetLower = target.toLocaleLowerCase();
-    let tmp;
+    let swapTmp;
 
     const sourceLength = source.length;
     const targetLength = target.length;
@@ -64,12 +64,12 @@ export function _getLevenshteinSimilarityDistance(source: string, target: string
 
     // Always use the shorter string for columns to reduce space
     if (source.length < target.length) {
-        tmp = targetLower;
+        swapTmp = targetLower;
         targetLower = inputLower;
-        inputLower = tmp;
-        tmp = target;
+        inputLower = swapTmp;
+        swapTmp = target;
         target = source;
-        source = tmp;
+        source = swapTmp;
     }
 
     // Typed arrays → faster and avoid realloc
@@ -136,9 +136,9 @@ export function _getLevenshteinSimilarityDistance(source: string, target: string
             currentRow[j] = previousRow[j - 1]; // No cost
         }
 
-        tmp = previousRow;
+        swapTmp = previousRow;
         previousRow = currentRow;
-        currentRow = tmp;
+        currentRow = swapTmp;
     }
 
     return previousRow[targetLength] / (secondaryScore + 1); // negatives divided by positives, ensure no division by zero

--- a/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
+++ b/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
@@ -48,6 +48,8 @@ export function _fuzzySuggestions(params: {
  * Lower values mean more similar strings.
  */
 export function _getLevenshteinSimilarityDistance(inputText: string, suggestion: string): number {
+    const inputTextLower = inputText.toLocaleLowerCase();
+    const suggestionLower = suggestion.toLocaleLowerCase();
     // Always use the shorter string for columns to reduce space
     if (inputText.length < suggestion.length) {
         [inputText, suggestion] = [suggestion, inputText];
@@ -72,14 +74,16 @@ export function _getLevenshteinSimilarityDistance(inputText: string, suggestion:
         for (let j = 1; j <= targetLength; j++) {
             const sourceChar = inputText[i - 1];
             const targetChar = suggestion[j - 1];
+            const sourceCharLower = inputTextLower[i - 1];
+            const targetCharLower = suggestionLower[j - 1];
 
-            if (sourceChar.toLocaleLowerCase() === targetChar.toLocaleLowerCase()) {
+            if (sourceCharLower === targetCharLower) {
                 ++secondaryScore; // Favor case-insensitive matches;
                 if (sourceChar === targetChar) {
                     ++secondaryScore; // Favor exact matches
                 }
                 if (i > 1 && j > 1) {
-                    if (inputText[i - 2].toLocaleLowerCase() === suggestion[j - 2].toLocaleLowerCase()) {
+                    if (inputTextLower[i - 2] === suggestionLower[j - 2]) {
                         ++secondaryScore; // Favor case-insensitive consecutive matches
                         if (inputText[i - 2] === suggestion[j - 2]) {
                             ++secondaryScore; // Favor case-sensitive consecutive matches

--- a/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
+++ b/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
@@ -51,16 +51,16 @@ export function _fuzzySuggestions(params: {
  * {@link|https://github.com/ag-grid/ag-grid/issues/12473}
  */
 export function _getLevenshteinSimilarityDistance(source: string, target: string): number {
-    let inputLower = source.toLocaleLowerCase();
-    let targetLower = target.toLocaleLowerCase();
-    let swapTmp;
-
     const sourceLength = source.length;
     const targetLength = target.length;
 
     if (targetLength === 0) {
         return sourceLength ? sourceLength : 0;
     }
+
+    let inputLower = source.toLocaleLowerCase();
+    let targetLower = target.toLocaleLowerCase();
+    let swapTmp;
 
     // Always use the shorter string for columns to reduce space
     if (source.length < target.length) {


### PR DESCRIPTION
related to #12473
fix [AG-16338](https://ag-grid.atlassian.net/browse/AG-16338)

Chrome improvement (stable vs local, lower % - better):
<img width="1371" height="385" alt="Screenshot_20251204_163535" src="https://github.com/user-attachments/assets/64bdcda7-0538-429b-942d-4029d9f07d8e" />

<img width="1096" height="347" alt="Screenshot_20251204_163118" src="https://github.com/user-attachments/assets/e9d2369c-1629-4ee9-b86a-ef9becdd05cf" />

Safari improvement (stable vs local, lower ms - better): 
<img width="1177" height="77" alt="prod" src="https://github.com/user-attachments/assets/d3761e93-420f-4317-a3c0-bb26f574d9a0" />


![photo_2025-12-04_16-46-08sda](https://github.com/user-attachments/assets/7f201969-4af1-4a6d-8661-5944f3ef0158)
