### PR TITLE
AG-16610 full row editing leaves leaves empty editor bug patch

### DIFF
--- a/packages/ag-grid-community/src/edit/strategy/fullRowEditStrategy.ts
+++ b/packages/ag-grid-community/src/edit/strategy/fullRowEditStrategy.ts
@@ -6,7 +6,12 @@ import type { EditPosition, EditRowPosition, StartEditWithPositionParams } from 
 import type { IRowNode } from '../../interfaces/iRowNode';
 import type { CellCtrl } from '../../rendering/cell/cellCtrl';
 import { _getCellCtrl, _getRowCtrl } from '../utils/controllers';
-import { _populateModelValidationErrors, _setupEditor, _sourceAndPendingDiffer } from '../utils/editors';
+import {
+    _destroyEditor,
+    _populateModelValidationErrors,
+    _setupEditor,
+    _sourceAndPendingDiffer,
+} from '../utils/editors';
 import type { EditValidationAction, EditValidationResult } from './baseEditStrategy';
 import { BaseEditStrategy } from './baseEditStrategy';
 
@@ -183,10 +188,39 @@ export class FullRowEditStrategy extends BaseEditStrategy {
 
     public override cleanupEditors(position: EditRowPosition = {}, includeEditing?: boolean): void {
         super.cleanupEditors(position, includeEditing);
+
         for (const rowNode of this.startedRows) {
             this.dispatchRowEvent({ rowNode }, 'rowEditingStopped');
+            this.destroyEditorsForRow(rowNode);
         }
         this.startedRows.length = 0;
+    }
+
+    /**
+     * Destroys all editors for a row that started full row editing, including editors
+     * that are not represented in the edit model (e.g. empty/unedited editors).
+     */
+    private destroyEditorsForRow(rowNode: IRowNode): void {
+        const rowCtrl = _getRowCtrl(this.beans, { rowNode });
+        if (!rowCtrl) {
+            return; // Row not rendered, no editors to destroy.
+        }
+
+        const destroyedColumns = new Set<AgColumn>();
+        for (const cellCtrl of rowCtrl.getAllCellCtrls()) {
+            const column = cellCtrl.column;
+            if (destroyedColumns.has(column)) {
+                continue; // Column editor already processed.
+            }
+            destroyedColumns.add(column);
+
+            if (!cellCtrl.comp?.getCellEditor()) {
+                continue; // No editor to destroy.
+            }
+
+            // Destroy every editor created for this row, including those without edit model entries.
+            _destroyEditor(this.beans, cellCtrl, undefined, cellCtrl);
+        }
     }
 
     // returns null if no navigation should be performed

--- a/packages/ag-grid-community/src/edit/strategy/fullRowEditStrategy.ts
+++ b/packages/ag-grid-community/src/edit/strategy/fullRowEditStrategy.ts
@@ -206,20 +206,11 @@ export class FullRowEditStrategy extends BaseEditStrategy {
             return; // Row not rendered, no editors to destroy.
         }
 
-        const destroyedColumns = new Set<AgColumn>();
+        // Destroy every editor created for this row, including those without edit model entries.
         for (const cellCtrl of rowCtrl.getAllCellCtrls()) {
-            const column = cellCtrl.column;
-            if (destroyedColumns.has(column)) {
-                continue; // Column editor already processed.
+            if (cellCtrl.comp?.getCellEditor()) {
+                _destroyEditor(this.beans, cellCtrl, undefined, cellCtrl);
             }
-            destroyedColumns.add(column);
-
-            if (!cellCtrl.comp?.getCellEditor()) {
-                continue; // No editor to destroy.
-            }
-
-            // Destroy every editor created for this row, including those without edit model entries.
-            _destroyEditor(this.beans, cellCtrl, undefined, cellCtrl);
         }
     }
 

--- a/packages/ag-grid-community/src/edit/utils/editors.ts
+++ b/packages/ag-grid-community/src/edit/utils/editors.ts
@@ -446,11 +446,11 @@ type DestroyEditorParams = { event?: Event | null; silent?: boolean; cancel?: bo
 export function _destroyEditor(
     beans: BeanCollection,
     position: Required<EditPosition>,
-    params?: DestroyEditorParams
+    params?: DestroyEditorParams,
+    cellCtrl = _getCellCtrl(beans, position)
 ): void {
     const enableGroupEditing = beans.gos.get('enableGroupEdit');
-    const { editModelSvc } = beans;
-    const cellCtrl = _getCellCtrl(beans, position);
+    const editModelSvc = beans.editModelSvc;
 
     const edit = editModelSvc?.getEdit(position, true);
 
@@ -462,10 +462,11 @@ export function _destroyEditor(
         return;
     }
 
-    const { comp } = cellCtrl;
+    const comp = cellCtrl.comp;
+    const cellEditor = comp?.getCellEditor();
 
     // editor already cleaned up, refresh cell (React usually)
-    if (comp && !comp.getCellEditor()) {
+    if (comp && !cellEditor) {
         cellCtrl?.refreshCell();
 
         if (edit) {
@@ -484,7 +485,7 @@ export function _destroyEditor(
     }
 
     if (_hasValidationRules(beans)) {
-        const errorMessages = comp?.getCellEditor()?.getValidationErrors?.();
+        const errorMessages = edit && cellEditor?.getValidationErrors?.();
         const cellValidationModel = editModelSvc?.getCellValidationModel();
 
         if (errorMessages?.length) {
@@ -494,7 +495,9 @@ export function _destroyEditor(
         }
     }
 
-    editModelSvc?.setEdit(position, { state: 'changed' });
+    if (edit) {
+        editModelSvc?.setEdit(position, { state: 'changed' });
+    }
 
     comp?.setEditDetails(); // passing nothing stops editing
     comp?.refreshEditStyles(false, false);

--- a/testing/behavioural/src/cell-editing/cell-editing-regression.test.ts
+++ b/testing/behavioural/src/cell-editing/cell-editing-regression.test.ts
@@ -18,6 +18,7 @@ import {
     asyncSetTimeout,
     fakeElementAttribute,
     getAllRows,
+    getRowHtmlElement,
     waitForInput,
     waitForPopup,
 } from '../test-utils';
@@ -68,6 +69,155 @@ describe('Cell Editing Regression', () => {
             expect(inputElement).toHaveValue(expected as any);
             expect(valueFormatter).toHaveBeenCalled();
         });
+    });
+
+    test('full-row editing tab to next row starts editors when focusing read-only cell', async () => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [
+                { field: 'readOnly', headerName: 'Read Only', editable: false },
+                { field: 'make' },
+                { field: 'model' },
+            ],
+            defaultColDef: {
+                editable: true,
+            },
+            editType: 'fullRow',
+            rowData: [
+                { readOnly: 'RO-0', make: 'Toyota', model: 'Celica' },
+                { readOnly: 'RO-1', make: 'Ford', model: 'Mondeo' },
+            ],
+        });
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        await asyncSetTimeout(1);
+
+        const makeCellRow0 = getByTestId(gridDiv, agTestIdFor.cell('0', 'make'));
+        await userEvent.dblClick(makeCellRow0);
+        await waitForInput(gridDiv, makeCellRow0, { popup: false });
+
+        await userEvent.keyboard('{Tab}{Tab}');
+        await asyncSetTimeout(1);
+
+        const modelCellRow1 = getByTestId(gridDiv, agTestIdFor.cell('1', 'model'));
+        const editor = await waitForInput(gridDiv, modelCellRow1, { popup: false });
+        await userEvent.clear(editor);
+        await userEvent.type(editor, 'Updated');
+        await userEvent.keyboard('{Enter}');
+
+        expect(modelCellRow1).toHaveTextContent('Updated');
+    });
+
+    test('full-row editing fires rowEditingStopped on stopEditing', async () => {
+        const onRowEditingStopped = vi.fn();
+
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [{ field: 'make' }, { field: 'model' }],
+            defaultColDef: {
+                editable: true,
+            },
+            editType: 'fullRow',
+            rowData: [
+                { make: 'Toyota', model: 'Celica' },
+                { make: 'Ford', model: 'Mondeo' },
+            ],
+            onRowEditingStopped,
+        });
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        await asyncSetTimeout(1);
+
+        const makeCellRow0 = getByTestId(gridDiv, agTestIdFor.cell('0', 'make'));
+        await userEvent.dblClick(makeCellRow0);
+        await waitForInput(gridDiv, makeCellRow0, { popup: false });
+
+        api.stopEditing();
+        await asyncSetTimeout(1);
+
+        expect(onRowEditingStopped).toHaveBeenCalledTimes(1);
+        expect(onRowEditingStopped.mock.calls[0][0].rowIndex).toBe(0);
+    });
+
+    test('full-row editing closes empty editors when tabbing to next row', async () => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [{ field: 'make' }, { field: 'model' }, { field: 'model3' }],
+            defaultColDef: {
+                editable: true,
+            },
+            editType: 'fullRow',
+            rowData: [
+                { make: 'Toyota', model: 'Celica', model3: undefined },
+                { make: 'Ford', model: 'Mondeo', model3: undefined },
+            ],
+        });
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        await asyncSetTimeout(1);
+
+        const makeCellRow0 = getByTestId(gridDiv, agTestIdFor.cell('0', 'make'));
+        await userEvent.dblClick(makeCellRow0);
+        await waitForInput(gridDiv, makeCellRow0, { popup: false });
+        expect(getRowHtmlElement(api, '0')?.classList.contains('ag-row-editing')).toBe(true);
+        expect(getRowHtmlElement(api, '1')?.classList.contains('ag-row-editing')).toBe(false);
+        expect(api.isEditing({ rowIndex: 0, rowPinned: undefined, column: api.getColumn('model3')! })).toBe(true);
+
+        await userEvent.keyboard('{Tab}{Tab}{Tab}');
+        const makeCellRow1 = getByTestId(gridDiv, agTestIdFor.cell('1', 'make'));
+        await waitForInput(gridDiv, makeCellRow1, { popup: false });
+
+        await waitFor(() => {
+            const editingCells = api.getEditingCells();
+            expect(editingCells.length).toBeGreaterThan(0);
+            expect(editingCells.every((cell) => cell.rowIndex === 1)).toBe(true);
+        });
+        expect(getRowHtmlElement(api, '0')?.classList.contains('ag-row-editing')).toBe(false);
+        expect(getRowHtmlElement(api, '1')?.classList.contains('ag-row-editing')).toBe(true);
+        expect(api.isEditing({ rowIndex: 0, rowPinned: undefined, column: api.getColumn('model3')! })).toBe(false);
+        expect(api.isEditing({ rowIndex: 1, rowPinned: undefined, column: api.getColumn('model3')! })).toBe(true);
+
+        const emptyCellRow0 = getByTestId(gridDiv, agTestIdFor.cell('0', 'model3'));
+        expect(emptyCellRow0.querySelector('input')).toBeNull();
+    });
+
+    test('full-row editing closes empty editors when shift-tabbing to previous row', async () => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [{ field: 'make' }, { field: 'model' }, { field: 'model3' }],
+            defaultColDef: {
+                editable: true,
+            },
+            editType: 'fullRow',
+            rowData: [
+                { make: 'Toyota', model: 'Celica', model3: undefined },
+                { make: 'Ford', model: 'Mondeo', model3: undefined },
+            ],
+        });
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        await asyncSetTimeout(1);
+
+        const makeCellRow1 = getByTestId(gridDiv, agTestIdFor.cell('1', 'make'));
+        await userEvent.dblClick(makeCellRow1);
+        await waitForInput(gridDiv, makeCellRow1, { popup: false });
+        expect(getRowHtmlElement(api, '1')?.classList.contains('ag-row-editing')).toBe(true);
+        expect(getRowHtmlElement(api, '0')?.classList.contains('ag-row-editing')).toBe(false);
+        expect(api.isEditing({ rowIndex: 0, rowPinned: undefined, column: api.getColumn('model3')! })).toBe(false);
+        expect(api.isEditing({ rowIndex: 1, rowPinned: undefined, column: api.getColumn('model3')! })).toBe(true);
+
+        await userEvent.keyboard('{Shift>}{Tab}{/Shift}');
+        const model3CellRow0 = getByTestId(gridDiv, agTestIdFor.cell('0', 'model3'));
+        await waitForInput(gridDiv, model3CellRow0, { popup: false });
+
+        await waitFor(() => {
+            const editingCells = api.getEditingCells();
+            expect(editingCells.length).toBeGreaterThan(0);
+            expect(editingCells.every((cell) => cell.rowIndex === 0)).toBe(true);
+        });
+        expect(getRowHtmlElement(api, '0')?.classList.contains('ag-row-editing')).toBe(true);
+        expect(getRowHtmlElement(api, '1')?.classList.contains('ag-row-editing')).toBe(false);
+        expect(api.isEditing({ rowIndex: 0, rowPinned: undefined, column: api.getColumn('model3')! })).toBe(true);
+        expect(api.isEditing({ rowIndex: 1, rowPinned: undefined, column: api.getColumn('model3')! })).toBe(false);
+
+        const emptyCellRow1 = getByTestId(gridDiv, agTestIdFor.cell('1', 'model3'));
+        expect(emptyCellRow1.querySelector('input')).toBeNull();
     });
 
     // AG-15698 - row doesn't rerender after value is selected in rich select editor


### PR DESCRIPTION
The problem seems to lie in the fact that the model does not track properly empty cells.
Iterating through all editor controls that are not yet destroyed and destroying them seems the right solution

FIX AG-16610