### PR TITLE
[AG-16429] Fix(docs): absolute sorting refs in the default column header template

### DIFF
--- a/.run/Reset row height SSRM flickering.run.xml
+++ b/.run/Reset row height SSRM flickering.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Reset row height SSRM flickering" type="JavascriptDebugType" uri="https://plnkr.co/edit/PlHG2NL9x8Ax38Y1?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/SSRM Grand Total Row.run.xml
+++ b/.run/SSRM Grand Total Row.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="SSRM Grand Total Row" type="JavascriptDebugType" uri="https://plnkr.co/edit/ZhT2H7TRKcMLK6Vs?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/Set Master-details via a row update UMD.run.xml
+++ b/.run/Set Master-details via a row update UMD.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Set Master-details via a row update UMD" type="JavascriptDebugType" uri="https://plnkr.co/edit/zAXiCJ2NIM0VP8mM?open=main.ts">
-    <method v="2" />
-  </configuration>
-</component>

--- a/documentation/ag-grid-docs/src/content/docs/column-headers/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-headers/index.mdoc
@@ -185,17 +185,19 @@ You can provide an HTML template to the Default Header Component for simple layo
 
 When you provide your own template, everything should work as expected as long as you re-use the same `data-ref` attribute names.
 
-| Ref | Description |
-|-|-|
-| `eMenu` | The container where the column menu icon will appear to enable opening the column menu (in AG Grid Community, this is only used when `columnMenu = 'legacy'`). |
-| `eFilterButton` | The container where the column filter icon will appear to enable opening the filter (not used when `columnMenu = 'legacy'`). |
-| `eLabel` | The container where there is going to be an onClick mouse listener to trigger the sort. |
-| `eText` | The text displayed on the column. |
-| `eFilter` | The container with the icon that will appear if the user filters this column (only used when `columnMenu = 'legacy'` or `suppressHeaderFilterButton = true`). |
-| `eSortOrder` | If multiple columns are sorted, this shows the index that represents the position of this column in the order. |
-| `eSortAsc` | If the column is sorted ascending, this shows the ascending icon. |
-| `eSortDesc` | If the column is sorted descending, this shows the descending icon. |
-| `eSortNone` | If no sort is applied, this shows the no sort icon. Note this icon by default is empty. |
+| Ref                 | Description                                                                                                                                                    |
+|---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `eMenu`             | The container where the column menu icon will appear to enable opening the column menu (in AG Grid Community, this is only used when `columnMenu = 'legacy'`). |
+| `eFilterButton`     | The container where the column filter icon will appear to enable opening the filter (not used when `columnMenu = 'legacy'`).                                   |
+| `eLabel`            | The container where there is going to be an onClick mouse listener to trigger the sort.                                                                        |
+| `eText`             | The text displayed on the column.                                                                                                                              |
+| `eFilter`           | The container with the icon that will appear if the user filters this column (only used when `columnMenu = 'legacy'` or `suppressHeaderFilterButton = true`).  |
+| `eSortOrder`        | If multiple columns are sorted, this shows the index that represents the position of this column in the order.                                                 |
+| `eSortAsc`          | If the column is sorted ascending, this shows the ascending icon.                                                                                              |
+| `eSortDesc`         | If the column is sorted descending, this shows the descending icon.                                                                                            |
+| `eSortNone`         | If no sort is applied, this shows the no sort icon. Note this icon by default is empty.                                                                        |
+| `eSortAbsoluteAsc`  | If the column is sorted absolute ascending, this shows the absolute ascending icon.                                                                            |
+| `eSortAbsoluteDesc` | If the column is sorted absolute descending, this shows the absolute descending icon.                                                                          |
 
 The `data-ref` parameters are used by the grid to identify elements to add functionality to. If you leave an element out of your template, the functionality will not be added. For example if you do not specify `eLabel` then the column will not react to click events for sorting.
 


### PR DESCRIPTION
Remove unused run configurations and update column header ref documentation

- Remove obsolete run configuration files for SSRM and UMD examples
- Update column header reference table with new `eSortAbsoluteAsc` and `eSortAbsoluteDesc` entries
- Improve table formatting and consistency in documentation

Fix [AG-16429](https://ag-grid.atlassian.net/browse/AG-16429)