### PR TITLE
[AG-16487] Fix(ssrm): tc2

### DIFF
--- a/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyCache.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyCache.ts
@@ -895,6 +895,18 @@ export class LazyCache extends BeanStub {
             lazyNodesAfterStoreEnd.forEach((lazyNode) => this.destroyRowAtIndex(lazyNode.index));
         }
 
+        const hasActiveSort = (this.sortSvc?.getSortOptions() ?? []).some((opt) => opt.sort != null);
+        const hasStubNodes = this.nodeMap.find((lazyNode) => !!lazyNode.node.stub) != null;
+        const allRowsLoaded = this.isLastRowKnown && this.nodeMap.getSize() === this.numberOfRows && !hasStubNodes;
+        const shouldClientSideSortOnLoad =
+            this.gos.get('serverSideEnableClientSideSort') &&
+            (this.isStoreFullyLoaded() || allRowsLoaded) &&
+            hasActiveSort;
+
+        if (shouldClientSideSortOnLoad) {
+            this.clientSideSortRows();
+        }
+
         this.fireStoreUpdatedEvent();
 
         // Happens after store updated, as store updating can clear our excess rows.

--- a/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyCache.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyCache.ts
@@ -895,16 +895,15 @@ export class LazyCache extends BeanStub {
             lazyNodesAfterStoreEnd.forEach((lazyNode) => this.destroyRowAtIndex(lazyNode.index));
         }
 
-        const hasActiveSort = (this.sortSvc?.getSortOptions() ?? []).some((opt) => opt.sort != null);
-        const hasStubNodes = this.nodeMap.find((lazyNode) => !!lazyNode.node.stub) != null;
-        const allRowsLoaded = this.isLastRowKnown && this.nodeMap.getSize() === this.numberOfRows && !hasStubNodes;
-        const shouldClientSideSortOnLoad =
-            this.gos.get('serverSideEnableClientSideSort') &&
-            (this.isStoreFullyLoaded() || allRowsLoaded) &&
-            hasActiveSort;
+        if (this.gos.get('serverSideEnableClientSideSort')) {
+            const hasActiveSort = (this.sortSvc?.getSortOptions() ?? []).some((opt) => opt.sort != null);
+            const hasStubNodes = this.nodeMap.find((lazyNode) => !!lazyNode.node.stub) != null;
+            const allRowsLoaded = this.isLastRowKnown && this.nodeMap.getSize() === this.numberOfRows && !hasStubNodes;
+            const shouldClientSideSortOnLoad = (this.isStoreFullyLoaded() || allRowsLoaded) && hasActiveSort;
 
-        if (shouldClientSideSortOnLoad) {
-            this.clientSideSortRows();
+            if (shouldClientSideSortOnLoad) {
+                this.clientSideSortRows();
+            }
         }
 
         this.fireStoreUpdatedEvent();

--- a/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyCache.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyCache.ts
@@ -895,7 +895,7 @@ export class LazyCache extends BeanStub {
             lazyNodesAfterStoreEnd.forEach((lazyNode) => this.destroyRowAtIndex(lazyNode.index));
         }
 
-        if (this.gos.get('serverSideEnableClientSideSort')) {
+        if (this.gos.get('serverSideEnableClientSideSort') && !wasRefreshing) {
             const hasActiveSort = (this.sortSvc?.getSortOptions() ?? []).some((opt) => opt.sort != null);
             const hasStubNodes = this.nodeMap.find((lazyNode) => !!lazyNode.node.stub) != null;
             const allRowsLoaded = this.isLastRowKnown && this.nodeMap.getSize() === this.numberOfRows && !hasStubNodes;

--- a/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-refresh-client-side-sort.test.ts
+++ b/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-refresh-client-side-sort.test.ts
@@ -1,13 +1,19 @@
 import type {
     GridOptions,
-    IsServerSideGroupOpenByDefaultParams,
     IServerSideDatasource,
     IServerSideGetRowsParams,
     IServerSideGetRowsRequest,
+    IsServerSideGroupOpenByDefaultParams,
 } from 'ag-grid-community';
 import { ServerSideRowModelModule, TreeDataModule } from 'ag-grid-enterprise';
 
-import { GridRows, TestGridsManager, asyncSetTimeout, ssrmExpandAndLoadAll, waitForNoLoadingRows } from '../../test-utils';
+import {
+    GridRows,
+    TestGridsManager,
+    asyncSetTimeout,
+    ssrmExpandAndLoadAll,
+    waitForNoLoadingRows,
+} from '../../test-utils';
 import { createFakeServer, createServerSideDatasource, getSmallTreeDataSet } from './ssrmSmallTreeDataSet';
 
 describe('ag-grid SSRM treeData client-side sort refresh', () => {
@@ -90,11 +96,7 @@ describe('ag-grid SSRM treeData client-side sort refresh', () => {
 
     test('purge refresh keeps client-side sort order for leaf rows', async () => {
         const gridOptions: GridOptions = {
-            columnDefs: [
-                { field: 'employeeId', hide: true },
-                { field: 'name', hide: true },
-                { field: 'experience' },
-            ],
+            columnDefs: [{ field: 'employeeId', hide: true }, { field: 'name', hide: true }, { field: 'experience' }],
             autoGroupColumnDef: {
                 field: 'name',
             },

--- a/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-refresh-client-side-sort.test.ts
+++ b/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-refresh-client-side-sort.test.ts
@@ -1,7 +1,13 @@
-import type { GridOptions, IsServerSideGroupOpenByDefaultParams } from 'ag-grid-community';
+import type {
+    GridOptions,
+    IsServerSideGroupOpenByDefaultParams,
+    IServerSideDatasource,
+    IServerSideGetRowsParams,
+    IServerSideGetRowsRequest,
+} from 'ag-grid-community';
 import { ServerSideRowModelModule, TreeDataModule } from 'ag-grid-enterprise';
 
-import { GridRows, TestGridsManager, asyncSetTimeout, waitForNoLoadingRows } from '../../test-utils';
+import { GridRows, TestGridsManager, asyncSetTimeout, ssrmExpandAndLoadAll, waitForNoLoadingRows } from '../../test-utils';
 import { createFakeServer, createServerSideDatasource, getSmallTreeDataSet } from './ssrmSmallTreeDataSet';
 
 describe('ag-grid SSRM treeData client-side sort refresh', () => {
@@ -33,8 +39,7 @@ describe('ag-grid SSRM treeData client-side sort refresh', () => {
             rowModelType: 'serverSide',
             animateRows: false,
             serverSideEnableClientSideSort: true,
-            cacheBlockSize: 100,
-            maxBlocksInCache: 1,
+            cacheBlockSize: 2000000,
             getRowId: ({ data }) => data.employeeId,
             isServerSideGroupOpenByDefault: (params: IsServerSideGroupOpenByDefaultParams) => {
                 return params.rowNode.level < 1;
@@ -82,4 +87,173 @@ describe('ag-grid SSRM treeData client-side sort refresh', () => {
             · └── 102 GROUP collapsed id:102 ag-Grid-AutoColumn:"Malcolm Barrett" employeeId:"102" employeeName:"Malcolm Barrett" jobTitle:"Exec. Vice President" employmentType:"Permanent"
         `);
     });
+
+    test('purge refresh keeps client-side sort order for leaf rows', async () => {
+        const gridOptions: GridOptions = {
+            columnDefs: [
+                { field: 'employeeId', hide: true },
+                { field: 'name', hide: true },
+                { field: 'experience' },
+            ],
+            autoGroupColumnDef: {
+                field: 'name',
+            },
+            defaultColDef: { flex: 1 },
+            treeData: true,
+            rowModelType: 'serverSide',
+            animateRows: false,
+            serverSideEnableClientSideSort: true,
+            cacheBlockSize: 100,
+            maxBlocksInCache: 1,
+            getRowId: ({ data, parentKeys = [], level }) => {
+                const base = data.employeeId ?? data.name;
+                return `${parentKeys.join('/')}:${level}:${base}`;
+            },
+            isServerSideGroupOpenByDefault: (params: IsServerSideGroupOpenByDefaultParams) => {
+                return params.rowNode.level < 2;
+            },
+            isServerSideGroup: (dataItem: any) => {
+                return dataItem.group;
+            },
+            getServerSideGroupKey: (dataItem: any) => {
+                return dataItem.name;
+            },
+        };
+
+        const api = gridsManager.createGrid('ssrmTreeDataClientSideSortPurgeRefresh', gridOptions);
+
+        await asyncSetTimeout(1);
+
+        const data = getExperienceTreeDataSet();
+        const fakeServer = createExperienceFakeServer(data);
+        const datasource = createExperienceServerSideDatasource(fakeServer);
+
+        api!.setGridOption('serverSideDatasource', datasource);
+
+        await waitForNoLoadingRows(api);
+        await ssrmExpandAndLoadAll(api);
+
+        api!.applyColumnState({
+            state: [{ colId: 'experience', sort: 'asc' }],
+        });
+
+        const gridRows = new GridRows(api, 'ssrm tree data experience sorted');
+        await gridRows.check(`
+           ROOT id:<no-id>
+           └─┬ Root GROUP id:":0:200" ag-Grid-AutoColumn:"Root" employeeId:"200" name:"Root" experience:0
+           · ├── LEAF id:"Root:1:202" ag-Grid-AutoColumn:"Beta" employeeId:"202" name:"Beta" experience:1
+           · ├── LEAF id:"Root:1:203" ag-Grid-AutoColumn:"Gamma" employeeId:"203" name:"Gamma" experience:2
+           · └── LEAF id:"Root:1:201" ag-Grid-AutoColumn:"Alpha" employeeId:"201" name:"Alpha" experience:3
+        `);
+
+        api!.refreshServerSide({ purge: true });
+
+        await waitForNoLoadingRows(api);
+        await ssrmExpandAndLoadAll(api);
+
+        await gridRows.check(`
+            ROOT id:<no-id>
+            └─┬ Root GROUP id:":0:200" ag-Grid-AutoColumn:"Root" employeeId:"200" name:"Root" experience:0
+            · ├── LEAF id:"Root:1:202" ag-Grid-AutoColumn:"Beta" employeeId:"202" name:"Beta" experience:1
+            · ├── LEAF id:"Root:1:203" ag-Grid-AutoColumn:"Gamma" employeeId:"203" name:"Gamma" experience:2
+            · └── LEAF id:"Root:1:201" ag-Grid-AutoColumn:"Alpha" employeeId:"201" name:"Alpha" experience:3
+        `);
+    });
 });
+
+interface ExperienceNode {
+    employeeId: string;
+    name: string;
+    experience: number;
+    group?: boolean;
+    underlings?: ExperienceNode[];
+}
+
+interface ExperienceRow {
+    employeeId: string;
+    name: string;
+    experience: number;
+    group?: boolean;
+}
+
+interface ExperienceServer {
+    data: ExperienceNode[];
+    getData(request: IServerSideGetRowsRequest): ExperienceRow[];
+}
+
+function getExperienceTreeDataSet(): ExperienceNode[] {
+    return [
+        {
+            employeeId: '200',
+            name: 'Root',
+            experience: 0,
+            underlings: [
+                {
+                    employeeId: '201',
+                    name: 'Alpha',
+                    experience: 3,
+                },
+                {
+                    employeeId: '202',
+                    name: 'Beta',
+                    experience: 1,
+                },
+                {
+                    employeeId: '203',
+                    name: 'Gamma',
+                    experience: 2,
+                },
+            ],
+        },
+    ];
+}
+
+function createExperienceFakeServer(data: ExperienceNode[]): ExperienceServer {
+    return {
+        data,
+        getData(request: IServerSideGetRowsRequest): ExperienceRow[] {
+            function extractRowsFromData(groupKeys: string[], rows: ExperienceNode[]): ExperienceRow[] {
+                if (groupKeys.length === 0) {
+                    return rows.map((row) => ({
+                        group: !!row.underlings?.length,
+                        employeeId: row.employeeId,
+                        name: row.name,
+                        experience: row.experience,
+                    }));
+                }
+
+                const key = groupKeys[0];
+                for (let i = 0; i < rows.length; i++) {
+                    const node = rows[i];
+                    if (node.name === key) {
+                        const next = node.underlings ? node.underlings.slice() : [];
+                        return extractRowsFromData(groupKeys.slice(1), next);
+                    }
+                }
+                return [];
+            }
+
+            return extractRowsFromData(request.groupKeys ?? [], data);
+        },
+    };
+}
+
+function createExperienceServerSideDatasource(fakeServer: ExperienceServer): IServerSideDatasource {
+    const dataSource: IServerSideDatasource = {
+        getRows: (params: IServerSideGetRowsParams) => {
+            const allRows = fakeServer.getData(params.request);
+            const request = params.request;
+            const doingInfinite = request.startRow != null && request.endRow != null;
+            const result = doingInfinite
+                ? {
+                      rowData: allRows.slice(request.startRow, request.endRow),
+                      rowCount: allRows.length,
+                  }
+                : { rowData: allRows };
+            setTimeout(() => {
+                params.success(result);
+            }, 1);
+        },
+    };
+    return dataSource;
+}


### PR DESCRIPTION
SSRM tree data with `serverSideEnableClientSideSort` could lose the sorted order after `refreshServerSide({ purge: true })`. The store was rebuilt and reloaded, but the client-side sort was only re-applied when the “refresh finished” path ran. In the purge case, that path isn’t reached, so the rows were displayed in the original server order while the column header still showed an active sort.

  Fix this by reapplying client-side sort after a load completes when:
  - client-side sorting is enabled
  - a sort is active
  - and the store is fully loaded (including the “all rows loaded and no stubs” case where `isStoreFullyLoaded()` can still be false).

Fix [AG-16487](https://ag-grid.atlassian.net/browse/AG-16487)