### PR TITLE
RTI-3176 temporary fix for examples

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-delta-aggregation/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-delta-aggregation/main.ts
@@ -44,7 +44,7 @@ const gridOptions: GridOptions = {
             headerName: 'Total',
             type: 'totalColumn',
             minWidth: 120,
-            // we use getValue() instead of data.a so that it gets the aggregated values at the group level
+            aggFunc: 'sum',
             valueGetter: 'getValue("a") + getValue("b") + getValue("c") + getValue("d")',
         },
     ],

--- a/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-filter-sort-group/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-filter-sort-group/main.ts
@@ -39,7 +39,7 @@ const gridOptions: GridOptions = {
         {
             headerName: 'Total',
             type: 'totalColumn',
-            // we use getValue() instead of data.a so that it gets the aggregated values at the group level
+            aggFunc: 'sum',
             valueGetter: 'getValue("a") + getValue("b") + getValue("c") + getValue("d")',
         },
     ],
@@ -67,13 +67,8 @@ const gridOptions: GridOptions = {
     rowData: getRowData(),
     groupDefaultExpanded: 1,
     suppressAggFuncInHeader: true,
-    onCellValueChanged: onCellValueChanged,
+    refreshAfterGroupEdit: true,
 };
-
-function onCellValueChanged(params: CellValueChangedEvent) {
-    const changedData = [params.data];
-    params.api.applyTransaction({ update: changedData });
-}
 
 function getRowData() {
     const rowData = [];

--- a/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-groups/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-groups/main.ts
@@ -37,7 +37,7 @@ const gridOptions: GridOptions = {
         {
             headerName: 'Total',
             type: 'totalColumn',
-            // we use getValue() instead of data.a so that it gets the aggregated values at the group level
+            aggFunc: 'sum',
             valueGetter: 'getValue("a") + getValue("b") + getValue("c") + getValue("d")',
         },
     ],

--- a/documentation/ag-grid-docs/src/content/docs/change-detection/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/change-detection/index.mdoc
@@ -101,7 +101,7 @@ The example below shows change detection impacting the result of groups. The gri
 
 * Column 'Group' is marked as a [Row Group](./grouping/) and columns A to D are marked as [Aggregation](./aggregation/) columns so that their values are summed into the group level.
 
-* Column 'Total' has a valueGetter which gives a sum of all columns A to D.
+* Column 'Total' has a valueGetter which gives a sum of all columns A to D for the rows, and a `sum` aggregation for the groups.
 
 * Columns A to D are editable. If you edit a cells value, then the aggregate value at the group level is also updated to reflect the change. This is because the grid is recalculating the aggregations as a result of the change.
 
@@ -157,7 +157,14 @@ For this reason, if you want to update the sorting, filtering or group grouping 
 
 ### Example: Change Detection and Filter / Sort / Group
 
-The following example is the same as the example above [Change Detection and Groups](#example-change-detection-groups) except it gets the grid to do a transaction update so that the grouping, sorting and filtering are recomputed. From the example, the following can be noted:
+The following example is the same as the example above [Change Detection and Groups](#example-change-detection-groups) except it sets the flag `refreshAfterGroupEdit` to true.
+This flag tells the grid to refresh the grouping, sorting and filtering if the group column changes.
+
+See [Editing Groups](./grouping-edit/) for more on editing grouped data and `refreshAfterGroupEdit`.
+
+{% gridExampleRunner title="Change Detection with Filter / Sort / Group" name="change-detection-filter-sort-group" /%}
+
+From the example, the following can be noted:
 
 * As before, updating any value will update the total column and aggregated group columns.
 
@@ -166,8 +173,6 @@ The following example is the same as the example above [Change Detection and Gro
 * If you order by a column (eg order by 'A') and then change the data so that the order is incorrect, the grid will fix itself so that the ordering is maintained. In other words, the updated row will move to the new sorted position.
 
 * If you set a filter (eg filter 'A' to be 'less than 50') and then change the data so that a row no longer passes the filter, the grid will fix itself so that the filtering is maintained. In other words, the updated row will be removed if it no longer passes the filter.
-
-{% gridExampleRunner title="Change Detection with Filter / Sort / Group" name="change-detection-filter-sort-group" /%}
 
 ## Aggregation Path Selection
 


### PR DESCRIPTION
Changes the documentation and example regarding change detection to:
- work with total columns in groups, they were not updated as the column cannot detect a change correctly using a value getter if not including also a aggFunc for the way cell refresh works currently
- use `refreshAfterGroupEdit` in the example with group edit as this is now the preferred way to allow user to edit groups and refresh

Fix RTI-3176