### PR TITLE
[RTI-3169] Fix(editing): full async sends redundant search request

### DIFF
--- a/packages/ag-grid-enterprise/src/widgets/agRichSelect.ts
+++ b/packages/ag-grid-enterprise/src/widgets/agRichSelect.ts
@@ -239,7 +239,7 @@ export class AgRichSelect<TValue = any> extends AgPickerField<
 
         if (allowTyping) {
             /**
-             * Suppress event in full async mode when item is selected to prevent redundant async filtering call for valid options. RTI-3169
+             * Suppress event in full async mode when item is selected to prevent redundant async filtering call for valid options.
              */
             this.eInput.setValue(initialInputValue ?? valueFormatted, !!fromPicker && !!onSearch);
             return;

--- a/packages/ag-grid-enterprise/src/widgets/agRichSelect.ts
+++ b/packages/ag-grid-enterprise/src/widgets/agRichSelect.ts
@@ -221,7 +221,7 @@ export class AgRichSelect<TValue = any> extends AgPickerField<
         });
     }
 
-    private renderSelectedValue(): void {
+    private renderSelectedValue(fromPicker?: boolean): void {
         const { value, eDisplayField, config, gos } = this;
         const {
             allowTyping,
@@ -232,12 +232,16 @@ export class AgRichSelect<TValue = any> extends AgPickerField<
             suppressDeselectAll,
             suppressMultiSelectPillRenderer,
             valueFormatter,
+            onSearch,
         } = config;
 
         const valueFormatted = formatValueFn(value, valueFormatter);
 
         if (allowTyping) {
-            this.eInput.setValue(initialInputValue ?? valueFormatted);
+            /**
+             * Suppress event in full async mode when item is selected to prevent redundant async filtering call for valid options. RTI-3169
+             */
+            this.eInput.setValue(initialInputValue ?? valueFormatted, !!fromPicker && !!onSearch);
             return;
         }
 
@@ -672,7 +676,7 @@ export class AgRichSelect<TValue = any> extends AgPickerField<
         super.setValue(value, silent);
 
         if (!skipRendering) {
-            this.renderSelectedValue();
+            this.renderSelectedValue(fromPicker);
         }
 
         return this;


### PR DESCRIPTION
Update `renderSelectedValue` to accept a parameter for controlling input value setting behavior

- Add `fromPicker` parameter to `renderSelectedValue` method to conditionally suppress input value update
- Pass `fromPicker` flag when calling `renderSelectedValue` from `setValue`
- Use `fromPicker` and `onSearch` to determine whether to suppress input value update in async mode

Can be tested using rich select editor example in ag grid docs or https://plnkr.co/edit/g84nO2jZlQlvgrDj?open=main.js

Fixes [RTI-3169](https://ag-grid.atlassian.net/browse/RTI-3169)