### PR TITLE
RTI-3233 aggregation formatting bug

### DIFF
--- a/packages/ag-grid-community/src/columns/dataTypeService.ts
+++ b/packages/ag-grid-community/src/columns/dataTypeService.ts
@@ -792,7 +792,8 @@ function validateDataTypeDefinition(
     return true;
 }
 
-const numberOrBigint = (v: unknown) => typeof v === 'bigint' || typeof v === 'number';
+const isNumberOrBigintType = (v: unknown) => typeof v === 'bigint' || typeof v === 'number';
+const isNumberOrBigintBaseDataType = (v: string) => v === 'number' || v === 'bigint';
 
 function createGroupSafeValueFormatter(
     dataTypeDefinition: DataTypeDefinition | CoreDataTypeDefinition,
@@ -814,8 +815,8 @@ function createGroupSafeValueFormatter(
                 }
 
                 const { baseDataType } = dataTypeDefinition;
-                if (numberOrBigint(baseDataType) && aggFunc !== 'count') {
-                    if (numberOrBigint(value)) {
+                if (isNumberOrBigintBaseDataType(baseDataType) && aggFunc !== 'count') {
+                    if (isNumberOrBigintType(value)) {
                         return dataTypeDefinition.valueFormatter!(params);
                     }
 
@@ -825,12 +826,12 @@ function createGroupSafeValueFormatter(
                     let val = value.value;
                     if (typeof value.toNumber === 'function') {
                         val = value.toNumber();
-                    } else if ('value' in value && (numberOrBigint(val) || val == null)) {
+                    } else if ('value' in value && (isNumberOrBigintType(val) || val == null)) {
                         val = value.value;
                     } else {
                         val = null;
                     }
-                    if (val) {
+                    if (val != null) {
                         return dataTypeDefinition.valueFormatter!({ ...params, value: val });
                     }
                 }

--- a/packages/ag-grid-community/src/columns/dataTypeService.ts
+++ b/packages/ag-grid-community/src/columns/dataTypeService.ts
@@ -820,19 +820,18 @@ function createGroupSafeValueFormatter(
                         return dataTypeDefinition.valueFormatter!(params);
                     }
 
-                    if (typeof value !== 'object' || !value) {
+                    if (value == null) {
                         return undefined;
                     }
-                    let val = value.value;
-                    if (typeof value.toNumber === 'function') {
-                        val = value.toNumber();
-                    } else if ('value' in value && (isNumberOrBigintType(val) || val == null)) {
-                        val = value.value;
-                    } else {
-                        val = null;
-                    }
-                    if (val != null) {
-                        return dataTypeDefinition.valueFormatter!({ ...params, value: val });
+
+                    if (typeof value === 'object') {
+                        if (typeof value.toNumber === 'function') {
+                            return dataTypeDefinition.valueFormatter!({ ...params, value: value.toNumber() });
+                        }
+
+                        if ('value' in value) {
+                            return dataTypeDefinition.valueFormatter!({ ...params, value: value.value });
+                        }
                     }
                 }
 

--- a/testing/behavioural/src/grouping-data/grouping-aggregation-custom-object-display.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-aggregation-custom-object-display.test.ts
@@ -4,13 +4,27 @@ import { RowGroupingModule } from 'ag-grid-enterprise';
 
 import { GridRows, TestGridsManager } from '../test-utils';
 
-/** Custom aggFunc that returns an object with .value for display, as shown in the docs example */
+/** Custom aggFunc that returns an object with .value for display, as shown in the docs example.
+ * Also validates that aggregatedChildren is correctly populated. */
 function rangeAggFunc(params: IAggFuncParams): { max: number; min: number; value: number } {
-    const values = params.values;
+    const { values, aggregatedChildren } = params;
+    // aggregatedChildren should always be a non-empty array
+    expect(aggregatedChildren).toBeInstanceOf(Array);
+    expect(aggregatedChildren.length).toBeGreaterThan(0);
+
     if (params.rowNode.leafGroup) {
+        // For leaf groups, aggregatedChildren should be the data rows
+        for (const child of aggregatedChildren) {
+            expect(child.group).toBe(false);
+            expect(child.data).toBeDefined();
+        }
         const max = Math.max(...values);
         const min = Math.min(...values);
         return { max, min, value: max - min };
+    }
+    // For non-leaf groups, aggregatedChildren should be the child groups
+    for (const child of aggregatedChildren) {
+        expect(child.group).toBe(true);
     }
     let max = values[0].max;
     let min = values[0].min;
@@ -72,30 +86,14 @@ describe('ag-grid grouping custom aggregation object display value', () => {
             · └── LEAF id:uk-2 country:"UK" rangeTotal:25
         `);
 
+        // The raw aggData should still be the full object (needed for multi-level aggregation)
         const irelandGroupNode = findGroupRow(api, 'Ireland');
         const ukGroupNode = findGroupRow(api, 'UK');
-
-        // The raw aggData should still be the full object (needed for multi-level aggregation)
         expect(irelandGroupNode.aggData?.rangeTotal).toEqual({ max: 30, min: 10, value: 20 });
         expect(ukGroupNode.aggData?.rangeTotal).toEqual({ max: 25, min: 5, value: 20 });
-
-        // getCellValue with useFormatter: true should unwrap .value via groupSafeValueFormatter
-        // and NOT produce [object Object]
-        const irelandFormatted = api.getCellValue({
-            rowNode: irelandGroupNode,
-            colKey: 'rangeTotal',
-            useFormatter: true,
-        });
-        const ukFormatted = api.getCellValue({ rowNode: ukGroupNode, colKey: 'rangeTotal', useFormatter: true });
-
-        expect(irelandFormatted).not.toContain('[object Object]');
-        expect(ukFormatted).not.toContain('[object Object]');
-        expect(irelandFormatted).toBe('20');
-        expect(ukFormatted).toBe('20');
     });
 
-    test('groupSafeValueFormatter unwraps .value and passes it to user-supplied valueFormatter', () => {
-        const formatterCalls: any[] = [];
+    test('user-supplied valueFormatter that handles group objects shows unwrapped values', async () => {
         const api = gridMgr.createGrid('grouping-agg-object-display-formatter', {
             columnDefs: [
                 { field: 'country', rowGroup: true, hide: true },
@@ -103,8 +101,11 @@ describe('ag-grid grouping custom aggregation object display value', () => {
                     field: 'total',
                     colId: 'rangeTotal',
                     valueFormatter: (params) => {
-                        formatterCalls.push(params.value);
-                        return `Range: ${params.value}`;
+                        const val =
+                            typeof params.value === 'object' && params.value != null && 'value' in params.value
+                                ? params.value.value
+                                : params.value;
+                        return `Range: ${val}`;
                     },
                     aggFunc: rangeAggFunc,
                 },
@@ -121,19 +122,16 @@ describe('ag-grid grouping custom aggregation object display value', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const irelandGroupNode = findGroupRow(api, 'Ireland');
-
-        // The user-supplied valueFormatter receives the raw object because the user controls formatting.
-        // The groupSafeValueFormatter only applies to inferred formatters from DataTypeService.
-        const irelandFormatted = api.getCellValue({
-            rowNode: irelandGroupNode,
-            colKey: 'rangeTotal',
-            useFormatter: true,
-        });
-        // With a user-supplied formatter, the grid passes the raw value (the result of aggFunc)
-        // The user's formatter is responsible for handling it appropriately
-        expect(irelandFormatted).toBeDefined();
-        expect(formatterCalls.length).toBeGreaterThan(0);
+        // User-supplied formatter that handles groups correctly shows the unwrapped value
+        await new GridRows(api, 'group-aware user formatter grouping').check(`
+            ROOT id:ROOT_NODE_ID rangeTotal:"Range: undefined"
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland" rangeTotal:"Range: 20"
+            │ ├── LEAF id:ie-1 country:"Ireland" rangeTotal:"Range: 10"
+            │ └── LEAF id:ie-2 country:"Ireland" rangeTotal:"Range: 30"
+            └─┬ LEAF_GROUP id:row-group-country-UK ag-Grid-AutoColumn:"UK" rangeTotal:"Range: 20"
+            · ├── LEAF id:uk-1 country:"UK" rangeTotal:"Range: 5"
+            · └── LEAF id:uk-2 country:"UK" rangeTotal:"Range: 25"
+        `);
     });
 
     test('does not unwrap .value for leaf row data', () => {
@@ -171,7 +169,7 @@ describe('ag-grid grouping custom aggregation object display value', () => {
         expect(leafValue).toEqual({ value: 42, extra: 'data' });
     });
 
-    test('groupSafeValueFormatter unwraps .value in multi-level group aggregation', () => {
+    test('groupSafeValueFormatter unwraps .value in multi-level group aggregation', async () => {
         const api = gridMgr.createGrid('grouping-agg-object-multi-level', {
             columnDefs: [
                 { field: 'country', rowGroup: true, hide: true },
@@ -190,30 +188,19 @@ describe('ag-grid grouping custom aggregation object display value', () => {
             getRowId: (params) => params.data.id,
         });
 
-        // Top-level group (Ireland) - multi-level aggregation
-        const irelandGroup = findGroupRow(api, 'Ireland');
-
-        // The formatted display value should be the unwrapped .value, not [object Object]
-        const topLevelFormatted = api.getCellValue({
-            rowNode: irelandGroup,
-            colKey: 'rangeTotal',
-            useFormatter: true,
-        });
-        expect(topLevelFormatted).not.toContain('[object Object]');
-        expect(topLevelFormatted).toBe('45'); // max=50, min=5, range=45
-
-        // Sub-group (Ireland > 2020)
-        const year2020Group = findGroupRow(api, '2020');
-        const subGroupFormatted = api.getCellValue({
-            rowNode: year2020Group,
-            colKey: 'rangeTotal',
-            useFormatter: true,
-        });
-        expect(subGroupFormatted).not.toContain('[object Object]');
-        expect(subGroupFormatted).toBe('20'); // max=30, min=10, range=20
+        await new GridRows(api, 'multi-level grouping').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ filler id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland" rangeTotal:"45"
+            · ├─┬ LEAF_GROUP id:row-group-country-Ireland-year-2020 ag-Grid-AutoColumn:2020 rangeTotal:"20"
+            · │ ├── LEAF id:ie-2020-1 country:"Ireland" year:2020 rangeTotal:10
+            · │ └── LEAF id:ie-2020-2 country:"Ireland" year:2020 rangeTotal:30
+            · └─┬ LEAF_GROUP id:row-group-country-Ireland-year-2021 ag-Grid-AutoColumn:2021 rangeTotal:"45"
+            · · ├── LEAF id:ie-2021-1 country:"Ireland" year:2021 rangeTotal:5
+            · · └── LEAF id:ie-2021-2 country:"Ireland" year:2021 rangeTotal:50
+        `);
     });
 
-    test('groupSafeValueFormatter handles .value === 0 correctly', () => {
+    test('groupSafeValueFormatter handles .value === 0 correctly', async () => {
         const api = gridMgr.createGrid('grouping-agg-object-zero-value', {
             columnDefs: [
                 { field: 'country', rowGroup: true, hide: true },
@@ -229,15 +216,155 @@ describe('ag-grid grouping custom aggregation object display value', () => {
             getRowId: (params) => params.data.id,
         });
 
+        // value === 0 should still be formatted, not skipped as falsy
+        await new GridRows(api, 'zero value grouping').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland" rangeTotal:"0"
+            · ├── LEAF id:ie-1 country:"Ireland" rangeTotal:5
+            · └── LEAF id:ie-2 country:"Ireland" rangeTotal:5
+        `);
+
+        // Verify the raw aggData preserves the full object
         const irelandGroup = findGroupRow(api, 'Ireland');
         expect(irelandGroup.aggData?.rangeTotal).toEqual({ max: 5, min: 5, value: 0 });
+    });
 
-        // value === 0 should still be formatted, not skipped as falsy
+    test('groupSafeValueFormatter unwraps .value from bigint aggregation results', () => {
+        const bigintRangeAggFunc = (params: IAggFuncParams) => {
+            const { values } = params;
+            if (typeof values[0] === 'bigint') {
+                const max = values.reduce((a: bigint, b: bigint) => (a > b ? a : b));
+                const min = values.reduce((a: bigint, b: bigint) => (a < b ? a : b));
+                return { max, min, value: max - min };
+            }
+            let max = values[0].max as bigint;
+            let min = values[0].min as bigint;
+            for (const v of values) {
+                if (v.max > max) {
+                    max = v.max;
+                }
+                if (v.min < min) {
+                    min = v.min;
+                }
+            }
+            return { max, min, value: max - min };
+        };
+
+        const api = gridMgr.createGrid('grouping-bigint-agg', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'amount', colId: 'rangeAmount', cellDataType: 'bigint', aggFunc: bigintRangeAggFunc },
+            ],
+            defaultColDef: { flex: 1 },
+            autoGroupColumnDef: { minWidth: 220 },
+            groupDefaultExpanded: -1,
+            rowData: [
+                { id: 'ie-1', country: 'Ireland', amount: 10n },
+                { id: 'ie-2', country: 'Ireland', amount: 30n },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        const irelandGroup = findGroupRow(api, 'Ireland');
+        expect(irelandGroup.aggData?.rangeAmount).toEqual({ max: 30n, min: 10n, value: 20n });
+
+        // The groupSafeValueFormatter should unwrap .value (20n) and pass it to the bigint formatter
         const formatted = api.getCellValue({
             rowNode: irelandGroup,
-            colKey: 'rangeTotal',
+            colKey: 'rangeAmount',
+            useFormatter: true,
+        });
+        expect(formatted).toBe('20');
+    });
+
+    test('groupSafeValueFormatter handles bigint .value === 0n correctly', () => {
+        const bigintZeroAggFunc = (params: IAggFuncParams) => {
+            const { values } = params;
+            const max = values.reduce((a: bigint, b: bigint) => (a > b ? a : b));
+            const min = values.reduce((a: bigint, b: bigint) => (a < b ? a : b));
+            return { max, min, value: max - min };
+        };
+
+        const api = gridMgr.createGrid('grouping-bigint-zero', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'amount', colId: 'rangeAmount', cellDataType: 'bigint', aggFunc: bigintZeroAggFunc },
+            ],
+            defaultColDef: { flex: 1 },
+            groupDefaultExpanded: -1,
+            rowData: [
+                { id: 'ie-1', country: 'Ireland', amount: 5n },
+                { id: 'ie-2', country: 'Ireland', amount: 5n },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        const irelandGroup = findGroupRow(api, 'Ireland');
+        expect(irelandGroup.aggData?.rangeAmount).toEqual({ max: 5n, min: 5n, value: 0n });
+
+        // BigInt zero (0n) should still be formatted, not skipped as falsy
+        const formatted = api.getCellValue({
+            rowNode: irelandGroup,
+            colKey: 'rangeAmount',
             useFormatter: true,
         });
         expect(formatted).toBe('0');
+    });
+
+    test('groupSafeValueFormatter calls formatter when .value is null (v35.0.0 compat)', () => {
+        const nullValueAggFunc = () => ({ value: null });
+
+        const api = gridMgr.createGrid('grouping-agg-null-value', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'total', colId: 'nullTotal', aggFunc: nullValueAggFunc },
+            ],
+            defaultColDef: { flex: 1 },
+            groupDefaultExpanded: -1,
+            rowData: [
+                { id: 'ie-1', country: 'Ireland', total: 10 },
+                { id: 'ie-2', country: 'Ireland', total: 30 },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        const irelandGroup = findGroupRow(api, 'Ireland');
+        // v35.0.0 behavior: formatter is called with null, default number formatter returns ''
+        const formatted = api.getCellValue({
+            rowNode: irelandGroup,
+            colKey: 'nullTotal',
+            useFormatter: true,
+        });
+        expect(formatted).toBe('');
+    });
+
+    test('groupSafeValueFormatter calls toNumber() for BigDecimal-like aggregation results', () => {
+        const toNumberAggFunc = (params: IAggFuncParams) => {
+            const sum = params.values.reduce((a: number, b: number) => a + b, 0);
+            return { toNumber: () => sum };
+        };
+
+        const api = gridMgr.createGrid('grouping-agg-toNumber', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'total', colId: 'sumTotal', aggFunc: toNumberAggFunc },
+            ],
+            defaultColDef: { flex: 1 },
+            groupDefaultExpanded: -1,
+            rowData: [
+                { id: 'ie-1', country: 'Ireland', total: 10 },
+                { id: 'ie-2', country: 'Ireland', total: 30 },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        const irelandGroup = findGroupRow(api, 'Ireland');
+        // toNumber() should be called and its result passed to formatter
+        const formatted = api.getCellValue({
+            rowNode: irelandGroup,
+            colKey: 'sumTotal',
+            useFormatter: true,
+        });
+        expect(formatted).toBe('40');
     });
 });

--- a/testing/behavioural/src/grouping-data/grouping-aggregation-custom-object-display.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-aggregation-custom-object-display.test.ts
@@ -1,0 +1,243 @@
+import type { GridApi, IAggFuncParams, IRowNode } from 'ag-grid-community';
+import { ClientSideRowModelModule } from 'ag-grid-community';
+import { RowGroupingModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager } from '../test-utils';
+
+/** Custom aggFunc that returns an object with .value for display, as shown in the docs example */
+function rangeAggFunc(params: IAggFuncParams): { max: number; min: number; value: number } {
+    const values = params.values;
+    if (params.rowNode.leafGroup) {
+        const max = Math.max(...values);
+        const min = Math.min(...values);
+        return { max, min, value: max - min };
+    }
+    let max = values[0].max;
+    let min = values[0].min;
+    values.forEach((v: any) => {
+        max = Math.max(max, v.max);
+        min = Math.min(min, v.min);
+    });
+    return { max, min, value: max - min };
+}
+
+/** Find the first displayed group row with the given key */
+function findGroupRow(api: GridApi, key: string): IRowNode {
+    let found: IRowNode | undefined;
+    api.forEachNode((node) => {
+        if (node.group && node.key === key && !found) {
+            found = node;
+        }
+    });
+    if (!found) {
+        throw new Error(`Group row with key '${key}' not found`);
+    }
+    return found;
+}
+
+describe('ag-grid grouping custom aggregation object display value', () => {
+    const gridMgr = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule],
+    });
+
+    afterEach(() => {
+        gridMgr.reset();
+    });
+
+    test('groupSafeValueFormatter unwraps .value from aggregation result objects for display', async () => {
+        const api = gridMgr.createGrid('grouping-agg-object-display', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'total', colId: 'rangeTotal', aggFunc: rangeAggFunc },
+            ],
+            defaultColDef: { flex: 1 },
+            autoGroupColumnDef: { minWidth: 220 },
+            groupDefaultExpanded: -1,
+            rowData: [
+                { id: 'ie-1', country: 'Ireland', total: 10 },
+                { id: 'ie-2', country: 'Ireland', total: 30 },
+                { id: 'uk-1', country: 'UK', total: 5 },
+                { id: 'uk-2', country: 'UK', total: 25 },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        await new GridRows(api, 'formatted grouping').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland" rangeTotal:"20"
+            │ ├── LEAF id:ie-1 country:"Ireland" rangeTotal:10
+            │ └── LEAF id:ie-2 country:"Ireland" rangeTotal:30
+            └─┬ LEAF_GROUP id:row-group-country-UK ag-Grid-AutoColumn:"UK" rangeTotal:"20"
+            · ├── LEAF id:uk-1 country:"UK" rangeTotal:5
+            · └── LEAF id:uk-2 country:"UK" rangeTotal:25
+        `);
+
+        const irelandGroupNode = findGroupRow(api, 'Ireland');
+        const ukGroupNode = findGroupRow(api, 'UK');
+
+        // The raw aggData should still be the full object (needed for multi-level aggregation)
+        expect(irelandGroupNode.aggData?.rangeTotal).toEqual({ max: 30, min: 10, value: 20 });
+        expect(ukGroupNode.aggData?.rangeTotal).toEqual({ max: 25, min: 5, value: 20 });
+
+        // getCellValue with useFormatter: true should unwrap .value via groupSafeValueFormatter
+        // and NOT produce [object Object]
+        const irelandFormatted = api.getCellValue({
+            rowNode: irelandGroupNode,
+            colKey: 'rangeTotal',
+            useFormatter: true,
+        });
+        const ukFormatted = api.getCellValue({ rowNode: ukGroupNode, colKey: 'rangeTotal', useFormatter: true });
+
+        expect(irelandFormatted).not.toContain('[object Object]');
+        expect(ukFormatted).not.toContain('[object Object]');
+        expect(irelandFormatted).toBe('20');
+        expect(ukFormatted).toBe('20');
+    });
+
+    test('groupSafeValueFormatter unwraps .value and passes it to user-supplied valueFormatter', () => {
+        const formatterCalls: any[] = [];
+        const api = gridMgr.createGrid('grouping-agg-object-display-formatter', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                {
+                    field: 'total',
+                    colId: 'rangeTotal',
+                    valueFormatter: (params) => {
+                        formatterCalls.push(params.value);
+                        return `Range: ${params.value}`;
+                    },
+                    aggFunc: rangeAggFunc,
+                },
+            ],
+            defaultColDef: { flex: 1 },
+            autoGroupColumnDef: { minWidth: 220 },
+            groupDefaultExpanded: -1,
+            rowData: [
+                { id: 'ie-1', country: 'Ireland', total: 10 },
+                { id: 'ie-2', country: 'Ireland', total: 30 },
+                { id: 'uk-1', country: 'UK', total: 5 },
+                { id: 'uk-2', country: 'UK', total: 25 },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        const irelandGroupNode = findGroupRow(api, 'Ireland');
+
+        // The user-supplied valueFormatter receives the raw object because the user controls formatting.
+        // The groupSafeValueFormatter only applies to inferred formatters from DataTypeService.
+        const irelandFormatted = api.getCellValue({
+            rowNode: irelandGroupNode,
+            colKey: 'rangeTotal',
+            useFormatter: true,
+        });
+        // With a user-supplied formatter, the grid passes the raw value (the result of aggFunc)
+        // The user's formatter is responsible for handling it appropriately
+        expect(irelandFormatted).toBeDefined();
+        expect(formatterCalls.length).toBeGreaterThan(0);
+    });
+
+    test('does not unwrap .value for leaf row data', () => {
+        const api = gridMgr.createGrid('grouping-agg-object-leaf-noop', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                {
+                    field: 'stats',
+                    colId: 'stats',
+                    valueFormatter: (params) => JSON.stringify(params.value),
+                    aggFunc: 'first',
+                },
+            ],
+            defaultColDef: { flex: 1 },
+            groupDefaultExpanded: -1,
+            rowData: [
+                { id: 'ie-1', country: 'Ireland', stats: { value: 42, extra: 'data' } },
+                { id: 'ie-2', country: 'Ireland', stats: { value: 99, extra: 'more' } },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        // Find a leaf row
+        let leafNode: IRowNode | undefined;
+        api.forEachNode((node) => {
+            if (!node.group && !leafNode) {
+                leafNode = node;
+            }
+        });
+        expect(leafNode).toBeDefined();
+        expect(leafNode!.group).toBe(false);
+
+        // Leaf rows should still return the raw object (not unwrapped)
+        const leafValue = api.getCellValue({ rowNode: leafNode!, colKey: 'stats', useFormatter: false });
+        expect(leafValue).toEqual({ value: 42, extra: 'data' });
+    });
+
+    test('groupSafeValueFormatter unwraps .value in multi-level group aggregation', () => {
+        const api = gridMgr.createGrid('grouping-agg-object-multi-level', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', rowGroup: true, hide: true },
+                { field: 'total', colId: 'rangeTotal', aggFunc: rangeAggFunc },
+            ],
+            defaultColDef: { flex: 1 },
+            autoGroupColumnDef: { minWidth: 220 },
+            groupDefaultExpanded: -1,
+            rowData: [
+                { id: 'ie-2020-1', country: 'Ireland', year: 2020, total: 10 },
+                { id: 'ie-2020-2', country: 'Ireland', year: 2020, total: 30 },
+                { id: 'ie-2021-1', country: 'Ireland', year: 2021, total: 5 },
+                { id: 'ie-2021-2', country: 'Ireland', year: 2021, total: 50 },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        // Top-level group (Ireland) - multi-level aggregation
+        const irelandGroup = findGroupRow(api, 'Ireland');
+
+        // The formatted display value should be the unwrapped .value, not [object Object]
+        const topLevelFormatted = api.getCellValue({
+            rowNode: irelandGroup,
+            colKey: 'rangeTotal',
+            useFormatter: true,
+        });
+        expect(topLevelFormatted).not.toContain('[object Object]');
+        expect(topLevelFormatted).toBe('45'); // max=50, min=5, range=45
+
+        // Sub-group (Ireland > 2020)
+        const year2020Group = findGroupRow(api, '2020');
+        const subGroupFormatted = api.getCellValue({
+            rowNode: year2020Group,
+            colKey: 'rangeTotal',
+            useFormatter: true,
+        });
+        expect(subGroupFormatted).not.toContain('[object Object]');
+        expect(subGroupFormatted).toBe('20'); // max=30, min=10, range=20
+    });
+
+    test('groupSafeValueFormatter handles .value === 0 correctly', () => {
+        const api = gridMgr.createGrid('grouping-agg-object-zero-value', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'total', colId: 'rangeTotal', aggFunc: rangeAggFunc },
+            ],
+            defaultColDef: { flex: 1 },
+            autoGroupColumnDef: { minWidth: 220 },
+            groupDefaultExpanded: -1,
+            rowData: [
+                { id: 'ie-1', country: 'Ireland', total: 5 },
+                { id: 'ie-2', country: 'Ireland', total: 5 }, // same values -> range = 0
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        const irelandGroup = findGroupRow(api, 'Ireland');
+        expect(irelandGroup.aggData?.rangeTotal).toEqual({ max: 5, min: 5, value: 0 });
+
+        // value === 0 should still be formatted, not skipped as falsy
+        const formatted = api.getCellValue({
+            rowNode: irelandGroup,
+            colKey: 'rangeTotal',
+            useFormatter: true,
+        });
+        expect(formatted).toBe('0');
+    });
+});

--- a/testing/behavioural/src/tree-data/tree-data-aggregation-custom-object-display.test.ts
+++ b/testing/behavioural/src/tree-data/tree-data-aggregation-custom-object-display.test.ts
@@ -1,0 +1,242 @@
+import type { GridApi, IAggFuncParams, IRowNode } from 'ag-grid-community';
+import { ClientSideRowModelModule } from 'ag-grid-community';
+import { TreeDataModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager } from '../test-utils';
+
+/** Custom aggFunc that returns an object with .value for display.
+ * Uses typeof check instead of leafGroup since filler nodes in tree data don't have leafGroup set. */
+function rangeAggFunc(params: IAggFuncParams): { max: number; min: number; value: number } {
+    const values = params.values;
+    if (typeof values[0] === 'number') {
+        const max = Math.max(...values);
+        const min = Math.min(...values);
+        return { max, min, value: max - min };
+    }
+    let max = values[0].max;
+    let min = values[0].min;
+    values.forEach((v: any) => {
+        max = Math.max(max, v.max);
+        min = Math.min(min, v.min);
+    });
+    return { max, min, value: max - min };
+}
+
+/** Find the first displayed group row with the given key */
+function findGroupRow(api: GridApi, key: string): IRowNode {
+    let found: IRowNode | undefined;
+    api.forEachNode((node) => {
+        if (node.group && node.key === key && !found) {
+            found = node;
+        }
+    });
+    if (!found) {
+        throw new Error(`Group row with key '${key}' not found`);
+    }
+    return found;
+}
+
+describe('ag-grid tree data custom aggregation object display value', () => {
+    const gridMgr = new TestGridsManager({
+        modules: [ClientSideRowModelModule, TreeDataModule],
+    });
+
+    afterEach(() => {
+        gridMgr.reset();
+    });
+
+    test('groupSafeValueFormatter unwraps .value from aggregation result objects for display', async () => {
+        const api = gridMgr.createGrid('tree-data-agg-object-display', {
+            columnDefs: [{ field: 'total', colId: 'rangeTotal', aggFunc: rangeAggFunc }],
+            defaultColDef: { flex: 1 },
+            autoGroupColumnDef: { minWidth: 220 },
+            groupDefaultExpanded: -1,
+            treeData: true,
+            getDataPath: (data) => data.path,
+            rowData: [
+                { id: 'ie-1', path: ['Ireland', 'Row1'], total: 10 },
+                { id: 'ie-2', path: ['Ireland', 'Row2'], total: 30 },
+                { id: 'uk-1', path: ['UK', 'Row1'], total: 5 },
+                { id: 'uk-2', path: ['UK', 'Row2'], total: 25 },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        await new GridRows(api, 'formatted tree data').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ Ireland filler id:row-group-0-Ireland ag-Grid-AutoColumn:"Ireland" rangeTotal:"20"
+            │ ├── Row1 LEAF id:ie-1 ag-Grid-AutoColumn:"Row1" rangeTotal:10
+            │ └── Row2 LEAF id:ie-2 ag-Grid-AutoColumn:"Row2" rangeTotal:30
+            └─┬ UK filler id:row-group-0-UK ag-Grid-AutoColumn:"UK" rangeTotal:"20"
+            · ├── Row1 LEAF id:uk-1 ag-Grid-AutoColumn:"Row1" rangeTotal:5
+            · └── Row2 LEAF id:uk-2 ag-Grid-AutoColumn:"Row2" rangeTotal:25
+        `);
+
+        const irelandGroupNode = findGroupRow(api, 'Ireland');
+        const ukGroupNode = findGroupRow(api, 'UK');
+
+        // The raw aggData should still be the full object (needed for multi-level aggregation)
+        expect(irelandGroupNode.aggData?.rangeTotal).toEqual({ max: 30, min: 10, value: 20 });
+        expect(ukGroupNode.aggData?.rangeTotal).toEqual({ max: 25, min: 5, value: 20 });
+
+        // getCellValue with useFormatter: true should unwrap .value via groupSafeValueFormatter
+        // and NOT produce [object Object]
+        const irelandFormatted = api.getCellValue({
+            rowNode: irelandGroupNode,
+            colKey: 'rangeTotal',
+            useFormatter: true,
+        });
+        const ukFormatted = api.getCellValue({ rowNode: ukGroupNode, colKey: 'rangeTotal', useFormatter: true });
+
+        expect(irelandFormatted).not.toContain('[object Object]');
+        expect(ukFormatted).not.toContain('[object Object]');
+        expect(irelandFormatted).toBe('20');
+        expect(ukFormatted).toBe('20');
+    });
+
+    test('groupSafeValueFormatter unwraps .value and passes it to user-supplied valueFormatter', () => {
+        const formatterCalls: any[] = [];
+        const api = gridMgr.createGrid('tree-data-agg-object-display-formatter', {
+            columnDefs: [
+                {
+                    field: 'total',
+                    colId: 'rangeTotal',
+                    valueFormatter: (params) => {
+                        formatterCalls.push(params.value);
+                        return `Range: ${params.value}`;
+                    },
+                    aggFunc: rangeAggFunc,
+                },
+            ],
+            defaultColDef: { flex: 1 },
+            autoGroupColumnDef: { minWidth: 220 },
+            groupDefaultExpanded: -1,
+            treeData: true,
+            getDataPath: (data) => data.path,
+            rowData: [
+                { id: 'ie-1', path: ['Ireland', 'Row1'], total: 10 },
+                { id: 'ie-2', path: ['Ireland', 'Row2'], total: 30 },
+                { id: 'uk-1', path: ['UK', 'Row1'], total: 5 },
+                { id: 'uk-2', path: ['UK', 'Row2'], total: 25 },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        const irelandGroupNode = findGroupRow(api, 'Ireland');
+
+        // The user-supplied valueFormatter receives the raw object because the user controls formatting.
+        // The groupSafeValueFormatter only applies to inferred formatters from DataTypeService.
+        const irelandFormatted = api.getCellValue({
+            rowNode: irelandGroupNode,
+            colKey: 'rangeTotal',
+            useFormatter: true,
+        });
+        // With a user-supplied formatter, the grid passes the raw value (the result of aggFunc)
+        // The user's formatter is responsible for handling it appropriately
+        expect(irelandFormatted).toBeDefined();
+        expect(formatterCalls.length).toBeGreaterThan(0);
+    });
+
+    test('does not unwrap .value for leaf row data', () => {
+        const api = gridMgr.createGrid('tree-data-agg-object-leaf-noop', {
+            columnDefs: [
+                {
+                    field: 'stats',
+                    colId: 'stats',
+                    valueFormatter: (params) => JSON.stringify(params.value),
+                    aggFunc: 'first',
+                },
+            ],
+            defaultColDef: { flex: 1 },
+            groupDefaultExpanded: -1,
+            treeData: true,
+            getDataPath: (data) => data.path,
+            rowData: [
+                { id: 'ie-1', path: ['Ireland', 'Row1'], stats: { value: 42, extra: 'data' } },
+                { id: 'ie-2', path: ['Ireland', 'Row2'], stats: { value: 99, extra: 'more' } },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        // Find a leaf row
+        let leafNode: IRowNode | undefined;
+        api.forEachNode((node) => {
+            if (!node.group && !leafNode) {
+                leafNode = node;
+            }
+        });
+        expect(leafNode).toBeDefined();
+        expect(leafNode!.group).toBe(false);
+
+        // Leaf rows should still return the raw object (not unwrapped)
+        const leafValue = api.getCellValue({ rowNode: leafNode!, colKey: 'stats', useFormatter: false });
+        expect(leafValue).toEqual({ value: 42, extra: 'data' });
+    });
+
+    test('groupSafeValueFormatter unwraps .value in multi-level group aggregation', () => {
+        const api = gridMgr.createGrid('tree-data-agg-object-multi-level', {
+            columnDefs: [{ field: 'total', colId: 'rangeTotal', aggFunc: rangeAggFunc }],
+            defaultColDef: { flex: 1 },
+            autoGroupColumnDef: { minWidth: 220 },
+            groupDefaultExpanded: -1,
+            treeData: true,
+            getDataPath: (data) => data.path,
+            rowData: [
+                { id: 'ie-2020-1', path: ['Ireland', '2020', 'Row1'], total: 10 },
+                { id: 'ie-2020-2', path: ['Ireland', '2020', 'Row2'], total: 30 },
+                { id: 'ie-2021-1', path: ['Ireland', '2021', 'Row1'], total: 5 },
+                { id: 'ie-2021-2', path: ['Ireland', '2021', 'Row2'], total: 50 },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        // Top-level group (Ireland) - multi-level aggregation
+        const irelandGroup = findGroupRow(api, 'Ireland');
+
+        // The formatted display value should be the unwrapped .value, not [object Object]
+        const topLevelFormatted = api.getCellValue({
+            rowNode: irelandGroup,
+            colKey: 'rangeTotal',
+            useFormatter: true,
+        });
+        expect(topLevelFormatted).not.toContain('[object Object]');
+        expect(topLevelFormatted).toBe('45'); // max=50, min=5, range=45
+
+        // Sub-group (Ireland > 2020)
+        const year2020Group = findGroupRow(api, '2020');
+        const subGroupFormatted = api.getCellValue({
+            rowNode: year2020Group,
+            colKey: 'rangeTotal',
+            useFormatter: true,
+        });
+        expect(subGroupFormatted).not.toContain('[object Object]');
+        expect(subGroupFormatted).toBe('20'); // max=30, min=10, range=20
+    });
+
+    test('groupSafeValueFormatter handles .value === 0 correctly', () => {
+        const api = gridMgr.createGrid('tree-data-agg-object-zero-value', {
+            columnDefs: [{ field: 'total', colId: 'rangeTotal', aggFunc: rangeAggFunc }],
+            defaultColDef: { flex: 1 },
+            autoGroupColumnDef: { minWidth: 220 },
+            groupDefaultExpanded: -1,
+            treeData: true,
+            getDataPath: (data) => data.path,
+            rowData: [
+                { id: 'ie-1', path: ['Ireland', 'Row1'], total: 5 },
+                { id: 'ie-2', path: ['Ireland', 'Row2'], total: 5 }, // same values -> range = 0
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        const irelandGroup = findGroupRow(api, 'Ireland');
+        expect(irelandGroup.aggData?.rangeTotal).toEqual({ max: 5, min: 5, value: 0 });
+
+        // value === 0 should still be formatted, not skipped as falsy
+        const formatted = api.getCellValue({
+            rowNode: irelandGroup,
+            colKey: 'rangeTotal',
+            useFormatter: true,
+        });
+        expect(formatted).toBe('0');
+    });
+});

--- a/testing/behavioural/src/tree-data/tree-data-aggregation-custom-object-display.test.ts
+++ b/testing/behavioural/src/tree-data/tree-data-aggregation-custom-object-display.test.ts
@@ -5,13 +5,26 @@ import { TreeDataModule } from 'ag-grid-enterprise';
 import { GridRows, TestGridsManager } from '../test-utils';
 
 /** Custom aggFunc that returns an object with .value for display.
- * Uses typeof check instead of leafGroup since filler nodes in tree data don't have leafGroup set. */
+ * Uses typeof check instead of leafGroup since filler nodes in tree data don't have leafGroup set.
+ * Also validates that aggregatedChildren is correctly populated. */
 function rangeAggFunc(params: IAggFuncParams): { max: number; min: number; value: number } {
-    const values = params.values;
+    const { values, aggregatedChildren } = params;
+    // aggregatedChildren should always be a non-empty array
+    expect(aggregatedChildren).toBeInstanceOf(Array);
+    expect(aggregatedChildren.length).toBeGreaterThan(0);
+
     if (typeof values[0] === 'number') {
+        // Leaf-level aggregation: aggregatedChildren should be data rows
+        for (const child of aggregatedChildren) {
+            expect(child.data).toBeDefined();
+        }
         const max = Math.max(...values);
         const min = Math.min(...values);
         return { max, min, value: max - min };
+    }
+    // Non-leaf aggregation: aggregatedChildren should be group/filler nodes
+    for (const child of aggregatedChildren) {
+        expect(child.group).toBe(true);
     }
     let max = values[0].max;
     let min = values[0].min;
@@ -72,38 +85,25 @@ describe('ag-grid tree data custom aggregation object display value', () => {
             · └── Row2 LEAF id:uk-2 ag-Grid-AutoColumn:"Row2" rangeTotal:25
         `);
 
+        // The raw aggData should still be the full object (needed for multi-level aggregation)
         const irelandGroupNode = findGroupRow(api, 'Ireland');
         const ukGroupNode = findGroupRow(api, 'UK');
-
-        // The raw aggData should still be the full object (needed for multi-level aggregation)
         expect(irelandGroupNode.aggData?.rangeTotal).toEqual({ max: 30, min: 10, value: 20 });
         expect(ukGroupNode.aggData?.rangeTotal).toEqual({ max: 25, min: 5, value: 20 });
-
-        // getCellValue with useFormatter: true should unwrap .value via groupSafeValueFormatter
-        // and NOT produce [object Object]
-        const irelandFormatted = api.getCellValue({
-            rowNode: irelandGroupNode,
-            colKey: 'rangeTotal',
-            useFormatter: true,
-        });
-        const ukFormatted = api.getCellValue({ rowNode: ukGroupNode, colKey: 'rangeTotal', useFormatter: true });
-
-        expect(irelandFormatted).not.toContain('[object Object]');
-        expect(ukFormatted).not.toContain('[object Object]');
-        expect(irelandFormatted).toBe('20');
-        expect(ukFormatted).toBe('20');
     });
 
-    test('groupSafeValueFormatter unwraps .value and passes it to user-supplied valueFormatter', () => {
-        const formatterCalls: any[] = [];
+    test('user-supplied valueFormatter that handles group objects shows unwrapped values', async () => {
         const api = gridMgr.createGrid('tree-data-agg-object-display-formatter', {
             columnDefs: [
                 {
                     field: 'total',
                     colId: 'rangeTotal',
                     valueFormatter: (params) => {
-                        formatterCalls.push(params.value);
-                        return `Range: ${params.value}`;
+                        const val =
+                            typeof params.value === 'object' && params.value != null && 'value' in params.value
+                                ? params.value.value
+                                : params.value;
+                        return `Range: ${val}`;
                     },
                     aggFunc: rangeAggFunc,
                 },
@@ -122,19 +122,16 @@ describe('ag-grid tree data custom aggregation object display value', () => {
             getRowId: (params) => params.data.id,
         });
 
-        const irelandGroupNode = findGroupRow(api, 'Ireland');
-
-        // The user-supplied valueFormatter receives the raw object because the user controls formatting.
-        // The groupSafeValueFormatter only applies to inferred formatters from DataTypeService.
-        const irelandFormatted = api.getCellValue({
-            rowNode: irelandGroupNode,
-            colKey: 'rangeTotal',
-            useFormatter: true,
-        });
-        // With a user-supplied formatter, the grid passes the raw value (the result of aggFunc)
-        // The user's formatter is responsible for handling it appropriately
-        expect(irelandFormatted).toBeDefined();
-        expect(formatterCalls.length).toBeGreaterThan(0);
+        // User-supplied formatter that handles groups correctly shows the unwrapped value
+        await new GridRows(api, 'group-aware user formatter tree data').check(`
+            ROOT id:ROOT_NODE_ID rangeTotal:"Range: undefined"
+            ├─┬ Ireland filler id:row-group-0-Ireland ag-Grid-AutoColumn:"Ireland" rangeTotal:"Range: 20"
+            │ ├── Row1 LEAF id:ie-1 ag-Grid-AutoColumn:"Row1" rangeTotal:"Range: 10"
+            │ └── Row2 LEAF id:ie-2 ag-Grid-AutoColumn:"Row2" rangeTotal:"Range: 30"
+            └─┬ UK filler id:row-group-0-UK ag-Grid-AutoColumn:"UK" rangeTotal:"Range: 20"
+            · ├── Row1 LEAF id:uk-1 ag-Grid-AutoColumn:"Row1" rangeTotal:"Range: 5"
+            · └── Row2 LEAF id:uk-2 ag-Grid-AutoColumn:"Row2" rangeTotal:"Range: 25"
+        `);
     });
 
     test('does not unwrap .value for leaf row data', () => {
@@ -173,7 +170,7 @@ describe('ag-grid tree data custom aggregation object display value', () => {
         expect(leafValue).toEqual({ value: 42, extra: 'data' });
     });
 
-    test('groupSafeValueFormatter unwraps .value in multi-level group aggregation', () => {
+    test('groupSafeValueFormatter unwraps .value in multi-level group aggregation', async () => {
         const api = gridMgr.createGrid('tree-data-agg-object-multi-level', {
             columnDefs: [{ field: 'total', colId: 'rangeTotal', aggFunc: rangeAggFunc }],
             defaultColDef: { flex: 1 },
@@ -190,30 +187,19 @@ describe('ag-grid tree data custom aggregation object display value', () => {
             getRowId: (params) => params.data.id,
         });
 
-        // Top-level group (Ireland) - multi-level aggregation
-        const irelandGroup = findGroupRow(api, 'Ireland');
-
-        // The formatted display value should be the unwrapped .value, not [object Object]
-        const topLevelFormatted = api.getCellValue({
-            rowNode: irelandGroup,
-            colKey: 'rangeTotal',
-            useFormatter: true,
-        });
-        expect(topLevelFormatted).not.toContain('[object Object]');
-        expect(topLevelFormatted).toBe('45'); // max=50, min=5, range=45
-
-        // Sub-group (Ireland > 2020)
-        const year2020Group = findGroupRow(api, '2020');
-        const subGroupFormatted = api.getCellValue({
-            rowNode: year2020Group,
-            colKey: 'rangeTotal',
-            useFormatter: true,
-        });
-        expect(subGroupFormatted).not.toContain('[object Object]');
-        expect(subGroupFormatted).toBe('20'); // max=30, min=10, range=20
+        await new GridRows(api, 'multi-level tree data').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ Ireland filler id:row-group-0-Ireland ag-Grid-AutoColumn:"Ireland" rangeTotal:"45"
+            · ├─┬ 2020 filler id:row-group-0-Ireland-1-2020 ag-Grid-AutoColumn:"2020" rangeTotal:"20"
+            · │ ├── Row1 LEAF id:ie-2020-1 ag-Grid-AutoColumn:"Row1" rangeTotal:10
+            · │ └── Row2 LEAF id:ie-2020-2 ag-Grid-AutoColumn:"Row2" rangeTotal:30
+            · └─┬ 2021 filler id:row-group-0-Ireland-1-2021 ag-Grid-AutoColumn:"2021" rangeTotal:"45"
+            · · ├── Row1 LEAF id:ie-2021-1 ag-Grid-AutoColumn:"Row1" rangeTotal:5
+            · · └── Row2 LEAF id:ie-2021-2 ag-Grid-AutoColumn:"Row2" rangeTotal:50
+        `);
     });
 
-    test('groupSafeValueFormatter handles .value === 0 correctly', () => {
+    test('groupSafeValueFormatter handles .value === 0 correctly', async () => {
         const api = gridMgr.createGrid('tree-data-agg-object-zero-value', {
             columnDefs: [{ field: 'total', colId: 'rangeTotal', aggFunc: rangeAggFunc }],
             defaultColDef: { flex: 1 },
@@ -228,15 +214,120 @@ describe('ag-grid tree data custom aggregation object display value', () => {
             getRowId: (params) => params.data.id,
         });
 
+        // value === 0 should still be formatted, not skipped as falsy
+        await new GridRows(api, 'zero value tree data').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ Ireland filler id:row-group-0-Ireland ag-Grid-AutoColumn:"Ireland" rangeTotal:"0"
+            · ├── Row1 LEAF id:ie-1 ag-Grid-AutoColumn:"Row1" rangeTotal:5
+            · └── Row2 LEAF id:ie-2 ag-Grid-AutoColumn:"Row2" rangeTotal:5
+        `);
+
+        // Verify the raw aggData preserves the full object
         const irelandGroup = findGroupRow(api, 'Ireland');
         expect(irelandGroup.aggData?.rangeTotal).toEqual({ max: 5, min: 5, value: 0 });
+    });
 
-        // value === 0 should still be formatted, not skipped as falsy
+    test('groupSafeValueFormatter unwraps .value from bigint aggregation results', () => {
+        const bigintRangeAggFunc = (params: IAggFuncParams) => {
+            const { values } = params;
+            if (typeof values[0] === 'bigint') {
+                const max = values.reduce((a: bigint, b: bigint) => (a > b ? a : b));
+                const min = values.reduce((a: bigint, b: bigint) => (a < b ? a : b));
+                return { max, min, value: max - min };
+            }
+            let max = values[0].max as bigint;
+            let min = values[0].min as bigint;
+            for (const v of values) {
+                if (v.max > max) {
+                    max = v.max;
+                }
+                if (v.min < min) {
+                    min = v.min;
+                }
+            }
+            return { max, min, value: max - min };
+        };
+
+        const api = gridMgr.createGrid('tree-data-bigint-agg', {
+            columnDefs: [
+                { field: 'amount', colId: 'rangeAmount', cellDataType: 'bigint', aggFunc: bigintRangeAggFunc },
+            ],
+            defaultColDef: { flex: 1 },
+            autoGroupColumnDef: { minWidth: 220 },
+            groupDefaultExpanded: -1,
+            treeData: true,
+            getDataPath: (data) => data.path,
+            rowData: [
+                { id: 'ie-1', path: ['Ireland', 'Row1'], amount: 10n },
+                { id: 'ie-2', path: ['Ireland', 'Row2'], amount: 30n },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        const irelandGroup = findGroupRow(api, 'Ireland');
+        expect(irelandGroup.aggData?.rangeAmount).toEqual({ max: 30n, min: 10n, value: 20n });
+
+        // The groupSafeValueFormatter should unwrap .value (20n) and pass it to the bigint formatter
         const formatted = api.getCellValue({
             rowNode: irelandGroup,
-            colKey: 'rangeTotal',
+            colKey: 'rangeAmount',
             useFormatter: true,
         });
-        expect(formatted).toBe('0');
+        expect(formatted).toBe('20');
+    });
+
+    test('groupSafeValueFormatter calls formatter when .value is null (v35.0.0 compat)', () => {
+        const nullValueAggFunc = () => ({ value: null });
+
+        const api = gridMgr.createGrid('tree-data-agg-null-value', {
+            columnDefs: [{ field: 'total', colId: 'nullTotal', aggFunc: nullValueAggFunc }],
+            defaultColDef: { flex: 1 },
+            groupDefaultExpanded: -1,
+            treeData: true,
+            getDataPath: (data) => data.path,
+            rowData: [
+                { id: 'ie-1', path: ['Ireland', 'Row1'], total: 10 },
+                { id: 'ie-2', path: ['Ireland', 'Row2'], total: 30 },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        const irelandGroup = findGroupRow(api, 'Ireland');
+        // v35.0.0 behavior: formatter is called with null, default number formatter returns ''
+        const formatted = api.getCellValue({
+            rowNode: irelandGroup,
+            colKey: 'nullTotal',
+            useFormatter: true,
+        });
+        expect(formatted).toBe('');
+    });
+
+    test('groupSafeValueFormatter calls toNumber() for BigDecimal-like aggregation results', () => {
+        const toNumberAggFunc = (params: IAggFuncParams) => {
+            const sum = params.values.reduce((a: number, b: number) => a + b, 0);
+            return { toNumber: () => sum };
+        };
+
+        const api = gridMgr.createGrid('tree-data-agg-toNumber', {
+            columnDefs: [{ field: 'total', colId: 'sumTotal', aggFunc: toNumberAggFunc }],
+            defaultColDef: { flex: 1 },
+            groupDefaultExpanded: -1,
+            treeData: true,
+            getDataPath: (data) => data.path,
+            rowData: [
+                { id: 'ie-1', path: ['Ireland', 'Row1'], total: 10 },
+                { id: 'ie-2', path: ['Ireland', 'Row2'], total: 30 },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        const irelandGroup = findGroupRow(api, 'Ireland');
+        // toNumber() should be called and its result passed to formatter
+        const formatted = api.getCellValue({
+            rowNode: irelandGroup,
+            colKey: 'sumTotal',
+            useFormatter: true,
+        });
+        expect(formatted).toBe('40');
     });
 });


### PR DESCRIPTION
numberOrBigint was used both to check the value itself and the column type.
But the column type is a string and not a value type, that need to be compared as strings without typeof.

Reviewed the logic, and compared with b35 code, and fixed it accordingly

And added tests

FIX RTI-3233