### PR TITLE
AG-16448 add tests

### DIFF
--- a/testing/behavioural/src/cell-editing/cell-editing-batch.test.ts
+++ b/testing/behavioural/src/cell-editing/cell-editing-batch.test.ts
@@ -219,15 +219,35 @@ describe('Cell Editing Batch', () => {
         await userEvent.dblClick(cellA);
         const editor = await waitForInput(gridDiv, cellA, { popup: false });
         await userEvent.clear(editor);
-        await userEvent.type(editor, 'pending{Enter}');
+        await userEvent.type(editor, 'xx{Enter}');
         await asyncSetTimeout(1);
 
         api.refreshCells({ columns: ['b'], force: true });
         await asyncSetTimeout(1);
 
-        expect(cellB).toHaveTextContent('pending');
+        expect(cellB).toHaveTextContent('xx');
 
         api.commitBatchEdit();
         await asyncSetTimeout(1);
+
+        expect(cellB).toHaveTextContent('xx');
+
+        api.startBatchEdit();
+
+        await userEvent.dblClick(cellA);
+        const editor2 = await waitForInput(gridDiv, cellA, { popup: false });
+        await userEvent.clear(editor2);
+        await userEvent.type(editor2, 'yy{Enter}');
+        await asyncSetTimeout(1);
+
+        api.refreshCells({ columns: ['b'], force: true });
+        await asyncSetTimeout(1);
+
+        expect(cellB).toHaveTextContent('yy');
+
+        api.cancelBatchEdit();
+        await asyncSetTimeout(1);
+
+        expect(cellB).toHaveTextContent('xx');
     });
 });

--- a/testing/behavioural/src/cell-editing/cell-editing-batch.test.ts
+++ b/testing/behavioural/src/cell-editing/cell-editing-batch.test.ts
@@ -5,7 +5,7 @@ import { userEvent } from '@testing-library/user-event';
 import { agTestIdFor, getGridElement, setupAgTestIds } from 'ag-grid-community';
 import { BatchEditModule } from 'ag-grid-enterprise';
 
-import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+import { TestGridsManager, asyncSetTimeout, waitForInput } from '../test-utils';
 import { expect } from '../test-utils/matchers';
 
 describe('Cell Editing Batch', () => {
@@ -193,5 +193,41 @@ describe('Cell Editing Batch', () => {
         expect(cell).not.toHaveClass(/ag-cell-batch-edit/);
 
         commitButton.remove();
+    });
+
+    test('valueGetter sees pending edits during batch edit', async () => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [
+                { field: 'a', editable: true, cellEditor: 'agTextCellEditor' },
+                {
+                    field: 'b',
+                    valueGetter: (params) => params.getValue('a'),
+                },
+            ],
+            rowData: [{ id: '0', a: 'initial' }],
+            getRowId: (params) => params.data.id,
+        });
+
+        api.startBatchEdit();
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        await asyncSetTimeout(1);
+        const cellA = getByTestId(gridDiv, agTestIdFor.cell('0', 'a'));
+        const cellB = getByTestId(gridDiv, agTestIdFor.cell('0', 'b'));
+        expect(cellB).toHaveTextContent('initial');
+
+        await userEvent.dblClick(cellA);
+        const editor = await waitForInput(gridDiv, cellA, { popup: false });
+        await userEvent.clear(editor);
+        await userEvent.type(editor, 'pending{Enter}');
+        await asyncSetTimeout(1);
+
+        api.refreshCells({ columns: ['b'], force: true });
+        await asyncSetTimeout(1);
+
+        expect(cellB).toHaveTextContent('pending');
+
+        api.commitBatchEdit();
+        await asyncSetTimeout(1);
     });
 });

--- a/testing/behavioural/src/cell-editing/cell-editing.test.ts
+++ b/testing/behavioural/src/cell-editing/cell-editing.test.ts
@@ -308,39 +308,37 @@ describe('Cell Editing Start', () => {
         });
     });
 
-    describe('Value getters with pending edits', () => {
-        test('valueGetter reads live value from another cell editor', async () => {
-            const api = await gridMgr.createGridAndWait('myGrid', {
-                columnDefs: [
-                    { field: 'a', editable: true },
-                    {
-                        field: 'b',
-                        valueGetter: (params) => params.getValue('a'),
-                    },
-                ],
-                rowData: [{ id: '0', a: 'initial' }],
-                getRowId: (params) => params.data.id,
-            });
-
-            const gridDiv = getGridElement(api)! as HTMLElement;
-            await asyncSetTimeout(1);
-
-            const cellA = getByTestId(gridDiv, agTestIdFor.cell('0', 'a'));
-            const cellB = getByTestId(gridDiv, agTestIdFor.cell('0', 'b'));
-            expect(cellB).toHaveTextContent('initial');
-
-            await userEvent.dblClick(cellA);
-            await asyncSetTimeout(1);
-
-            const input = await waitForInput(gridDiv, cellA, { popup: false });
-            await userEvent.clear(input);
-            await userEvent.type(input, 'pending');
-            await asyncSetTimeout(1);
-
-            api.refreshCells({ columns: ['b'], force: true });
-            await asyncSetTimeout(1);
-
-            expect(cellB).toHaveTextContent('pending');
+    test('valueGetter reads live value from another cell editor', async () => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [
+                { field: 'a', editable: true },
+                {
+                    field: 'b',
+                    valueGetter: (params) => params.getValue('a'),
+                },
+            ],
+            rowData: [{ id: '0', a: 'initial' }],
+            getRowId: (params) => params.data.id,
         });
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        await asyncSetTimeout(1);
+
+        const cellA = getByTestId(gridDiv, agTestIdFor.cell('0', 'a'));
+        const cellB = getByTestId(gridDiv, agTestIdFor.cell('0', 'b'));
+        expect(cellB).toHaveTextContent('initial');
+
+        await userEvent.dblClick(cellA);
+        await asyncSetTimeout(1);
+
+        const input = await waitForInput(gridDiv, cellA, { popup: false });
+        await userEvent.clear(input);
+        await userEvent.type(input, 'pending');
+        await asyncSetTimeout(1);
+
+        api.refreshCells({ columns: ['b'], force: true });
+        await asyncSetTimeout(1);
+
+        expect(cellB).toHaveTextContent('pending');
     });
 });

--- a/testing/behavioural/src/cell-editing/cell-editing.test.ts
+++ b/testing/behavioural/src/cell-editing/cell-editing.test.ts
@@ -333,12 +333,34 @@ describe('Cell Editing Start', () => {
 
         const input = await waitForInput(gridDiv, cellA, { popup: false });
         await userEvent.clear(input);
-        await userEvent.type(input, 'pending');
+        await userEvent.type(input, 'xx');
         await asyncSetTimeout(1);
 
         api.refreshCells({ columns: ['b'], force: true });
         await asyncSetTimeout(1);
 
-        expect(cellB).toHaveTextContent('pending');
+        expect(cellB).toHaveTextContent('xx');
+
+        // Commit first edit and start a new edit session to test cancel
+        await userEvent.keyboard('{Enter}');
+        await asyncSetTimeout(1);
+
+        await userEvent.dblClick(cellA);
+        await asyncSetTimeout(1);
+        const input2 = await waitForInput(gridDiv, cellA, { popup: false });
+        await userEvent.clear(input2);
+        await userEvent.type(input2, 'yy');
+        await asyncSetTimeout(1);
+
+        api.refreshCells({ columns: ['b'], force: true });
+        await asyncSetTimeout(1);
+
+        expect(cellB).toHaveTextContent('yy');
+
+        // Cancel edit by pressing ESC, should revert to last committed value
+        await userEvent.keyboard('{Escape}');
+        await asyncSetTimeout(1);
+
+        expect(cellB).toHaveTextContent('xx');
     });
 });

--- a/testing/behavioural/src/cell-editing/cell-editing.test.ts
+++ b/testing/behavioural/src/cell-editing/cell-editing.test.ts
@@ -307,4 +307,40 @@ describe('Cell Editing Start', () => {
             expect(onCellValueChangedGrid).toHaveBeenCalledTimes(1);
         });
     });
+
+    describe('Value getters with pending edits', () => {
+        test('valueGetter reads live value from another cell editor', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    { field: 'a', editable: true },
+                    {
+                        field: 'b',
+                        valueGetter: (params) => params.getValue('a'),
+                    },
+                ],
+                rowData: [{ id: '0', a: 'initial' }],
+                getRowId: (params) => params.data.id,
+            });
+
+            const gridDiv = getGridElement(api)! as HTMLElement;
+            await asyncSetTimeout(1);
+
+            const cellA = getByTestId(gridDiv, agTestIdFor.cell('0', 'a'));
+            const cellB = getByTestId(gridDiv, agTestIdFor.cell('0', 'b'));
+            expect(cellB).toHaveTextContent('initial');
+
+            await userEvent.dblClick(cellA);
+            await asyncSetTimeout(1);
+
+            const input = await waitForInput(gridDiv, cellA, { popup: false });
+            await userEvent.clear(input);
+            await userEvent.type(input, 'pending');
+            await asyncSetTimeout(1);
+
+            api.refreshCells({ columns: ['b'], force: true });
+            await asyncSetTimeout(1);
+
+            expect(cellB).toHaveTextContent('pending');
+        });
+    });
 });

--- a/testing/behavioural/src/cell-editing/examples/batch-editing-doc.test.ts
+++ b/testing/behavioural/src/cell-editing/examples/batch-editing-doc.test.ts
@@ -1,0 +1,243 @@
+import { getByTestId } from '@testing-library/dom';
+import '@testing-library/jest-dom';
+import { userEvent } from '@testing-library/user-event';
+
+import type { GridOptions, ValueGetterParams } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    NumberEditorModule,
+    PinnedRowModule,
+    SelectEditorModule,
+    TextEditorModule,
+    agTestIdFor,
+    getGridElement,
+    setupAgTestIds,
+} from 'ag-grid-community';
+import {
+    BatchEditModule,
+    CellSelectionModule,
+    ColumnMenuModule,
+    ColumnsToolPanelModule,
+    ContextMenuModule,
+    CustomEditorModule,
+    RenderApiModule,
+    RowGroupingModule,
+} from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, asyncSetTimeout } from '../../test-utils';
+
+interface MedalRow {
+    id: string;
+    athlete: string;
+    age: number;
+    country: string;
+    date: string;
+    sport: string;
+    gold: number;
+    silver: number;
+    bronze: number;
+    total?: number;
+}
+
+describe('Batch editing documentation examples', () => {
+    const gridsManager = new TestGridsManager({
+        includeDefaultModules: true,
+        modules: [
+            ClientSideRowModelModule,
+            NumberEditorModule,
+            TextEditorModule,
+            SelectEditorModule,
+            PinnedRowModule,
+            BatchEditModule,
+            CellSelectionModule,
+            ColumnsToolPanelModule,
+            ColumnMenuModule,
+            ContextMenuModule,
+            CustomEditorModule,
+            RenderApiModule,
+            RowGroupingModule,
+        ],
+    });
+
+    beforeAll(() => {
+        setupAgTestIds();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+        vi.clearAllMocks();
+    });
+
+    test('batch editing API doc example preserves batch states and totals', async () => {
+        const rowData: MedalRow[] = [
+            {
+                id: '0',
+                athlete: 'Ali',
+                age: 24,
+                country: 'Ireland',
+                date: '2024-01-01',
+                sport: 'Rowing',
+                gold: 1,
+                silver: 2,
+                bronze: 3,
+            },
+            {
+                id: '1',
+                athlete: 'Bob',
+                age: 26,
+                country: 'Spain',
+                date: '2024-01-02',
+                sport: 'Cycling',
+                gold: 2,
+                silver: 1,
+                bronze: 0,
+            },
+        ];
+
+        const api = await gridsManager.createGridAndWait('batchEditingExample', {
+            columnDefs: [
+                { field: 'athlete', minWidth: 120 },
+                { field: 'age', aggFunc: 'avg' },
+                { field: 'country' },
+                { field: 'date' },
+                { field: 'sport', minWidth: 120 },
+                { field: 'gold' },
+                { field: 'silver' },
+                { field: 'bronze', minWidth: 100 },
+                {
+                    field: 'total',
+                    aggFunc: 'sum',
+                    valueGetter: (params: ValueGetterParams<MedalRow>) => {
+                        const { node, data, api: gridApi } = params;
+                        const overlay = node ? gridApi!.getEditRowValues(node) : undefined;
+                        const merged = Object.assign({}, data, overlay);
+                        return (merged.gold ?? 0) + (merged.silver ?? 0) + (merged.bronze ?? 0);
+                    },
+                    editable: false,
+                },
+            ],
+            rowData,
+            getRowId: (params) => params.data.id,
+            animateRows: false,
+            grandTotalRow: 'bottom',
+            defaultColDef: {
+                editable: true,
+                flex: 1,
+            },
+        } satisfies GridOptions<MedalRow>);
+
+        const gridElement = getGridElement(api)! as HTMLElement;
+        const getCell = async (rowId: string, colId: keyof Pick<MedalRow, 'gold' | 'silver' | 'bronze' | 'total'>) => {
+            api.ensureColumnVisible(colId);
+            await asyncSetTimeout(0);
+            return getByTestId(gridElement, agTestIdFor.cell(rowId, colId));
+        };
+        const goldCell = (rowId: string = '0') => getCell(rowId, 'gold');
+        const silverCell = (rowId: string = '0') => getCell(rowId, 'silver');
+        const totalCell = (rowId: string = '0') => getCell(rowId, 'total');
+        const bronzeCell = (rowId: string = '0') => getCell(rowId, 'bronze');
+        const bobOriginal = { ...rowData[1] };
+        const aliceGoldCell = await goldCell();
+        const aliceSilverCell = await silverCell();
+        const aliceTotalCell = await totalCell();
+
+        await new GridRows(api, 'batch editing initial').check(`
+            ROOT id:ROOT_NODE_ID age:{"count":2,"value":25} total:9
+            ├── LEAF id:0 athlete:"Ali" age:24 country:"Ireland" date:"2024-01-01" sport:"Rowing" gold:1 silver:2 bronze:3 total:6
+            ├── LEAF id:1 athlete:"Bob" age:26 country:"Spain" date:"2024-01-02" sport:"Cycling" gold:2 silver:1 bronze:0 total:3
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID age:{"count":2,"value":25} total:9
+        `);
+
+        expect(aliceTotalCell).toHaveTextContent('6');
+
+        const user = userEvent.setup();
+
+        api.startBatchEdit();
+        expect(api.isBatchEditing()).toBe(true);
+
+        await user.dblClick(aliceGoldCell);
+        await user.keyboard('100{Enter}');
+        expect(api.getCellEditorInstances()).toHaveLength(0);
+        expect(aliceGoldCell).toHaveTextContent('100');
+        expect(aliceGoldCell).toHaveClass('ag-cell-batch-edit');
+        expect(aliceTotalCell).toHaveTextContent('105');
+        expect(aliceTotalCell).not.toHaveClass('ag-cell-batch-edit');
+        expect(api.isBatchEditing()).toBe(true);
+
+        api.commitBatchEdit();
+        expect(api.isBatchEditing()).toBe(false);
+        expect(aliceGoldCell).not.toHaveClass('ag-cell-batch-edit');
+        await new GridRows(api, 'after first commit').check(`
+            ROOT id:ROOT_NODE_ID age:{"count":2,"value":25} total:108
+            ├── LEAF id:0 athlete:"Ali" age:24 country:"Ireland" date:"2024-01-01" sport:"Rowing" gold:100 silver:2 bronze:3 total:105
+            ├── LEAF id:1 athlete:"Bob" age:26 country:"Spain" date:"2024-01-02" sport:"Cycling" gold:2 silver:1 bronze:0 total:3
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID age:{"count":2,"value":25} total:108
+        `);
+
+        await user.dblClick(aliceGoldCell);
+        await user.keyboard('50{Enter}');
+        expect(api.isBatchEditing()).toBe(false);
+        expect(aliceGoldCell).toHaveTextContent('50');
+        expect(aliceGoldCell).not.toHaveClass('ag-cell-batch-edit');
+        expect(aliceTotalCell).toHaveTextContent('55');
+
+        api.startBatchEdit();
+        expect(api.isBatchEditing()).toBe(true);
+
+        await user.dblClick(aliceGoldCell);
+        await user.keyboard('120{Enter}');
+        expect(api.getCellEditorInstances()).toHaveLength(0);
+        expect(aliceGoldCell).toHaveTextContent('120');
+        expect(aliceGoldCell).toHaveClass('ag-cell-batch-edit');
+        expect(aliceTotalCell).toHaveTextContent('125');
+
+        await user.keyboard('{Tab}');
+        expect(api.isBatchEditing()).toBe(true);
+        const editorsAfterTab = api.getCellEditorInstances();
+        expect(editorsAfterTab).toHaveLength(1);
+        const silverEditorInput = aliceSilverCell.querySelector('input') as HTMLInputElement | null;
+        expect(silverEditorInput).toBeTruthy();
+        expect(silverEditorInput?.valueAsNumber).toBe(2);
+
+        await user.keyboard('{Enter}');
+        expect(api.getCellEditorInstances()).toHaveLength(0);
+        expect(aliceGoldCell).toHaveClass('ag-cell-batch-edit');
+        expect(aliceSilverCell).not.toHaveClass('ag-cell-batch-edit');
+        expect(api.isBatchEditing()).toBe(true);
+
+        api.commitBatchEdit();
+        expect(api.isBatchEditing()).toBe(false);
+        expect(aliceGoldCell).not.toHaveClass('ag-cell-batch-edit');
+        expect(aliceGoldCell).toHaveTextContent('120');
+        expect(aliceTotalCell).toHaveTextContent('125');
+
+        api.setFocusedCell(1, 'gold');
+        api.startBatchEdit();
+        expect(api.isBatchEditing()).toBe(true);
+
+        const bobGoldCell = await goldCell('1');
+        const bobBronzeCell = await bronzeCell('1');
+        await user.dblClick(bobGoldCell);
+        await user.keyboard('100{Enter}');
+        expect(api.getCellEditorInstances()).toHaveLength(0);
+        expect(bobBronzeCell).toHaveTextContent('0');
+        expect(bobGoldCell).toHaveClass('ag-cell-batch-edit');
+        expect(aliceTotalCell).toHaveTextContent('125');
+
+        api.commitBatchEdit();
+        expect(api.isBatchEditing()).toBe(false);
+        expect(api.getEditingCells()).toHaveLength(0);
+        expect(bobGoldCell).not.toHaveClass('ag-cell-batch-edit');
+        expect(bobGoldCell).toHaveTextContent('100');
+
+        api.applyTransaction({ update: [{ ...bobOriginal }] });
+        expect(bobGoldCell).toHaveTextContent(String(bobOriginal.gold));
+
+        await new GridRows(api, 'after all batch scenarios').check(`
+            ROOT id:ROOT_NODE_ID age:{"count":2,"value":25} total:128
+            ├── LEAF id:0 athlete:"Ali" age:24 country:"Ireland" date:"2024-01-01" sport:"Rowing" gold:120 silver:2 bronze:3 total:125
+            ├── LEAF id:1 athlete:"Bob" age:26 country:"Spain" date:"2024-01-02" sport:"Cycling" gold:2 silver:1 bronze:0 total:3
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID age:{"count":2,"value":25} total:128
+        `);
+    });
+});

--- a/testing/behavioural/src/cell-editing/examples/cell-editing-start-stop-doc.test.ts
+++ b/testing/behavioural/src/cell-editing/examples/cell-editing-start-stop-doc.test.ts
@@ -1,0 +1,594 @@
+import { getByTestId } from '@testing-library/dom';
+import '@testing-library/jest-dom';
+import { userEvent } from '@testing-library/user-event';
+
+import type { GridOptions, ICellEditorParams } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    NumberEditorModule,
+    PinnedRowModule,
+    SelectEditorModule,
+    TextEditorModule,
+    agTestIdFor,
+    getGridElement,
+    setupAgTestIds,
+} from 'ag-grid-community';
+import {
+    BatchEditModule,
+    CellSelectionModule,
+    ColumnMenuModule,
+    ColumnsToolPanelModule,
+    ContextMenuModule,
+    CustomEditorModule,
+    RenderApiModule,
+    RowGroupingModule,
+} from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, asyncSetTimeout } from '../../test-utils';
+
+interface PersonRow {
+    id: string;
+    firstName: string;
+    lastName: string;
+    gender: string;
+    age?: number;
+    mood: string;
+    country: string;
+    address: string;
+}
+
+interface EventRow {
+    id: string;
+    firstName: string;
+    lastName: string;
+}
+
+describe('Cell editing start/stop documentation examples', () => {
+    const gridsManager = new TestGridsManager({
+        includeDefaultModules: true,
+        modules: [
+            ClientSideRowModelModule,
+            NumberEditorModule,
+            TextEditorModule,
+            SelectEditorModule,
+            PinnedRowModule,
+            BatchEditModule,
+            CellSelectionModule,
+            ColumnsToolPanelModule,
+            ColumnMenuModule,
+            ContextMenuModule,
+            CustomEditorModule,
+            RenderApiModule,
+            RowGroupingModule,
+        ],
+    });
+
+    beforeAll(() => {
+        setupAgTestIds();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+        vi.clearAllMocks();
+    });
+
+    test('cell editing start/stop doc example interactions', async () => {
+        const baseRows: PersonRow[] = [
+            {
+                id: '0',
+                firstName: 'Bob',
+                lastName: 'Harrison',
+                gender: 'Male',
+                age: 21,
+                mood: 'Happy',
+                country: 'Ireland',
+                address: '1197 Thunder Rd',
+            },
+            {
+                id: '1',
+                firstName: 'Mary',
+                lastName: 'Wilson',
+                gender: 'Female',
+                age: 19,
+                mood: 'Sad',
+                country: 'Ireland',
+                address: '3685 Rocky Gld',
+            },
+        ];
+
+        const rowData: PersonRow[] = baseRows.map((row) => ({ ...row }));
+        const pinnedRow: PersonRow = {
+            id: 'pinned',
+            firstName: '##',
+            lastName: '##',
+            gender: '##',
+            address: '##',
+            mood: '##',
+            country: '##',
+        };
+
+        const eventLog: Array<[string, any]> = [];
+        const expectEventSequence = async (expected: Array<[string, any]>) => {
+            await asyncSetTimeout(0);
+            expect(eventLog).toHaveLength(expected.length);
+            const snapshot = [...eventLog];
+            eventLog.length = 0;
+            expect(snapshot).toEqual(expected);
+        };
+
+        const api = await gridsManager.createGridAndWait('cellEditingStartStop', {
+            columnDefs: [
+                { field: 'firstName' },
+                { field: 'lastName' },
+                { field: 'gender' },
+                { field: 'age' },
+                { field: 'mood' },
+                { field: 'country' },
+                { field: 'address', minWidth: 300 },
+            ],
+            rowData,
+            pinnedTopRowData: [pinnedRow],
+            pinnedBottomRowData: [pinnedRow],
+            defaultColDef: {
+                editable: true,
+                flex: 1,
+                minWidth: 110,
+            },
+            onCellEditingStarted: (event) => eventLog.push(['cellEditingStarted', { value: event.value }]),
+            onCellValueChanged: (event) =>
+                eventLog.push([
+                    'cellValueChanged',
+                    { newValue: event.newValue, oldValue: event.oldValue, source: event.source },
+                ]),
+            onCellEditingStopped: (event) =>
+                eventLog.push([
+                    'cellEditingStopped',
+                    {
+                        newValue: event.newValue,
+                        oldValue: event.oldValue,
+                        value: event.value,
+                        valueChanged: event.valueChanged,
+                    },
+                ]),
+        } satisfies GridOptions<PersonRow>);
+
+        const gridElement = getGridElement(api)! as HTMLElement;
+        const user = userEvent.setup();
+
+        api.ensureColumnVisible('firstName');
+        await asyncSetTimeout(0);
+        const editableFirstNameCell = getByTestId(gridElement, agTestIdFor.cell('0', 'firstName'));
+
+        await user.dblClick(editableFirstNameCell);
+        await user.keyboard('Fred');
+        await user.keyboard('{Enter}');
+        expect(api.getCellEditorInstances()).toHaveLength(0);
+        expect(editableFirstNameCell).toHaveTextContent('Fred');
+        await expectEventSequence([
+            ['cellEditingStarted', { value: 'Bob' }],
+            ['cellValueChanged', { newValue: 'Fred', oldValue: 'Bob', source: 'edit' }],
+            ['cellEditingStopped', { newValue: 'Fred', oldValue: 'Bob', value: 'Fred', valueChanged: true }],
+        ]);
+
+        await user.click(editableFirstNameCell);
+        await user.keyboard('{F2}');
+        await user.keyboard('{End}dy');
+        api.stopEditing();
+        expect(editableFirstNameCell).toHaveTextContent('Freddy');
+        await expectEventSequence([
+            ['cellEditingStarted', { value: 'Fred' }],
+            ['cellValueChanged', { newValue: 'Freddy', oldValue: 'Fred', source: 'edit' }],
+            ['cellEditingStopped', { newValue: 'Freddy', oldValue: 'Fred', value: 'Freddy', valueChanged: true }],
+        ]);
+
+        await user.click(editableFirstNameCell);
+        await user.keyboard('{F2}');
+        await user.keyboard('X');
+        api.stopEditing(true);
+        expect(editableFirstNameCell).toHaveTextContent('Freddy');
+        await expectEventSequence([
+            ['cellEditingStarted', { value: 'Freddy' }],
+            ['cellEditingStopped', { newValue: undefined, oldValue: 'Freddy', value: 'Freddy', valueChanged: false }],
+        ]);
+
+        await user.click(editableFirstNameCell);
+        await user.keyboard('Hi');
+        await user.keyboard('{Escape}');
+        expect(editableFirstNameCell).toHaveTextContent('Freddy');
+        await expectEventSequence([
+            ['cellEditingStarted', { value: 'Freddy' }],
+            ['cellEditingStopped', { newValue: undefined, oldValue: 'Freddy', value: 'Freddy', valueChanged: false }],
+        ]);
+
+        await user.click(editableFirstNameCell);
+        await user.keyboard('Fred');
+        await user.keyboard('{Enter}');
+        expect(editableFirstNameCell).toHaveTextContent('Fred');
+        await expectEventSequence([
+            ['cellEditingStarted', { value: 'Freddy' }],
+            ['cellValueChanged', { newValue: 'Fred', oldValue: 'Freddy', source: 'edit' }],
+            ['cellEditingStopped', { newValue: 'Fred', oldValue: 'Freddy', value: 'Fred', valueChanged: true }],
+        ]);
+
+        rowData[0].firstName = 'Freddy';
+        api.applyTransaction({ update: [rowData[0]] });
+        expect(editableFirstNameCell).toHaveTextContent('Freddy');
+
+        await new GridRows(api, 'cell editing start stop').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 firstName:"Freddy" lastName:"Harrison" gender:"Male" age:21 mood:"Happy" country:"Ireland" address:"1197 Thunder Rd"
+            └── LEAF id:1 firstName:"Mary" lastName:"Wilson" gender:"Female" age:19 mood:"Sad" country:"Ireland" address:"3685 Rocky Gld"
+        `);
+
+        const makeEventRows = (): EventRow[] => [
+            { id: '0', firstName: 'Ali', lastName: 'Johnson' },
+            { id: '1', firstName: 'Bob', lastName: 'Harrison' },
+        ];
+
+        type EventLogEntry = [string, any];
+        const editorEventLog: EventLogEntry[] = [];
+        const pushEditorEventLog = (name: string, payload: any) => editorEventLog.push([name, payload]);
+        let cancelBeforeStart = false;
+        let cancelAfterEnd = false;
+
+        class LoggingTestEditor {
+            private input!: HTMLInputElement;
+
+            public init(params: ICellEditorParams) {
+                this.input = document.createElement('input');
+                this.input.type = 'text';
+                this.input.value = params.value ?? '';
+            }
+
+            public getGui(): HTMLElement {
+                return this.input;
+            }
+
+            public afterGuiAttached() {
+                this.input?.focus();
+            }
+
+            public getValue(): string | null {
+                pushEditorEventLog('getValue', []);
+                return this.input?.value ?? null;
+            }
+
+            public isCancelBeforeStart(): boolean {
+                pushEditorEventLog('isCancelBeforeStart', []);
+                return cancelBeforeStart;
+            }
+
+            public isCancelAfterEnd(): boolean {
+                pushEditorEventLog('isCancelAfterEnd', []);
+                return cancelAfterEnd;
+            }
+        }
+
+        const eventsApi = await gridsManager.createGridAndWait('cellEditingStartStopEvents', {
+            columnDefs: [
+                { field: 'firstName', editable: true, cellEditor: LoggingTestEditor },
+                { field: 'lastName', editable: true },
+            ],
+            rowData: makeEventRows(),
+            getRowId: (params) => params.data.id,
+            defaultColDef: {
+                editable: true,
+                flex: 1,
+                minWidth: 110,
+            },
+            readOnlyEdit: false,
+            onCellEditingStarted: (event) => pushEditorEventLog('cellEditingStarted', { value: event.value }),
+            onCellValueChanged: (event) =>
+                pushEditorEventLog('cellValueChanged', {
+                    newValue: event.newValue,
+                    oldValue: event.oldValue,
+                    source: event.source,
+                }),
+            onCellEditingStopped: (event) =>
+                pushEditorEventLog('cellEditingStopped', {
+                    newValue: event.newValue,
+                    oldValue: event.oldValue,
+                    value: event.value,
+                    valueChanged: event.valueChanged,
+                }),
+        } satisfies GridOptions<EventRow>);
+
+        const eventsGridElement = getGridElement(eventsApi)! as HTMLElement;
+        const eventsUser = userEvent.setup();
+        const firstEventCell = () => getByTestId(eventsGridElement, agTestIdFor.cell('0', 'firstName'));
+        const secondEventCell = () => getByTestId(eventsGridElement, agTestIdFor.cell('1', 'firstName'));
+
+        await new GridRows(eventsApi, 'cell editing events baseline').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 firstName:"Ali" lastName:"Johnson"
+            └── LEAF id:1 firstName:"Bob" lastName:"Harrison"
+        `);
+
+        const resetEventsState = async () => {
+            editorEventLog.length = 0;
+            cancelBeforeStart = false;
+            cancelAfterEnd = false;
+            eventsApi.setGridOption('rowData', makeEventRows());
+            await asyncSetTimeout(0);
+            firstEventCell();
+        };
+
+        const setReadOnlyEdit = (value: boolean) => {
+            eventsApi.setGridOption('readOnlyEdit', value);
+            return Promise.resolve();
+        };
+
+        const expectEditorEventSequence = async (expected: EventLogEntry[]) => {
+            await asyncSetTimeout(0);
+            expect(editorEventLog).toHaveLength(expected.length);
+            const snapshot = [...editorEventLog];
+            editorEventLog.length = 0;
+            expect(snapshot).toEqual(expected);
+        };
+
+        const runEventScenario = async (
+            _label: string,
+            action: (readOnlyEdit: boolean) => Promise<void>,
+            expectations: { true: EventLogEntry[]; false: EventLogEntry[] },
+            options: {
+                beforeStart?: boolean;
+                afterEnd?: boolean;
+                verifyDom?: (readOnlyEdit: boolean) => Promise<void>;
+            } = {}
+        ) => {
+            for (const readOnlyEdit of [false, true] as const) {
+                await resetEventsState();
+                await setReadOnlyEdit(readOnlyEdit);
+                cancelBeforeStart = options?.beforeStart ?? false;
+                cancelAfterEnd = options?.afterEnd ?? false;
+                await action(readOnlyEdit);
+                await expectEditorEventSequence(expectations[String(readOnlyEdit) as 'true' | 'false']);
+                await asyncSetTimeout(0);
+                await options.verifyDom?.(readOnlyEdit);
+            }
+        };
+
+        await runEventScenario(
+            'edit enter stop',
+            async () => {
+                const cell = firstEventCell();
+                await eventsUser.dblClick(cell);
+                await eventsUser.keyboard('Fred');
+                await eventsUser.keyboard('{Enter}');
+            },
+            {
+                false: [
+                    ['isCancelBeforeStart', []],
+                    ['cellEditingStarted', { value: 'Ali' }],
+                    ['isCancelAfterEnd', []],
+                    ['getValue', []],
+                    ['cellValueChanged', { newValue: 'AliFred', oldValue: 'Ali', source: 'edit' }],
+                    [
+                        'cellEditingStopped',
+                        { newValue: 'AliFred', oldValue: 'Ali', value: 'AliFred', valueChanged: true },
+                    ],
+                ],
+                true: [
+                    ['isCancelBeforeStart', []],
+                    ['cellEditingStarted', { value: 'Ali' }],
+                    ['isCancelAfterEnd', []],
+                    ['getValue', []],
+                    [
+                        'cellEditingStopped',
+                        { newValue: 'AliFred', oldValue: 'Ali', value: 'AliFred', valueChanged: true },
+                    ],
+                ],
+            }
+        );
+
+        await runEventScenario(
+            'edit enter submit',
+            async () => {
+                const cell = firstEventCell();
+                await eventsUser.dblClick(cell);
+                await eventsUser.keyboard('Fred');
+                await eventsUser.keyboard('{Enter}');
+            },
+            {
+                false: [
+                    ['isCancelBeforeStart', []],
+                    ['cellEditingStarted', { value: 'Ali' }],
+                    ['isCancelAfterEnd', []],
+                    ['getValue', []],
+                    ['cellValueChanged', { newValue: 'AliFred', oldValue: 'Ali', source: 'edit' }],
+                    [
+                        'cellEditingStopped',
+                        { newValue: 'AliFred', oldValue: 'Ali', value: 'AliFred', valueChanged: true },
+                    ],
+                ],
+                true: [
+                    ['isCancelBeforeStart', []],
+                    ['cellEditingStarted', { value: 'Ali' }],
+                    ['isCancelAfterEnd', []],
+                    ['getValue', []],
+                    [
+                        'cellEditingStopped',
+                        { newValue: 'AliFred', oldValue: 'Ali', value: 'AliFred', valueChanged: true },
+                    ],
+                ],
+            }
+        );
+
+        await runEventScenario(
+            'edit cancel via escape',
+            async () => {
+                const cell = firstEventCell();
+                await eventsUser.dblClick(cell);
+                await eventsUser.keyboard('Fred');
+                await eventsUser.keyboard('{Escape}');
+            },
+            {
+                false: [
+                    ['isCancelBeforeStart', []],
+                    ['cellEditingStarted', { value: 'Ali' }],
+                    ['cellEditingStopped', { newValue: undefined, oldValue: 'Ali', value: 'Ali', valueChanged: false }],
+                ],
+                true: [
+                    ['isCancelBeforeStart', []],
+                    ['cellEditingStarted', { value: 'Ali' }],
+                    ['cellEditingStopped', { newValue: undefined, oldValue: 'Ali', value: 'Ali', valueChanged: false }],
+                ],
+            },
+            {
+                verifyDom: async (readOnly) => {
+                    if (!readOnly) {
+                        expect(firstEventCell()).toHaveTextContent('Ali');
+                    }
+                },
+            }
+        );
+
+        await runEventScenario(
+            'cancel before start',
+            async () => {
+                const cell = firstEventCell();
+                await eventsUser.dblClick(cell);
+            },
+            {
+                false: [
+                    ['isCancelBeforeStart', []],
+                    ['cellEditingStopped', { newValue: undefined, oldValue: 'Ali', value: 'Ali', valueChanged: false }],
+                    ['cellEditingStarted', { value: 'Ali' }],
+                ],
+                true: [
+                    ['isCancelBeforeStart', []],
+                    [
+                        'cellEditingStopped',
+                        { newValue: undefined, oldValue: undefined, value: 'Ali', valueChanged: false },
+                    ],
+                    ['cellEditingStopped', { newValue: undefined, oldValue: 'Ali', value: 'Ali', valueChanged: false }],
+                    ['cellEditingStarted', { value: 'Ali' }],
+                ],
+            },
+            {
+                beforeStart: true,
+                verifyDom: async (readOnly) => {
+                    if (!readOnly) {
+                        expect(firstEventCell()).toHaveTextContent('Ali');
+                    }
+                },
+            }
+        );
+
+        await runEventScenario(
+            'cancel after enter',
+            async () => {
+                const cell = firstEventCell();
+                await eventsUser.dblClick(cell);
+                await eventsUser.keyboard('Fred');
+                await eventsUser.keyboard('{Enter}');
+            },
+            {
+                false: [
+                    ['isCancelBeforeStart', []],
+                    [
+                        'cellEditingStopped',
+                        { newValue: undefined, oldValue: undefined, value: 'Ali', valueChanged: false },
+                    ],
+                    ['cellEditingStarted', { value: 'Ali' }],
+                    ['isCancelAfterEnd', []],
+                    ['cellEditingStopped', { newValue: undefined, oldValue: 'Ali', value: 'Ali', valueChanged: false }],
+                ],
+                true: [
+                    ['isCancelBeforeStart', []],
+                    ['cellEditingStarted', { value: 'Ali' }],
+                    ['isCancelAfterEnd', []],
+                    ['cellEditingStopped', { newValue: undefined, oldValue: 'Ali', value: 'Ali', valueChanged: false }],
+                ],
+            },
+            {
+                afterEnd: true,
+                verifyDom: async (readOnly) => {
+                    if (!readOnly) {
+                        expect(firstEventCell()).toHaveTextContent('Ali');
+                    }
+                },
+            }
+        );
+
+        await runEventScenario(
+            'stop editing commit',
+            async () => {
+                const cell = firstEventCell();
+                await eventsUser.dblClick(cell);
+                await eventsUser.keyboard('Fred');
+                eventsApi.stopEditing();
+            },
+            {
+                false: [
+                    ['isCancelBeforeStart', []],
+                    ['cellEditingStarted', { value: 'Ali' }],
+                    ['isCancelAfterEnd', []],
+                    ['getValue', []],
+                    ['cellValueChanged', { newValue: 'AliFred', oldValue: 'Ali', source: 'edit' }],
+                    [
+                        'cellEditingStopped',
+                        { newValue: 'AliFred', oldValue: 'Ali', value: 'AliFred', valueChanged: true },
+                    ],
+                ],
+                true: [
+                    ['isCancelBeforeStart', []],
+                    ['cellEditingStarted', { value: 'Ali' }],
+                    ['isCancelAfterEnd', []],
+                    ['getValue', []],
+                    [
+                        'cellEditingStopped',
+                        { newValue: 'AliFred', oldValue: 'Ali', value: 'AliFred', valueChanged: true },
+                    ],
+                ],
+            },
+            {
+                verifyDom: async (readOnly) => {
+                    if (!readOnly) {
+                        await expect(firstEventCell()).toHaveTextContent('AliFred');
+                    }
+                },
+            }
+        );
+
+        await runEventScenario(
+            'edit click another cell',
+            async () => {
+                const cell = firstEventCell();
+                await eventsUser.dblClick(cell);
+                await eventsUser.keyboard('Fred');
+                await eventsUser.click(secondEventCell());
+            },
+            {
+                false: [
+                    ['isCancelBeforeStart', []],
+                    ['cellEditingStarted', { value: 'Ali' }],
+                    ['isCancelAfterEnd', []],
+                    ['getValue', []],
+                    ['cellValueChanged', { newValue: 'AliFred', oldValue: 'Ali', source: 'edit' }],
+                    [
+                        'cellEditingStopped',
+                        { newValue: 'AliFred', oldValue: 'Ali', value: 'AliFred', valueChanged: true },
+                    ],
+                ],
+                true: [
+                    ['isCancelBeforeStart', []],
+                    ['cellEditingStarted', { value: 'Ali' }],
+                    ['isCancelAfterEnd', []],
+                    ['getValue', []],
+                    [
+                        'cellEditingStopped',
+                        { newValue: 'AliFred', oldValue: 'Ali', value: 'AliFred', valueChanged: true },
+                    ],
+                ],
+            },
+            {
+                verifyDom: async (readOnly) => {
+                    if (!readOnly) {
+                        expect(firstEventCell()).toHaveTextContent('Fred');
+                    }
+                },
+            }
+        );
+    });
+});

--- a/testing/behavioural/src/cell-editing/examples/full-row-editing-doc.test.ts
+++ b/testing/behavioural/src/cell-editing/examples/full-row-editing-doc.test.ts
@@ -1,0 +1,237 @@
+import '@testing-library/jest-dom';
+import { userEvent } from '@testing-library/user-event';
+
+import type { ColDef, GridOptions } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    NumberEditorModule,
+    PinnedRowModule,
+    SelectEditorModule,
+    TextEditorModule,
+    getGridElement,
+    setupAgTestIds,
+} from 'ag-grid-community';
+import {
+    BatchEditModule,
+    CellSelectionModule,
+    ColumnMenuModule,
+    ColumnsToolPanelModule,
+    ContextMenuModule,
+    CustomEditorModule,
+    RenderApiModule,
+    RowGroupingModule,
+} from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, asyncSetTimeout, waitForInput } from '../../test-utils';
+
+interface CarRow {
+    id: string;
+    make: string;
+    model: string;
+    price: number;
+    field4: string;
+    field5: string;
+    field6: string;
+}
+
+describe('Full-row editing documentation examples', () => {
+    const gridsManager = new TestGridsManager({
+        includeDefaultModules: true,
+        modules: [
+            ClientSideRowModelModule,
+            NumberEditorModule,
+            TextEditorModule,
+            SelectEditorModule,
+            PinnedRowModule,
+            BatchEditModule,
+            CellSelectionModule,
+            ColumnsToolPanelModule,
+            ColumnMenuModule,
+            ContextMenuModule,
+            CustomEditorModule,
+            RenderApiModule,
+            RowGroupingModule,
+        ],
+    });
+
+    beforeAll(() => {
+        setupAgTestIds();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+        vi.clearAllMocks();
+    });
+
+    test('full-row editing doc example tabbing and scrolling behaviour', async () => {
+        const makeValues = ['Porsche', 'Toyota', 'Ford', 'AAA', 'BBB', 'CCC'];
+        const baseColumnDefs: ColDef<CarRow>[] = [
+            {
+                field: 'make',
+                cellEditor: 'agSelectCellEditor',
+                cellEditorParams: { values: makeValues },
+            },
+            { field: 'model' },
+            { field: 'field4', headerName: 'Read Only', editable: false },
+            { field: 'price', cellEditor: 'agNumberCellEditor' },
+            {
+                headerName: 'Suppress Navigable',
+                field: 'field5',
+                suppressNavigable: true,
+                minWidth: 200,
+            },
+            { headerName: 'Read Only', field: 'field6', editable: false },
+        ];
+
+        const duplicateColumns: ColDef<CarRow>[] = [];
+        for (let repeat = 0; repeat < 2; repeat += 1) {
+            for (const [index, colDef] of baseColumnDefs.entries()) {
+                duplicateColumns.push({ ...colDef, colId: `${colDef.field}-${index}` });
+            }
+        }
+        const columnDefs: ColDef<CarRow>[] = duplicateColumns.map((colDef, index) => ({
+            ...colDef,
+            colId: `${colDef.colId}-${index}`,
+        }));
+
+        const baseRows = [
+            { make: 'Toyota', model: 'Celica', price: 35000, field4: 'S-XX', field5: 'S-22', field6: 'S-23' },
+            { make: 'Ford', model: 'Mondeo', price: 32000, field4: 'S-YY', field5: 'S-24', field6: 'S-25' },
+            { make: 'Porsche', model: 'Boxster', price: 72000, field4: 'S-ZZ', field5: 'S-26', field6: 'S-27' },
+        ];
+        const totalRows = 100;
+        const farRowIndex = totalRows - 1;
+        const farRowTemplate = baseRows[farRowIndex % baseRows.length];
+        const rowData: CarRow[] = [];
+        for (let index = 0; index < totalRows; index += 1) {
+            const template = baseRows[index % baseRows.length];
+            const batchIndex = Math.floor(index / baseRows.length);
+            rowData.push({
+                id: String(index),
+                ...template,
+                model: `${template.model} ${batchIndex}`,
+                price: template.price + batchIndex * 1000,
+            });
+        }
+        const rowsToTrimLater = rowData.slice(3);
+        const remainingRowCount = rowData.length - rowsToTrimLater.length;
+
+        const api = await gridsManager.createGridAndWait('fullRowEditingDoc', {
+            columnDefs,
+            rowData,
+            getRowId: (params) => params.data.id,
+            animateRows: false,
+            defaultColDef: { flex: 1, editable: true, cellDataType: false, minWidth: 120 },
+        } satisfies GridOptions<CarRow>);
+
+        const gridElement = getGridElement(api)! as HTMLElement;
+        const user = userEvent.setup();
+        const findCell = (rowIndex: number, colId: string): HTMLElement => {
+            const selector = `.ag-center-cols-container [row-index="${rowIndex}"] [col-id="${colId}"]`;
+            const cell = gridElement.querySelector<HTMLElement>(selector);
+            if (!cell) {
+                throw new Error(`Unable to locate cell row-index=${rowIndex} colId=${colId}`);
+            }
+            return cell;
+        };
+
+        const tabScenarios: Array<{ editType: 'fullRow' | 'singleCell'; tabCount: number }> = [
+            { editType: 'singleCell', tabCount: 4 },
+            { editType: 'fullRow', tabCount: 8 },
+        ];
+
+        for (const { editType, tabCount } of tabScenarios) {
+            api.setGridOption('editType', editType);
+            const modelCellRow1 = findCell(1, 'model-1-1');
+            await user.dblClick(modelCellRow1);
+            await waitForInput(gridElement, modelCellRow1);
+
+            for (let i = 0; i < tabCount + 2; i += 1) {
+                await user.keyboard('{Tab}');
+            }
+
+            const modelCellRow2 = findCell(2, 'model-1-1');
+            await waitForInput(gridElement, modelCellRow2);
+            api.stopEditing();
+            expect(api.getCellEditorInstances()).toHaveLength(0);
+        }
+
+        api.setGridOption('editType', 'fullRow');
+        const scrollModelCell = findCell(1, 'model-1-1');
+        await user.dblClick(scrollModelCell);
+        await waitForInput(gridElement, scrollModelCell);
+
+        api.ensureIndexVisible(farRowIndex);
+        await asyncSetTimeout(0);
+        expect(findCell(farRowIndex, 'make-0-0')).toHaveTextContent(farRowTemplate.make);
+
+        api.ensureColumnVisible('field6-5-11');
+        await asyncSetTimeout(0);
+        expect(findCell(farRowIndex, 'field6-5-11')).toHaveTextContent(farRowTemplate.field6);
+
+        api.ensureIndexVisible(0);
+        await asyncSetTimeout(0);
+        expect(findCell(0, 'field6-5-11')).toHaveTextContent('S-23');
+
+        api.ensureColumnVisible('make-0-0');
+        await asyncSetTimeout(0);
+        expect(findCell(0, 'make-0-0')).toHaveTextContent('Toyota');
+        expect(scrollModelCell.querySelector('input')).toBeTruthy();
+
+        api.stopEditing();
+        expect(api.getCellEditorInstances()).toHaveLength(0);
+
+        api.setGridOption('editType', 'fullRow');
+        const scrollAgainModelCell = findCell(1, 'model-1-1');
+        await user.dblClick(scrollAgainModelCell);
+        await waitForInput(gridElement, scrollAgainModelCell);
+        const scrollAgainMakeCell = findCell(1, 'make-0-0');
+        await asyncSetTimeout(0);
+        if (!scrollAgainMakeCell.querySelector('[role="combobox"]')) {
+            throw new Error('combobox not ready');
+        }
+
+        api.ensureColumnVisible('field5-4-10');
+        api.ensureColumnVisible('make-0-0');
+        expect(scrollAgainModelCell.querySelector('input')).toBeTruthy();
+        expect(scrollAgainMakeCell.querySelector('[role="combobox"]')).toBeTruthy();
+
+        api.stopEditing();
+        expect(api.getCellEditorInstances()).toHaveLength(0);
+
+        if (rowsToTrimLater.length) {
+            api.applyTransaction({ remove: rowsToTrimLater });
+            expect(api.getDisplayedRowCount()).toBe(remainingRowCount);
+        }
+
+        const trimmedColumnDefs = columnDefs.slice(0, 3);
+        api.setGridOption('columnDefs', trimmedColumnDefs);
+        api.refreshClientSideRowModel('everything');
+        const updatedDefs = api.getColumnDefs();
+        expect(updatedDefs).toBeTruthy();
+        expect(updatedDefs).toHaveLength(trimmedColumnDefs.length);
+
+        await new GridRows(api, 'full row editing trimmed baseline').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 make-0-0:"Toyota" model-1-1:"Celica 0" field4-2-2:"S-XX"
+            ├── LEAF id:1 make-0-0:"Ford" model-1-1:"Mondeo 0" field4-2-2:"S-YY"
+            └── LEAF id:2 make-0-0:"Porsche" model-1-1:"Boxster 0" field4-2-2:"S-ZZ"
+        `);
+
+        const modelCellRow1 = findCell(1, 'model-1-1');
+        await user.dblClick(modelCellRow1);
+        await waitForInput(gridElement, modelCellRow1);
+        await user.keyboard('XYZ');
+        await user.keyboard('{Tab}{Tab}');
+        api.stopEditing();
+        expect(api.getCellEditorInstances()).toHaveLength(0);
+        expect(modelCellRow1).toHaveTextContent('XYZ');
+
+        await new GridRows(api, 'full row editing snapshot').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 make-0-0:"Toyota" model-1-1:"Celica 0" field4-2-2:"S-XX"
+            ├── LEAF id:1 make-0-0:"Ford" model-1-1:"XYZ" field4-2-2:"S-YY"
+            └── LEAF id:2 make-0-0:"Porsche" model-1-1:"Boxster 0" field4-2-2:"S-ZZ"
+        `);
+    });
+});

--- a/testing/behavioural/src/formulas/formulas-filtering.test.ts
+++ b/testing/behavioural/src/formulas/formulas-filtering.test.ts
@@ -3,7 +3,6 @@ import { ClientSideRowModelModule, TextEditorModule, TextFilterModule, TooltipMo
 import { CellSelectionModule, FormulaModule, SetFilterModule } from 'ag-grid-enterprise';
 import type { SetFilter } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions } from '../test-utils';
 import { GridRows, TestGridsManager, applyTransactionChecked, waitForEvent } from '../test-utils';
 
 describe('ag-grid formulas filtering', () => {
@@ -231,18 +230,14 @@ describe('ag-grid formulas filtering', () => {
             await filterChanged;
         };
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['athlete'],
-        };
-
         await applyMichaelFilter();
 
-        let gridRows = new GridRows(api, 'filter Michael Phelps initial', gridRowsOptions);
+        let gridRows = new GridRows(api, 'filter Michael Phelps initial');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├── LEAF id:1 athlete:"Michael Phelps"
-            ├── LEAF id:2 athlete:"Michael Phelps"
-            └── LEAF id:3 athlete:"Michael Phelps"
+            ├── LEAF id:1 row-number:"1" athlete:"Michael Phelps"
+            ├── LEAF id:2 row-number:"2" athlete:"Michael Phelps"
+            └── LEAF id:3 row-number:"3" athlete:"Michael Phelps"
         `);
 
         await clearFilter();
@@ -253,13 +248,13 @@ describe('ag-grid formulas filtering', () => {
 
         await applyMichaelFilter();
 
-        gridRows = new GridRows(api, 'filter Michael Phelps after row 4 edit', gridRowsOptions);
+        gridRows = new GridRows(api, 'filter Michael Phelps after row 4 edit');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├── LEAF id:1 athlete:"Michael Phelps"
-            ├── LEAF id:2 athlete:"Michael Phelps"
-            ├── LEAF id:3 athlete:"Michael Phelps"
-            └── LEAF id:4 athlete:"Michael Phelps"
+            ├── LEAF id:1 row-number:"1" athlete:"Michael Phelps"
+            ├── LEAF id:2 row-number:"2" athlete:"Michael Phelps"
+            ├── LEAF id:3 row-number:"3" athlete:"Michael Phelps"
+            └── LEAF id:4 row-number:"4" athlete:"Michael Phelps"
         `);
     });
 
@@ -452,22 +447,18 @@ describe('ag-grid formulas filtering', () => {
             await filterChanged;
         };
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['athlete'],
-        };
-
         let cellChanged = waitForEvent('cellValueChanged', api);
         api.getRowNode('2')?.setDataValue('athlete', '=A1');
         await cellChanged;
 
         await toMichaelFilter();
 
-        let gridRows = new GridRows(api, 'filter Michael Phelps after row 2 edit', gridRowsOptions);
+        let gridRows = new GridRows(api, 'filter Michael Phelps after row 2 edit');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├── LEAF id:1 athlete:"Michael Phelps"
-            ├── LEAF id:2 athlete:"Michael Phelps"
-            └── LEAF id:3 athlete:"Michael Phelps"
+            ├── LEAF id:1 row-number:"1" athlete:"Michael Phelps" country:"United States" sport:"Swimming"
+            ├── LEAF id:2 row-number:"2" athlete:"Michael Phelps" country:"United States" sport:"Swimming"
+            └── LEAF id:3 row-number:"3" athlete:"Michael Phelps" country:"United States" sport:"Swimming"
         `);
 
         await clearFilter();
@@ -478,13 +469,13 @@ describe('ag-grid formulas filtering', () => {
 
         await toMichaelFilter();
 
-        gridRows = new GridRows(api, 'filter Michael Phelps after row 4 edit', gridRowsOptions);
+        gridRows = new GridRows(api, 'filter Michael Phelps after row 4 edit');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├── LEAF id:1 athlete:"Michael Phelps"
-            ├── LEAF id:2 athlete:"Michael Phelps"
-            ├── LEAF id:3 athlete:"Michael Phelps"
-            └── LEAF id:4 athlete:"Michael Phelps"
+            ├── LEAF id:1 row-number:"1" athlete:"Michael Phelps" country:"United States" sport:"Swimming"
+            ├── LEAF id:2 row-number:"2" athlete:"Michael Phelps" country:"United States" sport:"Swimming"
+            ├── LEAF id:3 row-number:"3" athlete:"Michael Phelps" country:"United States" sport:"Swimming"
+            └── LEAF id:4 row-number:"4" athlete:"Michael Phelps" country:"South Africa" sport:"Swimming"
         `);
     });
 
@@ -708,19 +699,15 @@ describe('ag-grid formulas filtering', () => {
         };
 
         await applyFilter('Michael');
-        let gridRows = new GridRows(api, 'custom filter', {
-            columns: ['athlete'],
-        });
+        let gridRows = new GridRows(api, 'custom filter');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├── LEAF id:1 athlete:"Michael Phelps"
-            └── LEAF id:2 athlete:"Michael Phelps"
+            ├── LEAF id:1 row-number:"1" athlete:"Michael Phelps" country:"United States" sport:"Swimming" year:2008 gold:8 silver:0 bronze:0 total:8
+            └── LEAF id:2 row-number:"2" athlete:"Michael Phelps" country:"United States" sport:"Swimming" year:2008 gold:0 silver:1 bronze:0 total:1
         `);
 
         await applyFilter('REF');
-        gridRows = new GridRows(api, 'custom filter', {
-            columns: ['athlete'],
-        });
+        gridRows = new GridRows(api, 'custom filter');
         await gridRows.check('empty');
     });
 });

--- a/testing/behavioural/src/formulas/formulas.test.ts
+++ b/testing/behavioural/src/formulas/formulas.test.ts
@@ -5,7 +5,6 @@ import type { GridOptions, Module } from 'ag-grid-community';
 import { ClientSideRowModelModule, TextEditorModule } from 'ag-grid-community';
 import { CellSelectionModule, FormulaModule } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions } from '../test-utils';
 import { GridRows, TestGridsManager, applyTransactionChecked, asyncSetTimeout } from '../test-utils';
 
 const rowNumberRefreshBufferMs = 25;
@@ -70,23 +69,22 @@ describe('ag-grid formulas general behaviour', () => {
 
         let gridRows = new GridRows(api, 'initial constants', {
             useFormatter: false,
-            columns: ['value'],
         });
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├── LEAF id:value-a1 value:10
-            ├── LEAF id:value-a2 value:20
-            ├── LEAF id:constant-pi value:3.14
-            ├── LEAF id:constant-hello value:"Hello"
-            ├── LEAF id:constant-true value:true
-            ├── LEAF id:relative-a1 value:10
-            ├── LEAF id:"absolute-row-a$1" value:10
-            ├── LEAF id:"absolute-col-$a1" value:10
-            ├── LEAF id:"absolute-both-$a$1" value:10
-            ├── LEAF id:relative-a2 value:20
-            ├── LEAF id:"absolute-row-a$2" value:20
-            ├── LEAF id:"absolute-col-$a2" value:20
-            └── LEAF id:"absolute-both-$a$2" value:20
+            ├── LEAF id:value-a1 row-number:"1" value:10
+            ├── LEAF id:value-a2 row-number:"2" value:20
+            ├── LEAF id:constant-pi row-number:"3" value:3.14
+            ├── LEAF id:constant-hello row-number:"4" value:"Hello"
+            ├── LEAF id:constant-true row-number:"5" value:true
+            ├── LEAF id:relative-a1 row-number:"6" value:10
+            ├── LEAF id:"absolute-row-a$1" row-number:"7" value:10
+            ├── LEAF id:"absolute-col-$a1" row-number:"8" value:10
+            ├── LEAF id:"absolute-both-$a$1" row-number:"9" value:10
+            ├── LEAF id:relative-a2 row-number:"10" value:20
+            ├── LEAF id:"absolute-row-a$2" row-number:"11" value:20
+            ├── LEAF id:"absolute-col-$a2" row-number:"12" value:20
+            └── LEAF id:"absolute-both-$a$2" row-number:"13" value:20
         `);
 
         const updatedRow2 = { ...rowData[1], value: 50 };
@@ -94,24 +92,23 @@ describe('ag-grid formulas general behaviour', () => {
         await asyncSetTimeout(rowNumberRefreshBufferMs);
 
         gridRows = new GridRows(api, 'after update', {
-            columns: ['value'],
             useFormatter: false,
         });
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├── LEAF id:value-a1 value:10
-            ├── LEAF id:value-a2 value:50
-            ├── LEAF id:constant-pi value:3.14
-            ├── LEAF id:constant-hello value:"Hello"
-            ├── LEAF id:constant-true value:true
-            ├── LEAF id:relative-a1 value:10
-            ├── LEAF id:"absolute-row-a$1" value:10
-            ├── LEAF id:"absolute-col-$a1" value:10
-            ├── LEAF id:"absolute-both-$a$1" value:10
-            ├── LEAF id:relative-a2 value:50
-            ├── LEAF id:"absolute-row-a$2" value:50
-            ├── LEAF id:"absolute-col-$a2" value:50
-            └── LEAF id:"absolute-both-$a$2" value:50
+            ├── LEAF id:value-a1 row-number:"1" value:10
+            ├── LEAF id:value-a2 row-number:"2" value:50
+            ├── LEAF id:constant-pi row-number:"3" value:3.14
+            ├── LEAF id:constant-hello row-number:"4" value:"Hello"
+            ├── LEAF id:constant-true row-number:"5" value:true
+            ├── LEAF id:relative-a1 row-number:"6" value:10
+            ├── LEAF id:"absolute-row-a$1" row-number:"7" value:10
+            ├── LEAF id:"absolute-col-$a1" row-number:"8" value:10
+            ├── LEAF id:"absolute-both-$a$1" row-number:"9" value:10
+            ├── LEAF id:relative-a2 row-number:"10" value:50
+            ├── LEAF id:"absolute-row-a$2" row-number:"11" value:50
+            ├── LEAF id:"absolute-col-$a2" row-number:"12" value:50
+            └── LEAF id:"absolute-both-$a$2" row-number:"13" value:50
         `);
     });
 
@@ -232,29 +229,27 @@ describe('ag-grid formulas general behaviour', () => {
 
         const api = gridsManager.createGrid('formulas-numeric-rows', gridOptions);
 
-        const gridRows = new GridRows(api, 'numeric helpers across rows', {
-            columns: ['value'],
-        });
+        const gridRows = new GridRows(api, 'numeric helpers across rows');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├── LEAF id:value-a1 value:2
-            ├── LEAF id:value-a2 value:4
-            ├── LEAF id:value-a3 value:6
-            ├── LEAF id:value-a4 value:8
-            ├── LEAF id:sum-a1-a4 value:20
-            ├── LEAF id:sumif-a-range-gt-4 value:14
-            ├── LEAF id:sumif-high-category-a-values value:12
-            ├── LEAF id:sumif-high-category-b-values value:60
-            ├── LEAF id:minus-a3-minus-a1 value:4
-            ├── LEAF id:multiply-a1-a2-times-2 value:16
-            ├── LEAF id:divide-a3-by-a2 value:1.5
-            ├── LEAF id:min-a1-a4 value:2
-            ├── LEAF id:max-a1-a4 value:8
-            ├── LEAF id:average-a1-a4 value:5
-            ├── LEAF id:median-a1-a4 value:5
-            ├── LEAF id:percent-b2 value:0.2
-            ├── LEAF id:power-b2-squared value:400
-            └── LEAF id:rand-fixed value:0.123
+            ├── LEAF id:value-a1 row-number:"1" value:2 altValue:10 category:"Low"
+            ├── LEAF id:value-a2 row-number:"2" value:4 altValue:20 category:"High"
+            ├── LEAF id:value-a3 row-number:"3" value:6 altValue:30 category:"Low"
+            ├── LEAF id:value-a4 row-number:"4" value:8 altValue:40 category:"High"
+            ├── LEAF id:sum-a1-a4 row-number:"5" value:20
+            ├── LEAF id:sumif-a-range-gt-4 row-number:"6" value:14
+            ├── LEAF id:sumif-high-category-a-values row-number:"7" value:12
+            ├── LEAF id:sumif-high-category-b-values row-number:"8" value:60
+            ├── LEAF id:minus-a3-minus-a1 row-number:"9" value:4
+            ├── LEAF id:multiply-a1-a2-times-2 row-number:"10" value:16
+            ├── LEAF id:divide-a3-by-a2 row-number:"11" value:1.5
+            ├── LEAF id:min-a1-a4 row-number:"12" value:2
+            ├── LEAF id:max-a1-a4 row-number:"13" value:8
+            ├── LEAF id:average-a1-a4 row-number:"14" value:5
+            ├── LEAF id:median-a1-a4 row-number:"15" value:5
+            ├── LEAF id:percent-b2 row-number:"16" value:0.2
+            ├── LEAF id:power-b2-squared row-number:"17" value:400
+            └── LEAF id:rand-fixed row-number:"18" value:0.123
         `);
     });
 
@@ -423,9 +418,7 @@ describe('ag-grid formulas general behaviour', () => {
 
             const api = gridsManager.createGrid('formulas-date', gridOptions);
 
-            const gridRows = new GridRows(api, 'date functions fixed clock', {
-                columns: ['today', 'now'],
-            });
+            const gridRows = new GridRows(api, 'date functions fixed clock');
 
             const rowNode = gridRows.displayedRows[0];
             const todayValue = api.getCellValue<Date>({ rowNode, colKey: 'today' })!;
@@ -442,7 +435,7 @@ describe('ag-grid formulas general behaviour', () => {
 
             await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            └── LEAF id:dates today:"${todayIso}" now:"${nowIso}"
+            └── LEAF id:dates row-number:"1" today:"${todayIso}" now:"${nowIso}"
         `);
 
             expect(todayIso).toBe(expectedToday.toISOString());
@@ -608,44 +601,40 @@ describe('ag-grid formulas general behaviour', () => {
 
         await asyncSetTimeout(rowNumberRefreshBufferMs);
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['result'],
-        };
-
-        let gridRows = new GridRows(api, 'initial long-hand formulas', gridRowsOptions);
+        let gridRows = new GridRows(api, 'initial long-hand formulas');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├── LEAF id:base
-            ├── LEAF id:longhand-row result:100
-            ├── LEAF id:absolute-row result:100
-            └── LEAF id:relative-row result:100
+            ├── LEAF id:base row-number:"1" source:100
+            ├── LEAF id:longhand-row row-number:"2" result:100
+            ├── LEAF id:absolute-row row-number:"3" result:100
+            └── LEAF id:relative-row row-number:"4" result:100
         `);
 
         applyTransactionChecked(api, { update: [{ id: 'base', source: 250 }] });
 
         await asyncSetTimeout(rowNumberRefreshBufferMs);
 
-        gridRows = new GridRows(api, 'after base update', gridRowsOptions);
+        gridRows = new GridRows(api, 'after base update');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├── LEAF id:base
-            ├── LEAF id:longhand-row result:250
-            ├── LEAF id:absolute-row result:250
-            └── LEAF id:relative-row result:250
+            ├── LEAF id:base row-number:"1" source:250
+            ├── LEAF id:longhand-row row-number:"2" result:250
+            ├── LEAF id:absolute-row row-number:"3" result:250
+            └── LEAF id:relative-row row-number:"4" result:250
         `);
 
         applyTransactionChecked(api, { add: [{ id: 'prepended', source: 10 }], addIndex: 0 });
 
         await asyncSetTimeout(rowNumberRefreshBufferMs);
 
-        gridRows = new GridRows(api, 'after prepending row', gridRowsOptions);
+        gridRows = new GridRows(api, 'after prepending row');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├── LEAF id:prepended
-            ├── LEAF id:base
-            ├── LEAF id:longhand-row result:250
-            ├── LEAF id:absolute-row result:10
-            └── LEAF id:relative-row result:250
+            ├── LEAF id:prepended row-number:"1" source:10
+            ├── LEAF id:base row-number:"2" source:250
+            ├── LEAF id:longhand-row row-number:"3" result:250
+            ├── LEAF id:absolute-row row-number:"4" result:10
+            └── LEAF id:relative-row row-number:"5" result:250
         `);
     });
 
@@ -689,27 +678,23 @@ describe('ag-grid formulas general behaviour', () => {
 
         const api = gridsManager.createGrid('formulas-abs-rel', gridOptions);
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['value'],
-        };
-
-        let gridRows = new GridRows(api, 'initial absolute/relative references', gridRowsOptions);
+        let gridRows = new GridRows(api, 'initial absolute/relative references');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├── LEAF id:x-base
-            ├── LEAF id:relative-A1 value:10
-            ├── LEAF id:"absolute-row-A$1" value:10
-            ├── LEAF id:"absolute-col-$A1" value:10
-            ├── LEAF id:"absolute-both-$A$1" value:10
-            ├── LEAF id:x-middle
-            ├── LEAF id:relative-forward-A6 value:40
-            ├── LEAF id:"absolute-row-forward-A$6" value:40
-            ├── LEAF id:"absolute-col-forward-$A6" value:40
-            ├── LEAF id:"absolute-both-forward-$A$6" value:40
-            ├── LEAF id:relative-self-A11 value:130
-            ├── LEAF id:"absolute-row-self-A$12" value:135
-            ├── LEAF id:"absolute-col-self-$A13" value:140
-            └── LEAF id:"absolute-mixed-A$1+$B2" value:25
+            ├── LEAF id:x-base row-number:"1" x:10 y:5
+            ├── LEAF id:relative-A1 row-number:"2" y:15 value:10
+            ├── LEAF id:"absolute-row-A$1" row-number:"3" value:10
+            ├── LEAF id:"absolute-col-$A1" row-number:"4" value:10
+            ├── LEAF id:"absolute-both-$A$1" row-number:"5" value:10
+            ├── LEAF id:x-middle row-number:"6" x:40 y:10
+            ├── LEAF id:relative-forward-A6 row-number:"7" value:40
+            ├── LEAF id:"absolute-row-forward-A$6" row-number:"8" value:40
+            ├── LEAF id:"absolute-col-forward-$A6" row-number:"9" value:40
+            ├── LEAF id:"absolute-both-forward-$A$6" row-number:"10" value:40
+            ├── LEAF id:relative-self-A11 row-number:"11" x:130 y:17 value:130
+            ├── LEAF id:"absolute-row-self-A$12" row-number:"12" x:135 y:18 value:135
+            ├── LEAF id:"absolute-col-self-$A13" row-number:"13" x:140 y:19 value:140
+            └── LEAF id:"absolute-mixed-A$1+$B2" row-number:"14" value:25
         `);
 
         const updatedRowData = [
@@ -740,23 +725,23 @@ describe('ag-grid formulas general behaviour', () => {
         api.updateGridOptions({ rowData: updatedRowData });
         await asyncSetTimeout(rowNumberRefreshBufferMs);
 
-        gridRows = new GridRows(api, 'after setRowData update', gridRowsOptions);
+        gridRows = new GridRows(api, 'after setRowData update');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├── LEAF id:x-base
-            ├── LEAF id:relative-A1 value:25
-            ├── LEAF id:"absolute-row-A$1" value:25
-            ├── LEAF id:"absolute-col-$A1" value:25
-            ├── LEAF id:"absolute-both-$A$1" value:25
-            ├── LEAF id:x-middle
-            ├── LEAF id:relative-forward-A6 value:60
-            ├── LEAF id:"absolute-row-forward-A$6" value:60
-            ├── LEAF id:"absolute-col-forward-$A6" value:60
-            ├── LEAF id:"absolute-both-forward-$A$6" value:60
-            ├── LEAF id:relative-self-A11 value:140
-            ├── LEAF id:"absolute-row-self-A$12" value:145
-            ├── LEAF id:"absolute-col-self-$A13" value:150
-            └── LEAF id:"absolute-mixed-A$1+$B2" value:43
+            ├── LEAF id:x-base row-number:"1" x:25 y:7
+            ├── LEAF id:relative-A1 row-number:"2" y:18 value:25
+            ├── LEAF id:"absolute-row-A$1" row-number:"3" value:25
+            ├── LEAF id:"absolute-col-$A1" row-number:"4" value:25
+            ├── LEAF id:"absolute-both-$A$1" row-number:"5" value:25
+            ├── LEAF id:x-middle row-number:"6" x:60 y:12
+            ├── LEAF id:relative-forward-A6 row-number:"7" value:60
+            ├── LEAF id:"absolute-row-forward-A$6" row-number:"8" value:60
+            ├── LEAF id:"absolute-col-forward-$A6" row-number:"9" value:60
+            ├── LEAF id:"absolute-both-forward-$A$6" row-number:"10" value:60
+            ├── LEAF id:relative-self-A11 row-number:"11" x:140 y:20 value:140
+            ├── LEAF id:"absolute-row-self-A$12" row-number:"12" x:145 y:21 value:145
+            ├── LEAF id:"absolute-col-self-$A13" row-number:"13" x:150 y:22 value:150
+            └── LEAF id:"absolute-mixed-A$1+$B2" row-number:"14" value:43
         `);
 
         applyTransactionChecked(api, {
@@ -765,24 +750,24 @@ describe('ag-grid formulas general behaviour', () => {
         });
         await asyncSetTimeout(rowNumberRefreshBufferMs);
 
-        gridRows = new GridRows(api, 'after inserting a new first row', gridRowsOptions);
+        gridRows = new GridRows(api, 'after inserting a new first row');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├── LEAF id:prepended-row
-            ├── LEAF id:x-base
-            ├── LEAF id:relative-A1 value:25
-            ├── LEAF id:"absolute-row-A$1" value:-5
-            ├── LEAF id:"absolute-col-$A1" value:25
-            ├── LEAF id:"absolute-both-$A$1" value:-5
-            ├── LEAF id:x-middle
-            ├── LEAF id:relative-forward-A6 value:60
-            ├── LEAF id:"absolute-row-forward-A$6"
-            ├── LEAF id:"absolute-col-forward-$A6" value:60
-            ├── LEAF id:"absolute-both-forward-$A$6"
-            ├── LEAF id:relative-self-A11 value:140
-            ├── LEAF id:"absolute-row-self-A$12" value:140
-            ├── LEAF id:"absolute-col-self-$A13" value:150
-            └── LEAF id:"absolute-mixed-A$1+$B2" value:13
+            ├── LEAF id:prepended-row row-number:"1" x:-5 y:-2
+            ├── LEAF id:x-base row-number:"2" x:25 y:7
+            ├── LEAF id:relative-A1 row-number:"3" y:18 value:25
+            ├── LEAF id:"absolute-row-A$1" row-number:"4" value:-5
+            ├── LEAF id:"absolute-col-$A1" row-number:"5" value:25
+            ├── LEAF id:"absolute-both-$A$1" row-number:"6" value:-5
+            ├── LEAF id:x-middle row-number:"7" x:60 y:12
+            ├── LEAF id:relative-forward-A6 row-number:"8" value:60
+            ├── LEAF id:"absolute-row-forward-A$6" row-number:"9"
+            ├── LEAF id:"absolute-col-forward-$A6" row-number:"10" value:60
+            ├── LEAF id:"absolute-both-forward-$A$6" row-number:"11"
+            ├── LEAF id:relative-self-A11 row-number:"12" x:140 y:20 value:140
+            ├── LEAF id:"absolute-row-self-A$12" row-number:"13" x:145 y:21 value:140
+            ├── LEAF id:"absolute-col-self-$A13" row-number:"14" x:150 y:22 value:150
+            └── LEAF id:"absolute-mixed-A$1+$B2" row-number:"15" value:13
         `);
 
         api.applyColumnState({
@@ -790,24 +775,24 @@ describe('ag-grid formulas general behaviour', () => {
             applyOrder: true,
         });
 
-        gridRows = new GridRows(api, 'after column reorder', gridRowsOptions);
+        gridRows = new GridRows(api, 'after column reorder');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├── LEAF id:prepended-row
-            ├── LEAF id:x-base
-            ├── LEAF id:relative-A1 value:25
-            ├── LEAF id:"absolute-row-A$1" value:-5
-            ├── LEAF id:"absolute-col-$A1" value:7
-            ├── LEAF id:"absolute-both-$A$1" value:-2
-            ├── LEAF id:x-middle
-            ├── LEAF id:relative-forward-A6 value:60
-            ├── LEAF id:"absolute-row-forward-A$6"
-            ├── LEAF id:"absolute-col-forward-$A6" value:12
-            ├── LEAF id:"absolute-both-forward-$A$6"
-            ├── LEAF id:relative-self-A11 value:140
-            ├── LEAF id:"absolute-row-self-A$12" value:140
-            ├── LEAF id:"absolute-col-self-$A13" value:22
-            └── LEAF id:"absolute-mixed-A$1+$B2" value:-5
+            ├── LEAF id:prepended-row row-number:"1" y:-2 x:-5
+            ├── LEAF id:x-base row-number:"2" y:7 x:25
+            ├── LEAF id:relative-A1 row-number:"3" y:18 value:25
+            ├── LEAF id:"absolute-row-A$1" row-number:"4" value:-5
+            ├── LEAF id:"absolute-col-$A1" row-number:"5" value:7
+            ├── LEAF id:"absolute-both-$A$1" row-number:"6" value:-2
+            ├── LEAF id:x-middle row-number:"7" y:12 x:60
+            ├── LEAF id:relative-forward-A6 row-number:"8" value:60
+            ├── LEAF id:"absolute-row-forward-A$6" row-number:"9"
+            ├── LEAF id:"absolute-col-forward-$A6" row-number:"10" value:12
+            ├── LEAF id:"absolute-both-forward-$A$6" row-number:"11"
+            ├── LEAF id:relative-self-A11 row-number:"12" y:20 x:140 value:140
+            ├── LEAF id:"absolute-row-self-A$12" row-number:"13" y:21 x:145 value:140
+            ├── LEAF id:"absolute-col-self-$A13" row-number:"14" y:22 x:150 value:22
+            └── LEAF id:"absolute-mixed-A$1+$B2" row-number:"15" value:-5
         `);
     });
 });

--- a/testing/behavioural/src/grouping-data/group-order-maintenance.test.ts
+++ b/testing/behavioural/src/grouping-data/group-order-maintenance.test.ts
@@ -1,7 +1,6 @@
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { RowGroupingModule } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions } from '../test-utils';
 import { GridRows, TestGridsManager, applyTransactionChecked } from '../test-utils';
 
 describe('group order maintenance', () => {
@@ -11,11 +10,6 @@ describe('group order maintenance', () => {
 
     beforeEach(() => gridsManager.reset());
     afterEach(() => gridsManager.reset());
-
-    const gridRowsOptions: GridRowsOptions = {
-        printIds: false,
-        columns: ['athlete'],
-    };
 
     test('new group is appended at end when groupMaintainOrder is true', async () => {
         const rowData = [
@@ -34,28 +28,28 @@ describe('group order maintenance', () => {
             getRowId: (p) => p.data.id,
         });
 
-        await new GridRows(api, 'initial', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ ├── LEAF athlete:"I1"
-            │ └── LEAF athlete:"I2"
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"It1"
+        await new GridRows(api, 'initial').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:1 country:"Ireland" athlete:"I1"
+            │ └── LEAF id:2 country:"Ireland" athlete:"I2"
+            └─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · └── LEAF id:3 country:"Italy" athlete:"It1"
         `);
 
         // Add a new row that creates a new group (France)
         applyTransactionChecked(api, { add: [{ id: '4', country: 'France', athlete: 'F1' }] });
 
         // Expect the new group to be appended at the end (Ireland, Italy, France)
-        await new GridRows(api, 'after add France', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ ├── LEAF athlete:"I1"
-            │ └── LEAF athlete:"I2"
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"It1"
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"F1"
+        await new GridRows(api, 'after add France').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:1 country:"Ireland" athlete:"I1"
+            │ └── LEAF id:2 country:"Ireland" athlete:"I2"
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ └── LEAF id:3 country:"Italy" athlete:"It1"
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · └── LEAF id:4 country:"France" athlete:"F1"
         `);
     });
 
@@ -77,30 +71,30 @@ describe('group order maintenance', () => {
             getRowId: (p) => p.data.id,
         });
 
-        await new GridRows(api, 'initial', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ ├── LEAF athlete:"I1"
-            │ └── LEAF athlete:"I2"
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"It1"
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"F1"
+        await new GridRows(api, 'initial').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:1 country:"Ireland" athlete:"I1"
+            │ └── LEAF id:2 country:"Ireland" athlete:"I2"
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ └── LEAF id:3 country:"Italy" athlete:"It1"
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · └── LEAF id:4 country:"France" athlete:"F1"
         `);
 
         // Update a leaf inside existing group (Ireland), do not move group
         applyTransactionChecked(api, { update: [{ id: '2', country: 'Ireland', athlete: 'I2-upd' }] });
 
         // Group order should be unchanged
-        await new GridRows(api, 'after update', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ ├── LEAF athlete:"I1"
-            │ └── LEAF athlete:"I2-upd"
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"It1"
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"F1"
+        await new GridRows(api, 'after update').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:1 country:"Ireland" athlete:"I1"
+            │ └── LEAF id:2 country:"Ireland" athlete:"I2-upd"
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ └── LEAF id:3 country:"Italy" athlete:"It1"
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · └── LEAF id:4 country:"France" athlete:"F1"
         `);
     });
 
@@ -122,29 +116,29 @@ describe('group order maintenance', () => {
             getRowId: (p) => p.data.id,
         });
 
-        await new GridRows(api, 'initial', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ ├── LEAF athlete:"I1"
-            │ └── LEAF athlete:"I2"
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"It1"
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"F1"
+        await new GridRows(api, 'initial').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:1 country:"Ireland" athlete:"I1"
+            │ └── LEAF id:2 country:"Ireland" athlete:"I2"
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ └── LEAF id:3 country:"Italy" athlete:"It1"
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · └── LEAF id:4 country:"France" athlete:"F1"
         `);
 
         applyTransactionChecked(api, { update: [{ id: '2', country: 'Ireland', athlete: 'I2-upd' }] });
 
         // Group order should remain the same even when groupMaintainOrder is false
-        await new GridRows(api, 'after update', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ ├── LEAF athlete:"I1"
-            │ └── LEAF athlete:"I2-upd"
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"It1"
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"F1"
+        await new GridRows(api, 'after update').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:1 country:"Ireland" athlete:"I1"
+            │ └── LEAF id:2 country:"Ireland" athlete:"I2-upd"
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ └── LEAF id:3 country:"Italy" athlete:"It1"
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · └── LEAF id:4 country:"France" athlete:"F1"
         `);
     });
 
@@ -168,28 +162,27 @@ describe('group order maintenance', () => {
             getRowId: (p) => p.data.id,
         });
 
-        await new GridRows(api, 'initial', { printIds: false, columns: ['athlete'] }).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"Zed"
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"Ann"
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"Mike"
+        await new GridRows(api, 'initial').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ └── LEAF id:1 country:"Ireland" athlete:"Zed"
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ └── LEAF id:2 country:"Italy" athlete:"Ann"
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · └── LEAF id:3 country:"France" athlete:"Mike"
         `);
 
         // Sort by a leaf column. Group order should remain insertion order.
         api.applyColumnState({ state: [{ colId: 'athlete', sort: 'asc' }] });
 
-        await new GridRows(api, 'leaf sort asc preserves group order', { printIds: false, columns: ['athlete'] })
-            .check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"Zed"
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"Ann"
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"Mike"
+        await new GridRows(api, 'leaf sort asc preserves group order').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ └── LEAF id:1 country:"Ireland" athlete:"Zed"
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ └── LEAF id:2 country:"Italy" athlete:"Ann"
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · └── LEAF id:3 country:"France" athlete:"Mike"
         `);
     });
 
@@ -213,40 +206,40 @@ describe('group order maintenance', () => {
             getRowId: (p) => p.data.id,
         });
 
-        await new GridRows(api, 'initial', { printIds: false, columns: ['athlete'] }).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"A"
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"B"
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"C"
+        await new GridRows(api, 'initial').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ └── LEAF id:1 country:"Ireland" athlete:"A"
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ └── LEAF id:2 country:"Italy" athlete:"B"
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · └── LEAF id:3 country:"France" athlete:"C"
         `);
 
         // Sort by the primary grouped column; groups should reorder alphabetically: France, Ireland, Italy
         api.applyColumnState({ state: [{ colId: 'country', sort: 'asc' }] });
 
-        await new GridRows(api, 'group sort asc', { printIds: false, columns: ['athlete'] }).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"C"
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"A"
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"B"
+        await new GridRows(api, 'group sort asc').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            │ └── LEAF id:3 country:"France" athlete:"C"
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ └── LEAF id:1 country:"Ireland" athlete:"A"
+            └─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · └── LEAF id:2 country:"Italy" athlete:"B"
         `);
 
         // Change to desc: Italy, Ireland, France
         api.applyColumnState({ state: [{ colId: 'country', sort: 'desc' }] });
 
-        await new GridRows(api, 'group sort desc', { printIds: false, columns: ['athlete'] }).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"B"
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"A"
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"C"
+        await new GridRows(api, 'group sort desc').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ └── LEAF id:2 country:"Italy" athlete:"B"
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ └── LEAF id:1 country:"Ireland" athlete:"A"
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · └── LEAF id:3 country:"France" athlete:"C"
         `);
     });
 
@@ -272,27 +265,26 @@ describe('group order maintenance', () => {
 
         // Force a group sort order first (desc): Italy, Ireland, France
         api.applyColumnState({ state: [{ colId: 'country', sort: 'desc' }] });
-        await new GridRows(api, 'after group sort desc', { printIds: false, columns: ['athlete'] }).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"A"
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"Z"
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"M"
+        await new GridRows(api, 'after group sort desc').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ └── LEAF id:2 country:"Italy" athlete:"A"
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ └── LEAF id:1 country:"Ireland" athlete:"Z"
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · └── LEAF id:3 country:"France" athlete:"M"
         `);
 
         // Now switch to a leaf sort; group order should remain the same
         api.applyColumnState({ state: [{ colId: 'athlete', sort: 'asc' }] });
-        await new GridRows(api, 'leaf sort maintains last group order', { printIds: false, columns: ['athlete'] })
-            .check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"A"
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"Z"
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"M"
+        await new GridRows(api, 'leaf sort maintains last group order').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ └── LEAF id:2 country:"Italy" athlete:"A"
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ └── LEAF id:1 country:"Ireland" athlete:"Z"
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · └── LEAF id:3 country:"France" athlete:"M"
         `);
     });
     test('after filtering removes a group, adding a new group appends at end', async () => {
@@ -312,39 +304,39 @@ describe('group order maintenance', () => {
             getRowId: (p) => p.data.id,
         });
 
-        await new GridRows(api, 'initial', gridRowsOptions).check(`
-                ROOT
-                ├─┬ LEAF_GROUP
-                │ └── LEAF athlete:"I1"
-                ├─┬ LEAF_GROUP
-                │ └── LEAF athlete:"T1"
-                └─┬ LEAF_GROUP
-                · └── LEAF athlete:"F1"
+        await new GridRows(api, 'initial').check(`
+                ROOT id:ROOT_NODE_ID
+                ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+                │ └── LEAF id:1 country:"Ireland" athlete:"I1"
+                ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+                │ └── LEAF id:2 country:"Italy" athlete:"T1"
+                └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+                · └── LEAF id:3 country:"France" athlete:"F1"
             `);
 
         // Filter out Italy group entirely
         api.setGridOption('quickFilterText', 'I1'); // shows only Ireland
-        await new GridRows(api, 'after filter Ireland only', gridRowsOptions).check(`
-        ROOT
-        └─┬ LEAF_GROUP
-        · └── LEAF athlete:"I1"
+        await new GridRows(api, 'after filter Ireland only').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            · └── LEAF id:1 country:"Ireland" athlete:"I1"
         `);
 
         // Clear filter and add a new country; new group must append after prior order (Ire, Ita, Fra, then new Spain)
         api.setGridOption('quickFilterText', undefined);
         applyTransactionChecked(api, { add: [{ id: '4', country: 'Spain', athlete: 'S1' }] });
 
-        await new GridRows(api, 'after add Spain', gridRowsOptions).check(`
-                ROOT
-                ├─┬ LEAF_GROUP
-                │ └── LEAF athlete:"I1"
-                ├─┬ LEAF_GROUP
-                │ └── LEAF athlete:"T1"
-                ├─┬ LEAF_GROUP
-                │ └── LEAF athlete:"F1"
-                └─┬ LEAF_GROUP
-                · └── LEAF athlete:"S1"
-            `);
+        await new GridRows(api, 'after add Spain').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ └── LEAF id:1 country:"Ireland" athlete:"I1"
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ └── LEAF id:2 country:"Italy" athlete:"T1"
+            ├─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            │ └── LEAF id:3 country:"France" athlete:"F1"
+            └─┬ LEAF_GROUP id:row-group-country-Spain ag-Grid-AutoColumn:"Spain"
+            · └── LEAF id:4 country:"Spain" athlete:"S1"
+        `);
     });
 
     test('after removing a group, adding a new group appends at end (sentinel append)', async () => {
@@ -364,38 +356,38 @@ describe('group order maintenance', () => {
             getRowId: (p) => p.data.id,
         });
 
-        await new GridRows(api, 'initial', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"I1"
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"It1"
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"F1"
+        await new GridRows(api, 'initial').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ └── LEAF id:1 country:"Ireland" athlete:"I1"
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ └── LEAF id:2 country:"Italy" athlete:"It1"
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · └── LEAF id:3 country:"France" athlete:"F1"
         `);
 
         // Remove the middle group (Italy)
         applyTransactionChecked(api, { remove: [{ id: '2', country: 'Italy', athlete: 'It1' }] });
 
-        await new GridRows(api, 'after remove Italy', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"I1"
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"F1"
+        await new GridRows(api, 'after remove Italy').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ └── LEAF id:1 country:"Ireland" athlete:"I1"
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · └── LEAF id:3 country:"France" athlete:"F1"
         `);
 
         // Add a new group (Spain) - should append at end
         applyTransactionChecked(api, { add: [{ id: '4', country: 'Spain', athlete: 'S1' }] });
 
-        await new GridRows(api, 'after add Spain', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"I1"
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"F1"
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"S1"
+        await new GridRows(api, 'after add Spain').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ └── LEAF id:1 country:"Ireland" athlete:"I1"
+            ├─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            │ └── LEAF id:3 country:"France" athlete:"F1"
+            └─┬ LEAF_GROUP id:row-group-country-Spain ag-Grid-AutoColumn:"Spain"
+            · └── LEAF id:4 country:"Spain" athlete:"S1"
         `);
     });
 });

--- a/testing/behavioural/src/grouping-data/grouping-aggregation.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-aggregation.test.ts
@@ -1,7 +1,6 @@
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { RowGroupingModule } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions } from '../test-utils';
 import { GridRows, TestGridsManager, applyTransactionChecked, cachedJSONObjects } from '../test-utils';
 
 describe('ag-grid grouping aggregation', () => {
@@ -44,30 +43,21 @@ describe('ag-grid grouping aggregation', () => {
             groupTotalRow: 'bottom',
         });
 
-        const gridRowsOptionsFormatted: GridRowsOptions = {
-            columns: ['sport', 'gold', 'silver'],
-        };
-
-        const gridRowsOptionsUnformatted: GridRowsOptions = {
-            ...gridRowsOptionsFormatted,
-            useFormatter: false,
-        };
-
-        await new GridRows(api, 'initial', gridRowsOptionsFormatted).check(`
+        await new GridRows(api, 'initial').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-country-Ireland
-            │ ├── LEAF id:1 sport:"Sailing" gold:1 silver:2
-            │ ├── LEAF id:2 sport:"Soccer" gold:2 silver:1
-            │ ├── LEAF id:3 sport:"Football" gold:1 silver:3
-            │ └─ footer id:rowGroupFooter_row-group-country-Ireland gold:4 silver:{"count":3,"value":2}
-            ├─┬ LEAF_GROUP id:row-group-country-Italy
-            │ ├── LEAF id:4 sport:"Soccer" gold:3 silver:1
-            │ ├── LEAF id:5 sport:"Football" gold:2 silver:2
-            │ └─ footer id:rowGroupFooter_row-group-country-Italy gold:5 silver:{"count":2,"value":1.5}
-            └─┬ LEAF_GROUP id:row-group-country-France
-            · ├── LEAF id:6 sport:"Tennis" gold:1 silver:1
-            · ├── LEAF id:7 sport:"Soccer" gold:2 silver:3
-            · └─ footer id:rowGroupFooter_row-group-country-France gold:3 silver:{"count":2,"value":2}
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:1 country:"Ireland" sport:"Sailing" gold:1 silver:2
+            │ ├── LEAF id:2 country:"Ireland" sport:"Soccer" gold:2 silver:1
+            │ ├── LEAF id:3 country:"Ireland" sport:"Football" gold:1 silver:3
+            │ └─ footer id:rowGroupFooter_row-group-country-Ireland ag-Grid-AutoColumn:"Total Ireland" gold:4 silver:{"count":3,"value":2}
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ ├── LEAF id:4 country:"Italy" sport:"Soccer" gold:3 silver:1
+            │ ├── LEAF id:5 country:"Italy" sport:"Football" gold:2 silver:2
+            │ └─ footer id:rowGroupFooter_row-group-country-Italy ag-Grid-AutoColumn:"Total Italy" gold:5 silver:{"count":2,"value":1.5}
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · ├── LEAF id:6 country:"France" sport:"Tennis" gold:1 silver:1
+            · ├── LEAF id:7 country:"France" sport:"Soccer" gold:2 silver:3
+            · └─ footer id:rowGroupFooter_row-group-country-France ag-Grid-AutoColumn:"Total France" gold:3 silver:{"count":2,"value":2}
         `);
 
         applyTransactionChecked(api, {
@@ -78,46 +68,46 @@ describe('ag-grid grouping aggregation', () => {
             ],
         });
 
-        await new GridRows(api, 'after update', gridRowsOptionsFormatted).check(`
+        await new GridRows(api, 'after update', { useFormatter: false }).check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-country-Ireland
-            │ ├── LEAF id:1 sport:"Swimming" gold:12 silver:7
-            │ ├── LEAF id:2 sport:"Soccer" gold:2 silver:1
-            │ ├── LEAF id:3 sport:"Football" gold:1 silver:3
-            │ └─ footer id:rowGroupFooter_row-group-country-Ireland gold:15 silver:{"count":3,"value":3.6666666666666665}
-            ├─┬ LEAF_GROUP id:row-group-country-Italy
-            │ ├── LEAF id:4 sport:"Soccer" gold:3 silver:1
-            │ ├── LEAF id:5 sport:"Football" gold:2 silver:2
-            │ └─ footer id:rowGroupFooter_row-group-country-Italy gold:5 silver:{"count":2,"value":1.5}
-            ├─┬ LEAF_GROUP id:row-group-country-France
-            │ ├── LEAF id:6 sport:"Tennis" gold:1 silver:1
-            │ ├── LEAF id:7 sport:"Soccer" gold:2 silver:3
-            │ └─ footer id:rowGroupFooter_row-group-country-France gold:3 silver:{"count":2,"value":2}
-            └─┬ LEAF_GROUP id:"row-group-country-United Kingdom"
-            · ├── LEAF id:8 sport:"Rowing" gold:4 silver:4
-            · ├── LEAF id:9 sport:"Athletics" gold:5 silver:3
-            · └─ footer id:"rowGroupFooter_row-group-country-United Kingdom" gold:9 silver:{"count":2,"value":3.5}
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:1 country:"Ireland" sport:"Swimming" gold:12 silver:7
+            │ ├── LEAF id:2 country:"Ireland" sport:"Soccer" gold:2 silver:1
+            │ ├── LEAF id:3 country:"Ireland" sport:"Football" gold:1 silver:3
+            │ └─ footer id:rowGroupFooter_row-group-country-Ireland ag-Grid-AutoColumn:"Ireland" gold:15 silver:{"count":3,"value":3.6666666666666665}
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ ├── LEAF id:4 country:"Italy" sport:"Soccer" gold:3 silver:1
+            │ ├── LEAF id:5 country:"Italy" sport:"Football" gold:2 silver:2
+            │ └─ footer id:rowGroupFooter_row-group-country-Italy ag-Grid-AutoColumn:"Italy" gold:5 silver:{"count":2,"value":1.5}
+            ├─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            │ ├── LEAF id:6 country:"France" sport:"Tennis" gold:1 silver:1
+            │ ├── LEAF id:7 country:"France" sport:"Soccer" gold:2 silver:3
+            │ └─ footer id:rowGroupFooter_row-group-country-France ag-Grid-AutoColumn:"France" gold:3 silver:{"count":2,"value":2}
+            └─┬ LEAF_GROUP id:"row-group-country-United Kingdom" ag-Grid-AutoColumn:"United Kingdom"
+            · ├── LEAF id:8 country:"United Kingdom" sport:"Rowing" gold:4 silver:4
+            · ├── LEAF id:9 country:"United Kingdom" sport:"Athletics" gold:5 silver:3
+            · └─ footer id:"rowGroupFooter_row-group-country-United Kingdom" ag-Grid-AutoColumn:"United Kingdom" gold:9 silver:{"count":2,"value":3.5}
         `);
 
-        await new GridRows(api, 'after update', gridRowsOptionsUnformatted).check(`
+        await new GridRows(api, 'after update', { useFormatter: false }).check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-country-Ireland
-            │ ├── LEAF id:1 sport:"Swimming" gold:12 silver:7
-            │ ├── LEAF id:2 sport:"Soccer" gold:2 silver:1
-            │ ├── LEAF id:3 sport:"Football" gold:1 silver:3
-            │ └─ footer id:rowGroupFooter_row-group-country-Ireland gold:15 silver:{"count":3,"value":3.6666666666666665}
-            ├─┬ LEAF_GROUP id:row-group-country-Italy
-            │ ├── LEAF id:4 sport:"Soccer" gold:3 silver:1
-            │ ├── LEAF id:5 sport:"Football" gold:2 silver:2
-            │ └─ footer id:rowGroupFooter_row-group-country-Italy gold:5 silver:{"count":2,"value":1.5}
-            ├─┬ LEAF_GROUP id:row-group-country-France
-            │ ├── LEAF id:6 sport:"Tennis" gold:1 silver:1
-            │ ├── LEAF id:7 sport:"Soccer" gold:2 silver:3
-            │ └─ footer id:rowGroupFooter_row-group-country-France gold:3 silver:{"count":2,"value":2}
-            └─┬ LEAF_GROUP id:"row-group-country-United Kingdom"
-            · ├── LEAF id:8 sport:"Rowing" gold:4 silver:4
-            · ├── LEAF id:9 sport:"Athletics" gold:5 silver:3
-            · └─ footer id:"rowGroupFooter_row-group-country-United Kingdom" gold:9 silver:{"count":2,"value":3.5}
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:1 country:"Ireland" sport:"Swimming" gold:12 silver:7
+            │ ├── LEAF id:2 country:"Ireland" sport:"Soccer" gold:2 silver:1
+            │ ├── LEAF id:3 country:"Ireland" sport:"Football" gold:1 silver:3
+            │ └─ footer id:rowGroupFooter_row-group-country-Ireland ag-Grid-AutoColumn:"Ireland" gold:15 silver:{"count":3,"value":3.6666666666666665}
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ ├── LEAF id:4 country:"Italy" sport:"Soccer" gold:3 silver:1
+            │ ├── LEAF id:5 country:"Italy" sport:"Football" gold:2 silver:2
+            │ └─ footer id:rowGroupFooter_row-group-country-Italy ag-Grid-AutoColumn:"Italy" gold:5 silver:{"count":2,"value":1.5}
+            ├─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            │ ├── LEAF id:6 country:"France" sport:"Tennis" gold:1 silver:1
+            │ ├── LEAF id:7 country:"France" sport:"Soccer" gold:2 silver:3
+            │ └─ footer id:rowGroupFooter_row-group-country-France ag-Grid-AutoColumn:"France" gold:3 silver:{"count":2,"value":2}
+            └─┬ LEAF_GROUP id:"row-group-country-United Kingdom" ag-Grid-AutoColumn:"United Kingdom"
+            · ├── LEAF id:8 country:"United Kingdom" sport:"Rowing" gold:4 silver:4
+            · ├── LEAF id:9 country:"United Kingdom" sport:"Athletics" gold:5 silver:3
+            · └─ footer id:"rowGroupFooter_row-group-country-United Kingdom" ag-Grid-AutoColumn:"United Kingdom" gold:9 silver:{"count":2,"value":3.5}
         `);
     });
 
@@ -223,19 +213,16 @@ describe('ag-grid grouping aggregation', () => {
             getRowId: (params) => params.data.id,
         });
 
-        await new GridRows(api, 'custom aggregation functions (raw)', {
-            columns: ['scores', 'metadata'],
-            useFormatter: false,
-        }).check(`
+        await new GridRows(api, 'custom aggregation functions (raw)', { useFormatter: false }).check(`
             ROOT id:ROOT_NODE_ID scores:87.84 metadata:{"minPriority":null}
-            ├─ footer id:rowGroupFooter_ROOT_NODE_ID scores:87.84 metadata:{"minPriority":null}
-            ├─┬ LEAF_GROUP id:row-group-category-A
-            │ ├── LEAF id:1 scores:[80,90,85] metadata:{"priority":1}
-            │ ├── LEAF id:2 scores:[75,88,92] metadata:{"priority":2}
-            │ └─ footer id:rowGroupFooter_row-group-category-A scores:85 metadata:{"minPriority":1}
-            └─┬ LEAF_GROUP id:row-group-category-B
-            · ├── LEAF id:3 scores:[95,87,90] metadata:{"priority":1}
-            · └─ footer id:rowGroupFooter_row-group-category-B scores:90.67 metadata:{"minPriority":1}
+            ├─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:null scores:87.84 metadata:{"minPriority":null}
+            ├─┬ LEAF_GROUP id:row-group-category-A ag-Grid-AutoColumn:"A"
+            │ ├── LEAF id:1 category:"A" scores:[80,90,85] metadata:{"priority":1}
+            │ ├── LEAF id:2 category:"A" scores:[75,88,92] metadata:{"priority":2}
+            │ └─ footer id:rowGroupFooter_row-group-category-A ag-Grid-AutoColumn:"A" scores:85 metadata:{"minPriority":1}
+            └─┬ LEAF_GROUP id:row-group-category-B ag-Grid-AutoColumn:"B"
+            · ├── LEAF id:3 category:"B" scores:[95,87,90] metadata:{"priority":1}
+            · └─ footer id:rowGroupFooter_row-group-category-B ag-Grid-AutoColumn:"B" scores:90.67 metadata:{"minPriority":1}
         `);
 
         await new GridRows(api, 'custom aggregation functions (formatted)').check(`
@@ -255,10 +242,7 @@ describe('ag-grid grouping aggregation', () => {
             add: [{ id: '4', category: 'C', scores: [70, 74, 78], metadata: { priority: 2 } }],
         });
 
-        await new GridRows(api, 'after transaction (raw)', {
-            columns: ['scores', 'metadata'],
-            useFormatter: false,
-        }).check(`
+        await new GridRows(api, 'after transaction (raw)', { useFormatter: false }).check(`
             ROOT id:ROOT_NODE_ID scores:83.72 metadata:{"minPriority":null}
             ├─ footer id:rowGroupFooter_ROOT_NODE_ID scores:83.72 metadata:{"minPriority":null}
             ├─┬ LEAF_GROUP id:row-group-category-A

--- a/testing/behavioural/src/grouping-data/grouping-aggregation.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-aggregation.test.ts
@@ -244,17 +244,17 @@ describe('ag-grid grouping aggregation', () => {
 
         await new GridRows(api, 'after transaction (raw)', { useFormatter: false }).check(`
             ROOT id:ROOT_NODE_ID scores:83.72 metadata:{"minPriority":null}
-            ├─ footer id:rowGroupFooter_ROOT_NODE_ID scores:83.72 metadata:{"minPriority":null}
-            ├─┬ LEAF_GROUP id:row-group-category-A
-            │ ├── LEAF id:1 scores:[80,90,85] metadata:{"priority":1}
-            │ ├── LEAF id:2 scores:[82,94,88] metadata:{"priority":3}
-            │ └─ footer id:rowGroupFooter_row-group-category-A scores:86.5 metadata:{"minPriority":1}
-            ├─┬ LEAF_GROUP id:row-group-category-B
-            │ ├── LEAF id:3 scores:[95,87,90] metadata:{"priority":1}
-            │ └─ footer id:rowGroupFooter_row-group-category-B scores:90.67 metadata:{"minPriority":1}
-            └─┬ LEAF_GROUP id:row-group-category-C
-            · ├── LEAF id:4 scores:[70,74,78] metadata:{"priority":2}
-            · └─ footer id:rowGroupFooter_row-group-category-C scores:74 metadata:{"minPriority":2}
+            ├─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:null scores:83.72 metadata:{"minPriority":null}
+            ├─┬ LEAF_GROUP id:row-group-category-A ag-Grid-AutoColumn:"A"
+            │ ├── LEAF id:1 category:"A" scores:[80,90,85] metadata:{"priority":1}
+            │ ├── LEAF id:2 category:"A" scores:[82,94,88] metadata:{"priority":3}
+            │ └─ footer id:rowGroupFooter_row-group-category-A ag-Grid-AutoColumn:"A" scores:86.5 metadata:{"minPriority":1}
+            ├─┬ LEAF_GROUP id:row-group-category-B ag-Grid-AutoColumn:"B"
+            │ ├── LEAF id:3 category:"B" scores:[95,87,90] metadata:{"priority":1}
+            │ └─ footer id:rowGroupFooter_row-group-category-B ag-Grid-AutoColumn:"B" scores:90.67 metadata:{"minPriority":1}
+            └─┬ LEAF_GROUP id:row-group-category-C ag-Grid-AutoColumn:"C"
+            · ├── LEAF id:4 category:"C" scores:[70,74,78] metadata:{"priority":2}
+            · └─ footer id:rowGroupFooter_row-group-category-C ag-Grid-AutoColumn:"C" scores:74 metadata:{"minPriority":2}
         `);
 
         await new GridRows(api, 'after transaction (formatted)').check(`

--- a/testing/behavioural/src/grouping-data/grouping-complex-transactions.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-complex-transactions.test.ts
@@ -1,10 +1,7 @@
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { RowGroupingModule } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions } from '../test-utils';
 import { GridRows, TestGridsManager, applyTransactionChecked } from '../test-utils';
-
-const gridRowsOptions: GridRowsOptions = {};
 
 describe('ag-grid grouping complex transactions', () => {
     const gridsManager = new TestGridsManager({
@@ -54,7 +51,7 @@ describe('ag-grid grouping complex transactions', () => {
             getRowId: (params) => params.data.id,
         });
 
-        let gridRows = new GridRows(api, 'initial', gridRowsOptions);
+        let gridRows = new GridRows(api, 'initial');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
@@ -73,7 +70,7 @@ describe('ag-grid grouping complex transactions', () => {
             remove: [row0],
         });
 
-        gridRows = new GridRows(api, 'complex transaction 1', gridRowsOptions);
+        gridRows = new GridRows(api, 'complex transaction 1');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
@@ -96,7 +93,7 @@ describe('ag-grid grouping complex transactions', () => {
             remove: [row2, row3],
         });
 
-        gridRows = new GridRows(api, 'complex transaction 2', gridRowsOptions);
+        gridRows = new GridRows(api, 'complex transaction 2');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-France ag-Grid-AutoColumn:"France"
@@ -133,7 +130,7 @@ describe('ag-grid grouping complex transactions', () => {
         // Flush async transactions
         api.flushAsyncTransactions();
 
-        await new GridRows(api, 'async batched adds', gridRowsOptions).check(`
+        await new GridRows(api, 'async batched adds').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
             │ └── LEAF id:1 country:"Ireland" athlete:"John Smith" sport:"Sailing"
@@ -155,7 +152,7 @@ describe('ag-grid grouping complex transactions', () => {
         // Flush async transactions
         api.flushAsyncTransactions();
 
-        await new GridRows(api, 'async batched mixed operations', gridRowsOptions).check(`
+        await new GridRows(api, 'async batched mixed operations').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
             │ └── LEAF id:1 country:"Ireland" athlete:"John Smith Updated" sport:"Sailing"
@@ -180,7 +177,7 @@ describe('ag-grid grouping complex transactions', () => {
             getRowId: (params) => params.data.id,
         });
 
-        await new GridRows(api, 'initial', gridRowsOptions).check(`
+        await new GridRows(api, 'initial').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
             │ ├── LEAF id:a country:"Ireland" athlete:"John Smith" sport:"Sailing"
@@ -194,7 +191,7 @@ describe('ag-grid grouping complex transactions', () => {
             update: [{ id: 'a', country: 'Italy', athlete: 'John Smith', sport: 'Sailing' }],
         });
 
-        await new GridRows(api, 'moved John Smith to Italy', gridRowsOptions).check(`
+        await new GridRows(api, 'moved John Smith to Italy').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
             │ └── LEAF id:b country:"Ireland" athlete:"Jane Doe" sport:"Soccer"
@@ -211,7 +208,7 @@ describe('ag-grid grouping complex transactions', () => {
             ],
         });
 
-        await new GridRows(api, 'moved Jane and Mario to France', gridRowsOptions).check(`
+        await new GridRows(api, 'moved Jane and Mario to France').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
             │ └── LEAF id:a country:"Italy" athlete:"John Smith" sport:"Sailing"
@@ -240,7 +237,7 @@ describe('ag-grid grouping complex transactions', () => {
             getRowId: (params) => params.data.id,
         });
 
-        await new GridRows(api, 'initial', gridRowsOptions).check(`
+        await new GridRows(api, 'initial').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
             │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2020 ag-Grid-AutoColumn:2020
@@ -256,7 +253,7 @@ describe('ag-grid grouping complex transactions', () => {
         // Remove all Ireland 2020 rows - the year group should be removed
         applyTransactionChecked(api, { remove: [rowA, rowB] });
 
-        await new GridRows(api, 'Ireland 2020 group removed', gridRowsOptions).check(`
+        await new GridRows(api, 'Ireland 2020 group removed').check(`
             ROOT id:ROOT_NODE_ID 
             ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
             │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2021 ag-Grid-AutoColumn:2021
@@ -269,7 +266,7 @@ describe('ag-grid grouping complex transactions', () => {
         // Remove the last Ireland row - the country group should be removed
         applyTransactionChecked(api, { remove: [rowC] });
 
-        await new GridRows(api, 'Ireland country group removed', gridRowsOptions).check(`
+        await new GridRows(api, 'Ireland country group removed').check(`
             ROOT id:ROOT_NODE_ID
             └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
             · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2020 ag-Grid-AutoColumn:2020
@@ -279,7 +276,7 @@ describe('ag-grid grouping complex transactions', () => {
         // Remove the last row completely
         applyTransactionChecked(api, { remove: [rowD] });
 
-        await new GridRows(api, 'all groups removed', gridRowsOptions).check('empty');
+        await new GridRows(api, 'all groups removed').check('empty');
 
         // Add back some data to verify groups are recreated properly
         applyTransactionChecked(api, {
@@ -289,7 +286,7 @@ describe('ag-grid grouping complex transactions', () => {
             ],
         });
 
-        await new GridRows(api, 'new groups created', gridRowsOptions).check(`
+        await new GridRows(api, 'new groups created').check(`
             ROOT id:ROOT_NODE_ID
             └─┬ filler id:row-group-country-Spain ag-Grid-AutoColumn:"Spain"
             · └─┬ LEAF_GROUP id:row-group-country-Spain-year-2022 ag-Grid-AutoColumn:2022
@@ -334,7 +331,7 @@ describe('ag-grid grouping complex transactions', () => {
         // All modes should result in the same final structure
         if (mode === 'together') {
             // Together mode may have different ordering due to mixed sync/async operations
-            await new GridRows(api, `${mode} final result`, gridRowsOptions).check(`
+            await new GridRows(api, `${mode} final result`).check(`
                 ROOT id:ROOT_NODE_ID
                 ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
                 │ └── LEAF id:b country:"Ireland" athlete:"Jane Doe" sport:"Soccer"
@@ -344,7 +341,7 @@ describe('ag-grid grouping complex transactions', () => {
                 · └── LEAF id:c country:"Italy" athlete:"Mario Rossi" sport:"Soccer"
             `);
         } else {
-            await new GridRows(api, `${mode} final result`, gridRowsOptions).check(`
+            await new GridRows(api, `${mode} final result`).check(`
                 ROOT id:ROOT_NODE_ID
                 ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
                 │ └── LEAF id:b country:"Ireland" athlete:"Jane Doe" sport:"Soccer"

--- a/testing/behavioural/src/grouping-data/grouping-custom-cell-data-types.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-custom-cell-data-types.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, test } from 'vitest';
+
+import type { GridOptions } from 'ag-grid-community';
+import { ClientSideRowModelModule, GROUP_HIERARCHY_COLUMN_ID_PREFIX } from 'ag-grid-community';
+import { ColumnsToolPanelModule, FiltersToolPanelModule, RowGroupingModule, SideBarModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, cachedJSONObjects } from '../test-utils';
+
+interface CustomCellDataRow {
+    id: string;
+    athlete: string;
+    countryObject: { code: string };
+    sportObject: { name: string };
+    date: string;
+    total: number;
+}
+
+describe('grouping providing custom cell data types', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [
+            ClientSideRowModelModule,
+            RowGroupingModule,
+            SideBarModule,
+            ColumnsToolPanelModule,
+            FiltersToolPanelModule,
+        ],
+    });
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    test('group hierarchy splits date values into year and month groups', async () => {
+        const DATE_REGEX = /\d{2}\/\d{2}\/\d{4}/;
+
+        const DATA_TYPE_DEFINITIONS: GridOptions<CustomCellDataRow>['dataTypeDefinitions'] = {
+            country: {
+                baseDataType: 'object',
+                extendsDataType: 'object',
+                valueParser: (params) =>
+                    params.newValue == null || params.newValue === '' ? null : { code: params.newValue },
+                valueFormatter: (params) => (params.value == null ? '' : params.value.code),
+                dataTypeMatcher: (value) => value && !!value.code,
+            },
+            sport: {
+                baseDataType: 'object',
+                extendsDataType: 'object',
+                valueParser: (params) =>
+                    params.newValue == null || params.newValue === '' ? null : { name: params.newValue },
+                valueFormatter: (params) => (params.value == null ? '' : params.value.name),
+                dataTypeMatcher: (value) => value && !!value.name,
+            },
+            dateString: {
+                baseDataType: 'dateString',
+                extendsDataType: 'dateString',
+                valueParser: (params) =>
+                    params.newValue != null && params.newValue.match(DATE_REGEX) ? params.newValue : null,
+                valueFormatter: (params) => (params.value == null ? '' : params.value),
+                dataTypeMatcher: (value) => typeof value === 'string' && !!value.match(DATE_REGEX),
+                dateParser: (value) => {
+                    if (value == null || value === '') {
+                        return undefined;
+                    }
+                    const dateParts = value.split('/');
+                    return dateParts.length === 3
+                        ? new Date(parseInt(dateParts[2]), parseInt(dateParts[1]) - 1, parseInt(dateParts[0]))
+                        : undefined;
+                },
+                dateFormatter: (value) => {
+                    if (value == null) {
+                        return undefined;
+                    }
+                    const date = String(value.getDate());
+                    const month = String(value.getMonth() + 1);
+                    return `${date.length === 1 ? '0' + date : date}/${month.length === 1 ? '0' + month : month}/${value.getFullYear()}`;
+                },
+            },
+        };
+
+        const rowData = cachedJSONObjects.array<CustomCellDataRow>([
+            {
+                id: '1',
+                athlete: 'Athlete A',
+                countryObject: { code: 'US' },
+                sportObject: { name: 'Swimming' },
+                date: '24/08/2008',
+                total: 4,
+            },
+            {
+                id: '2',
+                athlete: 'Athlete B',
+                countryObject: { code: 'GB' },
+                sportObject: { name: 'Cycling' },
+                date: '25/08/2008',
+                total: 2,
+            },
+            {
+                id: '3',
+                athlete: 'Athlete C',
+                countryObject: { code: 'BR' },
+                sportObject: { name: 'Running' },
+                date: '01/09/2008',
+                total: 3,
+            },
+        ]);
+
+        const api = gridsManager.createGrid('customCellDataTypes', {
+            columnDefs: [
+                { field: 'athlete' },
+                { field: 'countryObject', headerName: 'Country', cellDataType: 'country' },
+                { field: 'sportObject', headerName: 'Sport', cellDataType: 'sport' },
+                {
+                    field: 'date',
+                    cellDataType: 'dateString',
+                    rowGroup: true,
+                    enableRowGroup: true,
+                    groupHierarchy: ['year', 'month'],
+                },
+                { field: 'total', aggFunc: 'sum' },
+            ],
+            rowData,
+            getRowId: (params) => params.data.id,
+            animateRows: false,
+            groupDefaultExpanded: -1,
+            groupTotalRow: 'bottom',
+            grandTotalRow: 'bottom',
+            alwaysAggregateAtRootLevel: true,
+            autoGroupColumnDef: { headerName: 'Date Hierarchy' },
+            dataTypeDefinitions: DATA_TYPE_DEFINITIONS,
+            sideBar: true,
+            defaultColDef: {},
+        } satisfies GridOptions<CustomCellDataRow>);
+
+        const colPrefix = GROUP_HIERARCHY_COLUMN_ID_PREFIX;
+        const level0GroupRowId = `row-group-${colPrefix}-date-year-2008`;
+        const level1GroupRowId = `${level0GroupRowId}-${colPrefix}-date-month-8`;
+        const level2GroupRowId = `${level1GroupRowId}-date-24/08/2008`;
+
+        const getRowNodeOrFail = (rowId: string) => {
+            const node = api.getRowNode(rowId);
+            expect(node).toBeTruthy();
+            return node!;
+        };
+
+        const setAllGroupNodesExpanded = (expanded: boolean) => {
+            api.forEachNode((node) => {
+                if (node.group) {
+                    node.setExpanded(expanded, undefined, true);
+                }
+            });
+        };
+
+        const expectGroupLabelAndCount = (rowId: string, expectedKey: string, expectedChildren: number) => {
+            const rowNode = api.getRowNode(rowId);
+            expect(rowNode?.key).toBe(expectedKey);
+            expect(rowNode?.allChildrenCount).toBe(expectedChildren);
+        };
+
+        const getRowGroupColIds = () => api.getRowGroupColumns().map((column) => column.getColId());
+        const initialRowGroupIds = ['ag-Grid-HierarchyColumn-date-year', 'ag-Grid-HierarchyColumn-date-month', 'date'];
+        const expectRowGroupColumnCount = (count: number) => expect(getRowGroupColIds()).toHaveLength(count);
+
+        setAllGroupNodesExpanded(false);
+        expectGroupLabelAndCount(level0GroupRowId, '2008', 3);
+
+        const level0RowNode = getRowNodeOrFail(level0GroupRowId);
+        level0RowNode.setExpanded(true, undefined, true);
+        expectGroupLabelAndCount(level1GroupRowId, '8', 2);
+
+        const level1RowNode = getRowNodeOrFail(level1GroupRowId);
+        level1RowNode.setExpanded(true, undefined, true);
+        expectGroupLabelAndCount(level2GroupRowId, '24/08/2008', 1);
+
+        setAllGroupNodesExpanded(true);
+        await new GridRows(api, 'custom cell data hierarchy').check(`
+            ROOT id:ROOT_NODE_ID ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null total:9
+            ├─┬ filler id:row-group-ag-Grid-HierarchyColumn-date-year-2008 ag-Grid-AutoColumn:"2008" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null
+            │ ├─┬ filler id:row-group-ag-Grid-HierarchyColumn-date-year-2008-ag-Grid-HierarchyColumn-date-month-8 ag-Grid-AutoColumn:"8" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null
+            │ │ ├─┬ LEAF_GROUP id:"row-group-ag-Grid-HierarchyColumn-date-year-2008-ag-Grid-HierarchyColumn-date-month-8-date-24/08/2008" ag-Grid-AutoColumn:"24/08/2008" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null
+            │ │ │ ├── LEAF id:1 ag-Grid-HierarchyColumn-date-year:"2008" ag-Grid-HierarchyColumn-date-month:"8" athlete:"Athlete A" countryObject:"US" sportObject:"Swimming" date:"24/08/2008" total:4
+            │ │ │ └─ footer id:"rowGroupFooter_row-group-ag-Grid-HierarchyColumn-date-year-2008-ag-Grid-HierarchyColumn-date-month-8-date-24/08/2008" ag-Grid-AutoColumn:"Total 24/08/2008" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null total:4
+            │ │ ├─┬ LEAF_GROUP id:"row-group-ag-Grid-HierarchyColumn-date-year-2008-ag-Grid-HierarchyColumn-date-month-8-date-25/08/2008" ag-Grid-AutoColumn:"25/08/2008" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null
+            │ │ │ ├── LEAF id:2 ag-Grid-HierarchyColumn-date-year:"2008" ag-Grid-HierarchyColumn-date-month:"8" athlete:"Athlete B" countryObject:"GB" sportObject:"Cycling" date:"25/08/2008" total:2
+            │ │ │ └─ footer id:"rowGroupFooter_row-group-ag-Grid-HierarchyColumn-date-year-2008-ag-Grid-HierarchyColumn-date-month-8-date-25/08/2008" ag-Grid-AutoColumn:"Total 25/08/2008" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null total:2
+            │ │ └─ footer id:rowGroupFooter_row-group-ag-Grid-HierarchyColumn-date-year-2008-ag-Grid-HierarchyColumn-date-month-8 ag-Grid-AutoColumn:"Total 8" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null total:6
+            │ ├─┬ filler id:row-group-ag-Grid-HierarchyColumn-date-year-2008-ag-Grid-HierarchyColumn-date-month-9 ag-Grid-AutoColumn:"9" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null
+            │ │ ├─┬ LEAF_GROUP id:"row-group-ag-Grid-HierarchyColumn-date-year-2008-ag-Grid-HierarchyColumn-date-month-9-date-01/09/2008" ag-Grid-AutoColumn:"01/09/2008" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null
+            │ │ │ ├── LEAF id:3 ag-Grid-HierarchyColumn-date-year:"2008" ag-Grid-HierarchyColumn-date-month:"9" athlete:"Athlete C" countryObject:"BR" sportObject:"Running" date:"01/09/2008" total:3
+            │ │ │ └─ footer id:"rowGroupFooter_row-group-ag-Grid-HierarchyColumn-date-year-2008-ag-Grid-HierarchyColumn-date-month-9-date-01/09/2008" ag-Grid-AutoColumn:"Total 01/09/2008" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null total:3
+            │ │ └─ footer id:rowGroupFooter_row-group-ag-Grid-HierarchyColumn-date-year-2008-ag-Grid-HierarchyColumn-date-month-9 ag-Grid-AutoColumn:"Total 9" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null total:3
+            │ └─ footer id:rowGroupFooter_row-group-ag-Grid-HierarchyColumn-date-year-2008 ag-Grid-AutoColumn:"Total 2008" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null total:9
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null total:9
+        `);
+
+        expect(getRowGroupColIds()).toEqual(initialRowGroupIds);
+        expectRowGroupColumnCount(3);
+
+        api.setColumnsVisible(['ag-Grid-HierarchyColumn-date-year', 'ag-Grid-HierarchyColumn-date-month'], true);
+        expect(getRowGroupColIds()).toEqual(initialRowGroupIds);
+        expectRowGroupColumnCount(3);
+
+        api.removeRowGroupColumns(['date']);
+        expect(getRowGroupColIds()).toEqual([
+            'ag-Grid-HierarchyColumn-date-year',
+            'ag-Grid-HierarchyColumn-date-month',
+        ]);
+        expectRowGroupColumnCount(2);
+        setAllGroupNodesExpanded(true);
+        await new GridRows(api, 'after removing original date group').check(`
+            ROOT id:ROOT_NODE_ID ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null total:9
+            ├─┬ filler id:row-group-ag-Grid-HierarchyColumn-date-year-2008 ag-Grid-AutoColumn:"2008" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null
+            │ ├─┬ LEAF_GROUP id:row-group-ag-Grid-HierarchyColumn-date-year-2008-ag-Grid-HierarchyColumn-date-month-8 ag-Grid-AutoColumn:"8" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null
+            │ │ ├── LEAF id:1 ag-Grid-HierarchyColumn-date-year:"2008" ag-Grid-HierarchyColumn-date-month:"8" athlete:"Athlete A" countryObject:"US" sportObject:"Swimming" date:"24/08/2008" total:4
+            │ │ ├── LEAF id:2 ag-Grid-HierarchyColumn-date-year:"2008" ag-Grid-HierarchyColumn-date-month:"8" athlete:"Athlete B" countryObject:"GB" sportObject:"Cycling" date:"25/08/2008" total:2
+            │ │ └─ footer id:rowGroupFooter_row-group-ag-Grid-HierarchyColumn-date-year-2008-ag-Grid-HierarchyColumn-date-month-8 ag-Grid-AutoColumn:"Total 8" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null total:6
+            │ ├─┬ LEAF_GROUP id:row-group-ag-Grid-HierarchyColumn-date-year-2008-ag-Grid-HierarchyColumn-date-month-9 ag-Grid-AutoColumn:"9" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null
+            │ │ ├── LEAF id:3 ag-Grid-HierarchyColumn-date-year:"2008" ag-Grid-HierarchyColumn-date-month:"9" athlete:"Athlete C" countryObject:"BR" sportObject:"Running" date:"01/09/2008" total:3
+            │ │ └─ footer id:rowGroupFooter_row-group-ag-Grid-HierarchyColumn-date-year-2008-ag-Grid-HierarchyColumn-date-month-9 ag-Grid-AutoColumn:"Total 9" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null total:3
+            │ └─ footer id:rowGroupFooter_row-group-ag-Grid-HierarchyColumn-date-year-2008 ag-Grid-AutoColumn:"Total 2008" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null total:9
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null total:9
+        `);
+
+        api.removeRowGroupColumns(['ag-Grid-HierarchyColumn-date-month']);
+        expect(getRowGroupColIds()).toEqual(['ag-Grid-HierarchyColumn-date-year']);
+        expectRowGroupColumnCount(1);
+        setAllGroupNodesExpanded(true);
+        await new GridRows(api, 'after removing month hierarchy group').check(`
+            ROOT id:ROOT_NODE_ID ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null total:9
+            ├─┬ LEAF_GROUP id:row-group-ag-Grid-HierarchyColumn-date-year-2008 ag-Grid-AutoColumn:"2008" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null
+            │ ├── LEAF id:1 ag-Grid-HierarchyColumn-date-year:"2008" ag-Grid-HierarchyColumn-date-month:"8" athlete:"Athlete A" countryObject:"US" sportObject:"Swimming" date:"24/08/2008" total:4
+            │ ├── LEAF id:2 ag-Grid-HierarchyColumn-date-year:"2008" ag-Grid-HierarchyColumn-date-month:"8" athlete:"Athlete B" countryObject:"GB" sportObject:"Cycling" date:"25/08/2008" total:2
+            │ ├── LEAF id:3 ag-Grid-HierarchyColumn-date-year:"2008" ag-Grid-HierarchyColumn-date-month:"9" athlete:"Athlete C" countryObject:"BR" sportObject:"Running" date:"01/09/2008" total:3
+            │ └─ footer id:rowGroupFooter_row-group-ag-Grid-HierarchyColumn-date-year-2008 ag-Grid-AutoColumn:"Total 2008" ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null total:9
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null total:9
+        `);
+
+        api.removeRowGroupColumns(['ag-Grid-HierarchyColumn-date-year']);
+        expect(getRowGroupColIds()).toEqual([]);
+        expectRowGroupColumnCount(0);
+        setAllGroupNodesExpanded(true);
+        await new GridRows(api, 'after removing all hierarchy groups').check(`
+            ROOT id:ROOT_NODE_ID ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null total:9
+            ├── LEAF id:1 ag-Grid-HierarchyColumn-date-year:"2008" ag-Grid-HierarchyColumn-date-month:"8" athlete:"Athlete A" countryObject:"US" sportObject:"Swimming" date:"24/08/2008" total:4
+            ├── LEAF id:2 ag-Grid-HierarchyColumn-date-year:"2008" ag-Grid-HierarchyColumn-date-month:"8" athlete:"Athlete B" countryObject:"GB" sportObject:"Cycling" date:"25/08/2008" total:2
+            ├── LEAF id:3 ag-Grid-HierarchyColumn-date-year:"2008" ag-Grid-HierarchyColumn-date-month:"9" athlete:"Athlete C" countryObject:"BR" sportObject:"Running" date:"01/09/2008" total:3
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-HierarchyColumn-date-year:null ag-Grid-HierarchyColumn-date-month:null total:9
+        `);
+    });
+});

--- a/testing/behavioural/src/grouping-data/grouping-display-types.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-display-types.test.ts
@@ -1,7 +1,6 @@
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { RowGroupingModule } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions } from '../test-utils';
 import { GridRows, TestGridsManager, cachedJSONObjects } from '../test-utils';
 
 describe('ag-grid grouping display types and footers', () => {
@@ -43,20 +42,15 @@ describe('ag-grid grouping display types and footers', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['ag-Grid-AutoColumn', 'athlete', 'sport', 'gold'],
-            checkDom: false,
-        };
-
-        await new GridRows(api, 'group rows display', gridRowsOptions).check(`
+        await new GridRows(api, 'group rows display', { checkDom: false }).check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ LEAF_GROUP id:row-group-country-Ireland gold:3
-            │ ├── LEAF id:1 athlete:"John Smith" sport:"Sailing" gold:1
-            │ └── LEAF id:2 athlete:"Jane Doe" sport:"Soccer" gold:2
+            │ ├── LEAF id:1 country:"Ireland" athlete:"John Smith" sport:"Sailing" gold:1
+            │ └── LEAF id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer" gold:2
             ├─┬ LEAF_GROUP id:row-group-country-Italy gold:3
-            │ └── LEAF id:3 athlete:"Mario Rossi" sport:"Soccer" gold:3
+            │ └── LEAF id:3 country:"Italy" athlete:"Mario Rossi" sport:"Soccer" gold:3
             └─┬ LEAF_GROUP id:row-group-country-France gold:1
-            · └── LEAF id:4 athlete:"Jean Dupont" sport:"Tennis" gold:1
+            · └── LEAF id:4 country:"France" athlete:"Jean Dupont" sport:"Tennis" gold:1
         `);
     });
 
@@ -124,26 +118,22 @@ describe('ag-grid grouping display types and footers', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['athlete', 'sport', 'gold', 'silver'],
-        };
-
-        await new GridRows(api, 'with group total rows', gridRowsOptions).check(`
+        await new GridRows(api, 'with group total rows').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Ireland
-            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2020
-            │ │ ├── LEAF id:1 athlete:"John Smith" sport:"Sailing" gold:1 silver:2
-            │ │ ├── LEAF id:2 athlete:"Jane Doe" sport:"Soccer" gold:2 silver:1
-            │ │ └─ footer id:rowGroupFooter_row-group-country-Ireland-year-2020 gold:3 silver:3
-            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2021
-            │ │ ├── LEAF id:3 athlete:"Bob Johnson" sport:"Football" gold:3 silver:2
-            │ │ └─ footer id:rowGroupFooter_row-group-country-Ireland-year-2021 gold:3 silver:2
-            │ └─ footer id:rowGroupFooter_row-group-country-Ireland gold:6 silver:5
-            └─┬ filler id:row-group-country-Italy
-            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2020
-            · │ ├── LEAF id:4 athlete:"Mario Rossi" sport:"Soccer" gold:4 silver:3
-            · │ └─ footer id:rowGroupFooter_row-group-country-Italy-year-2020 gold:4 silver:3
-            · └─ footer id:rowGroupFooter_row-group-country-Italy gold:4 silver:3
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2020 ag-Grid-AutoColumn:2020
+            │ │ ├── LEAF id:1 country:"Ireland" year:2020 athlete:"John Smith" sport:"Sailing" gold:1 silver:2
+            │ │ ├── LEAF id:2 country:"Ireland" year:2020 athlete:"Jane Doe" sport:"Soccer" gold:2 silver:1
+            │ │ └─ footer id:rowGroupFooter_row-group-country-Ireland-year-2020 ag-Grid-AutoColumn:"Total 2020" gold:3 silver:3
+            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2021 ag-Grid-AutoColumn:2021
+            │ │ ├── LEAF id:3 country:"Ireland" year:2021 athlete:"Bob Johnson" sport:"Football" gold:3 silver:2
+            │ │ └─ footer id:rowGroupFooter_row-group-country-Ireland-year-2021 ag-Grid-AutoColumn:"Total 2021" gold:3 silver:2
+            │ └─ footer id:rowGroupFooter_row-group-country-Ireland ag-Grid-AutoColumn:"Total Ireland" gold:6 silver:5
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2020 ag-Grid-AutoColumn:2020
+            · │ ├── LEAF id:4 country:"Italy" year:2020 athlete:"Mario Rossi" sport:"Soccer" gold:4 silver:3
+            · │ └─ footer id:rowGroupFooter_row-group-country-Italy-year-2020 ag-Grid-AutoColumn:"Total 2020" gold:4 silver:3
+            · └─ footer id:rowGroupFooter_row-group-country-Italy ag-Grid-AutoColumn:"Total Italy" gold:4 silver:3
         `);
     });
 
@@ -171,18 +161,14 @@ describe('ag-grid grouping display types and footers', () => {
             groupSuppressBlankHeader: true,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['athlete', 'sport', 'gold'],
-        };
-
-        await new GridRows(api, 'grand total at top', gridRowsOptions).check(`
+        await new GridRows(api, 'grand total at top').check(`
             ROOT id:ROOT_NODE_ID gold:6
-            ├─ footer id:rowGroupFooter_ROOT_NODE_ID gold:6
-            ├─┬ LEAF_GROUP id:row-group-country-Ireland gold:3
-            │ ├── LEAF id:1 athlete:"John Smith" sport:"Sailing" gold:1
-            │ └── LEAF id:2 athlete:"Jane Doe" sport:"Soccer" gold:2
-            └─┬ LEAF_GROUP id:row-group-country-Italy gold:3
-            · └── LEAF id:3 athlete:"Mario Rossi" sport:"Soccer" gold:3
+            ├─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " gold:6
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland" gold:3
+            │ ├── LEAF id:1 country:"Ireland" athlete:"John Smith" sport:"Sailing" gold:1
+            │ └── LEAF id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer" gold:2
+            └─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy" gold:3
+            · └── LEAF id:3 country:"Italy" athlete:"Mario Rossi" sport:"Soccer" gold:3
         `);
     });
 
@@ -210,18 +196,14 @@ describe('ag-grid grouping display types and footers', () => {
             groupSuppressBlankHeader: true,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['athlete', 'sport', 'gold'],
-        };
-
-        await new GridRows(api, 'grand total at bottom', gridRowsOptions).check(`
+        await new GridRows(api, 'grand total at bottom').check(`
             ROOT id:ROOT_NODE_ID gold:6
-            ├─┬ LEAF_GROUP id:row-group-country-Ireland gold:3
-            │ ├── LEAF id:1 athlete:"John Smith" sport:"Sailing" gold:1
-            │ └── LEAF id:2 athlete:"Jane Doe" sport:"Soccer" gold:2
-            ├─┬ LEAF_GROUP id:row-group-country-Italy gold:3
-            │ └── LEAF id:3 athlete:"Mario Rossi" sport:"Soccer" gold:3
-            └─ footer id:rowGroupFooter_ROOT_NODE_ID gold:6
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland" gold:3
+            │ ├── LEAF id:1 country:"Ireland" athlete:"John Smith" sport:"Sailing" gold:1
+            │ └── LEAF id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer" gold:2
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy" gold:3
+            │ └── LEAF id:3 country:"Italy" athlete:"Mario Rossi" sport:"Soccer" gold:3
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " gold:6
         `);
     });
 
@@ -258,20 +240,16 @@ describe('ag-grid grouping display types and footers', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['task', 'status', 'hours'],
-        };
-
-        await new GridRows(api, 'custom group ordering', gridRowsOptions).check(`
+        await new GridRows(api, 'custom group ordering').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-priority-Low hours:8
-            │ ├── LEAF id:1 task:"Task A" status:"Completed" hours:5
-            │ └── LEAF id:5 task:"Task E" status:"In Progress" hours:3
-            ├─┬ LEAF_GROUP id:row-group-priority-High hours:22
-            │ ├── LEAF id:2 task:"Task B" status:"In Progress" hours:10
-            │ └── LEAF id:4 task:"Task D" status:"Completed" hours:12
-            └─┬ LEAF_GROUP id:row-group-priority-Medium hours:8
-            · └── LEAF id:3 task:"Task C" status:"Completed" hours:8
+            ├─┬ LEAF_GROUP id:row-group-priority-Low ag-Grid-AutoColumn:"Low" hours:8
+            │ ├── LEAF id:1 priority:"Low" task:"Task A" status:"Completed" hours:5
+            │ └── LEAF id:5 priority:"Low" task:"Task E" status:"In Progress" hours:3
+            ├─┬ LEAF_GROUP id:row-group-priority-High ag-Grid-AutoColumn:"High" hours:22
+            │ ├── LEAF id:2 priority:"High" task:"Task B" status:"In Progress" hours:10
+            │ └── LEAF id:4 priority:"High" task:"Task D" status:"Completed" hours:12
+            └─┬ LEAF_GROUP id:row-group-priority-Medium ag-Grid-AutoColumn:"Medium" hours:8
+            · └── LEAF id:3 priority:"Medium" task:"Task C" status:"Completed" hours:8
         `);
     });
 
@@ -300,30 +278,26 @@ describe('ag-grid grouping display types and footers', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['sales', 'profit'],
-        };
-
-        await new GridRows(api, 'multiple columns with sticky total rows', gridRowsOptions).check(`
+        await new GridRows(api, 'multiple columns with sticky total rows').check(`
             ROOT id:ROOT_NODE_ID sales:750 profit:150
-            ├─┬ filler id:row-group-region-North
-            │ ├─┬ LEAF_GROUP id:row-group-region-North-country-Ireland
-            │ │ ├── LEAF id:1 sales:100 profit:20
-            │ │ ├── LEAF id:2 sales:150 profit:30
-            │ │ └─ footer id:rowGroupFooter_row-group-region-North-country-Ireland sales:250 profit:50
-            │ ├─┬ LEAF_GROUP id:row-group-region-North-country-UK
-            │ │ ├── LEAF id:3 sales:200 profit:40
-            │ │ └─ footer id:rowGroupFooter_row-group-region-North-country-UK sales:200 profit:40
-            │ └─ footer id:rowGroupFooter_row-group-region-North sales:450 profit:90
-            ├─┬ filler id:row-group-region-South
-            │ ├─┬ LEAF_GROUP id:row-group-region-South-country-Italy
-            │ │ ├── LEAF id:4 sales:120 profit:25
-            │ │ └─ footer id:rowGroupFooter_row-group-region-South-country-Italy sales:120 profit:25
-            │ ├─┬ LEAF_GROUP id:row-group-region-South-country-Spain
-            │ │ ├── LEAF id:5 sales:180 profit:35
-            │ │ └─ footer id:rowGroupFooter_row-group-region-South-country-Spain sales:180 profit:35
-            │ └─ footer id:rowGroupFooter_row-group-region-South sales:300 profit:60
-            └─ footer id:rowGroupFooter_ROOT_NODE_ID sales:750 profit:150
+            ├─┬ filler id:row-group-region-North ag-Grid-AutoColumn:"North"
+            │ ├─┬ LEAF_GROUP id:row-group-region-North-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ │ ├── LEAF id:1 region:"North" country:"Ireland" sales:100 profit:20
+            │ │ ├── LEAF id:2 region:"North" country:"Ireland" sales:150 profit:30
+            │ │ └─ footer id:rowGroupFooter_row-group-region-North-country-Ireland ag-Grid-AutoColumn:"Total Ireland" sales:250 profit:50
+            │ ├─┬ LEAF_GROUP id:row-group-region-North-country-UK ag-Grid-AutoColumn:"UK"
+            │ │ ├── LEAF id:3 region:"North" country:"UK" sales:200 profit:40
+            │ │ └─ footer id:rowGroupFooter_row-group-region-North-country-UK ag-Grid-AutoColumn:"Total UK" sales:200 profit:40
+            │ └─ footer id:rowGroupFooter_row-group-region-North ag-Grid-AutoColumn:"Total North" sales:450 profit:90
+            ├─┬ filler id:row-group-region-South ag-Grid-AutoColumn:"South"
+            │ ├─┬ LEAF_GROUP id:row-group-region-South-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ │ ├── LEAF id:4 region:"South" country:"Italy" sales:120 profit:25
+            │ │ └─ footer id:rowGroupFooter_row-group-region-South-country-Italy ag-Grid-AutoColumn:"Total Italy" sales:120 profit:25
+            │ ├─┬ LEAF_GROUP id:row-group-region-South-country-Spain ag-Grid-AutoColumn:"Spain"
+            │ │ ├── LEAF id:5 region:"South" country:"Spain" sales:180 profit:35
+            │ │ └─ footer id:rowGroupFooter_row-group-region-South-country-Spain ag-Grid-AutoColumn:"Total Spain" sales:180 profit:35
+            │ └─ footer id:rowGroupFooter_row-group-region-South ag-Grid-AutoColumn:"Total South" sales:300 profit:60
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " sales:750 profit:150
         `);
     });
 });

--- a/testing/behavioural/src/grouping-data/grouping-edge-cases.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-edge-cases.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, test } from 'vitest';
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { RowGroupingModule } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions } from '../test-utils';
 import { GridRows, TestGridsManager, cachedJSONObjects } from '../test-utils';
 
 describe('ag-grid grouping edge cases', () => {
@@ -42,17 +41,13 @@ describe('ag-grid grouping edge cases', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['sport'],
-        };
-
-        await new GridRows(api, 'groupHideOpenParents=true', gridRowsOptions).check(`
-            ROOT id:ROOT_NODE_ID
-            ├── LEAF id:1 sport:"Sailing"
-            ├── LEAF id:3 sport:"Football"
-            ├── LEAF id:2 sport:"Soccer"
-            ├── LEAF id:4 sport:"Soccer"
-            └── LEAF id:5 sport:"Football"
+        await new GridRows(api, 'groupHideOpenParents=true').check(`
+            ROOT id:ROOT_NODE_ID ag-Grid-AutoColumn-country:null ag-Grid-AutoColumn-city:null
+            ├── LEAF id:1 ag-Grid-AutoColumn-country:"Ireland" ag-Grid-AutoColumn-city:"Dublin" country:"Ireland" city:"Dublin" sport:"Sailing"
+            ├── LEAF id:3 country:"Ireland" city:"Dublin" sport:"Football"
+            ├── LEAF id:2 ag-Grid-AutoColumn-city:"Cork" country:"Ireland" city:"Cork" sport:"Soccer"
+            ├── LEAF id:4 ag-Grid-AutoColumn-country:"Italy" ag-Grid-AutoColumn-city:"Rome" country:"Italy" city:"Rome" sport:"Soccer"
+            └── LEAF id:5 ag-Grid-AutoColumn-city:"Milan" country:"Italy" city:"Milan" sport:"Football"
         `);
     });
 
@@ -78,17 +73,13 @@ describe('ag-grid grouping edge cases', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['name'],
-        };
-
-        await new GridRows(api, 'groupHideParentOfSingleChild=true', gridRowsOptions).check(`
+        await new GridRows(api, 'groupHideParentOfSingleChild=true').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-department-Engineering
-            │ ├── LEAF id:1 name:"Alice"
-            │ └── LEAF id:2 name:"Bob"
-            ├── LEAF id:3 name:"Charlie"
-            └── LEAF id:4 name:"Diana"
+            ├─┬ filler id:row-group-department-Engineering ag-Grid-AutoColumn:"Engineering"
+            │ ├── LEAF id:1 department:"Engineering" team:"Frontend" name:"Alice"
+            │ └── LEAF id:2 department:"Engineering" team:"Backend" name:"Bob"
+            ├── LEAF id:3 department:"Marketing" team:"Digital" name:"Charlie"
+            └── LEAF id:4 department:"Sales" team:"Enterprise" name:"Diana"
         `);
     });
 
@@ -112,16 +103,12 @@ describe('ag-grid grouping edge cases', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['name'],
-        };
-
-        await new GridRows(api, 'groupHideParentOfSingleChild="leafGroupsOnly"', gridRowsOptions).check(`
+        await new GridRows(api, 'groupHideParentOfSingleChild="leafGroupsOnly"').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-department-Engineering
-            │ └── LEAF id:1 name:"Alice"
-            └─┬ filler id:row-group-department-Marketing
-            · └── LEAF id:2 name:"Charlie"
+            ├─┬ filler id:row-group-department-Engineering ag-Grid-AutoColumn:"Engineering"
+            │ └── LEAF id:1 department:"Engineering" team:"Frontend" name:"Alice"
+            └─┬ filler id:row-group-department-Marketing ag-Grid-AutoColumn:"Marketing"
+            · └── LEAF id:2 department:"Marketing" team:"Digital" name:"Charlie"
         `);
     });
 
@@ -148,21 +135,17 @@ describe('ag-grid grouping edge cases', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['name'],
-        };
-
-        await new GridRows(api, 'groupAllowUnbalanced with nulls', gridRowsOptions).check(`
+        await new GridRows(api, 'groupAllowUnbalanced with nulls').check(`
             ROOT id:ROOT_NODE_ID
-            ├── LEAF id:5 name:"Item 5"
-            ├─┬ filler id:row-group-category-A
-            │ ├── LEAF id:2 name:"Item 2"
-            │ └─┬ LEAF_GROUP id:row-group-category-A-subcategory-A1
-            │ · └── LEAF id:1 name:"Item 1"
-            ├─┬ filler id:row-group-category-B
-            │ └── LEAF id:3 name:"Item 3"
-            └─┬ filler id:row-group-subcategory-C1
-            · └── LEAF id:4 name:"Item 4"
+            ├── LEAF id:5 category:"" subcategory:"" name:"Item 5"
+            ├─┬ filler id:row-group-category-A ag-Grid-AutoColumn:"A"
+            │ ├── LEAF id:2 category:"A" subcategory:null name:"Item 2"
+            │ └─┬ LEAF_GROUP id:row-group-category-A-subcategory-A1 ag-Grid-AutoColumn:"A1"
+            │ · └── LEAF id:1 category:"A" subcategory:"A1" name:"Item 1"
+            ├─┬ filler id:row-group-category-B ag-Grid-AutoColumn:"B"
+            │ └── LEAF id:3 category:"B" name:"Item 3"
+            └─┬ filler id:row-group-subcategory-C1 ag-Grid-AutoColumn:"C1"
+            · └── LEAF id:4 category:null subcategory:"C1" name:"Item 4"
         `);
     });
 
@@ -188,21 +171,17 @@ describe('ag-grid grouping edge cases', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['name'],
-        };
-
-        await new GridRows(api, 'groupSuppressBlankHeader=true', gridRowsOptions).check(`
+        await new GridRows(api, 'groupSuppressBlankHeader=true').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-category-Valid
-            │ └─┬ LEAF_GROUP id:row-group-category-Valid-subcategory-
-            │ · ├── LEAF id:3 name:"Item 3"
-            │ · └── LEAF id:4 name:"Item 4"
-            └─┬ filler id:row-group-category-
-            · ├─┬ LEAF_GROUP id:row-group-category--subcategory-Sub1
-            · │ └── LEAF id:1 name:"Item 1"
-            · └─┬ LEAF_GROUP id:row-group-category--subcategory-Sub2
-            · · └── LEAF id:2 name:"Item 2"
+            ├─┬ filler id:row-group-category-Valid ag-Grid-AutoColumn:"Valid"
+            │ └─┬ LEAF_GROUP id:row-group-category-Valid-subcategory- ag-Grid-AutoColumn:"(Blanks)"
+            │ · ├── LEAF id:3 category:"Valid" subcategory:"" name:"Item 3"
+            │ · └── LEAF id:4 category:"Valid" subcategory:null name:"Item 4"
+            └─┬ filler id:row-group-category- ag-Grid-AutoColumn:"(Blanks)"
+            · ├─┬ LEAF_GROUP id:row-group-category--subcategory-Sub1 ag-Grid-AutoColumn:"Sub1"
+            · │ └── LEAF id:1 category:"" subcategory:"Sub1" name:"Item 1"
+            · └─┬ LEAF_GROUP id:row-group-category--subcategory-Sub2 ag-Grid-AutoColumn:"Sub2"
+            · · └── LEAF id:2 category:null subcategory:"Sub2" name:"Item 2"
         `);
     });
 });

--- a/testing/behavioural/src/grouping-data/grouping-expanded-state.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-expanded-state.test.ts
@@ -624,21 +624,19 @@ describe('ag-grid grouping expanded state', () => {
             getRowId: (params) => params.data.id,
         });
 
-        await new GridRows(api, 'custom groupDefaultExpanded callback', {
-            columns: ['title'],
-        }).check(`
+        await new GridRows(api, 'custom groupDefaultExpanded callback').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-priority-High
-            │ ├─┬ LEAF_GROUP collapsed id:row-group-priority-High-category-Bug
-            │ │ └── LEAF hidden id:1 title:"Critical Issue"
-            │ └─┬ LEAF_GROUP collapsed id:row-group-priority-High-category-Feature
-            │ · └── LEAF hidden id:2 title:"Important Feature"
-            ├─┬ filler collapsed id:row-group-priority-Low
-            │ └─┬ LEAF_GROUP collapsed hidden id:row-group-priority-Low-category-Bug
-            │ · └── LEAF hidden id:3 title:"Minor Issue"
-            └─┬ filler collapsed id:row-group-priority-Medium
-            · └─┬ LEAF_GROUP collapsed hidden id:row-group-priority-Medium-category-Task
-            · · └── LEAF hidden id:4 title:"Regular Task"
+            ├─┬ filler id:row-group-priority-High ag-Grid-AutoColumn:"High"
+            │ ├─┬ LEAF_GROUP collapsed id:row-group-priority-High-category-Bug ag-Grid-AutoColumn:"Bug"
+            │ │ └── LEAF hidden id:1 priority:"High" category:"Bug" title:"Critical Issue"
+            │ └─┬ LEAF_GROUP collapsed id:row-group-priority-High-category-Feature ag-Grid-AutoColumn:"Feature"
+            │ · └── LEAF hidden id:2 priority:"High" category:"Feature" title:"Important Feature"
+            ├─┬ filler collapsed id:row-group-priority-Low ag-Grid-AutoColumn:"Low"
+            │ └─┬ LEAF_GROUP collapsed hidden id:row-group-priority-Low-category-Bug ag-Grid-AutoColumn:"Bug"
+            │ · └── LEAF hidden id:3 priority:"Low" category:"Bug" title:"Minor Issue"
+            └─┬ filler collapsed id:row-group-priority-Medium ag-Grid-AutoColumn:"Medium"
+            · └─┬ LEAF_GROUP collapsed hidden id:row-group-priority-Medium-category-Task ag-Grid-AutoColumn:"Task"
+            · · └── LEAF hidden id:4 priority:"Medium" category:"Task" title:"Regular Task"
         `);
     });
 
@@ -670,20 +668,18 @@ describe('ag-grid grouping expanded state', () => {
             getRowId: (params) => params.data.id,
         });
 
-        await new GridRows(api, 'isGroupOpenByDefault callback', {
-            columns: ['sales'],
-        }).check(`
+        await new GridRows(api, 'isGroupOpenByDefault callback').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-status-Active sales:4500
-            │ ├─┬ LEAF_GROUP collapsed id:row-group-status-Active-region-North sales:1000
-            │ │ └── LEAF hidden id:1 sales:1000
-            │ ├─┬ LEAF_GROUP collapsed id:row-group-status-Active-region-South sales:1500
-            │ │ └── LEAF hidden id:2 sales:1500
-            │ └─┬ LEAF_GROUP collapsed id:row-group-status-Active-region-East sales:2000
-            │ · └── LEAF hidden id:4 sales:2000
-            └─┬ filler collapsed id:row-group-status-Inactive sales:500
-            · └─┬ LEAF_GROUP collapsed hidden id:row-group-status-Inactive-region-North sales:500
-            · · └── LEAF hidden id:3 sales:500
+            ├─┬ filler id:row-group-status-Active ag-Grid-AutoColumn:"Active" sales:4500
+            │ ├─┬ LEAF_GROUP collapsed id:row-group-status-Active-region-North ag-Grid-AutoColumn:"North" sales:1000
+            │ │ └── LEAF hidden id:1 status:"Active" region:"North" sales:1000
+            │ ├─┬ LEAF_GROUP collapsed id:row-group-status-Active-region-South ag-Grid-AutoColumn:"South" sales:1500
+            │ │ └── LEAF hidden id:2 status:"Active" region:"South" sales:1500
+            │ └─┬ LEAF_GROUP collapsed id:row-group-status-Active-region-East ag-Grid-AutoColumn:"East" sales:2000
+            │ · └── LEAF hidden id:4 status:"Active" region:"East" sales:2000
+            └─┬ filler collapsed id:row-group-status-Inactive ag-Grid-AutoColumn:"Inactive" sales:500
+            · └─┬ LEAF_GROUP collapsed hidden id:row-group-status-Inactive-region-North ag-Grid-AutoColumn:"North" sales:500
+            · · └── LEAF hidden id:3 status:"Inactive" region:"North" sales:500
         `);
     });
 
@@ -709,17 +705,17 @@ describe('ag-grid grouping expanded state', () => {
         });
 
         // Initial state - only regions expanded
-        await new GridRows(api, 'initial state', { columns: ['city'] }).check(`
+        await new GridRows(api, 'initial state').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler collapsed id:row-group-region-North
-            │ ├─┬ LEAF_GROUP collapsed hidden id:row-group-region-North-country-USA
-            │ │ ├── LEAF hidden id:1 city:"New York"
-            │ │ └── LEAF hidden id:2 city:"Boston"
-            │ └─┬ LEAF_GROUP collapsed hidden id:row-group-region-North-country-Canada
-            │ · └── LEAF hidden id:3 city:"Toronto"
-            └─┬ filler collapsed id:row-group-region-South
-            · └─┬ LEAF_GROUP collapsed hidden id:row-group-region-South-country-USA
-            · · └── LEAF hidden id:4 city:"Miami"
+            ├─┬ filler collapsed id:row-group-region-North ag-Grid-AutoColumn:"North"
+            │ ├─┬ LEAF_GROUP collapsed hidden id:row-group-region-North-country-USA ag-Grid-AutoColumn:"USA"
+            │ │ ├── LEAF hidden id:1 region:"North" country:"USA" city:"New York"
+            │ │ └── LEAF hidden id:2 region:"North" country:"USA" city:"Boston"
+            │ └─┬ LEAF_GROUP collapsed hidden id:row-group-region-North-country-Canada ag-Grid-AutoColumn:"Canada"
+            │ · └── LEAF hidden id:3 region:"North" country:"Canada" city:"Toronto"
+            └─┬ filler collapsed id:row-group-region-South ag-Grid-AutoColumn:"South"
+            · └─┬ LEAF_GROUP collapsed hidden id:row-group-region-South-country-USA ag-Grid-AutoColumn:"USA"
+            · · └── LEAF hidden id:4 region:"South" country:"USA" city:"Miami"
         `);
 
         // Programmatically expand regions and specific countries
@@ -733,17 +729,17 @@ describe('ag-grid grouping expanded state', () => {
         api.setRowNodeExpanded(northUSANode!, true, undefined, true);
         api.setRowNodeExpanded(southUSANode!, true, undefined, true);
 
-        await new GridRows(api, 'after programmatic expansion', { columns: ['city'] }).check(`
+        await new GridRows(api, 'after programmatic expansion').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-region-North
-            │ ├─┬ LEAF_GROUP id:row-group-region-North-country-USA
-            │ │ ├── LEAF id:1 city:"New York"
-            │ │ └── LEAF id:2 city:"Boston"
-            │ └─┬ LEAF_GROUP collapsed id:row-group-region-North-country-Canada
-            │ · └── LEAF hidden id:3 city:"Toronto"
-            └─┬ filler id:row-group-region-South
-            · └─┬ LEAF_GROUP id:row-group-region-South-country-USA
-            · · └── LEAF id:4 city:"Miami"
+            ├─┬ filler id:row-group-region-North ag-Grid-AutoColumn:"North"
+            │ ├─┬ LEAF_GROUP id:row-group-region-North-country-USA ag-Grid-AutoColumn:"USA"
+            │ │ ├── LEAF id:1 region:"North" country:"USA" city:"New York"
+            │ │ └── LEAF id:2 region:"North" country:"USA" city:"Boston"
+            │ └─┬ LEAF_GROUP collapsed id:row-group-region-North-country-Canada ag-Grid-AutoColumn:"Canada"
+            │ · └── LEAF hidden id:3 region:"North" country:"Canada" city:"Toronto"
+            └─┬ filler id:row-group-region-South ag-Grid-AutoColumn:"South"
+            · └─┬ LEAF_GROUP id:row-group-region-South-country-USA ag-Grid-AutoColumn:"USA"
+            · · └── LEAF id:4 region:"South" country:"USA" city:"Miami"
         `);
 
         // Add new data and verify expansion state persists
@@ -754,19 +750,19 @@ describe('ag-grid grouping expanded state', () => {
             ],
         });
 
-        await new GridRows(api, 'after adding data', { columns: ['city'] }).check(`
+        await new GridRows(api, 'after adding data').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-region-North
-            │ ├─┬ LEAF_GROUP id:row-group-region-North-country-USA
-            │ │ ├── LEAF id:1 city:"New York"
-            │ │ ├── LEAF id:2 city:"Boston"
-            │ │ └── LEAF id:5 city:"Chicago"
-            │ └─┬ LEAF_GROUP collapsed id:row-group-region-North-country-Canada
-            │ · ├── LEAF hidden id:3 city:"Toronto"
-            │ · └── LEAF hidden id:6 city:"Montreal"
-            └─┬ filler id:row-group-region-South
-            · └─┬ LEAF_GROUP id:row-group-region-South-country-USA
-            · · └── LEAF id:4 city:"Miami"
+            ├─┬ filler id:row-group-region-North ag-Grid-AutoColumn:"North"
+            │ ├─┬ LEAF_GROUP id:row-group-region-North-country-USA ag-Grid-AutoColumn:"USA"
+            │ │ ├── LEAF id:1 region:"North" country:"USA" city:"New York"
+            │ │ ├── LEAF id:2 region:"North" country:"USA" city:"Boston"
+            │ │ └── LEAF id:5 region:"North" country:"USA" city:"Chicago"
+            │ └─┬ LEAF_GROUP collapsed id:row-group-region-North-country-Canada ag-Grid-AutoColumn:"Canada"
+            │ · ├── LEAF hidden id:3 region:"North" country:"Canada" city:"Toronto"
+            │ · └── LEAF hidden id:6 region:"North" country:"Canada" city:"Montreal"
+            └─┬ filler id:row-group-region-South ag-Grid-AutoColumn:"South"
+            · └─┬ LEAF_GROUP id:row-group-region-South-country-USA ag-Grid-AutoColumn:"USA"
+            · · └── LEAF id:4 region:"South" country:"USA" city:"Miami"
         `);
     });
 });

--- a/testing/behavioural/src/grouping-data/grouping-filter-aggregation.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-filter-aggregation.test.ts
@@ -1,7 +1,6 @@
 import { ClientSideRowModelModule, CsvExportModule } from 'ag-grid-community';
 import { RowGroupingModule } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions } from '../test-utils';
 import {
     GridRows,
     TestGridsManager,
@@ -59,28 +58,24 @@ describe('ag-grid grouping filter aggregation', () => {
                 groupSuppressBlankHeader: true,
             });
 
-            const gridRowsOptions: GridRowsOptions = {
-                columns: ['year', 'sport', 'gold'],
-            };
-
-            await new GridRows(api, 'initial', gridRowsOptions).check(`
+            await new GridRows(api, 'initial').check(`
                 ROOT id:ROOT_NODE_ID gold:30
-                ├─ footer id:rowGroupFooter_ROOT_NODE_ID gold:30
-                ├─┬ LEAF_GROUP id:row-group-country-Ireland gold:6
-                │ ├── LEAF id:0 year:2020 sport:"Sailing" gold:1
-                │ ├── LEAF id:1 year:2020 sport:"Soccer" gold:2
-                │ └── LEAF id:2 year:2021 sport:"Football" gold:3
-                ├─┬ LEAF_GROUP id:row-group-country-Italy gold:9
-                │ ├── LEAF id:3 year:2020 sport:"Soccer" gold:4
-                │ └── LEAF id:4 year:2021 sport:"Football" gold:5
-                ├─┬ LEAF_GROUP id:row-group-country-France gold:3
-                │ ├── LEAF id:5 year:2020 sport:"Tennis" gold:1
-                │ └── LEAF id:6 year:2021 sport:"Soccer" gold:2
-                ├─┬ LEAF_GROUP id:row-group-country-Spain gold:7
-                │ ├── LEAF id:7 year:2020 sport:"Basketball" gold:3
-                │ └── LEAF id:8 year:2021 sport:"Soccer" gold:4
-                └─┬ LEAF_GROUP id:row-group-country-Germany gold:5
-                · └── LEAF id:9 year:2021 sport:"Football" gold:5
+                ├─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " gold:30
+                ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland" gold:6
+                │ ├── LEAF id:0 country:"Ireland" year:2020 sport:"Sailing" gold:1
+                │ ├── LEAF id:1 country:"Ireland" year:2020 sport:"Soccer" gold:2
+                │ └── LEAF id:2 country:"Ireland" year:2021 sport:"Football" gold:3
+                ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy" gold:9
+                │ ├── LEAF id:3 country:"Italy" year:2020 sport:"Soccer" gold:4
+                │ └── LEAF id:4 country:"Italy" year:2021 sport:"Football" gold:5
+                ├─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France" gold:3
+                │ ├── LEAF id:5 country:"France" year:2020 sport:"Tennis" gold:1
+                │ └── LEAF id:6 country:"France" year:2021 sport:"Soccer" gold:2
+                ├─┬ LEAF_GROUP id:row-group-country-Spain ag-Grid-AutoColumn:"Spain" gold:7
+                │ ├── LEAF id:7 country:"Spain" year:2020 sport:"Basketball" gold:3
+                │ └── LEAF id:8 country:"Spain" year:2021 sport:"Soccer" gold:4
+                └─┬ LEAF_GROUP id:row-group-country-Germany ag-Grid-AutoColumn:"Germany" gold:5
+                · └── LEAF id:9 country:"Germany" year:2021 sport:"Football" gold:5
             `);
 
             // Filter by year >= 2021
@@ -88,19 +83,19 @@ describe('ag-grid grouping filter aggregation', () => {
                 year: { filterType: 'number', type: 'greaterThanOrEqual', filter: 2021 },
             });
 
-            await new GridRows(api, 'filter by year >= 2021', gridRowsOptions).check(`
+            await new GridRows(api, 'filter by year >= 2021').check(`
                 ROOT id:ROOT_NODE_ID gold:19
-                ├─ footer id:rowGroupFooter_ROOT_NODE_ID gold:19
-                ├─┬ LEAF_GROUP id:row-group-country-Ireland gold:3
-                │ └── LEAF id:2 year:2021 sport:"Football" gold:3
-                ├─┬ LEAF_GROUP id:row-group-country-Italy gold:5
-                │ └── LEAF id:4 year:2021 sport:"Football" gold:5
-                ├─┬ LEAF_GROUP id:row-group-country-France gold:2
-                │ └── LEAF id:6 year:2021 sport:"Soccer" gold:2
-                ├─┬ LEAF_GROUP id:row-group-country-Spain gold:4
-                │ └── LEAF id:8 year:2021 sport:"Soccer" gold:4
-                └─┬ LEAF_GROUP id:row-group-country-Germany gold:5
-                · └── LEAF id:9 year:2021 sport:"Football" gold:5
+                ├─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " gold:19
+                ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland" gold:3
+                │ └── LEAF id:2 country:"Ireland" year:2021 sport:"Football" gold:3
+                ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy" gold:5
+                │ └── LEAF id:4 country:"Italy" year:2021 sport:"Football" gold:5
+                ├─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France" gold:2
+                │ └── LEAF id:6 country:"France" year:2021 sport:"Soccer" gold:2
+                ├─┬ LEAF_GROUP id:row-group-country-Spain ag-Grid-AutoColumn:"Spain" gold:4
+                │ └── LEAF id:8 country:"Spain" year:2021 sport:"Soccer" gold:4
+                └─┬ LEAF_GROUP id:row-group-country-Germany ag-Grid-AutoColumn:"Germany" gold:5
+                · └── LEAF id:9 country:"Germany" year:2021 sport:"Football" gold:5
             `);
 
             // Additional filter by sport containing "Soccer"
@@ -109,13 +104,13 @@ describe('ag-grid grouping filter aggregation', () => {
                 sport: { filterType: 'text', type: 'contains', filter: 'Soccer' },
             });
 
-            await new GridRows(api, 'filter by year >= 2021 AND sport contains Soccer', gridRowsOptions).check(`
+            await new GridRows(api, 'filter by year >= 2021 AND sport contains Soccer').check(`
                 ROOT id:ROOT_NODE_ID gold:6
-                ├─ footer id:rowGroupFooter_ROOT_NODE_ID gold:6
-                ├─┬ LEAF_GROUP id:row-group-country-France gold:2
-                │ └── LEAF id:6 year:2021 sport:"Soccer" gold:2
-                └─┬ LEAF_GROUP id:row-group-country-Spain gold:4
-                · └── LEAF id:8 year:2021 sport:"Soccer" gold:4
+                ├─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " gold:6
+                ├─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France" gold:2
+                │ └── LEAF id:6 country:"France" year:2021 sport:"Soccer" gold:2
+                └─┬ LEAF_GROUP id:row-group-country-Spain ag-Grid-AutoColumn:"Spain" gold:4
+                · └── LEAF id:8 country:"Spain" year:2021 sport:"Soccer" gold:4
             `);
 
             // Update data during filtering
@@ -133,40 +128,40 @@ describe('ag-grid grouping filter aggregation', () => {
                 setRowDataChecked(api, rowData);
             }
 
-            await new GridRows(api, 'after adding Portugal Soccer 2021', gridRowsOptions).check(`
+            await new GridRows(api, 'after adding Portugal Soccer 2021').check(`
                 ROOT id:ROOT_NODE_ID gold:12
-                ├─ footer id:rowGroupFooter_ROOT_NODE_ID gold:12
-                ├─┬ LEAF_GROUP id:row-group-country-France gold:2
-                │ └── LEAF id:6 year:2021 sport:"Soccer" gold:2
-                ├─┬ LEAF_GROUP id:row-group-country-Spain gold:4
-                │ └── LEAF id:8 year:2021 sport:"Soccer" gold:4
-                └─┬ LEAF_GROUP id:row-group-country-Portugal gold:6
-                · └── LEAF id:10 year:2021 sport:"Soccer" gold:6
+                ├─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " gold:12
+                ├─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France" gold:2
+                │ └── LEAF id:6 country:"France" year:2021 sport:"Soccer" gold:2
+                ├─┬ LEAF_GROUP id:row-group-country-Spain ag-Grid-AutoColumn:"Spain" gold:4
+                │ └── LEAF id:8 country:"Spain" year:2021 sport:"Soccer" gold:4
+                └─┬ LEAF_GROUP id:row-group-country-Portugal ag-Grid-AutoColumn:"Portugal" gold:6
+                · └── LEAF id:10 country:"Portugal" year:2021 sport:"Soccer" gold:6
             `);
 
             // Clear filters
             api.setFilterModel(null);
 
-            await new GridRows(api, 'filters cleared', gridRowsOptions).check(`
+            await new GridRows(api, 'filters cleared').check(`
                 ROOT id:ROOT_NODE_ID gold:36
-                ├─ footer id:rowGroupFooter_ROOT_NODE_ID gold:36
-                ├─┬ LEAF_GROUP id:row-group-country-Ireland gold:6
-                │ ├── LEAF id:0 year:2020 sport:"Sailing" gold:1
-                │ ├── LEAF id:1 year:2020 sport:"Soccer" gold:2
-                │ └── LEAF id:2 year:2021 sport:"Football" gold:3
-                ├─┬ LEAF_GROUP id:row-group-country-Italy gold:9
-                │ ├── LEAF id:3 year:2020 sport:"Soccer" gold:4
-                │ └── LEAF id:4 year:2021 sport:"Football" gold:5
-                ├─┬ LEAF_GROUP id:row-group-country-France gold:3
-                │ ├── LEAF id:5 year:2020 sport:"Tennis" gold:1
-                │ └── LEAF id:6 year:2021 sport:"Soccer" gold:2
-                ├─┬ LEAF_GROUP id:row-group-country-Spain gold:7
-                │ ├── LEAF id:7 year:2020 sport:"Basketball" gold:3
-                │ └── LEAF id:8 year:2021 sport:"Soccer" gold:4
-                ├─┬ LEAF_GROUP id:row-group-country-Germany gold:5
-                │ └── LEAF id:9 year:2021 sport:"Football" gold:5
-                └─┬ LEAF_GROUP id:row-group-country-Portugal gold:6
-                · └── LEAF id:10 year:2021 sport:"Soccer" gold:6
+                ├─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " gold:36
+                ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland" gold:6
+                │ ├── LEAF id:0 country:"Ireland" year:2020 sport:"Sailing" gold:1
+                │ ├── LEAF id:1 country:"Ireland" year:2020 sport:"Soccer" gold:2
+                │ └── LEAF id:2 country:"Ireland" year:2021 sport:"Football" gold:3
+                ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy" gold:9
+                │ ├── LEAF id:3 country:"Italy" year:2020 sport:"Soccer" gold:4
+                │ └── LEAF id:4 country:"Italy" year:2021 sport:"Football" gold:5
+                ├─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France" gold:3
+                │ ├── LEAF id:5 country:"France" year:2020 sport:"Tennis" gold:1
+                │ └── LEAF id:6 country:"France" year:2021 sport:"Soccer" gold:2
+                ├─┬ LEAF_GROUP id:row-group-country-Spain ag-Grid-AutoColumn:"Spain" gold:7
+                │ ├── LEAF id:7 country:"Spain" year:2020 sport:"Basketball" gold:3
+                │ └── LEAF id:8 country:"Spain" year:2021 sport:"Soccer" gold:4
+                ├─┬ LEAF_GROUP id:row-group-country-Germany ag-Grid-AutoColumn:"Germany" gold:5
+                │ └── LEAF id:9 country:"Germany" year:2021 sport:"Football" gold:5
+                └─┬ LEAF_GROUP id:row-group-country-Portugal ag-Grid-AutoColumn:"Portugal" gold:6
+                · └── LEAF id:10 country:"Portugal" year:2021 sport:"Soccer" gold:6
             `);
 
             const csv = unindentText(api.getDataAsCsv({ suppressQuotes: true }));
@@ -216,44 +211,40 @@ describe('ag-grid grouping filter aggregation', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['athlete', 'sport', 'gold'],
-        };
-
-        await new GridRows(api, 'initial', gridRowsOptions).check(`
+        await new GridRows(api, 'initial').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-country-Ireland gold:3
-            │ ├── LEAF id:1 athlete:"John Smith" sport:"Sailing" gold:1
-            │ └── LEAF id:2 athlete:"Jane Doe" sport:"Soccer" gold:2
-            ├─┬ LEAF_GROUP id:row-group-country-Italy gold:3
-            │ └── LEAF id:3 athlete:"Mario Rossi" sport:"Soccer" gold:3
-            └─┬ LEAF_GROUP id:row-group-country-France gold:1
-            · └── LEAF id:4 athlete:"Jean Dupont" sport:"Tennis" gold:1
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland" gold:3
+            │ ├── LEAF id:1 country:"Ireland" athlete:"John Smith" sport:"Sailing" gold:1
+            │ └── LEAF id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer" gold:2
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy" gold:3
+            │ └── LEAF id:3 country:"Italy" athlete:"Mario Rossi" sport:"Soccer" gold:3
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France" gold:1
+            · └── LEAF id:4 country:"France" athlete:"Jean Dupont" sport:"Tennis" gold:1
         `);
 
         // Apply quick filter for "Soccer"
         api.setGridOption('quickFilterText', 'Soccer');
 
-        await new GridRows(api, 'quick filter Soccer', gridRowsOptions).check(`
+        await new GridRows(api, 'quick filter Soccer').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-country-Ireland gold:2
-            │ └── LEAF id:2 athlete:"Jane Doe" sport:"Soccer" gold:2
-            └─┬ LEAF_GROUP id:row-group-country-Italy gold:3
-            · └── LEAF id:3 athlete:"Mario Rossi" sport:"Soccer" gold:3
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland" gold:2
+            │ └── LEAF id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer" gold:2
+            └─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy" gold:3
+            · └── LEAF id:3 country:"Italy" athlete:"Mario Rossi" sport:"Soccer" gold:3
         `);
 
         // Clear quick filter
         api.setGridOption('quickFilterText', '');
 
-        await new GridRows(api, 'quick filter cleared', gridRowsOptions).check(`
+        await new GridRows(api, 'quick filter cleared').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-country-Ireland gold:3
-            │ ├── LEAF id:1 athlete:"John Smith" sport:"Sailing" gold:1
-            │ └── LEAF id:2 athlete:"Jane Doe" sport:"Soccer" gold:2
-            ├─┬ LEAF_GROUP id:row-group-country-Italy gold:3
-            │ └── LEAF id:3 athlete:"Mario Rossi" sport:"Soccer" gold:3
-            └─┬ LEAF_GROUP id:row-group-country-France gold:1
-            · └── LEAF id:4 athlete:"Jean Dupont" sport:"Tennis" gold:1
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland" gold:3
+            │ ├── LEAF id:1 country:"Ireland" athlete:"John Smith" sport:"Sailing" gold:1
+            │ └── LEAF id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer" gold:2
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy" gold:3
+            │ └── LEAF id:3 country:"Italy" athlete:"Mario Rossi" sport:"Soccer" gold:3
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France" gold:1
+            · └── LEAF id:4 country:"France" athlete:"Jean Dupont" sport:"Tennis" gold:1
         `);
 
         const csv = unindentText(api.getDataAsCsv({ suppressQuotes: true }));
@@ -294,31 +285,27 @@ describe('ag-grid grouping filter aggregation', () => {
             doesExternalFilterPass: (node) => (node.data ? node.data.active : true),
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['athlete', 'sport', 'gold', 'active'],
-        };
-
-        await new GridRows(api, 'external filter active=true', gridRowsOptions).check(`
+        await new GridRows(api, 'external filter active=true').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-country-Ireland gold:1
-            │ └── LEAF id:1 athlete:"John Smith" sport:"Sailing" gold:1 active:true
-            └─┬ LEAF_GROUP id:row-group-country-Italy gold:3
-            · └── LEAF id:3 athlete:"Mario Rossi" sport:"Soccer" gold:3 active:true
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland" gold:1
+            │ └── LEAF id:1 country:"Ireland" athlete:"John Smith" sport:"Sailing" gold:1 active:true
+            └─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy" gold:3
+            · └── LEAF id:3 country:"Italy" athlete:"Mario Rossi" sport:"Soccer" gold:3 active:true
         `);
 
         // Change external filter to show all
         api.setGridOption('doesExternalFilterPass', (_node) => true);
         api.onFilterChanged();
 
-        await new GridRows(api, 'external filter removed', gridRowsOptions).check(`
+        await new GridRows(api, 'external filter removed').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-country-Ireland gold:3
-            │ ├── LEAF id:1 athlete:"John Smith" sport:"Sailing" gold:1 active:true
-            │ └── LEAF id:2 athlete:"Jane Doe" sport:"Soccer" gold:2 active:false
-            ├─┬ LEAF_GROUP id:row-group-country-Italy gold:3
-            │ └── LEAF id:3 athlete:"Mario Rossi" sport:"Soccer" gold:3 active:true
-            └─┬ LEAF_GROUP id:row-group-country-France gold:1
-            · └── LEAF id:4 athlete:"Jean Dupont" sport:"Tennis" gold:1 active:false
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland" gold:3
+            │ ├── LEAF id:1 country:"Ireland" athlete:"John Smith" sport:"Sailing" gold:1 active:true
+            │ └── LEAF id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer" gold:2 active:false
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy" gold:3
+            │ └── LEAF id:3 country:"Italy" athlete:"Mario Rossi" sport:"Soccer" gold:3 active:true
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France" gold:1
+            · └── LEAF id:4 country:"France" athlete:"Jean Dupont" sport:"Tennis" gold:1 active:false
         `);
 
         const csv = unindentText(api.getDataAsCsv({ suppressQuotes: true }));

--- a/testing/behavioural/src/grouping-data/grouping-initial-group-order.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-initial-group-order.test.ts
@@ -2,7 +2,6 @@ import type { InitialGroupOrderComparatorParams } from 'ag-grid-community';
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { RowGroupingModule } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions } from '../test-utils';
 import {
     GridRows,
     TestGridsManager,
@@ -43,14 +42,6 @@ describe('ag-grid initialGroupOrderComparator', () => {
             { id: '6', country: 'Germany', sport: 'Tennis', athlete: 'Heidi' },
         ]);
 
-    const gridRowsOptions: GridRowsOptions = {
-        columns: ['athlete', 'country'],
-    };
-
-    const gridRowsOptionsTwoLevel: GridRowsOptions = {
-        columns: ['athlete', 'country', 'sport'],
-    };
-
     // Two-level grouping tests (country -> sport)
     test('two-level: load from scratch without ids', async () => {
         const state = { called: false };
@@ -69,22 +60,22 @@ describe('ag-grid initialGroupOrderComparator', () => {
 
         expect(state.called).toBe(true);
 
-        await new GridRows(api, 'two-level initial no ids', gridRowsOptionsTwoLevel).check(`
+        await new GridRows(api, 'two-level initial no ids').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Germany
-            │ ├─┬ LEAF_GROUP id:row-group-country-Germany-sport-Soccer
+            ├─┬ filler id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Germany-sport-Soccer ag-Grid-AutoColumn:"Soccer"
             │ │ └── LEAF id:4 country:"Germany" sport:"Soccer" athlete:"Albert"
-            │ └─┬ LEAF_GROUP id:row-group-country-Germany-sport-Tennis
+            │ └─┬ LEAF_GROUP id:row-group-country-Germany-sport-Tennis ag-Grid-AutoColumn:"Tennis"
             │ · └── LEAF id:5 country:"Germany" sport:"Tennis" athlete:"Heidi"
-            ├─┬ filler id:row-group-country-Italy
-            │ ├─┬ LEAF_GROUP id:row-group-country-Italy-sport-Tennis
+            ├─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Italy-sport-Tennis ag-Grid-AutoColumn:"Tennis"
             │ │ └── LEAF id:2 country:"Italy" sport:"Tennis" athlete:"Mario"
-            │ └─┬ LEAF_GROUP id:row-group-country-Italy-sport-Soccer
+            │ └─┬ LEAF_GROUP id:row-group-country-Italy-sport-Soccer ag-Grid-AutoColumn:"Soccer"
             │ · └── LEAF id:3 country:"Italy" sport:"Soccer" athlete:"Luigi"
-            └─┬ filler id:row-group-country-Ireland
-            · ├─┬ LEAF_GROUP id:row-group-country-Ireland-sport-Soccer
+            └─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            · ├─┬ LEAF_GROUP id:row-group-country-Ireland-sport-Soccer ag-Grid-AutoColumn:"Soccer"
             · │ └── LEAF id:0 country:"Ireland" sport:"Soccer" athlete:"John"
-            · └─┬ LEAF_GROUP id:row-group-country-Ireland-sport-Tennis
+            · └─┬ LEAF_GROUP id:row-group-country-Ireland-sport-Tennis ag-Grid-AutoColumn:"Tennis"
             · · └── LEAF id:1 country:"Ireland" sport:"Tennis" athlete:"Jane"
         `);
     });
@@ -107,22 +98,22 @@ describe('ag-grid initialGroupOrderComparator', () => {
 
         expect(state.called).toBe(true);
 
-        await new GridRows(api, 'two-level initial with ids', gridRowsOptionsTwoLevel).check(`
+        await new GridRows(api, 'two-level initial with ids').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Germany
-            │ ├─┬ LEAF_GROUP id:row-group-country-Germany-sport-Soccer
+            ├─┬ filler id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Germany-sport-Soccer ag-Grid-AutoColumn:"Soccer"
             │ │ └── LEAF id:5 country:"Germany" sport:"Soccer" athlete:"Albert"
-            │ └─┬ LEAF_GROUP id:row-group-country-Germany-sport-Tennis
+            │ └─┬ LEAF_GROUP id:row-group-country-Germany-sport-Tennis ag-Grid-AutoColumn:"Tennis"
             │ · └── LEAF id:6 country:"Germany" sport:"Tennis" athlete:"Heidi"
-            ├─┬ filler id:row-group-country-Italy
-            │ ├─┬ LEAF_GROUP id:row-group-country-Italy-sport-Tennis
+            ├─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Italy-sport-Tennis ag-Grid-AutoColumn:"Tennis"
             │ │ └── LEAF id:3 country:"Italy" sport:"Tennis" athlete:"Mario"
-            │ └─┬ LEAF_GROUP id:row-group-country-Italy-sport-Soccer
+            │ └─┬ LEAF_GROUP id:row-group-country-Italy-sport-Soccer ag-Grid-AutoColumn:"Soccer"
             │ · └── LEAF id:4 country:"Italy" sport:"Soccer" athlete:"Luigi"
-            └─┬ filler id:row-group-country-Ireland
-            · ├─┬ LEAF_GROUP id:row-group-country-Ireland-sport-Soccer
+            └─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            · ├─┬ LEAF_GROUP id:row-group-country-Ireland-sport-Soccer ag-Grid-AutoColumn:"Soccer"
             · │ └── LEAF id:1 country:"Ireland" sport:"Soccer" athlete:"John"
-            · └─┬ LEAF_GROUP id:row-group-country-Ireland-sport-Tennis
+            · └─┬ LEAF_GROUP id:row-group-country-Ireland-sport-Tennis ag-Grid-AutoColumn:"Tennis"
             · · └── LEAF id:2 country:"Ireland" sport:"Tennis" athlete:"Jane"
         `);
 
@@ -132,22 +123,22 @@ describe('ag-grid initialGroupOrderComparator', () => {
 
         expect(state.called).toBe(true);
 
-        await new GridRows(api, 'two-level initial with ids', gridRowsOptionsTwoLevel).check(`
+        await new GridRows(api, 'two-level initial with ids').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Italy
-            │ ├─┬ LEAF_GROUP id:row-group-country-Italy-sport-Tennis
+            ├─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Italy-sport-Tennis ag-Grid-AutoColumn:"Tennis"
             │ │ └── LEAF id:3 country:"Italy" sport:"Tennis" athlete:"Mario"
-            │ └─┬ LEAF_GROUP id:row-group-country-Italy-sport-Soccer
+            │ └─┬ LEAF_GROUP id:row-group-country-Italy-sport-Soccer ag-Grid-AutoColumn:"Soccer"
             │ · └── LEAF id:4 country:"Italy" sport:"Soccer" athlete:"Luigi"
-            ├─┬ filler id:row-group-country-Germany
-            │ ├─┬ LEAF_GROUP id:row-group-country-Germany-sport-Soccer
+            ├─┬ filler id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Germany-sport-Soccer ag-Grid-AutoColumn:"Soccer"
             │ │ └── LEAF id:5 country:"Germany" sport:"Soccer" athlete:"Albert"
-            │ └─┬ LEAF_GROUP id:row-group-country-Germany-sport-Tennis
+            │ └─┬ LEAF_GROUP id:row-group-country-Germany-sport-Tennis ag-Grid-AutoColumn:"Tennis"
             │ · └── LEAF id:6 country:"Germany" sport:"Tennis" athlete:"Heidi"
-            └─┬ filler id:row-group-country-Ireland
-            · ├─┬ LEAF_GROUP id:row-group-country-Ireland-sport-Soccer
+            └─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            · ├─┬ LEAF_GROUP id:row-group-country-Ireland-sport-Soccer ag-Grid-AutoColumn:"Soccer"
             · │ └── LEAF id:1 country:"Ireland" sport:"Soccer" athlete:"John"
-            · └─┬ LEAF_GROUP id:row-group-country-Ireland-sport-Tennis
+            · └─┬ LEAF_GROUP id:row-group-country-Ireland-sport-Tennis ag-Grid-AutoColumn:"Tennis"
             · · └── LEAF id:2 country:"Ireland" sport:"Tennis" athlete:"Jane"
         `);
     });
@@ -165,15 +156,15 @@ describe('ag-grid initialGroupOrderComparator', () => {
 
         expect(state.called).toBe(true);
 
-        await new GridRows(api, 'initial no ids', gridRowsOptions).check(`
+        await new GridRows(api, 'initial no ids').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-country-Germany
+            ├─┬ LEAF_GROUP id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
             │ ├── LEAF id:4 country:"Germany" athlete:"Albert"
             │ └── LEAF id:5 country:"Germany" athlete:"Heidi"
-            ├─┬ LEAF_GROUP id:row-group-country-Italy
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
             │ ├── LEAF id:2 country:"Italy" athlete:"Mario"
             │ └── LEAF id:3 country:"Italy" athlete:"Luigi"
-            └─┬ LEAF_GROUP id:row-group-country-Ireland
+            └─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
             · ├── LEAF id:0 country:"Ireland" athlete:"John"
             · └── LEAF id:1 country:"Ireland" athlete:"Jane"
         `);
@@ -193,15 +184,15 @@ describe('ag-grid initialGroupOrderComparator', () => {
 
         expect(state.called).toBe(true);
 
-        await new GridRows(api, 'initial with ids', gridRowsOptions).check(`
+        await new GridRows(api, 'initial with ids').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-country-Germany
+            ├─┬ LEAF_GROUP id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
             │ ├── LEAF id:5 country:"Germany" athlete:"Albert"
             │ └── LEAF id:6 country:"Germany" athlete:"Heidi"
-            ├─┬ LEAF_GROUP id:row-group-country-Italy
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
             │ ├── LEAF id:3 country:"Italy" athlete:"Mario"
             │ └── LEAF id:4 country:"Italy" athlete:"Luigi"
-            └─┬ LEAF_GROUP id:row-group-country-Ireland
+            └─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
             · ├── LEAF id:1 country:"Ireland" athlete:"John"
             · └── LEAF id:2 country:"Ireland" athlete:"Jane"
         `);
@@ -212,15 +203,15 @@ describe('ag-grid initialGroupOrderComparator', () => {
 
         expect(state.called).toBe(true);
 
-        await new GridRows(api, 'initial with ids', gridRowsOptions).check(`
+        await new GridRows(api, 'initial with ids').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-country-Italy
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
             │ ├── LEAF id:3 country:"Italy" athlete:"Mario"
             │ └── LEAF id:4 country:"Italy" athlete:"Luigi"
-            ├─┬ LEAF_GROUP id:row-group-country-Germany
+            ├─┬ LEAF_GROUP id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
             │ ├── LEAF id:5 country:"Germany" athlete:"Albert"
             │ └── LEAF id:6 country:"Germany" athlete:"Heidi"
-            └─┬ LEAF_GROUP id:row-group-country-Ireland
+            └─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
             · ├── LEAF id:1 country:"Ireland" athlete:"John"
             · └── LEAF id:2 country:"Ireland" athlete:"Jane"
         `);
@@ -242,15 +233,15 @@ describe('ag-grid initialGroupOrderComparator', () => {
 
         expect(state.called).toBe(true);
 
-        await new GridRows(api, 'setRowData with ids', gridRowsOptions).check(`
+        await new GridRows(api, 'setRowData with ids').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-country-Germany
+            ├─┬ LEAF_GROUP id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
             │ ├── LEAF id:5 country:"Germany" athlete:"Albert"
             │ └── LEAF id:6 country:"Germany" athlete:"Heidi"
-            ├─┬ LEAF_GROUP id:row-group-country-Italy
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
             │ ├── LEAF id:3 country:"Italy" athlete:"Mario"
             │ └── LEAF id:4 country:"Italy" athlete:"Luigi"
-            └─┬ LEAF_GROUP id:row-group-country-Ireland
+            └─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
             · ├── LEAF id:1 country:"Ireland" athlete:"John"
             · └── LEAF id:2 country:"Ireland" athlete:"Jane"
         `);
@@ -271,17 +262,17 @@ describe('ag-grid initialGroupOrderComparator', () => {
 
         expect(state.called).toBe(true);
 
-        await new GridRows(api, 'setRowData with ids', gridRowsOptions).check(`
+        await new GridRows(api, 'setRowData with ids').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-country-Germany
+            ├─┬ LEAF_GROUP id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
             │ ├── LEAF id:4 country:"Germany" athlete:"Luigi"
             │ ├── LEAF id:6 country:"Germany" athlete:"Heidi"
             │ ├── LEAF id:3 country:"Germany" athlete:"Mario"
             │ └── LEAF id:5 country:"Germany" athlete:"Albert"
-            ├─┬ LEAF_GROUP id:row-group-country-Spain
+            ├─┬ LEAF_GROUP id:row-group-country-Spain ag-Grid-AutoColumn:"Spain"
             │ ├── LEAF id:2 country:"Spain" athlete:"Jane"
             │ └── LEAF id:7 country:"Spain" athlete:"Jose"
-            └─┬ LEAF_GROUP id:row-group-country-Italy
+            └─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
             · └── LEAF id:1 country:"Italy" athlete:"John"
         `);
     });
@@ -300,9 +291,9 @@ describe('ag-grid initialGroupOrderComparator', () => {
 
         expect(state.called).toBe(false); // Only one group
 
-        await new GridRows(api, 'transactions with ids (with update)', gridRowsOptions).check(`
+        await new GridRows(api, 'transactions with ids (with update)').check(`
             ROOT id:ROOT_NODE_ID
-            └─┬ LEAF_GROUP id:row-group-country-Ireland
+            └─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
             · ├── LEAF id:1 country:"Ireland" athlete:"John"
             · └── LEAF id:2 country:"Ireland" athlete:"Jane"
         `);
@@ -314,17 +305,17 @@ describe('ag-grid initialGroupOrderComparator', () => {
 
         expect(state.called).toBe(true);
 
-        await new GridRows(api, 'transactions with ids (with update)', gridRowsOptions).check(`
+        await new GridRows(api, 'transactions with ids (with update)').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-country-Germany
+            ├─┬ LEAF_GROUP id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
             │ ├── LEAF id:5 country:"Germany" athlete:"Albert"
             │ └── LEAF id:6 country:"Germany" athlete:"Heidi"
-            ├─┬ LEAF_GROUP id:row-group-country-Spain
+            ├─┬ LEAF_GROUP id:row-group-country-Spain ag-Grid-AutoColumn:"Spain"
             │ └── LEAF id:1 country:"Spain" athlete:"Alberto"
-            ├─┬ LEAF_GROUP id:row-group-country-Italy
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
             │ ├── LEAF id:3 country:"Italy" athlete:"Mario"
             │ └── LEAF id:4 country:"Italy" athlete:"Luigi"
-            └─┬ LEAF_GROUP id:row-group-country-Ireland
+            └─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
             · └── LEAF id:2 country:"Ireland" athlete:"Jane"
         `);
     });

--- a/testing/behavioural/src/grouping-data/grouping-selection.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-selection.test.ts
@@ -1,7 +1,6 @@
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { RowGroupingModule } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions } from '../test-utils';
 import { GridRows, TestGridsManager, applyTransactionChecked, cachedJSONObjects } from '../test-utils';
 
 describe('ag-grid grouping selection', () => {
@@ -45,11 +44,6 @@ describe('ag-grid grouping selection', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['athlete', 'sport'],
-            checkSelectedNodes: true,
-        };
-
         // Select multiple rows including groups and leaves
         api.setNodesSelected({
             nodes: [
@@ -61,22 +55,22 @@ describe('ag-grid grouping selection', () => {
             ],
             newValue: true,
         });
-        await new GridRows(api, 'initial selection', gridRowsOptions).check(`
+        await new GridRows(api, 'initial selection').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP selected id:row-group-country-Ireland
-            │ ├── LEAF id:1 athlete:"John Smith" sport:"Sailing"
-            │ ├── LEAF id:2 athlete:"Jane Doe" sport:"Soccer"
-            │ └── LEAF selected id:3 athlete:"Bob Johnson" sport:"Football"
-            ├─┬ LEAF_GROUP id:row-group-country-Italy
-            │ ├── LEAF selected id:4 athlete:"Mario Rossi" sport:"Soccer"
-            │ └── LEAF id:5 athlete:"Luigi Verdi" sport:"Football"
-            ├─┬ LEAF_GROUP selected id:row-group-country-France
-            │ ├── LEAF id:6 athlete:"Jean Dupont" sport:"Tennis"
-            │ └── LEAF id:7 athlete:"Marie Martin" sport:"Soccer"
-            ├─┬ LEAF_GROUP id:row-group-country-Spain
-            │ └── LEAF id:8 athlete:"Carlos Garcia" sport:"Basketball"
-            └─┬ LEAF_GROUP id:row-group-country-Germany
-            · └── LEAF selected id:9 athlete:"Hans Mueller" sport:"Football"
+            ├─┬ LEAF_GROUP selected id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:1 country:"Ireland" athlete:"John Smith" sport:"Sailing"
+            │ ├── LEAF id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer"
+            │ └── LEAF selected id:3 country:"Ireland" athlete:"Bob Johnson" sport:"Football"
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ ├── LEAF selected id:4 country:"Italy" athlete:"Mario Rossi" sport:"Soccer"
+            │ └── LEAF id:5 country:"Italy" athlete:"Luigi Verdi" sport:"Football"
+            ├─┬ LEAF_GROUP selected id:row-group-country-France ag-Grid-AutoColumn:"France"
+            │ ├── LEAF id:6 country:"France" athlete:"Jean Dupont" sport:"Tennis"
+            │ └── LEAF id:7 country:"France" athlete:"Marie Martin" sport:"Soccer"
+            ├─┬ LEAF_GROUP id:row-group-country-Spain ag-Grid-AutoColumn:"Spain"
+            │ └── LEAF id:8 country:"Spain" athlete:"Carlos Garcia" sport:"Basketball"
+            └─┬ LEAF_GROUP id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
+            · └── LEAF selected id:9 country:"Germany" athlete:"Hans Mueller" sport:"Football"
         `);
 
         // Add a new item and verify selection state is maintained
@@ -84,23 +78,23 @@ describe('ag-grid grouping selection', () => {
             add: [{ id: '10', country: 'Ireland', athlete: "Pat O'Brien", sport: 'Rugby' }],
         });
 
-        await new GridRows(api, 'after adding to Ireland', gridRowsOptions).check(`
+        await new GridRows(api, 'after adding to Ireland').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP selected id:row-group-country-Ireland 
-            │ ├── LEAF id:1 athlete:"John Smith" sport:"Sailing"
-            │ ├── LEAF id:2 athlete:"Jane Doe" sport:"Soccer"
-            │ ├── LEAF selected id:3 athlete:"Bob Johnson" sport:"Football"
-            │ └── LEAF id:10 athlete:"Pat O'Brien" sport:"Rugby"
-            ├─┬ LEAF_GROUP id:row-group-country-Italy 
-            │ ├── LEAF selected id:4 athlete:"Mario Rossi" sport:"Soccer"
-            │ └── LEAF id:5 athlete:"Luigi Verdi" sport:"Football"
-            ├─┬ LEAF_GROUP selected id:row-group-country-France 
-            │ ├── LEAF id:6 athlete:"Jean Dupont" sport:"Tennis"
-            │ └── LEAF id:7 athlete:"Marie Martin" sport:"Soccer"
-            ├─┬ LEAF_GROUP id:row-group-country-Spain 
-            │ └── LEAF id:8 athlete:"Carlos Garcia" sport:"Basketball"
-            └─┬ LEAF_GROUP id:row-group-country-Germany 
-            · └── LEAF selected id:9 athlete:"Hans Mueller" sport:"Football"
+            ├─┬ LEAF_GROUP selected id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:1 country:"Ireland" athlete:"John Smith" sport:"Sailing"
+            │ ├── LEAF id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer"
+            │ ├── LEAF selected id:3 country:"Ireland" athlete:"Bob Johnson" sport:"Football"
+            │ └── LEAF id:10 country:"Ireland" athlete:"Pat O'Brien" sport:"Rugby"
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ ├── LEAF selected id:4 country:"Italy" athlete:"Mario Rossi" sport:"Soccer"
+            │ └── LEAF id:5 country:"Italy" athlete:"Luigi Verdi" sport:"Football"
+            ├─┬ LEAF_GROUP selected id:row-group-country-France ag-Grid-AutoColumn:"France"
+            │ ├── LEAF id:6 country:"France" athlete:"Jean Dupont" sport:"Tennis"
+            │ └── LEAF id:7 country:"France" athlete:"Marie Martin" sport:"Soccer"
+            ├─┬ LEAF_GROUP id:row-group-country-Spain ag-Grid-AutoColumn:"Spain"
+            │ └── LEAF id:8 country:"Spain" athlete:"Carlos Garcia" sport:"Basketball"
+            └─┬ LEAF_GROUP id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
+            · └── LEAF selected id:9 country:"Germany" athlete:"Hans Mueller" sport:"Football"
         `);
 
         // Select a new child in a selected group
@@ -109,23 +103,23 @@ describe('ag-grid grouping selection', () => {
             newValue: true,
         });
 
-        await new GridRows(api, 'select new child in selected group', gridRowsOptions).check(`
+        await new GridRows(api, 'select new child in selected group').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP selected id:row-group-country-Ireland 
-            │ ├── LEAF id:1 athlete:"John Smith" sport:"Sailing"
-            │ ├── LEAF id:2 athlete:"Jane Doe" sport:"Soccer"
-            │ ├── LEAF selected id:3 athlete:"Bob Johnson" sport:"Football"
-            │ └── LEAF selected id:10 athlete:"Pat O'Brien" sport:"Rugby"
-            ├─┬ LEAF_GROUP id:row-group-country-Italy 
-            │ ├── LEAF selected id:4 athlete:"Mario Rossi" sport:"Soccer"
-            │ └── LEAF id:5 athlete:"Luigi Verdi" sport:"Football"
-            ├─┬ LEAF_GROUP selected id:row-group-country-France 
-            │ ├── LEAF id:6 athlete:"Jean Dupont" sport:"Tennis"
-            │ └── LEAF id:7 athlete:"Marie Martin" sport:"Soccer"
-            ├─┬ LEAF_GROUP id:row-group-country-Spain 
-            │ └── LEAF id:8 athlete:"Carlos Garcia" sport:"Basketball"
-            └─┬ LEAF_GROUP id:row-group-country-Germany 
-            · └── LEAF selected id:9 athlete:"Hans Mueller" sport:"Football"
+            ├─┬ LEAF_GROUP selected id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:1 country:"Ireland" athlete:"John Smith" sport:"Sailing"
+            │ ├── LEAF id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer"
+            │ ├── LEAF selected id:3 country:"Ireland" athlete:"Bob Johnson" sport:"Football"
+            │ └── LEAF selected id:10 country:"Ireland" athlete:"Pat O'Brien" sport:"Rugby"
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ ├── LEAF selected id:4 country:"Italy" athlete:"Mario Rossi" sport:"Soccer"
+            │ └── LEAF id:5 country:"Italy" athlete:"Luigi Verdi" sport:"Football"
+            ├─┬ LEAF_GROUP selected id:row-group-country-France ag-Grid-AutoColumn:"France"
+            │ ├── LEAF id:6 country:"France" athlete:"Jean Dupont" sport:"Tennis"
+            │ └── LEAF id:7 country:"France" athlete:"Marie Martin" sport:"Soccer"
+            ├─┬ LEAF_GROUP id:row-group-country-Spain ag-Grid-AutoColumn:"Spain"
+            │ └── LEAF id:8 country:"Spain" athlete:"Carlos Garcia" sport:"Basketball"
+            └─┬ LEAF_GROUP id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
+            · └── LEAF selected id:9 country:"Germany" athlete:"Hans Mueller" sport:"Football"
         `);
     });
 
@@ -154,12 +148,7 @@ describe('ag-grid grouping selection', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['athlete', 'sport'],
-            checkSelectedNodes: true,
-        };
-
-        await new GridRows(api, 'initial', gridRowsOptions).check(`
+        await new GridRows(api, 'initial').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ LEAF_GROUP id:row-group-country-Ireland 
             │ ├── LEAF id:1 athlete:"John Smith" sport:"Sailing"
@@ -174,7 +163,7 @@ describe('ag-grid grouping selection', () => {
             newValue: true,
         });
 
-        await new GridRows(api, 'select Ireland group', gridRowsOptions).check(`
+        await new GridRows(api, 'select Ireland group').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ LEAF_GROUP selected id:row-group-country-Ireland 
             │ ├── LEAF selected id:1 athlete:"John Smith" sport:"Sailing"
@@ -189,7 +178,7 @@ describe('ag-grid grouping selection', () => {
             newValue: false,
         });
 
-        await new GridRows(api, 'deselect one child', gridRowsOptions).check(`
+        await new GridRows(api, 'deselect one child').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ LEAF_GROUP id:row-group-country-Ireland 
             │ ├── LEAF id:1 athlete:"John Smith" sport:"Sailing"
@@ -222,51 +211,46 @@ describe('ag-grid grouping selection', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['athlete', 'sport'],
-            checkSelectedNodes: true,
-        };
-
         // Select some nodes before filtering
         api.setNodesSelected({
             nodes: [api.getRowNode('1')!, api.getRowNode('2')!, api.getRowNode('4')!],
             newValue: true,
         });
 
-        await new GridRows(api, 'initial selection', gridRowsOptions).check(`
+        await new GridRows(api, 'initial selection').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-country-Ireland 
-            │ ├── LEAF selected id:1 athlete:"John Smith" sport:"Sailing"
-            │ ├── LEAF selected id:2 athlete:"Jane Doe" sport:"Soccer"
-            │ └── LEAF id:3 athlete:"Bob Johnson" sport:"Football"
-            └─┬ LEAF_GROUP id:row-group-country-Italy 
-            · ├── LEAF selected id:4 athlete:"Mario Rossi" sport:"Soccer"
-            · └── LEAF id:5 athlete:"Luigi Verdi" sport:"Football"
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF selected id:1 country:"Ireland" athlete:"John Smith" sport:"Sailing"
+            │ ├── LEAF selected id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer"
+            │ └── LEAF id:3 country:"Ireland" athlete:"Bob Johnson" sport:"Football"
+            └─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├── LEAF selected id:4 country:"Italy" athlete:"Mario Rossi" sport:"Soccer"
+            · └── LEAF id:5 country:"Italy" athlete:"Luigi Verdi" sport:"Football"
         `);
 
         // Filter by sport = "Soccer"
         api.setFilterModel({ sport: { type: 'equals', filter: 'Soccer' } });
 
-        await new GridRows(api, 'filter by Soccer', gridRowsOptions).check(`
+        await new GridRows(api, 'filter by Soccer').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-country-Ireland 
-            │ └── LEAF selected id:2 athlete:"Jane Doe" sport:"Soccer"
-            └─┬ LEAF_GROUP id:row-group-country-Italy 
-            · └── LEAF selected id:4 athlete:"Mario Rossi" sport:"Soccer"
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ └── LEAF selected id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer"
+            └─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · └── LEAF selected id:4 country:"Italy" athlete:"Mario Rossi" sport:"Soccer"
         `);
 
         // Clear filter - selection should be preserved
         api.setFilterModel(null);
 
-        await new GridRows(api, 'filter cleared', gridRowsOptions).check(`
+        await new GridRows(api, 'filter cleared').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-country-Ireland 
-            │ ├── LEAF selected id:1 athlete:"John Smith" sport:"Sailing"
-            │ ├── LEAF selected id:2 athlete:"Jane Doe" sport:"Soccer"
-            │ └── LEAF id:3 athlete:"Bob Johnson" sport:"Football"
-            └─┬ LEAF_GROUP id:row-group-country-Italy 
-            · ├── LEAF selected id:4 athlete:"Mario Rossi" sport:"Soccer"
-            · └── LEAF id:5 athlete:"Luigi Verdi" sport:"Football"
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF selected id:1 country:"Ireland" athlete:"John Smith" sport:"Sailing"
+            │ ├── LEAF selected id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer"
+            │ └── LEAF id:3 country:"Ireland" athlete:"Bob Johnson" sport:"Football"
+            └─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├── LEAF selected id:4 country:"Italy" athlete:"Mario Rossi" sport:"Soccer"
+            · └── LEAF id:5 country:"Italy" athlete:"Luigi Verdi" sport:"Football"
         `);
     });
 
@@ -294,11 +278,6 @@ describe('ag-grid grouping selection', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['athlete', 'sport'],
-            checkSelectedNodes: true,
-        };
-
         // Select nested groups and leaves
         api.setNodesSelected({
             nodes: [
@@ -309,7 +288,7 @@ describe('ag-grid grouping selection', () => {
             newValue: true,
         });
 
-        await new GridRows(api, 'multi-level selection', gridRowsOptions).check(`
+        await new GridRows(api, 'multi-level selection').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Ireland 
             │ ├─┬ LEAF_GROUP selected id:row-group-country-Ireland-year-2020 

--- a/testing/behavioural/src/grouping-data/grouping-selection.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-selection.test.ts
@@ -290,17 +290,17 @@ describe('ag-grid grouping selection', () => {
 
         await new GridRows(api, 'multi-level selection').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Ireland 
-            │ ├─┬ LEAF_GROUP selected id:row-group-country-Ireland-year-2020 
-            │ │ ├── LEAF id:1 athlete:"John Smith" sport:"Sailing"
-            │ │ └── LEAF id:2 athlete:"Jane Doe" sport:"Soccer"
-            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2021 
-            │ · └── LEAF selected id:3 athlete:"Bob Johnson" sport:"Football"
-            └─┬ filler selected id:row-group-country-Italy 
-            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2020 
-            · │ └── LEAF id:4 athlete:"Mario Rossi" sport:"Soccer"
-            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2021 
-            · · └── LEAF id:5 athlete:"Luigi Verdi" sport:"Football"
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP selected id:row-group-country-Ireland-year-2020 ag-Grid-AutoColumn:2020
+            │ │ ├── LEAF id:1 country:"Ireland" year:2020 athlete:"John Smith" sport:"Sailing"
+            │ │ └── LEAF id:2 country:"Ireland" year:2020 athlete:"Jane Doe" sport:"Soccer"
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2021 ag-Grid-AutoColumn:2021
+            │ · └── LEAF selected id:3 country:"Ireland" year:2021 athlete:"Bob Johnson" sport:"Football"
+            └─┬ filler selected id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2020 ag-Grid-AutoColumn:2020
+            · │ └── LEAF id:4 country:"Italy" year:2020 athlete:"Mario Rossi" sport:"Soccer"
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2021 ag-Grid-AutoColumn:2021
+            · · └── LEAF id:5 country:"Italy" year:2021 athlete:"Luigi Verdi" sport:"Football"
         `);
     });
 });

--- a/testing/behavioural/src/grouping-data/grouping-simple-data.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-simple-data.test.ts
@@ -2,7 +2,7 @@ import type { ColDef, GridOptions } from 'ag-grid-community';
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { RowGroupingModule } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions, RowSnapshot } from '../test-utils';
+import type { RowSnapshot } from '../test-utils';
 import {
     GridRows,
     TestGridsManager,
@@ -414,23 +414,19 @@ describe('ag-grid grouping simple data', () => {
             { id: '4', country: 'Italy', year: 2001, name: 'Marvin Minsky' },
         ]);
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['country', 'year', 'name'],
-        };
-
-        let gridRows = new GridRows(api, 'first', gridRowsOptions);
+        let gridRows = new GridRows(api, 'first');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Ireland
-            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ │ ├── LEAF id:0 name:"John Von Neumann" country:"Ireland" year:2000
             │ │ └── LEAF id:1 name:"Ada Lovelace" country:"Ireland" year:2000
-            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001 ag-Grid-AutoColumn:2001
             │ · └── LEAF id:2 name:"Alan Turing" country:"Ireland" year:2001
-            └─┬ filler id:row-group-country-Italy
-            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             · │ └── LEAF id:3 name:"Donald Knuth" country:"Italy" year:2000
-            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001 ag-Grid-AutoColumn:2001
             · · └── LEAF id:4 name:"Marvin Minsky" country:"Italy" year:2001
         `);
 
@@ -442,19 +438,19 @@ describe('ag-grid grouping simple data', () => {
             { id: '4', country: 'Italy', year: 2001, name: 'Marvin Minsky' },
         ]);
 
-        gridRows = new GridRows(api, 'update 1', gridRowsOptions);
+        gridRows = new GridRows(api, 'update 1');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Germany
-            │ ├─┬ LEAF_GROUP id:row-group-country-Germany-year-2000
+            ├─┬ filler id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Germany-year-2000 ag-Grid-AutoColumn:2000
             │ │ ├── LEAF id:0 name:"John Von Neumann" country:"Germany" year:2000
             │ │ └── LEAF id:1 name:"Ada Lovelace" country:"Germany" year:2000
-            │ └─┬ LEAF_GROUP id:row-group-country-Germany-year-2001
+            │ └─┬ LEAF_GROUP id:row-group-country-Germany-year-2001 ag-Grid-AutoColumn:2001
             │ · └── LEAF id:2 name:"Alan Turing" country:"Germany" year:2001
-            └─┬ filler id:row-group-country-Italy
-            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             · │ └── LEAF id:3 name:"Donald Knuth" country:"Italy" year:2000
-            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001 ag-Grid-AutoColumn:2001
             · · └── LEAF id:4 name:"Marvin Minsky" country:"Italy" year:2001
         `);
     });
@@ -858,30 +854,26 @@ describe('ag-grid grouping simple data', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['name'],
-        };
-
-        await new GridRows(api, 'deep hierarchy', gridRowsOptions).check(`
+        await new GridRows(api, 'deep hierarchy').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-l1-A
-            │ └─┬ filler id:row-group-l1-A-l2-A1
-            │ · ├─┬ filler id:row-group-l1-A-l2-A1-l3-A1a
-            │ · │ └─┬ filler id:row-group-l1-A-l2-A1-l3-A1a-l4-A1a1
-            │ · │ · ├─┬ LEAF_GROUP id:row-group-l1-A-l2-A1-l3-A1a-l4-A1a1-l5-A1a1i
-            │ · │ · │ └── LEAF id:1 name:"Deep Item 1"
-            │ · │ · └─┬ LEAF_GROUP id:row-group-l1-A-l2-A1-l3-A1a-l4-A1a1-l5-A1a1ii
-            │ · │ · · └── LEAF id:2 name:"Deep Item 2"
-            │ · └─┬ filler id:row-group-l1-A-l2-A1-l3-A1b
-            │ · · └─┬ filler id:row-group-l1-A-l2-A1-l3-A1b-l4-A1b1
-            │ · · · └─┬ LEAF_GROUP id:row-group-l1-A-l2-A1-l3-A1b-l4-A1b1-l5-A1b1i
-            │ · · · · └── LEAF id:3 name:"Deep Item 3"
-            └─┬ filler id:row-group-l1-B
-            · └─┬ filler id:row-group-l1-B-l2-B1
-            · · └─┬ filler id:row-group-l1-B-l2-B1-l3-B1a
-            · · · └─┬ filler id:row-group-l1-B-l2-B1-l3-B1a-l4-B1a1
-            · · · · └─┬ LEAF_GROUP id:row-group-l1-B-l2-B1-l3-B1a-l4-B1a1-l5-B1a1i
-            · · · · · └── LEAF id:4 name:"Deep Item 4"
+            ├─┬ filler id:row-group-l1-A ag-Grid-AutoColumn:"A"
+            │ └─┬ filler id:row-group-l1-A-l2-A1 ag-Grid-AutoColumn:"A1"
+            │ · ├─┬ filler id:row-group-l1-A-l2-A1-l3-A1a ag-Grid-AutoColumn:"A1a"
+            │ · │ └─┬ filler id:row-group-l1-A-l2-A1-l3-A1a-l4-A1a1 ag-Grid-AutoColumn:"A1a1"
+            │ · │ · ├─┬ LEAF_GROUP id:row-group-l1-A-l2-A1-l3-A1a-l4-A1a1-l5-A1a1i ag-Grid-AutoColumn:"A1a1i"
+            │ · │ · │ └── LEAF id:1 l1:"A" l2:"A1" l3:"A1a" l4:"A1a1" l5:"A1a1i" name:"Deep Item 1"
+            │ · │ · └─┬ LEAF_GROUP id:row-group-l1-A-l2-A1-l3-A1a-l4-A1a1-l5-A1a1ii ag-Grid-AutoColumn:"A1a1ii"
+            │ · │ · · └── LEAF id:2 l1:"A" l2:"A1" l3:"A1a" l4:"A1a1" l5:"A1a1ii" name:"Deep Item 2"
+            │ · └─┬ filler id:row-group-l1-A-l2-A1-l3-A1b ag-Grid-AutoColumn:"A1b"
+            │ · · └─┬ filler id:row-group-l1-A-l2-A1-l3-A1b-l4-A1b1 ag-Grid-AutoColumn:"A1b1"
+            │ · · · └─┬ LEAF_GROUP id:row-group-l1-A-l2-A1-l3-A1b-l4-A1b1-l5-A1b1i ag-Grid-AutoColumn:"A1b1i"
+            │ · · · · └── LEAF id:3 l1:"A" l2:"A1" l3:"A1b" l4:"A1b1" l5:"A1b1i" name:"Deep Item 3"
+            └─┬ filler id:row-group-l1-B ag-Grid-AutoColumn:"B"
+            · └─┬ filler id:row-group-l1-B-l2-B1 ag-Grid-AutoColumn:"B1"
+            · · └─┬ filler id:row-group-l1-B-l2-B1-l3-B1a ag-Grid-AutoColumn:"B1a"
+            · · · └─┬ filler id:row-group-l1-B-l2-B1-l3-B1a-l4-B1a1 ag-Grid-AutoColumn:"B1a1"
+            · · · · └─┬ LEAF_GROUP id:row-group-l1-B-l2-B1-l3-B1a-l4-B1a1-l5-B1a1i ag-Grid-AutoColumn:"B1a1i"
+            · · · · · └── LEAF id:4 l1:"B" l2:"B1" l3:"B1a" l4:"B1a1" l5:"B1a1i" name:"Deep Item 4"
         `);
     });
 });

--- a/testing/behavioural/src/grouping-data/grouping-sorting.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-sorting.test.ts
@@ -1,7 +1,6 @@
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { RowGroupingModule } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions } from '../test-utils';
 import { GridRows, TestGridsManager } from '../test-utils';
 
 describe('ag-grid grouping sorting', () => {
@@ -40,20 +39,15 @@ describe('ag-grid grouping sorting', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            printIds: false,
-            columns: ['athlete', 'sport', 'gold'],
-        };
-
-        await new GridRows(api, 'initial', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ ├── LEAF athlete:"John Smith" sport:"Sailing" gold:1
-            │ ├── LEAF athlete:"Jane Doe" sport:"Soccer" gold:2
-            │ └── LEAF athlete:"Bob Johnson" sport:"Football" gold:3
-            └─┬ LEAF_GROUP
-            · ├── LEAF athlete:"Mario Rossi" sport:"Soccer" gold:4
-            · └── LEAF athlete:"Luigi Verdi" sport:"Football" gold:5
+        await new GridRows(api, 'initial').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:1 country:"Ireland" athlete:"John Smith" sport:"Sailing" gold:1
+            │ ├── LEAF id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer" gold:2
+            │ └── LEAF id:3 country:"Ireland" athlete:"Bob Johnson" sport:"Football" gold:3
+            └─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├── LEAF id:4 country:"Italy" athlete:"Mario Rossi" sport:"Soccer" gold:4
+            · └── LEAF id:5 country:"Italy" athlete:"Luigi Verdi" sport:"Football" gold:5
         `);
 
         // Sort by sport ascending
@@ -61,15 +55,15 @@ describe('ag-grid grouping sorting', () => {
             state: [{ colId: 'sport', sort: 'asc' }],
         });
 
-        await new GridRows(api, 'sort by sport asc', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ ├── LEAF athlete:"Bob Johnson" sport:"Football" gold:3
-            │ ├── LEAF athlete:"John Smith" sport:"Sailing" gold:1
-            │ └── LEAF athlete:"Jane Doe" sport:"Soccer" gold:2
-            └─┬ LEAF_GROUP
-            · ├── LEAF athlete:"Luigi Verdi" sport:"Football" gold:5
-            · └── LEAF athlete:"Mario Rossi" sport:"Soccer" gold:4
+        await new GridRows(api, 'sort by sport asc').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:3 country:"Ireland" athlete:"Bob Johnson" sport:"Football" gold:3
+            │ ├── LEAF id:1 country:"Ireland" athlete:"John Smith" sport:"Sailing" gold:1
+            │ └── LEAF id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer" gold:2
+            └─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├── LEAF id:5 country:"Italy" athlete:"Luigi Verdi" sport:"Football" gold:5
+            · └── LEAF id:4 country:"Italy" athlete:"Mario Rossi" sport:"Soccer" gold:4
         `);
 
         // Sort by gold descending
@@ -77,15 +71,15 @@ describe('ag-grid grouping sorting', () => {
             state: [{ colId: 'gold', sort: 'desc' }],
         });
 
-        await new GridRows(api, 'sort by sport asc + gold desc', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ ├── LEAF athlete:"Bob Johnson" sport:"Football" gold:3
-            │ ├── LEAF athlete:"John Smith" sport:"Sailing" gold:1
-            │ └── LEAF athlete:"Jane Doe" sport:"Soccer" gold:2
-            └─┬ LEAF_GROUP
-            · ├── LEAF athlete:"Luigi Verdi" sport:"Football" gold:5
-            · └── LEAF athlete:"Mario Rossi" sport:"Soccer" gold:4
+        await new GridRows(api, 'sort by sport asc + gold desc').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:3 country:"Ireland" athlete:"Bob Johnson" sport:"Football" gold:3
+            │ ├── LEAF id:1 country:"Ireland" athlete:"John Smith" sport:"Sailing" gold:1
+            │ └── LEAF id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer" gold:2
+            └─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├── LEAF id:5 country:"Italy" athlete:"Luigi Verdi" sport:"Football" gold:5
+            · └── LEAF id:4 country:"Italy" athlete:"Mario Rossi" sport:"Soccer" gold:4
         `);
 
         // Multi-column sort: sport asc, then gold desc
@@ -96,15 +90,15 @@ describe('ag-grid grouping sorting', () => {
             ],
         });
 
-        await new GridRows(api, 'multi-column sort', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ ├── LEAF athlete:"Jane Doe" sport:"Soccer" gold:2
-            │ ├── LEAF athlete:"John Smith" sport:"Sailing" gold:1
-            │ └── LEAF athlete:"Bob Johnson" sport:"Football" gold:3
-            └─┬ LEAF_GROUP
-            · ├── LEAF athlete:"Mario Rossi" sport:"Soccer" gold:4
-            · └── LEAF athlete:"Luigi Verdi" sport:"Football" gold:5
+        await new GridRows(api, 'multi-column sort').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer" gold:2
+            │ ├── LEAF id:1 country:"Ireland" athlete:"John Smith" sport:"Sailing" gold:1
+            │ └── LEAF id:3 country:"Ireland" athlete:"Bob Johnson" sport:"Football" gold:3
+            └─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├── LEAF id:4 country:"Italy" athlete:"Mario Rossi" sport:"Soccer" gold:4
+            · └── LEAF id:5 country:"Italy" athlete:"Luigi Verdi" sport:"Football" gold:5
         `);
     });
 
@@ -132,27 +126,22 @@ describe('ag-grid grouping sorting', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            printIds: false,
-            columns: ['athlete', 'sport', 'gold'],
-        };
-
         // Sort by gold descending first
         api.applyColumnState({
             state: [{ colId: 'gold', sort: 'desc' }],
         });
 
-        await new GridRows(api, 'sort by gold desc', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ ├── LEAF athlete:"Bob Johnson" sport:"Football" gold:3
-            │ ├── LEAF athlete:"Jane Doe" sport:"Soccer" gold:2
-            │ └── LEAF athlete:"John Smith" sport:"Sailing" gold:1
-            ├─┬ LEAF_GROUP
-            │ ├── LEAF athlete:"Luigi Verdi" sport:"Football" gold:5
-            │ └── LEAF athlete:"Mario Rossi" sport:"Soccer" gold:4
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"Jean Dupont" sport:"Soccer" gold:1
+        await new GridRows(api, 'sort by gold desc').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:3 country:"Ireland" athlete:"Bob Johnson" sport:"Football" gold:3
+            │ ├── LEAF id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer" gold:2
+            │ └── LEAF id:1 country:"Ireland" athlete:"John Smith" sport:"Sailing" gold:1
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ ├── LEAF id:5 country:"Italy" athlete:"Luigi Verdi" sport:"Football" gold:5
+            │ └── LEAF id:4 country:"Italy" athlete:"Mario Rossi" sport:"Soccer" gold:4
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · └── LEAF id:6 country:"France" athlete:"Jean Dupont" sport:"Soccer" gold:1
         `);
 
         // Filter by sport containing "Soccer"
@@ -160,14 +149,14 @@ describe('ag-grid grouping sorting', () => {
             sport: { filterType: 'text', type: 'contains', filter: 'Soccer' },
         });
 
-        await new GridRows(api, 'filter Soccer + sort gold desc', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"Jane Doe" sport:"Soccer" gold:2
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"Mario Rossi" sport:"Soccer" gold:4
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"Jean Dupont" sport:"Soccer" gold:1
+        await new GridRows(api, 'filter Soccer + sort gold desc').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ └── LEAF id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer" gold:2
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ └── LEAF id:4 country:"Italy" athlete:"Mario Rossi" sport:"Soccer" gold:4
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · └── LEAF id:6 country:"France" athlete:"Jean Dupont" sport:"Soccer" gold:1
         `);
 
         // Change sort to athlete ascending while filter is active
@@ -175,30 +164,30 @@ describe('ag-grid grouping sorting', () => {
             state: [{ colId: 'athlete', sort: 'asc' }],
         });
 
-        await new GridRows(api, 'filter Soccer + sort athlete asc', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"Jane Doe" sport:"Soccer" gold:2
-            ├─┬ LEAF_GROUP
-            │ └── LEAF athlete:"Mario Rossi" sport:"Soccer" gold:4
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"Jean Dupont" sport:"Soccer" gold:1
+        await new GridRows(api, 'filter Soccer + sort athlete asc').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ └── LEAF id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer" gold:2
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ └── LEAF id:4 country:"Italy" athlete:"Mario Rossi" sport:"Soccer" gold:4
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · └── LEAF id:6 country:"France" athlete:"Jean Dupont" sport:"Soccer" gold:1
         `);
 
         // Clear filter, sort should remain
         api.setFilterModel(null);
 
-        await new GridRows(api, 'clear filter, keep sort athlete asc', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ ├── LEAF athlete:"Bob Johnson" sport:"Football" gold:3
-            │ ├── LEAF athlete:"Jane Doe" sport:"Soccer" gold:2
-            │ └── LEAF athlete:"John Smith" sport:"Sailing" gold:1
-            ├─┬ LEAF_GROUP
-            │ ├── LEAF athlete:"Luigi Verdi" sport:"Football" gold:5
-            │ └── LEAF athlete:"Mario Rossi" sport:"Soccer" gold:4
-            └─┬ LEAF_GROUP
-            · └── LEAF athlete:"Jean Dupont" sport:"Soccer" gold:1
+        await new GridRows(api, 'clear filter, keep sort athlete asc').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:3 country:"Ireland" athlete:"Bob Johnson" sport:"Football" gold:3
+            │ ├── LEAF id:2 country:"Ireland" athlete:"Jane Doe" sport:"Soccer" gold:2
+            │ └── LEAF id:1 country:"Ireland" athlete:"John Smith" sport:"Sailing" gold:1
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ ├── LEAF id:5 country:"Italy" athlete:"Luigi Verdi" sport:"Football" gold:5
+            │ └── LEAF id:4 country:"Italy" athlete:"Mario Rossi" sport:"Soccer" gold:4
+            └─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · └── LEAF id:6 country:"France" athlete:"Jean Dupont" sport:"Soccer" gold:1
         `);
     });
 
@@ -233,20 +222,15 @@ describe('ag-grid grouping sorting', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            printIds: false,
-            columns: ['task', 'priority', 'score'],
-        };
-
-        await new GridRows(api, 'initial', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ ├── LEAF task:"Task A" priority:"High" score:10
-            │ ├── LEAF task:"Task B" priority:"Low" score:5
-            │ └── LEAF task:"Task C" priority:"Medium" score:8
-            └─┬ LEAF_GROUP
-            · ├── LEAF task:"Task D" priority:"High" score:12
-            · └── LEAF task:"Task E" priority:"Low" score:3
+        await new GridRows(api, 'initial').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:1 country:"Ireland" task:"Task A" priority:"High" score:10
+            │ ├── LEAF id:2 country:"Ireland" task:"Task B" priority:"Low" score:5
+            │ └── LEAF id:3 country:"Ireland" task:"Task C" priority:"Medium" score:8
+            └─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├── LEAF id:4 country:"Italy" task:"Task D" priority:"High" score:12
+            · └── LEAF id:5 country:"Italy" task:"Task E" priority:"Low" score:3
         `);
 
         // Sort by priority using custom comparator
@@ -254,15 +238,15 @@ describe('ag-grid grouping sorting', () => {
             state: [{ colId: 'priority', sort: 'asc' }],
         });
 
-        await new GridRows(api, 'sort by priority with custom comparator', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ ├── LEAF task:"Task A" priority:"High" score:10
-            │ ├── LEAF task:"Task C" priority:"Medium" score:8
-            │ └── LEAF task:"Task B" priority:"Low" score:5
-            └─┬ LEAF_GROUP
-            · ├── LEAF task:"Task D" priority:"High" score:12
-            · └── LEAF task:"Task E" priority:"Low" score:3
+        await new GridRows(api, 'sort by priority with custom comparator').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:1 country:"Ireland" task:"Task A" priority:"High" score:10
+            │ ├── LEAF id:3 country:"Ireland" task:"Task C" priority:"Medium" score:8
+            │ └── LEAF id:2 country:"Ireland" task:"Task B" priority:"Low" score:5
+            └─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├── LEAF id:4 country:"Italy" task:"Task D" priority:"High" score:12
+            · └── LEAF id:5 country:"Italy" task:"Task E" priority:"Low" score:3
         `);
 
         // Sort by priority descending
@@ -270,15 +254,15 @@ describe('ag-grid grouping sorting', () => {
             state: [{ colId: 'priority', sort: 'desc' }],
         });
 
-        await new GridRows(api, 'sort by priority desc', gridRowsOptions).check(`
-            ROOT
-            ├─┬ LEAF_GROUP
-            │ ├── LEAF task:"Task B" priority:"Low" score:5
-            │ ├── LEAF task:"Task C" priority:"Medium" score:8
-            │ └── LEAF task:"Task A" priority:"High" score:10
-            └─┬ LEAF_GROUP
-            · ├── LEAF task:"Task E" priority:"Low" score:3
-            · └── LEAF task:"Task D" priority:"High" score:12
+        await new GridRows(api, 'sort by priority desc').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF id:2 country:"Ireland" task:"Task B" priority:"Low" score:5
+            │ ├── LEAF id:3 country:"Ireland" task:"Task C" priority:"Medium" score:8
+            │ └── LEAF id:1 country:"Ireland" task:"Task A" priority:"High" score:10
+            └─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├── LEAF id:5 country:"Italy" task:"Task E" priority:"Low" score:3
+            · └── LEAF id:4 country:"Italy" task:"Task D" priority:"High" score:12
         `);
     });
 
@@ -306,24 +290,19 @@ describe('ag-grid grouping sorting', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            printIds: false,
-            columns: ['athlete', 'sport', 'gold'],
-        };
-
-        await new GridRows(api, 'initial', gridRowsOptions).check(`
-            ROOT
-            ├─┬ filler
-            │ ├─┬ LEAF_GROUP
-            │ │ ├── LEAF athlete:"John Smith" sport:"Sailing" gold:1
-            │ │ └── LEAF athlete:"Jane Doe" sport:"Soccer" gold:2
-            │ └─┬ LEAF_GROUP
-            │ · └── LEAF athlete:"Bob Johnson" sport:"Football" gold:3
-            └─┬ filler
-            · ├─┬ LEAF_GROUP
-            · │ └── LEAF athlete:"Mario Rossi" sport:"Soccer" gold:4
-            · └─┬ LEAF_GROUP
-            · · └── LEAF athlete:"Luigi Verdi" sport:"Football" gold:5
+        await new GridRows(api, 'initial').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2020 ag-Grid-AutoColumn:2020
+            │ │ ├── LEAF id:1 country:"Ireland" year:2020 athlete:"John Smith" sport:"Sailing" gold:1
+            │ │ └── LEAF id:2 country:"Ireland" year:2020 athlete:"Jane Doe" sport:"Soccer" gold:2
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2021 ag-Grid-AutoColumn:2021
+            │ · └── LEAF id:3 country:"Ireland" year:2021 athlete:"Bob Johnson" sport:"Football" gold:3
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2020 ag-Grid-AutoColumn:2020
+            · │ └── LEAF id:4 country:"Italy" year:2020 athlete:"Mario Rossi" sport:"Soccer" gold:4
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2021 ag-Grid-AutoColumn:2021
+            · · └── LEAF id:5 country:"Italy" year:2021 athlete:"Luigi Verdi" sport:"Football" gold:5
         `);
 
         // Sort by sport ascending within each group
@@ -331,19 +310,19 @@ describe('ag-grid grouping sorting', () => {
             state: [{ colId: 'sport', sort: 'asc' }],
         });
 
-        await new GridRows(api, 'sort by sport asc', gridRowsOptions).check(`
-            ROOT
-            ├─┬ filler
-            │ ├─┬ LEAF_GROUP
-            │ │ ├── LEAF athlete:"John Smith" sport:"Sailing" gold:1
-            │ │ └── LEAF athlete:"Jane Doe" sport:"Soccer" gold:2
-            │ └─┬ LEAF_GROUP
-            │ · └── LEAF athlete:"Bob Johnson" sport:"Football" gold:3
-            └─┬ filler
-            · ├─┬ LEAF_GROUP
-            · │ └── LEAF athlete:"Mario Rossi" sport:"Soccer" gold:4
-            · └─┬ LEAF_GROUP
-            · · └── LEAF athlete:"Luigi Verdi" sport:"Football" gold:5
+        await new GridRows(api, 'sort by sport asc').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2020 ag-Grid-AutoColumn:2020
+            │ │ ├── LEAF id:1 country:"Ireland" year:2020 athlete:"John Smith" sport:"Sailing" gold:1
+            │ │ └── LEAF id:2 country:"Ireland" year:2020 athlete:"Jane Doe" sport:"Soccer" gold:2
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2021 ag-Grid-AutoColumn:2021
+            │ · └── LEAF id:3 country:"Ireland" year:2021 athlete:"Bob Johnson" sport:"Football" gold:3
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2020 ag-Grid-AutoColumn:2020
+            · │ └── LEAF id:4 country:"Italy" year:2020 athlete:"Mario Rossi" sport:"Soccer" gold:4
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2021 ag-Grid-AutoColumn:2021
+            · · └── LEAF id:5 country:"Italy" year:2021 athlete:"Luigi Verdi" sport:"Football" gold:5
         `);
 
         // Sort by gold descending within each group
@@ -351,19 +330,19 @@ describe('ag-grid grouping sorting', () => {
             state: [{ colId: 'gold', sort: 'desc' }],
         });
 
-        await new GridRows(api, 'sort by gold desc', gridRowsOptions).check(`
-            ROOT
-            ├─┬ filler
-            │ ├─┬ LEAF_GROUP
-            │ │ ├── LEAF athlete:"John Smith" sport:"Sailing" gold:1
-            │ │ └── LEAF athlete:"Jane Doe" sport:"Soccer" gold:2
-            │ └─┬ LEAF_GROUP
-            │ · └── LEAF athlete:"Bob Johnson" sport:"Football" gold:3
-            └─┬ filler
-            · ├─┬ LEAF_GROUP
-            · │ └── LEAF athlete:"Mario Rossi" sport:"Soccer" gold:4
-            · └─┬ LEAF_GROUP
-            · · └── LEAF athlete:"Luigi Verdi" sport:"Football" gold:5
+        await new GridRows(api, 'sort by gold desc').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2020 ag-Grid-AutoColumn:2020
+            │ │ ├── LEAF id:1 country:"Ireland" year:2020 athlete:"John Smith" sport:"Sailing" gold:1
+            │ │ └── LEAF id:2 country:"Ireland" year:2020 athlete:"Jane Doe" sport:"Soccer" gold:2
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2021 ag-Grid-AutoColumn:2021
+            │ · └── LEAF id:3 country:"Ireland" year:2021 athlete:"Bob Johnson" sport:"Football" gold:3
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2020 ag-Grid-AutoColumn:2020
+            · │ └── LEAF id:4 country:"Italy" year:2020 athlete:"Mario Rossi" sport:"Soccer" gold:4
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2021 ag-Grid-AutoColumn:2021
+            · · └── LEAF id:5 country:"Italy" year:2021 athlete:"Luigi Verdi" sport:"Football" gold:5
         `);
     });
 });

--- a/testing/behavioural/src/grouping-data/grouping-with-immutable-row-data.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-with-immutable-row-data.test.ts
@@ -2,7 +2,6 @@ import type { GridOptions } from 'ag-grid-community';
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { RowGroupingModule } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions } from '../test-utils';
 import { GridRows, TestGridsManager, cachedJSONObjects, setRowDataChecked } from '../test-utils';
 
 describe('ag-grid grouping with transactions', () => {
@@ -42,24 +41,20 @@ describe('ag-grid grouping with transactions', () => {
             ])
         );
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['country', 'year', 'name'],
-        };
-
-        let gridRows = new GridRows(api, 'first', gridRowsOptions);
+        let gridRows = new GridRows(api, 'first');
 
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Ireland
-            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ │ ├── LEAF id:0 name:"John Von Neumann" country:"Ireland" year:2000
             │ │ └── LEAF id:1 name:"Ada Lovelace" country:"Ireland" year:2000
-            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001 ag-Grid-AutoColumn:2001
             │ · └── LEAF id:2 name:"Alan Turing" country:"Ireland" year:2001
-            └─┬ filler id:row-group-country-Italy
-            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             · │ └── LEAF id:3 name:"Donald Knuth" country:"Italy" year:2000
-            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001 ag-Grid-AutoColumn:2001
             · · └── LEAF id:4 name:"Marvin Minsky" country:"Italy" year:2001
         `);
 
@@ -74,17 +69,17 @@ describe('ag-grid grouping with transactions', () => {
             ])
         );
 
-        gridRows = new GridRows(api, 'update 1', gridRowsOptions);
+        gridRows = new GridRows(api, 'update 1');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Ireland
-            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ │ ├── LEAF id:0 name:"John Von Neumann" country:"Ireland" year:2000
             │ │ └── LEAF id:1 name:"Ada Lovelace" country:"Ireland" year:2000
-            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001 ag-Grid-AutoColumn:2001
             │ · └── LEAF id:2 name:"Alan Turing" country:"Ireland" year:2001
-            └─┬ filler id:row-group-country-Italy
-            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             · · ├── LEAF id:3 name:"Donald Knuth" country:"Italy" year:2000
             · · └── LEAF id:4 name:"Marvin Minsky" country:"Italy" year:2000
         `);
@@ -100,19 +95,19 @@ describe('ag-grid grouping with transactions', () => {
             ])
         );
 
-        gridRows = new GridRows(api, 'update 2', gridRowsOptions);
+        gridRows = new GridRows(api, 'update 2');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Ireland
-            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ │ ├── LEAF id:0 name:"John Von Neumann" country:"Ireland" year:2000
             │ │ └── LEAF id:1 name:"Ada Lovelace" country:"Ireland" year:2000
-            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001 ag-Grid-AutoColumn:2001
             │ · └── LEAF id:2 name:"Alan Turing" country:"Ireland" year:2001
-            └─┬ filler id:row-group-country-Italy
-            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             · │ └── LEAF id:3 name:"Donald Knuth" country:"Italy" year:2000
-            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001 ag-Grid-AutoColumn:2001
             · · └── LEAF id:4 name:"Marvin Minsky" country:"Italy" year:2001
         `);
 
@@ -129,20 +124,20 @@ describe('ag-grid grouping with transactions', () => {
             ])
         );
 
-        gridRows = new GridRows(api, 'add', gridRowsOptions);
+        gridRows = new GridRows(api, 'add');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Ireland
-            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ │ ├── LEAF id:0 name:"John Von Neumann" country:"Ireland" year:2000
             │ │ └── LEAF id:1 name:"Ada Lovelace" country:"Ireland" year:2000
-            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001 ag-Grid-AutoColumn:2001
             │ · ├── LEAF id:2 name:"Alan Turing" country:"Ireland" year:2001
             │ · └── LEAF id:5 name:"Grace Hopper" country:"Ireland" year:2001
-            └─┬ filler id:row-group-country-Italy
-            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             · │ └── LEAF id:3 name:"Donald Knuth" country:"Italy" year:2000
-            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001 ag-Grid-AutoColumn:2001
             · · ├── LEAF id:6 name:"xxx" country:"Italy" year:2001
             · · └── LEAF id:4 name:"Marvin Minsky" country:"Italy" year:2001
         `);
@@ -159,20 +154,20 @@ describe('ag-grid grouping with transactions', () => {
             ])
         );
 
-        gridRows = new GridRows(api, 'remove', gridRowsOptions);
+        gridRows = new GridRows(api, 'remove');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Ireland
-            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ │ ├── LEAF id:0 name:"John Von Neumann" country:"Ireland" year:2000
             │ │ └── LEAF id:1 name:"Ada Lovelace" country:"Ireland" year:2000
-            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001 ag-Grid-AutoColumn:2001
             │ · ├── LEAF id:2 name:"Alan Turing" country:"Ireland" year:2001
             │ · └── LEAF id:5 name:"Grace Hopper" country:"Ireland" year:2001
-            └─┬ filler id:row-group-country-Italy
-            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             · │ └── LEAF id:3 name:"Donald Knuth" country:"Italy" year:2000
-            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001 ag-Grid-AutoColumn:2001
             · · └── LEAF id:4 name:"Marvin Minsky" country:"Italy" year:2001
         `);
 
@@ -188,17 +183,17 @@ describe('ag-grid grouping with transactions', () => {
             ])
         );
 
-        gridRows = new GridRows(api, 'remove, update, add', gridRowsOptions);
+        gridRows = new GridRows(api, 'remove, update, add');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Ireland
-            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ · ├── LEAF id:0 name:"John Von Neumann" country:"Ireland" year:2000
             │ · └── LEAF id:1 name:"Ada Lovelace" country:"Ireland" year:2000
-            └─┬ filler id:row-group-country-Italy
-            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2001
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2001 ag-Grid-AutoColumn:2001
             · │ └── LEAF id:4 name:"Marvin Minsky" country:"Italy" year:2001
-            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-1940
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-1940 ag-Grid-AutoColumn:1940
             · · ├── LEAF id:2 name:"Alan M. Turing" country:"Italy" year:1940
             · · ├── LEAF id:5 name:"Grace Brewster Murray Hopper" country:"Italy" year:1940
             · · └── LEAF id:6 name:"unknown" country:"Italy" year:1940
@@ -216,27 +211,27 @@ describe('ag-grid grouping with transactions', () => {
             ])
         );
 
-        gridRows = new GridRows(api, 'update, reorder', gridRowsOptions);
+        gridRows = new GridRows(api, 'update, reorder');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Ireland
-            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ │ ├── LEAF id:0 name:"John Von Neumann" country:"Ireland" year:2000
             │ │ └── LEAF id:1 name:"Ada Lovelace" country:"Ireland" year:2000
-            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-1940
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-1940 ag-Grid-AutoColumn:1940
             │ · └── LEAF id:2 name:"Alan M. Turing" country:"Ireland" year:1940
-            ├─┬ filler id:row-group-country-Italy
-            │ └─┬ LEAF_GROUP id:row-group-country-Italy-year-1940
+            ├─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ └─┬ LEAF_GROUP id:row-group-country-Italy-year-1940 ag-Grid-AutoColumn:1940
             │ · ├── LEAF id:5 name:"Grace Brewster Murray Hopper" country:"Italy" year:1940
             │ · └── LEAF id:4 name:"Marvin Minsky" country:"Italy" year:1940
-            └─┬ filler id:row-group-country-Germany
-            · └─┬ LEAF_GROUP id:row-group-country-Germany-year-1900
+            └─┬ filler id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
+            · └─┬ LEAF_GROUP id:row-group-country-Germany-year-1900 ag-Grid-AutoColumn:1900
             · · └── LEAF id:6 name:"unknown" country:"Germany" year:1900
         `);
 
         setRowDataChecked(api, []);
 
-        gridRows = new GridRows(api, 'clear', gridRowsOptions);
+        gridRows = new GridRows(api, 'clear');
         await gridRows.check('empty');
     });
 
@@ -264,24 +259,20 @@ describe('ag-grid grouping with transactions', () => {
             ])
         );
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['country', 'year', 'name'],
-        };
-
-        let gridRows = new GridRows(api, 'first', gridRowsOptions);
+        let gridRows = new GridRows(api, 'first');
 
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Ireland
-            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ │ ├── LEAF id:0 name:"John Von Neumann" country:"Ireland" year:2000
             │ │ └── LEAF id:1 name:"Ada Lovelace" country:"Ireland" year:2000
-            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001 ag-Grid-AutoColumn:2001
             │ · └── LEAF id:2 name:"Alan Turing" country:"Ireland" year:2001
-            └─┬ filler id:row-group-country-Italy
-            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             · │ └── LEAF id:3 name:"Donald Knuth" country:"Italy" year:2000
-            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001 ag-Grid-AutoColumn:2001
             · · └── LEAF id:4 name:"Marvin Minsky" country:"Italy" year:2001
         `);
 
@@ -296,19 +287,19 @@ describe('ag-grid grouping with transactions', () => {
             ])
         );
 
-        gridRows = new GridRows(api, 'update 1', gridRowsOptions);
+        gridRows = new GridRows(api, 'update 1');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Italy
-            │ ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            ├─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             │ │ └── LEAF id:3 name:"Donald Knuth" country:"Italy" year:2000
-            │ └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001
+            │ └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001 ag-Grid-AutoColumn:2001
             │ · └── LEAF id:4 name:"Marvin Minsky" country:"Italy" year:2001
-            └─┬ filler id:row-group-country-Germany
-            · ├─┬ LEAF_GROUP id:row-group-country-Germany-year-2000
+            └─┬ filler id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
+            · ├─┬ LEAF_GROUP id:row-group-country-Germany-year-2000 ag-Grid-AutoColumn:2000
             · │ ├── LEAF id:0 name:"John Von Neumann" country:"Germany" year:2000
             · │ └── LEAF id:1 name:"Ada Lovelace" country:"Germany" year:2000
-            · └─┬ LEAF_GROUP id:row-group-country-Germany-year-2001
+            · └─┬ LEAF_GROUP id:row-group-country-Germany-year-2001 ag-Grid-AutoColumn:2001
             · · └── LEAF id:2 name:"Alan Turing" country:"Germany" year:2001
         `);
 
@@ -320,11 +311,11 @@ describe('ag-grid grouping with transactions', () => {
             ])
         );
 
-        gridRows = new GridRows(api, 'update 2', gridRowsOptions);
+        gridRows = new GridRows(api, 'update 2');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            └─┬ filler id:row-group-country-Germany
-            · └─┬ LEAF_GROUP id:row-group-country-Germany-year-2000
+            └─┬ filler id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
+            · └─┬ LEAF_GROUP id:row-group-country-Germany-year-2000 ag-Grid-AutoColumn:2000
             · · ├── LEAF id:0 name:"John Von Neumann" country:"Germany" year:2000
             · · └── LEAF id:1 name:"Ada Lovelace" country:"Germany" year:2000
         `);
@@ -338,15 +329,15 @@ describe('ag-grid grouping with transactions', () => {
             ])
         );
 
-        gridRows = new GridRows(api, 'update 2', gridRowsOptions);
+        gridRows = new GridRows(api, 'update 2');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Germany
-            │ └─┬ LEAF_GROUP id:row-group-country-Germany-year-2000
+            ├─┬ filler id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
+            │ └─┬ LEAF_GROUP id:row-group-country-Germany-year-2000 ag-Grid-AutoColumn:2000
             │ · ├── LEAF id:0 name:"John Von Neumann" country:"Germany" year:2000
             │ · └── LEAF id:1 name:"Ada Lovelace" country:"Germany" year:2000
-            └─┬ filler id:row-group-country-Italy
-            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             · · └── LEAF id:3 name:"Donald Knuth" country:"Italy" year:2000
         `);
 
@@ -363,19 +354,19 @@ describe('ag-grid grouping with transactions', () => {
             ],
         });
 
-        gridRows = new GridRows(api, 'change columns', gridRowsOptions);
+        gridRows = new GridRows(api, 'change columns');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-country-Germany
+            ├─┬ LEAF_GROUP id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
             │ ├── LEAF id:0 name:"John Von Neumann" country:"Germany" year:2005
             │ └── LEAF id:1 name:"Ada Lovelace" country:"Germany" year:2005
-            └─┬ LEAF_GROUP id:row-group-country-Italy
+            └─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
             · └── LEAF id:3 name:"Donald Knuth" country:"Italy" year:2005
         `);
 
         setRowDataChecked(api, []);
 
-        gridRows = new GridRows(api, 'clear', gridRowsOptions);
+        gridRows = new GridRows(api, 'clear');
         await gridRows.check('empty');
     });
 
@@ -405,24 +396,20 @@ describe('ag-grid grouping with transactions', () => {
             }
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['country', 'year', 'name'],
-        };
-
-        let gridRows = new GridRows(api, 'first', gridRowsOptions);
+        let gridRows = new GridRows(api, 'first');
 
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler collapsed id:row-group-country-Ireland
-            │ ├─┬ LEAF_GROUP hidden id:row-group-country-Ireland-year-2000
+            ├─┬ filler collapsed id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP hidden id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ │ ├── LEAF hidden id:0 name:"John Von Neumann" country:"Ireland" year:2000
             │ │ └── LEAF hidden id:1 name:"Ada Lovelace" country:"Ireland" year:2000
-            │ └─┬ LEAF_GROUP hidden id:row-group-country-Ireland-year-2001
+            │ └─┬ LEAF_GROUP hidden id:row-group-country-Ireland-year-2001 ag-Grid-AutoColumn:2001
             │ · └── LEAF hidden id:2 name:"Alan Turing" country:"Ireland" year:2001
-            └─┬ filler id:row-group-country-Italy
-            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             · │ └── LEAF id:3 name:"Donald Knuth" country:"Italy" year:2000
-            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001 ag-Grid-AutoColumn:2001
             · · └── LEAF id:4 name:"Marvin Minsky" country:"Italy" year:2001
         `);
 
@@ -437,19 +424,19 @@ describe('ag-grid grouping with transactions', () => {
             ])
         );
 
-        gridRows = new GridRows(api, 'first', gridRowsOptions);
+        gridRows = new GridRows(api, 'first');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler collapsed id:row-group-country-Ireland
-            │ ├─┬ LEAF_GROUP hidden id:row-group-country-Ireland-year-2000
+            ├─┬ filler collapsed id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP hidden id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ │ ├── LEAF hidden id:0 name:"John Von Neumann" country:"Ireland" year:2000
             │ │ └── LEAF hidden id:1 name:"Ada Lovelace" country:"Ireland" year:2000
-            │ └─┬ LEAF_GROUP hidden id:row-group-country-Ireland-year-2001
+            │ └─┬ LEAF_GROUP hidden id:row-group-country-Ireland-year-2001 ag-Grid-AutoColumn:2001
             │ · └── LEAF hidden id:2 name:"Alan Turing" country:"Ireland" year:2001
-            └─┬ filler id:row-group-country-Italy
-            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             · │ └── LEAF id:3 name:"Donald Knuth" country:"Italy" year:2000
-            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001 ag-Grid-AutoColumn:2001
             · · └── LEAF id:4 name:"Marvin Minsky the second" country:"Italy" year:2001
         `);
 
@@ -464,17 +451,17 @@ describe('ag-grid grouping with transactions', () => {
             ])
         );
 
-        gridRows = new GridRows(api, 'first', gridRowsOptions);
+        gridRows = new GridRows(api, 'first');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler collapsed id:row-group-country-Ireland
-            │ └─┬ LEAF_GROUP hidden id:row-group-country-Ireland-year-2000
+            ├─┬ filler collapsed id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ └─┬ LEAF_GROUP hidden id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ · ├── LEAF hidden id:0 name:"John Von Neumann" country:"Ireland" year:2000
             │ · └── LEAF hidden id:1 name:"Ada Lovelace" country:"Ireland" year:2000
-            └─┬ filler id:row-group-country-Italy
-            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             · │ └── LEAF id:3 name:"Donald Knuth" country:"Italy" year:2000
-            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001 ag-Grid-AutoColumn:2001
             · · ├── LEAF id:2 name:"Alan Turing" country:"Italy" year:2001
             · · └── LEAF id:4 name:"Marvin Minsky the second" country:"Italy" year:2001
         `);

--- a/testing/behavioural/src/grouping-data/grouping-with-pivot.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-with-pivot.test.ts
@@ -44,7 +44,7 @@ describe('ag-grid grouping with pivot', () => {
         });
 
         const gridRowsOptions: GridRowsOptions = {
-            columns: [
+            forcedColumns: [
                 'ag-Grid-AutoColumn',
                 'pivot_year_2020_sales',
                 'pivot_year_2020_profit',
@@ -91,7 +91,7 @@ describe('ag-grid grouping with pivot', () => {
         });
 
         const gridRowsOptions: GridRowsOptions = {
-            columns: ['ag-Grid-AutoColumn', 'pivot_year_2020_sales', 'pivot_year_2021_sales'],
+            forcedColumns: ['ag-Grid-AutoColumn', 'pivot_year_2020_sales', 'pivot_year_2021_sales'],
             printHiddenRows: false,
         };
 
@@ -134,7 +134,7 @@ describe('ag-grid grouping with pivot', () => {
         });
 
         const gridRowsOptions: GridRowsOptions = {
-            columns: [
+            forcedColumns: [
                 'ag-Grid-AutoColumn',
                 'pivot_year-quarter_2020-Q1_sales',
                 'pivot_year-quarter_2020-Q2_sales',
@@ -188,7 +188,7 @@ describe('ag-grid grouping with pivot', () => {
 
         // Test with pivotComparator: columns should be ordered South, North, East (reverse alphabetical)
         const gridRowsOptions: GridRowsOptions = {
-            columns: ['ag-Grid-AutoColumn', 'South_sales', 'North_sales', 'East_sales'],
+            forcedColumns: ['ag-Grid-AutoColumn', 'South_sales', 'North_sales', 'East_sales'],
         };
 
         let gridRows = new GridRows(api, 'pivot with custom column ordering', gridRowsOptions);
@@ -258,7 +258,7 @@ describe('ag-grid grouping with pivot', () => {
         });
 
         const gridRowsOptions: GridRowsOptions = {
-            columns: ['salesperson', 'Jan_sales', 'Feb_sales', 'Mar_sales'],
+            forcedColumns: ['salesperson', 'Jan_sales', 'Feb_sales', 'Mar_sales'],
         };
 
         let gridRows = new GridRows(api, 'initial pivot data', gridRowsOptions);
@@ -333,7 +333,7 @@ describe('ag-grid grouping with pivot', () => {
         });
 
         const gridRowsOptions: GridRowsOptions = {
-            columns: [
+            forcedColumns: [
                 'department',
                 '2020_budget',
                 '2020_expenses',
@@ -383,7 +383,7 @@ describe('ag-grid grouping with pivot', () => {
         });
 
         const gridRowsOptions: GridRowsOptions = {
-            columns: ['category', 'North_revenue', 'South_revenue', 'East_revenue', 'West_revenue'],
+            forcedColumns: ['category', 'North_revenue', 'South_revenue', 'East_revenue', 'West_revenue'],
         };
 
         let gridRows = new GridRows(api, 'initial pivot columns', gridRowsOptions);
@@ -451,7 +451,7 @@ describe('ag-grid grouping with pivot', () => {
         });
 
         const gridRowsOptions: GridRowsOptions = {
-            columns: ['store', 'Jan_sales', 'Feb_sales', 'Mar_sales'],
+            forcedColumns: ['store', 'Jan_sales', 'Feb_sales', 'Mar_sales'],
         };
 
         let gridRows = new GridRows(api, 'initial pivot data', gridRowsOptions);
@@ -558,7 +558,7 @@ describe('ag-grid grouping with pivot', () => {
         });
 
         const gridRowsOptions: GridRowsOptions = {
-            columns: ['team', 'Q1_score', 'Q1_attempts', 'Q1_average', 'Q2_score', 'Q2_attempts', 'Q2_average'],
+            forcedColumns: ['team', 'Q1_score', 'Q1_attempts', 'Q1_average', 'Q2_score', 'Q2_attempts', 'Q2_average'],
         };
 
         const gridRows = new GridRows(api, 'custom aggregations in pivot', gridRowsOptions);
@@ -612,7 +612,7 @@ describe('ag-grid grouping with pivot', () => {
         });
 
         const gridRowsOptions: GridRowsOptions = {
-            columns: [
+            forcedColumns: [
                 'Jan_revenue',
                 'Jan_costs',
                 'Jan_profit',
@@ -659,7 +659,7 @@ describe('ag-grid grouping with pivot', () => {
         });
 
         const gridRowsOptions: GridRowsOptions = {
-            columns: [
+            forcedColumns: [
                 'category',
                 'North_sales',
                 'North_units',
@@ -757,7 +757,7 @@ describe('ag-grid grouping with pivot', () => {
         });
 
         const gridRowsOptions: GridRowsOptions = {
-            columns: [
+            forcedColumns: [
                 'ag-Grid-AutoColumn',
                 'pivot_quarter_Q1_budget',
                 'pivot_quarter_Q1_expenses',
@@ -810,7 +810,7 @@ describe('ag-grid grouping with pivot', () => {
         });
 
         const gridRowsOptions: GridRowsOptions = {
-            columns: ['ag-Grid-AutoColumn'], // Just check group structure, not pivot values
+            forcedColumns: ['ag-Grid-AutoColumn'], // Just check group structure, not pivot values
             printHiddenRows: false,
         };
 
@@ -854,7 +854,7 @@ describe('ag-grid grouping with pivot', () => {
         });
 
         const gridRowsOptions: GridRowsOptions = {
-            columns: ['ag-Grid-AutoColumn'], // Just test filtering behavior, not specific values
+            forcedColumns: ['ag-Grid-AutoColumn'], // Just test filtering behavior, not specific values
             printHiddenRows: false,
         };
 
@@ -1037,7 +1037,7 @@ describe('ag-grid grouping with pivot', () => {
         const pivotResultColumns = api.getPivotResultColumns();
 
         const gridRowsOptions: GridRowsOptions = {
-            columns: [
+            forcedColumns: [
                 'ag-Grid-AutoColumn',
                 // Use actual column names from the pivot result
                 ...(pivotResultColumns?.map((col) => col.getColId()) || []),

--- a/testing/behavioural/src/grouping-data/grouping-with-transactions.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-with-transactions.test.ts
@@ -207,16 +207,16 @@ describe('ag-grid grouping with transactions', () => {
 
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Ireland
-            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ │ ├── LEAF id:0 name:"John Von Neumann" country:"Ireland" year:2000
             │ │ └── LEAF id:1 name:"Ada Lovelace" country:"Ireland" year:2000
-            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001 ag-Grid-AutoColumn:2001
             │ · └── LEAF id:2 name:"Alan Turing" country:"Ireland" year:2001
-            └─┬ filler id:row-group-country-Italy
-            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             · │ └── LEAF id:3 name:"Donald Knuth" country:"Italy" year:2000
-            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001 ag-Grid-AutoColumn:2001
             · · └── LEAF id:4 name:"Marvin Minsky" country:"Italy" year:2001
         `);
 
@@ -238,16 +238,16 @@ describe('ag-grid grouping with transactions', () => {
         gridRows = new GridRows(api, 'update 1');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Italy
-            │ ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            ├─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             │ │ └── LEAF id:3 name:"Donald Knuth" country:"Italy" year:2000
-            │ └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001
+            │ └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001 ag-Grid-AutoColumn:2001
             │ · └── LEAF id:4 name:"Marvin Minsky" country:"Italy" year:2001
-            └─┬ filler id:row-group-country-Germany
-            · ├─┬ LEAF_GROUP id:row-group-country-Germany-year-2000
+            └─┬ filler id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
+            · ├─┬ LEAF_GROUP id:row-group-country-Germany-year-2000 ag-Grid-AutoColumn:2000
             · │ ├── LEAF id:0 name:"John Von Neumann" country:"Germany" year:2000
             · │ └── LEAF id:1 name:"Ada Lovelace" country:"Germany" year:2000
-            · └─┬ LEAF_GROUP id:row-group-country-Germany-year-2001
+            · └─┬ LEAF_GROUP id:row-group-country-Germany-year-2001 ag-Grid-AutoColumn:2001
             · · └── LEAF id:2 name:"Alan Turing" country:"Germany" year:2001
         `);
     });
@@ -287,16 +287,16 @@ describe('ag-grid grouping with transactions', () => {
         let gridRows = new GridRows(api, 'first');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Ireland
-            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ │ ├── LEAF id:0 name:"John Von Neumann" country:"Ireland" year:2000
             │ │ └── LEAF id:1 name:"Ada Lovelace" country:"Ireland" year:2000
-            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001 ag-Grid-AutoColumn:2001
             │ · └── LEAF id:2 name:"Alan Turing" country:"Ireland" year:2001
-            └─┬ filler id:row-group-country-Italy
-            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             · │ └── LEAF id:3 name:"Donald Knuth" country:"Italy" year:2000
-            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001 ag-Grid-AutoColumn:2001
             · · └── LEAF id:4 name:"Marvin Minsky" country:"Italy" year:2001
         `);
 
@@ -318,19 +318,19 @@ describe('ag-grid grouping with transactions', () => {
         gridRows = new GridRows(api, 'transaction 1');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Ireland
-            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ │ └── LEAF id:1 name:"Ada Lovelace" country:"Ireland" year:2000
-            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001 ag-Grid-AutoColumn:2001
             │ · └── LEAF id:2 name:"Alan Turing" country:"Ireland" year:2001
-            ├─┬ filler id:row-group-country-Italy
-            │ ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            ├─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             │ │ ├── LEAF id:3 name:"Donald Knuth" country:"Italy" year:2000
             │ │ └── LEAF id:5 name:"Grace Hopper 6" country:"Italy" year:2000
-            │ └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001
+            │ └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001 ag-Grid-AutoColumn:2001
             │ · └── LEAF id:4 name:"Marvin Minsky" country:"Italy" year:2001
-            └─┬ filler id:row-group-country-Switzerland
-            · └─┬ LEAF_GROUP id:row-group-country-Switzerland-year-2000
+            └─┬ filler id:row-group-country-Switzerland ag-Grid-AutoColumn:"Switzerland"
+            · └─┬ LEAF_GROUP id:row-group-country-Switzerland-year-2000 ag-Grid-AutoColumn:2000
             · · └── LEAF id:0 name:"John Von Neumann" country:"Switzerland" year:2000
         `);
 
@@ -358,13 +358,13 @@ describe('ag-grid grouping with transactions', () => {
         gridRows = new GridRows(api, 'transaction 2');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Italy
-            │ ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            ├─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             │ │ └── LEAF id:3 name:"Donald Knuth" country:"Italy" year:2000
-            │ └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001
+            │ └─┬ LEAF_GROUP id:row-group-country-Italy-year-2001 ag-Grid-AutoColumn:2001
             │ · └── LEAF id:4 name:"Marvin Minsky" country:"Italy" year:2001
-            └─┬ filler id:row-group-country-Germany
-            · └─┬ LEAF_GROUP id:row-group-country-Germany-year-3000
+            └─┬ filler id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
+            · └─┬ LEAF_GROUP id:row-group-country-Germany-year-3000 ag-Grid-AutoColumn:3000
             · · ├── LEAF id:0 name:"John Von Neumann" country:"Germany" year:3000
             · · ├── LEAF id:1 name:"Ada Lovelace" country:"Germany" year:3000
             · · ├── LEAF id:2 name:"Alan Turing" country:"Germany" year:3000
@@ -392,14 +392,14 @@ describe('ag-grid grouping with transactions', () => {
         gridRows = new GridRows(api, 'transaction 2');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
-            └─┬ filler id:row-group-country-Germany
-            · ├─┬ LEAF_GROUP id:row-group-country-Germany-year-3000
+            └─┬ filler id:row-group-country-Germany ag-Grid-AutoColumn:"Germany"
+            · ├─┬ LEAF_GROUP id:row-group-country-Germany-year-3000 ag-Grid-AutoColumn:3000
             · │ ├── LEAF id:6 name:"Albert Einstein" country:"Germany" year:3000
             · │ └── LEAF id:5 name:"added" country:"Germany" year:3000
-            · ├─┬ LEAF_GROUP id:row-group-country-Germany-year-2001
+            · ├─┬ LEAF_GROUP id:row-group-country-Germany-year-2001 ag-Grid-AutoColumn:2001
             · │ ├── LEAF id:2 name:"Alan Turing" country:"Germany" year:2001
             · │ └── LEAF id:4 name:"Marvin Minsky" country:"Germany" year:2001
-            · └─┬ LEAF_GROUP id:row-group-country-Germany-year-2000
+            · └─┬ LEAF_GROUP id:row-group-country-Germany-year-2000 ag-Grid-AutoColumn:2000
             · · ├── LEAF id:1 name:"Ada Lovelace" country:"Germany" year:2000
             · · └── LEAF id:3 name:"Donald Knuth" country:"Germany" year:2000
         `);
@@ -431,16 +431,16 @@ describe('ag-grid grouping with transactions', () => {
         // Verify initial structure
         await new GridRows(api, 'initial with multiple groups').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Ireland
-            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ │ └── LEAF id:1 name:"John" country:"Ireland" year:2000
-            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2001 ag-Grid-AutoColumn:2001
             │ · └── LEAF id:2 name:"Jane" country:"Ireland" year:2001
-            ├─┬ filler id:row-group-country-Italy
-            │ └─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            ├─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ └─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             │ · └── LEAF id:3 name:"Mario" country:"Italy" year:2000
-            └─┬ filler id:row-group-country-France
-            · └─┬ LEAF_GROUP id:row-group-country-France-year-2000
+            └─┬ filler id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · └─┬ LEAF_GROUP id:row-group-country-France-year-2000 ag-Grid-AutoColumn:2000
             · · └── LEAF id:4 name:"Pierre" country:"France" year:2000
         `);
 
@@ -451,14 +451,14 @@ describe('ag-grid grouping with transactions', () => {
 
         await new GridRows(api, 'after removing year 2001 group').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Ireland
-            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ · └── LEAF id:1 name:"John" country:"Ireland" year:2000
-            ├─┬ filler id:row-group-country-Italy
-            │ └─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            ├─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ └─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             │ · └── LEAF id:3 name:"Mario" country:"Italy" year:2000
-            └─┬ filler id:row-group-country-France
-            · └─┬ LEAF_GROUP id:row-group-country-France-year-2000
+            └─┬ filler id:row-group-country-France ag-Grid-AutoColumn:"France"
+            · └─┬ LEAF_GROUP id:row-group-country-France-year-2000 ag-Grid-AutoColumn:2000
             · · └── LEAF id:4 name:"Pierre" country:"France" year:2000
         `);
 
@@ -469,11 +469,11 @@ describe('ag-grid grouping with transactions', () => {
 
         await new GridRows(api, 'after removing entire France group').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Ireland
-            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ · └── LEAF id:1 name:"John" country:"Ireland" year:2000
-            └─┬ filler id:row-group-country-Italy
-            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             · · └── LEAF id:3 name:"Mario" country:"Italy" year:2000
         `);
 
@@ -484,8 +484,8 @@ describe('ag-grid grouping with transactions', () => {
 
         await new GridRows(api, 'after removing Ireland group').check(`
             ROOT id:ROOT_NODE_ID
-            └─┬ filler id:row-group-country-Italy
-            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
+            └─┬ filler id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2000 ag-Grid-AutoColumn:2000
             · · └── LEAF id:3 name:"Mario" country:"Italy" year:2000
         `);
     });
@@ -521,11 +521,11 @@ describe('ag-grid grouping with transactions', () => {
             ├── LEAF id:4 name:"Empty" country:"" year:""
             ├── LEAF id:5 name:"Null" country:null year:null
             ├── LEAF id:6 name:"Orphan"
-            ├─┬ filler id:row-group-country-Ireland
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
             │ ├── LEAF id:2 name:"Jane" country:"Ireland"
-            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
+            │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ · └── LEAF id:1 name:"John" country:"Ireland" year:2000
-            └─┬ filler id:row-group-year-2000
+            └─┬ filler id:row-group-year-2000 ag-Grid-AutoColumn:2000
             · └── LEAF id:3 name:"Mario" year:2000
         `);
 
@@ -535,15 +535,15 @@ describe('ag-grid grouping with transactions', () => {
 
         await new GridRows(api, 'balanced groups with empty keys', { useFormatter: false }).check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Ireland
-            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
+            ├─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000 ag-Grid-AutoColumn:2000
             │ │ └── LEAF id:1 name:"John" country:"Ireland" year:2000
             │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-
             │ · └── LEAF id:2 name:"Jane" country:"Ireland"
             └─┬ filler id:row-group-country-
-            · ├─┬ LEAF_GROUP id:row-group-country--year-2000
+            · ├─┬ LEAF_GROUP id:row-group-country--year-2000 ag-Grid-AutoColumn:2000
             · │ └── LEAF id:3 name:"Mario" year:2000
-            · └─┬ LEAF_GROUP id:row-group-country--year-
+            · └─┬ LEAF_GROUP id:row-group-country--year- ag-Grid-AutoColumn:""
             · · ├── LEAF id:4 name:"Empty" country:"" year:""
             · · ├── LEAF id:5 name:"Null" country:null year:null
             · · └── LEAF id:6 name:"Orphan"
@@ -601,20 +601,20 @@ describe('ag-grid grouping with transactions', () => {
 
         await new GridRows(api, 'custom key creators grouping').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Europe
-            │ └─┬ LEAF_GROUP id:row-group-country-Europe-year-2000s
+            ├─┬ filler id:row-group-country-Europe ag-Grid-AutoColumn:"Ireland"
+            │ └─┬ LEAF_GROUP id:row-group-country-Europe-year-2000s ag-Grid-AutoColumn:2001
             │ · ├── LEAF id:1 name:"John" country:"Ireland" year:2001
             │ · └── LEAF id:2 name:"Pierre" country:"France" year:2005
-            ├─┬ filler id:"row-group-country-North America"
-            │ ├─┬ LEAF_GROUP id:"row-group-country-North America-year-2000s"
+            ├─┬ filler id:"row-group-country-North America" ag-Grid-AutoColumn:"USA"
+            │ ├─┬ LEAF_GROUP id:"row-group-country-North America-year-2000s" ag-Grid-AutoColumn:2001
             │ │ └── LEAF id:3 name:"Bob" country:"USA" year:2001
-            │ └─┬ LEAF_GROUP id:"row-group-country-North America-year-1990s"
+            │ └─┬ LEAF_GROUP id:"row-group-country-North America-year-1990s" ag-Grid-AutoColumn:1995
             │ · └── LEAF id:4 name:"Alex" country:"Canada" year:1995
-            ├─┬ filler id:"row-group-country-South America"
-            │ └─┬ LEAF_GROUP id:"row-group-country-South America-year-1990s"
+            ├─┬ filler id:"row-group-country-South America" ag-Grid-AutoColumn:"Brazil"
+            │ └─┬ LEAF_GROUP id:"row-group-country-South America-year-1990s" ag-Grid-AutoColumn:1999
             │ · └── LEAF id:5 name:"Carlos" country:"Brazil" year:1999
-            └─┬ filler id:row-group-country-Other
-            · └─┬ LEAF_GROUP id:row-group-country-Other-year-2010s
+            └─┬ filler id:row-group-country-Other ag-Grid-AutoColumn:"Unknown"
+            · └─┬ LEAF_GROUP id:row-group-country-Other-year-2010s ag-Grid-AutoColumn:2010
             · · └── LEAF id:6 name:"Mystery" country:"Unknown" year:2010
         `);
 
@@ -625,19 +625,19 @@ describe('ag-grid grouping with transactions', () => {
 
         await new GridRows(api, 'after updating to change custom key').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-country-Europe
-            │ ├─┬ LEAF_GROUP id:row-group-country-Europe-year-2000s
+            ├─┬ filler id:row-group-country-Europe ag-Grid-AutoColumn:"Ireland"
+            │ ├─┬ LEAF_GROUP id:row-group-country-Europe-year-2000s ag-Grid-AutoColumn:2001
             │ │ ├── LEAF id:1 name:"John" country:"Ireland" year:2001
             │ │ └── LEAF id:2 name:"Pierre" country:"France" year:2005
-            │ └─┬ LEAF_GROUP id:row-group-country-Europe-year-2010s
+            │ └─┬ LEAF_GROUP id:row-group-country-Europe-year-2010s ag-Grid-AutoColumn:2010
             │ · └── LEAF id:6 name:"Mystery Irish" country:"Ireland" year:2010
-            ├─┬ filler id:"row-group-country-North America"
-            │ ├─┬ LEAF_GROUP id:"row-group-country-North America-year-2000s"
+            ├─┬ filler id:"row-group-country-North America" ag-Grid-AutoColumn:"USA"
+            │ ├─┬ LEAF_GROUP id:"row-group-country-North America-year-2000s" ag-Grid-AutoColumn:2001
             │ │ └── LEAF id:3 name:"Bob" country:"USA" year:2001
-            │ └─┬ LEAF_GROUP id:"row-group-country-North America-year-1990s"
+            │ └─┬ LEAF_GROUP id:"row-group-country-North America-year-1990s" ag-Grid-AutoColumn:1995
             │ · └── LEAF id:4 name:"Alex" country:"Canada" year:1995
-            └─┬ filler id:"row-group-country-South America"
-            · └─┬ LEAF_GROUP id:"row-group-country-South America-year-1990s"
+            └─┬ filler id:"row-group-country-South America" ag-Grid-AutoColumn:"Brazil"
+            · └─┬ LEAF_GROUP id:"row-group-country-South America-year-1990s" ag-Grid-AutoColumn:1999
             · · └── LEAF id:5 name:"Carlos" country:"Brazil" year:1999
         `);
     });
@@ -667,15 +667,15 @@ describe('ag-grid grouping with transactions', () => {
 
         await new GridRows(api, 'initial departments').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-department-Engineering
-            │ ├─┬ LEAF_GROUP id:row-group-department-Engineering-level-Junior
+            ├─┬ filler id:row-group-department-Engineering ag-Grid-AutoColumn:"Engineering"
+            │ ├─┬ LEAF_GROUP id:row-group-department-Engineering-level-Junior ag-Grid-AutoColumn:"Junior"
             │ │ └── LEAF id:1 name:"Alice" department:"Engineering" level:"Junior"
-            │ └─┬ LEAF_GROUP id:row-group-department-Engineering-level-Senior
+            │ └─┬ LEAF_GROUP id:row-group-department-Engineering-level-Senior ag-Grid-AutoColumn:"Senior"
             │ · └── LEAF id:2 name:"Bob" department:"Engineering" level:"Senior"
-            └─┬ filler id:row-group-department-Sales
-            · ├─┬ LEAF_GROUP id:row-group-department-Sales-level-Junior
+            └─┬ filler id:row-group-department-Sales ag-Grid-AutoColumn:"Sales"
+            · ├─┬ LEAF_GROUP id:row-group-department-Sales-level-Junior ag-Grid-AutoColumn:"Junior"
             · │ └── LEAF id:3 name:"Charlie" department:"Sales" level:"Junior"
-            · └─┬ LEAF_GROUP id:row-group-department-Sales-level-Senior
+            · └─┬ LEAF_GROUP id:row-group-department-Sales-level-Senior ag-Grid-AutoColumn:"Senior"
             · · └── LEAF id:4 name:"Diana" department:"Sales" level:"Senior"
         `);
 
@@ -686,14 +686,14 @@ describe('ag-grid grouping with transactions', () => {
 
         await new GridRows(api, 'after moving Alice to Sales').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-department-Engineering
-            │ └─┬ LEAF_GROUP id:row-group-department-Engineering-level-Senior
+            ├─┬ filler id:row-group-department-Engineering ag-Grid-AutoColumn:"Engineering"
+            │ └─┬ LEAF_GROUP id:row-group-department-Engineering-level-Senior ag-Grid-AutoColumn:"Senior"
             │ · └── LEAF id:2 name:"Bob" department:"Engineering" level:"Senior"
-            └─┬ filler id:row-group-department-Sales
-            · ├─┬ LEAF_GROUP id:row-group-department-Sales-level-Junior
+            └─┬ filler id:row-group-department-Sales ag-Grid-AutoColumn:"Sales"
+            · ├─┬ LEAF_GROUP id:row-group-department-Sales-level-Junior ag-Grid-AutoColumn:"Junior"
             · │ ├── LEAF id:1 name:"Alice" department:"Sales" level:"Junior"
             · │ └── LEAF id:3 name:"Charlie" department:"Sales" level:"Junior"
-            · └─┬ LEAF_GROUP id:row-group-department-Sales-level-Senior
+            · └─┬ LEAF_GROUP id:row-group-department-Sales-level-Senior ag-Grid-AutoColumn:"Senior"
             · · └── LEAF id:4 name:"Diana" department:"Sales" level:"Senior"
         `);
 
@@ -704,14 +704,14 @@ describe('ag-grid grouping with transactions', () => {
 
         await new GridRows(api, 'after moving Bob to new department').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-department-Sales
-            │ ├─┬ LEAF_GROUP id:row-group-department-Sales-level-Junior
+            ├─┬ filler id:row-group-department-Sales ag-Grid-AutoColumn:"Sales"
+            │ ├─┬ LEAF_GROUP id:row-group-department-Sales-level-Junior ag-Grid-AutoColumn:"Junior"
             │ │ ├── LEAF id:1 name:"Alice" department:"Sales" level:"Junior"
             │ │ └── LEAF id:3 name:"Charlie" department:"Sales" level:"Junior"
-            │ └─┬ LEAF_GROUP id:row-group-department-Sales-level-Senior
+            │ └─┬ LEAF_GROUP id:row-group-department-Sales-level-Senior ag-Grid-AutoColumn:"Senior"
             │ · └── LEAF id:4 name:"Diana" department:"Sales" level:"Senior"
-            └─┬ filler id:row-group-department-Marketing
-            · └─┬ LEAF_GROUP id:row-group-department-Marketing-level-Manager
+            └─┬ filler id:row-group-department-Marketing ag-Grid-AutoColumn:"Marketing"
+            · └─┬ LEAF_GROUP id:row-group-department-Marketing-level-Manager ag-Grid-AutoColumn:"Manager"
             · · └── LEAF id:2 name:"Bob" department:"Marketing" level:"Manager"
         `);
 
@@ -725,16 +725,16 @@ describe('ag-grid grouping with transactions', () => {
 
         await new GridRows(api, 'after batch move to Engineering').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-department-Sales
-            │ └─┬ LEAF_GROUP id:row-group-department-Sales-level-Junior
+            ├─┬ filler id:row-group-department-Sales ag-Grid-AutoColumn:"Sales"
+            │ └─┬ LEAF_GROUP id:row-group-department-Sales-level-Junior ag-Grid-AutoColumn:"Junior"
             │ · └── LEAF id:1 name:"Alice" department:"Sales" level:"Junior"
-            ├─┬ filler id:row-group-department-Marketing
-            │ └─┬ LEAF_GROUP id:row-group-department-Marketing-level-Manager
+            ├─┬ filler id:row-group-department-Marketing ag-Grid-AutoColumn:"Marketing"
+            │ └─┬ LEAF_GROUP id:row-group-department-Marketing-level-Manager ag-Grid-AutoColumn:"Manager"
             │ · └── LEAF id:2 name:"Bob" department:"Marketing" level:"Manager"
-            └─┬ filler id:row-group-department-Engineering
-            · ├─┬ LEAF_GROUP id:row-group-department-Engineering-level-Senior
+            └─┬ filler id:row-group-department-Engineering ag-Grid-AutoColumn:"Engineering"
+            · ├─┬ LEAF_GROUP id:row-group-department-Engineering-level-Senior ag-Grid-AutoColumn:"Senior"
             · │ └── LEAF id:3 name:"Charlie" department:"Engineering" level:"Senior"
-            · └─┬ LEAF_GROUP id:row-group-department-Engineering-level-Junior
+            · └─┬ LEAF_GROUP id:row-group-department-Engineering-level-Junior ag-Grid-AutoColumn:"Junior"
             · · └── LEAF id:4 name:"Diana" department:"Engineering" level:"Junior"
         `);
     });
@@ -789,15 +789,15 @@ describe('ag-grid grouping with transactions', () => {
 
         await new GridRows(api, 'after complex async operations').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ filler id:row-group-status-Completed
-            │ ├─┬ LEAF_GROUP id:row-group-status-Completed-priority-High
+            ├─┬ filler id:row-group-status-Completed ag-Grid-AutoColumn:"Completed"
+            │ ├─┬ LEAF_GROUP id:row-group-status-Completed-priority-High ag-Grid-AutoColumn:"High"
             │ │ └── LEAF id:1 name:"Task1" status:"Completed" priority:"High"
-            │ └─┬ LEAF_GROUP id:row-group-status-Completed-priority-Medium
+            │ └─┬ LEAF_GROUP id:row-group-status-Completed-priority-Medium ag-Grid-AutoColumn:"Medium"
             │ · └── LEAF id:4 name:"Task4" status:"Completed" priority:"Medium"
-            └─┬ filler id:row-group-status-Blocked
-            · ├─┬ LEAF_GROUP id:row-group-status-Blocked-priority-Low
+            └─┬ filler id:row-group-status-Blocked ag-Grid-AutoColumn:"Blocked"
+            · ├─┬ LEAF_GROUP id:row-group-status-Blocked-priority-Low ag-Grid-AutoColumn:"Low"
             · │ └── LEAF id:2 name:"Task2" status:"Blocked" priority:"Low"
-            · └─┬ LEAF_GROUP id:row-group-status-Blocked-priority-Critical
+            · └─┬ LEAF_GROUP id:row-group-status-Blocked-priority-Critical ag-Grid-AutoColumn:"Critical"
             · · ├── LEAF id:5 name:"Task5" status:"Blocked" priority:"Critical"
             · · └── LEAF id:6 name:"Task6" status:"Blocked" priority:"Critical"
         `);

--- a/testing/behavioural/src/grouping-data/grouping-with-transactions.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-with-transactions.test.ts
@@ -2,7 +2,6 @@ import type { GridOptions } from 'ag-grid-community';
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { RowGroupingModule } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions } from '../test-utils';
 import { GridRows, TestGridsManager, applyTransactionChecked, executeTransactionsAsync } from '../test-utils';
 
 describe('ag-grid grouping with transactions', () => {
@@ -204,11 +203,7 @@ describe('ag-grid grouping with transactions', () => {
             api
         );
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['country', 'year', 'name'],
-        };
-
-        let gridRows = new GridRows(api, 'first', gridRowsOptions);
+        let gridRows = new GridRows(api, 'first');
 
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
@@ -240,7 +235,7 @@ describe('ag-grid grouping with transactions', () => {
             api
         );
 
-        gridRows = new GridRows(api, 'update 1', gridRowsOptions);
+        gridRows = new GridRows(api, 'update 1');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Italy
@@ -289,10 +284,7 @@ describe('ag-grid grouping with transactions', () => {
             api
         );
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['country', 'year', 'name'],
-        };
-        let gridRows = new GridRows(api, 'first', gridRowsOptions);
+        let gridRows = new GridRows(api, 'first');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Ireland
@@ -323,7 +315,7 @@ describe('ag-grid grouping with transactions', () => {
             api
         );
 
-        gridRows = new GridRows(api, 'transaction 1', gridRowsOptions);
+        gridRows = new GridRows(api, 'transaction 1');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Ireland
@@ -363,7 +355,7 @@ describe('ag-grid grouping with transactions', () => {
             api
         );
 
-        gridRows = new GridRows(api, 'transaction 2', gridRowsOptions);
+        gridRows = new GridRows(api, 'transaction 2');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Italy
@@ -397,7 +389,7 @@ describe('ag-grid grouping with transactions', () => {
             api
         );
 
-        gridRows = new GridRows(api, 'transaction 2', gridRowsOptions);
+        gridRows = new GridRows(api, 'transaction 2');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             └─┬ filler id:row-group-country-Germany
@@ -436,12 +428,8 @@ describe('ag-grid grouping with transactions', () => {
             ],
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['country', 'year', 'name'],
-        };
-
         // Verify initial structure
-        await new GridRows(api, 'initial with multiple groups', gridRowsOptions).check(`
+        await new GridRows(api, 'initial with multiple groups').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Ireland
             │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
@@ -461,7 +449,7 @@ describe('ag-grid grouping with transactions', () => {
             remove: [{ id: '2' }],
         });
 
-        await new GridRows(api, 'after removing year 2001 group', gridRowsOptions).check(`
+        await new GridRows(api, 'after removing year 2001 group').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Ireland
             │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
@@ -479,7 +467,7 @@ describe('ag-grid grouping with transactions', () => {
             remove: [{ id: '4' }],
         });
 
-        await new GridRows(api, 'after removing entire France group', gridRowsOptions).check(`
+        await new GridRows(api, 'after removing entire France group').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Ireland
             │ └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
@@ -494,7 +482,7 @@ describe('ag-grid grouping with transactions', () => {
             remove: [{ id: '1' }],
         });
 
-        await new GridRows(api, 'after removing Ireland group', gridRowsOptions).check(`
+        await new GridRows(api, 'after removing Ireland group').check(`
             ROOT id:ROOT_NODE_ID
             └─┬ filler id:row-group-country-Italy
             · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2000
@@ -528,13 +516,7 @@ describe('ag-grid grouping with transactions', () => {
             ],
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['country', 'year', 'name'],
-
-            useFormatter: false,
-        };
-
-        await new GridRows(api, 'unbalanced groups with missing values', gridRowsOptions).check(`
+        await new GridRows(api, 'unbalanced groups with missing values', { useFormatter: false }).check(`
             ROOT id:ROOT_NODE_ID
             ├── LEAF id:4 name:"Empty" country:"" year:""
             ├── LEAF id:5 name:"Null" country:null year:null
@@ -551,7 +533,7 @@ describe('ag-grid grouping with transactions', () => {
         api.setGridOption('groupAllowUnbalanced', false);
         api.refreshClientSideRowModel();
 
-        await new GridRows(api, 'balanced groups with empty keys', gridRowsOptions).check(`
+        await new GridRows(api, 'balanced groups with empty keys', { useFormatter: false }).check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Ireland
             │ ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2000
@@ -617,11 +599,7 @@ describe('ag-grid grouping with transactions', () => {
             ],
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['country', 'year', 'name'],
-        };
-
-        await new GridRows(api, 'custom key creators grouping', gridRowsOptions).check(`
+        await new GridRows(api, 'custom key creators grouping').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Europe
             │ └─┬ LEAF_GROUP id:row-group-country-Europe-year-2000s
@@ -645,7 +623,7 @@ describe('ag-grid grouping with transactions', () => {
             update: [{ id: '6', country: 'Ireland', year: 2010, name: 'Mystery Irish' }],
         });
 
-        await new GridRows(api, 'after updating to change custom key', gridRowsOptions).check(`
+        await new GridRows(api, 'after updating to change custom key').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Europe
             │ ├─┬ LEAF_GROUP id:row-group-country-Europe-year-2000s
@@ -687,11 +665,7 @@ describe('ag-grid grouping with transactions', () => {
             ],
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['department', 'level', 'name'],
-        };
-
-        await new GridRows(api, 'initial departments', gridRowsOptions).check(`
+        await new GridRows(api, 'initial departments').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-department-Engineering
             │ ├─┬ LEAF_GROUP id:row-group-department-Engineering-level-Junior
@@ -710,7 +684,7 @@ describe('ag-grid grouping with transactions', () => {
             update: [{ id: '1', department: 'Sales', level: 'Junior', name: 'Alice' }],
         });
 
-        await new GridRows(api, 'after moving Alice to Sales', gridRowsOptions).check(`
+        await new GridRows(api, 'after moving Alice to Sales').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-department-Engineering
             │ └─┬ LEAF_GROUP id:row-group-department-Engineering-level-Senior
@@ -728,7 +702,7 @@ describe('ag-grid grouping with transactions', () => {
             update: [{ id: '2', department: 'Marketing', level: 'Manager', name: 'Bob' }],
         });
 
-        await new GridRows(api, 'after moving Bob to new department', gridRowsOptions).check(`
+        await new GridRows(api, 'after moving Bob to new department').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-department-Sales
             │ ├─┬ LEAF_GROUP id:row-group-department-Sales-level-Junior
@@ -749,7 +723,7 @@ describe('ag-grid grouping with transactions', () => {
             ],
         });
 
-        await new GridRows(api, 'after batch move to Engineering', gridRowsOptions).check(`
+        await new GridRows(api, 'after batch move to Engineering').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-department-Sales
             │ └─┬ LEAF_GROUP id:row-group-department-Sales-level-Junior
@@ -792,10 +766,6 @@ describe('ag-grid grouping with transactions', () => {
             api
         );
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['status', 'priority', 'name'],
-        };
-
         // Complex async operations that test race conditions
         await executeTransactionsAsync(
             [
@@ -817,7 +787,7 @@ describe('ag-grid grouping with transactions', () => {
             api
         );
 
-        await new GridRows(api, 'after complex async operations', gridRowsOptions).check(`
+        await new GridRows(api, 'after complex async operations').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-status-Completed
             │ ├─┬ LEAF_GROUP id:row-group-status-Completed-priority-High

--- a/testing/behavioural/src/row-data/row-data-order.test.ts
+++ b/testing/behavioural/src/row-data/row-data-order.test.ts
@@ -3,7 +3,6 @@ import type { MockInstance } from 'vitest';
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import type { GridOptions, RowDataTransaction } from 'ag-grid-community';
 
-import type { GridRowsOptions } from '../test-utils';
 import {
     GridRows,
     TestGridsManager,
@@ -745,10 +744,6 @@ describe('ag-grid rows-ordering', () => {
                 { id: '3', x: 6 },
             ];
 
-            const gridRowsOptions: GridRowsOptions = {
-                checkDom: false,
-            };
-
             consoleWarnSpy = vitest.spyOn(console, 'warn').mockImplementation(() => {});
 
             const api = gridsManager.createGrid('myGrid', {
@@ -761,7 +756,7 @@ describe('ag-grid rows-ordering', () => {
             expect(consoleWarnSpy).toHaveBeenCalled();
             consoleWarnSpy.mockReset();
 
-            await new GridRows(api, 'data', gridRowsOptions).check(`
+            await new GridRows(api, 'data', { checkDom: false }).check(`
                 ROOT id:ROOT_NODE_ID
                 ├── LEAF id:1 x:1
                 ├── LEAF id:2 x:2
@@ -790,7 +785,7 @@ describe('ag-grid rows-ordering', () => {
             expect(consoleWarnSpy).toHaveBeenCalled();
             consoleWarnSpy.mockReset();
 
-            await new GridRows(api, 'data', gridRowsOptions).check(`
+            await new GridRows(api, 'data', { checkDom: false }).check(`
                 ROOT id:ROOT_NODE_ID
                 ├── LEAF id:1 x:1
                 ├── LEAF id:13 x:131

--- a/testing/behavioural/src/selection/cell-selection.test.ts
+++ b/testing/behavioural/src/selection/cell-selection.test.ts
@@ -690,19 +690,15 @@ describe('Cell Selection', () => {
 
             assertColumnsSelected([], api);
 
-            await new GridRows(api, 'grid', {
-                printIds: false,
-                printRowIndices: false,
-                columns: ['sport'],
-            }).check(`
-                ROOT
-                ├── LEAF sport:"cricket"
-                ├── LEAF sport:"football"
-                ├── LEAF sport:"golf"
-                ├── LEAF sport:"rowing"
-                ├── LEAF sport:"rugby"
-                ├── LEAF sport:"swimming"
-                └── LEAF sport:"tennis"
+            await new GridRows(api, 'grid').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:3 sport:"cricket" year:2003 amount:11 day:"friday"
+                ├── LEAF id:0 sport:"football" year:2021 amount:43 day:"monday"
+                ├── LEAF id:4 sport:"golf" year:2021 amount:7 day:"monday"
+                ├── LEAF id:6 sport:"rowing" year:2019 amount:32 day:"saturday"
+                ├── LEAF id:1 sport:"rugby" year:2020 amount:102 day:"sunday"
+                ├── LEAF id:5 sport:"swimming" year:2020 amount:93 day:"tuesday"
+                └── LEAF id:2 sport:"tennis" year:2018 amount:235 day:"thursday"
             `);
         });
 

--- a/testing/behavioural/src/test-utils/gridRows/gridRows.ts
+++ b/testing/behavioural/src/test-utils/gridRows/gridRows.ts
@@ -19,7 +19,7 @@ export interface GridRowsOptions<TData = any> {
     /**
      * Columns to include when making the diagram. If true, all columns will be included.
      * If an array, it must contain the id of the columns to include. Default is false, no columns.
-     * Default is true
+     * Default is true. There is usually no need to defined this.
      */
     columns?: (string | Column)[] | boolean;
 
@@ -37,7 +37,7 @@ export interface GridRowsOptions<TData = any> {
 
     errors?: GridRowsErrors<TData>;
 
-    /** Forces treeData to be checked as true or false */
+    /** Forces treeData to be checked as true or false. There is usually no need to set this. */
     treeData?: boolean;
 
     /** Adds data field values to the snapshot, e.g. ['group'] -> data.group:"value" */
@@ -62,6 +62,11 @@ export class GridRows<TData = any> {
     #displayedRowsSet: Set<RowNode<TData>> | null = null;
     readonly #detailGridRows: Map<IRowNode<TData> | GridApi, GridRows<any>>;
 
+    /**
+     * @param api The grid API instance
+     * @param label A label to identify the grid in error messages and diagrams
+     * @param options Options to configure the GridRows instance - please try to not use this, the default options should be enough
+     */
     public constructor(
         api: GridApi<TData>,
         public readonly label: string = '',

--- a/testing/behavioural/src/test-utils/gridRows/gridRows.ts
+++ b/testing/behavioural/src/test-utils/gridRows/gridRows.ts
@@ -21,7 +21,7 @@ export interface GridRowsOptions<TData = any> {
      * If an array, it must contain the id of the columns to include. Default is false, no columns.
      * Default is true. There is usually no need to defined this.
      */
-    columns?: (string | Column)[] | boolean;
+    forcedColumns?: (string | Column)[] | boolean;
 
     /** If false, the id will not be shown in the diagram. Default is true */
     printIds?: boolean;
@@ -38,7 +38,7 @@ export interface GridRowsOptions<TData = any> {
     errors?: GridRowsErrors<TData>;
 
     /** Forces treeData to be checked as true or false. There is usually no need to set this. */
-    treeData?: boolean;
+    forcedTreeData?: boolean;
 
     /** Adds data field values to the snapshot, e.g. ['group'] -> data.group:"value" */
     nodeDataProps?: string[];
@@ -75,7 +75,7 @@ export class GridRows<TData = any> {
         this.api = api;
         const errors = options.errors || new GridRowsErrors<TData>();
         this.errors = errors;
-        this.treeData = options.treeData ?? !!api.getGridOption('treeData');
+        this.treeData = options.forcedTreeData ?? !!api.getGridOption('treeData');
         const rowNodes: RowNode<TData>[] = [];
         const displayedRows: RowNode<TData>[] = [];
         const rootNodesSet = new Set<RowNode<TData>>();
@@ -100,7 +100,7 @@ export class GridRows<TData = any> {
                         const detailGridRow = new GridRows(api, label, {
                             ...options,
                             errors,
-                            columns: options.columns ?? true,
+                            forcedColumns: options.forcedColumns ?? true,
                         });
                         detailGridRows.set(row, detailGridRow);
                         detailGridRows.set(api, detailGridRow);
@@ -168,7 +168,7 @@ export class GridRows<TData = any> {
 
     public makeDiagram(printErrors = false): string {
         let columns: Column[] | null = null;
-        const optionsColumns = this.options.columns ?? true;
+        const optionsColumns = this.options.forcedColumns ?? true;
         if (optionsColumns) {
             columns = this.api.getAllGridColumns();
             if (Array.isArray(optionsColumns)) {

--- a/testing/behavioural/src/tree-data/datapath/stages/tree-aggregation.test.ts
+++ b/testing/behavioural/src/tree-data/datapath/stages/tree-aggregation.test.ts
@@ -1,7 +1,6 @@
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { TreeDataModule } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions } from '../../../test-utils';
 import {
     GridRows,
     TestGridsManager,
@@ -50,22 +49,18 @@ describe('ag-grid tree aggregation', () => {
             getDataPath: (data: any) => data.path,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['name', 'x'],
-        };
-
-        await new GridRows(api, 'initial', gridRowsOptions).check(`
+        await new GridRows(api, 'initial').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ A GROUP id:1 name:"John Von Neumann" x:9
-            │ ├─┬ B GROUP id:2 name:"Alan Turing" x:3
-            │ │ ├── D LEAF id:4 name:"Donald Knuth" x:1
-            │ │ └── E LEAF id:5 name:"Grace Hopper" x:2
-            │ └─┬ C GROUP id:3 name:"A. Church" x:6
-            │ · ├── F LEAF id:6 name:"Linus Torvalds" x:2
-            │ · ├── G LEAF id:7 name:"Brian Kernighan" x:2
-            │ · └─┬ H filler id:row-group-0-A-1-C-2-H x:2
-            │ · · └── I LEAF id:8 name:"Claude Elwood Shannon" x:2
-            └── J LEAF id:9 name:"E. Dijkstra" x:2
+            ├─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" name:"John Von Neumann" x:9
+            │ ├─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" name:"Alan Turing" x:3
+            │ │ ├── D LEAF id:4 ag-Grid-AutoColumn:"D" name:"Donald Knuth" x:1
+            │ │ └── E LEAF id:5 ag-Grid-AutoColumn:"E" name:"Grace Hopper" x:2
+            │ └─┬ C GROUP id:3 ag-Grid-AutoColumn:"C" name:"A. Church" x:6
+            │ · ├── F LEAF id:6 ag-Grid-AutoColumn:"F" name:"Linus Torvalds" x:2
+            │ · ├── G LEAF id:7 ag-Grid-AutoColumn:"G" name:"Brian Kernighan" x:2
+            │ · └─┬ H filler id:row-group-0-A-1-C-2-H ag-Grid-AutoColumn:"H" x:2
+            │ · · └── I LEAF id:8 ag-Grid-AutoColumn:"I" name:"Claude Elwood Shannon" x:2
+            └── J LEAF id:9 ag-Grid-AutoColumn:"J" name:"E. Dijkstra" x:2
         `);
 
         api.setGridOption(
@@ -83,18 +78,18 @@ describe('ag-grid tree aggregation', () => {
             ])
         );
 
-        await new GridRows(api, 'update x', gridRowsOptions).check(`
+        await new GridRows(api, 'update x').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ A GROUP id:1 name:"John Von Neumann" x:26
-            │ ├─┬ B GROUP id:2 name:"Alan Turing" x:12
-            │ │ ├── E LEAF id:5 name:"Grace Hopper" x:2
-            │ │ └── D LEAF id:4 name:"Donald Knuth" x:10
-            │ └─┬ C GROUP id:3 name:"A. Church" x:14
-            │ · ├── F LEAF id:6 name:"Linus Torvalds" x:2
-            │ · ├── G LEAF id:7 name:"Brian Kernighan" x:2
-            │ · └─┬ H filler id:row-group-0-A-1-C-2-H x:10
-            │ · · └── I LEAF id:8 name:"Claude Elwood Shannon" x:10
-            └── J LEAF id:9 name:"E. Dijkstra" x:2
+            ├─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" name:"John Von Neumann" x:26
+            │ ├─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" name:"Alan Turing" x:12
+            │ │ ├── E LEAF id:5 ag-Grid-AutoColumn:"E" name:"Grace Hopper" x:2
+            │ │ └── D LEAF id:4 ag-Grid-AutoColumn:"D" name:"Donald Knuth" x:10
+            │ └─┬ C GROUP id:3 ag-Grid-AutoColumn:"C" name:"A. Church" x:14
+            │ · ├── F LEAF id:6 ag-Grid-AutoColumn:"F" name:"Linus Torvalds" x:2
+            │ · ├── G LEAF id:7 ag-Grid-AutoColumn:"G" name:"Brian Kernighan" x:2
+            │ · └─┬ H filler id:row-group-0-A-1-C-2-H ag-Grid-AutoColumn:"H" x:10
+            │ · · └── I LEAF id:8 ag-Grid-AutoColumn:"I" name:"Claude Elwood Shannon" x:10
+            └── J LEAF id:9 ag-Grid-AutoColumn:"J" name:"E. Dijkstra" x:2
         `);
 
         api.setGridOption(
@@ -111,17 +106,17 @@ describe('ag-grid tree aggregation', () => {
             ])
         );
 
-        await new GridRows(api, 'delete', gridRowsOptions).check(`
+        await new GridRows(api, 'delete').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ A GROUP id:1 name:"John Von Neumann" x:24
-            │ ├─┬ B GROUP id:2 name:"Alan Turing" x:12
-            │ │ ├── E LEAF id:5 name:"Grace Hopper" x:2
-            │ │ └── D LEAF id:4 name:"Donald Knuth" x:10
-            │ └─┬ C GROUP id:3 name:"A. Church" x:12
-            │ · ├── F LEAF id:6 name:"Linus Torvalds" x:2
-            │ · └─┬ H filler id:row-group-0-A-1-C-2-H x:10
-            │ · · └── I LEAF id:8 name:"Claude Elwood Shannon" x:10
-            └── J LEAF id:9 name:"E. Dijkstra" x:2
+            ├─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" name:"John Von Neumann" x:24
+            │ ├─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" name:"Alan Turing" x:12
+            │ │ ├── E LEAF id:5 ag-Grid-AutoColumn:"E" name:"Grace Hopper" x:2
+            │ │ └── D LEAF id:4 ag-Grid-AutoColumn:"D" name:"Donald Knuth" x:10
+            │ └─┬ C GROUP id:3 ag-Grid-AutoColumn:"C" name:"A. Church" x:12
+            │ · ├── F LEAF id:6 ag-Grid-AutoColumn:"F" name:"Linus Torvalds" x:2
+            │ · └─┬ H filler id:row-group-0-A-1-C-2-H ag-Grid-AutoColumn:"H" x:10
+            │ · · └── I LEAF id:8 ag-Grid-AutoColumn:"I" name:"Claude Elwood Shannon" x:10
+            └── J LEAF id:9 ag-Grid-AutoColumn:"J" name:"E. Dijkstra" x:2
         `);
 
         const movedRowData = cachedJSONObjects.array([
@@ -137,17 +132,17 @@ describe('ag-grid tree aggregation', () => {
 
         setRowDataChecked(api, movedRowData);
 
-        await new GridRows(api, 'move', gridRowsOptions).check(`
+        await new GridRows(api, 'move').check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ A GROUP id:1 name:"John Von Neumann" x:25
-            │ ├─┬ B GROUP id:2 name:"Alan Turing" x:24
-            │ │ ├── E LEAF id:5 name:"Grace Hopper" x:2
-            │ │ ├── D LEAF id:4 name:"Donald Knuth" x:10
-            │ │ ├─┬ F filler id:row-group-0-A-1-B-2-F x:2
-            │ │ │ └── G LEAF id:6 name:"Linus Torvalds" x:2
-            │ │ └── H LEAF id:8 name:"Claude Elwood Shannon" x:10
-            │ └── C LEAF id:3 name:"A. Church" x:1
-            └── J LEAF id:9 name:"E. Dijkstra" x:2
+            ├─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" name:"John Von Neumann" x:25
+            │ ├─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" name:"Alan Turing" x:24
+            │ │ ├── E LEAF id:5 ag-Grid-AutoColumn:"E" name:"Grace Hopper" x:2
+            │ │ ├── D LEAF id:4 ag-Grid-AutoColumn:"D" name:"Donald Knuth" x:10
+            │ │ ├─┬ F filler id:row-group-0-A-1-B-2-F ag-Grid-AutoColumn:"F" x:2
+            │ │ │ └── G LEAF id:6 ag-Grid-AutoColumn:"G" name:"Linus Torvalds" x:2
+            │ │ └── H LEAF id:8 ag-Grid-AutoColumn:"H" name:"Claude Elwood Shannon" x:10
+            │ └── C LEAF id:3 ag-Grid-AutoColumn:"C" name:"A. Church" x:1
+            └── J LEAF id:9 ag-Grid-AutoColumn:"J" name:"E. Dijkstra" x:2
         `);
     });
 
@@ -182,24 +177,20 @@ describe('ag-grid tree aggregation', () => {
                 getDataPath: (data: any) => data.path,
             });
 
-            const gridRowsOptions: GridRowsOptions = {
-                columns: ['x', 'y'],
-            };
-
-            await new GridRows(api, 'initial', gridRowsOptions).check(`
+            await new GridRows(api, 'initial').check(`
                 ROOT id:ROOT_NODE_ID
-                └─┬ A GROUP id:0 x:12 y:28
-                · ├─┬ B GROUP id:1 x:2 y:3
-                · │ ├── D LEAF id:2 x:1 y:1
-                · │ └── E LEAF id:3 x:1 y:2
-                · └─┬ C filler id:row-group-0-A-1-C x:10 y:25
-                · · ├── F LEAF id:4 x:2 y:3
-                · · ├── G LEAF id:5 x:2 y:4
-                · · └─┬ H filler id:row-group-0-A-1-C-2-H x:6 y:18
-                · · · ├── I LEAF id:6 x:2 y:5
-                · · · ├── J LEAF id:7 x:2 y:6
-                · · · └─┬ K filler id:row-group-0-A-1-C-2-H-3-K x:2 y:7
-                · · · · └── L LEAF id:8 x:2 y:7
+                └─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:12 y:28
+                · ├─┬ B GROUP id:1 ag-Grid-AutoColumn:"B" x:2 y:3
+                · │ ├── D LEAF id:2 ag-Grid-AutoColumn:"D" x:1 y:1
+                · │ └── E LEAF id:3 ag-Grid-AutoColumn:"E" x:1 y:2
+                · └─┬ C filler id:row-group-0-A-1-C ag-Grid-AutoColumn:"C" x:10 y:25
+                · · ├── F LEAF id:4 ag-Grid-AutoColumn:"F" x:2 y:3
+                · · ├── G LEAF id:5 ag-Grid-AutoColumn:"G" x:2 y:4
+                · · └─┬ H filler id:row-group-0-A-1-C-2-H ag-Grid-AutoColumn:"H" x:6 y:18
+                · · · ├── I LEAF id:6 ag-Grid-AutoColumn:"I" x:2 y:5
+                · · · ├── J LEAF id:7 ag-Grid-AutoColumn:"J" x:2 y:6
+                · · · └─┬ K filler id:row-group-0-A-1-C-2-H-3-K ag-Grid-AutoColumn:"K" x:2 y:7
+                · · · · └── L LEAF id:8 ag-Grid-AutoColumn:"L" x:2 y:7
             `);
 
             if (mode === 'transactions') {
@@ -219,17 +210,17 @@ describe('ag-grid tree aggregation', () => {
                 );
             }
 
-            await new GridRows(api, 'transaction 0 (remove)', gridRowsOptions).check(`
+            await new GridRows(api, 'transaction 0 (remove)').check(`
                 ROOT id:ROOT_NODE_ID
-                └─┬ A GROUP id:0 x:9 y:19
-                · ├─┬ B GROUP id:1 x:1 y:1
-                · │ └── D LEAF id:2 x:1 y:1
-                · └─┬ C filler id:row-group-0-A-1-C x:8 y:18
-                · · ├── F LEAF id:4 x:2 y:3
-                · · ├── G LEAF id:5 x:2 y:4
-                · · └─┬ H filler id:row-group-0-A-1-C-2-H x:4 y:11
-                · · · ├── I LEAF id:6 x:2 y:5
-                · · · └── J LEAF id:7 x:2 y:6
+                └─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:9 y:19
+                · ├─┬ B GROUP id:1 ag-Grid-AutoColumn:"B" x:1 y:1
+                · │ └── D LEAF id:2 ag-Grid-AutoColumn:"D" x:1 y:1
+                · └─┬ C filler id:row-group-0-A-1-C ag-Grid-AutoColumn:"C" x:8 y:18
+                · · ├── F LEAF id:4 ag-Grid-AutoColumn:"F" x:2 y:3
+                · · ├── G LEAF id:5 ag-Grid-AutoColumn:"G" x:2 y:4
+                · · └─┬ H filler id:row-group-0-A-1-C-2-H ag-Grid-AutoColumn:"H" x:4 y:11
+                · · · ├── I LEAF id:6 ag-Grid-AutoColumn:"I" x:2 y:5
+                · · · └── J LEAF id:7 ag-Grid-AutoColumn:"J" x:2 y:6
             `);
 
             if (mode === 'transactions') {
@@ -260,20 +251,20 @@ describe('ag-grid tree aggregation', () => {
                 );
             }
 
-            await new GridRows(api, 'transaction 1 (re-add, update)', gridRowsOptions).check(`
+            await new GridRows(api, 'transaction 1 (re-add, update)').check(`
                 ROOT id:ROOT_NODE_ID
-                └─┬ A GROUP id:0 x:110 y:1022
-                · ├─┬ B GROUP id:1 x:2 y:3
-                · │ ├── D LEAF id:2 x:1 y:1
-                · │ └── E LEAF id:3 x:1 y:2
-                · └─┬ C filler id:row-group-0-A-1-C x:108 y:1019
-                · · ├── F LEAF id:4 x:2 y:3
-                · · ├── G LEAF id:5 x:2 y:4
-                · · └─┬ H filler id:row-group-0-A-1-C-2-H x:104 y:1012
-                · · · ├── I LEAF id:6 x:100 y:5
-                · · · ├── J LEAF id:7 x:2 y:1000
-                · · · └─┬ K filler id:row-group-0-A-1-C-2-H-3-K x:2 y:7
-                · · · · └── L LEAF id:8 x:2 y:7
+                └─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:110 y:1022
+                · ├─┬ B GROUP id:1 ag-Grid-AutoColumn:"B" x:2 y:3
+                · │ ├── D LEAF id:2 ag-Grid-AutoColumn:"D" x:1 y:1
+                · │ └── E LEAF id:3 ag-Grid-AutoColumn:"E" x:1 y:2
+                · └─┬ C filler id:row-group-0-A-1-C ag-Grid-AutoColumn:"C" x:108 y:1019
+                · · ├── F LEAF id:4 ag-Grid-AutoColumn:"F" x:2 y:3
+                · · ├── G LEAF id:5 ag-Grid-AutoColumn:"G" x:2 y:4
+                · · └─┬ H filler id:row-group-0-A-1-C-2-H ag-Grid-AutoColumn:"H" x:104 y:1012
+                · · · ├── I LEAF id:6 ag-Grid-AutoColumn:"I" x:100 y:5
+                · · · ├── J LEAF id:7 ag-Grid-AutoColumn:"J" x:2 y:1000
+                · · · └─┬ K filler id:row-group-0-A-1-C-2-H-3-K ag-Grid-AutoColumn:"K" x:2 y:7
+                · · · · └── L LEAF id:8 ag-Grid-AutoColumn:"L" x:2 y:7
             `);
 
             if (mode === 'transactions') {
@@ -298,21 +289,21 @@ describe('ag-grid tree aggregation', () => {
                 ]);
             }
 
-            await new GridRows(api, 'transaction 2 (change path)', gridRowsOptions).check(`
+            await new GridRows(api, 'transaction 2 (change path)').check(`
                 ROOT id:ROOT_NODE_ID
-                ├─┬ A GROUP id:0 x:6 y:13
-                │ ├─┬ B GROUP id:1 x:2 y:3
-                │ │ ├── D LEAF id:2 x:1 y:1
-                │ │ └── E LEAF id:3 x:1 y:2
-                │ └─┬ C filler id:row-group-0-A-1-C x:4 y:10
-                │ · ├── F LEAF id:4 x:2 y:3
-                │ · └─┬ H filler id:row-group-0-A-1-C-2-H x:2 y:7
-                │ · · └─┬ K filler id:row-group-0-A-1-C-2-H-3-K x:2 y:7
-                │ · · · └── L LEAF id:8 x:2 y:7
-                └─┬ X filler id:row-group-0-X x:6 y:15
-                · ├── W LEAF id:5 x:2 y:4
-                · ├── Y LEAF id:6 x:2 y:5
-                · └── Z LEAF id:7 x:2 y:6
+                ├─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:6 y:13
+                │ ├─┬ B GROUP id:1 ag-Grid-AutoColumn:"B" x:2 y:3
+                │ │ ├── D LEAF id:2 ag-Grid-AutoColumn:"D" x:1 y:1
+                │ │ └── E LEAF id:3 ag-Grid-AutoColumn:"E" x:1 y:2
+                │ └─┬ C filler id:row-group-0-A-1-C ag-Grid-AutoColumn:"C" x:4 y:10
+                │ · ├── F LEAF id:4 ag-Grid-AutoColumn:"F" x:2 y:3
+                │ · └─┬ H filler id:row-group-0-A-1-C-2-H ag-Grid-AutoColumn:"H" x:2 y:7
+                │ · · └─┬ K filler id:row-group-0-A-1-C-2-H-3-K ag-Grid-AutoColumn:"K" x:2 y:7
+                │ · · · └── L LEAF id:8 ag-Grid-AutoColumn:"L" x:2 y:7
+                └─┬ X filler id:row-group-0-X ag-Grid-AutoColumn:"X" x:6 y:15
+                · ├── W LEAF id:5 ag-Grid-AutoColumn:"W" x:2 y:4
+                · ├── Y LEAF id:6 ag-Grid-AutoColumn:"Y" x:2 y:5
+                · └── Z LEAF id:7 ag-Grid-AutoColumn:"Z" x:2 y:6
             `);
 
             api.setGridOption('columnDefs', [
@@ -320,21 +311,21 @@ describe('ag-grid tree aggregation', () => {
                 { field: 'y', aggFunc: 'avg' },
             ]);
 
-            await new GridRows(api, 'change aggFunc', gridRowsOptions).check(`
+            await new GridRows(api, 'change aggFunc').check(`
                 ROOT id:ROOT_NODE_ID
-                ├─┬ A GROUP id:0 x:6 y:{"count":4,"value":3.25}
-                │ ├─┬ B GROUP id:1 x:2 y:{"count":2,"value":1.5}
-                │ │ ├── D LEAF id:2 x:1 y:1
-                │ │ └── E LEAF id:3 x:1 y:2
-                │ └─┬ C filler id:row-group-0-A-1-C x:4 y:{"count":2,"value":5}
-                │ · ├── F LEAF id:4 x:2 y:3
-                │ · └─┬ H filler id:row-group-0-A-1-C-2-H x:2 y:{"count":1,"value":7}
-                │ · · └─┬ K filler id:row-group-0-A-1-C-2-H-3-K x:2 y:{"count":1,"value":7}
-                │ · · · └── L LEAF id:8 x:2 y:7
-                └─┬ X filler id:row-group-0-X x:6 y:{"count":3,"value":5}
-                · ├── W LEAF id:5 x:2 y:4
-                · ├── Y LEAF id:6 x:2 y:5
-                · └── Z LEAF id:7 x:2 y:6
+                ├─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:6 y:{"count":4,"value":3.25}
+                │ ├─┬ B GROUP id:1 ag-Grid-AutoColumn:"B" x:2 y:{"count":2,"value":1.5}
+                │ │ ├── D LEAF id:2 ag-Grid-AutoColumn:"D" x:1 y:1
+                │ │ └── E LEAF id:3 ag-Grid-AutoColumn:"E" x:1 y:2
+                │ └─┬ C filler id:row-group-0-A-1-C ag-Grid-AutoColumn:"C" x:4 y:{"count":2,"value":5}
+                │ · ├── F LEAF id:4 ag-Grid-AutoColumn:"F" x:2 y:3
+                │ · └─┬ H filler id:row-group-0-A-1-C-2-H ag-Grid-AutoColumn:"H" x:2 y:{"count":1,"value":7}
+                │ · · └─┬ K filler id:row-group-0-A-1-C-2-H-3-K ag-Grid-AutoColumn:"K" x:2 y:{"count":1,"value":7}
+                │ · · · └── L LEAF id:8 ag-Grid-AutoColumn:"L" x:2 y:7
+                └─┬ X filler id:row-group-0-X ag-Grid-AutoColumn:"X" x:6 y:{"count":3,"value":5}
+                · ├── W LEAF id:5 ag-Grid-AutoColumn:"W" x:2 y:4
+                · ├── Y LEAF id:6 ag-Grid-AutoColumn:"Y" x:2 y:5
+                · └── Z LEAF id:7 ag-Grid-AutoColumn:"Z" x:2 y:6
             `);
 
             if (mode === 'transactions') {
@@ -362,17 +353,17 @@ describe('ag-grid tree aggregation', () => {
                 );
             }
 
-            await new GridRows(api, 'transaction 4 (update and change path)', gridRowsOptions).check(`
+            await new GridRows(api, 'transaction 4 (update and change path)').check(`
                 ROOT id:ROOT_NODE_ID
-                ├─┬ A GROUP id:0 x:102 y:{"count":2,"value":51.5}
-                │ ├─┬ B GROUP id:1 x:100 y:{"count":1,"value":100}
-                │ │ └── R LEAF id:8 x:100 y:100
-                │ └─┬ C filler id:row-group-0-A-1-C x:2 y:{"count":1,"value":3}
-                │ · └── F LEAF id:4 x:2 y:3
-                └─┬ X filler id:row-group-0-X x:300 y:{"count":2,"value":150}
-                · ├── Y LEAF id:6 x:100 y:100
-                · └─┬ W GROUP id:7 x:200 y:{"count":1,"value":200}
-                · · └── W LEAF id:5 x:200 y:200
+                ├─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:102 y:{"count":2,"value":51.5}
+                │ ├─┬ B GROUP id:1 ag-Grid-AutoColumn:"B" x:100 y:{"count":1,"value":100}
+                │ │ └── R LEAF id:8 ag-Grid-AutoColumn:"R" x:100 y:100
+                │ └─┬ C filler id:row-group-0-A-1-C ag-Grid-AutoColumn:"C" x:2 y:{"count":1,"value":3}
+                │ · └── F LEAF id:4 ag-Grid-AutoColumn:"F" x:2 y:3
+                └─┬ X filler id:row-group-0-X ag-Grid-AutoColumn:"X" x:300 y:{"count":2,"value":150}
+                · ├── Y LEAF id:6 ag-Grid-AutoColumn:"Y" x:100 y:100
+                · └─┬ W GROUP id:7 ag-Grid-AutoColumn:"W" x:200 y:{"count":1,"value":200}
+                · · └── W LEAF id:5 ag-Grid-AutoColumn:"W" x:200 y:200
             `);
         }
     );
@@ -405,19 +396,15 @@ describe('ag-grid tree aggregation', () => {
                 getDataPath: (data: any) => data.path,
             });
 
-            const gridRowsOptions: GridRowsOptions = {
-                columns: ['x', 'y'],
-            };
-
-            await new GridRows(api, 'initial', gridRowsOptions).check(`
+            await new GridRows(api, 'initial').check(`
                 ROOT id:ROOT_NODE_ID x:6 y:10
-                └─┬ A GROUP id:0 x:6 y:10
-                · ├─┬ B GROUP id:1 x:2 y:3
-                · │ ├── D LEAF id:2 x:1 y:1
-                · │ └── E LEAF id:3 x:1 y:2
-                · └─┬ C filler id:row-group-0-A-1-C x:4 y:7
-                · · ├── F LEAF id:4 x:2 y:3
-                · · └── G LEAF id:5 x:2 y:4
+                └─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:6 y:10
+                · ├─┬ B GROUP id:1 ag-Grid-AutoColumn:"B" x:2 y:3
+                · │ ├── D LEAF id:2 ag-Grid-AutoColumn:"D" x:1 y:1
+                · │ └── E LEAF id:3 ag-Grid-AutoColumn:"E" x:1 y:2
+                · └─┬ C filler id:row-group-0-A-1-C ag-Grid-AutoColumn:"C" x:4 y:7
+                · · ├── F LEAF id:4 ag-Grid-AutoColumn:"F" x:2 y:3
+                · · └── G LEAF id:5 ag-Grid-AutoColumn:"G" x:2 y:4
             `);
 
             if (mode === 'transactions') {
@@ -435,14 +422,14 @@ describe('ag-grid tree aggregation', () => {
                 );
             }
 
-            await new GridRows(api, 'transaction 1', gridRowsOptions).check(`
+            await new GridRows(api, 'transaction 1').check(`
                 ROOT id:ROOT_NODE_ID x:5 y:8
-                └─┬ A GROUP id:0 x:5 y:8
-                · ├─┬ B GROUP id:1 x:1 y:1
-                · │ └── D LEAF id:2 x:1 y:1
-                · └─┬ C filler id:row-group-0-A-1-C x:4 y:7
-                · · ├── F LEAF id:4 x:2 y:3
-                · · └── G LEAF id:5 x:2 y:4
+                └─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:5 y:8
+                · ├─┬ B GROUP id:1 ag-Grid-AutoColumn:"B" x:1 y:1
+                · │ └── D LEAF id:2 ag-Grid-AutoColumn:"D" x:1 y:1
+                · └─┬ C filler id:row-group-0-A-1-C ag-Grid-AutoColumn:"C" x:4 y:7
+                · · ├── F LEAF id:4 ag-Grid-AutoColumn:"F" x:2 y:3
+                · · └── G LEAF id:5 ag-Grid-AutoColumn:"G" x:2 y:4
             `);
 
             if (mode === 'transactions') {
@@ -460,38 +447,38 @@ describe('ag-grid tree aggregation', () => {
                 );
             }
 
-            await new GridRows(api, 'transaction 2', gridRowsOptions).check(`
+            await new GridRows(api, 'transaction 2').check(`
                 ROOT id:ROOT_NODE_ID x:103 y:105
-                └─┬ A GROUP id:0 x:103 y:105
-                · ├─┬ B GROUP id:1 x:1 y:1
-                · │ └── D LEAF id:2 x:1 y:1
-                · └─┬ C filler id:row-group-0-A-1-C x:102 y:104
-                · · ├── F LEAF id:4 x:100 y:100
-                · · └── G LEAF id:5 x:2 y:4
+                └─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:103 y:105
+                · ├─┬ B GROUP id:1 ag-Grid-AutoColumn:"B" x:1 y:1
+                · │ └── D LEAF id:2 ag-Grid-AutoColumn:"D" x:1 y:1
+                · └─┬ C filler id:row-group-0-A-1-C ag-Grid-AutoColumn:"C" x:102 y:104
+                · · ├── F LEAF id:4 ag-Grid-AutoColumn:"F" x:100 y:100
+                · · └── G LEAF id:5 ag-Grid-AutoColumn:"G" x:2 y:4
             `);
 
             api.setGridOption('alwaysAggregateAtRootLevel', false);
 
-            await new GridRows(api, 'alwaysAggregateAtRootLevel=false', gridRowsOptions).check(`
+            await new GridRows(api, 'alwaysAggregateAtRootLevel=false').check(`
                 ROOT id:ROOT_NODE_ID
-                └─┬ A GROUP id:0 x:103 y:105
-                · ├─┬ B GROUP id:1 x:1 y:1
-                · │ └── D LEAF id:2 x:1 y:1
-                · └─┬ C filler id:row-group-0-A-1-C x:102 y:104
-                · · ├── F LEAF id:4 x:100 y:100
-                · · └── G LEAF id:5 x:2 y:4
+                └─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:103 y:105
+                · ├─┬ B GROUP id:1 ag-Grid-AutoColumn:"B" x:1 y:1
+                · │ └── D LEAF id:2 ag-Grid-AutoColumn:"D" x:1 y:1
+                · └─┬ C filler id:row-group-0-A-1-C ag-Grid-AutoColumn:"C" x:102 y:104
+                · · ├── F LEAF id:4 ag-Grid-AutoColumn:"F" x:100 y:100
+                · · └── G LEAF id:5 ag-Grid-AutoColumn:"G" x:2 y:4
             `);
 
             api.setGridOption('alwaysAggregateAtRootLevel', true);
 
-            await new GridRows(api, 'alwaysAggregateAtRootLevel=true', gridRowsOptions).check(`
+            await new GridRows(api, 'alwaysAggregateAtRootLevel=true').check(`
                 ROOT id:ROOT_NODE_ID x:103 y:105
-                └─┬ A GROUP id:0 x:103 y:105
-                · ├─┬ B GROUP id:1 x:1 y:1
-                · │ └── D LEAF id:2 x:1 y:1
-                · └─┬ C filler id:row-group-0-A-1-C x:102 y:104
-                · · ├── F LEAF id:4 x:100 y:100
-                · · └── G LEAF id:5 x:2 y:4
+                └─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:103 y:105
+                · ├─┬ B GROUP id:1 ag-Grid-AutoColumn:"B" x:1 y:1
+                · │ └── D LEAF id:2 ag-Grid-AutoColumn:"D" x:1 y:1
+                · └─┬ C filler id:row-group-0-A-1-C ag-Grid-AutoColumn:"C" x:102 y:104
+                · · ├── F LEAF id:4 ag-Grid-AutoColumn:"F" x:100 y:100
+                · · └── G LEAF id:5 ag-Grid-AutoColumn:"G" x:2 y:4
             `);
         }
     );

--- a/testing/behavioural/src/tree-data/datapath/stages/tree-filter-aggregation.test.ts
+++ b/testing/behavioural/src/tree-data/datapath/stages/tree-filter-aggregation.test.ts
@@ -1,7 +1,6 @@
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { RowGroupingModule, TreeDataModule } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions } from '../../../test-utils';
 import {
     GridRows,
     TestGridsManager,
@@ -58,38 +57,34 @@ describe('ag-grid tree aggregation and filter', () => {
                 groupSuppressBlankHeader: true,
             });
 
-            const gridRowsOptions: GridRowsOptions = {
-                columns: ['x', 'y'],
-            };
-
-            await new GridRows(api, 'initial', gridRowsOptions).check(`
+            await new GridRows(api, 'initial').check(`
                 ROOT id:ROOT_NODE_ID x:100
-                ├─ footer id:rowGroupFooter_ROOT_NODE_ID x:100
-                ├─┬ A GROUP id:0 x:80 y:1
-                │ ├─┬ B GROUP id:1 x:29 y:2
-                │ │ ├── D LEAF id:3 x:14 y:4
-                │ │ └── E LEAF id:4 x:15 y:5
-                │ └─┬ C GROUP id:2 x:51 y:3
-                │ · ├── F LEAF id:5 x:16 y:1
-                │ · ├── G LEAF id:6 x:17 y:2
-                │ · └─┬ H filler id:row-group-0-A-1-C-2-H x:18
-                │ · · └── I LEAF id:7 x:18 y:3
-                └─┬ J GROUP id:8 x:20 y:4
-                · └── K LEAF id:9 x:20 y:5
+                ├─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " x:100
+                ├─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:80 y:1
+                │ ├─┬ B GROUP id:1 ag-Grid-AutoColumn:"B" x:29 y:2
+                │ │ ├── D LEAF id:3 ag-Grid-AutoColumn:"D" x:14 y:4
+                │ │ └── E LEAF id:4 ag-Grid-AutoColumn:"E" x:15 y:5
+                │ └─┬ C GROUP id:2 ag-Grid-AutoColumn:"C" x:51 y:3
+                │ · ├── F LEAF id:5 ag-Grid-AutoColumn:"F" x:16 y:1
+                │ · ├── G LEAF id:6 ag-Grid-AutoColumn:"G" x:17 y:2
+                │ · └─┬ H filler id:row-group-0-A-1-C-2-H ag-Grid-AutoColumn:"H" x:18
+                │ · · └── I LEAF id:7 ag-Grid-AutoColumn:"I" x:18 y:3
+                └─┬ J GROUP id:8 ag-Grid-AutoColumn:"J" x:20 y:4
+                · └── K LEAF id:9 ag-Grid-AutoColumn:"K" x:20 y:5
             `);
 
             api.setFilterModel({
                 y: { filterType: 'number', type: 'greaterThan', filter: 4 },
             });
 
-            await new GridRows(api, 'filter greater than', gridRowsOptions).check(`
+            await new GridRows(api, 'filter greater than').check(`
                 ROOT id:ROOT_NODE_ID x:35
-                ├─ footer id:rowGroupFooter_ROOT_NODE_ID x:35
-                ├─┬ A GROUP id:0 x:15 y:1
-                │ └─┬ B GROUP id:1 x:15 y:2
-                │ · └── E LEAF id:4 x:15 y:5
-                └─┬ J GROUP id:8 x:20 y:4
-                · └── K LEAF id:9 x:20 y:5
+                ├─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " x:35
+                ├─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:15 y:1
+                │ └─┬ B GROUP id:1 ag-Grid-AutoColumn:"B" x:15 y:2
+                │ · └── E LEAF id:4 ag-Grid-AutoColumn:"E" x:15 y:5
+                └─┬ J GROUP id:8 ag-Grid-AutoColumn:"J" x:20 y:4
+                · └── K LEAF id:9 ag-Grid-AutoColumn:"K" x:20 y:5
             `);
 
             if (mode === 'transactions') {
@@ -103,15 +98,15 @@ describe('ag-grid tree aggregation and filter', () => {
                 setRowDataChecked(api, rowData);
             }
 
-            await new GridRows(api, 'filter greater than - update 1', gridRowsOptions).check(`
+            await new GridRows(api, 'filter greater than - update 1').check(`
                 ROOT id:ROOT_NODE_ID x:49
-                ├─ footer id:rowGroupFooter_ROOT_NODE_ID x:49
-                ├─┬ A GROUP id:0 x:29 y:1
-                │ └─┬ B GROUP id:1 x:29 y:2
-                │ · ├── D LEAF id:3 x:14 y:200
-                │ · └── E LEAF id:4 x:15 y:5
-                └─┬ J GROUP id:8 x:20 y:4
-                · └── K LEAF id:9 x:20 y:5
+                ├─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " x:49
+                ├─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:29 y:1
+                │ └─┬ B GROUP id:1 ag-Grid-AutoColumn:"B" x:29 y:2
+                │ · ├── D LEAF id:3 ag-Grid-AutoColumn:"D" x:14 y:200
+                │ · └── E LEAF id:4 ag-Grid-AutoColumn:"E" x:15 y:5
+                └─┬ J GROUP id:8 ag-Grid-AutoColumn:"J" x:20 y:4
+                · └── K LEAF id:9 ag-Grid-AutoColumn:"K" x:20 y:5
             `);
 
             if (mode === 'transactions') {
@@ -121,13 +116,13 @@ describe('ag-grid tree aggregation and filter', () => {
                 setRowDataChecked(api, rowData);
             }
 
-            await new GridRows(api, 'filter greater than - update 2', gridRowsOptions).check(`
+            await new GridRows(api, 'filter greater than - update 2').check(`
                 ROOT id:ROOT_NODE_ID x:29
-                ├─ footer id:rowGroupFooter_ROOT_NODE_ID x:29
-                └─┬ A GROUP id:0 x:29 y:1
-                · └─┬ B GROUP id:1 x:29 y:2
-                · · ├── D LEAF id:3 x:14 y:200
-                · · └── E LEAF id:4 x:15 y:5
+                ├─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " x:29
+                └─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:29 y:1
+                · └─┬ B GROUP id:1 ag-Grid-AutoColumn:"B" x:29 y:2
+                · · ├── D LEAF id:3 ag-Grid-AutoColumn:"D" x:14 y:200
+                · · └── E LEAF id:4 ag-Grid-AutoColumn:"E" x:15 y:5
             `);
 
             if (mode === 'transactions') {
@@ -137,83 +132,83 @@ describe('ag-grid tree aggregation and filter', () => {
                 setRowDataChecked(api, rowData);
             }
 
-            await new GridRows(api, 'filter greater than - remove', gridRowsOptions).check(`
+            await new GridRows(api, 'filter greater than - remove').check(`
                 ROOT id:ROOT_NODE_ID x:15
-                ├─ footer id:rowGroupFooter_ROOT_NODE_ID x:15
-                └─┬ A GROUP id:0 x:15 y:1
-                · └─┬ B GROUP id:1 x:15 y:2
-                · · └── E LEAF id:4 x:15 y:5
+                ├─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " x:15
+                └─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:15 y:1
+                · └─┬ B GROUP id:1 ag-Grid-AutoColumn:"B" x:15 y:2
+                · · └── E LEAF id:4 ag-Grid-AutoColumn:"E" x:15 y:5
             `);
 
             api.setFilterModel({
                 y: { filterType: 'number', type: 'lessThan', filter: 2 },
             });
 
-            await new GridRows(api, 'filter less than', gridRowsOptions).check(`
+            await new GridRows(api, 'filter less than').check(`
                 ROOT id:ROOT_NODE_ID x:86
-                ├─ footer id:rowGroupFooter_ROOT_NODE_ID x:86
-                ├─┬ A GROUP id:0 x:66 y:1
-                │ ├─┬ B GROUP id:1 x:15 y:2
-                │ │ └── E LEAF id:4 x:15 y:5
-                │ └─┬ C GROUP id:2 x:51 y:3
-                │ · ├── F LEAF id:5 x:16 y:1
-                │ · ├── G LEAF id:6 x:17 y:2
-                │ · └─┬ H filler id:row-group-0-A-1-C-2-H x:18
-                │ · · └── I LEAF id:7 x:18 y:3
-                └─┬ J GROUP id:8 x:20 y:4
-                · └── K LEAF id:9 x:20 y:0
+                ├─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " x:86
+                ├─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:66 y:1
+                │ ├─┬ B GROUP id:1 ag-Grid-AutoColumn:"B" x:15 y:2
+                │ │ └── E LEAF id:4 ag-Grid-AutoColumn:"E" x:15 y:5
+                │ └─┬ C GROUP id:2 ag-Grid-AutoColumn:"C" x:51 y:3
+                │ · ├── F LEAF id:5 ag-Grid-AutoColumn:"F" x:16 y:1
+                │ · ├── G LEAF id:6 ag-Grid-AutoColumn:"G" x:17 y:2
+                │ · └─┬ H filler id:row-group-0-A-1-C-2-H ag-Grid-AutoColumn:"H" x:18
+                │ · · └── I LEAF id:7 ag-Grid-AutoColumn:"I" x:18 y:3
+                └─┬ J GROUP id:8 ag-Grid-AutoColumn:"J" x:20 y:4
+                · └── K LEAF id:9 ag-Grid-AutoColumn:"K" x:20 y:0
             `);
 
             api.setGridOption('excludeChildrenWhenTreeDataFiltering', true);
 
-            await new GridRows(api, 'excludeChildrenWhenTreeDataFiltering=true', gridRowsOptions).check(`
+            await new GridRows(api, 'excludeChildrenWhenTreeDataFiltering=true').check(`
                 ROOT id:ROOT_NODE_ID x:36
-                ├─ footer id:rowGroupFooter_ROOT_NODE_ID x:36
-                ├─┬ A GROUP id:0 x:16 y:1
-                │ └─┬ C GROUP id:2 x:16 y:3
-                │ · └── F LEAF id:5 x:16 y:1
-                └─┬ J GROUP id:8 x:20 y:4
-                · └── K LEAF id:9 x:20 y:0
+                ├─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " x:36
+                ├─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:16 y:1
+                │ └─┬ C GROUP id:2 ag-Grid-AutoColumn:"C" x:16 y:3
+                │ · └── F LEAF id:5 ag-Grid-AutoColumn:"F" x:16 y:1
+                └─┬ J GROUP id:8 ag-Grid-AutoColumn:"J" x:20 y:4
+                · └── K LEAF id:9 ag-Grid-AutoColumn:"K" x:20 y:0
             `);
 
             api.setGridOption('suppressAggFilteredOnly', true);
 
-            await new GridRows(api, 'suppressAggFilteredOnly=true', gridRowsOptions).check(`
+            await new GridRows(api, 'suppressAggFilteredOnly=true').check(`
                 ROOT id:ROOT_NODE_ID x:86
-                ├─ footer id:rowGroupFooter_ROOT_NODE_ID x:86
-                ├─┬ A GROUP id:0 x:66 y:1
-                │ └─┬ C GROUP id:2 x:51 y:3
-                │ · └── F LEAF id:5 x:16 y:1
-                └─┬ J GROUP id:8 x:20 y:4
-                · └── K LEAF id:9 x:20 y:0
+                ├─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " x:86
+                ├─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:66 y:1
+                │ └─┬ C GROUP id:2 ag-Grid-AutoColumn:"C" x:51 y:3
+                │ · └── F LEAF id:5 ag-Grid-AutoColumn:"F" x:16 y:1
+                └─┬ J GROUP id:8 ag-Grid-AutoColumn:"J" x:20 y:4
+                · └── K LEAF id:9 ag-Grid-AutoColumn:"K" x:20 y:0
             `);
 
             api.setGridOption('suppressAggFilteredOnly', false);
             api.setGridOption('grandTotalRow', 'bottom');
 
-            await new GridRows(api, 'suppressAggFilteredOnly=false grandTotalRow=bottom', gridRowsOptions).check(`
+            await new GridRows(api, 'suppressAggFilteredOnly=false grandTotalRow=bottom').check(`
                 ROOT id:ROOT_NODE_ID x:36
-                ├─┬ A GROUP id:0 x:16 y:1
-                │ └─┬ C GROUP id:2 x:16 y:3
-                │ · └── F LEAF id:5 x:16 y:1
-                ├─┬ J GROUP id:8 x:20 y:4
-                │ └── K LEAF id:9 x:20 y:0
-                └─ footer id:rowGroupFooter_ROOT_NODE_ID x:36
+                ├─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:16 y:1
+                │ └─┬ C GROUP id:2 ag-Grid-AutoColumn:"C" x:16 y:3
+                │ · └── F LEAF id:5 ag-Grid-AutoColumn:"F" x:16 y:1
+                ├─┬ J GROUP id:8 ag-Grid-AutoColumn:"J" x:20 y:4
+                │ └── K LEAF id:9 ag-Grid-AutoColumn:"K" x:20 y:0
+                └─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " x:36
             `);
 
             api.setGridOption('groupTotalRow', 'bottom');
 
-            await new GridRows(api, 'groupTotalRow=top', gridRowsOptions).check(`
+            await new GridRows(api, 'groupTotalRow=top').check(`
                 ROOT id:ROOT_NODE_ID x:36
-                ├─┬ A GROUP id:0 x:16 y:1
-                │ ├─┬ C GROUP id:2 x:16 y:3
-                │ │ ├── F LEAF id:5 x:16 y:1
-                │ │ └─ footer id:rowGroupFooter_2 x:16 y:3
-                │ └─ footer id:rowGroupFooter_0 x:16 y:1
-                ├─┬ J GROUP id:8 x:20 y:4
-                │ ├── K LEAF id:9 x:20 y:0
-                │ └─ footer id:rowGroupFooter_8 x:20 y:4
-                └─ footer id:rowGroupFooter_ROOT_NODE_ID x:36
+                ├─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:16 y:1
+                │ ├─┬ C GROUP id:2 ag-Grid-AutoColumn:"C" x:16 y:3
+                │ │ ├── F LEAF id:5 ag-Grid-AutoColumn:"F" x:16 y:1
+                │ │ └─ footer id:rowGroupFooter_2 ag-Grid-AutoColumn:"Total C" x:16 y:3
+                │ └─ footer id:rowGroupFooter_0 ag-Grid-AutoColumn:"Total A" x:16 y:1
+                ├─┬ J GROUP id:8 ag-Grid-AutoColumn:"J" x:20 y:4
+                │ ├── K LEAF id:9 ag-Grid-AutoColumn:"K" x:20 y:0
+                │ └─ footer id:rowGroupFooter_8 ag-Grid-AutoColumn:"Total J" x:20 y:4
+                └─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " x:36
             `);
         }
     );

--- a/testing/behavioural/src/tree-data/datapath/stages/tree-filter-sort.test.ts
+++ b/testing/behavioural/src/tree-data/datapath/stages/tree-filter-sort.test.ts
@@ -1,7 +1,6 @@
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { TreeDataModule } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions } from '../../../test-utils';
 import { GridRows, TestGridsManager, cachedJSONObjects, setRowDataChecked } from '../../../test-utils';
 
 describe('ag-grid tree filter sort', () => {
@@ -38,26 +37,21 @@ describe('ag-grid tree filter sort', () => {
             getDataPath: (data: any) => data.orgHierarchy,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            printIds: false,
-            columns: ['name'],
-        };
-
-        await new GridRows(api, 'initial', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP name:"John Von Neumann"
-            · ├─┬ B GROUP name:"Alan Turing"
-            · │ ├── D LEAF name:"Donald Knuth"
-            · │ └── E LEAF name:"Grace Hopper"
-            · └── C LEAF name:"A. Church"
+        await new GridRows(api, 'initial').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" name:"John Von Neumann"
+            · ├─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" name:"Alan Turing"
+            · │ ├── D LEAF id:4 ag-Grid-AutoColumn:"D" name:"Donald Knuth"
+            · │ └── E LEAF id:5 ag-Grid-AutoColumn:"E" name:"Grace Hopper"
+            · └── C LEAF id:3 ag-Grid-AutoColumn:"C" name:"A. Church"
         `);
 
         api.setFilterModel({ name: { type: 'equals', filter: 'A. Church' } });
 
-        await new GridRows(api, 'filter 1', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP name:"John Von Neumann"
-            · └── C LEAF name:"A. Church"
+        await new GridRows(api, 'filter 1').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" name:"John Von Neumann"
+            · └── C LEAF id:3 ag-Grid-AutoColumn:"C" name:"A. Church"
         `);
 
         setRowDataChecked(api, [
@@ -68,23 +62,23 @@ describe('ag-grid tree filter sort', () => {
             { id: '4', name: 'Donald Knuth', orgHierarchy: ['A', 'B', 'D'] },
         ]);
 
-        await new GridRows(api, 'filter 1 rowData 2', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP name:"John Von Neumann"
-            · ├─┬ B GROUP name:"Alan Turing"
-            · │ └── E LEAF name:"A. Church"
-            · └── C LEAF name:"A. Church"
+        await new GridRows(api, 'filter 1 rowData 2').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" name:"John Von Neumann"
+            · ├─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" name:"Alan Turing"
+            · │ └── E LEAF id:5 ag-Grid-AutoColumn:"E" name:"A. Church"
+            · └── C LEAF id:3 ag-Grid-AutoColumn:"C" name:"A. Church"
         `);
 
         api.setFilterModel({ name: { type: 'equals', filter: 'Grace Hopper' } });
 
         setRowDataChecked(api, rowData);
 
-        await new GridRows(api, 'filter 2', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP name:"John Von Neumann"
-            · └─┬ B GROUP name:"Alan Turing"
-            · · └── E LEAF name:"Grace Hopper"
+        await new GridRows(api, 'filter 2').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" name:"John Von Neumann"
+            · └─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" name:"Alan Turing"
+            · · └── E LEAF id:5 ag-Grid-AutoColumn:"E" name:"Grace Hopper"
         `);
 
         setRowDataChecked(api, [
@@ -96,37 +90,37 @@ describe('ag-grid tree filter sort', () => {
             { id: '6', name: 'unknown', orgHierarchy: ['A', 'C', 'K'] },
         ]);
 
-        await new GridRows(api, 'filter 2 rowData 2', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP name:"John Von Neumann"
-            · └─┬ B GROUP name:"Grace Hopper"
-            · · ├── D LEAF name:"Donald Knuth"
-            · · └─┬ E filler
-            · · · └── W LEAF name:"Grace Hopper"
+        await new GridRows(api, 'filter 2 rowData 2').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" name:"John Von Neumann"
+            · └─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" name:"Grace Hopper"
+            · · ├── D LEAF id:4 ag-Grid-AutoColumn:"D" name:"Donald Knuth"
+            · · └─┬ E filler id:row-group-0-A-1-B-2-E ag-Grid-AutoColumn:"E"
+            · · · └── W LEAF id:5 ag-Grid-AutoColumn:"W" name:"Grace Hopper"
         `);
 
         api.setFilterModel({ name: { type: 'equals', filter: 'Donald Knuth' } });
 
-        await new GridRows(api, 'filter 3 rowData 2', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP name:"John Von Neumann"
-            · └─┬ B GROUP name:"Grace Hopper"
-            · · └── D LEAF name:"Donald Knuth"
+        await new GridRows(api, 'filter 3 rowData 2').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" name:"John Von Neumann"
+            · └─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" name:"Grace Hopper"
+            · · └── D LEAF id:4 ag-Grid-AutoColumn:"D" name:"Donald Knuth"
         `);
 
         setRowDataChecked(api, rowData);
 
-        await new GridRows(api, 'filter 3', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP name:"John Von Neumann"
-            · └─┬ B GROUP name:"Alan Turing"
-            · · └── D LEAF name:"Donald Knuth"
+        await new GridRows(api, 'filter 3').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" name:"John Von Neumann"
+            · └─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" name:"Alan Turing"
+            · · └── D LEAF id:4 ag-Grid-AutoColumn:"D" name:"Donald Knuth"
         `);
 
         api.setFilterModel({ name: { type: 'equals', filter: 'Kurt Gödel' } });
 
-        await new GridRows(api, 'filter 4', gridRowsOptions).check(`
-            ROOT
+        await new GridRows(api, 'filter 4').check(`
+            ROOT id:ROOT_NODE_ID
         `);
 
         setRowDataChecked(api, [
@@ -137,26 +131,26 @@ describe('ag-grid tree filter sort', () => {
             { id: '5', name: 'Grace Hopper', orgHierarchy: ['A', 'B', 'E'] },
         ]);
 
-        await new GridRows(api, 'filter 4 rowData 3', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP name:"Kurt Gödel"
-            · ├─┬ B GROUP name:"Alan Turing"
-            · │ ├── D LEAF name:"Donald Knuth"
-            · │ └── E LEAF name:"Grace Hopper"
-            · └── C LEAF name:"A. Church"
+        await new GridRows(api, 'filter 4 rowData 3').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" name:"Kurt Gödel"
+            · ├─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" name:"Alan Turing"
+            · │ ├── D LEAF id:4 ag-Grid-AutoColumn:"D" name:"Donald Knuth"
+            · │ └── E LEAF id:5 ag-Grid-AutoColumn:"E" name:"Grace Hopper"
+            · └── C LEAF id:3 ag-Grid-AutoColumn:"C" name:"A. Church"
         `);
 
         api.setFilterModel({});
 
         setRowDataChecked(api, rowData);
 
-        await new GridRows(api, 'no filter', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP name:"John Von Neumann"
-            · ├─┬ B GROUP name:"Alan Turing"
-            · │ ├── D LEAF name:"Donald Knuth"
-            · │ └── E LEAF name:"Grace Hopper"
-            · └── C LEAF name:"A. Church"
+        await new GridRows(api, 'no filter').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" name:"John Von Neumann"
+            · ├─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" name:"Alan Turing"
+            · │ ├── D LEAF id:4 ag-Grid-AutoColumn:"D" name:"Donald Knuth"
+            · │ └── E LEAF id:5 ag-Grid-AutoColumn:"E" name:"Grace Hopper"
+            · └── C LEAF id:3 ag-Grid-AutoColumn:"C" name:"A. Church"
         `);
     });
 
@@ -185,37 +179,32 @@ describe('ag-grid tree filter sort', () => {
             getDataPath: (data: any) => data.orgHierarchy,
         });
 
-        const gridRowsOptions: GridRowsOptions = {
-            printIds: false,
-            columns: ['value', 'x'],
-        };
-
-        await new GridRows(api, 'initial', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP value:12 x:1
-            · ├─┬ B GROUP value:17 x:1
-            · │ ├── D LEAF value:13 x:1
-            · │ └── E LEAF value:11 x:0
-            · ├── C LEAF value:15 x:1
-            · └─┬ F filler
-            · · ├── G LEAF value:10 x:0
-            · · └── H LEAF value:16 x:1
+        await new GridRows(api, 'initial').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" value:12 x:1
+            · ├─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" value:17 x:1
+            · │ ├── D LEAF id:4 ag-Grid-AutoColumn:"D" value:13 x:1
+            · │ └── E LEAF id:5 ag-Grid-AutoColumn:"E" value:11 x:0
+            · ├── C LEAF id:3 ag-Grid-AutoColumn:"C" value:15 x:1
+            · └─┬ F filler id:row-group-0-A-1-F ag-Grid-AutoColumn:"F"
+            · · ├── G LEAF id:6 ag-Grid-AutoColumn:"G" value:10 x:0
+            · · └── H LEAF id:7 ag-Grid-AutoColumn:"H" value:16 x:1
         `);
 
         api.applyColumnState({
             state: [{ colId: 'value', sort: 'asc' }],
         });
 
-        await new GridRows(api, 'sort value asc', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP value:12 x:1
-            · ├─┬ F filler
-            · │ ├── G LEAF value:10 x:0
-            · │ └── H LEAF value:16 x:1
-            · ├── C LEAF value:15 x:1
-            · └─┬ B GROUP value:17 x:1
-            · · ├── E LEAF value:11 x:0
-            · · └── D LEAF value:13 x:1
+        await new GridRows(api, 'sort value asc').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" value:12 x:1
+            · ├─┬ F filler id:row-group-0-A-1-F ag-Grid-AutoColumn:"F"
+            · │ ├── G LEAF id:6 ag-Grid-AutoColumn:"G" value:10 x:0
+            · │ └── H LEAF id:7 ag-Grid-AutoColumn:"H" value:16 x:1
+            · ├── C LEAF id:3 ag-Grid-AutoColumn:"C" value:15 x:1
+            · └─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" value:17 x:1
+            · · ├── E LEAF id:5 ag-Grid-AutoColumn:"E" value:11 x:0
+            · · └── D LEAF id:4 ag-Grid-AutoColumn:"D" value:13 x:1
         `);
 
         api.setGridOption(
@@ -231,46 +220,46 @@ describe('ag-grid tree filter sort', () => {
             ])
         );
 
-        await new GridRows(api, 'sort value asc rowData 2', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP value:12 x:1
-            · ├─┬ F filler
-            · │ ├── G LEAF value:10 x:0
-            · │ └── H LEAF value:16 x:1
-            · ├── C LEAF value:15 x:1
-            · └─┬ B GROUP value:17 x:1
-            · · ├── e LEAF value:11 x:0
-            · · └── d LEAF value:13 x:1
+        await new GridRows(api, 'sort value asc rowData 2').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" value:12 x:1
+            · ├─┬ F filler id:row-group-0-A-1-F ag-Grid-AutoColumn:"F"
+            · │ ├── G LEAF id:6 ag-Grid-AutoColumn:"G" value:10 x:0
+            · │ └── H LEAF id:7 ag-Grid-AutoColumn:"H" value:16 x:1
+            · ├── C LEAF id:3 ag-Grid-AutoColumn:"C" value:15 x:1
+            · └─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" value:17 x:1
+            · · ├── e LEAF id:5 ag-Grid-AutoColumn:"e" value:11 x:0
+            · · └── d LEAF id:4 ag-Grid-AutoColumn:"d" value:13 x:1
         `);
 
         api.applyColumnState({
             state: [{ colId: 'value', sort: 'desc' }],
         });
 
-        await new GridRows(api, 'sort value desc  rowData 2', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP value:12 x:1
-            · ├─┬ B GROUP value:17 x:1
-            · │ ├── d LEAF value:13 x:1
-            · │ └── e LEAF value:11 x:0
-            · ├── C LEAF value:15 x:1
-            · └─┬ F filler
-            · · ├── H LEAF value:16 x:1
-            · · └── G LEAF value:10 x:0
+        await new GridRows(api, 'sort value desc  rowData 2').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" value:12 x:1
+            · ├─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" value:17 x:1
+            · │ ├── d LEAF id:4 ag-Grid-AutoColumn:"d" value:13 x:1
+            · │ └── e LEAF id:5 ag-Grid-AutoColumn:"e" value:11 x:0
+            · ├── C LEAF id:3 ag-Grid-AutoColumn:"C" value:15 x:1
+            · └─┬ F filler id:row-group-0-A-1-F ag-Grid-AutoColumn:"F"
+            · · ├── H LEAF id:7 ag-Grid-AutoColumn:"H" value:16 x:1
+            · · └── G LEAF id:6 ag-Grid-AutoColumn:"G" value:10 x:0
         `);
 
         setRowDataChecked(api, rowData);
 
-        await new GridRows(api, 'sort value desc', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP value:12 x:1
-            · ├─┬ B GROUP value:17 x:1
-            · │ ├── D LEAF value:13 x:1
-            · │ └── E LEAF value:11 x:0
-            · ├── C LEAF value:15 x:1
-            · └─┬ F filler
-            · · ├── H LEAF value:16 x:1
-            · · └── G LEAF value:10 x:0
+        await new GridRows(api, 'sort value desc').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" value:12 x:1
+            · ├─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" value:17 x:1
+            · │ ├── D LEAF id:4 ag-Grid-AutoColumn:"D" value:13 x:1
+            · │ └── E LEAF id:5 ag-Grid-AutoColumn:"E" value:11 x:0
+            · ├── C LEAF id:3 ag-Grid-AutoColumn:"C" value:15 x:1
+            · └─┬ F filler id:row-group-0-A-1-F ag-Grid-AutoColumn:"F"
+            · · ├── H LEAF id:7 ag-Grid-AutoColumn:"H" value:16 x:1
+            · · └── G LEAF id:6 ag-Grid-AutoColumn:"G" value:10 x:0
         `);
 
         api.applyColumnState({
@@ -280,32 +269,32 @@ describe('ag-grid tree filter sort', () => {
             ],
         });
 
-        await new GridRows(api, 'sort x asc', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP value:12 x:1
-            · ├─┬ F filler
-            · │ ├── G LEAF value:10 x:0
-            · │ └── H LEAF value:16 x:1
-            · ├─┬ B GROUP value:17 x:1
-            · │ ├── E LEAF value:11 x:0
-            · │ └── D LEAF value:13 x:1
-            · └── C LEAF value:15 x:1
+        await new GridRows(api, 'sort x asc').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" value:12 x:1
+            · ├─┬ F filler id:row-group-0-A-1-F ag-Grid-AutoColumn:"F"
+            · │ ├── G LEAF id:6 ag-Grid-AutoColumn:"G" value:10 x:0
+            · │ └── H LEAF id:7 ag-Grid-AutoColumn:"H" value:16 x:1
+            · ├─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" value:17 x:1
+            · │ ├── E LEAF id:5 ag-Grid-AutoColumn:"E" value:11 x:0
+            · │ └── D LEAF id:4 ag-Grid-AutoColumn:"D" value:13 x:1
+            · └── C LEAF id:3 ag-Grid-AutoColumn:"C" value:15 x:1
         `);
 
         api.applyColumnState({
             state: [{ colId: 'x', sort: 'desc' }],
         });
 
-        await new GridRows(api, 'sort x desc', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP value:12 x:1
-            · ├─┬ B GROUP value:17 x:1
-            · │ ├── D LEAF value:13 x:1
-            · │ └── E LEAF value:11 x:0
-            · ├── C LEAF value:15 x:1
-            · └─┬ F filler
-            · · ├── H LEAF value:16 x:1
-            · · └── G LEAF value:10 x:0
+        await new GridRows(api, 'sort x desc').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" value:12 x:1
+            · ├─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" value:17 x:1
+            · │ ├── D LEAF id:4 ag-Grid-AutoColumn:"D" value:13 x:1
+            · │ └── E LEAF id:5 ag-Grid-AutoColumn:"E" value:11 x:0
+            · ├── C LEAF id:3 ag-Grid-AutoColumn:"C" value:15 x:1
+            · └─┬ F filler id:row-group-0-A-1-F ag-Grid-AutoColumn:"F"
+            · · ├── H LEAF id:7 ag-Grid-AutoColumn:"H" value:16 x:1
+            · · └── G LEAF id:6 ag-Grid-AutoColumn:"G" value:10 x:0
         `);
 
         api.setGridOption(
@@ -321,50 +310,50 @@ describe('ag-grid tree filter sort', () => {
             ])
         );
 
-        await new GridRows(api, 'sort x desc rowData 3', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP value:12 x:1
-            · ├─┬ B GROUP value:17 x:1
-            · │ ├── E LEAF value:11 x:1
-            · │ └── D LEAF value:13 x:0
-            · ├── C LEAF value:15 x:0
-            · └─┬ F filler
-            · · ├── H LEAF value:16 x:1
-            · · └── G LEAF value:10 x:1
+        await new GridRows(api, 'sort x desc rowData 3').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" value:12 x:1
+            · ├─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" value:17 x:1
+            · │ ├── E LEAF id:5 ag-Grid-AutoColumn:"E" value:11 x:1
+            · │ └── D LEAF id:4 ag-Grid-AutoColumn:"D" value:13 x:0
+            · ├── C LEAF id:3 ag-Grid-AutoColumn:"C" value:15 x:0
+            · └─┬ F filler id:row-group-0-A-1-F ag-Grid-AutoColumn:"F"
+            · · ├── H LEAF id:7 ag-Grid-AutoColumn:"H" value:16 x:1
+            · · └── G LEAF id:6 ag-Grid-AutoColumn:"G" value:10 x:1
         `);
 
         api.setFilterModel({ x: { type: 'equals', filter: 0 } });
 
-        await new GridRows(api, 'sort x desc, filter x===0, rowData 3', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP value:12 x:1
-            · ├─┬ B GROUP value:17 x:1
-            · │ └── D LEAF value:13 x:0
-            · └── C LEAF value:15 x:0
+        await new GridRows(api, 'sort x desc, filter x===0, rowData 3').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" value:12 x:1
+            · ├─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" value:17 x:1
+            · │ └── D LEAF id:4 ag-Grid-AutoColumn:"D" value:13 x:0
+            · └── C LEAF id:3 ag-Grid-AutoColumn:"C" value:15 x:0
         `);
 
         setRowDataChecked(api, rowData);
 
-        await new GridRows(api, 'sort x desc, filter x===0, rowData 3', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP value:12 x:1
-            · ├─┬ B GROUP value:17 x:1
-            · │ └── E LEAF value:11 x:0
-            · └─┬ F filler
-            · · └── G LEAF value:10 x:0
+        await new GridRows(api, 'sort x desc, filter x===0, rowData 3').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" value:12 x:1
+            · ├─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" value:17 x:1
+            · │ └── E LEAF id:5 ag-Grid-AutoColumn:"E" value:11 x:0
+            · └─┬ F filler id:row-group-0-A-1-F ag-Grid-AutoColumn:"F"
+            · · └── G LEAF id:6 ag-Grid-AutoColumn:"G" value:10 x:0
         `);
 
         api.applyColumnState({
             state: [{ colId: 'x', sort: 'asc' }],
         });
 
-        await new GridRows(api, 'sort x desc, filter x===0', gridRowsOptions).check(`
-            ROOT
-            └─┬ A GROUP value:12 x:1
-            · ├─┬ F filler
-            · │ └── G LEAF value:10 x:0
-            · └─┬ B GROUP value:17 x:1
-            · · └── E LEAF value:11 x:0
+        await new GridRows(api, 'sort x desc, filter x===0').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:1 ag-Grid-AutoColumn:"A" value:12 x:1
+            · ├─┬ F filler id:row-group-0-A-1-F ag-Grid-AutoColumn:"F"
+            · │ └── G LEAF id:6 ag-Grid-AutoColumn:"G" value:10 x:0
+            · └─┬ B GROUP id:2 ag-Grid-AutoColumn:"B" value:17 x:1
+            · · └── E LEAF id:5 ag-Grid-AutoColumn:"E" value:11 x:0
         `);
     });
 });

--- a/testing/behavioural/src/tree-data/datapath/tree-data-without-tree-module.test.ts
+++ b/testing/behavioural/src/tree-data/datapath/tree-data-without-tree-module.test.ts
@@ -60,9 +60,7 @@ describe('ag-grid tree data without tree module', () => {
 
         consoleErrorSpy.mockRestore();
 
-        const gridRows = new GridRows(api, 'data', {
-            treeData: false,
-        });
+        const gridRows = new GridRows(api, 'data', { forcedTreeData: false });
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID groupType:"Filler"
             ├── LEAF id:0 groupType:"Provided" x:1

--- a/testing/behavioural/src/tree-data/datapath/tree-data.test.ts
+++ b/testing/behavioural/src/tree-data/datapath/tree-data.test.ts
@@ -12,7 +12,7 @@ import {
     getRowsSnapshot,
     setRowDataChecked,
 } from '../../test-utils';
-import type { GridRowsOptions, RowSnapshot } from '../../test-utils';
+import type { RowSnapshot } from '../../test-utils';
 import { simpleHierarchyRowsSnapshot } from './simpleHierarchyRowsSnapshot';
 
 const getDataPath = (data: any) => data.orgHierarchy;
@@ -117,9 +117,7 @@ describe('ag-grid tree data', () => {
 
         const api = gridsManager.createGrid('myGrid', gridOptions);
 
-        const gridRowsOptions: GridRowsOptions = {};
-
-        const gridRows = new GridRows(api, 'data', gridRowsOptions);
+        const gridRows = new GridRows(api, 'data');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID groupType:"Filler"
             ├─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" groupType:"Provided"
@@ -174,9 +172,7 @@ describe('ag-grid tree data', () => {
 
         const api = gridsManager.createGrid('myGrid', gridOptions);
 
-        const gridRowsOptions: GridRowsOptions = {};
-
-        const gridRows = new GridRows(api, 'data', gridRowsOptions);
+        const gridRows = new GridRows(api, 'data');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID groupType:"Filler"
             ├─┬ A GROUP id:2 ag-Grid-AutoColumn:"A" groupType:"Provided"

--- a/testing/behavioural/src/tree-data/datapath/tree-expanded-state.test.ts
+++ b/testing/behavioural/src/tree-data/datapath/tree-expanded-state.test.ts
@@ -8,7 +8,6 @@ import {
     asyncSetTimeout,
     setRowDataChecked,
 } from '../../test-utils';
-import type { GridRowsOptions } from '../../test-utils';
 
 const getDataPath = (data: any) => data.orgHierarchy;
 
@@ -16,8 +15,6 @@ describe('ag-grid tree expanded state', () => {
     const gridsManager = new TestGridsManager({
         modules: [ClientSideRowModelModule, TreeDataModule],
     });
-
-    const gridRowsOptions: GridRowsOptions = {};
 
     beforeEach(() => {
         gridsManager.reset();
@@ -67,7 +64,7 @@ describe('ag-grid tree expanded state', () => {
 
         await asyncSetTimeout(1);
 
-        await new GridRows(api, '', gridRowsOptions).check(`
+        await new GridRows(api, '').check(`
             ROOT id:ROOT_NODE_ID
             └─┬ "Erica Rogers" GROUP collapsed id:0 ag-Grid-AutoColumn:"Erica Rogers" jobTitle:"CEO" employmentType:"Permanent"
             · └─┬ "Malcolm Barrett" GROUP collapsed hidden id:1 ag-Grid-AutoColumn:"Malcolm Barrett" jobTitle:"Exec. Vice President" employmentType:"Permanent"
@@ -88,7 +85,7 @@ describe('ag-grid tree expanded state', () => {
 
         await asyncSetTimeout(1);
 
-        await new GridRows(api, '', gridRowsOptions).check(`
+        await new GridRows(api, '').check(`
             ROOT id:ROOT_NODE_ID
             └─┬ "Erica Rogers" GROUP id:0 ag-Grid-AutoColumn:"Erica Rogers" jobTitle:"CEO" employmentType:"Permanent"
             · ├─┬ "Malcolm Barrett" GROUP id:1 ag-Grid-AutoColumn:"Malcolm Barrett" jobTitle:"Exec. Vice President" employmentType:"Permanent"
@@ -111,7 +108,7 @@ describe('ag-grid tree expanded state', () => {
 
         await asyncSetTimeout(1);
 
-        await new GridRows(api, '', gridRowsOptions).check(`
+        await new GridRows(api, '').check(`
             ROOT id:ROOT_NODE_ID
             └─┬ "Erica Rogers" GROUP id:0 ag-Grid-AutoColumn:"Erica Rogers" jobTitle:"CEO" employmentType:"Permanent"
             · ├─┬ "Malcolm Barrett" GROUP id:1 ag-Grid-AutoColumn:"Malcolm Barrett" jobTitle:"Exec. Vice President" employmentType:"Permanent"
@@ -154,7 +151,7 @@ describe('ag-grid tree expanded state', () => {
             getRowId: (params) => params.data.key,
         });
 
-        let gridRows = new GridRows(api, 'initial', gridRowsOptions);
+        let gridRows = new GridRows(api, 'initial');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             └─┬ Desktop filler collapsed id:row-group-0-Desktop ag-Grid-AutoColumn:"Desktop"
@@ -167,7 +164,7 @@ describe('ag-grid tree expanded state', () => {
         api.getRowNode('row-group-0-Desktop')!.setExpanded(true, undefined, true);
         api.getRowNode('row-group-0-Desktop-1-ProjectAlpha')!.setExpanded(true, undefined, true);
 
-        gridRows = new GridRows(api, 'expanded', gridRowsOptions);
+        gridRows = new GridRows(api, 'expanded');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             └─┬ Desktop filler id:row-group-0-Desktop ag-Grid-AutoColumn:"Desktop"
@@ -195,7 +192,7 @@ describe('ag-grid tree expanded state', () => {
 
         update();
 
-        gridRows = new GridRows(api, 'updated', gridRowsOptions);
+        gridRows = new GridRows(api, 'updated');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             └─┬ Desktop filler id:row-group-0-Desktop ag-Grid-AutoColumn:"Desktop"

--- a/testing/behavioural/src/tree-data/datapath/tree-file-manager.test.ts
+++ b/testing/behavioural/src/tree-data/datapath/tree-file-manager.test.ts
@@ -2,7 +2,6 @@ import { ClientSideRowModelModule } from 'ag-grid-community';
 import type { GridOptions, IRowNode } from 'ag-grid-community';
 import { TreeDataModule } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions } from '../../test-utils';
 import { GridRows, TestGridsManager, applyTransactionChecked } from '../../test-utils';
 
 describe('ag-grid tree transactions', () => {
@@ -42,75 +41,71 @@ describe('ag-grid tree transactions', () => {
 
         api.getRowNode('2')!.setSelected(true);
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: [],
-        };
-
-        await new GridRows(api, 'initial', gridRowsOptions).check(`
-            ROOT id:ROOT_NODE_ID
-            ├─┬ Documents GROUP id:1
-            │ ├─┬ txt GROUP selected id:2
-            │ │ └── notes.txt LEAF id:3
-            │ ├─┬ pdf GROUP id:4
-            │ │ ├── book.pdf LEAF id:5
-            │ │ └── cv.pdf LEAF id:6
-            │ ├─┬ xls GROUP id:7
-            │ │ └── accounts.xls LEAF id:8
-            │ └─┬ stuff GROUP id:9
-            │ · └── xyz.txt LEAF id:10
-            ├─┬ Music filler id:row-group-0-Music
-            │ └─┬ mp3 filler id:row-group-0-Music-1-mp3
-            │ · ├─┬ pop GROUP id:11
-            │ · │ └── theme.mp3 LEAF id:13
-            │ · └── jazz LEAF id:14
-            └── temp.txt LEAF id:12
+        await new GridRows(api, 'initial').check(`
+            ROOT id:ROOT_NODE_ID size:"0 MB"
+            ├─┬ Documents GROUP id:1 ag-Grid-AutoColumn:"Documents" size:"24.6 MB"
+            │ ├─┬ txt GROUP selected id:2 ag-Grid-AutoColumn:"txt" size:"14.7 MB"
+            │ │ └── notes.txt LEAF id:3 ag-Grid-AutoColumn:"notes.txt" size:"14.7 MB"
+            │ ├─┬ pdf GROUP id:4 ag-Grid-AutoColumn:"pdf" size:"4.5 MB"
+            │ │ ├── book.pdf LEAF id:5 ag-Grid-AutoColumn:"book.pdf" size:"2.1 MB"
+            │ │ └── cv.pdf LEAF id:6 ag-Grid-AutoColumn:"cv.pdf" size:"2.4 MB"
+            │ ├─┬ xls GROUP id:7 ag-Grid-AutoColumn:"xls" size:"4.3 MB"
+            │ │ └── accounts.xls LEAF id:8 ag-Grid-AutoColumn:"accounts.xls" size:"4.3 MB"
+            │ └─┬ stuff GROUP id:9 ag-Grid-AutoColumn:"stuff" size:"1.1 MB"
+            │ · └── xyz.txt LEAF id:10 ag-Grid-AutoColumn:"xyz.txt" size:"1.1 MB"
+            ├─┬ Music filler id:row-group-0-Music ag-Grid-AutoColumn:"Music" size:"202 MB"
+            │ └─┬ mp3 filler id:row-group-0-Music-1-mp3 ag-Grid-AutoColumn:"mp3" size:"202 MB"
+            │ · ├─┬ pop GROUP id:11 ag-Grid-AutoColumn:"pop" size:"101 MB"
+            │ · │ └── theme.mp3 LEAF id:13 ag-Grid-AutoColumn:"theme.mp3" size:"101 MB"
+            │ · └── jazz LEAF id:14 ag-Grid-AutoColumn:"jazz" size:"101 MB"
+            └── temp.txt LEAF id:12 ag-Grid-AutoColumn:"temp.txt" size:"101 MB"
         `);
 
         // Move 'txt' into 'stuff'
         moveSelectedNodeToTarget('9');
 
-        await new GridRows(api, 'move Documents/txt to Documents/stuff/', gridRowsOptions).check(`
-            ROOT id:ROOT_NODE_ID
-            ├─┬ Documents GROUP id:1
-            │ ├─┬ pdf GROUP id:4
-            │ │ ├── book.pdf LEAF id:5
-            │ │ └── cv.pdf LEAF id:6
-            │ ├─┬ xls GROUP id:7
-            │ │ └── accounts.xls LEAF id:8
-            │ └─┬ stuff GROUP id:9
-            │ · ├─┬ txt GROUP selected id:2
-            │ · │ └── notes.txt LEAF id:3
-            │ · └── xyz.txt LEAF id:10
-            ├─┬ Music filler id:row-group-0-Music
-            │ └─┬ mp3 filler id:row-group-0-Music-1-mp3
-            │ · ├─┬ pop GROUP id:11
-            │ · │ └── theme.mp3 LEAF id:13
-            │ · └── jazz LEAF id:14
-            └── temp.txt LEAF id:12
+        await new GridRows(api, 'move Documents/txt to Documents/stuff/').check(`
+            ROOT id:ROOT_NODE_ID size:"0 MB"
+            ├─┬ Documents GROUP id:1 ag-Grid-AutoColumn:"Documents" size:"24.6 MB"
+            │ ├─┬ pdf GROUP id:4 ag-Grid-AutoColumn:"pdf" size:"4.5 MB"
+            │ │ ├── book.pdf LEAF id:5 ag-Grid-AutoColumn:"book.pdf" size:"2.1 MB"
+            │ │ └── cv.pdf LEAF id:6 ag-Grid-AutoColumn:"cv.pdf" size:"2.4 MB"
+            │ ├─┬ xls GROUP id:7 ag-Grid-AutoColumn:"xls" size:"4.3 MB"
+            │ │ └── accounts.xls LEAF id:8 ag-Grid-AutoColumn:"accounts.xls" size:"4.3 MB"
+            │ └─┬ stuff GROUP id:9 ag-Grid-AutoColumn:"stuff" size:"15.8 MB"
+            │ · ├─┬ txt GROUP selected id:2 ag-Grid-AutoColumn:"txt" size:"14.7 MB"
+            │ · │ └── notes.txt LEAF id:3 ag-Grid-AutoColumn:"notes.txt" size:"14.7 MB"
+            │ · └── xyz.txt LEAF id:10 ag-Grid-AutoColumn:"xyz.txt" size:"1.1 MB"
+            ├─┬ Music filler id:row-group-0-Music ag-Grid-AutoColumn:"Music" size:"202 MB"
+            │ └─┬ mp3 filler id:row-group-0-Music-1-mp3 ag-Grid-AutoColumn:"mp3" size:"202 MB"
+            │ · ├─┬ pop GROUP id:11 ag-Grid-AutoColumn:"pop" size:"101 MB"
+            │ · │ └── theme.mp3 LEAF id:13 ag-Grid-AutoColumn:"theme.mp3" size:"101 MB"
+            │ · └── jazz LEAF id:14 ag-Grid-AutoColumn:"jazz" size:"101 MB"
+            └── temp.txt LEAF id:12 ag-Grid-AutoColumn:"temp.txt" size:"101 MB"
         `);
 
         applyTransactionChecked(api, { update: [{ id: '7', filePath: ['Documents', 'stuff', 'var', 'xls-renamed'] }] });
 
-        await new GridRows(api, 'rename "Documents/xls" to "Documents/stuff/var/xls-renamed"', gridRowsOptions).check(`
-            ROOT id:ROOT_NODE_ID
-            ├─┬ Documents GROUP id:1
-            │ ├─┬ pdf GROUP id:4
-            │ │ ├── book.pdf LEAF id:5
-            │ │ └── cv.pdf LEAF id:6
-            │ ├─┬ xls filler id:row-group-0-Documents-1-xls
-            │ │ └── accounts.xls LEAF id:8
-            │ └─┬ stuff GROUP id:9
-            │ · ├─┬ txt GROUP selected id:2
-            │ · │ └── notes.txt LEAF id:3
-            │ · ├─┬ var filler id:row-group-0-Documents-1-stuff-2-var
-            │ · │ └── xls-renamed LEAF id:7
-            │ · └── xyz.txt LEAF id:10
-            ├─┬ Music filler id:row-group-0-Music
-            │ └─┬ mp3 filler id:row-group-0-Music-1-mp3
-            │ · ├─┬ pop GROUP id:11
-            │ · │ └── theme.mp3 LEAF id:13
-            │ · └── jazz LEAF id:14
-            └── temp.txt LEAF id:12
+        await new GridRows(api, 'rename "Documents/xls" to "Documents/stuff/var/xls-renamed"').check(`
+            ROOT id:ROOT_NODE_ID size:"0 MB"
+            ├─┬ Documents GROUP id:1 ag-Grid-AutoColumn:"Documents" size:"24.6 MB"
+            │ ├─┬ pdf GROUP id:4 ag-Grid-AutoColumn:"pdf" size:"4.5 MB"
+            │ │ ├── book.pdf LEAF id:5 ag-Grid-AutoColumn:"book.pdf" size:"2.1 MB"
+            │ │ └── cv.pdf LEAF id:6 ag-Grid-AutoColumn:"cv.pdf" size:"2.4 MB"
+            │ ├─┬ xls filler id:row-group-0-Documents-1-xls ag-Grid-AutoColumn:"xls" size:"4.3 MB"
+            │ │ └── accounts.xls LEAF id:8 ag-Grid-AutoColumn:"accounts.xls" size:"4.3 MB"
+            │ └─┬ stuff GROUP id:9 ag-Grid-AutoColumn:"stuff" size:"15.8 MB"
+            │ · ├─┬ txt GROUP selected id:2 ag-Grid-AutoColumn:"txt" size:"14.7 MB"
+            │ · │ └── notes.txt LEAF id:3 ag-Grid-AutoColumn:"notes.txt" size:"14.7 MB"
+            │ · ├─┬ var filler id:row-group-0-Documents-1-stuff-2-var ag-Grid-AutoColumn:"var" size:"0 MB"
+            │ · │ └── xls-renamed LEAF id:7 ag-Grid-AutoColumn:"xls-renamed" size:"0 MB"
+            │ · └── xyz.txt LEAF id:10 ag-Grid-AutoColumn:"xyz.txt" size:"1.1 MB"
+            ├─┬ Music filler id:row-group-0-Music ag-Grid-AutoColumn:"Music" size:"202 MB"
+            │ └─┬ mp3 filler id:row-group-0-Music-1-mp3 ag-Grid-AutoColumn:"mp3" size:"202 MB"
+            │ · ├─┬ pop GROUP id:11 ag-Grid-AutoColumn:"pop" size:"101 MB"
+            │ · │ └── theme.mp3 LEAF id:13 ag-Grid-AutoColumn:"theme.mp3" size:"101 MB"
+            │ · └── jazz LEAF id:14 ag-Grid-AutoColumn:"jazz" size:"101 MB"
+            └── temp.txt LEAF id:12 ag-Grid-AutoColumn:"temp.txt" size:"101 MB"
         `);
 
         function getRowsToUpdate(node: IRowNode, parentPath: string[]) {

--- a/testing/behavioural/src/tree-data/datapath/tree-transactions.test.ts
+++ b/testing/behavioural/src/tree-data/datapath/tree-transactions.test.ts
@@ -9,9 +9,6 @@ import {
     cachedJSONObjects,
     executeTransactionsAsync,
 } from '../../test-utils';
-import type { GridRowsOptions } from '../../test-utils';
-
-const gridRowsOptions: GridRowsOptions = {};
 
 describe('ag-grid tree transactions', () => {
     const gridsManager = new TestGridsManager({
@@ -59,7 +56,7 @@ describe('ag-grid tree transactions', () => {
             getDataPath: (data) => data.path,
         });
 
-        let gridRows = new GridRows(api, 'rowData', gridRowsOptions);
+        let gridRows = new GridRows(api, 'rowData');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├── A LEAF id:0 ag-Grid-AutoColumn:"A" x:"0"
@@ -71,7 +68,7 @@ describe('ag-grid tree transactions', () => {
 
         applyTransactionChecked(api, transactions[0]);
 
-        gridRows = new GridRows(api, 'Transaction 0', gridRowsOptions);
+        gridRows = new GridRows(api, 'Transaction 0');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├── A LEAF id:0 ag-Grid-AutoColumn:"A" x:"0"
@@ -84,7 +81,7 @@ describe('ag-grid tree transactions', () => {
 
         applyTransactionChecked(api, transactions[1]);
 
-        gridRows = new GridRows(api, 'Transaction 1', gridRowsOptions);
+        gridRows = new GridRows(api, 'Transaction 1');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:"0"
@@ -102,7 +99,7 @@ describe('ag-grid tree transactions', () => {
 
         applyTransactionChecked(api, transactions[2]);
 
-        gridRows = new GridRows(api, 'Transaction 2', gridRowsOptions);
+        gridRows = new GridRows(api, 'Transaction 2');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:"0"
@@ -119,7 +116,7 @@ describe('ag-grid tree transactions', () => {
 
         applyTransactionChecked(api, transactions[3]);
 
-        gridRows = new GridRows(api, 'final', gridRowsOptions);
+        gridRows = new GridRows(api, 'final');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ A GROUP id:0 ag-Grid-AutoColumn:"A" x:"0"
@@ -164,7 +161,7 @@ describe('ag-grid tree transactions', () => {
             getDataPath: (data) => data.path,
         });
 
-        await new GridRows(api, 'rowData', gridRowsOptions).check(`
+        await new GridRows(api, 'rowData').check(`
             ROOT id:ROOT_NODE_ID
             ├── A LEAF id:0 ag-Grid-AutoColumn:"A"
             └─┬ X filler id:row-group-0-X ag-Grid-AutoColumn:"X"
@@ -174,7 +171,7 @@ describe('ag-grid tree transactions', () => {
 
         await executeTransactionsAsync(transactions, api);
 
-        const gridRows = new GridRows(api, 'final', gridRowsOptions);
+        const gridRows = new GridRows(api, 'final');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ A GROUP id:0 ag-Grid-AutoColumn:"A"
@@ -229,7 +226,7 @@ describe('ag-grid tree transactions', () => {
 
         await loadedPromise;
 
-        const gridRows = new GridRows(api, 'data', gridRowsOptions);
+        const gridRows = new GridRows(api, 'data');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             └─┬ filler1 filler id:row-group-0-filler1 ag-Grid-AutoColumn:"filler1"
@@ -275,7 +272,7 @@ describe('ag-grid tree transactions', () => {
         applyTransactionChecked(api, { add: more });
 
         // Verify filler IDs and structure regardless of insertion order
-        await new GridRows(api, 'more', gridRowsOptions).check(`
+        await new GridRows(api, 'more').check(`
             ROOT id:ROOT_NODE_ID
             └─┬ filler1 filler id:row-group-0-filler1 ag-Grid-AutoColumn:"filler1"
             · └─┬ X1 GROUP id:X1 ag-Grid-AutoColumn:"X1" id:"X1"

--- a/testing/behavioural/src/tree-data/hierarchical/grouping-hierarchical-with-immutable-row-data.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/grouping-hierarchical-with-immutable-row-data.test.ts
@@ -2,8 +2,7 @@ import type { GridOptions } from 'ag-grid-community';
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { RowGroupingModule, TreeDataModule } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions } from '../../test-utils';
-import { GridRows, TestGridsManager, cachedJSONObjects } from '../../test-utils';
+import { GridRows, TestGridsManager, cachedJSONObjects, setRowDataChecked } from '../../test-utils';
 
 describe('ag-grid grouping treeDataChildrenField with set immutable data', () => {
     const gridsManager = new TestGridsManager({
@@ -56,11 +55,7 @@ describe('ag-grid grouping treeDataChildrenField with set immutable data', () =>
             ])
         );
 
-        const gridRowsOptions: GridRowsOptions = {
-            columns: ['country', 'year', 'name'],
-        };
-
-        let gridRows = new GridRows(api, 'first', gridRowsOptions);
+        let gridRows = new GridRows(api, 'first');
 
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
@@ -100,7 +95,7 @@ describe('ag-grid grouping treeDataChildrenField with set immutable data', () =>
             ])
         );
 
-        gridRows = new GridRows(api, 'update 1', gridRowsOptions);
+        gridRows = new GridRows(api, 'update 1');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Ireland
@@ -138,7 +133,7 @@ describe('ag-grid grouping treeDataChildrenField with set immutable data', () =>
             ])
         );
 
-        gridRows = new GridRows(api, 'update 2', gridRowsOptions);
+        gridRows = new GridRows(api, 'update 2');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Ireland
@@ -179,7 +174,7 @@ describe('ag-grid grouping treeDataChildrenField with set immutable data', () =>
             ])
         );
 
-        gridRows = new GridRows(api, 'add', gridRowsOptions);
+        gridRows = new GridRows(api, 'add');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Ireland
@@ -221,7 +216,7 @@ describe('ag-grid grouping treeDataChildrenField with set immutable data', () =>
             ])
         );
 
-        gridRows = new GridRows(api, 'remove', gridRowsOptions);
+        gridRows = new GridRows(api, 'remove');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Ireland
@@ -264,7 +259,7 @@ describe('ag-grid grouping treeDataChildrenField with set immutable data', () =>
             ])
         );
 
-        gridRows = new GridRows(api, 'remove, update, add', gridRowsOptions);
+        gridRows = new GridRows(api, 'remove, update, add');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Ireland
@@ -301,7 +296,7 @@ describe('ag-grid grouping treeDataChildrenField with set immutable data', () =>
             ])
         );
 
-        gridRows = new GridRows(api, 'update, reorder', gridRowsOptions);
+        gridRows = new GridRows(api, 'update, reorder');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ filler id:row-group-country-Ireland
@@ -322,7 +317,7 @@ describe('ag-grid grouping treeDataChildrenField with set immutable data', () =>
 
         setRowDataChecked(api, []);
 
-        gridRows = new GridRows(api, 'clear', gridRowsOptions);
+        gridRows = new GridRows(api, 'clear');
         await gridRows.check('empty');
     });
 

--- a/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-transactions.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-transactions.test.ts
@@ -4,9 +4,6 @@ import { ClientSideRowModelModule } from 'ag-grid-community';
 import { TreeDataModule } from 'ag-grid-enterprise';
 
 import { GridRows, TestGridsManager, applyTransactionChecked, executeTransactionsAsync } from '../../test-utils';
-import type { GridRowsOptions } from '../../test-utils';
-
-const defaultGridRowsOptions: GridRowsOptions = {};
 
 describe('ag-grid hierarchical tree data reset', () => {
     const gridsManager = new TestGridsManager({
@@ -67,7 +64,7 @@ describe('ag-grid hierarchical tree data reset', () => {
             expect.anything()
         );
 
-        await new GridRows(api, 'tree', defaultGridRowsOptions).check(`
+        await new GridRows(api, 'tree').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ A GROUP id:A ag-Grid-AutoColumn:"A"
             │ └── B LEAF id:B ag-Grid-AutoColumn:"B"

--- a/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-without-tree-module.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-without-tree-module.test.ts
@@ -47,9 +47,7 @@ describe('ag-grid tree data without tree module', () => {
 
         consoleErrorSpy.mockRestore();
 
-        const gridRows = new GridRows(api, 'data', {
-            treeData: false,
-        });
+        const gridRows = new GridRows(api, 'data', { forcedTreeData: false });
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├── LEAF id:0 x:1

--- a/testing/behavioural/src/tree-data/hierarchical/treeDataChildrenField.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/treeDataChildrenField.test.ts
@@ -3,7 +3,6 @@ import type { GridOptions } from 'ag-grid-community';
 import { TreeDataModule } from 'ag-grid-enterprise';
 
 import { GridRows, TestGridsManager } from '../../test-utils';
-import type { GridRowsOptions } from '../../test-utils';
 
 describe('ag-grid treeDataChildrenField', () => {
     const gridsManager = new TestGridsManager({
@@ -40,9 +39,7 @@ describe('ag-grid treeDataChildrenField', () => {
 
         const api = gridsManager.createGrid('myGrid', gridOptions);
 
-        const gridRowsOptions: GridRowsOptions = {};
-
-        let gridRows = new GridRows(api, 'data', gridRowsOptions);
+        let gridRows = new GridRows(api, 'data');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├── LEAF id:1 x:"a"
@@ -53,7 +50,7 @@ describe('ag-grid treeDataChildrenField', () => {
 
         api.setGridOption('treeDataChildrenField', 'children');
 
-        gridRows = new GridRows(api, 'data', gridRowsOptions);
+        gridRows = new GridRows(api, 'data');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├── LEAF id:1 x:"a"
@@ -64,7 +61,7 @@ describe('ag-grid treeDataChildrenField', () => {
 
         api.setGridOption('treeDataChildrenField', undefined);
 
-        gridRows = new GridRows(api, 'data', gridRowsOptions);
+        gridRows = new GridRows(api, 'data');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├── LEAF id:1 x:"a"
@@ -122,9 +119,7 @@ describe('ag-grid treeDataChildrenField', () => {
 
         const api = gridsManager.createGrid('myGrid', gridOptions);
 
-        const gridRowsOptions: GridRowsOptions = {};
-
-        let gridRows = new GridRows(api, 'data', gridRowsOptions);
+        let gridRows = new GridRows(api, 'data');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├── LEAF id:1 x:"a"
@@ -137,7 +132,7 @@ describe('ag-grid treeDataChildrenField', () => {
             treeDataChildrenField: 'children1',
         });
 
-        gridRows = new GridRows(api, 'data', gridRowsOptions);
+        gridRows = new GridRows(api, 'data');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ 1 GROUP id:1 ag-Grid-AutoColumn:"1" x:"a"
@@ -151,7 +146,7 @@ describe('ag-grid treeDataChildrenField', () => {
 
         api.setGridOption('treeDataChildrenField', 'subObject.children2');
 
-        gridRows = new GridRows(api, 'data', gridRowsOptions);
+        gridRows = new GridRows(api, 'data');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ 1 GROUP id:1 ag-Grid-AutoColumn:"1" x:"a"
@@ -165,7 +160,7 @@ describe('ag-grid treeDataChildrenField', () => {
 
         api.setGridOption('treeDataChildrenField', 'xxx');
 
-        gridRows = new GridRows(api, 'data', gridRowsOptions);
+        gridRows = new GridRows(api, 'data');
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
             ├── 1 LEAF id:1 ag-Grid-AutoColumn:"1" x:"a"

--- a/testing/behavioural/src/tree-data/parentid/parentid-tree-data-without-tree-module.test.ts
+++ b/testing/behavioural/src/tree-data/parentid/parentid-tree-data-without-tree-module.test.ts
@@ -48,9 +48,7 @@ describe('ag-grid parentId tree data without tree module', () => {
 
         consoleErrorSpy.mockRestore();
 
-        await new GridRows(api, 'data', {
-            treeData: false,
-        }).check(`
+        await new GridRows(api, 'data', { forcedTreeData: false }).check(`
             ROOT id:ROOT_NODE_ID
             ├── LEAF id:1 x:"1"
             ├── LEAF id:2 x:"2"

--- a/testing/behavioural/src/tree-data/parentid/parentid-tree-expanded-state.test.ts
+++ b/testing/behavioural/src/tree-data/parentid/parentid-tree-expanded-state.test.ts
@@ -2,7 +2,6 @@ import { ClientSideRowModelModule } from 'ag-grid-community';
 import { TreeDataModule } from 'ag-grid-enterprise';
 
 import { GridRows, TestGridsManager, asyncSetTimeout, setRowDataChecked } from '../../test-utils';
-import type { GridRowsOptions } from '../../test-utils';
 
 describe('ag-grid parentId tree expanded state', () => {
     const gridsManager = new TestGridsManager({
@@ -141,9 +140,7 @@ describe('ag-grid parentId tree expanded state', () => {
             getRowId: (params) => params.data.x,
         });
 
-        const gridRowsOptions: GridRowsOptions = {};
-
-        const gridRows = new GridRows(api, 'default expanded 1', gridRowsOptions);
+        const gridRows = new GridRows(api, 'default expanded 1');
 
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID
@@ -186,9 +183,7 @@ describe('ag-grid parentId tree expanded state', () => {
             getRowId: (params) => params.data.x,
         });
 
-        const gridRowsOptions: GridRowsOptions = {};
-
-        const gridRows = new GridRows(api, 'default expanded 1', gridRowsOptions);
+        const gridRows = new GridRows(api, 'default expanded 1');
 
         await gridRows.check(`
             ROOT id:ROOT_NODE_ID


### PR DESCRIPTION
- Add new editing tests for value getter that when editing returns the current value being edited in a value getter
- Add new editing unit tests for edit that mimic and extend the existing documentation tests, so we can run them as part of our unit test bundle and do more regression checks
- Improves all the snapshots that were using printIds = false and specific list of columns in the various unit tests, preferring the GridRows without options