### PR TITLE
AG-16819 fix(filter): prevent character duplication in IME on blur/tab

### DIFF
--- a/packages/ag-grid-community/src/agStack/widgets/agAbstractInputField.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agAbstractInputField.ts
@@ -67,7 +67,7 @@ export abstract class AgAbstractInputField<
 
     public override postConstruct() {
         super.postConstruct();
-        this.setInputType(this.inputType!);
+        this.setInputType(this.inputType ?? 'text');
 
         const { eLabel, eWrapper, eInput, className } = this;
         eLabel.classList.add(`${className}-label`);
@@ -95,10 +95,47 @@ export abstract class AgAbstractInputField<
         this.activateTabIndex([eInput], tabIndex);
     }
 
+    /**
+     * Registers input and IME composition listeners.
+     * Handles a browser quirk: after compositionend, some IMEs fire an input event
+     * that duplicates the committed character. We capture the correct value at
+     * compositionend and correct the DOM on the following input event if needed.
+     */
     protected addInputListeners() {
+        let valueAtCompositionEnd: string | null = null;
+
         this.addManagedElementListeners(this.eInput, {
-            input: (e: InputEvent) => this.setValue((e.target as HTMLInputElement).value as TValue),
+            compositionstart: () => {
+                valueAtCompositionEnd = null;
+            },
+            compositionend: () => {
+                valueAtCompositionEnd = (this.eInput as HTMLInputElement).value;
+                this.setValue(valueAtCompositionEnd as TValue);
+            },
+            input: (e: InputEvent) => {
+                if (e.isComposing) {
+                    return;
+                }
+
+                if (valueAtCompositionEnd !== null) {
+                    this.reconcileValueAfterComposition(e.target as HTMLInputElement, valueAtCompositionEnd);
+                    valueAtCompositionEnd = null;
+                    return;
+                }
+
+                this.setValue((e.target as HTMLInputElement).value as TValue);
+            },
         });
+    }
+
+    /**
+     * Corrects DOM if the browser duplicated the committed character in the input
+     * event that follows compositionend. Internal state was already set in compositionend.
+     */
+    private reconcileValueAfterComposition(inputEl: HTMLInputElement, correctValue: string): void {
+        if (inputEl.value !== correctValue) {
+            inputEl.value = correctValue;
+        }
     }
 
     public setInputType(inputType?: string) {

--- a/packages/ag-grid-community/src/filter/floating/provided/floatingFilterTextInputService.ts
+++ b/packages/ag-grid-community/src/filter/floating/provided/floatingFilterTextInputService.ts
@@ -14,17 +14,44 @@ export class FloatingFilterTextInputService extends BeanStub implements Floating
         super();
     }
 
+    /**
+     * Sets up the text input and IME-aware value change listeners.
+     * During composition we suppress sync so the parent filter is not updated
+     * with intermediate text. We trigger sync once on compositionend and ignore
+     * the immediately following input event to avoid double application.
+     */
     public setupGui(parentElement: HTMLElement): void {
         this.eInput = this.createManagedBean(new AgInputTextField(this.params?.config));
-
         const eInput = this.eInput.getGui();
-
         parentElement.appendChild(eInput);
 
-        const listener = (e: KeyboardEvent) => this.onValueChanged(e);
-        this.addManagedListeners(eInput, {
-            input: listener,
-            keydown: listener,
+        let isComposing = false;
+        let skipNextInputEvent = false;
+
+        const handleValueChange = (e: KeyboardEvent | InputEvent) => {
+            if (isComposing) {
+                return;
+            }
+            if (skipNextInputEvent && e.type === 'input') {
+                skipNextInputEvent = false;
+                return;
+            }
+            skipNextInputEvent = false;
+            this.onValueChanged(e as KeyboardEvent);
+        };
+
+        this.addManagedElementListeners(eInput, {
+            compositionstart: () => {
+                isComposing = true;
+                skipNextInputEvent = false;
+            },
+            compositionend: (e: CompositionEvent) => {
+                isComposing = false;
+                skipNextInputEvent = true;
+                this.onValueChanged(e as unknown as KeyboardEvent);
+            },
+            input: handleValueChange,
+            keydown: handleValueChange,
         });
     }
 


### PR DESCRIPTION
## Description

### 🤔 This is a ...
- [x] 🐞 Bug fix

### 🔗 Related Issues
fix #13151

### 💡 Background and Solution

#### **Demos for Review**
**Bug Reproduction:** [Issue #13151](https://github.com/ag-grid/ag-grid/issues/13151) (Video attached in issue)

**Fixed Behavior (After Patch):**

https://github.com/user-attachments/assets/d4115653-edf3-4856-ba60-8b69270364d4

#### **1. The Problem: Character Duplication on Focus Loss**
When using a **Text Floating Filter** with Korean IME (and other composition-based IMEs), typing a character and then immediately pressing `Tab` or clicking outside (triggering a `blur`) causes the character to be duplicated (e.g., "가" becomes "가가").

#### **2. Root Cause Analysis**
The issue is caused by a race condition in **Chromium-based browsers**:
- **IME Buffer Flush:** On a `blur` or `tab` event, the browser fires `compositionend` followed by a final `input` event to flush the IME buffer.
- **Redundant Commits:** The previous implementation did not distinguish this final `input` from normal typing. It applied the value from `compositionend` and then applied the subsequent "ghost" `input` event as well, leading to duplication in the internal state (and sometimes in the DOM).

#### **3. The Solution: Composition Guard & Reconciliation**
I implemented a **Composition-Aware input management** strategy:

- **State Tracking:** In `agAbstractInputField`, the value at composition end is stored in a closure variable (`valueAtCompositionEnd`), and the native `e.isComposing` flag is used in the `input` handler to detect when the user is still composing. This identifies the "just finished composition" window so we can treat the next `input` differently.
- **Value Locking:** Internal `setValue` is not called while `e.isComposing` is true. The value is committed once in the `compositionend` handler so the IME buffer is not double-applied.
- **Manual Reconciliation:** On the `input` event that immediately follows `compositionend`, the logic does not call `setValue` again. Instead, it reconciles the DOM with the value already saved at `compositionend` (via `reconcileValueAfterComposition`) to undo any character duplication the browser may have written.
- **Service Sync:** In `floatingFilterTextInputService`, `isComposing` and `skipNextInputEvent` ensure that the parent filter is notified only once when the IME lifecycle is complete (on `compositionend`), and the following ghost `input` event is ignored.

### 🛠 What changed

| File | Change Description |
| --- | --- |
| `agAbstractInputField.ts` | Added composition-aware input handling: store value at `compositionend`, guard `input` with `e.isComposing`, and on the next `input` reconcile the DOM (no second `setValue`) to prevent duplicate commits on blur/tab. |
| `floatingFilterTextInputService.ts` | Added IME lifecycle handling: sync to the parent filter once on `compositionend` and skip the immediately following `input` event so value synchronization occurs only after IME finalization. |
