### PR TITLE
[AG-16202] Fix(filtering): when using celldatatype datetime the min max valid date validations do not work

### DIFF
--- a/.run/Datetime filter bug.run.xml
+++ b/.run/Datetime filter bug.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Datetime filter bug" type="JavascriptDebugType" uri="https://plnkr.co/edit/78E3AxduPsMJgu66?open=main.js">
+    <method v="2" />
+  </configuration>
+</component>

--- a/packages/ag-grid-community/src/filter/provided/date/defaultDateComponent.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/defaultDateComponent.ts
@@ -110,8 +110,8 @@ export class DefaultDateComponent extends Component implements IDateComp {
         } else {
             inputElement.type = 'text';
         }
-        const parsedMinValidDate = grabDate(minValidDate, minValidYear, true);
-        const parsedMaxValidDate = grabDate(maxValidDate, maxValidYear, false);
+        const parsedMinValidDate = parseOrConstructDate(minValidDate, minValidYear, true);
+        const parsedMaxValidDate = parseOrConstructDate(maxValidDate, maxValidYear, false);
 
         if (parsedMinValidDate && parsedMaxValidDate && parsedMinValidDate.getTime() > parsedMaxValidDate.getTime()) {
             _warn(87);
@@ -164,17 +164,17 @@ export class DefaultDateComponent extends Component implements IDateComp {
     }
 }
 
-function grabDate(validationDate: unknown, validationYear: unknown, isMin: boolean): null | Date {
-    if (validationDate instanceof Date) {
-        return validationDate;
-    }
-    if (validationDate && validationYear) {
+function parseOrConstructDate(date: string | Date | undefined, year: number | undefined, isMin: boolean): null | Date {
+    if (date && year) {
         _warn(isMin ? 85 : 86);
     }
-    if (validationDate && typeof validationDate === 'string') {
-        return _parseDateTimeFromString(validationDate);
-    } else if (validationYear && typeof validationYear === 'number') {
-        return _parseDateTimeFromString(`${validationYear}-${isMin ? '01-01' : '12-31'}`);
+    if (date instanceof Date) {
+        return date;
+    }
+    if (date) {
+        return _parseDateTimeFromString(date);
+    } else if (year) {
+        return _parseDateTimeFromString(`${year}-${isMin ? '01-01' : '12-31'}`);
     }
     return null;
 }

--- a/packages/ag-grid-community/src/filter/provided/date/defaultDateComponent.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/defaultDateComponent.ts
@@ -20,6 +20,8 @@ const DefaultDateElement: ElementParams = {
         },
     ],
 };
+const DATETIME_LOCAL_FORMAT = `YYYY-MM-DDTHH:mm`;
+
 export class DefaultDateComponent extends Component implements IDateComp {
     private readonly eDateInput: GridInputTextField = RefPlaceholder;
 
@@ -109,49 +111,20 @@ export class DefaultDateComponent extends Component implements IDateComp {
         } else {
             inputElement.type = 'text';
         }
+        const parsedMinValidDate = grabDate(minValidDate, minValidYear, true);
+        const parsedMaxValidDate = grabDate(maxValidDate, maxValidYear, false);
 
-        if (minValidDate && minValidYear) {
-            _warn(85);
+        if (parsedMinValidDate && parsedMaxValidDate && parsedMinValidDate.getTime() > parsedMaxValidDate.getTime()) {
+            _warn(87);
         }
+        const format = shouldUseDateTimeLocal ? DATETIME_LOCAL_FORMAT : undefined; // undefined === default format YYYY-MM-DD
 
-        if (maxValidDate && maxValidYear) {
-            _warn(86);
+        if (parsedMinValidDate) {
+            inputElement.min = _dateToFormattedString(parsedMinValidDate, format);
         }
-
-        if (minValidDate && maxValidDate) {
-            const [parsedMinValidDate, parsedMaxValidDate] = [minValidDate, maxValidDate].map((v) =>
-                v instanceof Date ? v : _parseDateTimeFromString(v)
-            );
-
-            if (
-                parsedMinValidDate &&
-                parsedMaxValidDate &&
-                parsedMinValidDate.getTime() > parsedMaxValidDate.getTime()
-            ) {
-                _warn(87);
-            }
+        if (parsedMaxValidDate) {
+            inputElement.max = _dateToFormattedString(parsedMaxValidDate, format);
         }
-
-        if (minValidDate) {
-            if (minValidDate instanceof Date) {
-                inputElement.min = _dateToFormattedString(minValidDate);
-            } else {
-                inputElement.min = minValidDate;
-            }
-        } else if (minValidYear) {
-            inputElement.min = `${minValidYear}-01-01`;
-        }
-
-        if (maxValidDate) {
-            if (maxValidDate instanceof Date) {
-                inputElement.max = _dateToFormattedString(maxValidDate);
-            } else {
-                inputElement.max = maxValidDate;
-            }
-        } else if (maxValidYear) {
-            inputElement.max = `${maxValidYear}-12-31`;
-        }
-
         this.isApply = params.location === 'floatingFilter' && !!buttons?.includes('apply');
     }
 
@@ -191,4 +164,19 @@ export class DefaultDateComponent extends Component implements IDateComp {
     private shouldUseBrowserDatePicker(params: IDateParams): boolean {
         return params?.filterParams?.browserDatePicker ?? true;
     }
+}
+
+function grabDate(validationDate: unknown, validationYear: unknown, isMin: boolean) {
+    if (validationDate instanceof Date) {
+        return validationDate;
+    }
+    if (validationDate && validationYear) {
+        _warn(isMin ? 85 : 86);
+    }
+    if (validationDate && typeof validationDate === 'string') {
+        return _parseDateTimeFromString(validationDate);
+    } else if (validationYear && typeof validationYear === 'number') {
+        return _parseDateTimeFromString(`${validationYear}-${isMin ? '01-01' : '12-31'}`);
+    }
+    return null;
 }

--- a/packages/ag-grid-community/src/filter/provided/date/defaultDateComponent.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/defaultDateComponent.ts
@@ -1,6 +1,6 @@
 import { RefPlaceholder } from '../../../agStack/interfaces/agComponent';
 import { _isBrowserSafari } from '../../../agStack/utils/browser';
-import { _dateToFormattedString, _parseDateTimeFromString, _serialiseDate } from '../../../agStack/utils/date';
+import { _parseDateTimeFromString, _serialiseDate } from '../../../agStack/utils/date';
 import { AgInputTextFieldSelector } from '../../../agStack/widgets/agInputTextField';
 import type { IDateComp, IDateParams } from '../../../interfaces/dateComponent';
 import type { IAfterGuiAttachedParams } from '../../../interfaces/iAfterGuiAttachedParams';
@@ -20,6 +20,7 @@ const DefaultDateElement: ElementParams = {
         },
     ],
 };
+
 export class DefaultDateComponent extends Component implements IDateComp {
     private readonly eDateInput: GridInputTextField = RefPlaceholder;
 
@@ -109,49 +110,19 @@ export class DefaultDateComponent extends Component implements IDateComp {
         } else {
             inputElement.type = 'text';
         }
+        const parsedMinValidDate = grabDate(minValidDate, minValidYear, true);
+        const parsedMaxValidDate = grabDate(maxValidDate, maxValidYear, false);
 
-        if (minValidDate && minValidYear) {
-            _warn(85);
+        if (parsedMinValidDate && parsedMaxValidDate && parsedMinValidDate.getTime() > parsedMaxValidDate.getTime()) {
+            _warn(87);
         }
 
-        if (maxValidDate && maxValidYear) {
-            _warn(86);
+        if (parsedMinValidDate) {
+            inputElement.min = _serialiseDate(parsedMinValidDate, shouldUseDateTimeLocal)!;
         }
-
-        if (minValidDate && maxValidDate) {
-            const [parsedMinValidDate, parsedMaxValidDate] = [minValidDate, maxValidDate].map((v) =>
-                v instanceof Date ? v : _parseDateTimeFromString(v)
-            );
-
-            if (
-                parsedMinValidDate &&
-                parsedMaxValidDate &&
-                parsedMinValidDate.getTime() > parsedMaxValidDate.getTime()
-            ) {
-                _warn(87);
-            }
+        if (parsedMaxValidDate) {
+            inputElement.max = _serialiseDate(parsedMaxValidDate, shouldUseDateTimeLocal)!;
         }
-
-        if (minValidDate) {
-            if (minValidDate instanceof Date) {
-                inputElement.min = _dateToFormattedString(minValidDate);
-            } else {
-                inputElement.min = minValidDate;
-            }
-        } else if (minValidYear) {
-            inputElement.min = `${minValidYear}-01-01`;
-        }
-
-        if (maxValidDate) {
-            if (maxValidDate instanceof Date) {
-                inputElement.max = _dateToFormattedString(maxValidDate);
-            } else {
-                inputElement.max = maxValidDate;
-            }
-        } else if (maxValidYear) {
-            inputElement.max = `${maxValidYear}-12-31`;
-        }
-
         this.isApply = params.location === 'floatingFilter' && !!buttons?.includes('apply');
     }
 
@@ -191,4 +162,19 @@ export class DefaultDateComponent extends Component implements IDateComp {
     private shouldUseBrowserDatePicker(params: IDateParams): boolean {
         return params?.filterParams?.browserDatePicker ?? true;
     }
+}
+
+function grabDate(validationDate: unknown, validationYear: unknown, isMin: boolean): null | Date {
+    if (validationDate instanceof Date) {
+        return validationDate;
+    }
+    if (validationDate && validationYear) {
+        _warn(isMin ? 85 : 86);
+    }
+    if (validationDate && typeof validationDate === 'string') {
+        return _parseDateTimeFromString(validationDate);
+    } else if (validationYear && typeof validationYear === 'number') {
+        return _parseDateTimeFromString(`${validationYear}-${isMin ? '01-01' : '12-31'}`);
+    }
+    return null;
 }


### PR DESCRIPTION
improve min/max date handling in DefaultDateComponent

plunker for testing (points to local) https://plnkr.co/edit/78E3AxduPsMJgu66?open=main.js

Fixes [AG-16202](https://ag-grid.atlassian.net/browse/AG-16202)