### PR TITLE
AG-16688 single empty edit cell focus bug

### DIFF
--- a/packages/ag-grid-community/src/edit/strategy/singleCellEditStrategy.ts
+++ b/packages/ag-grid-community/src/edit/strategy/singleCellEditStrategy.ts
@@ -28,13 +28,26 @@ export class SingleCellEditStrategy extends BaseEditStrategy {
             return res;
         }
 
-        const { rowNode, column } = position || {};
+        const rowNode = position?.rowNode;
+        const column = position?.column;
+        const trackedRowNode = this.rowNode;
+        const trackedColumn = this.column;
 
-        if ((!this.rowNode || !this.column) && rowNode && column) {
-            return null;
+        if ((!trackedRowNode || !trackedColumn) && rowNode && column) {
+            return null; // no existing edit, so don't stop
         }
 
-        return this.rowNode !== rowNode || this.column !== column;
+        if (trackedRowNode !== rowNode || trackedColumn !== column) {
+            return true; // stop editing if moving to a different cell
+        }
+
+        // Both tracked and position cells are null/undefined (cells match after check above).
+        // Stop orphan editors from tabbing into empty cells.
+        if (!trackedRowNode && !trackedColumn) {
+            return this.model.hasEdits(undefined, { withOpenEditor: true });
+        }
+
+        return false; // continue editing the same cell
     }
 
     public override midBatchInputsAllowed(position?: EditPosition): boolean {

--- a/testing/behavioural/src/cell-editing/cell-editing-regression.test.ts
+++ b/testing/behavioural/src/cell-editing/cell-editing-regression.test.ts
@@ -14,6 +14,7 @@ import {
 } from 'ag-grid-enterprise';
 
 import {
+    EditEventTracker,
     GridRows,
     TestGridsManager,
     asyncSetTimeout,
@@ -88,6 +89,7 @@ describe('Cell Editing Regression', () => {
                 { readOnly: 'RO-1', make: 'Ford', model: 'Mondeo' },
             ],
         });
+        const eventTracker = new EditEventTracker(api);
 
         const gridDiv = getGridElement(api)! as HTMLElement;
         await asyncSetTimeout(1);
@@ -106,6 +108,20 @@ describe('Cell Editing Regression', () => {
         await userEvent.keyboard('{Enter}');
 
         expect(modelCellRow1).toHaveTextContent('Updated');
+
+        // Row 0: 2 editors started (make, model - readOnly is not editable)
+        // Row 0: 2 editors stopped when tabbing to row 1
+        // Row 1: 2 editors started
+        // Row 1: 2 editors stopped on Enter, with 1 value changed
+        expect(eventTracker.counts).toEqual({
+            cellEditingStarted: 4,
+            cellEditingStopped: 4,
+            cellValueChanged: 1,
+            rowValueChanged: 1,
+            cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
+        });
     });
 
     test('full-row editing fires rowEditingStopped on stopEditing', async () => {
@@ -123,6 +139,7 @@ describe('Cell Editing Regression', () => {
             ],
             onRowEditingStopped,
         });
+        const eventTracker = new EditEventTracker(api);
 
         const gridDiv = getGridElement(api)! as HTMLElement;
         await asyncSetTimeout(1);
@@ -136,6 +153,17 @@ describe('Cell Editing Regression', () => {
 
         expect(onRowEditingStopped).toHaveBeenCalledTimes(1);
         expect(onRowEditingStopped.mock.calls[0][0].rowIndex).toBe(0);
+
+        // 2 editors started (make, model), 2 editors stopped
+        expect(eventTracker.counts).toEqual({
+            cellEditingStarted: 2,
+            cellEditingStopped: 2,
+            cellValueChanged: 0,
+            rowValueChanged: 0,
+            cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
+        });
     });
 
     test('full-row editing closes empty editors when tabbing to next row', async () => {
@@ -150,6 +178,7 @@ describe('Cell Editing Regression', () => {
                 { make: 'Ford', model: 'Mondeo', model3: undefined },
             ],
         });
+        const eventTracker = new EditEventTracker(api);
 
         const gridDiv = getGridElement(api)! as HTMLElement;
         await asyncSetTimeout(1);
@@ -177,6 +206,18 @@ describe('Cell Editing Regression', () => {
 
         const emptyCellRow0 = getByTestId(gridDiv, agTestIdFor.cell('0', 'model3'));
         expect(emptyCellRow0.querySelector('input')).toBeNull();
+
+        // Row 0: 3 editors started, then 1 extra start/stop during tab navigation, then 3 editors stopped
+        // Row 1: 3 editors started (still open at end of test)
+        expect(eventTracker.counts).toEqual({
+            cellEditingStarted: 7,
+            cellEditingStopped: 4,
+            cellValueChanged: 0,
+            rowValueChanged: 0,
+            cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
+        });
     });
 
     test('full-row editing closes empty editors when shift-tabbing to previous row', async () => {
@@ -191,6 +232,7 @@ describe('Cell Editing Regression', () => {
                 { make: 'Ford', model: 'Mondeo', model3: undefined },
             ],
         });
+        const eventTracker = new EditEventTracker(api);
 
         const gridDiv = getGridElement(api)! as HTMLElement;
         await asyncSetTimeout(1);
@@ -219,6 +261,18 @@ describe('Cell Editing Regression', () => {
 
         const emptyCellRow1 = getByTestId(gridDiv, agTestIdFor.cell('1', 'model3'));
         expect(emptyCellRow1.querySelector('input')).toBeNull();
+
+        // Row 1: 3 editors started, then 1 extra start/stop during tab navigation, then 3 editors stopped
+        // Row 0: 3 editors started (still open at end of test)
+        expect(eventTracker.counts).toEqual({
+            cellEditingStarted: 7,
+            cellEditingStopped: 4,
+            cellValueChanged: 0,
+            rowValueChanged: 0,
+            cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
+        });
     });
 
     // AG-15698 - row doesn't rerender after value is selected in rich select editor
@@ -354,6 +408,7 @@ describe('Cell Editing Regression', () => {
             rowData: [{ code: 0 }, { code: 2 }],
             onCellEditRequest: ({ source }) => onCellEditRequest(source),
         });
+        const eventTracker = new EditEventTracker(api);
 
         const gridDiv = getGridElement(api)! as HTMLElement;
         await asyncSetTimeout(1);
@@ -409,6 +464,16 @@ describe('Cell Editing Regression', () => {
         expect(onCellEditRequest).toHaveBeenCalledTimes(2);
         expect(onCellEditRequest).toHaveBeenNthCalledWith(1, 'edit');
         expect(onCellEditRequest).toHaveBeenNthCalledWith(2, 'edit');
+        // 2 editors started/stopped, no value changes (readOnlyEdit mode)
+        expect(eventTracker.counts).toEqual({
+            cellEditingStarted: 2,
+            cellEditingStopped: 2,
+            cellValueChanged: 0,
+            rowValueChanged: 0,
+            cellEditRequest: 2,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
+        });
     });
 
     // Regression test for first cell edit event newValue is Symbol(unedited)
@@ -466,6 +531,7 @@ describe('Cell Editing Regression', () => {
                     onCellEditingStopped: ({ newValue, valueChanged }) =>
                         onCellEditingStopped({ newValue, valueChanged }),
                 });
+                const eventTracker = new EditEventTracker(api);
 
                 const gridDiv = getGridElement(api)! as HTMLElement;
                 await asyncSetTimeout(1);
@@ -486,6 +552,16 @@ describe('Cell Editing Regression', () => {
 
                 expect(onCellEditingStopped).toHaveBeenCalledTimes(1);
                 expect(onCellEditingStopped).toHaveBeenCalledWith(expected);
+                // 1 editor started/stopped, no value changes (readOnlyEdit mode)
+                expect(eventTracker.counts).toEqual({
+                    cellEditingStarted: 1,
+                    cellEditingStopped: 1,
+                    cellValueChanged: 0,
+                    rowValueChanged: 0,
+                    cellEditRequest: expected.valueChanged ? 1 : 0,
+                    bulkEditingStarted: 0,
+                    bulkEditingStopped: 0,
+                });
             }
         );
 
@@ -509,6 +585,7 @@ describe('Cell Editing Regression', () => {
                     onCellEditingStopped: ({ newValue, valueChanged }) =>
                         onCellEditingStopped({ newValue, valueChanged }),
                 });
+                const eventTracker = new EditEventTracker(api);
 
                 const gridDiv = getGridElement(api)! as HTMLElement;
                 await asyncSetTimeout(1);
@@ -531,6 +608,16 @@ describe('Cell Editing Regression', () => {
 
                 expect(onCellEditingStopped).toHaveBeenCalledTimes(1);
                 expect(onCellEditingStopped).toHaveBeenCalledWith(expected);
+                // 1 editor started/stopped, no value changes (Escape cancels)
+                expect(eventTracker.counts).toEqual({
+                    cellEditingStarted: 1,
+                    cellEditingStopped: 1,
+                    cellValueChanged: 0,
+                    rowValueChanged: 0,
+                    cellEditRequest: 0,
+                    bulkEditingStarted: 0,
+                    bulkEditingStopped: 0,
+                });
             }
         );
     });
@@ -544,6 +631,8 @@ describe('Cell Editing Regression', () => {
             onCellValueChangedColDef?: jest.Mock<any, any, any>,
             extraOptions?: GridOptions
         ): Promise<{
+            api: GridApi;
+            eventTracker: EditEventTracker;
             onCellValueChanged: jest.Mock<any, any, any>;
             onCellValueChangedColDef?: jest.Mock<any, any, any>;
         }> => {
@@ -562,12 +651,13 @@ describe('Cell Editing Regression', () => {
                     onCellValueChanged({ newValue, oldValue, source }),
                 ...extraOptions,
             });
+            const eventTracker = new EditEventTracker(api);
 
             const gridDiv = getGridElement(api)! as HTMLElement;
             await asyncSetTimeout(1);
             const cell = getByTestId(gridDiv, agTestIdFor.cell('0', 'field'));
             await editAction(api, gridDiv, cell);
-            return { onCellValueChanged, onCellValueChangedColDef };
+            return { api, eventTracker, onCellValueChanged, onCellValueChangedColDef };
         };
 
         beforeEach(() => {
@@ -575,7 +665,7 @@ describe('Cell Editing Regression', () => {
         });
 
         test('dblClick edit should have source=edit', async () => {
-            const { onCellValueChanged, onCellValueChangedColDef } = await testACell(
+            const { eventTracker, onCellValueChanged, onCellValueChangedColDef } = await testACell(
                 async (api, gridDiv, cell) => {
                     await user.dblClick(cell);
                     const inputElement = await waitForInput(gridDiv, cell);
@@ -598,10 +688,20 @@ describe('Cell Editing Regression', () => {
                 newValue: 'A Value15',
                 oldValue: 'A Value',
             });
+            // 1 editor started/stopped with 1 value change
+            expect(eventTracker.counts).toEqual({
+                cellEditingStarted: 1,
+                cellEditingStopped: 1,
+                cellValueChanged: 1,
+                rowValueChanged: 0,
+                cellEditRequest: 0,
+                bulkEditingStarted: 0,
+                bulkEditingStopped: 0,
+            });
         });
 
         test('dblClick edit and click away should have source=edit', async () => {
-            const { onCellValueChanged, onCellValueChangedColDef } = await testACell(
+            const { eventTracker, onCellValueChanged, onCellValueChangedColDef } = await testACell(
                 async (api, gridDiv, cell) => {
                     await user.dblClick(cell);
                     const inputElement = await waitForInput(gridDiv, cell);
@@ -624,6 +724,16 @@ describe('Cell Editing Regression', () => {
             });
             expect(onCellValueChangedColDef).toHaveBeenCalledTimes(1);
             expect(onCellValueChangedColDef).toHaveBeenCalledWith({ newValue: 'A Value15', oldValue: 'A Value' });
+            // 1 editor started/stopped with 1 value change
+            expect(eventTracker.counts).toEqual({
+                cellEditingStarted: 1,
+                cellEditingStopped: 1,
+                cellValueChanged: 1,
+                rowValueChanged: 0,
+                cellEditRequest: 0,
+                bulkEditingStarted: 0,
+                bulkEditingStopped: 0,
+            });
         });
 
         test('copy/paste edit should have source=paste', async () => {
@@ -802,6 +912,7 @@ describe('Cell Editing Regression', () => {
                 },
             ],
         });
+        const eventTracker = new EditEventTracker(api);
 
         const gridDiv = getGridElement(api)! as HTMLElement;
         await asyncSetTimeout(1);
@@ -837,6 +948,17 @@ describe('Cell Editing Regression', () => {
         expect(valueSetterCalls[1].newValue).toBeNull();
         expect(valueSetterCalls[1].oldValue).toBe(42);
         expect(scoreCell).toHaveTextContent('0');
+
+        // Delete key triggers value change without opening editor, but fires stop events
+        expect(eventTracker.counts).toEqual({
+            cellEditingStarted: 0,
+            cellEditingStopped: 2,
+            cellValueChanged: 2,
+            rowValueChanged: 0,
+            cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
+        });
     });
 
     test.each(['ui', 'data'] as const)(
@@ -868,6 +990,7 @@ describe('Cell Editing Regression', () => {
                     });
                 },
             });
+            const eventTracker = new EditEventTracker(api);
 
             const gridDiv = getGridElement(api)! as HTMLElement;
             await asyncSetTimeout(1);
@@ -908,6 +1031,17 @@ describe('Cell Editing Regression', () => {
             expect(cellValueChangedEvents[0].oldValue).toBe('Michael Phelps');
             // The newValue should be the transformed uppercase value, not the original lowercase input
             expect(cellValueChangedEvents[0].newValue).toBe('USAIN BOLT');
+
+            // UI edit: 1 editor started/stopped; data edit: no editors
+            expect(eventTracker.counts).toEqual({
+                cellEditingStarted: source === 'ui' ? 1 : 0,
+                cellEditingStopped: source === 'ui' ? 1 : 0,
+                cellValueChanged: 1,
+                rowValueChanged: 0,
+                cellEditRequest: 0,
+                bulkEditingStarted: 0,
+                bulkEditingStopped: 0,
+            });
         }
     );
 
@@ -940,6 +1074,7 @@ describe('Cell Editing Regression', () => {
                     });
                 },
             });
+            const eventTracker = new EditEventTracker(api);
 
             const gridDiv = getGridElement(api)! as HTMLElement;
             await asyncSetTimeout(1);
@@ -980,6 +1115,17 @@ describe('Cell Editing Regression', () => {
             expect(cellValueChangedEvents[0].oldValue).toBe('United States');
             // The newValue should be the primitive string, not an object like {country: 'Canada'}
             expect(cellValueChangedEvents[0].newValue).toBe('Canada');
+
+            // UI edit: 1 editor started/stopped; data edit: no editors
+            expect(eventTracker.counts).toEqual({
+                cellEditingStarted: source === 'ui' ? 1 : 0,
+                cellEditingStopped: source === 'ui' ? 1 : 0,
+                cellValueChanged: 1,
+                rowValueChanged: 0,
+                cellEditRequest: 0,
+                bulkEditingStarted: 0,
+                bulkEditingStopped: 0,
+            });
         }
     );
 
@@ -996,6 +1142,7 @@ describe('Cell Editing Regression', () => {
                 { make: 'Toyota', model: 'Corolla', price: 29600, electric: false },
             ],
         });
+        const eventTracker = new EditEventTracker(api);
 
         const gridDiv = getGridElement(api)! as HTMLElement;
         await asyncSetTimeout(1);
@@ -1025,6 +1172,20 @@ describe('Cell Editing Regression', () => {
         api.setFocusedCell(1, 'make');
         await asyncSetTimeout(10);
 
+        // Verify that the orphan editor from row 0 price cell is closed after focus change
+        expect(api.getCellEditorInstances()).toHaveLength(0);
+        expect(priceCell.querySelector('input[type="text"]')).toBeNull();
+        expect(api.getEditingCells()).toHaveLength(0);
+        expect(eventTracker.counts).toEqual({
+            cellEditingStarted: 3,
+            cellEditingStopped: 3,
+            cellValueChanged: 0,
+            rowValueChanged: 0,
+            cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
+        });
+
         // Start editing on the new cell (simulates what happens when clicking an editable cell)
         api.startEditingCell({ rowIndex: 1, colKey: 'make' });
         await asyncSetTimeout(10);
@@ -1036,6 +1197,22 @@ describe('Cell Editing Regression', () => {
         expect(priceCell.querySelector('input[type="text"]')).toBeNull();
         expect(api.getEditingCells()).toHaveLength(1);
         expect(api.getEditingCells()[0].rowIndex).toBe(1);
+
+        // Stop editing to clean up
+        api.stopEditing();
+        await asyncSetTimeout(1);
+
+        // Verify events: 4 starts (make, model, price in row 0, then make in row 1)
+        // and 4 stops (make, model, price in row 0, then make in row 1)
+        expect(eventTracker.counts).toEqual({
+            cellEditingStarted: 4,
+            cellEditingStopped: 4,
+            cellValueChanged: 0,
+            rowValueChanged: 0,
+            cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
+        });
     });
 
     test('full row editing: tabbing into empty cell then clicking another cell closes editors', async () => {
@@ -1052,6 +1229,7 @@ describe('Cell Editing Regression', () => {
                 { make: 'Toyota', model: 'Corolla', price: 29600, electric: false },
             ],
         });
+        const eventTracker = new EditEventTracker(api);
 
         const gridDiv = getGridElement(api)! as HTMLElement;
         await asyncSetTimeout(1);
@@ -1079,6 +1257,21 @@ describe('Cell Editing Regression', () => {
         api.setFocusedCell(1, 'make');
         await asyncSetTimeout(10);
 
+        // Verify that row 0 editors are closed after focus change
+        expect(api.getCellEditorInstances()).toHaveLength(0);
+        expect(getRowHtmlElement(api, '0')?.classList.contains('ag-row-editing')).toBe(false);
+        expect(priceCell.querySelector('input')).toBeNull();
+        expect(api.getEditingCells()).toHaveLength(0);
+        expect(eventTracker.counts).toEqual({
+            cellEditingStarted: 4,
+            cellEditingStopped: 4,
+            cellValueChanged: 0,
+            rowValueChanged: 0,
+            cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
+        });
+
         // Start editing on the new row
         api.startEditingCell({ rowIndex: 1, colKey: 'make' });
         await asyncSetTimeout(10);
@@ -1095,5 +1288,20 @@ describe('Cell Editing Regression', () => {
         const editingCells = api.getEditingCells();
         expect(editingCells.length).toBeGreaterThan(0);
         expect(editingCells.every((cell) => cell.rowIndex === 1)).toBe(true);
+
+        // Stop editing to clean up
+        api.stopEditing();
+        await asyncSetTimeout(1);
+
+        // Verify events: row 0 starts 4 editors, row 0 stops 4 editors, row 1 starts 4 editors, row 1 stops 4 editors
+        expect(eventTracker.counts).toEqual({
+            cellEditingStarted: 8,
+            cellEditingStopped: 8,
+            cellValueChanged: 0,
+            rowValueChanged: 0,
+            cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
+        });
     });
 });

--- a/testing/behavioural/src/cell-editing/cell-editing-regression.test.ts
+++ b/testing/behavioural/src/cell-editing/cell-editing-regression.test.ts
@@ -982,4 +982,118 @@ describe('Cell Editing Regression', () => {
             expect(cellValueChangedEvents[0].newValue).toBe('Canada');
         }
     );
+
+    test('tabbing into empty cell then clicking another cell closes editor', async () => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [{ field: 'make' }, { field: 'model' }, { field: 'price' }, { field: 'electric' }],
+            defaultColDef: {
+                editable: true,
+            },
+            rowData: [
+                // First row has missing price - this is key to reproducing the bug
+                { make: 'Tesla', model: 'Model Y', electric: true },
+                { make: 'Ford', model: 'F-Series', price: 33850, electric: false },
+                { make: 'Toyota', model: 'Corolla', price: 29600, electric: false },
+            ],
+        });
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        await asyncSetTimeout(1);
+
+        // Step 1: Start editing the 'Tesla' cell (top-left)
+        const makeCell = getByTestId(gridDiv, agTestIdFor.cell('0', 'make'));
+        await userEvent.dblClick(makeCell);
+        await waitForInput(gridDiv, makeCell, { popup: false });
+        expect(api.getCellEditorInstances()).toHaveLength(1);
+
+        // Step 2: Press Tab twice to navigate to the empty price cell
+        await userEvent.keyboard('{Tab}');
+        await asyncSetTimeout(1);
+        const modelCell = getByTestId(gridDiv, agTestIdFor.cell('0', 'model'));
+        await waitForInput(gridDiv, modelCell, { popup: false });
+        expect(api.getCellEditorInstances()).toHaveLength(1);
+
+        await userEvent.keyboard('{Tab}');
+        await asyncSetTimeout(1);
+        const priceCell = getByTestId(gridDiv, agTestIdFor.cell('0', 'price'));
+        await waitForInput(gridDiv, priceCell, { popup: false });
+        expect(api.getCellEditorInstances()).toHaveLength(1);
+
+        // Step 3: Click on another cell (e.g., Ford's make cell in row 1)
+        // setFocusedCell triggers focus change which should stop editing through
+        // the focus change handler. Then startEditingCell begins editing the new cell.
+        api.setFocusedCell(1, 'make');
+        await asyncSetTimeout(10);
+
+        // Start editing on the new cell (simulates what happens when clicking an editable cell)
+        api.startEditingCell({ rowIndex: 1, colKey: 'make' });
+        await asyncSetTimeout(10);
+
+        // Step 4: Verify the editor is closed
+        // The input field from price cell should be removed after clicking another cell
+        // Row 1 make should be the only editing cell now
+        expect(api.getCellEditorInstances()).toHaveLength(1);
+        expect(priceCell.querySelector('input[type="text"]')).toBeNull();
+        expect(api.getEditingCells()).toHaveLength(1);
+        expect(api.getEditingCells()[0].rowIndex).toBe(1);
+    });
+
+    test('full row editing: tabbing into empty cell then clicking another cell closes editors', async () => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [{ field: 'make' }, { field: 'model' }, { field: 'price' }, { field: 'electric' }],
+            defaultColDef: {
+                editable: true,
+            },
+            editType: 'fullRow',
+            rowData: [
+                // First row has missing price - this is key to reproducing the bug
+                { make: 'Tesla', model: 'Model Y', electric: true },
+                { make: 'Ford', model: 'F-Series', price: 33850, electric: false },
+                { make: 'Toyota', model: 'Corolla', price: 29600, electric: false },
+            ],
+        });
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        await asyncSetTimeout(1);
+
+        // Step 1: Start editing the 'Tesla' row by double-clicking the make cell
+        const makeCell = getByTestId(gridDiv, agTestIdFor.cell('0', 'make'));
+        await userEvent.dblClick(makeCell);
+        await waitForInput(gridDiv, makeCell, { popup: false });
+        // Full row edit should have editors for all 4 columns
+        expect(api.getCellEditorInstances().length).toBeGreaterThanOrEqual(3);
+        expect(getRowHtmlElement(api, '0')?.classList.contains('ag-row-editing')).toBe(true);
+
+        // Step 2: Press Tab twice to navigate to the empty price cell
+        await userEvent.keyboard('{Tab}');
+        await asyncSetTimeout(1);
+        const modelCell = getByTestId(gridDiv, agTestIdFor.cell('0', 'model'));
+        await waitForInput(gridDiv, modelCell, { popup: false });
+
+        await userEvent.keyboard('{Tab}');
+        await asyncSetTimeout(1);
+        const priceCell = getByTestId(gridDiv, agTestIdFor.cell('0', 'price'));
+        await waitForInput(gridDiv, priceCell, { popup: false });
+
+        // Step 3: Click on another row (Ford's make cell in row 1)
+        api.setFocusedCell(1, 'make');
+        await asyncSetTimeout(10);
+
+        // Start editing on the new row
+        api.startEditingCell({ rowIndex: 1, colKey: 'make' });
+        await asyncSetTimeout(10);
+
+        // Step 4: Verify row 0 editors are closed
+        // Row 0 should no longer be in edit mode
+        expect(getRowHtmlElement(api, '0')?.classList.contains('ag-row-editing')).toBe(false);
+        expect(getRowHtmlElement(api, '1')?.classList.contains('ag-row-editing')).toBe(true);
+
+        // Row 0 price cell should not have an input anymore
+        expect(priceCell.querySelector('input')).toBeNull();
+
+        // All editing cells should be in row 1
+        const editingCells = api.getEditingCells();
+        expect(editingCells.length).toBeGreaterThan(0);
+        expect(editingCells.every((cell) => cell.rowIndex === 1)).toBe(true);
+    });
 });

--- a/testing/behavioural/src/cell-editing/cell-editing.test.ts
+++ b/testing/behavioural/src/cell-editing/cell-editing.test.ts
@@ -5,7 +5,7 @@ import { userEvent } from '@testing-library/user-event';
 import type { ColDef } from 'ag-grid-community';
 import { agTestIdFor, getGridElement, setupAgTestIds } from 'ag-grid-community';
 
-import { TestGridsManager, asyncSetTimeout, waitForInput } from '../test-utils';
+import { TestGridsManager, asyncSetTimeout, waitForInput, EditEventTracker } from '../test-utils';
 import { expect } from '../test-utils/matchers';
 
 describe('Cell Editing Start', () => {
@@ -249,6 +249,7 @@ describe('Cell Editing Start', () => {
                 },
                 onCellValueChanged: () => onCellValueChangedGrid(),
             });
+            const eventTracker = new EditEventTracker(api);
 
             const gridDiv = getGridElement(api)! as HTMLElement;
             await asyncSetTimeout(1);
@@ -263,6 +264,17 @@ describe('Cell Editing Start', () => {
             expect(cell).toHaveTextContent('12');
             expect(onCellValueChangedColumn).toHaveBeenCalledTimes(1);
             expect(onCellValueChangedGrid).toHaveBeenCalledTimes(1);
+
+            // 1 editor started/stopped with 1 value change
+            expect(eventTracker.counts).toEqual({
+                cellEditingStarted: 1,
+                cellEditingStopped: 1,
+                cellValueChanged: 1,
+                rowValueChanged: 0,
+                cellEditRequest: 0,
+                bulkEditingStarted: 0,
+                bulkEditingStopped: 0,
+            });
         });
 
         test('onValueChanged - valueSetter', async () => {
@@ -287,6 +299,7 @@ describe('Cell Editing Start', () => {
                 rowData,
                 onCellValueChanged: () => onCellValueChangedGrid(),
             });
+            const eventTracker = new EditEventTracker(api);
 
             const gridDiv = getGridElement(api)! as HTMLElement;
             await asyncSetTimeout(1);
@@ -305,6 +318,17 @@ describe('Cell Editing Start', () => {
             expect(valueSetter).toHaveBeenCalledTimes(1);
             expect(onCellValueChangedColumn).toHaveBeenCalledTimes(1);
             expect(onCellValueChangedGrid).toHaveBeenCalledTimes(1);
+
+            // 1 editor started/stopped with 1 value change
+            expect(eventTracker.counts).toEqual({
+                cellEditingStarted: 1,
+                cellEditingStopped: 1,
+                cellValueChanged: 1,
+                rowValueChanged: 0,
+                cellEditRequest: 0,
+                bulkEditingStarted: 0,
+                bulkEditingStopped: 0,
+            });
         });
     });
 
@@ -320,6 +344,7 @@ describe('Cell Editing Start', () => {
             rowData: [{ id: '0', a: 'initial' }],
             getRowId: (params) => params.data.id,
         });
+        const eventTracker = new EditEventTracker(api);
 
         const gridDiv = getGridElement(api)! as HTMLElement;
         await asyncSetTimeout(1);
@@ -367,6 +392,17 @@ describe('Cell Editing Start', () => {
         await asyncSetTimeout(1);
 
         expect(cellB).toHaveTextContent('xx');
+
+        // 2 edit sessions: first committed with value change, second cancelled
+        expect(eventTracker.counts).toEqual({
+            cellEditingStarted: 2,
+            cellEditingStopped: 2,
+            cellValueChanged: 1,
+            rowValueChanged: 0,
+            cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
+        });
     });
 
     test('valueCache does not store editing values (AG-16448)', async () => {
@@ -384,6 +420,7 @@ describe('Cell Editing Start', () => {
             getRowId: (params) => params.data.id,
             valueCache: true, // Enable value caching
         });
+        const eventTracker = new EditEventTracker(api);
 
         const gridDiv = getGridElement(api)! as HTMLElement;
         await asyncSetTimeout(1);
@@ -434,6 +471,17 @@ describe('Cell Editing Start', () => {
         await asyncSetTimeout(1);
 
         expect(cellB).toHaveTextContent('committed');
+
+        // 2 edit sessions: first cancelled, second committed with value change
+        expect(eventTracker.counts).toEqual({
+            cellEditingStarted: 2,
+            cellEditingStopped: 2,
+            cellValueChanged: 1,
+            rowValueChanged: 0,
+            cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
+        });
     });
 
     test('valueCache does not cache editing values even during edit (AG-16448)', async () => {
@@ -457,6 +505,7 @@ describe('Cell Editing Start', () => {
             getRowId: (params) => params.data.id,
             valueCache: true,
         });
+        const eventTracker = new EditEventTracker(api);
 
         const gridDiv = getGridElement(api)! as HTMLElement;
         await asyncSetTimeout(1);
@@ -495,6 +544,17 @@ describe('Cell Editing Start', () => {
 
         // Now the value should update
         expect(cellB).toHaveTextContent('Computed: typing');
+
+        // 1 editor started/stopped with 1 value change
+        expect(eventTracker.counts).toEqual({
+            cellEditingStarted: 1,
+            cellEditingStopped: 1,
+            cellValueChanged: 1,
+            rowValueChanged: 0,
+            cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
+        });
     });
 
     test('edited cell shows editing value while dependent valueGetter shows committed value (AG-16448)', async () => {
@@ -514,6 +574,7 @@ describe('Cell Editing Start', () => {
             getRowId: (params) => params.data.id,
             valueCache: true,
         });
+        const eventTracker = new EditEventTracker(api);
 
         const gridDiv = getGridElement(api)! as HTMLElement;
         await asyncSetTimeout(1);
@@ -550,6 +611,17 @@ describe('Cell Editing Start', () => {
         // Now both should be updated
         expect(cellA).toHaveTextContent('editing');
         expect(cellComputed).toHaveTextContent('Echo: editing');
+
+        // 1 editor started/stopped with 1 value change
+        expect(eventTracker.counts).toEqual({
+            cellEditingStarted: 1,
+            cellEditingStopped: 1,
+            cellValueChanged: 1,
+            rowValueChanged: 0,
+            cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
+        });
     });
 
     test('valueCache is actually caching values', async () => {

--- a/testing/behavioural/src/cell-editing/cell-editing.test.ts
+++ b/testing/behavioural/src/cell-editing/cell-editing.test.ts
@@ -5,7 +5,7 @@ import { userEvent } from '@testing-library/user-event';
 import type { ColDef } from 'ag-grid-community';
 import { agTestIdFor, getGridElement, setupAgTestIds } from 'ag-grid-community';
 
-import { TestGridsManager, asyncSetTimeout, waitForInput, EditEventTracker } from '../test-utils';
+import { EditEventTracker, TestGridsManager, asyncSetTimeout, waitForInput } from '../test-utils';
 import { expect } from '../test-utils/matchers';
 
 describe('Cell Editing Start', () => {

--- a/testing/behavioural/src/cell-editing/cell-editing.test.ts
+++ b/testing/behavioural/src/cell-editing/cell-editing.test.ts
@@ -552,7 +552,7 @@ describe('Cell Editing Start', () => {
         expect(cellComputed).toHaveTextContent('Echo: editing');
     });
 
-    test('valueCache is actually caching values (AG-16448)', async () => {
+    test('valueCache is actually caching values', async () => {
         // This test verifies that the value cache is actually active and caching
         let valueGetterCallCount = 0;
         const api = await gridMgr.createGridAndWait('myGrid', {

--- a/testing/behavioural/src/cell-editing/clipboard/clipboard-fill-handle.test.ts
+++ b/testing/behavioural/src/cell-editing/clipboard/clipboard-fill-handle.test.ts
@@ -98,6 +98,8 @@ describe('Clipboard Paste Behaviour: fill handle', () => {
             cellValueChanged: 1,
             rowValueChanged: 0,
             cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
         });
 
         await asyncSetTimeout(1);

--- a/testing/behavioural/src/cell-editing/clipboard/clipboard-paste.test.ts
+++ b/testing/behavioural/src/cell-editing/clipboard/clipboard-paste.test.ts
@@ -95,6 +95,8 @@ describe('Clipboard Paste Behaviour: paste flows', () => {
             cellValueChanged: 1,
             rowValueChanged: 0,
             cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
         });
         expect(lastSetValue).toBe('Top Value');
         expect(valueSetterTargets).toEqual(['ROW_1']);
@@ -155,6 +157,8 @@ describe('Clipboard Paste Behaviour: paste flows', () => {
             cellValueChanged: 1,
             rowValueChanged: 0,
             cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
         });
         expect(lastSetValue).toBe('Top Value');
         expect(valueSetterTargets).toEqual(['ROW_1']);

--- a/testing/behavioural/src/cell-editing/group-edit/group-edit-clipboard-paste.test.ts
+++ b/testing/behavioural/src/cell-editing/group-edit/group-edit-clipboard-paste.test.ts
@@ -114,6 +114,8 @@ describe('Group Edit: clipboard paste', () => {
             cellValueChanged: 1,
             rowValueChanged: 0,
             cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
         });
         expect(new Set(valueSetterTargets)).toEqual(new Set(['a-1']));
     });

--- a/testing/behavioural/src/cell-editing/set-value/cell-editing-bulk-edit.test.ts
+++ b/testing/behavioural/src/cell-editing/set-value/cell-editing-bulk-edit.test.ts
@@ -105,6 +105,8 @@ describe('Cell Editing: bulk edit', () => {
             cellValueChanged: valueSetterCalls,
             rowValueChanged: 0,
             cellEditRequest: 0,
+            bulkEditingStarted: batchEnabled ? 0 : 1,
+            bulkEditingStopped: batchEnabled ? 0 : 1,
         });
 
         expect(api.getDisplayedRowAtIndex(0)?.data?.a).toBe('Bulk Value');
@@ -113,5 +115,280 @@ describe('Cell Editing: bulk edit', () => {
         expect(api.getDisplayedRowAtIndex(1)?.data?.b).toBe('Bulk Value');
         expect(valueSetterTargets).toEqual(['ROW_0:a', 'ROW_0:b', 'ROW_1:a', 'ROW_1:b']);
         expect(valueSetterCalls).toBe(4);
+    });
+
+    test('bulk edit skips non-editable cells', async () => {
+        let valueSetterCalls = 0;
+        const valueSetterTargets: string[] = [];
+        const valueSetter = ({
+            data,
+            newValue,
+            colDef,
+        }: {
+            data: { id: string; a: string; b: string };
+            newValue: any;
+            colDef: { field?: string };
+        }) => {
+            valueSetterCalls += 1;
+            if (colDef.field) {
+                valueSetterTargets.push(`${data.id}:${colDef.field}`);
+                data[colDef.field as 'a' | 'b'] = newValue;
+            }
+            return true;
+        };
+
+        const api = await gridMgr.createGridAndWait('cellEditingBulkSkipNonEditable', {
+            cellSelection: true,
+            columnDefs: [
+                { field: 'a', editable: true, valueSetter },
+                { field: 'b', editable: (params) => params.data.id !== 'ROW_1', valueSetter },
+            ],
+            rowData: [
+                { id: 'ROW_0', a: 'A0', b: 'B0' },
+                { id: 'ROW_1', a: 'A1', b: 'B1' },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+        const eventTracker = new EditEventTracker(api);
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+
+        const beforeRows = new GridRows(api, 'before bulk edit skip non-editable');
+        await beforeRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:ROW_0 a:"A0" b:"B0"
+            └── LEAF id:ROW_1 a:"A1" b:"B1"
+        `);
+
+        await asyncSetTimeout(0);
+
+        const user = userEvent.setup({ skipHover: true });
+        const cell = getByTestId(gridDiv, agTestIdFor.cell('ROW_0', 'a'));
+        await user.click(cell);
+        api.addCellRange({ rowStartIndex: 0, rowEndIndex: 1, columns: ['a', 'b'] });
+        api.startEditingCell({ rowIndex: 0, colKey: 'a' });
+        const input = await waitForInput(gridDiv, cell);
+        await user.clear(input);
+        await user.type(input, 'Bulk Value');
+        await user.keyboard('{Control>}{Enter}{/Control}');
+        await asyncSetTimeout(0);
+
+        // ROW_1:b should not be updated because it's not editable
+        const afterRows = new GridRows(api, 'after bulk edit skip non-editable');
+        await afterRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:ROW_0 a:"Bulk Value" b:"Bulk Value"
+            └── LEAF id:ROW_1 a:"Bulk Value" b:"B1"
+        `);
+
+        expect(eventTracker.counts).toEqual({
+            cellEditingStarted: 1,
+            cellEditingStopped: 4,
+            cellValueChanged: 3,
+            rowValueChanged: 0,
+            cellEditRequest: 0,
+            bulkEditingStarted: 1,
+            bulkEditingStopped: 1,
+        });
+
+        expect(valueSetterTargets).toEqual(['ROW_0:a', 'ROW_0:b', 'ROW_1:a']);
+        expect(valueSetterCalls).toBe(3);
+    });
+
+    test('bulk edit with single cell range updates only that cell', async () => {
+        let valueSetterCalls = 0;
+        const valueSetterTargets: string[] = [];
+        const valueSetter = ({
+            data,
+            newValue,
+            colDef,
+        }: {
+            data: { id: string; a: string; b: string };
+            newValue: any;
+            colDef: { field?: string };
+        }) => {
+            valueSetterCalls += 1;
+            if (colDef.field) {
+                valueSetterTargets.push(`${data.id}:${colDef.field}`);
+                data[colDef.field as 'a' | 'b'] = newValue;
+            }
+            return true;
+        };
+
+        const api = await gridMgr.createGridAndWait('cellEditingBulkSingleCell', {
+            cellSelection: true,
+            defaultColDef: {
+                editable: true,
+            },
+            columnDefs: [
+                { field: 'a', valueSetter },
+                { field: 'b', valueSetter },
+            ],
+            rowData: [
+                { id: 'ROW_0', a: 'A0', b: 'B0' },
+                { id: 'ROW_1', a: 'A1', b: 'B1' },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+        const eventTracker = new EditEventTracker(api);
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+
+        const beforeRows = new GridRows(api, 'before bulk edit single cell');
+        await beforeRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:ROW_0 a:"A0" b:"B0"
+            └── LEAF id:ROW_1 a:"A1" b:"B1"
+        `);
+
+        await asyncSetTimeout(0);
+
+        const user = userEvent.setup({ skipHover: true });
+        const cell = getByTestId(gridDiv, agTestIdFor.cell('ROW_0', 'a'));
+        await user.click(cell);
+        // Add a single cell range for just this cell
+        api.addCellRange({ rowStartIndex: 0, rowEndIndex: 0, columns: ['a'] });
+        api.startEditingCell({ rowIndex: 0, colKey: 'a' });
+        const input = await waitForInput(gridDiv, cell);
+        await user.clear(input);
+        await user.type(input, 'Single Value');
+        await user.keyboard('{Control>}{Enter}{/Control}');
+        await asyncSetTimeout(0);
+
+        const afterRows = new GridRows(api, 'after bulk edit single cell');
+        await afterRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:ROW_0 a:"Single Value" b:"B0"
+            └── LEAF id:ROW_1 a:"A1" b:"B1"
+        `);
+
+        expect(eventTracker.counts).toEqual({
+            cellEditingStarted: 1,
+            cellEditingStopped: 2,
+            cellValueChanged: 1,
+            rowValueChanged: 0,
+            cellEditRequest: 0,
+            bulkEditingStarted: 1,
+            bulkEditingStopped: 1,
+        });
+
+        expect(valueSetterTargets).toEqual(['ROW_0:a']);
+        expect(valueSetterCalls).toBe(1);
+    });
+
+    test('Ctrl+Enter without cell range does not trigger bulk edit', async () => {
+        const api = await gridMgr.createGridAndWait('cellEditingBulkNoRange', {
+            cellSelection: true,
+            defaultColDef: {
+                editable: true,
+            },
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+            rowData: [
+                { id: 'ROW_0', a: 'A0', b: 'B0' },
+                { id: 'ROW_1', a: 'A1', b: 'B1' },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+        const eventTracker = new EditEventTracker(api);
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+
+        const beforeRows = new GridRows(api, 'before Ctrl+Enter no range');
+        await beforeRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:ROW_0 a:"A0" b:"B0"
+            └── LEAF id:ROW_1 a:"A1" b:"B1"
+        `);
+
+        await asyncSetTimeout(0);
+
+        const user = userEvent.setup({ skipHover: true });
+        const cell = getByTestId(gridDiv, agTestIdFor.cell('ROW_0', 'a'));
+        await user.click(cell);
+        api.clearCellSelection(); // Clear any selection
+        api.startEditingCell({ rowIndex: 0, colKey: 'a' });
+        const input = await waitForInput(gridDiv, cell);
+        await user.clear(input);
+        await user.type(input, 'New Value');
+        await user.keyboard('{Control>}{Enter}{/Control}');
+        await asyncSetTimeout(0);
+
+        // Without a range, Ctrl+Enter should not trigger bulk edit events
+        expect(eventTracker.counts.bulkEditingStarted).toBe(0);
+        expect(eventTracker.counts.bulkEditingStopped).toBe(0);
+        // The cell should still be in editing mode (normal Enter behaviour not triggered)
+        expect(eventTracker.counts.cellEditingStarted).toBe(1);
+    });
+
+    test('bulk edit updates cells in row then column order', async () => {
+        const updateOrder: string[] = [];
+        const valueSetter = ({
+            data,
+            newValue,
+            colDef,
+        }: {
+            data: { id: string; a: string; b: string; c: string };
+            newValue: any;
+            colDef: { field?: string };
+        }) => {
+            if (colDef.field) {
+                updateOrder.push(`${data.id}:${colDef.field}`);
+                data[colDef.field as 'a' | 'b' | 'c'] = newValue;
+            }
+            return true;
+        };
+
+        const api = await gridMgr.createGridAndWait('cellEditingBulkColumnOrder', {
+            cellSelection: true,
+            defaultColDef: {
+                editable: true,
+            },
+            columnDefs: [
+                { field: 'a', valueSetter },
+                { field: 'b', valueSetter },
+                { field: 'c', valueSetter },
+            ],
+            rowData: [
+                { id: 'ROW_0', a: 'A0', b: 'B0', c: 'C0' },
+                { id: 'ROW_1', a: 'A1', b: 'B1', c: 'C1' },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+        const eventTracker = new EditEventTracker(api);
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+
+        const beforeRows = new GridRows(api, 'before bulk edit column order');
+        await beforeRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:ROW_0 a:"A0" b:"B0" c:"C0"
+            └── LEAF id:ROW_1 a:"A1" b:"B1" c:"C1"
+        `);
+
+        await asyncSetTimeout(0);
+
+        const user = userEvent.setup({ skipHover: true });
+        const cell = getByTestId(gridDiv, agTestIdFor.cell('ROW_0', 'a'));
+        await user.click(cell);
+        api.addCellRange({ rowStartIndex: 0, rowEndIndex: 1, columns: ['a', 'b', 'c'] });
+        api.startEditingCell({ rowIndex: 0, colKey: 'a' });
+        const input = await waitForInput(gridDiv, cell);
+        await user.clear(input);
+        await user.type(input, 'X');
+        await user.keyboard('{Control>}{Enter}{/Control}');
+        await asyncSetTimeout(0);
+
+        const afterRows = new GridRows(api, 'after bulk edit column order');
+        await afterRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:ROW_0 a:"X" b:"X" c:"X"
+            └── LEAF id:ROW_1 a:"X" b:"X" c:"X"
+        `);
+
+        expect(eventTracker.counts.bulkEditingStarted).toBe(1);
+        expect(eventTracker.counts.bulkEditingStopped).toBe(1);
+
+        // Should update in row order, then column order within each row
+        expect(updateOrder).toEqual(['ROW_0:a', 'ROW_0:b', 'ROW_0:c', 'ROW_1:a', 'ROW_1:b', 'ROW_1:c']);
     });
 });

--- a/testing/behavioural/src/cell-editing/set-value/cell-editing-delete-range.test.ts
+++ b/testing/behavioural/src/cell-editing/set-value/cell-editing-delete-range.test.ts
@@ -82,6 +82,8 @@ describe('Cell Editing: delete and range clearing', () => {
             cellValueChanged: valueSetterCalls,
             rowValueChanged: 0,
             cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
         });
 
         expect(api.getDisplayedRowAtIndex(0)?.data?.field ?? null).toBeNull();
@@ -158,6 +160,8 @@ describe('Cell Editing: delete and range clearing', () => {
             cellValueChanged: 0,
             rowValueChanged: 0,
             cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
         });
 
         expect(api.getDisplayedRowAtIndex(0)?.data?.field).toBe('Initial Value');
@@ -234,6 +238,8 @@ describe('Cell Editing: delete and range clearing', () => {
             cellValueChanged: valueSetterCalls,
             rowValueChanged: 0,
             cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
         });
 
         expect(api.getDisplayedRowAtIndex(0)?.data?.field ?? null).toBeNull();
@@ -320,6 +326,8 @@ describe('Cell Editing: delete and range clearing', () => {
             cellValueChanged: valueSetterCalls,
             rowValueChanged: 0,
             cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
         });
 
         expect(api.getDisplayedRowAtIndex(0)?.data?.a ?? null).toBeNull();

--- a/testing/behavioural/src/cell-editing/set-value/cell-editing-full-row-batch.test.ts
+++ b/testing/behavioural/src/cell-editing/set-value/cell-editing-full-row-batch.test.ts
@@ -81,6 +81,8 @@ describe('Cell Editing: full-row batch', () => {
             cellValueChanged: action === 'commit' ? 1 : 0,
             rowValueChanged: action === 'commit' ? 1 : 0,
             cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
         });
 
         const row = api.getDisplayedRowAtIndex(0)?.data as { a: string; b: string } | undefined;

--- a/testing/behavioural/src/cell-editing/set-value/cell-editing-set-data-value.test.ts
+++ b/testing/behavioural/src/cell-editing/set-value/cell-editing-set-data-value.test.ts
@@ -66,6 +66,8 @@ describe('Cell Editing: setDataValue sources', () => {
                 cellValueChanged: 1,
                 rowValueChanged: 0,
                 cellEditRequest: 0,
+                bulkEditingStarted: 0,
+                bulkEditingStopped: 0,
             });
 
             expect(valueSetterTargets).toEqual(['ROW_0']);
@@ -118,6 +120,8 @@ describe('Cell Editing: setDataValue sources', () => {
             cellValueChanged: 1,
             rowValueChanged: 0,
             cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
         });
 
         expect(api.getDisplayedRowAtIndex(0)?.data?.field).toBe('default-value');
@@ -170,6 +174,8 @@ describe('Cell Editing: setDataValue sources', () => {
             cellValueChanged: 1,
             rowValueChanged: 0,
             cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
         });
 
         expect(api.getDisplayedRowAtIndex(0)?.data?.field).toBe('paste-value');
@@ -225,6 +231,8 @@ describe('Cell Editing: setDataValue sources', () => {
             cellValueChanged: 0,
             rowValueChanged: 0,
             cellEditRequest: 1,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
         });
 
         expect(api.getDisplayedRowAtIndex(0)?.data?.field).toBe('Initial Value');

--- a/testing/behavioural/src/cell-editing/set-value/cell-editing-undo-redo.test.ts
+++ b/testing/behavioural/src/cell-editing/set-value/cell-editing-undo-redo.test.ts
@@ -81,6 +81,14 @@ describe('Cell Editing: undo/redo', () => {
             bulkEditingStopped: 0,
         });
 
+        // 1 undo, 1 redo
+        expect(eventTracker.undoCounts).toEqual({
+            undoStarted: 1,
+            undoEnded: 1,
+            redoStarted: 1,
+            redoEnded: 1,
+        });
+
         expect(api.getDisplayedRowAtIndex(0)?.data?.field).toBe('Updated Value');
         expect(valueSetterCalls).toBe(3);
         expect(valueSetterTargets).toEqual(['ROW_0', 'ROW_0', 'ROW_0']);
@@ -134,19 +142,30 @@ describe('Cell Editing: undo/redo', () => {
             await waitFor(() => expect(new Set(rowValueChangedNodes)).toEqual(new Set(['ROW_0'])));
 
             api.undoCellEditing();
+            await asyncSetTimeout(0);
             await waitFor(() => expect(new Set(rowValueChangedNodes)).toEqual(new Set(['ROW_0'])));
 
             api.redoCellEditing();
+            await asyncSetTimeout(0);
             await waitFor(() => expect(new Set(rowValueChangedNodes)).toEqual(new Set(['ROW_0'])));
 
+            // 1 initial edit + 1 undo + 1 redo = 3 cellValueChanged
             expect(eventTracker.counts).toEqual({
                 cellEditingStarted: 2,
                 cellEditingStopped: batchEnabled ? 3 : 2,
-                cellValueChanged: 1,
+                cellValueChanged: 3,
                 rowValueChanged: 1,
                 cellEditRequest: 0,
                 bulkEditingStarted: 0,
                 bulkEditingStopped: 0,
+            });
+
+            // 1 undo, 1 redo
+            expect(eventTracker.undoCounts).toEqual({
+                undoStarted: 1,
+                undoEnded: 1,
+                redoStarted: 1,
+                redoEnded: 1,
             });
         }
     );
@@ -163,6 +182,7 @@ describe('Cell Editing: undo/redo', () => {
             ],
             getRowId: (params) => params.data.id,
         });
+        const eventTracker = new EditEventTracker(api);
 
         const gridDiv = getGridElement(api)! as HTMLElement;
         const user = userEvent.setup({ skipHover: true });
@@ -194,5 +214,23 @@ describe('Cell Editing: undo/redo', () => {
         await asyncSetTimeout(0);
         expect(getByTestId(gridDiv, agTestIdFor.cell('ROW_0', 'a'))).toHaveTextContent('A0-EDIT');
         expect(api.getCurrentUndoSize()).toBe(1);
+
+        // Editing started/stopped counts include row 0 and row 1 full-row editing lifecycle
+        // 1 initial edit + 1 undo + 1 redo = 3 cellValueChanged
+        expect(eventTracker.counts).toEqual({
+            cellEditingStarted: 5,
+            cellEditingStopped: 5,
+            cellValueChanged: 3,
+            rowValueChanged: 1,
+            cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
+        });
+        expect(eventTracker.undoCounts).toEqual({
+            undoStarted: 1,
+            undoEnded: 1,
+            redoStarted: 1,
+            redoEnded: 1,
+        });
     });
 });

--- a/testing/behavioural/src/cell-editing/set-value/cell-editing-undo-redo.test.ts
+++ b/testing/behavioural/src/cell-editing/set-value/cell-editing-undo-redo.test.ts
@@ -77,6 +77,8 @@ describe('Cell Editing: undo/redo', () => {
             cellValueChanged: valueSetterCalls,
             rowValueChanged: 0,
             cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
         });
 
         expect(api.getDisplayedRowAtIndex(0)?.data?.field).toBe('Updated Value');
@@ -143,6 +145,8 @@ describe('Cell Editing: undo/redo', () => {
                 cellValueChanged: 1,
                 rowValueChanged: 1,
                 cellEditRequest: 0,
+                bulkEditingStarted: 0,
+                bulkEditingStopped: 0,
             });
         }
     );

--- a/testing/behavioural/src/test-utils/test-utils-events.ts
+++ b/testing/behavioural/src/test-utils/test-utils-events.ts
@@ -88,6 +88,12 @@ export type EditEventCounts = {
     bulkEditingStopped: number;
 };
 
+export type UndoCounts = {
+    undoStarted: number;
+    undoEnded: number;
+    redoStarted: number;
+    redoEnded: number;
+};
 const DEFAULT_EDIT_EVENT_COUNTS = {
     cellEditingStarted: 0,
     cellEditingStopped: 0,
@@ -98,8 +104,16 @@ const DEFAULT_EDIT_EVENT_COUNTS = {
     bulkEditingStopped: 0,
 };
 
+const DEFAULT_UNDO_COUNTS = {
+    undoStarted: 0,
+    undoEnded: 0,
+    redoStarted: 0,
+    redoEnded: 0,
+};
+
 export class EditEventTracker {
     public readonly counts: EditEventCounts = { ...DEFAULT_EDIT_EVENT_COUNTS };
+    public readonly undoCounts: UndoCounts = { ...DEFAULT_UNDO_COUNTS };
 
     private readonly listeners: Array<{ event: AgPublicEventType; listener: () => void }> = [];
 
@@ -111,11 +125,24 @@ export class EditEventTracker {
         this.track('cellEditRequest');
         this.track('bulkEditingStarted');
         this.track('bulkEditingStopped');
+        this.trackUndo('undoStarted');
+        this.trackUndo('undoEnded');
+        this.trackUndo('redoStarted');
+        this.trackUndo('redoEnded');
     }
 
     private track(event: AgPublicEventType): void {
         const listener = () => {
             this.counts[event] += 1;
+        };
+
+        this.listeners.push({ event, listener });
+        this.api.addEventListener(event, listener);
+    }
+
+    private trackUndo(event: AgPublicEventType): void {
+        const listener = () => {
+            this.undoCounts[event] += 1;
         };
 
         this.listeners.push({ event, listener });
@@ -131,5 +158,6 @@ export class EditEventTracker {
 
     public reset(): void {
         Object.assign(this.counts, DEFAULT_EDIT_EVENT_COUNTS);
+        Object.assign(this.undoCounts, DEFAULT_UNDO_COUNTS);
     }
 }

--- a/testing/behavioural/src/test-utils/test-utils-events.ts
+++ b/testing/behavioural/src/test-utils/test-utils-events.ts
@@ -84,6 +84,8 @@ export type EditEventCounts = {
     cellValueChanged: number;
     rowValueChanged: number;
     cellEditRequest: number;
+    bulkEditingStarted: number;
+    bulkEditingStopped: number;
 };
 
 const DEFAULT_EDIT_EVENT_COUNTS = {
@@ -92,6 +94,8 @@ const DEFAULT_EDIT_EVENT_COUNTS = {
     cellValueChanged: 0,
     rowValueChanged: 0,
     cellEditRequest: 0,
+    bulkEditingStarted: 0,
+    bulkEditingStopped: 0,
 };
 
 export class EditEventTracker {
@@ -105,6 +109,8 @@ export class EditEventTracker {
         this.track('cellValueChanged');
         this.track('rowValueChanged');
         this.track('cellEditRequest');
+        this.track('bulkEditingStarted');
+        this.track('bulkEditingStopped');
     }
 
     private track(event: AgPublicEventType): void {


### PR DESCRIPTION
focusing another cell while editing an empty cell keep the editor open

- Fix the issue in shouldStop that was blocking destroying the empty cell
- Add tests for single and multi row focus change
- Extra: added more tests for bulk edit and expectations for bulk edit

FIX AG-16688