### PR TITLE
AG-16812 Fix sort type not preserved when restoring state via setState

### DIFF
--- a/packages/ag-grid-community/src/misc/state/stateService.ts
+++ b/packages/ag-grid-community/src/misc/state/stateService.ts
@@ -433,10 +433,11 @@ export class StateService extends BeanStub implements NamedBean {
 
         const shouldSetSortState = shouldSetState('sort', sortState);
         if (shouldSetSortState) {
-            sortState?.sortModel.forEach(({ colId, sort }, sortIndex) => {
+            sortState?.sortModel.forEach(({ colId, sort, type }, sortIndex) => {
                 const columnState = getColumnState(colId);
                 columnState.sort = sort;
                 columnState.sortIndex = sortIndex;
+                columnState.sortType = type;
             });
         }
         if (shouldSetSortState || !partialColumnState) {

--- a/testing/behavioural/src/grid-state/grid-state.test.ts
+++ b/testing/behavioural/src/grid-state/grid-state.test.ts
@@ -648,6 +648,55 @@ describe('StateService - Grid State Management', () => {
             expect(restoredState).toEqual(savedState);
         });
 
+        test('should preserve absolute sort type when restoring state via setState', async () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: defaultColumnDefs,
+                rowData: defaultRowData,
+            });
+
+            api.applyColumnState({
+                state: [{ colId: 'age', sort: 'asc', sortType: 'absolute' }],
+            });
+
+            const savedState = api.getState();
+            expect(savedState.sort?.sortModel).toEqual([{ colId: 'age', sort: 'asc', type: 'absolute' }]);
+
+            // Clear sort and restore from saved state
+            api.applyColumnState({ state: [{ colId: 'age', sort: null }] });
+            expect(api.getState().sort?.sortModel ?? []).toHaveLength(0);
+
+            api.setState(savedState);
+            await asyncSetTimeout(50);
+
+            expect(api.getState().sort?.sortModel).toEqual([{ colId: 'age', sort: 'asc', type: 'absolute' }]);
+        });
+
+        test('should clear absolute sort from a column not present in the restored sort state', async () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: defaultColumnDefs,
+                rowData: defaultRowData,
+            });
+
+            // Set absolute sort on 'age', default sort on 'name'
+            api.applyColumnState({
+                state: [
+                    { colId: 'age', sort: 'asc', sortType: 'absolute', sortIndex: 0 },
+                    { colId: 'name', sort: 'desc', sortIndex: 1 },
+                ],
+            });
+
+            expect(api.getState().sort?.sortModel).toEqual([
+                { colId: 'age', sort: 'asc', type: 'absolute' },
+                { colId: 'name', sort: 'desc', type: 'default' },
+            ]);
+
+            // Restore a state that only sorts 'name' — 'age' absolute sort should be cleared
+            api.setState({ sort: { sortModel: [{ colId: 'name', sort: 'asc', type: 'default' }] } });
+            await asyncSetTimeout(50);
+
+            expect(api.getState().sort?.sortModel).toEqual([{ colId: 'name', sort: 'asc', type: 'default' }]);
+        });
+
         test('should initialize grid with initial state', async () => {
             const initialState: GridState = {
                 sort: {


### PR DESCRIPTION
Fix [AG-16812](https://ag-grid.atlassian.net/browse/AG-16812)

When restoring grid state via `setState()`, the `type` field (`'absolute'` | `'default'`) from each `SortModelItem` was not being applied to the column state. The `sort` direction was correctly restored, but the absolute sort behaviour was silently dropped.

**Root cause:** In `stateService.ts`, the `forEach` destructured only `colId` and `sort` from each `SortModelItem`, ignoring `type`. The fix extracts `type` and assigns it to `columnState.sortType`.

**Tests added:**
- Restoring a saved state with an absolute-sorted column preserves `type: 'absolute'`
- Restoring a state that omits a previously-absolute-sorted column correctly clears that column's sort (proving `defaultState.sortType` not being `null` is not a separate bug)