### PR TITLE
AG-3390 - Update sitemap page generation to use the latest sitemap

### DIFF
--- a/documentation/ag-grid-docs/astro.config.mjs
+++ b/documentation/ag-grid-docs/astro.config.mjs
@@ -8,6 +8,7 @@ import { loadEnv } from 'vite';
 import mkcert from 'vite-plugin-mkcert';
 import svgr from 'vite-plugin-svgr';
 
+import agCacheSitemap from '../../external/ag-website-shared/plugins/agCacheSitemap';
 import agLinkChecker from '../../external/ag-website-shared/plugins/agLinkChecker';
 import buildTime from './plugins/agBuildTime';
 import agHotModuleReload from './plugins/agHotModuleReload';
@@ -203,5 +204,9 @@ export default defineConfig({
             skip: CHECK_REDIRECTS !== 'true',
         }),
         agLinkChecker({ include: CHECK_LINKS === 'true' }),
+
+        agCacheSitemap({
+            cacheFolder: './.astro/cache/sitemap',
+        }),
     ],
 });

--- a/documentation/ag-grid-docs/astro.config.mjs
+++ b/documentation/ag-grid-docs/astro.config.mjs
@@ -10,6 +10,7 @@ import svgr from 'vite-plugin-svgr';
 
 import agCacheSitemap from '../../external/ag-website-shared/plugins/agCacheSitemap';
 import agLinkChecker from '../../external/ag-website-shared/plugins/agLinkChecker';
+import { SITEMAP_CACHE_DIR } from '../../external/ag-website-shared/src/constants';
 import buildTime from './plugins/agBuildTime';
 import agHotModuleReload from './plugins/agHotModuleReload';
 import agHtaccessGen from './plugins/agHtaccessGen';
@@ -206,7 +207,7 @@ export default defineConfig({
         agLinkChecker({ include: CHECK_LINKS === 'true' }),
 
         agCacheSitemap({
-            cacheFolder: './.astro/cache/sitemap',
+            cacheFolder: SITEMAP_CACHE_DIR,
         }),
     ],
 });

--- a/documentation/ag-grid-docs/project.json
+++ b/documentation/ag-grid-docs/project.json
@@ -19,6 +19,7 @@
         "!{projectRoot}/vitest.config.ts",
         "{workspaceRoot}/external/ag-website-shared/**",
         "charts",
+        "{projectRoot}/.astro/cache/sitemap/**",
         { "env": "PUBLIC_PACKAGE_VERSION" }
       ],
       "cache": true,

--- a/documentation/ag-grid-docs/project.json
+++ b/documentation/ag-grid-docs/project.json
@@ -23,15 +23,24 @@
         { "env": "PUBLIC_PACKAGE_VERSION" }
       ],
       "cache": true,
-      "command": "astro build",
+      "command": "tsx ../../external/ag-website-shared/scripts/buildWithSitemapCache.ts",
       "options": {
         "cwd": "{projectRoot}",
         "silent": true
       },
       "configurations": {
-        "staging": {},
-        "archive": {},
-        "production": {},
+        "staging": {
+          "silent": true,
+          "clean-cache": true
+        },
+        "archive": {
+          "silent": true,
+          "clean-cache": true
+        },
+        "production": {
+          "silent": true,
+          "clean-cache": true
+        },
         "verbose": {
           "silent": null
         }

--- a/documentation/ag-grid-docs/src/constants.ts
+++ b/documentation/ag-grid-docs/src/constants.ts
@@ -91,6 +91,7 @@ export const SITE_URL = import.meta.env?.SITE_URL || import.meta.env?.PUBLIC_SIT
 
 export const STAGING_SITE_URL = 'https://grid-staging.ag-grid.com';
 export const PRODUCTION_SITE_URLS = ['https://ag-grid.com', 'https://www.ag-grid.com'];
+export const PRODUCTION_SITE_URL = PRODUCTION_SITE_URLS[0];
 export const USE_PUBLISHED_PACKAGES = isTruthy(import.meta.env?.PUBLIC_USE_PUBLISHED_PACKAGES);
 
 export const URL_CONFIG: Record<'local' | 'staging' | 'production', { hosts: string[]; baseUrl?: string }> = {

--- a/documentation/ag-grid-docs/src/pages/debug/meta.json.ts
+++ b/documentation/ag-grid-docs/src/pages/debug/meta.json.ts
@@ -1,13 +1,12 @@
+import { getGitDate, getGitHash, getGitShortHash } from '@ag-website-shared/utils/gitUtils';
 import { SITE_BASE_URL, SITE_URL, agChartsVersion, agGridVersion } from '@constants';
 import { getIsArchive, getIsDev, getIsProduction, getIsStaging } from '@utils/env';
-import { execSync } from 'child_process';
 
 export async function GET() {
-    const removeNewlineRegex = /\n/gm;
     const buildDate = new Date();
-    const hash = execSync('git rev-parse HEAD').toString().replace(removeNewlineRegex, '');
-    const shortHash = execSync('git rev-parse --short HEAD').toString().replace(removeNewlineRegex, '');
-    const gitDate = execSync('git --no-pager log -1 --format="%ai"').toString().replace(removeNewlineRegex, '');
+    const hash = getGitHash();
+    const shortHash = getGitShortHash();
+    const gitDate = getGitDate();
 
     const body = {
         buildDate,

--- a/documentation/ag-grid-docs/src/pages/sitemap.astro
+++ b/documentation/ag-grid-docs/src/pages/sitemap.astro
@@ -6,8 +6,9 @@ import parseSitemap from '@ag-website-shared/components/sitemap/utils/sitemaputi
 import { getGitHash } from '@ag-website-shared/utils/gitUtils';
 import Layout from '../layouts/Layout.astro';
 import { PRODUCTION_SITE_URL } from '@constants';
+import { SITEMAP_CACHE_DIR } from '@ag-website-shared/constants';
 
-const cacheFolder = path.resolve('./.astro/cache/sitemap');
+const cacheFolder = path.resolve(SITEMAP_CACHE_DIR);
 const cachedSitemapPath = path.join(cacheFolder, 'sitemap-0.xml');
 const cachedMetaPath = path.join(cacheFolder, 'debug', 'meta.json');
 const currentHash = getGitHash();

--- a/documentation/ag-grid-docs/src/pages/sitemap.astro
+++ b/documentation/ag-grid-docs/src/pages/sitemap.astro
@@ -1,54 +1,16 @@
 ---
-import { promises as fs } from 'node:fs';
-import path from 'node:path';
 import { Sitemap } from '@ag-website-shared/components/sitemap/Sitemap';
 import parseSitemap from '@ag-website-shared/components/sitemap/utils/sitemaputils';
-import { getGitHash } from '@ag-website-shared/utils/gitUtils';
+import { getSitemapXml } from '@ag-website-shared/utils/getSitemapXml';
 import Layout from '../layouts/Layout.astro';
 import { PRODUCTION_SITE_URL } from '@constants';
 import { SITEMAP_CACHE_DIR } from '@ag-website-shared/constants';
 
-const cacheFolder = path.resolve(SITEMAP_CACHE_DIR);
-const cachedSitemapPath = path.join(cacheFolder, 'sitemap-0.xml');
-const cachedMetaPath = path.join(cacheFolder, 'debug', 'meta.json');
-const currentHash = getGitHash();
-
-const readCachedHash = async () => {
-    try {
-        const raw = await fs.readFile(cachedMetaPath, 'utf8');
-        const cachedMeta = JSON.parse(raw);
-        return cachedMeta?.git?.hash ?? null;
-    } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-            return null;
-        }
-
-        throw error;
-    }
-};
-
-let xmlSitemap: string | null = null;
-try {
-    await fs.access(cachedSitemapPath);
-    const cachedHash = await readCachedHash();
-    if (cachedHash === currentHash) {
-        xmlSitemap = await fs.readFile(cachedSitemapPath, 'utf8');
-        console.info(`Sitemap cache hash match. Using '${cachedSitemapPath}' for hash '${currentHash}'`);
-    } else {
-        console.warn(`Sitemap cache hash mismatch. Current: ${currentHash}, cached: ${cachedHash ?? 'unknown'}.`);
-    }
-} catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        throw error;
-    }
-}
-
-if (xmlSitemap == null) {
-    const sitemapUrl = path.join(PRODUCTION_SITE_URL, 'sitemap-0.xml');
-    const response = await fetch(sitemapUrl);
-    xmlSitemap = await response.text();
-    console.log('No cached sitemap found, fetched from live site.');
-}
+const sitemapUrl = `${PRODUCTION_SITE_URL.replace(/\/$/, '')}/sitemap-0.xml`;
+const xmlSitemap = await getSitemapXml({
+    cacheDir: SITEMAP_CACHE_DIR,
+    sitemapUrl,
+});
 
 const parsedSitemap = parseSitemap(xmlSitemap);
 ---

--- a/documentation/ag-grid-docs/src/pages/sitemap.astro
+++ b/documentation/ag-grid-docs/src/pages/sitemap.astro
@@ -1,10 +1,54 @@
 ---
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
 import { Sitemap } from '@ag-website-shared/components/sitemap/Sitemap';
 import parseSitemap from '@ag-website-shared/components/sitemap/utils/sitemaputils';
+import { getGitHash } from '@ag-website-shared/utils/gitUtils';
 import Layout from '../layouts/Layout.astro';
+import { PRODUCTION_SITE_URL } from '@constants';
 
-const response = await fetch('https://www.ag-grid.com/sitemap-0.xml');
-const xmlSitemap = await response.text();
+const cacheFolder = path.resolve('./.astro/cache/sitemap');
+const cachedSitemapPath = path.join(cacheFolder, 'sitemap-0.xml');
+const cachedMetaPath = path.join(cacheFolder, 'debug', 'meta.json');
+const currentHash = getGitHash();
+
+const readCachedHash = async () => {
+    try {
+        const raw = await fs.readFile(cachedMetaPath, 'utf8');
+        const cachedMeta = JSON.parse(raw);
+        return cachedMeta?.git?.hash ?? null;
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return null;
+        }
+
+        throw error;
+    }
+};
+
+let xmlSitemap: string | null = null;
+try {
+    await fs.access(cachedSitemapPath);
+    const cachedHash = await readCachedHash();
+    if (cachedHash === currentHash) {
+        xmlSitemap = await fs.readFile(cachedSitemapPath, 'utf8');
+        console.info(`Sitemap cache hash match. Using '${cachedSitemapPath}' for hash '${currentHash}'`);
+    } else {
+        console.warn(`Sitemap cache hash mismatch. Current: ${currentHash}, cached: ${cachedHash ?? 'unknown'}.`);
+    }
+} catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+    }
+}
+
+if (xmlSitemap == null) {
+    const sitemapUrl = path.join(PRODUCTION_SITE_URL, 'sitemap-0.xml');
+    const response = await fetch(sitemapUrl);
+    xmlSitemap = await response.text();
+    console.log('No cached sitemap found, fetched from live site.');
+}
+
 const parsedSitemap = parseSitemap(xmlSitemap);
 ---
 

--- a/documentation/ag-grid-docs/src/utils/sitemap.ts
+++ b/documentation/ag-grid-docs/src/utils/sitemap.ts
@@ -46,7 +46,12 @@ const isRedirectPage = (page: string) => {
  * Exclude specific pages
  */
 const isNonPublicContent = (page: string) => {
-    return page.endsWith('/style-guide/');
+    return (
+        page.endsWith('/style-guide/') ||
+        // Contact form result pages
+        page.endsWith('/contact/failure/') ||
+        page.endsWith('/contact/success/')
+    );
 };
 
 const filterIgnoredPages = (page: string) => {

--- a/external/ag-website-shared/plugins/agCacheSitemap.ts
+++ b/external/ag-website-shared/plugins/agCacheSitemap.ts
@@ -1,0 +1,53 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { AstroIntegration } from 'astro';
+
+import { getGitHash } from '../src/utils/gitUtils';
+
+type Options = {
+    cacheFolder: string;
+};
+
+export default function createPlugin({ cacheFolder }: Options): AstroIntegration {
+    return {
+        name: 'ag-cache-sitemap',
+        hooks: {
+            'astro:build:done': async ({ dir, logger }) => {
+                const currentHash = getGitHash();
+                const outputDir = fileURLToPath(dir);
+                const sitemapSourcePath = path.join(outputDir, 'sitemap-0.xml');
+                const metaSourcePath = path.join(outputDir, 'debug', 'meta.json');
+
+                const cacheRoot = path.resolve(cacheFolder);
+                const cacheSitemapPath = path.join(cacheRoot, 'sitemap-0.xml');
+                const cacheMetaPath = path.join(cacheRoot, 'debug', 'meta.json');
+
+                const readCachedHash = async () => {
+                    try {
+                        const raw = await fs.readFile(cacheMetaPath, 'utf8');
+                        const cachedMeta = JSON.parse(raw);
+                        return cachedMeta?.git?.hash ?? null;
+                    } catch (error) {
+                        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+                            return null;
+                        }
+
+                        throw error;
+                    }
+                };
+
+                const cachedHash = await readCachedHash();
+                if (cachedHash === currentHash) {
+                    logger.info(`Sitemap cache already up to date for ${currentHash}.`);
+                    return;
+                }
+
+                await fs.mkdir(path.dirname(cacheMetaPath), { recursive: true });
+                await fs.copyFile(sitemapSourcePath, cacheSitemapPath);
+                await fs.copyFile(metaSourcePath, cacheMetaPath);
+                logger.info(`Cached sitemap and meta.json for ${currentHash}.`);
+            },
+        },
+    };
+}

--- a/external/ag-website-shared/plugins/agCacheSitemap.ts
+++ b/external/ag-website-shared/plugins/agCacheSitemap.ts
@@ -1,7 +1,7 @@
+import type { AstroIntegration } from 'astro';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { AstroIntegration } from 'astro';
 
 import { getGitHash } from '../src/utils/gitUtils';
 

--- a/external/ag-website-shared/scripts/buildWithSitemapCache.ts
+++ b/external/ag-website-shared/scripts/buildWithSitemapCache.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env tsx
+import { spawnSync } from 'node:child_process';
+import { rmSync } from 'node:fs';
+import path from 'node:path';
+
+import { SITEMAP_CACHE_DIR } from '../src/constants';
+
+const rawArgs = process.argv.slice(2);
+const hasFlag = (flag: string) =>
+    rawArgs.includes(flag) || rawArgs.some((arg) => arg.startsWith(`${flag}=`) && arg !== `${flag}=false`);
+const skipSecondBuild = hasFlag('--skip-second-build');
+const cleanCache = hasFlag('--clean-cache');
+const astroArgs = [
+    'build',
+    ...rawArgs.filter((arg) => !arg.startsWith('--skip-second-build') && !arg.startsWith('--clean-cache')),
+];
+
+const cleanSitemapCache = async () => {
+    const cacheFolder = path.resolve(SITEMAP_CACHE_DIR);
+    rmSync(cacheFolder, { recursive: true, force: true });
+};
+
+const runBuild = () => {
+    const result = spawnSync('astro', astroArgs, { stdio: 'inherit', shell: true });
+    if (result.status !== 0) {
+        process.exit(result.status ?? 1);
+    }
+};
+
+if (cleanCache) {
+    console.log('✨ Cleaning sitemap cache');
+    cleanSitemapCache();
+}
+
+runBuild();
+
+if (!skipSecondBuild) {
+    if (!rawArgs.includes('--silent')) {
+        console.log('♻️ Building again to use latest sitemap');
+    }
+
+    runBuild();
+}

--- a/external/ag-website-shared/src/constants.ts
+++ b/external/ag-website-shared/src/constants.ts
@@ -23,3 +23,6 @@ export const CONTACT_FORM_DATA = {
         formLocationId: '00NQ500000CVgqT',
     },
 };
+
+// Relative to website folder
+export const SITEMAP_CACHE_DIR = '.astro/cache/sitemap';

--- a/external/ag-website-shared/src/utils/getSitemapXml.ts
+++ b/external/ag-website-shared/src/utils/getSitemapXml.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+
 import { getGitHash } from './gitUtils';
 
 type Logger = Pick<Console, 'info' | 'warn' | 'log'>;
@@ -40,11 +41,12 @@ export const getSitemapXml = async ({
     try {
         await fs.access(cachedSitemapPath);
         const cachedHash = await readCachedHash(cachedMetaPath);
+
+        xmlSitemap = await fs.readFile(cachedSitemapPath, 'utf8');
         if (cachedHash === currentHash) {
-            xmlSitemap = await fs.readFile(cachedSitemapPath, 'utf8');
-            logger.info(`Sitemap cache hash match. Using '${cachedSitemapPath}' for hash '${currentHash}'`);
+            logger.info(`✅ Sitemap cache hash match. Using '${cachedSitemapPath}' for hash '${currentHash}'`);
         } else {
-            logger.warn(`Sitemap cache hash mismatch. Current: ${currentHash}, cached: ${cachedHash ?? 'unknown'}.`);
+            logger.warn(`⚠️ Sitemap cache hash mismatch. Current: ${currentHash}, cached: ${cachedHash ?? 'unknown'}.`);
         }
     } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
@@ -55,7 +57,7 @@ export const getSitemapXml = async ({
     if (xmlSitemap == null) {
         const response = await fetch(sitemapUrl);
         xmlSitemap = await response.text();
-        logger.log('No cached sitemap found, fetched from live site.');
+        logger.log('⚠️ No cached sitemap found, fetched from live site.');
     }
 
     return xmlSitemap;

--- a/external/ag-website-shared/src/utils/getSitemapXml.ts
+++ b/external/ag-website-shared/src/utils/getSitemapXml.ts
@@ -1,0 +1,62 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { getGitHash } from './gitUtils';
+
+type Logger = Pick<Console, 'info' | 'warn' | 'log'>;
+
+type GetSitemapXmlOptions = {
+    cacheDir: string;
+    sitemapUrl: string;
+    logger?: Logger;
+    gitHash?: string;
+};
+
+const readCachedHash = async (cachedMetaPath: string) => {
+    try {
+        const raw = await fs.readFile(cachedMetaPath, 'utf8');
+        const cachedMeta = JSON.parse(raw);
+        return cachedMeta?.git?.hash ?? null;
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return null;
+        }
+
+        throw error;
+    }
+};
+
+export const getSitemapXml = async ({
+    cacheDir,
+    sitemapUrl,
+    logger = console,
+    gitHash,
+}: GetSitemapXmlOptions): Promise<string> => {
+    const cacheFolder = path.resolve(cacheDir);
+    const cachedSitemapPath = path.join(cacheFolder, 'sitemap-0.xml');
+    const cachedMetaPath = path.join(cacheFolder, 'debug', 'meta.json');
+    const currentHash = gitHash ?? getGitHash();
+
+    let xmlSitemap: string | null = null;
+    try {
+        await fs.access(cachedSitemapPath);
+        const cachedHash = await readCachedHash(cachedMetaPath);
+        if (cachedHash === currentHash) {
+            xmlSitemap = await fs.readFile(cachedSitemapPath, 'utf8');
+            logger.info(`Sitemap cache hash match. Using '${cachedSitemapPath}' for hash '${currentHash}'`);
+        } else {
+            logger.warn(`Sitemap cache hash mismatch. Current: ${currentHash}, cached: ${cachedHash ?? 'unknown'}.`);
+        }
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+            throw error;
+        }
+    }
+
+    if (xmlSitemap == null) {
+        const response = await fetch(sitemapUrl);
+        xmlSitemap = await response.text();
+        logger.log('No cached sitemap found, fetched from live site.');
+    }
+
+    return xmlSitemap;
+};

--- a/external/ag-website-shared/src/utils/gitUtils.ts
+++ b/external/ag-website-shared/src/utils/gitUtils.ts
@@ -1,0 +1,11 @@
+import { execSync } from 'child_process';
+
+const removeNewlineRegex = /\n/gm;
+
+export const getGitHash = () => execSync('git rev-parse HEAD').toString().replace(removeNewlineRegex, '');
+
+export const getGitShortHash = () =>
+    execSync('git rev-parse --short=8 HEAD').toString().replace(removeNewlineRegex, '');
+
+export const getGitDate = () =>
+    execSync('git --no-pager log -1 --format="%ai"').toString().replace(removeNewlineRegex, '');


### PR DESCRIPTION
## Changes

* Run the build twice for non dev environments - first time generates the sitemap xml and caches it (along with the git hash used to generate it). Second time uses the cached sitemap xml to generate the sitemap page
* In dev, use the cached sitemap xml if it exists