### PR TITLE
RTI-3206 Use absolute references to preserve the result after sort

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/formulas/_examples/formulas-context-iterator/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/formulas/_examples/formulas-context-iterator/main.ts
@@ -36,7 +36,7 @@ const rowData = [
         rid: 'r8',
         gold: 1,
         silver: 2,
-        result: '=COUNTEQ(REF(COLUMN("c0"),ROW("r1"),COLUMN("c1"),ROW("r8")),2)',
+        result: '=COUNTEQ($A$1:$B$8,2)',
     },
 ];
 

--- a/documentation/ag-grid-docs/src/content/docs/formulas/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/formulas/index.mdoc
@@ -212,6 +212,7 @@ The grid provides an alternative iterator `params.args` which provides wrapped a
 This means that ranges are provided as a `RangeParam` object, which is iterable for navigating the values in the range.
 
 The following example demonstrates how to implement a custom function `COUNTEQ` which counts the number of values in a range that match the second parameter. 
+In the example we use this function in the "Result" column to count the number of times the value "2" appears in the given range.
 
 {% gridExampleRunner title="Contextual Iterator" name="formulas-context-iterator" exampleHeight=390 /%}
 


### PR DESCRIPTION
Fix [RTI-3206](https://ag-grid.atlassian.net/browse/RTI-3206)