### PR TITLE
Fix PR review reactions: gate on exit code, distinguish findings

### DIFF
--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = bbd7db6f880ec584ceb176b3ab79076918ded28c
-	parent = 6734e22d04417ae138acaa947fc188970f396087
+	commit = ae9edea620feed79c99d07134b17f3d12f218c78
+	parent = 4f8bfc807bc0f0bda0150626c53a43c4369c8fcb
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/github/actions/codex-pr-review/action.yml
+++ b/external/ag-shared/github/actions/codex-pr-review/action.yml
@@ -25,8 +25,9 @@ description: Run a Codex PR review with complete log suppression - no LLM output
 # | Auth not configured (skipped)        | No  | None     | No                    | No                 |
 # | Codex exits non-zero                 | Yes then removed | None | No             | No                 |
 # | Codex exits 0, empty output          | Yes then removed | None | No             | No                 |
-# | Codex exits 0, no findings           | Yes then removed | 👍   | Yes (created/updated) | No                 |
-# | Codex exits 0, 1+ findings           | Yes then removed | 👎   | Yes (created/updated) | Yes (if JSON mode) |
+# | Codex exits 0 (markdown mode)        | Yes then removed | None | Yes (created/updated) | No                 |
+# | Codex exits 0, no findings (JSON)    | Yes then removed | 👍   | Yes (created/updated) | No                 |
+# | Codex exits 0, 1+ findings (JSON)    | Yes then removed | 👎   | Yes (created/updated) | Yes                |
 #
 inputs:
     openai-api-key:
@@ -118,6 +119,10 @@ runs:
                   core.setOutput('reaction_id', reaction.id);
 
         - name: Clean Up Old Completion Reactions
+          # Removes prior +1/-1 reactions from github-actions[bot] on this PR.
+          # Note: github-actions[bot] is a shared identity for all GITHUB_TOKEN-based actions,
+          # so this could theoretically remove reactions from other workflows. Accepted trade-off:
+          # GitHub limits each user to one reaction per type per issue, so blast radius is minimal.
           if: steps.check-auth.outputs.skipped != 'true'
           uses: actions/github-script@v7
           continue-on-error: true
@@ -649,7 +654,7 @@ runs:
                   });
 
         - name: React Success
-          if: steps.check-auth.outputs.skipped != 'true' && steps.verify.outputs.success == 'true' && steps.post-comment.outputs.has_findings != 'true'
+          if: steps.check-auth.outputs.skipped != 'true' && steps.verify.outputs.success == 'true' && steps.post-comment.outputs.has_findings == 'false'
           uses: actions/github-script@v7
           continue-on-error: true
           env:

--- a/external/ag-shared/github/actions/codex-pr-review/action.yml
+++ b/external/ag-shared/github/actions/codex-pr-review/action.yml
@@ -10,13 +10,23 @@ description: Run a Codex PR review with complete log suppression - no LLM output
 #    (only those with no user reactions or replies - preserving conversations)
 # 5. POST RESULTS: Create/update summary comment (<!-- codex-pr-review --> marker)
 #    and post new inline comments on specific file/line locations
-# 6. REACT COMPLETE: Remove 👀 from PR description, add 👍 on success
+# 6. REACT COMPLETE: Remove 👀 from PR description, add 👍 (no findings) or 👎 (has findings)
 # 7. CLEANUP FILES: Remove sensitive review output and auth files
 #
 # Re-review behaviour:
 # - Summary comment is updated in-place (found via marker)
 # - Old inline comments are deleted (unless users have reacted/replied)
 # - Reactions target the PR description, not the trigger comment
+#
+# PR-visible output states (old 👍/👎 reactions are cleaned up at the start of each run):
+#
+# | Scenario                             | 👀  | Reaction | Summary comment       | Inline comments    |
+# |--------------------------------------|-----|----------|-----------------------|--------------------|
+# | Auth not configured (skipped)        | No  | None     | No                    | No                 |
+# | Codex exits non-zero                 | Yes then removed | None | No             | No                 |
+# | Codex exits 0, empty output          | Yes then removed | None | No             | No                 |
+# | Codex exits 0, no findings           | Yes then removed | 👍   | Yes (created/updated) | No                 |
+# | Codex exits 0, 1+ findings           | Yes then removed | 👎   | Yes (created/updated) | Yes (if JSON mode) |
 #
 inputs:
     openai-api-key:
@@ -106,6 +116,36 @@ runs:
                     content: 'eyes'
                   });
                   core.setOutput('reaction_id', reaction.id);
+
+        - name: Clean Up Old Completion Reactions
+          if: steps.check-auth.outputs.skipped != 'true'
+          uses: actions/github-script@v7
+          continue-on-error: true
+          env:
+              PR_NUMBER: ${{ inputs.pr-number }}
+          with:
+              github-token: ${{ inputs.github-token }}
+              script: |
+                  const prNumber = parseInt(process.env.PR_NUMBER, 10);
+                  const reactions = await github.paginate(
+                    github.rest.reactions.listForIssue,
+                    {
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: prNumber,
+                      per_page: 100
+                    }
+                  );
+                  for (const reaction of reactions) {
+                    if (reaction.user?.login === 'github-actions[bot]' && (reaction.content === '+1' || reaction.content === '-1')) {
+                      await github.rest.reactions.deleteForIssue({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: prNumber,
+                        reaction_id: reaction.id
+                      });
+                    }
+                  }
 
         - name: Fetch PR refs
           if: steps.check-auth.outputs.skipped != 'true'
@@ -318,6 +358,12 @@ runs:
           shell: bash
           run: |
               output_file="${{ steps.codex.outputs.output_file }}"
+              exit_code="${{ steps.codex.outputs.exit_code }}"
+              if [ "$exit_code" != "0" ]; then
+                echo "success=false" >> $GITHUB_OUTPUT
+                echo "::error::Codex exited with code ${exit_code}"
+                exit 1
+              fi
               if [ -f "${output_file}" ] && [ -s "${output_file}" ]; then
                 echo "success=true" >> $GITHUB_OUTPUT
                 echo "Review output generated successfully"
@@ -328,6 +374,7 @@ runs:
               fi
 
         - name: Post Review Comment
+          id: post-comment
           if: steps.check-auth.outputs.skipped != 'true' && steps.verify.outputs.success == 'true' && inputs.post-comment == 'true'
           uses: actions/github-script@v7
           env:
@@ -419,6 +466,7 @@ runs:
                       // Build summary comment body from JSON
                       const verdictEmoji = review.verdict?.assessment === 'correct' ? ':white_check_mark:' : ':x:';
                       const totalFindings = (review.stats?.p0_count || 0) + (review.stats?.p1_count || 0) + (review.stats?.p2_count || 0) + (review.stats?.p3_count || 0);
+                      core.setOutput('has_findings', String(totalFindings > 0));
                       const statsLine = `P0: ${review.stats?.p0_count || 0} | P1: ${review.stats?.p1_count || 0} | P2: ${review.stats?.p2_count || 0} | P3: ${review.stats?.p3_count || 0}`;
 
                       // Build summary line
@@ -601,7 +649,7 @@ runs:
                   });
 
         - name: React Success
-          if: steps.check-auth.outputs.skipped != 'true' && steps.verify.outputs.success == 'true'
+          if: steps.check-auth.outputs.skipped != 'true' && steps.verify.outputs.success == 'true' && steps.post-comment.outputs.has_findings != 'true'
           uses: actions/github-script@v7
           continue-on-error: true
           env:
@@ -614,6 +662,22 @@ runs:
                     repo: context.repo.repo,
                     issue_number: parseInt(process.env.PR_NUMBER, 10),
                     content: '+1'
+                  });
+
+        - name: React Has Findings
+          if: steps.check-auth.outputs.skipped != 'true' && steps.verify.outputs.success == 'true' && steps.post-comment.outputs.has_findings == 'true'
+          uses: actions/github-script@v7
+          continue-on-error: true
+          env:
+              PR_NUMBER: ${{ inputs.pr-number }}
+          with:
+              github-token: ${{ inputs.github-token }}
+              script: |
+                  await github.rest.reactions.createForIssue({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: parseInt(process.env.PR_NUMBER, 10),
+                    content: '-1'
                   });
 
         - name: Cleanup Sensitive Files


### PR DESCRIPTION
Three fixes to the codex-pr-review action reaction behaviour:

1. **Gate thumbs-up on Codex exit code** — previously, if Codex exited non-zero but still wrote partial output, the verify step passed and 👍 was posted despite the failure.
2. **Distinguish findings from clean reviews** — 👍 for no findings, 👎 for 1+ findings (was always 👍).
3. **Clean up stale reactions on re-review** — old 👍/👎 from prior runs are removed at the start of each run so only the latest result is visible.