### PR TITLE
[AG-16479] Fix(selection): regression sourcerowindex is 1 for all rows when row selection is enabled

### DIFF
--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideNodeManager.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideNodeManager.ts
@@ -341,6 +341,7 @@ export class ClientSideNodeManager<TData = any> extends BeanStub {
         node.expanded = false;
         if (sourceRowIndex != null) {
             node.sourceRowIndex = sourceRowIndex;
+            node.rowIndex = sourceRowIndex;
         }
         node.setDataAndId(data, String(this.nextId++));
         const id = node.id!;

--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideNodeManager.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideNodeManager.ts
@@ -42,7 +42,6 @@ export class ClientSideNodeManager<TData = any> extends BeanStub {
                     continue;
                 }
                 const node = this.createRowNode(data, level, writeIdx);
-                node.sourceRowIndex = writeIdx;
                 allLeafs[writeIdx++] = node;
                 if (processedNested && !processedNested.has(data)) {
                     processedNested.add(data);
@@ -304,7 +303,6 @@ export class ClientSideNodeManager<TData = any> extends BeanStub {
         for (let i = 0; i < addLength; i++) {
             const node = this.createRowNode(add[i], 0, addIndex);
             adds.add(node);
-            node.sourceRowIndex = addIndex;
             allLeafs[addIndex] = node;
             addedNodes[i] = node; // Write new nodes
             addIndex++;

--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideNodeManager.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideNodeManager.ts
@@ -41,7 +41,7 @@ export class ClientSideNodeManager<TData = any> extends BeanStub {
                 if (!data) {
                     continue;
                 }
-                const node = this.createRowNode(data, level);
+                const node = this.createRowNode(data, level, writeIdx);
                 node.sourceRowIndex = writeIdx;
                 allLeafs[writeIdx++] = node;
                 if (processedNested && !processedNested.has(data)) {
@@ -302,7 +302,7 @@ export class ClientSideNodeManager<TData = any> extends BeanStub {
         const addedNodes: RowNode<TData>[] = new Array(addLength);
         const adds = changedRowNodes.adds;
         for (let i = 0; i < addLength; i++) {
-            const node = this.createRowNode(add[i], 0);
+            const node = this.createRowNode(add[i], 0, addIndex);
             adds.add(node);
             node.sourceRowIndex = addIndex;
             allLeafs[addIndex] = node;
@@ -335,12 +335,15 @@ export class ClientSideNodeManager<TData = any> extends BeanStub {
         }
     }
 
-    private createRowNode(data: TData, level: number): RowNode<TData> {
+    private createRowNode(data: TData, level: number, sourceRowIndex?: number): RowNode<TData> {
         const node = new RowNode<TData>(this.beans);
         node.parent = this.rootNode;
         node.level = level;
         node.group = false;
         node.expanded = false;
+        if (sourceRowIndex != null) {
+            node.sourceRowIndex = sourceRowIndex;
+        }
         node.setDataAndId(data, String(this.nextId++));
         const id = node.id!;
         const allNodesMap = this.allNodesMap;

--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideNodeManager.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideNodeManager.ts
@@ -341,7 +341,6 @@ export class ClientSideNodeManager<TData = any> extends BeanStub {
         node.expanded = false;
         if (sourceRowIndex != null) {
             node.sourceRowIndex = sourceRowIndex;
-            node.rowIndex = sourceRowIndex;
         }
         node.setDataAndId(data, String(this.nextId++));
         const id = node.id!;

--- a/packages/ag-grid-community/src/entities/rowNode.ts
+++ b/packages/ag-grid-community/src/entities/rowNode.ts
@@ -766,7 +766,6 @@ export class RowNode<TData = any>
         if (this.rowIndex !== rowIndex) {
             this.rowIndex = rowIndex;
             this.dispatchRowEvent('rowIndexChanged');
-            this.beans.selectionSvc?.updateRowSelectable(this, true);
         }
     }
 

--- a/packages/ag-grid-community/src/entities/rowNode.ts
+++ b/packages/ag-grid-community/src/entities/rowNode.ts
@@ -766,6 +766,7 @@ export class RowNode<TData = any>
         if (this.rowIndex !== rowIndex) {
             this.rowIndex = rowIndex;
             this.dispatchRowEvent('rowIndexChanged');
+            this.beans.selectionSvc?.updateRowSelectable(this, true);
         }
     }
 

--- a/testing/behavioural/src/selection/source-row-index.test.ts
+++ b/testing/behavioural/src/selection/source-row-index.test.ts
@@ -19,7 +19,7 @@ describe('sourceRowIndex in isRowSelectable', () => {
         gridMgr.reset();
     });
 
-    test('sourceRowIndex and rowIndex should be populated in isRowSelectable', () => {
+    test('sourceRowIndex should be populated in isRowSelectable', () => {
         const nodeLog: { id: string | undefined; sourceRowIndex: number; rowIndex: number | null }[] = [];
 
         const gridOptions: GridOptions = {
@@ -65,14 +65,6 @@ describe('sourceRowIndex in isRowSelectable', () => {
                 expect(log.sourceRowIndex).toBeGreaterThanOrEqual(0);
                 expect(log.sourceRowIndex).toBeLessThan(3);
             });
-
-            // At least one call for this node should have a non-null rowIndex
-            const hasPopulatedRowIndex = logs.some((log) => log.rowIndex !== null);
-            expect(hasPopulatedRowIndex).toBe(true);
-
-            // The last call for this node should have the correct rowIndex (if it was called after setRowIndex)
-            const lastLog = logs[logs.length - 1];
-            expect(lastLog.rowIndex).not.toBeNull();
         });
     });
 });

--- a/testing/behavioural/src/selection/source-row-index.test.ts
+++ b/testing/behavioural/src/selection/source-row-index.test.ts
@@ -1,0 +1,78 @@
+import { ClientSideRowModelModule } from 'ag-grid-community';
+import type { GridOptions } from 'ag-grid-community';
+
+import { TestGridsManager } from '../test-utils';
+
+describe('sourceRowIndex in isRowSelectable', () => {
+    const columnDefs = [{ field: 'sport' }];
+    const rowData = [{ sport: 'football' }, { sport: 'rugby' }, { sport: 'tennis' }];
+
+    const gridMgr = new TestGridsManager({
+        modules: [ClientSideRowModelModule],
+    });
+
+    beforeEach(() => {
+        gridMgr.reset();
+    });
+
+    afterEach(() => {
+        gridMgr.reset();
+    });
+
+    test('sourceRowIndex and rowIndex should be populated in isRowSelectable', () => {
+        const nodeLog: { id: string | undefined; sourceRowIndex: number; rowIndex: number | null }[] = [];
+
+        const gridOptions: GridOptions = {
+            columnDefs,
+            rowData,
+            rowSelection: {
+                mode: 'multiRow',
+                isRowSelectable: (node) => {
+                    nodeLog.push({
+                        id: node.id,
+                        sourceRowIndex: node.sourceRowIndex,
+                        rowIndex: node.rowIndex,
+                    });
+                    return true;
+                },
+            },
+        };
+
+        gridMgr.createGrid('myGrid', gridOptions);
+
+        // For 3 rows, we expect isRowSelectable to be called at least 3 times during initial load (once for each node)
+        // Then it should be called again when rowIndex is set.
+        expect(nodeLog.length).toBeGreaterThanOrEqual(3);
+
+        // Group by node ID (or reference if we had it, but ID is fine here as it's set before updateRowSelectable)
+        const nodeMap: Record<string, typeof nodeLog> = {};
+        nodeLog.forEach((log) => {
+            const id = log.id!;
+            if (!nodeMap[id]) {
+                nodeMap[id] = [];
+            }
+            nodeMap[id].push(log);
+        });
+
+        const ids = Object.keys(nodeMap);
+        expect(ids.length).toBe(3);
+
+        ids.forEach((id) => {
+            const logs = nodeMap[id];
+
+            // All calls for this node should have a valid sourceRowIndex (not -1)
+            logs.forEach((log) => {
+                expect(log.sourceRowIndex).toBeGreaterThanOrEqual(0);
+                expect(log.sourceRowIndex).toBeLessThan(3);
+            });
+
+            // At least one call for this node should have a non-null rowIndex
+            const hasPopulatedRowIndex = logs.some((log) => log.rowIndex !== null);
+            expect(hasPopulatedRowIndex).toBe(true);
+
+            // The last call for this node should have the correct rowIndex (if it was called after setRowIndex)
+            const lastLog = logs[logs.length - 1];
+            expect(lastLog.rowIndex).not.toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
Set sourceRowIndex in RowNode creation and update row selectable after row index change

Fixes [AG-16479](https://ag-grid.atlassian.net/browse/AG-16479)