### PR TITLE
RTI-3167 - Add resetRowHeights api json back in

### DIFF
--- a/documentation/ag-grid-docs/src/content/api-documentation/grid-api/api.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/grid-api/api.json
@@ -761,7 +761,12 @@
             }
         },
         "getSizesForCurrentTheme": {},
-
+        "resetRowHeights": {
+            "more": {
+                "name": "Changing Row Height",
+                "url": "./row-height/#changing-row-height"
+            }
+        },
         "onRowHeightChanged": {
             "more": {
                 "name": "Changing Row Height",


### PR DESCRIPTION
Originally removed in: https://github.com/ag-grid/ag-grid/pull/10401/files#diff-968a14c0f0014a03ca6b5aeac1fa27436b7817596958e4ed6ec8325450ba6cd0L664-L669

Fix [RTI-3167](https://ag-grid.atlassian.net/browse/RTI-3167)