### PR TITLE
[RTI-3152] Fix(docs): sortingorder jsdoc

### DIFF
--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -804,7 +804,7 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
      */
     initialSortIndex?: number;
     /**
-     * An array defining the order in which sorting occurs (if sorting is enabled) with any of the following in any order `(SortDef | SortDirection)[]`.
+     * An array defining the order in which sorting occurs (if sorting is enabled)`.
      * <br /><br />
      * Defaults:
      *


### PR DESCRIPTION
Update sorting documentation to clarify the type of `initialSortOrder` parameter.

Fix [RTI-3152](https://ag-grid.atlassian.net/browse/RTI-3152)