### PR TITLE
Update aggregation-overview spec to use stable test data

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/aggregation/_examples/aggregation-overview/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation/_examples/aggregation-overview/example.spec.ts
@@ -2,11 +2,11 @@ import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     test.eachFramework('Example', async ({ agIdFor }) => {
-        await expect(agIdFor.autoGroupCell('row-group-country-Canada')).toContainText('Canada (351)', {
+        await expect(agIdFor.autoGroupCell('row-group-country-Netherlands')).toContainText('Netherlands (4)', {
             useInnerText: true,
         });
-        await expect(agIdFor.cell('row-group-country-Canada', 'bronze')).toContainText('104');
-        await expect(agIdFor.cell('row-group-country-Canada', 'silver')).toContainText('5');
-        await expect(agIdFor.cell('row-group-country-Canada', 'gold')).toContainText('0.47863247863247865');
+        await expect(agIdFor.cell('row-group-country-Netherlands', 'bronze')).toContainText('4');
+        await expect(agIdFor.cell('row-group-country-Netherlands', 'silver')).toContainText('0.75');
+        await expect(agIdFor.cell('row-group-country-Netherlands', 'gold')).toContainText('3');
     });
 });


### PR DESCRIPTION
Update the aggregation-overview example spec to assert against Netherlands (4 rows) instead of Canada (351 rows), using stable aggregated values that won't break with data changes.