### PR TITLE
[AG-16028] Maintenance(docs): improve richselect complex object example

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select/_examples/rich-select-complex-objects/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select/_examples/rich-select-complex-objects/main.ts
@@ -56,7 +56,6 @@ const gridOptions: GridOptions = {
     defaultColDef: {
         width: 200,
         editable: true,
-        filter: true,
         cellEditor: 'agRichSelectCellEditor',
     },
     columnDefs: columnDefs,

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select/_examples/rich-select-complex-objects/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select/_examples/rich-select-complex-objects/main.ts
@@ -22,7 +22,6 @@ const columnDefs: ColDef[] = [
         headerName: 'Color (Column as String Type)',
         field: 'color',
         width: 250,
-        cellEditor: 'agRichSelectCellEditor',
         cellEditorParams: {
             formatValue: (v) => v.name,
             parseValue: (v) => v.name,
@@ -39,7 +38,7 @@ const columnDefs: ColDef[] = [
         width: 290,
         valueFormatter: (p) => `${p.value.name} (${p.value.code})`,
         valueParser: (p) => p.newValue,
-        cellEditor: 'agRichSelectCellEditor',
+        cellDataType: 'object',
         cellEditorParams: {
             formatValue: (v) => v.name,
             values: colors,
@@ -57,6 +56,8 @@ const gridOptions: GridOptions = {
     defaultColDef: {
         width: 200,
         editable: true,
+        filter: true,
+        cellEditor: 'agRichSelectCellEditor',
     },
     columnDefs: columnDefs,
     rowData: colors.map((v) => ({ color: v.name, detailedColor: v })),

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select/index.mdoc
@@ -153,6 +153,7 @@ columnDefs: [
         cellEditor: 'agRichSelectCellEditor',
         valueFormatter: (p) => `${p.value.name} (${p.value.code})`,
         valueParser: (p) => p.newValue,
+        cellDataType: 'object',
         cellEditorParams: {
             values: colors,
             formatValue: (v) => v.name,


### PR DESCRIPTION
Update rich select examples to use cellDataType and enable filtering

- Add cellDataType: 'object' to rich select column definitions for proper type handling
- Enable filtering on rich select columns by adding filter: true to defaultColDef
- Update column definitions to use agRichSelectCellEditor consistently
- Refactor example to support object-based value handling with proper formatting and parsing

Fix [AG-16028](https://ag-grid.atlassian.net/browse/AG-16028)

<img width="1085" height="481" alt="Screenshot_20251222_162635" src="https://github.com/user-attachments/assets/733798de-dbba-4dec-91d9-211c9c39bd66" />
<img width="1085" height="481" alt="Screenshot_20251222_162629" src="https://github.com/user-attachments/assets/05f1e238-5385-4f4d-98fd-7a45bbff83f2" />
<img width="1085" height="481" alt="Screenshot_20251222_162621" src="https://github.com/user-attachments/assets/4dd6a571-fa9b-4603-b381-d10298848e14" />
<img width="1085" height="481" alt="Screenshot_20251222_162617" src="https://github.com/user-attachments/assets/3f1c105e-bec8-4aa3-9d2a-9f279930605c" />
<img width="1016" height="733" alt="Screenshot_20251222_162719" src="https://github.com/user-attachments/assets/cd0f448a-7d44-44d2-bd4c-1c00e0ed9a48" />

