### PR TITLE
AG-13371 React AgGridProvider Doc updates

### DIFF
--- a/documentation/ag-grid-docs/src/components/license-setup/components/LicenseSetup.tsx
+++ b/documentation/ag-grid-docs/src/components/license-setup/components/LicenseSetup.tsx
@@ -81,7 +81,7 @@ export const LicenseSetup: FunctionComponent<Props> = ({ library, framework, pat
         () =>
             getBootstrapSnippet({
                 framework,
-                license: (licenseState.chartsNoGridEnterpriseError ? '' : userLicense) || 'your License Key',
+                license: (licenseState.chartsNoGridEnterpriseError ? '' : userLicense) || 'YOUR_LICENSE_KEY',
                 isIntegratedCharts,
             }),
         [framework, licenseState, userLicense, isIntegratedCharts]

--- a/documentation/ag-grid-docs/src/components/license-setup/utils/templates.ts
+++ b/documentation/ag-grid-docs/src/components/license-setup/utils/templates.ts
@@ -4,24 +4,21 @@ type TemplateFunction = (data: { license?: string; isIntegratedCharts?: boolean 
 type LicenseTemplate = Record<Framework, TemplateFunction>;
 
 export const GRID_LICENSE_TEMPLATES: LicenseTemplate = {
-    react: ({ license, isIntegratedCharts }) => `import React from "react";
-import { render } from "react-dom";
+    react: ({
+        license,
+        isIntegratedCharts,
+    }) => `import { AllEnterpriseModule${isIntegratedCharts ? ', IntegratedChartsModule' : ''} } from "ag-grid-enterprise";
+${isIntegratedCharts ? 'import { AgChartsEnterpriseModule } from "ag-charts-enterprise";\n' : ''}import { AgGridProvider, AgGridReact } from "ag-grid-react";
 
-import { ModuleRegistry } from "ag-grid-community";
-import { AllEnterpriseModule, LicenseManager${isIntegratedCharts ? ', IntegratedChartsModule' : ''} } from "ag-grid-enterprise";
-${isIntegratedCharts ? 'import { AgChartsEnterpriseModule } from "ag-charts-enterprise";\n' : ''}
-import App from "./App";
+const modules = [${isIntegratedCharts ? '\n    AllEnterpriseModule,\n    IntegratedChartsModule.with(AgChartsEnterpriseModule),\n' : 'AllEnterpriseModule'}];
 
-ModuleRegistry.registerModules([${isIntegratedCharts ? '\n    AllEnterpriseModule,\n    IntegratedChartsModule.with(AgChartsEnterpriseModule)\n' : 'AllEnterpriseModule'}]);
-
-LicenseManager.setLicenseKey("${license}");
-
-document.addEventListener('DOMContentLoaded', () => {
-    render(
-        <App/>,
-        document.querySelector('#app')
+function App() {
+    return (
+        <AgGridProvider modules={modules} licenseKey="${license}">
+            <AgGridReact /* ... props */ />
+        </AgGridProvider>
     );
-});
+}
 `,
     angular: ({ license, isIntegratedCharts }) => {
         return `import { ModuleRegistry } from "ag-grid-community";
@@ -31,11 +28,20 @@ ModuleRegistry.registerModules([${isIntegratedCharts ? '\n    AllEnterpriseModul
 
 LicenseManager.setLicenseKey("${license}");
 
-// Template
-<ag-grid-angular
-   [rowData]="rowData"
-   [columnDefs]="columnDefs"
-   [modules]="modules" />
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [AgGridAngular],
+  template: 
+  \`<ag-grid-angular
+      [rowData]="rowData"
+      [columnDefs]="columnDefs"
+    />\`,
+})
+export class AppComponent {
+ /* Class implementation */
+}
+
 `;
     },
     javascript: ({ license, isIntegratedCharts }) => {

--- a/documentation/ag-grid-docs/src/components/license-setup/utils/templates.ts
+++ b/documentation/ag-grid-docs/src/components/license-setup/utils/templates.ts
@@ -19,6 +19,12 @@ function App() {
         </AgGridProvider>
     );
 }
+
+// For versions <35.1 use the LicenseManager and ModuleRegistry directly
+
+// import { LicenseManager, ModuleRegistry } from "ag-grid-enterprise";
+// ModuleRegistry.registerModules([${isIntegratedCharts ? '\n//   AllEnterpriseModule,\n//   IntegratedChartsModule.with(AgChartsEnterpriseModule)\n// ' : 'AllEnterpriseModule'}]);
+// LicenseManager.setLicenseKey("${license}");
 `,
     angular: ({ license, isIntegratedCharts }) => {
         return `import { ModuleRegistry } from "ag-grid-community";

--- a/documentation/ag-grid-docs/src/components/module-mappings/ModuleMappings.tsx
+++ b/documentation/ag-grid-docs/src/components/module-mappings/ModuleMappings.tsx
@@ -38,7 +38,7 @@ ModuleRegistry.registerModules([
 
 export const ModuleMappings: FunctionComponent<Props> = ({ framework, modules }) => {
     const gridRef = useRef<AgGridReact>(null);
-    const moduleConfig = useModuleConfig(gridRef);
+    const moduleConfig = useModuleConfig(gridRef, framework);
     const { selectedDependenciesSnippet, setSelectedModules, bundleOption, rowModelOption } = moduleConfig;
 
     const rowData = useMemo(() => {

--- a/documentation/ag-grid-docs/src/components/module-mappings/getModuleMappingsSnippet.test.ts
+++ b/documentation/ag-grid-docs/src/components/module-mappings/getModuleMappingsSnippet.test.ts
@@ -1,255 +1,390 @@
 import { getModuleMappingsSnippet } from './getModuleMappingsSnippet';
 
 describe('getModuleMappingsSnippet', () => {
-    test('empty', () => {
-        const selectedModules = { community: [], enterprise: [] };
-        expect(getModuleMappingsSnippet({ chartsImportType: 'none', selectedModules })).toEqual(undefined);
-    });
-
-    test('community', () => {
-        const selectedModules = { community: ['ValidationModule'], enterprise: [] };
-        expect(getModuleMappingsSnippet({ chartsImportType: 'none', selectedModules })).toMatchInlineSnapshot(`
-          "import {
-              ModuleRegistry,
-              ValidationModule,
-          } from 'ag-grid-community';
-
-          ModuleRegistry.registerModules([
-              ValidationModule,
-          ]);"
-        `);
-    });
-
-    test('multiple community', () => {
-        const selectedModules = { community: ['ValidationModule', 'ColumnHoverModule'], enterprise: [] };
-        expect(getModuleMappingsSnippet({ chartsImportType: 'none', selectedModules })).toMatchInlineSnapshot(`
-          "import {
-              ModuleRegistry,
-              ValidationModule,
-              ColumnHoverModule,
-          } from 'ag-grid-community';
-
-          ModuleRegistry.registerModules([
-              ValidationModule,
-              ColumnHoverModule,
-          ]);"
-        `);
-    });
-
-    test('enterprise', () => {
-        const selectedModules = { community: [], enterprise: ['SetFilterModule'] };
-        expect(getModuleMappingsSnippet({ chartsImportType: 'none', selectedModules })).toMatchInlineSnapshot(`
-          "import {
-              ModuleRegistry,
-          } from 'ag-grid-community';
-          import {
-              SetFilterModule,
-          } from 'ag-grid-enterprise';
-
-          ModuleRegistry.registerModules([
-              SetFilterModule,
-          ]);"
-        `);
-    });
-
-    test('multiple community', () => {
-        const selectedModules = { community: [], enterprise: ['SetFilterModule', 'RowGroupingModule'] };
-        expect(getModuleMappingsSnippet({ chartsImportType: 'none', selectedModules })).toMatchInlineSnapshot(`
-          "import {
-              ModuleRegistry,
-          } from 'ag-grid-community';
-          import {
-              SetFilterModule,
-              RowGroupingModule,
-          } from 'ag-grid-enterprise';
-
-          ModuleRegistry.registerModules([
-              SetFilterModule,
-              RowGroupingModule,
-          ]);"
-        `);
-    });
-
-    test('community and enterprise', () => {
-        const selectedModules = { community: ['AllCommunityModule'], enterprise: ['SetFilterModule'] };
-        expect(getModuleMappingsSnippet({ chartsImportType: 'none', selectedModules })).toMatchInlineSnapshot(`
-          "import {
-              ModuleRegistry,
-              AllCommunityModule,
-          } from 'ag-grid-community';
-          import {
-              SetFilterModule,
-          } from 'ag-grid-enterprise';
-
-          ModuleRegistry.registerModules([
-              AllCommunityModule,
-              SetFilterModule,
-          ]);"
-        `);
-    });
-
-    describe('charts - sparklines', () => {
-        test('no bundles', () => {
-            const selectedModules = { community: [], enterprise: ['SparklinesModule'] };
-            expect(getModuleMappingsSnippet({ chartsImportType: 'community', selectedModules })).toMatchInlineSnapshot(`
-              "import { AgChartsCommunityModule } from 'ag-charts-community';
-              import {
-                  ModuleRegistry,
-              } from 'ag-grid-community';
-              import {
-                  SparklinesModule,
-              } from 'ag-grid-enterprise';
-
-              ModuleRegistry.registerModules([
-                  SparklinesModule.with(AgChartsCommunityModule),
-              ]);"
-            `);
+    describe('default (non-React) framework', () => {
+        test('empty', () => {
+            const selectedModules = { community: [], enterprise: [] };
+            expect(
+                getModuleMappingsSnippet({ chartsImportType: 'none', selectedModules, framework: 'javascript' })
+            ).toEqual(undefined);
         });
 
-        test('all community', () => {
-            const selectedModules = { community: ['AllCommunityModule'], enterprise: ['SparklinesModule'] };
-            expect(getModuleMappingsSnippet({ chartsImportType: 'community', selectedModules })).toMatchInlineSnapshot(`
-              "import { AgChartsCommunityModule } from 'ag-charts-community';
-              import {
-                  ModuleRegistry,
-                  AllCommunityModule,
-              } from 'ag-grid-community';
-              import {
-                  SparklinesModule,
-              } from 'ag-grid-enterprise';
-
-              ModuleRegistry.registerModules([
-                  AllCommunityModule,
-                  SparklinesModule.with(AgChartsCommunityModule),
-              ]);"
-            `);
-        });
-    });
-
-    describe('charts - integrated charts', () => {
-        test('no bundles (with enterprise charts)', () => {
-            const selectedModules = { community: [], enterprise: ['IntegratedChartsModule'] };
-            expect(getModuleMappingsSnippet({ chartsImportType: 'enterprise', selectedModules }))
+        test('community', () => {
+            const selectedModules = { community: ['ValidationModule'], enterprise: [] };
+            expect(getModuleMappingsSnippet({ chartsImportType: 'none', selectedModules, framework: 'javascript' }))
                 .toMatchInlineSnapshot(`
-              "import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
-              import {
+              "import {
                   ModuleRegistry,
+                  ValidationModule,
               } from 'ag-grid-community';
-              import {
-                  IntegratedChartsModule,
-              } from 'ag-grid-enterprise';
 
               ModuleRegistry.registerModules([
-                  IntegratedChartsModule.with(AgChartsEnterpriseModule),
+                  ValidationModule,
               ]);"
             `);
         });
 
-        test('all community (with enterprise charts)', () => {
-            const selectedModules = { community: ['AllCommunityModule'], enterprise: ['IntegratedChartsModule'] };
-            expect(getModuleMappingsSnippet({ chartsImportType: 'enterprise', selectedModules }))
+        test('multiple community', () => {
+            const selectedModules = { community: ['ValidationModule', 'ColumnHoverModule'], enterprise: [] };
+            expect(getModuleMappingsSnippet({ chartsImportType: 'none', selectedModules, framework: 'javascript' }))
                 .toMatchInlineSnapshot(`
-              "import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
+              "import {
+                  ModuleRegistry,
+                  ValidationModule,
+                  ColumnHoverModule,
+              } from 'ag-grid-community';
+
+              ModuleRegistry.registerModules([
+                  ValidationModule,
+                  ColumnHoverModule,
+              ]);"
+            `);
+        });
+
+        test('enterprise', () => {
+            const selectedModules = { community: [], enterprise: ['SetFilterModule'] };
+            expect(getModuleMappingsSnippet({ chartsImportType: 'none', selectedModules, framework: 'javascript' }))
+                .toMatchInlineSnapshot(`
+              "import {
+                  ModuleRegistry,
+              } from 'ag-grid-community';
               import {
+                  SetFilterModule,
+              } from 'ag-grid-enterprise';
+
+              ModuleRegistry.registerModules([
+                  SetFilterModule,
+              ]);"
+            `);
+        });
+
+        test('multiple enterprise', () => {
+            const selectedModules = { community: [], enterprise: ['SetFilterModule', 'RowGroupingModule'] };
+            expect(getModuleMappingsSnippet({ chartsImportType: 'none', selectedModules, framework: 'javascript' }))
+                .toMatchInlineSnapshot(`
+              "import {
+                  ModuleRegistry,
+              } from 'ag-grid-community';
+              import {
+                  SetFilterModule,
+                  RowGroupingModule,
+              } from 'ag-grid-enterprise';
+
+              ModuleRegistry.registerModules([
+                  SetFilterModule,
+                  RowGroupingModule,
+              ]);"
+            `);
+        });
+
+        test('community and enterprise', () => {
+            const selectedModules = { community: ['AllCommunityModule'], enterprise: ['SetFilterModule'] };
+            expect(getModuleMappingsSnippet({ chartsImportType: 'none', selectedModules, framework: 'javascript' }))
+                .toMatchInlineSnapshot(`
+              "import {
                   ModuleRegistry,
                   AllCommunityModule,
               } from 'ag-grid-community';
               import {
-                  IntegratedChartsModule,
+                  SetFilterModule,
               } from 'ag-grid-enterprise';
 
               ModuleRegistry.registerModules([
                   AllCommunityModule,
-                  IntegratedChartsModule.with(AgChartsEnterpriseModule),
+                  SetFilterModule,
               ]);"
             `);
+        });
+
+        describe('charts - sparklines', () => {
+            test('no bundles', () => {
+                const selectedModules = { community: [], enterprise: ['SparklinesModule'] };
+                expect(
+                    getModuleMappingsSnippet({
+                        chartsImportType: 'community',
+                        selectedModules,
+                        framework: 'angular',
+                    })
+                ).toMatchInlineSnapshot(`
+                  "import { AgChartsCommunityModule } from 'ag-charts-community';
+                  import {
+                      ModuleRegistry,
+                  } from 'ag-grid-community';
+                  import {
+                      SparklinesModule,
+                  } from 'ag-grid-enterprise';
+
+                  ModuleRegistry.registerModules([
+                      SparklinesModule.with(AgChartsCommunityModule),
+                  ]);"
+                `);
+            });
+
+            test('all community', () => {
+                const selectedModules = { community: ['AllCommunityModule'], enterprise: ['SparklinesModule'] };
+                expect(
+                    getModuleMappingsSnippet({
+                        chartsImportType: 'community',
+                        selectedModules,
+                        framework: 'vue',
+                    })
+                ).toMatchInlineSnapshot(`
+                  "import { AgChartsCommunityModule } from 'ag-charts-community';
+                  import {
+                      ModuleRegistry,
+                      AllCommunityModule,
+                  } from 'ag-grid-community';
+                  import {
+                      SparklinesModule,
+                  } from 'ag-grid-enterprise';
+
+                  ModuleRegistry.registerModules([
+                      AllCommunityModule,
+                      SparklinesModule.with(AgChartsCommunityModule),
+                  ]);"
+                `);
+            });
+        });
+
+        describe('charts - integrated charts', () => {
+            test('no bundles (with enterprise charts)', () => {
+                const selectedModules = { community: [], enterprise: ['IntegratedChartsModule'] };
+                expect(
+                    getModuleMappingsSnippet({
+                        chartsImportType: 'enterprise',
+                        selectedModules,
+                        framework: 'javascript',
+                    })
+                ).toMatchInlineSnapshot(`
+                  "import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
+                  import {
+                      ModuleRegistry,
+                  } from 'ag-grid-community';
+                  import {
+                      IntegratedChartsModule,
+                  } from 'ag-grid-enterprise';
+
+                  ModuleRegistry.registerModules([
+                      IntegratedChartsModule.with(AgChartsEnterpriseModule),
+                  ]);"
+                `);
+            });
+
+            test('all community (with enterprise charts)', () => {
+                const selectedModules = { community: ['AllCommunityModule'], enterprise: ['IntegratedChartsModule'] };
+                expect(
+                    getModuleMappingsSnippet({
+                        chartsImportType: 'enterprise',
+                        selectedModules,
+                        framework: 'javascript',
+                    })
+                ).toMatchInlineSnapshot(`
+                  "import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
+                  import {
+                      ModuleRegistry,
+                      AllCommunityModule,
+                  } from 'ag-grid-community';
+                  import {
+                      IntegratedChartsModule,
+                  } from 'ag-grid-enterprise';
+
+                  ModuleRegistry.registerModules([
+                      AllCommunityModule,
+                      IntegratedChartsModule.with(AgChartsEnterpriseModule),
+                  ]);"
+                `);
+            });
+        });
+
+        describe('charts - both sparklines and integrated charts', () => {
+            test('no bundles (with enterprise charts)', () => {
+                const selectedModules = { community: [], enterprise: ['SparklinesModule', 'IntegratedChartsModule'] };
+                expect(
+                    getModuleMappingsSnippet({
+                        chartsImportType: 'enterprise',
+                        selectedModules,
+                        framework: 'javascript',
+                    })
+                ).toMatchInlineSnapshot(`
+                  "import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
+                  import {
+                      ModuleRegistry,
+                  } from 'ag-grid-community';
+                  import {
+                      SparklinesModule,
+                      IntegratedChartsModule,
+                  } from 'ag-grid-enterprise';
+
+                  ModuleRegistry.registerModules([
+                      SparklinesModule.with(AgChartsEnterpriseModule),
+                      IntegratedChartsModule.with(AgChartsEnterpriseModule),
+                  ]);"
+                `);
+            });
+
+            test('all community (with enterprise charts)', () => {
+                const selectedModules = {
+                    community: ['AllCommunityModule'],
+                    enterprise: ['SparklinesModule', 'IntegratedChartsModule'],
+                };
+                expect(
+                    getModuleMappingsSnippet({
+                        chartsImportType: 'enterprise',
+                        selectedModules,
+                        framework: 'javascript',
+                    })
+                ).toMatchInlineSnapshot(`
+                  "import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
+                  import {
+                      ModuleRegistry,
+                      AllCommunityModule,
+                  } from 'ag-grid-community';
+                  import {
+                      SparklinesModule,
+                      IntegratedChartsModule,
+                  } from 'ag-grid-enterprise';
+
+                  ModuleRegistry.registerModules([
+                      AllCommunityModule,
+                      SparklinesModule.with(AgChartsEnterpriseModule),
+                      IntegratedChartsModule.with(AgChartsEnterpriseModule),
+                  ]);"
+                `);
+            });
+        });
+
+        /**
+         * With `AllEnterpriseModule`, only `chartsImportType` is used to
+         * determine which charts to import
+         */
+        describe('all enterprise', () => {
+            test('community charts', () => {
+                const selectedModules = { community: [], enterprise: ['AllEnterpriseModule'] };
+                expect(
+                    getModuleMappingsSnippet({
+                        chartsImportType: 'community',
+                        selectedModules,
+                        framework: 'javascript',
+                    })
+                ).toMatchInlineSnapshot(`
+                  "import { AgChartsCommunityModule } from 'ag-charts-community';
+                  import {
+                      ModuleRegistry,
+                  } from 'ag-grid-community';
+                  import {
+                      AllEnterpriseModule,
+                  } from 'ag-grid-enterprise';
+
+                  ModuleRegistry.registerModules([
+                      AllEnterpriseModule.with(AgChartsCommunityModule),
+                  ]);"
+                `);
+            });
+
+            test('enterprise charts', () => {
+                const selectedModules = { community: [], enterprise: ['AllEnterpriseModule'] };
+                expect(
+                    getModuleMappingsSnippet({
+                        chartsImportType: 'enterprise',
+                        selectedModules,
+                        framework: 'javascript',
+                    })
+                ).toMatchInlineSnapshot(`
+                  "import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
+                  import {
+                      ModuleRegistry,
+                  } from 'ag-grid-community';
+                  import {
+                      AllEnterpriseModule,
+                  } from 'ag-grid-enterprise';
+
+                  ModuleRegistry.registerModules([
+                      AllEnterpriseModule.with(AgChartsEnterpriseModule),
+                  ]);"
+                `);
+            });
         });
     });
 
-    describe('charts - both sparklines and integrated charts', () => {
-        test('no bundles (with enterprise charts)', () => {
-            const selectedModules = { community: [], enterprise: ['SparklinesModule', 'IntegratedChartsModule'] };
-            expect(getModuleMappingsSnippet({ chartsImportType: 'enterprise', selectedModules }))
-                .toMatchInlineSnapshot(`
-              "import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
-              import {
-                  ModuleRegistry,
-              } from 'ag-grid-community';
-              import {
-                  SparklinesModule,
-                  IntegratedChartsModule,
-              } from 'ag-grid-enterprise';
+    describe('react framework', () => {
+        test('empty', () => {
+            const selectedModules = { community: [], enterprise: [] };
+            expect(getModuleMappingsSnippet({ chartsImportType: 'none', selectedModules, framework: 'react' })).toEqual(
+                undefined
+            );
+        });
 
-              ModuleRegistry.registerModules([
-                  SparklinesModule.with(AgChartsEnterpriseModule),
-                  IntegratedChartsModule.with(AgChartsEnterpriseModule),
-              ]);"
+        test('community', () => {
+            const selectedModules = { community: ['ValidationModule'], enterprise: [] };
+            expect(getModuleMappingsSnippet({ chartsImportType: 'none', selectedModules, framework: 'react' }))
+                .toMatchInlineSnapshot(`
+              "import {
+                  ValidationModule,
+              } from 'ag-grid-community';
+              import { AgGridProvider, AgGridReact } from 'ag-grid-react';
+
+              const modules = [
+                  ValidationModule,
+              ];
+
+              function App() {
+                  return (
+                      <AgGridProvider modules={modules}>
+                          <AgGridReact /* ... props */ />
+                      </AgGridProvider>
+                  );
+              }"
             `);
         });
 
-        test('all community (with enterprise charts)', () => {
-            const selectedModules = {
-                community: ['AllCommunityModule'],
-                enterprise: ['SparklinesModule', 'IntegratedChartsModule'],
-            };
-            expect(getModuleMappingsSnippet({ chartsImportType: 'enterprise', selectedModules }))
+        test('community and enterprise', () => {
+            const selectedModules = { community: ['AllCommunityModule'], enterprise: ['SetFilterModule'] };
+            expect(getModuleMappingsSnippet({ chartsImportType: 'none', selectedModules, framework: 'react' }))
                 .toMatchInlineSnapshot(`
-              "import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
-              import {
-                  ModuleRegistry,
+              "import {
                   AllCommunityModule,
               } from 'ag-grid-community';
               import {
-                  SparklinesModule,
-                  IntegratedChartsModule,
+                  SetFilterModule,
               } from 'ag-grid-enterprise';
+              import { AgGridProvider, AgGridReact } from 'ag-grid-react';
 
-              ModuleRegistry.registerModules([
+              const modules = [
                   AllCommunityModule,
-                  SparklinesModule.with(AgChartsEnterpriseModule),
-                  IntegratedChartsModule.with(AgChartsEnterpriseModule),
-              ]);"
+                  SetFilterModule,
+              ];
+
+              function App() {
+                  return (
+                      <AgGridProvider modules={modules}>
+                          <AgGridReact /* ... props */ />
+                      </AgGridProvider>
+                  );
+              }"
             `);
         });
-    });
 
-    /**
-     * With `AllEnterpriseModule`, only `chartsImportType` is used to
-     * determine which charts to import
-     */
-    describe('all enterprise', () => {
-        test('community charts', () => {
+        test('all enterprise with charts', () => {
             const selectedModules = { community: [], enterprise: ['AllEnterpriseModule'] };
-            expect(getModuleMappingsSnippet({ chartsImportType: 'community', selectedModules })).toMatchInlineSnapshot(`
-              "import { AgChartsCommunityModule } from 'ag-charts-community';
-              import {
-                  ModuleRegistry,
-              } from 'ag-grid-community';
+            expect(getModuleMappingsSnippet({ chartsImportType: 'enterprise', selectedModules, framework: 'react' }))
+                .toMatchInlineSnapshot(`
+              "import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
               import {
                   AllEnterpriseModule,
               } from 'ag-grid-enterprise';
+              import { AgGridProvider, AgGridReact } from 'ag-grid-react';
 
-              ModuleRegistry.registerModules([
-                  AllEnterpriseModule.with(AgChartsCommunityModule),
-              ]);"
-            `);
-        });
-
-        test('enterprise charts', () => {
-            const selectedModules = { community: [], enterprise: ['AllEnterpriseModule'] };
-            expect(getModuleMappingsSnippet({ chartsImportType: 'enterprise', selectedModules }))
-                .toMatchInlineSnapshot(`
-              "import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
-              import {
-                  ModuleRegistry,
-              } from 'ag-grid-community';
-              import {
-                  AllEnterpriseModule,
-              } from 'ag-grid-enterprise';
-
-              ModuleRegistry.registerModules([
+              const modules = [
                   AllEnterpriseModule.with(AgChartsEnterpriseModule),
-              ]);"
+              ];
+
+              function App() {
+                  return (
+                      <AgGridProvider modules={modules}>
+                          <AgGridReact /* ... props */ />
+                      </AgGridProvider>
+                  );
+              }"
             `);
         });
     });

--- a/documentation/ag-grid-docs/src/components/module-mappings/getModuleMappingsSnippet.ts
+++ b/documentation/ag-grid-docs/src/components/module-mappings/getModuleMappingsSnippet.ts
@@ -1,9 +1,12 @@
+import type { Framework } from '@ag-grid-types';
+
 import { ALL_ENTERPRISE_MODULE, INTEGRATED_CHARTS_MODULE, SPARKLINES_MODULE } from './constants';
 
 export type ChartsImportType = 'enterprise' | 'community' | 'none';
 interface Params {
     chartsImportType: ChartsImportType;
     selectedModules: SelectedModules;
+    framework: Framework;
 }
 
 export interface SelectedModules {
@@ -13,15 +16,28 @@ export interface SelectedModules {
 
 const TAB_SPACING = '    ';
 
-const getCodeSnippet = ({ chartsImportType, selectedModules }: Params) => {
+const getModulesWithCharts = (
+    modules: string[],
+    chartsImportType: ChartsImportType
+): { name: string; withCharts: boolean }[] => {
+    return modules.map((name) => {
+        const isChartsModule = [SPARKLINES_MODULE.moduleName, INTEGRATED_CHARTS_MODULE.moduleName].includes(name);
+        const isEnterpriseModule = name === ALL_ENTERPRISE_MODULE;
+        const needsCharts =
+            (chartsImportType === 'community' || chartsImportType === 'enterprise') &&
+            (isChartsModule || isEnterpriseModule);
+
+        return { name, withCharts: needsCharts };
+    });
+};
+
+const getChartsModuleName = (chartsImportType: ChartsImportType): string => {
+    return chartsImportType === 'community' ? 'AgChartsCommunityModule' : 'AgChartsEnterpriseModule';
+};
+
+const getReactCodeSnippet = ({ chartsImportType, selectedModules }: Omit<Params, 'framework'>) => {
     const { community, enterprise } = selectedModules;
-    const communityImportsString = community.length
-        ? community
-              .map((name) => {
-                  return `${TAB_SPACING}${name},`;
-              })
-              .join('\n')
-        : '';
+    const communityImportsString = community.length ? community.map((name) => `${TAB_SPACING}${name},`).join('\n') : '';
     const enterpriseImportsString = enterprise.length
         ? enterprise.map((name) => `${TAB_SPACING}${name},`).join('\n')
         : '';
@@ -31,24 +47,67 @@ const getCodeSnippet = ({ chartsImportType, selectedModules }: Params) => {
             : chartsImportType === 'enterprise'
               ? "import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';"
               : '';
-    const allModules = community
-        .concat(enterprise)
-        .map((name) => {
-            const isChartsModule = [SPARKLINES_MODULE.moduleName, INTEGRATED_CHARTS_MODULE.moduleName].includes(name);
-            const isEnterpriseModule = name === ALL_ENTERPRISE_MODULE;
-            const isCommunityCharts = chartsImportType === 'community' && (isChartsModule || isEnterpriseModule);
-            const isEnterpriseCharts = chartsImportType === 'enterprise' && (isChartsModule || isEnterpriseModule);
 
-            let exportName = name;
-            if (isCommunityCharts) {
-                exportName = `${name}.with(AgChartsCommunityModule)`;
-            } else if (isEnterpriseCharts) {
-                exportName = `${name}.with(AgChartsEnterpriseModule)`;
-            }
-
-            return exportName;
+    const allModulesWithCharts = getModulesWithCharts(community.concat(enterprise), chartsImportType);
+    const chartsModuleName = getChartsModuleName(chartsImportType);
+    const modulesArrayContent = allModulesWithCharts
+        .map(({ name, withCharts }) => {
+            const exportName = withCharts ? `${name}.with(${chartsModuleName})` : name;
+            return `${TAB_SPACING}${exportName},`;
         })
-        .map((name) => `${TAB_SPACING}${name},`)
+        .join('\n');
+
+    const communityImport = communityImportsString
+        ? `import {\n${communityImportsString}\n} from 'ag-grid-community';`
+        : '';
+    const enterpriseImport = enterpriseImportsString
+        ? `import {\n${enterpriseImportsString}\n} from 'ag-grid-enterprise';`
+        : '';
+
+    const imports = [
+        chartsImport,
+        communityImport,
+        enterpriseImport,
+        "import { AgGridProvider, AgGridReact } from 'ag-grid-react';",
+    ]
+        .filter(Boolean)
+        .join('\n');
+
+    return `${imports}
+
+const modules = [
+${modulesArrayContent}
+];
+
+function App() {
+    return (
+        <AgGridProvider modules={modules}>
+            <AgGridReact /* ... props */ />
+        </AgGridProvider>
+    );
+}`;
+};
+
+const getDefaultCodeSnippet = ({ chartsImportType, selectedModules }: Omit<Params, 'framework'>) => {
+    const { community, enterprise } = selectedModules;
+    const communityImportsString = community.length ? community.map((name) => `${TAB_SPACING}${name},`).join('\n') : '';
+    const enterpriseImportsString = enterprise.length
+        ? enterprise.map((name) => `${TAB_SPACING}${name},`).join('\n')
+        : '';
+    const chartsImport =
+        chartsImportType === 'community'
+            ? "import { AgChartsCommunityModule } from 'ag-charts-community';"
+            : chartsImportType === 'enterprise'
+              ? "import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';"
+              : '';
+
+    const allModulesWithCharts = getModulesWithCharts(community.concat(enterprise), chartsImportType);
+    const chartsModuleName = getChartsModuleName(chartsImportType);
+    const modulesArrayContent = allModulesWithCharts
+        .map(({ name, withCharts }) => {
+            const exportName = withCharts ? `${name}.with(${chartsModuleName})` : name;
+            return `${TAB_SPACING}${exportName},`;
+        })
         .join('\n');
 
     return `${chartsImport ? `${chartsImport}\n` : ''}import {
@@ -62,14 +121,18 @@ ${enterpriseImportsString}
     }
 
 ModuleRegistry.registerModules([
-${allModules}
+${modulesArrayContent}
 ]);`;
 };
 
-export function getModuleMappingsSnippet({ chartsImportType, selectedModules }: Params): string | undefined {
+export function getModuleMappingsSnippet({ chartsImportType, selectedModules, framework }: Params): string | undefined {
     if (!selectedModules.community.length && !selectedModules.enterprise.length) {
         return;
     }
 
-    return getCodeSnippet({ chartsImportType, selectedModules });
+    if (framework === 'react') {
+        return getReactCodeSnippet({ chartsImportType, selectedModules });
+    }
+
+    return getDefaultCodeSnippet({ chartsImportType, selectedModules });
 }

--- a/documentation/ag-grid-docs/src/components/module-mappings/useModuleConfig.ts
+++ b/documentation/ag-grid-docs/src/components/module-mappings/useModuleConfig.ts
@@ -1,3 +1,4 @@
+import type { Framework } from '@ag-grid-types';
 import { throwDevWarning } from '@ag-website-shared/utils/throwDevWarning';
 import { type RefObject, useCallback, useMemo, useState } from 'react';
 
@@ -32,7 +33,7 @@ const getChartsImportType = (chartOptions: ChartOptions): ChartsImportType => {
     return chartsImport;
 };
 
-export function useModuleConfig(gridRef: RefObject<AgGridReact>) {
+export function useModuleConfig(gridRef: RefObject<AgGridReact>, framework: Framework) {
     const [rowModelOption, setRowModelOption] = useState<string>('ClientSideRowModelModule');
     const [bundleOption, setBundleOption] = useState<BundleOptionValue>('');
     const [chartOptions, setChartOptions] = useState(DEFAULT_CHART_OPTIONS);
@@ -88,8 +89,8 @@ export function useModuleConfig(gridRef: RefObject<AgGridReact>) {
     }, [selectedModules, bundleOption, rowModelOption, chartOptions]);
     const selectedDependenciesSnippet = useMemo(() => {
         const chartsImportType = getChartsImportType(chartOptions);
-        return getModuleMappingsSnippet({ chartsImportType, selectedModules: allImportModules });
-    }, [allImportModules, chartOptions]);
+        return getModuleMappingsSnippet({ chartsImportType, selectedModules: allImportModules, framework });
+    }, [allImportModules, chartOptions, framework]);
 
     const updateRowModelOption = useCallback((moduleName: string) => {
         setRowModelOption(moduleName);

--- a/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
@@ -168,11 +168,13 @@ const gridOptions = {
 
 ```js
 import { AllCommunityModule } from 'ag-grid-community';
-import { AgGridProvider } from 'ag-grid-react';  
+import { AgGridProvider } from 'ag-grid-react';
+
+const modules = [AllCommunityModule];
 
 function App() {
     return (
-        <AgGridProvider modules={[AllCommunityModule]}>
+        <AgGridProvider modules={modules}>
             {/* Your AgGridReact components go here */}
         </AgGridProvider>
     );
@@ -220,17 +222,21 @@ const GridExample = () => {
 
 {% numberHeading number="5" title="React Data Grid Component" level="h3" %}
 
-Return the `AgGridReact` component, wrapped in a parent container `div` with a fixed height. Set Rows and Columns as `AgGridReact` component attributes:
+Return the `AgGridReact` component inside `AgGridProvider`, wrapped in a parent container `div` with a fixed height:
 
 ```jsx
+const modules = [AllCommunityModule];
+
 return (
-    // Data Grid will fill the size of the parent container
-    <div style={{ height: 500 }}>
-        <AgGridReact
-            rowData={rowData}
-            columnDefs={colDefs}
-        />
-    </div>
+    <AgGridProvider modules={modules}>
+        {/* Data Grid will fill the size of the parent container */}
+        <div style={{ height: 500 }}>
+            <AgGridReact
+                rowData={rowData}
+                columnDefs={colDefs}
+            />
+        </div>
+    </AgGridProvider>
 )
 ```
 {% /numberHeading %}

--- a/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/getting-started/index.mdoc
@@ -161,20 +161,26 @@ const gridOptions = {
 {% metaTag tags=["aggridreact"] /%}
 <!-- Create React -->
 
-{% numberHeading number="2" title="Register Modules" level="h3" %}
+{% numberHeading number="2" title="Provide Modules" level="h3" %}
 
 
- Register the `AllCommunityModule` to access all Community features:
+ Pass the `AllCommunityModule` to the `AgGridProvider` to access all Community features:
 
 ```js
-import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community'; 
+import { AllCommunityModule } from 'ag-grid-community';
+import { AgGridProvider } from 'ag-grid-react';  
 
-// Register all Community features
-ModuleRegistry.registerModules([AllCommunityModule]);
+function App() {
+    return (
+        <AgGridProvider modules={[AllCommunityModule]}>
+            {/* Your AgGridReact components go here */}
+        </AgGridProvider>
+    );
+}
 ```
 
 {% note %}
-To minimize bundle size, only register the modules you want to use. See the [Modules](./modules/) docs for more information.
+To minimize bundle size, only provide the modules you want to use. See the [Modules](./modules/) docs for more information.
 {% /note %}
 {% /numberHeading %}
 

--- a/documentation/ag-grid-docs/src/content/docs/installation/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/installation/index.mdoc
@@ -87,24 +87,37 @@ You can test AG Grid Enterprise locally without a licence. To test in production
 ### Registering Modules
 {% /if %}
 
-Register the `AllCommunityModule` to access all Community features:
+{% if isFramework("react") %}
+Use `AgGridProvider` to provide modules to all grid instances. Provide `AllCommunityModule` to access all Community features or `AllEnterpriseModule` to access all Community ***and*** Enterprise features:
+
+```jsx
+import { AllCommunityModule } from 'ag-grid-community';
+// import { AllEnterpriseModule } from 'ag-grid-enterprise';
+import { AgGridProvider, AgGridReact } from 'ag-grid-react';
+
+function App() {
+    return (
+        <AgGridProvider modules={[AllCommunityModule]}>
+            <AgGridReact /* ... props */ />
+        </AgGridProvider>
+    );
+}
+```
+
+{% /if %}
+
+{% if isFramework("javascript", "angular", "vue") %}
+Register the `AllCommunityModule` to access all Community features or `AllEnterpriseModule` to access all Community ***and*** Enterprise features:
 
 ```js
-import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community'; 
+import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community';
+// import { AllEnterpriseModule } from 'ag-grid-enterprise';
 
 // Register all Community features
 ModuleRegistry.registerModules([AllCommunityModule]);
 ```
 
-Register the `AllEnterpriseBundle` to access all Community ***and*** Enterprise features:
-
-```js
-import { ModuleRegistry } from 'ag-grid-community'; 
-import { AllEnterpriseModule } from 'ag-grid-enterprise';
-
-// Register all Community and Enterprise features
-ModuleRegistry.registerModules([AllEnterpriseModule]);
-```
+{% /if %}
 
 {% note %}
 To minimize bundle size, only register the modules you want to use. See the [Selecting Modules](./modules/) docs for more information.
@@ -119,10 +132,10 @@ To minimize bundle size, only register the modules you want to use. See the [Sel
 {% /if %}
 
 {% if isFramework("react") %}
-Import the `AgGridReact` component from the `ag-grid-react` package:
+Import `AgGridProvider` and `AgGridReact` from the `ag-grid-react` package:
 
 ```js
-import { AgGridReact } from 'ag-grid-react';
+import { AgGridProvider, AgGridReact } from 'ag-grid-react';
 ```
 {% /if %}
 

--- a/documentation/ag-grid-docs/src/content/docs/installation/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/installation/index.mdoc
@@ -95,9 +95,11 @@ import { AllCommunityModule } from 'ag-grid-community';
 // import { AllEnterpriseModule } from 'ag-grid-enterprise';
 import { AgGridProvider, AgGridReact } from 'ag-grid-react';
 
+const modules = [AllCommunityModule];
+
 function App() {
     return (
-        <AgGridProvider modules={[AllCommunityModule]}>
+        <AgGridProvider modules={modules}>
             <AgGridReact /* ... props */ />
         </AgGridProvider>
     );

--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-installation/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-installation/index.mdoc
@@ -5,6 +5,31 @@ enterprise: true
 
 This section shows how to install Integrated Charts.
 
+{% if isFramework("react") %}
+The Integrated Enterprise Charts module, which includes AG Charts Enterprise, can be provided via `AgGridProvider` as follows:
+
+```jsx
+import { ClientSideRowModelModule } from 'ag-grid-community';
+import { IntegratedChartsModule } from 'ag-grid-enterprise';
+import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
+import { AgGridProvider, AgGridReact } from 'ag-grid-react';
+
+const modules = [
+    ClientSideRowModelModule,
+    IntegratedChartsModule.with(AgChartsEnterpriseModule),
+];
+
+function App() {
+    return (
+        <AgGridProvider modules={modules}>
+            <AgGridReact /* ... props */ />
+        </AgGridProvider>
+    );
+}
+```
+{% /if %}
+
+{% if isFramework("javascript", "angular", "vue") %}
 The Integrated Enterprise Charts module, which includes AG Charts Enterprise, can be imported as follows:
 
 ```ts
@@ -18,6 +43,7 @@ ModuleRegistry.registerModules([
     IntegratedChartsModule.with(AgChartsEnterpriseModule)
 ]);
 ```
+{% /if %}
 
 {% note %}
 AG Charts Community (`AgChartsCommunityModule`) is available from the `ag-charts-community` package.

--- a/documentation/ag-grid-docs/src/content/docs/modules/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/modules/index.mdoc
@@ -141,9 +141,6 @@ If using the bundles (`AllCommunityModule`/`AllEnterpriseModule`), the `Validati
 {% if isFramework("react") %}
 When including AG Grid in your application the required modules must be registered with the grid before it is instantiated. You can either register them globally, via the `ModuleRegistry`, via the `AgGridProvider` or pass them directly to each grid.
 
-{% note %}
-If using server-side rendering, ensure modules are registered in the client side of your application.
-{% /note %}
 
 {% /if %}
 
@@ -152,14 +149,13 @@ If using server-side rendering, ensure modules are registered in the client side
 When including AG Grid in your application the required modules must be registered with the grid before it is instantiated. You can either register them globally, via the `ModuleRegistry` or pass them directly to each grid.
 {% /if %}
 
-### Providing Modules Globally
-
-You can import and register modules globally, but you need to ensure that this is done before **_any_** grids are instantiated. Any modules registered globally will be available to all grids.
-
-A real-world example might be that we wish to use the `Client-Side Row Model` (the default row model) together with the `CSV`, `Excel` and `Master/Detail` features.
-
 {% if isFramework("react") %}
-Wrap your application (or the part that uses AG Grid) with `AgGridProvider` and pass the modules:
+
+### Providing Modules via AgGridProvider
+
+Since v35.1 use the `AgGridProvider` component to provide modules to all `AgGridReact` components within the scope of the provider.
+
+As an example to use the `Client-Side Row Model` (the default row model) together with the `CSV`, `Excel` and `Master/Detail` features, you would do the following:
 
 ```jsx
 import { ClientSideRowModelModule, CsvExportModule } from 'ag-grid-community';
@@ -183,15 +179,13 @@ function App() {
 }
 ```
 
-
-
-{% note %}
-As an alternative, you can register modules globally using `ModuleRegistry.registerModules([modules])` outside of the React component tree.
-{% /note %}
 {% /if %}
 
-{% if isFramework("javascript", "angular", "vue") %}
-We need to register the grid modules we wish to use via the `ModuleRegistry`.
+### Providing Modules Globally
+
+You can import and register modules globally, but you need to ensure that this is done before **_any_** grids are instantiated. Any modules registered globally will be available to all grids.
+
+As an example to use the `Client-Side Row Model` (the default row model) together with the `CSV`, `Excel` and `Master/Detail` features, you would do the following:
 
 ```js
 import { ModuleRegistry, ClientSideRowModelModule, CsvExportModule } from 'ag-grid-community';
@@ -204,6 +198,11 @@ ModuleRegistry.registerModules([
     MasterDetailModule
 ]);
 ```
+
+{% if isFramework("react") %}
+{% note %}
+If using server-side rendering, ensure modules are registered in the client side of your application.
+{% /note %}
 {% /if %}
 
 ### Providing Modules To Individual Grids
@@ -217,7 +216,7 @@ The steps required are:
 * Import Modules
 * Pass to Grid
 
-Using the same real-world example from above (the `Client-Side Row Model` together with the `CSV`, `Excel` and `Master/Detail` features), how we register the modules is now different.
+Using the same example from above (the `Client-Side Row Model` together with the `CSV`, `Excel` and `Master/Detail` features), how we register the modules is now different.
 
 {% if isFramework("javascript") %}
 We pass the modules to createGrid via the `modules` property of the `params`.

--- a/documentation/ag-grid-docs/src/content/docs/modules/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/modules/index.mdoc
@@ -28,14 +28,16 @@ The grid provides two module bundles for ease of use:
 
 {% if isFramework("react") %}
 ```jsx
-import { AllCommunityModule } from 'ag-grid-community'; 
-// import { AllEnterpriseModule } from 'ag-grid-enterprise'; 
+import { AllCommunityModule } from 'ag-grid-community';
+// import { AllEnterpriseModule } from 'ag-grid-enterprise';
 import { AgGridProvider, AgGridReact } from 'ag-grid-react';
+
+const modules = [AllCommunityModule]; // or [AllEnterpriseModule]
 
 // Wrap your application (or the part that uses AG Grid) with AgGridProvider
 function App() {
     return (
-        <AgGridProvider modules={ [AllCommunityModule] }>            
+        <AgGridProvider modules={modules}>
             <AgGridReact /* ... props */ />
         </AgGridProvider>
     );
@@ -67,11 +69,11 @@ import { AllEnterpriseModule } from 'ag-grid-enterprise';
 import { AgGridProvider, AgGridReact } from 'ag-grid-react';
 
 // All Enterprise Features, with Integrated Charts and Sparklines
+const modules = [AllEnterpriseModule.with(AgChartsEnterpriseModule)];
+
 function App() {
     return (
-        <AgGridProvider 
-            modules={ [AllEnterpriseModule.with(AgChartsEnterpriseModule)] }
-            >
+        <AgGridProvider modules={modules}>
             <AgGridReact /* ... props */ />
         </AgGridProvider>
     );

--- a/documentation/ag-grid-docs/src/content/docs/modules/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/modules/index.mdoc
@@ -19,33 +19,78 @@ Alternatively, if you are not concerned about bundle size and you want access to
 
 ## Bundles
 
-The `AllCommunityModule` bundle contains all of the modules available in AG Grid Community. The `AllEnterpriseModule` bundle contains all of the modules available in Community and Enterprise. Registering one of these bundles replicates the behaviour of the package versions of AG Grid prior to version 33:
+The grid provides two module bundles for ease of use:
 
+ - `AllCommunityModule` bundle contains all of the modules available in AG Grid Community.
+ - `AllEnterpriseModule` bundle contains `AllCommunityModule` and all modules available in AG Grid Enterprise. 
+ 
+ Registering one of these bundles replicates the behaviour of the package versions of AG Grid prior to version 33:
+
+{% if isFramework("react") %}
+```jsx
+import { AllCommunityModule } from 'ag-grid-community'; 
+// import { AllEnterpriseModule } from 'ag-grid-enterprise'; 
+import { AgGridProvider, AgGridReact } from 'ag-grid-react';
+
+// Wrap your application (or the part that uses AG Grid) with AgGridProvider
+function App() {
+    return (
+        <AgGridProvider modules={ [AllCommunityModule] }>            
+            <AgGridReact /* ... props */ />
+        </AgGridProvider>
+    );
+}
+```
+{% /if %}
+
+{% if isFramework("javascript", "angular", "vue") %}
 ```js
-// Import ModuleRegistry and the required module
 import {
     ModuleRegistry,
-    AllCommunityModule, // or AllEnterpriseModule
+    AllCommunityModule
 } from 'ag-grid-community';
+// import { AllEnterpriseModule } from 'ag-grid-enterprise';
 
 // Register the module
 ModuleRegistry.registerModules([
     AllCommunityModule, // or AllEnterpriseModule
 ]);
 ```
+{% /if %}
 
 If you are using [Integrated Charts](./integrated-charts/) or [Sparklines](./sparklines-overview/), then you need to provide the relevant module from AG Charts to `AllEnterpriseModule`, for example:
 
+{% if isFramework("react") %}
+```jsx
+import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
+import { AgGridProvider, AgGridReact } from 'ag-grid-react';
+
+// All Enterprise Features, with Integrated Charts and Sparklines
+function App() {
+    return (
+        <AgGridProvider 
+            modules={ [AllEnterpriseModule.with(AgChartsEnterpriseModule)] }
+            >
+            <AgGridReact /* ... props */ />
+        </AgGridProvider>
+    );
+}
+```
+{% /if %}
+
+{% if isFramework("javascript", "angular", "vue") %}
 ```js
 import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
 import { ModuleRegistry } from 'ag-grid-community';
-import { AllEnterpriseModule,} from 'ag-grid-enterprise';
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
 
-// All Enterprise Features, with Integrated Charts and Sparklines 
+// All Enterprise Features, with Integrated Charts and Sparklines
 ModuleRegistry.registerModules([
     AllEnterpriseModule.with(AgChartsEnterpriseModule),
 ]);
 ```
+{% /if %}
 
 ## Selecting Modules
 
@@ -53,34 +98,97 @@ To work out which modules are required, select the features of the grid that you
 
 {% moduleMappings /%}
 
+{% if isFramework("react") %}
+{% note %}The code snippet above shows providing modules via `AgGridProvider`. It is also possible to [Provide Modules To Individual Grids](#providing-modules-to-individual-grids) or use the `ModuleRegistry` for global registration.{% /note %}
+{% /if %}
+{% if isFramework("javascript", "angular", "vue") %}
 {% note %}The code snippet above shows registering modules globally. It is also possible to [Provide Modules To Individual Grids](#providing-modules-to-individual-grids){% /note %}
+{% /if %}
 
 ## Development Validations
 
 The `ValidationModule` adds helpful console warnings/errors that can help identify bad configuration during development. When using Modules it is recommended to only include it in your development build to ensure your production build is as small as possible.
 
+{% if isFramework("react") %}
+```jsx
+import { ValidationModule } from 'ag-grid-community';
+
+const modules = [
+    // Other modules...
+    // Include ValidationModule only in development
+    ...(process.env.NODE_ENV !== 'production' ? [ValidationModule] : []),
+];
+```
+{% /if %}
+
+{% if isFramework("javascript", "angular", "vue") %}
 ```js
+import { ModuleRegistry, ValidationModule } from 'ag-grid-community';
+
 // via process.env.NODE_ENV
 if(process.env.NODE_ENV !== 'production') {
     ModuleRegistry.registerModules([ValidationModule]);
 }
 ```
+{% /if %}
 
- If using the bundles (`AllCommunityModule`/`AllEnterpriseModule`), the `ValidationModule` is included by default.
+If using the bundles (`AllCommunityModule`/`AllEnterpriseModule`), the `ValidationModule` is included by default.
 
 ## Registering AG Grid Modules
 
-When including AG Grid in your application via modules it is your responsibility to register the required modules with the grid before it is instantiated. You can either register them globally or pass them individually to each grid instance.
+{% if isFramework("react") %}
+When including AG Grid in your application the required modules must be registered with the grid before it is instantiated. You can either register them globally, via the `ModuleRegistry`, via the `AgGridProvider` or pass them directly to each grid.
+
+{% note %}
+If using server-side rendering, ensure modules are registered in the client side of your application.
+{% /note %}
+
+{% /if %}
+
+
+{% if isFramework("javascript", "angular", "vue") %}
+When including AG Grid in your application the required modules must be registered with the grid before it is instantiated. You can either register them globally, via the `ModuleRegistry` or pass them directly to each grid.
+{% /if %}
 
 ### Providing Modules Globally
 
 You can import and register modules globally, but you need to ensure that this is done before **_any_** grids are instantiated. Any modules registered globally will be available to all grids.
 
-* Import Modules
-* Register Modules
-
 A real-world example might be that we wish to use the `Client-Side Row Model` (the default row model) together with the `CSV`, `Excel` and `Master/Detail` features.
 
+{% if isFramework("react") %}
+Wrap your application (or the part that uses AG Grid) with `AgGridProvider` and pass the modules:
+
+```jsx
+import { ClientSideRowModelModule, CsvExportModule } from 'ag-grid-community';
+import { ExcelExportModule, MasterDetailModule } from 'ag-grid-enterprise';
+import { AgGridProvider, AgGridReact } from 'ag-grid-react';
+
+const modules = [
+    ClientSideRowModelModule,
+    CsvExportModule,
+    ExcelExportModule,
+    MasterDetailModule,
+];
+
+function App() {
+    return (
+        <AgGridProvider modules={modules}>
+            {/* All AgGridReact components within this provider will have access to these modules */}
+            <AgGridReact /* ... props */ />
+        </AgGridProvider>
+    );
+}
+```
+
+
+
+{% note %}
+As an alternative, you can register modules globally using `ModuleRegistry.registerModules([modules])` outside of the React component tree.
+{% /note %}
+{% /if %}
+
+{% if isFramework("javascript", "angular", "vue") %}
 We need to register the grid modules we wish to use via the `ModuleRegistry`.
 
 ```js
@@ -94,11 +202,6 @@ ModuleRegistry.registerModules([
     MasterDetailModule
 ]);
 ```
-
-{% if isFramework("react") %}
-{% note %}
-If using server-side rendering, modules need to be registered on the client and not the server.
-{% /note %}
 {% /if %}
 
 ### Providing Modules To Individual Grids
@@ -161,35 +264,30 @@ export class GridExample {
 {% /if %}
 
 {% if isFramework("react") %}
-We pass the modules to the `modules` prop:
-{% /if %}
+Use `AgGridProvider` for shared modules and pass grid-specific modules directly to `AgGridReact` via the `modules` prop. Modules from both sources will be combined:
 
-{% if isFramework("react") %}
-```js
-import React, { useState } from 'react';
-import { createRoot } from 'react-dom/client';
-import { AgGridReact } from 'ag-grid-react';
+```jsx
 import { ClientSideRowModelModule, CsvExportModule } from 'ag-grid-community';
 import { ExcelExportModule, MasterDetailModule } from 'ag-grid-enterprise';
+import { AgGridProvider, AgGridReact } from 'ag-grid-react';
 
-const GridExample = () => {
-    // ... rest of component ...
+// Shared modules available to all grids
+const sharedModules = [ClientSideRowModelModule, CsvExportModule];
 
+// Grid-specific modules
+const gridSpecificModules = [ExcelExportModule, MasterDetailModule];
+
+function App() {
     return (
-        <div style={{height: 400, width: 900}}>
+        <AgGridProvider modules={sharedModules}>
             <AgGridReact
-                // Pass Modules to this individual grid
-                modules={[
-                    ClientSideRowModelModule,
-                    CsvExportModule,
-                    ExcelExportModule,
-                    MasterDetailModule
-                ]}
+                // These modules are combined with those from AgGridProvider
+                modules={gridSpecificModules}
                 // ... other properties
             />
-        </div>
+        </AgGridProvider>
     );
-};
+}
 ```
 {% /if %}
 
@@ -218,11 +316,16 @@ data() {
 ```
 {% /if %}
 
-The following example shows how you can configure individual grids using a combination of shared Global registrations as well as individual grid module registration. Note the following:
+The following example shows how you can configure individual grids using a combination of shared modules as well as individual grid module registration. Note the following:
 
+{% if isFramework("react") %}
+* Shared modules via `AgGridProvider`:  `[ClientSideRowModelModule, ColumnMenuModule, ContextMenuModule]`.
+{% /if %}
+{% if isFramework("javascript", "angular", "vue") %}
 * Globally registered modules:  `[ClientSideRowModelModule, ColumnMenuModule, ContextMenuModule]`.
+{% /if %}
 * Left Grid individually registers: `[ClipboardModule, CsvExportModule, SetFilterModule]`
-* Right Grid individually registers: `[ CsvExportModule, ExcelExportModule, NumberFilterModule, TextFilterModule]`
+* Right Grid individually registers: `[CsvExportModule, ExcelExportModule, NumberFilterModule, TextFilterModule]`
 
 To see the difference in features open the context menu and open the column filter:
 

--- a/documentation/ag-grid-docs/src/content/docs/sparklines-installation/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/sparklines-installation/index.mdoc
@@ -8,6 +8,48 @@ This section shows how to install Sparklines.
 Sparklines are an enterprise grid feature powered by AG Charts.
 You can use either AG Charts Community or AG Charts Enterprise, depending on your setup.
 
+{% if isFramework("react") %}
+The Sparklines module can be provided via `AgGridProvider` as follows:
+
+{% tabs %}
+    {% tabItem id="SparklinesInstallationChartsCommunityReact" label="Using AG Charts Community" %}
+```jsx
+import { AgChartsCommunityModule } from 'ag-charts-community';
+import { SparklinesModule } from 'ag-grid-enterprise';
+import { AgGridProvider, AgGridReact } from 'ag-grid-react';
+
+const modules = [SparklinesModule.with(AgChartsCommunityModule)];
+
+function App() {
+    return (
+        <AgGridProvider modules={modules}>
+            <AgGridReact /* ... props */ />
+        </AgGridProvider>
+    );
+}
+```
+    {% /tabItem %}
+    {% tabItem id="SparklinesInstallationChartsEnterpriseReact" label="Using AG Charts Enterprise" %}
+```jsx
+import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
+import { SparklinesModule } from 'ag-grid-enterprise';
+import { AgGridProvider, AgGridReact } from 'ag-grid-react';
+
+const modules = [SparklinesModule.with(AgChartsEnterpriseModule)];
+
+function App() {
+    return (
+        <AgGridProvider modules={modules}>
+            <AgGridReact /* ... props */ />
+        </AgGridProvider>
+    );
+}
+```
+    {% /tabItem %}
+{% /tabs %}
+{% /if %}
+
+{% if isFramework("javascript", "angular", "vue") %}
 The Sparklines module can be imported as follows:
 
 {% tabs %}
@@ -18,6 +60,7 @@ The Sparklines module can be imported as follows:
         {% partial file="./_sparklines_charts_enterprise.mdoc" /%}
     {% /tabItem %}
 {% /tabs %}
+{% /if %}
 
 ## Next Up
 


### PR DESCRIPTION
Fix [AG-13371](https://ag-grid.atlassian.net/browse/AG-13371) 

Updates docs for React to show the AgGridProvider instead of ModuleRegistry.
Show how to use the AgGridProvider to provide a license key for React instead of via the LicenseManager