### PR TITLE
eslint-no-unused-expressions

### DIFF
--- a/documentation/ag-grid-docs/src/components/example-runner/components/CodeOptions.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/components/CodeOptions.tsx
@@ -67,7 +67,9 @@ function CodeOptionSelector({
                 value={internalFramework}
                 onChange={(event) => {
                     onChange(event);
-                    tracking && tracking(event.target.value);
+                    if (tracking) {
+                        tracking(event.target.value);
+                    }
                 }}
                 onBlur={onChange}
             >

--- a/documentation/ag-grid-docs/src/components/example-runner/components/CodeOptions.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/components/CodeOptions.tsx
@@ -67,9 +67,7 @@ function CodeOptionSelector({
                 value={internalFramework}
                 onChange={(event) => {
                     onChange(event);
-                    if (tracking) {
-                        tracking(event.target.value);
-                    }
+                    tracking?.(event.target.value);
                 }}
                 onBlur={onChange}
             >

--- a/documentation/ag-grid-docs/src/stores/darkmodeStore.ts
+++ b/documentation/ag-grid-docs/src/stores/darkmodeStore.ts
@@ -23,7 +23,7 @@ const updateHtml = (darkmode: boolean | undefined) => {
     htmlEl.classList.add('no-transitions');
     htmlEl.dataset.darkMode = darkmode === true ? 'true' : 'false';
     htmlEl.dataset.agThemeMode = htmlEl.dataset.darkMode === 'true' ? 'dark-blue' : 'light';
-    htmlEl.offsetHeight; // Trigger a reflow, flushing the CSS changes
+    void htmlEl.offsetHeight; // Trigger a reflow, flushing the CSS changes
     htmlEl.classList.remove('no-transitions');
 
     const darkModeEvent = { type: 'color-scheme-change', darkmode };

--- a/documentation/ag-grid-docs/src/utils/grid/generator-utils.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/generator-utils.ts
@@ -15,11 +15,11 @@ type GeneratorState = 'started' | 'stopped';
 export function createGenerator({ interval = 1000, callback }: { interval: number; callback: () => void }) {
     let currentInterval = interval;
     let state: GeneratorState = 'stopped';
-    let timeout;
+    let timeout: ReturnType<typeof setTimeout>;
 
     const createTimeout = () => {
         return setTimeout(() => {
-            callback && callback();
+            callback?.();
 
             if (state !== 'stopped') {
                 timeout = createTimeout();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -94,6 +94,15 @@ export default [
                     varsIgnorePattern: '^_+$',
                 },
             ],
+            // Disallow using logical short-circuit expressions as control flow (eg. `a && fn()`).
+            '@typescript-eslint/no-unused-expressions': [
+                'error',
+                {
+                    allowShortCircuit: false,
+                    allowTernary: false,
+                    allowTaggedTemplates: false,
+                },
+            ],
             'no-undef': 'warn',
             'no-lonely-if': 'error',
             curly: 'error',

--- a/packages/ag-grid-community/src/agStack/events/localEventService.ts
+++ b/packages/ag-grid-community/src/agStack/events/localEventService.ts
@@ -153,7 +153,12 @@ export class LocalEventService<TEventType extends string> implements IEventEmitt
             const flush = () => {
                 window.setTimeout(this.flushAsyncQueue.bind(this), 0);
             };
-            this.frameworkOverrides ? this.frameworkOverrides.wrapIncoming(flush) : flush();
+            const frameworkOverrides = this.frameworkOverrides;
+            if (frameworkOverrides) {
+                frameworkOverrides.wrapIncoming(flush);
+            } else {
+                flush();
+            }
             // mark that it is scheduled
             this.scheduled = true;
         }

--- a/packages/ag-grid-community/src/agStack/focus/agTabGuardFeature.ts
+++ b/packages/ag-grid-community/src/agStack/focus/agTabGuardFeature.ts
@@ -72,9 +72,11 @@ export class AgTabGuardFeature<
         const compProxy: ITabGuard = {
             setTabIndex: (tabIndex) => {
                 for (const tabGuard of tabGuards) {
-                    tabIndex == null
-                        ? tabGuard.removeAttribute('tabindex')
-                        : tabGuard.setAttribute('tabindex', tabIndex);
+                    if (tabIndex == null) {
+                        tabGuard.removeAttribute('tabindex');
+                    } else {
+                        tabGuard.setAttribute('tabindex', tabIndex);
+                    }
                 }
             },
         };

--- a/packages/ag-grid-community/src/columns/baseColsService.ts
+++ b/packages/ag-grid-community/src/columns/baseColsService.ts
@@ -123,7 +123,9 @@ export abstract class BaseColsService extends BeanStub implements IColsService {
             columnCallback(column, added, source);
         }
 
-        autoGroupsNeedBuilding && this.colModel.refreshCols(false, source);
+        if (autoGroupsNeedBuilding) {
+            this.colModel.refreshCols(false, source);
+        }
 
         this.visibleCols.refresh(source);
 
@@ -256,7 +258,11 @@ export abstract class BaseColsService extends BeanStub implements IColsService {
 
             if (include) {
                 const useIndex = colIsNew ? index != null || initialIndex != null : index != null;
-                useIndex ? colsWithIndex.push(col) : colsWithValue.push(col);
+                if (useIndex) {
+                    colsWithIndex.push(col);
+                } else {
+                    colsWithValue.push(col);
+                }
             }
         }
 

--- a/packages/ag-grid-community/src/columns/selectionColService.ts
+++ b/packages/ag-grid-community/src/columns/selectionColService.ts
@@ -247,7 +247,9 @@ export class SelectionColService extends BeanStub implements NamedBean, IColumnC
                 default:
                     cols = centerCols;
             }
-            cols && _removeFromArray(cols, column);
+            if (cols) {
+                _removeFromArray(cols, column);
+            }
         };
 
         const rowNumbersCol = this.beans.rowNumbersSvc?.getColumn(ROW_NUMBERS_COLUMN_ID);

--- a/packages/ag-grid-community/src/edit/editModelService.ts
+++ b/packages/ag-grid-community/src/edit/editModelService.ts
@@ -163,7 +163,10 @@ export class EditModelService extends BeanStub implements NamedBean, IEditModelS
     }
 
     public setEdit(position: Required<EditPosition>, edit: Partial<EditValue>): Readonly<EditValue> {
-        (this.edits.size === 0 || !this.edits.has(position.rowNode)) && this.edits.set(position.rowNode, new Map());
+        const edits = this.edits;
+        if (edits.size === 0 || !edits.has(position.rowNode)) {
+            edits.set(position.rowNode, new Map());
+        }
 
         const currentEdit = this._getEdit(position);
 

--- a/packages/ag-grid-community/src/edit/editService.ts
+++ b/packages/ag-grid-community/src/edit/editService.ts
@@ -271,7 +271,9 @@ export class EditService extends BeanStub implements NamedBean, IEditService {
         const res = this.shouldStartEditing(position, event, startedEdit, source);
 
         if (res === false && source !== 'api') {
-            this.isEditing(position) && this.stopEditing();
+            if (this.isEditing(position)) {
+                this.stopEditing();
+            }
             return;
         }
 
@@ -757,13 +759,17 @@ export class EditService extends BeanStub implements NamedBean, IEditService {
             if (this.cellEditingInvalidCommitBlocks()) {
                 (event as Event)?.preventDefault?.();
                 if (focus) {
-                    !cellCtrl?.hasBrowserFocus() && cellCtrl?.focusCell();
+                    if (cellCtrl && !cellCtrl.hasBrowserFocus()) {
+                        cellCtrl.focusCell();
+                    }
                     cellCtrl?.comp?.getCellEditor()?.focusIn?.();
                 }
                 return 'block-stop';
             }
 
-            cellCtrl && this.revertSingleCellEdit(cellCtrl);
+            if (cellCtrl) {
+                this.revertSingleCellEdit(cellCtrl);
+            }
 
             return 'revert-continue';
         }

--- a/packages/ag-grid-community/src/edit/strategy/baseEditStrategy.ts
+++ b/packages/ag-grid-community/src/edit/strategy/baseEditStrategy.ts
@@ -163,9 +163,9 @@ export abstract class BaseEditStrategy extends BeanStub {
             if (actions.keep.length > 0) {
                 for (const cell of actions.keep) {
                     const cellCtrl = _getCellCtrl(this.beans, cell);
-
-                    if (!this.editSvc?.cellEditingInvalidCommitBlocks()) {
-                        cellCtrl && this.editSvc.revertSingleCellEdit(cellCtrl);
+                    const editSvc = this.editSvc;
+                    if (!editSvc?.cellEditingInvalidCommitBlocks() && cellCtrl) {
+                        editSvc.revertSingleCellEdit(cellCtrl);
                     }
                 }
             }

--- a/packages/ag-grid-community/src/pinnedRowModel/staticPinnedRowModel.ts
+++ b/packages/ag-grid-community/src/pinnedRowModel/staticPinnedRowModel.ts
@@ -253,7 +253,9 @@ function forEach<T extends { id: string | undefined }>(
 ): void {
     cache.order.forEach((id, index) => {
         const node = getById(cache, id);
-        node && callback(node, index);
+        if (node) {
+            callback(node, index);
+        }
     });
 }
 

--- a/packages/ag-grid-community/src/rendering/cellRenderers/skeletonCellRenderer.ts
+++ b/packages/ag-grid-community/src/rendering/cellRenderers/skeletonCellRenderer.ts
@@ -19,8 +19,10 @@ export class SkeletonCellRenderer extends Component implements ILoadingCellRende
 
         if (params.deferRender) {
             this.setupLoading(params);
+        } else if (params.node.failedLoad) {
+            this.setupFailed();
         } else {
-            params.node.failedLoad ? this.setupFailed() : this.setupLoading(params);
+            this.setupLoading(params);
         }
     }
 

--- a/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
@@ -1848,7 +1848,11 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
 
     private setRowTopStyle(topPx: string): void {
         for (const gui of this.allRowGuis) {
-            this.suppressRowTransform ? gui.rowComp.setTop(topPx) : gui.rowComp.setTransform(`translateY(${topPx})`);
+            if (this.suppressRowTransform) {
+                gui.rowComp.setTop(topPx);
+            } else {
+                gui.rowComp.setTransform(`translateY(${topPx})`);
+            }
         }
     }
 

--- a/packages/ag-grid-community/src/styling/stylingUtils.ts
+++ b/packages/ag-grid-community/src/styling/stylingUtils.ts
@@ -42,7 +42,11 @@ export function processClassRules(
             }
 
             forEachSingleClass(className, (singleClass) => {
-                resultOfRule ? (classesToApply[singleClass] = true) : (classesToRemove[singleClass] = true);
+                if (resultOfRule) {
+                    classesToApply[singleClass] = true;
+                } else {
+                    classesToRemove[singleClass] = true;
+                }
             });
         }
     }

--- a/packages/ag-grid-enterprise/src/cellRenderers/loadingCellRenderer.ts
+++ b/packages/ag-grid-enterprise/src/cellRenderers/loadingCellRenderer.ts
@@ -18,7 +18,11 @@ export class LoadingCellRenderer extends Component implements ILoadingCellRender
     }
 
     public init(params: ILoadingCellRendererParams): void {
-        params.node.failedLoad ? this.setupFailed() : this.setupLoading();
+        if (params.node.failedLoad) {
+            this.setupFailed();
+        } else {
+            this.setupLoading();
+        }
     }
 
     private setupFailed(): void {

--- a/packages/ag-grid-enterprise/src/charts/chartComp/chartController.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/chartController.ts
@@ -143,7 +143,11 @@ export class ChartController extends BeanStub<ChartControllerEvent> {
 
         // if the chart should be unlinked or chart ranges suppressed, remove all cell ranges; otherwise, set the chart range
         const removeChartCellRanges = chartModelParams.unlinkChart || chartModelParams.suppressChartRanges;
-        removeChartCellRanges ? this.rangeSvc?.setCellRanges([]) : this.setChartRange();
+        if (removeChartCellRanges) {
+            this.rangeSvc?.setCellRanges([]);
+        } else {
+            this.setChartRange();
+        }
     }
 
     public updateForGridChange(params?: { maintainColState?: boolean; setColsFromRange?: boolean }): void {

--- a/packages/ag-grid-enterprise/src/charts/chartComp/chartProxies/cartesian/cartesianChartProxy.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/chartProxies/cartesian/cartesianChartProxy.ts
@@ -210,7 +210,11 @@ export abstract class CartesianChartProxy<
     }
 
     private crossFilteringAddSelectedPoint(multiSelection: boolean, value: string): void {
-        multiSelection ? this.crossFilteringSelectedPoints.push(value) : (this.crossFilteringSelectedPoints = [value]);
+        if (multiSelection) {
+            this.crossFilteringSelectedPoints.push(value);
+        } else {
+            this.crossFilteringSelectedPoints = [value];
+        }
     }
 
     protected isHorizontal(commonChartOptions: AgCartesianChartOptions): boolean {

--- a/packages/ag-grid-enterprise/src/charts/chartComp/chartProxies/combo/comboChartProxy.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/chartProxies/combo/comboChartProxy.ts
@@ -79,7 +79,11 @@ export class ComboChartProxy extends CartesianChartProxy<'line' | 'bar' | 'area'
             const colId = field.colId;
             const seriesChartType = seriesChartTypes.find((s) => s.colId === colId);
             if (seriesChartType) {
-                seriesChartType.secondaryAxis ? secondaryYKeys.push(colId) : primaryYKeys.push(colId);
+                if (seriesChartType.secondaryAxis) {
+                    secondaryYKeys.push(colId);
+                } else {
+                    primaryYKeys.push(colId);
+                }
             }
         }
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
@@ -586,7 +586,11 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
                 checked = column.isVisible();
             }
 
-            checked ? checkedCount++ : uncheckedCount++;
+            if (checked) {
+                checkedCount++;
+            } else {
+                uncheckedCount++;
+            }
         });
 
         if (checkedCount > 0 && uncheckedCount > 0) {

--- a/packages/ag-grid-enterprise/src/filterToolPanel/agFiltersToolPanelList.ts
+++ b/packages/ag-grid-enterprise/src/filterToolPanel/agFiltersToolPanelList.ts
@@ -98,7 +98,11 @@ export class AgFiltersToolPanelList extends Component<AgFiltersToolPanelListEven
         }
         const pivotModeActive = this.colModel.isPivotMode();
         const shouldSyncColumnLayoutWithGrid = !this.params.suppressSyncLayoutWithGrid && !pivotModeActive;
-        shouldSyncColumnLayoutWithGrid ? this.syncFilterLayout() : this.buildTreeFromProvidedColumnDefs();
+        if (shouldSyncColumnLayoutWithGrid) {
+            this.syncFilterLayout();
+        } else {
+            this.buildTreeFromProvidedColumnDefs();
+        }
         this.refreshAriaLabel();
     }
 
@@ -384,7 +388,11 @@ export class AgFiltersToolPanelList extends Component<AgFiltersToolPanelListEven
             const updateFilterExpandState = !colIds || colIds.includes(colId);
 
             if (updateFilterExpandState) {
-                expand ? filterComp.expand() : filterComp.collapse();
+                if (expand) {
+                    filterComp.expand();
+                } else {
+                    filterComp.collapse();
+                }
                 updatedColIds.push(colId);
             }
 
@@ -421,7 +429,11 @@ export class AgFiltersToolPanelList extends Component<AgFiltersToolPanelListEven
                 return;
             }
 
-            filterGroup.isExpanded() ? expandedCount++ : notExpandedCount++;
+            if (filterGroup.isExpanded()) {
+                expandedCount++;
+            } else {
+                notExpandedCount++;
+            }
 
             for (const child of filterGroup.getChildren()) {
                 if (child instanceof ToolPanelFilterGroupComp) {

--- a/packages/ag-grid-enterprise/src/filterToolPanel/toolPanelFilterComp.ts
+++ b/packages/ag-grid-enterprise/src/filterToolPanel/toolPanelFilterComp.ts
@@ -149,7 +149,11 @@ export class ToolPanelFilterComp extends Component<ToolPanelFilterCompEvent> {
     }
 
     public toggleExpanded(): void {
-        this.expanded ? this.collapse() : this.expand();
+        if (this.expanded) {
+            this.collapse();
+        } else {
+            this.expand();
+        }
     }
 
     public expand(): void {

--- a/packages/ag-grid-enterprise/src/multiFilter/multiFilter.ts
+++ b/packages/ag-grid-enterprise/src/multiFilter/multiFilter.ts
@@ -187,7 +187,11 @@ export class MultiFilter extends BaseMultiFilter<MultiFilterWrapper> implements 
         const setFilterModel = (filter: IFilterComp, filterModel: any) => {
             return new AgPromise<void>((resolve) => {
                 const promise = filter.setModel(filterModel);
-                promise ? promise.then(() => resolve()) : resolve();
+                if (promise) {
+                    promise.then(() => resolve());
+                } else {
+                    resolve();
+                }
             });
         };
 

--- a/packages/ag-grid-enterprise/src/multiFilter/multiFilter.ts
+++ b/packages/ag-grid-enterprise/src/multiFilter/multiFilter.ts
@@ -188,7 +188,7 @@ export class MultiFilter extends BaseMultiFilter<MultiFilterWrapper> implements 
             return new AgPromise<void>((resolve) => {
                 const promise = filter.setModel(filterModel);
                 if (promise) {
-                    promise.then(() => resolve());
+                    promise.then(resolve);
                 } else {
                     resolve();
                 }

--- a/packages/ag-grid-enterprise/src/pivot/pivotColDefService.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotColDefService.ts
@@ -317,7 +317,11 @@ export class PivotColDefService extends BeanStub implements NamedBean, IPivotCol
 
             // add total colDef to group and pivot colDefs array
             const children = (groupDef as ColGroupDef).children;
-            insertAfter ? children.push(totalColDef) : children.unshift(totalColDef);
+            if (insertAfter) {
+                children.push(totalColDef);
+            } else {
+                children.unshift(totalColDef);
+            }
             pivotColumnDefs.push(totalColDef);
         }
 
@@ -366,7 +370,11 @@ export class PivotColDefService extends BeanStub implements NamedBean, IPivotCol
                 : colDef;
 
             pivotColumnDefs.push(colDef);
-            insertAtEnd ? pivotColumnGroupDefs.push(valueGroup) : pivotColumnGroupDefs.unshift(valueGroup);
+            if (insertAtEnd) {
+                pivotColumnGroupDefs.push(valueGroup);
+            } else {
+                pivotColumnGroupDefs.unshift(valueGroup);
+            }
         }
     }
 

--- a/packages/ag-grid-react/src/reactUi/header/headerCellComp.tsx
+++ b/packages/ag-grid-react/src/reactUi/header/headerCellComp.tsx
@@ -58,7 +58,11 @@ const HeaderCellComp = ({ ctrl }: { ctrl: HeaderCellCtrl }) => {
             setUserStyles: (styles: HeaderStyle) => setUserStyles(styles),
             setAriaSort: (sort?: AriaSortState) => {
                 if (eGui.current) {
-                    sort ? _setAriaSort(eGui.current, sort) : _removeAriaSort(eGui.current);
+                    if (sort) {
+                        _setAriaSort(eGui.current, sort);
+                    } else {
+                        _removeAriaSort(eGui.current);
+                    }
                 }
             },
             setUserCompDetails: (compDetails: UserCompDetails) => setUserCompDetails(compDetails),

--- a/packages/ag-grid-react/src/reactUi/header/headerFilterCellComp.tsx
+++ b/packages/ag-grid-react/src/reactUi/header/headerFilterCellComp.tsx
@@ -49,7 +49,7 @@ const HeaderFilterCellComp = ({ ctrl }: { ctrl: HeaderFilterCellCtrl }) => {
             return;
         }
 
-        userCompResolve.current && userCompResolve.current(value);
+        userCompResolve.current?.(value);
     };
 
     const setRef = useCallback((eRef: HTMLDivElement | null) => {

--- a/plugins/ag-grid-generate-code-reference-files/src/copySrcFilesForGeneration.js
+++ b/plugins/ag-grid-generate-code-reference-files/src/copySrcFilesForGeneration.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const fs = require('fs');
 
 function copyFileWithTSNoCheck(sourceFile, destinationDir, destinationFile) {
@@ -24,7 +25,6 @@ function copyFileWithTSNoCheck(sourceFile, destinationDir, destinationFile) {
             (err) => {
                 if (err) {
                     console.error(`Error writing file: ${err}`);
-                    return;
                 }
             }
         );

--- a/plugins/ag-grid-generate-code-reference-files/src/executors/generate/formatAST.js
+++ b/plugins/ag-grid-generate-code-reference-files/src/executors/generate/formatAST.js
@@ -34,7 +34,7 @@ function findInNodeTree(ts) {
 // }
 const printer = (ts) => ts.createPrinter({ removeComments: true, omitTrailingSemicolon: true });
 
-function getFullJsDoc(ts) {
+function getFullJsDoc(_ts) {
     return function (node) {
         if (node.jsDoc) {
             const result = node.jsDoc.map((j) => {
@@ -46,7 +46,7 @@ function getFullJsDoc(ts) {
     };
 }
 
-function getJsDoc(ts) {
+function getJsDoc(_ts) {
     return function (node) {
         if (node.jsDoc && node.jsDoc.length === 1) {
             const j = node.jsDoc[0];

--- a/plugins/ag-grid-generate-code-reference-files/src/executors/generate/generate-code-reference-files.ts
+++ b/plugins/ag-grid-generate-code-reference-files/src/executors/generate/generate-code-reference-files.ts
@@ -112,7 +112,9 @@ function extractNestedTypes<T extends ts.Node>(
 
     if (ts.isPropertySignature(node)) {
         results[node.name.getText()] = getJsDoc(node);
-        node.type && extractNestedTypes(node.type, srcFile, includeQuestionMark, results, visited);
+        if (node.type) {
+            extractNestedTypes(node.type, srcFile, includeQuestionMark, results, visited);
+        }
         return;
     }
 

--- a/plugins/ag-grid-task-autogen/src/generate-example-files.ts
+++ b/plugins/ag-grid-task-autogen/src/generate-example-files.ts
@@ -45,10 +45,14 @@ export const createDependencies: CreateDependencies = (opts, ctx) => {
 
     const result: ReturnType<CreateDependencies> = [];
     for (const [name, config] of Object.entries(projects)) {
-        if (!config.tags?.includes('type:generated-example')) continue;
+        if (!config.tags?.includes('type:generated-example')) {
+            continue;
+        }
 
         const parent = config.tags?.find((t) => t.startsWith('scope:'))?.split(':')[1];
-        if (!parent) continue;
+        if (!parent) {
+            continue;
+        }
 
         const dependency: RawProjectGraphDependency = {
             source: `${parent}`,

--- a/testing/behavioural/src/selection/utils.ts
+++ b/testing/behavioural/src/selection/utils.ts
@@ -49,14 +49,22 @@ export class GridActions {
 
     selectRowsByIndex(indices: number[], click: boolean): void {
         for (const i of indices) {
-            click ? this.clickRowByIndex(i, { ctrlKey: true }) : this.toggleCheckboxByIndex(i);
+            if (click) {
+                this.clickRowByIndex(i, { ctrlKey: true });
+            } else {
+                this.toggleCheckboxByIndex(i);
+            }
         }
         assertSelectedRowsByIndex(indices, this.api);
     }
 
     selectRowsById(ids: string[], click: boolean): void {
         for (const i of ids) {
-            click ? this.clickRowById(i, { ctrlKey: true }) : this.toggleCheckboxById(i);
+            if (click) {
+                this.clickRowById(i, { ctrlKey: true });
+            } else {
+                this.toggleCheckboxById(i);
+            }
         }
         assertSelectedRowElementsById(ids, this.api);
     }


### PR DESCRIPTION
eslint rule for "unused expressions" that can be misused too easily.
Fix all the lint issues in the project

When offsetWidth or offsetHeight need to be accessed to cause a refresh, it can be written as `void el.offsetHeight;` to skip the validation and make the intent clear