### PR TITLE
[RTI-3151] Fix(ssrm): row node is destroyed only if its a footer

### DIFF
--- a/packages/ag-grid-enterprise/src/serverSideRowModel/blocks/blockUtils.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/blocks/blockUtils.ts
@@ -85,7 +85,7 @@ export class BlockUtils extends BeanStub implements NamedBean {
             rowNode.childStore = null;
         }
         const sibling = rowNode.sibling;
-        if (sibling && rowNode.footer) {
+        if (sibling && !rowNode.footer) {
             this.destroyRowNode(sibling, false);
         }
 


### PR DESCRIPTION
Revert the change introduced in b35 to b34: new code doesn't make sense. 

Relevant LOC https://github.com/ag-grid/ag-grid/pull/12565/files#diff-86a0d4e304e19be5b0e54286165041afb3e6429f85f6a002e6c7c9af27d9e1b3L89-R88 

Fix [RTI-3151](https://ag-grid.atlassian.net/browse/RTI-3151)