### PR TITLE
[AG-16459] Fix(state): rowgroupexpansion collapsedrowgroupids exposes non bucket data

### DIFF
--- a/.run/sdwvit_fix_state_rowgroupexpansion-collapsedrowgroupids-exposes-non-bucket-data_AG-16459.run.xml
+++ b/.run/sdwvit_fix_state_rowgroupexpansion-collapsedrowgroupids-exposes-non-bucket-data_AG-16459.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="sdwvit/fix/state/rowgroupexpansion-collapsedrowgroupids-exposes-non-bucket-data/AG-16459" type="JavascriptDebugType" uri="https://plnkr.co/edit/EjhzIKqxpNOamZyE?open=main.js">
+    <method v="2" />
+  </configuration>
+</component>

--- a/packages/ag-grid-community/src/interfaces/iExpansionService.ts
+++ b/packages/ag-grid-community/src/interfaces/iExpansionService.ts
@@ -9,7 +9,7 @@ export interface RowGroupExpansionState {
      */
     expandedRowGroupIds: string[];
     /**
-     * Collapsed Row Group Ids array is only used in SSRM when bulk expansion feature is enabled.
+     * Collapsed Row Group Ids array is only used in SSRM when bulk expansion feature is not used.
      * It contains row IDs that were explicitly collapsed.
      */
     collapsedRowGroupIds?: string[];

--- a/packages/ag-grid-community/src/interfaces/iExpansionService.ts
+++ b/packages/ag-grid-community/src/interfaces/iExpansionService.ts
@@ -3,9 +3,14 @@ import type { RowNode } from '../entities/rowNode';
 import type { RowCtrl } from '../rendering/row/rowCtrl';
 
 export interface RowGroupExpansionState {
+    /**
+     * By default, all group nodes in a grid are collapsed.
+     * This array would contain row IDs that were explicitly explanded.
+     */
     expandedRowGroupIds: string[];
     /**
-     * @deprecated Collapsed nodes array is unused and will be removed in the future versions.
+     * Collapsed Row Group Ids array is only used in SSRM when bulk expansion feature is enabled.
+     * It contains row IDs that were explicitly collapsed.
      */
     collapsedRowGroupIds?: string[];
 }

--- a/packages/ag-grid-community/src/interfaces/iExpansionService.ts
+++ b/packages/ag-grid-community/src/interfaces/iExpansionService.ts
@@ -5,7 +5,7 @@ import type { RowCtrl } from '../rendering/row/rowCtrl';
 export interface RowGroupExpansionState {
     /**
      * By default, all group nodes in a grid are collapsed.
-     * This array would contain row IDs that were explicitly explanded.
+     * This array would contain row IDs that were explicitly expanded.
      */
     expandedRowGroupIds: string[];
     /**

--- a/packages/ag-grid-community/src/interfaces/iExpansionService.ts
+++ b/packages/ag-grid-community/src/interfaces/iExpansionService.ts
@@ -4,7 +4,10 @@ import type { RowCtrl } from '../rendering/row/rowCtrl';
 
 export interface RowGroupExpansionState {
     expandedRowGroupIds: string[];
-    collapsedRowGroupIds: string[];
+    /**
+     * @deprecated Collapsed nodes array is unused and will be removed in the future versions.
+     */
+    collapsedRowGroupIds?: string[];
 }
 
 export interface RowGroupBulkExpansionState {

--- a/packages/ag-grid-enterprise/src/rowHierarchy/clientSideExpansionService.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/clientSideExpansionService.ts
@@ -51,7 +51,7 @@ export class ClientSideExpansionService
 
             if (node.expanded) {
                 expandedRowGroupIds.push(id);
-            } else {
+            } else if (node.isExpandable()) {
                 collapsedRowGroupIds.push(id);
             }
         });

--- a/packages/ag-grid-enterprise/src/rowHierarchy/clientSideExpansionService.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/clientSideExpansionService.ts
@@ -51,7 +51,7 @@ export class ClientSideExpansionService
 
             if (node.expanded) {
                 expandedRowGroupIds.push(id);
-            } else if (node.isExpandable() && allowCollapsed) {
+            } else if (allowCollapsed && node.isExpandable()) {
                 collapsedRowGroupIds.push(id);
             }
         });

--- a/packages/ag-grid-enterprise/src/rowHierarchy/clientSideExpansionService.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/clientSideExpansionService.ts
@@ -42,7 +42,6 @@ export class ClientSideExpansionService
 
     public getExpansionState(): RowGroupExpansionState {
         const expandedRowGroupIds: string[] = [];
-        const collapsedRowGroupIds: string[] = [];
         this.beans.rowModel.forEachNode((node) => {
             const id = node.id;
             if (!id) {
@@ -51,11 +50,9 @@ export class ClientSideExpansionService
 
             if (node.expanded) {
                 expandedRowGroupIds.push(id);
-            } else if (node.isExpandable()) {
-                collapsedRowGroupIds.push(id);
             }
         });
-        return { expandedRowGroupIds, collapsedRowGroupIds };
+        return { expandedRowGroupIds, collapsedRowGroupIds: [] };
     }
 
     public expandAll(expand: boolean): void {

--- a/packages/ag-grid-enterprise/src/rowHierarchy/clientSideExpansionService.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/clientSideExpansionService.ts
@@ -40,8 +40,9 @@ export class ClientSideExpansionService
         this.onGroupExpandedOrCollapsed();
     }
 
-    public getExpansionState(): RowGroupExpansionState {
+    private getInternalExpansionState(allowCollapsed = false) {
         const expandedRowGroupIds: string[] = [];
+        const collapsedRowGroupIds: string[] = [];
         this.beans.rowModel.forEachNode((node) => {
             const id = node.id;
             if (!id) {
@@ -50,9 +51,15 @@ export class ClientSideExpansionService
 
             if (node.expanded) {
                 expandedRowGroupIds.push(id);
+            } else if (node.isExpandable() && allowCollapsed) {
+                collapsedRowGroupIds.push(id);
             }
         });
-        return { expandedRowGroupIds, collapsedRowGroupIds: [] };
+        return { expandedRowGroupIds, collapsedRowGroupIds };
+    }
+
+    public getExpansionState(): RowGroupExpansionState {
+        return this.getInternalExpansionState();
     }
 
     public expandAll(expand: boolean): void {
@@ -122,7 +129,7 @@ export class ClientSideExpansionService
     }
 
     public setDetailsExpansionState(detailGridApi: GridApi): void {
-        const expansionState = this.getExpansionState();
+        const expansionState = this.getInternalExpansionState(true);
         const allExpanded = expansionState.collapsedRowGroupIds.length === 0;
         const allCollapsed = expansionState.expandedRowGroupIds.length === 0;
         if (allCollapsed === allExpanded) {

--- a/testing/behavioural/src/grid-state/grid-state-full.test.ts
+++ b/testing/behavioural/src/grid-state/grid-state-full.test.ts
@@ -81,7 +81,7 @@ describe('Grid State Full Snapshot', () => {
             rangeSelection: undefined,
             rowGroup: undefined,
             rowGroupExpansion: {
-                collapsedRowGroupIds: ['0', '1', '2', '3', '4'], // TODO: FIX as part of https://ag-grid.zendesk.com/agent/tickets/40345
+                collapsedRowGroupIds: [],
                 expandedRowGroupIds: [],
             },
             rowSelection: undefined,
@@ -178,19 +178,7 @@ describe('Grid State Full Snapshot', () => {
                 groupColIds: ['sport'],
             },
             rowGroupExpansion: {
-                collapsedRowGroupIds: [
-                    //TODO FIX
-                    'row-group-sport-Football',
-                    '0',
-                    'row-group-sport-Tennis',
-                    '1',
-                    'row-group-sport-Golf',
-                    '2',
-                    'row-group-sport-Basketball',
-                    '3',
-                    'row-group-sport-Swimming',
-                    '4',
-                ],
+                collapsedRowGroupIds: [],
                 expandedRowGroupIds: [],
             },
             rowSelection: [

--- a/testing/behavioural/src/grid-state/grid-state.test.ts
+++ b/testing/behavioural/src/grid-state/grid-state.test.ts
@@ -270,26 +270,14 @@ describe('StateService - Grid State Management', () => {
             });
 
             expect(api.getState().rowGroupExpansion).toEqual({
-                collapsedRowGroupIds: [
-                    // TODO: FIX as part of https://ag-grid.zendesk.com/agent/tickets/40345
-                    'row-group-sport-Football',
-                    '0',
-                    'row-group-sport-Tennis',
-                    '1',
-                    'row-group-sport-Golf',
-                    '2',
-                    'row-group-sport-Basketball',
-                    '3',
-                    'row-group-sport-Swimming',
-                    '4',
-                ],
+                collapsedRowGroupIds: [],
                 expandedRowGroupIds: [],
             });
 
             api.expandAll();
 
             expect(api.getState().rowGroupExpansion).toEqual({
-                collapsedRowGroupIds: ['0', '1', '2', '3', '4'], // TODO: FIX as part of https://ag-grid.zendesk.com/agent/tickets/40345
+                collapsedRowGroupIds: [],
                 expandedRowGroupIds: [
                     'row-group-sport-Football',
                     'row-group-sport-Tennis',


### PR DESCRIPTION
Fix row group expansion to exclude non-bucket data from collapsedRowGroupIds

- Add run configuration file for testing

fixes [AG-16459](https://ag-grid.atlassian.net/browse/AG-16459)
fixes [AG-16470](https://ag-grid.atlassian.net/browse/AG-16470)