### PR TITLE
AG-3390 - Add react-instantsearch to root to fix deps issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "postcss-url": "^10.1.3",
     "prettier": "3.2.5",
     "prompts": "^2.4.2",
+    "react-instantsearch": "^7.7.0",
     "stylelint": "^16.10.0",
     "stylelint-config-standard": "^36.0.1",
     "ts-jest": "^29.1.0",


### PR DESCRIPTION
Have issues `ai` dependency needing to be installed when `nx build` is run