### PR TITLE
[AG-3471] Feature(sidebar): tool panel deferred apply mode for grouping pivoting aggregations

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="TypeScriptCompiler">
+    <option name="memoryLimit" value="4096" />
     <option name="useTypesFromServer" value="true" />
   </component>
 </project>

--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -8,7 +8,6 @@
     <excludedPredefinedLibrary name="ag-grid/documentation/ag-grid-docs/node_modules" />
     <excludedPredefinedLibrary name="ag-grid/documentation/update-algolia-indices/node_modules" />
     <excludedPredefinedLibrary name="ag-grid/external/ag-shared/node_modules" />
-    <excludedPredefinedLibrary name="ag-grid/external/ag-website-shared/node_modules" />
     <excludedPredefinedLibrary name="ag-grid/node_modules" />
     <excludedPredefinedLibrary name="ag-grid/packages/ag-grid-angular/node_modules" />
     <excludedPredefinedLibrary name="ag-grid/packages/ag-grid-community/node_modules" />
@@ -16,6 +15,7 @@
     <excludedPredefinedLibrary name="ag-grid/packages/ag-grid-react/node_modules" />
     <excludedPredefinedLibrary name="ag-grid/packages/ag-grid-vue3/node_modules" />
     <excludedPredefinedLibrary name="ag-grid/plugins/ag-grid-generate-code-reference-files/node_modules" />
+    <excludedPredefinedLibrary name="ag-grid/plugins/ag-grid-generate-example-files/dist/node_modules" />
     <excludedPredefinedLibrary name="ag-grid/plugins/ag-grid-generate-example-files/node_modules" />
     <excludedPredefinedLibrary name="ag-grid/plugins/ag-grid-task-autogen/node_modules" />
     <excludedPredefinedLibrary name="ag-grid/testing/accessibility/node_modules" />
@@ -24,5 +24,6 @@
     <excludedPredefinedLibrary name="ag-grid/testing/module-size-angular/node_modules" />
     <excludedPredefinedLibrary name="ag-grid/testing/module-size/node_modules" />
     <excludedPredefinedLibrary name="ag-grid/testing/public-recipes/e2e/node_modules" />
+    <excludedPredefinedLibrary name="tsconfig$paths" />
   </component>
 </project>

--- a/community-modules/styles/src/internal/base/parts/_columns-tool-panel.scss
+++ b/community-modules/styles/src/internal/base/parts/_columns-tool-panel.scss
@@ -42,3 +42,23 @@
         @include ag.list-item-hovered();
     }
 }
+
+.ag-column-panel-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--ag-widget-vertical-spacing) var(--ag-widget-horizontal-spacing);
+    justify-content: flex-end;
+    overflow: hidden;
+    padding: var(--ag-widget-container-vertical-padding) var(--ag-widget-container-horizontal-padding);
+    border-top: var(--ag-borders-secondary) var(--ag-secondary-border-color);
+}
+
+.ag-column-panel-buttons-button {
+    line-height: 1.5;
+
+    &:disabled:hover {
+        color: var(--ag-button-disabled-text-color);
+        background-color: var(--ag-button-disabled-background-color);
+        border: var(--ag-button-disabled-border);
+    }
+}

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/example.spec.ts
@@ -1,0 +1,11 @@
+import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+
+test.agExample(import.meta, () => {
+    test.eachFramework('Example', async ({ page }) => {
+        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+        await clickAllButtons(page);
+        // END PLACEHOLDER
+    });
+});

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/fakeServer.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/fakeServer.ts
@@ -7,7 +7,9 @@ type ServerResponse = {
     pivotResultFields?: string[];
 };
 
-export function createServerSideDatasource(server: { getData: (request: IServerSideGetRowsRequest) => ServerResponse }): IServerSideDatasource {
+export function createServerSideDatasource(server: {
+    getData: (request: IServerSideGetRowsRequest) => ServerResponse;
+}): IServerSideDatasource {
     return {
         getRows: (params) => {
             const response = server.getData(params.request);
@@ -96,10 +98,10 @@ export function createFakeServer(allData: IOlympicData[]) {
                 return values.length;
             }
             case 'first': {
-                return values.length ? ((values[0] as any) ?? null) : null;
+                return values.length ? (values[0] as any) ?? null : null;
             }
             case 'last': {
-                return values.length ? ((values[values.length - 1] as any) ?? null) : null;
+                return values.length ? (values[values.length - 1] as any) ?? null : null;
             }
             default:
                 return values.reduce((sum, value) => sum + (toNumber(value) ?? 0), 0);
@@ -177,7 +179,7 @@ export function createFakeServer(allData: IOlympicData[]) {
                     const matchingRows = targetRows.filter((row) => matchesPivotKey(row, pivotColIds, pivotKey));
                     for (const valueCol of valueCols) {
                         const field = createPivotField(pivotKey, valueCol.id);
-                        result[field] = aggregateValues(matchingRows, valueCol.id, valueCol.aggFunc);
+                        result[field] = aggregateValues(matchingRows, valueCol.id, valueCol.aggFunc!);
                     }
                 }
                 return result as IOlympicData;
@@ -215,7 +217,7 @@ export function createFakeServer(allData: IOlympicData[]) {
 
                         const groupRow: any = { [groupField]: key, childCount: groupRows.length };
                         for (const valueCol of valueCols) {
-                            groupRow[valueCol.id] = aggregateValues(groupRows, valueCol.id, valueCol.aggFunc);
+                            groupRow[valueCol.id] = aggregateValues(groupRows, valueCol.id, valueCol.aggFunc!);
                         }
                         return groupRow as IOlympicData;
                     });

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/fakeServer.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/fakeServer.ts
@@ -1,0 +1,245 @@
+import type { IServerSideDatasource, IServerSideGetRowsRequest } from 'ag-grid-community';
+
+type ServerResponse = {
+    success: boolean;
+    rows: IOlympicData[];
+    lastRow: number;
+    pivotResultFields?: string[];
+};
+
+export function createServerSideDatasource(server: { getData: (request: IServerSideGetRowsRequest) => ServerResponse }): IServerSideDatasource {
+    return {
+        getRows: (params) => {
+            const response = server.getData(params.request);
+
+            setTimeout(() => {
+                if (response.success) {
+                    params.success({
+                        rowData: response.rows,
+                        rowCount: response.lastRow,
+                        pivotResultFields: response.pivotResultFields,
+                    });
+                } else {
+                    params.fail();
+                }
+            }, 200);
+        },
+    };
+}
+
+export function createFakeServer(allData: IOlympicData[]) {
+    const matchesPivotKey = (row: IOlympicData, pivotColIds: string[], pivotKey: string[]) => {
+        for (let i = 0; i < pivotColIds.length; i++) {
+            if (String((row as any)[pivotColIds[i]]) !== pivotKey[i]) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    const createPivotField = (pivotKey: string[], valueColId: string) => `${pivotKey.join('_')}_${valueColId}`;
+
+    const toNumber = (value: unknown): number | null => {
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            return value;
+        }
+        if (typeof value === 'string') {
+            const parsed = Number(value);
+            return Number.isFinite(parsed) ? parsed : null;
+        }
+        return null;
+    };
+
+    const aggregateValues = (rows: IOlympicData[], field: string, aggFunc: string): number | string | null => {
+        const values = rows.map((row) => (row as any)[field]);
+
+        switch (aggFunc) {
+            case 'sum': {
+                return values.reduce((sum, value) => sum + (toNumber(value) ?? 0), 0);
+            }
+            case 'min': {
+                let min: number | null = null;
+                for (const value of values) {
+                    const num = toNumber(value);
+                    if (num == null) {
+                        continue;
+                    }
+                    min = min == null ? num : Math.min(min, num);
+                }
+                return min;
+            }
+            case 'max': {
+                let max: number | null = null;
+                for (const value of values) {
+                    const num = toNumber(value);
+                    if (num == null) {
+                        continue;
+                    }
+                    max = max == null ? num : Math.max(max, num);
+                }
+                return max;
+            }
+            case 'avg': {
+                let sum = 0;
+                let count = 0;
+                for (const value of values) {
+                    const num = toNumber(value);
+                    if (num == null) {
+                        continue;
+                    }
+                    sum += num;
+                    count++;
+                }
+                return count > 0 ? sum / count : null;
+            }
+            case 'count': {
+                return values.length;
+            }
+            case 'first': {
+                return values.length ? ((values[0] as any) ?? null) : null;
+            }
+            case 'last': {
+                return values.length ? ((values[values.length - 1] as any) ?? null) : null;
+            }
+            default:
+                return values.reduce((sum, value) => sum + (toNumber(value) ?? 0), 0);
+        }
+    };
+
+    const sortRows = (rows: IOlympicData[], sortModel: IServerSideGetRowsRequest['sortModel']) => {
+        if (!sortModel?.length) {
+            return rows;
+        }
+
+        return [...rows].sort((a: any, b: any) => {
+            for (const sort of sortModel) {
+                const left = a[sort.colId];
+                const right = b[sort.colId];
+
+                if (left === right) {
+                    continue;
+                }
+
+                const compare = left > right ? 1 : -1;
+                return sort.sort === 'asc' ? compare : -compare;
+            }
+            return 0;
+        });
+    };
+
+    const compareKeys = (left: string, right: string): number => {
+        const leftNum = toNumber(left);
+        const rightNum = toNumber(right);
+        if (leftNum != null && rightNum != null) {
+            return leftNum - rightNum;
+        }
+        return left.localeCompare(right, undefined, { numeric: true, sensitivity: 'base' });
+    };
+
+    return {
+        getData: (request: IServerSideGetRowsRequest): ServerResponse => {
+            let rows = allData;
+            const { rowGroupCols = [], pivotCols = [], groupKeys = [], valueCols = [], sortModel = [] } = request;
+
+            for (let i = 0; i < groupKeys.length; i++) {
+                const key = groupKeys[i];
+                const rowGroupCol = rowGroupCols[i];
+                if (!rowGroupCol) {
+                    continue;
+                }
+                rows = rows.filter((row) => String((row as any)[rowGroupCol.id]) === String(key));
+            }
+
+            const isGrouping = rowGroupCols.length > groupKeys.length;
+            let resultRows: IOlympicData[];
+            let pivotResultFields: string[] | undefined;
+
+            const hasPivot = pivotCols.length > 0 && valueCols.length > 0;
+            const pivotColIds = pivotCols.map((col) => col.id);
+            const pivotKeys = hasPivot
+                ? Array.from(new Set(rows.map((row) => pivotColIds.map((id) => String((row as any)[id])).join('|'))))
+                      .map((key) => key.split('|'))
+                      .sort((a, b) => {
+                          const len = Math.max(a.length, b.length);
+                          for (let i = 0; i < len; i++) {
+                              const cmp = compareKeys(a[i] ?? '', b[i] ?? '');
+                              if (cmp !== 0) {
+                                  return cmp;
+                              }
+                          }
+                          return 0;
+                      })
+                : [];
+
+            const buildPivotedRow = (targetRows: IOlympicData[], base: any = {}) => {
+                const result: any = { ...base };
+                for (const pivotKey of pivotKeys) {
+                    const matchingRows = targetRows.filter((row) => matchesPivotKey(row, pivotColIds, pivotKey));
+                    for (const valueCol of valueCols) {
+                        const field = createPivotField(pivotKey, valueCol.id);
+                        result[field] = aggregateValues(matchingRows, valueCol.id, valueCol.aggFunc);
+                    }
+                }
+                return result as IOlympicData;
+            };
+
+            if (isGrouping) {
+                const rowGroupCol = rowGroupCols[groupKeys.length];
+                const groupField = rowGroupCol.id;
+                const grouped = new Map<string, IOlympicData[]>();
+
+                for (const row of rows) {
+                    const key = String((row as any)[groupField]);
+                    const bucket = grouped.get(key);
+                    if (bucket) {
+                        bucket.push(row);
+                    } else {
+                        grouped.set(key, [row]);
+                    }
+                }
+
+                resultRows = Array.from(grouped.entries())
+                    .sort(([leftKey, leftRows], [rightKey, rightRows]) => {
+                        if (groupField === 'country') {
+                            const countDiff = rightRows.length - leftRows.length;
+                            if (countDiff !== 0) {
+                                return countDiff;
+                            }
+                        }
+                        return compareKeys(leftKey, rightKey);
+                    })
+                    .map(([key, groupRows]) => {
+                        if (hasPivot) {
+                            return buildPivotedRow(groupRows, { [groupField]: key, childCount: groupRows.length });
+                        }
+
+                        const groupRow: any = { [groupField]: key, childCount: groupRows.length };
+                        for (const valueCol of valueCols) {
+                            groupRow[valueCol.id] = aggregateValues(groupRows, valueCol.id, valueCol.aggFunc);
+                        }
+                        return groupRow as IOlympicData;
+                    });
+            } else {
+                resultRows = hasPivot ? [buildPivotedRow(rows)] : [...rows];
+            }
+
+            if (hasPivot) {
+                pivotResultFields = pivotKeys.flatMap((pivotKey) =>
+                    valueCols.map((valueCol) => createPivotField(pivotKey, valueCol.id))
+                );
+            }
+
+            const sortedRows = sortRows(resultRows, sortModel);
+            const start = request.startRow ?? 0;
+            const end = request.endRow ?? sortedRows.length;
+            const requestedRows = sortedRows.slice(start, end);
+
+            return {
+                success: true,
+                rows: requestedRows,
+                lastRow: sortedRows.length,
+                pivotResultFields,
+            };
+        },
+    };
+}

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/index.html
@@ -1,6 +1,3 @@
 <div class="example-wrapper">
-    <div>
-        <span class="button-group" id="pivot-mode-status">Grid Pivot Mode: Off</span>
-    </div>
     <div id="myGrid"></div>
 </div>

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/index.html
@@ -1,0 +1,6 @@
+<div class="example-wrapper">
+    <div>
+        <span class="button-group" id="pivot-mode-status">Grid Pivot Mode: Off</span>
+    </div>
+    <div id="myGrid"></div>
+</div>

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
@@ -1,84 +1,97 @@
-import type { ColDef, GridApi, GridOptions, IServerSideDatasource, IServerSideGetRowsRequest } from 'ag-grid-community';
-import { ModuleRegistry, ValidationModule, createGrid } from 'ag-grid-community';
+import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
+import { ClientSideRowModelModule, ModuleRegistry, ValidationModule, createGrid } from 'ag-grid-community';
 import {
     ColumnMenuModule,
     ColumnsToolPanelModule,
     ContextMenuModule,
     PivotModule,
-    ServerSideRowModelModule,
+    RowGroupingPanelModule,
 } from 'ag-grid-enterprise';
 
 ModuleRegistry.registerModules([
+    ClientSideRowModelModule,
     ColumnsToolPanelModule,
     ColumnMenuModule,
     ContextMenuModule,
     PivotModule,
-    ServerSideRowModelModule,
+    RowGroupingPanelModule,
     ...(process.env.NODE_ENV !== 'production' ? [ValidationModule] : []),
 ]);
 
 const columnDefs: ColDef[] = [
-    { field: 'athlete', minWidth: 180, enableRowGroup: true, enablePivot: true },
-    { field: 'age', enableRowGroup: true, enablePivot: true },
-    { field: 'country', minWidth: 160, enableRowGroup: true, enablePivot: true },
-    { field: 'year', enableRowGroup: true, enablePivot: true },
-    { field: 'sport', minWidth: 180, enableRowGroup: true, enablePivot: true },
-    { field: 'gold', enableValue: true },
-    { field: 'silver', enableValue: true },
-    { field: 'bronze', enableValue: true },
-    { field: 'total', enableValue: true },
+    {
+        field: 'athlete',
+        minWidth: 200,
+        enableRowGroup: true,
+        enablePivot: true,
+    },
+    {
+        field: 'age',
+        enableValue: true,
+    },
+    {
+        field: 'country',
+        minWidth: 200,
+        enableRowGroup: true,
+        enablePivot: true,
+        rowGroupIndex: 1,
+    },
+    {
+        field: 'year',
+        enableRowGroup: true,
+        enablePivot: true,
+        pivotIndex: 1,
+    },
+    {
+        field: 'date',
+        minWidth: 180,
+        enableRowGroup: true,
+        enablePivot: true,
+    },
+    {
+        field: 'sport',
+        minWidth: 200,
+        enableRowGroup: true,
+        enablePivot: true,
+        rowGroupIndex: 2,
+    },
+    {
+        field: 'gold',
+        hide: true,
+        enableValue: true,
+    },
+    {
+        field: 'silver',
+        hide: true,
+        enableValue: true,
+        aggFunc: 'sum',
+    },
+    {
+        field: 'bronze',
+        hide: true,
+        enableValue: true,
+        aggFunc: 'sum',
+    },
+    {
+        headerName: 'Total',
+        field: 'total',
+    },
 ];
 
 let gridApi: GridApi<IOlympicData>;
-let requestSequence = 0;
-
-const logColumnStateSnapshot = (source: string) => {
-    try {
-        if (!gridApi) {
-            return;
-        }
-
-        const getColIdSafe = (col: any): string => {
-            if (!col) {
-                return 'unknown';
-            }
-            if (typeof col.getColId === 'function') {
-                return col.getColId();
-            }
-            if (typeof col.getId === 'function') {
-                return col.getId();
-            }
-            return String(col.colId ?? col.field ?? 'unknown');
-        };
-
-        const visibleCols = gridApi.getAllDisplayedColumns().map(getColIdSafe).join(', ');
-        const rowGroups = gridApi.getRowGroupColumns().map(getColIdSafe).join(', ');
-        const pivots = gridApi.getPivotColumns().map(getColIdSafe).join(', ');
-        const values = gridApi.getValueColumns().map(getColIdSafe).join(', ');
-
-        console.log(
-            `${source} | pivotMode=${gridApi.isPivotMode()} | visible=[${visibleCols}] | rowGroups=[${rowGroups}] | pivots=[${pivots}] | values=[${values}]`
-        );
-    } catch (error) {
-        console.warn('logging failed', error);
-    }
-};
-
-const onColumnMoved = () => logColumnStateSnapshot('columnMoved');
-const onColumnVisible = () => logColumnStateSnapshot('columnVisible');
-const onColumnRowGroupChanged = () => logColumnStateSnapshot('columnRowGroupChanged');
-const onColumnPivotChanged = () => logColumnStateSnapshot('columnPivotChanged');
-const onColumnValueChanged = () => logColumnStateSnapshot('columnValueChanged');
-const onColumnPivotModeChanged = () => logColumnStateSnapshot('columnPivotModeChanged');
 
 const gridOptions: GridOptions<IOlympicData> = {
     columnDefs,
     defaultColDef: {
         flex: 1,
-        minWidth: 100,
+        minWidth: 150,
     },
-    enableStrictPivotColumnOrder: true,
-    rowModelType: 'serverSide',
+    autoGroupColumnDef: {
+        minWidth: 250,
+    },
+    pivotMode: true,
+    rowGroupPanelShow: 'always',
+    pivotPanelShow: 'always',
     sideBar: {
         toolPanels: [
             {
@@ -95,61 +108,14 @@ const gridOptions: GridOptions<IOlympicData> = {
         ],
         defaultToolPanel: 'columns',
     },
-    onColumnMoved,
-    onColumnVisible,
-    onColumnRowGroupChanged,
-    onColumnPivotChanged,
-    onColumnValueChanged,
-    onColumnPivotModeChanged,
 };
 
+// setup the grid after the page has finished loading
 document.addEventListener('DOMContentLoaded', function () {
     const gridDiv = document.querySelector<HTMLElement>('#myGrid')!;
     gridApi = createGrid(gridDiv, gridOptions);
 
     fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
         .then((response) => response.json())
-        .then((data: IOlympicData[]) => {
-            const fakeServer = createFakeServer(data);
-            const datasource = createServerSideDatasource(fakeServer);
-            gridApi!.setGridOption('serverSideDatasource', datasource);
-        });
+        .then((data: IOlympicData[]) => gridApi!.setGridOption('rowData', data));
 });
-
-function createServerSideDatasource(server: {
-    getData: (request: IServerSideGetRowsRequest) => any;
-}): IServerSideDatasource {
-    return {
-        getRows: (params) => {
-            const requestId = ++requestSequence;
-            console.log(`Server request sent (#${requestId})`, params.request);
-            const response = server.getData(params.request);
-
-            setTimeout(() => {
-                if (response.success) {
-                    console.log(`Server response received (#${requestId})`, {
-                        startRow: params.request.startRow,
-                        endRow: params.request.endRow,
-                        returnedRows: response.rows.length,
-                    });
-                    params.success({ rowData: response.rows });
-                } else {
-                    console.log(`Server request failed (#${requestId})`);
-                    params.fail();
-                }
-            }, 200);
-        },
-    };
-}
-
-function createFakeServer(allData: IOlympicData[]) {
-    return {
-        getData: (request: IServerSideGetRowsRequest) => {
-            const requestedRows = allData.slice(request.startRow, request.endRow);
-            return {
-                success: true,
-                rows: requestedRows,
-            };
-        },
-    };
-}

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
@@ -57,10 +57,10 @@ const logColumnStateSnapshot = (source: string) => {
         const values = gridApi.getValueColumns().map(getColIdSafe).join(', ');
 
         console.log(
-            `[CTP Deferred Example] ${source} | pivotMode=${gridApi.isPivotMode()} | visible=[${visibleCols}] | rowGroups=[${rowGroups}] | pivots=[${pivots}] | values=[${values}]`
+            `${source} | pivotMode=${gridApi.isPivotMode()} | visible=[${visibleCols}] | rowGroups=[${rowGroups}] | pivots=[${pivots}] | values=[${values}]`
         );
     } catch (error) {
-        console.warn('[CTP Deferred Example] logging failed', error);
+        console.warn('logging failed', error);
     }
 };
 
@@ -122,19 +122,19 @@ function createServerSideDatasource(server: {
     return {
         getRows: (params) => {
             const requestId = ++requestSequence;
-            console.log(`[CTP Deferred Example] Server request sent (#${requestId})`, params.request);
+            console.log(`Server request sent (#${requestId})`, params.request);
             const response = server.getData(params.request);
 
             setTimeout(() => {
                 if (response.success) {
-                    console.log(`[CTP Deferred Example] Server response received (#${requestId})`, {
+                    console.log(`Server response received (#${requestId})`, {
                         startRow: params.request.startRow,
                         endRow: params.request.endRow,
                         returnedRows: response.rows.length,
                     });
                     params.success({ rowData: response.rows });
                 } else {
-                    console.log(`[CTP Deferred Example] Server request failed (#${requestId})`);
+                    console.log(`Server request failed (#${requestId})`);
                     params.fail();
                 }
             }, 200);

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
@@ -49,20 +49,9 @@ const gridOptions: GridOptions<IOlympicData> = {
     },
 };
 
-function updateStatus(): void {
-    const status = document.getElementById('pivot-mode-status');
-    if (!status || !gridApi) {
-        return;
-    }
-    status.textContent = `Grid Pivot Mode: ${gridApi.isPivotMode() ? 'On' : 'Off'}`;
-}
-
 document.addEventListener('DOMContentLoaded', function () {
     const gridDiv = document.querySelector<HTMLElement>('#myGrid')!;
     gridApi = createGrid(gridDiv, gridOptions);
-
-    updateStatus();
-    gridApi.addEventListener('columnPivotModeChanged', updateStatus);
 
     fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
         .then((response) => response.json())

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
@@ -30,6 +30,7 @@ const columnDefs: ColDef[] = [
 ];
 
 let gridApi: GridApi<IOlympicData>;
+let requestSequence = 0;
 
 const logColumnStateSnapshot = (source: string) => {
     try {
@@ -76,6 +77,7 @@ const gridOptions: GridOptions<IOlympicData> = {
         flex: 1,
         minWidth: 100,
     },
+    enableStrictPivotColumnOrder: true,
     rowModelType: 'serverSide',
     sideBar: {
         toolPanels: [
@@ -117,19 +119,20 @@ document.addEventListener('DOMContentLoaded', function () {
 function createServerSideDatasource(server: { getData: (request: IServerSideGetRowsRequest) => any }): IServerSideDatasource {
     return {
         getRows: (params) => {
-            console.log('[CTP Deferred Example] SSRM getRows request', params.request);
+            const requestId = ++requestSequence;
+            console.log(`[CTP Deferred Example] Server request sent (#${requestId})`, params.request);
             const response = server.getData(params.request);
 
             setTimeout(() => {
                 if (response.success) {
-                    console.log('[CTP Deferred Example] SSRM getRows success', {
+                    console.log(`[CTP Deferred Example] Server response received (#${requestId})`, {
                         startRow: params.request.startRow,
                         endRow: params.request.endRow,
                         returnedRows: response.rows.length,
                     });
                     params.success({ rowData: response.rows });
                 } else {
-                    console.log('[CTP Deferred Example] SSRM getRows fail');
+                    console.log(`[CTP Deferred Example] Server request failed (#${requestId})`);
                     params.fail();
                 }
             }, 200);

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
@@ -116,7 +116,9 @@ document.addEventListener('DOMContentLoaded', function () {
         });
 });
 
-function createServerSideDatasource(server: { getData: (request: IServerSideGetRowsRequest) => any }): IServerSideDatasource {
+function createServerSideDatasource(server: {
+    getData: (request: IServerSideGetRowsRequest) => any;
+}): IServerSideDatasource {
     return {
         getRows: (params) => {
             const requestId = ++requestSequence;

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
@@ -1,13 +1,19 @@
-import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
-import { ClientSideRowModelModule, ModuleRegistry, ValidationModule, createGrid } from 'ag-grid-community';
-import { ColumnMenuModule, ColumnsToolPanelModule, ContextMenuModule, PivotModule } from 'ag-grid-enterprise';
+import type { ColDef, GridApi, GridOptions, IServerSideDatasource, IServerSideGetRowsRequest } from 'ag-grid-community';
+import { ModuleRegistry, ValidationModule, createGrid } from 'ag-grid-community';
+import {
+    ColumnMenuModule,
+    ColumnsToolPanelModule,
+    ContextMenuModule,
+    PivotModule,
+    ServerSideRowModelModule,
+} from 'ag-grid-enterprise';
 
 ModuleRegistry.registerModules([
-    ClientSideRowModelModule,
     ColumnsToolPanelModule,
     ColumnMenuModule,
     ContextMenuModule,
     PivotModule,
+    ServerSideRowModelModule,
     ...(process.env.NODE_ENV !== 'production' ? [ValidationModule] : []),
 ]);
 
@@ -31,6 +37,7 @@ const gridOptions: GridOptions<IOlympicData> = {
         flex: 1,
         minWidth: 100,
     },
+    rowModelType: 'serverSide',
     sideBar: {
         toolPanels: [
             {
@@ -55,5 +62,37 @@ document.addEventListener('DOMContentLoaded', function () {
 
     fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
         .then((response) => response.json())
-        .then((data: IOlympicData[]) => gridApi!.setGridOption('rowData', data));
+        .then((data: IOlympicData[]) => {
+            const fakeServer = createFakeServer(data);
+            const datasource = createServerSideDatasource(fakeServer);
+            gridApi!.setGridOption('serverSideDatasource', datasource);
+        });
 });
+
+function createServerSideDatasource(server: { getData: (request: IServerSideGetRowsRequest) => any }): IServerSideDatasource {
+    return {
+        getRows: (params) => {
+            const response = server.getData(params.request);
+
+            setTimeout(() => {
+                if (response.success) {
+                    params.success({ rowData: response.rows });
+                } else {
+                    params.fail();
+                }
+            }, 200);
+        },
+    };
+}
+
+function createFakeServer(allData: IOlympicData[]) {
+    return {
+        getData: (request: IServerSideGetRowsRequest) => {
+            const requestedRows = allData.slice(request.startRow, request.endRow);
+            return {
+                success: true,
+                rows: requestedRows,
+            };
+        },
+    };
+}

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
@@ -1,0 +1,70 @@
+import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
+import { ClientSideRowModelModule, ModuleRegistry, ValidationModule, createGrid } from 'ag-grid-community';
+import { ColumnMenuModule, ColumnsToolPanelModule, ContextMenuModule, PivotModule } from 'ag-grid-enterprise';
+
+ModuleRegistry.registerModules([
+    ClientSideRowModelModule,
+    ColumnsToolPanelModule,
+    ColumnMenuModule,
+    ContextMenuModule,
+    PivotModule,
+    ...(process.env.NODE_ENV !== 'production' ? [ValidationModule] : []),
+]);
+
+const columnDefs: ColDef[] = [
+    { field: 'athlete', minWidth: 180, enableRowGroup: true, enablePivot: true },
+    { field: 'age', enableRowGroup: true, enablePivot: true },
+    { field: 'country', minWidth: 160, enableRowGroup: true, enablePivot: true },
+    { field: 'year', enableRowGroup: true, enablePivot: true },
+    { field: 'sport', minWidth: 180, enableRowGroup: true, enablePivot: true },
+    { field: 'gold', enableValue: true },
+    { field: 'silver', enableValue: true },
+    { field: 'bronze', enableValue: true },
+    { field: 'total', enableValue: true },
+];
+
+let gridApi: GridApi<IOlympicData>;
+
+const gridOptions: GridOptions<IOlympicData> = {
+    columnDefs,
+    defaultColDef: {
+        flex: 1,
+        minWidth: 100,
+    },
+    sideBar: {
+        toolPanels: [
+            {
+                id: 'columns',
+                labelDefault: 'Columns',
+                labelKey: 'columns',
+                iconKey: 'columns',
+                toolPanel: 'agColumnsToolPanel',
+                toolPanelParams: {
+                    deferApply: true,
+                    buttons: ['apply', 'cancel'],
+                },
+            },
+        ],
+        defaultToolPanel: 'columns',
+    },
+};
+
+function updateStatus(): void {
+    const status = document.getElementById('pivot-mode-status');
+    if (!status || !gridApi) {
+        return;
+    }
+    status.textContent = `Grid Pivot Mode: ${gridApi.isPivotMode() ? 'On' : 'Off'}`;
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    const gridDiv = document.querySelector<HTMLElement>('#myGrid')!;
+    gridApi = createGrid(gridDiv, gridOptions);
+
+    updateStatus();
+    gridApi.addEventListener('columnPivotModeChanged', updateStatus);
+
+    fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
+        .then((response) => response.json())
+        .then((data: IOlympicData[]) => gridApi!.setGridOption('rowData', data));
+});

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
@@ -1,20 +1,23 @@
 import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
-import { ClientSideRowModelModule, ModuleRegistry, ValidationModule, createGrid } from 'ag-grid-community';
+import { ModuleRegistry, ValidationModule, createGrid } from 'ag-grid-community';
 import {
     ColumnMenuModule,
     ColumnsToolPanelModule,
     ContextMenuModule,
     PivotModule,
     RowGroupingPanelModule,
+    ServerSideRowModelModule,
 } from 'ag-grid-enterprise';
 
+import { createFakeServer, createServerSideDatasource } from './fakeServer';
+
 ModuleRegistry.registerModules([
-    ClientSideRowModelModule,
     ColumnsToolPanelModule,
     ColumnMenuModule,
     ContextMenuModule,
     PivotModule,
     RowGroupingPanelModule,
+    ServerSideRowModelModule,
     ...(process.env.NODE_ENV !== 'production' ? [ValidationModule] : []),
 ]);
 
@@ -55,27 +58,10 @@ const columnDefs: ColDef[] = [
         enablePivot: true,
         rowGroupIndex: 2,
     },
-    {
-        field: 'gold',
-        hide: true,
-        enableValue: true,
-    },
-    {
-        field: 'silver',
-        hide: true,
-        enableValue: true,
-        aggFunc: 'sum',
-    },
-    {
-        field: 'bronze',
-        hide: true,
-        enableValue: true,
-        aggFunc: 'sum',
-    },
-    {
-        headerName: 'Total',
-        field: 'total',
-    },
+    { field: 'gold', hide: true, enableValue: true },
+    { field: 'silver', hide: true, enableValue: true, aggFunc: 'sum' },
+    { field: 'bronze', hide: true, enableValue: true, aggFunc: 'sum' },
+    { headerName: 'Total', field: 'total', enableValue: true },
 ];
 
 let gridApi: GridApi<IOlympicData>;
@@ -90,6 +76,7 @@ const gridOptions: GridOptions<IOlympicData> = {
         minWidth: 250,
     },
     pivotMode: true,
+    rowModelType: 'serverSide',
     rowGroupPanelShow: 'always',
     pivotPanelShow: 'always',
     sideBar: {
@@ -108,6 +95,7 @@ const gridOptions: GridOptions<IOlympicData> = {
         ],
         defaultToolPanel: 'columns',
     },
+    getChildCount: (data: any) => (typeof data?.childCount === 'number' ? data.childCount : undefined),
 };
 
 // setup the grid after the page has finished loading
@@ -117,5 +105,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
     fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
         .then((response) => response.json())
-        .then((data: IOlympicData[]) => gridApi!.setGridOption('rowData', data));
+        .then((data: IOlympicData[]) => {
+            const fakeServer = createFakeServer(data);
+            const datasource = createServerSideDatasource(fakeServer);
+            gridApi!.setGridOption('serverSideDatasource', datasource);
+        });
 });

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
@@ -31,6 +31,45 @@ const columnDefs: ColDef[] = [
 
 let gridApi: GridApi<IOlympicData>;
 
+const logColumnStateSnapshot = (source: string) => {
+    try {
+        if (!gridApi) {
+            return;
+        }
+
+        const getColIdSafe = (col: any): string => {
+            if (!col) {
+                return 'unknown';
+            }
+            if (typeof col.getColId === 'function') {
+                return col.getColId();
+            }
+            if (typeof col.getId === 'function') {
+                return col.getId();
+            }
+            return String(col.colId ?? col.field ?? 'unknown');
+        };
+
+        const visibleCols = gridApi.getAllDisplayedColumns().map(getColIdSafe).join(', ');
+        const rowGroups = gridApi.getRowGroupColumns().map(getColIdSafe).join(', ');
+        const pivots = gridApi.getPivotColumns().map(getColIdSafe).join(', ');
+        const values = gridApi.getValueColumns().map(getColIdSafe).join(', ');
+
+        console.log(
+            `[CTP Deferred Example] ${source} | pivotMode=${gridApi.isPivotMode()} | visible=[${visibleCols}] | rowGroups=[${rowGroups}] | pivots=[${pivots}] | values=[${values}]`
+        );
+    } catch (error) {
+        console.warn('[CTP Deferred Example] logging failed', error);
+    }
+};
+
+const onColumnMoved = () => logColumnStateSnapshot('columnMoved');
+const onColumnVisible = () => logColumnStateSnapshot('columnVisible');
+const onColumnRowGroupChanged = () => logColumnStateSnapshot('columnRowGroupChanged');
+const onColumnPivotChanged = () => logColumnStateSnapshot('columnPivotChanged');
+const onColumnValueChanged = () => logColumnStateSnapshot('columnValueChanged');
+const onColumnPivotModeChanged = () => logColumnStateSnapshot('columnPivotModeChanged');
+
 const gridOptions: GridOptions<IOlympicData> = {
     columnDefs,
     defaultColDef: {
@@ -54,6 +93,12 @@ const gridOptions: GridOptions<IOlympicData> = {
         ],
         defaultToolPanel: 'columns',
     },
+    onColumnMoved,
+    onColumnVisible,
+    onColumnRowGroupChanged,
+    onColumnPivotChanged,
+    onColumnValueChanged,
+    onColumnPivotModeChanged,
 };
 
 document.addEventListener('DOMContentLoaded', function () {
@@ -72,12 +117,19 @@ document.addEventListener('DOMContentLoaded', function () {
 function createServerSideDatasource(server: { getData: (request: IServerSideGetRowsRequest) => any }): IServerSideDatasource {
     return {
         getRows: (params) => {
+            console.log('[CTP Deferred Example] SSRM getRows request', params.request);
             const response = server.getData(params.request);
 
             setTimeout(() => {
                 if (response.success) {
+                    console.log('[CTP Deferred Example] SSRM getRows success', {
+                        startRow: params.request.startRow,
+                        endRow: params.request.endRow,
+                        returnedRows: response.rows.length,
+                    });
                     params.success({ rowData: response.rows });
                 } else {
+                    console.log('[CTP Deferred Example] SSRM getRows fail');
                     params.fail();
                 }
             }, 200);

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/styles.css
@@ -1,0 +1,17 @@
+.example-wrapper {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+#myGrid {
+    flex: 1 1 0px;
+    width: 100%;
+}
+
+.button-group {
+    padding-bottom: 4px;
+    display: inline-block;
+    font-family: Verdana, Geneva, Tahoma, sans-serif;
+    font-size: 13px;
+}

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/styles.css
@@ -8,10 +8,3 @@
     flex: 1 1 0px;
     width: 100%;
 }
-
-.button-group {
-    padding-bottom: 4px;
-    display: inline-block;
-    font-family: Verdana, Geneva, Tahoma, sans-serif;
-    font-size: 13px;
-}

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/index.mdoc
@@ -24,6 +24,41 @@ Selecting columns means different things depending on whether the grid is in piv
 -   **Pivot Mode Off**: When pivot mode is off, selecting a column toggles the visibility of the column. A selected column is visible and an unselected column is hidden. With `allowDragFromColumnsToolPanel=true`, you can drag a column from the tool panel onto the grid and it will become visible.
 -   **Pivot Mode On**: When pivot mode is on, selecting a column will trigger the column to be either aggregated, grouped or pivoted depending on what is allowed for that column.
 
+## Deferred Apply Mode
+
+You can configure the Columns Tool Panel to stage changes and require an explicit **Apply** action before they are committed.
+
+```{% frameworkTransform=true %}
+const gridOptions = {
+    sideBar: {
+        toolPanels: [
+            {
+                id: 'columns',
+                labelDefault: 'Columns',
+                labelKey: 'columns',
+                iconKey: 'columns',
+                toolPanel: 'agColumnsToolPanel',
+                toolPanelParams: {
+                    deferApply: true,
+                    buttons: ['apply', 'cancel'],
+                },
+            },
+        ],
+        defaultToolPanel: 'columns',
+    },
+};
+```
+
+When `deferApply=true`:
+
+-   Changes made in the Columns Tool Panel are staged as pending changes.
+-   **Apply** commits pending changes.
+-   **Cancel** discards pending changes.
+
+Changes made outside the Columns Tool Panel (for example via other grid entry points) continue to apply immediately.
+
+{% gridExampleRunner title="Deferred Apply Mode" name="deferred-apply-mode"  exampleHeight=630 /%}
+
 ## Columns Tool Panel Sections
 
 The Columns Tool Panel is split into different sections as described from the top:

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/index.mdoc
@@ -59,7 +59,7 @@ Changes made outside the Columns Tool Panel (for example via other grid entry po
 
 The example below uses the Server-Side Row Model.
 
-{% gridExampleRunner title="Deferred Apply Mode" name="deferred-apply-mode"  exampleHeight=630 /%}
+{% gridExampleRunner title="Deferred Apply Mode" name="deferred-apply-mode"  exampleHeight=730 /%}
 
 ## Columns Tool Panel Sections
 

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/index.mdoc
@@ -57,6 +57,8 @@ When `deferApply=true`:
 
 Changes made outside the Columns Tool Panel (for example via other grid entry points) continue to apply immediately.
 
+The example below uses the Server-Side Row Model.
+
 {% gridExampleRunner title="Deferred Apply Mode" name="deferred-apply-mode"  exampleHeight=630 /%}
 
 ## Columns Tool Panel Sections

--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -301,7 +301,9 @@ export class ColumnModel extends BeanStub implements NamedBean {
                 );
             });
 
-            const valueColumnsInDisplayOrder = (valueColumns ?? []).filter((col) => cols.map[col.getColId()] !== undefined);
+            const valueColumnsInDisplayOrder = (valueColumns ?? []).filter(
+                (col) => cols.map[col.getColId()] !== undefined
+            );
             return [...nonValueColumns, ...valueColumnsInDisplayOrder];
         }
 

--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -291,20 +291,24 @@ export class ColumnModel extends BeanStub implements NamedBean {
         const showRowNumbers = _isRowNumbers(beans);
         const valueColumns = valueColsSvc?.columns;
 
-        const res = cols.list.filter((col) => {
-            const isAutoGroupCol = isColumnGroupAutoCol(col);
-            if (showAutoGroupAndValuesOnly) {
-                const isValueCol = valueColumns?.includes(col);
+        if (showAutoGroupAndValuesOnly) {
+            const nonValueColumns = cols.list.filter((col) => {
+                const isAutoGroupCol = isColumnGroupAutoCol(col);
                 return (
                     isAutoGroupCol ||
-                    isValueCol ||
                     (showSelectionColumn && isColumnSelectionCol(col)) ||
                     (showRowNumbers && isRowNumberCol(col))
                 );
-            } else {
-                // keep col if a) it's auto-group or b) it's visible
-                return isAutoGroupCol || col.isVisible();
-            }
+            });
+
+            const valueColumnsInDisplayOrder = (valueColumns ?? []).filter((col) => cols.map[col.getColId()] !== undefined);
+            return [...nonValueColumns, ...valueColumnsInDisplayOrder];
+        }
+
+        const res = cols.list.filter((col) => {
+            const isAutoGroupCol = isColumnGroupAutoCol(col);
+            // keep col if a) it's auto-group or b) it's visible
+            return isAutoGroupCol || col.isVisible();
         });
 
         return res;

--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -277,6 +277,9 @@ export class ColumnModel extends BeanStub implements NamedBean {
         return this.cols;
     }
 
+    /**
+     * Returns a canonical list of columns to show.
+     */
     public getColsToShow(): AgColumn[] {
         if (!this.cols) {
             return [];
@@ -307,13 +310,11 @@ export class ColumnModel extends BeanStub implements NamedBean {
             return [...nonValueColumns, ...valueColumnsInDisplayOrder];
         }
 
-        const res = cols.list.filter((col) => {
+        return cols.list.filter((col) => {
             const isAutoGroupCol = isColumnGroupAutoCol(col);
             // keep col if a) it's auto-group or b) it's visible
             return isAutoGroupCol || col.isVisible();
         });
-
-        return res;
     }
 
     // on events 'groupDisplayType', 'treeData', 'treeDataDisplayType', 'groupHideOpenParents'

--- a/packages/ag-grid-community/src/interfaces/iToolPanel.ts
+++ b/packages/ag-grid-community/src/interfaces/iToolPanel.ts
@@ -52,6 +52,10 @@ export interface IToolPanelColumnCompParams {
     contractColumnSelection: boolean;
     /** Suppress updating the layout of columns as they are rearranged in the grid */
     suppressSyncLayoutWithGrid: boolean;
+    /** Defer applying Columns Tool Panel changes until an explicit apply action */
+    deferApply?: boolean;
+    /** Action buttons shown in the Columns Tool Panel when `deferApply` is enabled */
+    buttons?: ('apply' | 'cancel')[];
 }
 
 export interface IToolPanelFiltersCompParams {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
@@ -562,7 +562,8 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
             this.eventType,
             this.params.onDeferredPivotColumnStateUpdate,
             this.params.onDeferredVisibilityColumnStateUpdate,
-            this.params.getToolPanelPivotMode?.()
+            this.params.getToolPanelPivotMode?.(),
+            this.params.getToolPanelColumnFunctionState
         );
     }
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
@@ -28,7 +28,7 @@ import { syncLayoutWithGrid, toolPanelCreateColumnTree } from '../sideBar/common
 import { VirtualList } from '../widgets/virtualList';
 import { ExpandState } from './agPrimaryColsHeader';
 import { ColumnModelItem } from './columnModelItem';
-import { getCurrentColumnsBeingMoved, getCurrentDragValue, getMoveTargetIndex, isMoveBlocked, moveItem } from './columnMoveUtils';
+import { getCurrentColumnsBeingMoved, getCurrentDragValue, isMoveBlocked, moveItem } from './columnMoveUtils';
 import type { ToolPanelColumnCompParams } from './columnToolPanel';
 import { selectAllChildren } from './modelItemUtils';
 import { ToolPanelColumnComp } from './toolPanelColumnComp';
@@ -176,13 +176,7 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
                 moveItem: (
                     currentDragValue: AgColumn | AgProvidedColumnGroup | null,
                     lastHoveredListItem: VirtualListDragItem<ToolPanelColumnGroupComp | ToolPanelColumnComp> | null
-                ) => {
-                    const currentColumns = getCurrentColumnsBeingMoved(currentDragValue);
-                    if (this.stageDeferredColumnMove(currentColumns, lastHoveredListItem)) {
-                        return;
-                    }
-                    moveItem(beans, currentColumns, lastHoveredListItem);
-                },
+                ) => moveItem(beans, getCurrentColumnsBeingMoved(currentDragValue), lastHoveredListItem),
             })
         );
     }
@@ -212,20 +206,6 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
 
         const nextItem = Math.min(Math.max(currentIndex + movePadding + diff, 0), this.displayedColsList.length - 1);
 
-        const hoveredComponent = this.virtualList.getComponentAt(nextItem) as
-            | ToolPanelColumnComp
-            | ToolPanelColumnGroupComp
-            | undefined;
-        if (
-            this.stageDeferredColumnMove(currentColumns, {
-                rowIndex: nextItem,
-                position: isUp ? 'top' : 'bottom',
-                component: hoveredComponent ?? null,
-            } as VirtualListDragItem<ToolPanelColumnGroupComp | ToolPanelColumnComp>)
-        ) {
-            return;
-        }
-
         this.skipRefocus = true;
         moveItem(beans, currentColumns, {
             rowIndex: nextItem,
@@ -236,61 +216,6 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
         this.focusRowIfAlive(nextItem - movePadding).then(() => {
             this.skipRefocus = false;
         });
-    }
-
-    private stageDeferredColumnMove(
-        currentColumns: AgColumn[],
-        lastHoveredListItem: VirtualListDragItem<ToolPanelColumnGroupComp | ToolPanelColumnComp> | null
-    ): boolean {
-        const onDeferredColumnOrderUpdate = this.params.onDeferredColumnOrderUpdate;
-        if (!onDeferredColumnOrderUpdate) {
-            return false;
-        }
-
-        if (!lastHoveredListItem) {
-            return true;
-        }
-
-        const { component } = lastHoveredListItem;
-        let lastHoveredColumn: AgColumn | null = null;
-        let isBefore = lastHoveredListItem.position === 'top';
-
-        if (component instanceof ToolPanelColumnGroupComp) {
-            const columns = component.getColumns();
-            lastHoveredColumn = columns[0] ?? null;
-            isBefore = true;
-        } else if (component) {
-            lastHoveredColumn = component.column;
-        }
-
-        if (!lastHoveredColumn) {
-            const hoveredItem = this.displayedColsList[lastHoveredListItem.rowIndex];
-            if (hoveredItem) {
-                if (hoveredItem.group) {
-                    const columns = hoveredItem.columnGroup.getLeafColumns();
-                    lastHoveredColumn = columns[0] ?? null;
-                    isBefore = true;
-                } else {
-                    lastHoveredColumn = hoveredItem.column;
-                }
-            }
-        }
-
-        if (!lastHoveredColumn) {
-            return true;
-        }
-
-        const allColumns = this.params.getToolPanelColumnsInOrder?.() ?? this.beans.colModel.getCols();
-        const targetIndex = getMoveTargetIndex(allColumns, currentColumns, lastHoveredColumn, isBefore);
-        if (targetIndex == null) {
-            return true;
-        }
-
-        const movedIds = new Set(currentColumns.map((currentColumn) => currentColumn.getColId()));
-        const nextOrder = allColumns.filter((existingColumn) => !movedIds.has(existingColumn.getColId()));
-        nextOrder.splice(targetIndex, 0, ...currentColumns);
-        onDeferredColumnOrderUpdate(nextOrder.map((nextColumn) => nextColumn.getColId()));
-        return true;
     }
 
     private createComponentFromItem(

--- a/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
@@ -264,6 +264,19 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
         }
 
         if (!lastHoveredColumn) {
+            const hoveredItem = this.displayedColsList[lastHoveredListItem.rowIndex];
+            if (hoveredItem) {
+                if (hoveredItem.group) {
+                    const columns = hoveredItem.columnGroup.getLeafColumns();
+                    lastHoveredColumn = columns[0] ?? null;
+                    isBefore = true;
+                } else {
+                    lastHoveredColumn = hoveredItem.column;
+                }
+            }
+        }
+
+        if (!lastHoveredColumn) {
             return true;
         }
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
@@ -251,7 +251,7 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
 
         const expandedStates = this.getExpandedStates();
 
-        const pivotModeActive = this.colModel.isPivotMode();
+        const pivotModeActive = this.params.getToolPanelPivotMode?.() ?? this.colModel.isPivotMode();
         const shouldSyncColumnLayoutWithGrid = !params.suppressSyncLayoutWithGrid && !pivotModeActive;
 
         if (shouldSyncColumnLayoutWithGrid) {
@@ -555,14 +555,22 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
     }
 
     public doSetSelectedAll(selectAllChecked: boolean): void {
-        selectAllChildren(this.beans, this.allColsTree, selectAllChecked, this.eventType);
+        selectAllChildren(
+            this.beans,
+            this.allColsTree,
+            selectAllChecked,
+            this.eventType,
+            this.params.onDeferredPivotColumnStateUpdate,
+            this.params.onDeferredVisibilityColumnStateUpdate,
+            this.params.getToolPanelPivotMode?.()
+        );
     }
 
     private getSelectionState(): boolean | undefined {
         let checkedCount = 0;
         let uncheckedCount = 0;
 
-        const pivotMode = this.colModel.isPivotMode();
+        const pivotMode = this.params.getToolPanelPivotMode?.() ?? this.colModel.isPivotMode();
 
         this.forEachItem((item) => {
             if (item.group) {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
@@ -591,13 +591,17 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
                 if (noPivotModeOptionsAllowed) {
                     return;
                 }
-                checked = column.isValueActive() || column.isPivotActive() || column.isRowGroupActive();
+                checked = this.params.isColumnCheckedInToolPanel
+                    ? this.params.isColumnCheckedInToolPanel(column, pivotMode)
+                    : column.isValueActive() || column.isPivotActive() || column.isRowGroupActive();
             } else {
                 if (colDef.lockVisible) {
                     return;
                 }
 
-                checked = column.isVisible();
+                checked = this.params.isColumnCheckedInToolPanel
+                    ? this.params.isColumnCheckedInToolPanel(column, pivotMode)
+                    : column.isVisible();
             }
 
             if (checked) {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
@@ -222,21 +222,16 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
         item: ColumnModelItem,
         listItemElement: HTMLElement
     ): ToolPanelColumnGroupComp | ToolPanelColumnComp {
-        const allowDragging = this.allowDragging;
+        const { allowDragging, eventType, params, groupsExist } = this;
         if (item.group) {
-            const renderedGroup = new ToolPanelColumnGroupComp(
-                item,
-                allowDragging,
-                this.eventType,
-                listItemElement,
-                this.params
-            );
+            // Pass tool-panel params through so each row/group can use deferred callbacks and staged-state helpers.
+            const renderedGroup = new ToolPanelColumnGroupComp(item, allowDragging, eventType, listItemElement, params);
             this.createBean(renderedGroup);
 
             return renderedGroup;
         }
 
-        const columnComp = new ToolPanelColumnComp(item, allowDragging, this.groupsExist, listItemElement, this.params);
+        const columnComp = new ToolPanelColumnComp(item, allowDragging, groupsExist, listItemElement, params);
         this.createBean(columnComp);
 
         return columnComp;
@@ -251,6 +246,8 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
 
         const expandedStates = this.getExpandedStates();
 
+        // Prefer tool-panel state when available. In deferred mode, pivot mode can be staged but not yet applied,
+        // and the UI should still reflect the staged state.
         const pivotModeActive = this.params.getToolPanelPivotMode?.() ?? this.colModel.isPivotMode();
         const shouldSyncColumnLayoutWithGrid = !params.suppressSyncLayoutWithGrid && !pivotModeActive;
 
@@ -555,15 +552,17 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
     }
 
     public doSetSelectedAll(selectAllChecked: boolean): void {
+        const { beans, allColsTree, eventType, params } = this;
+        // In deferred mode, stage checkbox actions as pending changes instead of applying immediately.
         selectAllChildren(
-            this.beans,
-            this.allColsTree,
+            beans,
+            allColsTree,
             selectAllChecked,
-            this.eventType,
-            this.params.onDeferredPivotColumnStateUpdate,
-            this.params.onDeferredVisibilityColumnStateUpdate,
-            this.params.getToolPanelPivotMode?.(),
-            this.params.getToolPanelColumnFunctionState
+            eventType,
+            params.onDeferredPivotColumnStateUpdate,
+            params.onDeferredVisibilityColumnStateUpdate,
+            params.getToolPanelPivotMode?.(),
+            params.getToolPanelColumnFunctionState
         );
     }
 
@@ -571,6 +570,8 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
         let checkedCount = 0;
         let uncheckedCount = 0;
 
+        // Prefer tool-panel state when available. In deferred mode, pivot mode can be staged but not yet applied,
+        // and the UI should still reflect the staged state.
         const pivotMode = this.params.getToolPanelPivotMode?.() ?? this.colModel.isPivotMode();
 
         this.forEachItem((item) => {
@@ -586,6 +587,8 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
 
             let checked: boolean;
 
+            // Header checkbox state (checked/indeterminate) should match staged row-group/pivot/value/visibility
+            // state in deferred mode.
             if (pivotMode) {
                 const noPivotModeOptionsAllowed =
                     !column.isAllowPivot() && !column.isAllowRowGroup() && !column.isAllowValue();

--- a/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
@@ -176,7 +176,13 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
                 moveItem: (
                     currentDragValue: AgColumn | AgProvidedColumnGroup | null,
                     lastHoveredListItem: VirtualListDragItem<ToolPanelColumnGroupComp | ToolPanelColumnComp> | null
-                ) => moveItem(beans, getCurrentColumnsBeingMoved(currentDragValue), lastHoveredListItem),
+                ) => {
+                    const currentColumns = getCurrentColumnsBeingMoved(currentDragValue);
+                    if (this.stageDeferredColumnMove(currentColumns, lastHoveredListItem)) {
+                        return;
+                    }
+                    moveItem(beans, currentColumns, lastHoveredListItem);
+                },
             })
         );
     }
@@ -206,27 +212,17 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
 
         const nextItem = Math.min(Math.max(currentIndex + movePadding + diff, 0), this.displayedColsList.length - 1);
 
-        const onDeferredColumnOrderUpdate = this.params.onDeferredColumnOrderUpdate;
-        if (onDeferredColumnOrderUpdate) {
-            const hoveredItem = this.displayedColsList[nextItem];
-            if (!hoveredItem) {
-                return;
-            }
-            const hoveredColumn = hoveredItem.group ? hoveredItem.columnGroup.getLeafColumns()[0] : hoveredItem.column;
-            if (!hoveredColumn) {
-                return;
-            }
-
-            const allColumns = this.params.getToolPanelColumnsInOrder?.() ?? beans.colModel.getCols();
-            const targetIndex = getMoveTargetIndex(allColumns, currentColumns, hoveredColumn, isUp);
-            if (targetIndex == null) {
-                return;
-            }
-
-            const movedIds = new Set(currentColumns.map((currentColumn) => currentColumn.getColId()));
-            const nextOrder = allColumns.filter((existingColumn) => !movedIds.has(existingColumn.getColId()));
-            nextOrder.splice(targetIndex, 0, ...currentColumns);
-            onDeferredColumnOrderUpdate(nextOrder.map((nextColumn) => nextColumn.getColId()));
+        const hoveredComponent = this.virtualList.getComponentAt(nextItem) as
+            | ToolPanelColumnComp
+            | ToolPanelColumnGroupComp
+            | undefined;
+        if (
+            this.stageDeferredColumnMove(currentColumns, {
+                rowIndex: nextItem,
+                position: isUp ? 'top' : 'bottom',
+                component: hoveredComponent ?? null,
+            } as VirtualListDragItem<ToolPanelColumnGroupComp | ToolPanelColumnComp>)
+        ) {
             return;
         }
 
@@ -240,6 +236,48 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
         this.focusRowIfAlive(nextItem - movePadding).then(() => {
             this.skipRefocus = false;
         });
+    }
+
+    private stageDeferredColumnMove(
+        currentColumns: AgColumn[],
+        lastHoveredListItem: VirtualListDragItem<ToolPanelColumnGroupComp | ToolPanelColumnComp> | null
+    ): boolean {
+        const onDeferredColumnOrderUpdate = this.params.onDeferredColumnOrderUpdate;
+        if (!onDeferredColumnOrderUpdate) {
+            return false;
+        }
+
+        if (!lastHoveredListItem) {
+            return true;
+        }
+
+        const { component } = lastHoveredListItem;
+        let lastHoveredColumn: AgColumn | null = null;
+        let isBefore = lastHoveredListItem.position === 'top';
+
+        if (component instanceof ToolPanelColumnGroupComp) {
+            const columns = component.getColumns();
+            lastHoveredColumn = columns[0] ?? null;
+            isBefore = true;
+        } else if (component) {
+            lastHoveredColumn = component.column;
+        }
+
+        if (!lastHoveredColumn) {
+            return true;
+        }
+
+        const allColumns = this.params.getToolPanelColumnsInOrder?.() ?? this.beans.colModel.getCols();
+        const targetIndex = getMoveTargetIndex(allColumns, currentColumns, lastHoveredColumn, isBefore);
+        if (targetIndex == null) {
+            return true;
+        }
+
+        const movedIds = new Set(currentColumns.map((currentColumn) => currentColumn.getColId()));
+        const nextOrder = allColumns.filter((existingColumn) => !movedIds.has(existingColumn.getColId()));
+        nextOrder.splice(targetIndex, 0, ...currentColumns);
+        onDeferredColumnOrderUpdate(nextOrder.map((nextColumn) => nextColumn.getColId()));
+        return true;
     }
 
     private createComponentFromItem(

--- a/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
@@ -28,7 +28,7 @@ import { syncLayoutWithGrid, toolPanelCreateColumnTree } from '../sideBar/common
 import { VirtualList } from '../widgets/virtualList';
 import { ExpandState } from './agPrimaryColsHeader';
 import { ColumnModelItem } from './columnModelItem';
-import { getCurrentColumnsBeingMoved, getCurrentDragValue, isMoveBlocked, moveItem } from './columnMoveUtils';
+import { getCurrentColumnsBeingMoved, getCurrentDragValue, getMoveTargetIndex, isMoveBlocked, moveItem } from './columnMoveUtils';
 import type { ToolPanelColumnCompParams } from './columnToolPanel';
 import { selectAllChildren } from './modelItemUtils';
 import { ToolPanelColumnComp } from './toolPanelColumnComp';
@@ -205,6 +205,30 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
         }
 
         const nextItem = Math.min(Math.max(currentIndex + movePadding + diff, 0), this.displayedColsList.length - 1);
+
+        const onDeferredColumnOrderUpdate = this.params.onDeferredColumnOrderUpdate;
+        if (onDeferredColumnOrderUpdate) {
+            const hoveredItem = this.displayedColsList[nextItem];
+            if (!hoveredItem) {
+                return;
+            }
+            const hoveredColumn = hoveredItem.group ? hoveredItem.columnGroup.getLeafColumns()[0] : hoveredItem.column;
+            if (!hoveredColumn) {
+                return;
+            }
+
+            const allColumns = this.params.getToolPanelColumnsInOrder?.() ?? beans.colModel.getCols();
+            const targetIndex = getMoveTargetIndex(allColumns, currentColumns, hoveredColumn, isUp);
+            if (targetIndex == null) {
+                return;
+            }
+
+            const movedIds = new Set(currentColumns.map((currentColumn) => currentColumn.getColId()));
+            const nextOrder = allColumns.filter((existingColumn) => !movedIds.has(existingColumn.getColId()));
+            nextOrder.splice(targetIndex, 0, ...currentColumns);
+            onDeferredColumnOrderUpdate(nextOrder.map((nextColumn) => nextColumn.getColId()));
+            return;
+        }
 
         this.skipRefocus = true;
         moveItem(beans, currentColumns, {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
@@ -224,13 +224,19 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
     ): ToolPanelColumnGroupComp | ToolPanelColumnComp {
         const allowDragging = this.allowDragging;
         if (item.group) {
-            const renderedGroup = new ToolPanelColumnGroupComp(item, allowDragging, this.eventType, listItemElement);
+            const renderedGroup = new ToolPanelColumnGroupComp(
+                item,
+                allowDragging,
+                this.eventType,
+                listItemElement,
+                this.params
+            );
             this.createBean(renderedGroup);
 
             return renderedGroup;
         }
 
-        const columnComp = new ToolPanelColumnComp(item, allowDragging, this.groupsExist, listItemElement);
+        const columnComp = new ToolPanelColumnComp(item, allowDragging, this.groupsExist, listItemElement, this.params);
         this.createBean(columnComp);
 
         return columnComp;

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnMoveUtils.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnMoveUtils.ts
@@ -18,8 +18,8 @@ export const getCurrentColumnsBeingMoved = (column: AgColumn | AgProvidedColumnG
     return column ? [column] : [];
 };
 
-const getMoveTargetIndex = (
-    beans: BeanCollection,
+export const getMoveTargetIndex = (
+    allColumns: AgColumn[],
     currentColumns: AgColumn[] | null,
     lastHoveredColumn: AgColumn,
     isBefore: boolean
@@ -28,7 +28,6 @@ const getMoveTargetIndex = (
         return null;
     }
 
-    const allColumns = beans.colModel.getCols();
     const targetColumnIndex = allColumns.indexOf(lastHoveredColumn);
     const adjustedTarget = isBefore ? targetColumnIndex : targetColumnIndex + 1;
     const diff = getMoveDiff(allColumns, currentColumns, adjustedTarget);
@@ -90,7 +89,7 @@ export const moveItem = (
         return;
     }
 
-    const targetIndex: number | null = getMoveTargetIndex(beans, currentColumns, lastHoveredColumn, isBefore);
+    const targetIndex: number | null = getMoveTargetIndex(beans.colModel.getCols(), currentColumns, lastHoveredColumn, isBefore);
 
     if (targetIndex != null) {
         beans.colMoves?.moveColumns(currentColumns, targetIndex, 'toolPanelUi');

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnMoveUtils.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnMoveUtils.ts
@@ -89,7 +89,12 @@ export const moveItem = (
         return;
     }
 
-    const targetIndex: number | null = getMoveTargetIndex(beans.colModel.getCols(), currentColumns, lastHoveredColumn, isBefore);
+    const targetIndex: number | null = getMoveTargetIndex(
+        beans.colModel.getCols(),
+        currentColumns,
+        lastHoveredColumn,
+        isBefore
+    );
 
     if (targetIndex != null) {
         beans.colMoves?.moveColumns(currentColumns, targetIndex, 'toolPanelUi');

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnMoveUtils.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnMoveUtils.ts
@@ -18,7 +18,7 @@ export const getCurrentColumnsBeingMoved = (column: AgColumn | AgProvidedColumnG
     return column ? [column] : [];
 };
 
-export const getMoveTargetIndex = (
+const getMoveTargetIndex = (
     allColumns: AgColumn[],
     currentColumns: AgColumn[] | null,
     lastHoveredColumn: AgColumn,

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.css
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.css
@@ -49,4 +49,10 @@
 
 .ag-column-panel-buttons-button {
     line-height: 1.5;
+
+    &:disabled:hover {
+        color: var(--ag-button-disabled-text-color);
+        background-color: var(--ag-button-disabled-background-color);
+        border: var(--ag-button-disabled-border);
+    }
 }

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.css
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.css
@@ -36,3 +36,17 @@
 :where(.ag-column-panel) .ag-column-drop-vertical:where(:not(.ag-last-column-drop)) {
     border-bottom: var(--ag-tool-panel-separator-border);
 }
+
+.ag-column-panel-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--ag-widget-vertical-spacing) var(--ag-widget-horizontal-spacing);
+    justify-content: flex-end;
+    overflow: hidden;
+    padding: var(--ag-widget-container-vertical-padding) var(--ag-widget-container-horizontal-padding);
+    border-top: var(--ag-tool-panel-separator-border);
+}
+
+.ag-column-panel-buttons-button {
+    line-height: 1.5;
+}

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.test.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.test.ts
@@ -1,0 +1,66 @@
+import { ColumnToolPanel } from './columnToolPanel';
+
+const createDeferredModeParams = () =>
+    ({
+        deferApply: true,
+        buttons: [],
+        suppressPivotMode: true,
+        suppressRowGroups: true,
+        suppressValues: true,
+        suppressPivots: true,
+    }) as any;
+
+const createPanel = (): ColumnToolPanel & Record<string, any> => {
+    const panel = new ColumnToolPanel() as any;
+    panel.gos = {
+        addCommon: (params: any) => params,
+        isModuleRegistered: () => false,
+    };
+    panel.beans = {
+        colModel: {
+            getColDefCols: () => [],
+            isPivotMode: () => false,
+            getColDefCol: () => undefined,
+        },
+        rowGroupColsSvc: { columns: [] },
+        pivotColsSvc: { columns: [] },
+        valueColsSvc: { columns: [] },
+    };
+
+    panel.createBean = jest.fn(() => ({
+        init: jest.fn(),
+        addCss: jest.fn(),
+    }));
+    panel.appendChild = jest.fn();
+    panel.destroyBean = jest.fn();
+
+    return panel;
+};
+
+describe('ColumnToolPanel', () => {
+    it('cleans up all deferred sync listeners on refresh and destroy cycles', () => {
+        const panel = createPanel();
+        const cleanupCallsPerInit: jest.Mock[][] = [];
+
+        panel.addManagedEventListeners = jest.fn(() => {
+            const cleanupFuncs = Array.from({ length: 6 }, () => jest.fn(() => null));
+            cleanupCallsPerInit.push(cleanupFuncs);
+            return cleanupFuncs;
+        });
+
+        panel.init(createDeferredModeParams());
+        panel.refresh(createDeferredModeParams());
+        panel.destroyChildren();
+
+        expect(cleanupCallsPerInit).toHaveLength(2);
+        expect(cleanupCallsPerInit[0]).toHaveLength(6);
+        expect(cleanupCallsPerInit[1]).toHaveLength(6);
+
+        for (const cleanup of cleanupCallsPerInit[0]) {
+            expect(cleanup).toHaveBeenCalledTimes(1);
+        }
+        for (const cleanup of cleanupCallsPerInit[1]) {
+            expect(cleanup).toHaveBeenCalledTimes(1);
+        }
+    });
+});

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -2,6 +2,7 @@ import type {
     BeanCollection,
     ColDef,
     ColGroupDef,
+    ColumnState,
     ColumnToolPanelState,
     IColumnToolPanel,
     IToolPanelColumnCompParams,
@@ -22,7 +23,9 @@ import type { PivotModePanel } from './pivotModePanel';
 
 export interface ToolPanelColumnCompParams<TData = any, TContext = any>
     extends IToolPanelParams<TData, TContext, ColumnToolPanelState>,
-        IToolPanelColumnCompParams {}
+        IToolPanelColumnCompParams {
+    onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void;
+}
 
 export class ColumnToolPanel extends Component implements IColumnToolPanel, IToolPanelComp {
     private initialised = false;
@@ -77,6 +80,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         this.params = mergedParams;
         if (mergedParams.deferApply) {
             this.deferredService.initialiseFromApplied(this.getCurrentStateForDeferredMode());
+            this.params.onDeferredPivotColumnStateUpdate = this.onDeferredPivotColumnStateUpdate.bind(this);
         }
 
         const { childDestroyFuncs, colToolPanelFactory, gos } = this;
@@ -294,6 +298,10 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         pendingState.pivotMode = newValue;
         this.deferredService.setPendingState(pendingState);
         return true;
+    }
+
+    private onDeferredPivotColumnStateUpdate(stateItems: ColumnState[]): void {
+        this.deferredService.applyPivotColumnStateToPending(stateItems);
     }
 
     public getState(): ColumnToolPanelState {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -600,6 +600,10 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             });
 
         _applyColumnState(this.beans, { state: columnState }, 'toolPanelUi');
+
+        // Preserve deferred value column ordering (aggregation order) from the tool panel state.
+        const valueColumnsInOrder = this.getColumnsByColIds(state.valueCols.map((valueCol) => valueCol.colId));
+        this.beans.valueColsSvc?.setColumns(valueColumnsInOrder, 'toolPanelUi');
     }
 
     public getState(): ColumnToolPanelState {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -55,7 +55,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
     private valuesDropZonePanel?: ValuesDropZonePanel;
     private pivotDropZonePanel?: PivotDropZonePanel;
     private colToolPanelFactory?: ColumnToolPanelFactory;
-    private readonly deferredService = new ColumnToolPanelDeferredService();
+    private deferredService!: ColumnToolPanelDeferredService;
     private deferredButtonsComp?: FilterButtonComp;
 
     constructor() {
@@ -95,6 +95,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             ...params,
         };
         this.params = mergedParams;
+        this.deferredService = new ColumnToolPanelDeferredService();
         if (mergedParams.deferApply) {
             this.deferredService.reconcileFromApplied(this.getCurrentStateForDeferredMode());
             this.params.onDeferredPivotColumnStateUpdate = this.onDeferredPivotColumnStateUpdate.bind(this);
@@ -177,6 +178,10 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         }
 
         if (mergedParams.deferApply) {
+            /**
+             * Deferred apply can rebuild this panel on refresh/cancel.
+             * Keep all destroy callbacks so old column listeners are removed.
+             */
             const deferredSyncListeners = this.addManagedEventListeners({
                 newColumnsLoaded: this.syncDeferredFromApplied.bind(this),
                 columnPivotModeChanged: this.syncDeferredFromApplied.bind(this),
@@ -185,6 +190,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
                 columnValueChanged: this.syncDeferredFromApplied.bind(this),
                 columnVisible: this.syncDeferredFromApplied.bind(this),
             });
+            /** Tear down every deferred-sync listener when this panel is rebuilt. */
             childDestroyFuncs.push(...deferredSyncListeners);
         }
 
@@ -381,6 +387,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         };
     }
 
+    /** Stage pivot mode changes so deferred apply can commit them as an explicit action. */
     private onDeferredPivotModeToggle(newValue: boolean): boolean {
         const pendingState = this.deferredService.getPendingState();
         pendingState.pivotMode = newValue;
@@ -390,18 +397,21 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         return true;
     }
 
+    /** Stage pivot column state edits instead of applying them immediately to grid state. */
     private onDeferredPivotColumnStateUpdate(stateItems: ColumnState[]): void {
         this.deferredService.applyPivotColumnStateToPending(stateItems);
         this.primaryColsPanel?.syncLayoutWithGrid();
         this.refreshDeferredButtonsState();
     }
 
+    /** Stage visibility edits so deferred apply/cancel controls column visibility changes. */
     private onDeferredVisibilityColumnStateUpdate(stateItems: ColumnState[]): void {
         this.deferredService.applyVisibilityColumnStateToPending(stateItems);
         this.primaryColsPanel?.syncLayoutWithGrid();
         this.refreshDeferredButtonsState();
     }
 
+    /** Stage row group ordering to keep deferred mode pending state in sync with tool panel interactions. */
     private onDeferredRowGroupColumnsUpdate(columns: AgColumn[]): boolean {
         this.deferredService.setPendingRowGroupColumns(columns.map((column) => column.getColId()));
         this.primaryColsPanel?.syncLayoutWithGrid();
@@ -409,6 +419,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         return true;
     }
 
+    /** Stage pivot ordering to keep deferred mode pending state in sync with tool panel interactions. */
     private onDeferredPivotColumnsUpdate(columns: AgColumn[]): boolean {
         this.deferredService.setPendingPivotColumns(columns.map((column) => column.getColId()));
         this.primaryColsPanel?.syncLayoutWithGrid();
@@ -416,6 +427,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         return true;
     }
 
+    /** Stage value columns and agg funcs so deferred apply preserves aggregation intent before commit. */
     private onDeferredValueColumnsUpdate(columns: AgColumn[]): boolean {
         const { aggFuncSvc } = this.beans;
         const pendingAggFuncMap = new Map(
@@ -438,6 +450,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         return true;
     }
 
+    /** Update staged aggregation functions without mutating live value column state. */
     private onDeferredValueColumnAggFuncUpdate(column: AgColumn, aggFunc: string): boolean {
         const pendingState = this.deferredService.getPendingState();
         const colId = column.getColId();
@@ -453,20 +466,24 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         return true;
     }
 
+    /** Resolve staged row group ids to column instances for deferred mode rendering. */
     private getDeferredPendingRowGroupColumns(): AgColumn[] {
         return this.getColumnsByColIds(this.deferredService.getPendingStateSnapshot().rowGroupColIds);
     }
 
+    /** Resolve staged pivot ids to column instances for deferred mode rendering. */
     private getDeferredPendingPivotColumns(): AgColumn[] {
         return this.getColumnsByColIds(this.deferredService.getPendingStateSnapshot().pivotColIds);
     }
 
+    /** Resolve staged value ids to column instances so pending value order is visible before apply. */
     private getDeferredPendingValueColumns(): AgColumn[] {
         return this.getColumnsByColIds(
             this.deferredService.getPendingStateSnapshot().valueCols.map((valueCol) => valueCol.colId)
         );
     }
 
+    /** Read staged aggregation function values so deferred mode editors show pending state. */
     private getDeferredPendingAggregationFunction(column: AgColumn): string | null | undefined {
         const valueCol = this.deferredService
             .getPendingStateSnapshot()
@@ -479,6 +496,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         return colIds.map((colId) => colModel.getColDefCol(colId)).filter((column): column is AgColumn => !!column);
     }
 
+    /** Re-sync deferred pending state when external column changes occur while edits are staged. */
     private syncDeferredFromApplied(): void {
         this.deferredService.reconcileFromAppliedPreservingPending(this.getCurrentStateForDeferredMode());
         this.refreshDeferredButtonsState();
@@ -535,6 +553,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         };
     }
 
+    /** Add apply/cancel controls */
     private initDeferredButtonsIfNeeded(): void {
         if (!this.params.deferApply || !this.params.buttons?.length) {
             return;
@@ -568,10 +587,12 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         this.refreshDeferredButtonsState();
     }
 
+    /** Enable/disable deferred action controls based on whether staged changes exist. */
     private refreshDeferredButtonsState(): void {
         this.deferredButtonsComp?.updateValidity(this.deferredService.hasPendingChanges());
     }
 
+    /** Apply staged deferred changes and reset the pending snapshot to the now-applied state. */
     private onDeferredApply(): void {
         const pendingState = this.deferredService.getPendingState();
         this.applyDeferredState(pendingState);
@@ -579,11 +600,13 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         this.refreshDeferredButtonsState();
     }
 
+    /** Drop staged deferred changes and rebuild the panel from current applied grid state. */
     private onDeferredCancel(): void {
         this.deferredService.cancelPending();
         this.refresh(this.params);
     }
 
+    /** Apply the staged deferred snapshot as one batch to avoid partial intermediate grid states. */
     private applyDeferredState(state: ColumnToolPanelDeferredState): void {
         const { colModel, gos, ctrlsSvc } = this.beans;
         const currentState = this.getCurrentStateForDeferredMode();

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -1,4 +1,5 @@
 import type {
+    AgColumn,
     BeanCollection,
     ColDef,
     ColGroupDef,
@@ -113,15 +114,38 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
 
         if (colToolPanelFactory) {
             if (!mergedParams.suppressRowGroups && hasRowGroupingModule) {
-                this.rowGroupDropZonePanel = colToolPanelFactory.createRowGroupPanel(this, childDestroyFuncs);
+                this.rowGroupDropZonePanel = mergedParams.deferApply
+                    ? colToolPanelFactory.createRowGroupPanelWithUpdateHandler(
+                          this,
+                          childDestroyFuncs,
+                          this.onDeferredRowGroupColumnsUpdate.bind(this),
+                          this.getDeferredPendingRowGroupColumns.bind(this)
+                      )
+                    : colToolPanelFactory.createRowGroupPanel(this, childDestroyFuncs);
             }
 
             if (!mergedParams.suppressValues && hasRowGroupingModule) {
-                this.valuesDropZonePanel = colToolPanelFactory.createValuesPanel(this, childDestroyFuncs);
+                this.valuesDropZonePanel = mergedParams.deferApply
+                    ? colToolPanelFactory.createValuesPanelWithUpdateHandler(
+                          this,
+                          childDestroyFuncs,
+                          this.onDeferredValueColumnsUpdate.bind(this),
+                          this.getDeferredPendingValueColumns.bind(this),
+                          this.onDeferredValueColumnAggFuncUpdate.bind(this),
+                          this.getDeferredPendingAggregationFunction.bind(this)
+                      )
+                    : colToolPanelFactory.createValuesPanel(this, childDestroyFuncs);
             }
 
             if (!mergedParams.suppressPivots && hasPivotModule) {
-                this.pivotDropZonePanel = colToolPanelFactory.createPivotPanel(this, childDestroyFuncs);
+                this.pivotDropZonePanel = mergedParams.deferApply
+                    ? colToolPanelFactory.createPivotPanelWithUpdateHandler(
+                          this,
+                          childDestroyFuncs,
+                          this.onDeferredPivotColumnsUpdate.bind(this),
+                          this.getDeferredPendingPivotColumns.bind(this)
+                      )
+                    : colToolPanelFactory.createPivotPanel(this, childDestroyFuncs);
             }
 
             this.setLastVisible();
@@ -170,7 +194,15 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         this.rowGroupDropZonePanel = colToolPanelFactory.setPanelVisible(
             this.rowGroupDropZonePanel,
             visible,
-            colToolPanelFactory.createRowGroupPanel.bind(colToolPanelFactory, this, this.childDestroyFuncs)
+            this.params.deferApply
+                ? colToolPanelFactory.createRowGroupPanelWithUpdateHandler.bind(
+                      colToolPanelFactory,
+                      this,
+                      this.childDestroyFuncs,
+                      this.onDeferredRowGroupColumnsUpdate.bind(this),
+                      this.getDeferredPendingRowGroupColumns.bind(this)
+                  )
+                : colToolPanelFactory.createRowGroupPanel.bind(colToolPanelFactory, this, this.childDestroyFuncs)
         );
         this.setLastVisible();
     }
@@ -184,7 +216,17 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         this.valuesDropZonePanel = colToolPanelFactory.setPanelVisible(
             this.valuesDropZonePanel,
             visible,
-            colToolPanelFactory.createValuesPanel.bind(colToolPanelFactory, this, this.childDestroyFuncs)
+            this.params.deferApply
+                ? colToolPanelFactory.createValuesPanelWithUpdateHandler.bind(
+                      colToolPanelFactory,
+                      this,
+                      this.childDestroyFuncs,
+                      this.onDeferredValueColumnsUpdate.bind(this),
+                      this.getDeferredPendingValueColumns.bind(this),
+                      this.onDeferredValueColumnAggFuncUpdate.bind(this),
+                      this.getDeferredPendingAggregationFunction.bind(this)
+                  )
+                : colToolPanelFactory.createValuesPanel.bind(colToolPanelFactory, this, this.childDestroyFuncs)
         );
         this.setLastVisible();
     }
@@ -198,7 +240,15 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         this.pivotDropZonePanel = colToolPanelFactory.setPanelVisible(
             this.pivotDropZonePanel,
             visible,
-            colToolPanelFactory.createPivotPanel.bind(colToolPanelFactory, this, this.childDestroyFuncs)
+            this.params.deferApply
+                ? colToolPanelFactory.createPivotPanelWithUpdateHandler.bind(
+                      colToolPanelFactory,
+                      this,
+                      this.childDestroyFuncs,
+                      this.onDeferredPivotColumnsUpdate.bind(this),
+                      this.getDeferredPendingPivotColumns.bind(this)
+                  )
+                : colToolPanelFactory.createPivotPanel.bind(colToolPanelFactory, this, this.childDestroyFuncs)
         );
         this.pivotDropZonePanel?.setDisplayed(visible);
         this.setLastVisible();
@@ -316,6 +366,73 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
     private onDeferredVisibilityColumnStateUpdate(stateItems: ColumnState[]): void {
         this.deferredService.applyVisibilityColumnStateToPending(stateItems);
         this.refreshDeferredButtonsState();
+    }
+
+    private onDeferredRowGroupColumnsUpdate(columns: AgColumn[]): boolean {
+        this.deferredService.setPendingRowGroupColumns(columns.map((column) => column.getColId()));
+        this.refreshDeferredButtonsState();
+        return true;
+    }
+
+    private onDeferredPivotColumnsUpdate(columns: AgColumn[]): boolean {
+        this.deferredService.setPendingPivotColumns(columns.map((column) => column.getColId()));
+        this.refreshDeferredButtonsState();
+        return true;
+    }
+
+    private onDeferredValueColumnsUpdate(columns: AgColumn[]): boolean {
+        const pendingAggFuncMap = new Map(
+            this.deferredService.getPendingState().valueCols.map((valueCol) => [valueCol.colId, valueCol.aggFunc] as const)
+        );
+        this.deferredService.setPendingValueColumns(
+            columns.map((column) => ({
+                colId: column.getColId(),
+                aggFunc: pendingAggFuncMap.get(column.getColId()) ?? column.getAggFunc() ?? null,
+            }))
+        );
+        this.refreshDeferredButtonsState();
+        return true;
+    }
+
+    private onDeferredValueColumnAggFuncUpdate(column: AgColumn, aggFunc: string): boolean {
+        const pendingState = this.deferredService.getPendingState();
+        const colId = column.getColId();
+        const existing = pendingState.valueCols.find((valueCol) => valueCol.colId === colId);
+        if (existing) {
+            existing.aggFunc = aggFunc;
+        } else {
+            pendingState.valueCols.push({ colId, aggFunc });
+        }
+        this.deferredService.setPendingState(pendingState);
+        this.valuesDropZonePanel?.refreshGui();
+        this.refreshDeferredButtonsState();
+        return true;
+    }
+
+    private getDeferredPendingRowGroupColumns(): AgColumn[] {
+        return this.getColumnsByColIds(this.deferredService.getPendingState().rowGroupColIds);
+    }
+
+    private getDeferredPendingPivotColumns(): AgColumn[] {
+        return this.getColumnsByColIds(this.deferredService.getPendingState().pivotColIds);
+    }
+
+    private getDeferredPendingValueColumns(): AgColumn[] {
+        return this.getColumnsByColIds(this.deferredService.getPendingState().valueCols.map((valueCol) => valueCol.colId));
+    }
+
+    private getDeferredPendingAggregationFunction(column: AgColumn): string | null | undefined {
+        const valueCol = this.deferredService
+            .getPendingState()
+            .valueCols.find((pendingValueCol) => pendingValueCol.colId === column.getColId());
+        return typeof valueCol?.aggFunc === 'string' ? valueCol.aggFunc : null;
+    }
+
+    private getColumnsByColIds(colIds: string[]): AgColumn[] {
+        const { colModel } = this.beans;
+        return colIds
+            .map((colId) => colModel.getColDefCol(colId))
+            .filter((column): column is AgColumn => !!column);
     }
 
     private initDeferredButtonsIfNeeded(): void {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -96,7 +96,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         };
         this.params = mergedParams;
         if (mergedParams.deferApply) {
-            this.deferredService.initialiseFromApplied(this.getCurrentStateForDeferredMode());
+            this.deferredService.reconcileFromApplied(this.getCurrentStateForDeferredMode());
             this.params.onDeferredPivotColumnStateUpdate = this.onDeferredPivotColumnStateUpdate.bind(this);
             this.params.onDeferredVisibilityColumnStateUpdate = this.onDeferredVisibilityColumnStateUpdate.bind(this);
             this.params.getToolPanelPivotMode = this.getToolPanelPivotMode.bind(this);
@@ -417,6 +417,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
     }
 
     private onDeferredValueColumnsUpdate(columns: AgColumn[]): boolean {
+        const { aggFuncSvc } = this.beans;
         const pendingAggFuncMap = new Map(
             this.deferredService
                 .getPendingState()
@@ -425,7 +426,11 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         this.deferredService.setPendingValueColumns(
             columns.map((column) => ({
                 colId: column.getColId(),
-                aggFunc: pendingAggFuncMap.get(column.getColId()) ?? column.getAggFunc() ?? null,
+                aggFunc:
+                    pendingAggFuncMap.get(column.getColId()) ??
+                    column.getAggFunc() ??
+                    aggFuncSvc?.getDefaultAggFunc(column) ??
+                    null,
             }))
         );
         this.primaryColsPanel?.syncLayoutWithGrid();

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -27,6 +27,7 @@ export interface ToolPanelColumnCompParams<TData = any, TContext = any>
         IToolPanelColumnCompParams {
     onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void;
     onDeferredVisibilityColumnStateUpdate?: (stateItems: ColumnState[]) => void;
+    getToolPanelPivotMode?: () => boolean;
 }
 
 export class ColumnToolPanel extends Component implements IColumnToolPanel, IToolPanelComp {
@@ -85,6 +86,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             this.deferredService.initialiseFromApplied(this.getCurrentStateForDeferredMode());
             this.params.onDeferredPivotColumnStateUpdate = this.onDeferredPivotColumnStateUpdate.bind(this);
             this.params.onDeferredVisibilityColumnStateUpdate = this.onDeferredVisibilityColumnStateUpdate.bind(this);
+            this.params.getToolPanelPivotMode = this.getToolPanelPivotMode.bind(this);
         }
 
         const { childDestroyFuncs, colToolPanelFactory, gos } = this;
@@ -160,12 +162,12 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
 
         if (mergedParams.deferApply) {
             const [deferredSyncListener] = this.addManagedEventListeners({
-                newColumnsLoaded: () => {
-                    if (!this.deferredService.hasPendingChanges()) {
-                        this.deferredService.reconcileFromApplied(this.getCurrentStateForDeferredMode());
-                        this.refreshDeferredButtonsState();
-                    }
-                },
+                newColumnsLoaded: this.syncDeferredFromAppliedIfNoPending.bind(this),
+                columnPivotModeChanged: this.syncDeferredFromAppliedIfNoPending.bind(this),
+                columnRowGroupChanged: this.syncDeferredFromAppliedIfNoPending.bind(this),
+                columnPivotChanged: this.syncDeferredFromAppliedIfNoPending.bind(this),
+                columnValueChanged: this.syncDeferredFromAppliedIfNoPending.bind(this),
+                columnVisible: this.syncDeferredFromAppliedIfNoPending.bind(this),
             });
             childDestroyFuncs.push(() => deferredSyncListener());
         }
@@ -366,6 +368,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         const pendingState = this.deferredService.getPendingState();
         pendingState.pivotMode = newValue;
         this.deferredService.setPendingState(pendingState);
+        this.primaryColsPanel?.syncLayoutWithGrid();
         this.refreshDeferredButtonsState();
         return true;
     }
@@ -445,6 +448,18 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         return colIds
             .map((colId) => colModel.getColDefCol(colId))
             .filter((column): column is AgColumn => !!column);
+    }
+
+    private syncDeferredFromAppliedIfNoPending(): void {
+        if (this.deferredService.hasPendingChanges()) {
+            return;
+        }
+        this.deferredService.reconcileFromApplied(this.getCurrentStateForDeferredMode());
+        this.refreshDeferredButtonsState();
+    }
+
+    private getToolPanelPivotMode(): boolean {
+        return this.params.deferApply ? this.deferredService.getPendingState().pivotMode : this.beans.colModel.isPivotMode();
     }
 
     private initDeferredButtonsIfNeeded(): void {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -178,12 +178,12 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
 
         if (mergedParams.deferApply) {
             const [deferredSyncListener] = this.addManagedEventListeners({
-                newColumnsLoaded: this.syncDeferredFromAppliedIfNoPending.bind(this),
-                columnPivotModeChanged: this.syncDeferredFromAppliedIfNoPending.bind(this),
-                columnRowGroupChanged: this.syncDeferredFromAppliedIfNoPending.bind(this),
-                columnPivotChanged: this.syncDeferredFromAppliedIfNoPending.bind(this),
-                columnValueChanged: this.syncDeferredFromAppliedIfNoPending.bind(this),
-                columnVisible: this.syncDeferredFromAppliedIfNoPending.bind(this),
+                newColumnsLoaded: this.syncDeferredFromApplied.bind(this),
+                columnPivotModeChanged: this.syncDeferredFromApplied.bind(this),
+                columnRowGroupChanged: this.syncDeferredFromApplied.bind(this),
+                columnPivotChanged: this.syncDeferredFromApplied.bind(this),
+                columnValueChanged: this.syncDeferredFromApplied.bind(this),
+                columnVisible: this.syncDeferredFromApplied.bind(this),
             });
             childDestroyFuncs.push(() => deferredSyncListener());
         }
@@ -474,11 +474,8 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         return colIds.map((colId) => colModel.getColDefCol(colId)).filter((column): column is AgColumn => !!column);
     }
 
-    private syncDeferredFromAppliedIfNoPending(): void {
-        if (this.deferredService.hasPendingChanges()) {
-            return;
-        }
-        this.deferredService.reconcileFromApplied(this.getCurrentStateForDeferredMode());
+    private syncDeferredFromApplied(): void {
+        this.deferredService.reconcileFromAppliedPreservingPending(this.getCurrentStateForDeferredMode());
         this.refreshDeferredButtonsState();
     }
 
@@ -584,6 +581,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
 
     private applyDeferredState(state: ColumnToolPanelDeferredState): void {
         const { colModel, gos, ctrlsSvc } = this.beans;
+        const currentState = this.getCurrentStateForDeferredMode();
         if (colModel.isPivotMode() !== state.pivotMode) {
             gos.updateGridOptions({ options: { pivotMode: state.pivotMode }, source: 'toolPanelUi' as any });
             for (const ctrl of ctrlsSvc.getHeaderRowContainerCtrls()) {
@@ -592,32 +590,65 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         }
 
         const allColumns = colModel.getColDefCols() ?? [];
+        const currentRowGroupIndexMap = new Map(
+            currentState.rowGroupColIds.map((colId, index) => [colId, index] as const)
+        );
+        const currentPivotIndexMap = new Map(currentState.pivotColIds.map((colId, index) => [colId, index] as const));
+        const currentValueAggMap = new Map(
+            currentState.valueCols.map((valueCol) => [valueCol.colId, valueCol.aggFunc] as const)
+        );
+        const currentVisibleColIdSet = new Set(currentState.visibleColIds);
+
         const rowGroupIndexMap = new Map(state.rowGroupColIds.map((colId, index) => [colId, index] as const));
         const pivotIndexMap = new Map(state.pivotColIds.map((colId, index) => [colId, index] as const));
         const valueAggMap = new Map(state.valueCols.map((valueCol) => [valueCol.colId, valueCol.aggFunc] as const));
         const visibleColIdSet = new Set(state.visibleColIds);
 
-        const columnState: ColumnState[] = allColumns.map((column) => {
+        const columnState: ColumnState[] = [];
+        for (const column of allColumns) {
             const colId = column.getColId();
+
+            const currentRowGroupIndex = currentRowGroupIndexMap.get(colId);
+            const currentPivotIndex = currentPivotIndexMap.get(colId);
+            const currentAggFunc = currentValueAggMap.has(colId) ? currentValueAggMap.get(colId)! : null;
+            const currentHidden = !currentVisibleColIdSet.has(colId);
+
             const rowGroupIndex = rowGroupIndexMap.get(colId);
             const pivotIndex = pivotIndexMap.get(colId);
             const aggFunc = valueAggMap.has(colId) ? valueAggMap.get(colId)! : null;
-            return {
+            const hidden = !visibleColIdSet.has(colId);
+
+            if (
+                currentRowGroupIndex === rowGroupIndex &&
+                currentPivotIndex === pivotIndex &&
+                currentAggFunc === aggFunc &&
+                currentHidden === hidden
+            ) {
+                continue;
+            }
+
+            columnState.push({
                 colId,
                 rowGroup: rowGroupIndex != null,
                 rowGroupIndex: rowGroupIndex ?? null,
                 pivot: pivotIndex != null,
                 pivotIndex: pivotIndex ?? null,
                 aggFunc,
-                hide: !visibleColIdSet.has(colId),
-            };
-        });
+                hide: hidden,
+            });
+        }
 
-        _applyColumnState(this.beans, { state: columnState }, 'toolPanelUi');
+        if (columnState.length > 0) {
+            _applyColumnState(this.beans, { state: columnState }, 'toolPanelUi');
+        }
 
         // Preserve deferred value column ordering (aggregation order) from the tool panel state.
-        const valueColumnsInOrder = this.getColumnsByColIds(state.valueCols.map((valueCol) => valueCol.colId));
-        this.beans.valueColsSvc?.setColumns(valueColumnsInOrder, 'toolPanelUi');
+        const currentValueOrder = currentState.valueCols.map((valueCol) => valueCol.colId);
+        const nextValueOrder = state.valueCols.map((valueCol) => valueCol.colId);
+        if (!areStringArraysEqual(currentValueOrder, nextValueOrder)) {
+            const valueColumnsInOrder = this.getColumnsByColIds(nextValueOrder);
+            this.beans.valueColsSvc?.setColumns(valueColumnsInOrder, 'toolPanelUi');
+        }
     }
 
     public getState(): ColumnToolPanelState {
@@ -630,4 +661,16 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         this.destroyChildren();
         super.destroy();
     }
+}
+
+function areStringArraysEqual(a: string[], b: string[]): boolean {
+    if (a.length !== b.length) {
+        return false;
+    }
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) {
+            return false;
+        }
+    }
+    return true;
 }

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -177,7 +177,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         }
 
         if (mergedParams.deferApply) {
-            const [deferredSyncListener] = this.addManagedEventListeners({
+            const deferredSyncListeners = this.addManagedEventListeners({
                 newColumnsLoaded: this.syncDeferredFromApplied.bind(this),
                 columnPivotModeChanged: this.syncDeferredFromApplied.bind(this),
                 columnRowGroupChanged: this.syncDeferredFromApplied.bind(this),
@@ -185,7 +185,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
                 columnValueChanged: this.syncDeferredFromApplied.bind(this),
                 columnVisible: this.syncDeferredFromApplied.bind(this),
             });
-            childDestroyFuncs.push(() => deferredSyncListener());
+            childDestroyFuncs.push(...deferredSyncListeners);
         }
 
         this.initDeferredButtonsIfNeeded();

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -34,8 +34,6 @@ export interface ToolPanelColumnCompParams<TData = any, TContext = any>
         pivot: boolean;
         value: boolean;
     };
-    onDeferredColumnOrderUpdate?: (colIds: string[]) => void;
-    getToolPanelColumnsInOrder?: () => AgColumn[];
 }
 
 export class ColumnToolPanel extends Component implements IColumnToolPanel, IToolPanelComp {
@@ -97,8 +95,6 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             this.params.getToolPanelPivotMode = this.getToolPanelPivotMode.bind(this);
             this.params.isColumnCheckedInToolPanel = this.isColumnCheckedInToolPanel.bind(this);
             this.params.getToolPanelColumnFunctionState = this.getToolPanelColumnFunctionState.bind(this);
-            this.params.onDeferredColumnOrderUpdate = this.onDeferredColumnOrderUpdate.bind(this);
-            this.params.getToolPanelColumnsInOrder = this.getToolPanelColumnsInOrder.bind(this);
         }
 
         const { childDestroyFuncs, colToolPanelFactory, gos } = this;
@@ -368,7 +364,6 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         const colDefCols = colModel.getColDefCols() ?? [];
         return {
             pivotMode: colModel.isPivotMode(),
-            colOrderIds: (colModel.getCols() ?? []).map((col) => col.getColId()),
             rowGroupColIds: rowGroupColsSvc?.columns.map((col) => col.getColId()) ?? [],
             pivotColIds: pivotColsSvc?.columns.map((col) => col.getColId()) ?? [],
             valueCols: (valueColsSvc?.columns ?? []).map((col) => ({
@@ -427,11 +422,6 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         this.primaryColsPanel?.syncLayoutWithGrid();
         this.refreshDeferredButtonsState();
         return true;
-    }
-
-    private onDeferredColumnOrderUpdate(colIds: string[]): void {
-        this.deferredService.setPendingColumnOrder(colIds);
-        this.refreshDeferredButtonsState();
     }
 
     private onDeferredValueColumnAggFuncUpdate(column: AgColumn, aggFunc: string): boolean {
@@ -532,23 +522,6 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         };
     }
 
-    private getToolPanelColumnsInOrder(): AgColumn[] {
-        const { colModel } = this.beans;
-        if (!this.params.deferApply) {
-            return colModel.getCols() ?? [];
-        }
-
-        const pendingColIds = this.deferredService.getPendingState().colOrderIds;
-        if (pendingColIds.length === 0) {
-            return colModel.getCols() ?? [];
-        }
-
-        const mapped = pendingColIds
-            .map((colId) => colModel.getColDefCol(colId))
-            .filter((column): column is AgColumn => !!column);
-        return mapped.length > 0 ? mapped : colModel.getCols() ?? [];
-    }
-
     private initDeferredButtonsIfNeeded(): void {
         if (!this.params.deferApply || !this.params.buttons?.length) {
             return;
@@ -605,28 +578,12 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         }
 
         const allColumns = colModel.getColDefCols() ?? [];
-        const appliedOrderColIds = this.deferredService.getAppliedState().colOrderIds;
-        const shouldApplyColumnOrder =
-            state.colOrderIds.length > 0 && JSON.stringify(state.colOrderIds) !== JSON.stringify(appliedOrderColIds);
-        const orderedColIds = (() => {
-            const allColIds = allColumns.map((column) => column.getColId());
-            if (!state.colOrderIds.length) {
-                return allColIds;
-            }
-            const existing = state.colOrderIds.filter((colId) => allColIds.includes(colId));
-            const missing = allColIds.filter((colId) => !existing.includes(colId));
-            return [...existing, ...missing];
-        })();
-        const allColumnsById = new Map(allColumns.map((column) => [column.getColId(), column] as const));
         const rowGroupIndexMap = new Map(state.rowGroupColIds.map((colId, index) => [colId, index] as const));
         const pivotIndexMap = new Map(state.pivotColIds.map((colId, index) => [colId, index] as const));
         const valueAggMap = new Map(state.valueCols.map((valueCol) => [valueCol.colId, valueCol.aggFunc] as const));
         const visibleColIdSet = new Set(state.visibleColIds);
 
-        const columnState: ColumnState[] = orderedColIds
-            .map((colId) => allColumnsById.get(colId))
-            .filter((column): column is AgColumn => !!column)
-            .map((column) => {
+        const columnState: ColumnState[] = allColumns.map((column) => {
                 const colId = column.getColId();
                 const rowGroupIndex = rowGroupIndexMap.get(colId);
                 const pivotIndex = pivotIndexMap.get(colId);
@@ -643,13 +600,6 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             });
 
         _applyColumnState(this.beans, { state: columnState }, 'toolPanelUi');
-        if (shouldApplyColumnOrder) {
-            _applyColumnState(
-                this.beans,
-                { state: orderedColIds.map((colId) => ({ colId })), applyOrder: true },
-                'toolPanelUi'
-            );
-        }
     }
 
     public getState(): ColumnToolPanelState {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -158,6 +158,18 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             childDestroyFuncs.push(() => pivotModeListener());
         }
 
+        if (mergedParams.deferApply) {
+            const [deferredSyncListener] = this.addManagedEventListeners({
+                newColumnsLoaded: () => {
+                    if (!this.deferredService.hasPendingChanges()) {
+                        this.deferredService.reconcileFromApplied(this.getCurrentStateForDeferredMode());
+                        this.refreshDeferredButtonsState();
+                    }
+                },
+            });
+            childDestroyFuncs.push(() => deferredSyncListener());
+        }
+
         this.initDeferredButtonsIfNeeded();
 
         this.initialised = true;

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -269,7 +269,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             pivotColIds: pivotColsSvc?.columns.map((col) => col.getColId()) ?? [],
             valueCols: (valueColsSvc?.columns ?? []).map((col) => ({
                 colId: col.getColId(),
-                aggFunc: col.getAggFunc(),
+                aggFunc: col.getAggFunc() ?? null,
             })),
         };
     }

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -25,6 +25,7 @@ export interface ToolPanelColumnCompParams<TData = any, TContext = any>
     extends IToolPanelParams<TData, TContext, ColumnToolPanelState>,
         IToolPanelColumnCompParams {
     onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void;
+    onDeferredVisibilityColumnStateUpdate?: (stateItems: ColumnState[]) => void;
 }
 
 export class ColumnToolPanel extends Component implements IColumnToolPanel, IToolPanelComp {
@@ -82,6 +83,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         if (mergedParams.deferApply) {
             this.deferredService.initialiseFromApplied(this.getCurrentStateForDeferredMode());
             this.params.onDeferredPivotColumnStateUpdate = this.onDeferredPivotColumnStateUpdate.bind(this);
+            this.params.onDeferredVisibilityColumnStateUpdate = this.onDeferredVisibilityColumnStateUpdate.bind(this);
         }
 
         const { childDestroyFuncs, colToolPanelFactory, gos } = this;
@@ -285,6 +287,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
 
     private getCurrentStateForDeferredMode(): ColumnToolPanelDeferredState {
         const { colModel, rowGroupColsSvc, pivotColsSvc, valueColsSvc } = this.beans;
+        const colDefCols = colModel.getColDefCols() ?? [];
         return {
             pivotMode: colModel.isPivotMode(),
             rowGroupColIds: rowGroupColsSvc?.columns.map((col) => col.getColId()) ?? [],
@@ -293,6 +296,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
                 colId: col.getColId(),
                 aggFunc: col.getAggFunc() ?? null,
             })),
+            visibleColIds: colDefCols.filter((col) => col.isVisible()).map((col) => col.getColId()),
         };
     }
 
@@ -306,6 +310,11 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
 
     private onDeferredPivotColumnStateUpdate(stateItems: ColumnState[]): void {
         this.deferredService.applyPivotColumnStateToPending(stateItems);
+        this.refreshDeferredButtonsState();
+    }
+
+    private onDeferredVisibilityColumnStateUpdate(stateItems: ColumnState[]): void {
+        this.deferredService.applyVisibilityColumnStateToPending(stateItems);
         this.refreshDeferredButtonsState();
     }
 
@@ -368,6 +377,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         const rowGroupIndexMap = new Map(state.rowGroupColIds.map((colId, index) => [colId, index] as const));
         const pivotIndexMap = new Map(state.pivotColIds.map((colId, index) => [colId, index] as const));
         const valueAggMap = new Map(state.valueCols.map((valueCol) => [valueCol.colId, valueCol.aggFunc] as const));
+        const visibleColIdSet = new Set(state.visibleColIds);
 
         const columnState: ColumnState[] = allColumns.map((column) => {
             const colId = column.getColId();
@@ -381,6 +391,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
                 pivot: pivotIndex != null,
                 pivotIndex: pivotIndex ?? null,
                 aggFunc,
+                hide: !visibleColIdSet.has(colId),
             };
         });
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -605,6 +605,9 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         }
 
         const allColumns = colModel.getColDefCols() ?? [];
+        const appliedOrderColIds = this.deferredService.getAppliedState().colOrderIds;
+        const shouldApplyColumnOrder =
+            state.colOrderIds.length > 0 && JSON.stringify(state.colOrderIds) !== JSON.stringify(appliedOrderColIds);
         const orderedColIds = (() => {
             const allColIds = allColumns.map((column) => column.getColId());
             if (!state.colOrderIds.length) {
@@ -640,11 +643,13 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             });
 
         _applyColumnState(this.beans, { state: columnState }, 'toolPanelUi');
-        _applyColumnState(
-            this.beans,
-            { state: orderedColIds.map((colId) => ({ colId })), applyOrder: true },
-            'toolPanelUi'
-        );
+        if (shouldApplyColumnOrder) {
+            _applyColumnState(
+                this.beans,
+                { state: orderedColIds.map((colId) => ({ colId })), applyOrder: true },
+                'toolPanelUi'
+            );
+        }
     }
 
     public getState(): ColumnToolPanelState {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -10,7 +10,14 @@ import type {
     IToolPanelComp,
     IToolPanelParams,
 } from 'ag-grid-community';
-import { Component, FilterButtonComp, _addGridCommonParams, _applyColumnState, _clearElement, _last } from 'ag-grid-community';
+import {
+    Component,
+    FilterButtonComp,
+    _addGridCommonParams,
+    _applyColumnState,
+    _clearElement,
+    _last,
+} from 'ag-grid-community';
 
 import type { PivotDropZonePanel } from '../rowGrouping/columnDropZones/pivotDropZonePanel';
 import type { RowGroupDropZonePanel } from '../rowGrouping/columnDropZones/rowGroupDropZonePanel';
@@ -411,7 +418,9 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
 
     private onDeferredValueColumnsUpdate(columns: AgColumn[]): boolean {
         const pendingAggFuncMap = new Map(
-            this.deferredService.getPendingState().valueCols.map((valueCol) => [valueCol.colId, valueCol.aggFunc] as const)
+            this.deferredService
+                .getPendingState()
+                .valueCols.map((valueCol) => [valueCol.colId, valueCol.aggFunc] as const)
         );
         this.deferredService.setPendingValueColumns(
             columns.map((column) => ({
@@ -448,7 +457,9 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
     }
 
     private getDeferredPendingValueColumns(): AgColumn[] {
-        return this.getColumnsByColIds(this.deferredService.getPendingState().valueCols.map((valueCol) => valueCol.colId));
+        return this.getColumnsByColIds(
+            this.deferredService.getPendingState().valueCols.map((valueCol) => valueCol.colId)
+        );
     }
 
     private getDeferredPendingAggregationFunction(column: AgColumn): string | null | undefined {
@@ -460,9 +471,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
 
     private getColumnsByColIds(colIds: string[]): AgColumn[] {
         const { colModel } = this.beans;
-        return colIds
-            .map((colId) => colModel.getColDefCol(colId))
-            .filter((column): column is AgColumn => !!column);
+        return colIds.map((colId) => colModel.getColDefCol(colId)).filter((column): column is AgColumn => !!column);
     }
 
     private syncDeferredFromAppliedIfNoPending(): void {
@@ -474,7 +483,9 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
     }
 
     private getToolPanelPivotMode(): boolean {
-        return this.params.deferApply ? this.deferredService.getPendingState().pivotMode : this.beans.colModel.isPivotMode();
+        return this.params.deferApply
+            ? this.deferredService.getPendingState().pivotMode
+            : this.beans.colModel.isPivotMode();
     }
 
     private isColumnCheckedInToolPanel(column: AgColumn, pivotMode: boolean): boolean {
@@ -533,7 +544,10 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         const localeTextFunc = this.getLocaleTextFunc();
         const buttons = this.params.buttons.map((type) => ({
             type,
-            label: localeTextFunc(type === 'apply' ? 'applyFilter' : 'cancelFilter', type === 'apply' ? 'Apply' : 'Cancel'),
+            label: localeTextFunc(
+                type === 'apply' ? 'applyFilter' : 'cancelFilter',
+                type === 'apply' ? 'Apply' : 'Cancel'
+            ),
         }));
         buttonComp.updateButtons(buttons);
         this.appendChild(buttonComp);
@@ -584,20 +598,20 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         const visibleColIdSet = new Set(state.visibleColIds);
 
         const columnState: ColumnState[] = allColumns.map((column) => {
-                const colId = column.getColId();
-                const rowGroupIndex = rowGroupIndexMap.get(colId);
-                const pivotIndex = pivotIndexMap.get(colId);
-                const aggFunc = valueAggMap.has(colId) ? valueAggMap.get(colId)! : null;
-                return {
-                    colId,
-                    rowGroup: rowGroupIndex != null,
-                    rowGroupIndex: rowGroupIndex ?? null,
-                    pivot: pivotIndex != null,
-                    pivotIndex: pivotIndex ?? null,
-                    aggFunc,
-                    hide: !visibleColIdSet.has(colId),
-                };
-            });
+            const colId = column.getColId();
+            const rowGroupIndex = rowGroupIndexMap.get(colId);
+            const pivotIndex = pivotIndexMap.get(colId);
+            const aggFunc = valueAggMap.has(colId) ? valueAggMap.get(colId)! : null;
+            return {
+                colId,
+                rowGroup: rowGroupIndex != null,
+                rowGroupIndex: rowGroupIndex ?? null,
+                pivot: pivotIndex != null,
+                pivotIndex: pivotIndex ?? null,
+                aggFunc,
+                hide: !visibleColIdSet.has(colId),
+            };
+        });
 
         _applyColumnState(this.beans, { state: columnState }, 'toolPanelUi');
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -95,6 +95,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             ...params,
         };
         this.params = mergedParams;
+        /** Recreate deferred state per panel init so refresh/cancel starts from a clean staged model. */
         this.deferredService = new ColumnToolPanelDeferredService();
         if (mergedParams.deferApply) {
             this.deferredService.reconcileFromApplied(this.getCurrentStateForDeferredMode());
@@ -367,6 +368,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         this.destroyChildren();
         this.init(params);
         if (this.params.deferApply) {
+            /** Reconcile again after child rebuild so pending/apply buttons reflect the latest applied grid snapshot. */
             this.deferredService.reconcileFromApplied(this.getCurrentStateForDeferredMode());
         }
         return true;

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -64,6 +64,8 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             suppressValues: false,
             suppressPivots: false,
             suppressSyncLayoutWithGrid: false,
+            deferApply: false,
+            buttons: ['apply', 'cancel'],
         });
         const mergedParams = {
             ...defaultParams,

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -449,22 +449,22 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
     }
 
     private getDeferredPendingRowGroupColumns(): AgColumn[] {
-        return this.getColumnsByColIds(this.deferredService.getPendingState().rowGroupColIds);
+        return this.getColumnsByColIds(this.deferredService.getPendingStateSnapshot().rowGroupColIds);
     }
 
     private getDeferredPendingPivotColumns(): AgColumn[] {
-        return this.getColumnsByColIds(this.deferredService.getPendingState().pivotColIds);
+        return this.getColumnsByColIds(this.deferredService.getPendingStateSnapshot().pivotColIds);
     }
 
     private getDeferredPendingValueColumns(): AgColumn[] {
         return this.getColumnsByColIds(
-            this.deferredService.getPendingState().valueCols.map((valueCol) => valueCol.colId)
+            this.deferredService.getPendingStateSnapshot().valueCols.map((valueCol) => valueCol.colId)
         );
     }
 
     private getDeferredPendingAggregationFunction(column: AgColumn): string | null | undefined {
         const valueCol = this.deferredService
-            .getPendingState()
+            .getPendingStateSnapshot()
             .valueCols.find((pendingValueCol) => pendingValueCol.colId === column.getColId());
         return typeof valueCol?.aggFunc === 'string' ? valueCol.aggFunc : null;
     }
@@ -481,7 +481,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
 
     private getToolPanelPivotMode(): boolean {
         return this.params.deferApply
-            ? this.deferredService.getPendingState().pivotMode
+            ? this.deferredService.getPendingStateSnapshot().pivotMode
             : this.beans.colModel.isPivotMode();
     }
 
@@ -500,7 +500,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             return column.isVisible();
         }
 
-        const pendingState = this.deferredService.getPendingState();
+        const pendingState = this.deferredService.getPendingStateSnapshot();
         const colId = column.getColId();
         if (pivotMode) {
             return (
@@ -521,7 +521,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             };
         }
 
-        const pendingState = this.deferredService.getPendingState();
+        const pendingState = this.deferredService.getPendingStateSnapshot();
         const colId = column.getColId();
         return {
             rowGroup: pendingState.rowGroupColIds.includes(colId),

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -28,6 +28,12 @@ export interface ToolPanelColumnCompParams<TData = any, TContext = any>
     onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void;
     onDeferredVisibilityColumnStateUpdate?: (stateItems: ColumnState[]) => void;
     getToolPanelPivotMode?: () => boolean;
+    isColumnCheckedInToolPanel?: (column: AgColumn, pivotMode: boolean) => boolean;
+    getToolPanelColumnFunctionState?: (column: AgColumn) => {
+        rowGroup: boolean;
+        pivot: boolean;
+        value: boolean;
+    };
 }
 
 export class ColumnToolPanel extends Component implements IColumnToolPanel, IToolPanelComp {
@@ -87,6 +93,8 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             this.params.onDeferredPivotColumnStateUpdate = this.onDeferredPivotColumnStateUpdate.bind(this);
             this.params.onDeferredVisibilityColumnStateUpdate = this.onDeferredVisibilityColumnStateUpdate.bind(this);
             this.params.getToolPanelPivotMode = this.getToolPanelPivotMode.bind(this);
+            this.params.isColumnCheckedInToolPanel = this.isColumnCheckedInToolPanel.bind(this);
+            this.params.getToolPanelColumnFunctionState = this.getToolPanelColumnFunctionState.bind(this);
         }
 
         const { childDestroyFuncs, colToolPanelFactory, gos } = this;
@@ -100,7 +108,8 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
                 ? colToolPanelFactory.createPivotModePanelWithToggleHandler(
                       this,
                       childDestroyFuncs,
-                      onTogglePivotMode
+                      onTogglePivotMode,
+                      this.getToolPanelPivotMode.bind(this)
                   )
                 : colToolPanelFactory.createPivotModePanel(this, childDestroyFuncs);
         }
@@ -192,6 +201,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
                       this,
                       this.childDestroyFuncs,
                       this.onDeferredPivotModeToggle.bind(this),
+                      this.getToolPanelPivotMode.bind(this),
                       true
                   )
                 : colToolPanelFactory.createPivotModePanel.bind(colToolPanelFactory, this, this.childDestroyFuncs, true)
@@ -375,22 +385,26 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
 
     private onDeferredPivotColumnStateUpdate(stateItems: ColumnState[]): void {
         this.deferredService.applyPivotColumnStateToPending(stateItems);
+        this.primaryColsPanel?.syncLayoutWithGrid();
         this.refreshDeferredButtonsState();
     }
 
     private onDeferredVisibilityColumnStateUpdate(stateItems: ColumnState[]): void {
         this.deferredService.applyVisibilityColumnStateToPending(stateItems);
+        this.primaryColsPanel?.syncLayoutWithGrid();
         this.refreshDeferredButtonsState();
     }
 
     private onDeferredRowGroupColumnsUpdate(columns: AgColumn[]): boolean {
         this.deferredService.setPendingRowGroupColumns(columns.map((column) => column.getColId()));
+        this.primaryColsPanel?.syncLayoutWithGrid();
         this.refreshDeferredButtonsState();
         return true;
     }
 
     private onDeferredPivotColumnsUpdate(columns: AgColumn[]): boolean {
         this.deferredService.setPendingPivotColumns(columns.map((column) => column.getColId()));
+        this.primaryColsPanel?.syncLayoutWithGrid();
         this.refreshDeferredButtonsState();
         return true;
     }
@@ -405,6 +419,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
                 aggFunc: pendingAggFuncMap.get(column.getColId()) ?? column.getAggFunc() ?? null,
             }))
         );
+        this.primaryColsPanel?.syncLayoutWithGrid();
         this.refreshDeferredButtonsState();
         return true;
     }
@@ -460,6 +475,44 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
 
     private getToolPanelPivotMode(): boolean {
         return this.params.deferApply ? this.deferredService.getPendingState().pivotMode : this.beans.colModel.isPivotMode();
+    }
+
+    private isColumnCheckedInToolPanel(column: AgColumn, pivotMode: boolean): boolean {
+        if (!this.params.deferApply) {
+            if (pivotMode) {
+                return column.isPivotActive() || column.isRowGroupActive() || column.isValueActive();
+            }
+            return column.isVisible();
+        }
+
+        const pendingState = this.deferredService.getPendingState();
+        const colId = column.getColId();
+        if (pivotMode) {
+            return (
+                pendingState.pivotColIds.includes(colId) ||
+                pendingState.rowGroupColIds.includes(colId) ||
+                pendingState.valueCols.some((valueCol) => valueCol.colId === colId)
+            );
+        }
+        return pendingState.visibleColIds.includes(colId);
+    }
+
+    private getToolPanelColumnFunctionState(column: AgColumn): { rowGroup: boolean; pivot: boolean; value: boolean } {
+        if (!this.params.deferApply) {
+            return {
+                rowGroup: column.isRowGroupActive(),
+                pivot: column.isPivotActive(),
+                value: column.isValueActive(),
+            };
+        }
+
+        const pendingState = this.deferredService.getPendingState();
+        const colId = column.getColId();
+        return {
+            rowGroup: pendingState.rowGroupColIds.includes(colId),
+            pivot: pendingState.pivotColIds.includes(colId),
+            value: pendingState.valueCols.some((valueCol) => valueCol.colId === colId),
+        };
     }
 
     private initDeferredButtonsIfNeeded(): void {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -34,6 +34,8 @@ export interface ToolPanelColumnCompParams<TData = any, TContext = any>
         pivot: boolean;
         value: boolean;
     };
+    onDeferredColumnOrderUpdate?: (colIds: string[]) => void;
+    getToolPanelColumnsInOrder?: () => AgColumn[];
 }
 
 export class ColumnToolPanel extends Component implements IColumnToolPanel, IToolPanelComp {
@@ -95,6 +97,8 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             this.params.getToolPanelPivotMode = this.getToolPanelPivotMode.bind(this);
             this.params.isColumnCheckedInToolPanel = this.isColumnCheckedInToolPanel.bind(this);
             this.params.getToolPanelColumnFunctionState = this.getToolPanelColumnFunctionState.bind(this);
+            this.params.onDeferredColumnOrderUpdate = this.onDeferredColumnOrderUpdate.bind(this);
+            this.params.getToolPanelColumnsInOrder = this.getToolPanelColumnsInOrder.bind(this);
         }
 
         const { childDestroyFuncs, colToolPanelFactory, gos } = this;
@@ -364,6 +368,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         const colDefCols = colModel.getColDefCols() ?? [];
         return {
             pivotMode: colModel.isPivotMode(),
+            colOrderIds: (colModel.getCols() ?? []).map((col) => col.getColId()),
             rowGroupColIds: rowGroupColsSvc?.columns.map((col) => col.getColId()) ?? [],
             pivotColIds: pivotColsSvc?.columns.map((col) => col.getColId()) ?? [],
             valueCols: (valueColsSvc?.columns ?? []).map((col) => ({
@@ -422,6 +427,11 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         this.primaryColsPanel?.syncLayoutWithGrid();
         this.refreshDeferredButtonsState();
         return true;
+    }
+
+    private onDeferredColumnOrderUpdate(colIds: string[]): void {
+        this.deferredService.setPendingColumnOrder(colIds);
+        this.refreshDeferredButtonsState();
     }
 
     private onDeferredValueColumnAggFuncUpdate(column: AgColumn, aggFunc: string): boolean {
@@ -485,6 +495,13 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             return column.isVisible();
         }
 
+        if (!this.deferredService.hasPendingChanges()) {
+            if (pivotMode) {
+                return column.isPivotActive() || column.isRowGroupActive() || column.isValueActive();
+            }
+            return column.isVisible();
+        }
+
         const pendingState = this.deferredService.getPendingState();
         const colId = column.getColId();
         if (pivotMode) {
@@ -498,7 +515,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
     }
 
     private getToolPanelColumnFunctionState(column: AgColumn): { rowGroup: boolean; pivot: boolean; value: boolean } {
-        if (!this.params.deferApply) {
+        if (!this.params.deferApply || !this.deferredService.hasPendingChanges()) {
             return {
                 rowGroup: column.isRowGroupActive(),
                 pivot: column.isPivotActive(),
@@ -513,6 +530,23 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             pivot: pendingState.pivotColIds.includes(colId),
             value: pendingState.valueCols.some((valueCol) => valueCol.colId === colId),
         };
+    }
+
+    private getToolPanelColumnsInOrder(): AgColumn[] {
+        const { colModel } = this.beans;
+        if (!this.params.deferApply) {
+            return colModel.getCols() ?? [];
+        }
+
+        const pendingColIds = this.deferredService.getPendingState().colOrderIds;
+        if (pendingColIds.length === 0) {
+            return colModel.getCols() ?? [];
+        }
+
+        const mapped = pendingColIds
+            .map((colId) => colModel.getColDefCol(colId))
+            .filter((column): column is AgColumn => !!column);
+        return mapped.length > 0 ? mapped : colModel.getCols() ?? [];
     }
 
     private initDeferredButtonsIfNeeded(): void {
@@ -571,28 +605,46 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         }
 
         const allColumns = colModel.getColDefCols() ?? [];
+        const orderedColIds = (() => {
+            const allColIds = allColumns.map((column) => column.getColId());
+            if (!state.colOrderIds.length) {
+                return allColIds;
+            }
+            const existing = state.colOrderIds.filter((colId) => allColIds.includes(colId));
+            const missing = allColIds.filter((colId) => !existing.includes(colId));
+            return [...existing, ...missing];
+        })();
+        const allColumnsById = new Map(allColumns.map((column) => [column.getColId(), column] as const));
         const rowGroupIndexMap = new Map(state.rowGroupColIds.map((colId, index) => [colId, index] as const));
         const pivotIndexMap = new Map(state.pivotColIds.map((colId, index) => [colId, index] as const));
         const valueAggMap = new Map(state.valueCols.map((valueCol) => [valueCol.colId, valueCol.aggFunc] as const));
         const visibleColIdSet = new Set(state.visibleColIds);
 
-        const columnState: ColumnState[] = allColumns.map((column) => {
-            const colId = column.getColId();
-            const rowGroupIndex = rowGroupIndexMap.get(colId);
-            const pivotIndex = pivotIndexMap.get(colId);
-            const aggFunc = valueAggMap.has(colId) ? valueAggMap.get(colId)! : null;
-            return {
-                colId,
-                rowGroup: rowGroupIndex != null,
-                rowGroupIndex: rowGroupIndex ?? null,
-                pivot: pivotIndex != null,
-                pivotIndex: pivotIndex ?? null,
-                aggFunc,
-                hide: !visibleColIdSet.has(colId),
-            };
-        });
+        const columnState: ColumnState[] = orderedColIds
+            .map((colId) => allColumnsById.get(colId))
+            .filter((column): column is AgColumn => !!column)
+            .map((column) => {
+                const colId = column.getColId();
+                const rowGroupIndex = rowGroupIndexMap.get(colId);
+                const pivotIndex = pivotIndexMap.get(colId);
+                const aggFunc = valueAggMap.has(colId) ? valueAggMap.get(colId)! : null;
+                return {
+                    colId,
+                    rowGroup: rowGroupIndex != null,
+                    rowGroupIndex: rowGroupIndex ?? null,
+                    pivot: pivotIndex != null,
+                    pivotIndex: pivotIndex ?? null,
+                    aggFunc,
+                    hide: !visibleColIdSet.has(colId),
+                };
+            });
 
-        _applyColumnState(this.beans, { state: columnState, applyOrder: true }, 'toolPanelUi');
+        _applyColumnState(this.beans, { state: columnState }, 'toolPanelUi');
+        _applyColumnState(
+            this.beans,
+            { state: orderedColIds.map((colId) => ({ colId })), applyOrder: true },
+            'toolPanelUi'
+        );
     }
 
     public getState(): ColumnToolPanelState {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -9,7 +9,7 @@ import type {
     IToolPanelComp,
     IToolPanelParams,
 } from 'ag-grid-community';
-import { Component, _addGridCommonParams, _clearElement, _last } from 'ag-grid-community';
+import { Component, FilterButtonComp, _addGridCommonParams, _applyColumnState, _clearElement, _last } from 'ag-grid-community';
 
 import type { PivotDropZonePanel } from '../rowGrouping/columnDropZones/pivotDropZonePanel';
 import type { RowGroupDropZonePanel } from '../rowGrouping/columnDropZones/rowGroupDropZonePanel';
@@ -40,6 +40,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
     private pivotDropZonePanel?: PivotDropZonePanel;
     private colToolPanelFactory?: ColumnToolPanelFactory;
     private readonly deferredService = new ColumnToolPanelDeferredService();
+    private deferredButtonsComp?: FilterButtonComp;
 
     constructor() {
         super({ tag: 'div', cls: 'ag-column-panel' });
@@ -130,6 +131,8 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             });
             childDestroyFuncs.push(() => pivotModeListener());
         }
+
+        this.initDeferredButtonsIfNeeded();
 
         this.initialised = true;
     }
@@ -297,11 +300,91 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         const pendingState = this.deferredService.getPendingState();
         pendingState.pivotMode = newValue;
         this.deferredService.setPendingState(pendingState);
+        this.refreshDeferredButtonsState();
         return true;
     }
 
     private onDeferredPivotColumnStateUpdate(stateItems: ColumnState[]): void {
         this.deferredService.applyPivotColumnStateToPending(stateItems);
+        this.refreshDeferredButtonsState();
+    }
+
+    private initDeferredButtonsIfNeeded(): void {
+        if (!this.params.deferApply || !this.params.buttons?.length) {
+            return;
+        }
+
+        const buttonComp = this.createBean(new FilterButtonComp({ className: 'ag-column-panel-buttons' }));
+        this.deferredButtonsComp = buttonComp;
+
+        const localeTextFunc = this.getLocaleTextFunc();
+        const buttons = this.params.buttons.map((type) => ({
+            type,
+            label: localeTextFunc(type === 'apply' ? 'applyFilter' : 'cancelFilter', type === 'apply' ? 'Apply' : 'Cancel'),
+        }));
+        buttonComp.updateButtons(buttons);
+        this.appendChild(buttonComp);
+
+        this.addManagedListeners(buttonComp, {
+            apply: this.onDeferredApply.bind(this),
+            cancel: this.onDeferredCancel.bind(this),
+        });
+
+        this.childDestroyFuncs.push(() => {
+            if (this.deferredButtonsComp) {
+                this.deferredButtonsComp = this.destroyBean(this.deferredButtonsComp);
+            }
+        });
+
+        this.refreshDeferredButtonsState();
+    }
+
+    private refreshDeferredButtonsState(): void {
+        this.deferredButtonsComp?.updateValidity(this.deferredService.hasPendingChanges());
+    }
+
+    private onDeferredApply(): void {
+        const pendingState = this.deferredService.getPendingState();
+        this.applyDeferredState(pendingState);
+        this.deferredService.reconcileFromApplied(this.getCurrentStateForDeferredMode());
+        this.refreshDeferredButtonsState();
+    }
+
+    private onDeferredCancel(): void {
+        this.deferredService.cancelPending();
+        this.refresh(this.params);
+    }
+
+    private applyDeferredState(state: ColumnToolPanelDeferredState): void {
+        const { colModel, gos, ctrlsSvc } = this.beans;
+        if (colModel.isPivotMode() !== state.pivotMode) {
+            gos.updateGridOptions({ options: { pivotMode: state.pivotMode }, source: 'toolPanelUi' as any });
+            for (const ctrl of ctrlsSvc.getHeaderRowContainerCtrls()) {
+                ctrl.refresh();
+            }
+        }
+
+        const allColumns = colModel.getColDefCols() ?? [];
+        const rowGroupIndexMap = new Map(state.rowGroupColIds.map((colId, index) => [colId, index] as const));
+        const pivotIndexMap = new Map(state.pivotColIds.map((colId, index) => [colId, index] as const));
+        const valueAggMap = new Map(state.valueCols.map((valueCol) => [valueCol.colId, valueCol.aggFunc] as const));
+
+        const columnState: ColumnState[] = allColumns.map((column) => {
+            const colId = column.getColId();
+            const rowGroupIndex = rowGroupIndexMap.get(colId);
+            const pivotIndex = pivotIndexMap.get(colId);
+            const aggFunc = valueAggMap.has(colId) ? valueAggMap.get(colId)! : null;
+            return {
+                colId,
+                rowGroup: rowGroupIndex != null,
+                rowGroupIndex: rowGroupIndex ?? null,
+                pivot: pivotIndex != null,
+                pivotIndex: pivotIndex ?? null,
+                aggFunc,
+            };
+        });
+
+        _applyColumnState(this.beans, { state: columnState, applyOrder: true }, 'toolPanelUi');
     }
 
     public getState(): ColumnToolPanelState {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -15,6 +15,8 @@ import type { RowGroupDropZonePanel } from '../rowGrouping/columnDropZones/rowGr
 import type { ValuesDropZonePanel } from '../rowGrouping/columnDropZones/valueDropZonePanel';
 import { AgPrimaryCols } from './agPrimaryCols';
 import { columnToolPanelCSS } from './columnToolPanel.css-GENERATED';
+import type { ColumnToolPanelDeferredState } from './columnToolPanelDeferredService';
+import { ColumnToolPanelDeferredService } from './columnToolPanelDeferredService';
 import type { ColumnToolPanelFactory } from './columnToolPanelFactory';
 import type { PivotModePanel } from './pivotModePanel';
 
@@ -34,6 +36,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
     private valuesDropZonePanel?: ValuesDropZonePanel;
     private pivotDropZonePanel?: PivotDropZonePanel;
     private colToolPanelFactory?: ColumnToolPanelFactory;
+    private readonly deferredService = new ColumnToolPanelDeferredService();
 
     constructor() {
         super({ tag: 'div', cls: 'ag-column-panel' });
@@ -72,6 +75,9 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             ...params,
         };
         this.params = mergedParams;
+        if (mergedParams.deferApply) {
+            this.deferredService.initialiseFromApplied(this.getCurrentStateForDeferredMode());
+        }
 
         const { childDestroyFuncs, colToolPanelFactory, gos } = this;
 
@@ -249,7 +255,23 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
     public refresh(params: ToolPanelColumnCompParams): boolean {
         this.destroyChildren();
         this.init(params);
+        if (this.params.deferApply) {
+            this.deferredService.reconcileFromApplied(this.getCurrentStateForDeferredMode());
+        }
         return true;
+    }
+
+    private getCurrentStateForDeferredMode(): ColumnToolPanelDeferredState {
+        const { colModel, rowGroupColsSvc, pivotColsSvc, valueColsSvc } = this.beans;
+        return {
+            pivotMode: colModel.isPivotMode(),
+            rowGroupColIds: rowGroupColsSvc?.columns.map((col) => col.getColId()) ?? [],
+            pivotColIds: pivotColsSvc?.columns.map((col) => col.getColId()) ?? [],
+            valueCols: (valueColsSvc?.columns ?? []).map((col) => ({
+                colId: col.getColId(),
+                aggFunc: col.getAggFunc(),
+            })),
+        };
     }
 
     public getState(): ColumnToolPanelState {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -83,9 +83,16 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
 
         const hasPivotModule = gos.isModuleRegistered('SharedPivot');
         const hasRowGroupingModule = hasPivotModule || gos.isModuleRegistered('SharedRowGrouping');
+        const onTogglePivotMode = mergedParams.deferApply ? this.onDeferredPivotModeToggle.bind(this) : undefined;
 
         if (!mergedParams.suppressPivotMode && colToolPanelFactory && hasPivotModule) {
-            this.pivotModePanel = colToolPanelFactory.createPivotModePanel(this, childDestroyFuncs);
+            this.pivotModePanel = onTogglePivotMode
+                ? colToolPanelFactory.createPivotModePanelWithToggleHandler(
+                      this,
+                      childDestroyFuncs,
+                      onTogglePivotMode
+                  )
+                : colToolPanelFactory.createPivotModePanel(this, childDestroyFuncs);
         }
 
         // DO NOT CHANGE TO createManagedBean
@@ -132,7 +139,15 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         this.pivotModePanel = colToolPanelFactory.setPanelVisible(
             this.pivotModePanel,
             visible,
-            colToolPanelFactory.createPivotModePanel.bind(colToolPanelFactory, this, this.childDestroyFuncs, true)
+            this.params.deferApply
+                ? colToolPanelFactory.createPivotModePanelWithToggleHandler.bind(
+                      colToolPanelFactory,
+                      this,
+                      this.childDestroyFuncs,
+                      this.onDeferredPivotModeToggle.bind(this),
+                      true
+                  )
+                : colToolPanelFactory.createPivotModePanel.bind(colToolPanelFactory, this, this.childDestroyFuncs, true)
         );
         this.setLastVisible();
     }
@@ -272,6 +287,13 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
                 aggFunc: col.getAggFunc() ?? null,
             })),
         };
+    }
+
+    private onDeferredPivotModeToggle(newValue: boolean): boolean {
+        const pendingState = this.deferredService.getPendingState();
+        pendingState.pivotMode = newValue;
+        this.deferredService.setPendingState(pendingState);
+        return true;
     }
 
     public getState(): ColumnToolPanelState {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.test.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.test.ts
@@ -13,7 +13,7 @@ const createState = (overrides: Partial<ColumnToolPanelDeferredState> = {}): Col
 describe('ColumnToolPanelDeferredService', () => {
     it('invalidates pending snapshot cache when reconciling applied state with no pending changes', () => {
         const service = new ColumnToolPanelDeferredService();
-        service.initialiseFromApplied(createState({ visibleColIds: ['athlete', 'age', 'country'] }));
+        service.reconcileFromApplied(createState({ visibleColIds: ['athlete', 'age', 'country'] }));
 
         const snapshotBefore = service.getPendingStateSnapshot();
         expect(snapshotBefore.visibleColIds).toEqual(['athlete', 'age', 'country']);
@@ -27,7 +27,7 @@ describe('ColumnToolPanelDeferredService', () => {
 
     it('returns immutable pending snapshots so external callers cannot mutate service state', () => {
         const service = new ColumnToolPanelDeferredService();
-        service.initialiseFromApplied(
+        service.reconcileFromApplied(
             createState({
                 valueCols: [{ colId: 'age', aggFunc: 'sum' }],
                 visibleColIds: ['athlete', 'age'],

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.test.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.test.ts
@@ -42,4 +42,19 @@ describe('ColumnToolPanelDeferredService', () => {
         expect(latestSnapshot.visibleColIds).toEqual(['athlete', 'age', 'country']);
         expect(latestSnapshot.valueCols).toEqual([{ colId: 'age', aggFunc: 'max' }]);
     });
+
+    it('stages agg changes without mutating applied value columns', () => {
+        const service = new ColumnToolPanelDeferredService();
+        service.reconcileFromApplied(
+            createState({
+                valueCols: [{ colId: 'age', aggFunc: 'sum' }],
+            })
+        );
+
+        service.applyPivotColumnStateToPending([{ colId: 'age', aggFunc: 'max' }]);
+
+        expect(service.getAppliedState().valueCols).toEqual([{ colId: 'age', aggFunc: 'sum' }]);
+        expect(service.getPendingState().valueCols).toEqual([{ colId: 'age', aggFunc: 'max' }]);
+        expect(service.hasPendingChanges()).toBe(true);
+    });
 });

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.test.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.test.ts
@@ -25,7 +25,7 @@ describe('ColumnToolPanelDeferredService', () => {
         expect(snapshotAfter.visibleColIds).toEqual(['age', 'country']);
     });
 
-    it('returns immutable pending snapshots so external callers cannot mutate service state', () => {
+    it('returns mutable pending snapshots', () => {
         const service = new ColumnToolPanelDeferredService();
         service.reconcileFromApplied(
             createState({
@@ -35,18 +35,11 @@ describe('ColumnToolPanelDeferredService', () => {
         );
 
         const snapshot = service.getPendingStateSnapshot() as any;
-        expect(Object.isFrozen(snapshot)).toBe(true);
-        expect(Object.isFrozen(snapshot.visibleColIds)).toBe(true);
-        expect(Object.isFrozen(snapshot.valueCols)).toBe(true);
-        expect(Object.isFrozen(snapshot.valueCols[0])).toBe(true);
-
-        expect(() => snapshot.visibleColIds.push('country')).toThrow();
-        expect(() => {
-            snapshot.valueCols[0].aggFunc = 'max';
-        }).toThrow();
+        snapshot.visibleColIds.push('country');
+        snapshot.valueCols[0].aggFunc = 'max';
 
         const latestSnapshot = service.getPendingStateSnapshot();
-        expect(latestSnapshot.visibleColIds).toEqual(['athlete', 'age']);
-        expect(latestSnapshot.valueCols).toEqual([{ colId: 'age', aggFunc: 'sum' }]);
+        expect(latestSnapshot.visibleColIds).toEqual(['athlete', 'age', 'country']);
+        expect(latestSnapshot.valueCols).toEqual([{ colId: 'age', aggFunc: 'max' }]);
     });
 });

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.test.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.test.ts
@@ -1,0 +1,52 @@
+import { ColumnToolPanelDeferredService } from './columnToolPanelDeferredService';
+import type { ColumnToolPanelDeferredState } from './columnToolPanelDeferredService';
+
+const createState = (overrides: Partial<ColumnToolPanelDeferredState> = {}): ColumnToolPanelDeferredState => ({
+    pivotMode: false,
+    rowGroupColIds: [],
+    pivotColIds: [],
+    valueCols: [],
+    visibleColIds: ['athlete', 'age', 'country'],
+    ...overrides,
+});
+
+describe('ColumnToolPanelDeferredService', () => {
+    it('invalidates pending snapshot cache when reconciling applied state with no pending changes', () => {
+        const service = new ColumnToolPanelDeferredService();
+        service.initialiseFromApplied(createState({ visibleColIds: ['athlete', 'age', 'country'] }));
+
+        const snapshotBefore = service.getPendingStateSnapshot();
+        expect(snapshotBefore.visibleColIds).toEqual(['athlete', 'age', 'country']);
+        expect(service.hasPendingChanges()).toBe(false);
+
+        service.reconcileFromAppliedPreservingPending(createState({ visibleColIds: ['age', 'country'] }));
+
+        const snapshotAfter = service.getPendingStateSnapshot();
+        expect(snapshotAfter.visibleColIds).toEqual(['age', 'country']);
+    });
+
+    it('returns immutable pending snapshots so external callers cannot mutate service state', () => {
+        const service = new ColumnToolPanelDeferredService();
+        service.initialiseFromApplied(
+            createState({
+                valueCols: [{ colId: 'age', aggFunc: 'sum' }],
+                visibleColIds: ['athlete', 'age'],
+            })
+        );
+
+        const snapshot = service.getPendingStateSnapshot() as any;
+        expect(Object.isFrozen(snapshot)).toBe(true);
+        expect(Object.isFrozen(snapshot.visibleColIds)).toBe(true);
+        expect(Object.isFrozen(snapshot.valueCols)).toBe(true);
+        expect(Object.isFrozen(snapshot.valueCols[0])).toBe(true);
+
+        expect(() => snapshot.visibleColIds.push('country')).toThrow();
+        expect(() => {
+            snapshot.valueCols[0].aggFunc = 'max';
+        }).toThrow();
+
+        const latestSnapshot = service.getPendingStateSnapshot();
+        expect(latestSnapshot.visibleColIds).toEqual(['athlete', 'age']);
+        expect(latestSnapshot.valueCols).toEqual([{ colId: 'age', aggFunc: 'sum' }]);
+    });
+});

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
@@ -7,7 +7,6 @@ export interface DeferredValueColumnState {
 
 export interface ColumnToolPanelDeferredState {
     pivotMode: boolean;
-    colOrderIds: string[];
     rowGroupColIds: string[];
     pivotColIds: string[];
     valueCols: DeferredValueColumnState[];
@@ -16,7 +15,6 @@ export interface ColumnToolPanelDeferredState {
 
 const EMPTY_STATE: ColumnToolPanelDeferredState = {
     pivotMode: false,
-    colOrderIds: [],
     rowGroupColIds: [],
     pivotColIds: [],
     valueCols: [],
@@ -26,7 +24,6 @@ const EMPTY_STATE: ColumnToolPanelDeferredState = {
 function cloneState(state: ColumnToolPanelDeferredState): ColumnToolPanelDeferredState {
     return {
         pivotMode: state.pivotMode,
-        colOrderIds: [...state.colOrderIds],
         rowGroupColIds: [...state.rowGroupColIds],
         pivotColIds: [...state.pivotColIds],
         valueCols: state.valueCols.map((valueCol) => ({
@@ -115,12 +112,6 @@ export class ColumnToolPanelDeferredService {
             colId: valueCol.colId,
             aggFunc: valueCol.aggFunc,
         }));
-        this.setPendingState(pendingState);
-    }
-
-    public setPendingColumnOrder(colIds: string[]): void {
-        const pendingState = this.getPendingState();
-        pendingState.colOrderIds = [...colIds];
         this.setPendingState(pendingState);
     }
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
@@ -13,6 +13,22 @@ export interface ColumnToolPanelDeferredState {
     visibleColIds: string[];
 }
 
+interface PendingPatch {
+    pivotMode?: boolean;
+
+    rowGroupColIds?: string[];
+    rowGroupTouchedColIds?: string[];
+
+    pivotColIds?: string[];
+    pivotTouchedColIds?: string[];
+
+    valueColOrder?: string[];
+    valueTouchedColIds?: string[];
+    valueAggOverrides?: { [colId: string]: string | IAggFunc | null };
+
+    visibilityOverrides?: { [colId: string]: boolean };
+}
+
 const EMPTY_STATE: ColumnToolPanelDeferredState = {
     pivotMode: false,
     rowGroupColIds: [],
@@ -36,15 +52,15 @@ function cloneState(state: ColumnToolPanelDeferredState): ColumnToolPanelDeferre
 
 export class ColumnToolPanelDeferredService {
     private appliedState: ColumnToolPanelDeferredState = cloneState(EMPTY_STATE);
-    private pendingState: ColumnToolPanelDeferredState = cloneState(EMPTY_STATE);
+    private patch: PendingPatch = {};
 
     public initialiseFromApplied(state: ColumnToolPanelDeferredState): void {
         this.appliedState = cloneState(state);
-        this.pendingState = cloneState(state);
+        this.patch = {};
     }
 
     public setPendingState(state: ColumnToolPanelDeferredState): void {
-        this.pendingState = cloneState(state);
+        this.patch = buildPatch(this.appliedState, state);
     }
 
     public applyPivotColumnStateToPending(stateItems: ColumnState[]): void {
@@ -117,21 +133,50 @@ export class ColumnToolPanelDeferredService {
 
     public reconcileFromApplied(state: ColumnToolPanelDeferredState): void {
         this.appliedState = cloneState(state);
-        this.pendingState = cloneState(state);
+        this.patch = {};
+    }
+
+    public reconcileFromAppliedPreservingPending(state: ColumnToolPanelDeferredState): void {
+        if (!this.hasPendingChanges()) {
+            this.appliedState = cloneState(state);
+            this.patch = {};
+            return;
+        }
+
+        const existingPatch = this.patch;
+        this.appliedState = cloneState(state);
+        const rebasedPendingState = applyPatchToState(this.appliedState, existingPatch, true);
+        const nextPatch = buildPatch(this.appliedState, rebasedPendingState);
+
+        // Preserve original touched metadata across rebases so untouched IDs don't become touched
+        // just because external updates changed relative ordering.
+        if (nextPatch.rowGroupColIds && existingPatch.rowGroupTouchedColIds) {
+            nextPatch.rowGroupTouchedColIds = [...existingPatch.rowGroupTouchedColIds];
+        }
+        if (nextPatch.pivotColIds && existingPatch.pivotTouchedColIds) {
+            nextPatch.pivotTouchedColIds = [...existingPatch.pivotTouchedColIds];
+        }
+        if (nextPatch.valueColOrder && existingPatch.valueTouchedColIds) {
+            nextPatch.valueTouchedColIds = [...existingPatch.valueTouchedColIds];
+        }
+
+        this.patch = nextPatch;
     }
 
     public commitPending(): ColumnToolPanelDeferredState {
-        this.appliedState = cloneState(this.pendingState);
+        const pendingState = this.getPendingState();
+        this.appliedState = cloneState(pendingState);
+        this.patch = {};
         return this.getAppliedState();
     }
 
     public cancelPending(): ColumnToolPanelDeferredState {
-        this.pendingState = cloneState(this.appliedState);
+        this.patch = {};
         return this.getPendingState();
     }
 
     public hasPendingChanges(): boolean {
-        return !areStatesEqual(this.appliedState, this.pendingState);
+        return hasPatchChanges(this.patch);
     }
 
     public getAppliedState(): ColumnToolPanelDeferredState {
@@ -139,7 +184,7 @@ export class ColumnToolPanelDeferredService {
     }
 
     public getPendingState(): ColumnToolPanelDeferredState {
-        return cloneState(this.pendingState);
+        return applyPatchToState(this.appliedState, this.patch, false);
     }
 }
 
@@ -147,32 +192,309 @@ function addUnique(ids: string[], colId: string): string[] {
     return ids.includes(colId) ? ids : [...ids, colId];
 }
 
-function areStatesEqual(a: ColumnToolPanelDeferredState, b: ColumnToolPanelDeferredState): boolean {
-    if (a.pivotMode !== b.pivotMode) {
-        return false;
-    }
-    if (!areStringArraysEqual(a.rowGroupColIds, b.rowGroupColIds)) {
-        return false;
-    }
-    if (!areStringArraysEqual(a.pivotColIds, b.pivotColIds)) {
-        return false;
-    }
-    if (!areStringArraysEqual(a.visibleColIds, b.visibleColIds)) {
-        return false;
-    }
-    if (a.valueCols.length !== b.valueCols.length) {
-        return false;
+function hasPatchChanges(patch: PendingPatch): boolean {
+    return (
+        patch.pivotMode !== undefined ||
+        patch.rowGroupColIds !== undefined ||
+        patch.pivotColIds !== undefined ||
+        patch.valueColOrder !== undefined ||
+        hasRecordEntries(patch.valueAggOverrides) ||
+        hasRecordEntries(patch.visibilityOverrides)
+    );
+}
+
+function hasRecordEntries(record: { [key: string]: unknown } | undefined): boolean {
+    return !!record && Object.keys(record).length > 0;
+}
+
+function buildPatch(applied: ColumnToolPanelDeferredState, pending: ColumnToolPanelDeferredState): PendingPatch {
+    const patch: PendingPatch = {};
+
+    if (pending.pivotMode !== applied.pivotMode) {
+        patch.pivotMode = pending.pivotMode;
     }
 
-    for (let i = 0; i < a.valueCols.length; i++) {
-        const left = a.valueCols[i];
-        const right = b.valueCols[i];
-        if (left.colId !== right.colId || left.aggFunc !== right.aggFunc) {
-            return false;
+    if (!areStringArraysEqual(pending.rowGroupColIds, applied.rowGroupColIds)) {
+        patch.rowGroupColIds = [...pending.rowGroupColIds];
+        patch.rowGroupTouchedColIds = [
+            ...getTouchedOrderedAndMembershipIds(applied.rowGroupColIds, pending.rowGroupColIds),
+        ];
+    }
+
+    if (!areStringArraysEqual(pending.pivotColIds, applied.pivotColIds)) {
+        patch.pivotColIds = [...pending.pivotColIds];
+        patch.pivotTouchedColIds = [...getTouchedOrderedAndMembershipIds(applied.pivotColIds, pending.pivotColIds)];
+    }
+
+    const appliedValueIds = applied.valueCols.map((valueCol) => valueCol.colId);
+    const pendingValueIds = pending.valueCols.map((valueCol) => valueCol.colId);
+    if (!areStringArraysEqual(appliedValueIds, pendingValueIds)) {
+        patch.valueColOrder = [...pendingValueIds];
+        patch.valueTouchedColIds = [...getTouchedOrderedAndMembershipIds(appliedValueIds, pendingValueIds)];
+    }
+
+    const valueAggOverrides = buildValueAggOverrides(applied.valueCols, pending.valueCols);
+    if (hasRecordEntries(valueAggOverrides)) {
+        patch.valueAggOverrides = valueAggOverrides;
+    }
+
+    const visibilityOverrides = buildVisibilityOverrides(applied.visibleColIds, pending.visibleColIds);
+    if (hasRecordEntries(visibilityOverrides)) {
+        patch.visibilityOverrides = visibilityOverrides;
+    }
+
+    return patch;
+}
+
+function buildVisibilityOverrides(
+    appliedVisibleColIds: string[],
+    pendingVisibleColIds: string[]
+): {
+    [colId: string]: boolean;
+} {
+    const overrides: { [colId: string]: boolean } = {};
+    const appliedVisibleSet = new Set(appliedVisibleColIds);
+    const pendingVisibleSet = new Set(pendingVisibleColIds);
+    const allIds = new Set([...appliedVisibleSet, ...pendingVisibleSet]);
+
+    for (const colId of allIds) {
+        const appliedVisible = appliedVisibleSet.has(colId);
+        const pendingVisible = pendingVisibleSet.has(colId);
+        if (appliedVisible !== pendingVisible) {
+            overrides[colId] = pendingVisible;
         }
     }
 
-    return true;
+    return overrides;
+}
+
+function buildValueAggOverrides(
+    appliedValueCols: DeferredValueColumnState[],
+    pendingValueCols: DeferredValueColumnState[]
+): { [colId: string]: string | IAggFunc | null } {
+    const overrides: { [colId: string]: string | IAggFunc | null } = {};
+    const appliedAggs = getValueAggMap(appliedValueCols);
+    const pendingAggs = getValueAggMap(pendingValueCols);
+    const allIds = new Set([...appliedAggs.keys(), ...pendingAggs.keys()]);
+
+    for (const colId of allIds) {
+        const appliedAgg = appliedAggs.get(colId) ?? null;
+        const pendingAgg = pendingAggs.get(colId) ?? null;
+        if (appliedAgg !== pendingAgg) {
+            overrides[colId] = pendingAgg;
+        }
+    }
+
+    return overrides;
+}
+
+function applyPatchToState(
+    appliedState: ColumnToolPanelDeferredState,
+    patch: PendingPatch,
+    preserveUntouchedOrderOnRebase: boolean
+): ColumnToolPanelDeferredState {
+    const pendingState = cloneState(appliedState);
+
+    if (patch.pivotMode !== undefined) {
+        pendingState.pivotMode = patch.pivotMode;
+    }
+
+    if (patch.rowGroupColIds) {
+        pendingState.rowGroupColIds = preserveUntouchedOrderOnRebase
+            ? mergeOrderedIdsWithTouched(
+                  appliedState.rowGroupColIds,
+                  patch.rowGroupColIds,
+                  new Set(patch.rowGroupTouchedColIds ?? patch.rowGroupColIds)
+              )
+            : [...patch.rowGroupColIds];
+    }
+
+    if (patch.pivotColIds) {
+        pendingState.pivotColIds = preserveUntouchedOrderOnRebase
+            ? mergeOrderedIdsWithTouched(
+                  appliedState.pivotColIds,
+                  patch.pivotColIds,
+                  new Set(patch.pivotTouchedColIds ?? patch.pivotColIds)
+              )
+            : [...patch.pivotColIds];
+    }
+
+    if (patch.valueColOrder || patch.valueAggOverrides) {
+        pendingState.valueCols = buildPatchedValueCols(appliedState.valueCols, patch, preserveUntouchedOrderOnRebase);
+    }
+
+    if (patch.visibilityOverrides) {
+        const visibleSet = new Set(appliedState.visibleColIds);
+        for (const [colId, visible] of Object.entries(patch.visibilityOverrides)) {
+            if (visible) {
+                visibleSet.add(colId);
+            } else {
+                visibleSet.delete(colId);
+            }
+        }
+        pendingState.visibleColIds = [...visibleSet];
+    }
+
+    return pendingState;
+}
+
+function buildPatchedValueCols(
+    appliedValueCols: DeferredValueColumnState[],
+    patch: PendingPatch,
+    preserveUntouchedOrderOnRebase: boolean
+): DeferredValueColumnState[] {
+    const appliedAggMap = getValueAggMap(appliedValueCols);
+    const aggOverrides = patch.valueAggOverrides ?? {};
+    const hasOverride = (colId: string) => Object.prototype.hasOwnProperty.call(aggOverrides, colId);
+
+    const appliedOrder = appliedValueCols.map((valueCol) => valueCol.colId);
+    let order = patch.valueColOrder ? [...patch.valueColOrder] : [...appliedOrder];
+
+    if (patch.valueColOrder && preserveUntouchedOrderOnRebase) {
+        order = mergeOrderedIdsWithTouched(
+            appliedOrder,
+            patch.valueColOrder,
+            new Set(patch.valueTouchedColIds ?? patch.valueColOrder)
+        );
+    }
+
+    // A staged agg func for a non-value column should stage adding it as a value column.
+    for (const [colId, aggFunc] of Object.entries(aggOverrides)) {
+        if (aggFunc !== null && !order.includes(colId)) {
+            order.push(colId);
+        }
+    }
+
+    const result: DeferredValueColumnState[] = [];
+    for (const colId of order) {
+        const aggFunc = hasOverride(colId) ? aggOverrides[colId] : appliedAggMap.get(colId) ?? null;
+        if (aggFunc === null) {
+            continue;
+        }
+        result.push({ colId, aggFunc });
+    }
+
+    return result;
+}
+
+function getValueAggMap(valueCols: DeferredValueColumnState[]): Map<string, string | IAggFunc | null> {
+    return new Map(valueCols.map((valueCol) => [valueCol.colId, valueCol.aggFunc] as const));
+}
+
+function getTouchedOrderedAndMembershipIds(applied: string[], pending: string[]): string[] {
+    const touched = new Set<string>();
+
+    const appliedSet = new Set(applied);
+    const pendingSet = new Set(pending);
+    const allIds = new Set([...appliedSet, ...pendingSet]);
+
+    for (const colId of allIds) {
+        if (appliedSet.has(colId) !== pendingSet.has(colId)) {
+            touched.add(colId);
+        }
+    }
+
+    const movedCommonIds = getMovedCommonIds(applied, pending);
+    for (const colId of movedCommonIds) {
+        touched.add(colId);
+    }
+
+    return [...touched];
+}
+
+function getMovedCommonIds(applied: string[], pending: string[]): string[] {
+    const appliedIndex = new Map(applied.map((id, index) => [id, index] as const));
+    const commonPendingIds = pending.filter((id) => appliedIndex.has(id));
+
+    if (commonPendingIds.length <= 1) {
+        return [];
+    }
+
+    const indexSequence = commonPendingIds.map((id) => appliedIndex.get(id)!);
+    const lisIndices = getLisIndices(indexSequence);
+    const untouchedCommonIds = new Set(lisIndices.map((i) => commonPendingIds[i]));
+
+    return commonPendingIds.filter((id) => !untouchedCommonIds.has(id));
+}
+
+function getLisIndices(values: number[]): number[] {
+    const n = values.length;
+    if (n === 0) {
+        return [];
+    }
+
+    const lengths = new Array<number>(n).fill(1);
+    const previous = new Array<number>(n).fill(-1);
+
+    let bestLen = 1;
+    let bestEnd = 0;
+
+    for (let i = 1; i < n; i++) {
+        for (let j = 0; j < i; j++) {
+            if (values[j] < values[i] && lengths[j] + 1 > lengths[i]) {
+                lengths[i] = lengths[j] + 1;
+                previous[i] = j;
+            }
+        }
+        if (lengths[i] > bestLen) {
+            bestLen = lengths[i];
+            bestEnd = i;
+        }
+    }
+
+    const lisIndices: number[] = [];
+    let cursor = bestEnd;
+    while (cursor !== -1) {
+        lisIndices.push(cursor);
+        cursor = previous[cursor];
+    }
+    lisIndices.reverse();
+
+    return lisIndices;
+}
+
+function mergeOrderedIdsWithTouched(base: string[], pending: string[], touched: Set<string>): string[] {
+    if (!touched.size) {
+        return [...base];
+    }
+
+    const result = base.filter((id) => !touched.has(id));
+    const pendingTouchedIds = pending.filter((id) => touched.has(id));
+
+    for (const touchedId of pendingTouchedIds) {
+        const existingIdx = result.indexOf(touchedId);
+        if (existingIdx >= 0) {
+            result.splice(existingIdx, 1);
+        }
+
+        const pendingIndex = pending.indexOf(touchedId);
+        let lowerBound = 0;
+        for (let i = pendingIndex - 1; i >= 0; i--) {
+            const candidate = pending[i];
+            const candidateIndex = result.indexOf(candidate);
+            if (candidateIndex >= 0) {
+                lowerBound = Math.max(lowerBound, candidateIndex + 1);
+            }
+        }
+
+        let upperBound = result.length;
+        for (let i = pendingIndex + 1; i < pending.length; i++) {
+            const candidate = pending[i];
+            const candidateIndex = result.indexOf(candidate);
+            if (candidateIndex >= 0) {
+                upperBound = Math.min(upperBound, candidateIndex);
+            }
+        }
+
+        const insertAt = lowerBound <= upperBound ? upperBound : lowerBound;
+        if (insertAt >= result.length) {
+            result.push(touchedId);
+        } else {
+            result.splice(insertAt, 0, touchedId);
+        }
+    }
+
+    return result;
 }
 
 function areStringArraysEqual(a: string[], b: string[]): boolean {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
@@ -78,12 +78,6 @@ export class ColumnToolPanelDeferredService {
     private pendingStateCache: ColumnToolPanelDeferredState = cloneState(EMPTY_STATE);
     private pendingStateCacheDirty = true;
 
-    public initialiseFromApplied(state: ColumnToolPanelDeferredState): void {
-        this.appliedState = cloneState(state);
-        this.patch = {};
-        this.pendingStateCacheDirty = true;
-    }
-
     public setPendingState(state: ColumnToolPanelDeferredState): void {
         this.patch = buildPatch(this.appliedState, state);
         this.pendingStateCacheDirty = true;
@@ -389,6 +383,7 @@ function buildPatchedValueCols(
 
     const appliedOrder = appliedValueCols.map((valueCol) => valueCol.colId);
     let order = patch.valueColOrder ? [...patch.valueColOrder] : [...appliedOrder];
+    const orderSet = new Set(order);
 
     if (patch.valueColOrder && preserveUntouchedOrderOnRebase) {
         order = mergeOrderedIdsWithTouched(
@@ -401,8 +396,9 @@ function buildPatchedValueCols(
     // A staged agg func for a non-value column should stage adding it as a value column.
     for (const colId of Object.keys(aggOverrides)) {
         const aggFunc = aggOverrides[colId];
-        if (aggFunc !== null && !order.includes(colId)) {
+        if (aggFunc !== null && !orderSet.has(colId)) {
             order.push(colId);
+            orderSet.add(colId);
         }
     }
 
@@ -527,7 +523,7 @@ function mergeOrderedIdsWithTouched(base: string[], pending: string[], touched: 
         for (let i = pendingIndex - 1; i >= 0; i--) {
             const candidate = pending[i];
             const candidateIndex = resultIndexById.get(candidate);
-            if (candidateIndex >= 0) {
+            if (candidateIndex != null && candidateIndex >= 0) {
                 lowerBound = Math.max(lowerBound, candidateIndex + 1);
             }
         }
@@ -536,7 +532,7 @@ function mergeOrderedIdsWithTouched(base: string[], pending: string[], touched: 
         for (let i = pendingIndex + 1; i < pending.length; i++) {
             const candidate = pending[i];
             const candidateIndex = resultIndexById.get(candidate);
-            if (candidateIndex >= 0) {
+            if (candidateIndex != null && candidateIndex >= 0) {
                 upperBound = Math.min(upperBound, candidateIndex);
             }
         }

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
@@ -37,6 +37,7 @@ const EMPTY_STATE: ColumnToolPanelDeferredState = {
     visibleColIds: [],
 };
 
+/** Clone deferred state so callers cannot mutate internal service references. */
 function cloneState(state: ColumnToolPanelDeferredState): ColumnToolPanelDeferredState {
     return {
         pivotMode: state.pivotMode,
@@ -50,6 +51,7 @@ function cloneState(state: ColumnToolPanelDeferredState): ColumnToolPanelDeferre
     };
 }
 
+/** Freeze state snapshots so deferred mode consumers treat pending state as read-only. */
 function freezeState(state: ColumnToolPanelDeferredState): ColumnToolPanelDeferredState {
     const rowGroupColIds = Object.freeze([...state.rowGroupColIds]) as string[];
     const pivotColIds = Object.freeze([...state.pivotColIds]) as string[];
@@ -72,17 +74,20 @@ function freezeState(state: ColumnToolPanelDeferredState): ColumnToolPanelDeferr
     }) as ColumnToolPanelDeferredState;
 }
 
+/** Track applied state plus a patch so deferred mode can stage edits without immediate grid mutation. */
 export class ColumnToolPanelDeferredService {
     private appliedState: ColumnToolPanelDeferredState = cloneState(EMPTY_STATE);
     private patch: PendingPatch = {};
     private pendingStateCache: ColumnToolPanelDeferredState = cloneState(EMPTY_STATE);
     private pendingStateCacheDirty = true;
 
+    /** Replace staged state by rebuilding the patch against current applied state. */
     public setPendingState(state: ColumnToolPanelDeferredState): void {
         this.patch = buildPatch(this.appliedState, state);
         this.pendingStateCacheDirty = true;
     }
 
+    /** Stage pivot/row-group/value mutations from column state updates in deferred mode. */
     public applyPivotColumnStateToPending(stateItems: ColumnState[]): void {
         const pendingState = this.getPendingState();
         for (const state of stateItems) {
@@ -116,6 +121,7 @@ export class ColumnToolPanelDeferredService {
         this.setPendingState(pendingState);
     }
 
+    /** Stage visibility updates from column state changes in deferred mode. */
     public applyVisibilityColumnStateToPending(stateItems: ColumnState[]): void {
         const pendingState = this.getPendingState();
         for (const state of stateItems) {
@@ -130,18 +136,21 @@ export class ColumnToolPanelDeferredService {
         this.setPendingState(pendingState);
     }
 
+    /** Stage row-group order updates from tool panel interactions. */
     public setPendingRowGroupColumns(colIds: string[]): void {
         const pendingState = this.getPendingState();
         pendingState.rowGroupColIds = [...colIds];
         this.setPendingState(pendingState);
     }
 
+    /** Stage pivot order updates from tool panel interactions. */
     public setPendingPivotColumns(colIds: string[]): void {
         const pendingState = this.getPendingState();
         pendingState.pivotColIds = [...colIds];
         this.setPendingState(pendingState);
     }
 
+    /** Stage value column order and aggregation function updates. */
     public setPendingValueColumns(valueCols: DeferredValueColumnState[]): void {
         const pendingState = this.getPendingState();
         pendingState.valueCols = valueCols.map((valueCol) => ({
@@ -151,12 +160,14 @@ export class ColumnToolPanelDeferredService {
         this.setPendingState(pendingState);
     }
 
+    /** Reset deferred state to a new applied baseline after apply or panel refresh. */
     public reconcileFromApplied(state: ColumnToolPanelDeferredState): void {
         this.appliedState = cloneState(state);
         this.patch = {};
         this.pendingStateCacheDirty = true;
     }
 
+    /** Rebase staged edits onto new applied state so pending deferred edits survive external grid changes. */
     public reconcileFromAppliedPreservingPending(state: ColumnToolPanelDeferredState): void {
         if (!this.hasPendingChanges()) {
             this.appliedState = cloneState(state);
@@ -186,24 +197,29 @@ export class ColumnToolPanelDeferredService {
         this.pendingStateCacheDirty = true;
     }
 
+    /** Drop all staged edits and return the applied-equivalent pending state. */
     public cancelPending(): ColumnToolPanelDeferredState {
         this.patch = {};
         this.pendingStateCacheDirty = true;
         return this.getPendingState();
     }
 
+    /** Report whether deferred mode currently has staged edits to apply or cancel. */
     public hasPendingChanges(): boolean {
         return hasPatchChanges(this.patch);
     }
 
+    /** Return a defensive copy of applied state. */
     public getAppliedState(): ColumnToolPanelDeferredState {
         return cloneState(this.appliedState);
     }
 
+    /** Return a defensive copy of pending state. */
     public getPendingState(): ColumnToolPanelDeferredState {
         return cloneState(this.getPendingStateSnapshot());
     }
 
+    /** Return a frozen pending snapshot for read-only consumers in deferred mode UI. */
     public getPendingStateSnapshot(): Readonly<ColumnToolPanelDeferredState> {
         if (this.pendingStateCacheDirty) {
             this.pendingStateCache = freezeState(applyPatchToState(this.appliedState, this.patch, false));
@@ -213,10 +229,12 @@ export class ColumnToolPanelDeferredService {
     }
 }
 
+/** Add an id only when absent so staged ordered lists stay unique. */
 function addUnique(ids: string[], colId: string): string[] {
     return ids.includes(colId) ? ids : [...ids, colId];
 }
 
+/** Check whether the staged patch contains any deferred changes. */
 function hasPatchChanges(patch: PendingPatch): boolean {
     return (
         patch.pivotMode !== undefined ||
@@ -228,10 +246,12 @@ function hasPatchChanges(patch: PendingPatch): boolean {
     );
 }
 
+/** Check whether override records contain at least one staged key. */
 function hasRecordEntries(record: { [key: string]: unknown } | undefined): boolean {
     return !!record && Object.keys(record).length > 0;
 }
 
+/** Build a minimal patch that captures pending state differences from applied state. */
 function buildPatch(applied: ColumnToolPanelDeferredState, pending: ColumnToolPanelDeferredState): PendingPatch {
     const patch: PendingPatch = {};
 
@@ -271,6 +291,7 @@ function buildPatch(applied: ColumnToolPanelDeferredState, pending: ColumnToolPa
     return patch;
 }
 
+/** Build visibility overrides so deferred mode stage hidden/visible deltas only. */
 function buildVisibilityOverrides(
     appliedVisibleColIds: string[],
     pendingVisibleColIds: string[]
@@ -293,6 +314,7 @@ function buildVisibilityOverrides(
     return overrides;
 }
 
+/** Build aggregation overrides so deferred mode stage value agg deltas only. */
 function buildValueAggOverrides(
     appliedValueCols: DeferredValueColumnState[],
     pendingValueCols: DeferredValueColumnState[]
@@ -313,6 +335,7 @@ function buildValueAggOverrides(
     return overrides;
 }
 
+/** Apply a staged patch to applied state to materialise current deferred pending state. */
 function applyPatchToState(
     appliedState: ColumnToolPanelDeferredState,
     patch: PendingPatch,
@@ -364,6 +387,7 @@ function applyPatchToState(
     return pendingState;
 }
 
+/** Build staged value columns after applying order and aggregation overrides. */
 function buildPatchedValueCols(
     appliedValueCols: DeferredValueColumnState[],
     patch: PendingPatch,
@@ -406,10 +430,12 @@ function buildPatchedValueCols(
     return result;
 }
 
+/** Map value column ids to aggregation functions for patch comparisons and materialisation. */
 function getValueAggMap(valueCols: DeferredValueColumnState[]): Map<string, string | IAggFunc | null> {
     return new Map(valueCols.map((valueCol) => [valueCol.colId, valueCol.aggFunc] as const));
 }
 
+/** Track ids whose membership or ordering changed so rebasing preserves untouched order. */
 function getTouchedOrderedAndMembershipIds(applied: string[], pending: string[]): string[] {
     const touched = new Set<string>();
 
@@ -431,6 +457,7 @@ function getTouchedOrderedAndMembershipIds(applied: string[], pending: string[])
     return [...touched];
 }
 
+/** Detect common ids that changed order between applied and pending sequences. */
 function getMovedCommonIds(applied: string[], pending: string[]): string[] {
     const appliedIndex = new Map(applied.map((id, index) => [id, index] as const));
     const commonPendingIds = pending.filter((id) => appliedIndex.has(id));
@@ -446,6 +473,7 @@ function getMovedCommonIds(applied: string[], pending: string[]): string[] {
     return commonPendingIds.filter((id) => !untouchedCommonIds.has(id));
 }
 
+/** Compute LIS indices to identify common ids that keep relative order across reorder operations. */
 function getLisIndices(values: number[]): number[] {
     const n = values.length;
     if (n === 0) {
@@ -490,6 +518,7 @@ function getLisIndices(values: number[]): number[] {
     return lisIndices;
 }
 
+/** Merge touched ids into base order while keeping untouched ids stable during rebase. */
 function mergeOrderedIdsWithTouched(base: string[], pending: string[], touched: Set<string>): string[] {
     if (!touched.size) {
         return [...base];
@@ -540,6 +569,7 @@ function mergeOrderedIdsWithTouched(base: string[], pending: string[], touched: 
     return result;
 }
 
+/** Compare ordered id arrays to detect deferred order changes. */
 function areStringArraysEqual(a: string[], b: string[]): boolean {
     if (a.length !== b.length) {
         return false;

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
@@ -7,6 +7,7 @@ export interface DeferredValueColumnState {
 
 export interface ColumnToolPanelDeferredState {
     pivotMode: boolean;
+    colOrderIds: string[];
     rowGroupColIds: string[];
     pivotColIds: string[];
     valueCols: DeferredValueColumnState[];
@@ -15,6 +16,7 @@ export interface ColumnToolPanelDeferredState {
 
 const EMPTY_STATE: ColumnToolPanelDeferredState = {
     pivotMode: false,
+    colOrderIds: [],
     rowGroupColIds: [],
     pivotColIds: [],
     valueCols: [],
@@ -24,6 +26,7 @@ const EMPTY_STATE: ColumnToolPanelDeferredState = {
 function cloneState(state: ColumnToolPanelDeferredState): ColumnToolPanelDeferredState {
     return {
         pivotMode: state.pivotMode,
+        colOrderIds: [...state.colOrderIds],
         rowGroupColIds: [...state.rowGroupColIds],
         pivotColIds: [...state.pivotColIds],
         valueCols: state.valueCols.map((valueCol) => ({
@@ -112,6 +115,12 @@ export class ColumnToolPanelDeferredService {
             colId: valueCol.colId,
             aggFunc: valueCol.aggFunc,
         }));
+        this.setPendingState(pendingState);
+    }
+
+    public setPendingColumnOrder(colIds: string[]): void {
+        const pendingState = this.getPendingState();
+        pendingState.colOrderIds = [...colIds];
         this.setPendingState(pendingState);
     }
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
@@ -308,7 +308,7 @@ function applyPatchToState(
         pivotMode: appliedState.pivotMode,
         rowGroupColIds: appliedState.rowGroupColIds,
         pivotColIds: appliedState.pivotColIds,
-        valueCols: appliedState.valueCols,
+        valueCols: appliedState.valueCols.map((valueCol) => ({ colId: valueCol.colId, aggFunc: valueCol.aggFunc })),
         visibleColIds: appliedState.visibleColIds,
     };
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
@@ -94,6 +94,27 @@ export class ColumnToolPanelDeferredService {
         this.setPendingState(pendingState);
     }
 
+    public setPendingRowGroupColumns(colIds: string[]): void {
+        const pendingState = this.getPendingState();
+        pendingState.rowGroupColIds = [...colIds];
+        this.setPendingState(pendingState);
+    }
+
+    public setPendingPivotColumns(colIds: string[]): void {
+        const pendingState = this.getPendingState();
+        pendingState.pivotColIds = [...colIds];
+        this.setPendingState(pendingState);
+    }
+
+    public setPendingValueColumns(valueCols: DeferredValueColumnState[]): void {
+        const pendingState = this.getPendingState();
+        pendingState.valueCols = valueCols.map((valueCol) => ({
+            colId: valueCol.colId,
+            aggFunc: valueCol.aggFunc,
+        }));
+        this.setPendingState(pendingState);
+    }
+
     public reconcileFromApplied(state: ColumnToolPanelDeferredState): void {
         this.appliedState = cloneState(state);
         this.pendingState = cloneState(state);

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
@@ -1,6 +1,6 @@
 import type { ColumnState, IAggFunc } from 'ag-grid-community';
 
-export interface DeferredValueColumnState {
+interface DeferredValueColumnState {
     colId: string;
     aggFunc: string | IAggFunc | null;
 }
@@ -131,7 +131,7 @@ export class ColumnToolPanelDeferredService {
     }
 
     public hasPendingChanges(): boolean {
-        return JSON.stringify(this.appliedState) !== JSON.stringify(this.pendingState);
+        return !areStatesEqual(this.appliedState, this.pendingState);
     }
 
     public getAppliedState(): ColumnToolPanelDeferredState {
@@ -145,4 +145,44 @@ export class ColumnToolPanelDeferredService {
 
 function addUnique(ids: string[], colId: string): string[] {
     return ids.includes(colId) ? ids : [...ids, colId];
+}
+
+function areStatesEqual(a: ColumnToolPanelDeferredState, b: ColumnToolPanelDeferredState): boolean {
+    if (a.pivotMode !== b.pivotMode) {
+        return false;
+    }
+    if (!areStringArraysEqual(a.rowGroupColIds, b.rowGroupColIds)) {
+        return false;
+    }
+    if (!areStringArraysEqual(a.pivotColIds, b.pivotColIds)) {
+        return false;
+    }
+    if (!areStringArraysEqual(a.visibleColIds, b.visibleColIds)) {
+        return false;
+    }
+    if (a.valueCols.length !== b.valueCols.length) {
+        return false;
+    }
+
+    for (let i = 0; i < a.valueCols.length; i++) {
+        const left = a.valueCols[i];
+        const right = b.valueCols[i];
+        if (left.colId !== right.colId || left.aggFunc !== right.aggFunc) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function areStringArraysEqual(a: string[], b: string[]): boolean {
+    if (a.length !== b.length) {
+        return false;
+    }
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) {
+            return false;
+        }
+    }
+    return true;
 }

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
@@ -325,7 +325,8 @@ function applyPatchToState(
 
     if (patch.visibilityOverrides) {
         const visibleSet = new Set(appliedState.visibleColIds);
-        for (const [colId, visible] of Object.entries(patch.visibilityOverrides)) {
+        for (const colId of Object.keys(patch.visibilityOverrides)) {
+            const visible = patch.visibilityOverrides[colId];
             if (visible) {
                 visibleSet.add(colId);
             } else {
@@ -359,7 +360,8 @@ function buildPatchedValueCols(
     }
 
     // A staged agg func for a non-value column should stage adding it as a value column.
-    for (const [colId, aggFunc] of Object.entries(aggOverrides)) {
+    for (const colId of Object.keys(aggOverrides)) {
+        const aggFunc = aggOverrides[colId];
         if (aggFunc !== null && !order.includes(colId)) {
             order.push(colId);
         }

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
@@ -10,6 +10,7 @@ export interface ColumnToolPanelDeferredState {
     rowGroupColIds: string[];
     pivotColIds: string[];
     valueCols: DeferredValueColumnState[];
+    visibleColIds: string[];
 }
 
 const EMPTY_STATE: ColumnToolPanelDeferredState = {
@@ -17,6 +18,7 @@ const EMPTY_STATE: ColumnToolPanelDeferredState = {
     rowGroupColIds: [],
     pivotColIds: [],
     valueCols: [],
+    visibleColIds: [],
 };
 
 function cloneState(state: ColumnToolPanelDeferredState): ColumnToolPanelDeferredState {
@@ -28,6 +30,7 @@ function cloneState(state: ColumnToolPanelDeferredState): ColumnToolPanelDeferre
             colId: valueCol.colId,
             aggFunc: valueCol.aggFunc,
         })),
+        visibleColIds: [...state.visibleColIds],
     };
 }
 
@@ -73,6 +76,20 @@ export class ColumnToolPanelDeferredService {
                     pendingState.valueCols.push({ colId, aggFunc });
                 }
             }
+        }
+        this.setPendingState(pendingState);
+    }
+
+    public applyVisibilityColumnStateToPending(stateItems: ColumnState[]): void {
+        const pendingState = this.getPendingState();
+        for (const state of stateItems) {
+            const { colId, hide } = state;
+            if (!colId || hide === undefined) {
+                continue;
+            }
+            pendingState.visibleColIds = hide
+                ? pendingState.visibleColIds.filter((id) => id !== colId)
+                : addUnique(pendingState.visibleColIds, colId);
         }
         this.setPendingState(pendingState);
     }

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
@@ -37,48 +37,11 @@ const EMPTY_STATE: ColumnToolPanelDeferredState = {
     visibleColIds: [],
 };
 
-/** Clone deferred state so callers cannot mutate internal service references. */
-function cloneState(state: ColumnToolPanelDeferredState): ColumnToolPanelDeferredState {
-    return {
-        pivotMode: state.pivotMode,
-        rowGroupColIds: [...state.rowGroupColIds],
-        pivotColIds: [...state.pivotColIds],
-        valueCols: state.valueCols.map((valueCol) => ({
-            colId: valueCol.colId,
-            aggFunc: valueCol.aggFunc,
-        })),
-        visibleColIds: [...state.visibleColIds],
-    };
-}
-
-/** Freeze state snapshots so deferred mode consumers treat pending state as read-only. */
-function freezeState(state: ColumnToolPanelDeferredState): ColumnToolPanelDeferredState {
-    const rowGroupColIds = Object.freeze([...state.rowGroupColIds]) as string[];
-    const pivotColIds = Object.freeze([...state.pivotColIds]) as string[];
-    const valueCols = Object.freeze(
-        state.valueCols.map((valueCol) =>
-            Object.freeze({
-                colId: valueCol.colId,
-                aggFunc: valueCol.aggFunc,
-            })
-        )
-    ) as DeferredValueColumnState[];
-    const visibleColIds = Object.freeze([...state.visibleColIds]) as string[];
-
-    return Object.freeze({
-        pivotMode: state.pivotMode,
-        rowGroupColIds,
-        pivotColIds,
-        valueCols,
-        visibleColIds,
-    }) as ColumnToolPanelDeferredState;
-}
-
 /** Track applied state plus a patch so deferred mode can stage edits without immediate grid mutation. */
 export class ColumnToolPanelDeferredService {
-    private appliedState: ColumnToolPanelDeferredState = cloneState(EMPTY_STATE);
+    private appliedState: ColumnToolPanelDeferredState = EMPTY_STATE;
     private patch: PendingPatch = {};
-    private pendingStateCache: ColumnToolPanelDeferredState = cloneState(EMPTY_STATE);
+    private pendingStateCache: ColumnToolPanelDeferredState = EMPTY_STATE;
     private pendingStateCacheDirty = true;
 
     /** Replace staged state by rebuilding the patch against current applied state. */
@@ -162,7 +125,7 @@ export class ColumnToolPanelDeferredService {
 
     /** Reset deferred state to a new applied baseline after apply or panel refresh. */
     public reconcileFromApplied(state: ColumnToolPanelDeferredState): void {
-        this.appliedState = cloneState(state);
+        this.appliedState = state;
         this.patch = {};
         this.pendingStateCacheDirty = true;
     }
@@ -170,14 +133,14 @@ export class ColumnToolPanelDeferredService {
     /** Rebase staged edits onto new applied state so pending deferred edits survive external grid changes. */
     public reconcileFromAppliedPreservingPending(state: ColumnToolPanelDeferredState): void {
         if (!this.hasPendingChanges()) {
-            this.appliedState = cloneState(state);
+            this.appliedState = state;
             this.patch = {};
             this.pendingStateCacheDirty = true;
             return;
         }
 
         const existingPatch = this.patch;
-        this.appliedState = cloneState(state);
+        this.appliedState = state;
         const rebasedPendingState = applyPatchToState(this.appliedState, existingPatch, true);
         const nextPatch = buildPatch(this.appliedState, rebasedPendingState);
 
@@ -209,20 +172,20 @@ export class ColumnToolPanelDeferredService {
         return hasPatchChanges(this.patch);
     }
 
-    /** Return a defensive copy of applied state. */
+    /** Return the current applied state baseline. */
     public getAppliedState(): ColumnToolPanelDeferredState {
-        return cloneState(this.appliedState);
+        return this.appliedState;
     }
 
-    /** Return a defensive copy of pending state. */
+    /** Return current pending state. */
     public getPendingState(): ColumnToolPanelDeferredState {
-        return cloneState(this.getPendingStateSnapshot());
+        return this.getPendingStateSnapshot();
     }
 
-    /** Return a frozen pending snapshot for read-only consumers in deferred mode UI. */
+    /** Return cached pending state, recomputed when patch or applied state changes. */
     public getPendingStateSnapshot(): Readonly<ColumnToolPanelDeferredState> {
         if (this.pendingStateCacheDirty) {
-            this.pendingStateCache = freezeState(applyPatchToState(this.appliedState, this.patch, false));
+            this.pendingStateCache = applyPatchToState(this.appliedState, this.patch, false);
             this.pendingStateCacheDirty = false;
         }
         return this.pendingStateCache;
@@ -341,7 +304,13 @@ function applyPatchToState(
     patch: PendingPatch,
     preserveUntouchedOrderOnRebase: boolean
 ): ColumnToolPanelDeferredState {
-    const pendingState = cloneState(appliedState);
+    const pendingState: ColumnToolPanelDeferredState = {
+        pivotMode: appliedState.pivotMode,
+        rowGroupColIds: appliedState.rowGroupColIds,
+        pivotColIds: appliedState.pivotColIds,
+        valueCols: appliedState.valueCols,
+        visibleColIds: appliedState.visibleColIds,
+    };
 
     if (patch.pivotMode !== undefined) {
         pendingState.pivotMode = patch.pivotMode;

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
@@ -1,4 +1,4 @@
-import type { IAggFunc } from 'ag-grid-community';
+import type { ColumnState, IAggFunc } from 'ag-grid-community';
 
 export interface DeferredValueColumnState {
     colId: string;
@@ -44,6 +44,39 @@ export class ColumnToolPanelDeferredService {
         this.pendingState = cloneState(state);
     }
 
+    public applyPivotColumnStateToPending(stateItems: ColumnState[]): void {
+        const pendingState = this.getPendingState();
+        for (const state of stateItems) {
+            const { colId, pivot, rowGroup, aggFunc } = state;
+            if (!colId) {
+                continue;
+            }
+            if (pivot !== undefined) {
+                pendingState.pivotColIds = pivot
+                    ? addUnique(pendingState.pivotColIds, colId)
+                    : pendingState.pivotColIds.filter((id) => id !== colId);
+            }
+            if (rowGroup !== undefined) {
+                pendingState.rowGroupColIds = rowGroup
+                    ? addUnique(pendingState.rowGroupColIds, colId)
+                    : pendingState.rowGroupColIds.filter((id) => id !== colId);
+            }
+            if (aggFunc !== undefined) {
+                const index = pendingState.valueCols.findIndex((valueCol) => valueCol.colId === colId);
+                if (aggFunc === null) {
+                    if (index >= 0) {
+                        pendingState.valueCols.splice(index, 1);
+                    }
+                } else if (index >= 0) {
+                    pendingState.valueCols[index].aggFunc = aggFunc;
+                } else {
+                    pendingState.valueCols.push({ colId, aggFunc });
+                }
+            }
+        }
+        this.setPendingState(pendingState);
+    }
+
     public reconcileFromApplied(state: ColumnToolPanelDeferredState): void {
         this.appliedState = cloneState(state);
         this.pendingState = cloneState(state);
@@ -70,4 +103,8 @@ export class ColumnToolPanelDeferredService {
     public getPendingState(): ColumnToolPanelDeferredState {
         return cloneState(this.pendingState);
     }
+}
+
+function addUnique(ids: string[], colId: string): string[] {
+    return ids.includes(colId) ? ids : [...ids, colId];
 }

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
@@ -50,17 +50,43 @@ function cloneState(state: ColumnToolPanelDeferredState): ColumnToolPanelDeferre
     };
 }
 
+function freezeState(state: ColumnToolPanelDeferredState): ColumnToolPanelDeferredState {
+    const rowGroupColIds = Object.freeze([...state.rowGroupColIds]) as string[];
+    const pivotColIds = Object.freeze([...state.pivotColIds]) as string[];
+    const valueCols = Object.freeze(
+        state.valueCols.map((valueCol) =>
+            Object.freeze({
+                colId: valueCol.colId,
+                aggFunc: valueCol.aggFunc,
+            })
+        )
+    ) as DeferredValueColumnState[];
+    const visibleColIds = Object.freeze([...state.visibleColIds]) as string[];
+
+    return Object.freeze({
+        pivotMode: state.pivotMode,
+        rowGroupColIds,
+        pivotColIds,
+        valueCols,
+        visibleColIds,
+    }) as ColumnToolPanelDeferredState;
+}
+
 export class ColumnToolPanelDeferredService {
     private appliedState: ColumnToolPanelDeferredState = cloneState(EMPTY_STATE);
     private patch: PendingPatch = {};
+    private pendingStateCache: ColumnToolPanelDeferredState = cloneState(EMPTY_STATE);
+    private pendingStateCacheDirty = true;
 
     public initialiseFromApplied(state: ColumnToolPanelDeferredState): void {
         this.appliedState = cloneState(state);
         this.patch = {};
+        this.pendingStateCacheDirty = true;
     }
 
     public setPendingState(state: ColumnToolPanelDeferredState): void {
         this.patch = buildPatch(this.appliedState, state);
+        this.pendingStateCacheDirty = true;
     }
 
     public applyPivotColumnStateToPending(stateItems: ColumnState[]): void {
@@ -134,12 +160,14 @@ export class ColumnToolPanelDeferredService {
     public reconcileFromApplied(state: ColumnToolPanelDeferredState): void {
         this.appliedState = cloneState(state);
         this.patch = {};
+        this.pendingStateCacheDirty = true;
     }
 
     public reconcileFromAppliedPreservingPending(state: ColumnToolPanelDeferredState): void {
         if (!this.hasPendingChanges()) {
             this.appliedState = cloneState(state);
             this.patch = {};
+            this.pendingStateCacheDirty = true;
             return;
         }
 
@@ -161,17 +189,20 @@ export class ColumnToolPanelDeferredService {
         }
 
         this.patch = nextPatch;
+        this.pendingStateCacheDirty = true;
     }
 
     public commitPending(): ColumnToolPanelDeferredState {
         const pendingState = this.getPendingState();
         this.appliedState = cloneState(pendingState);
         this.patch = {};
+        this.pendingStateCacheDirty = true;
         return this.getAppliedState();
     }
 
     public cancelPending(): ColumnToolPanelDeferredState {
         this.patch = {};
+        this.pendingStateCacheDirty = true;
         return this.getPendingState();
     }
 
@@ -184,7 +215,15 @@ export class ColumnToolPanelDeferredService {
     }
 
     public getPendingState(): ColumnToolPanelDeferredState {
-        return applyPatchToState(this.appliedState, this.patch, false);
+        return cloneState(this.getPendingStateSnapshot());
+    }
+
+    public getPendingStateSnapshot(): Readonly<ColumnToolPanelDeferredState> {
+        if (this.pendingStateCacheDirty) {
+            this.pendingStateCache = freezeState(applyPatchToState(this.appliedState, this.patch, false));
+            this.pendingStateCacheDirty = false;
+        }
+        return this.pendingStateCache;
     }
 }
 
@@ -425,33 +464,41 @@ function getLisIndices(values: number[]): number[] {
         return [];
     }
 
-    const lengths = new Array<number>(n).fill(1);
-    const previous = new Array<number>(n).fill(-1);
+    const tailsValueIndices: number[] = [];
+    const previousIndex = new Array<number>(n).fill(-1);
 
-    let bestLen = 1;
-    let bestEnd = 0;
+    for (let i = 0; i < n; i++) {
+        const value = values[i];
+        let left = 0;
+        let right = tailsValueIndices.length;
 
-    for (let i = 1; i < n; i++) {
-        for (let j = 0; j < i; j++) {
-            if (values[j] < values[i] && lengths[j] + 1 > lengths[i]) {
-                lengths[i] = lengths[j] + 1;
-                previous[i] = j;
+        while (left < right) {
+            const mid = (left + right) >> 1;
+            if (values[tailsValueIndices[mid]] < value) {
+                left = mid + 1;
+            } else {
+                right = mid;
             }
         }
-        if (lengths[i] > bestLen) {
-            bestLen = lengths[i];
-            bestEnd = i;
+
+        if (left > 0) {
+            previousIndex[i] = tailsValueIndices[left - 1];
+        }
+
+        if (left === tailsValueIndices.length) {
+            tailsValueIndices.push(i);
+        } else {
+            tailsValueIndices[left] = i;
         }
     }
 
     const lisIndices: number[] = [];
-    let cursor = bestEnd;
-    while (cursor !== -1) {
+    let cursor = tailsValueIndices[tailsValueIndices.length - 1];
+    while (cursor != null && cursor >= 0) {
         lisIndices.push(cursor);
-        cursor = previous[cursor];
+        cursor = previousIndex[cursor];
     }
     lisIndices.reverse();
-
     return lisIndices;
 }
 
@@ -462,6 +509,7 @@ function mergeOrderedIdsWithTouched(base: string[], pending: string[], touched: 
 
     const result = base.filter((id) => !touched.has(id));
     const pendingTouchedIds = pending.filter((id) => touched.has(id));
+    const pendingIndexById = new Map(pending.map((id, index) => [id, index] as const));
 
     for (const touchedId of pendingTouchedIds) {
         const existingIdx = result.indexOf(touchedId);
@@ -469,11 +517,16 @@ function mergeOrderedIdsWithTouched(base: string[], pending: string[], touched: 
             result.splice(existingIdx, 1);
         }
 
-        const pendingIndex = pending.indexOf(touchedId);
+        const pendingIndex = pendingIndexById.get(touchedId);
+        if (pendingIndex == null) {
+            continue;
+        }
+
+        const resultIndexById = new Map(result.map((id, index) => [id, index] as const));
         let lowerBound = 0;
         for (let i = pendingIndex - 1; i >= 0; i--) {
             const candidate = pending[i];
-            const candidateIndex = result.indexOf(candidate);
+            const candidateIndex = resultIndexById.get(candidate);
             if (candidateIndex >= 0) {
                 lowerBound = Math.max(lowerBound, candidateIndex + 1);
             }
@@ -482,7 +535,7 @@ function mergeOrderedIdsWithTouched(base: string[], pending: string[], touched: 
         let upperBound = result.length;
         for (let i = pendingIndex + 1; i < pending.length; i++) {
             const candidate = pending[i];
-            const candidateIndex = result.indexOf(candidate);
+            const candidateIndex = resultIndexById.get(candidate);
             if (candidateIndex >= 0) {
                 upperBound = Math.min(upperBound, candidateIndex);
             }

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
@@ -1,0 +1,73 @@
+import type { IAggFunc } from 'ag-grid-community';
+
+export interface DeferredValueColumnState {
+    colId: string;
+    aggFunc: string | IAggFunc | null;
+}
+
+export interface ColumnToolPanelDeferredState {
+    pivotMode: boolean;
+    rowGroupColIds: string[];
+    pivotColIds: string[];
+    valueCols: DeferredValueColumnState[];
+}
+
+const EMPTY_STATE: ColumnToolPanelDeferredState = {
+    pivotMode: false,
+    rowGroupColIds: [],
+    pivotColIds: [],
+    valueCols: [],
+};
+
+function cloneState(state: ColumnToolPanelDeferredState): ColumnToolPanelDeferredState {
+    return {
+        pivotMode: state.pivotMode,
+        rowGroupColIds: [...state.rowGroupColIds],
+        pivotColIds: [...state.pivotColIds],
+        valueCols: state.valueCols.map((valueCol) => ({
+            colId: valueCol.colId,
+            aggFunc: valueCol.aggFunc,
+        })),
+    };
+}
+
+export class ColumnToolPanelDeferredService {
+    private appliedState: ColumnToolPanelDeferredState = cloneState(EMPTY_STATE);
+    private pendingState: ColumnToolPanelDeferredState = cloneState(EMPTY_STATE);
+
+    public initialiseFromApplied(state: ColumnToolPanelDeferredState): void {
+        this.appliedState = cloneState(state);
+        this.pendingState = cloneState(state);
+    }
+
+    public setPendingState(state: ColumnToolPanelDeferredState): void {
+        this.pendingState = cloneState(state);
+    }
+
+    public reconcileFromApplied(state: ColumnToolPanelDeferredState): void {
+        this.appliedState = cloneState(state);
+        this.pendingState = cloneState(state);
+    }
+
+    public commitPending(): ColumnToolPanelDeferredState {
+        this.appliedState = cloneState(this.pendingState);
+        return this.getAppliedState();
+    }
+
+    public cancelPending(): ColumnToolPanelDeferredState {
+        this.pendingState = cloneState(this.appliedState);
+        return this.getPendingState();
+    }
+
+    public hasPendingChanges(): boolean {
+        return JSON.stringify(this.appliedState) !== JSON.stringify(this.pendingState);
+    }
+
+    public getAppliedState(): ColumnToolPanelDeferredState {
+        return cloneState(this.appliedState);
+    }
+
+    public getPendingState(): ColumnToolPanelDeferredState {
+        return cloneState(this.pendingState);
+    }
+}

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelDeferredService.ts
@@ -186,14 +186,6 @@ export class ColumnToolPanelDeferredService {
         this.pendingStateCacheDirty = true;
     }
 
-    public commitPending(): ColumnToolPanelDeferredState {
-        const pendingState = this.getPendingState();
-        this.appliedState = cloneState(pendingState);
-        this.patch = {};
-        this.pendingStateCacheDirty = true;
-        return this.getAppliedState();
-    }
-
     public cancelPending(): ColumnToolPanelDeferredState {
         this.patch = {};
         this.pendingStateCacheDirty = true;

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelFactory.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelFactory.ts
@@ -38,6 +38,15 @@ export class ColumnToolPanelFactory extends BeanStub implements NamedBean {
         return this.createPanel(parent, destroyFuncs, new PivotModePanel(), prepend);
     }
 
+    public createPivotModePanelWithToggleHandler(
+        parent: Component,
+        destroyFuncs: (() => void)[],
+        onTogglePivotMode: (newValue: boolean) => boolean,
+        prepend?: boolean
+    ): PivotModePanel {
+        return this.createPanel(parent, destroyFuncs, new PivotModePanel(onTogglePivotMode), prepend);
+    }
+
     private createPanel<C extends RowGroupDropZonePanel | ValuesDropZonePanel | PivotDropZonePanel | PivotModePanel>(
         parent: Component,
         destroyFuncs: (() => void)[],

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelFactory.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelFactory.ts
@@ -1,4 +1,4 @@
-import type { BeanName, Component, NamedBean } from 'ag-grid-community';
+import type { AgColumn, BeanName, Component, IAggFunc, NamedBean } from 'ag-grid-community';
 import { BeanStub } from 'ag-grid-community';
 
 import { PivotDropZonePanel } from '../rowGrouping/columnDropZones/pivotDropZonePanel';
@@ -26,12 +26,51 @@ export class ColumnToolPanelFactory extends BeanStub implements NamedBean {
         return this.createPanel(parent, destroyFuncs, new RowGroupDropZonePanel(false));
     }
 
+    public createRowGroupPanelWithUpdateHandler(
+        parent: Component,
+        destroyFuncs: (() => void)[],
+        onUpdateItems: (columns: AgColumn[]) => boolean,
+        getExistingItems: () => AgColumn[]
+    ): RowGroupDropZonePanel {
+        return this.createPanel(parent, destroyFuncs, new RowGroupDropZonePanel(false, onUpdateItems, getExistingItems));
+    }
+
     public createValuesPanel(parent: Component, destroyFuncs: (() => void)[]): ValuesDropZonePanel {
         return this.createPanel(parent, destroyFuncs, new ValuesDropZonePanel(false));
     }
 
+    public createValuesPanelWithUpdateHandler(
+        parent: Component,
+        destroyFuncs: (() => void)[],
+        onUpdateItems: (columns: AgColumn[]) => boolean,
+        getExistingItems: () => AgColumn[],
+        onAggregationFunctionChange: (column: AgColumn, aggFunc: string) => boolean,
+        getPendingAggregationFunction: (column: AgColumn) => string | IAggFunc | null | undefined
+    ): ValuesDropZonePanel {
+        return this.createPanel(
+            parent,
+            destroyFuncs,
+            new ValuesDropZonePanel(
+                false,
+                onUpdateItems,
+                getExistingItems,
+                onAggregationFunctionChange,
+                getPendingAggregationFunction
+            )
+        );
+    }
+
     public createPivotPanel(parent: Component, destroyFuncs: (() => void)[]): PivotDropZonePanel {
         return this.createPanel(parent, destroyFuncs, new PivotDropZonePanel(false));
+    }
+
+    public createPivotPanelWithUpdateHandler(
+        parent: Component,
+        destroyFuncs: (() => void)[],
+        onUpdateItems: (columns: AgColumn[]) => boolean,
+        getExistingItems: () => AgColumn[]
+    ): PivotDropZonePanel {
+        return this.createPanel(parent, destroyFuncs, new PivotDropZonePanel(false, onUpdateItems, getExistingItems));
     }
 
     public createPivotModePanel(parent: Component, destroyFuncs: (() => void)[], prepend?: boolean): PivotModePanel {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelFactory.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelFactory.ts
@@ -32,7 +32,11 @@ export class ColumnToolPanelFactory extends BeanStub implements NamedBean {
         onUpdateItems: (columns: AgColumn[]) => boolean,
         getExistingItems: () => AgColumn[]
     ): RowGroupDropZonePanel {
-        return this.createPanel(parent, destroyFuncs, new RowGroupDropZonePanel(false, onUpdateItems, getExistingItems));
+        return this.createPanel(
+            parent,
+            destroyFuncs,
+            new RowGroupDropZonePanel(false, onUpdateItems, getExistingItems)
+        );
     }
 
     public createValuesPanel(parent: Component, destroyFuncs: (() => void)[]): ValuesDropZonePanel {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelFactory.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelFactory.ts
@@ -26,6 +26,7 @@ export class ColumnToolPanelFactory extends BeanStub implements NamedBean {
         return this.createPanel(parent, destroyFuncs, new RowGroupDropZonePanel(false));
     }
 
+    /** Create a row-group panel wired to deferred mode handlers instead of immediate grid mutation. */
     public createRowGroupPanelWithUpdateHandler(
         parent: Component,
         destroyFuncs: (() => void)[],
@@ -43,6 +44,7 @@ export class ColumnToolPanelFactory extends BeanStub implements NamedBean {
         return this.createPanel(parent, destroyFuncs, new ValuesDropZonePanel(false));
     }
 
+    /** Create a values panel that reads/writes staged deferred value state and aggregation functions. */
     public createValuesPanelWithUpdateHandler(
         parent: Component,
         destroyFuncs: (() => void)[],
@@ -68,6 +70,7 @@ export class ColumnToolPanelFactory extends BeanStub implements NamedBean {
         return this.createPanel(parent, destroyFuncs, new PivotDropZonePanel(false));
     }
 
+    /** Create a pivot panel wired to deferred mode handlers so pending pivot order is preserved. */
     public createPivotPanelWithUpdateHandler(
         parent: Component,
         destroyFuncs: (() => void)[],
@@ -81,6 +84,7 @@ export class ColumnToolPanelFactory extends BeanStub implements NamedBean {
         return this.createPanel(parent, destroyFuncs, new PivotModePanel(), prepend);
     }
 
+    /** Create a pivot mode panel that stages pivot mode changes until deferred apply confirms them. */
     public createPivotModePanelWithToggleHandler(
         parent: Component,
         destroyFuncs: (() => void)[],

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelFactory.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanelFactory.ts
@@ -81,9 +81,10 @@ export class ColumnToolPanelFactory extends BeanStub implements NamedBean {
         parent: Component,
         destroyFuncs: (() => void)[],
         onTogglePivotMode: (newValue: boolean) => boolean,
+        getPivotMode: () => boolean,
         prepend?: boolean
     ): PivotModePanel {
-        return this.createPanel(parent, destroyFuncs, new PivotModePanel(onTogglePivotMode), prepend);
+        return this.createPanel(parent, destroyFuncs, new PivotModePanel(onTogglePivotMode, getPivotMode), prepend);
     }
 
     private createPanel<C extends RowGroupDropZonePanel | ValuesDropZonePanel | PivotDropZonePanel | PivotModePanel>(

--- a/packages/ag-grid-enterprise/src/columnToolPanel/modelItemUtils.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/modelItemUtils.ts
@@ -110,6 +110,7 @@ function setAllPivotActive(
     onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void
 ): void {
     const colStateItems: ColumnState[] = [];
+    const shouldAlwaysStageDeferredPivot = !!onDeferredPivotColumnStateUpdate;
 
     const turnOnAction = (col: AgColumn) => {
         // don't change any column that's already got a function active
@@ -139,7 +140,7 @@ function setAllPivotActive(
 
     const turnOffAction = (col: AgColumn) => {
         const isActive = col.isPivotActive() || col.isRowGroupActive() || col.isValueActive();
-        if (isActive) {
+        if (shouldAlwaysStageDeferredPivot || isActive) {
             colStateItems.push({
                 colId: col.getId(),
                 pivot: false,

--- a/packages/ag-grid-enterprise/src/columnToolPanel/modelItemUtils.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/modelItemUtils.ts
@@ -69,12 +69,13 @@ function setAllVisible(
     onDeferredVisibilityColumnStateUpdate?: (stateItems: ColumnState[]) => void
 ): void {
     const colStateItems: ColumnState[] = [];
+    const shouldAlwaysStageDeferredVisibility = !!onDeferredVisibilityColumnStateUpdate;
 
     for (const col of columns) {
         if (col.getColDef().lockVisible) {
             continue;
         }
-        if (col.isVisible() != visible) {
+        if (shouldAlwaysStageDeferredVisibility || col.isVisible() != visible) {
             colStateItems.push({
                 colId: col.getId(),
                 hide: !visible,

--- a/packages/ag-grid-enterprise/src/columnToolPanel/modelItemUtils.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/modelItemUtils.ts
@@ -10,7 +10,8 @@ export function selectAllChildren(
     eventType: ColumnEventType,
     onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void,
     onDeferredVisibilityColumnStateUpdate?: (stateItems: ColumnState[]) => void,
-    pivotModeOverride?: boolean
+    pivotModeOverride?: boolean,
+    getToolPanelColumnFunctionState?: (column: AgColumn) => { rowGroup: boolean; pivot: boolean; value: boolean }
 ): void {
     const cols = extractAllLeafColumns(colTree);
     setAllColumns(
@@ -20,7 +21,8 @@ export function selectAllChildren(
         eventType,
         onDeferredPivotColumnStateUpdate,
         onDeferredVisibilityColumnStateUpdate,
-        pivotModeOverride
+        pivotModeOverride,
+        getToolPanelColumnFunctionState
     );
 }
 
@@ -31,10 +33,18 @@ export function setAllColumns(
     eventType: ColumnEventType,
     onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void,
     onDeferredVisibilityColumnStateUpdate?: (stateItems: ColumnState[]) => void,
-    pivotModeOverride?: boolean
+    pivotModeOverride?: boolean,
+    getToolPanelColumnFunctionState?: (column: AgColumn) => { rowGroup: boolean; pivot: boolean; value: boolean }
 ): void {
     if (pivotModeOverride ?? beans.colModel.isPivotMode()) {
-        setAllPivot(beans, cols, selectAllChecked, eventType, onDeferredPivotColumnStateUpdate);
+        setAllPivot(
+            beans,
+            cols,
+            selectAllChecked,
+            eventType,
+            onDeferredPivotColumnStateUpdate,
+            getToolPanelColumnFunctionState
+        );
     } else {
         setAllVisible(beans, cols, selectAllChecked, eventType, onDeferredVisibilityColumnStateUpdate);
     }
@@ -97,9 +107,17 @@ function setAllPivot(
     columns: AgColumn[],
     value: boolean,
     eventType: ColumnEventType,
-    onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void
+    onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void,
+    getToolPanelColumnFunctionState?: (column: AgColumn) => { rowGroup: boolean; pivot: boolean; value: boolean }
 ): void {
-    setAllPivotActive(beans, columns, value, eventType, onDeferredPivotColumnStateUpdate);
+    setAllPivotActive(
+        beans,
+        columns,
+        value,
+        eventType,
+        onDeferredPivotColumnStateUpdate,
+        getToolPanelColumnFunctionState
+    );
 }
 
 function setAllPivotActive(
@@ -107,14 +125,19 @@ function setAllPivotActive(
     columns: AgColumn[],
     value: boolean,
     eventType: ColumnEventType,
-    onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void
+    onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void,
+    getToolPanelColumnFunctionState?: (column: AgColumn) => { rowGroup: boolean; pivot: boolean; value: boolean }
 ): void {
     const colStateItems: ColumnState[] = [];
     const shouldAlwaysStageDeferredPivot = !!onDeferredPivotColumnStateUpdate;
 
     const turnOnAction = (col: AgColumn) => {
+        const currentFunctionState = getToolPanelColumnFunctionState?.(col);
+        const isAnyFunctionActive = currentFunctionState
+            ? currentFunctionState.rowGroup || currentFunctionState.pivot || currentFunctionState.value
+            : col.isAnyFunctionActive();
         // don't change any column that's already got a function active
-        if (col.isAnyFunctionActive()) {
+        if (isAnyFunctionActive) {
             return;
         }
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/modelItemUtils.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/modelItemUtils.ts
@@ -8,10 +8,18 @@ export function selectAllChildren(
     colTree: ColumnModelItem[],
     selectAllChecked: boolean,
     eventType: ColumnEventType,
-    onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void
+    onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void,
+    onDeferredVisibilityColumnStateUpdate?: (stateItems: ColumnState[]) => void
 ): void {
     const cols = extractAllLeafColumns(colTree);
-    setAllColumns(beans, cols, selectAllChecked, eventType, onDeferredPivotColumnStateUpdate);
+    setAllColumns(
+        beans,
+        cols,
+        selectAllChecked,
+        eventType,
+        onDeferredPivotColumnStateUpdate,
+        onDeferredVisibilityColumnStateUpdate
+    );
 }
 
 export function setAllColumns(
@@ -19,12 +27,13 @@ export function setAllColumns(
     cols: AgColumn[],
     selectAllChecked: boolean,
     eventType: ColumnEventType,
-    onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void
+    onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void,
+    onDeferredVisibilityColumnStateUpdate?: (stateItems: ColumnState[]) => void
 ): void {
     if (beans.colModel.isPivotMode()) {
         setAllPivot(beans, cols, selectAllChecked, eventType, onDeferredPivotColumnStateUpdate);
     } else {
-        setAllVisible(beans, cols, selectAllChecked, eventType);
+        setAllVisible(beans, cols, selectAllChecked, eventType, onDeferredVisibilityColumnStateUpdate);
     }
 }
 
@@ -49,7 +58,13 @@ function extractAllLeafColumns(allItems: ColumnModelItem[]): AgColumn[] {
     return res;
 }
 
-function setAllVisible(beans: BeanCollection, columns: AgColumn[], visible: boolean, eventType: ColumnEventType): void {
+function setAllVisible(
+    beans: BeanCollection,
+    columns: AgColumn[],
+    visible: boolean,
+    eventType: ColumnEventType,
+    onDeferredVisibilityColumnStateUpdate?: (stateItems: ColumnState[]) => void
+): void {
     const colStateItems: ColumnState[] = [];
 
     for (const col of columns) {
@@ -65,6 +80,10 @@ function setAllVisible(beans: BeanCollection, columns: AgColumn[], visible: bool
     }
 
     if (colStateItems.length > 0) {
+        if (onDeferredVisibilityColumnStateUpdate) {
+            onDeferredVisibilityColumnStateUpdate(colStateItems);
+            return;
+        }
         _applyColumnState(beans, { state: colStateItems }, eventType);
     }
 }

--- a/packages/ag-grid-enterprise/src/columnToolPanel/modelItemUtils.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/modelItemUtils.ts
@@ -3,6 +3,7 @@ import { _applyColumnState } from 'ag-grid-community';
 
 import type { ColumnModelItem } from './columnModelItem';
 
+/** Apply select-all from groups while supporting deferred-mode staging callbacks. */
 export function selectAllChildren(
     beans: BeanCollection,
     colTree: ColumnModelItem[],
@@ -26,6 +27,7 @@ export function selectAllChildren(
     );
 }
 
+/** Route select-all updates to pivot/value or visibility paths, with optional deferred overrides. */
 export function setAllColumns(
     beans: BeanCollection,
     cols: AgColumn[],
@@ -79,6 +81,7 @@ function setAllVisible(
     onDeferredVisibilityColumnStateUpdate?: (stateItems: ColumnState[]) => void
 ): void {
     const colStateItems: ColumnState[] = [];
+    /** Stage full desired visibility in deferred mode, not only visible diffs against applied state. */
     const shouldAlwaysStageDeferredVisibility = !!onDeferredVisibilityColumnStateUpdate;
 
     for (const col of columns) {
@@ -129,6 +132,7 @@ function setAllPivotActive(
     getToolPanelColumnFunctionState?: (column: AgColumn) => { rowGroup: boolean; pivot: boolean; value: boolean }
 ): void {
     const colStateItems: ColumnState[] = [];
+    /** Stage explicit pivot off actions in deferred mode, even if applied state is already inactive. */
     const shouldAlwaysStageDeferredPivot = !!onDeferredPivotColumnStateUpdate;
 
     const turnOnAction = (col: AgColumn) => {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/modelItemUtils.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/modelItemUtils.ts
@@ -7,20 +7,22 @@ export function selectAllChildren(
     beans: BeanCollection,
     colTree: ColumnModelItem[],
     selectAllChecked: boolean,
-    eventType: ColumnEventType
+    eventType: ColumnEventType,
+    onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void
 ): void {
     const cols = extractAllLeafColumns(colTree);
-    setAllColumns(beans, cols, selectAllChecked, eventType);
+    setAllColumns(beans, cols, selectAllChecked, eventType, onDeferredPivotColumnStateUpdate);
 }
 
 export function setAllColumns(
     beans: BeanCollection,
     cols: AgColumn[],
     selectAllChecked: boolean,
-    eventType: ColumnEventType
+    eventType: ColumnEventType,
+    onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void
 ): void {
     if (beans.colModel.isPivotMode()) {
-        setAllPivot(beans, cols, selectAllChecked, eventType);
+        setAllPivot(beans, cols, selectAllChecked, eventType, onDeferredPivotColumnStateUpdate);
     } else {
         setAllVisible(beans, cols, selectAllChecked, eventType);
     }
@@ -67,15 +69,22 @@ function setAllVisible(beans: BeanCollection, columns: AgColumn[], visible: bool
     }
 }
 
-function setAllPivot(beans: BeanCollection, columns: AgColumn[], value: boolean, eventType: ColumnEventType): void {
-    setAllPivotActive(beans, columns, value, eventType);
+function setAllPivot(
+    beans: BeanCollection,
+    columns: AgColumn[],
+    value: boolean,
+    eventType: ColumnEventType,
+    onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void
+): void {
+    setAllPivotActive(beans, columns, value, eventType, onDeferredPivotColumnStateUpdate);
 }
 
 function setAllPivotActive(
     beans: BeanCollection,
     columns: AgColumn[],
     value: boolean,
-    eventType: ColumnEventType
+    eventType: ColumnEventType,
+    onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void
 ): void {
     const colStateItems: ColumnState[] = [];
 
@@ -122,6 +131,10 @@ function setAllPivotActive(
     columns.forEach(action);
 
     if (colStateItems.length > 0) {
+        if (onDeferredPivotColumnStateUpdate) {
+            onDeferredPivotColumnStateUpdate(colStateItems);
+            return;
+        }
         _applyColumnState(beans, { state: colStateItems }, eventType);
     }
 }

--- a/packages/ag-grid-enterprise/src/columnToolPanel/modelItemUtils.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/modelItemUtils.ts
@@ -9,7 +9,8 @@ export function selectAllChildren(
     selectAllChecked: boolean,
     eventType: ColumnEventType,
     onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void,
-    onDeferredVisibilityColumnStateUpdate?: (stateItems: ColumnState[]) => void
+    onDeferredVisibilityColumnStateUpdate?: (stateItems: ColumnState[]) => void,
+    pivotModeOverride?: boolean
 ): void {
     const cols = extractAllLeafColumns(colTree);
     setAllColumns(
@@ -18,7 +19,8 @@ export function selectAllChildren(
         selectAllChecked,
         eventType,
         onDeferredPivotColumnStateUpdate,
-        onDeferredVisibilityColumnStateUpdate
+        onDeferredVisibilityColumnStateUpdate,
+        pivotModeOverride
     );
 }
 
@@ -28,9 +30,10 @@ export function setAllColumns(
     selectAllChecked: boolean,
     eventType: ColumnEventType,
     onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void,
-    onDeferredVisibilityColumnStateUpdate?: (stateItems: ColumnState[]) => void
+    onDeferredVisibilityColumnStateUpdate?: (stateItems: ColumnState[]) => void,
+    pivotModeOverride?: boolean
 ): void {
-    if (beans.colModel.isPivotMode()) {
+    if (pivotModeOverride ?? beans.colModel.isPivotMode()) {
         setAllPivot(beans, cols, selectAllChecked, eventType, onDeferredPivotColumnStateUpdate);
     } else {
         setAllVisible(beans, cols, selectAllChecked, eventType, onDeferredVisibilityColumnStateUpdate);

--- a/packages/ag-grid-enterprise/src/columnToolPanel/pivotModePanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/pivotModePanel.ts
@@ -14,7 +14,10 @@ const PivotModePanelElement: ElementParams = {
 };
 export class PivotModePanel extends Component {
     private readonly cbPivotMode: GridCheckbox = RefPlaceholder;
-    constructor(private readonly onTogglePivotMode?: (newValue: boolean) => boolean) {
+    constructor(
+        private readonly onTogglePivotMode?: (newValue: boolean) => boolean,
+        private readonly getPivotMode?: () => boolean
+    ) {
         super();
     }
 
@@ -23,14 +26,15 @@ export class PivotModePanel extends Component {
 
         const cbPivotMode = this.cbPivotMode;
         const { colModel, ctrlsSvc, gos } = this.beans;
+        const getPivotMode = () => this.getPivotMode?.() ?? colModel.isPivotMode();
 
-        cbPivotMode.setValue(colModel.isPivotMode());
+        cbPivotMode.setValue(getPivotMode());
         const localeTextFunc = this.getLocaleTextFunc();
         cbPivotMode.setLabel(localeTextFunc('pivotMode', 'Pivot Mode'));
 
         const onBtPivotMode = () => {
             const newValue = !!cbPivotMode.getValue();
-            if (newValue !== colModel.isPivotMode()) {
+            if (newValue !== getPivotMode()) {
                 if (this.onTogglePivotMode?.(newValue)) {
                     return;
                 }
@@ -42,7 +46,7 @@ export class PivotModePanel extends Component {
         };
 
         const onPivotModeChanged = () => {
-            const pivotModeActive = colModel.isPivotMode();
+            const pivotModeActive = getPivotMode();
             cbPivotMode.setValue(pivotModeActive);
         };
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/pivotModePanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/pivotModePanel.ts
@@ -14,6 +14,7 @@ const PivotModePanelElement: ElementParams = {
 };
 export class PivotModePanel extends Component {
     private readonly cbPivotMode: GridCheckbox = RefPlaceholder;
+    /** Allow deferred mode to intercept pivot-mode toggles and stage them instead of applying immediately. */
     constructor(
         private readonly onTogglePivotMode?: (newValue: boolean) => boolean,
         private readonly getPivotMode?: () => boolean

--- a/packages/ag-grid-enterprise/src/columnToolPanel/pivotModePanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/pivotModePanel.ts
@@ -14,6 +14,9 @@ const PivotModePanelElement: ElementParams = {
 };
 export class PivotModePanel extends Component {
     private readonly cbPivotMode: GridCheckbox = RefPlaceholder;
+    constructor(private readonly onTogglePivotMode?: (newValue: boolean) => boolean) {
+        super();
+    }
 
     public postConstruct(): void {
         this.setTemplate(PivotModePanelElement, [AgToggleButtonSelector]);
@@ -28,6 +31,9 @@ export class PivotModePanel extends Component {
         const onBtPivotMode = () => {
             const newValue = !!cbPivotMode.getValue();
             if (newValue !== colModel.isPivotMode()) {
+                if (this.onTogglePivotMode?.(newValue)) {
+                    return;
+                }
                 gos.updateGridOptions({ options: { pivotMode: newValue }, source: 'toolPanelUi' as any });
                 for (const c of ctrlsSvc.getHeaderRowContainerCtrls()) {
                     c.refresh();

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
@@ -212,7 +212,8 @@ export class ToolPanelColumnComp extends Component {
             [this.column],
             nextState,
             'toolPanelUi',
-            this.params.onDeferredPivotColumnStateUpdate
+            this.params.onDeferredPivotColumnStateUpdate,
+            this.params.onDeferredVisibilityColumnStateUpdate
         );
     }
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
@@ -163,6 +163,7 @@ export class ToolPanelColumnComp extends Component {
             return;
         }
 
+        /** Pass deferred callbacks so context-menu actions stage pending pivot/value/group changes. */
         const contextMenu = this.createBean(
             new ToolPanelContextMenu(column, e, this.focusWrapper, {
                 getToolPanelPivotMode: this.params.getToolPanelPivotMode,
@@ -213,6 +214,7 @@ export class ToolPanelColumnComp extends Component {
             return;
         }
 
+        /** Route checkbox actions through deferred-aware column updates when deferred mode is active. */
         setAllColumns(
             this.beans,
             [this.column],

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
@@ -157,7 +157,7 @@ export class ToolPanelColumnComp extends Component {
     }
 
     private onContextMenu(e: MouseEvent | Touch): void {
-        const { column, gos } = this;
+        const { column, gos, params } = this;
 
         if (gos.get('functionsReadOnly')) {
             return;
@@ -166,9 +166,9 @@ export class ToolPanelColumnComp extends Component {
         /** Pass deferred callbacks so context-menu actions stage pending pivot/value/group changes. */
         const contextMenu = this.createBean(
             new ToolPanelContextMenu(column, e, this.focusWrapper, {
-                getToolPanelPivotMode: this.params.getToolPanelPivotMode,
-                onDeferredPivotColumnStateUpdate: this.params.onDeferredPivotColumnStateUpdate,
-                getToolPanelColumnFunctionState: this.params.getToolPanelColumnFunctionState,
+                getToolPanelPivotMode: params.getToolPanelPivotMode,
+                onDeferredPivotColumnStateUpdate: params.onDeferredPivotColumnStateUpdate,
+                getToolPanelColumnFunctionState: params.getToolPanelColumnFunctionState,
             })
         );
         this.addDestroyFunc(() => {
@@ -201,6 +201,7 @@ export class ToolPanelColumnComp extends Component {
     }
 
     private onChangeCommon(nextState: boolean): void {
+        const { params } = this;
         // ignore lock visible columns
         if (this.cbSelect.isReadOnly()) {
             return;
@@ -220,10 +221,10 @@ export class ToolPanelColumnComp extends Component {
             [this.column],
             nextState,
             'toolPanelUi',
-            this.params.onDeferredPivotColumnStateUpdate,
-            this.params.onDeferredVisibilityColumnStateUpdate,
-            this.params.getToolPanelPivotMode?.(),
-            this.params.getToolPanelColumnFunctionState
+            params.onDeferredPivotColumnStateUpdate,
+            params.onDeferredVisibilityColumnStateUpdate,
+            params.getToolPanelPivotMode?.(),
+            params.getToolPanelColumnFunctionState
         );
     }
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
@@ -213,7 +213,8 @@ export class ToolPanelColumnComp extends Component {
             nextState,
             'toolPanelUi',
             this.params.onDeferredPivotColumnStateUpdate,
-            this.params.onDeferredVisibilityColumnStateUpdate
+            this.params.onDeferredVisibilityColumnStateUpdate,
+            this.params.getToolPanelPivotMode?.()
         );
     }
 
@@ -295,7 +296,7 @@ export class ToolPanelColumnComp extends Component {
 
     private onColumnStateChanged(): void {
         this.processingColumnStateChange = true;
-        const isPivotMode = this.beans.colModel.isPivotMode();
+        const isPivotMode = this.params.getToolPanelPivotMode?.() ?? this.beans.colModel.isPivotMode();
         if (isPivotMode) {
             // if reducing, checkbox means column is one of pivot, value or group
             const anyFunctionActive = this.column.isAnyFunctionActive();

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
@@ -220,7 +220,8 @@ export class ToolPanelColumnComp extends Component {
             'toolPanelUi',
             this.params.onDeferredPivotColumnStateUpdate,
             this.params.onDeferredVisibilityColumnStateUpdate,
-            this.params.getToolPanelPivotMode?.()
+            this.params.getToolPanelPivotMode?.(),
+            this.params.getToolPanelColumnFunctionState
         );
     }
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
@@ -304,18 +304,15 @@ export class ToolPanelColumnComp extends Component {
     private onColumnStateChanged(): void {
         this.processingColumnStateChange = true;
         const isPivotMode = this.params.getToolPanelPivotMode?.() ?? this.beans.colModel.isPivotMode();
-        const isColumnChecked = this.params.isColumnCheckedInToolPanel
-            ? this.params.isColumnCheckedInToolPanel(this.column, isPivotMode)
-            : isPivotMode
-              ? this.column.isAnyFunctionActive()
-              : this.column.isVisible();
-        if (isPivotMode) {
-            // if reducing, checkbox means column is one of pivot, value or group
-            this.cbSelect.setValue(isColumnChecked);
+        let isColumnChecked: boolean;
+
+        if (this.params.isColumnCheckedInToolPanel) {
+            isColumnChecked = this.params.isColumnCheckedInToolPanel(this.column, isPivotMode);
         } else {
-            // if not reducing, the checkbox tells us if column is visible or not
-            this.cbSelect.setValue(isColumnChecked);
+            isColumnChecked = isPivotMode ? this.column.isAnyFunctionActive() : this.column.isVisible();
         }
+
+        this.cbSelect.setValue(isColumnChecked);
 
         let canBeToggled = true;
         let canBeDragged = true;

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
@@ -163,7 +163,13 @@ export class ToolPanelColumnComp extends Component {
             return;
         }
 
-        const contextMenu = this.createBean(new ToolPanelContextMenu(column, e, this.focusWrapper));
+        const contextMenu = this.createBean(
+            new ToolPanelContextMenu(column, e, this.focusWrapper, {
+                getToolPanelPivotMode: this.params.getToolPanelPivotMode,
+                onDeferredPivotColumnStateUpdate: this.params.onDeferredPivotColumnStateUpdate,
+                getToolPanelColumnFunctionState: this.params.getToolPanelColumnFunctionState,
+            })
+        );
         this.addDestroyFunc(() => {
             if (contextMenu.isAlive()) {
                 this.destroyBean(contextMenu);
@@ -297,13 +303,17 @@ export class ToolPanelColumnComp extends Component {
     private onColumnStateChanged(): void {
         this.processingColumnStateChange = true;
         const isPivotMode = this.params.getToolPanelPivotMode?.() ?? this.beans.colModel.isPivotMode();
+        const isColumnChecked = this.params.isColumnCheckedInToolPanel
+            ? this.params.isColumnCheckedInToolPanel(this.column, isPivotMode)
+            : isPivotMode
+              ? this.column.isAnyFunctionActive()
+              : this.column.isVisible();
         if (isPivotMode) {
             // if reducing, checkbox means column is one of pivot, value or group
-            const anyFunctionActive = this.column.isAnyFunctionActive();
-            this.cbSelect.setValue(anyFunctionActive);
+            this.cbSelect.setValue(isColumnChecked);
         } else {
             // if not reducing, the checkbox tells us if column is visible or not
-            this.cbSelect.setValue(this.column.isVisible());
+            this.cbSelect.setValue(isColumnChecked);
         }
 
         let canBeToggled = true;

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
@@ -314,8 +314,8 @@ export class ToolPanelColumnComp extends Component {
 
         this.cbSelect.setValue(isColumnChecked);
 
-        let canBeToggled = true;
-        let canBeDragged = true;
+        let canBeToggled: boolean;
+        let canBeDragged: boolean;
         if (isPivotMode) {
             // when in pivot mode, the item should be read only if:
             //  a) gui is not allowed make any changes

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
@@ -25,9 +25,9 @@ import {
 } from 'ag-grid-community';
 
 import type { ColumnModelItem } from './columnModelItem';
+import type { ToolPanelColumnCompParams } from './columnToolPanel';
 import { createPivotState, setAllColumns, updateColumns } from './modelItemUtils';
 import { ToolPanelContextMenu } from './toolPanelContextMenu';
-import type { ToolPanelColumnCompParams } from './columnToolPanel';
 
 const ToolPanelColumnElement: ElementParams = {
     tag: 'div',

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
@@ -27,6 +27,7 @@ import {
 import type { ColumnModelItem } from './columnModelItem';
 import { createPivotState, setAllColumns, updateColumns } from './modelItemUtils';
 import { ToolPanelContextMenu } from './toolPanelContextMenu';
+import type { ToolPanelColumnCompParams } from './columnToolPanel';
 
 const ToolPanelColumnElement: ElementParams = {
     tag: 'div',
@@ -46,18 +47,21 @@ export class ToolPanelColumnComp extends Component {
     private readonly displayName: string | null;
     private processingColumnStateChange = false;
     private tooltipFeature?: TooltipFeature;
+    private readonly params: ToolPanelColumnCompParams;
 
     constructor(
         public modelItem: ColumnModelItem,
         private readonly allowDragging: boolean,
         private readonly groupsExist: boolean,
-        private readonly focusWrapper: HTMLElement
+        private readonly focusWrapper: HTMLElement,
+        params: ToolPanelColumnCompParams
     ) {
         super();
         const { column, depth, displayName } = modelItem;
         this.column = column;
         this.columnDepth = depth;
         this.displayName = displayName;
+        this.params = params;
     }
 
     public postConstruct(): void {
@@ -203,7 +207,13 @@ export class ToolPanelColumnComp extends Component {
             return;
         }
 
-        setAllColumns(this.beans, [this.column], nextState, 'toolPanelUi');
+        setAllColumns(
+            this.beans,
+            [this.column],
+            nextState,
+            'toolPanelUi',
+            this.params.onDeferredPivotColumnStateUpdate
+        );
     }
 
     private refreshAriaLabel(): void {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnGroupComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnGroupComp.ts
@@ -31,6 +31,7 @@ import {
 import type { ColumnModelItem } from './columnModelItem';
 import { createPivotState, selectAllChildren, updateColumns } from './modelItemUtils';
 import { ToolPanelContextMenu } from './toolPanelContextMenu';
+import type { ToolPanelColumnCompParams } from './columnToolPanel';
 
 const ToolPanelColumnGroupElement: ElementParams = {
     tag: 'div',
@@ -66,18 +67,21 @@ export class ToolPanelColumnGroupComp extends Component {
     private readonly displayName: string | null;
     private processingColumnStateChange = false;
     private tooltipFeature?: TooltipFeature;
+    private readonly params: ToolPanelColumnCompParams;
 
     constructor(
         public readonly modelItem: ColumnModelItem,
         private readonly allowDragging: boolean,
         private readonly eventType: ColumnEventType,
-        private readonly focusWrapper: HTMLElement
+        private readonly focusWrapper: HTMLElement,
+        params: ToolPanelColumnCompParams
     ) {
         super();
         const { columnGroup, depth, displayName } = modelItem;
         this.columnGroup = columnGroup;
         this.columnDepth = depth;
         this.displayName = displayName;
+        this.params = params;
     }
 
     public postConstruct(): void {
@@ -330,7 +334,13 @@ export class ToolPanelColumnGroupComp extends Component {
             return;
         }
 
-        selectAllChildren(this.beans, this.modelItem.children, nextState, this.eventType);
+        selectAllChildren(
+            this.beans,
+            this.modelItem.children,
+            nextState,
+            this.eventType,
+            this.params.onDeferredPivotColumnStateUpdate
+        );
     }
 
     private refreshAriaLabel(): void {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnGroupComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnGroupComp.ts
@@ -29,9 +29,9 @@ import {
 } from 'ag-grid-community';
 
 import type { ColumnModelItem } from './columnModelItem';
+import type { ToolPanelColumnCompParams } from './columnToolPanel';
 import { createPivotState, selectAllChildren, updateColumns } from './modelItemUtils';
 import { ToolPanelContextMenu } from './toolPanelContextMenu';
-import type { ToolPanelColumnCompParams } from './columnToolPanel';
 
 const ToolPanelColumnGroupElement: ElementParams = {
     tag: 'div',

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnGroupComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnGroupComp.ts
@@ -339,7 +339,8 @@ export class ToolPanelColumnGroupComp extends Component {
             this.modelItem.children,
             nextState,
             this.eventType,
-            this.params.onDeferredPivotColumnStateUpdate
+            this.params.onDeferredPivotColumnStateUpdate,
+            this.params.onDeferredVisibilityColumnStateUpdate
         );
     }
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnGroupComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnGroupComp.ts
@@ -189,7 +189,13 @@ export class ToolPanelColumnGroupComp extends Component {
             return;
         }
 
-        const contextMenu = this.createBean(new ToolPanelContextMenu(columnGroup, e, this.focusWrapper));
+        const contextMenu = this.createBean(
+            new ToolPanelContextMenu(columnGroup, e, this.focusWrapper, {
+                getToolPanelPivotMode: this.params.getToolPanelPivotMode,
+                onDeferredPivotColumnStateUpdate: this.params.onDeferredPivotColumnStateUpdate,
+                getToolPanelColumnFunctionState: this.params.getToolPanelColumnFunctionState,
+            })
+        );
         this.addDestroyFunc(() => {
             if (contextMenu.isAlive()) {
                 this.destroyBean(contextMenu);
@@ -418,6 +424,11 @@ export class ToolPanelColumnGroupComp extends Component {
     }
 
     private isColumnChecked(column: AgColumn, pivotMode: boolean): boolean {
+        const checkedInToolPanel = this.params.isColumnCheckedInToolPanel?.(column, pivotMode);
+        if (checkedInToolPanel != null) {
+            return checkedInToolPanel;
+        }
+
         if (pivotMode) {
             const pivoted = column.isPivotActive();
             const grouped = column.isRowGroupActive();

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnGroupComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnGroupComp.ts
@@ -340,7 +340,8 @@ export class ToolPanelColumnGroupComp extends Component {
             nextState,
             this.eventType,
             this.params.onDeferredPivotColumnStateUpdate,
-            this.params.onDeferredVisibilityColumnStateUpdate
+            this.params.onDeferredVisibilityColumnStateUpdate,
+            this.params.getToolPanelPivotMode?.()
         );
     }
 
@@ -374,7 +375,7 @@ export class ToolPanelColumnGroupComp extends Component {
     }
 
     private workOutSelectedValue(): boolean | undefined {
-        const pivotMode = this.beans.colModel.isPivotMode();
+        const pivotMode = this.params.getToolPanelPivotMode?.() ?? this.beans.colModel.isPivotMode();
 
         const visibleLeafColumns = this.getVisibleLeafColumns();
 
@@ -399,7 +400,7 @@ export class ToolPanelColumnGroupComp extends Component {
     }
 
     private workOutReadOnlyValue(): boolean {
-        const pivotMode = this.beans.colModel.isPivotMode();
+        const pivotMode = this.params.getToolPanelPivotMode?.() ?? this.beans.colModel.isPivotMode();
 
         let colsThatCanAction = 0;
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnGroupComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnGroupComp.ts
@@ -347,7 +347,8 @@ export class ToolPanelColumnGroupComp extends Component {
             this.eventType,
             this.params.onDeferredPivotColumnStateUpdate,
             this.params.onDeferredVisibilityColumnStateUpdate,
-            this.params.getToolPanelPivotMode?.()
+            this.params.getToolPanelPivotMode?.(),
+            this.params.getToolPanelColumnFunctionState
         );
     }
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnGroupComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnGroupComp.ts
@@ -183,7 +183,7 @@ export class ToolPanelColumnGroupComp extends Component {
     }
 
     private onContextMenu(e: MouseEvent | Touch): void {
-        const { columnGroup, gos } = this;
+        const { columnGroup, gos, params } = this;
 
         if (gos.get('functionsReadOnly')) {
             return;
@@ -192,9 +192,9 @@ export class ToolPanelColumnGroupComp extends Component {
         /** Pass deferred callbacks so context-menu actions stage pending pivot/value/group changes. */
         const contextMenu = this.createBean(
             new ToolPanelContextMenu(columnGroup, e, this.focusWrapper, {
-                getToolPanelPivotMode: this.params.getToolPanelPivotMode,
-                onDeferredPivotColumnStateUpdate: this.params.onDeferredPivotColumnStateUpdate,
-                getToolPanelColumnFunctionState: this.params.getToolPanelColumnFunctionState,
+                getToolPanelPivotMode: params.getToolPanelPivotMode,
+                onDeferredPivotColumnStateUpdate: params.onDeferredPivotColumnStateUpdate,
+                getToolPanelColumnFunctionState: params.getToolPanelColumnFunctionState,
             })
         );
         this.addDestroyFunc(() => {
@@ -335,6 +335,7 @@ export class ToolPanelColumnGroupComp extends Component {
     }
 
     private onChangeCommon(nextState: boolean): void {
+        const { eventType, modelItem, params } = this;
         this.refreshAriaLabel();
 
         if (this.processingColumnStateChange) {
@@ -344,13 +345,13 @@ export class ToolPanelColumnGroupComp extends Component {
         /** Route group checkbox actions through deferred-aware bulk updates when deferred mode is active. */
         selectAllChildren(
             this.beans,
-            this.modelItem.children,
+            modelItem.children,
             nextState,
-            this.eventType,
-            this.params.onDeferredPivotColumnStateUpdate,
-            this.params.onDeferredVisibilityColumnStateUpdate,
-            this.params.getToolPanelPivotMode?.(),
-            this.params.getToolPanelColumnFunctionState
+            eventType,
+            params.onDeferredPivotColumnStateUpdate,
+            params.onDeferredVisibilityColumnStateUpdate,
+            params.getToolPanelPivotMode?.(),
+            params.getToolPanelColumnFunctionState
         );
     }
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnGroupComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnGroupComp.ts
@@ -189,6 +189,7 @@ export class ToolPanelColumnGroupComp extends Component {
             return;
         }
 
+        /** Pass deferred callbacks so context-menu actions stage pending pivot/value/group changes. */
         const contextMenu = this.createBean(
             new ToolPanelContextMenu(columnGroup, e, this.focusWrapper, {
                 getToolPanelPivotMode: this.params.getToolPanelPivotMode,
@@ -340,6 +341,7 @@ export class ToolPanelColumnGroupComp extends Component {
             return;
         }
 
+        /** Route group checkbox actions through deferred-aware bulk updates when deferred mode is active. */
         selectAllChildren(
             this.beans,
             this.modelItem.children,

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelContextMenu.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelContextMenu.ts
@@ -1,4 +1,4 @@
-import type { AgColumn, AgProvidedColumnGroup, IconName, MenuItemDef } from 'ag-grid-community';
+import type { AgColumn, AgProvidedColumnGroup, ColumnState, IconName, MenuItemDef } from 'ag-grid-community';
 import { Component, _createIconNoSpan, _focusInto, isColumn, isProvidedColumnGroup } from 'ag-grid-community';
 
 import { getGroupingLocaleText, isRowGroupColLocked } from '../rowGrouping/rowGroupingUtils';
@@ -29,7 +29,16 @@ export class ToolPanelContextMenu extends Component {
     constructor(
         private readonly column: AgColumn | AgProvidedColumnGroup,
         private readonly mouseEventOrTouch: MouseEvent | Touch,
-        private readonly parentEl: HTMLElement
+        private readonly parentEl: HTMLElement,
+        private readonly options?: {
+            getToolPanelPivotMode?: () => boolean;
+            onDeferredPivotColumnStateUpdate?: (stateItems: ColumnState[]) => void;
+            getToolPanelColumnFunctionState?: (column: AgColumn) => {
+                rowGroup: boolean;
+                pivot: boolean;
+                value: boolean;
+            };
+        }
     ) {
         super({ tag: 'div', cls: 'ag-menu' });
     }
@@ -74,7 +83,7 @@ export class ToolPanelContextMenu extends Component {
         }
         this.columns = columns;
 
-        const isPivotMode = this.beans.colModel.isPivotMode();
+        const isPivotMode = this.options?.getToolPanelPivotMode?.() ?? this.beans.colModel.isPivotMode();
 
         this.allowScrollIntoView = !isPivotMode && columns.some(this.isColumnValidForScrollIntoView);
         this.allowGrouping = columns.some((col) => col.isPrimary() && col.isAllowRowGroup());
@@ -90,7 +99,13 @@ export class ToolPanelContextMenu extends Component {
         const menuItemMap = new Map<MenuItemName, MenuItemProperty>();
         this.menuItemMap = menuItemMap;
 
-        const isPivotMode = colModel.isPivotMode();
+        const isPivotMode = this.options?.getToolPanelPivotMode?.() ?? colModel.isPivotMode();
+        const getColumnFunctionState = (col: AgColumn) =>
+            this.options?.getToolPanelColumnFunctionState?.(col) ?? {
+                rowGroup: col.isRowGroupActive(),
+                pivot: col.isPivotActive(),
+                value: col.isValueActive(),
+            };
 
         menuItemMap.set('scrollIntoView', {
             allowedFunction: (col) => !col.isPinned() && !isPivotMode && this.isColumnValidForScrollIntoView(col),
@@ -112,15 +127,18 @@ export class ToolPanelContextMenu extends Component {
             col.isPrimary() && col.isAllowRowGroup() && !isRowGroupColLocked(col, beans);
         menuItemMap.set('rowGroup', {
             allowedFunction: rowGroupAllowed,
-            activeFunction: (col) => col.isRowGroupActive(),
+            activeFunction: (col) => getColumnFunctionState(col).rowGroup,
             activateLabel: () => getGroupingLocaleText(localeTextFunc, 'groupBy', displayName!),
             deactivateLabel: () => getGroupingLocaleText(localeTextFunc, 'ungroupBy', displayName!),
             activateFunction: () =>
-                rowGroupColsSvc?.setColumns(
-                    this.addColumnsToList(rowGroupColsSvc.columns, rowGroupAllowed),
-                    'toolPanelUi'
-                ),
+                this.applyDeferredPivotColumnState((col) =>
+                    rowGroupAllowed(col) ? { colId: col.getColId(), rowGroup: true } : undefined
+                ) ||
+                rowGroupColsSvc?.setColumns(this.addColumnsToList(rowGroupColsSvc.columns, rowGroupAllowed), 'toolPanelUi'),
             deActivateFunction: () =>
+                this.applyDeferredPivotColumnState((col) =>
+                    rowGroupAllowed(col) ? { colId: col.getColId(), rowGroup: false } : undefined
+                ) ||
                 rowGroupColsSvc?.setColumns(
                     this.removeColumnsFromList(rowGroupColsSvc.columns, rowGroupAllowed),
                     'toolPanelUi'
@@ -132,13 +150,23 @@ export class ToolPanelContextMenu extends Component {
         const valueAllowed = (col: AgColumn) => col.isPrimary() && col.isAllowValue();
         menuItemMap.set('value', {
             allowedFunction: valueAllowed,
-            activeFunction: (col) => col.isValueActive(),
+            activeFunction: (col) => getColumnFunctionState(col).value,
             activateLabel: () => localeTextFunc('addToValues', `Add ${displayName} to values`, [displayName!]),
             deactivateLabel: () =>
                 localeTextFunc('removeFromValues', `Remove ${displayName} from values`, [displayName!]),
             activateFunction: () =>
-                valueColsSvc?.setColumns(this.addColumnsToList(valueColsSvc.columns, valueAllowed), 'toolPanelUi'),
+                this.applyDeferredPivotColumnState((col) => {
+                    if (!valueAllowed(col)) {
+                        return undefined;
+                    }
+                    const aggFunc =
+                        typeof col.getAggFunc() === 'string' ? col.getAggFunc() : beans.aggFuncSvc?.getDefaultAggFunc(col);
+                    return { colId: col.getColId(), aggFunc };
+                }) || valueColsSvc?.setColumns(this.addColumnsToList(valueColsSvc.columns, valueAllowed), 'toolPanelUi'),
             deActivateFunction: () =>
+                this.applyDeferredPivotColumnState((col) =>
+                    valueAllowed(col) ? { colId: col.getColId(), aggFunc: null } : undefined
+                ) ||
                 valueColsSvc?.setColumns(this.removeColumnsFromList(valueColsSvc.columns, valueAllowed), 'toolPanelUi'),
             addIcon: 'valuePanel',
             removeIcon: 'valuePanel',
@@ -147,17 +175,35 @@ export class ToolPanelContextMenu extends Component {
         const pivotAllowed = (col: AgColumn) => isPivotMode && col.isPrimary() && col.isAllowPivot();
         menuItemMap.set('pivot', {
             allowedFunction: pivotAllowed,
-            activeFunction: (col) => col.isPivotActive(),
+            activeFunction: (col) => getColumnFunctionState(col).pivot,
             activateLabel: () => localeTextFunc('addToLabels', `Add ${displayName} to labels`, [displayName!]),
             deactivateLabel: () =>
                 localeTextFunc('removeFromLabels', `Remove ${displayName} from labels`, [displayName!]),
             activateFunction: () =>
-                pivotColsSvc?.setColumns(this.addColumnsToList(pivotColsSvc.columns, pivotAllowed), 'toolPanelUi'),
+                this.applyDeferredPivotColumnState((col) =>
+                    pivotAllowed(col) ? { colId: col.getColId(), pivot: true } : undefined
+                ) || pivotColsSvc?.setColumns(this.addColumnsToList(pivotColsSvc.columns, pivotAllowed), 'toolPanelUi'),
             deActivateFunction: () =>
+                this.applyDeferredPivotColumnState((col) =>
+                    pivotAllowed(col) ? { colId: col.getColId(), pivot: false } : undefined
+                ) ||
                 pivotColsSvc?.setColumns(this.removeColumnsFromList(pivotColsSvc.columns, pivotAllowed), 'toolPanelUi'),
             addIcon: 'pivotPanel',
             removeIcon: 'pivotPanel',
         });
+    }
+
+    private applyDeferredPivotColumnState(getState: (col: AgColumn) => ColumnState | undefined): boolean {
+        const onDeferredPivotColumnStateUpdate = this.options?.onDeferredPivotColumnStateUpdate;
+        if (!onDeferredPivotColumnStateUpdate) {
+            return false;
+        }
+
+        const stateItems = this.columns.map((col) => getState(col)).filter((state): state is ColumnState => !!state);
+        if (stateItems.length > 0) {
+            onDeferredPivotColumnStateUpdate(stateItems);
+        }
+        return true;
     }
 
     private isColumnValidForScrollIntoView(col: AgColumn): boolean {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelContextMenu.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelContextMenu.ts
@@ -166,6 +166,9 @@ export class ToolPanelContextMenu extends Component {
                         typeof col.getAggFunc() === 'string'
                             ? col.getAggFunc()
                             : beans.aggFuncSvc?.getDefaultAggFunc(col);
+                    if (aggFunc == null) {
+                        return undefined;
+                    }
                     return { colId: col.getColId(), aggFunc };
                 }) ||
                 valueColsSvc?.setColumns(this.addColumnsToList(valueColsSvc.columns, valueAllowed), 'toolPanelUi'),

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelContextMenu.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelContextMenu.ts
@@ -202,6 +202,7 @@ export class ToolPanelContextMenu extends Component {
         });
     }
 
+    /** Stage context-menu pivot/value/group changes through deferred callbacks when present. */
     private applyDeferredPivotColumnState(getState: (col: AgColumn) => ColumnState | undefined): boolean {
         const onDeferredPivotColumnStateUpdate = this.options?.onDeferredPivotColumnStateUpdate;
         if (!onDeferredPivotColumnStateUpdate) {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelContextMenu.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelContextMenu.ts
@@ -134,7 +134,10 @@ export class ToolPanelContextMenu extends Component {
                 this.applyDeferredPivotColumnState((col) =>
                     rowGroupAllowed(col) ? { colId: col.getColId(), rowGroup: true } : undefined
                 ) ||
-                rowGroupColsSvc?.setColumns(this.addColumnsToList(rowGroupColsSvc.columns, rowGroupAllowed), 'toolPanelUi'),
+                rowGroupColsSvc?.setColumns(
+                    this.addColumnsToList(rowGroupColsSvc.columns, rowGroupAllowed),
+                    'toolPanelUi'
+                ),
             deActivateFunction: () =>
                 this.applyDeferredPivotColumnState((col) =>
                     rowGroupAllowed(col) ? { colId: col.getColId(), rowGroup: false } : undefined
@@ -160,9 +163,12 @@ export class ToolPanelContextMenu extends Component {
                         return undefined;
                     }
                     const aggFunc =
-                        typeof col.getAggFunc() === 'string' ? col.getAggFunc() : beans.aggFuncSvc?.getDefaultAggFunc(col);
+                        typeof col.getAggFunc() === 'string'
+                            ? col.getAggFunc()
+                            : beans.aggFuncSvc?.getDefaultAggFunc(col);
                     return { colId: col.getColId(), aggFunc };
-                }) || valueColsSvc?.setColumns(this.addColumnsToList(valueColsSvc.columns, valueAllowed), 'toolPanelUi'),
+                }) ||
+                valueColsSvc?.setColumns(this.addColumnsToList(valueColsSvc.columns, valueAllowed), 'toolPanelUi'),
             deActivateFunction: () =>
                 this.applyDeferredPivotColumnState((col) =>
                     valueAllowed(col) ? { colId: col.getColId(), aggFunc: null } : undefined

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelContextMenu.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelContextMenu.ts
@@ -75,6 +75,7 @@ export class ToolPanelContextMenu extends Component {
     }
 
     private initializeProperties(column: AgColumn | AgProvidedColumnGroup): void {
+        const { options } = this;
         let columns: AgColumn[];
         if (isProvidedColumnGroup(column)) {
             columns = column.getLeafColumns();
@@ -83,7 +84,7 @@ export class ToolPanelContextMenu extends Component {
         }
         this.columns = columns;
 
-        const isPivotMode = this.options?.getToolPanelPivotMode?.() ?? this.beans.colModel.isPivotMode();
+        const isPivotMode = options?.getToolPanelPivotMode?.() ?? this.beans.colModel.isPivotMode();
 
         this.allowScrollIntoView = !isPivotMode && columns.some(this.isColumnValidForScrollIntoView);
         this.allowGrouping = columns.some((col) => col.isPrimary() && col.isAllowRowGroup());
@@ -92,6 +93,7 @@ export class ToolPanelContextMenu extends Component {
     }
 
     private buildMenuItemMap(): void {
+        const { options } = this;
         const localeTextFunc = this.getLocaleTextFunc();
         const { beans, displayName } = this;
         const { rowGroupColsSvc, valueColsSvc, pivotColsSvc, colModel } = beans;
@@ -99,9 +101,9 @@ export class ToolPanelContextMenu extends Component {
         const menuItemMap = new Map<MenuItemName, MenuItemProperty>();
         this.menuItemMap = menuItemMap;
 
-        const isPivotMode = this.options?.getToolPanelPivotMode?.() ?? colModel.isPivotMode();
+        const isPivotMode = options?.getToolPanelPivotMode?.() ?? colModel.isPivotMode();
         const getColumnFunctionState = (col: AgColumn) =>
-            this.options?.getToolPanelColumnFunctionState?.(col) ?? {
+            options?.getToolPanelColumnFunctionState?.(col) ?? {
                 rowGroup: col.isRowGroupActive(),
                 pivot: col.isPivotActive(),
                 value: col.isValueActive(),
@@ -204,12 +206,13 @@ export class ToolPanelContextMenu extends Component {
 
     /** Stage context-menu pivot/value/group changes through deferred callbacks when present. */
     private applyDeferredPivotColumnState(getState: (col: AgColumn) => ColumnState | undefined): boolean {
-        const onDeferredPivotColumnStateUpdate = this.options?.onDeferredPivotColumnStateUpdate;
+        const { columns, options } = this;
+        const onDeferredPivotColumnStateUpdate = options?.onDeferredPivotColumnStateUpdate;
         if (!onDeferredPivotColumnStateUpdate) {
             return false;
         }
 
-        const stateItems = this.columns.map((col) => getState(col)).filter((state): state is ColumnState => !!state);
+        const stateItems = columns.map((col) => getState(col)).filter((state): state is ColumnState => !!state);
         if (stateItems.length > 0) {
             onDeferredPivotColumnStateUpdate(stateItems);
         }

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/baseDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/baseDropZonePanel.ts
@@ -86,6 +86,7 @@ export abstract class BaseDropZonePanel extends PillDropZonePanel<DropZoneColumn
         return this.dropZonePurpose === 'rowGroup';
     }
 
+    /** Delegate item updates to deferred handlers when present; return true when handled. */
     protected handleUpdateItems(columns: AgColumn[]): boolean {
         return this.onUpdateItems?.(this.dropZonePurpose, columns) ?? false;
     }

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/baseDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/baseDropZonePanel.ts
@@ -1,4 +1,4 @@
-import type { AgColumn, ColumnEventType, DragItem, DropTarget, GridDraggingEvent } from 'ag-grid-community';
+import type { AgColumn, ColumnEventType, DragItem, DropTarget, GridDraggingEvent, IAggFunc } from 'ag-grid-community';
 import { DragSourceType, _shouldUpdateColVisibilityAfterGroup } from 'ag-grid-community';
 
 import type { PillDropZonePanelParams } from '../../widgets/pillDropZonePanel';
@@ -10,7 +10,10 @@ export type TDropZone = 'rowGroup' | 'pivot' | 'aggregation';
 export abstract class BaseDropZonePanel extends PillDropZonePanel<DropZoneColumnComp, AgColumn> {
     constructor(
         horizontal: boolean,
-        private readonly dropZonePurpose: TDropZone
+        private readonly dropZonePurpose: TDropZone,
+        private readonly onUpdateItems?: (dropZone: TDropZone, columns: AgColumn[]) => boolean,
+        private readonly onAggregationFunctionChange?: (column: AgColumn, aggFunc: string) => boolean,
+        private readonly getPendingAggregationFunction?: (column: AgColumn) => string | IAggFunc | null | undefined
     ) {
         super(horizontal);
         this.addElementClasses(this.getGui(), this.dropZonePurpose.toLowerCase());
@@ -83,12 +86,24 @@ export abstract class BaseDropZonePanel extends PillDropZonePanel<DropZoneColumn
         return this.dropZonePurpose === 'rowGroup';
     }
 
+    protected handleUpdateItems(columns: AgColumn[]): boolean {
+        return this.onUpdateItems?.(this.dropZonePurpose, columns) ?? false;
+    }
+
     protected createPillComponent(
         column: AgColumn,
         dropTarget: DropTarget,
         ghost: boolean,
         horizontal: boolean
     ): DropZoneColumnComp {
-        return new DropZoneColumnComp(column, dropTarget, ghost, this.dropZonePurpose, horizontal);
+        return new DropZoneColumnComp(
+            column,
+            dropTarget,
+            ghost,
+            this.dropZonePurpose,
+            horizontal,
+            this.onAggregationFunctionChange,
+            this.getPendingAggregationFunction
+        );
     }
 }

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/baseDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/baseDropZonePanel.ts
@@ -86,7 +86,6 @@ export abstract class BaseDropZonePanel extends PillDropZonePanel<DropZoneColumn
         return this.dropZonePurpose === 'rowGroup';
     }
 
-    /** Delegate item updates to deferred handlers when present; return true when handled. */
     protected handleUpdateItems(columns: AgColumn[]): boolean {
         return this.onUpdateItems?.(this.dropZonePurpose, columns) ?? false;
     }

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/dropZoneColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/dropZoneColumnComp.ts
@@ -1,4 +1,4 @@
-import type { AgColumn, DragAndDropIcon, DragItem, DropTarget, SortIndicatorComp } from 'ag-grid-community';
+import type { AgColumn, DragAndDropIcon, DragItem, DropTarget, IAggFunc, SortIndicatorComp } from 'ag-grid-community';
 import { Component, DragSourceType, KeyCode, RefPlaceholder, _createElement } from 'ag-grid-community';
 
 import { PillDragComp } from '../../widgets/pillDragComp';
@@ -17,7 +17,9 @@ export class DropZoneColumnComp extends PillDragComp<AgColumn> {
         dragSourceDropTarget: DropTarget,
         ghost: boolean,
         private readonly dropZonePurpose: TDropZone,
-        horizontal: boolean
+        horizontal: boolean,
+        private readonly onAggregationFunctionChange?: (column: AgColumn, aggFunc: string) => boolean,
+        private readonly getPendingAggregationFunction?: (column: AgColumn) => string | IAggFunc | null | undefined
     ) {
         super(dragSourceDropTarget, ghost, horizontal);
     }
@@ -141,7 +143,7 @@ export class DropZoneColumnComp extends PillDragComp<AgColumn> {
         let aggFuncName: string = '';
 
         if (this.isAggregationZone()) {
-            const aggFunc = this.column.getAggFunc();
+            const aggFunc = this.getPendingAggregationFunction?.(this.column) ?? this.column.getAggFunc();
             // if aggFunc is a string, we can use it, but if it's a function, then we swap with 'func'
             const aggFuncString = typeof aggFunc === 'string' ? aggFunc : 'agg';
             const localeTextFunc = this.getLocaleTextFunc();
@@ -319,6 +321,9 @@ export class DropZoneColumnComp extends PillDragComp<AgColumn> {
         const itemSelected = () => {
             hidePopup();
             this.getGui().focus();
+            if (this.onAggregationFunctionChange?.(this.column, value)) {
+                return;
+            }
             this.beans.valueColsSvc?.setColumnAggFunc?.(this.column, value, 'toolPanelDragAndDrop');
         };
 

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/dropZoneColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/dropZoneColumnComp.ts
@@ -321,6 +321,7 @@ export class DropZoneColumnComp extends PillDragComp<AgColumn> {
         const itemSelected = () => {
             hidePopup();
             this.getGui().focus();
+            /** Let deferred mode consume the agg-func update so live column state stays unchanged until apply. */
             if (this.onAggregationFunctionChange?.(this.column, value)) {
                 return;
             }

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/dropZoneColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/dropZoneColumnComp.ts
@@ -321,7 +321,6 @@ export class DropZoneColumnComp extends PillDragComp<AgColumn> {
         const itemSelected = () => {
             hidePopup();
             this.getGui().focus();
-            /** Let deferred mode consume the agg-func update so live column state stays unchanged until apply. */
             if (this.onAggregationFunctionChange?.(this.column, value)) {
                 return;
             }

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/pivotDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/pivotDropZonePanel.ts
@@ -4,8 +4,12 @@ import { _createIconNoSpan } from 'ag-grid-community';
 import { BaseDropZonePanel } from './baseDropZonePanel';
 
 export class PivotDropZonePanel extends BaseDropZonePanel {
-    constructor(horizontal: boolean) {
-        super(horizontal, 'pivot');
+    constructor(
+        horizontal: boolean,
+        onUpdateItems?: (columns: AgColumn[]) => boolean,
+        private readonly getExistingItemsOverride?: () => AgColumn[]
+    ) {
+        super(horizontal, 'pivot', onUpdateItems ? (_dropZone, columns) => onUpdateItems(columns) : undefined);
     }
 
     public postConstruct(): void {
@@ -77,6 +81,9 @@ export class PivotDropZonePanel extends BaseDropZonePanel {
     }
 
     protected updateItems(columns: AgColumn[]): void {
+        if (this.handleUpdateItems(columns)) {
+            return;
+        }
         this.beans.pivotColsSvc?.setColumns(columns, 'toolPanelUi');
     }
 
@@ -85,6 +92,10 @@ export class PivotDropZonePanel extends BaseDropZonePanel {
     }
 
     protected getExistingItems(): AgColumn[] {
+        const override = this.getExistingItemsOverride?.();
+        if (override) {
+            return override;
+        }
         return this.beans.pivotColsSvc?.columns ?? [];
     }
 }

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/pivotDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/pivotDropZonePanel.ts
@@ -4,7 +4,6 @@ import { _createIconNoSpan } from 'ag-grid-community';
 import { BaseDropZonePanel } from './baseDropZonePanel';
 
 export class PivotDropZonePanel extends BaseDropZonePanel {
-    /** Accept deferred-mode overrides for staged pivot list updates and pending item source. */
     constructor(
         horizontal: boolean,
         onUpdateItems?: (columns: AgColumn[]) => boolean,
@@ -82,7 +81,6 @@ export class PivotDropZonePanel extends BaseDropZonePanel {
     }
 
     protected updateItems(columns: AgColumn[]): void {
-        /** Skip live service update when deferred mode handles staging. */
         if (this.handleUpdateItems(columns)) {
             return;
         }
@@ -94,7 +92,6 @@ export class PivotDropZonePanel extends BaseDropZonePanel {
     }
 
     protected getExistingItems(): AgColumn[] {
-        /** Read pending pivot items in deferred mode so UI reflects staged order. */
         const override = this.getExistingItemsOverride?.();
         if (override) {
             return override;

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/pivotDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/pivotDropZonePanel.ts
@@ -4,6 +4,7 @@ import { _createIconNoSpan } from 'ag-grid-community';
 import { BaseDropZonePanel } from './baseDropZonePanel';
 
 export class PivotDropZonePanel extends BaseDropZonePanel {
+    /** Accept deferred-mode overrides for staged pivot list updates and pending item source. */
     constructor(
         horizontal: boolean,
         onUpdateItems?: (columns: AgColumn[]) => boolean,
@@ -81,6 +82,7 @@ export class PivotDropZonePanel extends BaseDropZonePanel {
     }
 
     protected updateItems(columns: AgColumn[]): void {
+        /** Skip live service update when deferred mode handles staging. */
         if (this.handleUpdateItems(columns)) {
             return;
         }
@@ -92,6 +94,7 @@ export class PivotDropZonePanel extends BaseDropZonePanel {
     }
 
     protected getExistingItems(): AgColumn[] {
+        /** Read pending pivot items in deferred mode so UI reflects staged order. */
         const override = this.getExistingItemsOverride?.();
         if (override) {
             return override;

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/rowGroupDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/rowGroupDropZonePanel.ts
@@ -4,7 +4,6 @@ import { _createIconNoSpan } from 'ag-grid-community';
 import { BaseDropZonePanel } from './baseDropZonePanel';
 
 export class RowGroupDropZonePanel extends BaseDropZonePanel {
-    /** Accept deferred-mode overrides for staged row-group updates and pending item source. */
     constructor(
         horizontal: boolean,
         onUpdateItems?: (columns: AgColumn[]) => boolean,
@@ -44,7 +43,6 @@ export class RowGroupDropZonePanel extends BaseDropZonePanel {
     }
 
     protected updateItems(columns: AgColumn[]) {
-        /** Skip live service update when deferred mode handles staging. */
         if (this.handleUpdateItems(columns)) {
             return;
         }
@@ -56,7 +54,6 @@ export class RowGroupDropZonePanel extends BaseDropZonePanel {
     }
 
     protected getExistingItems(): AgColumn[] {
-        /** Read pending row-group items in deferred mode so UI reflects staged order. */
         const override = this.getExistingItemsOverride?.();
         if (override) {
             return override;

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/rowGroupDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/rowGroupDropZonePanel.ts
@@ -4,8 +4,12 @@ import { _createIconNoSpan } from 'ag-grid-community';
 import { BaseDropZonePanel } from './baseDropZonePanel';
 
 export class RowGroupDropZonePanel extends BaseDropZonePanel {
-    constructor(horizontal: boolean) {
-        super(horizontal, 'rowGroup');
+    constructor(
+        horizontal: boolean,
+        onUpdateItems?: (columns: AgColumn[]) => boolean,
+        private readonly getExistingItemsOverride?: () => AgColumn[]
+    ) {
+        super(horizontal, 'rowGroup', onUpdateItems ? (_dropZone, columns) => onUpdateItems(columns) : undefined);
     }
 
     public postConstruct(): void {
@@ -39,6 +43,9 @@ export class RowGroupDropZonePanel extends BaseDropZonePanel {
     }
 
     protected updateItems(columns: AgColumn[]) {
+        if (this.handleUpdateItems(columns)) {
+            return;
+        }
         this.beans.rowGroupColsSvc?.setColumns(columns, 'toolPanelUi');
     }
 
@@ -47,6 +54,10 @@ export class RowGroupDropZonePanel extends BaseDropZonePanel {
     }
 
     protected getExistingItems(): AgColumn[] {
+        const override = this.getExistingItemsOverride?.();
+        if (override) {
+            return override;
+        }
         return this.beans.rowGroupColsSvc?.columns ?? [];
     }
 }

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/rowGroupDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/rowGroupDropZonePanel.ts
@@ -4,6 +4,7 @@ import { _createIconNoSpan } from 'ag-grid-community';
 import { BaseDropZonePanel } from './baseDropZonePanel';
 
 export class RowGroupDropZonePanel extends BaseDropZonePanel {
+    /** Accept deferred-mode overrides for staged row-group updates and pending item source. */
     constructor(
         horizontal: boolean,
         onUpdateItems?: (columns: AgColumn[]) => boolean,
@@ -43,6 +44,7 @@ export class RowGroupDropZonePanel extends BaseDropZonePanel {
     }
 
     protected updateItems(columns: AgColumn[]) {
+        /** Skip live service update when deferred mode handles staging. */
         if (this.handleUpdateItems(columns)) {
             return;
         }
@@ -54,6 +56,7 @@ export class RowGroupDropZonePanel extends BaseDropZonePanel {
     }
 
     protected getExistingItems(): AgColumn[] {
+        /** Read pending row-group items in deferred mode so UI reflects staged order. */
         const override = this.getExistingItemsOverride?.();
         if (override) {
             return override;

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/valueDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/valueDropZonePanel.ts
@@ -4,6 +4,7 @@ import { _createIconNoSpan } from 'ag-grid-community';
 import { BaseDropZonePanel } from './baseDropZonePanel';
 
 export class ValuesDropZonePanel extends BaseDropZonePanel {
+    /** Accept deferred-mode overrides for staged value updates and aggregation-function state. */
     constructor(
         horizontal: boolean,
         onUpdateItems?: (columns: AgColumn[]) => boolean,
@@ -55,6 +56,7 @@ export class ValuesDropZonePanel extends BaseDropZonePanel {
     }
 
     protected updateItems(columns: AgColumn[]): void {
+        /** Skip live service update when deferred mode handles staging. */
         if (this.handleUpdateItems(columns)) {
             return;
         }
@@ -62,6 +64,7 @@ export class ValuesDropZonePanel extends BaseDropZonePanel {
     }
 
     protected getExistingItems(): AgColumn[] {
+        /** Read pending value items in deferred mode so UI reflects staged order. */
         const override = this.getExistingItemsOverride?.();
         if (override) {
             return override;

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/valueDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/valueDropZonePanel.ts
@@ -1,11 +1,23 @@
-import type { AgColumn, DragAndDropIcon, GridDraggingEvent } from 'ag-grid-community';
+import type { AgColumn, DragAndDropIcon, GridDraggingEvent, IAggFunc } from 'ag-grid-community';
 import { _createIconNoSpan } from 'ag-grid-community';
 
 import { BaseDropZonePanel } from './baseDropZonePanel';
 
 export class ValuesDropZonePanel extends BaseDropZonePanel {
-    constructor(horizontal: boolean) {
-        super(horizontal, 'aggregation');
+    constructor(
+        horizontal: boolean,
+        onUpdateItems?: (columns: AgColumn[]) => boolean,
+        private readonly getExistingItemsOverride?: () => AgColumn[],
+        onAggregationFunctionChange?: (column: AgColumn, aggFunc: string) => boolean,
+        getPendingAggregationFunction?: (column: AgColumn) => string | IAggFunc | null | undefined
+    ) {
+        super(
+            horizontal,
+            'aggregation',
+            onUpdateItems ? (_dropZone, columns) => onUpdateItems(columns) : undefined,
+            onAggregationFunctionChange,
+            getPendingAggregationFunction
+        );
     }
 
     public postConstruct(): void {
@@ -43,10 +55,17 @@ export class ValuesDropZonePanel extends BaseDropZonePanel {
     }
 
     protected updateItems(columns: AgColumn[]): void {
+        if (this.handleUpdateItems(columns)) {
+            return;
+        }
         this.beans.valueColsSvc?.setColumns(columns, 'toolPanelUi');
     }
 
     protected getExistingItems(): AgColumn[] {
+        const override = this.getExistingItemsOverride?.();
+        if (override) {
+            return override;
+        }
         return this.beans.valueColsSvc?.columns ?? [];
     }
 }

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/valueDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/valueDropZonePanel.ts
@@ -4,7 +4,6 @@ import { _createIconNoSpan } from 'ag-grid-community';
 import { BaseDropZonePanel } from './baseDropZonePanel';
 
 export class ValuesDropZonePanel extends BaseDropZonePanel {
-    /** Accept deferred-mode overrides for staged value updates and aggregation-function state. */
     constructor(
         horizontal: boolean,
         onUpdateItems?: (columns: AgColumn[]) => boolean,
@@ -56,7 +55,6 @@ export class ValuesDropZonePanel extends BaseDropZonePanel {
     }
 
     protected updateItems(columns: AgColumn[]): void {
-        /** Skip live service update when deferred mode handles staging. */
         if (this.handleUpdateItems(columns)) {
             return;
         }
@@ -64,7 +62,6 @@ export class ValuesDropZonePanel extends BaseDropZonePanel {
     }
 
     protected getExistingItems(): AgColumn[] {
-        /** Read pending value items in deferred mode so UI reflects staged order. */
         const override = this.getExistingItemsOverride?.();
         if (override) {
             return override;

--- a/packages/ag-grid-enterprise/src/widgets/pillDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/widgets/pillDropZonePanel.ts
@@ -598,7 +598,10 @@ export abstract class PillDropZonePanel<TPill extends PillDragComp<TItem>, TItem
 
     private createItemComponent(item: TItem, ghost: boolean): TPill {
         const itemComponent = this.createPillComponent(item, this.dropTarget, ghost, this.horizontal);
-        itemComponent.addEventListener('columnRemove', this.removeItems.bind(this, [item]));
+        itemComponent.addEventListener('columnRemove', () => {
+            this.removeItems([item]);
+            this.refreshGui();
+        });
 
         this.createBean(itemComponent);
         this.guiDestroyFunctions.push(() => this.destroyBean(itemComponent));

--- a/packages/ag-grid-enterprise/src/widgets/pillDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/widgets/pillDropZonePanel.ts
@@ -600,7 +600,6 @@ export abstract class PillDropZonePanel<TPill extends PillDragComp<TItem>, TItem
         const itemComponent = this.createPillComponent(item, this.dropTarget, ghost, this.horizontal);
         itemComponent.addEventListener('columnRemove', () => {
             this.removeItems([item]);
-            /** Rebuild pills so deferred-mode pending updates are reflected immediately after remove. */
             this.refreshGui();
         });
 

--- a/packages/ag-grid-enterprise/src/widgets/pillDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/widgets/pillDropZonePanel.ts
@@ -600,6 +600,7 @@ export abstract class PillDropZonePanel<TPill extends PillDragComp<TItem>, TItem
         const itemComponent = this.createPillComponent(item, this.dropTarget, ghost, this.horizontal);
         itemComponent.addEventListener('columnRemove', () => {
             this.removeItems([item]);
+            /** Rebuild pills so deferred-mode pending updates are reflected immediately after remove. */
             this.refreshGui();
         });
 

--- a/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
@@ -3,6 +3,7 @@ import { getGridElement } from 'ag-grid-community';
 import { AllEnterpriseModule } from 'ag-grid-enterprise';
 
 import { moveItem } from '../../../../packages/ag-grid-enterprise/src/columnToolPanel/columnMoveUtils';
+import { ToolPanelContextMenu } from '../../../../packages/ag-grid-enterprise/src/columnToolPanel/toolPanelContextMenu';
 import { TestGridsManager, asyncSetTimeout } from '../test-utils';
 
 describe('Columns Tool Panel Deferred Apply Mode', () => {
@@ -80,6 +81,40 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
     const setDeferredVisibilityFromToolPanel = (gridApi: GridApi, colId: string, visible: boolean): void => {
         const toolPanel = getToolPanel(gridApi);
         toolPanel.onDeferredVisibilityColumnStateUpdate([{ colId, hide: !visible }]);
+    };
+
+    const triggerDeferredContextMenuAction = (
+        gridApi: GridApi,
+        colId: string,
+        menuItem: 'value' | 'rowGroup' | 'pivot',
+        action: 'activateFunction' | 'deActivateFunction'
+    ): void => {
+        const toolPanel = getToolPanel(gridApi);
+        const column = gridApi.getColumn(colId) as any;
+        if (!column) {
+            throw new Error(`Expected ${colId} column to exist`);
+        }
+
+        const gridDiv = getGridElement(gridApi)! as HTMLElement;
+        const contextMenu = column.createBean(
+            new ToolPanelContextMenu(column, new MouseEvent('contextmenu'), gridDiv, {
+                getToolPanelPivotMode: toolPanel.getToolPanelPivotMode?.bind(toolPanel),
+                onDeferredPivotColumnStateUpdate: toolPanel.onDeferredPivotColumnStateUpdate?.bind(toolPanel),
+                getToolPanelColumnFunctionState: toolPanel.getToolPanelColumnFunctionState?.bind(toolPanel),
+            })
+        ) as any;
+
+        const menuItemConfig = contextMenu.menuItemMap.get(menuItem);
+        if (!menuItemConfig) {
+            throw new Error(`Expected deferred context menu item "${menuItem}" to exist`);
+        }
+
+        const menuAction = menuItemConfig[action];
+        if (typeof menuAction !== 'function') {
+            throw new Error(`Expected deferred context menu item "${menuItem}" action "${action}"`);
+        }
+
+        menuAction();
     };
 
     const stageComboChangesFromToolPanel = (gridApi: GridApi): void => {
@@ -354,6 +389,92 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['age']);
         expect(gridApi.getColumn('age')!.getAggFunc()).toBe('sum');
         expect(applyButton.disabled).toBe(true);
+    });
+
+    test('stages adding a value column in non-pivot mode and applies with a default agg function', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        const toolPanel = getToolPanel(gridApi);
+        const athleteCol = gridApi.getColumn('athlete');
+        if (!athleteCol) {
+            throw new Error('Expected athlete column to exist');
+        }
+
+        const { applyButton } = getButtons(gridApi);
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual([]);
+        expect(applyButton.disabled).toBe(true);
+
+        toolPanel.onDeferredValueColumnsUpdate([athleteCol]);
+        await asyncSetTimeout(1);
+
+        // Deferred mode: adding a value column via drop zone should stage even when no agg func was set yet.
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual([]);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+
+        getButtons(gridApi).applyButton.click();
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['athlete']);
+        expect(gridApi.getColumn('athlete')!.getAggFunc()).not.toBeNull();
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+    });
+
+    test('deferred context menu add to values stages and applies value column', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        const { applyButton } = getButtons(gridApi);
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual([]);
+        expect(applyButton.disabled).toBe(true);
+
+        triggerDeferredContextMenuAction(gridApi, 'athlete', 'value', 'activateFunction');
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual([]);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+
+        getButtons(gridApi).applyButton.click();
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['athlete']);
+        expect(gridApi.getColumn('athlete')!.getAggFunc()).not.toBeNull();
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+    });
+
+    test('deferred context menu remove from values stages and applies removal', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        gridApi.setValueColumns(['athlete']);
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['athlete']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+
+        triggerDeferredContextMenuAction(gridApi, 'athlete', 'value', 'deActivateFunction');
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['athlete']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+
+        getButtons(gridApi).applyButton.click();
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual([]);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
     });
 
     test('discards deferred value aggregation function change when Cancel is clicked', async () => {

--- a/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
@@ -63,6 +63,15 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         toggle?.toggle();
     };
 
+    const setColumnSelectionFromToolPanel = (gridApi: GridApi, colId: string, selected: boolean): void => {
+        const toolPanel = gridApi.getToolPanelInstance('columns') as any;
+        const listPanel = toolPanel?.primaryColsPanel?.primaryColsListPanel as any;
+        const displayedColsList = listPanel?.getDisplayedColsList?.() as any[] | undefined;
+        const rowIndex = displayedColsList?.findIndex((item) => !item.group && item.column?.getColId?.() === colId);
+        const listItemComp = rowIndex != null && rowIndex >= 0 ? listPanel?.virtualList?.getComponentAt(rowIndex) : null;
+        listItemComp?.onSelectAllChanged?.(selected);
+    };
+
     test('does not apply pivot mode until Apply is clicked', async () => {
         const gridApi = await gridMgr.createGridAndWait('myGrid', {
             columnDefs,
@@ -108,6 +117,56 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         await asyncSetTimeout(1);
 
         expect(gridApi.isPivotMode()).toBe(false);
+        expect(applyButton.disabled).toBe(true);
+    });
+
+    test('does not apply column visibility change until Apply is clicked', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        const { applyButton } = getButtons(gridApi);
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
+        expect(applyButton.disabled).toBe(true);
+
+        setColumnSelectionFromToolPanel(gridApi, 'athlete', false);
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
+        expect(applyButton.disabled).toBe(false);
+
+        applyButton.click();
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(false);
+        expect(applyButton.disabled).toBe(true);
+    });
+
+    test('discards deferred column visibility change when Cancel is clicked', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        const { applyButton, cancelButton } = getButtons(gridApi);
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
+        expect(applyButton.disabled).toBe(true);
+
+        setColumnSelectionFromToolPanel(gridApi, 'athlete', false);
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
+        expect(applyButton.disabled).toBe(false);
+
+        cancelButton.click();
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
         expect(applyButton.disabled).toBe(true);
     });
 });

--- a/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
@@ -184,6 +184,36 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         expect(getButtons(gridApi).applyButton.disabled).toBe(true);
     });
 
+    test('select all checkbox controls checkbox state and stages changes in deferred mode', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        const toolPanel = getToolPanel(gridApi);
+        const primaryColsPanel = toolPanel.primaryColsPanel as any;
+        const primaryColsListPanel = primaryColsPanel.primaryColsListPanel as any;
+        const primaryColsHeaderPanel = primaryColsPanel.primaryColsHeaderPanel as any;
+
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
+        expect(gridApi.getColumn('age')!.isVisible()).toBe(true);
+        expect(gridApi.getColumn('country')!.isVisible()).toBe(true);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+
+        primaryColsListPanel.doSetSelectedAll(false);
+        await asyncSetTimeout(1);
+
+        // Header and child checkbox state are updated...
+        expect(primaryColsHeaderPanel.eSelect.getValue()).toBe(false);
+        // ...but applied grid visibility is unchanged until an explicit deferred action is staged and applied.
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
+        expect(gridApi.getColumn('age')!.isVisible()).toBe(true);
+        expect(gridApi.getColumn('country')!.isVisible()).toBe(true);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+    });
+
     test('does not apply value aggregation function change until Apply is clicked', async () => {
         const gridApi = await gridMgr.createGridAndWait('myGrid', {
             columnDefs,

--- a/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridApi, SideBarDef } from 'ag-grid-community';
+import type { AgColumn, ColDef, GridApi, SideBarDef } from 'ag-grid-community';
 import { getGridElement } from 'ag-grid-community';
 import { AllEnterpriseModule } from 'ag-grid-enterprise';
 
@@ -48,7 +48,9 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         const gridDiv = getGridElement(gridApi)! as HTMLElement;
         const buttons = Array.from(gridDiv.querySelectorAll('button.ag-column-panel-buttons-button'));
         const applyButton = buttons.find((button) => button.classList.contains('ag-column-panel-buttons-apply-button'));
-        const cancelButton = buttons.find((button) => !button.classList.contains('ag-column-panel-buttons-apply-button'));
+        const cancelButton = buttons.find(
+            (button) => !button.classList.contains('ag-column-panel-buttons-apply-button')
+        );
 
         if (!applyButton || !cancelButton) {
             throw new Error('Expected Apply and Cancel buttons to be rendered in the column tool panel');
@@ -377,7 +379,11 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
             pivotMode: false,
         });
 
-        const getColumnOrder = () => gridApi.getAllDisplayedColumns().slice(0, 3).map((col) => col.getColId());
+        const getColumnOrder = () =>
+            gridApi
+                .getAllDisplayedColumns()
+                .slice(0, 3)
+                .map((col) => col.getColId());
         expect(getColumnOrder()).toEqual(['athlete', 'age', 'country']);
         expect(getButtons(gridApi).applyButton.disabled).toBe(true);
 
@@ -391,7 +397,7 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         }
 
         // Move athlete below age through the same move utility used by the CTP.
-        moveItem(primaryColsListPanel.beans, [athleteCol], {
+        moveItem(primaryColsListPanel.beans, [athleteCol as AgColumn], {
             component: { column: ageCol } as any,
             position: 'bottom',
             rowIndex: 1,

--- a/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
@@ -580,6 +580,53 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         expect(getButtons(gridApi).applyButton.disabled).toBe(true);
     });
 
+    test('preserves latest external reorder for untouched value columns across repeated external updates', async () => {
+        const gridApi = gridMgr.createGrid('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: true,
+        });
+        await asyncSetTimeout(1);
+
+        gridApi.setValueColumns(['athlete', 'age', 'country']);
+        await asyncSetTimeout(1);
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['athlete', 'age', 'country']);
+
+        const toolPanel = getToolPanel(gridApi);
+        const countryCol = gridApi.getColumn('country');
+        const athleteCol = gridApi.getColumn('athlete');
+        const ageCol = gridApi.getColumn('age');
+        if (!countryCol || !athleteCol || !ageCol) {
+            throw new Error('Expected country, athlete and age columns to exist');
+        }
+
+        // Stage moving country to the front.
+        toolPanel.onDeferredValueColumnsUpdate([countryCol, athleteCol, ageCol]);
+        await asyncSetTimeout(1);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+
+        // Repeated external reorders of untouched value columns while deferred state is dirty.
+        gridApi.setValueColumns(['age', 'athlete', 'country']);
+        await asyncSetTimeout(1);
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['age', 'athlete', 'country']);
+
+        gridApi.setValueColumns(['athlete', 'age', 'country']);
+        await asyncSetTimeout(1);
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['athlete', 'age', 'country']);
+
+        gridApi.setValueColumns(['age', 'athlete', 'country']);
+        await asyncSetTimeout(1);
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['age', 'athlete', 'country']);
+
+        getButtons(gridApi).applyButton.click();
+        await asyncSetTimeout(1);
+
+        // Expected: staged move is preserved, untouched existing order follows latest external update.
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['country', 'age', 'athlete']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+    });
+
     test('clicking remove on a value pill updates deferred UI only until Apply', async () => {
         const gridApi = gridMgr.createGrid('myGrid', {
             columnDefs,
@@ -738,6 +785,36 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         expect(gridApi.getPivotColumns().map((col) => col.getColId())).toEqual(['athlete']);
         expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['age']);
         expect(gridApi.getColumn('age')!.getAggFunc()).toBe('sum');
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+    });
+
+    test('applies deferred visibility changes when pivot mode is toggled on', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        expect(gridApi.isPivotMode()).toBe(false);
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+
+        const toolPanel = getToolPanel(gridApi);
+        togglePivotModeFromToolPanel(gridApi);
+        setDeferredVisibilityFromToolPanel(gridApi, 'athlete', false);
+        await asyncSetTimeout(1);
+
+        // Staged only, applied grid state unchanged before Apply.
+        expect(gridApi.isPivotMode()).toBe(false);
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+
+        getButtons(gridApi).applyButton.click();
+        await asyncSetTimeout(1);
+
+        expect(gridApi.isPivotMode()).toBe(true);
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(false);
         expect(getButtons(gridApi).applyButton.disabled).toBe(true);
     });
 

--- a/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
@@ -373,6 +373,213 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         expect(getButtons(gridApi).applyButton.disabled).toBe(true);
     });
 
+    test('preserves external value agg func updates while deferred value reorder is pending', async () => {
+        const gridApi = gridMgr.createGrid('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: true,
+        });
+        await asyncSetTimeout(1);
+
+        gridApi.setValueColumns(['athlete', 'age']);
+        await asyncSetTimeout(1);
+
+        const toolPanel = getToolPanel(gridApi);
+        const athleteCol = gridApi.getColumn('athlete');
+        const ageCol = gridApi.getColumn('age');
+        if (!athleteCol || !ageCol) {
+            throw new Error('Expected athlete and age columns to exist');
+        }
+
+        // Stage reorder only (no staged agg-func change).
+        toolPanel.onDeferredValueColumnsUpdate([ageCol, athleteCol]);
+        await asyncSetTimeout(1);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+
+        // External change outside CTP while pending is dirty.
+        gridApi.applyColumnState({
+            state: [{ colId: 'athlete', aggFunc: 'max' }],
+        });
+        await asyncSetTimeout(1);
+        expect(gridApi.getColumn('athlete')!.getAggFunc()).toBe('max');
+
+        getButtons(gridApi).applyButton.click();
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['age', 'athlete']);
+        expect(gridApi.getColumn('athlete')!.getAggFunc()).toBe('max');
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+    });
+
+    test('preserves external row group updates when only pivot mode is staged', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        togglePivotModeFromToolPanel(gridApi);
+        await asyncSetTimeout(1);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+
+        // External update in untouched dimension while deferred state is dirty.
+        gridApi.setRowGroupColumns(['country']);
+        await asyncSetTimeout(1);
+        expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual(['country']);
+
+        getButtons(gridApi).applyButton.click();
+        await asyncSetTimeout(1);
+
+        expect(gridApi.isPivotMode()).toBe(true);
+        expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual(['country']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+    });
+
+    test('preserves external visibility updates on untouched columns', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        // Stage a visibility change for athlete only.
+        setDeferredVisibilityFromToolPanel(gridApi, 'athlete', false);
+        await asyncSetTimeout(1);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+
+        // External visibility update for a different column.
+        gridApi.applyColumnState({
+            state: [{ colId: 'country', hide: true }],
+        });
+        await asyncSetTimeout(1);
+        expect(gridApi.getColumn('country')!.isVisible()).toBe(false);
+
+        getButtons(gridApi).applyButton.click();
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(false);
+        expect(gridApi.getColumn('country')!.isVisible()).toBe(false);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+    });
+
+    test('preserves external reorder for untouched row-group columns during deferred rebase', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        // Start with two grouped columns.
+        gridApi.setRowGroupColumns(['athlete', 'age']);
+        await asyncSetTimeout(1);
+        expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual(['athlete', 'age']);
+
+        const toolPanel = getToolPanel(gridApi);
+        const countryCol = gridApi.getColumn('country');
+        const athleteCol = gridApi.getColumn('athlete');
+        const ageCol = gridApi.getColumn('age');
+        if (!countryCol || !athleteCol || !ageCol) {
+            throw new Error('Expected country, athlete and age columns to exist');
+        }
+
+        // Stage inserting a new row-group column at the front.
+        toolPanel.onDeferredRowGroupColumnsUpdate([countryCol, athleteCol, ageCol]);
+        await asyncSetTimeout(1);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+
+        // External update reorders the existing grouped columns while deferred state is dirty.
+        gridApi.setRowGroupColumns(['age', 'athlete']);
+        await asyncSetTimeout(1);
+        expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual(['age', 'athlete']);
+
+        getButtons(gridApi).applyButton.click();
+        await asyncSetTimeout(1);
+
+        // Expected: staged insertion is preserved, untouched existing order follows external update.
+        expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual(['country', 'age', 'athlete']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+    });
+
+    test('preserves external value membership/order updates when only value agg is staged', async () => {
+        const gridApi = gridMgr.createGrid('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: true,
+        });
+        await asyncSetTimeout(1);
+
+        gridApi.setValueColumns(['athlete', 'age']);
+        await asyncSetTimeout(1);
+
+        const toolPanel = getToolPanel(gridApi);
+        const ageCol = gridApi.getColumn('age');
+        if (!ageCol) {
+            throw new Error('Expected age column to exist');
+        }
+
+        // Stage agg update only, no staged value order/membership changes.
+        toolPanel.onDeferredValueColumnAggFuncUpdate(ageCol, 'avg');
+        await asyncSetTimeout(1);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+
+        // External update changes membership/order in untouched dimension.
+        gridApi.setValueColumns(['country', 'age']);
+        await asyncSetTimeout(1);
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['country', 'age']);
+
+        getButtons(gridApi).applyButton.click();
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['country', 'age']);
+        expect(gridApi.getColumn('age')!.getAggFunc()).toBe('avg');
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+    });
+
+    test('preserves external reorder for untouched value columns during deferred rebase', async () => {
+        const gridApi = gridMgr.createGrid('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: true,
+        });
+        await asyncSetTimeout(1);
+
+        // Start with three value columns so staged change is order-only (no membership add/remove).
+        gridApi.setValueColumns(['athlete', 'age', 'country']);
+        await asyncSetTimeout(1);
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['athlete', 'age', 'country']);
+
+        const toolPanel = getToolPanel(gridApi);
+        const countryCol = gridApi.getColumn('country');
+        const athleteCol = gridApi.getColumn('athlete');
+        const ageCol = gridApi.getColumn('age');
+        if (!countryCol || !athleteCol || !ageCol) {
+            throw new Error('Expected country, athlete and age columns to exist');
+        }
+
+        // Stage moving country to the front.
+        toolPanel.onDeferredValueColumnsUpdate([countryCol, athleteCol, ageCol]);
+        await asyncSetTimeout(1);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+
+        // External update reorders existing value columns while deferred state is dirty.
+        gridApi.setValueColumns(['age', 'athlete', 'country']);
+        await asyncSetTimeout(1);
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['age', 'athlete', 'country']);
+
+        getButtons(gridApi).applyButton.click();
+        await asyncSetTimeout(1);
+
+        // Expected: staged move is preserved, untouched existing order follows external update.
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['country', 'age', 'athlete']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+    });
+
     test('clicking remove on a value pill updates deferred UI only until Apply', async () => {
         const gridApi = gridMgr.createGrid('myGrid', {
             columnDefs,

--- a/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
@@ -336,6 +336,87 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         expect(getButtons(gridApi).applyButton.disabled).toBe(true);
     });
 
+    test('applies deferred value column reorder in the same order as staged', async () => {
+        const gridApi = gridMgr.createGrid('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: true,
+        });
+        await asyncSetTimeout(1);
+
+        gridApi.setValueColumns(['athlete', 'age']);
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['athlete', 'age']);
+        expect(gridApi.getAllDisplayedColumns().map((col) => col.getColId())).toEqual(['athlete', 'age']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+
+        const toolPanel = getToolPanel(gridApi);
+        const athleteCol = gridApi.getColumn('athlete');
+        const ageCol = gridApi.getColumn('age');
+        if (!athleteCol || !ageCol) {
+            throw new Error('Expected athlete and age columns to exist');
+        }
+
+        toolPanel.onDeferredValueColumnsUpdate([ageCol, athleteCol]);
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['athlete', 'age']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+
+        getButtons(gridApi).applyButton.click();
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['age', 'athlete']);
+        expect(gridApi.getAllDisplayedColumns().map((col) => col.getColId())).toEqual(['age', 'athlete']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+    });
+
+    test('clicking remove on a value pill updates deferred UI only until Apply', async () => {
+        const gridApi = gridMgr.createGrid('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: true,
+        });
+        await asyncSetTimeout(1);
+
+        gridApi.setValueColumns(['athlete']);
+        await asyncSetTimeout(1);
+
+        const toolPanel = getToolPanel(gridApi);
+        const valuesDropZonePanel = toolPanel.valuesDropZonePanel as any;
+        const valuesGui = valuesDropZonePanel?.getGui?.() as HTMLElement | undefined;
+        if (!valuesGui) {
+            throw new Error('Expected values drop zone panel to exist');
+        }
+
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['athlete']);
+        if (valuesGui.querySelectorAll('.ag-column-drop-cell').length === 0) {
+            const athleteCol = gridApi.getColumn('athlete');
+            if (!athleteCol) {
+                throw new Error('Expected athlete column to exist');
+            }
+            valuesDropZonePanel.addItem(athleteCol);
+            await asyncSetTimeout(1);
+        }
+        expect(valuesGui.querySelectorAll('.ag-column-drop-cell').length).toBe(1);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+
+        const removeButton = valuesGui.querySelector('.ag-column-drop-cell-button') as HTMLElement | null;
+        if (!removeButton) {
+            throw new Error('Expected value pill remove button to exist');
+        }
+        removeButton.click();
+        await asyncSetTimeout(1);
+
+        // Deferred mode: pill is removed visually, but grid state is unchanged until Apply.
+        expect(valuesGui.querySelectorAll('.ag-column-drop-cell').length).toBe(0);
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['athlete']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+    });
+
     test('does not apply row group column reorder until Apply is clicked', async () => {
         const gridApi = await gridMgr.createGridAndWait('myGrid', {
             columnDefs,

--- a/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
@@ -68,6 +68,15 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
 
     const getToolPanel = (gridApi: GridApi): any => gridApi.getToolPanelInstance('columns') as any;
 
+    const createFirstLeafComp = (primaryColsListPanel: any): any => {
+        const firstLeafItem = primaryColsListPanel.getDisplayedColsList().find((item: any) => !item.group);
+        if (!firstLeafItem) {
+            throw new Error('Expected a leaf column item in the primary columns list');
+        }
+
+        return primaryColsListPanel.createComponentFromItem(firstLeafItem, document.createElement('div'));
+    };
+
     const setDeferredVisibilityFromToolPanel = (gridApi: GridApi, colId: string, visible: boolean): void => {
         const toolPanel = getToolPanel(gridApi);
         toolPanel.onDeferredVisibilityColumnStateUpdate([{ colId, hide: !visible }]);
@@ -90,12 +99,13 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
     };
 
     test('does not apply pivot mode until Apply is clicked', async () => {
-        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+        const gridApi = gridMgr.createGrid('myGrid', {
             columnDefs,
             rowData,
             sideBar,
             pivotMode: false,
         });
+        await asyncSetTimeout(1);
 
         const { applyButton } = getButtons(gridApi);
         expect(applyButton.disabled).toBe(true);
@@ -280,6 +290,42 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
         expect(gridApi.getColumn('age')!.isVisible()).toBe(true);
         expect(gridApi.getColumn('country')!.isVisible()).toBe(true);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+    });
+
+    test('shares deferred callbacks through tool panel params across list and leaf components', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        const toolPanel = getToolPanel(gridApi);
+        const primaryColsPanel = toolPanel.primaryColsPanel as any;
+        const primaryColsListPanel = primaryColsPanel.primaryColsListPanel as any;
+        const toolPanelParams = toolPanel.params as any;
+        const listParams = primaryColsListPanel.params as any;
+
+        const firstLeafComp = createFirstLeafComp(primaryColsListPanel);
+
+        const leafParams = firstLeafComp.params as any;
+        const deferredVisibilityUpdate = toolPanelParams.onDeferredVisibilityColumnStateUpdate;
+
+        expect(typeof deferredVisibilityUpdate).toBe('function');
+        expect(listParams).toBe(toolPanelParams);
+        expect(leafParams).toBe(toolPanelParams);
+        expect(listParams.onDeferredVisibilityColumnStateUpdate).toBe(deferredVisibilityUpdate);
+        expect(leafParams.onDeferredVisibilityColumnStateUpdate).toBe(deferredVisibilityUpdate);
+
+        deferredVisibilityUpdate([{ colId: 'athlete', hide: true }]);
+        await asyncSetTimeout(1);
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+
+        leafParams.onDeferredVisibilityColumnStateUpdate([{ colId: 'athlete', hide: false }]);
+        await asyncSetTimeout(1);
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
         expect(getButtons(gridApi).applyButton.disabled).toBe(true);
     });
 
@@ -627,48 +673,37 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         expect(getButtons(gridApi).applyButton.disabled).toBe(true);
     });
 
-    test('clicking remove on a value pill updates deferred UI only until Apply', async () => {
-        const gridApi = gridMgr.createGrid('myGrid', {
+    test('removing deferred value column does not mutate grid until Apply', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
             columnDefs,
             rowData,
             sideBar,
-            pivotMode: true,
+            pivotMode: false,
         });
-        await asyncSetTimeout(1);
-
-        gridApi.setValueColumns(['athlete']);
-        await asyncSetTimeout(1);
 
         const toolPanel = getToolPanel(gridApi);
-        const valuesDropZonePanel = toolPanel.valuesDropZonePanel as any;
-        const valuesGui = valuesDropZonePanel?.getGui?.() as HTMLElement | undefined;
-        if (!valuesGui) {
-            throw new Error('Expected values drop zone panel to exist');
+        const athleteCol = gridApi.getColumn('athlete');
+        if (!athleteCol) {
+            throw new Error('Expected athlete column to exist');
         }
 
-        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['athlete']);
-        if (valuesGui.querySelectorAll('.ag-column-drop-cell').length === 0) {
-            const athleteCol = gridApi.getColumn('athlete');
-            if (!athleteCol) {
-                throw new Error('Expected athlete column to exist');
-            }
-            valuesDropZonePanel.addItem(athleteCol);
-            await asyncSetTimeout(1);
-        }
-        expect(valuesGui.querySelectorAll('.ag-column-drop-cell').length).toBe(1);
-        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual([]);
+        toolPanel.onDeferredValueColumnsUpdate([athleteCol]);
+        await asyncSetTimeout(1);
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual([]);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
 
-        const removeButton = valuesGui.querySelector('.ag-column-drop-cell-button') as HTMLElement | null;
-        if (!removeButton) {
-            throw new Error('Expected value pill remove button to exist');
-        }
-        removeButton.click();
+        toolPanel.onDeferredValueColumnsUpdate([]);
         await asyncSetTimeout(1);
 
-        // Deferred mode: pill is removed visually, but grid state is unchanged until Apply.
-        expect(valuesGui.querySelectorAll('.ag-column-drop-cell').length).toBe(0);
-        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['athlete']);
-        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+        // Removing the staged value column reverts pending state back to applied state.
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual([]);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+
+        getButtons(gridApi).applyButton.click();
+        await asyncSetTimeout(1);
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual([]);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
     });
 
     test('does not apply row group column reorder until Apply is clicked', async () => {

--- a/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
@@ -237,6 +237,41 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         expect(getButtons(gridApi).applyButton.disabled).toBe(true);
     });
 
+    test('does not apply row group column reorder until Apply is clicked', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        gridApi.setRowGroupColumns(['athlete', 'age']);
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual(['athlete', 'age']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+
+        const toolPanel = getToolPanel(gridApi);
+        const athleteCol = gridApi.getColumn('athlete');
+        const ageCol = gridApi.getColumn('age');
+        if (!athleteCol || !ageCol) {
+            throw new Error('Expected athlete and age columns to exist');
+        }
+
+        toolPanel.onDeferredRowGroupColumnsUpdate([ageCol, athleteCol]);
+        await asyncSetTimeout(1);
+
+        // Reorder is staged only while deferred mode is dirty.
+        expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual(['athlete', 'age']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+
+        getButtons(gridApi).applyButton.click();
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual(['age', 'athlete']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+    });
+
     test('applies combined deferred pivot, visibility and aggregation changes together', async () => {
         const gridApi = await gridMgr.createGridAndWait('myGrid', {
             columnDefs,

--- a/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
@@ -65,13 +65,9 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
 
     const getToolPanel = (gridApi: GridApi): any => gridApi.getToolPanelInstance('columns') as any;
 
-    const setColumnSelectionFromToolPanel = (gridApi: GridApi, colId: string, selected: boolean): void => {
-        const toolPanel = gridApi.getToolPanelInstance('columns') as any;
-        const listPanel = toolPanel?.primaryColsPanel?.primaryColsListPanel as any;
-        const displayedColsList = listPanel?.getDisplayedColsList?.() as any[] | undefined;
-        const rowIndex = displayedColsList?.findIndex((item) => !item.group && item.column?.getColId?.() === colId);
-        const listItemComp = rowIndex != null && rowIndex >= 0 ? listPanel?.virtualList?.getComponentAt(rowIndex) : null;
-        listItemComp?.onSelectAllChanged?.(selected);
+    const setDeferredVisibilityFromToolPanel = (gridApi: GridApi, colId: string, visible: boolean): void => {
+        const toolPanel = getToolPanel(gridApi);
+        toolPanel.onDeferredVisibilityColumnStateUpdate([{ colId, hide: !visible }]);
     };
 
     test('does not apply pivot mode until Apply is clicked', async () => {
@@ -119,7 +115,7 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         await asyncSetTimeout(1);
 
         expect(gridApi.isPivotMode()).toBe(false);
-        expect(applyButton.disabled).toBe(true);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
     });
 
     test('does not apply column visibility change until Apply is clicked', async () => {
@@ -134,11 +130,11 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
         expect(applyButton.disabled).toBe(true);
 
-        setColumnSelectionFromToolPanel(gridApi, 'athlete', false);
+        setDeferredVisibilityFromToolPanel(gridApi, 'athlete', false);
         await asyncSetTimeout(1);
 
         expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
-        expect(applyButton.disabled).toBe(false);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
 
         applyButton.click();
         await asyncSetTimeout(1);
@@ -159,17 +155,17 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
         expect(applyButton.disabled).toBe(true);
 
-        setColumnSelectionFromToolPanel(gridApi, 'athlete', false);
+        setDeferredVisibilityFromToolPanel(gridApi, 'athlete', false);
         await asyncSetTimeout(1);
 
         expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
-        expect(applyButton.disabled).toBe(false);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
 
         cancelButton.click();
         await asyncSetTimeout(1);
 
         expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
-        expect(applyButton.disabled).toBe(true);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
     });
 
     test('does not apply value aggregation function change until Apply is clicked', async () => {
@@ -222,6 +218,6 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         await asyncSetTimeout(1);
 
         expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual([]);
-        expect(applyButton.disabled).toBe(true);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
     });
 });

--- a/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
@@ -1,0 +1,113 @@
+import type { ColDef, GridApi, SideBarDef } from 'ag-grid-community';
+import { getGridElement } from 'ag-grid-community';
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+
+describe('Columns Tool Panel Deferred Apply Mode', () => {
+    const gridMgr = new TestGridsManager({
+        modules: [AllEnterpriseModule],
+    });
+
+    const columnDefs: ColDef[] = [
+        { field: 'athlete', enablePivot: true, enableRowGroup: true, enableValue: true },
+        { field: 'age', enablePivot: true, enableRowGroup: true, enableValue: true },
+        { field: 'country', enablePivot: true, enableRowGroup: true, enableValue: true },
+    ];
+
+    const rowData = [
+        { athlete: 'Athlete A', age: 20, country: 'UK' },
+        { athlete: 'Athlete B', age: 21, country: 'USA' },
+    ];
+
+    const sideBar: SideBarDef = {
+        toolPanels: [
+            {
+                id: 'columns',
+                labelDefault: 'Columns',
+                labelKey: 'columns',
+                iconKey: 'columnsToolPanel',
+                toolPanel: 'agColumnsToolPanel',
+                toolPanelParams: {
+                    deferApply: true,
+                    buttons: ['apply', 'cancel'],
+                },
+            },
+        ],
+        defaultToolPanel: 'columns',
+    };
+
+    afterEach(() => {
+        gridMgr.reset();
+        vi.resetAllMocks();
+        vi.clearAllMocks();
+    });
+
+    const getButtons = (gridApi: GridApi): { applyButton: HTMLButtonElement; cancelButton: HTMLButtonElement } => {
+        const gridDiv = getGridElement(gridApi)! as HTMLElement;
+        const buttons = Array.from(gridDiv.querySelectorAll('button.ag-column-panel-buttons-button'));
+        const applyButton = buttons.find((button) => button.classList.contains('ag-column-panel-buttons-apply-button'));
+        const cancelButton = buttons.find((button) => !button.classList.contains('ag-column-panel-buttons-apply-button'));
+
+        if (!applyButton || !cancelButton) {
+            throw new Error('Expected Apply and Cancel buttons to be rendered in the column tool panel');
+        }
+
+        return { applyButton: applyButton as HTMLButtonElement, cancelButton: cancelButton as HTMLButtonElement };
+    };
+
+    const togglePivotModeFromToolPanel = (gridApi: GridApi): void => {
+        const toolPanel = gridApi.getToolPanelInstance('columns') as any;
+        const pivotModePanel = toolPanel?.pivotModePanel as any;
+        const toggle = pivotModePanel?.cbPivotMode as any;
+        toggle?.toggle();
+    };
+
+    test('does not apply pivot mode until Apply is clicked', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        const { applyButton } = getButtons(gridApi);
+        expect(applyButton.disabled).toBe(true);
+
+        togglePivotModeFromToolPanel(gridApi);
+        await asyncSetTimeout(1);
+
+        expect(gridApi.isPivotMode()).toBe(false);
+        expect(applyButton.disabled).toBe(false);
+
+        applyButton.click();
+        await asyncSetTimeout(1);
+
+        expect(gridApi.isPivotMode()).toBe(true);
+        expect(applyButton.disabled).toBe(true);
+    });
+
+    test('discards deferred pivot mode change when Cancel is clicked', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        const { applyButton, cancelButton } = getButtons(gridApi);
+        expect(applyButton.disabled).toBe(true);
+
+        togglePivotModeFromToolPanel(gridApi);
+        await asyncSetTimeout(1);
+
+        expect(gridApi.isPivotMode()).toBe(false);
+        expect(applyButton.disabled).toBe(false);
+
+        cancelButton.click();
+        await asyncSetTimeout(1);
+
+        expect(gridApi.isPivotMode()).toBe(false);
+        expect(applyButton.disabled).toBe(true);
+    });
+});

--- a/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
@@ -414,6 +414,45 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         expect(getButtons(gridApi).applyButton.disabled).toBe(true);
     });
 
+    test('applies deferred dragged column move order only when Apply is clicked', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        const getColumnOrder = () => gridApi.getAllDisplayedColumns().slice(0, 3).map((col) => col.getColId());
+        expect(getColumnOrder()).toEqual(['athlete', 'age', 'country']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+
+        const toolPanel = getToolPanel(gridApi);
+        const primaryColsPanel = toolPanel.primaryColsPanel as any;
+        const primaryColsListPanel = primaryColsPanel.primaryColsListPanel as any;
+        const athleteCol = gridApi.getColumn('athlete');
+        const ageCol = gridApi.getColumn('age');
+        if (!athleteCol || !ageCol) {
+            throw new Error('Expected athlete and age columns to exist');
+        }
+
+        // Simulate drag-move hover state used by the virtual-list drag path: move athlete below age.
+        primaryColsListPanel.stageDeferredColumnMove([athleteCol], {
+            component: { column: ageCol },
+            position: 'bottom',
+            rowIndex: 1,
+        });
+        await asyncSetTimeout(1);
+
+        expect(getColumnOrder()).toEqual(['athlete', 'age', 'country']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+
+        getButtons(gridApi).applyButton.click();
+        await asyncSetTimeout(1);
+
+        expect(getColumnOrder()).toEqual(['age', 'athlete', 'country']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+    });
+
     test('applies combined deferred pivot, visibility and aggregation changes together', async () => {
         const gridApi = await gridMgr.createGridAndWait('myGrid', {
             columnDefs,

--- a/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
@@ -956,7 +956,6 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
         expect(getButtons(gridApi).applyButton.disabled).toBe(true);
 
-        const toolPanel = getToolPanel(gridApi);
         togglePivotModeFromToolPanel(gridApi);
         setDeferredVisibilityFromToolPanel(gridApi, 'athlete', false);
         await asyncSetTimeout(1);

--- a/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
@@ -63,6 +63,8 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         toggle?.toggle();
     };
 
+    const getToolPanel = (gridApi: GridApi): any => gridApi.getToolPanelInstance('columns') as any;
+
     const setColumnSelectionFromToolPanel = (gridApi: GridApi, colId: string, selected: boolean): void => {
         const toolPanel = gridApi.getToolPanelInstance('columns') as any;
         const listPanel = toolPanel?.primaryColsPanel?.primaryColsListPanel as any;
@@ -167,6 +169,59 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         await asyncSetTimeout(1);
 
         expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
+        expect(applyButton.disabled).toBe(true);
+    });
+
+    test('does not apply value aggregation function change until Apply is clicked', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        const { applyButton } = getButtons(gridApi);
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual([]);
+        expect(applyButton.disabled).toBe(true);
+
+        const toolPanel = getToolPanel(gridApi);
+        toolPanel.onDeferredValueColumnAggFuncUpdate(gridApi.getColumn('age'), 'sum');
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual([]);
+        expect(applyButton.disabled).toBe(false);
+
+        applyButton.click();
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['age']);
+        expect(gridApi.getColumn('age')!.getAggFunc()).toBe('sum');
+        expect(applyButton.disabled).toBe(true);
+    });
+
+    test('discards deferred value aggregation function change when Cancel is clicked', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        const { applyButton, cancelButton } = getButtons(gridApi);
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual([]);
+        expect(applyButton.disabled).toBe(true);
+
+        const toolPanel = getToolPanel(gridApi);
+        toolPanel.onDeferredValueColumnAggFuncUpdate(gridApi.getColumn('age'), 'sum');
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual([]);
+        expect(applyButton.disabled).toBe(false);
+
+        cancelButton.click();
+        await asyncSetTimeout(1);
+
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual([]);
         expect(applyButton.disabled).toBe(true);
     });
 });

--- a/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
@@ -2,6 +2,7 @@ import type { ColDef, GridApi, SideBarDef } from 'ag-grid-community';
 import { getGridElement } from 'ag-grid-community';
 import { AllEnterpriseModule } from 'ag-grid-enterprise';
 
+import { moveItem } from '../../../../packages/ag-grid-enterprise/src/columnToolPanel/columnMoveUtils';
 import { TestGridsManager, asyncSetTimeout } from '../test-utils';
 
 describe('Columns Tool Panel Deferred Apply Mode', () => {
@@ -368,53 +369,7 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         expect(getButtons(gridApi).applyButton.disabled).toBe(true);
     });
 
-    test('applies deferred column move order only when Apply is clicked', async () => {
-        const gridApi = await gridMgr.createGridAndWait('myGrid', {
-            columnDefs,
-            rowData,
-            sideBar,
-            pivotMode: false,
-        });
-
-        const getColumnOrder = () => gridApi.getAllDisplayedColumns().slice(0, 3).map((col) => col.getColId());
-        expect(getColumnOrder()).toEqual(['athlete', 'age', 'country']);
-        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
-
-        const toolPanel = getToolPanel(gridApi);
-        const primaryColsPanel = toolPanel.primaryColsPanel as any;
-        const primaryColsListPanel = primaryColsPanel.primaryColsListPanel as any;
-        const athleteCol = gridApi.getColumn('athlete');
-        if (!athleteCol) {
-            throw new Error('Expected athlete column to exist');
-        }
-
-        // Move athlete below age through the CTP list move path.
-        const athleteItem = primaryColsListPanel.displayedColsList.find(
-            (item: any) => !item.group && item.column.getColId() === 'athlete'
-        );
-        if (!athleteItem) {
-            throw new Error('Expected athlete model item in displayedColsList');
-        }
-        primaryColsListPanel.moveItems(
-            {
-                modelItem: athleteItem,
-                columnDepth: athleteItem.depth,
-            } as any,
-            false
-        );
-        await asyncSetTimeout(1);
-
-        expect(getColumnOrder()).toEqual(['athlete', 'age', 'country']);
-        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
-
-        getButtons(gridApi).applyButton.click();
-        await asyncSetTimeout(1);
-
-        expect(getColumnOrder()).toEqual(['age', 'athlete', 'country']);
-        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
-    });
-
-    test('applies deferred dragged column move order only when Apply is clicked', async () => {
+    test('column move order applies synchronously and is preserved after Apply', async () => {
         const gridApi = await gridMgr.createGridAndWait('myGrid', {
             columnDefs,
             rowData,
@@ -435,16 +390,17 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
             throw new Error('Expected athlete and age columns to exist');
         }
 
-        // Simulate drag-move hover state used by the virtual-list drag path: move athlete below age.
-        primaryColsListPanel.stageDeferredColumnMove([athleteCol], {
-            component: { column: ageCol },
+        // Move athlete below age through the same move utility used by the CTP.
+        moveItem(primaryColsListPanel.beans, [athleteCol], {
+            component: { column: ageCol } as any,
             position: 'bottom',
             rowIndex: 1,
         });
         await asyncSetTimeout(1);
 
-        expect(getColumnOrder()).toEqual(['athlete', 'age', 'country']);
-        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+        // Reordering is synchronous: order changes immediately and does not create pending changes.
+        expect(getColumnOrder()).toEqual(['age', 'athlete', 'country']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
 
         getButtons(gridApi).applyButton.click();
         await asyncSetTimeout(1);

--- a/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
@@ -214,6 +214,72 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         expect(getButtons(gridApi).applyButton.disabled).toBe(false);
     });
 
+    test('default checkbox state follows current grid visibility state', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [
+                { field: 'athlete', enablePivot: true, enableRowGroup: true, enableValue: true },
+                { field: 'age', hide: true, enablePivot: true, enableRowGroup: true, enableValue: true },
+                { field: 'country', enablePivot: true, enableRowGroup: true, enableValue: true },
+            ],
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        const toolPanel = getToolPanel(gridApi);
+        const isCheckedInToolPanel = toolPanel.isColumnCheckedInToolPanel.bind(toolPanel) as (
+            column: any,
+            pivotMode: boolean
+        ) => boolean;
+
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
+        expect(gridApi.getColumn('age')!.isVisible()).toBe(false);
+        expect(gridApi.getColumn('country')!.isVisible()).toBe(true);
+
+        expect(isCheckedInToolPanel(gridApi.getColumn('athlete'), false)).toBe(true);
+        expect(isCheckedInToolPanel(gridApi.getColumn('age'), false)).toBe(false);
+        expect(isCheckedInToolPanel(gridApi.getColumn('country'), false)).toBe(true);
+    });
+
+    test('clicking select all checks all column checkboxes in deferred mode', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        const toolPanel = getToolPanel(gridApi);
+        const primaryColsPanel = toolPanel.primaryColsPanel as any;
+        const primaryColsListPanel = primaryColsPanel.primaryColsListPanel as any;
+        const primaryColsHeaderPanel = primaryColsPanel.primaryColsHeaderPanel as any;
+
+        const getRenderedSelectionStates = (): boolean[] => {
+            const states: boolean[] = [];
+            primaryColsListPanel.virtualList.forEachRenderedRow((comp: any) => {
+                if (!comp.modelItem?.group) {
+                    states.push(!!comp.isSelected());
+                }
+            });
+            return states;
+        };
+
+        primaryColsListPanel.doSetSelectedAll(false);
+        await asyncSetTimeout(1);
+
+        expect(getRenderedSelectionStates().every((selected) => !selected)).toBe(true);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+
+        primaryColsHeaderPanel.eSelect.getInputElement().click();
+        await asyncSetTimeout(1);
+
+        expect(getRenderedSelectionStates().every((selected) => selected)).toBe(true);
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
+        expect(gridApi.getColumn('age')!.isVisible()).toBe(true);
+        expect(gridApi.getColumn('country')!.isVisible()).toBe(true);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+    });
+
     test('does not apply value aggregation function change until Apply is clicked', async () => {
         const gridApi = await gridMgr.createGridAndWait('myGrid', {
             columnDefs,
@@ -299,6 +365,52 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         await asyncSetTimeout(1);
 
         expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual(['age', 'athlete']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+    });
+
+    test('applies deferred column move order only when Apply is clicked', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        const getColumnOrder = () => gridApi.getAllDisplayedColumns().slice(0, 3).map((col) => col.getColId());
+        expect(getColumnOrder()).toEqual(['athlete', 'age', 'country']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+
+        const toolPanel = getToolPanel(gridApi);
+        const primaryColsPanel = toolPanel.primaryColsPanel as any;
+        const primaryColsListPanel = primaryColsPanel.primaryColsListPanel as any;
+        const athleteCol = gridApi.getColumn('athlete');
+        if (!athleteCol) {
+            throw new Error('Expected athlete column to exist');
+        }
+
+        // Move athlete below age through the CTP list move path.
+        const athleteItem = primaryColsListPanel.displayedColsList.find(
+            (item: any) => !item.group && item.column.getColId() === 'athlete'
+        );
+        if (!athleteItem) {
+            throw new Error('Expected athlete model item in displayedColsList');
+        }
+        primaryColsListPanel.moveItems(
+            {
+                modelItem: athleteItem,
+                columnDepth: athleteItem.depth,
+            } as any,
+            false
+        );
+        await asyncSetTimeout(1);
+
+        expect(getColumnOrder()).toEqual(['athlete', 'age', 'country']);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+
+        getButtons(gridApi).applyButton.click();
+        await asyncSetTimeout(1);
+
+        expect(getColumnOrder()).toEqual(['age', 'athlete', 'country']);
         expect(getButtons(gridApi).applyButton.disabled).toBe(true);
     });
 

--- a/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-apply-mode.test.ts
@@ -70,6 +70,22 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         toolPanel.onDeferredVisibilityColumnStateUpdate([{ colId, hide: !visible }]);
     };
 
+    const stageComboChangesFromToolPanel = (gridApi: GridApi): void => {
+        const toolPanel = getToolPanel(gridApi);
+        const countryCol = gridApi.getColumn('country');
+        const athleteCol = gridApi.getColumn('athlete');
+        const ageCol = gridApi.getColumn('age');
+        if (!countryCol || !athleteCol || !ageCol) {
+            throw new Error('Expected country, athlete and age columns to exist');
+        }
+        togglePivotModeFromToolPanel(gridApi);
+        toolPanel.onDeferredRowGroupColumnsUpdate([countryCol]);
+        toolPanel.onDeferredPivotColumnsUpdate([athleteCol]);
+        toolPanel.onDeferredValueColumnsUpdate([ageCol]);
+        toolPanel.onDeferredValueColumnAggFuncUpdate(ageCol, 'sum');
+        setDeferredVisibilityFromToolPanel(gridApi, 'athlete', false);
+    };
+
     test('does not apply pivot mode until Apply is clicked', async () => {
         const gridApi = await gridMgr.createGridAndWait('myGrid', {
             columnDefs,
@@ -217,6 +233,67 @@ describe('Columns Tool Panel Deferred Apply Mode', () => {
         cancelButton.click();
         await asyncSetTimeout(1);
 
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual([]);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+    });
+
+    test('applies combined deferred pivot, visibility and aggregation changes together', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        expect(gridApi.isPivotMode()).toBe(false);
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
+        expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual([]);
+        expect(gridApi.getPivotColumns().map((col) => col.getColId())).toEqual([]);
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual([]);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+
+        stageComboChangesFromToolPanel(gridApi);
+        await asyncSetTimeout(1);
+
+        // Staged only, nothing applied yet
+        expect(gridApi.isPivotMode()).toBe(false);
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
+        expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual([]);
+        expect(gridApi.getPivotColumns().map((col) => col.getColId())).toEqual([]);
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual([]);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+
+        getButtons(gridApi).applyButton.click();
+        await asyncSetTimeout(1);
+
+        expect(gridApi.isPivotMode()).toBe(true);
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(false);
+        expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual(['country']);
+        expect(gridApi.getPivotColumns().map((col) => col.getColId())).toEqual(['athlete']);
+        expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual(['age']);
+        expect(gridApi.getColumn('age')!.getAggFunc()).toBe('sum');
+        expect(getButtons(gridApi).applyButton.disabled).toBe(true);
+    });
+
+    test('cancels combined deferred pivot, visibility and aggregation changes together', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar,
+            pivotMode: false,
+        });
+
+        stageComboChangesFromToolPanel(gridApi);
+        await asyncSetTimeout(1);
+        expect(getButtons(gridApi).applyButton.disabled).toBe(false);
+
+        getButtons(gridApi).cancelButton.click();
+        await asyncSetTimeout(1);
+
+        expect(gridApi.isPivotMode()).toBe(false);
+        expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
+        expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual([]);
+        expect(gridApi.getPivotColumns().map((col) => col.getColId())).toEqual([]);
         expect(gridApi.getValueColumns().map((col) => col.getColId())).toEqual([]);
         expect(getButtons(gridApi).applyButton.disabled).toBe(true);
     });


### PR DESCRIPTION
 This PR introduces Deferred Apply Mode for the Columns Tool Panel.
  With `toolPanelParams.deferApply = true`, tool panel interactions no longer mutate grid column state immediately. Instead, changes are staged in a dedicated deferred state model and only committed on `Apply` (or discarded on `Cancel`).

  ### Architecture Overview

  - Added a deferred state layer (`ColumnToolPanelDeferredService`) that tracks:
      - the current applied grid state
      - the pending patch produced by tool panel interactions
  - Tool panel UI components (checkboxes, drop zones, context menu, pivot mode toggle) are wired to read/write pending state when deferred mode is enabled.
  - Existing immediate-apply flows remain unchanged; deferred behavior is opt-in via `deferApply`.
  - On `Apply`, pending state is materialized into a single column-state application path.
  - On `Cancel`, pending state is dropped and the panel is rebuilt from applied state.
  - Deferred state is also synchronized with external grid events so staged edits remain coherent if column state changes outside the panel.

  ### Staged Changes Covered

  When deferred mode is enabled, pending state includes:

  - Pivot mode toggling
  - Column visibility selection
  - Row Group / Pivot / Values assignments
  - Value column ordering
  - Aggregation function changes

  Fixes [AG-3471](https://ag-grid.atlassian.net/browse/AG-3471).