### PR TITLE
AG-16675 fix shadow dom event target

### DIFF
--- a/packages/ag-grid-community/src/agStack/core/baseDragService.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseDragService.ts
@@ -64,7 +64,7 @@ export class BaseDragService<
     private readonly dragSources: DragSourceEntry[] = [];
 
     public get startTarget(): EventTarget | null {
-        return _getEventTarget(this.drag?.start) ?? null;
+        return this.drag?.startTarget ?? null;
     }
 
     /** True if there is at least one active pointer drag in any BaseDragService instance in the page */
@@ -540,6 +540,8 @@ class Dragging {
     public readonly handlers: TempEventHandler[] = [];
     public lastDrag: PointerEvent | MouseEvent | Touch | null = null;
     public pointerCapture: PointerCapture | null = null;
+    /** The actual target element from composedPath, captured at drag start time */
+    public readonly startTarget: EventTarget | null;
 
     constructor(
         public readonly rootEl: Document | ShadowRoot,
@@ -548,6 +550,8 @@ class Dragging {
         public readonly pointerId: number | null = null
     ) {
         this.eElement = params.eElement;
+        // Capture the target immediately using composedPath, as it may return empty after event dispatch
+        this.startTarget = _getEventTarget(start);
     }
 }
 

--- a/packages/ag-grid-community/src/agStack/core/baseDragService.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseDragService.ts
@@ -12,6 +12,7 @@ import { _isFocusableFormField } from '../utils/dom';
 import type { TempEventHandler } from '../utils/event';
 import {
     _areEventsNear,
+    _getEventTarget,
     _getFirstActiveTouch,
     _isEventFromThisInstance,
     addTempEventHandlers,
@@ -62,7 +63,7 @@ export class BaseDragService<
     private readonly dragSources: DragSourceEntry[] = [];
 
     public get startTarget(): EventTarget | null {
-        return this.drag?.start.target ?? null;
+        return _getEventTarget(this.drag?.start) ?? null;
     }
 
     /** True if there is at least one active pointer drag in any BaseDragService instance in the page */
@@ -310,7 +311,7 @@ export class BaseDragService<
         const dragPreventEventDefault = (e: Event) => this.draggingPreventDefault(e);
 
         const rootNode = _getRootNode(beans);
-        const target = touchEvent.target ?? params.eElement;
+        const target = _getEventTarget(touchEvent) ?? params.eElement;
         this.initDrag(
             touchDrag,
             [target, 'touchmove', touchMoveEvent, PASSIVE_TRUE],
@@ -548,6 +549,6 @@ class Dragging {
 }
 
 const getEventTargetElement = (event: Event): Element | null => {
-    const target = event.target;
+    const target = _getEventTarget(event);
     return target instanceof Element ? target : null;
 };

--- a/packages/ag-grid-community/src/agStack/core/baseDragService.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseDragService.ts
@@ -15,7 +15,6 @@ import {
     _getEventTarget,
     _getFirstActiveTouch,
     _isEventFromThisInstance,
-    _setTouchStartTarget,
     addTempEventHandlers,
     clearTempEventHandlers,
     preventEventDefault,
@@ -232,7 +231,7 @@ export class BaseDragService<
         const rootEl = _getRootNode(beans);
         const eElement = params.eElement;
         const pointerId = pointerEvent.pointerId;
-        const pointerDrag = new Dragging(rootEl, params, pointerEvent, pointerId);
+        const pointerDrag = new Dragging(rootEl, params, pointerEvent, _getEventTarget(pointerEvent), pointerId);
 
         activePointerDrags ??= new WeakMap();
         activePointerDrags.set(rootEl, pointerDrag);
@@ -305,8 +304,8 @@ export class BaseDragService<
         const beans = this.beans;
         const rootEl = _getRootNode(beans);
         const touch = touchEvent.touches[0];
-        _setTouchStartTarget(touch, touchEvent);
-        const touchDrag = new Dragging(rootEl, params, touch);
+        const target = _getEventTarget(touchEvent) ?? params.eElement;
+        const touchDrag = new Dragging(rootEl, params, touch, target);
 
         const touchMoveEvent = (e: TouchEvent) => this.onTouchMove(e);
         const touchEndEvent = (e: TouchEvent) => this.onTouchUp(e);
@@ -314,7 +313,6 @@ export class BaseDragService<
         const dragPreventEventDefault = (e: Event) => this.draggingPreventDefault(e);
 
         const rootNode = _getRootNode(beans);
-        const target = _getEventTarget(touchEvent) ?? params.eElement;
         this.initDrag(
             touchDrag,
             [target, 'touchmove', touchMoveEvent, PASSIVE_TRUE],
@@ -357,7 +355,7 @@ export class BaseDragService<
         const beans = this.beans;
         this.destroyDrag();
 
-        const mouseDrag = new Dragging(_getRootNode(beans), params, mouseEvent);
+        const mouseDrag = new Dragging(_getRootNode(beans), params, mouseEvent, _getEventTarget(mouseEvent));
 
         const mouseMoveEvent = (event: MouseEvent) => this.onMouseOrPointerMove(event);
         const mouseUpEvent = (event: MouseEvent) => this.onMouseOrPointerUp(event);
@@ -540,18 +538,15 @@ class Dragging {
     public readonly handlers: TempEventHandler[] = [];
     public lastDrag: PointerEvent | MouseEvent | Touch | null = null;
     public pointerCapture: PointerCapture | null = null;
-    /** The actual target element from composedPath, captured at drag start time */
-    public readonly startTarget: EventTarget | null;
 
     constructor(
         public readonly rootEl: Document | ShadowRoot,
         public readonly params: DragListenerParams,
         public readonly start: PointerEvent | MouseEvent | Touch,
+        public readonly startTarget: EventTarget | null,
         public readonly pointerId: number | null = null
     ) {
         this.eElement = params.eElement;
-        // Capture the target immediately using composedPath, as it may return empty after event dispatch
-        this.startTarget = _getEventTarget(start);
     }
 }
 

--- a/packages/ag-grid-community/src/agStack/core/baseDragService.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseDragService.ts
@@ -15,6 +15,7 @@ import {
     _getEventTarget,
     _getFirstActiveTouch,
     _isEventFromThisInstance,
+    _setTouchStartTarget,
     addTempEventHandlers,
     clearTempEventHandlers,
     preventEventDefault,
@@ -303,7 +304,9 @@ export class BaseDragService<
 
         const beans = this.beans;
         const rootEl = _getRootNode(beans);
-        const touchDrag = new Dragging(rootEl, params, touchEvent.touches[0]);
+        const touch = touchEvent.touches[0];
+        _setTouchStartTarget(touch, touchEvent);
+        const touchDrag = new Dragging(rootEl, params, touch);
 
         const touchMoveEvent = (e: TouchEvent) => this.onTouchMove(e);
         const touchEndEvent = (e: TouchEvent) => this.onTouchUp(e);

--- a/packages/ag-grid-community/src/agStack/focus/tabGuardCtrl.ts
+++ b/packages/ag-grid-community/src/agStack/focus/tabGuardCtrl.ts
@@ -4,6 +4,7 @@ import type { BaseEvents } from '../interfaces/baseEvents';
 import type { BaseProperties } from '../interfaces/baseProperties';
 import type { IPropertiesService } from '../interfaces/iProperties';
 import { _getDocument } from '../utils/document';
+import { _getEventTarget } from '../utils/event';
 import { _findFocusableElements, _findNextFocusableElement } from '../utils/focus';
 import type { StopPropagationCallbacks } from './agManagedFocusFeature';
 import { AgManagedFocusFeature } from './agManagedFocusFeature';
@@ -161,7 +162,7 @@ export class AgTabGuardCtrl<
     private onFocus(e: FocusEvent): void {
         if (this.isFocusableContainer && !this.eFocusableElement.contains(e.relatedTarget as HTMLElement)) {
             if (!this.allowFocus) {
-                this.findNextElementOutsideAndFocus(e.target === this.eBottomGuard);
+                this.findNextElementOutsideAndFocus(_getEventTarget(e) === this.eBottomGuard);
                 return;
             }
         }
@@ -179,7 +180,7 @@ export class AgTabGuardCtrl<
                 ? this.providedIsEmpty()
                 : _findFocusableElements(this.eFocusableElement, '.ag-tab-guard').length === 0;
             if (isEmpty) {
-                this.findNextElementOutsideAndFocus(e.target === this.eBottomGuard);
+                this.findNextElementOutsideAndFocus(_getEventTarget(e) === this.eBottomGuard);
                 return;
             }
         }
@@ -188,14 +189,14 @@ export class AgTabGuardCtrl<
             return;
         }
 
-        const fromBottom = e.target === this.eBottomGuard;
+        const fromBottom = _getEventTarget(e) === this.eBottomGuard;
 
         const hasFocusedInnerElement = this.providedFocusInnerElement
             ? this.providedFocusInnerElement(fromBottom)
             : this.focusInnerElement(fromBottom);
         if (!hasFocusedInnerElement && this.forceFocusOutWhenTabGuardsAreEmpty) {
             // nothing actually got focused, so force out
-            this.findNextElementOutsideAndFocus(e.target === this.eBottomGuard);
+            this.findNextElementOutsideAndFocus(_getEventTarget(e) === this.eBottomGuard);
         }
     }
 

--- a/packages/ag-grid-community/src/agStack/popup/basePopupService.ts
+++ b/packages/ag-grid-community/src/agStack/popup/basePopupService.ts
@@ -24,7 +24,7 @@ import {
     _getElementRectWithOffset,
     _observeResize,
 } from '../utils/dom';
-import { _isElementInEventPath } from '../utils/event';
+import { _getEventTarget, _isElementInEventPath } from '../utils/event';
 import { _exists } from '../utils/generic';
 import { AgPromise, _wrapInterval } from '../utils/promise';
 
@@ -734,7 +734,7 @@ export abstract class BasePopupService<
         // if the user did not write their own Custom Element to be rendered as popup
         // and this component has an additional popup element, they should have the
         // `ag-custom-component-popup` class to be detected as part of the Custom Component
-        return this.isElementWithinCustomPopup(event.target as HTMLElement);
+        return this.isElementWithinCustomPopup(_getEventTarget(event) as HTMLElement);
     }
 
     public isElementWithinCustomPopup(el: HTMLElement): boolean {

--- a/packages/ag-grid-community/src/agStack/tooltip/baseTooltipStateManager.ts
+++ b/packages/ag-grid-community/src/agStack/tooltip/baseTooltipStateManager.ts
@@ -8,6 +8,7 @@ import type { IPropertiesService } from '../interfaces/iProperties';
 import type { TooltipCtrl } from '../interfaces/iTooltip';
 import { _isIOSUserAgent } from '../utils/browser';
 import { _getActiveDomElement, _getDocument } from '../utils/document';
+import { _getEventTarget } from '../utils/event';
 import { _exists } from '../utils/generic';
 
 enum TooltipStates {
@@ -398,7 +399,7 @@ export abstract class BaseTooltipStateManager<
 
             [this.onDocumentKeyDownCallback] = this.addManagedElementListeners(_getDocument(this.beans), {
                 keydown: (e) => {
-                    if (!eGui.contains(e?.target as HTMLElement)) {
+                    if (!eGui.contains(_getEventTarget(e) as HTMLElement)) {
                         this.onKeyDown();
                     }
                 },

--- a/packages/ag-grid-community/src/agStack/utils/event.ts
+++ b/packages/ag-grid-community/src/agStack/utils/event.ts
@@ -57,7 +57,8 @@ let touchTargetMap: WeakMap<Touch, EventTarget> | undefined;
 export function _setTouchStartTarget(touch: Touch, touchEvent: TouchEvent): void {
     const target = _getEventTarget(touchEvent);
     if (target) {
-        (touchTargetMap ??= new WeakMap()).set(touch, target);
+        touchTargetMap ??= new WeakMap();
+        touchTargetMap.set(touch, target);
     }
 }
 
@@ -71,17 +72,17 @@ export function _getEventTarget(event: EventWithEventTarget | null | undefined):
     if (!event) {
         return null;
     }
-    // Check WeakMap cache for Touch objects (they don't have composedPath)
-    const cachedTarget = touchTargetMap?.get(event as Touch);
-    if (cachedTarget) {
-        return cachedTarget;
-    }
     // composedPath()[0] gives us the actual target even across shadow DOM boundaries
     if (typeof (event as Event).composedPath === 'function') {
         const path = (event as Event).composedPath();
         if (path && path.length > 0) {
             return path[0];
         }
+    }
+    // Check WeakMap cache for Touch objects (they don't have composedPath)
+    const cachedTarget = touchTargetMap?.get(event as Touch);
+    if (cachedTarget) {
+        return cachedTarget;
     }
     return event.target ?? null;
 }

--- a/packages/ag-grid-community/src/agStack/utils/event.ts
+++ b/packages/ag-grid-community/src/agStack/utils/event.ts
@@ -43,6 +43,7 @@ export function _isElementInEventPath(element: HTMLElement, event: Event): boole
  * WeakMap to store the composed target for Touch objects.
  * When extracting a Touch from a TouchEvent, call _setTouchStartTarget to store the real target.
  * This allows _getEventTarget to return the correct target for Shadow DOM scenarios.
+ * Note: This is a bit of a hack until we don't refactor the code to not cast Touch to Events.
  */
 let touchTargetMap: WeakMap<Touch, EventTarget> | undefined;
 
@@ -64,15 +65,15 @@ export function _setTouchStartTarget(touch: Touch, touchEvent: TouchEvent): void
  * For Touch objects, uses the target stored via _setTouchStartTarget if available.
  */
 export function _getEventTarget(
-    event: Event | Touch | { readonly target: EventTarget | null; composedPath?(): EventTarget[] | null } | null | undefined
+    event:
+        | Event
+        | Touch
+        | { readonly target: EventTarget | null; composedPath?(): EventTarget[] | null }
+        | null
+        | undefined
 ): EventTarget | null {
     if (!event) {
         return null;
-    }
-    // Check WeakMap for Touch objects
-    const touchTarget = touchTargetMap?.get(event as Touch);
-    if (touchTarget) {
-        return touchTarget;
     }
     // composedPath()[0] gives us the actual target even across shadow DOM boundaries
     const composedPath = (event as Event).composedPath;
@@ -80,6 +81,12 @@ export function _getEventTarget(
         const path = composedPath.call(event);
         if (path && path.length > 0) {
             return path[0];
+        }
+    } else {
+        // Check WeakMap for Touch objects
+        const touchTarget = touchTargetMap?.get(event as Touch);
+        if (touchTarget) {
+            return touchTarget;
         }
     }
     return event.target ?? null;

--- a/packages/ag-grid-community/src/agStack/utils/event.ts
+++ b/packages/ag-grid-community/src/agStack/utils/event.ts
@@ -39,6 +39,27 @@ export function _isElementInEventPath(element: HTMLElement, event: Event): boole
     return _getEventPath(event).indexOf(element) >= 0;
 }
 
+/**
+ * Gets the actual target element from an event, handling Shadow DOM correctly.
+ * When events cross shadow DOM boundaries, `event.target` may be retargeted to the shadow host.
+ * This function uses `composedPath()[0]` to get the actual element that received the event.
+ */
+export function _getEventTarget(
+    event: Event | { readonly target: EventTarget | null; composedPath?(): EventTarget[] | null } | null | undefined
+): EventTarget | null {
+    if (!event) {
+        return null;
+    }
+    // composedPath()[0] gives us the actual target even across shadow DOM boundaries
+    if (typeof event.composedPath === 'function') {
+        const path = event.composedPath();
+        if (path && path.length > 0) {
+            return path[0];
+        }
+    }
+    return event.target ?? null;
+}
+
 function _createEventPath(event: { target: EventTarget }): EventTarget[] {
     const res: EventTarget[] = [];
     let pointer: any = event.target;
@@ -140,7 +161,7 @@ export const _getFirstActiveTouch = (touch: Touch, touchList: TouchList): Touch 
 // master / detail grids, and a child grid is found, then it returns false. this stops things like copy/paste
 // getting executed on many grids at the same time.
 export function _isEventFromThisInstance(beans: UtilBeanCollection, event: UIEvent): boolean {
-    return beans.gos.isElementInThisInstance(event.target as HTMLElement);
+    return beans.gos.isElementInThisInstance(_getEventTarget(event) as HTMLElement);
 }
 
 export function _anchorElementToMouseMoveEvent(

--- a/packages/ag-grid-community/src/agStack/utils/event.ts
+++ b/packages/ag-grid-community/src/agStack/utils/event.ts
@@ -40,19 +40,44 @@ export function _isElementInEventPath(element: HTMLElement, event: Event): boole
 }
 
 /**
+ * WeakMap to store the composed target for Touch objects.
+ * When extracting a Touch from a TouchEvent, call _setTouchStartTarget to store the real target.
+ * This allows _getEventTarget to return the correct target for Shadow DOM scenarios.
+ */
+let touchTargetMap: WeakMap<Touch, EventTarget> | undefined;
+
+/**
+ * Stores the composed target for a Touch object extracted from a TouchEvent.
+ * Call this when extracting the first touch from a touchstart event.
+ */
+export function _setTouchStartTarget(touch: Touch, touchEvent: TouchEvent): void {
+    const target = _getEventTarget(touchEvent);
+    if (target) {
+        (touchTargetMap ??= new WeakMap()).set(touch, target);
+    }
+}
+
+/**
  * Gets the actual target element from an event, handling Shadow DOM correctly.
  * When events cross shadow DOM boundaries, `event.target` may be retargeted to the shadow host.
  * This function uses `composedPath()[0]` to get the actual element that received the event.
+ * For Touch objects, uses the target stored via _setTouchStartTarget if available.
  */
 export function _getEventTarget(
-    event: Event | { readonly target: EventTarget | null; composedPath?(): EventTarget[] | null } | null | undefined
+    event: Event | Touch | { readonly target: EventTarget | null; composedPath?(): EventTarget[] | null } | null | undefined
 ): EventTarget | null {
     if (!event) {
         return null;
     }
+    // Check WeakMap for Touch objects
+    const touchTarget = touchTargetMap?.get(event as Touch);
+    if (touchTarget) {
+        return touchTarget;
+    }
     // composedPath()[0] gives us the actual target even across shadow DOM boundaries
-    if (typeof event.composedPath === 'function') {
-        const path = event.composedPath();
+    const composedPath = (event as Event).composedPath;
+    if (typeof composedPath === 'function') {
+        const path = composedPath.call(event);
         if (path && path.length > 0) {
             return path[0];
         }

--- a/packages/ag-grid-community/src/agStack/utils/event.ts
+++ b/packages/ag-grid-community/src/agStack/utils/event.ts
@@ -45,28 +45,13 @@ type EventWithEventTarget =
     | { readonly target: EventTarget | null; composedPath?(): EventTarget[] | null };
 
 /**
- * WeakMap to cache the composed target for Touch objects.
- * Touch objects don't have composedPath(), so we store the target from the parent TouchEvent.
- */
-let touchTargetMap: WeakMap<Touch, EventTarget> | undefined;
-
-/**
- * Stores the composed target for a Touch object extracted from a TouchEvent.
- * Call this when extracting the first touch from a touchstart event.
- */
-export function _setTouchStartTarget(touch: Touch, touchEvent: TouchEvent): void {
-    const target = _getEventTarget(touchEvent);
-    if (target) {
-        touchTargetMap ??= new WeakMap();
-        touchTargetMap.set(touch, target);
-    }
-}
-
-/**
  * Gets the actual target element from an event, handling Shadow DOM correctly.
  * When events cross shadow DOM boundaries, `event.target` may be retargeted to the shadow host.
  * This function uses `composedPath()[0]` to get the actual element that received the event.
- * For Touch objects, uses the target stored via _setTouchStartTarget.
+ *
+ * WARNING: The browser empties `composedPath()` after the event dispatch cycle completes.
+ * If you need the target after dispatch (e.g., in setTimeout, Promise callbacks, or stored events),
+ * capture it synchronously and store it explicitly.
  */
 export function _getEventTarget(event: EventWithEventTarget | null | undefined): EventTarget | null {
     if (!event) {
@@ -78,11 +63,6 @@ export function _getEventTarget(event: EventWithEventTarget | null | undefined):
         if (path && path.length > 0) {
             return path[0];
         }
-    }
-    // Check WeakMap cache for Touch objects (they don't have composedPath)
-    const cachedTarget = touchTargetMap?.get(event as Touch);
-    if (cachedTarget) {
-        return cachedTarget;
     }
     return event.target ?? null;
 }

--- a/packages/ag-grid-community/src/agStack/utils/event.ts
+++ b/packages/ag-grid-community/src/agStack/utils/event.ts
@@ -39,11 +39,14 @@ export function _isElementInEventPath(element: HTMLElement, event: Event): boole
     return _getEventPath(event).indexOf(element) >= 0;
 }
 
+type EventWithEventTarget =
+    | Event
+    | Touch
+    | { readonly target: EventTarget | null; composedPath?(): EventTarget[] | null };
+
 /**
- * WeakMap to store the composed target for Touch objects.
- * When extracting a Touch from a TouchEvent, call _setTouchStartTarget to store the real target.
- * This allows _getEventTarget to return the correct target for Shadow DOM scenarios.
- * Note: This is a bit of a hack until we don't refactor the code to not cast Touch to Events.
+ * WeakMap to cache the composed target for Touch objects.
+ * Touch objects don't have composedPath(), so we store the target from the parent TouchEvent.
  */
 let touchTargetMap: WeakMap<Touch, EventTarget> | undefined;
 
@@ -62,31 +65,22 @@ export function _setTouchStartTarget(touch: Touch, touchEvent: TouchEvent): void
  * Gets the actual target element from an event, handling Shadow DOM correctly.
  * When events cross shadow DOM boundaries, `event.target` may be retargeted to the shadow host.
  * This function uses `composedPath()[0]` to get the actual element that received the event.
- * For Touch objects, uses the target stored via _setTouchStartTarget if available.
+ * For Touch objects, uses the target stored via _setTouchStartTarget.
  */
-export function _getEventTarget(
-    event:
-        | Event
-        | Touch
-        | { readonly target: EventTarget | null; composedPath?(): EventTarget[] | null }
-        | null
-        | undefined
-): EventTarget | null {
+export function _getEventTarget(event: EventWithEventTarget | null | undefined): EventTarget | null {
     if (!event) {
         return null;
     }
+    // Check WeakMap cache for Touch objects (they don't have composedPath)
+    const cachedTarget = touchTargetMap?.get(event as Touch);
+    if (cachedTarget) {
+        return cachedTarget;
+    }
     // composedPath()[0] gives us the actual target even across shadow DOM boundaries
-    const composedPath = (event as Event).composedPath;
-    if (typeof composedPath === 'function') {
-        const path = composedPath.call(event);
+    if (typeof (event as Event).composedPath === 'function') {
+        const path = (event as Event).composedPath();
         if (path && path.length > 0) {
             return path[0];
-        }
-    } else {
-        // Check WeakMap for Touch objects
-        const touchTarget = touchTargetMap?.get(event as Touch);
-        if (touchTarget) {
-            return touchTarget;
         }
     }
     return event.target ?? null;

--- a/packages/ag-grid-community/src/agStack/widgets/agAbstractInputField.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agAbstractInputField.ts
@@ -6,6 +6,7 @@ import type { IPropertiesService } from '../interfaces/iProperties';
 import { _setAriaLabel } from '../utils/aria';
 import type { AgElementParams } from '../utils/dom';
 import { _addOrRemoveAttribute, _setDisabled, _setElementWidth } from '../utils/dom';
+import { _getEventTarget } from '../utils/event';
 import type { AgAbstractFieldEvent, FieldElement } from './agAbstractField';
 import { AgAbstractField } from './agAbstractField';
 import type { AgInputFieldParams } from './agFieldParams';
@@ -97,7 +98,7 @@ export abstract class AgAbstractInputField<
 
     protected addInputListeners() {
         this.addManagedElementListeners(this.eInput, {
-            input: (e: InputEvent) => this.setValue((e.target as HTMLInputElement).value as TValue),
+            input: (e: InputEvent) => this.setValue((_getEventTarget(e) as HTMLInputElement).value as TValue),
         });
     }
 

--- a/packages/ag-grid-community/src/agStack/widgets/agCheckbox.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agCheckbox.ts
@@ -3,6 +3,7 @@ import type { AgCoreBeanCollection } from '../interfaces/agCoreBeanCollection';
 import type { BaseEvents } from '../interfaces/baseEvents';
 import type { BaseProperties } from '../interfaces/baseProperties';
 import type { IPropertiesService } from '../interfaces/iProperties';
+import { _getEventTarget } from '../utils/event';
 import { AgAbstractInputField } from './agAbstractInputField';
 import type { AgCheckboxParams, LabelAlignment } from './agFieldParams';
 import type { AgWidgetSelectorType } from './agWidgetSelectorType';
@@ -153,7 +154,7 @@ export class AgCheckbox<
             return;
         }
         const previousValue = this.isSelected();
-        const selected = (this.selected = (e.target as HTMLInputElement).checked);
+        const selected = (this.selected = (_getEventTarget(e) as HTMLInputElement).checked);
         this.refreshSelectedClass(selected);
         this.dispatchChange(selected, previousValue, e);
     }

--- a/packages/ag-grid-community/src/agStack/widgets/agPickerField.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agPickerField.ts
@@ -10,6 +10,7 @@ import { _setAriaExpanded, _setAriaRole } from '../utils/aria';
 import { _isNothingFocused } from '../utils/document';
 import type { AgElementParams } from '../utils/dom';
 import { _formatSize, _getAbsoluteWidth, _getInnerHeight, _setElementWidth } from '../utils/dom';
+import { _getEventTarget } from '../utils/event';
 import type { AgAbstractFieldEvent } from './agAbstractField';
 import { AgAbstractField } from './agAbstractField';
 import { agPickerFieldCSS } from './agPickerField.css-GENERATED';
@@ -175,7 +176,7 @@ export abstract class AgPickerField<
             // if the focusableEl is not the wrapper and the mousedown
             // targets the focusableEl, we should not expand/collapse the picker.
             // Note: this will happen when AgRichSelect is set with `allowTyping=true`
-            if (focusableEl !== this.eWrapper && e?.target === focusableEl) {
+            if (focusableEl !== this.eWrapper && _getEventTarget(e) === focusableEl) {
                 return;
             }
 

--- a/packages/ag-grid-community/src/filter/filterMenuFactory.ts
+++ b/packages/ag-grid-community/src/filter/filterMenuFactory.ts
@@ -1,5 +1,6 @@
 import { KeyCode } from '../agStack/constants/keyCode';
 import { _isVisible } from '../agStack/utils/dom';
+import { _getEventTarget } from '../agStack/utils/event';
 import { _findNextFocusableElement, _findTabbableParent, _focusInto } from '../agStack/utils/focus';
 import type { NamedBean } from '../context/bean';
 import { BeanStub } from '../context/beanStub';
@@ -53,7 +54,7 @@ export class FilterMenuFactory extends BeanStub implements NamedBean, IMenuFacto
                 });
             },
             containerType,
-            mouseEvent.target as HTMLElement,
+            _getEventTarget(mouseEvent) as HTMLElement,
             _isLegacyMenuEnabled(this.gos),
             onClosedCallback
         );

--- a/packages/ag-grid-community/src/gridBodyComp/gridBodyCtrl.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/gridBodyCtrl.ts
@@ -1,6 +1,6 @@
 import { _isInvisibleScrollbar } from '../agStack/utils/browser';
 import { _isElementChildOfClass, _requestAnimationFrame } from '../agStack/utils/dom';
-import { _isEventFromThisInstance } from '../agStack/utils/event';
+import { _getEventTarget, _isEventFromThisInstance } from '../agStack/utils/event';
 import type { ColumnModel } from '../columns/columnModel';
 import { BeanStub } from '../context/beanStub';
 import type { BeanCollection } from '../context/context';
@@ -194,14 +194,15 @@ export class GridBodyCtrl extends BeanStub {
         for (const element of elements) {
             this.addManagedElementListeners(element, {
                 focusin: (e: FocusEvent) => {
-                    const { target } = e;
+                    const target = _getEventTarget(e);
                     // element being focused is nested?
                     const isFocusedElementNested = _isElementChildOfClass(target as HTMLElement, 'ag-root', element);
 
                     element.classList.toggle('ag-has-focus', !isFocusedElementNested);
                 },
                 focusout: (e: FocusEvent) => {
-                    const { target, relatedTarget } = e;
+                    const target = _getEventTarget(e);
+                    const relatedTarget = e.relatedTarget;
                     const gridContainRelatedTarget = element.contains(relatedTarget as HTMLElement);
                     const isNestedRelatedTarget = _isElementChildOfClass(
                         relatedTarget as HTMLElement,
@@ -249,7 +250,8 @@ export class GridBodyCtrl extends BeanStub {
     private disableBrowserDragging(): void {
         this.addManagedElementListeners(this.eGridBody, {
             dragstart: (event: DragEvent) => {
-                if (event.target instanceof HTMLImageElement) {
+                const target = _getEventTarget(event);
+                if (target instanceof HTMLImageElement) {
                     event.preventDefault();
                     return false;
                 }
@@ -427,7 +429,7 @@ export class GridBodyCtrl extends BeanStub {
             event.preventDefault();
         }
 
-        const { target } = (mouseEvent || touch)!;
+        const target = _getEventTarget(mouseEvent || touch)!;
 
         if (target === this.eBodyViewport || target === this.ctrlsSvc.get('center').eViewport) {
             // show it

--- a/packages/ag-grid-community/src/gridBodyComp/gridBodyCtrl.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/gridBodyCtrl.ts
@@ -419,7 +419,7 @@ export class GridBodyCtrl extends BeanStub {
         this.eCenterColsViewport.scrollBy({ left: deltaX || deltaY });
     }
 
-    private onBodyViewportContextMenu(mouseEvent?: MouseEvent, touch?: Touch, touchEvent?: TouchEvent): void {
+    private onBodyViewportContextMenu(mouseEvent?: MouseEvent, touch?: Touch, touchEvent?: TouchEvent, touchTarget?: EventTarget | null): void {
         if (!mouseEvent && !touchEvent) {
             return;
         }
@@ -429,7 +429,7 @@ export class GridBodyCtrl extends BeanStub {
             event.preventDefault();
         }
 
-        const target = _getEventTarget(mouseEvent || touch)!;
+        const target = mouseEvent ? _getEventTarget(mouseEvent) : touchTarget;
 
         if (target === this.eBodyViewport || target === this.ctrlsSvc.get('center').eViewport) {
             // show it

--- a/packages/ag-grid-community/src/gridBodyComp/mouseEventUtils.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/mouseEventUtils.ts
@@ -1,14 +1,24 @@
+import { _getEventTarget } from '../agStack/utils/event';
 import type { BeanCollection } from '../context/context';
 import type { GridOptionsService } from '../gridOptionsService';
 import { _isDomLayout } from '../gridOptionsUtils';
 import type { CellPosition } from '../interfaces/iCellPosition';
 import { _getCellCtrlForEventTarget } from '../rendering/renderUtils';
 
+/**
+ * Gets the cell position for a mouse/keyboard/touch event.
+ *
+ * Note: Touch objects don't have composedPath() so Shadow DOM support is limited for touch.
+ * For MouseEvent/KeyboardEvent, uses composedPath() for proper Shadow DOM support.
+ */
 export function _getCellPositionForEvent(
     gos: GridOptionsService,
     event: MouseEvent | KeyboardEvent | Touch
 ): CellPosition | null {
-    return _getCellCtrlForEventTarget(gos, event.target)?.getFocusedCellPosition() ?? null;
+    // For MouseEvent/KeyboardEvent, _getEventTarget uses composedPath for Shadow DOM support.
+    // Touch objects don't have composedPath - they only have .target which may be retargeted.
+    // TODO: Address Touch Shadow DOM support separately.
+    return _getCellCtrlForEventTarget(gos, _getEventTarget(event as Event))?.getFocusedCellPosition() ?? null;
 }
 
 export function _getNormalisedMousePosition(

--- a/packages/ag-grid-community/src/gridBodyComp/mouseEventUtils.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/mouseEventUtils.ts
@@ -5,20 +5,12 @@ import { _isDomLayout } from '../gridOptionsUtils';
 import type { CellPosition } from '../interfaces/iCellPosition';
 import { _getCellCtrlForEventTarget } from '../rendering/renderUtils';
 
-/**
- * Gets the cell position for a mouse/keyboard/touch event.
- *
- * Note: Touch objects don't have composedPath() so Shadow DOM support is limited for touch.
- * For MouseEvent/KeyboardEvent, uses composedPath() for proper Shadow DOM support.
- */
+/** Gets the cell position for a mouse/keyboard/touch event. */
 export function _getCellPositionForEvent(
     gos: GridOptionsService,
     event: MouseEvent | KeyboardEvent | Touch
 ): CellPosition | null {
-    // For MouseEvent/KeyboardEvent, _getEventTarget uses composedPath for Shadow DOM support.
-    // Touch objects don't have composedPath - they only have .target which may be retargeted.
-    // TODO: Address Touch Shadow DOM support separately.
-    return _getCellCtrlForEventTarget(gos, _getEventTarget(event as Event))?.getFocusedCellPosition() ?? null;
+    return _getCellCtrlForEventTarget(gos, _getEventTarget(event))?.getFocusedCellPosition() ?? null;
 }
 
 export function _getNormalisedMousePosition(

--- a/packages/ag-grid-community/src/gridBodyComp/rowContainer/rowContainerEventsFeature.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/rowContainer/rowContainerEventsFeature.ts
@@ -1,5 +1,5 @@
 import { KeyCode, _normaliseQwertyAzerty } from '../../agStack/constants/keyCode';
-import { _isEventFromThisInstance, _isEventSupported } from '../../agStack/utils/event';
+import { _getEventTarget, _isEventFromThisInstance, _isEventSupported } from '../../agStack/utils/event';
 import { _isEventFromPrintableCharacter } from '../../agStack/utils/keyboard';
 import { BeanStub } from '../../context/beanStub';
 import type { EditService } from '../../edit/editService';
@@ -54,7 +54,7 @@ export class RowContainerEventsFeature extends BeanStub {
             return;
         }
 
-        const { cellCtrl, rowCtrl } = this.getControlsForEventTarget(mouseEvent.target);
+        const { cellCtrl, rowCtrl } = this.getControlsForEventTarget(_getEventTarget(mouseEvent));
 
         if (eventName === 'contextmenu') {
             if (cellCtrl?.column) {
@@ -83,7 +83,7 @@ export class RowContainerEventsFeature extends BeanStub {
     }
 
     private processKeyboardEvent(eventName: string, keyboardEvent: KeyboardEvent): void {
-        const { cellCtrl, rowCtrl } = this.getControlsForEventTarget(keyboardEvent.target);
+        const { cellCtrl, rowCtrl } = this.getControlsForEventTarget(_getEventTarget(keyboardEvent));
 
         if (keyboardEvent.defaultPrevented) {
             return;
@@ -237,7 +237,7 @@ export class RowContainerEventsFeature extends BeanStub {
             return;
         }
 
-        const { cellCtrl } = this.getControlsForEventTarget(event.target);
+        const { cellCtrl } = this.getControlsForEventTarget(_getEventTarget(event));
 
         if (this.editSvc?.isEditing(cellCtrl, { withOpenEditor: true })) {
             return;
@@ -252,7 +252,7 @@ export class RowContainerEventsFeature extends BeanStub {
             return;
         }
 
-        const { cellCtrl } = this.getControlsForEventTarget(event.target);
+        const { cellCtrl } = this.getControlsForEventTarget(_getEventTarget(event));
 
         if (this.editSvc?.isEditing(cellCtrl, { withOpenEditor: true })) {
             return;
@@ -263,7 +263,7 @@ export class RowContainerEventsFeature extends BeanStub {
     }
 
     private onCtrlAndV(clipboardSvc: IClipboardService | undefined, event: KeyboardEvent): void {
-        const { cellCtrl } = this.getControlsForEventTarget(event.target);
+        const { cellCtrl } = this.getControlsForEventTarget(_getEventTarget(event));
 
         if (this.editSvc?.isEditing(cellCtrl, { withOpenEditor: true })) {
             return;

--- a/packages/ag-grid-community/src/headerRendering/cells/floatingFilter/headerFilterCellCtrl.ts
+++ b/packages/ag-grid-community/src/headerRendering/cells/floatingFilter/headerFilterCellCtrl.ts
@@ -2,6 +2,7 @@ import { KeyCode } from '../../../agStack/constants/keyCode';
 import { _setAriaLabel } from '../../../agStack/utils/aria';
 import { _getActiveDomElement } from '../../../agStack/utils/document';
 import { _isElementChildOfClass } from '../../../agStack/utils/dom';
+import { _getEventTarget } from '../../../agStack/utils/event';
 import { _findNextFocusableElement, _focusInto } from '../../../agStack/utils/focus';
 import { setupCompBean } from '../../../components/emptyBean';
 import type { BeanStub } from '../../../context/beanStub';
@@ -234,7 +235,7 @@ export class HeaderFilterCellCtrl extends AbstractHeaderCellCtrl<IHeaderFilterCe
         const fromWithinHeader =
             !!e.relatedTarget && _isElementChildOfClass(e.relatedTarget as HTMLElement, 'ag-floating-filter');
 
-        if (notFromHeaderWrapper && fromWithinHeader && e.target === this.eGui) {
+        if (notFromHeaderWrapper && fromWithinHeader && _getEventTarget(e) === this.eGui) {
             const lastFocusEvent = this.lastFocusEvent;
             const fromTab = !!(lastFocusEvent && lastFocusEvent.key === KeyCode.TAB);
 

--- a/packages/ag-grid-community/src/headerRendering/gridHeaderCtrl.ts
+++ b/packages/ag-grid-community/src/headerRendering/gridHeaderCtrl.ts
@@ -190,13 +190,13 @@ export class GridHeaderCtrl extends BeanStub {
         }
     }
 
-    private onHeaderContextMenu(mouseEvent?: MouseEvent, touch?: Touch, touchEvent?: TouchEvent): void {
+    private onHeaderContextMenu(mouseEvent?: MouseEvent, touch?: Touch, touchEvent?: TouchEvent, touchTarget?: EventTarget | null): void {
         const { menuSvc, ctrlsSvc } = this.beans;
         if ((!mouseEvent && !touchEvent) || !menuSvc?.isHeaderContextMenuEnabled()) {
             return;
         }
 
-        const target = _getEventTarget(mouseEvent ?? touchEvent!) as HTMLElement;
+        const target = mouseEvent ? _getEventTarget(mouseEvent) : touchTarget ?? _getEventTarget(touchEvent!);
 
         if (target === this.eGui || target === ctrlsSvc.getHeaderRowContainerCtrl()?.eViewport) {
             menuSvc.showHeaderContextMenu(undefined, mouseEvent, touchEvent);

--- a/packages/ag-grid-community/src/headerRendering/gridHeaderCtrl.ts
+++ b/packages/ag-grid-community/src/headerRendering/gridHeaderCtrl.ts
@@ -1,6 +1,7 @@
 import { KeyCode } from '../agStack/constants/keyCode';
 import { _getActiveDomElement } from '../agStack/utils/document';
 import { _requestAnimationFrame } from '../agStack/utils/dom';
+import { _getEventTarget } from '../agStack/utils/event';
 import { _exists } from '../agStack/utils/generic';
 import { BeanStub } from '../context/beanStub';
 import type { BeanCollection } from '../context/context';
@@ -195,7 +196,7 @@ export class GridHeaderCtrl extends BeanStub {
             return;
         }
 
-        const { target } = (mouseEvent ?? touch)!;
+        const target = _getEventTarget(mouseEvent ?? touchEvent!) as HTMLElement;
 
         if (target === this.eGui || target === ctrlsSvc.getHeaderRowContainerCtrl()?.eViewport) {
             menuSvc.showHeaderContextMenu(undefined, mouseEvent, touchEvent);

--- a/packages/ag-grid-community/src/main-internal.ts
+++ b/packages/ag-grid-community/src/main-internal.ts
@@ -162,7 +162,7 @@ export {
     _isFocusableFormField,
     _placeCaretAtEnd,
 } from './agStack/utils/dom';
-export { _anchorElementToMouseMoveEvent, _isElementInEventPath } from './agStack/utils/event';
+export { _anchorElementToMouseMoveEvent, _getEventTarget, _isElementInEventPath } from './agStack/utils/event';
 export {
     _findFocusableElements,
     _findNextFocusableElement,

--- a/packages/ag-grid-community/src/misc/touchService.ts
+++ b/packages/ag-grid-community/src/misc/touchService.ts
@@ -97,7 +97,7 @@ export class TouchService extends BeanStub implements NamedBean {
 
         if (params.enableSorting) {
             const tapListener = (event: TapEvent) => {
-                const target = event.touchStart.target as HTMLElement;
+                const target = _getEventTarget(event.touchStart) as HTMLElement;
                 // When suppressMenuHide is true, a tap on the menu icon or filter button will bubble up
                 // to the header container, in that case we should not sort
                 if (suppressMenuHide && (eMenu?.contains(target) || eFilterButton?.contains(target))) {

--- a/packages/ag-grid-community/src/misc/touchService.ts
+++ b/packages/ag-grid-community/src/misc/touchService.ts
@@ -19,14 +19,24 @@ export class TouchService extends BeanStub implements NamedBean {
 
     public mockBodyContextMenu(
         ctrl: GridBodyCtrl,
-        listener: (mouseListener?: MouseEvent, touch?: Touch, touchEvent?: TouchEvent) => void
+        listener: (
+            mouseListener?: MouseEvent,
+            touch?: Touch,
+            touchEvent?: TouchEvent,
+            target?: EventTarget | null
+        ) => void
     ): void {
         this.mockContextMenu(ctrl, ctrl.eBodyViewport, listener);
     }
 
     public mockHeaderContextMenu(
         ctrl: GridHeaderCtrl,
-        listener: (mouseListener?: MouseEvent, touch?: Touch, touchEvent?: TouchEvent) => void
+        listener: (
+            mouseListener?: MouseEvent,
+            touch?: Touch,
+            touchEvent?: TouchEvent,
+            target?: EventTarget | null
+        ) => void
     ): void {
         this.mockContextMenu(ctrl, ctrl.eGui, listener);
     }
@@ -97,7 +107,7 @@ export class TouchService extends BeanStub implements NamedBean {
 
         if (params.enableSorting) {
             const tapListener = (event: TapEvent) => {
-                const target = _getEventTarget(event.touchStart) as HTMLElement;
+                const target = event.startTarget as HTMLElement;
                 // When suppressMenuHide is true, a tap on the menu icon or filter button will bubble up
                 // to the header container, in that case we should not sort
                 if (suppressMenuHide && (eMenu?.contains(target) || eFilterButton?.contains(target))) {
@@ -147,7 +157,12 @@ export class TouchService extends BeanStub implements NamedBean {
     private mockContextMenu(
         ctrl: BeanStub,
         element: HTMLElement,
-        listener: (mouseListener?: MouseEvent, touch?: Touch, touchEvent?: TouchEvent) => void
+        listener: (
+            mouseListener?: MouseEvent,
+            touch?: Touch,
+            touchEvent?: TouchEvent,
+            target?: EventTarget | null
+        ) => void
     ): void {
         // we do NOT want this when not in iPad
         if (!_isIOSUserAgent()) {
@@ -156,10 +171,10 @@ export class TouchService extends BeanStub implements NamedBean {
 
         const touchListener = new TouchListener(element);
         const longTapListener = (event: LongTapEvent) => {
-            if (!this.beans.gos.isElementInThisInstance(event.target as HTMLElement)) {
+            if (!this.beans.gos.isElementInThisInstance(event.startTarget as HTMLElement)) {
                 return;
             }
-            listener(undefined, event.touchStart, event.touchEvent);
+            listener(undefined, event.touchStart, event.touchEvent, event.startTarget);
         };
 
         ctrl.addManagedListeners(touchListener, { longTap: longTapListener });

--- a/packages/ag-grid-community/src/misc/touchService.ts
+++ b/packages/ag-grid-community/src/misc/touchService.ts
@@ -1,5 +1,5 @@
 import { _isIOSUserAgent } from '../agStack/utils/browser';
-import { _getEventTarget, _isEventFromThisInstance, _isEventSupported } from '../agStack/utils/event';
+import { _getEventTarget, _isEventSupported } from '../agStack/utils/event';
 import { _exists } from '../agStack/utils/generic';
 import type { NamedBean } from '../context/bean';
 import { BeanStub } from '../context/beanStub';
@@ -156,7 +156,7 @@ export class TouchService extends BeanStub implements NamedBean {
 
         const touchListener = new TouchListener(element);
         const longTapListener = (event: LongTapEvent) => {
-            if (!_isEventFromThisInstance(this.beans, event.touchEvent)) {
+            if (!this.beans.gos.isElementInThisInstance(event.target as HTMLElement)) {
                 return;
             }
             listener(undefined, event.touchStart, event.touchEvent);

--- a/packages/ag-grid-community/src/misc/touchService.ts
+++ b/packages/ag-grid-community/src/misc/touchService.ts
@@ -1,5 +1,5 @@
 import { _isIOSUserAgent } from '../agStack/utils/browser';
-import { _isEventFromThisInstance, _isEventSupported } from '../agStack/utils/event';
+import { _getEventTarget, _isEventFromThisInstance, _isEventSupported } from '../agStack/utils/event';
 import { _exists } from '../agStack/utils/generic';
 import type { NamedBean } from '../context/bean';
 import { BeanStub } from '../context/beanStub';
@@ -38,7 +38,7 @@ export class TouchService extends BeanStub implements NamedBean {
         }
 
         const listener = (mouseListener?: MouseEvent, touch?: Touch, touchEvent?: TouchEvent) => {
-            const { rowCtrl, cellCtrl } = ctrl.getControlsForEventTarget(touchEvent?.target ?? null);
+            const { rowCtrl, cellCtrl } = ctrl.getControlsForEventTarget(_getEventTarget(touchEvent));
             if (cellCtrl?.column) {
                 cellCtrl.dispatchCellContextMenuEvent(touchEvent ?? null);
             }

--- a/packages/ag-grid-community/src/rendering/cell/cellKeyboardListenerFeature.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellKeyboardListenerFeature.ts
@@ -1,5 +1,6 @@
 import { KeyCode } from '../../agStack/constants/keyCode';
 import { _isMacOsUserAgent } from '../../agStack/utils/browser';
+import { _getEventTarget } from '../../agStack/utils/event';
 import { BeanStub } from '../../context/beanStub';
 import type { BeanCollection } from '../../context/context';
 import { _populateModelValidationErrors } from '../../edit/utils/editors';
@@ -244,7 +245,7 @@ export class CellKeyboardListenerFeature extends BeanStub {
     public processCharacter(event: KeyboardEvent): void {
         // check this, in case focus is on a (for example) a text field inside the cell,
         // in which cse we should not be listening for these key pressed
-        const eventTarget = event.target;
+        const eventTarget = _getEventTarget(event);
         const eventOnChildComponent = eventTarget !== this.eGui;
         const {
             beans: { editSvc },

--- a/packages/ag-grid-community/src/rendering/cell/cellMouseListenerFeature.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellMouseListenerFeature.ts
@@ -1,5 +1,6 @@
 import { _isBrowserSafari } from '../../agStack/utils/browser';
 import { _isElementChildOfClass, _isFocusableFormField } from '../../agStack/utils/dom';
+import { _getEventTarget } from '../../agStack/utils/event';
 import { isRowNumberCol } from '../../columns/columnUtils';
 import { BeanStub } from '../../context/beanStub';
 import type { BeanCollection } from '../../context/context';
@@ -158,7 +159,7 @@ export class CellMouseListenerFeature extends BeanStub {
 
     private onMouseDown(mouseEvent: MouseEvent): void {
         const { shiftKey } = mouseEvent;
-        const target = mouseEvent.target as HTMLElement;
+        const target = _getEventTarget(mouseEvent) as HTMLElement;
         const { cellCtrl, beans } = this;
         const { eventSvc, rangeSvc, rowNumbersSvc, focusSvc, gos, editSvc } = beans;
         const { column, rowNode, cellPosition } = cellCtrl;
@@ -289,12 +290,14 @@ export class CellMouseListenerFeature extends BeanStub {
     }
 
     private mouseStayingInsideCell(e: MouseEvent): boolean {
-        if (!e.target || !e.relatedTarget) {
+        const target = _getEventTarget(e);
+        const relatedTarget = e.relatedTarget;
+        if (!target || !relatedTarget) {
             return false;
         }
         const eCell = this.cellCtrl.eGui;
-        const cellContainsTarget = eCell.contains(e.target as Node);
-        const cellContainsRelatedTarget = eCell.contains(e.relatedTarget as Node);
+        const cellContainsTarget = eCell.contains(target as Node);
+        const cellContainsRelatedTarget = eCell.contains(relatedTarget as Node);
         return cellContainsTarget && cellContainsRelatedTarget;
     }
 }

--- a/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
@@ -7,6 +7,7 @@ import {
     _isFocusableFormField,
     _isVisible,
 } from '../../agStack/utils/dom';
+import { _getEventTarget } from '../../agStack/utils/event';
 import { _findNextFocusableElement } from '../../agStack/utils/focus';
 import { _batchCall } from '../../agStack/utils/function';
 import { _exists, _makeNull } from '../../agStack/utils/generic';
@@ -1002,7 +1003,8 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
 
         const { rowGui, column } = groupInfo;
         const currentFullWidthContainer = rowGui.element;
-        const isFullWidthContainerFocused = currentFullWidthContainer === keyboardEvent.target;
+        const eventTarget = _getEventTarget(keyboardEvent);
+        const isFullWidthContainerFocused = currentFullWidthContainer === eventTarget;
 
         if (!isFullWidthContainerFocused) {
             return;
@@ -1025,11 +1027,10 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         if (keyboardEvent.defaultPrevented || _isStopPropagationForAgGrid(keyboardEvent)) {
             return;
         }
-        const currentFullWidthComp = this.allRowGuis.find((c) =>
-            c.element.contains(keyboardEvent.target as HTMLElement)
-        );
+        const eventTarget = _getEventTarget(keyboardEvent);
+        const currentFullWidthComp = this.allRowGuis.find((c) => c.element.contains(eventTarget as HTMLElement));
         const currentFullWidthContainer = currentFullWidthComp ? currentFullWidthComp.element : null;
-        const isFullWidthContainerFocused = currentFullWidthContainer === keyboardEvent.target;
+        const isFullWidthContainerFocused = currentFullWidthContainer === eventTarget;
         const activeEl = _getActiveDomElement(this.beans);
         let isDetailGridCellFocused = false;
 
@@ -1185,7 +1186,7 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
             return;
         }
 
-        const rowGui = this.findFullWidthRowGui(event.target as HTMLElement);
+        const rowGui = this.findFullWidthRowGui(_getEventTarget(event) as HTMLElement);
         const column = this.getColumnForFullWidth(rowGui);
 
         if (!rowGui || !column) {
@@ -1214,7 +1215,8 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
     }
 
     private onRowMouseDown(mouseEvent: MouseEvent) {
-        this.lastMouseDownOnDragger = _isElementChildOfClass(mouseEvent.target as HTMLElement, 'ag-row-drag', 3);
+        const eventTarget = _getEventTarget(mouseEvent) as HTMLElement;
+        this.lastMouseDownOnDragger = _isElementChildOfClass(eventTarget, 'ag-row-drag', 3);
 
         if (!this.isFullWidth() || this.isSuppressMouseEvent(mouseEvent)) {
             return;
@@ -1231,7 +1233,7 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
 
         const { rowGui, column } = groupInfo;
         const element = rowGui.element;
-        const target = mouseEvent.target as HTMLElement;
+        const target = _getEventTarget(mouseEvent) as HTMLElement;
         const node = this.rowNode;
 
         let forceBrowserFocus = mouseEvent.defaultPrevented || _isBrowserSafari();
@@ -1251,7 +1253,7 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
     public isSuppressMouseEvent(mouseEvent: MouseEvent): boolean {
         const { gos, rowNode } = this;
         if (this.isFullWidth()) {
-            const fullWidthRowGui = this.findFullWidthRowGui(mouseEvent.target as HTMLElement);
+            const fullWidthRowGui = this.findFullWidthRowGui(_getEventTarget(mouseEvent) as HTMLElement);
             return _suppressFullWidthMouseEvent(
                 gos,
                 fullWidthRowGui?.rowComp.getFullWidthCellRendererParams(),
@@ -1259,7 +1261,7 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
                 mouseEvent
             );
         }
-        const cellCtrl = _getCellCtrlForEventTarget(gos, mouseEvent.target);
+        const cellCtrl = _getCellCtrlForEventTarget(gos, _getEventTarget(mouseEvent));
         return cellCtrl != null && _suppressCellMouseEvent(gos, cellCtrl.column, rowNode, mouseEvent);
     }
 

--- a/packages/ag-grid-community/src/widgets/touchListener.ts
+++ b/packages/ag-grid-community/src/widgets/touchListener.ts
@@ -4,6 +4,7 @@ import type { IEventEmitter, IEventListener } from '../agStack/interfaces/iEvent
 import {
     _areEventsNear,
     _getFirstActiveTouch,
+    _setTouchStartTarget,
     addTempEventHandlers,
     clearTempEventHandlers,
     preventEventDefault,
@@ -82,6 +83,7 @@ export class TouchListener implements IEventEmitter<TouchListenerEvent> {
         }
 
         const touchStart = touchEvent.touches[0];
+        _setTouchStartTarget(touchStart, touchEvent);
         this.touchStart = touchStart;
 
         const handlers = this.handlers;

--- a/packages/ag-grid-community/src/widgets/touchListener.ts
+++ b/packages/ag-grid-community/src/widgets/touchListener.ts
@@ -5,7 +5,6 @@ import {
     _areEventsNear,
     _getEventTarget,
     _getFirstActiveTouch,
-    _setTouchStartTarget,
     addTempEventHandlers,
     clearTempEventHandlers,
     preventEventDefault,
@@ -14,16 +13,17 @@ import type { TempEventHandler } from '../agStack/utils/event';
 
 export interface TapEvent extends AgEvent<'tap'> {
     touchStart: Touch;
+    startTarget: EventTarget | null;
 }
 export interface DoubleTapEvent extends AgEvent<'doubleTap'> {
     touchStart: Touch;
+    startTarget: EventTarget | null;
 }
 
 export interface LongTapEvent extends AgEvent<'longTap'> {
     touchStart: Touch;
     touchEvent: TouchEvent;
-    /** The actual target element, captured at touchstart (composedPath may be empty after dispatch) */
-    target: EventTarget | null;
+    startTarget: EventTarget | null;
 }
 
 const DOUBLE_TAP_MILLISECONDS = 500;
@@ -53,6 +53,7 @@ export class TouchListener implements IEventEmitter<TouchListenerEvent> {
     private eventSvc: LocalEventService<TouchListenerEvent> | null | undefined = undefined;
 
     private touchStart: Touch | null = null;
+    private touchStartTarget: EventTarget | null = null;
     private lastTapTime: number | null = null;
     private longPressTimer: number = 0;
     private moved: boolean = false;
@@ -86,11 +87,10 @@ export class TouchListener implements IEventEmitter<TouchListenerEvent> {
         }
 
         const touchStart = touchEvent.touches[0];
-        _setTouchStartTarget(touchStart, touchEvent);
-        this.touchStart = touchStart;
 
         // Capture target now since composedPath() returns empty after dispatch
-        const target = _getEventTarget(touchEvent);
+        const target = (this.touchStartTarget = _getEventTarget(touchEvent));
+        this.touchStart = touchStart;
 
         const handlers = this.handlers;
         if (!handlers.length) {
@@ -116,7 +116,12 @@ export class TouchListener implements IEventEmitter<TouchListenerEvent> {
             this.longPressTimer = 0;
             if (this.touchStart === touchStart && !this.moved) {
                 this.moved = true;
-                this.eventSvc?.dispatchEvent<LongTapEvent>({ type: 'longTap', touchStart, touchEvent, target });
+                this.eventSvc?.dispatchEvent<LongTapEvent>({
+                    type: 'longTap',
+                    touchStart,
+                    touchEvent,
+                    startTarget: target,
+                });
             }
         }, LONG_PRESS_MILLISECONDS);
     }
@@ -140,7 +145,7 @@ export class TouchListener implements IEventEmitter<TouchListenerEvent> {
         }
 
         if (!this.moved) {
-            this.eventSvc?.dispatchEvent<TapEvent>({ type: 'tap', touchStart });
+            this.eventSvc?.dispatchEvent<TapEvent>({ type: 'tap', touchStart, startTarget: this.touchStartTarget });
             this.checkDoubleTap(touchStart);
         }
 
@@ -168,7 +173,11 @@ export class TouchListener implements IEventEmitter<TouchListenerEvent> {
             // if previous tap, see if duration is short enough to be considered double tap
             const interval = now - lastTapTime;
             if (interval > DOUBLE_TAP_MILLISECONDS) {
-                this.eventSvc?.dispatchEvent<DoubleTapEvent>({ type: 'doubleTap', touchStart });
+                this.eventSvc?.dispatchEvent<DoubleTapEvent>({
+                    type: 'doubleTap',
+                    touchStart,
+                    startTarget: this.touchStartTarget,
+                });
                 now = null; // this stops a triple tap ending up as two double taps
             }
         }
@@ -179,6 +188,7 @@ export class TouchListener implements IEventEmitter<TouchListenerEvent> {
         this.clearLongPress();
         clearTempEventHandlers(this.handlers);
         this.touchStart = null;
+        this.touchStartTarget = null;
     }
 
     private clearLongPress(): void {

--- a/packages/ag-grid-community/src/widgets/touchListener.ts
+++ b/packages/ag-grid-community/src/widgets/touchListener.ts
@@ -3,6 +3,7 @@ import type { AgEvent } from '../agStack/interfaces/agEvent';
 import type { IEventEmitter, IEventListener } from '../agStack/interfaces/iEventEmitter';
 import {
     _areEventsNear,
+    _getEventTarget,
     _getFirstActiveTouch,
     _setTouchStartTarget,
     addTempEventHandlers,
@@ -21,6 +22,8 @@ export interface DoubleTapEvent extends AgEvent<'doubleTap'> {
 export interface LongTapEvent extends AgEvent<'longTap'> {
     touchStart: Touch;
     touchEvent: TouchEvent;
+    /** The actual target element, captured at touchstart (composedPath may be empty after dispatch) */
+    target: EventTarget | null;
 }
 
 const DOUBLE_TAP_MILLISECONDS = 500;
@@ -86,6 +89,9 @@ export class TouchListener implements IEventEmitter<TouchListenerEvent> {
         _setTouchStartTarget(touchStart, touchEvent);
         this.touchStart = touchStart;
 
+        // Capture target now since composedPath() returns empty after dispatch
+        const target = _getEventTarget(touchEvent);
+
         const handlers = this.handlers;
         if (!handlers.length) {
             const eElement = this.eElement;
@@ -110,7 +116,7 @@ export class TouchListener implements IEventEmitter<TouchListenerEvent> {
             this.longPressTimer = 0;
             if (this.touchStart === touchStart && !this.moved) {
                 this.moved = true;
-                this.eventSvc?.dispatchEvent<LongTapEvent>({ type: 'longTap', touchStart, touchEvent });
+                this.eventSvc?.dispatchEvent<LongTapEvent>({ type: 'longTap', touchStart, touchEvent, target });
             }
         }, LONG_PRESS_MILLISECONDS);
     }

--- a/packages/ag-grid-enterprise/src/agStack/agColorPanel.ts
+++ b/packages/ag-grid-enterprise/src/agStack/agColorPanel.ts
@@ -7,7 +7,7 @@ import type {
     _BaseProperties,
     _IPropertiesService,
 } from 'ag-grid-community';
-import { KeyCode, RefPlaceholder, _AgComponentStub, _exists, _setDisplayed } from 'ag-grid-community';
+import { KeyCode, RefPlaceholder, _AgComponentStub, _exists, _getEventTarget, _setDisplayed } from 'ag-grid-community';
 
 import type { AgColorInput } from './agColorInput';
 import { AgColorInputSelector } from './agColorInput';
@@ -438,7 +438,7 @@ export class AgColorPanel<
     }
 
     private onRecentColorClick(e: MouseEvent | KeyboardEvent) {
-        const target = e.target as HTMLElement;
+        const target = _getEventTarget(e) as HTMLElement;
 
         if (!_exists(target.id)) {
             return;

--- a/packages/ag-grid-enterprise/src/agStack/agContextMenuService.ts
+++ b/packages/ag-grid-enterprise/src/agStack/agContextMenuService.ts
@@ -12,6 +12,7 @@ import {
     _anchorElementToMouseMoveEvent,
     _createAgElement,
     _focusInto,
+    _getEventTarget,
     _getPageBody,
     _getRootNode,
     _isPromise,
@@ -110,7 +111,7 @@ export class AgContextMenuService<
                     return;
                 }
 
-                const { target } = mouseEvent;
+                const target = _getEventTarget(mouseEvent);
 
                 // if there is no event target, it means the event was created by `api.showContextMenu`.
                 const isFromFakeEvent = !target;

--- a/packages/ag-grid-enterprise/src/agStack/agPanel.ts
+++ b/packages/ag-grid-enterprise/src/agStack/agPanel.ts
@@ -13,6 +13,7 @@ import {
     _AgComponentStub,
     _AgPositionableFeature,
     _getActiveDomElement,
+    _getEventTarget,
     _getInnerHeight,
     _getInnerWidth,
     _isVisible,
@@ -175,7 +176,7 @@ export class AgPanel<
                 if (
                     eGui.contains(e.relatedTarget as HTMLElement) ||
                     eGui.contains(_getActiveDomElement(beans)) ||
-                    this.eTitleBarButtons.contains(e.target as HTMLElement)
+                    this.eTitleBarButtons.contains(_getEventTarget(e) as HTMLElement)
                 ) {
                     e.preventDefault();
                     return;

--- a/packages/ag-grid-enterprise/src/agStack/agTabbedLayout.ts
+++ b/packages/ag-grid-enterprise/src/agStack/agTabbedLayout.ts
@@ -16,6 +16,7 @@ import {
     _focusInto,
     _getActiveDomElement,
     _getDocument,
+    _getEventTarget,
     _isKeyboardMode,
     _setAriaLabel,
     _setAriaRole,
@@ -177,7 +178,7 @@ export class AgTabbedLayout<
         const { suppressTrapFocus, enableCloseButton } = params;
 
         const activeElement = _getActiveDomElement(beans);
-        const target = e.target as HTMLElement;
+        const target = _getEventTarget(e) as HTMLElement;
         const backwards = e.shiftKey;
 
         if (eHeader.contains(activeElement)) {

--- a/packages/ag-grid-enterprise/src/agStack/agVirtualList.ts
+++ b/packages/ag-grid-enterprise/src/agStack/agVirtualList.ts
@@ -15,6 +15,7 @@ import {
     _AgTabGuardComp,
     _createAgElement,
     _getAriaPosInSet,
+    _getEventTarget,
     _observeResize,
     _requestAnimationFrame,
     _setAriaLabel,
@@ -156,7 +157,7 @@ export class AgVirtualList<
     }
 
     protected onFocusIn(e: FocusEvent): void {
-        const target = e.target as HTMLElement;
+        const target = _getEventTarget(e) as HTMLElement;
 
         if (target.classList.contains('ag-virtual-list-item')) {
             this.lastFocusedRowIndex = _getAriaPosInSet(target) - 1;

--- a/packages/ag-grid-enterprise/src/excelExport/zipContainer/compress.ts
+++ b/packages/ag-grid-enterprise/src/excelExport/zipContainer/compress.ts
@@ -1,3 +1,5 @@
+import { _getEventTarget } from 'ag-grid-community';
+
 const compressBlob = async (
     data: Blob
 ): Promise<{
@@ -19,8 +21,9 @@ const compressBlob = async (
         start: (controller) => {
             const reader = new FileReader();
             reader.onload = (e) => {
-                if (e.target?.result) {
-                    controller.enqueue(e.target.result);
+                const target = _getEventTarget(e) as FileReader;
+                if (target.result) {
+                    controller.enqueue(target.result);
                 }
 
                 controller.close();

--- a/packages/ag-grid-enterprise/src/menu/enterpriseMenu.ts
+++ b/packages/ag-grid-enterprise/src/menu/enterpriseMenu.ts
@@ -24,6 +24,7 @@ import {
     _createIconNoSpan,
     _error,
     _focusInto,
+    _getEventTarget,
     _isColumnMenuAnchoringEnabled,
     _isLegacyMenuEnabled,
     _setColMenuVisible,
@@ -97,7 +98,7 @@ export class EnterpriseMenuFactory extends BeanStub implements NamedBean, IMenuF
             containerType,
             defaultTab,
             undefined,
-            mouseEvent.target as HTMLElement,
+            _getEventTarget(mouseEvent) as HTMLElement,
             onClosedCallback
         );
     }

--- a/packages/ag-grid-enterprise/src/multiFilter/baseMultiFilter.ts
+++ b/packages/ag-grid-enterprise/src/multiFilter/baseMultiFilter.ts
@@ -6,6 +6,7 @@ import {
     _createElement,
     _focusInto,
     _getActiveDomElement,
+    _getEventTarget,
     _isNothingFocused,
     _setAriaRole,
 } from 'ag-grid-community';
@@ -333,7 +334,10 @@ export abstract class BaseMultiFilter<TFilterWrapper> extends TabGuardComp {
 
     protected onFocusIn(e: FocusEvent): void {
         const lastActivatedMenuItem = this.lastActivatedMenuItem;
-        if (lastActivatedMenuItem != null && !lastActivatedMenuItem.getGui().contains(e.target as HTMLElement)) {
+        if (
+            lastActivatedMenuItem != null &&
+            !lastActivatedMenuItem.getGui().contains(_getEventTarget(e) as HTMLElement)
+        ) {
             lastActivatedMenuItem.deactivate();
             this.lastActivatedMenuItem = null;
         }

--- a/packages/ag-grid-enterprise/src/rangeSelection/rangeService.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/rangeService.ts
@@ -97,6 +97,7 @@ export class RangeService extends BeanStub implements NamedBean, IRangeService, 
 
     private cellRanges: CellRange[] = [];
     private lastMouseEvent: MouseEvent | null;
+    private lastMouseEventTarget: EventTarget | null;
     private readonly bodyScrollListener = this.onBodyScroll.bind(this);
 
     private lastCellHovered: CellPosition | undefined;
@@ -261,9 +262,12 @@ export class RangeService extends BeanStub implements NamedBean, IRangeService, 
             return;
         }
 
-        this.updateValuesOnMove(_getEventTarget(mouseEvent));
+        // Reuse stored target if same event (composedPath() may be empty after dispatch)
+        const target = mouseEvent === this.lastMouseEvent ? this.lastMouseEventTarget : _getEventTarget(mouseEvent);
+        this.updateValuesOnMove(target);
 
         this.lastMouseEvent = mouseEvent;
+        this.lastMouseEventTarget = target;
 
         const isMouseAndStartInPinned = (position: string) =>
             lastCellHovered && lastCellHovered.rowPinned === position && newestRangeStartCell!.rowPinned === position;
@@ -307,6 +311,7 @@ export class RangeService extends BeanStub implements NamedBean, IRangeService, 
 
         this.ctrlsSvc.getGridBodyCtrl().eBodyViewport.removeEventListener('scroll', this.bodyScrollListener);
         this.lastMouseEvent = null;
+        this.lastMouseEventTarget = null;
         this.dragging = false;
         this.draggingRange = undefined;
         this.lastCellHovered = undefined;
@@ -1287,8 +1292,9 @@ export class RangeService extends BeanStub implements NamedBean, IRangeService, 
     // means we are selecting more (or less) cells, but the mouse isn't moving, so we recalculate
     // the selection by mimicking a new mouse event
     private onBodyScroll(): void {
-        if (this.dragging && this.lastMouseEvent) {
-            this.onDragging(this.lastMouseEvent);
+        const { dragging, lastMouseEvent } = this;
+        if (dragging && lastMouseEvent) {
+            this.onDragging(lastMouseEvent);
         }
     }
 

--- a/packages/ag-grid-enterprise/src/rangeSelection/rangeService.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/rangeService.ts
@@ -34,6 +34,7 @@ import {
     _getAbsoluteRowIndex,
     _getCellCtrlForEventTarget,
     _getEnableColumnSelection,
+    _getEventTarget,
     _getFirstRow,
     _getLastRow,
     _getRowAbove,
@@ -182,7 +183,7 @@ export class RangeService extends BeanStub implements NamedBean, IRangeService, 
     // Drag And Drop Target Methods
     public onDragStart(mouseEvent: MouseEvent): void {
         const gos = this.gos;
-        const target = mouseEvent.target as HTMLElement | null;
+        const target = _getEventTarget(mouseEvent);
         if (!_isCellSelectionEnabled(gos) || _getRowCtrlForEventTarget(gos, target)?.isSuppressMouseEvent(mouseEvent)) {
             return;
         }
@@ -260,7 +261,7 @@ export class RangeService extends BeanStub implements NamedBean, IRangeService, 
             return;
         }
 
-        this.updateValuesOnMove(mouseEvent.target);
+        this.updateValuesOnMove(_getEventTarget(mouseEvent));
 
         this.lastMouseEvent = mouseEvent;
 
@@ -417,7 +418,7 @@ export class RangeService extends BeanStub implements NamedBean, IRangeService, 
 
     public handleCellMouseDown(event: MouseEvent, cell: CellPosition): void {
         const { beans } = this;
-        const target = event.target as HTMLElement | null;
+        const target = _getEventTarget(event);
 
         if (this.shouldSuppressRangeSelection(target)) {
             return;

--- a/packages/ag-grid-enterprise/src/rangeSelection/rangeService.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/rangeService.ts
@@ -262,7 +262,9 @@ export class RangeService extends BeanStub implements NamedBean, IRangeService, 
             return;
         }
 
-        // Reuse stored target if same event (composedPath() may be empty after dispatch)
+        // When onBodyScroll() calls onDragging() with the same cached event, composedPath() may
+        // return an empty array (browsers clear it after dispatch). We detect this by checking
+        // event identity and reuse the previously captured target for the scroll recalculation.
         const target = mouseEvent === this.lastMouseEvent ? this.lastMouseEventTarget : _getEventTarget(mouseEvent);
         this.updateValuesOnMove(target);
 

--- a/packages/ag-grid-enterprise/src/rowNumbers/rowNumbersService.ts
+++ b/packages/ag-grid-enterprise/src/rowNumbers/rowNumbersService.ts
@@ -11,6 +11,7 @@ import {
     _debounce,
     _destroyColumnTree,
     _getColumnStateFromColDef,
+    _getEventTarget,
     _getFirstRow,
     _getRowNode,
     _interpretAsRightClick,
@@ -165,7 +166,7 @@ export class RowNumbersService extends BeanStub implements NamedBean, IRowNumber
         // if click interaction can't produce an outcome (i.e. no cell selection, no row-resizing), do nothing
         if (
             !this.isIntegratedWithSelection ||
-            (mouseEvent.target as HTMLElement).classList.contains('ag-row-numbers-resizer')
+            (_getEventTarget(mouseEvent) as HTMLElement).classList.contains('ag-row-numbers-resizer')
         ) {
             if (this.beans.rangeSvc) {
                 mouseEvent.preventDefault();

--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
@@ -19,6 +19,7 @@ import {
     _focusInto,
     _focusNextGridCoreContainer,
     _getActiveDomElement,
+    _getEventTarget,
     _isVisible,
     _removeFromParent,
     _setAriaControlsAndLabel,
@@ -89,7 +90,7 @@ class AgSideBar extends Component implements ISideBar {
         const sideBarGui = sideBarButtons.getGui();
         const activeElement = _getActiveDomElement(beans) as HTMLElement;
         const openPanel = eGui.querySelector('.ag-tool-panel-wrapper:not(.ag-hidden)') as HTMLElement;
-        const target = e.target as HTMLElement;
+        const target = _getEventTarget(e) as HTMLElement;
         const backwards = e.shiftKey;
 
         if (!openPanel) {
@@ -125,7 +126,7 @@ class AgSideBar extends Component implements ISideBar {
             nextEl = _isVisible(nextEl) ? nextEl : null;
         }
 
-        if (nextEl && nextEl !== e.target) {
+        if (nextEl && nextEl !== _getEventTarget(e)) {
             e.preventDefault();
             nextEl.focus();
         }

--- a/testing/behavioural/src/selection/shadow-dom-cell-selection.test.ts
+++ b/testing/behavioural/src/selection/shadow-dom-cell-selection.test.ts
@@ -1,0 +1,148 @@
+import { getByTestId } from '@testing-library/dom';
+
+import type { GridApi, GridOptions } from 'ag-grid-community';
+import { ClientSideRowModelModule, agTestIdFor, setupAgTestIds } from 'ag-grid-community';
+import { CellSelectionModule } from 'ag-grid-enterprise';
+
+import {
+    TestGridsManager,
+    assertSelectedCellRanges,
+    asyncSetTimeout,
+    mockGridLayout,
+    waitForEvent,
+} from '../test-utils';
+import { initPointerEventPolyfill } from '../test-utils/polyfills/pointerEvent';
+import {
+    cleanupShadowDomEventRetargeting,
+    initShadowDomEventRetargeting,
+} from '../test-utils/polyfills/shadowDomEventRetargeting';
+
+/**
+ * Tests for verifying AG Grid cell selection works correctly when inside Shadow DOM.
+ *
+ * When AG Grid is placed inside a Shadow DOM (e.g., via Angular's ViewEncapsulation.ShadowDom),
+ * event.target can be retargeted to the shadow host when events cross shadow boundaries.
+ * These tests verify that cell selection and interactions work correctly in this scenario.
+ */
+describe('AG Grid in Shadow DOM', () => {
+    let shadowHost: HTMLElement;
+    let shadowRoot: ShadowRoot;
+    let gridContainer: HTMLElement;
+    let api: GridApi | null = null;
+
+    const gridMgr = new TestGridsManager({
+        modules: [ClientSideRowModelModule, CellSelectionModule],
+        mockGridLayout: false, // We handle grid layout ourselves in beforeAll
+    });
+
+    beforeAll(() => {
+        mockGridLayout.init();
+        initPointerEventPolyfill();
+        initShadowDomEventRetargeting();
+        setupAgTestIds();
+    });
+
+    afterAll(() => {
+        cleanupShadowDomEventRetargeting();
+    });
+
+    beforeEach(() => {
+        gridMgr.reset();
+
+        // Create shadow DOM host
+        shadowHost = document.createElement('div');
+        shadowHost.id = 'shadow-host';
+        document.body.appendChild(shadowHost);
+
+        // Attach shadow root
+        shadowRoot = shadowHost.attachShadow({ mode: 'open' });
+
+        // Create grid container inside shadow root
+        gridContainer = document.createElement('div');
+        gridContainer.id = 'grid-container';
+        gridContainer.style.width = '500px';
+        gridContainer.style.height = '300px';
+        shadowRoot.appendChild(gridContainer);
+    });
+
+    afterEach(() => {
+        gridMgr.reset();
+        if (shadowHost.parentNode) {
+            shadowHost.remove();
+        }
+    });
+
+    const createGridInShadowDom = async (options?: Partial<GridOptions>): Promise<GridApi> => {
+        const gridOptions: GridOptions = {
+            columnDefs: [
+                { field: 'id', headerName: 'ID' },
+                { field: 'name', headerName: 'Name' },
+                { field: 'value', headerName: 'Value' },
+            ],
+            rowData: [
+                { id: 'A', name: 'Row A', value: 100 },
+                { id: 'B', name: 'Row B', value: 200 },
+                { id: 'C', name: 'Row C', value: 300 },
+            ],
+            cellSelection: true,
+            getRowId: (params) => params.data.id,
+            ...options,
+        };
+
+        api = gridMgr.createGrid(gridContainer, gridOptions);
+
+        await waitForEvent('firstDataRendered', api);
+        await asyncSetTimeout(1);
+        return api;
+    };
+
+    test('grid renders correctly inside Shadow DOM', async () => {
+        await createGridInShadowDom();
+
+        expect(api!.getDisplayedRowCount()).toBe(3);
+
+        // Verify cells are rendered inside shadow DOM
+        const cells = shadowRoot.querySelectorAll('.ag-cell');
+        expect(cells.length).toBeGreaterThan(0);
+    });
+
+    test('clicking a cell inside Shadow DOM selects it', async () => {
+        await createGridInShadowDom();
+
+        // Get cell using test ID within shadow root
+        const cell = getByTestId(gridContainer, agTestIdFor.cell('A', 'name'));
+        expect(cell).toBeTruthy();
+
+        // Use touchstart like other cell-selection tests do (because jsdom attaches touchstart, not mousedown)
+        const cellSelectionChanged = waitForEvent('cellSelectionChanged', api!);
+        cell.dispatchEvent(new MouseEvent('touchstart', { bubbles: true }));
+
+        await cellSelectionChanged;
+        await asyncSetTimeout(1);
+
+        // Verify selection
+        assertSelectedCellRanges([{ rowStartIndex: 0, rowEndIndex: 0, columns: ['name'] }], api!);
+    });
+
+    test('clicking different cells inside Shadow DOM updates selection', async () => {
+        await createGridInShadowDom();
+
+        // Click first cell
+        const cell1 = getByTestId(gridContainer, agTestIdFor.cell('A', 'name'));
+        let cellSelectionChanged = waitForEvent('cellSelectionChanged', api!);
+        cell1.dispatchEvent(new MouseEvent('touchstart', { bubbles: true }));
+        await cellSelectionChanged;
+        await asyncSetTimeout(1);
+
+        assertSelectedCellRanges([{ rowStartIndex: 0, rowEndIndex: 0, columns: ['name'] }], api!);
+
+        // Click different cell
+        const cell2 = getByTestId(gridContainer, agTestIdFor.cell('B', 'value'));
+        cellSelectionChanged = waitForEvent('cellSelectionChanged', api!);
+        cell2.dispatchEvent(new MouseEvent('touchstart', { bubbles: true }));
+        await cellSelectionChanged;
+        await asyncSetTimeout(1);
+
+        assertSelectedCellRanges([{ rowStartIndex: 1, rowEndIndex: 1, columns: ['value'] }], api!);
+    });
+});

--- a/testing/behavioural/src/test-utils/polyfills/shadowDomEventRetargeting.ts
+++ b/testing/behavioural/src/test-utils/polyfills/shadowDomEventRetargeting.ts
@@ -1,0 +1,66 @@
+/**
+ * Polyfill to simulate Shadow DOM event retargeting in jsdom.
+ *
+ * In browsers, `event.target` is retargeted to the shadow host when events bubble
+ * out of a shadow root, but `composedPath()[0]` returns the actual target.
+ * jsdom doesn't implement this, so we patch dispatchEvent to simulate it.
+ */
+
+let initialized = false;
+let originalDispatchEvent: typeof HTMLElement.prototype.dispatchEvent | null = null;
+
+function findShadowHost(target: EventTarget | null): HTMLElement | null {
+    if (!(target instanceof Node)) {
+        return null;
+    }
+    const root = target.getRootNode();
+    return root instanceof ShadowRoot ? (root.host as HTMLElement) : null;
+}
+
+export function initShadowDomEventRetargeting(): void {
+    if (initialized) {
+        return;
+    }
+    initialized = true;
+    originalDispatchEvent = HTMLElement.prototype.dispatchEvent;
+
+    HTMLElement.prototype.dispatchEvent = function (this: HTMLElement, event: Event): boolean {
+        const shadowHost = findShadowHost(this);
+
+        if (!shadowHost) {
+            return originalDispatchEvent!.call(this, event);
+        }
+
+        const originalTarget = this;
+        const originalComposedPath = event.composedPath.bind(event);
+        const fullPath = [originalTarget, ...originalComposedPath()];
+
+        // Override target to return shadow host (simulating browser retargeting)
+        Object.defineProperty(event, 'target', {
+            get: () => shadowHost,
+            configurable: true,
+        });
+
+        // composedPath() returns the full path including the actual original target
+        Object.defineProperty(event, 'composedPath', {
+            value: () => fullPath,
+            configurable: true,
+        });
+
+        try {
+            return originalDispatchEvent!.call(this, event);
+        } finally {
+            delete (event as any).target;
+            delete (event as any).composedPath;
+        }
+    };
+}
+
+export function cleanupShadowDomEventRetargeting(): void {
+    if (!initialized || !originalDispatchEvent) {
+        return;
+    }
+    HTMLElement.prototype.dispatchEvent = originalDispatchEvent;
+    originalDispatchEvent = null;
+    initialized = false;
+}

--- a/testing/behavioural/src/test-utils/utils.ts
+++ b/testing/behavioural/src/test-utils/utils.ts
@@ -112,6 +112,51 @@ export function unindentText(text: TemplateStringsArray | string | string[] | nu
 
 let consoleLicenseKeyErrorInitialized = false;
 
+/**
+ * Queries an element by test ID, including within shadow roots.
+ * This is necessary because @testing-library/dom's getByTestId doesn't search inside shadow roots.
+ */
+export function queryByTestIdDeep(container: Element | Document | ShadowRoot, testId: string): HTMLElement | null {
+    // First try the container itself
+    const directResult = container.querySelector<HTMLElement>(`[data-testid="${testId}"]`);
+    if (directResult) {
+        return directResult;
+    }
+
+    // Search in shadow roots
+    const searchInShadowRoots = (root: Element | Document | ShadowRoot): HTMLElement | null => {
+        const elements = root.querySelectorAll('*');
+        for (const element of elements) {
+            const shadowRoot = (element as Element).shadowRoot;
+            if (shadowRoot) {
+                const found = shadowRoot.querySelector<HTMLElement>(`[data-testid="${testId}"]`);
+                if (found) {
+                    return found;
+                }
+                const nested = searchInShadowRoots(shadowRoot);
+                if (nested) {
+                    return nested;
+                }
+            }
+        }
+        return null;
+    };
+
+    return searchInShadowRoots(container);
+}
+
+/**
+ * Gets an element by test ID, including within shadow roots.
+ * Throws an error if the element is not found.
+ */
+export function getByTestIdDeep(container: Element | Document | ShadowRoot, testId: string): HTMLElement {
+    const result = queryByTestIdDeep(container, testId);
+    if (!result) {
+        throw new Error(`Unable to find an element with data-testid="${testId}" (including shadow roots)`);
+    }
+    return result;
+}
+
 export function ignoreConsoleLicenseKeyError() {
     if (consoleLicenseKeyErrorInitialized) {
         return;


### PR DESCRIPTION
When AG Grid is rendered inside a Shadow DOM, event.target gets retargeted to the shadow host element when events bubble across the shadow boundary.
This caused cell selection, drag operations, and touch interactions to fail.

- Use event.composedPath()[0] instead of event.target to get the actual element that received the event
- Updated all event.target references across the codebase to use the _getEventTarget() utility function
- For Touch objects (which don't have composedPath()), store the initial target that was present on drag start
- Store targets explicitly where events are accessed after dispatch finishes (when composedPath() returns an empty array)

Changes:
- Added _getEventTarget() to support both Events and Touch objects in Shadow DOM
- Register touch target when starting drag operations and tap/long-tap events
- Updated all usages of event.target to use _getEventTarget(event) for correct Shadow DOM behaviour
- Dragging class captures startTarget at construction time
- rangeService stores lastMouseEventTarget alongside lastMouseEvent for reuse when the same event is accessed later
- LongTapEvent, DoubleTapEvent, TapEvent includes explicit target field (captured before the setTimeout delay)
- Added a test and jsdom polyfill for shadow DOM event retargeting

FIX AG-16675
