### PR TITLE
Update column header documentation and example for absolute sorting

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/column-headers/_examples/header-template/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-headers/_examples/header-template/main.ts
@@ -26,6 +26,7 @@ const columnDefs: ColDef[] = [
     { field: 'silver', sortable: false },
     { field: 'bronze', suppressHeaderFilterButton: true },
     { field: 'total', sortable: false },
+    { field: 'prevYearTotalDiff', sort: { type: 'absolute', direction: null } },
 ];
 
 let gridApi: GridApi<IOlympicData>;
@@ -43,6 +44,8 @@ const gridOptions: GridOptions<IOlympicData> = {
                         <span data-ref="eSortOrder" class="ag-header-icon ag-sort-order ag-hidden"></span>
                         <span data-ref="eSortAsc" class="ag-header-icon ag-sort-ascending-icon ag-hidden"></span>
                         <span data-ref="eSortDesc" class="ag-header-icon ag-sort-descending-icon ag-hidden"></span>
+                        <span data-ref="eSortAbsoluteAsc" class="ag-header-icon ag-sort-absolute-ascending-icon ag-hidden"></span>
+                        <span data-ref="eSortAbsoluteDesc" class="ag-header-icon ag-sort-absolute-descending-icon ag-hidden"></span>
                         <span data-ref="eSortMixed" class="ag-header-icon ag-sort-mixed-icon ag-hidden"></span>
                         <span data-ref="eSortNone" class="ag-header-icon ag-sort-none-icon ag-hidden"></span>
                         ** <span data-ref="eText" class="ag-header-cell-text" role="columnheader"></span>
@@ -60,5 +63,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
         .then((response) => response.json())
-        .then((data: IOlympicData[]) => gridApi!.setGridOption('rowData', data));
+        .then((data: IOlympicData[]) =>
+            gridApi!.setGridOption(
+                'rowData',
+                data.map((d) => ({
+                    ...d,
+                    prevYearTotalDiff: Math.floor((2 * window.agRandom() - 1) * d.total),
+                }))
+            )
+        );
 });

--- a/documentation/ag-grid-docs/src/content/docs/column-headers/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-headers/index.mdoc
@@ -178,6 +178,8 @@ You can provide an HTML template to the Default Header Component for simple layo
         <span data-ref="eSortOrder" class="ag-header-icon ag-header-label-icon ag-sort-order" aria-hidden="true"></span>
         <span data-ref="eSortAsc" class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon" aria-hidden="true"></span>
         <span data-ref="eSortDesc" class="ag-header-icon ag-header-label-icon ag-sort-descending-icon" aria-hidden="true"></span>
+        <span data-ref="eSortDesc" class="ag-header-icon ag-header-label-icon ag-sort-absolute-ascending-icon" aria-hidden="true"></span>
+        <span data-ref="eSortDesc" class="ag-header-icon ag-header-label-icon ag-sort-absolute-descending-icon" aria-hidden="true"></span>
         <span data-ref="eSortNone" class="ag-header-icon ag-header-label-icon ag-sort-none-icon" aria-hidden="true"></span>
     </div>
 </div>
@@ -195,9 +197,9 @@ When you provide your own template, everything should work as expected as long a
 | `eSortOrder`        | If multiple columns are sorted, this shows the index that represents the position of this column in the order.                                                 |
 | `eSortAsc`          | If the column is sorted ascending, this shows the ascending icon.                                                                                              |
 | `eSortDesc`         | If the column is sorted descending, this shows the descending icon.                                                                                            |
-| `eSortNone`         | If no sort is applied, this shows the no sort icon. Note this icon by default is empty.                                                                        |
 | `eSortAbsoluteAsc`  | If the column is sorted absolute ascending, this shows the absolute ascending icon.                                                                            |
 | `eSortAbsoluteDesc` | If the column is sorted absolute descending, this shows the absolute descending icon.                                                                          |
+| `eSortNone`         | If no sort is applied, this shows the no sort icon. Note this icon by default is empty.                                                                        |
 
 The `data-ref` parameters are used by the grid to identify elements to add functionality to. If you leave an element out of your template, the functionality will not be added. For example if you do not specify `eLabel` then the column will not react to click events for sorting.
 

--- a/documentation/ag-grid-docs/src/content/docs/column-headers/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-headers/index.mdoc
@@ -178,8 +178,8 @@ You can provide an HTML template to the Default Header Component for simple layo
         <span data-ref="eSortOrder" class="ag-header-icon ag-header-label-icon ag-sort-order" aria-hidden="true"></span>
         <span data-ref="eSortAsc" class="ag-header-icon ag-header-label-icon ag-sort-ascending-icon" aria-hidden="true"></span>
         <span data-ref="eSortDesc" class="ag-header-icon ag-header-label-icon ag-sort-descending-icon" aria-hidden="true"></span>
-        <span data-ref="eSortDesc" class="ag-header-icon ag-header-label-icon ag-sort-absolute-ascending-icon" aria-hidden="true"></span>
-        <span data-ref="eSortDesc" class="ag-header-icon ag-header-label-icon ag-sort-absolute-descending-icon" aria-hidden="true"></span>
+        <span data-ref="eSortAbsoluteAsc" class="ag-header-icon ag-header-label-icon ag-sort-absolute-ascending-icon ag-hidden"></span>
+        <span data-ref="eSortAbsoluteDesc" class="ag-header-icon ag-header-label-icon ag-sort-absolute-descending-icon ag-hidden"></span>
         <span data-ref="eSortNone" class="ag-header-icon ag-header-label-icon ag-sort-none-icon" aria-hidden="true"></span>
     </div>
 </div>


### PR DESCRIPTION
Update column header documentation and example for absolute sorting

- Add `eSortAbsoluteAsc` and `eSortAbsoluteDesc` to header template and documentation
- Update example to include `prevYearTotalDiff` field with absolute sort configuration
- Modify data generation to compute `prevYearTotalDiff` values dynamically
- Reorder `eSortNone` entry in documentation table for consistency

Fix [AG-16429](https://ag-grid.atlassian.net/browse/AG-16429)