### PR TITLE
AG-15351 drag move icon initial left

### DIFF
--- a/packages/ag-grid-community/src/agStack/core/baseDragAndDropService.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseDragAndDropService.ts
@@ -453,7 +453,8 @@ export abstract class BaseDragAndDropService<
 
         this.dragImageCompPromise = promise;
         promise?.then((dragImageComp) => {
-            if (promise !== this.dragImageCompPromise || !this.lastMouseEvent || !this.isAlive()) {
+            const lastMouseEvent = this.lastMouseEvent;
+            if (promise !== this.dragImageCompPromise || !lastMouseEvent || !this.isAlive()) {
                 this.destroyBean(dragImageComp);
                 return; // New promise was started, ignore this old one.
             }
@@ -470,6 +471,7 @@ export abstract class BaseDragAndDropService<
             if (dragImageComp) {
                 this.appendDragImageComp(dragImageComp);
                 this.updateDragImageComp();
+                this.positionDragImageComp(lastMouseEvent);
             }
         });
     }


### PR DESCRIPTION
In react, the component is created asynchronously, but positioning happens only on dragging and not when the component gets created.
So the first positioning never runs if the component is still not created. This fixes the issue by setting the position using the last mouse event whenever the component gets created.

Fix AG-15351