### PR TITLE
AG-16776 Document keyboard navigation for column moving and resizing

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/column-moving/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-moving/index.mdoc
@@ -5,13 +5,8 @@ title: "Column Moving"
 Columns can be moved in the grid in the following ways:
 
 -   Dragging the column header with the mouse or through touch.
--   Using the grid API.
-
-## API
-
-The grid API methods for moving columns are as follows:
-
-{% apiDocumentation source="grid-api/api.json" section="columnMoving" names=["moveColumns", "moveColumnByIndex"] /%}
+-   Using the [keyboard](#keyboard-navigation) to move focused column headers.
+-   Using the [grid API](#api).
 
 ## Simple Example
 
@@ -21,9 +16,22 @@ The example below demonstrates simple moving via mouse dragging and the API. The
 -   The **Medals First** and **Medals Last** buttons call the API `moveColumns(keys, toIndex)` to place the medals columns at the start or at the end respectively.
 -   The **Country First** button calls the API `moveColumns([key], toIndex)` to place the Country column first.
 -   The **Swap First Two** button calls the API `moveColumnByIndex(fromIndex, toIndex)` to swap the first two columns.
+-   Focusing a column header and pressing {% kbd "⇧ Shift" /%} + {% kbd "←" /%} / {% kbd "→" /%} moves the column in that direction.
 -   The **Print Columns** button calls the API `getAllGridColumns()` to print to the dev console the current column order.
 
 {% gridExampleRunner title="Column Moving Simple" name="moving-simple" /%}
+
+## Move via Keyboard
+
+Column headers can be moved using the keyboard. When a column header is focused, press {% kbd "⇧ Shift" /%} + {% kbd "←" /%} / {% kbd "→" /%} to move the column in that direction. The grid will automatically scroll to keep the moved column visible.
+
+See [Column Header Navigation](./keyboard-navigation/#column-header-navigation) for a full list of header keyboard interactions.
+
+## Move via API
+
+The grid API methods for moving columns are as follows:
+
+{% apiDocumentation source="grid-api/api.json" section="columnMoving" names=["moveColumns", "moveColumnByIndex"] /%}
 
 ## Moving Animation
 

--- a/documentation/ag-grid-docs/src/content/docs/column-moving/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-moving/index.mdoc
@@ -5,8 +5,8 @@ title: "Column Moving"
 Columns can be moved in the grid in the following ways:
 
 -   Dragging the column header with the mouse or through touch.
--   Using the [keyboard](#keyboard-navigation) to move focused column headers.
--   Using the [grid API](#api).
+-   Using the [keyboard](#move-via-keyboard) to move focused column headers.
+-   Using the [grid API](#move-via-api).
 
 ## Simple Example
 

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
@@ -3,7 +3,7 @@ title: "Column Sizing"
 description: "Column Sizing controls the way Columns are sized within the $framework Data Grid. Use auto-sizing or column-flex to control Column Size programmatically."
 ---
 
-All columns can be resized by dragging the top right portion of the column.
+Columns can be resized by dragging the right edge of the column header or by using the keyboard.
 
 ## Sizing
 
@@ -178,6 +178,12 @@ Just like Excel, each column can also be auto-resized by double clicking the rig
 -   Note that [Pinned Columns](./column-pinning), the [Selection Column](./row-selection-multi-row/#customising-the-checkbox-column) and the [Row Numbers](./row-numbers) column will not be scaled up to fill any empty space when using `scaleUpToFitGridWidth`.
 
 {% /note %}
+
+## Resize via Keyboard
+
+Column headers can be resized using the keyboard. When a column header is focused, press {% kbd "⌥ Alt" /%} + {% kbd "←" /%} / {% kbd "→" /%} to resize the column in that direction.
+
+See [Column Header Navigation](./keyboard-navigation/#column-header-navigation) for a full list of header keyboard interactions.
 
 ## Shift Resizing
 


### PR DESCRIPTION
Fix [AG-16776](https://ag-grid.atlassian.net/browse/AG-16776)

Adds keyboard navigation documentation to the column moving and column sizing docs pages:

- **Column Moving**: Updated intro to list three approaches (drag, keyboard, API). Added "Move via Keyboard" section documenting Shift + Arrow keys. Added keyboard bullet to the simple example.
- **Column Sizing**: Updated intro to mention keyboard resizing. Added "Resize via Keyboard" section documenting Alt + Arrow keys.

Both sections cross-link to the Column Header Navigation docs.