### PR TITLE
AG-4324 Restrict groupHideColumnsUntilExpanded to Client Side Row Model

### DIFF
--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
@@ -1424,7 +1424,7 @@ export class AgGridAngular<TData = any, TColDef extends ColDef<TData> = ColDef<a
     /** When using `groupDisplayType='multipleColumns'` or `groupHideOpenParents=true`, hides group columns for levels
      * that have not yet been expanded. Only the top-level group column is initially
      * visible; each subsequent level becomes visible when at least one group at the
-     * preceding level is expanded.
+     * preceding level is expanded. (Client Side Row Model only)
      * @default false
      * @agModule `RowGroupingModule`
      */

--- a/packages/ag-grid-community/src/entities/gridOptions.ts
+++ b/packages/ag-grid-community/src/entities/gridOptions.ts
@@ -1499,7 +1499,7 @@ export interface GridOptions<TData = any> {
      * When using `groupDisplayType='multipleColumns'` or `groupHideOpenParents=true`, hides group columns for levels
      * that have not yet been expanded. Only the top-level group column is initially
      * visible; each subsequent level becomes visible when at least one group at the
-     * preceding level is expanded.
+     * preceding level is expanded. (Client Side Row Model only)
      * @default false
      * @agModule `RowGroupingModule`
      */

--- a/packages/ag-grid-community/src/gridOptionsUtils.ts
+++ b/packages/ag-grid-community/src/gridOptionsUtils.ts
@@ -237,7 +237,7 @@ export function _isGroupMultiAutoColumn(gos: GridOptionsService) {
 }
 
 export function _isGroupHideColumnsUntilExpanded(gos: GridOptionsService) {
-    return _isGroupMultiAutoColumn(gos) && gos.get('groupHideColumnsUntilExpanded');
+    return _isGroupMultiAutoColumn(gos) && gos.get('groupHideColumnsUntilExpanded') && _isClientSideRowModel(gos);
 }
 
 export function _isGroupUseEntireRow(gos: GridOptionsService, pivotMode: boolean): boolean {

--- a/packages/ag-grid-vue3/src/components/utils.ts
+++ b/packages/ag-grid-vue3/src/components/utils.ts
@@ -1247,7 +1247,7 @@ export interface Props<TData> {
     /** When using `groupDisplayType='multipleColumns'` or `groupHideOpenParents=true`, hides group columns for levels
          * that have not yet been expanded. Only the top-level group column is initially
          * visible; each subsequent level becomes visible when at least one group at the
-         * preceding level is expanded.
+         * preceding level is expanded. (Client Side Row Model only)
          * @default false
          * @agModule `RowGroupingModule`
          */


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-4324

- Adds a `_isClientSideRowModel` guard to `_isGroupHideColumnsUntilExpanded` so the feature is a no-op on non-CSRM row models
- Updates JSDoc for `groupHideColumnsUntilExpanded` in `gridOptions.ts`, the Angular component, and the Vue 3 utils to note the Client Side Row Model restriction

Fix [AG-4324](https://ag-grid.atlassian.net/browse/AG-4324)