### PR TITLE
[AG-16637] Fix(filters): preset date filters keep resetting cache every event loop cycle 1 minute before midnight

### DIFF
--- a/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.test.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.test.ts
@@ -138,9 +138,9 @@ describe('getOrRefreshRangeCacheItem', () => {
         const second = handler.getOrRefreshRangeCacheItem(key, rangeFn);
 
         expect(rangeFn).toHaveBeenCalledTimes(2);
-        expect(first[0]).not.toBe(second[0]);
-        expect(first[1]).not.toBe(second[1]);
-        expect(second.map((date) => date.getTime())).toStrictEqual([3, 4]);
+        expect(first.from).not.toBe(second.from);
+        expect(first.to).not.toBe(second.to);
+        expect([second.from, second.to].map((date) => date.getTime())).toStrictEqual([3, 4]);
     });
 
     it('keeps separate caches per key', () => {
@@ -153,7 +153,7 @@ describe('getOrRefreshRangeCacheItem', () => {
 
         expect(rangeFnToday).toHaveBeenCalledTimes(1);
         expect(rangeFnYesterday).toHaveBeenCalledTimes(1);
-        expect(today.map((date) => date.getTime())).toStrictEqual([10, 20]);
-        expect(yesterday.map((date) => date.getTime())).toStrictEqual([30, 40]);
+        expect([today.from, today.to].map((date) => date.getTime())).toStrictEqual([10, 20]);
+        expect([yesterday.from, yesterday.to].map((date) => date.getTime())).toStrictEqual([30, 40]);
     });
 });

--- a/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.test.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.test.ts
@@ -1,4 +1,4 @@
-import { presetDateFilterTypeRelativeFromToMap } from './dateFilterHandler';
+import { DateFilterHandler, presetDateFilterTypeRelativeFromToMap } from './dateFilterHandler';
 
 describe('presetDateFilterTypeRelativeFromToMap', () => {
     const BASE = 'Wed Apr 08 2020 12:34:56 GMT+0000 (Coordinated Universal Time)';
@@ -97,4 +97,42 @@ describe('presetDateFilterTypeRelativeFromToMap', () => {
     ])('%s', (fnName, expected) =>
         it('works', () => expect(presetDateFilterTypeRelativeFromToMap[fnName](FROM).toString()).toContain(expected))
     );
+});
+
+describe('DateFilterHandler refresh scheduling', () => {
+    const BASE_TIME = new Date(2020, 3, 8, 23, 59, 10, 0);
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(BASE_TIME);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+    });
+
+    it('schedules refresh at the start of the next day', () => {
+        const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout');
+
+        // eslint-disable-next-line sonarjs/constructor-for-side-effects
+        new DateFilterHandler();
+
+        expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+        const [, delay] = setTimeoutSpy.mock.calls[0];
+        expect(delay).toBe(50 * 1000);
+    });
+
+    it('reschedules for the next midnight after running', () => {
+        const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout');
+
+        // eslint-disable-next-line sonarjs/constructor-for-side-effects
+        new DateFilterHandler();
+
+        jest.advanceTimersByTime(50 * 1000);
+
+        expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
+        const [, delay] = setTimeoutSpy.mock.calls[1];
+        expect(delay).toBe(24 * 60 * 60 * 1000);
+    });
 });

--- a/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.test.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.test.ts
@@ -1,3 +1,4 @@
+import type { ISimpleFilterModelPresetType } from '../iSimpleFilter';
 import { DateFilterHandler, presetDateFilterTypeRelativeFromToMap } from './dateFilterHandler';
 
 describe('presetDateFilterTypeRelativeFromToMap', () => {
@@ -99,40 +100,60 @@ describe('presetDateFilterTypeRelativeFromToMap', () => {
     );
 });
 
-describe('DateFilterHandler refresh scheduling', () => {
-    const BASE_TIME = new Date(2020, 3, 8, 23, 59, 10, 0);
+describe('getOrRefreshRangeCacheItem', () => {
+    const key = 'today' as ISimpleFilterModelPresetType;
 
     beforeEach(() => {
         jest.useFakeTimers();
-        jest.setSystemTime(BASE_TIME);
+        jest.setSystemTime(new Date(0));
     });
 
     afterEach(() => {
         jest.useRealTimers();
-        jest.restoreAllMocks();
     });
 
-    it('schedules refresh at the start of the next day', () => {
-        const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout');
+    it('returns cached range for the same key before expiry', () => {
+        const handler = new DateFilterHandler();
+        const rangeFn = jest.fn(() => [new Date(1), new Date(2)] as [Date, Date]);
 
-        // eslint-disable-next-line sonarjs/constructor-for-side-effects
-        new DateFilterHandler();
+        const first = handler.getOrRefreshRangeCacheItem(key, rangeFn);
+        const second = handler.getOrRefreshRangeCacheItem(key, rangeFn);
 
-        expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
-        const [, delay] = setTimeoutSpy.mock.calls[0];
-        expect(delay).toBe(50 * 1000);
+        expect(rangeFn).toHaveBeenCalledTimes(1);
+        expect(first[0]).toBe(second[0]);
+        expect(first[1]).toBe(second[1]);
     });
 
-    it('reschedules for the next midnight after running', () => {
-        const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout');
+    it('refreshes the cache when expired', () => {
+        const handler = new DateFilterHandler();
+        const rangeFn = jest
+            .fn()
+            .mockImplementationOnce(() => [new Date(1), new Date(2)] as [Date, Date])
+            .mockImplementationOnce(() => [new Date(3), new Date(4)] as [Date, Date]);
 
-        // eslint-disable-next-line sonarjs/constructor-for-side-effects
-        new DateFilterHandler();
+        const first = handler.getOrRefreshRangeCacheItem(key, rangeFn);
 
-        jest.advanceTimersByTime(50 * 1000);
+        jest.setSystemTime(new Date(86_400_001));
 
-        expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
-        const [, delay] = setTimeoutSpy.mock.calls[1];
-        expect(delay).toBe(24 * 60 * 60 * 1000);
+        const second = handler.getOrRefreshRangeCacheItem(key, rangeFn);
+
+        expect(rangeFn).toHaveBeenCalledTimes(2);
+        expect(first[0]).not.toBe(second[0]);
+        expect(first[1]).not.toBe(second[1]);
+        expect(second.map((date) => date.getTime())).toStrictEqual([3, 4]);
+    });
+
+    it('keeps separate caches per key', () => {
+        const handler = new DateFilterHandler();
+        const rangeFnToday = jest.fn(() => [new Date(10), new Date(20)] as [Date, Date]);
+        const rangeFnYesterday = jest.fn(() => [new Date(30), new Date(40)] as [Date, Date]);
+
+        const today = handler.getOrRefreshRangeCacheItem('today', rangeFnToday);
+        const yesterday = handler.getOrRefreshRangeCacheItem('yesterday', rangeFnYesterday);
+
+        expect(rangeFnToday).toHaveBeenCalledTimes(1);
+        expect(rangeFnYesterday).toHaveBeenCalledTimes(1);
+        expect(today.map((date) => date.getTime())).toStrictEqual([10, 20]);
+        expect(yesterday.map((date) => date.getTime())).toStrictEqual([30, 40]);
     });
 });

--- a/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.ts
@@ -20,26 +20,32 @@ function defaultDateComparator(filterDate: Date, cellValue: any): number {
     return 0;
 }
 
+type RangeCacheItem = { start: Date; end: Date; expires: number };
+
 export class DateFilterHandler extends ScalarFilterHandler<DateFilterModel, Date, IDateFilterParams> {
     public readonly filterType = 'date' as const;
     protected readonly FilterModelFormatterClass = DateFilterModelFormatter;
-    private readonly filterTypeToRangeCache = new Map<ISimpleFilterModelPresetType, [Date, Date]>();
+    private readonly filterTypeToRangeCache = new Map<ISimpleFilterModelPresetType, RangeCacheItem>();
 
     constructor() {
         super(mapValuesFromDateFilterModel, DEFAULT_DATE_FILTER_OPTIONS);
-        this.refreshFilterBaseDate();
     }
 
-    private refreshFilterBaseDate(): void {
-        if (this.isAlive()) {
-            this.filterTypeToRangeCache.clear();
-            const filterBaseDateTimeout = setTimeout(
-                () => this.refreshFilterBaseDate(),
-                // this evaluates to a number of ms between NOW and beginning of tomorrow
-                setStartOfNextDay(new Date()).getTime() - Date.now()
-            );
-            this.addDestroyFunc(() => clearTimeout(filterBaseDateTimeout));
+    getOrRefreshRangeCacheItem(
+        key: ISimpleFilterModelPresetType,
+        rangeFn: (s: Date, e: Date) => [Date, Date]
+    ): [Date, Date] {
+        const { filterTypeToRangeCache } = this;
+        let cache = filterTypeToRangeCache.get(key);
+        if (cache && cache.expires < Date.now()) {
+            cache = undefined;
         }
+        if (!cache) {
+            const [start, end] = rangeFn(new Date(), new Date());
+            cache = { start, end, expires: setStartOfNextDay(new Date()).getTime() - Date.now() };
+            filterTypeToRangeCache.set(key, cache);
+        }
+        return [cache.start, cache.end];
     }
 
     protected override comparator(): Comparator<Date> {
@@ -62,16 +68,13 @@ export class DateFilterHandler extends ScalarFilterHandler<DateFilterModel, Date
         if (!this.isValid(cellValue)) {
             return type === 'notEqual' || type === 'notBlank';
         }
-        const typeAsPreset = type as ISimpleFilterModelPresetType;
-        const presetDateRangeFn = presetDateFilterTypeRelativeFromToMap[typeAsPreset] as RelativeRangeFn;
+        const maybeTypeAsPreset = type as ISimpleFilterModelPresetType;
+        const presetDateRangeFn = presetDateFilterTypeRelativeFromToMap[maybeTypeAsPreset] as
+            | RelativeRangeFn
+            | undefined;
         if (presetDateRangeFn) {
-            // indicates we are in preset time ranges space
-            let cache = this.filterTypeToRangeCache.get(typeAsPreset);
-            if (!cache) {
-                cache = presetDateRangeFn(new Date(), new Date());
-                this.filterTypeToRangeCache.set(typeAsPreset, cache);
-            }
-            const [from, to] = cache;
+            // user selected a preset, calculate what they mean
+            const [from, to] = this.getOrRefreshRangeCacheItem(maybeTypeAsPreset, presetDateRangeFn);
             return comparator(from, cellValue) >= 0 && comparator(to, cellValue) < 0;
         }
 

--- a/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.ts
@@ -35,8 +35,8 @@ export class DateFilterHandler extends ScalarFilterHandler<DateFilterModel, Date
             this.filterTypeToRangeCache.clear();
             const filterBaseDateTimeout = setTimeout(
                 () => this.refreshFilterBaseDate(),
-                // this evaluates to a number of ms between NOW and beginning of tomorrow MINUS 1 minute
-                setStartOfNextDay(new Date()).getTime() - Date.now() - 60 * 1000
+                // this evaluates to a number of ms between NOW and beginning of tomorrow
+                setStartOfNextDay(new Date()).getTime() - Date.now()
             );
             this.addDestroyFunc(() => clearTimeout(filterBaseDateTimeout));
         }

--- a/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.ts
@@ -20,7 +20,11 @@ function defaultDateComparator(filterDate: Date, cellValue: any): number {
     return 0;
 }
 
-type RangeCacheItem = { start: Date; end: Date; expires: number };
+type Range = { from: Date; to: Date };
+
+interface RangeCacheItem extends Range {
+    expires: number;
+}
 
 export class DateFilterHandler extends ScalarFilterHandler<DateFilterModel, Date, IDateFilterParams> {
     public readonly filterType = 'date' as const;
@@ -31,21 +35,19 @@ export class DateFilterHandler extends ScalarFilterHandler<DateFilterModel, Date
         super(mapValuesFromDateFilterModel, DEFAULT_DATE_FILTER_OPTIONS);
     }
 
-    getOrRefreshRangeCacheItem(
-        key: ISimpleFilterModelPresetType,
-        rangeFn: (s: Date, e: Date) => [Date, Date]
-    ): [Date, Date] {
+    getOrRefreshRangeCacheItem(key: ISimpleFilterModelPresetType, rangeFn: (s: Date, e: Date) => [Date, Date]): Range {
         const { filterTypeToRangeCache } = this;
+        const now = Date.now();
         let cache = filterTypeToRangeCache.get(key);
-        if (cache && cache.expires < Date.now()) {
+        if (cache && cache.expires < now) {
             cache = undefined;
         }
         if (!cache) {
-            const [start, end] = rangeFn(new Date(), new Date());
-            cache = { start, end, expires: setStartOfNextDay(new Date()).getTime() - Date.now() };
+            const [from, to] = rangeFn(new Date(now), new Date(now));
+            cache = { from, to, expires: setStartOfNextDay(new Date(now)).getTime() - now };
             filterTypeToRangeCache.set(key, cache);
         }
-        return [cache.start, cache.end];
+        return cache;
     }
 
     protected override comparator(): Comparator<Date> {
@@ -74,7 +76,7 @@ export class DateFilterHandler extends ScalarFilterHandler<DateFilterModel, Date
             | undefined;
         if (presetDateRangeFn) {
             // user selected a preset, calculate what they mean
-            const [from, to] = this.getOrRefreshRangeCacheItem(maybeTypeAsPreset, presetDateRangeFn);
+            const { from, to } = this.getOrRefreshRangeCacheItem(maybeTypeAsPreset, presetDateRangeFn);
             return comparator(from, cellValue) >= 0 && comparator(to, cellValue) < 0;
         }
 


### PR DESCRIPTION
Update date filter refresh scheduling to trigger at start of next day 

Fixes [AG-16637](https://ag-grid.atlassian.net/browse/AG-16637)