### PR TITLE
[RTI-3249] Fix(bigint): validation in filters and editors

### DIFF
--- a/.rulesync/rules/ag-grid.md
+++ b/.rulesync/rules/ag-grid.md
@@ -179,6 +179,14 @@ While this transition is in progress, changes made to Theming API should be appl
     2. Mirror updates in the corresponding docs page.
     3. Run the relevant generation/typecheck commands.
 
+-   **Editing & Validation**
+    1. **Filters vs editing**: Filter inputs validate themselves; cell editing validation goes through the editor and edit model.
+    2. **Invalid edits**: Default behaviour is to revert invalid edits unless `invalidEditValueMode='block'` is set.
+    3. **Editor validation style**: Editors validate from raw input once (avoid double parsing).
+    4. **Data type hints**: `cellDataType` drives defaults; if missing, code often falls back to the existing cell value.
+    5. **Locale text**: Filter validation strings live in filter locale text; editor validation strings should be in the core locale map.
+    6. **User callback**: Avoid calling user provided callbacks more than necessary. Callbacks may have undesired side effects.
+
 ### Technical Requirements
 
 -   **Node.js**: Check `.nvmrc` for version

--- a/community-modules/locale/src/en-US.ts
+++ b/community-modules/locale/src/en-US.ts
@@ -691,6 +691,7 @@ export const AG_GRID_LOCALE_EN = {
     false: 'False',
     invalidDate: 'Invalid Date',
     invalidNumber: 'Invalid Number',
+    invalidBigInt: 'Invalid BigInt',
     january: 'January',
     february: 'February',
     march: 'March',

--- a/packages/ag-grid-community/src/edit/cellEditors/textCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/textCellEditor.ts
@@ -41,7 +41,10 @@ class TextCellEditorInput<TValue = any>
     public getValidationErrors(): string[] | null {
         const { params } = this;
         const { maxLength, getValidationErrors } = params;
-        const value = this.getValue();
+        const rawValue = this.eEditor.getValue();
+        const hasRawValue = _exists(rawValue);
+        const parsedValue = hasRawValue ? params.parseValue(rawValue as string) : undefined;
+        const value = !hasRawValue && !_exists(params.value) ? params.value : hasRawValue ? parsedValue : params.value;
 
         const translate = this.getLocaleTextFunc();
 
@@ -51,6 +54,14 @@ class TextCellEditorInput<TValue = any>
             internalErrors.push(
                 translate('maxLengthValidation', `Must be ${maxLength} characters or fewer.`, [String(maxLength)])
             );
+        }
+
+        const colDef = params.column.getColDef();
+        const isBigIntCell =
+            colDef.cellDataType === 'bigint' || (colDef.cellDataType == null && typeof params.value === 'bigint');
+
+        if (isBigIntCell && hasRawValue && String(rawValue).trim() !== '' && parsedValue == null) {
+            internalErrors.push(translate('invalidBigInt', 'Invalid BigInt'));
         }
 
         if (!internalErrors.length) {

--- a/packages/ag-grid-community/src/edit/cellEditors/textCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/textCellEditor.ts
@@ -59,14 +59,6 @@ class TextCellEditorInput<TValue = any>
             );
         }
 
-        const colDef = params.column.getColDef();
-        const isBigIntCell =
-            colDef.cellDataType === 'bigint' || (colDef.cellDataType == null && typeof params.value === 'bigint');
-
-        if (isBigIntCell && hasRawValue && String(rawValue).trim() !== '' && parsedValue == null) {
-            internalErrors.push(translate('invalidBigInt', 'Invalid BigInt'));
-        }
-
         if (!internalErrors.length) {
             internalErrors = null;
         }

--- a/packages/ag-grid-community/src/edit/cellEditors/textCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/textCellEditor.ts
@@ -42,9 +42,12 @@ class TextCellEditorInput<TValue = any>
         const { params } = this;
         const { maxLength, getValidationErrors } = params;
         const rawValue = this.eEditor.getValue();
-        const hasRawValue = _exists(rawValue);
-        const parsedValue = hasRawValue ? params.parseValue(rawValue as string) : undefined;
-        const value = !hasRawValue && !_exists(params.value) ? params.value : hasRawValue ? parsedValue : params.value;
+        const hasRawValue = rawValue != null;
+        const parsedValue = hasRawValue ? params.parseValue(rawValue) : undefined;
+        let value = params.value;
+        if (hasRawValue) {
+            value = parsedValue;
+        }
 
         const translate = this.getLocaleTextFunc();
 

--- a/packages/ag-grid-community/src/filter/filterLocaleText.ts
+++ b/packages/ag-grid-community/src/filter/filterLocaleText.ts
@@ -79,7 +79,6 @@ const FILTER_LOCALE_TEXT = {
     maxDateValidation: (variableValues: string[]) => `Date must be before ${variableValues[0]}`,
     strictMinValueValidation: (variableValues: string[]) => `Must be greater than ${variableValues[0]}`,
     strictMaxValueValidation: (variableValues: string[]) => `Must be less than ${variableValues[0]}`,
-    invalidBigInt: 'Invalid BigInt',
 };
 
 export type FilterLocaleTextKey = keyof typeof FILTER_LOCALE_TEXT;

--- a/packages/ag-grid-community/src/filter/filterLocaleText.ts
+++ b/packages/ag-grid-community/src/filter/filterLocaleText.ts
@@ -79,6 +79,7 @@ const FILTER_LOCALE_TEXT = {
     maxDateValidation: (variableValues: string[]) => `Date must be before ${variableValues[0]}`,
     strictMinValueValidation: (variableValues: string[]) => `Must be greater than ${variableValues[0]}`,
     strictMaxValueValidation: (variableValues: string[]) => `Must be less than ${variableValues[0]}`,
+    invalidBigInt: 'Invalid BigInt',
 };
 
 export type FilterLocaleTextKey = keyof typeof FILTER_LOCALE_TEXT;

--- a/packages/ag-grid-community/src/filter/provided/bigInt/bigIntFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/bigInt/bigIntFilter.ts
@@ -53,12 +53,31 @@ export class BigIntFilter extends SimpleFilter<
     }
 
     private refreshInputPairValidation(from: GridInputTextField, to: GridInputTextField, isFrom = false): void {
-        const localeKey = getValidityMessageKey(_parseBigIntOrNull(from), _parseBigIntOrNull(to), isFrom);
+        const { bigintParser } = this.params;
+        const fromValue = this.getParsedValue(from, bigintParser);
+        const toValue = this.getParsedValue(to, bigintParser);
+
+        const fromInvalid = this.isInvalidValue(from, fromValue);
+        const toInvalid = this.isInvalidValue(to, toValue);
+
+        const target = isFrom ? from : to;
+        const other = isFrom ? to : from;
+        const targetInvalid = isFrom ? fromInvalid : toInvalid;
+        const otherInvalid = isFrom ? toInvalid : fromInvalid;
+
+        const localeKey = targetInvalid
+            ? 'invalidBigInt'
+            : !fromInvalid && !toInvalid
+              ? getValidityMessageKey(fromValue, toValue, isFrom)
+              : null;
         const validityMessage = localeKey
             ? this.translate(localeKey, [String(isFrom ? to.getValue() : from.getValue())])
             : '';
-        (isFrom ? from : to).setCustomValidity(validityMessage);
-        (isFrom ? to : from).setCustomValidity('');
+
+        target.setCustomValidity(validityMessage);
+        if (!otherInvalid) {
+            other.setCustomValidity('');
+        }
         if (validityMessage.length > 0) {
             this.beans.ariaAnnounce.announceValue(validityMessage, 'dateFilter');
         }
@@ -214,6 +233,22 @@ export class BigIntFilter extends SimpleFilter<
 
     protected override canApply(_model: BigIntFilterModel | ICombinedSimpleModel<BigIntFilterModel> | null): boolean {
         return !this.hasInvalidInputs();
+    }
+
+    private getParsedValue(
+        element: GridInputTextField,
+        bigintParser: IBigIntFilterParams['bigintParser']
+    ): bigint | null {
+        const rawValue = element.getValue();
+        if (rawValue == null || (typeof rawValue === 'string' && rawValue.trim() === '')) {
+            return null;
+        }
+        return bigintParser ? bigintParser(rawValue) : _parseBigIntOrNull(rawValue);
+    }
+
+    private isInvalidValue(element: GridInputTextField, parsedValue: bigint | null): boolean {
+        const rawValue = element.getValue();
+        return rawValue != null && String(rawValue).trim() !== '' && parsedValue === null;
     }
 }
 

--- a/packages/ag-grid-community/src/filter/provided/bigInt/bigIntFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/bigInt/bigIntFilter.ts
@@ -65,14 +65,17 @@ export class BigIntFilter extends SimpleFilter<
         const targetInvalid = isFrom ? fromInvalid : toInvalid;
         const otherInvalid = isFrom ? toInvalid : fromInvalid;
 
-        const localeKey = targetInvalid
-            ? 'invalidBigInt'
-            : !fromInvalid && !toInvalid
-              ? getValidityMessageKey(fromValue, toValue, isFrom)
-              : null;
-        const validityMessage = localeKey
-            ? this.translate(localeKey, [String(isFrom ? to.getValue() : from.getValue())])
-            : '';
+        let validityMessage = '';
+
+        if (targetInvalid) {
+            const translate = this.getLocaleTextFunc();
+            validityMessage = translate('invalidBigInt', 'Invalid BigInt');
+        } else if (!fromInvalid && !toInvalid) {
+            const localeKey = getValidityMessageKey(fromValue, toValue, isFrom);
+            if (localeKey) {
+                validityMessage = this.translate(localeKey, [String(isFrom ? to.getValue() : from.getValue())]);
+            }
+        }
 
         target.setCustomValidity(validityMessage);
         if (!otherInvalid) {


### PR DESCRIPTION
  1. [RTI-3249] Fix(Edit): do not revert BigInt edits on invalid input by default
  2. [RTI-3232] Fix(Filter): treat non-numeric text as invalid BigInt filter input
  3. [RTI-3238] Fix(Filter): add BigInt in-range input validation
  
Fixes [RTI-3249](https://ag-grid.atlassian.net/browse/RTI-3249)
Fixes [RTI-3232](https://ag-grid.atlassian.net/browse/RTI-3232)
Fixes [RTI-3238](https://ag-grid.atlassian.net/browse/RTI-3238)