### PR TITLE
AG-3390 - Add release branch to node_modules cache key if on release

### DIFF
--- a/.github/actions/setup-nx/action.yml
+++ b/.github/actions/setup-nx/action.yml
@@ -35,29 +35,39 @@ runs:
             set -x
             
             branch=$(git branch --show-current)
-              if [[ ${branch} == 'latest' ]] ; then
-                # Latest
-                echo "base=latest-success" >> $GITHUB_OUTPUT
-                echo "NX_BASE=latest-success" >> $GITHUB_ENV
-                echo "type=latest" >> $GITHUB_OUTPUT
-                git fetch origin --depth 1 tag latest-success
-              elif [[ ${branch} =~ b[0-9][0-9]\..+ ]] ; then
-                # Release
-                echo "base=${branch}" >> $GITHUB_OUTPUT
-                echo "NX_BASE=${branch}" >> $GITHUB_ENV
-                echo "type=release" >> $GITHUB_OUTPUT
-              else
-                # PR
-                echo "base=origin/latest" >> $GITHUB_OUTPUT
-                echo "NX_BASE=origin/latest" >> $GITHUB_ENV
-                echo "type=pr" >> $GITHUB_OUTPUT
-                git fetch origin --depth 1 latest
+            if [[ ${branch} == 'latest' ]] ; then
+              # Latest
+              echo "base=latest-success" >> $GITHUB_OUTPUT
+              echo "NX_BASE=latest-success" >> $GITHUB_ENV
+              echo "type=latest" >> $GITHUB_OUTPUT
+              git fetch origin --depth 1 tag latest-success
+            elif [[ ${branch} =~ b[0-9][0-9]\..+ ]] ; then
+              # Release
+              echo "base=${branch}" >> $GITHUB_OUTPUT
+              echo "NX_BASE=${branch}" >> $GITHUB_ENV
+              echo "type=release" >> $GITHUB_OUTPUT
+              echo "release_branch=${branch}" >> $GITHUB_OUTPUT
+            else
+              # PR
+              echo "base=origin/latest" >> $GITHUB_OUTPUT
+              echo "NX_BASE=origin/latest" >> $GITHUB_ENV
+              echo "type=pr" >> $GITHUB_OUTPUT
+              git fetch origin --depth 1 latest
+
+              if [[ "${{ github.base_ref }}" =~ b[0-9][0-9]\..+ ]] ; then
+                echo "release_branch=${{ github.base_ref }}" >> $GITHUB_OUTPUT
               fi
+            fi
+
+            cat $GITHUB_OUTPUT
+            cat $GITHUB_ENV
 
         - name: Restore node_modules
           if: inputs.cache_mode == 'ro'
           id: cache_ro
           uses: actions/cache/restore@v4
+          env:
+            NODE_MODULES_HASH: ${{ hashFiles('yarn.lock','patches/*.patch', 'packages/*/package.json', 'plugins/*/package.json', 'community-modules/*/package.json', 'documentation/*/package.json', 'testing/*/package.json', 'external/*/package.json') }}
           with:
             path: |
               node_modules/
@@ -67,13 +77,16 @@ runs:
               testing/*/node_modules/
               documentation/*/node_modules/
               external/*/node_modules/
-            key: node_modules-${{ runner.os }}-${{hashFiles('yarn.lock','patches/*.patch', 'packages/*/package.json', 'plugins/*/package.json', 'community-modules/*/package.json', 'documentation/*/package.json', 'testing/*/package.json', 'external/*/package.json')}}
-            restore-keys: node_modules-${{ runner.os }}- # Take any latest cache if failed to find it for current yarn.lock
+            key: node_modules-${{ runner.os }}-${{ steps.nx_config.outputs.release_branch && format('release-{0}-{1}', steps.nx_config.outputs.release_branch, env.NODE_MODULES_HASH) || env.NODE_MODULES_HASH }}
+            restore-keys: ${{ steps.nx_config.outputs.release_branch && format('node_modules-{0}-release-{1}-', runner.os, steps.nx_config.outputs.release_branch) || format('node_modules-{0}-', runner.os) }}
+            # For releases add release branch to key, otherwise take any latest cache if failed to find it for current yarn.lock
 
         - name: Cache node_modules
           if: inputs.cache_mode == 'rw'
           id: cache_rw
           uses: actions/cache@v4
+          env:
+            NODE_MODULES_HASH: ${{ hashFiles('yarn.lock','patches/*.patch', 'packages/*/package.json', 'plugins/*/package.json', 'community-modules/*/package.json', 'documentation/*/package.json', 'testing/*/package.json', 'external/*/package.json') }}
           with:
               path: |
                   node_modules/
@@ -83,8 +96,9 @@ runs:
                   testing/*/node_modules/
                   documentation/*/node_modules/
                   external/*/node_modules/
-              key: node_modules-${{ runner.os }}-${{hashFiles('yarn.lock','patches/*.patch', 'packages/*/package.json', 'plugins/*/package.json', 'community-modules/*/package.json', 'documentation/*/package.json', 'testing/*/package.json', 'external/*/package.json')}}
-              restore-keys: node_modules-${{ runner.os }}- # Take any latest cache if failed to find it for current yarn.lock
+              key: node_modules-${{ runner.os }}-${{ steps.nx_config.outputs.release_branch && format('release-{0}-{1}', steps.nx_config.outputs.release_branch, env.NODE_MODULES_HASH) || env.NODE_MODULES_HASH }}
+              restore-keys: ${{ steps.nx_config.outputs.release_branch && format('node_modules-{0}-release-{1}-', runner.os, steps.nx_config.outputs.release_branch) || format('node_modules-{0}-', runner.os) }}
+              # For releases add release branch to key, otherwise take any latest cache if failed to find it for current yarn.lock
 
         - name: Cache Nx
           if: inputs.cache_mode == 'rw' && inputs.nx_restore != 'false'


### PR DESCRIPTION
Branch is based on `github.ref_name` (current branch) if it exists, otherwise `inputs.base_ref` (PR target branches)

From https://github.com/ag-grid/ag-charts/pull/5740