### PR TITLE
[AG-16651] Maintenance(website): add a link to the performance example repo on the demo page

### DIFF
--- a/documentation/ag-grid-docs/src/pages/example.astro
+++ b/documentation/ag-grid-docs/src/pages/example.astro
@@ -17,12 +17,16 @@ import LogoMark from '@components/logo/LogoMark';
         <div>
             <div class={styles.headerTitle}>
                 <h1 class={styles.headerHeading}>Performance</h1>
-                <a className={styles.videoTour} href="https://youtu.be/bcMvTUVbMvI" target="_blank" rel="noreferrer">
+                <a class="button-secondary" href="https://github.com/ag-grid/ag-grid-demos/tree/main/performance">
+                    <Icon name="github" svgClasses={styles.githubIcon} />
+                    <span>See on GitHub</span>
+                </a>
+                <!--<a className={styles.videoTour} href="https://youtu.be/bcMvTUVbMvI" target="_blank" rel="noreferrer">
                     <button class="button-secondary">
                         <Icon alt={`Youtube logo`} name="youtube" svgClasses={styles.youtubeIcon} />
                         <span>See the video tour</span>
                     </button>
-                </a>
+                </a>-->
             </div>
             <p>Example showing grid performance with adjustable rows and columns.</p>
         </div>

--- a/documentation/ag-grid-docs/src/pages/example.astro
+++ b/documentation/ag-grid-docs/src/pages/example.astro
@@ -21,12 +21,6 @@ import LogoMark from '@components/logo/LogoMark';
                     <Icon name="github" svgClasses={styles.githubIcon} />
                     <span>See on GitHub</span>
                 </a>
-                <!--<a className={styles.videoTour} href="https://youtu.be/bcMvTUVbMvI" target="_blank" rel="noreferrer">
-                    <button class="button-secondary">
-                        <Icon alt={`Youtube logo`} name="youtube" svgClasses={styles.youtubeIcon} />
-                        <span>See the video tour</span>
-                    </button>
-                </a>-->
             </div>
             <p>Example showing grid performance with adjustable rows and columns.</p>
         </div>


### PR DESCRIPTION
Add link to performance example repository on demo page

- Replace video tour link with GitHub link to performance example repo 

Fixes [AG-16651](https://ag-grid.atlassian.net/browse/AG-16651)