### PR TITLE
AG-16614 fix tree data promotion to group bug patch

### DIFF
--- a/packages/ag-grid-community/src/interfaces/iGroupEditService.ts
+++ b/packages/ag-grid-community/src/interfaces/iGroupEditService.ts
@@ -6,7 +6,6 @@ export interface IGroupEditService {
     isGroupingDrop(rowsDrop: RowsDrop): boolean;
     dropGroupEdit(rowsDrop: RowsDrop): boolean;
     canDropRow(row: IRowNode, rowsDrop: RowsDrop): boolean;
-    canDropStartGroup(target: IRowNode | null | undefined): boolean;
     fixRowsDrop(rowsDrop: RowsDrop, canSetParent: boolean, moving: boolean, yDelta: number): void;
     stopDragging(final: boolean): void;
     csrmFirstLeaf(parent: IRowNode | null): IRowNode | null;

--- a/packages/ag-grid-enterprise/src/rowHierarchy/groupEditService.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/groupEditService.ts
@@ -116,11 +116,12 @@ export class GroupEditService extends BeanStub implements _IGroupEditService {
         }
 
         const sourceLevel = rowNode.group ? rowNode.level : currentParent.level ?? -1;
-        const targetLevel = target
-            ? target.group
-                ? target.level
-                : target.parent?.level ?? -1
-            : comparisonParent?.level ?? -1;
+        let targetLevel = -1;
+        if (target) {
+            targetLevel = target.group ? target.level : target.parent?.level ?? -1;
+        } else if (comparisonParent) {
+            targetLevel = comparisonParent.level;
+        }
 
         if (sourceLevel >= 0 && targetLevel >= 0 && targetLevel !== sourceLevel) {
             return false;
@@ -148,9 +149,9 @@ export class GroupEditService extends BeanStub implements _IGroupEditService {
 
         const rootNode = rowsDrop.rootNode as IRowNode;
         const rowModel = this.beans.rowModel;
-        const canStartGroup = target ? this.canDropStartGroup(target) : false;
 
-        this.updateDropTarget(canStartGroup ? target : null, fromNudge, rowsDrop);
+        const canStartGroup = this.canStartGroup(target, treeData);
+        this.updateDropTarget(rowsDrop, fromNudge, canStartGroup);
 
         const lastRowIndex = this.beans.pageBounds?.getLastRow?.() ?? rowModel.getRowCount() - 1;
         if (canSetParent) {
@@ -164,15 +165,9 @@ export class GroupEditService extends BeanStub implements _IGroupEditService {
                 newParent = target?.parent ?? rootNode;
             }
 
-            if (
-                !fromNudge &&
-                target &&
-                canStartGroup &&
-                (!newParent || (!target.expanded && !!target.childrenAfterSort?.length))
-            ) {
-                this.startDropGroupDelay(target);
-            }
-        } else if (!fromNudge && target && canStartGroup) {
+        }
+
+        if (!fromNudge && target && canStartGroup && !(target.group && target.expanded)) {
             this.startDropGroupDelay(target);
         }
 
@@ -209,7 +204,9 @@ export class GroupEditService extends BeanStub implements _IGroupEditService {
         }
     }
 
-    private updateDropTarget(target: IRowNode | null, canExpand: boolean, rowsDrop: _RowsDrop): void {
+    private updateDropTarget(rowsDrop: _RowsDrop, fromNudge: boolean, canStartGroup: boolean): void {
+        const target = canStartGroup ? rowsDrop.target : null;
+
         if (this.dropGroupTarget && this.dropGroupTarget !== target) {
             this.resetDragGroup();
         }
@@ -218,7 +215,7 @@ export class GroupEditService extends BeanStub implements _IGroupEditService {
             return;
         }
 
-        if (canExpand && this.dropGroupThrottled && !target.expanded && target.isExpandable?.()) {
+        if (fromNudge && this.dropGroupThrottled && !target.expanded && target.isExpandable?.()) {
             target.setExpanded(true, undefined, true);
         }
 
@@ -403,14 +400,16 @@ export class GroupEditService extends BeanStub implements _IGroupEditService {
         return true;
     }
 
-    public canDropStartGroup(candidate: IRowNode | null | undefined) {
-        return (
-            !!candidate &&
-            candidate.level >= 0 &&
-            !candidate.footer &&
-            !candidate.detail &&
-            (candidate.isExpandable?.() || !!candidate.childrenAfterSort?.length)
-        );
+    private canStartGroup(target: IRowNode | null, treeData: boolean): boolean {
+        if (!target || target.level < 0 || target.footer || target.detail) {
+            return false; // cannot group into root, footer, or detail rows
+        }
+
+        if (target.group) {
+            return true;
+        }
+
+        return treeData; // in tree data any leaf can become a group
     }
 
     /** Flushes any pending group edits for batch processing */

--- a/packages/ag-grid-enterprise/src/rowHierarchy/groupEditService.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/groupEditService.ts
@@ -164,7 +164,6 @@ export class GroupEditService extends BeanStub implements _IGroupEditService {
             if (!newParent) {
                 newParent = target?.parent ?? rootNode;
             }
-
         }
 
         if (!fromNudge && target && canStartGroup && !(target.group && target.expanded)) {

--- a/testing/behavioural/src/drag-n-drop/grouping/managed-row-group-drag-edit-basic.test.ts
+++ b/testing/behavioural/src/drag-n-drop/grouping/managed-row-group-drag-edit-basic.test.ts
@@ -432,6 +432,83 @@ describe.each([false, true])('drag refreshAfterGroupEdit basics (suppress move %
         expect(api.getRowNode('2')?.data.group).toBe('B');
     });
 
+    test('rowDragInsertDelay does not promote leaf targets in row grouping', async () => {
+        const gridOptions: GridOptions = {
+            animateRows: true,
+            columnDefs: [
+                { field: 'group', rowGroup: true, hide: true },
+                { field: 'value', rowDrag: true },
+            ],
+            autoGroupColumnDef: { headerName: 'Group' },
+            rowData: [
+                { id: '1', group: 'A', value: 'A1' },
+                { id: '2', group: 'B', value: 'B1' },
+            ],
+            rowDragManaged: true,
+            suppressMoveWhenRowDragging,
+            refreshAfterGroupEdit: true,
+            rowDragInsertDelay: 60,
+            groupDefaultExpanded: -1,
+            getRowId: (params) => params.data.id,
+        };
+
+        const api = gridsManager.createGrid('row-group-edit-insert-delay-leaf', gridOptions);
+
+        const dispatcher = new RowDragDispatcher({ api });
+        await dispatcher.start('1');
+        await waitFor(() => expect(dispatcher.getDragGhostLabel()).toBe('A1'));
+        await dispatcher.move('2', { center: true });
+        await asyncSetTimeout(80);
+        await dispatcher.move('2', { center: true });
+
+        const lastMove = dispatcher.rowDragMoveEvents[dispatcher.rowDragMoveEvents.length - 1];
+        expect(lastMove?.rowsDrop?.position).not.toBe('inside');
+        expect(lastMove?.rowsDrop?.newParent?.id).toBe('row-group-group-B');
+
+        if (suppressMoveWhenRowDragging) {
+            const indicator = api.getRowDropPositionIndicator();
+            expect(indicator.dropIndicatorPosition).not.toBe('inside');
+        }
+
+        await dispatcher.finish();
+    });
+
+    test('rowDragInsertDelay skips expanded group targets', async () => {
+        const gridOptions: GridOptions = {
+            animateRows: true,
+            columnDefs: [
+                { field: 'group', rowGroup: true, hide: true },
+                { field: 'value', rowDrag: true },
+            ],
+            autoGroupColumnDef: { headerName: 'Group' },
+            rowData: [
+                { id: '1', group: 'A', value: 'A1' },
+                { id: '2', group: 'A', value: 'A2' },
+                { id: '3', group: 'B', value: 'B1' },
+            ],
+            rowDragManaged: true,
+            suppressMoveWhenRowDragging,
+            refreshAfterGroupEdit: true,
+            rowDragInsertDelay: 10000,
+            groupDefaultExpanded: -1,
+            getRowId: (params) => params.data.id,
+        };
+
+        const api = gridsManager.createGrid('row-group-edit-insert-delay-expanded', gridOptions);
+
+        const dispatcher = new RowDragDispatcher({ api });
+        await dispatcher.start('2');
+        await waitFor(() => expect(dispatcher.getDragGhostLabel()).toBe('A2'));
+        await dispatcher.move('row-group-group-B', { center: true });
+        await dispatcher.finish();
+        await asyncSetTimeout(0);
+
+        const dropInfo = dispatcher.rowDragEndEvents[0]?.rowsDrop;
+        expect(dropInfo?.position).toBe('above');
+        expect(dropInfo?.newParent?.id).toBe('row-group-group-B');
+        expect(api.getRowNode('2')?.data.group).toBe('B');
+    });
+
     test.each([0, -0.9, 0.9] as const)('moves a leaf in collapsed sibling group immediately y=%f', async (y) => {
         const gridOptions: GridOptions = {
             animateRows: true,

--- a/testing/behavioural/src/drag-n-drop/tree-data/tree-data-managed-row-drag-multi.test.ts
+++ b/testing/behavioural/src/drag-n-drop/tree-data/tree-data-managed-row-drag-multi.test.ts
@@ -173,6 +173,14 @@ describe.each([false, true])('tree drag multi flows (suppress move %s)', (suppre
 
         await dispatcher.move(targetRowId, { clientX, clientY });
 
+        if (suppressMoveWhenRowDragging) {
+            await waitFor(() => {
+                const indicator = api.getRowDropPositionIndicator();
+                expect(indicator.dropIndicatorPosition).not.toBe('none');
+                expect(['root-ops', 'root-ops-logs']).toContain(indicator.row?.id);
+            });
+        }
+
         for (let i = 0; i < 30 && !expandedBeforeDrop; ++i) {
             await asyncSetTimeout(20);
             api.forEachNode((node: IRowNode) => {
@@ -262,5 +270,113 @@ describe.each([false, true])('tree drag multi flows (suppress move %s)', (suppre
         expect(dropInfo?.pointerPos).toBe('inside');
         expect(dropInfo?.rows?.length ?? 0).toBeGreaterThan(0);
         expect(dropInfo?.newParent?.id ?? dropInfo?.overNode?.id).toBe('inbox');
+    });
+
+    test('rowDragInsertDelay promotes leaf targets without a validator', async () => {
+        const rowData = [
+            {
+                id: 'root',
+                name: 'Root',
+                type: 'folder',
+                children: [
+                    { id: 'inbox', name: 'Inbox', type: 'folder', children: [] },
+                    { id: 'incoming', name: 'Incoming', type: 'file', children: [] },
+                ],
+            },
+        ];
+
+        const api = createGrid('tree-managed-insert-promote-default', rowData, {
+            rowDragInsertDelay: 60,
+        });
+
+        const initialRows = new GridRows(api, 'insert promote default initial');
+        await initialRows.check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ root GROUP id:root ag-Grid-AutoColumn:"Root" type:"folder"
+            · ├── inbox LEAF id:inbox ag-Grid-AutoColumn:"Inbox" type:"folder"
+            · └── incoming LEAF id:incoming ag-Grid-AutoColumn:"Incoming" type:"file"
+        `);
+
+        const sourceRowId = 'incoming';
+        const targetRowId = 'inbox';
+        expect(getRowHtmlElement(api, sourceRowId)).toBeTruthy();
+        expect(getRowHtmlElement(api, targetRowId)).toBeTruthy();
+
+        const dispatcher = new RowDragDispatcher({ api });
+        await dispatcher.start(sourceRowId);
+        await waitFor(() => expect(dispatcher.getDragGhostLabel()).toBe('Incoming'));
+        await dispatcher.move(targetRowId, { yOffsetPercent: 0.45 });
+        await asyncSetTimeout(80);
+        await dispatcher.move(targetRowId, { center: true });
+
+        if (suppressMoveWhenRowDragging) {
+            await waitFor(() => {
+                const indicator = api.getRowDropPositionIndicator();
+                expect(indicator.dropIndicatorPosition).toBe('inside');
+                expect(indicator.row?.id).toBe('inbox');
+            });
+        }
+
+        await dispatcher.finish();
+        await asyncSetTimeout(0);
+
+        const dropInfo = dispatcher.rowDragEndEvents[0]?.rowsDrop;
+
+        const finalRows = new GridRows(api, 'insert promote default after');
+        await finalRows.check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ root GROUP id:root ag-Grid-AutoColumn:"Root" type:"folder"
+            · └─┬ inbox GROUP id:inbox ag-Grid-AutoColumn:"Inbox" type:"folder"
+            · · └── incoming LEAF id:incoming ag-Grid-AutoColumn:"Incoming" type:"file"
+        `);
+
+        expect(api.getRowNode('incoming')?.parent?.id).toBe('inbox');
+        expect(api.getRowNode('inbox')?.childrenAfterSort?.some((node) => node.id === 'incoming')).toBe(true);
+        expect(dropInfo?.newParent?.id ?? dropInfo?.overNode?.id).toBe('inbox');
+        expect(dropInfo?.position).toBe('inside');
+    });
+
+    test('rowDragInsertDelay skips already expanded groups', async () => {
+        const rowData = [
+            {
+                id: 'root',
+                name: 'Root',
+                type: 'folder',
+                children: [
+                    {
+                        id: 'alpha',
+                        name: 'Alpha',
+                        type: 'folder',
+                        children: [{ id: 'alpha-item', name: 'Alpha Item', type: 'file', children: [] }],
+                    },
+                    {
+                        id: 'beta',
+                        name: 'Beta',
+                        type: 'folder',
+                        children: [{ id: 'beta-item', name: 'Beta Item', type: 'file', children: [] }],
+                    },
+                ],
+            },
+        ];
+
+        const api = createGrid('tree-managed-insert-expanded', rowData, {
+            rowDragInsertDelay: 10000,
+            groupDefaultExpanded: -1,
+        });
+
+        await asyncSetTimeout(0);
+        expect(api.getRowNode('beta')?.expanded).toBe(true);
+
+        const dispatcher = new RowDragDispatcher({ api });
+        await dispatcher.start('alpha-item');
+        await waitFor(() => expect(dispatcher.getDragGhostLabel()).toBe('Alpha Item'));
+        await dispatcher.move('beta', { center: true });
+        await dispatcher.finish();
+        await asyncSetTimeout(0);
+
+        const dropInfo = dispatcher.rowDragEndEvents[0]?.rowsDrop;
+        expect(dropInfo?.position).toBe('above');
+        expect(dropInfo?.newParent?.id).toBe('beta');
+        expect(api.getRowNode('alpha-item')?.parent?.id).toBe('beta');
     });
 });


### PR DESCRIPTION
The logic to check if a leaf row can be promoted to group or expanded was not correct
This was introduced during the implementation of grouping drag-n-drop.
Test coverage didn't cover this case properly

Fix AG-16614