### PR TITLE
Fix codex-pr-review: stale inline comments and reaction placement

### DIFF
--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = 90555b1f12361df49f32638fbfa20229cfda8738
-	parent = fd29b9f4fefd12ae8321c823ac36369ce85e9e4f
+	commit = ab1f679dead48d6c89a2fbbf4b7e87dad0014aff
+	parent = 180cd088d2eb877f8630923b5c07d18008f6f3ed
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/github/actions/codex-pr-review/action.yml
+++ b/external/ag-shared/github/actions/codex-pr-review/action.yml
@@ -1,5 +1,23 @@
 name: codex-pr-review
 description: Run a Codex PR review with complete log suppression - no LLM output appears in workflow logs
+#
+# Flow Overview:
+#
+# 1. TRIGGER: PR opened/ready, `/pr-review` command comment, or manual dispatch
+# 2. REACT STARTED: Add 👀 reaction to the PR description to signal review in progress
+# 3. FETCH & REVIEW: Fetch PR refs, install tools, run Codex review
+# 4. CLEANUP OLD COMMENTS: Delete stale bot inline review comments from prior runs
+#    (only those with no user reactions or replies - preserving conversations)
+# 5. POST RESULTS: Create/update summary comment (<!-- codex-pr-review --> marker)
+#    and post new inline comments on specific file/line locations
+# 6. REACT COMPLETE: Remove 👀 from PR description, add 👍 on success
+# 7. CLEANUP FILES: Remove sensitive review output and auth files
+#
+# Re-review behaviour:
+# - Summary comment is updated in-place (found via marker)
+# - Old inline comments are deleted (unless users have reacted/replied)
+# - Reactions target the PR description, not the trigger comment
+#
 inputs:
     openai-api-key:
         description: 'OpenAI API key for Codex CLI (alternative to codex-auth-json-b64)'
@@ -28,7 +46,7 @@ inputs:
         required: false
         default: 'false'
     comment-id:
-        description: 'Comment ID to add reactions to (for issue_comment triggers)'
+        description: 'Deprecated - reactions now target the PR description. Kept for backwards compatibility.'
         required: false
         default: ''
     base-ref:
@@ -72,20 +90,22 @@ runs:
               fi
 
         - name: React Started
-          if: inputs.comment-id != '' && steps.check-auth.outputs.skipped != 'true'
+          if: steps.check-auth.outputs.skipped != 'true'
+          id: react-started
           uses: actions/github-script@v7
           continue-on-error: true
           env:
-              COMMENT_ID: ${{ inputs.comment-id }}
+              PR_NUMBER: ${{ inputs.pr-number }}
           with:
               github-token: ${{ inputs.github-token }}
               script: |
-                  await github.rest.reactions.createForIssueComment({
+                  const { data: reaction } = await github.rest.reactions.createForIssue({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    comment_id: parseInt(process.env.COMMENT_ID, 10),
+                    issue_number: parseInt(process.env.PR_NUMBER, 10),
                     content: 'eyes'
                   });
+                  core.setOutput('reaction_id', reaction.id);
 
         - name: Fetch PR refs
           if: steps.check-auth.outputs.skipped != 'true'
@@ -460,6 +480,51 @@ runs:
                     reviewBody = rawContent;
                   }
 
+                  // Clean up old inline review comments from previous Codex reviews
+                  // Only remove comments with no user reactions or replies (preserving conversations)
+                  try {
+                    const allReviewComments = await github.paginate(
+                      github.rest.pulls.listReviewComments,
+                      {
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        pull_number: prNumber,
+                        per_page: 100
+                      }
+                    );
+                    const botComments = allReviewComments.filter(c => c.user.login === 'github-actions[bot]');
+                    const nonBotComments = allReviewComments.filter(c => c.user.login !== 'github-actions[bot]');
+
+                    // Build set of bot comment IDs that have user replies
+                    const repliedToIds = new Set(
+                      nonBotComments
+                        .filter(c => c.in_reply_to_id)
+                        .map(c => c.in_reply_to_id)
+                    );
+
+                    let deleted = 0;
+                    let preserved = 0;
+                    for (const comment of botComments) {
+                      const hasUserReply = repliedToIds.has(comment.id);
+                      const hasReactions = (comment.reactions?.total_count || 0) > 0;
+                      if (!hasUserReply && !hasReactions) {
+                        await github.rest.pulls.deleteReviewComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          comment_id: comment.id
+                        });
+                        deleted++;
+                      } else {
+                        preserved++;
+                      }
+                    }
+                    if (deleted > 0 || preserved > 0) {
+                      console.log(`Cleaned up ${deleted} old inline review comments (preserved ${preserved} with user interactions)`);
+                    }
+                  } catch (e) {
+                    console.log(`Warning: Failed to clean up old review comments: ${e.message}`);
+                  }
+
                   // Post inline comments as a review if we have any
                   if (inlineReviewComments.length > 0) {
                     try {
@@ -518,19 +583,36 @@ runs:
                     console.log('Created new review comment');
                   }
 
-        - name: React Success
-          if: steps.check-auth.outputs.skipped != 'true' && inputs.comment-id != '' && steps.verify.outputs.success == 'true'
+        - name: Remove Eyes Reaction
+          if: always() && steps.check-auth.outputs.skipped != 'true' && steps.react-started.outputs.reaction_id != ''
           uses: actions/github-script@v7
           continue-on-error: true
           env:
-              COMMENT_ID: ${{ inputs.comment-id }}
+              PR_NUMBER: ${{ inputs.pr-number }}
+              REACTION_ID: ${{ steps.react-started.outputs.reaction_id }}
           with:
               github-token: ${{ inputs.github-token }}
               script: |
-                  await github.rest.reactions.createForIssueComment({
+                  await github.rest.reactions.deleteForIssue({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    comment_id: parseInt(process.env.COMMENT_ID, 10),
+                    issue_number: parseInt(process.env.PR_NUMBER, 10),
+                    reaction_id: parseInt(process.env.REACTION_ID, 10)
+                  });
+
+        - name: React Success
+          if: steps.check-auth.outputs.skipped != 'true' && steps.verify.outputs.success == 'true'
+          uses: actions/github-script@v7
+          continue-on-error: true
+          env:
+              PR_NUMBER: ${{ inputs.pr-number }}
+          with:
+              github-token: ${{ inputs.github-token }}
+              script: |
+                  await github.rest.reactions.createForIssue({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: parseInt(process.env.PR_NUMBER, 10),
                     content: '+1'
                   });
 

--- a/external/ag-shared/github/actions/codex-pr-review/action.yml
+++ b/external/ag-shared/github/actions/codex-pr-review/action.yml
@@ -401,7 +401,7 @@ runs:
                             path: finding.file,
                             line: finding.end_line || finding.line,
                             side: 'RIGHT',
-                            body: `${priorityEmoji} **[${finding.priority}] ${finding.title}**\n\n${finding.description}`
+                            body: `${priorityEmoji} **[${finding.priority}] ${finding.title}**\n\n${finding.description}\n\n${commentMarker}`
                           };
 
                           // For multi-line comments, add start_line and start_side
@@ -492,7 +492,7 @@ runs:
                         per_page: 100
                       }
                     );
-                    const botComments = allReviewComments.filter(c => c.user.login === 'github-actions[bot]');
+                    const botComments = allReviewComments.filter(c => c.user.login === 'github-actions[bot]' && c.body.includes(commentMarker));
                     const nonBotComments = allReviewComments.filter(c => c.user.login !== 'github-actions[bot]');
 
                     // Build set of bot comment IDs that have user replies


### PR DESCRIPTION
## Summary

- **Clean up stale inline review comments on re-review**: Before posting new inline comments, the action now deletes old bot review comments from previous runs. Comments with user reactions or replies are preserved to maintain conversations.
- **Move reaction icons to PR description**: The 👀 and 👍 reactions now target the PR description (where they used to be) instead of the `/pr-review` command comment. The 👀 reaction is properly removed when the review completes (even on failure).
- **Add flow documentation**: Added a comment block at the top of the action documenting the expected interaction flow for future maintainers.

Addresses feedback from PR #13080.

## Test plan

- [ ] Create a test PR with intentional issues, run `/pr-review` to get inline comments
- [ ] Fix the issues, run `/pr-review` again — verify old inline comments without user interaction are removed and new summary shows ✅
- [ ] Verify 👀 appears on PR description during review, is removed when done, and 👍 appears on PR description on success
- [ ] Reply to or react on an inline comment, re-run `/pr-review` — verify that comment is preserved