### PR TITLE
[AG-14571] Fix(filters): preset date ranges intl

### DIFF
--- a/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.test.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.test.ts
@@ -121,23 +121,22 @@ describe('getFirstDayOfWeek', () => {
     afterEach(() => {
         (Intl as any).Locale = originalLocale;
         if (originalNavigator) {
-            Object.defineProperty(global, 'navigator', { configurable: true, value: originalNavigator });
+            Object.defineProperty(globalThis, 'navigator', { configurable: true, value: originalNavigator });
         } else {
-            delete (global as any).navigator;
+            delete (globalThis as any).navigator;
         }
     });
 
     it('uses Intl.Locale.getWeekInfo when available', () => {
         const getWeekInfo = jest.fn(() => ({ firstDay: 0 }));
         class MockLocale {
-            constructor(_locale?: string) {}
             getWeekInfo() {
                 return getWeekInfo();
             }
         }
 
         (Intl as any).Locale = MockLocale;
-        Object.defineProperty(global, 'navigator', {
+        Object.defineProperty(globalThis, 'navigator', {
             configurable: true,
             value: { language: 'en-US', languages: ['en-US'] },
         });

--- a/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.test.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.test.ts
@@ -109,6 +109,50 @@ describe('presetDateFilterTypeRelativeFromToMap', () => {
     );
 });
 
+describe('getFirstDayOfWeek', () => {
+    const base = new Date('2020-04-08T12:34:56.000Z');
+    const originalLocale = (Intl as any).Locale;
+    const originalNavigator = typeof navigator === 'undefined' ? undefined : navigator;
+
+    beforeEach(() => {
+        jest.resetModules();
+    });
+
+    afterEach(() => {
+        (Intl as any).Locale = originalLocale;
+        if (originalNavigator) {
+            Object.defineProperty(global, 'navigator', { configurable: true, value: originalNavigator });
+        } else {
+            delete (global as any).navigator;
+        }
+    });
+
+    it('uses Intl.Locale.getWeekInfo when available', () => {
+        const getWeekInfo = jest.fn(() => ({ firstDay: 0 }));
+        class MockLocale {
+            constructor(_locale?: string) {}
+            getWeekInfo() {
+                return getWeekInfo();
+            }
+        }
+
+        (Intl as any).Locale = MockLocale;
+        Object.defineProperty(global, 'navigator', {
+            configurable: true,
+            value: { language: 'en-US', languages: ['en-US'] },
+        });
+
+        jest.isolateModules(() => {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const { presetDateFilterTypeRelativeFromToMap: map } = require('./dateFilterHandler');
+            const result = map.setStartOfWeek(new Date(base));
+            expect(result.toUTCString()).toContain('Sun, 05 Apr 2020');
+        });
+
+        expect(getWeekInfo).toHaveBeenCalledTimes(1);
+    });
+});
+
 describe('getOrRefreshRangeCacheItem', () => {
     const key = 'today' as ISimpleFilterModelPresetType;
 

--- a/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.ts
@@ -100,7 +100,7 @@ const getFirstDayOfWeek = (): number => {
 
     if (locale && typeof Intl !== 'undefined' && typeof (Intl as any).Locale === 'function') {
         try {
-            const weekInfo = new (Intl as any).Locale(locale).getWeekInfo();
+            const weekInfo = new (Intl as any).Locale(locale).getWeekInfo?.();
             firstDay = weekInfo?.firstDay;
         } catch {
             firstDay = undefined;

--- a/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.ts
@@ -107,7 +107,7 @@ const getFirstDayOfWeek = (): number => {
         }
     }
 
-    cachedFirstDayOfWeek = firstDay != null ? firstDay % 7 : DEFAULT_FIRST_DAY_OF_WEEK;
+    cachedFirstDayOfWeek = firstDay == null ? DEFAULT_FIRST_DAY_OF_WEEK : firstDay % 7;
     return cachedFirstDayOfWeek;
 };
 

--- a/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/dateFilterHandler.ts
@@ -100,14 +100,14 @@ const getFirstDayOfWeek = (): number => {
 
     if (locale && typeof Intl !== 'undefined' && typeof (Intl as any).Locale === 'function') {
         try {
-            const weekInfo = new (Intl as any).Locale(locale).weekInfo;
+            const weekInfo = new (Intl as any).Locale(locale).getWeekInfo();
             firstDay = weekInfo?.firstDay;
         } catch {
             firstDay = undefined;
         }
     }
 
-    cachedFirstDayOfWeek = firstDay ? firstDay % 7 : DEFAULT_FIRST_DAY_OF_WEEK;
+    cachedFirstDayOfWeek = firstDay != null ? firstDay % 7 : DEFAULT_FIRST_DAY_OF_WEEK;
     return cachedFirstDayOfWeek;
 };
 


### PR DESCRIPTION
Update `Intl.Locale` usage to `getWeekInfo()` method for date filter first day of week calculation

- Use `getWeekInfo()` method instead of `weekInfo` property on `Intl.Locale` for determining first day of week
- Update test to verify `getWeekInfo()` method is called correctly
- Improve null check for first day of week calculation using `!= null` instead of `?` operator
- Fix potential issue with `Intl.Locale` usage when `getWeekInfo()` is not available

Fixes [AG-14571](https://ag-grid.atlassian.net/browse/AG-14571)