### PR TITLE
[AG-16476] Fix(filters): mini set wrong object serialization

### DIFF
--- a/.run/Absolute sorting theming test.run.xml
+++ b/.run/Absolute sorting theming test.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Absolute sorting theming test" type="JavascriptDebugType" engineId="98ca6316-2f89-46d9-a9e5-fa9e2b0625b3" uri="https://plnkr.co/edit/4CcjQTZTuhoFUke4?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/CSRM master details.run.xml
+++ b/.run/CSRM master details.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="CSRM master details" type="JavascriptDebugType" uri="https://plnkr.co/edit/tXPXIpw4Txhnovwe?open=main.ts">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/Datetime filter bug.run.xml
+++ b/.run/Datetime filter bug.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Datetime filter bug" type="JavascriptDebugType" uri="https://plnkr.co/edit/78E3AxduPsMJgu66?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/Header Group Tooltip Value Getter feat.run.xml
+++ b/.run/Header Group Tooltip Value Getter feat.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Header Group Tooltip Value Getter feat" type="JavascriptDebugType" uri="https://plnkr.co/edit/NPMeY8YQqrX18I1c?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/Header Tooltip Value Getter feat.run.xml
+++ b/.run/Header Tooltip Value Getter feat.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Header Tooltip Value Getter feat" type="JavascriptDebugType" uri="https://plnkr.co/edit/riwX9Rc6ecKCH9d5?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/Master detail csrm.run.xml
+++ b/.run/Master detail csrm.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Master detail csrm" type="JavascriptDebugType" uri="https://plnkr.co/edit/ermQ69oRujnxeRSW?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/Master detail with grouping ssrm.run.xml
+++ b/.run/Master detail with grouping ssrm.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Master detail with grouping ssrm" type="JavascriptDebugType" uri="https://plnkr.co/edit/HtJlS5eDyKHEQFzP?open=main.ts">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/Mini filter value formatter.run.xml
+++ b/.run/Mini filter value formatter.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Mini filter value formatter" type="JavascriptDebugType" engineId="98ca6316-2f89-46d9-a9e5-fa9e2b0625b3" uri="https://plnkr.co/edit/4MC5MKLtNjTb0bEG?open=main.js">
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/New Filters Tool Panel.run.xml
+++ b/.run/New Filters Tool Panel.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="New Filters Tool Panel" type="JavascriptDebugType" uri="https://plnkr.co/edit/VYMsf07DHdPCFyPE?open=main.ts">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/Pivot Group Columns SSRM.run.xml
+++ b/.run/Pivot Group Columns SSRM.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Pivot Group Columns SSRM" type="JavascriptDebugType" uri="https://plnkr.co/edit/xCWTTJFMIQWaPU5L?open=index.jsx">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/Pivoting expansion state SSRM.run.xml
+++ b/.run/Pivoting expansion state SSRM.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Pivoting expansion state SSRM" type="JavascriptDebugType" uri="https://plnkr.co/edit/g5gCZoLwgnJvjVZa?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/Preset date sort testing.run.xml
+++ b/.run/Preset date sort testing.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Preset date sort testing" type="JavascriptDebugType" engineId="98ca6316-2f89-46d9-a9e5-fa9e2b0625b3" uri="https://plnkr.co/edit/rwM3Z4GI6iqBdXuC?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/Reset row height SSRM.run.xml
+++ b/.run/Reset row height SSRM.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Reset row height SSRM" type="JavascriptDebugType" uri="https://plnkr.co/edit/Vem7gNTKNRirlgpl?open=main.ts">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/Rich Select Async Values.run.xml
+++ b/.run/Rich Select Async Values.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Rich Select Async Values" type="JavascriptDebugType" uri="https://plnkr.co/edit/g84nO2jZlQlvgrDj?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/SSRM Grand Total Row .run.xml
+++ b/.run/SSRM Grand Total Row .run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="SSRM Grand Total Row " type="JavascriptDebugType" uri="https://plnkr.co/edit/ZhT2H7TRKcMLK6Vs?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/SSRM Preset date sort testing.run.xml
+++ b/.run/SSRM Preset date sort testing.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="SSRM Preset date sort testing" type="JavascriptDebugType" engineId="98ca6316-2f89-46d9-a9e5-fa9e2b0625b3" uri="https://plnkr.co/edit/o5hEce1vQlv5Fz1c?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/SSRM Transactions.run.xml
+++ b/.run/SSRM Transactions.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="SSRM Transactions" type="JavascriptDebugType" uri="https://plnkr.co/edit/enrc0qIQnMKbFw3R?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/SSRM basic no cache.run.xml
+++ b/.run/SSRM basic no cache.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="SSRM basic no cache" type="JavascriptDebugType" engineId="98ca6316-2f89-46d9-a9e5-fa9e2b0625b3" uri="https://plnkr.co/edit/kQe2Keoql20uL8tk?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/SSRM expand all.run.xml
+++ b/.run/SSRM expand all.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="SSRM expand all" type="JavascriptDebugType" uri="https://plnkr.co/edit/W3ybQSq855yKxcy5?preview">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/Set Master-details via a row update.run.xml
+++ b/.run/Set Master-details via a row update.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Set Master-details via a row update" type="JavascriptDebugType" uri="https://plnkr.co/edit/ocCkTZkDq11HQPUZ?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/Side bar outside of grid.run.xml
+++ b/.run/Side bar outside of grid.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Side bar outside of grid" type="JavascriptDebugType" uri="https://plnkr.co/edit/2tDNPMcAeKeDujdJ?open=main.ts">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/Tree Data with Master Detail CSRM.run.xml
+++ b/.run/Tree Data with Master Detail CSRM.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Tree Data with Master Detail CSRM" type="JavascriptDebugType" uri="https://plnkr.co/edit/29lgjotgApFd3ZCa?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/sdwvit_fix_state_rowgroupexpansion-collapsedrowgroupids-exposes-non-bucket-data_AG-16459.run.xml
+++ b/.run/sdwvit_fix_state_rowgroupexpansion-collapsedrowgroupids-exposes-non-bucket-data_AG-16459.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="sdwvit/fix/state/rowgroupexpansion-collapsedrowgroupids-exposes-non-bucket-data/AG-16459" type="JavascriptDebugType" uri="https://plnkr.co/edit/EjhzIKqxpNOamZyE?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/packages/ag-grid-enterprise/src/setFilter/flatSetDisplayValueModel.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/flatSetDisplayValueModel.ts
@@ -11,7 +11,8 @@ export class FlatSetDisplayValueModel<V> implements ISetDisplayValueModel<V> {
         private readonly valueSvc: ValueService,
         private readonly getValueFormatter: () => ((params: ValueFormatterParams) => string) | undefined,
         private readonly formatter: TextFormatter,
-        private readonly column: AgColumn
+        private readonly column: AgColumn,
+        private readonly getUseFormatterFromColumn: () => boolean
     ) {}
 
     public updateDisplayedValuesToAllAvailable(
@@ -40,7 +41,13 @@ export class FlatSetDisplayValueModel<V> implements ISetDisplayValueModel<V> {
                 }
             } else {
                 const value = getValue(key);
-                const valueFormatterValue = this.valueSvc.formatValue(this.column, null, value, valueFormatter, false);
+                const valueFormatterValue = this.valueSvc.formatValue(
+                    this.column,
+                    null,
+                    value,
+                    valueFormatter,
+                    this.getUseFormatterFromColumn()
+                );
 
                 const textFormatterValue = this.formatter(valueFormatterValue);
 

--- a/packages/ag-grid-enterprise/src/setFilter/setFilter.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilter.ts
@@ -101,7 +101,8 @@ export class SetFilter<V = string>
                   this.beans.valueSvc,
                   () => this.handler.valueFormatter,
                   this.formatter,
-                  column as AgColumn
+                  column as AgColumn,
+                  () => this.handler.shouldUseValueFormatterFromColumn()
               ) as any);
 
         handler.valueModel.allKeys.then((values) => {
@@ -430,6 +431,7 @@ export class SetFilter<V = string>
             params: this.params,
             translate: (translateKey: any) => translateForSetFilter(this, translateKey),
             valueFormatter: this.handler.valueFormatter,
+            shouldUseFormatterFromColumn: this.handler.shouldUseValueFormatterFromColumn(),
             item,
             isSelected,
             isTree,

--- a/packages/ag-grid-enterprise/src/setFilter/setFilterHandler.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilterHandler.ts
@@ -1,5 +1,6 @@
 import type {
     AgColumn,
+    ColDef,
     DoesFilterPassParams,
     FilterHandler,
     FilterHandlerParams,
@@ -51,6 +52,7 @@ export class SetFilterHandler<TValue = string>
     private caseSensitive: boolean = false;
     public valueFormatter?: (params: ValueFormatterParams) => string;
     private noValueFormatterSupplied = false;
+    private useValueFormatterFromColumn = false;
 
     public init(params: FilterHandlerParams<any, any, SetFilterModel, ISetFilterParams<any, TValue>>): void {
         this.updateParams(params);
@@ -106,7 +108,7 @@ export class SetFilterHandler<TValue = string>
         this.params = params;
         const {
             colDef,
-            filterParams: { caseSensitive, treeList, keyCreator, valueFormatter },
+            filterParams: { caseSensitive, treeList, keyCreator },
         } = params;
         this.caseSensitive = !!caseSensitive;
         const isGroupCol = !!colDef.showRowGroup;
@@ -114,7 +116,7 @@ export class SetFilterHandler<TValue = string>
         this.groupingTreeList = !!this.beans.rowGroupColsSvc?.columns.length && !!treeList && isGroupCol;
         const resolvedKeyCreator = keyCreator ?? colDef.keyCreator;
         this.createKey = this.generateCreateKey(resolvedKeyCreator, this.isTreeDataOrGrouping());
-        this.setValueFormatter(valueFormatter, resolvedKeyCreator, !!treeList, !!colDef.refData);
+        this.setValueFormatter(resolvedKeyCreator, params);
     }
 
     public doesFilterPass(params: DoesFilterPassParams<any, SetFilterModel>): boolean {
@@ -160,7 +162,7 @@ export class SetFilterHandler<TValue = string>
             null,
             value,
             this.valueFormatter,
-            false
+            this.useValueFormatterFromColumn
         );
 
         return (
@@ -401,24 +403,36 @@ export class SetFilterHandler<TValue = string>
     }
 
     private setValueFormatter(
-        providedValueFormatter: ((params: ValueFormatterParams) => string) | undefined,
         keyCreator: ((params: KeyCreatorParams<any, any>) => string) | undefined,
-        treeList: boolean,
-        isRefData: boolean
+        params: FilterHandlerParams<any, any, SetFilterModel, ISetFilterParams<any, TValue>>
     ) {
-        let valueFormatter = providedValueFormatter;
-        if (!valueFormatter) {
-            if (keyCreator && !treeList) {
-                _error(249);
-                return;
-            }
+        const {
+            colDef: { refData, valueFormatter },
+            filterParams: { treeList, valueFormatter: providedValueFormatter },
+        } = params;
+        const hasKeyCreatorButNoFormatterNorTreeList =
+            keyCreator && !(providedValueFormatter || treeList || valueFormatter);
+        if (hasKeyCreatorButNoFormatterNorTreeList) {
+            _error(249);
+            this.valueFormatter = undefined;
             this.noValueFormatterSupplied = true;
-            // ref data is handled by ValueService
-            if (!isRefData) {
-                valueFormatter = (params) => _toStringOrNull(params.value)!;
-            }
+            this.useValueFormatterFromColumn = false;
+            return;
         }
-        this.valueFormatter = valueFormatter;
+
+        let resolvedFormatter = providedValueFormatter;
+        if (!resolvedFormatter && !valueFormatter && !refData) {
+            // ref data is handled by ValueService
+            resolvedFormatter = (params) => _toStringOrNull(params.value)!;
+        }
+
+        this.valueFormatter = resolvedFormatter;
+        this.noValueFormatterSupplied = !providedValueFormatter && !valueFormatter;
+        this.useValueFormatterFromColumn = !providedValueFormatter && !!valueFormatter;
+    }
+
+    public shouldUseValueFormatterFromColumn(): boolean {
+        return this.useValueFormatterFromColumn && !this.valueFormatter;
     }
 
     public getCrossFilterModel(

--- a/packages/ag-grid-enterprise/src/setFilter/setFilterHandler.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilterHandler.ts
@@ -1,6 +1,5 @@
 import type {
     AgColumn,
-    ColDef,
     DoesFilterPassParams,
     FilterHandler,
     FilterHandlerParams,
@@ -152,9 +151,12 @@ export class SetFilterHandler<TValue = string>
 
     private getFormattedValue(key: string | null): string | null {
         let value: TValue | string | null = this.valueModel.getValueForFormatter(key);
-        if (this.noValueFormatterSupplied && this.isTreeDataOrGrouping() && Array.isArray(value)) {
-            // essentially get back the cell value
-            value = _last(value) as string;
+        if (this.isTreeDataOrGrouping() && Array.isArray(value)) {
+            const shouldUseLast = this.noValueFormatterSupplied || this.useValueFormatterFromColumn;
+            if (shouldUseLast) {
+                // essentially get back the cell value
+                value = _last(value) as string;
+            }
         }
 
         const formattedValue = this.beans.valueSvc.formatValue(

--- a/packages/ag-grid-enterprise/src/setFilter/setFilterListItem.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilterListItem.ts
@@ -413,13 +413,7 @@ export class SetFilterListItem<V> extends Component<SetFilterListItemEvent> {
     }
 
     private getFormattedValue(column: AgColumn, value: any) {
-        return this.beans.valueSvc.formatValue(
-            column,
-            null,
-            value,
-            this.valueFormatter,
-            !!this.useFormatterFromColumn
-        );
+        return this.beans.valueSvc.formatValue(column, null, value, this.valueFormatter, !!this.useFormatterFromColumn);
     }
 
     private renderCell(): void {

--- a/packages/ag-grid-enterprise/src/setFilter/setFilterListItem.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilterListItem.ts
@@ -57,6 +57,7 @@ export interface SetFilterListItemParams<V> {
     params: ISetFilterParams<any, V> & FilterDisplayParams<any, any, SetFilterModel>;
     translate: (key: SetFilterLocaleTextKey) => string;
     valueFormatter?: (params: ValueFormatterParams) => string;
+    shouldUseFormatterFromColumn?: boolean;
     item: SetFilterModelTreeItem | string | null;
     isSelected: boolean | undefined;
     isTree?: boolean;
@@ -106,6 +107,7 @@ export class SetFilterListItem<V> extends Component<SetFilterListItemEvent> {
     private readonly params: ISetFilterParams<any, V> & FilterDisplayParams<any, any, SetFilterModel>;
     private readonly translate: (key: SetFilterLocaleTextKey) => string;
     private readonly valueFormatter?: (params: ValueFormatterParams) => string;
+    private readonly useFormatterFromColumn?: boolean;
     private readonly isTree?: boolean;
     private readonly depth: number;
     private readonly isGroup?: boolean;
@@ -132,6 +134,7 @@ export class SetFilterListItem<V> extends Component<SetFilterListItemEvent> {
         this.params = params.params;
         this.translate = params.translate;
         this.valueFormatter = params.valueFormatter;
+        this.useFormatterFromColumn = params.shouldUseFormatterFromColumn;
         this.item = params.item;
         this.isSelected = params.isSelected;
         this.isTree = params.isTree;
@@ -410,7 +413,13 @@ export class SetFilterListItem<V> extends Component<SetFilterListItemEvent> {
     }
 
     private getFormattedValue(column: AgColumn, value: any) {
-        return this.beans.valueSvc.formatValue(column, null, value, this.valueFormatter, false);
+        return this.beans.valueSvc.formatValue(
+            column,
+            null,
+            value,
+            this.valueFormatter,
+            !!this.useFormatterFromColumn
+        );
     }
 
     private renderCell(): void {


### PR DESCRIPTION
Fix wrong object serialization in Mini Set Filter by ensuring correct value formatter usage

- Pass `shouldUseFormatterFromColumn` flag to `ValueService.formatValue` to correctly determine if column's value formatter should be used
- Also delete a bunch of stored run configs, I won't store more than a few from now on. 
 
 
Fixes [AG-16476](https://ag-grid.atlassian.net/browse/AG-16476)