### PR TITLE
AG-16090 port ag-delay-render feature to legacy themes

### DIFF
--- a/.rulesync/rules/ag-grid.md
+++ b/.rulesync/rules/ag-grid.md
@@ -146,6 +146,12 @@ Essential practices:
 -   Self-review your changes before proposing commits
 -   Ensure tests exercise real implementations, not test helpers
 
+#### Styling
+
+The grid is in transition from Legacy Themes (.scss files written in Sass under `/community-modules/styles/`) to the Theming API (.css written in modern nested CSS under `/packages/`).
+
+While this transition is in progress, changes made to Theming API should be applied to Legacy Themes. When reviewing a PR with changes to the Theming API CSS, if the same PR does not have corresponding changes to Legacy Themes, this should be flagged as a P1 level issue.
+
 ### Common Development Tasks
 
 #### Quick Playbooks

--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -626,6 +626,28 @@
         }
     }
 
+    .ag-delay-render {
+        .ag-cell {
+            visibility: hidden;
+        }
+
+        .ag-row {
+            visibility: hidden;
+        }
+
+        .ag-spanned-cell-wrapper {
+            visibility: hidden;
+        }
+
+        .ag-header-cell {
+            visibility: hidden;
+        }
+
+        .ag-header-group-cell {
+            visibility: hidden;
+        }
+    }
+
     // /**
     //  ****************************
     //  * Column Panel


### PR DESCRIPTION
1. Port missing styles from Theming API ([CSS source file](https://github.com/ag-grid/ag-grid/blob/9bff6555d5ce53edc966376d978c244aa4dd9ac8/packages/ag-grid-community/src/rendering/column-delay-render.css)) to Legacy Themes
2. Add agent PR review rule to capture issues like this in future