### PR TITLE
[AG-14571] Fix(docs): relative date ranges

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/filter-date/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-date/index.mdoc
@@ -246,7 +246,7 @@ const columnDefs: ColDef[] = [
 ### Available Built-in Date Filter Options
 
 | Option Name        | Option Key     | Time Range Start >=                    | Time Range End <              |
-| ------------------ | -------------- | -------------------------------------- | :---------------------------- |
+|--------------------|----------------|----------------------------------------|:------------------------------|
 | Today              | `today`        | `Start Of Today`                       | `Start Of Tomorrow`           |
 | Yesterday          | `yesterday`    | `Start Of Yesterday`                   | `Start Of Today`              |
 | Tomorrow           | `tomorrow`     | `Start Of Tomorrow`                    | `Start Of Day After Tomorrow` |
@@ -274,11 +274,7 @@ const columnDefs: ColDef[] = [
 `Start Of Today`, `Start Of Tomorrow`, `Start Of XXX` point to the beginning of the corresponding day, e.g. `00:00:00.000` in the browser’s local time zone.
 {% /note %}
 
-### Server-Side Row Model (SSRM)
-
-When a user selects one of built-in date ranges, the filter model sent to the server includes the preset `type` (for example, `today` or `last7Days`) and leaves `dateFrom`/`dateTo` undefined. The server / user defined code is responsible for interpreting the preset and applying the equivalent date range logic using its own time zone and locale rules.
-
-See [SSRM Filtering](./server-side-model-filtering/) for the server-side filtering contract.
+For date range filters, the Grid State model and the SSRM request model share the same shape, so you can persist the state and replay it on the server. See [SSRM Date Range Filters](./server-side-model-filtering/#date-range-filters) for the server-side filtering contract.
 
 ## Range Input Validation and Error States
 

--- a/documentation/ag-grid-docs/src/content/docs/filter-date/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-date/index.mdoc
@@ -274,7 +274,7 @@ const columnDefs: ColDef[] = [
 `Start Of Today`, `Start Of Tomorrow`, `Start Of XXX` point to the beginning of the corresponding day, e.g. `00:00:00.000` in the browser’s local time zone.
 {% /note %}
 
-For date range filters, the Grid State model and the SSRM request model share the same shape, so you can persist the state and replay it on the server. See [SSRM Date Range Filters](./server-side-model-filtering/#date-range-filters) for the server-side filtering contract.
+For date range filters, the Grid State model matches the SSRM request model shape. See [SSRM Date Range Filters](./server-side-model-filtering/#date-range-filters) for the server-side filtering contract.
 
 ## Range Input Validation and Error States
 

--- a/documentation/ag-grid-docs/src/content/docs/filter-date/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/filter-date/index.mdoc
@@ -246,7 +246,7 @@ const columnDefs: ColDef[] = [
 ### Available Built-in Date Filter Options
 
 | Option Name        | Option Key     | Time Range Start >=                    | Time Range End <              |
-| ------------------ | -------------- | -------------------------------------- | :---------------------------- |
+|--------------------|----------------|----------------------------------------|:------------------------------|
 | Today              | `today`        | `Start Of Today`                       | `Start Of Tomorrow`           |
 | Yesterday          | `yesterday`    | `Start Of Yesterday`                   | `Start Of Today`              |
 | Tomorrow           | `tomorrow`     | `Start Of Tomorrow`                    | `Start Of Day After Tomorrow` |
@@ -274,11 +274,7 @@ const columnDefs: ColDef[] = [
 `Start Of Today`, `Start Of Tomorrow`, `Start Of XXX` point to the beginning of the corresponding day, e.g. `00:00:00.000` in the browser’s local time zone.
 {% /note %}
 
-### Server-Side Row Model (SSRM)
-
-When a user selects one of built-in date ranges, the filter model sent to the server includes the preset `type` (for example, `today` or `last7Days`) and leaves `dateFrom`/`dateTo` undefined. The server / user defined code is responsible for interpreting the preset and applying the equivalent date range logic using its own time zone and locale rules.
-
-See [SSRM Filtering](./server-side-model-filtering/) for the server-side filtering contract.
+For date range filters, the Grid State preset range filter model and the SSRM request model share the same shape, so you can persist the state and replay it on the server. See [SSRM Date Range Filters](./server-side-model-filtering/#date-range-filters) for the server-side filtering contract.
 
 ## Range Input Validation and Error States
 

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/index.mdoc
@@ -80,6 +80,12 @@ When using a Date Filter with built-in date ranges (for example, Today or Last 7
 
 {% interfaceDocumentation interfaceName="PresetDateRangeFilterModel" config={"description":""} /%}
 
+The type above is exported from `ag-grid-community`:
+
+```js
+import { PresetDateRangeFilterModel } from 'ag-grid-community';
+```
+
 ## Set Filtering
 
 Filtering using the [Set Filter](./filter-set/) has a few differences to filtering with Simple Filters.

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/index.mdoc
@@ -80,12 +80,6 @@ When using a Date Filter with built-in date ranges (for example, Today or Last 7
 
 {% interfaceDocumentation interfaceName="PresetDateRangeFilterModel" config={"description":""} /%}
 
-The type above is exported from `ag-grid-community`:
-
-```js
-import { PresetDateRangeFilterModel } from 'ag-grid-community';
-```
-
 ## Set Filtering
 
 Filtering using the [Set Filter](./filter-set/) has a few differences to filtering with Simple Filters.


### PR DESCRIPTION
Docs: align date range filter guidance with SSRM docs

  - Replace SSRM subsection in Date Filter with Grid State preset range model note and link to SSRM date ranges
  - Add import snippet for PresetDateRangeFilterModel in SSRM filtering docs for discoverability

Fixes [AG-14571](https://ag-grid.atlassian.net/browse/AG-14571)