### PR TITLE
[AG-16487] Fix(ssrm): regression call api refreshserverside to load rows doesnt resort and also doesnt clear the column header sort indicator

### DIFF
--- a/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyCache.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyCache.ts
@@ -1049,12 +1049,12 @@ export class LazyCache extends BeanStub {
     /**
      * Client side sorting
      */
-    public clientSideSortRows() {
+    public clientSideSortRows(): boolean {
         const sortOptions = this.sortSvc?.getSortOptions() ?? [];
         const isAnySort = sortOptions.some((opt) => opt.sort != null);
         const rowNodeSorter = this.rowNodeSorter;
         if (!isAnySort || !rowNodeSorter) {
-            return;
+            return false;
         }
 
         // the node map does not need entirely recreated, only the indexes need updated.
@@ -1068,6 +1068,7 @@ export class LazyCache extends BeanStub {
             const node = sortedNodes[i];
             nodesMap.set({ id: node.id!, node, index: i });
         }
+        return true;
     }
 
     /**

--- a/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyStore.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyStore.ts
@@ -723,6 +723,15 @@ export class LazyStore extends BeanStub implements IServerSideStore {
 
     // gets called when row data updated, and no more refreshing needed
     public fireRefreshFinishedEvent(): void {
+        const isClientSideSortingEnabled = this.gos.get('serverSideEnableClientSideSort');
+        const isClientSideSort = isClientSideSortingEnabled && this.cache.isStoreFullyLoaded();
+        if (isClientSideSort) {
+            // ensure refreshed rows remain in client-side sorted order
+            const didSort = this.cache.clientSideSortRows();
+            if (didSort) {
+                this.fireStoreUpdatedEvent();
+            }
+        }
         this.eventSvc.dispatchEvent({
             type: 'storeRefreshed',
             route: this.parentRowNode.getRoute(),

--- a/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-refresh-client-side-sort.test.ts
+++ b/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-refresh-client-side-sort.test.ts
@@ -1,0 +1,85 @@
+import type { GridOptions, IsServerSideGroupOpenByDefaultParams } from 'ag-grid-community';
+import { ServerSideRowModelModule, TreeDataModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, asyncSetTimeout, waitForNoLoadingRows } from '../../test-utils';
+import { createFakeServer, createServerSideDatasource, getSmallTreeDataSet } from './ssrmSmallTreeDataSet';
+
+describe('ag-grid SSRM treeData client-side sort refresh', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelModule, TreeDataModule],
+    });
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    test('refreshServerSide keeps client-side sort order', async () => {
+        const gridOptions: GridOptions = {
+            columnDefs: [
+                { field: 'employeeId', hide: true },
+                { field: 'employeeName', hide: true },
+                { field: 'jobTitle' },
+                { field: 'employmentType' },
+            ],
+            autoGroupColumnDef: {
+                field: 'employeeName',
+            },
+            defaultColDef: { flex: 1 },
+            treeData: true,
+            rowModelType: 'serverSide',
+            animateRows: false,
+            serverSideEnableClientSideSort: true,
+            cacheBlockSize: 100,
+            maxBlocksInCache: 1,
+            getRowId: ({ data }) => data.employeeId,
+            isServerSideGroupOpenByDefault: (params: IsServerSideGroupOpenByDefaultParams) => {
+                return params.rowNode.level < 1;
+            },
+            isServerSideGroup: (dataItem: any) => {
+                return dataItem.group;
+            },
+            getServerSideGroupKey: (dataItem: any) => {
+                return dataItem.employeeId;
+            },
+        };
+
+        const api = gridsManager.createGrid('ssrmTreeDataClientSideSortRefresh', gridOptions);
+
+        await asyncSetTimeout(1);
+
+        const data = getSmallTreeDataSet();
+        const fakeServer = createFakeServer(data);
+        const datasource = createServerSideDatasource(fakeServer);
+
+        api!.setGridOption('serverSideDatasource', datasource);
+
+        await waitForNoLoadingRows(api);
+
+        api!.applyColumnState({
+            state: [{ colId: 'ag-Grid-AutoColumn', sort: 'asc' }],
+        });
+
+        const gridRows = new GridRows(api, 'ssrm tree data sorted');
+        await gridRows.check(`
+            ROOT id:<no-id>
+            └─┬ 101 GROUP id:101 ag-Grid-AutoColumn:"Erica Rogers" employeeId:"101" employeeName:"Erica Rogers" jobTitle:"CEO" employmentType:"Permanent"
+            · ├── 113 GROUP collapsed id:113 ag-Grid-AutoColumn:"Luke McBride" employeeId:"113" employeeName:"Luke McBride" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+            · └── 102 GROUP collapsed id:102 ag-Grid-AutoColumn:"Malcolm Barrett" employeeId:"102" employeeName:"Malcolm Barrett" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+        `);
+
+        api!.refreshServerSide({ purge: true });
+
+        await waitForNoLoadingRows(api);
+
+        await gridRows.check(`
+            ROOT id:<no-id>
+            └─┬ 101 GROUP id:101 ag-Grid-AutoColumn:"Erica Rogers" employeeId:"101" employeeName:"Erica Rogers" jobTitle:"CEO" employmentType:"Permanent"
+            · ├── 113 GROUP collapsed id:113 ag-Grid-AutoColumn:"Luke McBride" employeeId:"113" employeeName:"Luke McBride" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+            · └── 102 GROUP collapsed id:102 ag-Grid-AutoColumn:"Malcolm Barrett" employeeId:"102" employeeName:"Malcolm Barrett" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+        `);
+    });
+});


### PR DESCRIPTION
Ensure client-side sort order is preserved after refresh in SSRM tree data by calling `clientSideSortRows` and firing store updated event when applicable.

Fixes [AG-16487](https://ag-grid.atlassian.net/browse/AG-16487)