### PR TITLE
[RTI-3146] Fix(docs): improve sortingorder jsdoc

### DIFF
--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -824,9 +824,7 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
      *  - `> 0` Sort valueA after valueB
      *  - `< 0` Sort valueA before valueB
      */
-    comparator?:
-        | SortComparatorFn<TData, TValue>
-        | Partial<Record<NonNullable<SortType>, SortComparatorFn<TData, TValue>>>;
+    comparator?: SortComparatorFn<TData, TValue> | Partial<Record<SortType, SortComparatorFn<TData, TValue>>>;
     /**
      * Set to `true` if you want the unsorted icon to be shown when no sort is applied to this column.
      * @default false

--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -819,7 +819,7 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
      * - `nodeA`,  `nodeB` are the corresponding RowNodes. Useful if additional details are required by the sort.
      * - `isDescending` - `true` if sort direction is `desc`. Not to be used for inverting the return value as the grid already applies `asc` or `desc` ordering.
      *
-     * Return:
+     * Returns:
      *  - `0`  valueA is the same as valueB
      *  - `> 0` Sort valueA after valueB
      *  - `< 0` Sort valueA before valueB


### PR DESCRIPTION
- Refactor `comparator` type to use `SortType` directly instead of `NonNullable<SortType>`  
- Maintains backward compatibility with existing `SortComparatorFn` and `Partial<Record<...>>` types

Fix [RTI-3146](https://ag-grid.atlassian.net/browse/RTI-3146)