### PR TITLE
Extract sort logic into helper function for reusability

### DIFF
--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -3,12 +3,27 @@
   <component name="JavaScriptLibraryMappings">
     <file url="file://$PROJECT_DIR$" libraries="{Node.js Core}" />
     <excludedPredefinedLibrary name="HTML" />
+    <excludedPredefinedLibrary name="ag-grid/community-modules/locale/node_modules" />
+    <excludedPredefinedLibrary name="ag-grid/community-modules/styles/node_modules" />
+    <excludedPredefinedLibrary name="ag-grid/documentation/ag-grid-docs/node_modules" />
+    <excludedPredefinedLibrary name="ag-grid/documentation/update-algolia-indices/node_modules" />
+    <excludedPredefinedLibrary name="ag-grid/external/ag-shared/node_modules" />
     <excludedPredefinedLibrary name="ag-grid/node_modules" />
     <excludedPredefinedLibrary name="ag-grid/packages/ag-grid-angular/node_modules" />
     <excludedPredefinedLibrary name="ag-grid/packages/ag-grid-community/node_modules" />
     <excludedPredefinedLibrary name="ag-grid/packages/ag-grid-enterprise/node_modules" />
     <excludedPredefinedLibrary name="ag-grid/packages/ag-grid-react/node_modules" />
     <excludedPredefinedLibrary name="ag-grid/packages/ag-grid-vue3/node_modules" />
+    <excludedPredefinedLibrary name="ag-grid/plugins/ag-grid-generate-code-reference-files/node_modules" />
+    <excludedPredefinedLibrary name="ag-grid/plugins/ag-grid-generate-example-files/dist/node_modules" />
+    <excludedPredefinedLibrary name="ag-grid/plugins/ag-grid-generate-example-files/node_modules" />
+    <excludedPredefinedLibrary name="ag-grid/plugins/ag-grid-task-autogen/node_modules" />
+    <excludedPredefinedLibrary name="ag-grid/testing/accessibility/node_modules" />
+    <excludedPredefinedLibrary name="ag-grid/testing/behavioural/node_modules" />
+    <excludedPredefinedLibrary name="ag-grid/testing/csp/node_modules" />
+    <excludedPredefinedLibrary name="ag-grid/testing/module-size-angular/node_modules" />
+    <excludedPredefinedLibrary name="ag-grid/testing/module-size/node_modules" />
+    <excludedPredefinedLibrary name="ag-grid/testing/public-recipes/e2e/node_modules" />
     <excludedPredefinedLibrary name="tsconfig$paths" />
   </component>
 </project>

--- a/packages/ag-grid-community/src/entities/agColumn.ts
+++ b/packages/ag-grid-community/src/entities/agColumn.ts
@@ -1,3 +1,4 @@
+import { AgBeanStub } from '../agStack/core/agBeanStub';
 import { LocalEventService } from '../agStack/events/localEventService';
 import type { AgEvent } from '../agStack/interfaces/agEvent';
 import type { IAgEventEmitter } from '../agStack/interfaces/iEventEmitter';
@@ -5,6 +6,7 @@ import { _exists, _missing } from '../agStack/utils/generic';
 import { _escapeString } from '../agStack/utils/string';
 import type { ColumnState } from '../columns/columnStateUtils';
 import { BeanStub } from '../context/beanStub';
+import { BeanCollection } from '../context/context';
 import type { ColumnEvent, ColumnEventType } from '../events';
 import { _addGridCommonParams } from '../gridOptionsUtils';
 import type {
@@ -856,4 +858,26 @@ export function _normalizeSortDirection(sortDirectionLike?: unknown): SortDirect
 
 export function _normalizeSortType(sortTypeLike?: unknown): SortType {
     return _isSortTypeValid(sortTypeLike) ? sortTypeLike : 'default';
+}
+
+export function _getDisplaySortForColumn(column: AgColumn, beans: BeanCollection) {
+    const sortDef = beans.sortSvc!.getDisplaySortForColumn(column);
+    const type = _normalizeSortType(sortDef?.type);
+    const direction = _normalizeSortDirection(sortDef?.direction);
+    const allowedSortTypes = column.getAvailableSortTypes();
+    const isDefaultSortAllowed = allowedSortTypes.has('default');
+    const isAbsoluteSortAllowed = allowedSortTypes.has('absolute');
+    const isAbsoluteSort = type === 'absolute';
+    const isDefaultSort = type === 'default';
+    const isAscending = direction === 'asc';
+    const isDescending = direction === 'desc';
+    return {
+        isDefaultSortAllowed,
+        isAbsoluteSortAllowed,
+        isAbsoluteSort,
+        isDefaultSort,
+        isAscending,
+        isDescending,
+        direction,
+    };
 }

--- a/packages/ag-grid-community/src/entities/agColumn.ts
+++ b/packages/ag-grid-community/src/entities/agColumn.ts
@@ -1,4 +1,3 @@
-import { AgBeanStub } from '../agStack/core/agBeanStub';
 import { LocalEventService } from '../agStack/events/localEventService';
 import type { AgEvent } from '../agStack/interfaces/agEvent';
 import type { IAgEventEmitter } from '../agStack/interfaces/iEventEmitter';
@@ -6,7 +5,7 @@ import { _exists, _missing } from '../agStack/utils/generic';
 import { _escapeString } from '../agStack/utils/string';
 import type { ColumnState } from '../columns/columnStateUtils';
 import { BeanStub } from '../context/beanStub';
-import { BeanCollection } from '../context/context';
+import type { BeanCollection } from '../context/context';
 import type { ColumnEvent, ColumnEventType } from '../events';
 import { _addGridCommonParams } from '../gridOptionsUtils';
 import type {

--- a/packages/ag-grid-community/src/main-internal.ts
+++ b/packages/ag-grid-community/src/main-internal.ts
@@ -268,6 +268,7 @@ export {
     _isSortTypeValid,
     _normalizeSortDirection,
     _normalizeSortType,
+    _getDisplaySortForColumn,
 } from './entities/agColumn';
 export { AgColumnGroup } from './entities/agColumnGroup';
 export { AgProvidedColumnGroup } from './entities/agProvidedColumnGroup';

--- a/packages/ag-grid-community/src/sort/sortIndicatorComp.ts
+++ b/packages/ag-grid-community/src/sort/sortIndicatorComp.ts
@@ -1,7 +1,7 @@
 import { RefPlaceholder } from '../agStack/interfaces/agComponent';
 import { _clearElement, _setDisplayed } from '../agStack/utils/dom';
 import type { AgColumn } from '../entities/agColumn';
-import { _normalizeSortDirection, _normalizeSortType } from '../entities/agColumn';
+import { _getDisplaySortForColumn } from '../entities/agColumn';
 import { _isColumnsSortingCoupledToGroup } from '../gridOptionsUtils';
 import type { ElementParams } from '../utils/element';
 import type { IconName } from '../utils/icon';
@@ -118,16 +118,15 @@ export class SortIndicatorComp extends Component {
     private updateIcons(): void {
         const { eSortAsc, eSortDesc, eSortAbsoluteAsc, eSortAbsoluteDesc, eSortNone, column, gos, beans } = this;
 
-        const sortDef = beans.sortSvc!.getDisplaySortForColumn(column);
-        const type = _normalizeSortType(sortDef?.type);
-        const direction = _normalizeSortDirection(sortDef?.direction);
-        const allowedSortTypes = column.getAvailableSortTypes();
-        const isDefaultSortAllowed = allowedSortTypes.has('default');
-        const isAbsoluteSortAllowed = allowedSortTypes.has('absolute');
-        const isAbsoluteSort = type === 'absolute';
-        const isDefaultSort = type === 'default';
-        const isAscending = direction === 'asc';
-        const isDescending = direction === 'desc';
+        const {
+            isDefaultSortAllowed,
+            isAbsoluteSortAllowed,
+            isAbsoluteSort,
+            isDefaultSort,
+            isAscending,
+            isDescending,
+            direction,
+        } = _getDisplaySortForColumn(column, beans);
 
         if (eSortAsc) {
             _setDisplayed(eSortAsc, isAscending && isDefaultSort && isDefaultSortAllowed, { skipAriaHidden: true });

--- a/packages/ag-grid-community/src/sort/sortIndicatorComp.ts
+++ b/packages/ag-grid-community/src/sort/sortIndicatorComp.ts
@@ -1,6 +1,6 @@
 import { RefPlaceholder } from '../agStack/interfaces/agComponent';
 import { _clearElement, _setDisplayed } from '../agStack/utils/dom';
-import type { AgColumn } from '../entities/agColumn';
+import { AgColumn, _getDisplaySortForColumn } from '../entities/agColumn';
 import { _normalizeSortDirection, _normalizeSortType } from '../entities/agColumn';
 import { _isColumnsSortingCoupledToGroup } from '../gridOptionsUtils';
 import type { ElementParams } from '../utils/element';
@@ -118,16 +118,15 @@ export class SortIndicatorComp extends Component {
     private updateIcons(): void {
         const { eSortAsc, eSortDesc, eSortAbsoluteAsc, eSortAbsoluteDesc, eSortNone, column, gos, beans } = this;
 
-        const sortDef = beans.sortSvc!.getDisplaySortForColumn(column);
-        const type = _normalizeSortType(sortDef?.type);
-        const direction = _normalizeSortDirection(sortDef?.direction);
-        const allowedSortTypes = column.getAvailableSortTypes();
-        const isDefaultSortAllowed = allowedSortTypes.has('default');
-        const isAbsoluteSortAllowed = allowedSortTypes.has('absolute');
-        const isAbsoluteSort = type === 'absolute';
-        const isDefaultSort = type === 'default';
-        const isAscending = direction === 'asc';
-        const isDescending = direction === 'desc';
+        const {
+            isDefaultSortAllowed,
+            isAbsoluteSortAllowed,
+            isAbsoluteSort,
+            isDefaultSort,
+            isAscending,
+            isDescending,
+            direction,
+        } = _getDisplaySortForColumn(column, beans);
 
         if (eSortAsc) {
             _setDisplayed(eSortAsc, isAscending && isDefaultSort && isDefaultSortAllowed, { skipAriaHidden: true });

--- a/packages/ag-grid-enterprise/src/menu/columnMenuFactory.ts
+++ b/packages/ag-grid-enterprise/src/menu/columnMenuFactory.ts
@@ -2,11 +2,10 @@ import type { AgColumn, AgProvidedColumnGroup, DefaultMenuItem, MenuItemDef, Nam
 import {
     BeanStub,
     _addGridCommonParams,
+    _getDisplaySortForColumn,
     _getGrandTotalRow,
     _isClientSideRowModel,
     _isLegacyMenuEnabled,
-    _normalizeSortDirection,
-    _normalizeSortType,
 } from 'ag-grid-community';
 
 import { isRowGroupColLocked } from '../rowGrouping/rowGroupingUtils';
@@ -127,16 +126,15 @@ export class ColumnMenuFactory extends BeanStub implements NamedBean {
             !isPrimary || (aggFuncSvc && column.isAllowValue() && (doingGrouping || grandTotalRow || treeData));
 
         if (sortSvc && !isLegacyMenuEnabled && column.isSortable()) {
-            const sortDef = column.getSortDef();
-            const type = _normalizeSortType(sortDef?.type);
-            const direction = _normalizeSortDirection(sortDef?.direction);
-            const allowedSortTypes = column.getAvailableSortTypes();
-            const isDefaultSortAllowed = allowedSortTypes.has('default');
-            const isAbsoluteSortAllowed = allowedSortTypes.has('absolute');
-            const isAbsoluteSort = type === 'absolute';
-            const isDefaultSort = type === 'default';
-            const isAscending = direction === 'asc';
-            const isDescending = direction === 'desc';
+            const {
+                isDefaultSortAllowed,
+                isAbsoluteSortAllowed,
+                isAbsoluteSort,
+                isDefaultSort,
+                isAscending,
+                isDescending,
+                direction,
+            } = _getDisplaySortForColumn(column, beans);
 
             if (isDefaultSortAllowed && !(isAscending && isDefaultSort)) {
                 result.push('sortAscending');


### PR DESCRIPTION
 - Extracted sort logic from multiple components into _getDisplaySortForColumn helper function
 - Simplified sort condition checks in sortIndicatorComp.ts and columnMenuFactory.ts
 - Added missing import for _getDisplaySortForColumn in main-internal.ts
 - Removed redundant code duplication across files
 - Improved maintainability and code consistency