### PR TITLE
AG-9710 header height should take into account header border width

### DIFF
--- a/packages/ag-grid-community/src/environment.ts
+++ b/packages/ag-grid-community/src/environment.ts
@@ -2,6 +2,7 @@ import type { BaseCssChangeKeys, CssVariable } from './agStack/core/baseEnvironm
 import { BaseEnvironment } from './agStack/core/baseEnvironment';
 import type { Theme } from './agStack/theming/theme';
 import type { ThemeImpl } from './agStack/theming/themeImpl';
+import type { ParamType } from './agStack/theming/themeTypeUtils';
 import type { NamedBean } from './context/bean';
 import type { BeanCollection } from './context/context';
 import type { AgEventTypeParams } from './events';
@@ -14,46 +15,22 @@ import { coreCSS } from './theming/core/core.css-GENERATED';
 import { themeQuartz } from './theming/parts/theme/themes';
 import { _error, _warn } from './validation/logging';
 
-const CELL_HORIZONTAL_PADDING: CssVariable<CssChangeKeys> = {
-    changeKey: 'cellHorizontalPadding',
-    type: 'length',
-    defaultValue: 16,
-};
+const cssVar = <K extends keyof CssChangeKeys>(
+    changeKey: K,
+    type: ParamType,
+    defaultValue: number,
+    noWarn?: boolean,
+    cacheDefault?: boolean
+): CssVariable<CssChangeKeys> => ({ changeKey, type, defaultValue, noWarn, cacheDefault });
 
-const INDENTATION_LEVEL: CssVariable<CssChangeKeys> = {
-    changeKey: 'indentationLevel',
-    type: 'length',
-    defaultValue: 0,
-    noWarn: true,
-    cacheDefault: true,
-};
-
-const ROW_GROUP_INDENT_SIZE: CssVariable<CssChangeKeys> = {
-    changeKey: 'rowGroupIndentSize',
-    type: 'length',
-    defaultValue: 0,
-};
-
-const ROW_HEIGHT: CssVariable<CssChangeKeys> = {
-    changeKey: 'rowHeight',
-    type: 'length',
-    defaultValue: 42,
-};
-const HEADER_HEIGHT: CssVariable<CssChangeKeys> = {
-    changeKey: 'headerHeight',
-    type: 'length',
-    defaultValue: 48,
-};
-const ROW_BORDER_WIDTH: CssVariable<CssChangeKeys> = {
-    changeKey: 'rowBorderWidth',
-    type: 'border',
-    defaultValue: 1,
-};
-const PINNED_BORDER_WIDTH: CssVariable<CssChangeKeys> = {
-    changeKey: 'pinnedRowBorderWidth',
-    type: 'border',
-    defaultValue: 1,
-};
+const CELL_HORIZONTAL_PADDING = cssVar('cellHorizontalPadding', 'length', 16);
+const INDENTATION_LEVEL = cssVar('indentationLevel', 'length', 0, true, true);
+const ROW_GROUP_INDENT_SIZE = cssVar('rowGroupIndentSize', 'length', 0);
+const ROW_HEIGHT = cssVar('rowHeight', 'length', 42);
+const HEADER_HEIGHT = cssVar('headerHeight', 'length', 48);
+const ROW_BORDER_WIDTH = cssVar('rowBorderWidth', 'border', 1);
+const PINNED_BORDER_WIDTH = cssVar('pinnedRowBorderWidth', 'border', 1);
+const HEADER_ROW_BORDER_WIDTH = cssVar('headerRowBorderWidth', 'border', 1);
 
 export function _addAdditionalCss(cssMap: Map<string, string[]>, modules: Module[]): void {
     for (const module of modules.sort((a, b) => a.moduleName.localeCompare(b.moduleName))) {
@@ -91,6 +68,10 @@ export class Environment
 
     public getRowBorderWidth(): number {
         return this.getCSSVariablePixelValue(ROW_BORDER_WIDTH);
+    }
+
+    public getHeaderRowBorderWidth(): number {
+        return this.getCSSVariablePixelValue(HEADER_ROW_BORDER_WIDTH);
     }
 
     public getDefaultRowHeight(): number {
@@ -205,6 +186,7 @@ export class Environment
 
 interface CssChangeKeys extends BaseCssChangeKeys {
     headerHeight: true;
+    headerRowBorderWidth: true;
     rowHeight: true;
     rowBorderWidth: true;
     pinnedRowBorderWidth: true;

--- a/packages/ag-grid-community/src/environment.ts
+++ b/packages/ag-grid-community/src/environment.ts
@@ -15,7 +15,7 @@ import { coreCSS } from './theming/core/core.css-GENERATED';
 import { themeQuartz } from './theming/parts/theme/themes';
 import { _error, _warn } from './validation/logging';
 
-const cssVar = <K extends keyof CssChangeKeys>(
+const cssVariable = <K extends keyof CssChangeKeys>(
     changeKey: K,
     type: ParamType,
     defaultValue: number,
@@ -23,14 +23,14 @@ const cssVar = <K extends keyof CssChangeKeys>(
     cacheDefault?: boolean
 ): CssVariable<CssChangeKeys> => ({ changeKey, type, defaultValue, noWarn, cacheDefault });
 
-const CELL_HORIZONTAL_PADDING = cssVar('cellHorizontalPadding', 'length', 16);
-const INDENTATION_LEVEL = cssVar('indentationLevel', 'length', 0, true, true);
-const ROW_GROUP_INDENT_SIZE = cssVar('rowGroupIndentSize', 'length', 0);
-const ROW_HEIGHT = cssVar('rowHeight', 'length', 42);
-const HEADER_HEIGHT = cssVar('headerHeight', 'length', 48);
-const ROW_BORDER_WIDTH = cssVar('rowBorderWidth', 'border', 1);
-const PINNED_BORDER_WIDTH = cssVar('pinnedRowBorderWidth', 'border', 1);
-const HEADER_ROW_BORDER_WIDTH = cssVar('headerRowBorderWidth', 'border', 1);
+const CELL_HORIZONTAL_PADDING = cssVariable('cellHorizontalPadding', 'length', 16);
+const INDENTATION_LEVEL = cssVariable('indentationLevel', 'length', 0, true, true);
+const ROW_GROUP_INDENT_SIZE = cssVariable('rowGroupIndentSize', 'length', 0);
+const ROW_HEIGHT = cssVariable('rowHeight', 'length', 42);
+const HEADER_HEIGHT = cssVariable('headerHeight', 'length', 48);
+const ROW_BORDER_WIDTH = cssVariable('rowBorderWidth', 'border', 1);
+const PINNED_BORDER_WIDTH = cssVariable('pinnedRowBorderWidth', 'border', 1);
+const HEADER_ROW_BORDER_WIDTH = cssVariable('headerRowBorderWidth', 'border', 1);
 
 export function _addAdditionalCss(cssMap: Map<string, string[]>, modules: Module[]): void {
     for (const module of modules.sort((a, b) => a.moduleName.localeCompare(b.moduleName))) {

--- a/packages/ag-grid-community/src/headerRendering/gridHeaderCtrl.ts
+++ b/packages/ag-grid-community/src/headerRendering/gridHeaderCtrl.ts
@@ -18,6 +18,7 @@ export class GridHeaderCtrl extends BeanStub {
     private comp: IGridHeaderComp;
     public eGui: HTMLElement;
     public headerHeight: number;
+    private headerHeightWithBorder: number;
 
     public setComp(comp: IGridHeaderComp, eGui: HTMLElement, eFocusableElement: HTMLElement): void {
         this.comp = comp;
@@ -91,20 +92,21 @@ export class GridHeaderCtrl extends BeanStub {
 
         totalHeaderHeight += groupHeight;
         totalHeaderHeight += headerHeight;
+        const headerBorderWidth = beans.environment.getHeaderRowBorderWidth();
+        const totalHeaderHeightWithBorder = totalHeaderHeight + headerBorderWidth;
 
-        if (this.headerHeight === totalHeaderHeight) {
-            return;
+        if (this.headerHeightWithBorder !== totalHeaderHeightWithBorder) {
+            this.headerHeightWithBorder = totalHeaderHeightWithBorder;
+            const px = `${totalHeaderHeightWithBorder}px`;
+            this.comp.setHeightAndMinHeight(px);
         }
 
-        this.headerHeight = totalHeaderHeight;
-
-        const headerBorderWidth = beans.environment.getHeaderRowBorderWidth();
-        const px = `${totalHeaderHeight + headerBorderWidth}px`;
-        this.comp.setHeightAndMinHeight(px);
-
-        this.eventSvc.dispatchEvent({
-            type: 'headerHeightChanged',
-        });
+        if (this.headerHeight !== totalHeaderHeight) {
+            this.headerHeight = totalHeaderHeight;
+            this.eventSvc.dispatchEvent({
+                type: 'headerHeightChanged',
+            });
+        }
     }
 
     private onPivotModeChanged(beans: BeanCollection): void {

--- a/packages/ag-grid-community/src/headerRendering/gridHeaderCtrl.ts
+++ b/packages/ag-grid-community/src/headerRendering/gridHeaderCtrl.ts
@@ -98,9 +98,8 @@ export class GridHeaderCtrl extends BeanStub {
 
         this.headerHeight = totalHeaderHeight;
 
-        // one extra pixel is needed here to account for the
-        // height of the border
-        const px = `${totalHeaderHeight + 1}px`;
+        const headerBorderWidth = beans.environment.getHeaderRowBorderWidth();
+        const px = `${totalHeaderHeight + headerBorderWidth}px`;
         this.comp.setHeightAndMinHeight(px);
 
         this.eventSvc.dispatchEvent({


### PR DESCRIPTION
Fix AG-9710

https://ag-grid.atlassian.net/browse/AG-9710

Changes:
 - fix hard coded assumption of a 1px header border width in grid layout code
 - create cssVariable utility function to help with minification of css variable measurement code