### PR TITLE
AG-16788 Replace placeholder e2e tests for rich select examples

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-async/_examples/rich-select-async-values/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-async/_examples/rich-select-async-values/example.spec.ts
@@ -1,11 +1,57 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
+
+const languages = ['English', 'Spanish', 'French', 'Portuguese', '(other)'];
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('should load async values and display all options in dropdown', async ({ agIdFor, page }) => {
+        // Verify the first cell shows a valid language value
+        const cell = agIdFor.cell('0', 'language');
+        const cellText = await cell.textContent();
+        expect(languages).toContain(cellText);
+
+        // Double-click to open the rich select editor
+        await cell.dblclick();
+
+        // Wait for the popup to appear
+        const popup = page.locator('.ag-rich-select-list').first();
+        await expect(popup).toBeVisible();
+
+        // Wait for async values to load (1s server delay)
+        const options = popup.locator('.ag-rich-select-row');
+        await expect(options).toHaveCount(5, { timeout: 5000 });
+
+        // Verify all language options are present
+        for (const lang of languages) {
+            await expect(popup.locator('.ag-rich-select-row', { hasText: lang }).first()).toBeVisible();
+        }
+
+        await page.keyboard.press('Escape');
     });
+
+    test.eachFramework(
+        'should update cell value when selecting an option from the async dropdown',
+        async ({ agIdFor, page }) => {
+            const cell = agIdFor.cell('0', 'language');
+            const originalValue = await cell.textContent();
+
+            // Pick a different language
+            const newLanguage = languages.find((lang) => lang !== originalValue)!;
+
+            // Open the editor
+            await cell.dblclick();
+
+            const popup = page.locator('.ag-rich-select-list').first();
+            await expect(popup).toBeVisible();
+
+            // Wait for async options to load
+            await expect(popup.locator('.ag-rich-select-row')).toHaveCount(5, { timeout: 5000 });
+
+            // Select the new language
+            const option = popup.locator('.ag-rich-select-row', { hasText: newLanguage }).first();
+            await option.click();
+
+            // Verify the cell value updated
+            await expect(cell).toHaveText(newLanguage);
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-async/_examples/rich-select-full-async-values/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-async/_examples/rich-select-full-async-values/example.spec.ts
@@ -1,11 +1,73 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
+
+const languages = ['English', 'Spanish', 'French', 'Portuguese', '(other)'];
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('should open editor with a visible typing input', async ({ agIdFor, page }) => {
+        // Verify the first cell shows a valid language value
+        const cell = agIdFor.cell('0', 'language');
+        const cellText = await cell.textContent();
+        expect(languages).toContain(cellText);
+
+        // Double-click to open the rich select editor
+        await cell.dblclick();
+
+        // With filterListAsync + allowTyping, the text input is visible immediately
+        const editorInput = page.locator('.ag-rich-select-field-input .ag-input-field-input').first();
+        await expect(editorInput).toBeVisible();
+
+        await page.keyboard.press('Escape');
     });
+
+    test.eachFramework(
+        'should show filtered async results after typing a search term',
+        async ({ agIdFor, page }) => {
+            const cell = agIdFor.cell('0', 'language');
+
+            // Open editor
+            await cell.dblclick();
+
+            const editorInput = page.locator('.ag-rich-select-field-input .ag-input-field-input').first();
+            await expect(editorInput).toBeVisible();
+
+            // Fill with 'Sp' — only 'Spanish' matches the server-side filter
+            await editorInput.fill('Sp');
+
+            // Popup should appear once the async response resolves (debounce 300ms + server 1000ms)
+            const popup = page.locator('.ag-rich-select-list').first();
+            await expect(popup).toBeVisible({ timeout: 5000 });
+
+            // Only Spanish matches 'Sp'
+            await expect(popup.locator('.ag-rich-select-row')).toHaveCount(1, { timeout: 5000 });
+            await expect(popup.locator('.ag-rich-select-row', { hasText: 'Spanish' }).first()).toBeVisible();
+
+            await page.keyboard.press('Escape');
+        }
+    );
+
+    test.eachFramework(
+        'should update cell value when selecting from the async-filtered list',
+        async ({ agIdFor, page }) => {
+            const cell = agIdFor.cell('0', 'language');
+
+            // Open editor
+            await cell.dblclick();
+
+            const editorInput = page.locator('.ag-rich-select-field-input .ag-input-field-input').first();
+            await expect(editorInput).toBeVisible();
+
+            // Filter to 'English' specifically (exact match, returns only English)
+            await editorInput.fill('English');
+
+            const popup = page.locator('.ag-rich-select-list').first();
+            await expect(popup).toBeVisible({ timeout: 5000 });
+
+            // Click the English option
+            const option = popup.locator('.ag-rich-select-row', { hasText: 'English' }).first();
+            await option.click();
+
+            // Verify the cell updated
+            await expect(cell).toHaveText('English');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-async/_examples/rich-select-full-async-values/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-async/_examples/rich-select-full-async-values/example.spec.ts
@@ -19,31 +19,28 @@ test.agExample(import.meta, () => {
         await page.keyboard.press('Escape');
     });
 
-    test.eachFramework(
-        'should show filtered async results after typing a search term',
-        async ({ agIdFor, page }) => {
-            const cell = agIdFor.cell('0', 'language');
+    test.eachFramework('should show filtered async results after typing a search term', async ({ agIdFor, page }) => {
+        const cell = agIdFor.cell('0', 'language');
 
-            // Open editor
-            await cell.dblclick();
+        // Open editor
+        await cell.dblclick();
 
-            const editorInput = page.locator('.ag-rich-select-field-input .ag-input-field-input').first();
-            await expect(editorInput).toBeVisible();
+        const editorInput = page.locator('.ag-rich-select-field-input .ag-input-field-input').first();
+        await expect(editorInput).toBeVisible();
 
-            // Fill with 'Sp' — only 'Spanish' matches the server-side filter
-            await editorInput.fill('Sp');
+        // Fill with 'Sp' — only 'Spanish' matches the server-side filter
+        await editorInput.fill('Sp');
 
-            // Popup should appear once the async response resolves (debounce 300ms + server 1000ms)
-            const popup = page.locator('.ag-rich-select-list').first();
-            await expect(popup).toBeVisible({ timeout: 5000 });
+        // Popup should appear once the async response resolves (debounce 300ms + server 1000ms)
+        const popup = page.locator('.ag-rich-select-list').first();
+        await expect(popup).toBeVisible({ timeout: 5000 });
 
-            // Only Spanish matches 'Sp'
-            await expect(popup.locator('.ag-rich-select-row')).toHaveCount(1, { timeout: 5000 });
-            await expect(popup.locator('.ag-rich-select-row', { hasText: 'Spanish' }).first()).toBeVisible();
+        // Only Spanish matches 'Sp'
+        await expect(popup.locator('.ag-rich-select-row')).toHaveCount(1, { timeout: 5000 });
+        await expect(popup.locator('.ag-rich-select-row', { hasText: 'Spanish' }).first()).toBeVisible();
 
-            await page.keyboard.press('Escape');
-        }
-    );
+        await page.keyboard.press('Escape');
+    });
 
     test.eachFramework(
         'should update cell value when selecting from the async-filtered list',

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-async/_examples/rich-select-paged-async-filtering/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-async/_examples/rich-select-paged-async-filtering/example.spec.ts
@@ -1,11 +1,74 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('should open editor with a visible typing input', async ({ agIdFor, page }) => {
+        // Verify the first cell shows a language in the expected format
+        const cell = agIdFor.cell('0', 'language');
+        const cellText = await cell.textContent();
+        expect(cellText).toMatch(/^Language \d+$/);
+
+        // Double-click to open the rich select editor
+        await cell.dblclick();
+
+        // With filterListAsync + allowTyping, the text input is visible immediately
+        const editorInput = page.locator('.ag-rich-select-field-input .ag-input-field-input').first();
+        await expect(editorInput).toBeVisible();
+
+        await page.keyboard.press('Escape');
     });
+
+    test.eachFramework(
+        'should show filtered paged results after typing a search term',
+        async ({ agIdFor, page }) => {
+            const cell = agIdFor.cell('0', 'language');
+
+            // Open editor
+            await cell.dblclick();
+
+            const editorInput = page.locator('.ag-rich-select-field-input .ag-input-field-input').first();
+            await expect(editorInput).toBeVisible();
+
+            // Type '5000' — matches 'Language 5000' and 'Language 15000' in the 20,000-item dataset
+            await editorInput.fill('5000');
+
+            // Popup appears once the server responds (debounce 300ms + server 300ms)
+            const popup = page.locator('.ag-rich-select-list').first();
+            await expect(popup).toBeVisible({ timeout: 5000 });
+
+            // 'Language 5000' must be among the filtered results
+            await expect(popup.locator('.ag-rich-select-row', { hasText: 'Language 5000' }).first()).toBeVisible({
+                timeout: 5000,
+            });
+
+            await page.keyboard.press('Escape');
+        }
+    );
+
+    test.eachFramework(
+        'should update cell value when selecting from filtered paged results',
+        async ({ agIdFor, page }) => {
+            const cell = agIdFor.cell('0', 'language');
+
+            // Open editor
+            await cell.dblclick();
+
+            const editorInput = page.locator('.ag-rich-select-field-input .ag-input-field-input').first();
+            await expect(editorInput).toBeVisible();
+
+            // Fill with exact text 'Language 5000' — this is the only 20,000-item match
+            // ('Language 15000' does not contain 'Language 5000' as a substring)
+            await editorInput.fill('Language 5000');
+
+            // Wait for filtered results
+            const popup = page.locator('.ag-rich-select-list').first();
+            await expect(popup).toBeVisible({ timeout: 5000 });
+
+            const option = popup.locator('.ag-rich-select-row', { hasText: 'Language 5000' }).first();
+            await expect(option).toBeVisible({ timeout: 5000 });
+            await option.click();
+
+            // Verify the cell value updated
+            await expect(cell).toHaveText('Language 5000');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-async/_examples/rich-select-paged-async-filtering/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-async/_examples/rich-select-paged-async-filtering/example.spec.ts
@@ -17,32 +17,29 @@ test.agExample(import.meta, () => {
         await page.keyboard.press('Escape');
     });
 
-    test.eachFramework(
-        'should show filtered paged results after typing a search term',
-        async ({ agIdFor, page }) => {
-            const cell = agIdFor.cell('0', 'language');
+    test.eachFramework('should show filtered paged results after typing a search term', async ({ agIdFor, page }) => {
+        const cell = agIdFor.cell('0', 'language');
 
-            // Open editor
-            await cell.dblclick();
+        // Open editor
+        await cell.dblclick();
 
-            const editorInput = page.locator('.ag-rich-select-field-input .ag-input-field-input').first();
-            await expect(editorInput).toBeVisible();
+        const editorInput = page.locator('.ag-rich-select-field-input .ag-input-field-input').first();
+        await expect(editorInput).toBeVisible();
 
-            // Type '5000' — matches 'Language 5000' and 'Language 15000' in the 20,000-item dataset
-            await editorInput.fill('5000');
+        // Type '5000' — matches 'Language 5000' and 'Language 15000' in the 20,000-item dataset
+        await editorInput.fill('5000');
 
-            // Popup appears once the server responds (debounce 300ms + server 300ms)
-            const popup = page.locator('.ag-rich-select-list').first();
-            await expect(popup).toBeVisible({ timeout: 5000 });
+        // Popup appears once the server responds (debounce 300ms + server 300ms)
+        const popup = page.locator('.ag-rich-select-list').first();
+        await expect(popup).toBeVisible({ timeout: 5000 });
 
-            // 'Language 5000' must be among the filtered results
-            await expect(popup.locator('.ag-rich-select-row', { hasText: 'Language 5000' }).first()).toBeVisible({
-                timeout: 5000,
-            });
+        // 'Language 5000' must be among the filtered results
+        await expect(popup.locator('.ag-rich-select-row', { hasText: 'Language 5000' }).first()).toBeVisible({
+            timeout: 5000,
+        });
 
-            await page.keyboard.press('Escape');
-        }
-    );
+        await page.keyboard.press('Escape');
+    });
 
     test.eachFramework(
         'should update cell value when selecting from filtered paged results',

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-async/_examples/rich-select-paged-async-values/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-async/_examples/rich-select-paged-async-values/example.spec.ts
@@ -1,11 +1,54 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'should load first page of values and display languages in expected format',
+        async ({ agIdFor, page }) => {
+            // Verify the first cell shows a value in the expected format
+            const cell = agIdFor.cell('0', 'language');
+            const cellText = await cell.textContent();
+            expect(cellText).toMatch(/^Language \d+$/);
+
+            // Double-click to open the rich select editor
+            await cell.dblclick();
+
+            // Wait for the popup to appear
+            const popup = page.locator('.ag-rich-select-list').first();
+            await expect(popup).toBeVisible();
+
+            // Wait for the first page to load (300ms server delay)
+            const firstOption = popup.locator('.ag-rich-select-row').first();
+            await expect(firstOption).toBeVisible({ timeout: 5000 });
+
+            // Verify options follow the expected pattern
+            const firstOptionText = await firstOption.textContent();
+            expect(firstOptionText).toMatch(/^Language \d+$/);
+
+            await page.keyboard.press('Escape');
+        }
+    );
+
+    test.eachFramework(
+        'should update cell value when selecting an option from the paged dropdown',
+        async ({ agIdFor, page }) => {
+            const cell = agIdFor.cell('0', 'language');
+
+            // Open editor
+            await cell.dblclick();
+
+            const popup = page.locator('.ag-rich-select-list').first();
+            await expect(popup).toBeVisible();
+
+            // Wait for first page to load
+            const firstOption = popup.locator('.ag-rich-select-row').first();
+            await expect(firstOption).toBeVisible({ timeout: 5000 });
+
+            // Read the text of the first visible option (initial page position depends on current cell value)
+            const optionText = (await firstOption.textContent())!.trim();
+
+            // Click it and verify the cell updates to that value
+            await firstOption.click();
+            await expect(cell).toContainText(optionText);
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-async/_examples/rich-select-paged-async-values/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-async/_examples/rich-select-paged-async-values/example.spec.ts
@@ -29,6 +29,46 @@ test.agExample(import.meta, () => {
     );
 
     test.eachFramework(
+        'should load the next page of values when scrolling to the bottom of the dropdown',
+        async ({ agIdFor, page }) => {
+            const cell = agIdFor.cell('0', 'language');
+            await cell.dblclick();
+
+            const popup = page.locator('.ag-rich-select-list').first();
+            await expect(popup).toBeVisible();
+
+            // Scroll to the top so we start from a known position and wait for top items to load
+            await popup.evaluate((el) => {
+                el.scrollTop = 0;
+            });
+            await expect(popup.locator('.ag-rich-select-row').first()).toBeVisible({ timeout: 5000 });
+
+            // Record the language number of the last visible row at the top of the list
+            const lastVisibleRowBefore = popup.locator('.ag-rich-select-row').last();
+            const textBefore = (await lastVisibleRowBefore.textContent()) ?? '';
+            const numberBefore = parseInt(/Language (\d+)/.exec(textBefore)?.[1] ?? '0');
+            expect(numberBefore).toBeGreaterThan(0);
+
+            // Scroll to the bottom of the virtual list (represents all 20,000 items) to trigger
+            // next-page loading — the load threshold is 8 rows from the end of loaded data
+            await popup.evaluate((el) => {
+                el.scrollTop = el.scrollHeight;
+            });
+
+            // After scrolling, new pages are fetched from the server (300ms delay).
+            // The last visible row should now show a higher-numbered language than before.
+            await expect(async () => {
+                const lastVisibleRowAfter = popup.locator('.ag-rich-select-row').last();
+                const textAfter = (await lastVisibleRowAfter.textContent()) ?? '';
+                const numberAfter = parseInt(/Language (\d+)/.exec(textAfter)?.[1] ?? '0');
+                expect(numberAfter).toBeGreaterThan(numberBefore);
+            }).toPass({ timeout: 5000 });
+
+            await page.keyboard.press('Escape');
+        }
+    );
+
+    test.eachFramework(
         'should update cell value when selecting an option from the paged dropdown',
         async ({ agIdFor, page }) => {
             const cell = agIdFor.cell('0', 'language');

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-customisation/_examples/rich-select-allow-typing/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-customisation/_examples/rich-select-allow-typing/example.spec.ts
@@ -1,11 +1,78 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'should display both column headers and open editor with typing input for Match column',
+        async ({ agIdFor, page }) => {
+            // Verify both column headers are visible
+            const matchHeader = page.locator('.ag-header-cell', { hasText: 'Allow Typing (Match)' });
+            await expect(matchHeader.first()).toBeVisible();
+
+            const matchAnyHeader = page.locator('.ag-header-cell', { hasText: 'Allow Typing (MatchAny)' });
+            await expect(matchAnyHeader.first()).toBeVisible();
+
+            // Double-click the first cell in the Match column to open the editor
+            const cell = agIdFor.cell('0', 'color').first();
+            await cell.dblclick();
+
+            // Verify the rich select popup list appears
+            const popup = page.locator('.ag-rich-select-list').first();
+            await expect(popup).toBeVisible();
+
+            // Verify the text input is visible inside the editor (proves allowTyping: true)
+            const editorInput = page.locator('.ag-rich-select-field-input .ag-input-field-input').first();
+            await expect(editorInput).toBeVisible();
+
+            // Close the editor
+            await page.keyboard.press('Escape');
+        }
+    );
+
+    test.eachFramework(
+        'should filter list differently based on search type when typing',
+        async ({ agIdFor, page }) => {
+            // --- Test Match column (prefix search) ---
+
+            const matchCell = agIdFor.cell('0', 'color').first();
+            await matchCell.dblclick();
+
+            const matchPopup = page.locator('.ag-rich-select-list').first();
+            await expect(matchPopup).toBeVisible();
+
+            // Type 'Blue' to filter the list by prefix
+            await page.keyboard.type('Blue');
+
+            // 'Blue' should appear in the filtered list (starts with 'Blue')
+            await expect(
+                matchPopup.locator('.ag-rich-select-row', { hasText: 'Blue' }).first()
+            ).toBeVisible();
+
+            // 'AliceBlue' should NOT appear because it does not start with 'Blue' (prefix search)
+            await expect(
+                matchPopup.locator('.ag-rich-select-row', { hasText: 'AliceBlue' })
+            ).toHaveCount(0);
+
+            // Close the editor
+            await page.keyboard.press('Escape');
+
+            // --- Test MatchAny column (substring search) ---
+
+            const matchAnyCell = agIdFor.cell('0', 'color_1').first();
+            await matchAnyCell.dblclick();
+
+            const matchAnyPopup = page.locator('.ag-rich-select-list').first();
+            await expect(matchAnyPopup).toBeVisible();
+
+            // Type 'Blue' to filter the list by substring
+            await page.keyboard.type('Blue');
+
+            // 'AliceBlue' should appear because it contains 'Blue' (substring search)
+            await expect(
+                matchAnyPopup.locator('.ag-rich-select-row', { hasText: 'AliceBlue' }).first()
+            ).toBeVisible();
+
+            // Close the editor
+            await page.keyboard.press('Escape');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-customisation/_examples/rich-select-allow-typing/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-customisation/_examples/rich-select-allow-typing/example.spec.ts
@@ -28,51 +28,42 @@ test.agExample(import.meta, () => {
         }
     );
 
-    test.eachFramework(
-        'should filter list differently based on search type when typing',
-        async ({ agIdFor, page }) => {
-            // --- Test Match column (prefix search) ---
+    test.eachFramework('should filter list differently based on search type when typing', async ({ agIdFor, page }) => {
+        // --- Test Match column (prefix search) ---
 
-            const matchCell = agIdFor.cell('0', 'color').first();
-            await matchCell.dblclick();
+        const matchCell = agIdFor.cell('0', 'color').first();
+        await matchCell.dblclick();
 
-            const matchPopup = page.locator('.ag-rich-select-list').first();
-            await expect(matchPopup).toBeVisible();
+        const matchPopup = page.locator('.ag-rich-select-list').first();
+        await expect(matchPopup).toBeVisible();
 
-            // Type 'Blue' to filter the list by prefix
-            await page.keyboard.type('Blue');
+        // Type 'Blue' to filter the list by prefix
+        await page.keyboard.type('Blue');
 
-            // 'Blue' should appear in the filtered list (starts with 'Blue')
-            await expect(
-                matchPopup.locator('.ag-rich-select-row', { hasText: 'Blue' }).first()
-            ).toBeVisible();
+        // 'Blue' should appear in the filtered list (starts with 'Blue')
+        await expect(matchPopup.locator('.ag-rich-select-row', { hasText: 'Blue' }).first()).toBeVisible();
 
-            // 'AliceBlue' should NOT appear because it does not start with 'Blue' (prefix search)
-            await expect(
-                matchPopup.locator('.ag-rich-select-row', { hasText: 'AliceBlue' })
-            ).toHaveCount(0);
+        // 'AliceBlue' should NOT appear because it does not start with 'Blue' (prefix search)
+        await expect(matchPopup.locator('.ag-rich-select-row', { hasText: 'AliceBlue' })).toHaveCount(0);
 
-            // Close the editor
-            await page.keyboard.press('Escape');
+        // Close the editor
+        await page.keyboard.press('Escape');
 
-            // --- Test MatchAny column (substring search) ---
+        // --- Test MatchAny column (substring search) ---
 
-            const matchAnyCell = agIdFor.cell('0', 'color_1').first();
-            await matchAnyCell.dblclick();
+        const matchAnyCell = agIdFor.cell('0', 'color_1').first();
+        await matchAnyCell.dblclick();
 
-            const matchAnyPopup = page.locator('.ag-rich-select-list').first();
-            await expect(matchAnyPopup).toBeVisible();
+        const matchAnyPopup = page.locator('.ag-rich-select-list').first();
+        await expect(matchAnyPopup).toBeVisible();
 
-            // Type 'Blue' to filter the list by substring
-            await page.keyboard.type('Blue');
+        // Type 'Blue' to filter the list by substring
+        await page.keyboard.type('Blue');
 
-            // 'AliceBlue' should appear because it contains 'Blue' (substring search)
-            await expect(
-                matchAnyPopup.locator('.ag-rich-select-row', { hasText: 'AliceBlue' }).first()
-            ).toBeVisible();
+        // 'AliceBlue' should appear because it contains 'Blue' (substring search)
+        await expect(matchAnyPopup.locator('.ag-rich-select-row', { hasText: 'AliceBlue' }).first()).toBeVisible();
 
-            // Close the editor
-            await page.keyboard.press('Escape');
-        }
-    );
+        // Close the editor
+        await page.keyboard.press('Escape');
+    });
 });

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-customisation/_examples/rich-select-allow-typing/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-customisation/_examples/rich-select-allow-typing/example.spec.ts
@@ -38,7 +38,8 @@ test.agExample(import.meta, () => {
         await expect(matchPopup).toBeVisible();
 
         // Type 'Blue' to filter the list by prefix
-        await page.keyboard.type('Blue');
+        const matchEditorInput = page.locator('.ag-rich-select-field-input .ag-input-field-input').first();
+        await matchEditorInput.fill('Blue');
 
         // 'Blue' should appear in the filtered list (starts with 'Blue')
         await expect(matchPopup.locator('.ag-rich-select-row', { hasText: 'Blue' }).first()).toBeVisible();
@@ -58,7 +59,8 @@ test.agExample(import.meta, () => {
         await expect(matchAnyPopup).toBeVisible();
 
         // Type 'Blue' to filter the list by substring
-        await page.keyboard.type('Blue');
+        const matchAnyEditorInput = page.locator('.ag-rich-select-field-input .ag-input-field-input').first();
+        await matchAnyEditorInput.fill('Blue');
 
         // 'AliceBlue' should appear because it contains 'Blue' (substring search)
         await expect(matchAnyPopup.locator('.ag-rich-select-row', { hasText: 'AliceBlue' }).first()).toBeVisible();

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-customisation/_examples/rich-select-cell-renderer/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-customisation/_examples/rich-select-cell-renderer/example.spec.ts
@@ -1,11 +1,49 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework(
+        'should display header, valid cell content, and open editor with options',
+        async ({ agIdFor, page }) => {
+            // Verify the column header is visible with the expected text
+            const header = agIdFor.headerCell('color');
+            await expect(header).toContainText('Rich Select Editor');
+
+            // Verify the first cell displays a non-empty colour name
+            const cell = agIdFor.cell('0', 'color').first();
+            const cellText = await cell.textContent();
+            expect(cellText?.trim().length).toBeGreaterThan(0);
+
+            // Double-click the cell to open the rich select editor
+            await cell.dblclick();
+
+            // Verify the rich select popup list appears
+            const popup = page.locator('.ag-rich-select-list').first();
+            await expect(popup).toBeVisible();
+
+            // Verify the popup contains colour options
+            const options = popup.locator('.ag-rich-select-row');
+            await expect(options.first()).toBeVisible();
+        }
+    );
+
+    test.eachFramework('should update cell value when selecting a different option', async ({ agIdFor, page }) => {
+        const cell = agIdFor.cell('0', 'color').first();
+
+        // Double-click to open the rich select editor
+        await cell.dblclick();
+
+        // Wait for the popup to appear
+        const popup = page.locator('.ag-rich-select-list').first();
+        await expect(popup).toBeVisible();
+
+        // Click the first visible row in the popup (the list opens scrolled to the current
+        // selected value, so we click whatever row is at the top of the viewport)
+        const firstRow = popup.locator('.ag-rich-select-row').first();
+        await expect(firstRow).toBeVisible();
+        const optionText = (await firstRow.innerText()).trim();
+        await firstRow.click();
+
+        // Verify the cell value has been updated to the selected colour
+        await expect(cell).toContainText(optionText);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-customisation/_examples/rich-select-complex-objects/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-customisation/_examples/rich-select-complex-objects/example.spec.ts
@@ -1,11 +1,83 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework(
+        'should display correct initial cell values for both string and complex object columns',
+        async ({ agIdFor }) => {
+            // Verify the column headers are visible with the expected text
+            const stringHeader = agIdFor.headerCell('color');
+            await expect(stringHeader).toContainText('Color (Column as String Type)');
+
+            const objectHeader = agIdFor.headerCell('detailedColor');
+            await expect(objectHeader).toContainText('Color (Column as Complex Object)');
+
+            // Verify row 0 string column shows the plain name
+            const row0Color = agIdFor.cell('0', 'color');
+            await expect(row0Color).toContainText('Pink');
+
+            // Verify row 0 complex object column shows the formatted value
+            const row0DetailedColor = agIdFor.cell('0', 'detailedColor');
+            await expect(row0DetailedColor).toContainText('Pink (#FFC0CB)');
+
+            // Verify row 2 string column shows the plain name
+            const row2Color = agIdFor.cell('2', 'color');
+            await expect(row2Color).toContainText('Blue');
+
+            // Verify row 2 complex object column shows the formatted value
+            const row2DetailedColor = agIdFor.cell('2', 'detailedColor');
+            await expect(row2DetailedColor).toContainText('Blue (#0000FF)');
+        }
+    );
+
+    test.eachFramework('should update cell value when selecting a different option', async ({ agIdFor, page }) => {
+        // --- Edit the string column (color) ---
+
+        const colorCell = agIdFor.cell('0', 'color');
+
+        // Double-click to open the rich select editor
+        await colorCell.dblclick();
+
+        // Verify the rich select popup list appears
+        const popup = page.locator('.ag-rich-select-list').first();
+        await expect(popup).toBeVisible();
+
+        // Verify all 4 colour options are displayed
+        const options = popup.locator('.ag-rich-select-row');
+        await expect(options).toHaveCount(4);
+
+        // Verify the option labels show the formatted name values
+        await expect(options.nth(0)).toContainText('Pink');
+        await expect(options.nth(1)).toContainText('Purple');
+        await expect(options.nth(2)).toContainText('Blue');
+        await expect(options.nth(3)).toContainText('Green');
+
+        // Click the "Green" option
+        const greenOption = popup.locator('.ag-rich-select-row', { hasText: 'Green' }).first();
+        await greenOption.click();
+
+        // Verify the cell value has been updated via parseValue (extracts just the name string)
+        await expect(colorCell).toContainText('Green');
+
+        // --- Edit the complex object column (detailedColor) ---
+
+        const detailedColorCell = agIdFor.cell('1', 'detailedColor');
+
+        // Double-click to open the rich select editor
+        await detailedColorCell.dblclick();
+
+        // Verify the rich select popup list appears
+        const objectPopup = page.locator('.ag-rich-select-list').first();
+        await expect(objectPopup).toBeVisible();
+
+        // Verify all 4 colour options are displayed
+        const objectOptions = objectPopup.locator('.ag-rich-select-row');
+        await expect(objectOptions).toHaveCount(4);
+
+        // Click the "Blue" option
+        const blueOption = objectPopup.locator('.ag-rich-select-row', { hasText: 'Blue' }).first();
+        await blueOption.click();
+
+        // Verify the cell value has been updated with the valueFormatter applied to the full complex object
+        await expect(detailedColorCell).toContainText('Blue (#0000FF)');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-customisation/_examples/rich-select-format-values/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-customisation/_examples/rich-select-format-values/example.spec.ts
@@ -1,11 +1,56 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
+
+const languages = ['English', 'Spanish', 'French', 'Portuguese', '(other)'];
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'should display header, original-case cell values, and uppercase options in editor',
+        async ({ agIdFor, page }) => {
+            // Verify the column header is visible with the expected text
+            const header = agIdFor.headerCell('language');
+            await expect(header).toContainText('Rich Select Editor');
+
+            // Verify the first cell displays a valid language value in original case (not uppercased)
+            const cell = agIdFor.cell('0', 'language');
+            const cellText = await cell.textContent();
+            expect(languages).toContain(cellText);
+
+            // Double-click the cell to open the rich select editor
+            await cell.dblclick();
+
+            // Verify the rich select popup list appears
+            const popup = page.locator('.ag-rich-select-list').first();
+            await expect(popup).toBeVisible();
+
+            // Verify all 5 language options are displayed
+            const options = popup.locator('.ag-rich-select-row');
+            await expect(options).toHaveCount(5);
+
+            // Verify the formatValue callback displays items in uppercase
+            await expect(popup.locator('.ag-rich-select-row', { hasText: 'ENGLISH' }).first()).toBeVisible();
+            await expect(popup.locator('.ag-rich-select-row', { hasText: 'SPANISH' }).first()).toBeVisible();
+            await expect(popup.locator('.ag-rich-select-row', { hasText: '(OTHER)' }).first()).toBeVisible();
+        }
+    );
+
+    test.eachFramework(
+        'should store original-case value when selecting a formatted uppercase option',
+        async ({ agIdFor, page }) => {
+            const cell = agIdFor.cell('0', 'language');
+
+            // Double-click to open the rich select editor
+            await cell.dblclick();
+
+            // Wait for the popup to appear
+            const popup = page.locator('.ag-rich-select-list').first();
+            await expect(popup).toBeVisible();
+
+            // Click the "FRENCH" option (displayed in uppercase by formatValue)
+            const option = popup.locator('.ag-rich-select-row', { hasText: 'FRENCH' }).first();
+            await option.click();
+
+            // Verify the cell stores and displays the original-case value, not the formatted uppercase
+            await expect(cell).toContainText('French');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-customisation/_examples/rich-select-multi-select/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-customisation/_examples/rich-select-multi-select/example.spec.ts
@@ -1,11 +1,65 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework(
+        'should display header and keep multi-select editor open after clicking options',
+        async ({ agIdFor, page }) => {
+            // Verify the column header contains the expected text
+            const header = agIdFor.headerCell('colors');
+            await expect(header).toContainText('Colours');
+
+            // Double-click the first row cell to open the rich select editor
+            const cell = agIdFor.cell('0', 'colors');
+            await cell.dblclick();
+
+            // Verify the rich select popup list appears
+            const popup = page.locator('.ag-rich-select-list').first();
+            await expect(popup).toBeVisible();
+
+            // Click the first visible option in the popup (the list opens scrolled to the
+            // current selection, so we interact with whatever rows are in the viewport)
+            const firstOption = popup.locator('.ag-rich-select-row').first();
+            await expect(firstOption).toBeVisible();
+            await firstOption.click();
+
+            // Multi-select: popup should remain open after clicking an option
+            await expect(popup).toBeVisible();
+
+            // Click the second visible option
+            const secondOption = popup.locator('.ag-rich-select-row').nth(1);
+            await expect(secondOption).toBeVisible();
+            await secondOption.click();
+
+            // Multi-select: popup should still remain open after clicking another option
+            await expect(popup).toBeVisible();
+
+            // Press Escape to cancel editing without confirming changes
+            await page.keyboard.press('Escape');
+
+            // Verify the popup is no longer visible after pressing Escape
+            await expect(popup).not.toBeVisible();
+        }
+    );
+
+    test.eachFramework('should show selected state for options in multi-select editor', async ({ agIdFor, page }) => {
+        // Double-click the first row cell to open the rich select editor
+        const cell = agIdFor.cell('0', 'colors');
+        await cell.dblclick();
+
+        // Verify the rich select popup list appears
+        const popup = page.locator('.ag-rich-select-list').first();
+        await expect(popup).toBeVisible();
+
+        // Verify that at least one option has the selected class, reflecting
+        // the pre-selected colours from the initial random row data (1-4 colours per row)
+        const selectedRows = popup.locator('.ag-rich-select-row-selected');
+        const selectedCount = await selectedRows.count();
+        expect(selectedCount).toBeGreaterThanOrEqual(1);
+
+        // Press Escape to close the editor
+        await page.keyboard.press('Escape');
+
+        // Verify the popup is no longer visible
+        await expect(popup).not.toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-customisation/_examples/rich-select-search-values/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-customisation/_examples/rich-select-search-values/example.spec.ts
@@ -1,43 +1,37 @@
 import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework(
-        'should display all three search mode column headers',
-        async ({ page }) => {
-            // Verify all three column headers are visible with the expected text
-            const fuzzyHeader = page.locator('.ag-header-cell', { hasText: 'Fuzzy Search' });
-            await expect(fuzzyHeader).toBeVisible();
+    test.eachFramework('should display all three search mode column headers', async ({ page }) => {
+        // Verify all three column headers are visible with the expected text
+        const fuzzyHeader = page.locator('.ag-header-cell', { hasText: 'Fuzzy Search' });
+        await expect(fuzzyHeader).toBeVisible();
 
-            const matchHeader = page.locator('.ag-header-cell', { hasText: 'Match Search' });
-            await expect(matchHeader).toBeVisible();
+        const matchHeader = page.locator('.ag-header-cell', { hasText: 'Match Search' });
+        await expect(matchHeader).toBeVisible();
 
-            const matchAnyHeader = page.locator('.ag-header-cell', { hasText: 'Match Any Search' });
-            await expect(matchAnyHeader).toBeVisible();
-        }
-    );
+        const matchAnyHeader = page.locator('.ag-header-cell', { hasText: 'Match Any Search' });
+        await expect(matchAnyHeader).toBeVisible();
+    });
 
-    test.eachFramework(
-        'should open the rich select editor popup with colour options',
-        async ({ agIdFor, page }) => {
-            // Get the first cell in the Fuzzy Search column (col-id 'color')
-            const cell = agIdFor.cell('0', 'color').first();
-            await expect(cell).toBeVisible();
+    test.eachFramework('should open the rich select editor popup with colour options', async ({ agIdFor, page }) => {
+        // Get the first cell in the Fuzzy Search column (col-id 'color')
+        const cell = agIdFor.cell('0', 'color').first();
+        await expect(cell).toBeVisible();
 
-            // Double-click the cell to open the rich select editor
-            await cell.dblclick();
+        // Double-click the cell to open the rich select editor
+        await cell.dblclick();
 
-            // Verify the rich select popup list appears
-            const popup = page.locator('.ag-rich-select-list').first();
-            await expect(popup).toBeVisible();
+        // Verify the rich select popup list appears
+        const popup = page.locator('.ag-rich-select-list').first();
+        await expect(popup).toBeVisible();
 
-            // Verify the popup contains colour options
-            await expect(popup.locator('.ag-rich-select-row').first()).toBeVisible();
+        // Verify the popup contains colour options
+        await expect(popup.locator('.ag-rich-select-row').first()).toBeVisible();
 
-            // Close the editor by pressing Escape
-            await page.keyboard.press('Escape');
+        // Close the editor by pressing Escape
+        await page.keyboard.press('Escape');
 
-            // Verify the popup is no longer visible
-            await expect(popup).not.toBeVisible();
-        }
-    );
+        // Verify the popup is no longer visible
+        await expect(popup).not.toBeVisible();
+    });
 });

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-customisation/_examples/rich-select-search-values/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select-customisation/_examples/rich-select-search-values/example.spec.ts
@@ -1,11 +1,43 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'should display all three search mode column headers',
+        async ({ page }) => {
+            // Verify all three column headers are visible with the expected text
+            const fuzzyHeader = page.locator('.ag-header-cell', { hasText: 'Fuzzy Search' });
+            await expect(fuzzyHeader).toBeVisible();
+
+            const matchHeader = page.locator('.ag-header-cell', { hasText: 'Match Search' });
+            await expect(matchHeader).toBeVisible();
+
+            const matchAnyHeader = page.locator('.ag-header-cell', { hasText: 'Match Any Search' });
+            await expect(matchAnyHeader).toBeVisible();
+        }
+    );
+
+    test.eachFramework(
+        'should open the rich select editor popup with colour options',
+        async ({ agIdFor, page }) => {
+            // Get the first cell in the Fuzzy Search column (col-id 'color')
+            const cell = agIdFor.cell('0', 'color').first();
+            await expect(cell).toBeVisible();
+
+            // Double-click the cell to open the rich select editor
+            await cell.dblclick();
+
+            // Verify the rich select popup list appears
+            const popup = page.locator('.ag-rich-select-list').first();
+            await expect(popup).toBeVisible();
+
+            // Verify the popup contains colour options
+            await expect(popup.locator('.ag-rich-select-row').first()).toBeVisible();
+
+            // Close the editor by pressing Escape
+            await page.keyboard.press('Escape');
+
+            // Verify the popup is no longer visible
+            await expect(popup).not.toBeVisible();
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select/_examples/rich-select-editor/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/provided-cell-editors-rich-select/_examples/rich-select-editor/example.spec.ts
@@ -1,11 +1,54 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
+
+const languages = ['English', 'Spanish', 'French', 'Portuguese', '(other)'];
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework(
+        'should display header, valid cell content, and open editor with all options',
+        async ({ agIdFor, page }) => {
+            // Verify the column header is visible with the expected text
+            const header = agIdFor.headerCell('language');
+            await expect(header).toContainText('Rich Select Editor');
+
+            // Verify the first cell displays a valid language value
+            const cell = agIdFor.cell('0', 'language');
+            const cellText = await cell.textContent();
+            expect(languages).toContain(cellText);
+
+            // Double-click the cell to open the rich select editor
+            await cell.dblclick();
+
+            // Verify the rich select popup list appears
+            const popup = page.locator('.ag-rich-select-list').first();
+            await expect(popup).toBeVisible();
+
+            // Verify all 5 language options are displayed
+            const options = popup.locator('.ag-rich-select-row');
+            await expect(options).toHaveCount(5);
+        }
+    );
+
+    test.eachFramework('should update cell value when selecting a different option', async ({ agIdFor, page }) => {
+        const cell = agIdFor.cell('0', 'language');
+
+        // Read the current cell value
+        const originalValue = await cell.textContent();
+
+        // Pick a language that differs from the current value
+        const newLanguage = languages.find((lang) => lang !== originalValue)!;
+
+        // Double-click to open the rich select editor
+        await cell.dblclick();
+
+        // Wait for the popup to appear
+        const popup = page.locator('.ag-rich-select-list').first();
+        await expect(popup).toBeVisible();
+
+        // Click the option with the different language
+        const option = popup.locator('.ag-rich-select-row', { hasText: newLanguage }).first();
+        await option.click();
+
+        // Verify the cell value has been updated to the newly selected language
+        await expect(cell).toHaveText(newLanguage);
     });
 });


### PR DESCRIPTION
Fix [AG-16788](https://ag-grid.atlassian.net/browse/AG-16788)

Replaces placeholder `example.spec.ts` files with real Playwright tests for all Rich Select Cell Editor documentation examples.

**Pages covered:**
- `provided-cell-editors-rich-select` — basic editor (open popup, verify options, select value)
- `provided-cell-editors-rich-select-customisation` — allow-typing, cell-renderer, complex-objects, format-values, multi-select, search-values
- `provided-cell-editors-rich-select-async` — async values, paged async values, async filtering, paged async filtering
