### PR TITLE
AG-16762 Small improvements to demos

### DIFF
--- a/documentation/ag-grid-docs/src/components/demos/examples/finance/FinanceExample.tsx
+++ b/documentation/ag-grid-docs/src/components/demos/examples/finance/FinanceExample.tsx
@@ -4,7 +4,6 @@ import React, { useCallback, useMemo, useRef, useState } from 'react';
 
 import {
     AllCommunityModule,
-    ClientSideRowModelModule,
     type ColDef,
     type GetRowIdFunc,
     type GetRowIdParams,
@@ -94,7 +93,6 @@ const BREAKPOINT_CONFIG: Record<
 
 const modules = [
     AllCommunityModule,
-    ClientSideRowModelModule,
     AdvancedFilterModule,
     ColumnsToolPanelModule,
     ExcelExportModule,
@@ -193,6 +191,7 @@ export const FinanceExample: React.FC<Props> = ({
             {
                 field: 'ticker',
                 cellRenderer: getTickerCellRenderer(Boolean(breakpointConfig.hideTickerName)),
+                enableRowGroup: false,
                 ...tickerWidthDefs,
             },
             {
@@ -200,6 +199,7 @@ export const FinanceExample: React.FC<Props> = ({
                 field: 'timeline',
                 sortable: false,
                 filter: false,
+                enableRowGroup: false,
                 cellRenderer: 'agSparklineCellRenderer',
                 cellRendererParams: {
                     sparklineOptions: {
@@ -225,6 +225,7 @@ export const FinanceExample: React.FC<Props> = ({
                 cellDataType: 'number',
                 filter: 'agNumberColumnFilter',
                 type: 'rightAligned',
+                enableRowGroup: false,
                 cellRenderer: 'agAnimateShowChangeCellRenderer',
                 valueGetter: ({ data }: ValueGetterParams) => data && data.quantity * (data.price / data.purchasePrice),
                 valueFormatter: numberFormatter,
@@ -236,6 +237,7 @@ export const FinanceExample: React.FC<Props> = ({
                 colId: 'totalValue',
                 headerName: 'Total Value',
                 type: 'rightAligned',
+                enableRowGroup: false,
                 cellDataType: 'number',
                 filter: 'agNumberColumnFilter',
                 valueGetter: ({ data }: ValueGetterParams) => data && data.quantity * data.price,
@@ -251,18 +253,20 @@ export const FinanceExample: React.FC<Props> = ({
             allColDefs.push(
                 {
                     field: 'quantity',
+                    enableRowGroup: false,
                     cellDataType: 'number',
                     type: 'rightAligned',
                     valueFormatter: numberFormatter,
-                    maxWidth: 75,
+                    minWidth: 75,
                 },
                 {
                     headerName: 'Price',
                     field: 'purchasePrice',
+                    enableRowGroup: false,
                     cellDataType: 'number',
                     type: 'rightAligned',
                     valueFormatter: numberFormatter,
-                    maxWidth: 75,
+                    minWidth: 75,
                 }
             );
         }

--- a/documentation/ag-grid-docs/src/components/demos/examples/inventory/InventoryExample.tsx
+++ b/documentation/ag-grid-docs/src/components/demos/examples/inventory/InventoryExample.tsx
@@ -111,6 +111,7 @@ export const InventoryExample: FunctionComponent<Props> = ({ gridTheme = 'ag-the
                 cellRenderer: StockCellRenderer,
                 headerClass: 'header-inventory',
                 sortable: false,
+                tooltipValueGetter: ({ data: { available, variants } }) => `${available} Stock / ${variants} Variants`,
             },
             {
                 field: 'incoming',
@@ -123,7 +124,7 @@ export const InventoryExample: FunctionComponent<Props> = ({ gridTheme = 'ag-the
             },
             {
                 field: 'price',
-                width: 120,
+                width: 150,
                 headerClass: 'header-price',
                 cellRenderer: PriceCellRenderer,
             },
@@ -137,7 +138,7 @@ export const InventoryExample: FunctionComponent<Props> = ({ gridTheme = 'ag-the
                 valueFormatter: ({ value }: ValueFormatterParams) => `£${value}`,
                 width: 150,
             },
-            { field: 'actions', cellRenderer: ActionsCellRenderer, minWidth: 194 },
+            { field: 'actions', cellRenderer: ActionsCellRenderer, minWidth: 194, sortable: false, filter: false },
         ];
 
         return allColDefs.filter(

--- a/external/ag-shared/prompts/commands/pr/create.md
+++ b/external/ag-shared/prompts/commands/pr/create.md
@@ -122,6 +122,7 @@ Follow git-conventions for the PR:
 -   **Body:** JIRA-linked: include link(s) to the JIRA ticket(s). No JIRA: concise description of the change.
 -   Keep descriptions concise - this is a public repo.
 -   Never attribute agentic tooling.
+-   If JIRA-linked include "Fix #AG-XXXX"
 
 ### STEP 7: Report Result
 


### PR DESCRIPTION
Fix AG-16762

- Finance demo: remove duplicate `ClientSideRowModelModule`, disable row grouping on non-groupable columns, change `maxWidth` to `minWidth` on quantity/price columns
- Inventory demo: add tooltip to stock column, widen price column, disable sort/filter on actions column