### PR TITLE
AG-16448 value getter fixes

### DIFF
--- a/packages/ag-grid-community/src/api/gridApi.ts
+++ b/packages/ag-grid-community/src/api/gridApi.ts
@@ -97,6 +97,8 @@ export interface GetCellValueParams<TValue = any> {
     colKey: string | Column<TValue>;
     /** If `true` formatted value will be returned. */
     useFormatter?: boolean;
+    /** When `false` (default) returns the in-progress edit value; when `true` forces the last committed value from the row data. */
+    committed?: boolean;
 }
 
 export interface _CoreGridApi<TData = any> {

--- a/packages/ag-grid-community/src/api/gridApi.ts
+++ b/packages/ag-grid-community/src/api/gridApi.ts
@@ -97,7 +97,10 @@ export interface GetCellValueParams<TValue = any> {
     colKey: string | Column<TValue>;
     /** If `true` formatted value will be returned. */
     useFormatter?: boolean;
-    /** When `false` (default) returns the in-progress edit value; when `true` forces the last committed value from the row data. */
+    /**
+     * When `false` (default) returns the in-progress edit value, if there is an edit in progress;
+     * When `true` forces the last committed value from the row data, before edit started, so the actual value.
+     */
     committed?: boolean;
 }
 

--- a/packages/ag-grid-community/src/edit/utils/editors.ts
+++ b/packages/ag-grid-community/src/edit/utils/editors.ts
@@ -73,14 +73,15 @@ export function _setupEditors(
 
         if (!curCellCtrl) {
             if (cellRowNode && cellColumn) {
-                const oldValue = valueSvc.getValue(cellColumn as AgColumn, cellRowNode, undefined, 'api');
+                const oldValue = valueSvc.getValue(cellColumn as AgColumn, cellRowNode, false, 'api');
                 const isNewValueCell = position?.rowNode === cellRowNode && position?.column === cellColumn;
                 const cellStartValue = (isNewValueCell && key) || undefined;
 
                 const newValue =
                     cellStartValue ??
                     editSvc?.getCellDataValue(cellPosition, false) ??
-                    valueSvc.getValueForDisplay({ column: cellColumn as AgColumn, node: cellRowNode })?.value ??
+                    valueSvc.getValueForDisplay({ column: cellColumn as AgColumn, node: cellRowNode, source: 'ui' })
+                        ?.value ??
                     oldValue ??
                     UNEDITED;
 
@@ -266,7 +267,7 @@ function _createEditorParams(
 
     const value =
         initialNewValue === UNEDITED
-            ? valueSvc.getValueForDisplay({ column: agColumn, node: rowNode })?.value
+            ? valueSvc.getValueForDisplay({ column: agColumn, node: rowNode, source: 'ui' })?.value
             : initialNewValue;
 
     // if formula, normalise the value to shorthand for users.
@@ -395,7 +396,7 @@ export function _syncFromEditor(
     if (!edit?.sourceValue) {
         // sourceValue not set means sync called without corresponding startEdit - from API call
         const editValue: Partial<EditValue> = {
-            sourceValue: valueSvc.getValue(column as AgColumn, rowNode, undefined, 'api'),
+            sourceValue: valueSvc.getValue(column as AgColumn, rowNode, false, 'api'),
             pendingValue: edit ? getNormalisedFormula(beans, edit.editorValue, false, column) : UNEDITED,
         };
 

--- a/packages/ag-grid-community/src/export/baseGridSerializingSession.ts
+++ b/packages/ag-grid-community/src/export/baseGridSerializingSession.ts
@@ -94,14 +94,14 @@ export abstract class BaseGridSerializingSession<T> implements GridSerializingSe
                             accumulatedRowIndex,
                             column,
                             node,
-                            value: this.valueSvc.getValueForDisplay({ column, node }).value,
+                            value: this.valueSvc.getValueForDisplay({ column, node, source: 'api' }).value,
                             type,
                             parseValue: (valueToParse: string) =>
                                 this.valueSvc.parseValue(
                                     column,
                                     node,
                                     valueToParse,
-                                    this.valueSvc.getValue(column, node, undefined)
+                                    this.valueSvc.getValue(column, node, false, 'api')
                                 ),
                             formatValue: (valueToFormat: any) =>
                                 this.valueSvc.formatValue(column, node, valueToFormat) ?? valueToFormat,
@@ -125,6 +125,7 @@ export abstract class BaseGridSerializingSession<T> implements GridSerializingSe
                     node: pointer,
                     includeValueFormatted: true,
                     exporting: true,
+                    source: 'api',
                 });
                 concatenatedGroupValue = ` -> ${valueFormatted ?? value ?? ''}${concatenatedGroupValue}`;
                 pointer = pointer.parent;
@@ -142,6 +143,7 @@ export abstract class BaseGridSerializingSession<T> implements GridSerializingSe
             includeValueFormatted: true,
             exporting: true,
             useRawFormula,
+            source: 'api',
         });
         return {
             value: value ?? '',

--- a/packages/ag-grid-community/src/filter/filterDataTypeUtils.ts
+++ b/packages/ag-grid-community/src/filter/filterDataTypeUtils.ts
@@ -200,7 +200,7 @@ export function _getFilterParamsForDataType(
     const usingSetFilter = filter === 'agSetColumnFilter';
     if (!filterValueGetter && dataTypeDefinition.baseDataType === 'object' && !usingSetFilter) {
         filterValueGetter = ({ column, node }: ValueGetterParams) =>
-            formatValue({ column, node, value: beans.valueSvc.getValue(column as AgColumn, node) });
+            formatValue({ column, node, value: beans.valueSvc.getValue(column as AgColumn, node, false, 'api') });
     }
     const filterParamsMap = usingSetFilter ? setFilterParamsForEachDataType : filterParamsForEachDataType;
     const filterParamsGetter = filterParamsMap[dataTypeDefinition.baseDataType];

--- a/packages/ag-grid-community/src/filter/filterValueService.ts
+++ b/packages/ag-grid-community/src/filter/filterValueService.ts
@@ -2,9 +2,8 @@ import type { NamedBean } from '../context/bean';
 import { BeanStub } from '../context/beanStub';
 import type { BeanName } from '../context/context';
 import type { AgColumn } from '../entities/agColumn';
-import type { ColDef, ValueGetterFunc, ValueGetterParams } from '../entities/colDef';
+import type { ValueGetterFunc } from '../entities/colDef';
 import type { RowNode } from '../entities/rowNode';
-import { _addGridCommonParams } from '../gridOptionsUtils';
 import type { IRowNode } from '../interfaces/iRowNode';
 
 export class FilterValueService extends BeanStub implements NamedBean {
@@ -14,42 +13,18 @@ export class FilterValueService extends BeanStub implements NamedBean {
         if (!rowNode) {
             return;
         }
-        const colDef = column.getColDef();
         const { selectableFilter, valueSvc, formula } = this.beans;
         const filterValueGetter =
             filterValueGetterOverride ??
             selectableFilter?.getFilterValueGetter(column.getColId()) ??
-            colDef.filterValueGetter;
+            column.getColDef().filterValueGetter;
         if (filterValueGetter) {
-            return this.executeFilterValueGetter(filterValueGetter, rowNode.data, column, rowNode, colDef);
+            return valueSvc.executeValueGetterNoCache(filterValueGetter, rowNode.data, column, rowNode);
         }
-        const value = valueSvc.getValue(column, rowNode);
+        const value = valueSvc.getValue(column, rowNode, false, 'api');
         if (column.isAllowFormula() && formula?.isFormula(value)) {
             return formula.resolveValue(column, rowNode as RowNode);
         }
         return value;
-    }
-
-    private executeFilterValueGetter(
-        // eslint-disable-next-line @typescript-eslint/ban-types
-        valueGetter: string | Function,
-        data: any,
-        column: AgColumn,
-        node: IRowNode,
-        colDef: ColDef
-    ): any {
-        const { expressionSvc, valueSvc } = this.beans;
-        const params: ValueGetterParams = _addGridCommonParams(this.gos, {
-            data,
-            node,
-            column,
-            colDef,
-            getValue: valueSvc.getValueCallback.bind(valueSvc, node),
-        });
-
-        if (typeof valueGetter === 'function') {
-            return valueGetter(params);
-        }
-        return expressionSvc?.evaluate(valueGetter, params);
     }
 }

--- a/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
@@ -518,7 +518,7 @@ export class CellCtrl extends BeanStub {
         const res: ICellRendererParams = _addGridCommonParams(gos, {
             value: value,
             valueFormatted: valueFormatted,
-            getValue: () => valueSvc.getValueForDisplay({ column, node: rowNode }).value,
+            getValue: () => valueSvc.getValueForDisplay({ column, node: rowNode, source: 'ui' }).value,
             setValue: (value: any) =>
                 editSvc?.setDataValue({ rowNode, column }, value) || rowNode.setDataValue(column, value),
             formatValue: this.formatValue.bind(this),
@@ -669,6 +669,7 @@ export class CellCtrl extends BeanStub {
             column: this.column,
             node: this.rowNode,
             includeValueFormatted: true,
+            source: 'ui',
         });
         this.value = value;
         this.valueFormatted = valueFormatted;

--- a/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
@@ -1320,6 +1320,7 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
                 const { value, valueFormatted } = this.beans.valueSvc.getValueForDisplay({
                     node: this.rowNode,
                     includeValueFormatted: true,
+                    source: 'ui',
                 });
                 params.value = value;
                 params.valueFormatted = valueFormatted;

--- a/packages/ag-grid-community/src/rendering/spanning/rowSpanCache.ts
+++ b/packages/ag-grid-community/src/rendering/spanning/rowSpanCache.ts
@@ -133,6 +133,9 @@ export class RowSpanCache extends BeanStub {
                 return;
             }
 
+            // check value is equal, if not, no span
+            const value = valueSvc.getValue(column, node, false, 'api');
+
             // if level or key is different, cells do not span.
             if (
                 lastNode == null ||
@@ -140,12 +143,10 @@ export class RowSpanCache extends BeanStub {
                 node.footer ||
                 (spanData && node.rowIndex - 1 !== spanData?.getLastNode().rowIndex) // no span if rows not contiguous (SSRM)
             ) {
-                setNewHead(node, valueSvc.getValue(column, node));
+                setNewHead(node, value);
                 return;
             }
 
-            // check value is equal, if not, no span
-            const value = valueSvc.getValue(column, node);
             if (isCustomCompare) {
                 const params: SpanRowsParams = _addGridCommonParams(gos, {
                     valueA: lastValue,

--- a/packages/ag-grid-community/src/valueService/cellApi.ts
+++ b/packages/ag-grid-community/src/valueService/cellApi.ts
@@ -8,13 +8,18 @@ export function expireValueCache(beans: BeanCollection): void {
 }
 
 export function getCellValue<TValue = any>(beans: BeanCollection, params: GetCellValueParams<TValue>): any {
-    const { colKey, rowNode, useFormatter } = params;
+    const { colKey, rowNode, useFormatter, committed } = params;
 
     const column = beans.colModel.getColDefCol(colKey) ?? beans.colModel.getCol(colKey);
     if (_missing(column)) {
         return null;
     }
-    const result = beans.valueSvc.getValueForDisplay({ column, node: rowNode, includeValueFormatted: useFormatter });
+    const result = beans.valueSvc.getValueForDisplay({
+        column,
+        node: rowNode,
+        includeValueFormatted: useFormatter,
+        source: committed ? 'api' : 'ui',
+    });
     if (useFormatter) {
         return result.valueFormatted ?? _toString(result.value);
     }

--- a/packages/ag-grid-community/src/valueService/valueService.test.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.test.ts
@@ -27,6 +27,7 @@ describe('formatValue', () => {
         (valueSvc as any).expressionSvc = expressionSvc;
         (valueSvc as any).beans = {
             editSvc: mock<IEditService>('isEditing'),
+            gridOptions: {},
             expressionSvc,
         };
     });

--- a/packages/ag-grid-community/src/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.ts
@@ -7,41 +7,30 @@ import type { NamedBean } from '../context/bean';
 import { BeanStub } from '../context/beanStub';
 import type { BeanCollection } from '../context/context';
 import type { AgColumn } from '../entities/agColumn';
-import type {
-    KeyCreatorParams,
-    ValueFormatterParams,
-    ValueGetterParams,
-    ValueParserParams,
-    ValueSetterParams,
-} from '../entities/colDef';
+import type { ValueFormatterParams, ValueGetterParams, ValueParserParams, ValueSetterParams } from '../entities/colDef';
 import type { RowNode } from '../entities/rowNode';
 import type { CellValueChangedEvent } from '../events';
-import { _addGridCommonParams, _isServerSideRowModel } from '../gridOptionsUtils';
+import { _isServerSideRowModel } from '../gridOptionsUtils';
 import type { IFormulaDataService } from '../interfaces/formulas';
 import type { IEditService } from '../interfaces/iEditService';
 import type { IRowNode } from '../interfaces/iRowNode';
 import { _warn } from '../validation/logging';
-import type { ExpressionService } from './expressionService';
 import type { ValueCache } from './valueCache';
 
 export class ValueService extends BeanStub implements NamedBean {
     beanName = 'valueSvc' as const;
 
-    private expressionSvc?: ExpressionService;
     private colModel: ColumnModel;
     private valueCache?: ValueCache;
     private dataTypeSvc?: DataTypeService;
     private editSvc?: IEditService;
-    private hasEditSvc: boolean = false;
     private formulaDataSvc?: IFormulaDataService;
 
     public wireBeans(beans: BeanCollection): void {
-        this.expressionSvc = beans.expressionSvc;
         this.colModel = beans.colModel;
         this.valueCache = beans.valueCache;
         this.dataTypeSvc = beans.dataTypeSvc;
         this.editSvc = beans.editSvc;
-        this.hasEditSvc = !!beans.editSvc;
         this.formulaDataSvc = beans.formulaDataSvc;
     }
 
@@ -54,14 +43,6 @@ export class ValueService extends BeanStub implements NamedBean {
 
     private isSsrm = false;
 
-    private executeValueGetter: (
-        // eslint-disable-next-line @typescript-eslint/ban-types
-        valueGetter: string | Function,
-        data: any,
-        column: AgColumn,
-        rowNode: IRowNode
-    ) => any;
-
     public postConstruct(): void {
         if (!this.initialised) {
             this.init();
@@ -69,10 +50,7 @@ export class ValueService extends BeanStub implements NamedBean {
     }
 
     private init(): void {
-        const { gos, valueCache } = this;
-        this.executeValueGetter = valueCache
-            ? this.executeValueGetterWithValueCache.bind(this)
-            : this.executeValueGetterWithoutValueCache.bind(this);
+        const gos = this.gos;
         this.isSsrm = _isServerSideRowModel(gos);
         this.cellExpressions = gos.get('enableCellExpressions');
         this.isTreeData = gos.get('treeData');
@@ -98,7 +76,7 @@ export class ValueService extends BeanStub implements NamedBean {
         includeValueFormatted?: boolean;
         useRawFormula?: boolean;
         exporting?: boolean;
-        source?: 'ui' | 'api';
+        source: 'ui' | 'api';
     }): {
         value: any;
         valueFormatted: string | null;
@@ -152,7 +130,7 @@ export class ValueService extends BeanStub implements NamedBean {
 
         // if doing grouping and footers, we don't want to include the agg value
         // in the header when the group is open
-        const ignoreAggData = isOpenedGroup && !groupShowsAggData;
+        const ignoreAggData = !!isOpenedGroup && !groupShowsAggData;
         let value = this.getValue(column, node, ignoreAggData, source);
         let valueToFormat = value;
 
@@ -176,9 +154,9 @@ export class ValueService extends BeanStub implements NamedBean {
 
     public getValue(
         column: AgColumn,
-        rowNode?: IRowNode | null,
-        ignoreAggData = false,
-        source: 'ui' | 'api' | 'edit' | string = 'ui'
+        rowNode: IRowNode | null,
+        ignoreAggData: boolean,
+        source: 'ui' | 'api' | 'edit'
     ): any {
         // hack - the grid is getting refreshed before this bean gets initialised, race condition.
         // really should have a way so they get initialised in the right order???
@@ -192,9 +170,8 @@ export class ValueService extends BeanStub implements NamedBean {
 
         // pull these out to make code below easier to read
 
-        if (this.hasEditSvc && source === 'ui') {
-            const editSvc = this.editSvc!;
-
+        const editSvc = this.editSvc;
+        if (editSvc && source === 'ui') {
             // if the row is editing, we want to return the new value, if available
             if (editSvc.isEditing()) {
                 const newValue = editSvc.getCellDataValue({ rowNode, column }, true);
@@ -305,28 +282,31 @@ export class ValueService extends BeanStub implements NamedBean {
     }
 
     public parseValue(column: AgColumn, rowNode: IRowNode | null, newValue: any, oldValue: any): any {
+        const beans = this.beans;
         const colDef = column.getColDef();
 
         // we do not allow parsing of formulas
-        if (colDef.allowFormula && this.beans.formula?.isFormula(newValue)) {
+        if (colDef.allowFormula && beans.formula?.isFormula(newValue)) {
             return newValue;
         }
 
         const valueParser = colDef.valueParser;
 
         if (_exists(valueParser)) {
-            const params: ValueParserParams = _addGridCommonParams(this.gos, {
+            const params: ValueParserParams = {
+                api: beans.gridApi,
+                context: beans.gridOptions.context,
                 node: rowNode,
                 data: rowNode?.data,
                 oldValue,
                 newValue,
                 colDef,
                 column,
-            });
+            };
             if (typeof valueParser === 'function') {
                 return valueParser(params);
             }
-            return this.expressionSvc?.evaluate(valueParser, params);
+            return beans.expressionSvc?.evaluate(valueParser, params);
         }
         return newValue;
     }
@@ -334,7 +314,12 @@ export class ValueService extends BeanStub implements NamedBean {
     public getDeleteValue(column: AgColumn, rowNode: IRowNode): any {
         if (_exists(column.getColDef().valueParser)) {
             return (
-                this.parseValue(column, rowNode, '', this.getValueForDisplay({ column, node: rowNode }).value) ?? null
+                this.parseValue(
+                    column,
+                    rowNode,
+                    '',
+                    this.getValueForDisplay({ column, node: rowNode, source: 'ui' }).value
+                ) ?? null
             );
         }
         return null;
@@ -347,7 +332,7 @@ export class ValueService extends BeanStub implements NamedBean {
         suppliedFormatter?: (value: any) => string,
         useFormatterFromColumn = true
     ): string | null {
-        const { expressionSvc } = this.beans;
+        const beans = this.beans;
         let result: string | null = null;
         let formatter: ((value: any) => string) | string | undefined;
 
@@ -363,16 +348,19 @@ export class ValueService extends BeanStub implements NamedBean {
         if (formatter) {
             const data = node ? node.data : null;
 
-            const params: ValueFormatterParams = _addGridCommonParams(this.gos, {
+            const params: ValueFormatterParams = {
+                api: beans.gridApi,
+                context: beans.gridOptions.context,
                 value,
                 node,
                 data,
                 colDef,
                 column,
-            });
+            };
             if (typeof formatter === 'function') {
                 result = formatter(params);
             } else {
+                const expressionSvc = beans.expressionSvc;
                 result = expressionSvc ? expressionSvc.evaluate(formatter, params) : null;
             }
         } else if (colDef.refData) {
@@ -408,14 +396,17 @@ export class ValueService extends BeanStub implements NamedBean {
             return false;
         }
 
-        const params: ValueSetterParams = _addGridCommonParams(this.gos, {
+        const beans = this.beans;
+        const params: ValueSetterParams = {
+            api: beans.gridApi,
+            context: beans.gridOptions.context,
             node: rowNode,
             data: rowNode.data,
-            oldValue: this.getValue(column, rowNode, undefined, eventSource),
+            oldValue: this.getValue(column, rowNode, false, 'api'),
             newValue: newValue,
             colDef,
             column: column,
-        });
+        };
 
         params.newValue = newValue;
 
@@ -466,7 +457,7 @@ export class ValueService extends BeanStub implements NamedBean {
 
         this.valueCache?.onDataChanged();
 
-        const savedValue = this.getValue(column, rowNode);
+        const savedValue = this.getValue(column, rowNode, false, 'ui');
 
         this.dispatchCellValueChangedEvent(rowNode, params, savedValue, eventSource);
         if ((rowNode as RowNode).pinnedSibling) {
@@ -572,7 +563,7 @@ export class ValueService extends BeanStub implements NamedBean {
             if (typeof valueSetter === 'function') {
                 return valueSetter(setterParams);
             }
-            return this.expressionSvc?.evaluate(valueSetter, setterParams);
+            return this.beans.expressionSvc?.evaluate(valueSetter, setterParams);
         }
 
         return this.setValueUsingField(rowData, field, newValue, column.isFieldContainsDots());
@@ -654,7 +645,7 @@ export class ValueService extends BeanStub implements NamedBean {
         return !valuesAreSame;
     }
 
-    private executeValueGetterWithValueCache(
+    private executeValueGetter(
         // eslint-disable-next-line @typescript-eslint/ban-types
         valueGetter: string | Function,
         data: any,
@@ -663,82 +654,50 @@ export class ValueService extends BeanStub implements NamedBean {
     ): any {
         const colId = column.getColId();
 
-        // if inside the same turn, just return back the value we got last time
-        const valueFromCache = this.valueCache!.getValue(rowNode as RowNode, colId);
+        const valueCache = this.valueCache;
 
-        if (valueFromCache !== undefined) {
-            return valueFromCache;
+        // if inside the same turn, just return back the value we got last time
+        if (valueCache) {
+            const valueFromCache = valueCache.getValue(rowNode as RowNode, colId);
+            if (valueFromCache !== undefined) {
+                return valueFromCache;
+            }
         }
 
-        const result = this.executeValueGetterWithoutValueCache(valueGetter, data, column, rowNode);
+        const result = this.executeValueGetterNoCache(valueGetter, data, column, rowNode);
 
         // if a turn is active, store the value in case the grid asks for it again
-        this.valueCache!.setValue(rowNode as RowNode, colId, result);
+        valueCache?.setValue(rowNode as RowNode, colId, result);
 
         return result;
     }
 
-    private executeValueGetterWithoutValueCache(
+    public executeValueGetterNoCache(
         // eslint-disable-next-line @typescript-eslint/ban-types
         valueGetter: string | Function,
         data: any,
         column: AgColumn,
         rowNode: IRowNode
     ): any {
-        const params: ValueGetterParams = _addGridCommonParams(this.gos, {
+        const beans = this.beans;
+        const params: ValueGetterParams = {
+            api: beans.gridApi,
+            context: beans.gridOptions.context,
             data: data,
             node: rowNode,
             column: column,
             colDef: column.getColDef(),
-            getValue: this.getValueCallback.bind(this, rowNode),
-        });
+            getValue: (field: string | AgColumn) => {
+                const otherColumn = this.colModel.getColDefCol(field);
+                return otherColumn ? this.getValue(otherColumn, rowNode, false, 'api') : null;
+            },
+        };
 
         let result;
         if (typeof valueGetter === 'function') {
             result = valueGetter(params);
         } else {
-            result = this.expressionSvc?.evaluate(valueGetter, params);
-        }
-
-        return result;
-    }
-
-    public getValueCallback(node: IRowNode, field: string | AgColumn): any {
-        const otherColumn = this.colModel.getColDefCol(field);
-
-        if (otherColumn) {
-            return this.getValue(otherColumn, node);
-        }
-
-        return null;
-    }
-
-    // used by row grouping and pivot, to get key for a row. col can be a pivot col or a row grouping col
-    public getKeyForNode(col: AgColumn, rowNode: IRowNode): any {
-        const value = this.getValue(col, rowNode);
-        const keyCreator = col.getColDef().keyCreator;
-
-        let result = value;
-        if (keyCreator) {
-            const keyParams: KeyCreatorParams = _addGridCommonParams(this.gos, {
-                value: value,
-                colDef: col.getColDef(),
-                column: col,
-                node: rowNode,
-                data: rowNode.data,
-            });
-            result = keyCreator(keyParams);
-        }
-
-        // if already a string, or missing, just return it
-        if (typeof result === 'string' || result == null) {
-            return result;
-        }
-
-        result = String(result);
-
-        if (result === '[object Object]') {
-            _warn(121);
+            result = beans.expressionSvc?.evaluate(valueGetter, params);
         }
 
         return result;

--- a/packages/ag-grid-community/src/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.ts
@@ -69,6 +69,10 @@ export class ValueService extends BeanStub implements NamedBean {
      * Use this function to get a displayable cell value.
      * The values from this function are not used for sorting, filtering, or aggregation purposes.
      * Handles: groupHideOpenParents, showOpenedGroup and groupSuppressBlankHeader behaviours
+     *
+     * The source can be either 'ui' or 'api':
+     * - 'ui' - gets the value as seen by the user, including any in-progress edits
+     * - 'api' - gets the last committed value from the row data, ignoring any in-progress edits
      */
     public getValueForDisplay(params: {
         column?: AgColumn;
@@ -152,6 +156,13 @@ export class ValueService extends BeanStub implements NamedBean {
         };
     }
 
+    /**
+     * Gets a cell value.
+     *
+     * The source can be either 'ui' or 'api':
+     * - 'ui' - gets the value as seen by the user, including any in-progress edits
+     * - 'api' - gets the last committed value from the row data, ignoring any in-progress edits
+     */
     public getValue(
         column: AgColumn,
         rowNode: IRowNode | null,

--- a/packages/ag-grid-enterprise/src/charts/chartComp/datasource/chartDatasource.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/datasource/chartDatasource.ts
@@ -181,7 +181,7 @@ export class ChartDatasource extends BeanStub {
                 const column = this.colModel.getCol(colId);
 
                 if (column) {
-                    const valueObject = this.valueSvc.getValue(column, rowNode);
+                    const valueObject = this.valueSvc.getValue(column, rowNode, false, 'api');
 
                     // when grouping we also need to build up multi category labels for charts
                     if (grouping) {
@@ -240,7 +240,7 @@ export class ChartDatasource extends BeanStub {
                     const filteredOutColId = colId + '-filtered-out';
 
                     // add data value to value column
-                    const value = this.valueSvc.getValue(col, rowNode);
+                    const value = this.valueSvc.getValue(col, rowNode, false, 'api');
                     let actualValue = value;
 
                     // unwrap value objects if present
@@ -261,7 +261,7 @@ export class ChartDatasource extends BeanStub {
                     }
                 } else {
                     // add data value to value column
-                    let value = this.valueSvc.getValue(col, rowNode);
+                    let value = this.valueSvc.getValue(col, rowNode, false, 'api');
 
                     // unwrap value object if present
                     if (value && typeof value.value === 'number') {
@@ -439,7 +439,7 @@ export class ChartDatasource extends BeanStub {
                     // just like we do for the initialLabel
                     const groupColumn = this.colModel.getCol(GROUP_AUTO_COLUMN_ID);
                     if (groupColumn) {
-                        const valueObject = this.valueSvc.getValue(groupColumn, rowNode);
+                        const valueObject = this.valueSvc.getValue(groupColumn, rowNode, false, 'api');
                         const valueString = valueObject?.toString ? String(valueObject.toString()) : ' ';
                         labels.push(valueString);
                     }

--- a/packages/ag-grid-enterprise/src/charts/chartComp/services/chartColumnService.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/services/chartColumnService.ts
@@ -119,7 +119,7 @@ export class ChartColumnService extends BeanStub {
             return this.valueColsWithoutSeriesType.has(colId);
         }
 
-        let cellValue = this.valueSvc.getValue(col, row);
+        let cellValue = this.valueSvc.getValue(col, row, false, 'api');
 
         if (cellValue == null) {
             cellValue = this.extractLeafData(row, col);
@@ -149,7 +149,7 @@ export class ChartColumnService extends BeanStub {
     }
 
     private extractLeafData(row: RowNode, col: AgColumn): any {
-        const value = row.data && this.valueSvc.getValue(col, row);
+        const value = row.data && this.valueSvc.getValue(col, row, false, 'api');
         if (value != null) {
             return value;
         }

--- a/packages/ag-grid-enterprise/src/clipboard/clipboardService.ts
+++ b/packages/ag-grid-enterprise/src/clipboard/clipboardService.ts
@@ -510,9 +510,11 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
 
         const rowCallback: RowCallback = (currentRow: RowPosition, rowNode: RowNode, range: CellRange) => {
             updatedRowNodes.push(rowNode);
-            range.columns.forEach((column: AgColumn) =>
-                this.updateCellValue(rowNode, column, value, cellsToFlash, EXPORT_TYPE_CLIPBOARD, changedPath)
-            );
+            const columns = range.columns as AgColumn[];
+            for (let i = 0, len = columns.length; i < len; ++i) {
+                const column = columns[i];
+                this.updateCellValue(rowNode, column, value, cellsToFlash, EXPORT_TYPE_CLIPBOARD, changedPath);
+            }
         };
 
         this.iterateActiveRanges(rowCallback);
@@ -540,16 +542,17 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
             const processCellFromClipboardFunc = gos.getCallback('processCellFromClipboard');
 
             const rowCallback: RowCallback = (currentRow: RowPosition, rowNode: RowNode, range: CellRange) => {
-                const { columns } = range;
+                const columns = range.columns as AgColumn[];
                 // take reference of first row, this is the one we will be using to copy from
                 if (!firstRowValues.length) {
                     // two reasons for looping through columns
-                    columns.forEach((column: AgColumn) => {
+                    for (let i = 0, len = columns.length; i < len; ++i) {
+                        const column = columns[i];
                         // get the initial values to copy down
                         const value = this.processCell(
                             rowNode,
                             column,
-                            valueSvc.getValue(column, rowNode),
+                            valueSvc.getValue(column, rowNode, false, 'ui'),
                             EXPORT_TYPE_DRAG_COPY,
                             processCellForClipboardFunc,
                             false,
@@ -557,20 +560,21 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
                         );
 
                         firstRowValues.push(value);
-                    });
+                    }
                 } else {
                     // otherwise we are not the first row, so copy
                     updatedRowNodes.push(rowNode);
-                    columns.forEach((column: AgColumn, index) => {
+                    for (let i = 0, len = columns.length; i < len; ++i) {
+                        const column = columns[i];
                         if (!column.isCellEditable(rowNode) || column.isSuppressPaste(rowNode)) {
-                            return;
+                            continue;
                         }
 
-                        const isFormula = column.isAllowFormula() && formula?.isFormula(firstRowValues[index]);
+                        const isFormula = column.isAllowFormula() && formula?.isFormula(firstRowValues[i]);
 
                         if (isFormula) {
-                            firstRowValues[index] = formula?.updateFormulaByOffset({
-                                value: firstRowValues[index],
+                            firstRowValues[i] = formula?.updateFormulaByOffset({
+                                value: firstRowValues[i],
                                 rowDelta: 1,
                             });
                         }
@@ -578,7 +582,7 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
                         const firstRowValue = this.processCell(
                             rowNode,
                             column,
-                            firstRowValues[index],
+                            firstRowValues[i],
                             EXPORT_TYPE_DRAG_COPY,
                             processCellFromClipboardFunc,
                             true
@@ -593,7 +597,7 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
                         const { rowIndex, rowPinned } = currentRow;
                         const cellId = _createCellId({ rowIndex, column, rowPinned });
                         cellsToFlash[cellId] = true;
-                    });
+                    }
                 }
             };
 
@@ -686,9 +690,10 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
                 continue;
             }
 
-            clipboardRowData.forEach((value, index) =>
-                this.updateCellValue(rowNode, columnsToPasteInto[index], value, cellsToFlash, type, changedPath)
-            );
+            for (let i = 0, len = clipboardRowData.length; i < len; ++i) {
+                const value = clipboardRowData[i];
+                this.updateCellValue(rowNode, columnsToPasteInto[i], value, cellsToFlash, type, changedPath);
+            }
 
             updatedRowNodes.push(rowNode);
         }
@@ -941,7 +946,10 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
         }
 
         for (const range of ranges) {
-            range.columns.forEach((col: AgColumn) => columnsSet.add(col));
+            const columns = range.columns as AgColumn[];
+            for (let i = 0, len = columns.length; i < len; ++i) {
+                columnsSet.add(columns[i]);
+            }
             const { rowPositions, cellsToFlash } = this.getRangeRowPositionsAndCellsToFlash(rangeSvc, range);
             for (const rowPosition of rowPositions) {
                 const isInCache = flatCache.has(rowPosition.rowIndex);
@@ -1098,6 +1106,7 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
                 column: column as AgColumn,
                 node,
                 includeValueFormatted: true,
+                source: 'ui',
             });
 
             const val = valueFormatted ?? value ?? '';
@@ -1144,7 +1153,7 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
     }
 
     private processCell<T>(
-        rowNode: RowNode | undefined,
+        rowNode: RowNode,
         column: AgColumn,
         value: T,
         type: string,
@@ -1162,14 +1171,19 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
                 formatValue: (valueToFormat: any) =>
                     valueSvc.formatValue(column, rowNode ?? null, valueToFormat) ?? valueToFormat,
                 parseValue: (valueToParse: string) =>
-                    valueSvc.parseValue(column, rowNode ?? null, valueToParse, valueSvc.getValue(column, rowNode)),
+                    valueSvc.parseValue(
+                        column,
+                        rowNode ?? null,
+                        valueToParse,
+                        valueSvc.getValue(column, rowNode, false, 'ui')
+                    ),
             };
 
             return func(params);
         }
 
         if (canParse && column.getColDef().useValueParserForImport !== false) {
-            return valueSvc.parseValue(column, rowNode ?? null, value, valueSvc.getValue(column, rowNode));
+            return valueSvc.parseValue(column, rowNode ?? null, value, valueSvc.getValue(column, rowNode, false, 'ui'));
         }
 
         if (canFormat && column.getColDef().useValueFormatterForExport !== false) {

--- a/packages/ag-grid-enterprise/src/find/findCellRenderer.ts
+++ b/packages/ag-grid-enterprise/src/find/findCellRenderer.ts
@@ -18,6 +18,7 @@ export class FindCellRenderer extends Component implements ICellRenderer {
             column: column as AgColumn | undefined,
             node,
             includeValueFormatted: true,
+            source: 'ui',
         });
         const displayValue = valueFormatted ?? value ?? '';
         const eGui = this.getGui();

--- a/packages/ag-grid-enterprise/src/find/findService.ts
+++ b/packages/ag-grid-enterprise/src/find/findService.ts
@@ -437,7 +437,7 @@ export class FindService extends BeanStub implements NamedBean, IFindService {
                 let valueToFind: string | null;
                 const getFindText = (groupRowRendererParams as FindGroupRowRendererParams)?.getFindText;
                 if (getFindText) {
-                    const value = valueSvc.getValueForDisplay({ node }).value;
+                    const value = valueSvc.getValueForDisplay({ node, source: 'ui' }).value;
                     valueToFind = getFindText(
                         _addGridCommonParams(gos, {
                             value,
@@ -449,6 +449,7 @@ export class FindService extends BeanStub implements NamedBean, IFindService {
                                 const { valueFormatted } = valueSvc.getValueForDisplay({
                                     node,
                                     includeValueFormatted: true,
+                                    source: 'ui',
                                 });
                                 return valueFormatted;
                             },
@@ -458,6 +459,7 @@ export class FindService extends BeanStub implements NamedBean, IFindService {
                     const { value, valueFormatted } = valueSvc.getValueForDisplay({
                         node,
                         includeValueFormatted: true,
+                        source: 'ui',
                     });
                     valueToFind = valueFormatted ?? value;
                 }
@@ -493,7 +495,7 @@ export class FindService extends BeanStub implements NamedBean, IFindService {
                 const colDef = column.colDef;
                 const getFindText = colDef.getFindText;
                 if (getFindText) {
-                    const value = valueSvc.getValueForDisplay({ column, node }).value;
+                    const value = valueSvc.getValueForDisplay({ column, node, source: 'ui' }).value;
                     valueToFind = getFindText(
                         _addGridCommonParams(gos, {
                             value,
@@ -506,6 +508,7 @@ export class FindService extends BeanStub implements NamedBean, IFindService {
                                     column,
                                     node,
                                     includeValueFormatted: true,
+                                    source: 'ui',
                                 });
                                 return valueFormatted;
                             },
@@ -516,6 +519,7 @@ export class FindService extends BeanStub implements NamedBean, IFindService {
                         column,
                         node,
                         includeValueFormatted: true,
+                        source: 'ui',
                     });
                     valueToFind = valueFormatted ?? value;
                 }

--- a/packages/ag-grid-enterprise/src/groupHierarchy/groupHierarchyUtils.ts
+++ b/packages/ag-grid-enterprise/src/groupHierarchy/groupHierarchyUtils.ts
@@ -13,7 +13,7 @@ const getDate = (
     sourceCol: AgColumn,
     node: IRowNode | null
 ): Date | null => {
-    const innerValue = valueSvc.getValue(sourceCol, node);
+    const innerValue = valueSvc.getValue(sourceCol, node, false, 'api');
     let date: Date | null = null;
     if (innerValue instanceof Date) {
         date = innerValue;

--- a/packages/ag-grid-enterprise/src/menu/contextMenu.ts
+++ b/packages/ag-grid-enterprise/src/menu/contextMenu.ts
@@ -190,7 +190,7 @@ export class ContextMenuService extends BeanStub implements NamedBean, IContextM
         let { anchorToElement, value, source } = params;
 
         if (rowNode && column && value == null) {
-            value = this.beans.valueSvc.getValueForDisplay({ column, node: rowNode }).value;
+            value = this.beans.valueSvc.getValueForDisplay({ column, node: rowNode, source: 'ui' }).value;
         }
 
         if (anchorToElement == null) {
@@ -216,7 +216,7 @@ export class ContextMenuService extends BeanStub implements NamedBean, IContextM
         const rowNode = cellCtrl?.rowNode ?? rowCtrl?.rowNode ?? null;
         const column = cellCtrl?.column ?? rowCtrl?.findFullWidthInfoForEvent(mouseEvent || touchEvent)?.column ?? null;
         const { valueSvc, ctrlsSvc } = this.beans;
-        const value = column ? valueSvc.getValue(column, rowNode) : null;
+        const value = column ? valueSvc.getValue(column, rowNode, false, 'ui') : null;
 
         // if user clicked on a cell, anchor to that cell, otherwise anchor to the grid panel
         const gridBodyCon = ctrlsSvc.getGridBodyCtrl();

--- a/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
@@ -14,6 +14,7 @@ import type {
 } from 'ag-grid-community';
 import { BeanStub, _missing } from 'ag-grid-community';
 
+import { getKeyForNode } from '../rowHierarchy/rowHierarchyUtils';
 import type { PivotColDefService } from './pivotColDefService';
 
 const EXCEEDED_MAX_UNIQUE_VALUES = 'Exceeded maximum allowed pivot column count.';
@@ -229,12 +230,14 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
         pivotIndex: number,
         uniqueValues: Map<string, any>
     ): Map<string, any> {
+        const beans = this.beans;
         const mappedChildren: Map<string, RowNode[]> = new Map();
         const pivotColumn = pivotColumns[pivotIndex];
 
         // map the children out based on the pivot column
-        children.forEach((child: RowNode) => {
-            let key: string = this.valueSvc.getKeyForNode(pivotColumn, child);
+        for (let i = 0, len = children.length; i < len; i++) {
+            const child = children[i];
+            let key: string = getKeyForNode(beans, pivotColumn, child);
 
             if (_missing(key)) {
                 key = '';
@@ -252,11 +255,13 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
                 }
             }
 
-            if (!mappedChildren.has(key)) {
-                mappedChildren.set(key, []);
+            const mapped = mappedChildren.get(key);
+            if (mapped) {
+                mapped.push(child);
+            } else {
+                mappedChildren.set(key, [child]);
             }
-            mappedChildren.get(key)!.push(child);
-        });
+        }
 
         // if it's the last pivot column, return as is, otherwise go one level further in the map
         if (pivotIndex === pivotColumns.length - 1) {

--- a/packages/ag-grid-enterprise/src/rangeSelection/agFillHandle.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/agFillHandle.ts
@@ -350,10 +350,12 @@ export class AgFillHandle extends AbstractSelectionHandle {
             let skipValue: boolean = false;
 
             if (withinInitialRange) {
-                currentValue = valueSvc.getValue(col, rowNode);
+                currentValue = valueSvc.getValue(col, rowNode, false, 'ui');
                 initialValues.push(currentValue);
-                initialNonAggregatedValues.push(valueSvc.getValue(col, rowNode, true));
-                initialFormattedValues.push(valueSvc.getValueForDisplay({ column: col, node: rowNode }).valueFormatted);
+                initialNonAggregatedValues.push(valueSvc.getValue(col, rowNode, true, 'ui'));
+                initialFormattedValues.push(
+                    valueSvc.getValueForDisplay({ column: col, node: rowNode, source: 'ui' }).valueFormatted
+                );
                 withinInitialRange = updateInitialSet();
             } else {
                 const { value, fromUserFunction, sourceCol, sourceRowNode } = this.processValues({
@@ -369,7 +371,7 @@ export class AgFillHandle extends AbstractSelectionHandle {
 
                 currentValue = value;
                 if (col.isCellEditable(rowNode)) {
-                    const cellValue = valueSvc.getValue(col, rowNode);
+                    const cellValue = valueSvc.getValue(col, rowNode, false, 'ui');
 
                     if (!fromUserFunction) {
                         if (sourceCol) {
@@ -379,6 +381,7 @@ export class AgFillHandle extends AbstractSelectionHandle {
                                     column: sourceCol,
                                     node: sourceRowNode!,
                                     includeValueFormatted: true,
+                                    source: 'ui',
                                 }).valueFormatted;
 
                                 if (formattedValue != null) {
@@ -467,7 +470,7 @@ export class AgFillHandle extends AbstractSelectionHandle {
                 initialNonAggregatedValues,
                 initialFormattedValues,
                 currentIndex: idx,
-                currentCellValue: valueSvc.getValue(col, rowNode),
+                currentCellValue: valueSvc.getValue(col, rowNode, false, 'ui'),
                 direction,
                 column: col,
                 rowNode: rowNode,

--- a/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/groupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/groupStrategy.ts
@@ -9,7 +9,7 @@ import type {
 import { BeanStub, RowNode, _csrmFirstLeaf, _warn } from 'ag-grid-community';
 
 import type { IRowGroupingStrategy } from '../../rowHierarchy/rowHierarchyUtils';
-import { _getRowDefaultExpanded } from '../../rowHierarchy/rowHierarchyUtils';
+import { _getRowDefaultExpanded, getKeyForNode } from '../../rowHierarchy/rowHierarchyUtils';
 import { setRowNodeGroup } from '../rowGroupingUtils';
 import type { GroupColumn } from './groupColumns';
 import { groupColumnsChanged, makeGroupColumns } from './groupColumns';
@@ -64,7 +64,7 @@ export class GroupStrategy extends BeanStub implements IRowGroupingStrategy {
 
         const leafNode = _csrmFirstLeaf(node);
         const rowGroupColId = rowGroupCol.getId();
-        if (!showRowGroupCols) {
+        if (!showRowGroupCols || !leafNode) {
             return groupData;
         }
         const groupDisplayCols = showRowGroupCols.columns;
@@ -74,7 +74,7 @@ export class GroupStrategy extends BeanStub implements IRowGroupingStrategy {
             // if rowGroupColumn is present, then it's grid row grouping and we only include if configuration says so
             if (col.isRowGroupDisplayed(rowGroupColId)) {
                 // if maintain group value type, get the value from any leaf node.
-                groupData[col.getColId()] = valueSvc.getValue(rowGroupCol, leafNode);
+                groupData[col.getColId()] = valueSvc.getValue(rowGroupCol, leafNode, false, 'api');
             }
         }
 
@@ -259,7 +259,7 @@ export class GroupStrategy extends BeanStub implements IRowGroupingStrategy {
     }
 
     private moveNodeInWrongPath(rootNode: RowNode, childNode: RowNode): boolean {
-        const { valueSvc } = this.beans;
+        const beans = this.beans;
         const createGroupForEmpty = this.groupEmpty;
 
         let ancestor: RowNode | null = childNode.parent;
@@ -271,7 +271,7 @@ export class GroupStrategy extends BeanStub implements IRowGroupingStrategy {
         }
         for (let idx = groupCols.length - 1; idx >= 0; --idx) {
             const { col } = groupCols[idx];
-            let key = valueSvc.getKeyForNode(col, childNode);
+            let key = getKeyForNode(beans, col, childNode);
             if (key == null || key === '') {
                 if (!createGroupForEmpty) {
                     continue; // skip columns with empty keys when unbalanced trees are allowed
@@ -445,7 +445,6 @@ export class GroupStrategy extends BeanStub implements IRowGroupingStrategy {
     private insertOneNode(rootNode: RowNode, childNode: RowNode): void {
         let parentGroup = rootNode;
         const { beans, pivotMode, groupCols, groupEmpty } = this;
-        const valueSvc = beans.valueSvc;
         if (!groupCols) {
             return;
         }
@@ -453,7 +452,7 @@ export class GroupStrategy extends BeanStub implements IRowGroupingStrategy {
         for (let i = 0; i < len; ++i) {
             const groupCol = groupCols[i];
             const col = groupCol.col;
-            let key = valueSvc.getKeyForNode(col, childNode);
+            let key = getKeyForNode(beans, col, childNode);
             if (key == null || key === '') {
                 if (!groupEmpty) {
                     continue;
@@ -517,7 +516,7 @@ export class GroupStrategy extends BeanStub implements IRowGroupingStrategy {
 
         groupsById.set(id, groupNode);
 
-        groupNode.groupValue = leafNode && this.beans.valueSvc.getValue(col, leafNode);
+        groupNode.groupValue = leafNode && this.beans.valueSvc.getValue(col, leafNode, false, 'api');
 
         // why is this done here? we are not updating the children count as we go,
         // i suspect this is updated in the filter stage
@@ -548,7 +547,7 @@ export class GroupStrategy extends BeanStub implements IRowGroupingStrategy {
             groupNode._groupData = undefined;
             const rowGroupColumn = groupNode.rowGroupColumn;
             const leafNode = rowGroupColumn && _csrmFirstLeaf(groupNode);
-            groupNode.groupValue = leafNode && valueSvc.getValue(rowGroupColumn, leafNode);
+            groupNode.groupValue = leafNode && valueSvc.getValue(rowGroupColumn, leafNode, false, 'api');
         }
 
         const allLeafs = rowModel.rootNode?._leafs;

--- a/packages/ag-grid-enterprise/src/rowHierarchy/rowHierarchyUtils.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/rowHierarchyUtils.ts
@@ -1,9 +1,12 @@
+import { _addGridCommonParams, _warn } from 'ag-grid-community';
 import type {
+    AgColumn,
     Bean,
     BeanCollection,
     GridOptions,
     GridOptionsService,
     IRowNode,
+    KeyCreatorParams,
     NestedDataGetter,
     RefreshModelParams,
     RowNode,
@@ -85,4 +88,35 @@ export const _getRowDefaultExpanded = (
         rowGroupColumn: rowNode.rowGroupColumn!,
     };
     return isGroupOpenByDefault(params) == true;
+};
+
+// used by row grouping and pivot, to get key for a row. col can be a pivot col or a row grouping col
+export const getKeyForNode = (beans: BeanCollection, col: AgColumn, rowNode: IRowNode): any => {
+    const value = beans.valueSvc.getValue(col, rowNode, false, 'api');
+    const keyCreator = col.getColDef().keyCreator;
+
+    let result = value;
+    if (keyCreator) {
+        const keyParams: KeyCreatorParams = _addGridCommonParams(beans.gos, {
+            value: value,
+            colDef: col.getColDef(),
+            column: col,
+            node: rowNode,
+            data: rowNode.data,
+        });
+        result = keyCreator(keyParams);
+    }
+
+    // if already a string, or missing, just return it
+    if (typeof result === 'string' || result == null) {
+        return result;
+    }
+
+    result = String(result);
+
+    if (result === '[object Object]') {
+        _warn(121);
+    }
+
+    return result;
 };

--- a/packages/ag-grid-enterprise/src/rowHierarchy/showRowGroupColValueService.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/showRowGroupColValueService.ts
@@ -43,20 +43,20 @@ export class ShowRowGroupColValueService extends BeanStub implements NamedBean, 
             if (hideOpenParentsNode) {
                 return {
                     displayedNode: hideOpenParentsNode,
-                    value: valueSvc.getValue(column, hideOpenParentsNode),
+                    value: valueSvc.getValue(column, hideOpenParentsNode, false, 'api'),
                 };
             }
         }
 
         // cell value > showOpenedGroup
-        const value = valueSvc.getValue(column, node);
+        const value = valueSvc.getValue(column, node, false, 'api');
         if (value == null) {
             // showOpenedGroup
             const displayedNode = this.getDisplayedNode(node, column);
             if (displayedNode) {
                 return {
                     displayedNode,
-                    value: valueSvc.getValue(column, displayedNode),
+                    value: valueSvc.getValue(column, displayedNode, false, 'api'),
                 };
             }
         }

--- a/packages/ag-grid-enterprise/src/serverSideRowModel/blocks/blockUtils.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/blocks/blockUtils.ts
@@ -117,7 +117,7 @@ export class BlockUtils extends BeanStub implements NamedBean {
     }
 
     private setRowGroupInfo(rowNode: RowNode): void {
-        rowNode.key = this.valueSvc.getValue(rowNode.rowGroupColumn!, rowNode);
+        rowNode.key = this.valueSvc.getValue(rowNode.rowGroupColumn!, rowNode, false, 'api');
 
         if (rowNode.key === null || rowNode.key === undefined) {
             _doOnce(() => {
@@ -255,7 +255,7 @@ export class BlockUtils extends BeanStub implements NamedBean {
             if (usingTreeData) {
                 groupData[col.getColId()] = key;
             } else if (col.isRowGroupDisplayed(rowNode.rowGroupColumn!.getId())) {
-                const groupValue = this.valueSvc.getValue(rowNode.rowGroupColumn!, rowNode);
+                const groupValue = this.valueSvc.getValue(rowNode.rowGroupColumn!, rowNode, false, 'api');
                 groupData[col.getColId()] = groupValue;
             }
         }

--- a/packages/ag-grid-enterprise/src/setFilter/clientSideValueExtractor.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/clientSideValueExtractor.ts
@@ -1,6 +1,7 @@
 import type { AgColumn, IClientSideRowModel, RowNode } from 'ag-grid-community';
 import { AgPromise, BeanStub, _makeNull } from 'ag-grid-community';
 
+import { getKeyForNode } from '../rowHierarchy/rowHierarchyUtils';
 import { processDataPath } from './setFilterUtils';
 
 /** @param V type of value in the Set Filter */
@@ -103,7 +104,7 @@ export class ClientSideValuesExtractor<V> extends BeanStub {
             }
             dataPath = node.getRoute() ?? [node.key ?? node.id!];
         } else {
-            dataPath = groupedCols.map((groupCol) => this.beans.valueSvc.getKeyForNode(groupCol, node));
+            dataPath = groupedCols.map((groupCol) => getKeyForNode(this.beans, groupCol, node));
             dataPath.push(this.getValue(node) as any);
         }
         const processedDataPath = processDataPath(dataPath, treeData, groupAllowUnbalanced);

--- a/packages/ag-grid-enterprise/src/setFilter/setFilterHandler.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilterHandler.ts
@@ -23,6 +23,7 @@ import {
     _toStringOrNull,
 } from 'ag-grid-community';
 
+import { getKeyForNode } from '../rowHierarchy/rowHierarchyUtils';
 import { ClientSideValuesExtractor } from './clientSideValueExtractor';
 import { SetFilterAppliedModel } from './setFilterAppliedModel';
 import { processDataPath, translateForSetFilter } from './setFilterUtils';
@@ -355,13 +356,8 @@ export class SetFilterHandler<TValue = string>
     }
 
     private doesFilterPassForGrouping(node: IRowNode): boolean {
-        const {
-            appliedModel,
-            params,
-            gos,
-            beans: { rowGroupColsSvc, valueSvc },
-        } = this;
-        const dataPath = (rowGroupColsSvc?.columns ?? []).map((groupCol) => valueSvc.getKeyForNode(groupCol, node));
+        const { appliedModel, params, gos, beans } = this;
+        const dataPath = (beans.rowGroupColsSvc?.columns ?? []).map((groupCol) => getKeyForNode(beans, groupCol, node));
         dataPath.push(params.getValue(node));
         return appliedModel.has(
             this.createKey(processDataPath(dataPath, false, gos.get('groupAllowUnbalanced')) as any) as any

--- a/packages/ag-grid-enterprise/src/statusBar/providedPanels/aggregationComp.ts
+++ b/packages/ag-grid-enterprise/src/statusBar/providedPanels/aggregationComp.ts
@@ -190,7 +190,7 @@ export class AggregationComp extends Component implements IStatusPanelComp {
                             return;
                         }
 
-                        let value = valueSvc.getValue(col, rowNode);
+                        let value = valueSvc.getValue(col, rowNode, false, 'ui');
 
                         // if empty cell, skip it, doesn't impact count or anything
                         if (_missing(value) || value === '') {

--- a/testing/behavioural/src/test-utils/gridRows/gridRowsDiagramTree.ts
+++ b/testing/behavioural/src/test-utils/gridRows/gridRowsDiagramTree.ts
@@ -326,13 +326,19 @@ export class GridRowsDiagramTree {
                     continue;
                 }
 
-                const value = gridRows.api.getCellValue({ rowNode: row, colKey: column, useFormatter: false });
+                const value = gridRows.api.getCellValue({
+                    rowNode: row,
+                    colKey: column,
+                    useFormatter: false,
+                    committed: true,
+                });
                 let formattedValue = value;
                 if (gridRows.options.useFormatter ?? true) {
                     formattedValue = gridRows.api.getCellValue({
                         rowNode: row,
                         colKey: column,
                         useFormatter: true,
+                        committed: true,
                     });
                     if (formattedValue === String(value)) {
                         formattedValue = value;

--- a/testing/behavioural/src/test-utils/gridRows/validation/gridRowsDomValidator.ts
+++ b/testing/behavioural/src/test-utils/gridRows/validation/gridRowsDomValidator.ts
@@ -133,7 +133,12 @@ class GridRowDomValidator {
         }
 
         const api = this.gridRows.api;
-        const cellValue = api.getCellValue({ rowNode: row, colKey: column, useFormatter: true });
+        const cellValue = api.getCellValue({
+            rowNode: row,
+            colKey: column,
+            useFormatter: true,
+            committed: true,
+        });
         const stringCellValue = cellValue != null ? String(cellValue).trim() : '';
         const colDef = column.getColDef();
         const cellRenderer = colDef?.cellRenderer;
@@ -259,7 +264,12 @@ class GridRowDomValidator {
     }
 
     private getExpectedGroupTextFromColumn(row: RowNode<any>, column: Column<any>): string {
-        const cellValue = this.gridRows.api.getCellValue({ rowNode: row, colKey: column, useFormatter: true });
+        const cellValue = this.gridRows.api.getCellValue({
+            rowNode: row,
+            colKey: column,
+            useFormatter: true,
+            committed: true,
+        });
         const stringCellValue = cellValue != null ? String(cellValue).trim() : '';
         return this.getExpectedGroupCellText(row, column, stringCellValue) ?? '';
     }
@@ -349,7 +359,11 @@ class GridRowDomValidator {
             return false;
         }
 
-        const cellValue = this.gridRows.api.getCellValue({ rowNode: row, colKey: column });
+        const cellValue = this.gridRows.api.getCellValue({
+            rowNode: row,
+            colKey: column,
+            committed: true,
+        });
 
         if (!checkboxElement) {
             return true;


### PR DESCRIPTION
There are few problems that are caused by the fact that getValue when passing source: ui or source:undefined (that default to ui) returns the value being edited and not the actual cell value.

In this PR we make source when getting the value mandatory and we apply 'ui' or 'api' whenever we want to use the actual value or the value being edited.

- Expose a new "committed?:boolean" to get cell API, so the user, and our tests, can specify if we want to read the actual value or the value being edited. By default is false to not causing breaking changes. 
- removes getKeyForNode from valueService
- it is used only by grouping and pivoting, so it can go in the grouping hierarchy utils
- replaces forEach loops in pivotStage with normal faster loops
- Make source mandatory in getValue and getValueForDisplay
- ensure the consistency of source where we use value service.
- ensure that we never cache a 'ui' value in the ValueCache, we always want to use a 'api' value there.
- remove executeFilterValueGetter as it was not needed, the now exposed executeValueGetterNoCache does the same thing
- minor refactorings in the value service
    - remove _addGridCommonParams as it is slower and unnecessary to create an object and then adding fields than just doing {} object with all the fields in - and valueSvc is a hot path

Fix AG-16448