### PR TITLE
Documentation Update | Change row selection mode to 'multiRow'

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/grouping-row-selection/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/grouping-row-selection/index.mdoc
@@ -23,7 +23,7 @@ The example above demonstrates the following configuration:
 ```{% frameworkTransform=true %}
 const gridOptions = {
     rowSelection: {
-        mode: 'multiple',
+        mode: 'multiRow',
         groupSelects: 'descendants',
     },
 }


### PR DESCRIPTION
On current documentation:
<img width="375" height="208" alt="Image" src="https://github.com/user-attachments/assets/30cd3297-0e89-4fae-bb76-2c27b202483b" />

It should say `multiRow` as it says in other examples

When using `multiple`, the feature doesn't work and we get a warning

<img width="608" height="34" alt="Image" src="https://github.com/user-attachments/assets/d39a0f4e-e00b-4509-9856-874803c1f945" />
