### PR TITLE
AG-16448 find and copy use batch data

### DIFF
--- a/.rulesync/rules/ag-grid.md
+++ b/.rulesync/rules/ag-grid.md
@@ -80,7 +80,10 @@ For detailed information about preferred technologies and architectural constrai
 -   `yarn nx build:package <package>` – create ESM/CJS bundles to validate publishable output.
 -   `yarn nx build:umd <package>` – produce UMD bundles for browser distribution smoke-tests.
 -   `yarn nx run-many -t build` – rebuild all packages when changes span the dependency graph.
--   `yarn nx test <package>` – execute Jest suites for the affected package.
+-   `yarn nx test ag-behavioural-testing --run` – run behavioural tests in `testing/behavioural/` (primary test suite, uses Vitest).
+-   `yarn nx test ag-behavioural-testing --run "<file-pattern>"` – run specific behavioural test file.
+-   `yarn nx test ag-behavioural-testing --run "<file-pattern>" -t "<test-name>"` – run specific behavioural test by name.
+-   `yarn nx test <package>` – execute Jest unit tests for the affected package.
 -   `yarn nx test <package> --testPathPattern="<file-name>"` - test specific test file
 -   `yarn nx test <package> --testPathPattern="<file-name>" --testNamePattern="<test-name>"` - test specific test name in a specific test file
 -   `yarn nx e2e <package>` – run Playwright flows when altering website behaviour.
@@ -128,11 +131,11 @@ Core dependency chain: `ag-grid-community` → `ag-grid-enterprise` → framewor
 
 For comprehensive testing information, see [Testing Guide](.rulesync/rules/testing.md).
 
-Key testing tools:
+**Behavioural tests are the primary test suite.** When verifying grid changes, run behavioural tests first. Key testing tools:
 
--   **Unit tests**: Jest with jsdom environment
+-   **Behavioural tests** (primary): `testing/behavioural/` for grid behaviour verification — use Vitest
+-   **Unit tests**: Jest with jsdom environment for package-level tests
 -   **E2E tests**: Playwright for website interaction testing
--   **Behavioural tests**: `testing/behavioural/` for grid behaviour verification
 -   **Accessibility tests**: `testing/accessibility/` for a11y compliance
 -   **Performance tests**: `testing/performance/` for performance regression testing
 

--- a/.rulesync/rules/testing.md
+++ b/.rulesync/rules/testing.md
@@ -8,6 +8,16 @@ globs: ['**/*.test.ts', '**/*.spec.ts', 'testing/**/*']
 
 This guide covers testing strategies and best practices for the AG Grid codebase.
 
+## Behavioural Tests — Primary Test Suite
+
+Behavioural tests in `testing/behavioural/` are the primary test suite for AG Grid. They test the grid as a **black box**, instantiating the full grid to verify complex behaviours and features.
+
+**Key principles:**
+
+-   The unit under test is a **behaviour**, not a function, class, method, or file
+-   **Avoid mocking** — prefer fakes instead (e.g., fake DOM)
+-   Test at the edges of the system to ensure real integration using public APIs
+
 ## Test Structure
 
 ### Directory Layout
@@ -35,6 +45,31 @@ packages/ag-grid-community/src/
 
 ## Running Tests
 
+### Behavioural Tests (Vitest) – Primary Test Suite
+
+Behavioural tests in `testing/behavioural/` are the primary test suite for verifying grid behaviour. They use Vitest via Nx. Use `--run` to execute once (without watch mode):
+
+```bash
+# Run all behavioural tests
+yarn nx test ag-behavioural-testing --run
+
+# Run specific test file
+yarn nx test ag-behavioural-testing --run "cell-editing-regression"
+
+# Run specific test by name
+yarn nx test ag-behavioural-testing --run "cell-editing-regression" -t "should handle"
+```
+
+### Benchmarks
+
+```bash
+# Run all benchmarks
+yarn nx run ag-behavioural-testing:benchmark
+
+# Run specific benchmark file
+yarn nx run ag-behavioural-testing:benchmark -- src/tree-data/datapath/benchmarks/tree-data-path.bench.ts
+```
+
 ### Unit Tests (Jest)
 
 Unit tests in `packages/` use Jest. Use `--testPathPattern` and `--testNamePattern`:
@@ -55,21 +90,6 @@ yarn nx test ag-grid-community --testPathPattern="featureName" --testNamePattern
 ```bash
 # Run documentation E2E tests
 yarn nx e2e ag-grid-docs
-```
-
-### Behavioural Tests (Vitest)
-
-Behavioural tests in `testing/behavioural/` use Vitest via Nx. Use `--run` to execute once (without watch mode):
-
-```bash
-# Run all behavioural tests
-yarn nx test ag-behavioural-testing --run
-
-# Run specific test file
-yarn nx test ag-behavioural-testing --run "cell-editing-regression"
-
-# Run specific test by name
-yarn nx test ag-behavioural-testing --run "cell-editing-regression" -t "should handle"
 ```
 
 **Note:** Vitest does not support `--testPathPattern` or `--testNamePattern`. Use positional arguments for file matching and `-t` for test name filtering.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,26 @@
+Please also reference the following rules as needed. The list below is provided in TOON format, and `@` stands for the project root directory.
+
+rules[5]:
+  - path: @.codex/memories/benchmarks.md
+    description: Running and creating performance benchmarks for AG Grid
+    applyTo[2]: testing/performance/**/*,**/benchmark*
+  - path: @.codex/memories/code-quality.md
+    description: "Code quality practices including avoiding bloat, comment guidelines, and review practices"
+    applyTo[1]: packages/*/src/**/*.ts
+  - path: @.codex/memories/docs-pages.md
+    description: Creating and maintaining documentation pages for AG Grid
+    applyTo[2]: documentation/**/*.mdoc,documentation/**/*.md
+  - path: @.codex/memories/examples.md
+    description: Working with examples in AG Grid documentation
+    applyTo[2]: _examples/**/*,documentation/**/_examples/**/*
+  - path: @.codex/memories/testing.md
+    description: "Testing strategies, Jest patterns, and verification for AG Grid"
+    applyTo[3]: **/*.test.ts,**/*.spec.ts,testing/**/*
+
+# Additional Conventions Beyond the Built-in Functions
+
+As this project's AI coding tool, you must follow the additional conventions below, in addition to the built-in functions.
+
 ## AI Agent Instructions
 
 This file provides guidance to AI Agents when working with code in this repository.
@@ -73,7 +96,10 @@ For detailed information about preferred technologies and architectural constrai
 -   `yarn nx build:package <package>` – create ESM/CJS bundles to validate publishable output.
 -   `yarn nx build:umd <package>` – produce UMD bundles for browser distribution smoke-tests.
 -   `yarn nx run-many -t build` – rebuild all packages when changes span the dependency graph.
--   `yarn nx test <package>` – execute Jest suites for the affected package.
+-   `yarn nx test ag-behavioural-testing --run` – run behavioural tests in `testing/behavioural/` (primary test suite, uses Vitest).
+-   `yarn nx test ag-behavioural-testing --run "<file-pattern>"` – run specific behavioural test file.
+-   `yarn nx test ag-behavioural-testing --run "<file-pattern>" -t "<test-name>"` – run specific behavioural test by name.
+-   `yarn nx test <package>` – execute Jest unit tests for the affected package.
 -   `yarn nx test <package> --testPathPattern="<file-name>"` - test specific test file
 -   `yarn nx test <package> --testPathPattern="<file-name>" --testNamePattern="<test-name>"` - test specific test name in a specific test file
 -   `yarn nx e2e <package>` – run Playwright flows when altering website behaviour.
@@ -121,11 +147,11 @@ Core dependency chain: `ag-grid-community` → `ag-grid-enterprise` → framewor
 
 For comprehensive testing information, see [Testing Guide](.rulesync/rules/testing.md).
 
-Key testing tools:
+**Behavioural tests are the primary test suite.** When verifying grid changes, run behavioural tests first. Key testing tools:
 
--   **Unit tests**: Jest with jsdom environment
+-   **Behavioural tests** (primary): `testing/behavioural/` for grid behaviour verification — use Vitest
+-   **Unit tests**: Jest with jsdom environment for package-level tests
 -   **E2E tests**: Playwright for website interaction testing
--   **Behavioural tests**: `testing/behavioural/` for grid behaviour verification
 -   **Accessibility tests**: `testing/accessibility/` for a11y compliance
 -   **Performance tests**: `testing/performance/` for performance regression testing
 

--- a/packages/ag-grid-community/src/csvExport/csvCreator.ts
+++ b/packages/ag-grid-community/src/csvExport/csvCreator.ts
@@ -70,6 +70,7 @@ export class CsvCreator
             processRowGroupCallback,
             suppressQuotes,
             columnSeparator,
+            valueFrom,
         } = params!;
 
         return new CsvSerializingSession({
@@ -84,6 +85,7 @@ export class CsvCreator
             suppressQuotes: suppressQuotes || false,
             columnSeparator: columnSeparator || ',',
             rowGroupColsSvc,
+            valueFrom,
         });
     }
 

--- a/packages/ag-grid-community/src/export/baseGridSerializingSession.ts
+++ b/packages/ag-grid-community/src/export/baseGridSerializingSession.ts
@@ -11,6 +11,7 @@ import type {
     ProcessRowGroupForExportParams,
 } from '../interfaces/exportParams';
 import type { IColsService } from '../interfaces/iColsService';
+import type { CellValueResolveFrom } from '../interfaces/iEditService';
 import type { ValueService } from '../valueService/valueService';
 import type {
     GridSerializingParams,
@@ -29,6 +30,7 @@ export abstract class BaseGridSerializingSession<T> implements GridSerializingSe
     public processHeaderCallback?: (params: ProcessHeaderForExportParams) => string;
     public processGroupHeaderCallback?: (params: ProcessGroupHeaderForExportParams) => string;
     public processRowGroupCallback?: (params: ProcessRowGroupForExportParams) => string;
+    public valueFrom: CellValueResolveFrom = 'data';
 
     constructor(config: GridSerializingParams) {
         const {
@@ -41,6 +43,7 @@ export abstract class BaseGridSerializingSession<T> implements GridSerializingSe
             processHeaderCallback,
             processGroupHeaderCallback,
             processRowGroupCallback,
+            valueFrom,
         } = config;
 
         this.colModel = colModel;
@@ -52,6 +55,9 @@ export abstract class BaseGridSerializingSession<T> implements GridSerializingSe
         this.processHeaderCallback = processHeaderCallback;
         this.processGroupHeaderCallback = processGroupHeaderCallback;
         this.processRowGroupCallback = processRowGroupCallback;
+        if (valueFrom) {
+            this.valueFrom = valueFrom;
+        }
     }
 
     abstract addCustomContent(customContent: T): void;
@@ -94,14 +100,14 @@ export abstract class BaseGridSerializingSession<T> implements GridSerializingSe
                             accumulatedRowIndex,
                             column,
                             node,
-                            value: this.valueSvc.getValueForDisplay({ column, node, from: 'data' }).value,
+                            value: this.valueSvc.getValueForDisplay({ column, node, from: this.valueFrom }).value,
                             type,
                             parseValue: (valueToParse: string) =>
                                 this.valueSvc.parseValue(
                                     column,
                                     node,
                                     valueToParse,
-                                    this.valueSvc.getValue(column, node, 'data')
+                                    this.valueSvc.getValue(column, node, this.valueFrom)
                                 ),
                             formatValue: (valueToFormat: any) =>
                                 this.valueSvc.formatValue(column, node, valueToFormat) ?? valueToFormat,
@@ -125,7 +131,7 @@ export abstract class BaseGridSerializingSession<T> implements GridSerializingSe
                     node: pointer,
                     includeValueFormatted: true,
                     exporting: true,
-                    from: 'data',
+                    from: this.valueFrom,
                 });
                 concatenatedGroupValue = ` -> ${valueFormatted ?? value ?? ''}${concatenatedGroupValue}`;
                 pointer = pointer.parent;
@@ -143,7 +149,7 @@ export abstract class BaseGridSerializingSession<T> implements GridSerializingSe
             includeValueFormatted: true,
             exporting: true,
             useRawFormula,
-            from: 'data',
+            from: this.valueFrom,
         });
         return {
             value: value ?? '',

--- a/packages/ag-grid-community/src/export/iGridSerializer.ts
+++ b/packages/ag-grid-community/src/export/iGridSerializer.ts
@@ -11,6 +11,7 @@ import type {
 } from '../interfaces/exportParams';
 import type { IColsService } from '../interfaces/iColsService';
 import type { ColumnGroup } from '../interfaces/iColumn';
+import type { CellValueResolveFrom } from '../interfaces/iEditService';
 import type { ValueService } from '../valueService/valueService';
 
 export interface RowAccumulator {
@@ -33,6 +34,7 @@ export interface GridSerializingParams {
     colNames: ColumnNameService;
     valueSvc: ValueService;
     gos: GridOptionsService;
+    valueFrom?: CellValueResolveFrom;
     processCellCallback?: (params: ProcessCellForExportParams) => string;
     processHeaderCallback?: (params: ProcessHeaderForExportParams) => string;
     processGroupHeaderCallback?: (params: ProcessGroupHeaderForExportParams) => string;

--- a/packages/ag-grid-community/src/interfaces/exportParams.ts
+++ b/packages/ag-grid-community/src/interfaces/exportParams.ts
@@ -1,5 +1,6 @@
 import type { Column, ColumnGroup } from './iColumn';
 import type { AgGridCommon } from './iCommon';
+import type { CellValueResolveFrom } from './iEditService';
 import type { IRowNode } from './iRowNode';
 import type { RowPosition } from './iRowPosition';
 
@@ -65,6 +66,15 @@ export interface BaseExportParams {
      * @default false
      */
     skipPinnedBottom?: boolean;
+
+    /**
+     * The source to use for getting cell values: 'data', 'batch', or 'edit'.
+     * - `'data'`: Returns values from the underlying row data
+     * - `'batch'`: Returns pending batch edit values (falls back to data if not in batch mode)
+     * - `'edit'`: Returns current editor values including live typing
+     * @default 'data'
+     */
+    valueFrom?: CellValueResolveFrom;
 
     /**
      * A callback function that will be invoked once per row in the grid. Return true to omit the row from the export.

--- a/packages/ag-grid-enterprise/src/clipboard/clipboardService.ts
+++ b/packages/ag-grid-enterprise/src/clipboard/clipboardService.ts
@@ -545,7 +545,7 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
                         const value = this.processCell(
                             rowNode,
                             column,
-                            valueSvc.getValue(column, rowNode, 'edit'),
+                            valueSvc.getValue(column, rowNode, 'batch'),
                             EXPORT_TYPE_DRAG_COPY,
                             processCellForClipboardFunc,
                             false,
@@ -1094,7 +1094,7 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
                 column: column as AgColumn,
                 node,
                 includeValueFormatted: true,
-                from: 'data',
+                from: 'batch',
             });
 
             const val = valueFormatted ?? value ?? '';
@@ -1121,6 +1121,7 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
             suppressQuotes: true,
             columnSeparator: this.getClipboardDelimiter(),
             onlySelected: !rowPositions,
+            valueFrom: 'batch',
             processCellCallback: gos.getCallback('processCellForClipboard'),
             processRowGroupCallback: processRowGroupCallback,
             processHeaderCallback: gos.getCallback('processHeaderForClipboard'),

--- a/packages/ag-grid-enterprise/src/find/findService.ts
+++ b/packages/ag-grid-enterprise/src/find/findService.ts
@@ -143,6 +143,9 @@ export class FindService extends BeanStub implements NamedBean, IFindService {
             pinnedRowDataChanged: refreshAndKeepActive,
             cellValueChanged: refreshAndKeepActiveDebounced,
             rowNodeDataChanged: refreshAndKeepActiveDebounced,
+            cellEditingStopped: refreshAndKeepActiveDebounced,
+            cellEditValuesChanged: refreshAndKeepActiveDebounced,
+            batchEditingStopped: refreshAndKeepActiveDebounced,
         });
         const rowSpanSvc = this.beans.rowSpanSvc;
         if (rowSpanSvc) {
@@ -437,7 +440,7 @@ export class FindService extends BeanStub implements NamedBean, IFindService {
                 let valueToFind: string | null;
                 const getFindText = (groupRowRendererParams as FindGroupRowRendererParams)?.getFindText;
                 if (getFindText) {
-                    const value = valueSvc.getValueForDisplay({ node, from: 'edit' }).value;
+                    const value = valueSvc.getValueForDisplay({ node, from: 'batch' }).value;
                     valueToFind = getFindText(
                         _addGridCommonParams(gos, {
                             value,
@@ -449,7 +452,7 @@ export class FindService extends BeanStub implements NamedBean, IFindService {
                                 const { valueFormatted } = valueSvc.getValueForDisplay({
                                     node,
                                     includeValueFormatted: true,
-                                    from: 'edit',
+                                    from: 'batch',
                                 });
                                 return valueFormatted;
                             },
@@ -459,7 +462,7 @@ export class FindService extends BeanStub implements NamedBean, IFindService {
                     const { value, valueFormatted } = valueSvc.getValueForDisplay({
                         node,
                         includeValueFormatted: true,
-                        from: 'edit',
+                        from: 'batch',
                     });
                     valueToFind = valueFormatted ?? value;
                 }
@@ -495,7 +498,7 @@ export class FindService extends BeanStub implements NamedBean, IFindService {
                 const colDef = column.colDef;
                 const getFindText = colDef.getFindText;
                 if (getFindText) {
-                    const value = valueSvc.getValueForDisplay({ column, node, from: 'edit' }).value;
+                    const value = valueSvc.getValueForDisplay({ column, node, from: 'batch' }).value;
                     valueToFind = getFindText(
                         _addGridCommonParams(gos, {
                             value,
@@ -508,7 +511,7 @@ export class FindService extends BeanStub implements NamedBean, IFindService {
                                     column,
                                     node,
                                     includeValueFormatted: true,
-                                    from: 'edit',
+                                    from: 'batch',
                                 });
                                 return valueFormatted;
                             },
@@ -519,7 +522,7 @@ export class FindService extends BeanStub implements NamedBean, IFindService {
                         column,
                         node,
                         includeValueFormatted: true,
-                        from: 'edit',
+                        from: 'batch',
                     });
                     valueToFind = valueFormatted ?? value;
                 }

--- a/testing/behavioural/src/cell-editing/clipboard/clipboard-copy-batch.test.ts
+++ b/testing/behavioural/src/cell-editing/clipboard/clipboard-copy-batch.test.ts
@@ -1,0 +1,211 @@
+import { TextEditorModule, setupAgTestIds } from 'ag-grid-community';
+import { BatchEditModule, CellSelectionModule, ClipboardModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, asyncSetTimeout, clipboardUtils } from '../../test-utils';
+
+/**
+ * Tests verifying that clipboard copy operations use 'batch' source values
+ * (committed batch values) rather than 'edit' values (live typing in editors).
+ *
+ * This ensures that when copying during batch edit mode:
+ * - Committed batch values are copied (not the underlying data)
+ * - Live editor input (uncommitted typing) is NOT copied
+ */
+describe('Clipboard Copy: uses batch values not edit values', () => {
+    const gridMgr = new TestGridsManager({
+        modules: [ClipboardModule, CellSelectionModule, BatchEditModule, TextEditorModule],
+    });
+
+    beforeAll(() => {
+        setupAgTestIds();
+        clipboardUtils.init();
+    });
+
+    beforeEach(() => {
+        clipboardUtils.init();
+    });
+
+    afterEach(() => {
+        gridMgr.reset();
+        clipboardUtils.reset();
+    });
+
+    test('copy during batch edit copies pending batch values, not original data', async () => {
+        const api = await gridMgr.createGridAndWait('clipboardCopyBatch', {
+            columnDefs: [{ field: 'value', editable: true }],
+            rowData: [{ id: '0', value: 'original' }],
+            getRowId: (params) => params.data.id,
+        });
+
+        await new GridRows(api, 'initial state').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:0 value:"original"
+        `);
+
+        // Start batch edit and make a pending change
+        api.startBatchEdit();
+        await asyncSetTimeout(1);
+
+        const rowNode = api.getDisplayedRowAtIndex(0)!;
+        rowNode.setDataValue('value', 'batch-pending', 'paste'); // Uses batch source
+
+        // Verify the batch value is pending but not committed to data
+        expect(rowNode.data.value).toBe('original');
+        expect(api.getCellValue({ rowNode, colKey: 'value', from: 'batch' })).toBe('batch-pending');
+        expect(api.getCellValue({ rowNode, colKey: 'value', from: 'data' })).toBe('original');
+
+        // Copy the cell - should copy the batch value
+        api.setFocusedCell(0, 'value');
+        api.addCellRange({ rowStartIndex: 0, rowEndIndex: 0, columns: ['value'] });
+        api.copyToClipboard();
+        await asyncSetTimeout(1);
+
+        // Clipboard should contain the batch value, not the original data
+        expect(clipboardUtils.getText()).toBe('batch-pending');
+
+        api.cancelBatchEdit();
+    });
+
+    test('copy should NOT include live editor typing (edit values)', async () => {
+        const api = await gridMgr.createGridAndWait('clipboardCopyNotEdit', {
+            cellSelection: true,
+            columnDefs: [{ field: 'value', editable: true }],
+            rowData: [{ id: '0', value: 'original' }],
+            getRowId: (params) => params.data.id,
+        });
+
+        await new GridRows(api, 'initial state').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:0 value:"original"
+        `);
+
+        // Start batch edit
+        api.startBatchEdit();
+        await asyncSetTimeout(1);
+
+        // First, set a batch pending value
+        const rowNode = api.getDisplayedRowAtIndex(0)!;
+        rowNode.setDataValue('value', 'batch-value', 'paste');
+
+        // Now start editing the cell (simulates user typing)
+        api.startEditingCell({ rowIndex: 0, colKey: 'value' });
+        await asyncSetTimeout(1);
+
+        // Verify the edit value would be different from batch if we were checking edit source
+        // The editor should have 'batch-value' loaded, but if user types 'live-typing',
+        // we want to ensure copy still uses batch, not the live editor state
+
+        // For this test, the edit value equals batch value since editing just started
+        // The key point is we're using 'batch' source, which excludes uncommitted editor changes
+        expect(api.getCellValue({ rowNode, colKey: 'value', from: 'batch' })).toBe('batch-value');
+
+        // Add a range selection before copying (required for copyToClipboard to work)
+        api.addCellRange({ rowStartIndex: 0, rowEndIndex: 0, columns: ['value'] });
+
+        // Copy while cell is being edited - should copy batch value, not edit value
+        api.copyToClipboard();
+        await asyncSetTimeout(1);
+
+        // Should copy the batch value
+        expect(clipboardUtils.getText()).toBe('batch-value');
+
+        api.stopEditing();
+        api.cancelBatchEdit();
+    });
+
+    test('copyRangeDown uses batch values', async () => {
+        const api = await gridMgr.createGridAndWait('clipboardCopyRangeDown', {
+            cellSelection: true,
+            columnDefs: [{ field: 'value', editable: true }],
+            rowData: [
+                { id: '0', value: 'source' },
+                { id: '1', value: 'target1' },
+                { id: '2', value: 'target2' },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        await new GridRows(api, 'initial state').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 value:"source"
+            ├── LEAF id:1 value:"target1"
+            └── LEAF id:2 value:"target2"
+        `);
+
+        // Start batch edit and modify the source cell
+        api.startBatchEdit();
+        await asyncSetTimeout(1);
+
+        const sourceRow = api.getDisplayedRowAtIndex(0)!;
+        sourceRow.setDataValue('value', 'batch-source', 'paste');
+
+        // Verify batch value is set
+        expect(api.getCellValue({ rowNode: sourceRow, colKey: 'value', from: 'batch' })).toBe('batch-source');
+        expect(sourceRow.data.value).toBe('source'); // Original data unchanged
+
+        // Select range from row 0 to row 2 and copy down
+        api.addCellRange({ rowStartIndex: 0, rowEndIndex: 2, columns: ['value'] });
+        api.copySelectedRangeDown();
+        await asyncSetTimeout(1);
+
+        // After copyRangeDown, all rows should have the batch value from row 0
+        await new GridRows(api, 'after copy range down').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 value:"batch-source"
+            ├── LEAF id:1 value:"batch-source"
+            └── LEAF id:2 value:"batch-source"
+        `);
+
+        api.cancelBatchEdit();
+    });
+
+    test('copy without batch edit copies data values', async () => {
+        const api = await gridMgr.createGridAndWait('clipboardCopyNoBatch', {
+            columnDefs: [{ field: 'value', editable: true }],
+            rowData: [{ id: '0', value: 'data-value' }],
+            getRowId: (params) => params.data.id,
+        });
+
+        await new GridRows(api, 'initial state').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:0 value:"data-value"
+        `);
+
+        // Copy without batch edit - should copy the data value
+        api.setFocusedCell(0, 'value');
+        api.addCellRange({ rowStartIndex: 0, rowEndIndex: 0, columns: ['value'] });
+        api.copyToClipboard();
+        await asyncSetTimeout(1);
+
+        expect(clipboardUtils.getText()).toBe('data-value');
+    });
+
+    test('copy after batch commit copies committed data', async () => {
+        const api = await gridMgr.createGridAndWait('clipboardCopyAfterCommit', {
+            columnDefs: [{ field: 'value', editable: true }],
+            rowData: [{ id: '0', value: 'original' }],
+            getRowId: (params) => params.data.id,
+        });
+
+        // Start batch, make change, commit
+        api.startBatchEdit();
+        await asyncSetTimeout(1);
+
+        const rowNode = api.getDisplayedRowAtIndex(0)!;
+        rowNode.setDataValue('value', 'committed-value', 'paste');
+
+        api.commitBatchEdit();
+        await asyncSetTimeout(1);
+
+        // Verify data is now committed
+        expect(rowNode.data.value).toBe('committed-value');
+
+        // Copy after commit - should copy the committed value
+        api.setFocusedCell(0, 'value');
+        api.addCellRange({ rowStartIndex: 0, rowEndIndex: 0, columns: ['value'] });
+        api.copyToClipboard();
+        await asyncSetTimeout(1);
+
+        expect(clipboardUtils.getText()).toBe('committed-value');
+    });
+});

--- a/testing/behavioural/src/cell-editing/set-value/cell-editing-set-data-value.test.ts
+++ b/testing/behavioural/src/cell-editing/set-value/cell-editing-set-data-value.test.ts
@@ -6,7 +6,7 @@ import { agTestIdFor, getGridElement, setupAgTestIds } from 'ag-grid-community';
 
 import { EditEventTracker, GridRows, TestGridsManager, asyncSetTimeout, waitForInput } from '../../test-utils';
 
-describe('Cell Editing: setDataValue sources', () => {
+describe('Cell Editing: setDataValue', () => {
     const gridMgr = new TestGridsManager({
         includeDefaultModules: true,
     });
@@ -19,9 +19,70 @@ describe('Cell Editing: setDataValue sources', () => {
         gridMgr.reset();
     });
 
-    test.each(['rangeSvc', 'cellClear', 'redo', 'undo'] as const)(
-        'setDataValue source %s only updates once',
-        async (source) => {
+    describe('basic behavior', () => {
+        test.each(['paste', 'rangeSvc', 'cellClear', 'undo', 'redo'] as const)(
+            "'%s' source updates data once with correct events",
+            async (source) => {
+                let valueSetterCalls = 0;
+                const valueSetterTargets: string[] = [];
+                const valueSetter = ({ data, newValue }: { data: { id: string; field: string }; newValue: string }) => {
+                    valueSetterCalls += 1;
+                    valueSetterTargets.push(data.id);
+                    data.field = newValue;
+                    return true;
+                };
+
+                const api = await gridMgr.createGridAndWait(`cellEditingSetDataValue-${source}`, {
+                    columnDefs: [
+                        {
+                            field: 'field',
+                            editable: true,
+                            valueSetter,
+                        },
+                    ],
+                    rowData: [{ id: 'ROW_0', field: 'Initial Value' }],
+                    getRowId: (params) => params.data.id,
+                });
+                const eventTracker = new EditEventTracker(api);
+
+                const beforeRows = new GridRows(api, `before ${source} setDataValue`);
+                await beforeRows.check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:ROW_0 field:"Initial Value"
+            `);
+
+                const rowNode = api.getDisplayedRowAtIndex(0);
+                rowNode?.setDataValue('field', `${source}-value`, source);
+                await asyncSetTimeout(0);
+
+                const afterRows = new GridRows(api, `after ${source} setDataValue`);
+                await afterRows.check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:ROW_0 field:"${source}-value"
+            `);
+
+                // Verify data access methods
+                expect(rowNode?.data?.field).toBe(`${source}-value`);
+                expect(rowNode?.getDataValue('field')).toBe(`${source}-value`);
+                expect(api.getCellValue({ rowNode: rowNode!, colKey: 'field' })).toBe(`${source}-value`);
+                expect(api.getCellValue({ rowNode: rowNode!, colKey: 'field', from: 'data' })).toBe(`${source}-value`);
+
+                expect(eventTracker.counts).toEqual({
+                    cellEditingStarted: 0,
+                    cellEditingStopped: source === 'cellClear' ? 1 : 0,
+                    cellValueChanged: 1,
+                    rowValueChanged: 0,
+                    cellEditRequest: 0,
+                    bulkEditingStarted: 0,
+                    bulkEditingStopped: 0,
+                });
+
+                expect(valueSetterTargets).toEqual(['ROW_0']);
+                expect(valueSetterCalls).toBe(1);
+            }
+        );
+
+        test.each([undefined, 'ui', 'api', 'edit'] as const)("'%s' source updates data directly", async (source) => {
             let valueSetterCalls = 0;
             const valueSetterTargets: string[] = [];
             const valueSetter = ({ data, newValue }: { data: { id: string; field: string }; newValue: string }) => {
@@ -31,7 +92,7 @@ describe('Cell Editing: setDataValue sources', () => {
                 return true;
             };
 
-            const api = await gridMgr.createGridAndWait(`cellEditingSetDataValue-${source}`, {
+            const api = await gridMgr.createGridAndWait(`cellEditingSetDataValue-${source ?? 'default'}`, {
                 columnDefs: [
                     {
                         field: 'field',
@@ -44,253 +105,167 @@ describe('Cell Editing: setDataValue sources', () => {
             });
             const eventTracker = new EditEventTracker(api);
 
-            const beforeRows = new GridRows(api, `before ${source} setDataValue`);
+            const beforeRows = new GridRows(api, `before ${source ?? 'default'} setDataValue`);
             await beforeRows.check(`
                 ROOT id:ROOT_NODE_ID
                 └── LEAF id:ROW_0 field:"Initial Value"
             `);
 
             const rowNode = api.getDisplayedRowAtIndex(0);
-            rowNode?.setDataValue('field', `${source}-value`, source);
+            rowNode?.setDataValue('field', `${source ?? 'default'}-value`, source);
             await asyncSetTimeout(0);
 
-            const afterRows = new GridRows(api, `after ${source} setDataValue`);
+            const afterRows = new GridRows(api, `after ${source ?? 'default'} setDataValue`);
             await afterRows.check(`
                 ROOT id:ROOT_NODE_ID
-                └── LEAF id:ROW_0 field:"${source}-value"
+                └── LEAF id:ROW_0 field:"${source ?? 'default'}-value"
             `);
+
+            // Verify data access methods
+            expect(rowNode?.data?.field).toBe(`${source ?? 'default'}-value`);
+            expect(rowNode?.getDataValue('field')).toBe(`${source ?? 'default'}-value`);
+            expect(api.getCellValue({ rowNode: rowNode!, colKey: 'field' })).toBe(`${source ?? 'default'}-value`);
+            expect(api.getCellValue({ rowNode: rowNode!, colKey: 'field', from: 'data' })).toBe(
+                `${source ?? 'default'}-value`
+            );
 
             expect(eventTracker.counts).toEqual({
                 cellEditingStarted: 0,
-                cellEditingStopped: source === 'cellClear' ? 1 : 0,
+                cellEditingStopped: 0,
                 cellValueChanged: 1,
                 rowValueChanged: 0,
                 cellEditRequest: 0,
                 bulkEditingStarted: 0,
                 bulkEditingStopped: 0,
             });
-
             expect(valueSetterTargets).toEqual(['ROW_0']);
             expect(valueSetterCalls).toBe(1);
-        }
-    );
-
-    test('setDataValue without source updates once', async () => {
-        let valueSetterCalls = 0;
-        const valueSetterTargets: string[] = [];
-        const valueSetter = ({ data, newValue }: { data: { id: string; field: string }; newValue: string }) => {
-            valueSetterCalls += 1;
-            valueSetterTargets.push(data.id);
-            data.field = newValue;
-            return true;
-        };
-
-        const api = await gridMgr.createGridAndWait('cellEditingSetDataValue-default', {
-            columnDefs: [
-                {
-                    field: 'field',
-                    editable: true,
-                    valueSetter,
-                },
-            ],
-            rowData: [{ id: 'ROW_0', field: 'Initial Value' }],
-            getRowId: (params) => params.data.id,
         });
-        const eventTracker = new EditEventTracker(api);
-
-        const beforeRows = new GridRows(api, 'before default setDataValue');
-        await beforeRows.check(`
-            ROOT id:ROOT_NODE_ID
-            └── LEAF id:ROW_0 field:"Initial Value"
-        `);
-
-        const rowNode = api.getDisplayedRowAtIndex(0);
-        rowNode?.setDataValue('field', 'default-value');
-        await asyncSetTimeout(0);
-
-        const afterRows = new GridRows(api, 'after default setDataValue');
-        await afterRows.check(`
-            ROOT id:ROOT_NODE_ID
-            └── LEAF id:ROW_0 field:"default-value"
-        `);
-
-        expect(eventTracker.counts).toEqual({
-            cellEditingStarted: 0,
-            cellEditingStopped: 0,
-            cellValueChanged: 1,
-            rowValueChanged: 0,
-            cellEditRequest: 0,
-            bulkEditingStarted: 0,
-            bulkEditingStopped: 0,
-        });
-
-        expect(api.getDisplayedRowAtIndex(0)?.data?.field).toBe('default-value');
-        expect(valueSetterTargets).toEqual(['ROW_0']);
-        expect(valueSetterCalls).toBe(1);
     });
 
-    test('setDataValue paste source updates once when not editing', async () => {
-        let valueSetterCalls = 0;
-        const valueSetterTargets: string[] = [];
-        const valueSetter = ({ data, newValue }: { data: { id: string; field: string }; newValue: string }) => {
-            valueSetterCalls += 1;
-            valueSetterTargets.push(data.id);
-            data.field = newValue;
-            return true;
-        };
+    describe('readOnlyEdit mode', () => {
+        test('setDataValue fires cellEditRequest and does not update', async () => {
+            let valueSetterCalls = 0;
+            const editRequests: string[] = [];
+            const valueSetter = ({ data, newValue }: { data: { id: string; field: string }; newValue: string }) => {
+                valueSetterCalls += 1;
+                data.field = newValue;
+                return true;
+            };
 
-        const api = await gridMgr.createGridAndWait('cellEditingSetDataValue-paste', {
-            columnDefs: [
-                {
-                    field: 'field',
-                    editable: true,
-                    valueSetter,
+            const api = await gridMgr.createGridAndWait('cellEditingSetDataValue-readOnly', {
+                readOnlyEdit: true,
+                columnDefs: [
+                    {
+                        field: 'field',
+                        editable: true,
+                        valueSetter,
+                    },
+                ],
+                rowData: [{ id: 'ROW_0', field: 'Initial Value' }],
+                getRowId: (params) => params.data.id,
+                onCellEditRequest: (event) => {
+                    editRequests.push(`${event.node?.id ?? 'unknown'}:${event.colDef.field}:${event.newValue}`);
                 },
-            ],
-            rowData: [{ id: 'ROW_0', field: 'Initial Value' }],
-            getRowId: (params) => params.data.id,
+            });
+            const eventTracker = new EditEventTracker(api);
+
+            const beforeRows = new GridRows(api, 'before readOnly setDataValue');
+            await beforeRows.check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:ROW_0 field:"Initial Value"
+            `);
+
+            const rowNode = api.getDisplayedRowAtIndex(0);
+            rowNode?.setDataValue('field', 'readOnly-value', 'ui');
+            await asyncSetTimeout(0);
+
+            const afterRows = new GridRows(api, 'after readOnly setDataValue');
+            await afterRows.check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:ROW_0 field:"Initial Value"
+            `);
+
+            expect(eventTracker.counts).toEqual({
+                cellEditingStarted: 0,
+                cellEditingStopped: 0,
+                cellValueChanged: 0,
+                rowValueChanged: 0,
+                cellEditRequest: 1,
+                bulkEditingStarted: 0,
+                bulkEditingStopped: 0,
+            });
+
+            // Verify data access methods - all should return original value
+            expect(rowNode?.data?.field).toBe('Initial Value');
+            expect(rowNode?.getDataValue('field')).toBe('Initial Value');
+            expect(api.getCellValue({ rowNode: rowNode!, colKey: 'field' })).toBe('Initial Value');
+            expect(api.getCellValue({ rowNode: rowNode!, colKey: 'field', from: 'data' })).toBe('Initial Value');
+
+            expect(valueSetterCalls).toBe(0);
+            expect(editRequests).toEqual(['ROW_0:field:readOnly-value']);
         });
-        const eventTracker = new EditEventTracker(api);
-
-        const beforeRows = new GridRows(api, 'before paste setDataValue');
-        await beforeRows.check(`
-            ROOT id:ROOT_NODE_ID
-            └── LEAF id:ROW_0 field:"Initial Value"
-        `);
-
-        const rowNode = api.getDisplayedRowAtIndex(0);
-        rowNode?.setDataValue('field', 'paste-value', 'paste');
-        await asyncSetTimeout(0);
-
-        const afterRows = new GridRows(api, 'after paste setDataValue');
-        await afterRows.check(`
-            ROOT id:ROOT_NODE_ID
-            └── LEAF id:ROW_0 field:"paste-value"
-        `);
-
-        expect(eventTracker.counts).toEqual({
-            cellEditingStarted: 0,
-            cellEditingStopped: 0,
-            cellValueChanged: 1,
-            rowValueChanged: 0,
-            cellEditRequest: 0,
-            bulkEditingStarted: 0,
-            bulkEditingStopped: 0,
-        });
-
-        expect(api.getDisplayedRowAtIndex(0)?.data?.field).toBe('paste-value');
-        expect(valueSetterTargets).toEqual(['ROW_0']);
-        expect(valueSetterCalls).toBe(1);
     });
 
-    test('readOnlyEdit setDataValue fires cellEditRequest and does not update', async () => {
-        let valueSetterCalls = 0;
-        const editRequests: string[] = [];
-        const valueSetter = ({ data, newValue }: { data: { id: string; field: string }; newValue: string }) => {
-            valueSetterCalls += 1;
-            data.field = newValue;
-            return true;
-        };
+    describe('during active editing', () => {
+        test('setDataValue commits and stops editing', async () => {
+            let valueSetterCalls = 0;
+            const valueSetter = ({ data, newValue }: { data: { id: string; field: string }; newValue: string }) => {
+                valueSetterCalls += 1;
+                data.field = newValue;
+                return true;
+            };
 
-        const api = await gridMgr.createGridAndWait('cellEditingSetDataValue-readOnly', {
-            readOnlyEdit: true,
-            columnDefs: [
-                {
-                    field: 'field',
-                    editable: true,
-                    valueSetter,
-                },
-            ],
-            rowData: [{ id: 'ROW_0', field: 'Initial Value' }],
-            getRowId: (params) => params.data.id,
-            onCellEditRequest: (event) => {
-                editRequests.push(`${event.node?.id ?? 'unknown'}:${event.colDef.field}:${event.newValue}`);
-            },
+            const api = await gridMgr.createGridAndWait('cellEditingSetDataValue-editing', {
+                columnDefs: [
+                    {
+                        field: 'field',
+                        editable: true,
+                        valueSetter,
+                    },
+                ],
+                rowData: [{ id: 'ROW_0', field: 'Initial Value' }],
+                getRowId: (params) => params.data.id,
+            });
+
+            const beforeRows = new GridRows(api, 'before editing setDataValue');
+            await beforeRows.check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:ROW_0 field:"Initial Value"
+            `);
+
+            const gridDiv = getGridElement(api)! as HTMLElement;
+            const cell = getByTestId(gridDiv, agTestIdFor.cell('ROW_0', 'field'));
+            await userEvent.click(cell);
+            api.startEditingCell({ rowIndex: 0, colKey: 'field' });
+            const input = await waitForInput(gridDiv, cell);
+            await userEvent.clear(input);
+            await userEvent.type(input, 'Editor Value');
+
+            const rowNode = api.getDisplayedRowAtIndex(0);
+            rowNode?.setDataValue('field', 'Committed Value', 'ui');
+            await asyncSetTimeout(0);
+
+            await new GridRows(api, 'after editing setDataValue ui').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:ROW_0 field:"Editor Value"
+            `);
+
+            rowNode?.setDataValue('field', 'Committed Value', 'api');
+            await asyncSetTimeout(0);
+
+            await new GridRows(api, 'after editing setDataValue api').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:ROW_0 field:"Committed Value"
+            `);
+
+            // Verify data access methods after final commit
+            expect(rowNode?.data?.field).toBe('Committed Value');
+            expect(rowNode?.getDataValue('field')).toBe('Committed Value');
+            expect(api.getCellValue({ rowNode: rowNode!, colKey: 'field' })).toBe('Committed Value');
+            expect(api.getCellValue({ rowNode: rowNode!, colKey: 'field', from: 'data' })).toBe('Committed Value');
+
+            expect(valueSetterCalls).toBe(2);
         });
-        const eventTracker = new EditEventTracker(api);
-
-        const beforeRows = new GridRows(api, 'before readOnly setDataValue');
-        await beforeRows.check(`
-            ROOT id:ROOT_NODE_ID
-            └── LEAF id:ROW_0 field:"Initial Value"
-        `);
-
-        const rowNode = api.getDisplayedRowAtIndex(0);
-        rowNode?.setDataValue('field', 'readOnly-value', 'ui');
-        await asyncSetTimeout(0);
-
-        const afterRows = new GridRows(api, 'after readOnly setDataValue');
-        await afterRows.check(`
-            ROOT id:ROOT_NODE_ID
-            └── LEAF id:ROW_0 field:"Initial Value"
-        `);
-
-        expect(eventTracker.counts).toEqual({
-            cellEditingStarted: 0,
-            cellEditingStopped: 0,
-            cellValueChanged: 0,
-            rowValueChanged: 0,
-            cellEditRequest: 1,
-            bulkEditingStarted: 0,
-            bulkEditingStopped: 0,
-        });
-
-        expect(api.getDisplayedRowAtIndex(0)?.data?.field).toBe('Initial Value');
-        expect(valueSetterCalls).toBe(0);
-        expect(editRequests).toEqual(['ROW_0:field:readOnly-value']);
-    });
-
-    test('setDataValue during edit commits and stops editing', async () => {
-        let valueSetterCalls = 0;
-        const valueSetter = ({ data, newValue }: { data: { id: string; field: string }; newValue: string }) => {
-            valueSetterCalls += 1;
-            data.field = newValue;
-            return true;
-        };
-
-        const api = await gridMgr.createGridAndWait('cellEditingSetDataValue-editing', {
-            columnDefs: [
-                {
-                    field: 'field',
-                    editable: true,
-                    valueSetter,
-                },
-            ],
-            rowData: [{ id: 'ROW_0', field: 'Initial Value' }],
-            getRowId: (params) => params.data.id,
-        });
-
-        const beforeRows = new GridRows(api, 'before editing setDataValue');
-        await beforeRows.check(`
-            ROOT id:ROOT_NODE_ID
-            └── LEAF id:ROW_0 field:"Initial Value"
-        `);
-
-        const gridDiv = getGridElement(api)! as HTMLElement;
-        const cell = getByTestId(gridDiv, agTestIdFor.cell('ROW_0', 'field'));
-        await userEvent.click(cell);
-        api.startEditingCell({ rowIndex: 0, colKey: 'field' });
-        const input = await waitForInput(gridDiv, cell);
-        await userEvent.clear(input);
-        await userEvent.type(input, 'Editor Value');
-
-        const rowNode = api.getDisplayedRowAtIndex(0);
-        rowNode?.setDataValue('field', 'Committed Value', 'ui');
-        await asyncSetTimeout(0);
-
-        await new GridRows(api, 'after editing setDataValue ui').check(`
-            ROOT id:ROOT_NODE_ID
-            └── LEAF id:ROW_0 field:"Editor Value"
-        `);
-
-        rowNode?.setDataValue('field', 'Committed Value', 'api');
-        await asyncSetTimeout(0);
-
-        await new GridRows(api, 'after editing setDataValue api').check(`
-            ROOT id:ROOT_NODE_ID
-            └── LEAF id:ROW_0 field:"Committed Value"
-        `);
-
-        expect(valueSetterCalls).toBe(2);
     });
 });

--- a/testing/behavioural/src/cell-editing/set-value/cell-editing-setdatavalue-batch.test.ts
+++ b/testing/behavioural/src/cell-editing/set-value/cell-editing-setdatavalue-batch.test.ts
@@ -1,6 +1,7 @@
+import { setupAgTestIds } from 'ag-grid-community';
 import { BatchEditModule } from 'ag-grid-enterprise';
 
-import { TestGridsManager, asyncSetTimeout } from '../../test-utils';
+import { GridRows, TestGridsManager, asyncSetTimeout } from '../../test-utils';
 import { expect } from '../../test-utils/matchers';
 
 /**
@@ -16,6 +17,10 @@ describe('Cell Editing: setDataValue in Batch Mode', () => {
         modules: [BatchEditModule],
     });
 
+    beforeAll(() => {
+        setupAgTestIds();
+    });
+
     afterEach(() => {
         gridMgr.reset();
     });
@@ -24,7 +29,7 @@ describe('Cell Editing: setDataValue in Batch Mode', () => {
     const batchSources = ['paste', 'rangeSvc', 'cellClear', 'undo', 'redo'] as const;
 
     // Sources that bypass batch and write directly to data
-    const bypassSources = [undefined, 'ui', 'api', 'edit'] as const;
+    const bypassSources = [undefined, 'ui', 'api', 'edit', 'fillHandle', 'bulk'] as const;
 
     describe('sources that create pending batch values', () => {
         test.each(batchSources)("'%s' creates pending value during batch mode", async (eventSource) => {
@@ -34,11 +39,22 @@ describe('Cell Editing: setDataValue in Batch Mode', () => {
                 getRowId: (params) => params.data.id,
             });
 
+            await new GridRows(api, 'before batch edit').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 a:"initial"
+            `);
+
             api.startBatchEdit();
             await asyncSetTimeout(1);
 
             const rowNode = api.getDisplayedRowAtIndex(0)!;
             const result = rowNode.setDataValue('a', 'changed', eventSource);
+
+            // GridRows shows rendered values (pending in batch mode)
+            await new GridRows(api, `after ${eventSource} setDataValue`).check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 a:"changed"
+            `);
 
             expect(result).toBe(true);
             expect(rowNode.data.a).toBe('initial'); // Data unchanged
@@ -64,8 +80,18 @@ describe('Cell Editing: setDataValue in Batch Mode', () => {
             const rowNode = api.getDisplayedRowAtIndex(0)!;
             rowNode.setDataValue('a', 'committed', eventSource);
 
+            await new GridRows(api, 'before commit').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 a:"committed"
+            `);
+
             api.commitBatchEdit();
             await asyncSetTimeout(1);
+
+            await new GridRows(api, 'after commit').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 a:"committed"
+            `);
 
             expect(rowNode.data.a).toBe('committed');
         });
@@ -83,8 +109,18 @@ describe('Cell Editing: setDataValue in Batch Mode', () => {
             const rowNode = api.getDisplayedRowAtIndex(0)!;
             rowNode.setDataValue('a', 'pending', eventSource);
 
+            await new GridRows(api, 'before cancel').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 a:"pending"
+            `);
+
             api.cancelBatchEdit();
             await asyncSetTimeout(1);
+
+            await new GridRows(api, 'after cancel').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 a:"initial"
+            `);
 
             expect(rowNode.data.a).toBe('initial');
         });
@@ -98,11 +134,21 @@ describe('Cell Editing: setDataValue in Batch Mode', () => {
                 getRowId: (params) => params.data.id,
             });
 
+            await new GridRows(api, 'before batch edit').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 a:"initial"
+            `);
+
             api.startBatchEdit();
             await asyncSetTimeout(1);
 
             const rowNode = api.getDisplayedRowAtIndex(0)!;
             const result = rowNode.setDataValue('a', 'changed', eventSource);
+
+            await new GridRows(api, `after ${eventSource ?? 'undefined'} setDataValue`).check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 a:"changed"
+            `);
 
             expect(result).toBe(true);
             expect(rowNode.data.a).toBe('changed'); // Written directly to data
@@ -124,8 +170,18 @@ describe('Cell Editing: setDataValue in Batch Mode', () => {
                 getRowId: (params) => params.data.id,
             });
 
+            await new GridRows(api, 'before setDataValue').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 a:"initial"
+            `);
+
             const rowNode = api.getDisplayedRowAtIndex(0)!;
             const result = rowNode.setDataValue('a', 'changed', eventSource);
+
+            await new GridRows(api, `after ${eventSource ?? 'undefined'} setDataValue`).check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 a:"changed"
+            `);
 
             expect(result).toBe(true);
             expect(rowNode.data.a).toBe('changed');
@@ -141,8 +197,18 @@ describe('Cell Editing: setDataValue in Batch Mode', () => {
                 getRowId: (params) => params.data.id,
             });
 
+            await new GridRows(api, 'before paste').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 a:"initial"
+            `);
+
             const rowNode = api.getDisplayedRowAtIndex(0)!;
             const result = rowNode.setDataValue('a', 'pasted', 'paste');
+
+            await new GridRows(api, 'after paste').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 a:"pasted"
+            `);
 
             // 'paste' bypasses editSvc when not in batch mode, so value is written directly
             expect(result).toBe(true);
@@ -164,12 +230,22 @@ describe('Cell Editing: setDataValue in Batch Mode', () => {
                 getRowId: (params) => params.data.id,
             });
 
+            await new GridRows(api, 'initial state').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 a:"a-initial" b:"b-initial"
+            `);
+
             api.startBatchEdit();
             await asyncSetTimeout(1);
 
             const rowNode = api.getDisplayedRowAtIndex(0)!;
             rowNode.setDataValue('a', 'a-changed', 'paste');
             rowNode.setDataValue('b', 'b-changed', 'paste');
+
+            await new GridRows(api, 'after setDataValue calls').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 a:"a-changed" b:"b-changed"
+            `);
 
             expect(rowNode.data.a).toBe('a-initial');
             expect(rowNode.data.b).toBe('b-initial');
@@ -182,6 +258,11 @@ describe('Cell Editing: setDataValue in Batch Mode', () => {
 
             api.commitBatchEdit();
             await asyncSetTimeout(1);
+
+            await new GridRows(api, 'after commit').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 a:"a-changed" b:"b-changed"
+            `);
 
             expect(rowNode.data.a).toBe('a-changed');
             expect(rowNode.data.b).toBe('b-changed');

--- a/testing/behavioural/src/cell-editing/set-value/cell-editing-setdatavalue-batch.test.ts
+++ b/testing/behavioural/src/cell-editing/set-value/cell-editing-setdatavalue-batch.test.ts
@@ -1,0 +1,194 @@
+import { BatchEditModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../../test-utils';
+import { expect } from '../../test-utils/matchers';
+
+/**
+ * Tests for setDataValue behavior during batch editing.
+ *
+ * Key behavior:
+ * - Sources in SET_DATA_SOURCE_AS_API ('paste', 'rangeSvc', 'cellClear', 'redo', 'undo') create pending batch values
+ * - Other sources (undefined, 'ui', 'api', etc.) bypass batch mode and write directly to data
+ */
+describe('Cell Editing: setDataValue in Batch Mode', () => {
+    const gridMgr = new TestGridsManager({
+        includeDefaultModules: true,
+        modules: [BatchEditModule],
+    });
+
+    afterEach(() => {
+        gridMgr.reset();
+    });
+
+    // Sources that create pending batch values (SET_DATA_SOURCE_AS_API)
+    const batchSources = ['paste', 'rangeSvc', 'cellClear', 'undo', 'redo'] as const;
+
+    // Sources that bypass batch and write directly to data
+    const bypassSources = [undefined, 'ui', 'api', 'edit'] as const;
+
+    describe('sources that create pending batch values', () => {
+        test.each(batchSources)("'%s' creates pending value during batch mode", async (eventSource) => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'a', editable: true }],
+                rowData: [{ id: '0', a: 'initial' }],
+                getRowId: (params) => params.data.id,
+            });
+
+            api.startBatchEdit();
+            await asyncSetTimeout(1);
+
+            const rowNode = api.getDisplayedRowAtIndex(0)!;
+            const result = rowNode.setDataValue('a', 'changed', eventSource);
+
+            expect(result).toBe(true);
+            expect(rowNode.data.a).toBe('initial'); // Data unchanged
+            expect(rowNode.getDataValue('a')).toBe('initial'); // getDataValue returns committed data
+            expect(api.getCellValue({ rowNode, colKey: 'a' })).toBe('changed'); // Default returns pending
+            expect(api.getCellValue({ rowNode, colKey: 'a', from: 'batch' })).toBe('changed'); // Pending value
+            expect(api.getCellValue({ rowNode, colKey: 'a', from: 'data' })).toBe('initial'); // Data unchanged
+            expect(api.getCellValue({ rowNode, colKey: 'a', from: 'edit' })).toBe('changed'); // Edit value
+
+            api.cancelBatchEdit();
+        });
+
+        test.each(batchSources)("'%s' pending value is committed on commitBatchEdit", async (eventSource) => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'a', editable: true }],
+                rowData: [{ id: '0', a: 'initial' }],
+                getRowId: (params) => params.data.id,
+            });
+
+            api.startBatchEdit();
+            await asyncSetTimeout(1);
+
+            const rowNode = api.getDisplayedRowAtIndex(0)!;
+            rowNode.setDataValue('a', 'committed', eventSource);
+
+            api.commitBatchEdit();
+            await asyncSetTimeout(1);
+
+            expect(rowNode.data.a).toBe('committed');
+        });
+
+        test.each(batchSources)("'%s' pending value is reverted on cancelBatchEdit", async (eventSource) => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'a', editable: true }],
+                rowData: [{ id: '0', a: 'initial' }],
+                getRowId: (params) => params.data.id,
+            });
+
+            api.startBatchEdit();
+            await asyncSetTimeout(1);
+
+            const rowNode = api.getDisplayedRowAtIndex(0)!;
+            rowNode.setDataValue('a', 'pending', eventSource);
+
+            api.cancelBatchEdit();
+            await asyncSetTimeout(1);
+
+            expect(rowNode.data.a).toBe('initial');
+        });
+    });
+
+    describe('sources that bypass batch mode', () => {
+        test.each(bypassSources)("'%s' writes directly to data during batch mode", async (eventSource) => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'a', editable: true }],
+                rowData: [{ id: '0', a: 'initial' }],
+                getRowId: (params) => params.data.id,
+            });
+
+            api.startBatchEdit();
+            await asyncSetTimeout(1);
+
+            const rowNode = api.getDisplayedRowAtIndex(0)!;
+            const result = rowNode.setDataValue('a', 'changed', eventSource);
+
+            expect(result).toBe(true);
+            expect(rowNode.data.a).toBe('changed'); // Written directly to data
+            expect(rowNode.getDataValue('a')).toBe('changed'); // getDataValue returns committed data
+            expect(api.getCellValue({ rowNode, colKey: 'a' })).toBe('changed'); // Default
+            expect(api.getCellValue({ rowNode, colKey: 'a', from: 'batch' })).toBe('changed');
+            expect(api.getCellValue({ rowNode, colKey: 'a', from: 'data' })).toBe('changed');
+            expect(api.getCellValue({ rowNode, colKey: 'a', from: 'edit' })).toBe('changed');
+
+            api.cancelBatchEdit();
+        });
+    });
+
+    describe('behavior outside batch mode', () => {
+        test.each(bypassSources)("'%s' updates data directly when not in batch mode", async (eventSource) => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'a', editable: true }],
+                rowData: [{ id: '0', a: 'initial' }],
+                getRowId: (params) => params.data.id,
+            });
+
+            const rowNode = api.getDisplayedRowAtIndex(0)!;
+            const result = rowNode.setDataValue('a', 'changed', eventSource);
+
+            expect(result).toBe(true);
+            expect(rowNode.data.a).toBe('changed');
+            expect(rowNode.getDataValue('a')).toBe('changed');
+            expect(api.getCellValue({ rowNode, colKey: 'a' })).toBe('changed');
+            expect(api.getCellValue({ rowNode, colKey: 'a', from: 'data' })).toBe('changed');
+        });
+
+        test("'paste' writes directly to data when not in batch mode and not editing", async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'a', editable: true }],
+                rowData: [{ id: '0', a: 'initial' }],
+                getRowId: (params) => params.data.id,
+            });
+
+            const rowNode = api.getDisplayedRowAtIndex(0)!;
+            const result = rowNode.setDataValue('a', 'pasted', 'paste');
+
+            // 'paste' bypasses editSvc when not in batch mode, so value is written directly
+            expect(result).toBe(true);
+            expect(rowNode.data.a).toBe('pasted');
+            expect(rowNode.getDataValue('a')).toBe('pasted');
+            expect(api.getCellValue({ rowNode, colKey: 'a' })).toBe('pasted');
+            expect(api.getCellValue({ rowNode, colKey: 'a', from: 'data' })).toBe('pasted');
+        });
+    });
+
+    describe('multiple cells', () => {
+        test('multiple setDataValue calls during batch are all applied on commit', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    { field: 'a', editable: true },
+                    { field: 'b', editable: true },
+                ],
+                rowData: [{ id: '0', a: 'a-initial', b: 'b-initial' }],
+                getRowId: (params) => params.data.id,
+            });
+
+            api.startBatchEdit();
+            await asyncSetTimeout(1);
+
+            const rowNode = api.getDisplayedRowAtIndex(0)!;
+            rowNode.setDataValue('a', 'a-changed', 'paste');
+            rowNode.setDataValue('b', 'b-changed', 'paste');
+
+            expect(rowNode.data.a).toBe('a-initial');
+            expect(rowNode.data.b).toBe('b-initial');
+            expect(rowNode.getDataValue('a')).toBe('a-initial');
+            expect(rowNode.getDataValue('b')).toBe('b-initial');
+            expect(api.getCellValue({ rowNode, colKey: 'a', from: 'batch' })).toBe('a-changed');
+            expect(api.getCellValue({ rowNode, colKey: 'b', from: 'batch' })).toBe('b-changed');
+            expect(api.getCellValue({ rowNode, colKey: 'a', from: 'data' })).toBe('a-initial');
+            expect(api.getCellValue({ rowNode, colKey: 'b', from: 'data' })).toBe('b-initial');
+
+            api.commitBatchEdit();
+            await asyncSetTimeout(1);
+
+            expect(rowNode.data.a).toBe('a-changed');
+            expect(rowNode.data.b).toBe('b-changed');
+            expect(rowNode.getDataValue('a')).toBe('a-changed');
+            expect(rowNode.getDataValue('b')).toBe('b-changed');
+            expect(api.getCellValue({ rowNode, colKey: 'a' })).toBe('a-changed');
+            expect(api.getCellValue({ rowNode, colKey: 'b' })).toBe('b-changed');
+        });
+    });
+});

--- a/testing/behavioural/src/find/find-batch-values.test.ts
+++ b/testing/behavioural/src/find/find-batch-values.test.ts
@@ -1,0 +1,222 @@
+import { getByTestId } from '@testing-library/dom';
+import '@testing-library/jest-dom';
+import { userEvent } from '@testing-library/user-event';
+
+import { agTestIdFor, getGridElement, setupAgTestIds } from 'ag-grid-community';
+import { BatchEditModule, FindModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout, waitForInput } from '../test-utils';
+import { expect } from '../test-utils/matchers';
+
+/**
+ * Tests for find functionality using batch values (AG-16448).
+ * The find service should automatically update results when batch pending values change,
+ * by listening to cellEditingStopped events during batch editing.
+ */
+describe('Find with Batch Values', () => {
+    const gridMgr = new TestGridsManager({
+        includeDefaultModules: true,
+        modules: [BatchEditModule, FindModule],
+    });
+
+    beforeAll(() => setupAgTestIds());
+
+    afterEach(() => {
+        gridMgr.reset();
+        vi.resetAllMocks();
+        vi.clearAllMocks();
+    });
+
+    test('find automatically updates when batch pending value is created via UI editing', async () => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [{ field: 'a', editable: true, cellEditor: 'agTextCellEditor' }],
+            rowData: [
+                { id: '0', a: 'apple' },
+                { id: '1', a: 'banana' },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        // Set up find to search for 'orange' - initially 0 matches
+        api.setGridOption('findSearchValue', 'orange');
+        expect(api.findGetTotalMatches()).toBe(0);
+
+        // Start batch edit
+        api.startBatchEdit();
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        await asyncSetTimeout(1);
+        const cellA = getByTestId(gridDiv, agTestIdFor.cell('0', 'a'));
+
+        // Edit the first cell via UI to change 'apple' to 'orange'
+        await userEvent.dblClick(cellA);
+        const editor = await waitForInput(gridDiv, cellA, { popup: false });
+        await userEvent.clear(editor);
+        await userEvent.type(editor, 'orange{Enter}');
+        await asyncSetTimeout(10); // Wait for debounced refresh
+
+        // The data should still be 'apple' (not committed)
+        const rowNode = api.getDisplayedRowAtIndex(0)!;
+        expect(rowNode.data.a).toBe('apple');
+
+        // But getCellValue with from: 'batch' should return the pending value
+        expect(api.getCellValue({ rowNode, colKey: 'a', from: 'batch' })).toBe('orange');
+
+        // Find should automatically update - 'orange' should now be found
+        // WITHOUT manually clearing the search value
+        // The find service should listen to cellEditingStopped and refresh when batch editing is active
+        expect(api.findGetTotalMatches()).toBe(1);
+
+        // Now search for 'apple' - should no longer be found
+        api.setGridOption('findSearchValue', 'apple');
+        await asyncSetTimeout(1);
+        expect(api.findGetTotalMatches()).toBe(0);
+
+        // Cancel the batch edit
+        api.cancelBatchEdit();
+        await asyncSetTimeout(10); // Wait for refresh after cancel
+
+        // After cancel, find should automatically reflect the original committed values
+        expect(api.findGetTotalMatches()).toBe(1);
+
+        api.setGridOption('findSearchValue', 'orange');
+        await asyncSetTimeout(1);
+        expect(api.findGetTotalMatches()).toBe(0);
+    });
+
+    test('find automatically updates when batch pending value is created via setDataValue API', async () => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [{ field: 'a', editable: true, cellEditor: 'agTextCellEditor' }],
+            rowData: [
+                { id: '0', a: 'apple' },
+                { id: '1', a: 'banana' },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        // Set up find to search for 'orange' - initially 0 matches
+        api.setGridOption('findSearchValue', 'orange');
+        expect(api.findGetTotalMatches()).toBe(0);
+
+        // Start batch edit
+        api.startBatchEdit();
+        await asyncSetTimeout(1);
+
+        // Change value via setDataValue API (not UI editing)
+        // Use 'paste' as eventSource to ensure it's treated as an API call during batch mode
+        const rowNode = api.getDisplayedRowAtIndex(0)!;
+        rowNode.setDataValue('a', 'orange', 'paste');
+        await asyncSetTimeout(10); // Wait for debounced refresh
+
+        // The data should still be 'apple' (not committed)
+        expect(rowNode.data.a).toBe('apple');
+
+        // But getCellValue with from: 'batch' should return the pending value
+        expect(api.getCellValue({ rowNode, colKey: 'a', from: 'batch' })).toBe('orange');
+
+        // Find should automatically update - 'orange' should now be found
+        // WITHOUT manually clearing the search value
+        expect(api.findGetTotalMatches()).toBe(1);
+
+        // Now search for 'apple' - should no longer be found
+        api.setGridOption('findSearchValue', 'apple');
+        await asyncSetTimeout(1);
+        expect(api.findGetTotalMatches()).toBe(0);
+
+        // Cancel the batch edit
+        api.cancelBatchEdit();
+        await asyncSetTimeout(10); // Wait for refresh after cancel
+
+        // After cancel, find should automatically reflect the original committed values
+        expect(api.findGetTotalMatches()).toBe(1);
+
+        api.setGridOption('findSearchValue', 'orange');
+        await asyncSetTimeout(1);
+        expect(api.findGetTotalMatches()).toBe(0);
+    });
+
+    test('find automatically updates when batch edit is committed', async () => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [{ field: 'a', editable: true, cellEditor: 'agTextCellEditor' }],
+            rowData: [{ id: '0', a: 'initial' }],
+            getRowId: (params) => params.data.id,
+        });
+
+        api.startBatchEdit();
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        await asyncSetTimeout(1);
+        const cellA = getByTestId(gridDiv, agTestIdFor.cell('0', 'a'));
+
+        await userEvent.dblClick(cellA);
+        const editor = await waitForInput(gridDiv, cellA, { popup: false });
+        await userEvent.clear(editor);
+        await userEvent.type(editor, 'changed{Enter}');
+        await asyncSetTimeout(10); // Wait for debounced refresh
+
+        // During batch edit, find should use batch values - automatically updated
+        api.setGridOption('findSearchValue', 'changed');
+        await asyncSetTimeout(1);
+        expect(api.findGetTotalMatches()).toBe(1);
+
+        api.setGridOption('findSearchValue', 'initial');
+        await asyncSetTimeout(1);
+        expect(api.findGetTotalMatches()).toBe(0);
+
+        // Commit the batch edit
+        api.commitBatchEdit();
+        await asyncSetTimeout(10); // Wait for refresh after commit
+
+        // After commit, find should still find 'changed' (now the committed value)
+        api.setGridOption('findSearchValue', 'changed');
+        await asyncSetTimeout(1);
+        expect(api.findGetTotalMatches()).toBe(1);
+
+        api.setGridOption('findSearchValue', 'initial');
+        await asyncSetTimeout(1);
+        expect(api.findGetTotalMatches()).toBe(0);
+    });
+
+    test('find uses batch values with value formatters', async () => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [
+                {
+                    field: 'a',
+                    editable: true,
+                    cellEditor: 'agTextCellEditor',
+                    valueFormatter: (params) => `formatted:${params.value}`,
+                },
+            ],
+            rowData: [{ id: '0', a: 'test' }],
+            getRowId: (params) => params.data.id,
+        });
+
+        // Initially, find the formatted value
+        api.setGridOption('findSearchValue', 'formatted:test');
+        expect(api.findGetTotalMatches()).toBe(1);
+
+        api.startBatchEdit();
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        await asyncSetTimeout(1);
+        const cellA = getByTestId(gridDiv, agTestIdFor.cell('0', 'a'));
+
+        await userEvent.dblClick(cellA);
+        const editor = await waitForInput(gridDiv, cellA, { popup: false });
+        await userEvent.clear(editor);
+        await userEvent.type(editor, 'newvalue{Enter}');
+        await asyncSetTimeout(10); // Wait for debounced refresh
+
+        // Find should use the formatted batch value - automatically updated
+        api.setGridOption('findSearchValue', 'formatted:newvalue');
+        await asyncSetTimeout(1);
+        expect(api.findGetTotalMatches()).toBe(1);
+
+        // The old formatted value should not be found
+        api.setGridOption('findSearchValue', 'formatted:test');
+        await asyncSetTimeout(1);
+        expect(api.findGetTotalMatches()).toBe(0);
+
+        api.cancelBatchEdit();
+    });
+});

--- a/testing/behavioural/src/find/find-cell-info.test.ts
+++ b/testing/behavioural/src/find/find-cell-info.test.ts
@@ -1,0 +1,191 @@
+import { FindModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+import { expect } from '../test-utils/matchers';
+
+/**
+ * Tests for findGetNumMatches and findGetParts API functions.
+ */
+describe('Find Cell Info API', () => {
+    const gridMgr = new TestGridsManager({
+        includeDefaultModules: true,
+        modules: [FindModule],
+    });
+
+    afterEach(() => {
+        gridMgr.reset();
+    });
+
+    describe('findGetNumMatches', () => {
+        test('returns number of matches in a specific cell', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [{ value: 'aaa' }, { value: 'aba' }, { value: 'bbb' }],
+            });
+
+            api.setGridOption('findSearchValue', 'a');
+            await asyncSetTimeout(1);
+
+            const column = api.getColumn('value')!;
+
+            // First row 'aaa' has 3 matches of 'a'
+            const row0 = api.getDisplayedRowAtIndex(0)!;
+            expect(api.findGetNumMatches({ node: row0, column })).toBe(3);
+
+            // Second row 'aba' has 2 matches of 'a'
+            const row1 = api.getDisplayedRowAtIndex(1)!;
+            expect(api.findGetNumMatches({ node: row1, column })).toBe(2);
+
+            // Third row 'bbb' has 0 matches of 'a'
+            const row2 = api.getDisplayedRowAtIndex(2)!;
+            expect(api.findGetNumMatches({ node: row2, column })).toBe(0);
+        });
+
+        test('returns 0 when no search value is set', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [{ value: 'aaa' }],
+            });
+
+            const column = api.getColumn('value')!;
+            const row = api.getDisplayedRowAtIndex(0)!;
+
+            expect(api.findGetNumMatches({ node: row, column })).toBe(0);
+        });
+
+        test('works with multiple columns', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'a' }, { field: 'b' }],
+                rowData: [{ a: 'test', b: 'testing test' }],
+            });
+
+            api.setGridOption('findSearchValue', 'test');
+            await asyncSetTimeout(1);
+
+            const row = api.getDisplayedRowAtIndex(0)!;
+            const colA = api.getColumn('a')!;
+            const colB = api.getColumn('b')!;
+
+            // Column 'a' has 1 match of 'test'
+            expect(api.findGetNumMatches({ node: row, column: colA })).toBe(1);
+
+            // Column 'b' has 2 matches of 'test' ('testing test')
+            expect(api.findGetNumMatches({ node: row, column: colB })).toBe(2);
+        });
+    });
+
+    describe('findGetParts', () => {
+        test('returns parts with match info for cell value', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [{ value: 'hello world hello' }],
+            });
+
+            api.setGridOption('findSearchValue', 'hello');
+            await asyncSetTimeout(1);
+
+            const row = api.getDisplayedRowAtIndex(0)!;
+            const column = api.getColumn('value')!;
+
+            const parts = api.findGetParts({ node: row, column, value: 'hello world hello' });
+
+            // Should split into: 'hello', ' world ', 'hello'
+            expect(parts).toHaveLength(3);
+            expect(parts[0]).toEqual({ value: 'hello', match: true, activeMatch: false });
+            expect(parts[1]).toEqual({ value: ' world ' });
+            expect(parts[2]).toEqual({ value: 'hello', match: true, activeMatch: false });
+        });
+
+        test('marks active match in parts', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [{ value: 'aaa' }],
+            });
+
+            api.setGridOption('findSearchValue', 'a');
+            await asyncSetTimeout(1);
+
+            // Navigate to second match
+            api.findNext();
+            api.findNext();
+
+            const row = api.getDisplayedRowAtIndex(0)!;
+            const column = api.getColumn('value')!;
+
+            const parts = api.findGetParts({ node: row, column, value: 'aaa' });
+
+            expect(parts).toHaveLength(3);
+            expect(parts[0]).toEqual({ value: 'a', match: true, activeMatch: false });
+            expect(parts[1]).toEqual({ value: 'a', match: true, activeMatch: true });
+            expect(parts[2]).toEqual({ value: 'a', match: true, activeMatch: false });
+        });
+
+        test('returns single part when no matches', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [{ value: 'hello' }],
+            });
+
+            api.setGridOption('findSearchValue', 'xyz');
+            await asyncSetTimeout(1);
+
+            const row = api.getDisplayedRowAtIndex(0)!;
+            const column = api.getColumn('value')!;
+
+            const parts = api.findGetParts({ node: row, column, value: 'hello' });
+
+            // No matches, so just one part with the full value
+            expect(parts).toHaveLength(1);
+            expect(parts[0]).toEqual({ value: 'hello' });
+        });
+
+        test('handles empty value', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [{ value: '' }],
+            });
+
+            api.setGridOption('findSearchValue', 'test');
+            await asyncSetTimeout(1);
+
+            const row = api.getDisplayedRowAtIndex(0)!;
+            const column = api.getColumn('value')!;
+
+            const parts = api.findGetParts({ node: row, column, value: '' });
+
+            // Empty value returns empty array
+            expect(parts).toHaveLength(0);
+        });
+
+        test('handles precedingNumMatches for multi-value cells', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [{ value: 'aa bb aa' }],
+            });
+
+            api.setGridOption('findSearchValue', 'a');
+            await asyncSetTimeout(1);
+
+            // Navigate to third match (second 'aa')
+            api.findNext();
+            api.findNext();
+            api.findNext();
+
+            const row = api.getDisplayedRowAtIndex(0)!;
+            const column = api.getColumn('value')!;
+
+            // Get parts for second 'aa' with precedingNumMatches=2 (first 'aa' has 2 matches)
+            const parts = api.findGetParts({
+                node: row,
+                column,
+                value: 'aa',
+                precedingNumMatches: 2,
+            });
+
+            // The third match overall should be active in this part
+            expect(parts).toHaveLength(2);
+            expect(parts[0]).toEqual({ value: 'a', match: true, activeMatch: true });
+            expect(parts[1]).toEqual({ value: 'a', match: true, activeMatch: false });
+        });
+    });
+});

--- a/testing/behavioural/src/find/find-data-mutations.test.ts
+++ b/testing/behavioural/src/find/find-data-mutations.test.ts
@@ -1,0 +1,205 @@
+import { FindModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+import { expect } from '../test-utils/matchers';
+
+/**
+ * Tests for find with data mutations and cell updates.
+ */
+describe('Find Data Mutations', () => {
+    const gridMgr = new TestGridsManager({
+        includeDefaultModules: true,
+        modules: [FindModule],
+    });
+
+    afterEach(() => {
+        gridMgr.reset();
+    });
+
+    describe('Row Data Updates', () => {
+        test('find updates when row data is replaced', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [{ value: 'apple' }, { value: 'banana' }],
+            });
+
+            api.setGridOption('findSearchValue', 'apple');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(1);
+
+            // Replace all row data
+            api.setGridOption('rowData', [{ value: 'orange' }, { value: 'apple' }, { value: 'apple' }]);
+            await asyncSetTimeout(10);
+
+            expect(api.findGetTotalMatches()).toBe(2);
+        });
+
+        test('find updates when rows are added via transaction', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [{ id: '1', value: 'apple' }],
+                getRowId: (params) => params.data.id,
+            });
+
+            api.setGridOption('findSearchValue', 'apple');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(1);
+
+            // Add more rows with matching values
+            api.applyTransaction({
+                add: [
+                    { id: '2', value: 'apple' },
+                    { id: '3', value: 'apple' },
+                ],
+            });
+            await asyncSetTimeout(10);
+
+            expect(api.findGetTotalMatches()).toBe(3);
+        });
+
+        test('find updates when rows are removed via transaction', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [
+                    { id: '1', value: 'apple' },
+                    { id: '2', value: 'apple' },
+                    { id: '3', value: 'banana' },
+                ],
+                getRowId: (params) => params.data.id,
+            });
+
+            api.setGridOption('findSearchValue', 'apple');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(2);
+
+            // Remove one apple row
+            api.applyTransaction({ remove: [{ id: '1' }] });
+            await asyncSetTimeout(10);
+
+            expect(api.findGetTotalMatches()).toBe(1);
+        });
+
+        test('find updates when rows are updated via transaction', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [
+                    { id: '1', value: 'apple' },
+                    { id: '2', value: 'banana' },
+                ],
+                getRowId: (params) => params.data.id,
+            });
+
+            api.setGridOption('findSearchValue', 'orange');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(0);
+
+            // Update a row to have matching value
+            api.applyTransaction({ update: [{ id: '2', value: 'orange' }] });
+            await asyncSetTimeout(10);
+
+            expect(api.findGetTotalMatches()).toBe(1);
+        });
+    });
+
+    describe('Cell Value Updates', () => {
+        test('find updates when cell value is changed directly', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value', editable: true }],
+                rowData: [{ id: '1', value: 'apple' }],
+                getRowId: (params) => params.data.id,
+            });
+
+            api.setGridOption('findSearchValue', 'orange');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(0);
+
+            // Change cell value
+            const rowNode = api.getRowNode('1')!;
+            rowNode.setDataValue('value', 'orange');
+            await asyncSetTimeout(10);
+
+            expect(api.findGetTotalMatches()).toBe(1);
+        });
+    });
+
+    describe('Active Match Preservation', () => {
+        test('active match is preserved after data update if still valid', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [
+                    { id: '1', value: 'apple' },
+                    { id: '2', value: 'apple' },
+                    { id: '3', value: 'apple' },
+                ],
+                getRowId: (params) => params.data.id,
+            });
+
+            api.setGridOption('findSearchValue', 'apple');
+            await asyncSetTimeout(1);
+
+            // Navigate to second match
+            api.findNext();
+            api.findNext();
+            expect(api.findGetActiveMatch()!.numOverall).toBe(2);
+            expect(api.findGetActiveMatch()!.node.data.id).toBe('2');
+
+            // Add a row at the end - active match should still be valid
+            api.applyTransaction({ add: [{ id: '4', value: 'apple' }] });
+            await asyncSetTimeout(10);
+
+            expect(api.findGetTotalMatches()).toBe(4);
+            // Active match should still be on the same row
+            expect(api.findGetActiveMatch()!.node.data.id).toBe('2');
+        });
+
+        test('active match is cleared when matching row is removed', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [
+                    { id: '1', value: 'apple' },
+                    { id: '2', value: 'apple' },
+                ],
+                getRowId: (params) => params.data.id,
+            });
+
+            api.setGridOption('findSearchValue', 'apple');
+            await asyncSetTimeout(1);
+
+            // Navigate to first match
+            api.findNext();
+            expect(api.findGetActiveMatch()!.node.data.id).toBe('1');
+
+            // Remove the row with active match
+            api.applyTransaction({ remove: [{ id: '1' }] });
+            await asyncSetTimeout(10);
+
+            // Active match should be cleared or moved
+            expect(api.findGetTotalMatches()).toBe(1);
+        });
+
+        test('active match is cleared when cell value no longer matches', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value', editable: true }],
+                rowData: [
+                    { id: '1', value: 'apple' },
+                    { id: '2', value: 'banana' },
+                ],
+                getRowId: (params) => params.data.id,
+            });
+
+            api.setGridOption('findSearchValue', 'apple');
+            await asyncSetTimeout(1);
+
+            api.findNext();
+            expect(api.findGetActiveMatch()!.node.data.id).toBe('1');
+
+            // Change the value so it no longer matches
+            const rowNode = api.getRowNode('1')!;
+            rowNode.setDataValue('value', 'orange');
+            await asyncSetTimeout(10);
+
+            expect(api.findGetTotalMatches()).toBe(0);
+            expect(api.findGetActiveMatch()).toBeUndefined();
+        });
+    });
+});

--- a/testing/behavioural/src/find/find-navigation.test.ts
+++ b/testing/behavioural/src/find/find-navigation.test.ts
@@ -135,8 +135,6 @@ describe('Find Navigation', () => {
         api.findGoTo(1);
         expect(api.findGetActiveMatch()!.numOverall).toBe(1);
 
-        const callCountAfterFirst = scrollListener.mock.calls.length;
-
         // Without force, going to the same match does nothing
         api.findGoTo(1);
         expect(api.findGetActiveMatch()!.numOverall).toBe(1);

--- a/testing/behavioural/src/find/find-navigation.test.ts
+++ b/testing/behavioural/src/find/find-navigation.test.ts
@@ -1,0 +1,247 @@
+import { FindModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+import { expect } from '../test-utils/matchers';
+
+/**
+ * Tests for find navigation functionality (next, previous, goTo).
+ */
+describe('Find Navigation', () => {
+    const gridMgr = new TestGridsManager({
+        includeDefaultModules: true,
+        modules: [FindModule],
+    });
+
+    afterEach(() => {
+        gridMgr.reset();
+    });
+
+    test('findNext navigates through matches in order', async () => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [{ field: 'value' }],
+            rowData: [{ value: 'cat' }, { value: 'dog' }, { value: 'car' }, { value: 'cup' }],
+        });
+
+        api.setGridOption('findSearchValue', 'c');
+        await asyncSetTimeout(1);
+
+        // 'cat', 'car', 'cup' contain 'c', so 3 matches
+        expect(api.findGetTotalMatches()).toBe(3);
+
+        // Initially no active match
+        expect(api.findGetActiveMatch()).toBeUndefined();
+
+        // Navigate to first match
+        api.findNext();
+        let activeMatch = api.findGetActiveMatch();
+        expect(activeMatch).toBeDefined();
+        expect(activeMatch!.numOverall).toBe(1);
+        expect(activeMatch!.node.rowIndex).toBe(0);
+
+        // Navigate to second match
+        api.findNext();
+        activeMatch = api.findGetActiveMatch();
+        expect(activeMatch!.numOverall).toBe(2);
+        expect(activeMatch!.node.rowIndex).toBe(2); // 'car' is row index 2
+
+        // Navigate to third match
+        api.findNext();
+        activeMatch = api.findGetActiveMatch();
+        expect(activeMatch!.numOverall).toBe(3);
+        expect(activeMatch!.node.rowIndex).toBe(3); // 'cup' is row index 3
+
+        // Wraps around to first match
+        api.findNext();
+        activeMatch = api.findGetActiveMatch();
+        expect(activeMatch!.numOverall).toBe(1);
+        expect(activeMatch!.node.rowIndex).toBe(0);
+    });
+
+    test('findPrevious navigates through matches in reverse order', async () => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [{ field: 'value' }],
+            rowData: [{ value: 'cat' }, { value: 'dog' }, { value: 'car' }],
+        });
+
+        api.setGridOption('findSearchValue', 'c');
+        await asyncSetTimeout(1);
+
+        expect(api.findGetTotalMatches()).toBe(2); // 'cat' and 'car'
+
+        // findPrevious from no active match goes to last match
+        api.findPrevious();
+        let activeMatch = api.findGetActiveMatch();
+        expect(activeMatch).toBeDefined();
+        expect(activeMatch!.numOverall).toBe(2);
+        expect(activeMatch!.node.rowIndex).toBe(2); // 'car'
+
+        // Navigate to first match (going backwards)
+        api.findPrevious();
+        activeMatch = api.findGetActiveMatch();
+        expect(activeMatch!.numOverall).toBe(1);
+        expect(activeMatch!.node.rowIndex).toBe(0); // 'cat'
+
+        // Wraps around to last match
+        api.findPrevious();
+        activeMatch = api.findGetActiveMatch();
+        expect(activeMatch!.numOverall).toBe(2);
+        expect(activeMatch!.node.rowIndex).toBe(2); // 'car'
+    });
+
+    test('findGoTo navigates to specific match', async () => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [{ field: 'value' }],
+            rowData: [{ value: 'xone' }, { value: 'xtwo' }, { value: 'xthree' }, { value: 'xfour' }],
+        });
+
+        api.setGridOption('findSearchValue', 'x');
+        await asyncSetTimeout(1);
+
+        // Each row has one 'x'
+        expect(api.findGetTotalMatches()).toBe(4);
+
+        // Go to third match directly
+        api.findGoTo(3);
+        let activeMatch = api.findGetActiveMatch();
+        expect(activeMatch).toBeDefined();
+        expect(activeMatch!.numOverall).toBe(3);
+        expect(activeMatch!.node.rowIndex).toBe(2);
+
+        // Go to first match
+        api.findGoTo(1);
+        activeMatch = api.findGetActiveMatch();
+        expect(activeMatch!.numOverall).toBe(1);
+        expect(activeMatch!.node.rowIndex).toBe(0);
+
+        // Go to last match
+        api.findGoTo(4);
+        activeMatch = api.findGetActiveMatch();
+        expect(activeMatch!.numOverall).toBe(4);
+        expect(activeMatch!.node.rowIndex).toBe(3);
+    });
+
+    test('findGoTo with force=true refreshes even when already at match', async () => {
+        const scrollListener = vi.fn();
+
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [{ field: 'value' }],
+            rowData: [{ value: 'test' }, { value: 'other' }],
+            onBodyScrollEnd: scrollListener,
+        });
+
+        api.setGridOption('findSearchValue', 'test');
+        await asyncSetTimeout(1);
+
+        api.findGoTo(1);
+        expect(api.findGetActiveMatch()!.numOverall).toBe(1);
+
+        const callCountAfterFirst = scrollListener.mock.calls.length;
+
+        // Without force, going to the same match does nothing
+        api.findGoTo(1);
+        expect(api.findGetActiveMatch()!.numOverall).toBe(1);
+
+        // With force=true, it should trigger scroll/refresh even for same match
+        api.findGoTo(1, true);
+        expect(api.findGetActiveMatch()!.numOverall).toBe(1);
+        // We expect some scroll activity due to force
+    });
+
+    test('findClearActive clears the active match', async () => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [{ field: 'value' }],
+            rowData: [{ value: 'xone' }, { value: 'xtwo' }],
+        });
+
+        api.setGridOption('findSearchValue', 'x');
+        await asyncSetTimeout(1);
+
+        expect(api.findGetTotalMatches()).toBe(2);
+
+        // Navigate to first match
+        api.findNext();
+        expect(api.findGetActiveMatch()).toBeDefined();
+        expect(api.findGetActiveMatch()!.numOverall).toBe(1);
+
+        // Clear active match
+        api.findClearActive();
+        expect(api.findGetActiveMatch()).toBeUndefined();
+
+        // Total matches should still be available
+        expect(api.findGetTotalMatches()).toBe(2);
+
+        // Can navigate again after clearing
+        api.findNext();
+        expect(api.findGetActiveMatch()).toBeDefined();
+    });
+
+    test('navigation with multiple matches in same cell', async () => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [{ field: 'value' }],
+            rowData: [{ value: 'aaa' }, { value: 'bbb' }],
+        });
+
+        api.setGridOption('findSearchValue', 'a');
+        await asyncSetTimeout(1);
+
+        // 'aaa' has 3 matches of 'a'
+        expect(api.findGetTotalMatches()).toBe(3);
+
+        // Navigate through all matches in the cell
+        api.findNext();
+        expect(api.findGetActiveMatch()!.numOverall).toBe(1);
+        expect(api.findGetActiveMatch()!.numInMatch).toBe(1);
+        expect(api.findGetActiveMatch()!.node.rowIndex).toBe(0);
+
+        api.findNext();
+        expect(api.findGetActiveMatch()!.numOverall).toBe(2);
+        expect(api.findGetActiveMatch()!.numInMatch).toBe(2);
+        expect(api.findGetActiveMatch()!.node.rowIndex).toBe(0);
+
+        api.findNext();
+        expect(api.findGetActiveMatch()!.numOverall).toBe(3);
+        expect(api.findGetActiveMatch()!.numInMatch).toBe(3);
+        expect(api.findGetActiveMatch()!.node.rowIndex).toBe(0);
+
+        // Wraps back to first match
+        api.findNext();
+        expect(api.findGetActiveMatch()!.numOverall).toBe(1);
+        expect(api.findGetActiveMatch()!.numInMatch).toBe(1);
+    });
+
+    test('navigation across multiple columns', async () => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [{ field: 'a' }, { field: 'b' }, { field: 'c' }],
+            rowData: [
+                { a: 'find', b: 'no', c: 'find' },
+                { a: 'no', b: 'find', c: 'no' },
+            ],
+        });
+
+        api.setGridOption('findSearchValue', 'find');
+        await asyncSetTimeout(1);
+
+        expect(api.findGetTotalMatches()).toBe(3);
+
+        // First match in row 0, column 'a'
+        api.findNext();
+        let match = api.findGetActiveMatch()!;
+        expect(match.numOverall).toBe(1);
+        expect(match.node.rowIndex).toBe(0);
+        expect(match.column!.getColId()).toBe('a');
+
+        // Second match in row 0, column 'c'
+        api.findNext();
+        match = api.findGetActiveMatch()!;
+        expect(match.numOverall).toBe(2);
+        expect(match.node.rowIndex).toBe(0);
+        expect(match.column!.getColId()).toBe('c');
+
+        // Third match in row 1, column 'b'
+        api.findNext();
+        match = api.findGetActiveMatch()!;
+        expect(match.numOverall).toBe(3);
+        expect(match.node.rowIndex).toBe(1);
+        expect(match.column!.getColId()).toBe('b');
+    });
+});

--- a/testing/behavioural/src/find/find-options.test.ts
+++ b/testing/behavioural/src/find/find-options.test.ts
@@ -1,0 +1,195 @@
+import { FindModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+import { expect } from '../test-utils/matchers';
+
+/**
+ * Tests for find options: case sensitivity, pagination, etc.
+ */
+describe('Find Options', () => {
+    const gridMgr = new TestGridsManager({
+        includeDefaultModules: true,
+        modules: [FindModule],
+    });
+
+    afterEach(() => {
+        gridMgr.reset();
+    });
+
+    describe('Case Sensitivity', () => {
+        test('find is case-insensitive by default', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [{ value: 'Apple' }, { value: 'APPLE' }, { value: 'apple' }, { value: 'aPpLe' }],
+            });
+
+            api.setGridOption('findSearchValue', 'apple');
+            await asyncSetTimeout(1);
+
+            // All variations should match when case-insensitive
+            expect(api.findGetTotalMatches()).toBe(4);
+        });
+
+        test('caseSensitive option makes find case-sensitive', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [{ value: 'Apple' }, { value: 'APPLE' }, { value: 'apple' }, { value: 'aPpLe' }],
+                findOptions: { caseSensitive: true },
+            });
+
+            api.setGridOption('findSearchValue', 'apple');
+            await asyncSetTimeout(1);
+
+            // Only exact case match
+            expect(api.findGetTotalMatches()).toBe(1);
+
+            // Verify it's the lowercase one
+            api.findNext();
+            const match = api.findGetActiveMatch()!;
+            expect(match.node.data.value).toBe('apple');
+        });
+
+        test('caseSensitive option can be toggled dynamically', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [{ value: 'Apple' }, { value: 'apple' }],
+            });
+
+            api.setGridOption('findSearchValue', 'Apple');
+            await asyncSetTimeout(1);
+
+            // Case-insensitive: both match
+            expect(api.findGetTotalMatches()).toBe(2);
+
+            // Enable case sensitivity
+            api.setGridOption('findOptions', { caseSensitive: true });
+            await asyncSetTimeout(1);
+
+            // Only exact case match
+            expect(api.findGetTotalMatches()).toBe(1);
+
+            // Disable case sensitivity
+            api.setGridOption('findOptions', { caseSensitive: false });
+            await asyncSetTimeout(1);
+
+            // Both match again
+            expect(api.findGetTotalMatches()).toBe(2);
+        });
+    });
+
+    describe('Pagination', () => {
+        test('currentPageOnly option limits find to current page', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [
+                    { value: 'apple' },
+                    { value: 'apple' },
+                    { value: 'banana' },
+                    { value: 'apple' },
+                    { value: 'apple' },
+                    { value: 'cherry' },
+                ],
+                pagination: true,
+                paginationPageSize: 3,
+                findOptions: { currentPageOnly: true },
+            });
+
+            api.setGridOption('findSearchValue', 'apple');
+            await asyncSetTimeout(1);
+
+            // First page has 2 apples (rows 0, 1)
+            expect(api.findGetTotalMatches()).toBe(2);
+
+            // Navigate to second page
+            api.paginationGoToPage(1);
+            await asyncSetTimeout(1);
+
+            // Second page has 2 apples (rows 3, 4)
+            api.findRefresh();
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(2);
+        });
+
+        test('find all pages when currentPageOnly is false (default)', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [
+                    { value: 'apple' },
+                    { value: 'apple' },
+                    { value: 'banana' },
+                    { value: 'apple' },
+                    { value: 'apple' },
+                    { value: 'cherry' },
+                ],
+                pagination: true,
+                paginationPageSize: 3,
+            });
+
+            api.setGridOption('findSearchValue', 'apple');
+            await asyncSetTimeout(1);
+
+            // All 4 apples across all pages
+            expect(api.findGetTotalMatches()).toBe(4);
+        });
+    });
+
+    describe('Search Value Changes', () => {
+        test('changing search value updates matches', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [{ value: 'apple' }, { value: 'banana' }, { value: 'cherry' }],
+            });
+
+            api.setGridOption('findSearchValue', 'apple');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(1);
+
+            api.setGridOption('findSearchValue', 'banana');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(1);
+
+            api.setGridOption('findSearchValue', 'a');
+            await asyncSetTimeout(1);
+            // 'apple', 'banana' contain multiple 'a's
+            // apple has 1 'a', banana has 3 'a's = 4 total
+            expect(api.findGetTotalMatches()).toBe(4);
+        });
+
+        test('empty search value clears matches', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [{ value: 'apple' }, { value: 'banana' }],
+            });
+
+            api.setGridOption('findSearchValue', 'a');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBeGreaterThan(0);
+
+            api.findNext();
+            expect(api.findGetActiveMatch()).toBeDefined();
+
+            // Clear search value
+            api.setGridOption('findSearchValue', '');
+            await asyncSetTimeout(1);
+
+            expect(api.findGetTotalMatches()).toBe(0);
+            expect(api.findGetActiveMatch()).toBeUndefined();
+        });
+
+        test('undefined search value clears matches', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [{ value: 'apple' }],
+            });
+
+            api.setGridOption('findSearchValue', 'apple');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(1);
+
+            api.setGridOption('findSearchValue', undefined);
+            await asyncSetTimeout(1);
+
+            expect(api.findGetTotalMatches()).toBe(0);
+        });
+    });
+});

--- a/testing/behavioural/src/find/find-value-formatting.test.ts
+++ b/testing/behavioural/src/find/find-value-formatting.test.ts
@@ -1,0 +1,202 @@
+import { FindModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+import { expect } from '../test-utils/matchers';
+
+/**
+ * Tests for find with value formatters, value getters, and different data types.
+ */
+describe('Find Value Formatting', () => {
+    const gridMgr = new TestGridsManager({
+        includeDefaultModules: true,
+        modules: [FindModule],
+    });
+
+    afterEach(() => {
+        gridMgr.reset();
+    });
+
+    describe('Value Formatters', () => {
+        test('find searches formatted values, not raw values', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    {
+                        field: 'price',
+                        valueFormatter: (params) => `£${params.value.toFixed(2)}`,
+                    },
+                ],
+                rowData: [{ price: 100 }, { price: 200 }, { price: 150 }],
+            });
+
+            // Search for formatted value
+            api.setGridOption('findSearchValue', '£100.00');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(1);
+
+            // Search for raw value shouldn't match the formatted display
+            api.setGridOption('findSearchValue', '100');
+            await asyncSetTimeout(1);
+            // Will match '100' in '£100.00'
+            expect(api.findGetTotalMatches()).toBe(1);
+
+            // Search for currency symbol
+            api.setGridOption('findSearchValue', '£');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(3);
+        });
+
+        test('find works with date formatters', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    {
+                        field: 'date',
+                        valueFormatter: (params) => {
+                            const d = params.value as Date;
+                            return `${d.getDate()}/${d.getMonth() + 1}/${d.getFullYear()}`;
+                        },
+                    },
+                ],
+                rowData: [
+                    { date: new Date(2024, 0, 15) },
+                    { date: new Date(2024, 5, 20) },
+                    { date: new Date(2023, 11, 25) },
+                ],
+            });
+
+            // Search for year
+            api.setGridOption('findSearchValue', '2024');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(2);
+
+            // Search for specific date format
+            api.setGridOption('findSearchValue', '15/1/2024');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(1);
+        });
+    });
+
+    describe('Value Getters', () => {
+        test('find searches computed values from valueGetter', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    { field: 'firstName' },
+                    { field: 'lastName' },
+                    {
+                        headerName: 'Full Name',
+                        valueGetter: (params) => `${params.data.firstName} ${params.data.lastName}`,
+                    },
+                ],
+                rowData: [
+                    { firstName: 'John', lastName: 'Doe' },
+                    { firstName: 'Jane', lastName: 'Smith' },
+                ],
+            });
+
+            // Search for full name (computed value)
+            api.setGridOption('findSearchValue', 'John Doe');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(1);
+
+            // Search for partial
+            api.setGridOption('findSearchValue', 'Jane');
+            await asyncSetTimeout(1);
+            // Should find in both firstName column and Full Name column
+            expect(api.findGetTotalMatches()).toBe(2);
+        });
+    });
+
+    describe('Different Data Types', () => {
+        test('find with number values', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'number' }],
+                rowData: [{ number: 123 }, { number: 456 }, { number: 1234 }, { number: 12345 }],
+            });
+
+            api.setGridOption('findSearchValue', '123');
+            await asyncSetTimeout(1);
+            // Matches '123', '1234', '12345'
+            expect(api.findGetTotalMatches()).toBe(3);
+
+            api.setGridOption('findSearchValue', '456');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(1);
+        });
+
+        // Note: boolean values without valueFormatter return empty display value
+        // Users should add a valueFormatter to search boolean values
+
+        test('find with null and undefined values', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [{ value: null }, { value: undefined }, { value: 'test' }, { value: '' }],
+            });
+
+            api.setGridOption('findSearchValue', 'test');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(1);
+
+            // Null/undefined shouldn't match anything
+            api.setGridOption('findSearchValue', 'null');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(0);
+        });
+
+        test('find with special characters', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'value' }],
+                rowData: [
+                    { value: 'hello@world.com' },
+                    { value: 'price: $100' },
+                    { value: 'test (brackets)' },
+                    { value: 'a*b+c' },
+                ],
+            });
+
+            api.setGridOption('findSearchValue', '@');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(1);
+
+            api.setGridOption('findSearchValue', '$');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(1);
+
+            api.setGridOption('findSearchValue', '(brackets)');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(1);
+
+            api.setGridOption('findSearchValue', '*');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(1);
+        });
+    });
+
+    describe('getFindText Column Option', () => {
+        test('uses getFindText when provided', async () => {
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    {
+                        field: 'value',
+                        valueFormatter: () => 'formatted',
+                        getFindText: (params) => `searchable:${params.value}`,
+                    },
+                ],
+                rowData: [{ value: 'original' }],
+            });
+
+            // Display shows 'formatted' but search uses getFindText result
+            api.setGridOption('findSearchValue', 'searchable');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(1);
+
+            // Shouldn't find the formatted display value
+            api.setGridOption('findSearchValue', 'formatted');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(0);
+
+            // Can search for original value via getFindText
+            api.setGridOption('findSearchValue', 'original');
+            await asyncSetTimeout(1);
+            expect(api.findGetTotalMatches()).toBe(1);
+        });
+    });
+});


### PR DESCRIPTION
We want 'batch' for both find and clipboard copy, that means, the values that are in the batch, if we are in batch mode, or in the data, if not, but not in the editor cells

- Fix the exporter to accept a valueFrom to specify if we want to export 'edit' 'batch' or 'data', optional, needed by cliphoard
- Fix a bug in the find service not registering to batch edit events so not resetting the cache
- Change the find servide to use 'batch' instead of 'edit'
- Add tests
- Improve instructions around testing

FIX AG-16448