### PR TITLE
AG-3390 - Interactive Snyk vulnerability viewer

### DIFF
--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = e033c3f73715f6b7dc8c858095badd2efd05729d
-	parent = 65d697813e01713867ad5659560f8b5d8f712105
+	commit = cddb3f108e19475300d508d4ec81e4b9f1a75f2e
+	parent = 8e462657a540f13697339fd61fdcff2ef6391aec
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = a359ab89a52dee65475a46b6ddd81ef82943f079
-	parent = 18f4aceb6c6fc2f7cc446bf315f9b03c24d083de
+	commit = e033c3f73715f6b7dc8c858095badd2efd05729d
+	parent = 65d697813e01713867ad5659560f8b5d8f712105
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = cddb3f108e19475300d508d4ec81e4b9f1a75f2e
-	parent = 8e462657a540f13697339fd61fdcff2ef6391aec
+	commit = 6291054c31953361956bc031c487e4677603383b
+	parent = 93a082e191443fe225cdebb8eae18b5863cbb533
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/.snyk
+++ b/external/ag-shared/.snyk
@@ -3,6 +3,11 @@ version: v1.25.1
 
 ignore:
     SNYK-JS-MINIMATCH-15353389:
+        - '@nx/devkit@18.3.5 > tmp@0.2.1 > rimraf@3.0.2 > glob@7.2.3 > minimatch@3.1.2':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-03T16:21:08.360Z
         - '@nx/devkit@18.3.5 > ejs@3.1.10 > jake@10.9.4 > filelist@1.0.4 > minimatch@5.1.6':
               reason: >-
                   Used in build & dev - not included in final production build
@@ -14,6 +19,11 @@ ignore:
               expires: 2026-06-08T00:00:00.000Z
               created: 2026-03-02T10:13:56.772Z
     SNYK-JS-MINIMATCH-15309438:
+        - '@nx/devkit@18.3.5 > tmp@0.2.1 > rimraf@3.0.2 > glob@7.2.3 > minimatch@3.1.2':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-03T16:20:38.287Z
         - glob@8.0.3 > minimatch@5.1.6:
               reason: >-
                   Used in dev - ReDOS attack would only affect developer machines

--- a/external/ag-shared/package.json
+++ b/external/ag-shared/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "typescript": "^5.4.5",
     "glob": "8.0.3",
-    "@nx/devkit": "^18.3.4",
+    "@nx/devkit": "^18.3.5",
     "@types/yargs": "^17.0.32",
     "@swc/helpers": "0.5.3",
     "tinypool": "^1.0.2",

--- a/external/ag-shared/scripts/snyk-viewer/README.md
+++ b/external/ag-shared/scripts/snyk-viewer/README.md
@@ -145,21 +145,20 @@ shared across all per-file ignore operations in this section.
 
 Click the header to collapse/expand. Header shows:
 - Severity badge, vuln ID (linked to Snyk), title
-- Path/file count badge (`N paths · M files`)
-- **Via:** dep tags — click a tag to uncheck all dep paths via that dep (skip-by-dep)
-- **Skip ✕** — greys out the card and excludes it from "Add All" operations
+- Path/dep count badge (`N paths · M deps`)
+- **Via:** dep tags — click a tag to hide all dep groups for that dep (skip-by-dep)
+- **Skip ✕** — greys out the card and excludes it from "Mark All" operations
 
-Card body is sub-grouped by `.snyk` file. Each file subgroup shows:
-- **Fill reasons dropdown** — preset reason strings; selecting one fills all reason
-  inputs in that file group and resets the select to the placeholder
-- One checkbox row per dep path (uncheck to exclude from add operations)
-- Live **YAML preview** (`<details>` block) — updates as reasons are typed or expiry
-  changes; shows only the paths for that specific file
-- Copy button for the YAML preview
-- **Add to `<file>.snyk`** — validates all checked paths have reasons, then calls
-  `/add-snyk-ignore` for each. If an entry for `(vulnId, depPath)` already exists in
-  the file it is **updated in-place** (reason + expires replaced, created preserved).
-  The button re-enables after 2 s to allow re-adding with different values.
+Card body is sub-grouped by **top-level dep** (e.g. `lodash`, `webpack`). Each dep group shows:
+- Dep name (monospace, accent colour) and path count
+- **✓ In .snyk** badge if all paths in that dep are already ignored
+- **Reason input** — a single text field shared across all paths for that dep
+- **Preset dropdown** — preset reason strings; selecting one fills the reason input
+- One checkbox row per dep path (each row shows the `.snyk` file badge and the dep chain)
+- **Add N path(s) to .snyk** — validates reason and expiry, then calls `/add-snyk-ignore`
+  for each checked path in sequence. Paths may span multiple `.snyk` files; the button
+  fans out across all of them automatically. On success, all added rows convert to
+  already-ignored display and the reason row / button are removed from the DOM.
 
 #### Global actions
 
@@ -254,7 +253,8 @@ patch: {}
   them after, so the user's expanded/collapsed state survives a data refresh
 - **`skipState`** — module-level `{ vulns: Set, deps: Set }` persists across re-renders
   so skip selections survive review state updates
-- **Global path index** — each dep-path row in Section 3 gets a unique `globalIdx` so
-  `reason-s3-N` input IDs are stable and `handleAddAllSnykIgnore` can read them by index
+- **Global path index** — each dep-path row in Section 3 still gets a unique `globalIdx`
+  (stored on the path object) for future use, though current DOM reading uses element
+  content directly rather than index-based IDs
 - **CSS variables** — `--c-bg`, `--c-surface`, `--c-border`, `--c-accent`, `--c-text`,
   `--c-text-muted`, `--c-fix`, `--c-critical`, `--c-warn` etc. defined in `:root`

--- a/external/ag-shared/scripts/snyk-viewer/README.md
+++ b/external/ag-shared/scripts/snyk-viewer/README.md
@@ -133,6 +133,9 @@ active path with changed versions highlighted. Actions:
 - **Update All in This File** — batch-updates all stale paths in one file
 - **Update All .snyk Files** — batch-updates all stale paths across all files
 
+After any update action the panel dims (`opacity: 0.5`, `pointer-events: none`) while
+the `/data` refresh is in flight, then re-renders with the updated state.
+
 #### Shared expiry field
 
 A single expiry date input (pre-filled from the first expiry found in any `.snyk` file)
@@ -243,10 +246,12 @@ patch: {}
 - **IIFE modules** — `ui-browse.js` and `ui-review.js` are IIFEs; shared utilities are
   exposed via `window.SnykUtils`; entry points via `window.initBrowseAll` /
   `window.initReviewQueue`
-- **Delegated events** — a single `click` listener on `#rq-content` dispatches by
-  `data-action` attribute; avoids per-element listeners on re-rendered HTML
-- **Collapsible elements** — use native `<details>`/`<summary>`; no JS toggle needed for
-  open/close state
+- **Delegated events** — a single `click` listener on `#rq-content` is attached once
+  at init (`attachEvents()`) and dispatches by `data-action` attribute; avoids
+  per-element listeners and prevents duplicate handlers accumulating across re-renders
+- **Collapsible elements** — use native `<details>`/`<summary>`; `refreshIgnorePatterns`
+  snapshots which `.tool-section` elements are open before re-rendering and restores
+  them after, so the user's expanded/collapsed state survives a data refresh
 - **`skipState`** — module-level `{ vulns: Set, deps: Set }` persists across re-renders
   so skip selections survive review state updates
 - **Global path index** — each dep-path row in Section 3 gets a unique `globalIdx` so

--- a/external/ag-shared/scripts/snyk-viewer/README.md
+++ b/external/ag-shared/scripts/snyk-viewer/README.md
@@ -1,0 +1,255 @@
+# Snyk Vulnerability Viewer
+
+An interactive local web app for reviewing and resolving Snyk vulnerabilities in a monorepo.
+It reads a Snyk JSON output file, serves a browser UI, and provides one-click actions to
+apply fixes directly to the repository's source files.
+
+## Quick Start
+
+```bash
+yarn nx snyk:view
+# or directly:
+node index.mjs <snyk-output.json> [--port 3456] [--open]
+```
+
+The `--open` flag opens the browser automatically. The server binds to `127.0.0.1` only.
+
+---
+
+## File Structure
+
+| File | Purpose |
+|------|---------|
+| `index.mjs` | HTTP server — all routes, file mutation helpers, Snyk data loading |
+| `ui.html` | HTML skeleton — loads CSS/JS, bootstraps both tabs |
+| `ui-styles.css` | All CSS — dark theme, component styles |
+| `ui-browse.js` | Browse All tab + shared utilities (`window.SnykUtils`, `window.initBrowseAll`) |
+| `ui-review.js` | Review Queue tab (`window.initReviewQueue`) |
+
+The server serves `.css` and `.js` files statically from the same directory as `ui.html`.
+No build step. No bundler.
+
+---
+
+## Data Model
+
+Snyk's JSON output is an array of **project** objects (one per `package.json` scanned).
+Each project has a `vulnerabilities` array where each entry represents one vulnerability
+found via one specific dependency path (`vuln.from` array). The same vulnerability ID can
+appear multiple times across different projects and different dep paths.
+
+Key fields on each `vuln`:
+- `vuln.id` — Snyk vulnerability ID (e.g. `SNYK-JS-ANSIREGEX-1211`)
+- `vuln.severity` — `critical` | `high` | `medium` | `low`
+- `vuln.title` — human-readable name
+- `vuln.from` — dependency path array: `[rootPkg, topLevelDep@ver, ..., vulnerablePkg@ver]`
+- `vuln.name` / `vuln.packageName` — the vulnerable package name
+- `vuln.fixedIn` — array of versions that fix the vuln (may be empty)
+- `vuln.isUpgradable` — Snyk believes the top-level dep can be upgraded to fix it
+- `project.displayTargetFile` — relative path to the scanned `package.json`
+
+A **dep path** is `vuln.from.slice(1).join(' > ')` — the chain from the top-level dep to
+the vulnerable package, excluding the root.
+
+---
+
+## Header Summary Bar
+
+Always visible at the top:
+
+- **Severity pills** — Critical / High / Medium / Low counts (unique vuln IDs)
+- **N projects scanned ▾** — count of scanned `package.json` files; click for a popover
+  listing all project names
+- **N dep paths found** — total `(vuln × dep-path)` tuples across all projects
+- **N vulnerabilities ▾** — count of unique vuln IDs; click for a popover listing every
+  vuln with severity badge, Snyk link, and title; sorted critical → high → medium → low
+- **↻ Re-run Snyk scan** — runs `yarn nx snyk:test:json`, streams output to a log panel,
+  then reloads the in-memory data without a page refresh; optional "Backup old results"
+  checkbox renames the existing JSON file with a timestamp before overwriting
+
+---
+
+## Tab: Browse All
+
+A filterable/searchable list of all vulnerabilities with full details.
+
+**Controls:**
+- Free-text search (package name, vuln ID, CVE)
+- Severity filter chips (All / Critical / High / Medium / Low)
+- Group by: Vulnerability | Package | Project
+- Show ignored toggle — reveals vulnerabilities in `.snyk` ignore lists
+
+**Each vulnerability card shows:**
+- Severity badge, vuln ID (linked to `security.snyk.io`), title, CVE links
+- Dependency path(s) breadcrumb
+- Affected project(s)
+- Near-ignored indicator if the dep path has changed since the `.snyk` rule was written
+
+---
+
+## Tab: Review Queue
+
+A structured workflow for triaging every unresolved vulnerability. The tab has a
+progress bar (`reviewed / total`), a badge with the pending count, and a "Reset
+review state" button.
+
+Review decisions are persisted to `tmp/snyk-review-state.json` (keyed by vuln ID,
+statuses: `resolved` / `skipped` / `reopened`). This file is local and not committed.
+Resolved/skipped vulns move to a collapsible "Reviewed" accordion at the bottom.
+
+The queue is divided into **three always-visible sections**, each collapsible via
+`<details>`. A vuln can appear in multiple sections simultaneously.
+
+### Section 1 — Dependency Upgrades
+
+Groups all vulns by their **top-level dependency** (`vuln.from[1]`). Each card shows:
+
+- The dep name and all affected vuln IDs (with severity badges, linked to Snyk)
+- One row per `package.json` file that declares the dep, with current version
+- Per-file actions:
+  - **Check versions ▾** — fetches `npm view <pkg> versions` and displays a dropdown
+  - **Update package.json** — writes the selected version into the file
+  - **Remove dep** — deletes the entry from `dependencies` / `devDependencies` etc.
+
+### Section 2 — Yarn Resolutions
+
+Groups vulns where a **same-major fix version** exists (`vuln.fixedIn` has a version
+matching the current major of the vulnerable package). Each card shows:
+
+- The vulnerable package and the lowest fix version across all instances
+- Steps: check available versions, copy/apply the `resolutions` key to root `package.json`
+- **Apply to package.json** — writes `"**/pkg": "version"` into root `package.json resolutions`
+- Mark as Resolved button
+
+### Section 3 — Snyk Ignores
+
+#### Near-ignored panel (top, collapsible, amber-tinted)
+
+Shows vulns that already have a `.snyk` ignore rule but the dep path has changed
+(version bumped). Grouped by `.snyk` file. Each item shows the old path vs. the
+active path with changed versions highlighted. Actions:
+
+- **Update .snyk** — replaces the old path in that specific entry
+- **Update All in This File** — batch-updates all stale paths in one file
+- **Update All .snyk Files** — batch-updates all stale paths across all files
+
+#### Shared expiry field
+
+A single expiry date input (pre-filled from the first expiry found in any `.snyk` file)
+shared across all per-file ignore operations in this section.
+
+#### Per-vuln cards (one per unique vuln ID, collapsible)
+
+Click the header to collapse/expand. Header shows:
+- Severity badge, vuln ID (linked to Snyk), title
+- Path/file count badge (`N paths · M files`)
+- **Via:** dep tags — click a tag to uncheck all dep paths via that dep (skip-by-dep)
+- **Skip ✕** — greys out the card and excludes it from "Add All" operations
+
+Card body is sub-grouped by `.snyk` file. Each file subgroup shows:
+- **Fill reasons dropdown** — preset reason strings; selecting one fills all reason
+  inputs in that file group and resets the select to the placeholder
+- One checkbox row per dep path (uncheck to exclude from add operations)
+- Live **YAML preview** (`<details>` block) — updates as reasons are typed or expiry
+  changes; shows only the paths for that specific file
+- Copy button for the YAML preview
+- **Add to `<file>.snyk`** — validates all checked paths have reasons, then calls
+  `/add-snyk-ignore` for each. If an entry for `(vulnId, depPath)` already exists in
+  the file it is **updated in-place** (reason + expires replaced, created preserved).
+  The button re-enables after 2 s to allow re-adding with different values.
+
+#### Global actions
+
+- **✓ Add All to .snyk** — adds all checked paths across all non-skipped cards
+- **✓ Mark All as Resolved** — marks all non-skipped vulns as resolved
+
+---
+
+## Server API
+
+All mutation endpoints are `POST` with `Content-Type: application/json`. All responses
+are `{ ok: true, ... }` or `{ ok: false, error: "..." }`.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/data` | Vuln projects array + ignore patterns + shared expiry + root package name |
+| `GET` | `/review-state` | `tmp/snyk-review-state.json` contents |
+| `POST` | `/review-state` | Merge decisions `{ vulnId: { status, resolution?, note? } }` |
+| `POST` | `/reset-review-state` | Delete `tmp/snyk-review-state.json` |
+| `GET` | `/npm-versions?pkg=` | `npm view <pkg> versions --json`, newest-first, 15 s timeout |
+| `GET` | `/dep-field?pkg=&file=` | Which dep field (`dependencies`, `devDependencies`, etc.) a package lives in |
+| `POST` | `/update-dep-version` | Edit a dep version in a `package.json` (`packageJsonPath`, `dep`, `version`, `field?`) |
+| `POST` | `/remove-dep` | Delete a dep entry from a `package.json` (`packageJsonPath`, `dep`, `field?`) |
+| `POST` | `/apply-resolution` | Write a `resolutions` entry to root `package.json` (`key`, `version`) |
+| `POST` | `/add-snyk-ignore` | Add or update an ignore entry in a `.snyk` file (`snykFile`, `vulnId`, `path`, `reason`, `expires`) |
+| `POST` | `/update-snyk` | Update stale dep-path keys in `.snyk` files (`updates: [{snykFile, vulnId, oldPath, newPath}]`) |
+| `GET` | `/run-snyk` | SSE stream — runs `yarn nx snyk:test:json`, emits stdout/stderr, reloads data on success |
+| `GET` | `/*.css`, `/*.js` | Static UI files served from the same directory |
+
+### `/add-snyk-ignore` update behaviour
+
+If a `(vulnId, depPath)` entry already exists under the vuln ID block in the `.snyk`
+file, the entry is **replaced in-place** — the `reason` and `expires` values are updated
+and a new `created` timestamp is written. A new duplicate entry is never inserted.
+
+### Review state
+
+`tmp/snyk-review-state.json` schema:
+
+```json
+{
+  "decisions": {
+    "SNYK-JS-FOO-123": {
+      "status": "resolved",
+      "resolution": "snyk-ignore",
+      "note": "Added 3 path(s) to .snyk",
+      "timestamp": "2025-01-01T00:00:00.000Z"
+    }
+  }
+}
+```
+
+Statuses: `resolved` | `skipped` | `reopened`. A `resolved` vuln that reappears in the
+active scan data is automatically marked `reopened` on next render.
+
+---
+
+## `.snyk` File Format
+
+Snyk's policy file uses a specific indentation style that this tool matches exactly:
+
+```yaml
+ignore:
+    SNYK-JS-ANSIREGEX-1211:
+        - 'stylelint@15 > ansi-regex@3.0.0':
+              reason: >-
+                  Test/lint dependency - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2024-01-01T00:00:00.000Z
+patch: {}
+```
+
+- Vuln IDs: 4-space indent
+- Path list items: 8-space indent (`        - `)
+- Properties (`reason`, `expires`, `created`): 14-space indent
+- Reason block scalar content: 18-space indent
+- Keys with special characters (e.g. starting with `@`) are single-quoted by `js-yaml`
+
+---
+
+## Code Conventions
+
+- **No build step** — plain ES2020 JS in the browser; no TypeScript, no bundler
+- **IIFE modules** — `ui-browse.js` and `ui-review.js` are IIFEs; shared utilities are
+  exposed via `window.SnykUtils`; entry points via `window.initBrowseAll` /
+  `window.initReviewQueue`
+- **Delegated events** — a single `click` listener on `#rq-content` dispatches by
+  `data-action` attribute; avoids per-element listeners on re-rendered HTML
+- **Collapsible elements** — use native `<details>`/`<summary>`; no JS toggle needed for
+  open/close state
+- **`skipState`** — module-level `{ vulns: Set, deps: Set }` persists across re-renders
+  so skip selections survive review state updates
+- **Global path index** — each dep-path row in Section 3 gets a unique `globalIdx` so
+  `reason-s3-N` input IDs are stable and `handleAddAllSnykIgnore` can read them by index
+- **CSS variables** — `--c-bg`, `--c-surface`, `--c-border`, `--c-accent`, `--c-text`,
+  `--c-text-muted`, `--c-fix`, `--c-critical`, `--c-warn` etc. defined in `:root`

--- a/external/ag-shared/scripts/snyk-viewer/index.mjs
+++ b/external/ag-shared/scripts/snyk-viewer/index.mjs
@@ -9,10 +9,13 @@ import { exec, spawn } from 'child_process';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 function parseArgs(args) {
-    const result = { port: 3456, file: null, open: false };
+    const result = { port: 3456, file: null, open: false, name: null };
     for (let i = 0; i < args.length; i++) {
         if (args[i] === '--port' && args[i + 1]) {
             result.port = parseInt(args[i + 1], 10);
+            i++;
+        } else if (args[i] === '--name' && args[i + 1]) {
+            result.name = args[i + 1];
             i++;
         } else if (args[i] === '--open') {
             result.open = true;
@@ -300,6 +303,9 @@ try {
 } catch (err) {
     console.error('Could not read ui.html:', err.message);
     process.exit(1);
+}
+if (args.name) {
+    uiHtml = uiHtml.replaceAll('Snyk Vulnerability Viewer', `${args.name}: Snyk Vulnerability Viewer`);
 }
 
 function readBody(req) {

--- a/external/ag-shared/scripts/snyk-viewer/index.mjs
+++ b/external/ag-shared/scripts/snyk-viewer/index.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { createServer } from 'http';
 import { readFileSync, writeFileSync, mkdirSync, unlinkSync, readdirSync, renameSync, existsSync, statSync } from 'fs';
-import { resolve, dirname } from 'path';
+import { resolve, dirname, sep } from 'path';
 import { fileURLToPath } from 'url';
 import jsYaml from 'js-yaml';
 import { exec, spawn } from 'child_process';
@@ -191,7 +191,7 @@ function findSharedExpiry(rootDir) {
 function addSnykIgnoreEntry(snykFile, vulnId, depPath, reason, expires) {
     const rootDir = process.cwd();
     const absPath = resolve(rootDir, snykFile);
-    const rootPrefix = rootDir + '/';
+    const rootPrefix = rootDir + sep;
     if ((!absPath.startsWith(rootPrefix) && absPath !== resolve(rootDir, '.snyk')) || !snykFile.endsWith('.snyk')) {
         throw new Error('Invalid .snyk file path');
     }
@@ -398,7 +398,7 @@ const server = createServer((req, res) => {
             try {
                 const { updates } = JSON.parse(body);
                 const rootDir = process.cwd();
-                const rootPrefix = rootDir + '/';
+                const rootPrefix = rootDir + sep;
                 let updatedCount = 0;
                 for (const { snykFile, vulnId, oldPath, newPath } of (updates || [])) {
                     if (typeof snykFile !== 'string' || !snykFile.endsWith('.snyk')) continue;
@@ -498,7 +498,7 @@ const server = createServer((req, res) => {
                 const { packageJsonPath, dep, version, field } = JSON.parse(body);
                 const rootDir = process.cwd();
                 const absPath = resolve(rootDir, packageJsonPath);
-                const rootPrefix = rootDir + '/';
+                const rootPrefix = rootDir + sep;
                 if (!absPath.startsWith(rootPrefix) || !packageJsonPath.endsWith('package.json')) {
                     throw new Error('Invalid packageJsonPath');
                 }
@@ -536,7 +536,7 @@ const server = createServer((req, res) => {
                 const { packageJsonPath, dep, field } = JSON.parse(body);
                 const rootDir = process.cwd();
                 const absPath = resolve(rootDir, packageJsonPath);
-                const rootPrefix = rootDir + '/';
+                const rootPrefix = rootDir + sep;
                 if (!absPath.startsWith(rootPrefix) || !packageJsonPath.endsWith('package.json')) {
                     throw new Error('Invalid packageJsonPath');
                 }
@@ -624,7 +624,7 @@ const server = createServer((req, res) => {
         try {
             const rootDir = process.cwd();
             const absPath = resolve(rootDir, file);
-            const rootPrefix = rootDir + '/';
+            const rootPrefix = rootDir + sep;
             if ((!absPath.startsWith(rootPrefix) && absPath !== resolve(rootDir, 'package.json')) || !file.endsWith('package.json')) {
                 throw new Error('Invalid file path');
             }

--- a/external/ag-shared/scripts/snyk-viewer/index.mjs
+++ b/external/ag-shared/scripts/snyk-viewer/index.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { createServer } from 'http';
-import { readFileSync, writeFileSync, mkdirSync, unlinkSync, readdirSync, renameSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, mkdirSync, unlinkSync, readdirSync, renameSync, existsSync, statSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import jsYaml from 'js-yaml';
@@ -276,8 +276,11 @@ if (!args.file) {
 }
 
 let rawData;
+let snykFileMtime;
 try {
-    rawData = JSON.parse(readFileSync(resolve(args.file), 'utf8'));
+    const snykFilePath = resolve(args.file);
+    rawData = JSON.parse(readFileSync(snykFilePath, 'utf8'));
+    snykFileMtime = statSync(snykFilePath).mtime.toISOString();
 } catch (err) {
     console.error(`Failed to read/parse JSON file: ${args.file}`);
     console.error(err.message);
@@ -329,7 +332,7 @@ const server = createServer((req, res) => {
             rootPackageName = rootPkg.name || null;
         } catch { /* ignore */ }
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ projects: snykData, ignorePatternsByFile, sharedExpiry, rootPackageName }));
+        res.end(JSON.stringify({ projects: snykData, ignorePatternsByFile, sharedExpiry, rootPackageName, scanDate: snykFileMtime }));
         return;
     }
 
@@ -375,6 +378,7 @@ const server = createServer((req, res) => {
                     const newData = normaliseSnykData(newRaw);
                     snykData.length = 0;
                     newData.forEach(p => snykData.push(p));
+                    snykFileMtime = statSync(snykJsonPath).mtime.toISOString();
                     console.log(`Re-run complete: loaded ${snykData.length} project(s) from ${args.file}`);
                     send('done', { ok: true });
                 } catch (e) {

--- a/external/ag-shared/scripts/snyk-viewer/index.mjs
+++ b/external/ag-shared/scripts/snyk-viewer/index.mjs
@@ -1,0 +1,672 @@
+#!/usr/bin/env node
+import { createServer } from 'http';
+import { readFileSync, writeFileSync, mkdirSync, unlinkSync, readdirSync, renameSync, existsSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import jsYaml from 'js-yaml';
+import { exec, spawn } from 'child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function parseArgs(args) {
+    const result = { port: 3456, file: null, open: false };
+    for (let i = 0; i < args.length; i++) {
+        if (args[i] === '--port' && args[i + 1]) {
+            result.port = parseInt(args[i + 1], 10);
+            i++;
+        } else if (args[i] === '--open') {
+            result.open = true;
+        } else if (!args[i].startsWith('--')) {
+            result.file = args[i];
+        }
+    }
+    return result;
+}
+
+function openBrowser(url) {
+    const cmd =
+        process.platform === 'darwin' ? `open "${url}"` : process.platform === 'win32' ? `start "${url}"` : `xdg-open "${url}"`;
+    exec(cmd, (err) => {
+        if (err) console.error('Could not open browser automatically. Visit:', url);
+    });
+}
+
+function normaliseSnykData(raw) {
+    // Snyk outputs either a single project object or an array of project objects
+    const projects = Array.isArray(raw) ? raw : [raw];
+    return projects;
+}
+
+// Recursively find all .snyk files under dir, skipping node_modules and .git.
+function getSnykFiles(dir, found = []) {
+    let entries;
+    try {
+        entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+        return found;
+    }
+    for (const entry of entries) {
+        if (entry.name === 'node_modules' || entry.name === '.git') continue;
+        const full = resolve(dir, entry.name);
+        if (entry.isDirectory()) {
+            getSnykFiles(full, found);
+        } else if (entry.name === '.snyk') {
+            found.push(full);
+        }
+    }
+    return found;
+}
+
+// Parse ignore paths from a single .snyk YAML file (regex-based, zero dependencies).
+// Returns: { [vulnId]: Array<{ path: string, reason: string }> }
+// Handles both quoted and unquoted paths, and inline or block-scalar (>-) reasons.
+function parseSnykIgnorePaths(content) {
+    const result = {};
+    let currentId = null;
+    let currentPath = null;
+    let blockReasonLines = null; // non-null while collecting a >- block scalar
+    let blockReasonIndent = 0;
+
+    for (const line of content.split('\n')) {
+        // Collecting block scalar reason lines
+        if (blockReasonLines !== null) {
+            const trimmed = line.trim();
+            if (!trimmed) continue; // blank lines within block
+            const indent = line.match(/^( *)/)[1].length;
+            if (indent > blockReasonIndent) {
+                blockReasonLines.push(trimmed);
+                continue;
+            }
+            // Indentation dropped — end of block
+            if (currentPath) currentPath.reason = blockReasonLines.join(' ');
+            blockReasonLines = null;
+            // Fall through to process this line normally
+        }
+
+        // Vuln ID lines: "  SNYK-JS-FOO-123:" or "  CVE-2021-1234:"
+        const idMatch = line.match(/^\s{2,6}(SNYK-\S+|CVE-\d+-\d+|GHSA-\S+):\s*$/);
+        if (idMatch) {
+            currentId = idMatch[1];
+            currentPath = null;
+            result[currentId] = result[currentId] || [];
+        } else if (currentId) {
+            // Path lines: quoted "    - '@pkg@ver > @pkg@ver':" or unquoted "    - pkg@ver > pkg@ver:"
+            const pathMatch = line.match(/^\s+- (?:'(.+?)'|"(.+?)"|([\w@][^:]*?)):\s*$/);
+            if (pathMatch) {
+                currentPath = { path: (pathMatch[1] ?? pathMatch[2] ?? pathMatch[3]).trim(), reason: '' };
+                result[currentId].push(currentPath);
+            } else if (currentPath) {
+                // Inline reason: "    reason: some text"
+                const reasonInline = line.match(/^(\s+)reason:\s+([^>|].+)$/);
+                // Block scalar reason: "    reason: >-"
+                const reasonBlock = line.match(/^(\s+)reason:\s*[>|][+-]?\s*$/);
+                if (reasonInline) {
+                    currentPath.reason = reasonInline[2].trim().replace(/^['"]|['"]$/g, '');
+                } else if (reasonBlock) {
+                    blockReasonIndent = reasonBlock[1].length;
+                    blockReasonLines = [];
+                }
+            }
+        }
+    }
+
+    // Flush any pending block scalar at end of file
+    if (blockReasonLines?.length && currentPath) {
+        currentPath.reason = blockReasonLines.join(' ');
+    }
+
+    return result;
+}
+
+// Replaces a single path entry for vulnId in a .snyk file's content string.
+// Returns { content, changed } — content is the (potentially updated) file text.
+function updateSnykFilePath(content, vulnId, oldPath, newPath) {
+    const lines = content.split('\n');
+    let inVuln = false;
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const idMatch = line.match(/^\s{2,6}(SNYK-\S+|CVE-\d+-\d+|GHSA-\S+):\s*$/);
+        if (idMatch) { inVuln = idMatch[1] === vulnId; continue; }
+        if (!inVuln) continue;
+        const m = line.match(/^(\s+- )(?:'(.+?)'|"(.+?)"|([\w@][^:]*?)):(.*)/);
+        if (!m) continue;
+        const found = (m[2] ?? m[3] ?? m[4])?.trim();
+        if (found !== oldPath) continue;
+        lines[i] = `${m[1]}'${newPath}':${m[5]}`;
+        return { content: lines.join('\n'), changed: true };
+    }
+    return { content, changed: false };
+}
+
+// Parse all .snyk files found under rootDir.
+// Returns byFile: { [relFilePath]: { [vulnId]: Array<{path,reason}> } } so the client
+// can match each project only against the .snyk file in its own directory.
+function loadAllSnykIgnorePatterns(rootDir) {
+    const files = getSnykFiles(rootDir);
+    const byFile = {};
+    for (const file of files) {
+        try {
+            const patterns = parseSnykIgnorePaths(readFileSync(file, 'utf8'));
+            const relPath = file.slice(rootDir.length + 1).replace(/\\/g, '/');
+            byFile[relPath] = patterns;
+        } catch {
+            // Skip unreadable files
+        }
+    }
+    return { files, byFile };
+}
+
+// ── Review state helpers ──
+const reviewStatePath = () => resolve(process.cwd(), 'tmp', 'snyk-review-state.json');
+
+function readReviewState() {
+    try { return JSON.parse(readFileSync(reviewStatePath(), 'utf8')); }
+    catch { return { decisions: {} }; }
+}
+
+function writeReviewState(state) {
+    mkdirSync(resolve(process.cwd(), 'tmp'), { recursive: true });
+    writeFileSync(reviewStatePath(), JSON.stringify(state, null, 2), 'utf8');
+}
+
+// Returns the first `expires:` value found in any .snyk file.
+function findSharedExpiry(rootDir) {
+    const files = getSnykFiles(rootDir);
+    for (const file of files) {
+        try {
+            const m = readFileSync(file, 'utf8').match(/^\s*expires:\s*(\S+)/m);
+            if (m) return m[1];
+        } catch { /* skip */ }
+    }
+    return null;
+}
+
+// Adds or updates an ignore entry in a .snyk file.
+// If an entry for the same (vulnId, depPath) already exists it is replaced in-place.
+// Uses js-yaml to correctly quote the dep path key, and matches the snyk CLI's
+// indentation style: 4-space vuln IDs, 8-space path entries, 14-space properties.
+function addSnykIgnoreEntry(snykFile, vulnId, depPath, reason, expires) {
+    const rootDir = process.cwd();
+    const absPath = resolve(rootDir, snykFile);
+    const rootPrefix = rootDir + '/';
+    if ((!absPath.startsWith(rootPrefix) && absPath !== resolve(rootDir, '.snyk')) || !snykFile.endsWith('.snyk')) {
+        throw new Error('Invalid .snyk file path');
+    }
+    const created = new Date().toISOString();
+    let content;
+    if (existsSync(absPath)) {
+        content = readFileSync(absPath, 'utf8');
+    } else {
+        content = '# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\n\nignore:\npatch: {}\n';
+    }
+
+    // Use js-yaml to get a correctly-quoted key for the dep path.
+    // Dump as a single-key mapping, strip the ": null" value, then append ":".
+    // e.g. "@nx/foo@1 > bar@2"  →  "'@nx/foo@1 > bar@2':"
+    //      "vitest@2 > vite@3"  →  "vitest@2 > vite@3:"
+    const quotedKey = jsYaml.dump({ [depPath]: null }, { lineWidth: -1 })
+        .trim()
+        .replace(/:\s*null\s*$/, '') + ':';
+
+    // Indent reason text at 18 spaces for the >- block scalar content
+    const reasonText = reason.split('\n').map(l => '                  ' + l).join('\n');
+
+    // Build path entry with snyk's exact indentation (8-space list item, 14-space props)
+    const pathEntry = `        - ${quotedKey}\n` +
+                      `              reason: >-\n` +
+                      `${reasonText}\n` +
+                      `              expires: ${expires}\n` +
+                      `              created: ${created}\n`;
+
+    // Returns the index just after the newline that terminates a matched line
+    function afterLine(matchIndex, matchLength) {
+        const end = matchIndex + matchLength;
+        return content[end] === '\n' ? end + 1 : end;
+    }
+
+    const idEsc = vulnId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const idMatch = content.match(new RegExp(`^\\s{2,8}${idEsc}:\\s*$`, 'm'));
+
+    if (idMatch) {
+        const idLineEnd = afterLine(idMatch.index, idMatch[0].length);
+
+        // Search for an existing entry with the same dep path within this vuln's block.
+        // The block ends at the next 4-space-indented line (another vuln ID or section key).
+        const afterId = content.slice(idLineEnd);
+        const nextBlockMatch = afterId.match(/^[ ]{4}\S/m);
+        const vulnBlockContent = nextBlockMatch ? afterId.slice(0, nextBlockMatch.index) : afterId;
+
+        // An entry: 8-space list item line + property lines (12+ space indent)
+        const keyEsc = quotedKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const existingEntryRe = new RegExp(`        - ${keyEsc}\\n(?:[ ]{12,}[^\\n]*\\n)*`);
+        const existingEntry = vulnBlockContent.match(existingEntryRe);
+
+        if (existingEntry) {
+            // Replace existing entry in-place
+            const replaceStart = idLineEnd + existingEntry.index;
+            const replaceEnd = replaceStart + existingEntry[0].length;
+            content = content.slice(0, replaceStart) + pathEntry + content.slice(replaceEnd);
+        } else {
+            // Insert new path entry immediately after the existing ID line
+            content = content.slice(0, idLineEnd) + pathEntry + content.slice(idLineEnd);
+        }
+    } else {
+        // Insert new vuln block after 'ignore:' line
+        const ignoreMatch = content.match(/^ignore:\s*$/m);
+        if (ignoreMatch) {
+            const insertAt = afterLine(ignoreMatch.index, ignoreMatch[0].length);
+            content = content.slice(0, insertAt) + `    ${vulnId}:\n${pathEntry}` + content.slice(insertAt);
+        } else {
+            content += `\n    ${vulnId}:\n${pathEntry}`;
+        }
+    }
+
+    mkdirSync(dirname(absPath), { recursive: true });
+    writeFileSync(absPath, content, 'utf8');
+}
+
+const args = parseArgs(process.argv.slice(2));
+
+if (!args.file) {
+    console.error('Usage: node index.mjs <snyk-output.json> [--port 3456] [--open]');
+    process.exit(1);
+}
+
+let rawData;
+try {
+    rawData = JSON.parse(readFileSync(resolve(args.file), 'utf8'));
+} catch (err) {
+    console.error(`Failed to read/parse JSON file: ${args.file}`);
+    console.error(err.message);
+    process.exit(1);
+}
+
+const snykData = normaliseSnykData(rawData);
+
+// Log .snyk files found at startup (patterns are re-read on each /data request
+// so that updates written via POST /update-snyk are reflected on reload).
+const { files: snykFiles } = loadAllSnykIgnorePatterns(process.cwd());
+if (snykFiles.length) {
+    console.log(`Loaded ignore patterns from ${snykFiles.length} .snyk file(s):`);
+    snykFiles.forEach((f) => console.log(`  ${f}`));
+} else {
+    console.log('No .snyk files found — near-ignored matching will not be available.');
+}
+
+const uiTemplatePath = resolve(__dirname, 'ui.html');
+let uiHtml;
+try {
+    uiHtml = readFileSync(uiTemplatePath, 'utf8');
+} catch (err) {
+    console.error('Could not read ui.html:', err.message);
+    process.exit(1);
+}
+
+function readBody(req) {
+    return new Promise((resolve, reject) => {
+        let body = '';
+        req.on('data', chunk => { body += chunk; });
+        req.on('end', () => resolve(body));
+        req.on('error', reject);
+    });
+}
+
+const server = createServer((req, res) => {
+    const url = new URL(req.url, `http://localhost:${args.port}`);
+
+    if (url.pathname === '/data') {
+        const { byFile: ignorePatternsByFile } = loadAllSnykIgnorePatterns(process.cwd());
+        const sharedExpiry = findSharedExpiry(process.cwd());
+        let rootPackageName = null;
+        try {
+            const rootPkg = JSON.parse(readFileSync(resolve(process.cwd(), 'package.json'), 'utf8'));
+            rootPackageName = rootPkg.name || null;
+        } catch { /* ignore */ }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ projects: snykData, ignorePatternsByFile, sharedExpiry, rootPackageName }));
+        return;
+    }
+
+    if (url.pathname === '/run-snyk') {
+        const backup = url.searchParams.get('backup') === '1';
+        const snykJsonPath = resolve(process.cwd(), args.file);
+
+        res.writeHead(200, {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache',
+            'Connection': 'keep-alive',
+        });
+
+        const send = (event, data) => {
+            if (event !== 'message') res.write(`event: ${event}\n`);
+            res.write(`data: ${JSON.stringify(data)}\n\n`);
+        };
+
+        if (backup) {
+            if (existsSync(snykJsonPath)) {
+                const ts = new Date().toISOString().slice(0, 19).replace('T', '_').replace(/:/g, '-');
+                const backupPath = snykJsonPath.replace(/\.json$/, `_${ts}.json`);
+                try {
+                    renameSync(snykJsonPath, backupPath);
+                    send('message', { type: 'info', text: `Backed up to ${backupPath}\n` });
+                } catch (e) {
+                    send('message', { type: 'warn', text: `Could not back up: ${e.message}\n` });
+                }
+            } else {
+                send('message', { type: 'info', text: 'No existing file to back up.\n' });
+            }
+        }
+
+        send('message', { type: 'info', text: 'Running yarn nx snyk:test:json…\n' });
+
+        const child = spawn('yarn', ['nx', 'snyk:test:json', '--skip-nx-cache'], { cwd: process.cwd(), shell: true });
+        child.stdout.on('data', d => send('message', { type: 'stdout', text: d.toString() }));
+        child.stderr.on('data', d => send('message', { type: 'stderr', text: d.toString() }));
+        child.on('close', code => {
+            if (code === 0) {
+                try {
+                    const newRaw = JSON.parse(readFileSync(snykJsonPath, 'utf8'));
+                    const newData = normaliseSnykData(newRaw);
+                    snykData.length = 0;
+                    newData.forEach(p => snykData.push(p));
+                    console.log(`Re-run complete: loaded ${snykData.length} project(s) from ${args.file}`);
+                    send('done', { ok: true });
+                } catch (e) {
+                    send('done', { ok: false, error: `Command succeeded but could not read output: ${e.message}` });
+                }
+            } else {
+                send('done', { ok: false, error: `Command exited with code ${code}` });
+            }
+            res.end();
+        });
+        req.on('close', () => { try { child.kill(); } catch { /* ignore */ } });
+        return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/update-snyk') {
+        readBody(req).then(body => {
+            try {
+                const { updates } = JSON.parse(body);
+                const rootDir = process.cwd();
+                const rootPrefix = rootDir + '/';
+                let updatedCount = 0;
+                for (const { snykFile, vulnId, oldPath, newPath } of (updates || [])) {
+                    if (typeof snykFile !== 'string' || !snykFile.endsWith('.snyk')) continue;
+                    const absPath = resolve(rootDir, snykFile);
+                    if (!absPath.startsWith(rootPrefix) && absPath !== resolve(rootDir, '.snyk')) continue;
+                    try {
+                        const original = readFileSync(absPath, 'utf8');
+                        const { content: updated, changed } = updateSnykFilePath(original, vulnId, oldPath, newPath);
+                        if (changed) { writeFileSync(absPath, updated, 'utf8'); updatedCount++; }
+                    } catch { /* skip unreadable/unwritable files */ }
+                }
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ ok: true, updated: updatedCount }));
+            } catch (err) {
+                res.writeHead(400, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ ok: false, error: err.message }));
+            }
+        });
+        return;
+    }
+
+    // ── Review state endpoints ──
+    if (url.pathname === '/review-state') {
+        if (req.method === 'GET') {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify(readReviewState()));
+            return;
+        }
+        if (req.method === 'POST') {
+            readBody(req).then(body => {
+                try {
+                    const updates = JSON.parse(body); // { vulnId: { status, resolution?, note? } }
+                    const state = readReviewState();
+                    state.decisions = state.decisions || {};
+                    const ts = new Date().toISOString();
+                    for (const [id, decision] of Object.entries(updates)) {
+                        state.decisions[id] = { ...decision, timestamp: ts };
+                    }
+                    writeReviewState(state);
+                    res.writeHead(200, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({ ok: true }));
+                } catch (err) {
+                    res.writeHead(400, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({ ok: false, error: err.message }));
+                }
+            });
+            return;
+        }
+    }
+
+    // ── npm-versions endpoint ──
+    if (url.pathname === '/npm-versions') {
+        const pkg = url.searchParams.get('pkg');
+        if (!pkg || !/^[@\w][\w./@-]*$/.test(pkg)) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ ok: false, error: 'Invalid or missing pkg parameter' }));
+            return;
+        }
+        let done = false;
+        const child = spawn('npm', ['view', pkg, 'versions', '--json'], { cwd: process.cwd() });
+        let stdout = '', stderr = '';
+        const timer = setTimeout(() => {
+            if (done) return;
+            done = true;
+            child.kill();
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ ok: false, error: 'Timeout after 15s' }));
+        }, 15000);
+        child.stdout.on('data', d => { stdout += d; });
+        child.stderr.on('data', d => { stderr += d; });
+        child.on('close', code => {
+            clearTimeout(timer);
+            if (done) return;
+            done = true;
+            if (code !== 0) {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ ok: false, error: (stderr.trim() || `Exit code ${code}`) }));
+                return;
+            }
+            try {
+                const parsed = JSON.parse(stdout.trim());
+                const versions = Array.isArray(parsed) ? parsed : [parsed];
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ ok: true, versions: versions.slice().reverse() }));
+            } catch {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ ok: false, error: 'Could not parse npm output' }));
+            }
+        });
+        return;
+    }
+
+    // ── update-dep-version endpoint ──
+    if (req.method === 'POST' && url.pathname === '/update-dep-version') {
+        readBody(req).then(body => {
+            try {
+                const { packageJsonPath, dep, version, field } = JSON.parse(body);
+                const rootDir = process.cwd();
+                const absPath = resolve(rootDir, packageJsonPath);
+                const rootPrefix = rootDir + '/';
+                if (!absPath.startsWith(rootPrefix) || !packageJsonPath.endsWith('package.json')) {
+                    throw new Error('Invalid packageJsonPath');
+                }
+                const pkg = JSON.parse(readFileSync(absPath, 'utf8'));
+                let updated = false;
+                const fieldsToCheck = field ? [field] : ['dependencies', 'devDependencies', 'resolutions', 'peerDependencies'];
+                for (const f of fieldsToCheck) {
+                    if (pkg[f] && dep in pkg[f]) {
+                        pkg[f][dep] = version;
+                        updated = true;
+                        break;
+                    }
+                }
+                if (!updated && field) {
+                    pkg[field] = pkg[field] || {};
+                    pkg[field][dep] = version;
+                    updated = true;
+                }
+                if (!updated) throw new Error(`Package "${dep}" not found in ${packageJsonPath}`);
+                writeFileSync(absPath, JSON.stringify(pkg, null, 2) + '\n', 'utf8');
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ ok: true }));
+            } catch (err) {
+                res.writeHead(400, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ ok: false, error: err.message }));
+            }
+        });
+        return;
+    }
+
+    // ── remove-dep endpoint ──
+    if (req.method === 'POST' && url.pathname === '/remove-dep') {
+        readBody(req).then(body => {
+            try {
+                const { packageJsonPath, dep, field } = JSON.parse(body);
+                const rootDir = process.cwd();
+                const absPath = resolve(rootDir, packageJsonPath);
+                const rootPrefix = rootDir + '/';
+                if (!absPath.startsWith(rootPrefix) || !packageJsonPath.endsWith('package.json')) {
+                    throw new Error('Invalid packageJsonPath');
+                }
+                const pkg = JSON.parse(readFileSync(absPath, 'utf8'));
+                const fieldsToCheck = field ? [field] : ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'];
+                let removed = false;
+                for (const f of fieldsToCheck) {
+                    if (pkg[f] && dep in pkg[f]) {
+                        delete pkg[f][dep];
+                        removed = true;
+                        break;
+                    }
+                }
+                if (!removed) throw new Error(`Package "${dep}" not found in ${packageJsonPath}`);
+                writeFileSync(absPath, JSON.stringify(pkg, null, 2) + '\n', 'utf8');
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ ok: true }));
+            } catch (err) {
+                res.writeHead(400, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ ok: false, error: err.message }));
+            }
+        });
+        return;
+    }
+
+    // ── apply-resolution endpoint ──
+    if (req.method === 'POST' && url.pathname === '/apply-resolution') {
+        readBody(req).then(body => {
+            try {
+                const { key, version } = JSON.parse(body);
+                const absPath = resolve(process.cwd(), 'package.json');
+                const pkg = JSON.parse(readFileSync(absPath, 'utf8'));
+                pkg.resolutions = pkg.resolutions || {};
+                pkg.resolutions[key] = version;
+                writeFileSync(absPath, JSON.stringify(pkg, null, 2) + '\n', 'utf8');
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ ok: true, key, version }));
+            } catch (err) {
+                res.writeHead(400, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ ok: false, error: err.message }));
+            }
+        });
+        return;
+    }
+
+    // ── add-snyk-ignore endpoint ──
+    if (req.method === 'POST' && url.pathname === '/add-snyk-ignore') {
+        readBody(req).then(body => {
+            try {
+                const { snykFile, vulnId, path: depPath, reason, expires } = JSON.parse(body);
+                addSnykIgnoreEntry(snykFile, vulnId, depPath, reason, expires);
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ ok: true }));
+            } catch (err) {
+                res.writeHead(400, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ ok: false, error: err.message }));
+            }
+        });
+        return;
+    }
+
+    // ── reset-review-state endpoint ──
+    if (req.method === 'POST' && url.pathname === '/reset-review-state') {
+        try {
+            const p = reviewStatePath();
+            if (existsSync(p)) unlinkSync(p);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ ok: true }));
+        } catch (err) {
+            res.writeHead(500, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ ok: false, error: err.message }));
+        }
+        return;
+    }
+
+    // ── dep-field endpoint ──
+    if (url.pathname === '/dep-field') {
+        const pkg = url.searchParams.get('pkg');
+        const file = url.searchParams.get('file');
+        if (!pkg || !file) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ ok: false, error: 'Missing pkg or file parameter' }));
+            return;
+        }
+        try {
+            const rootDir = process.cwd();
+            const absPath = resolve(rootDir, file);
+            const rootPrefix = rootDir + '/';
+            if ((!absPath.startsWith(rootPrefix) && absPath !== resolve(rootDir, 'package.json')) || !file.endsWith('package.json')) {
+                throw new Error('Invalid file path');
+            }
+            const pkgJson = JSON.parse(readFileSync(absPath, 'utf8'));
+            const fields = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'];
+            let foundField = null;
+            let foundVersion = null;
+            for (const f of fields) {
+                if (pkgJson[f] && pkg in pkgJson[f]) {
+                    foundField = f;
+                    foundVersion = pkgJson[f][pkg];
+                    break;
+                }
+            }
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ ok: true, field: foundField, version: foundVersion }));
+        } catch (err) {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ ok: false, error: err.message }));
+        }
+        return;
+    }
+
+    // Serve static UI files (.css/.js) from the same directory as ui.html
+    const staticMatch = url.pathname.match(/^\/([a-zA-Z0-9-]+)\.(css|js)$/);
+    if (staticMatch) {
+        const mimeTypes = { css: 'text/css', js: 'application/javascript' };
+        try {
+            const content = readFileSync(resolve(__dirname, staticMatch[1] + '.' + staticMatch[2]));
+            res.writeHead(200, { 'Content-Type': mimeTypes[staticMatch[2]] });
+            res.end(content);
+        } catch {
+            res.writeHead(404);
+            res.end('Not found');
+        }
+        return;
+    }
+
+    if (url.pathname === '/' || url.pathname === '/index.html') {
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(uiHtml);
+        return;
+    }
+
+    res.writeHead(404);
+    res.end('Not found');
+});
+
+server.listen(args.port, '127.0.0.1', () => {
+    const url = `http://localhost:${args.port}`;
+    console.log(`\nSnyk Viewer running at ${url}`);
+    console.log(`Loaded ${snykData.length} project(s) from ${args.file}`);
+    console.log('Press Ctrl+C to stop.\n');
+    if (args.open) openBrowser(url);
+});

--- a/external/ag-shared/scripts/snyk-viewer/ui-browse.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-browse.js
@@ -609,7 +609,7 @@
             const evtSource = new EventSource(`/run-snyk?backup=${backup ? '1' : '0'}`);
             evtSource.addEventListener('message', e => {
                 const { text } = JSON.parse(e.data);
-                logBody.textContent += text;
+                logBody.textContent += text.replace(/\u001b\[[0-9;]*[a-zA-Z]/g, '');
                 logBody.scrollTop = logBody.scrollHeight;
             });
             evtSource.addEventListener('done', e => {

--- a/external/ag-shared/scripts/snyk-viewer/ui-browse.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-browse.js
@@ -609,7 +609,7 @@
             const evtSource = new EventSource(`/run-snyk?backup=${backup ? '1' : '0'}`);
             evtSource.addEventListener('message', e => {
                 const { text } = JSON.parse(e.data);
-                logBody.textContent += text.replace(/\u001b\[[0-9;]*[a-zA-Z]/g, '');
+                logBody.textContent += text.replace(new RegExp(String.fromCharCode(27) + '\\[[0-9;]*[a-zA-Z]', 'g'), '');
                 logBody.scrollTop = logBody.scrollHeight;
             });
             evtSource.addEventListener('done', e => {

--- a/external/ag-shared/scripts/snyk-viewer/ui-browse.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-browse.js
@@ -169,7 +169,7 @@
                 { key: 'low', label: 'Low', n: summary.bySev.low },
             ];
             sevPills.innerHTML = pills.map(p =>
-                `<span class="sev-pill ${p.key}">${p.label} <strong>${p.n}</strong></span>`
+                `<span class="sev-pill ${p.key}${p.n === 0 ? ' sev-pill-zero' : ''}">${p.label} <strong>${p.n}</strong></span>`
             ).join('');
 
             const projectNames = [...new Set(projects.map(p => projectName(p)))].sort();

--- a/external/ag-shared/scripts/snyk-viewer/ui-browse.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-browse.js
@@ -185,6 +185,23 @@
                     `<a href="https://security.snyk.io/vuln/${esc(v.id)}" target="_blank" rel="noopener" class="popover-vuln-id">${esc(v.id)}</a>` +
                     `<span class="popover-vuln-title">${esc(v.title)}</span></div>`
                 ).join('')}</div>`;
+
+            const copyBtn = document.getElementById('copy-summary-btn');
+            if (copyBtn) {
+                copyBtn.onclick = () => {
+                    const date = new Date().toISOString().slice(0, 10);
+                    const { projects, total, bySev, totalInstances } = summary;
+                    const sevParts = ['critical', 'high', 'medium', 'low']
+                        .filter(s => bySev[s] > 0)
+                        .map(s => `${bySev[s]} ${s}`)
+                        .join(', ');
+                    const text = `Snyk ${date}: ${projects} project${projects !== 1 ? 's' : ''}, ${total} vulnerabilit${total !== 1 ? 'ies' : 'y'} (${sevParts}), ${totalInstances} dep path${totalInstances !== 1 ? 's' : ''}`;
+                    navigator.clipboard.writeText(text).then(() => {
+                        copyBtn.textContent = '✓ Copied';
+                        setTimeout(() => { copyBtn.innerHTML = '&#x2398; Copy summary'; }, 2000);
+                    });
+                };
+            }
         }
 
         // ── POSTs path updates ──

--- a/external/ag-shared/scripts/snyk-viewer/ui-browse.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-browse.js
@@ -118,7 +118,7 @@
     // ════════════════════════════════════════════
     // Browse All tab initialisation
     // ════════════════════════════════════════════
-    window.initBrowseAll = function (projects, ignorePatternsByFile) {
+    window.initBrowseAll = function (projects, ignorePatternsByFile, scanDate) {
 
         // ── State ──
         const state = { search: '', sevFilter: 'all', groupBy: 'project', showIgnored: false };
@@ -185,6 +185,10 @@
                     `<a href="https://security.snyk.io/vuln/${esc(v.id)}" target="_blank" rel="noopener" class="popover-vuln-id">${esc(v.id)}</a>` +
                     `<span class="popover-vuln-title">${esc(v.title)}</span></div>`
                 ).join('')}</div>`;
+
+            if (scanDate) {
+                document.getElementById('stat-scan-date').textContent = 'Scanned ' + new Date(scanDate).toLocaleString();
+            }
 
             const copyBtn = document.getElementById('copy-summary-btn');
             if (copyBtn) {

--- a/external/ag-shared/scripts/snyk-viewer/ui-browse.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-browse.js
@@ -1,0 +1,623 @@
+/* Browse All tab + shared utility functions */
+(function () {
+    'use strict';
+
+    // ── Shared utilities (exported for use by Review Queue) ──
+    function esc(str) {
+        return String(str || '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+    function sevClass(vuln) { return (vuln.severity || 'low').toLowerCase(); }
+
+    function stripVer(dep) { return dep.replace(/@[^@]*$/, ''); }
+
+    function pathKey(fromArr) { return fromArr.slice(1).map(stripVer).join('>'); }
+
+    function projectName(project) {
+        return project.projectName === 'package.json'
+            ? (project.displayTargetFile || project.projectName)
+            : (project.projectName || project.displayTargetFile || '(unknown)');
+    }
+
+    function getSnykFilePath(project) {
+        const targetFile = project.displayTargetFile || '';
+        const slashIdx = targetFile.lastIndexOf('/');
+        const dir = slashIdx > 0 ? targetFile.slice(0, slashIdx) : '';
+        return dir ? `${dir}/.snyk` : '.snyk';
+    }
+
+    function getNearIgnoredPath(vuln, project, ignorePatternsByFile) {
+        if (!vuln.from?.length) return null;
+        const patterns = ignorePatternsByFile[getSnykFilePath(project)];
+        if (!patterns) return null;
+        const idPaths = patterns[vuln.id];
+        if (!idPaths) return null;
+        const key = pathKey(vuln.from);
+        for (const entry of idPaths) {
+            if (entry.path.split(' > ').map(stripVer).join('>') === key) return entry;
+        }
+        return null;
+    }
+
+    // ── Semver helpers ──
+    function semverParts(v) { return (v || '0.0.0').split('.').map(n => parseInt(n, 10) || 0); }
+    function semverMajor(v) { return semverParts(v)[0]; }
+    function semverLess(a, b) {
+        const pa = semverParts(a), pb = semverParts(b);
+        for (let i = 0; i < 3; i++) {
+            if (pa[i] < pb[i]) return true;
+            if (pa[i] > pb[i]) return false;
+        }
+        return false;
+    }
+
+    function sameMajorFixVersion(vuln) {
+        if (!vuln.fixedIn?.length) return null;
+        const major = semverMajor(vuln.version || '0');
+        const fixes = vuln.fixedIn.filter(v => semverMajor(v) === major);
+        if (!fixes.length) return null;
+        return fixes.reduce((min, v) => semverLess(v, min) ? v : min);
+    }
+
+    function upgradeTarget(vuln) {
+        return vuln.upgradePath?.find(v => v !== false) || null;
+    }
+
+    // ── DOM helpers ──
+    function depCrumbsHtml(parts, extraClass, versionChanged) {
+        if (!versionChanged) versionChanged = [];
+        const snykPath = esc(parts.join(' > '));
+        return `<div class="dep-path${extraClass ? ' ' + extraClass : ''}">${parts.map((p, i) => {
+            const isTarget = i === parts.length - 1;
+            const changed = versionChanged[i] || false;
+            let displayHtml;
+            if (changed) {
+                const name = stripVer(p);
+                const ver = p.slice(name.length);
+                displayHtml = `${esc(name)}<span class="ver-changed">${esc(ver)}</span>`;
+            } else {
+                displayHtml = esc(p);
+            }
+            return `<span class="dep-crumb${isTarget ? ' target' : ''}" data-copy="${esc(p)}" title="Click to copy">${displayHtml}</span>${i < parts.length - 1 ? '<span class="dep-arrow">→</span>' : ''}`;
+        }).join('')}<button class="dep-path-copy" data-copy="${snykPath}" title="Copy path in .snyk format">⎘</button></div>`;
+    }
+
+    function depPathHtml(from) {
+        if (!from || !from.length) return '<span style="color:var(--c-text-muted)">—</span>';
+        const parts = from.slice(1);
+        if (!parts.length) return '<span style="color:var(--c-text-muted)">Direct dependency</span>';
+        return depCrumbsHtml(parts);
+    }
+
+    function fixHtml(vuln) {
+        if (vuln.fixedIn && vuln.fixedIn.length > 0) {
+            return `<span class="fix-status fix-yes">✓ Fix available</span>`;
+        }
+        return `<span class="fix-status fix-no">– No fix</span>`;
+    }
+
+    function cveHtml(vuln) {
+        const cves = vuln.identifiers?.CVE || [];
+        if (!cves.length) return '';
+        return `<span class="cve-links">${cves.map(c =>
+            `<a class="cve-link" href="https://nvd.nist.gov/vuln/detail/${esc(c)}" target="_blank" rel="noopener">${esc(c)}</a>`
+        ).join('')}</span>`;
+    }
+
+    // Export shared utilities
+    window.SnykUtils = {
+        esc, sevClass, stripVer, pathKey, projectName, getSnykFilePath,
+        getNearIgnoredPath, semverMajor, sameMajorFixVersion, upgradeTarget,
+        depCrumbsHtml, depPathHtml, fixHtml, cveHtml,
+    };
+
+    // ════════════════════════════════════════════
+    // Browse All tab initialisation
+    // ════════════════════════════════════════════
+    window.initBrowseAll = function (projects, ignorePatternsByFile) {
+
+        // ── State ──
+        const state = { search: '', sevFilter: 'all', groupBy: 'project', showIgnored: false };
+
+        // ── Collect data ──
+        const allVulnEntries = [];
+        const allIgnored = [];
+        for (const project of projects) {
+            for (const vuln of (project.vulnerabilities || [])) {
+                allVulnEntries.push({ vuln, project });
+            }
+            for (const ign of (project.filtered?.ignore || [])) {
+                allIgnored.push({ ign, project });
+            }
+        }
+
+        function getNear(vuln, project) {
+            return getNearIgnoredPath(vuln, project, ignorePatternsByFile);
+        }
+
+        // ── Summary stats ──
+        function buildSummary() {
+            const bySev = { critical: 0, high: 0, medium: 0, low: 0 };
+            const uniqueIds = new Set();
+            const uniqueVulns = []; // { id, title, severity }
+            for (const { vuln } of allVulnEntries) {
+                if (!uniqueIds.has(vuln.id)) {
+                    uniqueIds.add(vuln.id);
+                    const sev = (vuln.severity || '').toLowerCase();
+                    if (sev in bySev) bySev[sev]++;
+                    uniqueVulns.push({ id: vuln.id, title: vuln.title || '', severity: sev });
+                }
+            }
+            const sevOrder = { critical: 0, high: 1, medium: 2, low: 3 };
+            uniqueVulns.sort((a, b) => (sevOrder[a.severity] ?? 4) - (sevOrder[b.severity] ?? 4) || a.id.localeCompare(b.id));
+            return { total: uniqueIds.size, bySev, projects: projects.length, vulns: uniqueVulns, totalInstances: allVulnEntries.length };
+        }
+
+        const summary = buildSummary();
+
+        // ── Render header ──
+        function renderHeader() {
+            const sevPills = document.getElementById('sev-pills');
+            const pills = [
+                { key: 'critical', label: 'Critical', n: summary.bySev.critical },
+                { key: 'high', label: 'High', n: summary.bySev.high },
+                { key: 'medium', label: 'Medium', n: summary.bySev.medium },
+                { key: 'low', label: 'Low', n: summary.bySev.low },
+            ];
+            sevPills.innerHTML = pills.map(p =>
+                `<span class="sev-pill ${p.key}">${p.label} <strong>${p.n}</strong></span>`
+            ).join('');
+
+            const projectNames = [...new Set(projects.map(p => projectName(p)))].sort();
+            document.getElementById('stat-projects').innerHTML =
+                `<strong>${summary.projects}</strong> project${summary.projects !== 1 ? 's' : ''} scanned ▾` +
+                `<div id="projects-popover">${projectNames.map(n => `<div class="popover-project">${esc(n)}</div>`).join('')}</div>`;
+            document.getElementById('stat-deps').innerHTML = `<strong>${summary.totalInstances}</strong> dep path${summary.totalInstances !== 1 ? 's' : ''} found`;
+            document.getElementById('stat-packages').innerHTML =
+                `<strong>${summary.total}</strong> vulnerabilit${summary.total !== 1 ? 'ies' : 'y'} ▾` +
+                `<div id="vulns-popover">${summary.vulns.map(v =>
+                    `<div class="popover-vuln">` +
+                    `<span class="sev-badge ${esc(sevClass(v))}" style="font-size:9px;padding:1px 4px">${esc(v.severity)}</span>` +
+                    `<a href="https://security.snyk.io/vuln/${esc(v.id)}" target="_blank" rel="noopener" class="popover-vuln-id">${esc(v.id)}</a>` +
+                    `<span class="popover-vuln-title">${esc(v.title)}</span></div>`
+                ).join('')}</div>`;
+        }
+
+        // ── POSTs path updates ──
+        function postUpdates(updates) {
+            fetch('/update-snyk', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ updates }),
+            })
+            .then(r => r.json())
+            .then(result => {
+                if (result.ok) location.reload();
+                else alert('Update failed: ' + result.error);
+            })
+            .catch(err => alert('Failed to reach server: ' + err.message));
+        }
+
+        // ── Filter ──
+        function filterEntries(entries) {
+            const q = state.search.toLowerCase();
+            return entries.filter(({ vuln }) => {
+                const sev = (vuln.severity || '').toLowerCase();
+                if (state.sevFilter !== 'all' && sev !== state.sevFilter) return false;
+                if (q) {
+                    const name = (vuln.name || vuln.packageName || '').toLowerCase();
+                    const id = (vuln.id || '').toLowerCase();
+                    const cves = (vuln.identifiers?.CVE || []).join(' ').toLowerCase();
+                    const title = (vuln.title || '').toLowerCase();
+                    if (!name.includes(q) && !id.includes(q) && !cves.includes(q) && !title.includes(q)) return false;
+                }
+                return true;
+            });
+        }
+
+        // ── Render a single vuln row ──
+        function renderVulnRow(vuln, projectEntries, key) {
+            const sev = sevClass(vuln);
+            const cves = vuln.identifiers?.CVE || [];
+            const hasFix = vuln.fixedIn && vuln.fixedIn.length > 0;
+
+            let nearIgnoredCount = 0;
+            const projHtml = projectEntries.map(({ vuln: v, project }) => {
+                const nearMatch = getNear(v, project);
+                const near = nearMatch !== null;
+                if (near) nearIgnoredCount++;
+
+                let pathsHtml;
+                if (near) {
+                    const { path: matchedPath, reason } = nearMatch;
+                    const activeParts = v.from?.slice(1) || [];
+                    const snykParts = matchedPath.split(' > ');
+                    const snykVerByName = new Map(snykParts.map(p => [stripVer(p), p.slice(stripVer(p).length)]));
+                    const activeVerByName = new Map(activeParts.map(p => [stripVer(p), p.slice(stripVer(p).length)]));
+                    const snykChanged = snykParts.map(p => {
+                        const name = stripVer(p), ver = p.slice(name.length);
+                        const av = activeVerByName.get(name);
+                        return av !== undefined && av !== ver;
+                    });
+                    const activeChanged = activeParts.map(p => {
+                        const name = stripVer(p), ver = p.slice(name.length);
+                        const sv = snykVerByName.get(name);
+                        return sv !== undefined && sv !== ver;
+                    });
+                    pathsHtml = `<div class="dep-paths">
+                        <div class="dep-path-row">
+                            <span class="dep-path-label label-snyk">.snyk</span>
+                            ${depCrumbsHtml(snykParts, 'snyk-path', snykChanged)}
+                        </div>
+                        <div class="dep-path-row">
+                            <span class="dep-path-label label-active">active</span>
+                            ${activeParts.length ? depCrumbsHtml(activeParts, '', activeChanged) : '<span style="color:var(--c-text-muted)">Direct dependency</span>'}
+                        </div>
+                        ${reason ? `<div class="snyk-ignore-reason"><strong>Reason:</strong>${esc(reason)}</div>` : ''}
+                    </div>`;
+                } else {
+                    const froms = Array.isArray(v.from) ? [v.from] : [];
+                    pathsHtml = froms.length
+                        ? `<div class="dep-paths">${froms.map(f => depPathHtml(f)).join('')}</div>`
+                        : `<div class="dep-paths">${depPathHtml(v.from)}</div>`;
+                }
+
+                const resolveBtn = near ? (() => {
+                    const snykFile = getSnykFilePath(project);
+                    const activePath = (v.from?.slice(1) || []).join(' > ');
+                    return `<button class="resolve-btn"
+                        data-snyk-file="${esc(snykFile)}"
+                        data-vuln-id="${esc(v.id)}"
+                        data-old-path="${esc(nearMatch.path)}"
+                        data-new-path="${esc(activePath)}">Update .snyk</button>`;
+                })() : '';
+
+                return `<div class="project-entry${near ? ' near-ignored' : ''}">
+                    <div class="project-name">
+                        <span>${esc(projectName(project))}</span>
+                        ${near ? `<span class="project-name-actions"><span class="near-ignored-badge">≈ .snyk path match</span>${resolveBtn}</span>` : ''}
+                    </div>
+                    ${pathsHtml}
+                </div>`;
+            }).join('');
+
+            const fixVersionsHtml = hasFix
+                ? `<div class="detail-section">
+                    <div class="detail-label">Fix in</div>
+                    <div class="fix-versions">${vuln.fixedIn.map(v => `<span class="fix-version">${esc(v)}</span>`).join('')}</div>
+                   </div>`
+                : '';
+
+            return `<div class="vuln-row ${sev}${nearIgnoredCount ? ' has-near-ignored' : ''}" data-key="${esc(key)}">
+                <div class="vuln-summary">
+                    <span class="sev-badge ${sev}">${sev}</span>
+                    <div class="vuln-main">
+                        <div class="vuln-title">${esc(vuln.title)}</div>
+                        <div class="vuln-meta">
+                            <span>${esc(vuln.name || vuln.packageName)}@${esc(vuln.version)}</span>
+                            ${cves.length ? `<span>${cveHtml(vuln)}</span>` : ''}
+                            ${nearIgnoredCount ? `<span class="near-ignored-row-badge">≈ .snyk match</span>` : ''}
+                        </div>
+                    </div>
+                    <span class="vuln-id-wrap">
+                        <a class="vuln-id-link" href="https://security.snyk.io/vuln/${esc(vuln.id)}" target="_blank" rel="noopener" onclick="event.stopPropagation()">${esc(vuln.id)}</a>
+                        <button class="copy-btn" data-copy="${esc(vuln.id)}" title="Copy ID" onclick="event.stopPropagation()">⎘</button>
+                    </span>
+                    ${fixHtml(vuln)}
+                    <span class="proj-count">${projectEntries.length} project${projectEntries.length !== 1 ? 's' : ''}</span>
+                    <span class="expand-icon">▼</span>
+                </div>
+                <div class="vuln-detail">
+                    ${fixVersionsHtml}
+                    <div class="detail-section">
+                        <div class="detail-label">Affected in ${projectEntries.length} project${projectEntries.length !== 1 ? 's' : ''}</div>
+                        ${projHtml}
+                    </div>
+                </div>
+            </div>`;
+        }
+
+        const sevOrder = { critical: 0, high: 1, medium: 2, low: 3 };
+
+        function renderVulnGroups(entries, keyPrefix) {
+            const byId = new Map();
+            for (const e of entries) {
+                if (!byId.has(e.vuln.id)) byId.set(e.vuln.id, { vuln: e.vuln, entries: [] });
+                byId.get(e.vuln.id).entries.push(e);
+            }
+            return [...byId.values()]
+                .sort((a, b) => (sevOrder[sevClass(a.vuln)] ?? 9) - (sevOrder[sevClass(b.vuln)] ?? 9))
+                .map(({ vuln, entries: es }) => renderVulnRow(vuln, es, `${keyPrefix}::${vuln.id}`))
+                .join('');
+        }
+
+        function buildReasonSummary(nearEntries) {
+            const byReason = new Map();
+            for (const { vuln, project } of nearEntries) {
+                const match = getNear(vuln, project);
+                const reason = match?.reason;
+                if (!reason) continue;
+                if (!byReason.has(reason)) byReason.set(reason, new Set());
+                byReason.get(reason).add(projectName(project));
+            }
+            if (!byReason.size) return '';
+            const entries = [...byReason.entries()].map(([reason, projs]) =>
+                `<div class="reason-entry">
+                    <div class="reason-text">${esc(reason)}</div>
+                    <div class="reason-refs">
+                        <span class="reason-refs-label">Found in:</span>
+                        ${[...projs].map(p => `<span class="reason-ref">${esc(p)}</span>`).join('')}
+                    </div>
+                </div>`
+            ).join('');
+            return `<div class="reason-summary"><div class="reason-summary-label">Why these were previously ignored</div>${entries}</div>`;
+        }
+
+        function twoSectionHtml(nearEntries, nearHtml, otherHtml) {
+            if (!nearHtml) return otherHtml;
+            const summary = buildReasonSummary(nearEntries);
+            let html = `<div class="section-divider near">≈ .snyk path matches</div>
+                <div class="near-actions"><button class="update-all-btn" id="update-all-btn">Update all .snyk paths</button></div>
+                ${summary}${nearHtml}`;
+            if (otherHtml) html += `<div class="section-divider">Other vulnerabilities</div>${otherHtml}`;
+            return html;
+        }
+
+        // ── Group views ──
+        function renderByVuln(entries) {
+            const byId = new Map();
+            for (const entry of entries) {
+                const id = entry.vuln.id;
+                if (!byId.has(id)) byId.set(id, { vuln: entry.vuln, near: [], other: [] });
+                const g = byId.get(id);
+                (getNear(entry.vuln, entry.project) !== null ? g.near : g.other).push(entry);
+            }
+            const sorted = [...byId.values()]
+                .sort((a, b) => (sevOrder[sevClass(a.vuln)] ?? 9) - (sevOrder[sevClass(b.vuln)] ?? 9));
+            const nearHtml = sorted.filter(g => g.near.length)
+                .map(({ vuln, near }) => renderVulnRow(vuln, near, vuln.id + ':near')).join('');
+            const otherHtml = sorted.filter(g => g.other.length)
+                .map(({ vuln, other }) => renderVulnRow(vuln, other, vuln.id + ':other')).join('');
+            return twoSectionHtml(sorted.flatMap(g => g.near), nearHtml, otherHtml);
+        }
+
+        function renderByPackage(entries) {
+            const byPkg = new Map();
+            for (const entry of entries) {
+                const pkg = entry.vuln.name || entry.vuln.packageName || '(unknown)';
+                if (!byPkg.has(pkg)) byPkg.set(pkg, { near: [], other: [] });
+                const g = byPkg.get(pkg);
+                (getNear(entry.vuln, entry.project) !== null ? g.near : g.other).push(entry);
+            }
+            const sorted = [...byPkg.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+            function renderPkgSection(filter) {
+                return sorted.filter(([, g]) => filter(g).length).map(([pkg, g]) => {
+                    const es = filter(g);
+                    return `<div class="group-header">${esc(pkg)} (${es.length} vuln${es.length !== 1 ? 's' : ''})</div>${renderVulnGroups(es, pkg)}`;
+                }).join('');
+            }
+            return twoSectionHtml(sorted.flatMap(([, g]) => g.near), renderPkgSection(g => g.near), renderPkgSection(g => g.other));
+        }
+
+        function renderByProject(entries) {
+            const byProj = new Map();
+            for (const entry of entries) {
+                const pname = projectName(entry.project);
+                if (!byProj.has(pname)) byProj.set(pname, { near: [], other: [] });
+                const g = byProj.get(pname);
+                (getNear(entry.vuln, entry.project) !== null ? g.near : g.other).push(entry);
+            }
+            const sorted = [...byProj.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+            function renderProjSection(filter) {
+                return sorted.filter(([, g]) => filter(g).length).map(([pname, g]) => {
+                    const es = filter(g);
+                    return `<div class="group-header">${esc(pname)} (${es.length} vuln${es.length !== 1 ? 's' : ''})</div>${renderVulnGroups(es, pname)}`;
+                }).join('');
+            }
+            return twoSectionHtml(sorted.flatMap(([, g]) => g.near), renderProjSection(g => g.near), renderProjSection(g => g.other));
+        }
+
+        // ── Render ignored ──
+        function renderIgnored() {
+            const list = document.getElementById('ignored-list');
+            const toggle = document.getElementById('ignored-toggle');
+            const badge = toggle.querySelector('.ignored-count-badge');
+            badge.textContent = allIgnored.length ? `(${allIgnored.length})` : '';
+            if (!allIgnored.length) {
+                document.getElementById('ignored-section').style.display = 'none';
+                return;
+            }
+            list.innerHTML = allIgnored.map(({ ign, project }) => {
+                const reasons = ign.filtered?.ignored || [];
+                const reasonText = reasons.map(r => r.reason || '').filter(Boolean)[0] || '';
+                const expires = reasons.map(r => r.expires).filter(Boolean)[0];
+                const expiryStr = expires ? ` · Expires ${new Date(expires).toLocaleDateString()}` : '';
+                return `<div class="ignored-row">
+                    <div><strong>${esc(ign.id)}</strong> · <span style="color:var(--c-text-muted)">${esc(ign.title || '')}</span> · <span style="font-size:11px">${esc(ign.name || ign.packageName || '')}@${esc(ign.version || '')}</span></div>
+                    <div class="project-name" style="font-size:11px;margin-top:3px">${esc(projectName(project))}</div>
+                    ${reasonText ? `<div class="ignored-reason">${esc(reasonText)}${expiryStr}</div>` : ''}
+                </div>`;
+            }).join('');
+        }
+
+        // ── Main render ──
+        function render() {
+            const filtered = filterEntries(allVulnEntries);
+            const list = document.getElementById('vuln-list');
+            const countBar = document.getElementById('count-bar');
+
+            let html = '';
+            if (state.groupBy === 'vuln') html = renderByVuln(filtered);
+            else if (state.groupBy === 'package') html = renderByPackage(filtered);
+            else html = renderByProject(filtered);
+
+            if (!html) {
+                list.innerHTML = `<div id="empty-state"><div class="empty-icon">🎉</div><div>No vulnerabilities match your filters.</div></div>`;
+            } else {
+                list.innerHTML = html;
+            }
+
+            const uniqueFiltered = new Set(filtered.map(e => e.vuln.id)).size;
+            countBar.textContent = `Showing ${uniqueFiltered} unique vulnerabilit${uniqueFiltered !== 1 ? 'ies' : 'y'}`;
+
+            list.querySelectorAll('.vuln-summary').forEach(summary => {
+                summary.addEventListener('click', () => {
+                    summary.closest('.vuln-row').classList.toggle('expanded');
+                });
+            });
+
+            list.querySelectorAll('.copy-btn, .dep-path-copy').forEach(btn => {
+                btn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    navigator.clipboard.writeText(btn.dataset.copy).then(() => {
+                        btn.textContent = '✓';
+                        btn.classList.add('copied');
+                        setTimeout(() => { btn.textContent = '⎘'; btn.classList.remove('copied'); }, 1500);
+                    });
+                });
+            });
+
+            list.querySelectorAll('.dep-crumb[data-copy]').forEach(crumb => {
+                crumb.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    navigator.clipboard.writeText(crumb.dataset.copy).then(() => {
+                        crumb.classList.add('flash');
+                        setTimeout(() => crumb.classList.remove('flash'), 1200);
+                    });
+                });
+            });
+
+            list.querySelectorAll('.resolve-btn').forEach(btn => {
+                btn.addEventListener('click', e => {
+                    e.stopPropagation();
+                    const { snykFile, vulnId, oldPath, newPath } = btn.dataset;
+                    btn.disabled = true;
+                    btn.textContent = 'Updating…';
+                    postUpdates([{ snykFile, vulnId, oldPath, newPath }]);
+                });
+            });
+
+            const updateAllBtn = document.getElementById('update-all-btn');
+            if (updateAllBtn) {
+                updateAllBtn.addEventListener('click', () => {
+                    const updates = [];
+                    const seen = new Set();
+                    for (const { vuln, project } of allVulnEntries) {
+                        const match = getNear(vuln, project);
+                        if (!match) continue;
+                        const activePath = (vuln.from?.slice(1) || []).join(' > ');
+                        if (!activePath || activePath === match.path) continue;
+                        const snykFile = getSnykFilePath(project);
+                        const key = `${snykFile}|${vuln.id}|${match.path}`;
+                        if (seen.has(key)) continue;
+                        seen.add(key);
+                        updates.push({ snykFile, vulnId: vuln.id, oldPath: match.path, newPath: activePath });
+                    }
+                    if (!updates.length) return;
+                    updateAllBtn.disabled = true;
+                    updateAllBtn.textContent = 'Updating…';
+                    postUpdates(updates);
+                });
+            }
+        }
+
+        // ── Controls wiring ──
+        document.getElementById('search').addEventListener('input', e => {
+            state.search = e.target.value;
+            render();
+        });
+
+        document.querySelectorAll('.chip[data-sev]').forEach(chip => {
+            chip.addEventListener('click', () => {
+                state.sevFilter = chip.dataset.sev;
+                document.querySelectorAll('.chip[data-sev]').forEach(c => c.classList.remove('active'));
+                chip.classList.add('active');
+                render();
+            });
+        });
+
+        document.querySelectorAll('.seg-btn[data-group]').forEach(btn => {
+            btn.addEventListener('click', () => {
+                state.groupBy = btn.dataset.group;
+                document.querySelectorAll('.seg-btn[data-group]').forEach(b => b.classList.remove('active'));
+                btn.classList.add('active');
+                render();
+            });
+        });
+
+        document.getElementById('show-ignored').addEventListener('change', e => {
+            state.showIgnored = e.target.checked;
+            const section = document.getElementById('ignored-section');
+            if (state.showIgnored) section.classList.add('open');
+            else section.classList.remove('open');
+        });
+
+        document.getElementById('ignored-toggle').addEventListener('click', () => {
+            document.getElementById('ignored-section').classList.toggle('open');
+        });
+
+        document.getElementById('stat-projects').addEventListener('click', e => {
+            e.stopPropagation();
+            document.getElementById('vulns-popover').classList.remove('open');
+            document.getElementById('projects-popover').classList.toggle('open');
+        });
+        document.getElementById('stat-packages').addEventListener('click', e => {
+            e.stopPropagation();
+            document.getElementById('projects-popover').classList.remove('open');
+            document.getElementById('vulns-popover').classList.toggle('open');
+        });
+        document.addEventListener('click', () => {
+            document.getElementById('projects-popover')?.classList.remove('open');
+            document.getElementById('vulns-popover')?.classList.remove('open');
+        });
+
+        // ── Re-run Snyk scan ──
+        document.getElementById('run-snyk-btn').addEventListener('click', () => {
+            const backup = document.getElementById('backup-cb').checked;
+            const btn = document.getElementById('run-snyk-btn');
+            btn.disabled = true;
+
+            const panel = document.getElementById('run-log-panel');
+            panel.style.display = '';
+            panel.innerHTML = `<div class="run-log-header">
+                <span class="run-log-title"><span class="run-log-spinner"></span> Running Snyk scan…</span>
+            </div><pre class="run-log-body"></pre>`;
+            panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+            const logBody = panel.querySelector('.run-log-body');
+
+            const evtSource = new EventSource(`/run-snyk?backup=${backup ? '1' : '0'}`);
+            evtSource.addEventListener('message', e => {
+                const { text } = JSON.parse(e.data);
+                logBody.textContent += text;
+                logBody.scrollTop = logBody.scrollHeight;
+            });
+            evtSource.addEventListener('done', e => {
+                evtSource.close();
+                const { ok, error } = JSON.parse(e.data);
+                const header = panel.querySelector('.run-log-header');
+                if (ok) {
+                    header.innerHTML = `<span class="run-log-title" style="color:var(--c-fix)">✓ Scan complete — reloading…</span>`;
+                    setTimeout(() => location.reload(), 800);
+                } else {
+                    header.innerHTML = `<span class="run-log-title" style="color:var(--c-critical)">⚠ Scan failed: ${esc(error || 'unknown error')}</span>`;
+                    btn.disabled = false;
+                }
+            });
+            evtSource.onerror = () => {
+                evtSource.close();
+                const header = panel.querySelector('.run-log-header');
+                header.innerHTML = `<span class="run-log-title" style="color:var(--c-critical)">⚠ Connection error</span>`;
+                btn.disabled = false;
+            };
+        });
+
+        // ── Init ──
+        renderHeader();
+        renderIgnored();
+        render();
+    };
+})();

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -1200,6 +1200,9 @@
 
         function refreshIgnorePatterns() {
             document.querySelector('.s3-near-panel')?.classList.add('refreshing');
+            document.body.insertAdjacentHTML('beforeend',
+                '<div class="rq-refresh-overlay"><div class="rq-refresh-spinner"></div></div>');
+            document.body.style.overflow = 'hidden';
             const openSectionIndices = new Set(
                 [...document.querySelectorAll('.tool-section')].map((el, i) => el.open ? i : -1).filter(i => i !== -1)
             );
@@ -1208,6 +1211,9 @@
                 renderReviewQueueTab();
                 document.querySelectorAll('.tool-section').forEach((el, i) => { if (openSectionIndices.has(i)) el.open = true; });
                 document.getElementById('rq-resolved-section')?.classList.add('open');
+            }).finally(() => {
+                document.querySelector('.rq-refresh-overlay')?.remove();
+                document.body.style.overflow = '';
             });
         }
 

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -531,6 +531,57 @@
                     </div>`;
                 }).join('');
 
+                // ── All-paths view: single flat group ──
+                const allPaths = [...byDep.values()].flat();
+                const allAllIgnored = allPaths.every(p => p.alreadyIgnored);
+                const pendingAllCount = allPaths.filter(p => !p.alreadyIgnored).length;
+                const allGroupId = `s3-all-${vi}`;
+                const allReasonInputId = `all-reason-${vi}`;
+                const allRowsHtml = allPaths.map(path => {
+                    if (path.alreadyIgnored) {
+                        return `<div class="path-checkbox-row path-already-ignored" data-top-dep="${esc(path.topLevelDep)}">
+                                <span class="path-already-ignored-check">&#x2713;</span>
+                                <span class="s3-file-badge">${esc(path.snykFile)}</span>
+                                <span class="path-deppath">${esc(path.depPath)}</span>
+                                <input type="text" class="ignore-form-input already-ignored-reason-input"
+                                    value="${esc(path.existingReason || '')}" placeholder="Reason&hellip;"
+                                    data-snyk-file="${esc(path.snykFile)}" data-vuln-id="${esc(id)}" data-dep-path="${esc(path.depPath)}">
+                                <button class="btn btn-sm btn-outline" data-action="update-ignore-reason"
+                                    data-snyk-file="${esc(path.snykFile)}" data-vuln-id="${esc(id)}" data-dep-path="${esc(path.depPath)}">Update</button>
+                                <span class="already-ignored-badge">Already in .snyk</span>
+                            </div>`;
+                    }
+                    return `<div class="path-checkbox-row" data-top-dep="${esc(path.topLevelDep)}">
+                            <input type="checkbox" class="path-cb" checked
+                                data-card="${cardId}" data-vuln-idx="${vi}" data-vuln-id="${esc(id)}">
+                            <span class="s3-file-badge">${esc(path.snykFile)}</span>
+                            <span class="path-deppath">${esc(path.depPath)}</span>
+                        </div>`;
+                }).join('');
+                const allGroupsHtml = `<div class="s3-dep-group${allAllIgnored ? ' s3-dep-group--done' : ''}" id="${esc(allGroupId)}">
+                    <div class="s3-dep-group-header" data-action="toggle-dep-group" data-group-id="${esc(allGroupId)}">
+                        <span class="s3-dep-group-chevron">&#x25BC;</span>
+                        <span class="s3-dep-group-count">${allPaths.length} path${allPaths.length !== 1 ? 's' : ''} across ${byDep.size} dep${byDep.size !== 1 ? 's' : ''}</span>
+                        ${allAllIgnored ? '<span class="already-ignored-badge">&#x2713; All in .snyk</span>' : ''}
+                    </div>
+                    <div class="s3-dep-group-body">
+                        ${!allAllIgnored ? `<div class="s3-dep-group-reason-row">
+                            <input class="s3-dep-reason ignore-form-input" id="${esc(allReasonInputId)}"
+                                placeholder="Reason for all paths\u2026">
+                            <select class="s3-dep-preset ignore-form-input" data-target-input="${esc(allReasonInputId)}">
+                                <option value="">Preset\u2026</option>
+                                ${presetOptionsHtml}
+                            </select>
+                        </div>` : ''}
+                        ${allRowsHtml}
+                        ${!allAllIgnored ? `<button class="btn btn-sm btn-accent s3-dep-add-btn"
+                            data-action="add-all-group"
+                            data-vuln-id="${esc(id)}" data-group-id="${esc(allGroupId)}">
+                            Add ${pendingAllCount} path${pendingAllCount !== 1 ? 's' : ''} to .snyk
+                        </button>` : ''}
+                    </div>
+                </div>`;
+
                 return `<details class="rq-card s3-vuln-card${skipped ? ' s3-card-skipped' : ''}${allPathsIgnored ? ' s3-card-all-ignored' : ''}" id="s3-card-${vi}" data-vuln-id="${esc(id)}">
                     <summary class="rq-card-header s3-card-header">
                         <div class="s3-card-header-main">
@@ -548,7 +599,7 @@
                     </summary>
                     ${skipped
                         ? '<div class="s3-skipped-overlay">Skipped</div>'
-                        : `<div class="rq-card-body">${s3ViewMode === 'by-dep' ? depGroupsHtml : fileGroupsHtml}</div>`}
+                        : `<div class="rq-card-body">${s3ViewMode === 'by-dep' ? depGroupsHtml : s3ViewMode === 'by-file' ? fileGroupsHtml : allGroupsHtml}</div>`}
                 </details>`;
             }).join('');
 
@@ -565,11 +616,12 @@
                     <span class="tool-section-chevron">&#x25BC;</span>
                     <span class="tool-section-num">3</span>
                     <span class="tool-section-title">Snyk Ignores</span>
-                    <span class="tool-section-desc">${s3ViewMode === 'by-dep' ? 'Per-vuln cards grouped by top-level dep.' : 'Per-vuln cards grouped by .snyk file.'}</span>
-                    <button class="btn btn-sm btn-outline s3-view-toggle" data-action="toggle-s3-view"
-                        title="${s3ViewMode === 'by-dep' ? 'Switch to group by .snyk file' : 'Switch to group by top-level dep'}">
-                        ${s3ViewMode === 'by-dep' ? 'By File' : 'By Dep'}
-                    </button>
+                    <span class="tool-section-desc">${s3ViewMode === 'by-dep' ? 'Grouped by top-level dep.' : s3ViewMode === 'by-file' ? 'Grouped by .snyk file.' : 'All paths in one list.'}</span>
+                    <div class="seg-btn-group s3-view-seg">
+                        <button class="seg-btn${s3ViewMode === 'by-dep' ? ' active' : ''}" data-action="set-s3-view" data-mode="by-dep">By Dep</button>
+                        <button class="seg-btn${s3ViewMode === 'by-file' ? ' active' : ''}" data-action="set-s3-view" data-mode="by-file">By File</button>
+                        <button class="seg-btn${s3ViewMode === 'all' ? ' active' : ''}" data-action="set-s3-view" data-mode="all">All</button>
+                    </div>
                     <span class="tool-section-badge">${ignoreVulns.size}</span>
                 </summary>
                 <div class="tool-section-body">
@@ -914,6 +966,79 @@
                 }
             }
 
+            async function handleAddAllGroup(btn) {
+                const { vulnId, groupId } = btn.dataset;
+                const group = document.getElementById(groupId);
+                const expires = document.getElementById('expiry-s3')?.value?.trim() || '';
+                const reason = group?.querySelector('.s3-dep-reason')?.value?.trim() || '';
+                if (!expires) { alert('Please enter an expiry date.'); return; }
+                if (!reason)  { alert('Please enter a reason.'); return; }
+
+                const toAdd = [];
+                group.querySelectorAll('.path-checkbox-row:not(.path-already-ignored)').forEach(row => {
+                    const cb = row.querySelector('input[type="checkbox"]');
+                    if (!cb?.checked) return;
+                    toAdd.push({
+                        snykFile: row.querySelector('.s3-file-badge')?.textContent || '',
+                        depPath:  row.querySelector('.path-deppath')?.textContent  || '',
+                        topDep:   row.dataset.topDep || '',
+                    });
+                });
+                if (!toAdd.length) { alert('No checked paths.'); return; }
+
+                btn.disabled = true;
+                for (let i = 0; i < toAdd.length; i++) {
+                    btn.textContent = `Adding ${i + 1}/${toAdd.length}\u2026`;
+                    const { snykFile, depPath } = toAdd[i];
+                    const r = await fetch('/add-snyk-ignore', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ snykFile, vulnId, path: depPath, reason, expires }),
+                    });
+                    const data = await r.json();
+                    if (!data.ok) {
+                        btn.disabled = false;
+                        btn.textContent = `Add ${toAdd.length} path${toAdd.length !== 1 ? 's' : ''} to .snyk`;
+                        alert('Failed: ' + data.error); return;
+                    }
+                }
+                btn.textContent = '\u2713 Added';
+
+                for (const { snykFile, depPath } of toAdd) {
+                    if (!localAddedPatterns[snykFile]) localAddedPatterns[snykFile] = {};
+                    if (!localAddedPatterns[snykFile][vulnId]) localAddedPatterns[snykFile][vulnId] = [];
+                    localAddedPatterns[snykFile][vulnId].push({ path: depPath, reason });
+                }
+                recomputeProgress();
+
+                group.querySelectorAll('.path-checkbox-row:not(.path-already-ignored)').forEach(row => {
+                    const cb = row.querySelector('input[type="checkbox"]');
+                    if (!cb?.checked) return;
+                    const snykFile = row.querySelector('.s3-file-badge')?.textContent || '';
+                    const depPath  = row.querySelector('.path-deppath')?.textContent  || '';
+                    const topDep   = row.dataset.topDep || '';
+                    row.className = 'path-checkbox-row path-already-ignored';
+                    row.dataset.topDep = topDep;
+                    row.innerHTML = `<span class="path-already-ignored-check">&#x2713;</span>`
+                        + `<span class="s3-file-badge">${esc(snykFile)}</span>`
+                        + `<span class="path-deppath">${esc(depPath)}</span>`
+                        + `<input type="text" class="ignore-form-input already-ignored-reason-input" value="${esc(reason)}" placeholder="Reason&hellip;" data-snyk-file="${esc(snykFile)}" data-vuln-id="${esc(vulnId)}" data-dep-path="${esc(depPath)}">`
+                        + `<button class="btn btn-sm btn-outline" data-action="update-ignore-reason" data-snyk-file="${esc(snykFile)}" data-vuln-id="${esc(vulnId)}" data-dep-path="${esc(depPath)}">Update</button>`
+                        + `<span class="already-ignored-badge">Already in .snyk</span>`;
+                });
+
+                group.querySelector('.s3-dep-group-reason-row')?.remove();
+                group.classList.add('s3-dep-group--done', 's3-dep-group--collapsed');
+                btn.remove();
+
+                const card = group.closest('.s3-vuln-card');
+                if (card) {
+                    updateCardCountBadge(card);
+                    card.open = false;
+                    card.querySelector('.s3-card-header')?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+                }
+            }
+
             // Preset dropdown — fills the dep-group reason input
             container.addEventListener('change', function (e) {
                 if (!e.target.classList.contains('s3-dep-preset')) return;
@@ -951,8 +1076,11 @@
                     handleRemoveDep(btn);
                 } else if (action === 'apply-resolution') {
                     handleApplyResolution(btn);
-                } else if (action === 'toggle-s3-view') {
-                    s3ViewMode = s3ViewMode === 'by-dep' ? 'by-file' : 'by-dep';
+                } else if (action === 'set-s3-view') {
+                    const newMode = btn.dataset.mode;
+                    if (newMode === s3ViewMode) { e.preventDefault(); return; }
+                    e.preventDefault();
+                    s3ViewMode = newMode;
                     const openSections = new Set(
                         [...document.querySelectorAll('.tool-section')].map((el, i) => el.open ? i : -1).filter(i => i !== -1)
                     );
@@ -968,6 +1096,8 @@
                     handleAddDepGroup(btn);
                 } else if (action === 'add-file-group') {
                     handleAddFileGroup(btn);
+                } else if (action === 'add-all-group') {
+                    handleAddAllGroup(btn);
                 } else if (action === 'add-snyk-ignore') {
                     handleAddSnykIgnore(btn);
                 } else if (action === 'update-snyk') {

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -102,7 +102,7 @@
                     }
                 }
 
-                // Ignore candidates — all unresolved vulns
+                // Ignore candidates — shown in Cat C; alreadyIgnored=true if path is already in .snyk
                 const snykFile = getSnykFilePath(project);
                 const depPath = (vuln.from?.slice(1) || []).join(' > ');
                 const topLevelDep = stripVer(vuln.from?.[1] || '');
@@ -110,7 +110,7 @@
                 const v = ignoreVulns.get(id);
                 const key = snykFile + '\0' + depPath;
                 if (!v.paths.some(p => p.snykFile + '\0' + p.depPath === key)) {
-                    v.paths.push({ snykFile, depPath, topLevelDep });
+                    v.paths.push({ snykFile, depPath, topLevelDep, alreadyIgnored: near != null });
                 }
             }
 
@@ -336,7 +336,7 @@
                 if (!skipped) {
                     for (const [, filePaths] of byFile) {
                         for (const p of filePaths) {
-                            if (!skipState.deps.has(p.topLevelDep)) {
+                            if (!skipState.deps.has(p.topLevelDep) && !p.alreadyIgnored) {
                                 allBatchItems.push({ vulnId: id, snykFile: p.snykFile, depPath: p.depPath, idx: p.idx });
                             }
                         }
@@ -360,8 +360,18 @@
                 const fileCount = byFile.size;
                 const countBadge = `<span class="s3-path-count-badge">${totalPaths} path${totalPaths !== 1 ? 's' : ''} &middot; ${fileCount} file${fileCount !== 1 ? 's' : ''}</span>`;
 
+                const allPathsIgnored = [...byFile.values()].every(fps => fps.every(p => p.alreadyIgnored));
+
                 const fileGroupsHtml = [...byFile.entries()].map(([snykFile, fps]) => {
+                    const allFileIgnored = fps.every(p => p.alreadyIgnored);
                     const rowsHtml = fps.map(path => {
+                        if (path.alreadyIgnored) {
+                            return `<div class="path-checkbox-row path-already-ignored" data-top-dep="${esc(path.topLevelDep)}">
+                                <span class="path-already-ignored-check">&#x2713;</span>
+                                <span class="path-deppath">${esc(path.depPath)}</span>
+                                <span class="already-ignored-badge">Already in .snyk</span>
+                            </div>`;
+                        }
                         const depSkipped = skipState.deps.has(path.topLevelDep);
                         return `<div class="path-checkbox-row${depSkipped ? ' dep-skipped' : ''}" data-top-dep="${esc(path.topLevelDep)}">
                             <input type="checkbox" class="path-cb"${depSkipped ? '' : ' checked'}
@@ -375,14 +385,16 @@
                         </div>`;
                     }).join('');
                     const fileId = snykFile.replace(/[^a-z0-9]/gi, '-');
-                    const filePaths = fps.map(p => ({ vulnId: id, depPath: p.depPath, idx: p.idx }));
-                    const fileYaml = buildGroupedYamlPreview(filePaths, [], expiry);
-                    return `<div class="batch-file-subgroup" data-snyk-file="${esc(snykFile)}">
-                        <div class="batch-file-subgroup-heading">
+                    const pendingPaths = fps.filter(p => !p.alreadyIgnored).map(p => ({ vulnId: id, depPath: p.depPath, idx: p.idx }));
+                    const fileYaml = buildGroupedYamlPreview(pendingPaths, [], expiry);
+                    return `<details class="batch-file-subgroup${allFileIgnored ? ' batch-file-subgroup--done' : ''}" data-snyk-file="${esc(snykFile)}"${allFileIgnored ? '' : ' open'}>
+                        <summary class="batch-file-subgroup-heading">
+                            <span class="batch-file-subgroup-chevron">&#x25BC;</span>
                             ${esc(snykFile)}
                             <span class="s3-file-path-count">${fps.length} path${fps.length !== 1 ? 's' : ''}</span>
-                        </div>
-                        <div class="prefill-row">
+                            ${allFileIgnored ? '<span class="batch-file-done-badge">&#x2713; In .snyk</span>' : ''}
+                        </summary>
+                        ${!allFileIgnored ? `<div class="prefill-row">
                             <select class="ignore-form-input preset-select cat-a-preset"
                                 data-card="${cardId}" data-vuln-idx="${vi}" data-snyk-file="${esc(snykFile)}">
                                 <option value="">Preset&#x2026;</option>
@@ -393,9 +405,9 @@
                                 placeholder="Prefill reason&#x2026;">
                             <button class="btn btn-sm btn-outline" data-action="prefill-reasons"
                                 data-card="${cardId}" data-vuln-idx="${vi}" data-snyk-file="${esc(snykFile)}">Apply to all</button>
-                        </div>
+                        </div>` : ''}
                         ${rowsHtml}
-                        <details class="batch-yaml-details">
+                        ${!allFileIgnored ? `<details class="batch-yaml-details">
                             <summary class="batch-yaml-summary">
                                 ${esc(snykFile)} YAML preview
                                 <button class="btn btn-sm btn-outline" data-action="copy-file-yaml"
@@ -405,11 +417,11 @@
                         </details>
                         <button class="btn btn-sm btn-accent" data-action="add-file-snyk-ignore"
                             data-card="${cardId}" data-vuln-idx="${vi}" data-snyk-file="${esc(snykFile)}"
-                            data-vuln-id="${esc(id)}">Add to ${esc(snykFile)}</button>
-                    </div>`;
+                            data-vuln-id="${esc(id)}">Add to ${esc(snykFile)}</button>` : ''}
+                    </details>`;
                 }).join('');
 
-                return `<details class="rq-card s3-vuln-card${skipped ? ' s3-card-skipped' : ''}" id="s3-card-${vi}" data-vuln-id="${esc(id)}" open>
+                return `<details class="rq-card s3-vuln-card${skipped ? ' s3-card-skipped' : ''}${allPathsIgnored ? ' s3-card-all-ignored' : ''}" id="s3-card-${vi}" data-vuln-id="${esc(id)}" ${allPathsIgnored ? '' : 'open'}>
                     <summary class="rq-card-header s3-card-header">
                         <div class="s3-card-header-main">
                             <span class="s3-card-chevron">&#x25BC;</span>
@@ -699,6 +711,38 @@
                     }
                 }
                 btn.textContent = '\u2713 Updated';
+
+                // Convert successfully-added rows to the resolved display (same as on load)
+                subgroup.querySelectorAll('.path-checkbox-row:not(.path-already-ignored)').forEach(row => {
+                    const cb = row.querySelector('.path-cb');
+                    if (!cb || !cb.checked) return;
+                    const topDep = row.dataset.topDep || '';
+                    const depPath = row.querySelector('.path-deppath')?.textContent || '';
+                    row.className = 'path-checkbox-row path-already-ignored';
+                    row.dataset.topDep = topDep;
+                    row.innerHTML = `<span class="path-already-ignored-check">&#x2713;</span>`
+                        + `<span class="path-deppath">${esc(depPath)}</span>`
+                        + `<span class="already-ignored-badge">Already in .snyk</span>`;
+                });
+
+                subgroup.removeAttribute('open');
+                subgroup.classList.add('batch-file-subgroup--done');
+                const heading = subgroup.querySelector('.batch-file-subgroup-heading');
+                if (heading && !heading.querySelector('.batch-file-done-badge')) {
+                    const badge = document.createElement('span');
+                    badge.className = 'batch-file-done-badge';
+                    badge.textContent = '\u2713 Added';
+                    heading.appendChild(badge);
+                }
+
+                // If all paths across all subgroups are now resolved, mark the whole card
+                const cardAllIgnored = !card.querySelector('.path-checkbox-row:not(.path-already-ignored)');
+                if (cardAllIgnored) {
+                    card.classList.add('s3-card-all-ignored');
+                    card.removeAttribute('open');
+                }
+
+                card.querySelector('.s3-card-header')?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
                 setTimeout(() => { btn.disabled = false; btn.textContent = `Add to ${snykFile}`; }, 2000);
             }
 

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -122,7 +122,7 @@
                 const v = ignoreVulns.get(id);
                 const key = snykFile + '\0' + depPath;
                 if (!v.paths.some(p => p.snykFile + '\0' + p.depPath === key)) {
-                    v.paths.push({ snykFile, depPath, topLevelDep, alreadyIgnored: near != null });
+                    v.paths.push({ snykFile, depPath, topLevelDep, alreadyIgnored: near != null, existingReason: near?.reason || '' });
                 }
             }
 
@@ -138,7 +138,8 @@
                     const v = ignoreVulns.get(id);
                     const key = snykFile + '\0' + depPath;
                     if (!v.paths.some(p => p.snykFile + '\0' + p.depPath === key)) {
-                        v.paths.push({ snykFile, depPath, topLevelDep, alreadyIgnored: true });
+                        const filteredReason = vuln.filtered?.ignored?.[0]?.reason || '';
+                        v.paths.push({ snykFile, depPath, topLevelDep, alreadyIgnored: true, existingReason: filteredReason });
                     }
                 }
             }
@@ -422,6 +423,11 @@
                             return `<div class="path-checkbox-row path-already-ignored" data-top-dep="${esc(path.topLevelDep)}">
                                 <span class="path-already-ignored-check">&#x2713;</span>
                                 <span class="path-deppath">${esc(path.depPath)}</span>
+                                <input type="text" class="ignore-form-input already-ignored-reason-input"
+                                    value="${esc(path.existingReason || '')}" placeholder="Reason&hellip;"
+                                    data-snyk-file="${esc(snykFile)}" data-vuln-id="${esc(id)}" data-dep-path="${esc(path.depPath)}">
+                                <button class="btn btn-sm btn-outline" data-action="update-ignore-reason"
+                                    data-snyk-file="${esc(snykFile)}" data-vuln-id="${esc(id)}" data-dep-path="${esc(path.depPath)}">Update</button>
                                 <span class="already-ignored-badge">Already in .snyk</span>
                             </div>`;
                         }
@@ -801,16 +807,20 @@
                 }
                 recomputeProgress();
 
-                // Convert successfully-added rows to the resolved display (same as on load)
+                // Convert successfully-added rows to the resolved display (editable reason + Update button)
                 subgroup.querySelectorAll('.path-checkbox-row:not(.path-already-ignored)').forEach(row => {
                     const cb = row.querySelector('.path-cb');
                     if (!cb || !cb.checked) return;
                     const topDep = row.dataset.topDep || '';
                     const depPath = row.querySelector('.path-deppath')?.textContent || '';
+                    const idx = cb.dataset.idx;
+                    const reason = document.getElementById(`reason-${cardId}-${idx}`)?.value?.trim() || '';
                     row.className = 'path-checkbox-row path-already-ignored';
                     row.dataset.topDep = topDep;
                     row.innerHTML = `<span class="path-already-ignored-check">&#x2713;</span>`
                         + `<span class="path-deppath">${esc(depPath)}</span>`
+                        + `<input type="text" class="ignore-form-input already-ignored-reason-input" value="${esc(reason)}" placeholder="Reason&hellip;" data-snyk-file="${esc(snykFile)}" data-vuln-id="${esc(vulnId)}" data-dep-path="${esc(depPath)}">`
+                        + `<button class="btn btn-sm btn-outline" data-action="update-ignore-reason" data-snyk-file="${esc(snykFile)}" data-vuln-id="${esc(vulnId)}" data-dep-path="${esc(depPath)}">Update</button>`
                         + `<span class="already-ignored-badge">Already in .snyk</span>`;
                 });
 
@@ -874,6 +884,8 @@
                     handleRemoveDep(btn);
                 } else if (action === 'apply-resolution') {
                     handleApplyResolution(btn);
+                } else if (action === 'update-ignore-reason') {
+                    handleUpdateIgnoreReason(btn);
                 } else if (action === 'add-all-snyk-ignore') {
                     handleAddAllSnykIgnore(btn);
                 } else if (action === 'add-file-snyk-ignore') {
@@ -1043,6 +1055,40 @@
                     btn.textContent = 'Check dep type \u2192';
                     panel.textContent = 'error: ' + err.message;
                 });
+        }
+
+        async function handleUpdateIgnoreReason(btn) {
+            const { snykFile, vulnId, depPath } = btn.dataset;
+            const expiryInput = document.getElementById('expiry-s3');
+            const expires = expiryInput?.value?.trim() || '';
+            if (!expires) { alert('Please enter an expiry date.'); return; }
+            const row = btn.closest('.path-checkbox-row');
+            const reason = row?.querySelector('.already-ignored-reason-input')?.value?.trim() || '';
+            if (!reason) { alert('Please enter a reason.'); return; }
+            btn.disabled = true;
+            btn.textContent = 'Updating\u2026';
+            try {
+                const r = await fetch('/add-snyk-ignore', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ snykFile, vulnId, path: depPath, reason, expires }),
+                });
+                const data = await r.json();
+                if (data.ok) {
+                    if (!localAddedPatterns[snykFile]) localAddedPatterns[snykFile] = {};
+                    if (!localAddedPatterns[snykFile][vulnId]) localAddedPatterns[snykFile][vulnId] = [];
+                    const arr = localAddedPatterns[snykFile][vulnId];
+                    const existing = arr.find(e => e.path === depPath);
+                    if (existing) existing.reason = reason;
+                    else arr.push({ path: depPath, reason });
+                    btn.textContent = '\u2713 Updated';
+                    setTimeout(() => { btn.disabled = false; btn.textContent = 'Update'; }, 2000);
+                } else {
+                    btn.disabled = false; btn.textContent = 'Update'; alert('Failed: ' + data.error);
+                }
+            } catch (err) {
+                btn.disabled = false; btn.textContent = 'Update'; alert('Request failed: ' + err.message);
+            }
         }
 
         async function handleAddAllSnykIgnore(btn) {

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -560,11 +560,11 @@
                     <span class="tool-section-num">3</span>
                     <span class="tool-section-title">Snyk Ignores</span>
                     <span class="tool-section-desc">${s3ViewMode === 'by-dep' ? 'Per-vuln cards grouped by top-level dep.' : 'Per-vuln cards grouped by .snyk file.'}</span>
-                    <span class="tool-section-badge">${ignoreVulns.size}</span>
                     <button class="btn btn-sm btn-outline s3-view-toggle" data-action="toggle-s3-view"
                         title="${s3ViewMode === 'by-dep' ? 'Switch to group by .snyk file' : 'Switch to group by top-level dep'}">
                         ${s3ViewMode === 'by-dep' ? 'By File' : 'By Dep'}
                     </button>
+                    <span class="tool-section-badge">${ignoreVulns.size}</span>
                 </summary>
                 <div class="tool-section-body">
                     ${expiryHtml}

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -410,7 +410,7 @@
                     resolvedPaths += fps.filter(p => p.alreadyIgnored).length;
                 }
                 const fileCount = byFile.size;
-                const resolvedPart = resolvedPaths > 0 ? ` &middot; ${resolvedPaths} resolved` : '';
+                const resolvedPart = resolvedPaths > 0 ? ` &middot; <span class="s3-resolved-count">${resolvedPaths} resolved</span>` : '';
                 const countBadge = `<span class="s3-path-count-badge">${totalPaths} path${totalPaths !== 1 ? 's' : ''} &middot; ${fileCount} file${fileCount !== 1 ? 's' : ''}${resolvedPart}</span>`;
 
                 const allPathsIgnored = [...byFile.values()].every(fps => fps.every(p => p.alreadyIgnored));
@@ -482,6 +482,7 @@
                             <a class="vuln-id-link" href="https://security.snyk.io/vuln/${esc(id)}" target="_blank" rel="noopener">${esc(id)}</a>
                             <span class="rq-card-title">${esc(vuln.title || '')}</span>
                             ${countBadge}
+                            ${allPathsIgnored ? '<span class="s3-all-resolved-badge">&#x2713; Resolved</span>' : ''}
                         </div>
                         <div class="s3-card-header-right">
                             ${depTagsHtml ? `<span class="s3-via-label">Via:</span> ${depTagsHtml}` : ''}
@@ -724,6 +725,26 @@
                 yamlEl.textContent = buildGroupedYamlPreview(filePaths, reasons, expiry);
             }
 
+            function updateCardCountBadge(card) {
+                const badge = card.querySelector('.s3-path-count-badge');
+                if (!badge) return;
+                const totalPaths = card.querySelectorAll('.path-checkbox-row').length;
+                const resolvedPaths = card.querySelectorAll('.path-checkbox-row.path-already-ignored').length;
+                const fileCount = card.querySelectorAll('.batch-file-subgroup').length;
+                const resolvedPart = resolvedPaths > 0 ? ` &middot; <span class="s3-resolved-count">${resolvedPaths} resolved</span>` : '';
+                badge.innerHTML = `${totalPaths} path${totalPaths !== 1 ? 's' : ''} &middot; ${fileCount} file${fileCount !== 1 ? 's' : ''}${resolvedPart}`;
+                const allResolved = totalPaths > 0 && resolvedPaths === totalPaths;
+                let checkBadge = card.querySelector('.s3-all-resolved-badge');
+                if (allResolved && !checkBadge) {
+                    checkBadge = document.createElement('span');
+                    checkBadge.className = 's3-all-resolved-badge';
+                    checkBadge.textContent = '\u2713 Resolved';
+                    badge.insertAdjacentElement('afterend', checkBadge);
+                } else if (!allResolved && checkBadge) {
+                    checkBadge.remove();
+                }
+            }
+
             async function handleAddFileSnykIgnore(btn) {
                 const cardId = btn.dataset.card;
                 const vulnIdx = parseInt(btn.dataset.vulnIdx);
@@ -802,6 +823,8 @@
                     badge.textContent = '\u2713 Added';
                     heading.appendChild(badge);
                 }
+
+                updateCardCountBadge(card);
 
                 // If all paths across all subgroups are now resolved, mark the whole card
                 const cardAllIgnored = !card.querySelector('.path-checkbox-row:not(.path-already-ignored)');

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -8,6 +8,7 @@
         'Lint dependency - not included in final production build',
         'Downstream dependency of [package] - not included in final production build',
         'Dev server only - not exposed in production',
+        'The website is a static site, so server-side vulns are not relevant',
         'MCP/dev tooling - not a directly exposed production dependency',
     ];
 

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -1,0 +1,1067 @@
+/* Review Queue tab */
+(function () {
+    'use strict';
+
+    const IGNORE_REASONS = [
+        'Used in build & dev - not included in final production build',
+        'Test/lint dependency - not included in final production build',
+        'Downstream dependency of [package] - not included in final production build',
+        'Dev server only - not exposed in production',
+        'MCP/dev tooling - not a directly exposed production dependency',
+    ];
+
+    window.initReviewQueue = function (projects, ignorePatternsByFile, reviewState, sharedExpiry, _rootPackageName) {
+        const { esc, sevClass, stripVer, getSnykFilePath, getNearIgnoredPath,
+                sameMajorFixVersion } = window.SnykUtils;
+
+        // ── Collect vuln entries ──
+        const allVulnEntries = [];
+        for (const project of projects) {
+            for (const vuln of (project.vulnerabilities || [])) {
+                allVulnEntries.push({ vuln, project });
+            }
+        }
+
+        // Local mutable copy of review state
+        const localRS = JSON.parse(JSON.stringify(reviewState));
+        localRS.decisions = localRS.decisions || {};
+
+        // ── Skip state (persists across re-renders) ──
+        const skipState = {
+            vulns: new Set(),  // skipped vuln IDs
+            deps: new Set(),   // skipped top-level dep names
+        };
+
+        function getNear(vuln, project) {
+            return getNearIgnoredPath(vuln, project, ignorePatternsByFile);
+        }
+
+        // ── Build sections ──
+        function buildSections() {
+            const decisions = localRS.decisions;
+
+            // Mark resolved vulns that reappeared as reopened
+            const activeIds = new Set(allVulnEntries.map(e => e.vuln.id));
+            for (const [id, dec] of Object.entries(decisions)) {
+                if (dec.status === 'resolved' && activeIds.has(id)) {
+                    decisions[id] = { ...dec, status: 'reopened' };
+                }
+            }
+
+            // Section 1: Dep groups — Map: depName → { depName, vulns: Map<id,{id,vuln}>, files: Map<pkgPath,version> }
+            const depGroups = new Map();
+            for (const { vuln, project } of allVulnEntries) {
+                const topDep = vuln.from?.[1] || '';
+                if (!topDep) continue;
+                const depName = stripVer(topDep);
+                const depVersion = topDep.slice(depName.length + 1);
+                if (!depGroups.has(depName)) depGroups.set(depName, { depName, vulns: new Map(), files: new Map() });
+                const g = depGroups.get(depName);
+                if (!g.vulns.has(vuln.id)) g.vulns.set(vuln.id, { id: vuln.id, vuln });
+                const pkgPath = project.displayTargetFile || 'package.json';
+                if (!g.files.has(pkgPath)) g.files.set(pkgPath, depVersion);
+            }
+
+            // Section 2: Resolution groups — Map: pkgName → { fixVersion, items: [{id,vuln,entries}] }
+            const resGroups = new Map();
+            for (const { vuln, project } of allVulnEntries) {
+                const fix = sameMajorFixVersion(vuln);
+                if (!fix) continue;
+                const pkg = vuln.name || vuln.packageName || '';
+                if (!pkg) continue;
+                if (!resGroups.has(pkg)) resGroups.set(pkg, { fixVersion: fix, itemsMap: new Map() });
+                const g = resGroups.get(pkg);
+                if (fix < g.fixVersion) g.fixVersion = fix;
+                if (!g.itemsMap.has(vuln.id)) g.itemsMap.set(vuln.id, { id: vuln.id, vuln, entries: [] });
+                g.itemsMap.get(vuln.id).entries.push({ vuln, project });
+            }
+            for (const g of resGroups.values()) {
+                g.items = [...g.itemsMap.values()];
+                delete g.itemsMap;
+            }
+
+            // Section 3: Ignore data
+            const nearItems = new Map();   // snykFile → [{id,vuln,entry,nearMatch,resolved}]
+            const ignoreVulns = new Map(); // id → {id,vuln,paths:[{snykFile,depPath,topLevelDep}]}
+
+            for (const { vuln, project } of allVulnEntries) {
+                const id = vuln.id;
+                const decision = decisions[id];
+                if (decision?.status === 'resolved') continue;
+
+                // Near-ignored check
+                const near = getNear(vuln, project);
+                if (near) {
+                    const sf = getSnykFilePath(project);
+                    if (!nearItems.has(sf)) nearItems.set(sf, []);
+                    const activePath = (vuln.from?.slice(1) || []).join(' > ');
+                    const resolved = activePath === near.path;
+                    const existing = nearItems.get(sf).find(item => item.id === id);
+                    if (!existing) {
+                        nearItems.get(sf).push({ id, vuln, entry: { vuln, project }, nearMatch: near, resolved });
+                    }
+                }
+
+                // Ignore candidates — all unresolved vulns
+                const snykFile = getSnykFilePath(project);
+                const depPath = (vuln.from?.slice(1) || []).join(' > ');
+                const topLevelDep = stripVer(vuln.from?.[1] || '');
+                if (!ignoreVulns.has(id)) ignoreVulns.set(id, { id, vuln, paths: [] });
+                const v = ignoreVulns.get(id);
+                const key = snykFile + '\0' + depPath;
+                if (!v.paths.some(p => p.snykFile + '\0' + p.depPath === key)) {
+                    v.paths.push({ snykFile, depPath, topLevelDep });
+                }
+            }
+
+            // Reviewed list
+            const reviewed = [];
+            const seenReviewed = new Set();
+            for (const [id, dec] of Object.entries(decisions)) {
+                if (dec.status !== 'resolved' && dec.status !== 'skipped') continue;
+                if (seenReviewed.has(id)) continue;
+                seenReviewed.add(id);
+                const entry = allVulnEntries.find(e => e.vuln.id === id);
+                if (entry) reviewed.push({ id, vuln: entry.vuln, decision: dec });
+            }
+
+            return { depGroups, resGroups, ignoreData: { nearItems, ignoreVulns }, reviewed };
+        }
+
+        // ── HTML helpers ──
+        function sevBadge(vuln) {
+            const s = sevClass(vuln);
+            return `<span class="sev-badge ${s}">${s}</span>`;
+        }
+
+        function vulnListHtml(items) {
+            return items.map(({ id, vuln }) => {
+                const cves = (vuln.identifiers?.CVE || []).map(c =>
+                    `<a class="cve-link" href="https://nvd.nist.gov/vuln/detail/${esc(c)}" target="_blank" rel="noopener">${esc(c)}</a>`
+                ).join(' ');
+                return `<div class="rq-vuln-item">
+                    ${sevBadge(vuln)}
+                    <a class="vuln-id-link" href="https://security.snyk.io/vuln/${esc(id)}" target="_blank" rel="noopener">${esc(id)}</a>
+                    <span class="rq-vuln-title">${esc(vuln.title || '')}</span>
+                    ${cves}
+                </div>`;
+            }).join('');
+        }
+
+        function installStep() {
+            return `<div class="rq-step">
+                <span class="step-num">3</span>
+                <div class="step-content">
+                    <span class="step-label">Install dependencies</span>
+                    <span class="step-code-line">npm run bootstrap <button class="btn btn-sm btn-outline" data-action="copy" data-copy="npm run bootstrap" style="margin-left:4px">&#x2398; Copy</button></span>
+                </div>
+            </div>`;
+        }
+
+        function checkVersionsBtn(pkg, recommendedVersion, panelId) {
+            return `<button class="btn btn-sm btn-outline" data-action="check-versions"
+                data-pkg="${esc(pkg)}"
+                data-recommend="${esc(recommendedVersion)}"
+                data-panel="${esc(panelId)}">Check versions &#x25BE;</button>
+            <div class="versions-panel" id="${esc(panelId)}" style="display:none"></div>`;
+        }
+
+        function allIds(items) { return items.map(i => i.id).join(','); }
+
+        function actionButtons(ids, resolution, note, extraHtml) {
+            return `<div class="rq-actions">
+                <button class="btn btn-primary" data-action="resolve" data-ids="${esc(ids)}" data-resolution="${esc(resolution)}" data-note="${esc(note)}">&#x2713; Mark as Resolved</button>
+                <button class="btn btn-outline" data-action="skip" data-ids="${esc(ids)}">Skip</button>
+                ${extraHtml || ''}
+            </div>`;
+        }
+
+        // ── Section 1: Dependency Upgrades ──
+        function renderDepUpgradeSection(depGroups) {
+            if (!depGroups.size) return '';
+            const cardsHtml = [...depGroups.entries()].map(([depName, group]) => {
+                const { vulns, files } = group;
+                const vulnBadgesHtml = [...vulns.entries()].map(([id, { vuln }]) => {
+                    const s = sevClass(vuln);
+                    return `<a class="vuln-tag-link" href="https://security.snyk.io/vuln/${esc(id)}" target="_blank" rel="noopener" title="${esc(vuln.title || '')}"><span class="sev-badge ${s}" style="font-size:9px;padding:1px 4px">${s}</span> <span style="font-family:monospace;font-size:11px">${esc(id)}</span></a>`;
+                }).join('');
+                const fileRowsHtml = [...files.entries()].map(([pkgPath, currentVer]) => {
+                    const safeId = (depName + '-' + pkgPath).replace(/[^a-z0-9]/gi, '-');
+                    const panelId = 'vp-dep-' + safeId;
+                    return `<div class="dep-card-file-row">
+                        <span class="dep-file-path">${esc(pkgPath)}</span>
+                        <span class="dep-file-version">@${esc(currentVer)}</span>
+                        <div class="dep-file-actions">
+                            <div>${checkVersionsBtn(depName, '', panelId)}</div>
+                            <button class="btn btn-sm btn-accent" data-action="update-dep"
+                                data-path="${esc(pkgPath)}" data-dep="${esc(depName)}" data-version="${esc(currentVer)}">Update package.json</button>
+                            <button class="btn btn-sm btn-outline" data-action="remove-dep"
+                                data-path="${esc(pkgPath)}" data-dep="${esc(depName)}">Remove dep</button>
+                        </div>
+                    </div>`;
+                }).join('');
+                return `<div class="dep-card">
+                    <div class="dep-card-header">
+                        <span class="dep-card-name">${esc(depName)}</span>
+                        <div class="dep-card-vulns">${vulnBadgesHtml}</div>
+                    </div>
+                    <div class="dep-card-body">${fileRowsHtml}</div>
+                </div>`;
+            }).join('');
+            return `<details class="tool-section" open>
+                <summary class="tool-section-header">
+                    <span class="tool-section-chevron">&#x25BC;</span>
+                    <span class="tool-section-num">1</span>
+                    <span class="tool-section-title">Dependency Upgrades</span>
+                    <span class="tool-section-desc">Group by top-level dep — try a newer version.</span>
+                    <span class="tool-section-badge">${depGroups.size}</span>
+                </summary>
+                <div class="tool-section-body">${cardsHtml}</div>
+            </details>`;
+        }
+
+        // ── Section 2: Yarn Resolutions ──
+        function renderResolutionSection(resGroups) {
+            if (!resGroups.size) return '';
+            const cardsHtml = [...resGroups.entries()].map(([pkg, batch]) => renderCatBCard(pkg, batch)).join('');
+            return `<details class="tool-section" open>
+                <summary class="tool-section-header">
+                    <span class="tool-section-chevron">&#x25BC;</span>
+                    <span class="tool-section-num">2</span>
+                    <span class="tool-section-title">Yarn Resolutions</span>
+                    <span class="tool-section-desc">Group by vulnerable package — pin a same-major fix.</span>
+                    <span class="tool-section-badge">${resGroups.size}</span>
+                </summary>
+                <div class="tool-section-body">${cardsHtml}</div>
+            </details>`;
+        }
+
+        function renderCatBCard(pkg, batch) {
+            const { fixVersion, items } = batch;
+            const resolutionKey = `**/${pkg}`;
+            const cardId = 'card-b-' + pkg.replace(/[^a-z0-9]/gi, '-');
+            const panelId = 'vp-b-' + pkg.replace(/[^a-z0-9]/gi, '-');
+            const ids = allIds(items);
+            return `<div class="rq-card" id="${esc(cardId)}">
+                <div class="rq-card-header">
+                    <span class="rq-card-title">Pin <code>${esc(pkg)}</code> &#x2192; <code>${esc(fixVersion)}</code></span>
+                </div>
+                <div class="rq-card-body">
+                    <div class="rq-vuln-list">${vulnListHtml(items)}</div>
+                    <div class="rq-steps">
+                        <div class="rq-step">
+                            <span class="step-num">1</span>
+                            <div class="step-content">
+                                <span class="step-label">Check available versions</span>
+                                ${checkVersionsBtn(pkg, fixVersion, panelId)}
+                            </div>
+                        </div>
+                        <div class="rq-step">
+                            <span class="step-num">2</span>
+                            <div class="step-content">
+                                <span class="step-label">Add resolution to root <code>package.json</code></span>
+                                <div class="resolution-snippet">
+                                    <code>"${esc(resolutionKey)}": "${esc(fixVersion)}"</code>
+                                    <button class="btn btn-sm btn-outline" data-action="copy" data-copy="${esc('"' + resolutionKey + '": "' + fixVersion + '"')}">&#x2398; Copy</button>
+                                </div>
+                                <button class="btn btn-sm btn-accent" data-action="apply-resolution"
+                                    data-key="${esc(resolutionKey)}" data-version="${esc(fixVersion)}">Apply to package.json</button>
+                            </div>
+                        </div>
+                        ${installStep()}
+                    </div>
+                    ${actionButtons(ids, 'yarn-resolution', 'Added ' + resolutionKey + ': ' + fixVersion)}
+                </div>
+            </div>`;
+        }
+
+        // ── Section 3: Snyk Ignores ──
+        function renderIgnoreSection(ignoreData) {
+            const { nearItems, ignoreVulns } = ignoreData;
+            const cardId = 's3';
+            const expiry = sharedExpiry || '';
+            const presetOptionsHtml = IGNORE_REASONS.map(r =>
+                `<option value="${esc(r)}">${esc(r)}</option>`
+            ).join('');
+
+            // Near-ignored panel
+            let nearHtml = '';
+            if (nearItems.size) {
+                const allNearUpdates = [];
+                for (const [sf, items] of nearItems.entries()) {
+                    for (const { id, nearMatch, entry, resolved } of items) {
+                        if (!resolved) {
+                            const activePath = (entry.vuln.from?.slice(1) || []).join(' > ');
+                            allNearUpdates.push({ snykFile: sf, vulnId: id, oldPath: nearMatch.path, newPath: activePath });
+                        }
+                    }
+                }
+                const updateAllBtn = allNearUpdates.length
+                    ? `<button class="btn btn-sm btn-warn" data-action="update-all-near"
+                            data-updates="${esc(JSON.stringify(allNearUpdates))}">Update All .snyk Files</button>`
+                    : '';
+                const nearGroupsHtml = [...nearItems.entries()].map(([sf, items]) => renderCatDGroup(sf, items)).join('');
+                nearHtml = `<details class="s3-near-panel" open>
+                    <summary class="s3-near-summary">
+                        <span>&#x26A1; Near-ignored &#x2014; stale .snyk paths</span>
+                        <span class="s3-near-count">${nearItems.size} file${nearItems.size !== 1 ? 's' : ''}</span>
+                        ${updateAllBtn}
+                    </summary>
+                    <div class="s3-near-body">${nearGroupsHtml}</div>
+                </details>`;
+            }
+
+            // Shared expiry
+            const expiryHtml = `<div class="s3-expiry-row">
+                <label class="ignore-form-label">Expiry (shared)</label>
+                <input type="text" class="ignore-form-input batch-ignore-expiry" id="expiry-${cardId}"
+                    data-card="${cardId}" value="${esc(expiry)}" placeholder="2026-06-08T00:00:00.000Z" style="width:280px">
+            </div>`;
+
+            // Build per-vuln cards with global path indices
+            let globalIdx = 0;
+            const vulnCards = [];
+            const allBatchItems = []; // for "Add All" button — populated after skipped filtering
+
+            for (const [id, { vuln, paths }] of ignoreVulns) {
+                const skipped = skipState.vulns.has(id);
+                const startIdx = globalIdx;
+                // Group paths by snyk file
+                const byFile = new Map();
+                for (const path of paths) {
+                    if (!byFile.has(path.snykFile)) byFile.set(path.snykFile, []);
+                    const idx = globalIdx++;
+                    byFile.get(path.snykFile).push({ ...path, idx });
+                }
+                if (!skipped) {
+                    for (const [, filePaths] of byFile) {
+                        for (const p of filePaths) {
+                            if (!skipState.deps.has(p.topLevelDep)) {
+                                allBatchItems.push({ vulnId: id, snykFile: p.snykFile, depPath: p.depPath, idx: p.idx });
+                            }
+                        }
+                    }
+                }
+                vulnCards.push({ id, vuln, skipped, byFile, startIdx });
+            }
+
+            const vulnCardsHtml = vulnCards.map(({ id, vuln, skipped, byFile }, vi) => {
+                // Unique top-level deps for skip-by-dep tags
+                const topDeps = new Set();
+                for (const [, fps] of byFile) for (const p of fps) topDeps.add(p.topLevelDep);
+                const depTagsHtml = [...topDeps].filter(Boolean).map(dep => {
+                    const active = skipState.deps.has(dep);
+                    return `<button class="skip-dep-tag${active ? ' skipped' : ''}" data-action="skip-dep" data-dep="${esc(dep)}">${esc(dep)} &#x2715;</button>`;
+                }).join('');
+
+                // Total path count and file count for header badge
+                let totalPaths = 0;
+                for (const [, fps] of byFile) totalPaths += fps.length;
+                const fileCount = byFile.size;
+                const countBadge = `<span class="s3-path-count-badge">${totalPaths} path${totalPaths !== 1 ? 's' : ''} &middot; ${fileCount} file${fileCount !== 1 ? 's' : ''}</span>`;
+
+                const fileGroupsHtml = [...byFile.entries()].map(([snykFile, fps]) => {
+                    const rowsHtml = fps.map(path => {
+                        const depSkipped = skipState.deps.has(path.topLevelDep);
+                        return `<div class="path-checkbox-row${depSkipped ? ' dep-skipped' : ''}" data-top-dep="${esc(path.topLevelDep)}">
+                            <input type="checkbox" class="path-cb"${depSkipped ? '' : ' checked'}
+                                data-card="${cardId}" data-idx="${path.idx}" data-vuln-idx="${vi}" data-vuln-id="${esc(id)}">
+                            <span class="path-deppath">${esc(path.depPath)}</span>
+                            <input type="text" class="ignore-form-input batch-ignore-reason"
+                                id="reason-${cardId}-${path.idx}"
+                                data-card="${cardId}" data-idx="${path.idx}" data-vuln-idx="${vi}"
+                                data-snyk-file="${esc(snykFile)}"
+                                placeholder="Reason&#x2026;">
+                        </div>`;
+                    }).join('');
+                    const fileId = snykFile.replace(/[^a-z0-9]/gi, '-');
+                    const filePaths = fps.map(p => ({ vulnId: id, depPath: p.depPath, idx: p.idx }));
+                    const fileYaml = buildGroupedYamlPreview(filePaths, [], expiry);
+                    return `<div class="batch-file-subgroup" data-snyk-file="${esc(snykFile)}">
+                        <div class="batch-file-subgroup-heading">
+                            ${esc(snykFile)}
+                            <span class="s3-file-path-count">${fps.length} path${fps.length !== 1 ? 's' : ''}</span>
+                        </div>
+                        <select class="ignore-form-input preset-select cat-a-preset"
+                            data-card="${cardId}" data-vuln-idx="${vi}" data-snyk-file="${esc(snykFile)}">
+                            <option value="">Fill reasons for this file&#x2026;</option>
+                            ${presetOptionsHtml}
+                        </select>
+                        ${rowsHtml}
+                        <details class="batch-yaml-details">
+                            <summary class="batch-yaml-summary">
+                                ${esc(snykFile)} YAML preview
+                                <button class="btn btn-sm btn-outline" data-action="copy-file-yaml"
+                                    data-vuln-idx="${vi}" data-snyk-file="${esc(snykFile)}">&#x2398; Copy</button>
+                            </summary>
+                            <pre class="yaml-snippet" id="batch-yaml-${cardId}-${vi}-${fileId}">${esc(fileYaml)}</pre>
+                        </details>
+                        <button class="btn btn-sm btn-accent" data-action="add-file-snyk-ignore"
+                            data-card="${cardId}" data-vuln-idx="${vi}" data-snyk-file="${esc(snykFile)}"
+                            data-vuln-id="${esc(id)}">Add to ${esc(snykFile)}</button>
+                    </div>`;
+                }).join('');
+
+                return `<details class="rq-card s3-vuln-card${skipped ? ' s3-card-skipped' : ''}" id="s3-card-${vi}" data-vuln-id="${esc(id)}" open>
+                    <summary class="rq-card-header s3-card-header">
+                        <div class="s3-card-header-main">
+                            <span class="s3-card-chevron">&#x25BC;</span>
+                            ${sevBadge(vuln)}
+                            <a class="vuln-id-link" href="https://security.snyk.io/vuln/${esc(id)}" target="_blank" rel="noopener">${esc(id)}</a>
+                            <span class="rq-card-title">${esc(vuln.title || '')}</span>
+                            ${countBadge}
+                        </div>
+                        <div class="s3-card-header-right">
+                            ${depTagsHtml ? `<span class="s3-via-label">Via:</span> ${depTagsHtml}` : ''}
+                            <button class="skip-btn${skipped ? ' active' : ''}" data-action="skip-vuln" data-vuln-id="${esc(id)}">Skip &#x2715;</button>
+                        </div>
+                    </summary>
+                    ${skipped
+                        ? '<div class="s3-skipped-overlay">Skipped</div>'
+                        : `<div class="rq-card-body">${fileGroupsHtml}</div>`}
+                </details>`;
+            }).join('');
+
+            const allVulnIds = [...ignoreVulns.keys()].filter(id => !skipState.vulns.has(id)).join(',');
+            const globalActionsHtml = `<div class="rq-actions s3-global-actions">
+                <button class="btn btn-accent" data-action="add-all-snyk-ignore"
+                    data-card="${cardId}"
+                    data-items="${esc(JSON.stringify(allBatchItems))}">&#x2713; Add All to .snyk &#x2014; ${allBatchItems.length} path${allBatchItems.length !== 1 ? 's' : ''}</button>
+                <button class="btn btn-primary" data-action="resolve"
+                    data-ids="${esc(allVulnIds)}"
+                    data-resolution="snyk-ignore"
+                    data-note="Added ${allBatchItems.length} path(s) to .snyk">&#x2713; Mark All as Resolved</button>
+            </div>`;
+
+            return `<details class="tool-section" open>
+                <summary class="tool-section-header">
+                    <span class="tool-section-chevron">&#x25BC;</span>
+                    <span class="tool-section-num">3</span>
+                    <span class="tool-section-title">Snyk Ignores</span>
+                    <span class="tool-section-desc">Per-vuln cards sub-grouped by .snyk file.</span>
+                    <span class="tool-section-badge">${ignoreVulns.size}</span>
+                </summary>
+                <div class="tool-section-body">
+                    ${expiryHtml}
+                    ${nearHtml}
+                    ${vulnCardsHtml}
+                    ${globalActionsHtml}
+                </div>
+            </details>`;
+        }
+
+        // ── Category D group (reused inside Section 3 near panel) ──
+        function renderCatDGroup(snykFile, items) {
+            const groupId = 'near-' + snykFile.replace(/[^a-z0-9]/gi, '-');
+            const allResolved = items.every(i => i.resolved);
+            const unresolvedItems = items.filter(i => !i.resolved);
+
+            const itemsHtml = items.map(({ id, vuln, entry, nearMatch, resolved }) => {
+                const activeParts = entry.vuln.from?.slice(1) || [];
+                const snykParts = nearMatch.path.split(' > ');
+                const snykVerByName = new Map(snykParts.map(p => [stripVer(p), p.slice(stripVer(p).length)]));
+                const activeVerByName = new Map(activeParts.map(p => [stripVer(p), p.slice(stripVer(p).length)]));
+
+                function highlightPath(parts, isSnyk) {
+                    return parts.map(p => {
+                        const name = stripVer(p);
+                        const ver = p.slice(name.length);
+                        const other = isSnyk ? activeVerByName.get(name) : snykVerByName.get(name);
+                        const changed = other !== undefined && other !== ver;
+                        return changed
+                            ? `${esc(name)}<span class="changed">${esc(ver)}</span>`
+                            : esc(p);
+                    }).join('<span style="color:var(--c-border);font-size:10px;margin:0 2px">&#x2192;</span>');
+                }
+
+                const activePath = activeParts.join(' > ');
+                return `<div class="near-item${resolved ? ' near-item-resolved' : ''}">
+                    <div class="near-item-header">
+                        ${sevBadge(vuln)}
+                        <a class="vuln-id-link" href="https://security.snyk.io/vuln/${esc(id)}" target="_blank" rel="noopener">${esc(id)}</a>
+                        <span style="color:var(--c-text-muted);font-size:12px">${esc(vuln.title || '')}</span>
+                        ${resolved ? '<span class="near-resolved-pill">&#x2713; path matches</span>' : ''}
+                    </div>
+                    ${!resolved ? `<div class="near-paths">
+                        <div class="near-path-row">
+                            <span class="near-path-lbl lbl-snyk">.snyk</span>
+                            <span class="near-path-text snyk-side">${highlightPath(snykParts, true)}</span>
+                        </div>
+                        <div class="near-path-row">
+                            <span class="near-path-lbl lbl-active">active</span>
+                            <span class="near-path-text">${activeParts.length ? highlightPath(activeParts, false) : '<em style="color:var(--c-text-muted)">Direct dependency</em>'}</span>
+                        </div>
+                        ${nearMatch.reason ? `<div style="font-size:11px;color:var(--c-text-muted);margin-top:4px;font-style:italic">${esc(nearMatch.reason)}</div>` : ''}
+                    </div>
+                    <div style="margin-top:8px">
+                        <button class="btn btn-sm btn-warn" data-action="update-snyk"
+                            data-snyk-file="${esc(snykFile)}"
+                            data-vuln-id="${esc(id)}"
+                            data-old-path="${esc(nearMatch.path)}"
+                            data-new-path="${esc(activePath)}">Update .snyk</button>
+                    </div>` : ''}
+                </div>`;
+            }).join('');
+
+            const allUpdates = unresolvedItems.map(({ id, nearMatch, entry }) => {
+                const activePath = (entry.vuln.from?.slice(1) || []).join(' > ');
+                return { snykFile, vulnId: id, oldPath: nearMatch.path, newPath: activePath };
+            });
+            const countBadge = `<span class="near-group-count">${items.length} vuln${items.length !== 1 ? 's' : ''}</span>`;
+            const resolvedPill = allResolved ? '<span class="near-group-resolved-pill">&#x2713; Resolved</span>' : '';
+            const toggleArrow = `<span class="near-toggle-arrow">${allResolved ? '&#x25B6;' : '&#x25BC;'}</span>`;
+            const updateAllBtn = !allResolved
+                ? `<button class="btn btn-sm btn-warn" data-action="update-all-near"
+                        data-updates="${esc(JSON.stringify(allUpdates))}">Update All in This File</button>`
+                : '';
+
+            return `<div class="near-group" id="${esc(groupId)}">
+                <div class="near-group-header near-group-toggle" data-action="toggle-near-group" data-group="${esc(groupId)}">
+                    <span class="near-toggle-arrow-wrap">${toggleArrow}</span>
+                    <span class="near-group-file">${esc(snykFile)}</span>
+                    ${countBadge}
+                    ${resolvedPill}
+                    ${updateAllBtn}
+                </div>
+                <div class="near-group-items" id="${esc(groupId)}-items" style="${allResolved ? 'display:none' : ''}">
+                    ${itemsHtml}
+                </div>
+            </div>`;
+        }
+
+        // ── YAML builders ──
+        function buildGroupedYamlPreview(batchItems, reasons, expiry) {
+            const byVuln = new Map();
+            batchItems.forEach(function (item, localIdx) {
+                if (!byVuln.has(item.vulnId)) byVuln.set(item.vulnId, []);
+                const reasonIdx = (item.idx !== undefined) ? item.idx : localIdx;
+                byVuln.get(item.vulnId).push({ depPath: item.depPath, idx: reasonIdx });
+            });
+            const created = new Date().toISOString().slice(0, 10) + 'T00:00:00.000Z';
+            const e = expiry || '<expiry>';
+            const blocks = [];
+            for (const [vulnId, paths] of byVuln.entries()) {
+                let block = '  ' + vulnId + ':';
+                for (const { depPath, idx } of paths) {
+                    const r = (typeof reasons === 'object' && reasons !== null)
+                        ? (Array.isArray(reasons) ? (reasons[idx] || '') : (reasons[idx] || ''))
+                        : '';
+                    block += '\n    - \'' + (depPath || '<dep-path>') + '\':' +
+                             '\n        reason: >-\n          ' + (r || '<reason>') +
+                             '\n        expires: ' + e +
+                             '\n        created: ' + created;
+                }
+                blocks.push(block);
+            }
+            return blocks.join('\n');
+        }
+
+        // ── Render the full tab ──
+        function renderReviewQueueTab() {
+            const { depGroups, resGroups, ignoreData, reviewed } = buildSections();
+
+            // Count unique pending vulns (union across all sections)
+            const pendingIds = new Set();
+            for (const g of depGroups.values()) for (const id of g.vulns.keys()) pendingIds.add(id);
+            for (const g of resGroups.values()) for (const { id } of g.items) pendingIds.add(id);
+            for (const id of ignoreData.ignoreVulns.keys()) pendingIds.add(id);
+            const pendingCount = pendingIds.size;
+            const total = pendingCount + reviewed.length;
+
+            const badge = document.getElementById('queue-badge');
+            if (badge) badge.textContent = pendingCount;
+
+            const pct = total > 0 ? Math.round((reviewed.length / total) * 100) : 0;
+            const fill = document.getElementById('rq-progress-fill');
+            const progressText = document.getElementById('rq-progress-text');
+            if (fill) fill.style.width = pct + '%';
+            if (progressText) progressText.textContent = `${reviewed.length} / ${total} reviewed`;
+
+            let html = '';
+            html += renderDepUpgradeSection(depGroups);
+            html += renderResolutionSection(resGroups);
+            html += renderIgnoreSection(ignoreData);
+
+            if (!depGroups.size && !resGroups.size && !ignoreData.ignoreVulns.size) {
+                html = `<div class="rq-empty"><div class="empty-icon">&#x1F389;</div><p>No pending items &#x2014; all vulnerabilities reviewed!</p></div>`;
+            }
+
+            if (reviewed.length) {
+                html += `<div class="rq-resolved-section" id="rq-resolved-section">
+                    <button class="rq-resolved-toggle" id="rq-resolved-toggle">
+                        <span>Reviewed (${reviewed.length})</span>
+                        <span class="toggle-arrow">&#x25BC;</span>
+                    </button>
+                    <div class="rq-resolved-list" id="rq-resolved-list">
+                        ${reviewed.map(({ id, vuln, decision }) => {
+                            const status = decision.status || 'skipped';
+                            const ts = decision.timestamp ? new Date(decision.timestamp).toLocaleString() : '';
+                            return `<div class="rq-resolved-item">
+                                <span class="status-badge status-${esc(status)}">${esc(status)}</span>
+                                <a class="vuln-id-link" href="https://security.snyk.io/vuln/${esc(id)}" target="_blank" rel="noopener">${esc(id)}</a>
+                                ${sevBadge(vuln)}
+                                <span class="rq-resolved-note">${esc(vuln.title || '')}</span>
+                                ${decision.note ? `<span class="rq-resolved-note" style="color:var(--c-fix)">${esc(decision.note)}</span>` : ''}
+                                <span class="rq-resolved-ts">${esc(ts)}</span>
+                            </div>`;
+                        }).join('')}
+                    </div>
+                </div>`;
+            }
+
+            document.getElementById('rq-content').innerHTML = html;
+            attachEvents();
+        }
+
+        // ── Event handling (delegated) ──
+        function attachEvents() {
+            const container = document.getElementById('rq-content');
+
+            // Rebuild YAML preview for a specific vuln+file combo
+            function rebuildFileYaml(vulnIdx, snykFile) {
+                const cardId = 's3';
+                const fileId = snykFile.replace(/[^a-z0-9]/gi, '-');
+                const yamlEl = document.getElementById(`batch-yaml-${cardId}-${vulnIdx}-${fileId}`);
+                if (!yamlEl) return;
+                const expiry = document.getElementById(`expiry-${cardId}`)?.value || '';
+                const card = document.getElementById(`s3-card-${vulnIdx}`);
+                if (!card) return;
+                const vulnId = card.dataset.vulnId || '';
+                const subgroup = card.querySelector(`.batch-file-subgroup[data-snyk-file="${CSS.escape(snykFile)}"]`);
+                if (!subgroup) return;
+                const rows = subgroup.querySelectorAll('.path-checkbox-row');
+                const filePaths = [];
+                rows.forEach(row => {
+                    const cb = row.querySelector('input[type="checkbox"]');
+                    const idx = cb ? parseInt(cb.dataset.idx) : NaN;
+                    if (isNaN(idx)) return;
+                    const depPathSpan = row.querySelector('.path-deppath');
+                    filePaths.push({ vulnId, depPath: depPathSpan?.textContent || '', idx });
+                });
+                const reasons = {};
+                filePaths.forEach(p => {
+                    const el = document.getElementById(`reason-s3-${p.idx}`);
+                    if (el) reasons[p.idx] = el.value;
+                });
+                yamlEl.textContent = buildGroupedYamlPreview(filePaths, reasons, expiry);
+            }
+
+            async function handleAddFileSnykIgnore(btn) {
+                const cardId = btn.dataset.card;
+                const vulnIdx = parseInt(btn.dataset.vulnIdx);
+                const snykFile = btn.dataset.snykFile;
+                const vulnId = btn.dataset.vulnId;
+                const expiryInput = document.getElementById('expiry-' + cardId);
+                const expires = expiryInput?.value?.trim() || '';
+                if (!expires) { alert('Please enter an expiry date.'); return; }
+
+                const card = document.getElementById(`s3-card-${vulnIdx}`);
+                const subgroup = card?.querySelector(`.batch-file-subgroup[data-snyk-file="${CSS.escape(snykFile)}"]`);
+                if (!subgroup) return;
+
+                const toAdd = [];
+                subgroup.querySelectorAll('.path-checkbox-row').forEach(row => {
+                    const cb = row.querySelector('input[type="checkbox"]');
+                    if (!cb || !cb.checked) return;
+                    const idx = parseInt(cb.dataset.idx);
+                    const depPathSpan = row.querySelector('.path-deppath');
+                    const depPath = depPathSpan?.textContent || '';
+                    const reason = document.getElementById(`reason-${cardId}-${idx}`)?.value?.trim() || '';
+                    toAdd.push({ vulnId, depPath, reason, snykFile });
+                });
+
+                if (!toAdd.length) { alert('No checked paths to add.'); return; }
+                const emptyReason = toAdd.find(p => !p.reason);
+                if (emptyReason) { alert('Please enter a reason for all checked paths.'); return; }
+
+                btn.disabled = true;
+                for (let i = 0; i < toAdd.length; i++) {
+                    const p = toAdd[i];
+                    btn.textContent = `Adding ${i + 1}/${toAdd.length}\u2026`;
+                    try {
+                        const r = await fetch('/add-snyk-ignore', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ snykFile: p.snykFile, vulnId: p.vulnId, path: p.depPath, reason: p.reason, expires }),
+                        });
+                        const data = await r.json();
+                        if (!data.ok) { btn.disabled = false; btn.textContent = `Add to ${snykFile}`; alert('Failed: ' + data.error); return; }
+                    } catch (err) {
+                        btn.disabled = false; btn.textContent = `Add to ${snykFile}`;
+                        alert('Request failed: ' + err.message); return;
+                    }
+                }
+                btn.textContent = '\u2713 Updated';
+                setTimeout(() => { btn.disabled = false; btn.textContent = `Add to ${snykFile}`; }, 2000);
+            }
+
+            // Preset dropdown
+            container.addEventListener('change', function (e) {
+                if (!e.target.classList.contains('preset-select')) return;
+                const vulnIdx = e.target.dataset.vulnIdx;
+                const snykFile = e.target.dataset.snykFile;
+                const val = e.target.value;
+                if (!val) return;
+                const card = document.getElementById(`s3-card-${vulnIdx}`);
+                const subgroup = card?.querySelector(`.batch-file-subgroup[data-snyk-file="${CSS.escape(snykFile)}"]`);
+                if (!subgroup) return;
+                subgroup.querySelectorAll('.batch-ignore-reason').forEach(inp => {
+                    inp.value = val;
+                });
+                e.target.value = '';
+                if (vulnIdx !== undefined && snykFile) rebuildFileYaml(parseInt(vulnIdx), snykFile);
+            });
+
+            container.addEventListener('click', function (e) {
+                const btn = e.target.closest('[data-action]');
+                if (!btn) return;
+                e.stopPropagation();
+                const action = btn.dataset.action;
+
+                if (action === 'check-versions') {
+                    handleCheckVersions(btn);
+                } else if (action === 'check-dep-field') {
+                    handleCheckDepField(btn);
+                } else if (action === 'update-dep') {
+                    handleUpdateDep(btn);
+                } else if (action === 'remove-dep') {
+                    handleRemoveDep(btn);
+                } else if (action === 'apply-resolution') {
+                    handleApplyResolution(btn);
+                } else if (action === 'add-all-snyk-ignore') {
+                    handleAddAllSnykIgnore(btn);
+                } else if (action === 'add-file-snyk-ignore') {
+                    handleAddFileSnykIgnore(btn);
+                } else if (action === 'add-snyk-ignore') {
+                    handleAddSnykIgnore(btn);
+                } else if (action === 'update-snyk') {
+                    handleUpdateSnyk(btn);
+                } else if (action === 'update-all-near') {
+                    handleUpdateAllNear(btn);
+                } else if (action === 'toggle-near-group') {
+                    const groupId = btn.dataset.group;
+                    const itemsEl = document.getElementById(groupId + '-items');
+                    if (itemsEl) {
+                        const open = itemsEl.style.display !== 'none';
+                        itemsEl.style.display = open ? 'none' : '';
+                        const arrow = btn.querySelector('.near-toggle-arrow');
+                        if (arrow) arrow.innerHTML = open ? '&#x25B6;' : '&#x25BC;';
+                    }
+                } else if (action === 'skip-vuln') {
+                    const vulnId = btn.dataset.vulnId;
+                    if (!vulnId) return;
+                    if (skipState.vulns.has(vulnId)) skipState.vulns.delete(vulnId);
+                    else skipState.vulns.add(vulnId);
+                    renderReviewQueueTab();
+                } else if (action === 'skip-dep') {
+                    const dep = btn.dataset.dep;
+                    if (skipState.deps.has(dep)) skipState.deps.delete(dep);
+                    else skipState.deps.add(dep);
+                    // Toggle checkboxes for this dep and collect affected (vulnIdx, snykFile) pairs
+                    const toRebuild = new Set();
+                    container.querySelectorAll(`.path-checkbox-row[data-top-dep="${CSS.escape(dep)}"]`).forEach(row => {
+                        const cb = row.querySelector('input[type="checkbox"]');
+                        if (cb) {
+                            cb.checked = !skipState.deps.has(dep);
+                            const vi = cb.dataset.vulnIdx;
+                            const sf = row.closest('.batch-file-subgroup')?.dataset.snykFile;
+                            if (vi !== undefined && sf) toRebuild.add(`${vi}\0${sf}`);
+                        }
+                    });
+                    // Toggle button style
+                    container.querySelectorAll(`[data-action="skip-dep"][data-dep="${CSS.escape(dep)}"]`).forEach(b => {
+                        b.classList.toggle('skipped', skipState.deps.has(dep));
+                    });
+                    // Rebuild YAML previews for affected vuln+file pairs
+                    toRebuild.forEach(key => {
+                        const sep = key.indexOf('\0');
+                        rebuildFileYaml(parseInt(key.slice(0, sep)), key.slice(sep + 1));
+                    });
+                } else if (action === 'copy-file-yaml') {
+                    const vi = btn.dataset.vulnIdx;
+                    const snykFile = btn.dataset.snykFile;
+                    const fileId = snykFile.replace(/[^a-z0-9]/gi, '-');
+                    const yamlEl = document.getElementById(`batch-yaml-s3-${vi}-${fileId}`);
+                    if (yamlEl) navigator.clipboard.writeText(yamlEl.textContent).then(() => {
+                        const orig = btn.textContent; btn.textContent = '\u2713 Copied';
+                        setTimeout(() => { btn.textContent = orig; }, 1500);
+                    });
+                } else if (action === 'resolve') {
+                    const ids = btn.dataset.ids.split(',').filter(Boolean);
+                    applyDecision(ids, 'resolved', { resolution: btn.dataset.resolution, note: btn.dataset.note });
+                } else if (action === 'skip') {
+                    applyDecision(btn.dataset.ids.split(',').filter(Boolean), 'skipped', {});
+                } else if (action === 'copy') {
+                    navigator.clipboard.writeText(btn.dataset.copy).then(() => {
+                        const orig = btn.textContent; btn.textContent = '\u2713 Copied';
+                        setTimeout(() => { btn.textContent = orig; }, 1500);
+                    });
+                } else if (action === 'copy-yaml') {
+                    const yaml = document.getElementById('yaml-' + btn.dataset.card);
+                    if (yaml) navigator.clipboard.writeText(yaml.textContent).then(() => {
+                        const orig = btn.textContent; btn.textContent = '\u2713 Copied';
+                        setTimeout(() => { btn.textContent = orig; }, 1500);
+                    });
+                }
+            });
+
+            // Live YAML preview updates
+            container.addEventListener('input', function (e) {
+                if (e.target.classList.contains('batch-ignore-reason')) {
+                    const vulnIdx = parseInt(e.target.dataset.vulnIdx);
+                    const snykFile = e.target.dataset.snykFile;
+                    if (!isNaN(vulnIdx) && snykFile) rebuildFileYaml(vulnIdx, snykFile);
+                }
+                if (e.target.classList.contains('batch-ignore-expiry')) {
+                    const cardId = e.target.dataset.card;
+                    if (!cardId) return;
+                    // Rebuild all file YAML previews
+                    container.querySelectorAll('[id^="batch-yaml-s3-"]').forEach(yamlEl => {
+                        const m = yamlEl.id.match(/^batch-yaml-s3-(\d+)-(.+)$/);
+                        if (!m) return;
+                        const vi = parseInt(m[1]);
+                        const fileId = m[2];
+                        // Find snyk file from matching subgroup
+                        const card = document.getElementById(`s3-card-${vi}`);
+                        if (!card) return;
+                        card.querySelectorAll('.batch-file-subgroup').forEach(sg => {
+                            const sf = sg.dataset.snykFile;
+                            if (sf && sf.replace(/[^a-z0-9]/gi, '-') === fileId) {
+                                rebuildFileYaml(vi, sf);
+                            }
+                        });
+                    });
+                }
+            });
+
+            const resolvedToggle = document.getElementById('rq-resolved-toggle');
+            if (resolvedToggle) {
+                resolvedToggle.addEventListener('click', () => {
+                    document.getElementById('rq-resolved-section').classList.toggle('open');
+                });
+            }
+        }
+
+        // ── Action handlers ──
+        function handleCheckVersions(btn) {
+            const { pkg, recommend, panel: panelId } = btn.dataset;
+            const panel = document.getElementById(panelId);
+            if (!panel) return;
+            if (panel.style.display === 'block') { panel.style.display = 'none'; return; }
+            btn.disabled = true;
+            btn.textContent = 'Fetching\u2026';
+            fetch(`/npm-versions?pkg=${encodeURIComponent(pkg)}`)
+                .then(r => r.json())
+                .then(data => {
+                    btn.disabled = false;
+                    btn.innerHTML = 'Check versions &#x25BE;';
+                    if (!data.ok) { panel.innerHTML = `<div class="versions-panel-title" style="color:var(--c-critical)">Error: ${esc(data.error)}</div>`; }
+                    else {
+                        const tags = data.versions.map(v => {
+                            const isRec = v === recommend;
+                            return `<span class="version-tag${isRec ? ' recommended' : ''}">${esc(v)}</span>`;
+                        }).join('');
+                        panel.innerHTML = `<div class="versions-panel-title">Available versions (newest first)</div><div class="versions-list">${tags}</div>`;
+                    }
+                    panel.style.display = 'block';
+                })
+                .catch(err => {
+                    btn.disabled = false;
+                    btn.innerHTML = 'Check versions &#x25BE;';
+                    panel.innerHTML = `<div class="versions-panel-title" style="color:var(--c-critical)">Request failed: ${esc(err.message)}</div>`;
+                    panel.style.display = 'block';
+                });
+        }
+
+        function handleCheckDepField(btn) {
+            const { pkg, file, panel: panelId } = btn.dataset;
+            const panel = document.getElementById(panelId);
+            if (!panel) return;
+            btn.disabled = true;
+            btn.textContent = 'Checking\u2026';
+            fetch(`/dep-field?pkg=${encodeURIComponent(pkg)}&file=${encodeURIComponent(file)}`)
+                .then(r => r.json())
+                .then(data => {
+                    btn.disabled = false;
+                    btn.textContent = 'Check dep type \u2192';
+                    if (data.ok && data.field) {
+                        panel.innerHTML = `<span class="dep-type-badge ${esc(data.field)}">${esc(data.field)}</span>`;
+                    } else if (data.ok) {
+                        panel.textContent = 'not found in package.json';
+                    } else {
+                        panel.textContent = 'error: ' + esc(data.error || '?');
+                    }
+                })
+                .catch(err => {
+                    btn.disabled = false;
+                    btn.textContent = 'Check dep type \u2192';
+                    panel.textContent = 'error: ' + err.message;
+                });
+        }
+
+        async function handleAddAllSnykIgnore(btn) {
+            const cardId = btn.dataset.card;
+            const expiryInput = document.getElementById('expiry-' + cardId);
+            const expires = expiryInput?.value?.trim() || '';
+            if (!expires) { alert('Please enter an expiry date.'); return; }
+            let batchItems;
+            try { batchItems = JSON.parse(btn.dataset.items); } catch { return; }
+            if (!batchItems.length) return;
+            const reasons = batchItems.map(function (item) {
+                return document.getElementById('reason-' + cardId + '-' + item.idx)?.value?.trim() || '';
+            });
+            const emptyIdx = reasons.findIndex(function (r) { return !r; });
+            if (emptyIdx >= 0) { alert('Please enter a reason for path ' + (emptyIdx + 1) + '.'); return; }
+            btn.disabled = true;
+            const allVulnIds = [...new Set(batchItems.map(function (i) { return i.vulnId; }))];
+            for (let i = 0; i < batchItems.length; i++) {
+                const item = batchItems[i];
+                btn.textContent = 'Adding ' + (i + 1) + '/' + batchItems.length + '\u2026';
+                try {
+                    const r = await fetch('/add-snyk-ignore', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ snykFile: item.snykFile, vulnId: item.vulnId, path: item.depPath, reason: reasons[i], expires }),
+                    });
+                    const data = await r.json();
+                    if (!data.ok) { btn.disabled = false; btn.textContent = '\u2713 Add All to .snyk'; alert('Failed: ' + data.error); return; }
+                } catch (err) {
+                    btn.disabled = false; btn.textContent = '\u2713 Add All to .snyk';
+                    alert('Request failed: ' + err.message); return;
+                }
+            }
+            btn.textContent = '\u2713 Added ' + batchItems.length + '/' + batchItems.length;
+            applyDecision(allVulnIds, 'resolved', { resolution: 'snyk-ignore', note: 'Added ' + batchItems.length + ' path(s) to .snyk' });
+        }
+
+        function handleUpdateDep(btn) {
+            const { path: pkgPath, dep, version } = btn.dataset;
+            btn.disabled = true;
+            btn.textContent = 'Updating\u2026';
+            fetch('/update-dep-version', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ packageJsonPath: pkgPath, dep, version }),
+            }).then(r => r.json()).then(data => {
+                if (data.ok) { btn.textContent = '\u2713 Updated'; btn.classList.add('btn-primary'); }
+                else { btn.disabled = false; btn.textContent = 'Update package.json'; alert('Failed: ' + data.error); }
+            }).catch(err => { btn.disabled = false; btn.textContent = 'Update package.json'; alert('Request failed: ' + err.message); });
+        }
+
+        function handleRemoveDep(btn) {
+            const { path: pkgPath, dep } = btn.dataset;
+            if (!confirm(`Remove "${dep}" from ${pkgPath}?`)) return;
+            btn.disabled = true;
+            btn.textContent = 'Removing\u2026';
+            fetch('/remove-dep', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ packageJsonPath: pkgPath, dep }),
+            }).then(r => r.json()).then(data => {
+                if (data.ok) { btn.textContent = '\u2713 Removed'; btn.classList.add('btn-primary'); }
+                else { btn.disabled = false; btn.textContent = 'Remove dep'; alert('Failed: ' + data.error); }
+            }).catch(err => { btn.disabled = false; btn.textContent = 'Remove dep'; alert('Request failed: ' + err.message); });
+        }
+
+        function handleApplyResolution(btn) {
+            const { key, version } = btn.dataset;
+            btn.disabled = true;
+            btn.textContent = 'Applying\u2026';
+            fetch('/apply-resolution', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ key, version }),
+            }).then(r => r.json()).then(data => {
+                if (data.ok) { btn.textContent = '\u2713 Applied'; btn.classList.add('btn-primary'); }
+                else { btn.disabled = false; btn.textContent = 'Apply to package.json'; alert('Failed: ' + data.error); }
+            }).catch(err => { btn.disabled = false; btn.textContent = 'Apply to package.json'; alert('Request failed: ' + err.message); });
+        }
+
+        function handleAddSnykIgnore(btn) {
+            const { snykFile, vulnId, depPath } = btn.dataset;
+            const form = btn.closest('.rq-ignore-inline') || document.getElementById('rq-content');
+            const reasonInput = form?.querySelector(`[data-field="reason"][data-vuln="${vulnId}"]`);
+            const expiryInput = form?.querySelector(`[data-field="expiry"][data-vuln="${vulnId}"]`);
+            const reason = reasonInput?.value?.trim() || '';
+            const expires = expiryInput?.value?.trim() || '';
+            if (!reason) { alert('Please enter a reason for ignoring this vulnerability.'); return; }
+            if (!expires) { alert('Please enter an expiry date.'); return; }
+            btn.disabled = true;
+            btn.textContent = 'Adding\u2026';
+            fetch('/add-snyk-ignore', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ snykFile, vulnId, path: depPath, reason, expires }),
+            }).then(r => r.json()).then(data => {
+                if (data.ok) { btn.textContent = '\u2713 Added to ' + snykFile; btn.classList.add('btn-primary'); }
+                else { btn.disabled = false; btn.textContent = 'Add to .snyk File'; alert('Failed: ' + data.error); }
+            }).catch(err => { btn.disabled = false; btn.textContent = 'Add to .snyk File'; alert('Request failed: ' + err.message); });
+        }
+
+        function handleUpdateSnyk(btn) {
+            const { snykFile, vulnId, oldPath, newPath } = btn.dataset;
+            btn.disabled = true;
+            btn.textContent = 'Updating\u2026';
+            fetch('/update-snyk', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ updates: [{ snykFile, vulnId, oldPath, newPath }] }),
+            }).then(r => r.json()).then(data => {
+                if (data.ok) { location.reload(); }
+                else { btn.disabled = false; btn.textContent = 'Update .snyk'; alert('Failed: ' + data.error); }
+            }).catch(err => { btn.disabled = false; btn.textContent = 'Update .snyk'; alert('Request failed: ' + err.message); });
+        }
+
+        function handleUpdateAllNear(btn) {
+            let updates;
+            try { updates = JSON.parse(btn.dataset.updates); } catch { return; }
+            if (!updates.length) return;
+            btn.disabled = true;
+            btn.textContent = 'Updating\u2026';
+            fetch('/update-snyk', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ updates }),
+            }).then(r => r.json()).then(data => {
+                if (data.ok) { location.reload(); }
+                else { btn.disabled = false; btn.textContent = 'Update All in This File'; alert('Failed: ' + data.error); }
+            }).catch(err => { btn.disabled = false; btn.textContent = 'Update All in This File'; alert('Request failed: ' + err.message); });
+        }
+
+        function applyDecision(ids, status, extra) {
+            const updates = {};
+            for (const id of ids) { updates[id] = { status, ...extra }; }
+            fetch('/review-state', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(updates),
+            }).then(r => r.json()).then(data => {
+                if (data.ok) {
+                    const ts = new Date().toISOString();
+                    for (const [id, decision] of Object.entries(updates)) {
+                        localRS.decisions[id] = { ...decision, timestamp: ts };
+                    }
+                    renderReviewQueueTab();
+                } else {
+                    alert('Failed to save: ' + data.error);
+                }
+            }).catch(err => alert('Request failed: ' + err.message));
+        }
+
+        const resetBtn = document.getElementById('reset-review-btn');
+        if (resetBtn) {
+            resetBtn.addEventListener('click', () => {
+                if (!confirm('Reset review state? All decisions will be cleared and all vulnerabilities will return to the queue.')) return;
+                fetch('/reset-review-state', { method: 'POST' })
+                    .then(r => r.json())
+                    .then(data => {
+                        if (data.ok) location.reload();
+                        else alert('Failed: ' + data.error);
+                    })
+                    .catch(err => alert('Request failed: ' + err.message));
+            });
+        }
+
+        renderReviewQueueTab();
+    };
+})();

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -43,6 +43,9 @@
         // ── Section 3 view mode: 'by-dep' (default) | 'by-file' ──
         let s3ViewMode = 'by-dep';
 
+        // ── Section 3 near-panel open state ──
+        let nearPanelOpen = true;
+
         function semverLt(a, b) {
             const pa = a.split('.').map(Number), pb = b.split('.').map(Number);
             for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
@@ -355,7 +358,7 @@
                             data-updates="${esc(JSON.stringify(allNearUpdates))}">Update All .snyk Files</button>`
                     : '';
                 const nearGroupsHtml = [...nearItems.entries()].map(([sf, items]) => renderCatDGroup(sf, items)).join('');
-                nearHtml = `<details class="s3-near-panel" open>
+                nearHtml = `<details class="s3-near-panel"${nearPanelOpen ? ' open' : ''}>
                     <summary class="s3-near-summary">
                         <span>&#x26A1; Outdated versions &#x2014; stale .snyk paths</span>
                         <span class="s3-near-count">${nearItems.size} file${nearItems.size !== 1 ? 's' : ''}</span>
@@ -1087,6 +1090,7 @@
                     const openCards = new Set(
                         [...document.querySelectorAll('.s3-vuln-card')].map((el, i) => el.open ? i : -1).filter(i => i !== -1)
                     );
+                    nearPanelOpen = document.querySelector('.s3-near-panel')?.open ?? nearPanelOpen;
                     renderReviewQueueTab();
                     document.querySelectorAll('.tool-section').forEach((el, i) => { if (openSections.has(i)) el.open = true; });
                     document.querySelectorAll('.s3-vuln-card').forEach((el, i) => { if (openCards.has(i)) el.open = true; });
@@ -1121,6 +1125,7 @@
                     if (!vulnId) return;
                     if (skipState.vulns.has(vulnId)) skipState.vulns.delete(vulnId);
                     else skipState.vulns.add(vulnId);
+                    nearPanelOpen = document.querySelector('.s3-near-panel')?.open ?? nearPanelOpen;
                     renderReviewQueueTab();
                 } else if (action === 'skip-dep') {
                     const dep = btn.dataset.dep;
@@ -1341,6 +1346,7 @@
             );
             return fetch('/data').then(r => r.json()).then(data => {
                 ignorePatternsByFile = data.ignorePatternsByFile || {};
+                nearPanelOpen = document.querySelector('.s3-near-panel')?.open ?? nearPanelOpen;
                 renderReviewQueueTab();
                 document.querySelectorAll('.tool-section').forEach((el, i) => { if (openSectionIndices.has(i)) el.open = true; });
                 document.getElementById('rq-resolved-section')?.classList.add('open');
@@ -1401,6 +1407,7 @@
                     for (const [id, decision] of Object.entries(updates)) {
                         localRS.decisions[id] = { ...decision, timestamp: ts };
                     }
+                    nearPanelOpen = document.querySelector('.s3-near-panel')?.open ?? nearPanelOpen;
                     renderReviewQueueTab();
                 } else {
                     alert('Failed to save: ' + data.error);

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -246,7 +246,7 @@
                     <div class="dep-card-body">${fileRowsHtml}</div>
                 </div>`;
             }).join('');
-            return `<details class="tool-section" open>
+            return `<details class="tool-section">
                 <summary class="tool-section-header">
                     <span class="tool-section-chevron">&#x25BC;</span>
                     <span class="tool-section-num">1</span>
@@ -262,7 +262,7 @@
         function renderResolutionSection(resGroups) {
             if (!resGroups.size) return '';
             const cardsHtml = [...resGroups.entries()].map(([pkg, batch]) => renderCatBCard(pkg, batch)).join('');
-            return `<details class="tool-section" open>
+            return `<details class="tool-section">
                 <summary class="tool-section-header">
                     <span class="tool-section-chevron">&#x25BC;</span>
                     <span class="tool-section-num">2</span>
@@ -383,6 +383,15 @@
                 vulnCards.push({ id, vuln, skipped, byFile, startIdx });
             }
 
+            // Sort by severity (critical→low), resolved cards to bottom
+            const SEV_ORDER = { critical: 0, high: 1, medium: 2, low: 3 };
+            vulnCards.sort((a, b) => {
+                const aResolved = [...a.byFile.values()].every(fps => fps.every(p => p.alreadyIgnored));
+                const bResolved = [...b.byFile.values()].every(fps => fps.every(p => p.alreadyIgnored));
+                if (aResolved !== bResolved) return aResolved ? 1 : -1;
+                return (SEV_ORDER[sevClass(a.vuln)] ?? 4) - (SEV_ORDER[sevClass(b.vuln)] ?? 4);
+            });
+
             const vulnCardsHtml = vulnCards.map(({ id, vuln, skipped, byFile }, vi) => {
                 // Unique top-level deps for skip-by-dep tags
                 const topDeps = new Set();
@@ -394,9 +403,14 @@
 
                 // Total path count and file count for header badge
                 let totalPaths = 0;
-                for (const [, fps] of byFile) totalPaths += fps.length;
+                let resolvedPaths = 0;
+                for (const [, fps] of byFile) {
+                    totalPaths += fps.length;
+                    resolvedPaths += fps.filter(p => p.alreadyIgnored).length;
+                }
                 const fileCount = byFile.size;
-                const countBadge = `<span class="s3-path-count-badge">${totalPaths} path${totalPaths !== 1 ? 's' : ''} &middot; ${fileCount} file${fileCount !== 1 ? 's' : ''}</span>`;
+                const resolvedPart = resolvedPaths > 0 ? ` &middot; ${resolvedPaths} resolved` : '';
+                const countBadge = `<span class="s3-path-count-badge">${totalPaths} path${totalPaths !== 1 ? 's' : ''} &middot; ${fileCount} file${fileCount !== 1 ? 's' : ''}${resolvedPart}</span>`;
 
                 const allPathsIgnored = [...byFile.values()].every(fps => fps.every(p => p.alreadyIgnored));
 
@@ -425,7 +439,7 @@
                     const fileId = snykFile.replace(/[^a-z0-9]/gi, '-');
                     const pendingPaths = fps.filter(p => !p.alreadyIgnored).map(p => ({ vulnId: id, depPath: p.depPath, idx: p.idx }));
                     const fileYaml = buildGroupedYamlPreview(pendingPaths, [], expiry);
-                    return `<details class="batch-file-subgroup${allFileIgnored ? ' batch-file-subgroup--done' : ''}" data-snyk-file="${esc(snykFile)}"${allFileIgnored ? '' : ' open'}>
+                    return `<details class="batch-file-subgroup${allFileIgnored ? ' batch-file-subgroup--done' : ''}" data-snyk-file="${esc(snykFile)}">
                         <summary class="batch-file-subgroup-heading">
                             <span class="batch-file-subgroup-chevron">&#x25BC;</span>
                             ${esc(snykFile)}
@@ -459,7 +473,7 @@
                     </details>`;
                 }).join('');
 
-                return `<details class="rq-card s3-vuln-card${skipped ? ' s3-card-skipped' : ''}${allPathsIgnored ? ' s3-card-all-ignored' : ''}" id="s3-card-${vi}" data-vuln-id="${esc(id)}" ${allPathsIgnored ? '' : 'open'}>
+                return `<details class="rq-card s3-vuln-card${skipped ? ' s3-card-skipped' : ''}${allPathsIgnored ? ' s3-card-all-ignored' : ''}" id="s3-card-${vi}" data-vuln-id="${esc(id)}">
                     <summary class="rq-card-header s3-card-header">
                         <div class="s3-card-header-main">
                             <span class="s3-card-chevron">&#x25BC;</span>
@@ -490,7 +504,7 @@
                     data-note="Added ${allBatchItems.length} path(s) to .snyk">&#x2713; Mark All as Resolved</button>
             </div>`;
 
-            return `<details class="tool-section" open>
+            return `<details class="tool-section">
                 <summary class="tool-section-header">
                     <span class="tool-section-chevron">&#x25BC;</span>
                     <span class="tool-section-num">3</span>

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -4,7 +4,8 @@
 
     const IGNORE_REASONS = [
         'Used in build & dev - not included in final production build',
-        'Test/lint dependency - not included in final production build',
+        'Test dependency - not included in final production build',
+        'Lint dependency - not included in final production build',
         'Downstream dependency of [package] - not included in final production build',
         'Dev server only - not exposed in production',
         'MCP/dev tooling - not a directly exposed production dependency',

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -453,11 +453,13 @@
                         </div>`;
                     }).join('');
                     return `<div class="s3-dep-group${allFileIgnored ? ' s3-dep-group--done' : ''}" data-snyk-file="${esc(snykFile)}" id="${esc(groupId)}">
-                        <div class="s3-dep-group-header">
+                        <div class="s3-dep-group-header" data-action="toggle-dep-group" data-group-id="${esc(groupId)}">
+                            <span class="s3-dep-group-chevron">&#x25BC;</span>
                             <span class="s3-dep-group-name">${esc(snykFile)}</span>
                             <span class="s3-dep-group-count">${fps.length} path${fps.length !== 1 ? 's' : ''}</span>
                             ${allFileIgnored ? '<span class="already-ignored-badge">&#x2713; In .snyk</span>' : ''}
                         </div>
+                        <div class="s3-dep-group-body">
                         ${!allFileIgnored ? `<div class="s3-dep-group-reason-row">
                             <input class="s3-dep-reason ignore-form-input" id="${esc(reasonInputId)}"
                                 placeholder="Reason for all paths in this file\u2026">
@@ -472,6 +474,7 @@
                             data-snyk-file="${esc(snykFile)}" data-vuln-id="${esc(id)}" data-group-id="${esc(groupId)}">
                             Add ${pendingCount} path${pendingCount !== 1 ? 's' : ''} to .snyk
                         </button>` : ''}
+                        </div>
                     </div>`;
                 }).join('');
 
@@ -503,11 +506,13 @@
                         </div>`;
                     }).join('');
                     return `<div class="s3-dep-group${allDepIgnored ? ' s3-dep-group--done' : ''}" data-dep="${esc(depName)}" id="${esc(groupId)}">
-                        <div class="s3-dep-group-header">
+                        <div class="s3-dep-group-header" data-action="toggle-dep-group" data-group-id="${esc(groupId)}">
+                            <span class="s3-dep-group-chevron">&#x25BC;</span>
                             <span class="s3-dep-group-name">${esc(depName)}</span>
                             <span class="s3-dep-group-count">${dps.length} path${dps.length !== 1 ? 's' : ''}</span>
                             ${allDepIgnored ? '<span class="already-ignored-badge">&#x2713; In .snyk</span>' : ''}
                         </div>
+                        <div class="s3-dep-group-body">
                         ${!allDepIgnored ? `<div class="s3-dep-group-reason-row">
                             <input class="s3-dep-reason ignore-form-input" id="${esc(reasonInputId)}"
                                 placeholder="Reason for ${esc(depName)}\u2026">
@@ -522,6 +527,7 @@
                             data-dep="${esc(depName)}" data-vuln-id="${esc(id)}" data-group-id="${esc(groupId)}">
                             Add ${pendingCount} path${pendingCount !== 1 ? 's' : ''} to .snyk
                         </button>` : ''}
+                        </div>
                     </div>`;
                 }).join('');
 
@@ -828,12 +834,14 @@
                 });
 
                 group.querySelector('.s3-dep-group-reason-row')?.remove();
-                group.classList.add('s3-dep-group--done');
+                group.classList.add('s3-dep-group--done', 's3-dep-group--collapsed');
                 btn.remove();
 
                 const card = group.closest('.s3-vuln-card');
                 if (card) {
                     updateCardCountBadge(card);
+                    const allGroupsDone = [...card.querySelectorAll('.s3-dep-group')].every(g => g.classList.contains('s3-dep-group--done'));
+                    if (allGroupsDone) card.open = false;
                     card.querySelector('.s3-card-header')?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
                 }
             }
@@ -894,12 +902,14 @@
                 });
 
                 group.querySelector('.s3-dep-group-reason-row')?.remove();
-                group.classList.add('s3-dep-group--done');
+                group.classList.add('s3-dep-group--done', 's3-dep-group--collapsed');
                 btn.remove();
 
                 const card = group.closest('.s3-vuln-card');
                 if (card) {
                     updateCardCountBadge(card);
+                    const allGroupsDone = [...card.querySelectorAll('.s3-dep-group')].every(g => g.classList.contains('s3-dep-group--done'));
+                    if (allGroupsDone) card.open = false;
                     card.querySelector('.s3-card-header')?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
                 }
             }
@@ -964,6 +974,9 @@
                     handleUpdateSnyk(btn);
                 } else if (action === 'update-all-near') {
                     handleUpdateAllNear(btn);
+                } else if (action === 'toggle-dep-group') {
+                    const group = document.getElementById(btn.dataset.groupId);
+                    if (group) group.classList.toggle('s3-dep-group--collapsed');
                 } else if (action === 'toggle-near-group') {
                     const groupId = btn.dataset.group;
                     const itemsEl = document.getElementById(groupId + '-items');

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -362,7 +362,6 @@
             // Build per-vuln cards with global path indices
             let globalIdx = 0;
             const vulnCards = [];
-            const allBatchItems = []; // for "Add All" button — populated after skipped filtering
 
             for (const [id, { vuln, paths }] of ignoreVulns) {
                 const skipped = skipState.vulns.has(id);
@@ -373,15 +372,6 @@
                     if (!byFile.has(path.snykFile)) byFile.set(path.snykFile, []);
                     const idx = globalIdx++;
                     byFile.get(path.snykFile).push({ ...path, idx });
-                }
-                if (!skipped) {
-                    for (const [, filePaths] of byFile) {
-                        for (const p of filePaths) {
-                            if (!skipState.deps.has(p.topLevelDep) && !p.alreadyIgnored) {
-                                allBatchItems.push({ vulnId: id, snykFile: p.snykFile, depPath: p.depPath, idx: p.idx });
-                            }
-                        }
-                    }
                 }
                 vulnCards.push({ id, vuln, skipped, byFile, startIdx });
             }
@@ -504,13 +494,10 @@
 
             const allVulnIds = [...ignoreVulns.keys()].filter(id => !skipState.vulns.has(id)).join(',');
             const globalActionsHtml = `<div class="rq-actions s3-global-actions">
-                <button class="btn btn-accent" data-action="add-all-snyk-ignore"
-                    data-card="${cardId}"
-                    data-items="${esc(JSON.stringify(allBatchItems))}">&#x2713; Add All to .snyk &#x2014; ${allBatchItems.length} path${allBatchItems.length !== 1 ? 's' : ''}</button>
                 <button class="btn btn-primary" data-action="resolve"
                     data-ids="${esc(allVulnIds)}"
                     data-resolution="snyk-ignore"
-                    data-note="Added ${allBatchItems.length} path(s) to .snyk">&#x2713; Mark All as Resolved</button>
+                    data-note="All paths added to .snyk">&#x2713; Mark All as Resolved</button>
             </div>`;
 
             return `<details class="tool-section">
@@ -887,8 +874,6 @@
                     handleApplyResolution(btn);
                 } else if (action === 'update-ignore-reason') {
                     handleUpdateIgnoreReason(btn);
-                } else if (action === 'add-all-snyk-ignore') {
-                    handleAddAllSnykIgnore(btn);
                 } else if (action === 'add-file-snyk-ignore') {
                     handleAddFileSnykIgnore(btn);
                 } else if (action === 'add-snyk-ignore') {
@@ -1090,41 +1075,6 @@
             } catch (err) {
                 btn.disabled = false; btn.textContent = 'Update'; alert('Request failed: ' + err.message);
             }
-        }
-
-        async function handleAddAllSnykIgnore(btn) {
-            const cardId = btn.dataset.card;
-            const expiryInput = document.getElementById('expiry-' + cardId);
-            const expires = expiryInput?.value?.trim() || '';
-            if (!expires) { alert('Please enter an expiry date.'); return; }
-            let batchItems;
-            try { batchItems = JSON.parse(btn.dataset.items); } catch { return; }
-            if (!batchItems.length) return;
-            const reasons = batchItems.map(function (item) {
-                return document.getElementById('reason-' + cardId + '-' + item.idx)?.value?.trim() || '';
-            });
-            const emptyIdx = reasons.findIndex(function (r) { return !r; });
-            if (emptyIdx >= 0) { alert('Please enter a reason for path ' + (emptyIdx + 1) + '.'); return; }
-            btn.disabled = true;
-            const allVulnIds = [...new Set(batchItems.map(function (i) { return i.vulnId; }))];
-            for (let i = 0; i < batchItems.length; i++) {
-                const item = batchItems[i];
-                btn.textContent = 'Adding ' + (i + 1) + '/' + batchItems.length + '\u2026';
-                try {
-                    const r = await fetch('/add-snyk-ignore', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ snykFile: item.snykFile, vulnId: item.vulnId, path: item.depPath, reason: reasons[i], expires }),
-                    });
-                    const data = await r.json();
-                    if (!data.ok) { btn.disabled = false; btn.textContent = '\u2713 Add All to .snyk'; alert('Failed: ' + data.error); return; }
-                } catch (err) {
-                    btn.disabled = false; btn.textContent = '\u2713 Add All to .snyk';
-                    alert('Request failed: ' + err.message); return;
-                }
-            }
-            btn.textContent = '\u2713 Added ' + batchItems.length + '/' + batchItems.length;
-            applyDecision(allVulnIds, 'resolved', { resolution: 'snyk-ignore', note: 'Added ' + batchItems.length + ' path(s) to .snyk' });
         }
 
         function handleUpdateDep(btn) {

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -667,12 +667,10 @@
                     </button>
                     <div class="rq-resolved-list" id="rq-resolved-list">
                         ${reviewed.map(({ id, vuln, decision }) => {
-                            const status = decision.status || 'skipped';
                             const ts = decision.timestamp ? new Date(decision.timestamp).toLocaleString() : '';
                             return `<div class="rq-resolved-item">
-                                <span class="status-badge status-${esc(status)}">${esc(status)}</span>
-                                <a class="vuln-id-link" href="https://security.snyk.io/vuln/${esc(id)}" target="_blank" rel="noopener">${esc(id)}</a>
                                 ${sevBadge(vuln)}
+                                <a class="vuln-id-link" href="https://security.snyk.io/vuln/${esc(id)}" target="_blank" rel="noopener">${esc(id)}</a>
                                 <span class="rq-resolved-note">${esc(vuln.title || '')}</span>
                                 ${decision.note ? `<span class="rq-resolved-decision-note">${esc(decision.note)}</span>` : ''}
                                 <span class="rq-resolved-ts">${esc(ts)}</span>

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -12,7 +12,8 @@
         'MCP/dev tooling - not a directly exposed production dependency',
     ];
 
-    window.initReviewQueue = function (projects, ignorePatternsByFile, reviewState, sharedExpiry, _rootPackageName) {
+    window.initReviewQueue = function (projects, ignorePatternsByFileInit, reviewState, sharedExpiry, _rootPackageName) {
+        let ignorePatternsByFile = ignorePatternsByFileInit;
         const { esc, sevClass, stripVer, getSnykFilePath, getNearIgnoredPath,
                 sameMajorFixVersion } = window.SnykUtils;
 
@@ -106,7 +107,7 @@
                         // Stale path (package names match but versions changed) — show in Near-ignored only
                         const sf = getSnykFilePath(project);
                         if (!nearItems.has(sf)) nearItems.set(sf, []);
-                        const existing = nearItems.get(sf).find(item => item.id === id);
+                        const existing = nearItems.get(sf).find(item => item.id === id && item.nearMatch.path === near.path);
                         if (!existing) {
                             nearItems.get(sf).push({ id, vuln, entry: { vuln, project }, nearMatch: near, resolved: false });
                         }
@@ -523,7 +524,14 @@
             const allResolved = items.every(i => i.resolved);
             const unresolvedItems = items.filter(i => !i.resolved);
 
-            const itemsHtml = items.map(({ id, vuln, entry, nearMatch, resolved }) => {
+            // Group items by vuln ID, preserving insertion order
+            const byVuln = new Map();
+            for (const item of items) {
+                if (!byVuln.has(item.id)) byVuln.set(item.id, []);
+                byVuln.get(item.id).push(item);
+            }
+
+            function renderPathEntry(id, entry, nearMatch) {
                 const activeParts = entry.vuln.from?.slice(1) || [];
                 const snykParts = nearMatch.path.split(' > ');
                 const snykVerByName = new Map(snykParts.map(p => [stripVer(p), p.slice(stripVer(p).length)]));
@@ -542,14 +550,8 @@
                 }
 
                 const activePath = activeParts.join(' > ');
-                return `<div class="near-item${resolved ? ' near-item-resolved' : ''}">
-                    <div class="near-item-header">
-                        ${sevBadge(vuln)}
-                        <a class="vuln-id-link" href="https://security.snyk.io/vuln/${esc(id)}" target="_blank" rel="noopener">${esc(id)}</a>
-                        <span style="color:var(--c-text-muted);font-size:12px">${esc(vuln.title || '')}</span>
-                        ${resolved ? '<span class="near-resolved-pill">&#x2713; path matches</span>' : ''}
-                    </div>
-                    ${!resolved ? `<div class="near-paths">
+                return `<div class="near-path-entry">
+                    <div class="near-paths">
                         <div class="near-path-row">
                             <span class="near-path-lbl lbl-snyk">.snyk</span>
                             <span class="near-path-text snyk-side">${highlightPath(snykParts, true)}</span>
@@ -566,15 +568,43 @@
                             data-vuln-id="${esc(id)}"
                             data-old-path="${esc(nearMatch.path)}"
                             data-new-path="${esc(activePath)}">Update .snyk</button>
-                    </div>` : ''}
+                    </div>
+                </div>`;
+            }
+
+            const vulnGroupsHtml = [...byVuln.entries()].map(([id, vulnItems]) => {
+                const vuln = vulnItems[0].vuln;
+                const unresolvedVulnItems = vulnItems.filter(i => !i.resolved);
+                const vulnUpdates = unresolvedVulnItems.map(({ nearMatch, entry }) => ({
+                    snykFile, vulnId: id,
+                    oldPath: nearMatch.path,
+                    newPath: (entry.vuln.from?.slice(1) || []).join(' > '),
+                }));
+                const updateAllVulnBtn = vulnUpdates.length > 1
+                    ? `<button class="btn btn-sm btn-warn" data-action="update-all-near"
+                            data-updates="${esc(JSON.stringify(vulnUpdates))}">Update all paths</button>`
+                    : '';
+                const pathsHtml = unresolvedVulnItems.map(({ entry, nearMatch }) =>
+                    renderPathEntry(id, entry, nearMatch)
+                ).join('');
+                return `<div class="near-item">
+                    <div class="near-item-header">
+                        ${sevBadge(vuln)}
+                        <a class="vuln-id-link" href="https://security.snyk.io/vuln/${esc(id)}" target="_blank" rel="noopener">${esc(id)}</a>
+                        <span style="color:var(--c-text-muted);font-size:12px">${esc(vuln.title || '')}</span>
+                        ${updateAllVulnBtn}
+                    </div>
+                    ${pathsHtml}
                 </div>`;
             }).join('');
 
-            const allUpdates = unresolvedItems.map(({ id, nearMatch, entry }) => {
-                const activePath = (entry.vuln.from?.slice(1) || []).join(' > ');
-                return { snykFile, vulnId: id, oldPath: nearMatch.path, newPath: activePath };
-            });
-            const countBadge = `<span class="near-group-count">${items.length} vuln${items.length !== 1 ? 's' : ''}</span>`;
+            const allUpdates = unresolvedItems.map(({ id, nearMatch, entry }) => ({
+                snykFile, vulnId: id,
+                oldPath: nearMatch.path,
+                newPath: (entry.vuln.from?.slice(1) || []).join(' > '),
+            }));
+            const uniqueVulnCount = byVuln.size;
+            const countBadge = `<span class="near-group-count">${uniqueVulnCount} vuln${uniqueVulnCount !== 1 ? 's' : ''}</span>`;
             const resolvedPill = allResolved ? '<span class="near-group-resolved-pill">&#x2713; Resolved</span>' : '';
             const toggleArrow = `<span class="near-toggle-arrow">${allResolved ? '&#x25B6;' : '&#x25BC;'}</span>`;
             const updateAllBtn = !allResolved
@@ -591,7 +621,7 @@
                     ${updateAllBtn}
                 </div>
                 <div class="near-group-items" id="${esc(groupId)}-items" style="${allResolved ? 'display:none' : ''}">
-                    ${itemsHtml}
+                    ${vulnGroupsHtml}
                 </div>
             </div>`;
         }
@@ -1139,6 +1169,23 @@
             }).catch(err => { btn.disabled = false; btn.textContent = 'Add to .snyk File'; alert('Request failed: ' + err.message); });
         }
 
+        function applyNearUpdatesToLocalPatterns(updates) {
+            for (const { snykFile: sf, vulnId: vid, newPath } of updates) {
+                if (!localAddedPatterns[sf]) localAddedPatterns[sf] = {};
+                if (!localAddedPatterns[sf][vid]) localAddedPatterns[sf][vid] = [];
+                const arr = localAddedPatterns[sf][vid];
+                if (!arr.find(e => e.path === newPath)) arr.push({ path: newPath, reason: '' });
+            }
+        }
+
+        function refreshIgnorePatterns() {
+            return fetch('/data').then(r => r.json()).then(data => {
+                ignorePatternsByFile = data.ignorePatternsByFile || {};
+                renderReviewQueueTab();
+                document.getElementById('rq-resolved-section')?.classList.add('open');
+            });
+        }
+
         function handleUpdateSnyk(btn) {
             const { snykFile, vulnId, oldPath, newPath } = btn.dataset;
             btn.disabled = true;
@@ -1148,8 +1195,12 @@
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ updates: [{ snykFile, vulnId, oldPath, newPath }] }),
             }).then(r => r.json()).then(data => {
-                if (data.ok) { location.reload(); }
-                else { btn.disabled = false; btn.textContent = 'Update .snyk'; alert('Failed: ' + data.error); }
+                if (data.ok) {
+                    btn.textContent = '\u2713 Updated';
+                    btn.classList.replace('btn-warn', 'btn-primary');
+                    applyNearUpdatesToLocalPatterns([{ snykFile, vulnId, newPath }]);
+                    setTimeout(refreshIgnorePatterns, 700);
+                } else { btn.disabled = false; btn.textContent = 'Update .snyk'; alert('Failed: ' + data.error); }
             }).catch(err => { btn.disabled = false; btn.textContent = 'Update .snyk'; alert('Request failed: ' + err.message); });
         }
 
@@ -1164,8 +1215,12 @@
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ updates }),
             }).then(r => r.json()).then(data => {
-                if (data.ok) { location.reload(); }
-                else { btn.disabled = false; btn.textContent = 'Update All in This File'; alert('Failed: ' + data.error); }
+                if (data.ok) {
+                    btn.textContent = '\u2713 All Updated';
+                    btn.classList.replace('btn-warn', 'btn-primary');
+                    applyNearUpdatesToLocalPatterns(updates);
+                    setTimeout(refreshIgnorePatterns, 700);
+                } else { btn.disabled = false; btn.textContent = 'Update All in This File'; alert('Failed: ' + data.error); }
             }).catch(err => { btn.disabled = false; btn.textContent = 'Update All in This File'; alert('Request failed: ' + err.message); });
         }
 

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -21,10 +21,15 @@
                 allVulnEntries.push({ vuln, project });
             }
         }
+        const reportVulnIds = new Set(allVulnEntries.map(e => e.vuln.id));
 
         // Local mutable copy of review state
         const localRS = JSON.parse(JSON.stringify(reviewState));
         localRS.decisions = localRS.decisions || {};
+
+        // Patterns added via the UI this session — checked alongside the original ignorePatternsByFile
+        // so buildSections() stays accurate after adds without a server round-trip
+        const localAddedPatterns = {};
 
         // ── Skip state (persists across re-renders) ──
         const skipState = {
@@ -33,7 +38,8 @@
         };
 
         function getNear(vuln, project) {
-            return getNearIgnoredPath(vuln, project, ignorePatternsByFile);
+            return getNearIgnoredPath(vuln, project, ignorePatternsByFile)
+                || getNearIgnoredPath(vuln, project, localAddedPatterns);
         }
 
         // ── Build sections ──
@@ -91,26 +97,48 @@
 
                 // Near-ignored check
                 const near = getNear(vuln, project);
+                const activePath = (vuln.from?.slice(1) || []).join(' > ');
                 if (near) {
-                    const sf = getSnykFilePath(project);
-                    if (!nearItems.has(sf)) nearItems.set(sf, []);
-                    const activePath = (vuln.from?.slice(1) || []).join(' > ');
-                    const resolved = activePath === near.path;
-                    const existing = nearItems.get(sf).find(item => item.id === id);
-                    if (!existing) {
-                        nearItems.get(sf).push({ id, vuln, entry: { vuln, project }, nearMatch: near, resolved });
+                    const exactMatch = activePath === near.path;
+                    if (!exactMatch) {
+                        // Stale path (package names match but versions changed) — show in Near-ignored only
+                        const sf = getSnykFilePath(project);
+                        if (!nearItems.has(sf)) nearItems.set(sf, []);
+                        const existing = nearItems.get(sf).find(item => item.id === id);
+                        if (!existing) {
+                            nearItems.get(sf).push({ id, vuln, entry: { vuln, project }, nearMatch: near, resolved: false });
+                        }
+                        continue;
                     }
+                    // Exact match — falls through to Snyk Ignores as alreadyIgnored
                 }
 
-                // Ignore candidates — shown in Cat C; alreadyIgnored=true if path is already in .snyk
+                // Ignore candidates — alreadyIgnored=true only for exact .snyk matches
                 const snykFile = getSnykFilePath(project);
-                const depPath = (vuln.from?.slice(1) || []).join(' > ');
+                const depPath = activePath;
                 const topLevelDep = stripVer(vuln.from?.[1] || '');
                 if (!ignoreVulns.has(id)) ignoreVulns.set(id, { id, vuln, paths: [] });
                 const v = ignoreVulns.get(id);
                 const key = snykFile + '\0' + depPath;
                 if (!v.paths.some(p => p.snykFile + '\0' + p.depPath === key)) {
                     v.paths.push({ snykFile, depPath, topLevelDep, alreadyIgnored: near != null });
+                }
+            }
+
+            // Include vulns suppressed by .snyk (filtered.ignore) — show as already-resolved in Snyk Ignores
+            for (const project of projects) {
+                for (const vuln of (project.filtered?.ignore || [])) {
+                    const id = vuln.id;
+                    if (decisions[id]?.status === 'resolved') continue;
+                    const snykFile = getSnykFilePath(project);
+                    const depPath = (vuln.from?.slice(1) || []).join(' > ');
+                    const topLevelDep = stripVer(vuln.from?.[1] || '');
+                    if (!ignoreVulns.has(id)) ignoreVulns.set(id, { id, vuln, paths: [] });
+                    const v = ignoreVulns.get(id);
+                    const key = snykFile + '\0' + depPath;
+                    if (!v.paths.some(p => p.snykFile + '\0' + p.depPath === key)) {
+                        v.paths.push({ snykFile, depPath, topLevelDep, alreadyIgnored: true });
+                    }
                 }
             }
 
@@ -125,7 +153,17 @@
                 if (entry) reviewed.push({ id, vuln: entry.vuln, decision: dec });
             }
 
-            return { depGroups, resGroups, ignoreData: { nearItems, ignoreVulns }, reviewed };
+            // Auto-resolve vulns whose every path is already covered by a .snyk entry
+            const autoResolvedIds = new Set();
+            for (const [id, { vuln, paths }] of ignoreVulns) {
+                if (paths.length && paths.every(p => p.alreadyIgnored) && !seenReviewed.has(id)) {
+                    autoResolvedIds.add(id);
+                    seenReviewed.add(id);
+                    reviewed.push({ id, vuln, decision: { status: 'resolved', resolution: 'snyk-ignore', note: 'All paths already in .snyk' } });
+                }
+            }
+
+            return { depGroups, resGroups, ignoreData: { nearItems, ignoreVulns, autoResolvedIds }, reviewed };
         }
 
         // ── HTML helpers ──
@@ -575,33 +613,39 @@
             return blocks.join('\n');
         }
 
+        // ── Progress bar ──
+        // applyProgress: update the DOM elements only (call with pre-computed counts)
+        function applyProgress(reviewed) {
+            const total = reportVulnIds.size;
+            const reviewedCount = reviewed.filter(r => reportVulnIds.has(r.id)).length;
+            const pct = total > 0 ? Math.round((reviewedCount / total) * 100) : 0;
+            const fill = document.getElementById('rq-progress-fill');
+            const progressText = document.getElementById('rq-progress-text');
+            const badge = document.getElementById('queue-badge');
+            if (fill) fill.style.width = pct + '%';
+            if (progressText) progressText.textContent = `${reviewedCount} / ${total} reviewed`;
+            if (badge) badge.textContent = total - reviewedCount;
+        }
+
+        // recomputeProgress: recompute from current data model and apply — call after any state change
+        function recomputeProgress() {
+            const { reviewed } = buildSections();
+            applyProgress(reviewed);
+        }
+
         // ── Render the full tab ──
         function renderReviewQueueTab() {
             const { depGroups, resGroups, ignoreData, reviewed } = buildSections();
 
-            // Count unique pending vulns (union across all sections)
-            const pendingIds = new Set();
-            for (const g of depGroups.values()) for (const id of g.vulns.keys()) pendingIds.add(id);
-            for (const g of resGroups.values()) for (const { id } of g.items) pendingIds.add(id);
-            for (const id of ignoreData.ignoreVulns.keys()) pendingIds.add(id);
-            const pendingCount = pendingIds.size;
-            const total = pendingCount + reviewed.length;
-
-            const badge = document.getElementById('queue-badge');
-            if (badge) badge.textContent = pendingCount;
-
-            const pct = total > 0 ? Math.round((reviewed.length / total) * 100) : 0;
-            const fill = document.getElementById('rq-progress-fill');
-            const progressText = document.getElementById('rq-progress-text');
-            if (fill) fill.style.width = pct + '%';
-            if (progressText) progressText.textContent = `${reviewed.length} / ${total} reviewed`;
+            applyProgress(reviewed);
 
             let html = '';
             html += renderDepUpgradeSection(depGroups);
             html += renderResolutionSection(resGroups);
             html += renderIgnoreSection(ignoreData);
 
-            if (!depGroups.size && !resGroups.size && !ignoreData.ignoreVulns.size) {
+            const pendingIgnoreCount = ignoreData.ignoreVulns.size - ignoreData.autoResolvedIds.size;
+            if (!depGroups.size && !resGroups.size && !pendingIgnoreCount) {
                 html = `<div class="rq-empty"><div class="empty-icon">&#x1F389;</div><p>No pending items &#x2014; all vulnerabilities reviewed!</p></div>`;
             }
 
@@ -711,6 +755,15 @@
                     }
                 }
                 btn.textContent = '\u2713 Updated';
+
+                // Update localAddedPatterns so buildSections() treats these paths as alreadyIgnored
+                for (const p of toAdd) {
+                    if (!localAddedPatterns[p.snykFile]) localAddedPatterns[p.snykFile] = {};
+                    if (!localAddedPatterns[p.snykFile][p.vulnId]) localAddedPatterns[p.snykFile][p.vulnId] = [];
+                    const arr = localAddedPatterns[p.snykFile][p.vulnId];
+                    if (!arr.find(e => e.path === p.depPath)) arr.push({ path: p.depPath, reason: p.reason });
+                }
+                recomputeProgress();
 
                 // Convert successfully-added rows to the resolved display (same as on load)
                 subgroup.querySelectorAll('.path-checkbox-row:not(.path-already-ignored)').forEach(row => {

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -40,6 +40,15 @@
             deps: new Set(),   // skipped top-level dep names
         };
 
+        function semverLt(a, b) {
+            const pa = a.split('.').map(Number), pb = b.split('.').map(Number);
+            for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+                const na = pa[i] || 0, nb = pb[i] || 0;
+                if (na !== nb) return na < nb;
+            }
+            return false;
+        }
+
         function getNear(vuln, project) {
             return getNearIgnoredPath(vuln, project, ignorePatternsByFile)
                 || getNearIgnoredPath(vuln, project, localAddedPatterns);
@@ -80,7 +89,7 @@
                 if (!pkg) continue;
                 if (!resGroups.has(pkg)) resGroups.set(pkg, { fixVersion: fix, itemsMap: new Map() });
                 const g = resGroups.get(pkg);
-                if (fix < g.fixVersion) g.fixVersion = fix;
+                if (semverLt(fix, g.fixVersion)) g.fixVersion = fix;
                 if (!g.itemsMap.has(vuln.id)) g.itemsMap.set(vuln.id, { id: vuln.id, vuln, entries: [] });
                 g.itemsMap.get(vuln.id).entries.push({ vuln, project });
             }
@@ -733,7 +742,8 @@
                 const filePaths = [];
                 rows.forEach(row => {
                     const cb = row.querySelector('input[type="checkbox"]');
-                    const idx = cb ? parseInt(cb.dataset.idx) : NaN;
+                    if (!cb || !cb.checked) return;
+                    const idx = parseInt(cb.dataset.idx);
                     if (isNaN(idx)) return;
                     const depPathSpan = row.querySelector('.path-deppath');
                     filePaths.push({ vulnId, depPath: depPathSpan?.textContent || '', idx });
@@ -889,6 +899,17 @@
                     if (!subgroup) return;
                     subgroup.querySelectorAll('.batch-ignore-reason').forEach(inp => { inp.value = val; });
                     if (vulnIdx !== undefined && snykFile) rebuildFileYaml(parseInt(vulnIdx), snykFile);
+                } else if (action === 'select-version') {
+                    const version = btn.dataset.version;
+                    const row = btn.closest('.dep-card-file-row');
+                    if (!row) return;
+                    const updateBtn = row.querySelector('[data-action="update-dep"]');
+                    if (updateBtn) {
+                        updateBtn.dataset.version = version;
+                        updateBtn.textContent = `Update to ${version}`;
+                    }
+                    btn.closest('.versions-list')?.querySelectorAll('.version-tag').forEach(t => t.classList.remove('selected'));
+                    btn.classList.add('selected');
                 } else if (action === 'check-versions') {
                     handleCheckVersions(btn);
                 } else if (action === 'check-dep-field') {
@@ -1030,9 +1051,9 @@
                     else {
                         const tags = data.versions.map(v => {
                             const isRec = v === recommend;
-                            return `<span class="version-tag${isRec ? ' recommended' : ''}">${esc(v)}</span>`;
+                            return `<button class="version-tag${isRec ? ' recommended' : ''}" data-action="select-version" data-version="${esc(v)}">${esc(v)}</button>`;
                         }).join('');
-                        panel.innerHTML = `<div class="versions-panel-title">Available versions (newest first)</div><div class="versions-list">${tags}</div>`;
+                        panel.innerHTML = `<div class="versions-panel-title">Available versions (newest first — click to select)</div><div class="versions-list">${tags}</div>`;
                     }
                     panel.style.display = 'block';
                 })

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -40,6 +40,9 @@
             deps: new Set(),   // skipped top-level dep names
         };
 
+        // ── Section 3 view mode: 'by-dep' (default) | 'by-file' ──
+        let s3ViewMode = 'by-dep';
+
         function semverLt(a, b) {
             const pa = a.split('.').map(Number), pb = b.split('.').map(Number);
             for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
@@ -376,49 +379,59 @@
             for (const [id, { vuln, paths }] of ignoreVulns) {
                 const skipped = skipState.vulns.has(id);
                 const startIdx = globalIdx;
-                // Group paths by snyk file
-                const byFile = new Map();
+                // Group paths by top-level dep
+                const byDep = new Map();
                 for (const path of paths) {
-                    if (!byFile.has(path.snykFile)) byFile.set(path.snykFile, []);
+                    if (!byDep.has(path.topLevelDep)) byDep.set(path.topLevelDep, []);
                     const idx = globalIdx++;
-                    byFile.get(path.snykFile).push({ ...path, idx });
+                    byDep.get(path.topLevelDep).push({ ...path, idx });
                 }
-                vulnCards.push({ id, vuln, skipped, byFile, startIdx });
+                vulnCards.push({ id, vuln, skipped, byDep, startIdx });
             }
 
             // Sort by severity (critical→low), resolved cards to bottom
             const SEV_ORDER = { critical: 0, high: 1, medium: 2, low: 3 };
             vulnCards.sort((a, b) => {
-                const aResolved = [...a.byFile.values()].every(fps => fps.every(p => p.alreadyIgnored));
-                const bResolved = [...b.byFile.values()].every(fps => fps.every(p => p.alreadyIgnored));
+                const aResolved = [...a.byDep.values()].every(dps => dps.every(p => p.alreadyIgnored));
+                const bResolved = [...b.byDep.values()].every(dps => dps.every(p => p.alreadyIgnored));
                 if (aResolved !== bResolved) return aResolved ? 1 : -1;
                 return (SEV_ORDER[sevClass(a.vuln)] ?? 4) - (SEV_ORDER[sevClass(b.vuln)] ?? 4);
             });
 
-            const vulnCardsHtml = vulnCards.map(({ id, vuln, skipped, byFile }, vi) => {
-                // Unique top-level deps for skip-by-dep tags
-                const topDeps = new Set();
-                for (const [, fps] of byFile) for (const p of fps) topDeps.add(p.topLevelDep);
-                const depTagsHtml = [...topDeps].filter(Boolean).map(dep => {
+            const vulnCardsHtml = vulnCards.map(({ id, vuln, skipped, byDep }, vi) => {
+                // Top-level dep tags for skip-by-dep
+                const depTagsHtml = [...byDep.keys()].filter(Boolean).map(dep => {
                     const active = skipState.deps.has(dep);
                     return `<button class="skip-dep-tag${active ? ' skipped' : ''}" data-action="skip-dep" data-dep="${esc(dep)}">${esc(dep)} &#x2715;</button>`;
                 }).join('');
 
-                // Total path count and file count for header badge
+                // Total path count and dep count for header badge
                 let totalPaths = 0;
                 let resolvedPaths = 0;
-                for (const [, fps] of byFile) {
-                    totalPaths += fps.length;
-                    resolvedPaths += fps.filter(p => p.alreadyIgnored).length;
+                for (const [, dps] of byDep) {
+                    totalPaths += dps.length;
+                    resolvedPaths += dps.filter(p => p.alreadyIgnored).length;
                 }
-                const fileCount = byFile.size;
+                const depCount = byDep.size;
                 const resolvedPart = resolvedPaths > 0 ? ` &middot; <span class="s3-resolved-count">${resolvedPaths} resolved</span>` : '';
-                const countBadge = `<span class="s3-path-count-badge">${totalPaths} path${totalPaths !== 1 ? 's' : ''} &middot; ${fileCount} file${fileCount !== 1 ? 's' : ''}${resolvedPart}</span>`;
+                const countBadge = `<span class="s3-path-count-badge">${totalPaths} path${totalPaths !== 1 ? 's' : ''} &middot; ${depCount} dep${depCount !== 1 ? 's' : ''}${resolvedPart}</span>`;
 
-                const allPathsIgnored = [...byFile.values()].every(fps => fps.every(p => p.alreadyIgnored));
+                const allPathsIgnored = [...byDep.values()].every(dps => dps.every(p => p.alreadyIgnored));
 
+                // ── By-file view: build byFile from byDep ──
+                const byFile = new Map();
+                for (const [, dps] of byDep) {
+                    for (const path of dps) {
+                        if (!byFile.has(path.snykFile)) byFile.set(path.snykFile, []);
+                        byFile.get(path.snykFile).push(path);
+                    }
+                }
                 const fileGroupsHtml = [...byFile.entries()].map(([snykFile, fps]) => {
                     const allFileIgnored = fps.every(p => p.alreadyIgnored);
+                    const pendingCount = fps.filter(p => !p.alreadyIgnored).length;
+                    const safeFileId = snykFile.replace(/[^a-z0-9]/gi, '-');
+                    const groupId = `s3-file-${vi}-${safeFileId}`;
+                    const reasonInputId = `file-reason-${vi}-${safeFileId}`;
                     const rowsHtml = fps.map(path => {
                         if (path.alreadyIgnored) {
                             return `<div class="path-checkbox-row path-already-ignored" data-top-dep="${esc(path.topLevelDep)}">
@@ -435,50 +448,81 @@
                         const depSkipped = skipState.deps.has(path.topLevelDep);
                         return `<div class="path-checkbox-row${depSkipped ? ' dep-skipped' : ''}" data-top-dep="${esc(path.topLevelDep)}">
                             <input type="checkbox" class="path-cb"${depSkipped ? '' : ' checked'}
-                                data-card="${cardId}" data-idx="${path.idx}" data-vuln-idx="${vi}" data-vuln-id="${esc(id)}">
+                                data-card="${cardId}" data-vuln-idx="${vi}" data-vuln-id="${esc(id)}">
                             <span class="path-deppath">${esc(path.depPath)}</span>
-                            <input type="text" class="ignore-form-input batch-ignore-reason"
-                                id="reason-${cardId}-${path.idx}"
-                                data-card="${cardId}" data-idx="${path.idx}" data-vuln-idx="${vi}"
-                                data-snyk-file="${esc(snykFile)}"
-                                placeholder="Reason&#x2026;">
                         </div>`;
                     }).join('');
-                    const fileId = snykFile.replace(/[^a-z0-9]/gi, '-');
-                    const pendingPaths = fps.filter(p => !p.alreadyIgnored).map(p => ({ vulnId: id, depPath: p.depPath, idx: p.idx }));
-                    const fileYaml = buildGroupedYamlPreview(pendingPaths, [], expiry);
-                    return `<details class="batch-file-subgroup${allFileIgnored ? ' batch-file-subgroup--done' : ''}" data-snyk-file="${esc(snykFile)}">
-                        <summary class="batch-file-subgroup-heading">
-                            <span class="batch-file-subgroup-chevron">&#x25BC;</span>
-                            ${esc(snykFile)}
-                            <span class="s3-file-path-count">${fps.length} path${fps.length !== 1 ? 's' : ''}</span>
-                            ${allFileIgnored ? '<span class="batch-file-done-badge">&#x2713; In .snyk</span>' : ''}
-                        </summary>
-                        ${!allFileIgnored ? `<div class="prefill-row">
-                            <select class="ignore-form-input preset-select cat-a-preset"
-                                data-card="${cardId}" data-vuln-idx="${vi}" data-snyk-file="${esc(snykFile)}">
-                                <option value="">Preset&#x2026;</option>
+                    return `<div class="s3-dep-group${allFileIgnored ? ' s3-dep-group--done' : ''}" data-snyk-file="${esc(snykFile)}" id="${esc(groupId)}">
+                        <div class="s3-dep-group-header">
+                            <span class="s3-dep-group-name">${esc(snykFile)}</span>
+                            <span class="s3-dep-group-count">${fps.length} path${fps.length !== 1 ? 's' : ''}</span>
+                            ${allFileIgnored ? '<span class="already-ignored-badge">&#x2713; In .snyk</span>' : ''}
+                        </div>
+                        ${!allFileIgnored ? `<div class="s3-dep-group-reason-row">
+                            <input class="s3-dep-reason ignore-form-input" id="${esc(reasonInputId)}"
+                                placeholder="Reason for all paths in this file\u2026">
+                            <select class="s3-dep-preset ignore-form-input" data-target-input="${esc(reasonInputId)}">
+                                <option value="">Preset\u2026</option>
                                 ${presetOptionsHtml}
                             </select>
-                            <input type="text" class="ignore-form-input prefill-text"
-                                data-card="${cardId}" data-vuln-idx="${vi}" data-snyk-file="${esc(snykFile)}"
-                                placeholder="Prefill reason&#x2026;">
-                            <button class="btn btn-sm btn-outline" data-action="prefill-reasons"
-                                data-card="${cardId}" data-vuln-idx="${vi}" data-snyk-file="${esc(snykFile)}">Apply to all</button>
                         </div>` : ''}
                         ${rowsHtml}
-                        ${!allFileIgnored ? `<details class="batch-yaml-details">
-                            <summary class="batch-yaml-summary">
-                                ${esc(snykFile)} YAML preview
-                                <button class="btn btn-sm btn-outline" data-action="copy-file-yaml"
-                                    data-vuln-idx="${vi}" data-snyk-file="${esc(snykFile)}">&#x2398; Copy</button>
-                            </summary>
-                            <pre class="yaml-snippet" id="batch-yaml-${cardId}-${vi}-${fileId}">${esc(fileYaml)}</pre>
-                        </details>
-                        <button class="btn btn-sm btn-accent" data-action="add-file-snyk-ignore"
-                            data-card="${cardId}" data-vuln-idx="${vi}" data-snyk-file="${esc(snykFile)}"
-                            data-vuln-id="${esc(id)}">Add to ${esc(snykFile)}</button>` : ''}
-                    </details>`;
+                        ${!allFileIgnored ? `<button class="btn btn-sm btn-accent s3-dep-add-btn"
+                            data-action="add-file-group"
+                            data-snyk-file="${esc(snykFile)}" data-vuln-id="${esc(id)}" data-group-id="${esc(groupId)}">
+                            Add ${pendingCount} path${pendingCount !== 1 ? 's' : ''} to .snyk
+                        </button>` : ''}
+                    </div>`;
+                }).join('');
+
+                const depGroupsHtml = [...byDep.entries()].map(([depName, dps]) => {
+                    const allDepIgnored = dps.every(p => p.alreadyIgnored);
+                    const pendingCount = dps.filter(p => !p.alreadyIgnored).length;
+                    const safeDepId = depName.replace(/[^a-z0-9]/gi, '-');
+                    const groupId = `s3-dep-${vi}-${safeDepId}`;
+                    const reasonInputId = `dep-reason-${vi}-${safeDepId}`;
+                    const rowsHtml = dps.map(path => {
+                        if (path.alreadyIgnored) {
+                            return `<div class="path-checkbox-row path-already-ignored" data-top-dep="${esc(depName)}">
+                                <span class="path-already-ignored-check">&#x2713;</span>
+                                <span class="s3-file-badge">${esc(path.snykFile)}</span>
+                                <span class="path-deppath">${esc(path.depPath)}</span>
+                                <input type="text" class="ignore-form-input already-ignored-reason-input"
+                                    value="${esc(path.existingReason || '')}" placeholder="Reason&hellip;"
+                                    data-snyk-file="${esc(path.snykFile)}" data-vuln-id="${esc(id)}" data-dep-path="${esc(path.depPath)}">
+                                <button class="btn btn-sm btn-outline" data-action="update-ignore-reason"
+                                    data-snyk-file="${esc(path.snykFile)}" data-vuln-id="${esc(id)}" data-dep-path="${esc(path.depPath)}">Update</button>
+                                <span class="already-ignored-badge">Already in .snyk</span>
+                            </div>`;
+                        }
+                        return `<div class="path-checkbox-row" data-top-dep="${esc(depName)}">
+                            <input type="checkbox" class="path-cb" checked
+                                data-card="${cardId}" data-vuln-idx="${vi}" data-vuln-id="${esc(id)}">
+                            <span class="s3-file-badge">${esc(path.snykFile)}</span>
+                            <span class="path-deppath">${esc(path.depPath)}</span>
+                        </div>`;
+                    }).join('');
+                    return `<div class="s3-dep-group${allDepIgnored ? ' s3-dep-group--done' : ''}" data-dep="${esc(depName)}" id="${esc(groupId)}">
+                        <div class="s3-dep-group-header">
+                            <span class="s3-dep-group-name">${esc(depName)}</span>
+                            <span class="s3-dep-group-count">${dps.length} path${dps.length !== 1 ? 's' : ''}</span>
+                            ${allDepIgnored ? '<span class="already-ignored-badge">&#x2713; In .snyk</span>' : ''}
+                        </div>
+                        ${!allDepIgnored ? `<div class="s3-dep-group-reason-row">
+                            <input class="s3-dep-reason ignore-form-input" id="${esc(reasonInputId)}"
+                                placeholder="Reason for ${esc(depName)}\u2026">
+                            <select class="s3-dep-preset ignore-form-input" data-target-input="${esc(reasonInputId)}">
+                                <option value="">Preset\u2026</option>
+                                ${presetOptionsHtml}
+                            </select>
+                        </div>` : ''}
+                        ${rowsHtml}
+                        ${!allDepIgnored ? `<button class="btn btn-sm btn-accent s3-dep-add-btn"
+                            data-action="add-dep-group"
+                            data-dep="${esc(depName)}" data-vuln-id="${esc(id)}" data-group-id="${esc(groupId)}">
+                            Add ${pendingCount} path${pendingCount !== 1 ? 's' : ''} to .snyk
+                        </button>` : ''}
+                    </div>`;
                 }).join('');
 
                 return `<details class="rq-card s3-vuln-card${skipped ? ' s3-card-skipped' : ''}${allPathsIgnored ? ' s3-card-all-ignored' : ''}" id="s3-card-${vi}" data-vuln-id="${esc(id)}">
@@ -498,7 +542,7 @@
                     </summary>
                     ${skipped
                         ? '<div class="s3-skipped-overlay">Skipped</div>'
-                        : `<div class="rq-card-body">${fileGroupsHtml}</div>`}
+                        : `<div class="rq-card-body">${s3ViewMode === 'by-dep' ? depGroupsHtml : fileGroupsHtml}</div>`}
                 </details>`;
             }).join('');
 
@@ -515,8 +559,12 @@
                     <span class="tool-section-chevron">&#x25BC;</span>
                     <span class="tool-section-num">3</span>
                     <span class="tool-section-title">Snyk Ignores</span>
-                    <span class="tool-section-desc">Per-vuln cards sub-grouped by .snyk file.</span>
+                    <span class="tool-section-desc">${s3ViewMode === 'by-dep' ? 'Per-vuln cards grouped by top-level dep.' : 'Per-vuln cards grouped by .snyk file.'}</span>
                     <span class="tool-section-badge">${ignoreVulns.size}</span>
+                    <button class="btn btn-sm btn-outline s3-view-toggle" data-action="toggle-s3-view"
+                        title="${s3ViewMode === 'by-dep' ? 'Switch to group by .snyk file' : 'Switch to group by top-level dep'}">
+                        ${s3ViewMode === 'by-dep' ? 'By File' : 'By Dep'}
+                    </button>
                 </summary>
                 <div class="tool-section-body">
                     ${expiryHtml}
@@ -635,33 +683,6 @@
             </div>`;
         }
 
-        // ── YAML builders ──
-        function buildGroupedYamlPreview(batchItems, reasons, expiry) {
-            const byVuln = new Map();
-            batchItems.forEach(function (item, localIdx) {
-                if (!byVuln.has(item.vulnId)) byVuln.set(item.vulnId, []);
-                const reasonIdx = (item.idx !== undefined) ? item.idx : localIdx;
-                byVuln.get(item.vulnId).push({ depPath: item.depPath, idx: reasonIdx });
-            });
-            const created = new Date().toISOString().slice(0, 10) + 'T00:00:00.000Z';
-            const e = expiry || '<expiry>';
-            const blocks = [];
-            for (const [vulnId, paths] of byVuln.entries()) {
-                let block = '  ' + vulnId + ':';
-                for (const { depPath, idx } of paths) {
-                    const r = (typeof reasons === 'object' && reasons !== null)
-                        ? (Array.isArray(reasons) ? (reasons[idx] || '') : (reasons[idx] || ''))
-                        : '';
-                    block += '\n    - \'' + (depPath || '<dep-path>') + '\':' +
-                             '\n        reason: >-\n          ' + (r || '<reason>') +
-                             '\n        expires: ' + e +
-                             '\n        created: ' + created;
-                }
-                blocks.push(block);
-            }
-            return blocks.join('\n');
-        }
-
         // ── Progress bar ──
         // applyProgress: update the DOM elements only (call with pre-computed counts)
         function applyProgress(reviewed) {
@@ -726,44 +747,14 @@
         function attachEvents() {
             const container = document.getElementById('rq-content');
 
-            // Rebuild YAML preview for a specific vuln+file combo
-            function rebuildFileYaml(vulnIdx, snykFile) {
-                const cardId = 's3';
-                const fileId = snykFile.replace(/[^a-z0-9]/gi, '-');
-                const yamlEl = document.getElementById(`batch-yaml-${cardId}-${vulnIdx}-${fileId}`);
-                if (!yamlEl) return;
-                const expiry = document.getElementById(`expiry-${cardId}`)?.value || '';
-                const card = document.getElementById(`s3-card-${vulnIdx}`);
-                if (!card) return;
-                const vulnId = card.dataset.vulnId || '';
-                const subgroup = card.querySelector(`.batch-file-subgroup[data-snyk-file="${CSS.escape(snykFile)}"]`);
-                if (!subgroup) return;
-                const rows = subgroup.querySelectorAll('.path-checkbox-row');
-                const filePaths = [];
-                rows.forEach(row => {
-                    const cb = row.querySelector('input[type="checkbox"]');
-                    if (!cb || !cb.checked) return;
-                    const idx = parseInt(cb.dataset.idx);
-                    if (isNaN(idx)) return;
-                    const depPathSpan = row.querySelector('.path-deppath');
-                    filePaths.push({ vulnId, depPath: depPathSpan?.textContent || '', idx });
-                });
-                const reasons = {};
-                filePaths.forEach(p => {
-                    const el = document.getElementById(`reason-s3-${p.idx}`);
-                    if (el) reasons[p.idx] = el.value;
-                });
-                yamlEl.textContent = buildGroupedYamlPreview(filePaths, reasons, expiry);
-            }
-
             function updateCardCountBadge(card) {
                 const badge = card.querySelector('.s3-path-count-badge');
                 if (!badge) return;
                 const totalPaths = card.querySelectorAll('.path-checkbox-row').length;
                 const resolvedPaths = card.querySelectorAll('.path-checkbox-row.path-already-ignored').length;
-                const fileCount = card.querySelectorAll('.batch-file-subgroup').length;
+                const depCount = card.querySelectorAll('.s3-dep-group').length;
                 const resolvedPart = resolvedPaths > 0 ? ` &middot; <span class="s3-resolved-count">${resolvedPaths} resolved</span>` : '';
-                badge.innerHTML = `${totalPaths} path${totalPaths !== 1 ? 's' : ''} &middot; ${fileCount} file${fileCount !== 1 ? 's' : ''}${resolvedPart}`;
+                badge.innerHTML = `${totalPaths} path${totalPaths !== 1 ? 's' : ''} &middot; ${depCount} dep${depCount !== 1 ? 's' : ''}${resolvedPart}`;
                 const allResolved = totalPaths > 0 && resolvedPaths === totalPaths;
                 let checkBadge = card.querySelector('.s3-all-resolved-badge');
                 if (allResolved && !checkBadge) {
@@ -776,70 +767,123 @@
                 }
             }
 
-            async function handleAddFileSnykIgnore(btn) {
-                const cardId = btn.dataset.card;
-                const vulnIdx = parseInt(btn.dataset.vulnIdx);
-                const snykFile = btn.dataset.snykFile;
-                const vulnId = btn.dataset.vulnId;
-                const expiryInput = document.getElementById('expiry-' + cardId);
-                const expires = expiryInput?.value?.trim() || '';
+            async function handleAddDepGroup(btn) {
+                const { groupId, vulnId } = btn.dataset;
+                const group = document.getElementById(groupId);
+                const expires = document.getElementById('expiry-s3')?.value?.trim() || '';
+                const reason = group?.querySelector('.s3-dep-reason')?.value?.trim() || '';
                 if (!expires) { alert('Please enter an expiry date.'); return; }
-
-                const card = document.getElementById(`s3-card-${vulnIdx}`);
-                const subgroup = card?.querySelector(`.batch-file-subgroup[data-snyk-file="${CSS.escape(snykFile)}"]`);
-                if (!subgroup) return;
+                if (!reason)  { alert('Please enter a reason.'); return; }
 
                 const toAdd = [];
-                subgroup.querySelectorAll('.path-checkbox-row').forEach(row => {
+                group.querySelectorAll('.path-checkbox-row:not(.path-already-ignored)').forEach(row => {
                     const cb = row.querySelector('input[type="checkbox"]');
-                    if (!cb || !cb.checked) return;
-                    const idx = parseInt(cb.dataset.idx);
-                    const depPathSpan = row.querySelector('.path-deppath');
-                    const depPath = depPathSpan?.textContent || '';
-                    const reason = document.getElementById(`reason-${cardId}-${idx}`)?.value?.trim() || '';
-                    toAdd.push({ vulnId, depPath, reason, snykFile });
+                    if (!cb?.checked) return;
+                    toAdd.push({
+                        snykFile: row.querySelector('.s3-file-badge')?.textContent || '',
+                        depPath:  row.querySelector('.path-deppath')?.textContent  || '',
+                    });
                 });
-
-                if (!toAdd.length) { alert('No checked paths to add.'); return; }
-                const emptyReason = toAdd.find(p => !p.reason);
-                if (emptyReason) { alert('Please enter a reason for all checked paths.'); return; }
+                if (!toAdd.length) { alert('No checked paths.'); return; }
 
                 btn.disabled = true;
                 for (let i = 0; i < toAdd.length; i++) {
-                    const p = toAdd[i];
                     btn.textContent = `Adding ${i + 1}/${toAdd.length}\u2026`;
-                    try {
-                        const r = await fetch('/add-snyk-ignore', {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ snykFile: p.snykFile, vulnId: p.vulnId, path: p.depPath, reason: p.reason, expires }),
-                        });
-                        const data = await r.json();
-                        if (!data.ok) { btn.disabled = false; btn.textContent = `Add to ${snykFile}`; alert('Failed: ' + data.error); return; }
-                    } catch (err) {
-                        btn.disabled = false; btn.textContent = `Add to ${snykFile}`;
-                        alert('Request failed: ' + err.message); return;
+                    const { snykFile, depPath } = toAdd[i];
+                    const r = await fetch('/add-snyk-ignore', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ snykFile, vulnId, path: depPath, reason, expires }),
+                    });
+                    const data = await r.json();
+                    if (!data.ok) {
+                        btn.disabled = false;
+                        btn.textContent = `Add ${toAdd.length} path${toAdd.length !== 1 ? 's' : ''} to .snyk`;
+                        alert('Failed: ' + data.error); return;
                     }
                 }
-                btn.textContent = '\u2713 Updated';
+                btn.textContent = '\u2713 Added';
 
-                // Update localAddedPatterns so buildSections() treats these paths as alreadyIgnored
-                for (const p of toAdd) {
-                    if (!localAddedPatterns[p.snykFile]) localAddedPatterns[p.snykFile] = {};
-                    if (!localAddedPatterns[p.snykFile][p.vulnId]) localAddedPatterns[p.snykFile][p.vulnId] = [];
-                    const arr = localAddedPatterns[p.snykFile][p.vulnId];
-                    if (!arr.find(e => e.path === p.depPath)) arr.push({ path: p.depPath, reason: p.reason });
+                for (const { snykFile, depPath } of toAdd) {
+                    if (!localAddedPatterns[snykFile]) localAddedPatterns[snykFile] = {};
+                    if (!localAddedPatterns[snykFile][vulnId]) localAddedPatterns[snykFile][vulnId] = [];
+                    localAddedPatterns[snykFile][vulnId].push({ path: depPath, reason });
                 }
                 recomputeProgress();
 
-                // Convert successfully-added rows to the resolved display (editable reason + Update button)
-                subgroup.querySelectorAll('.path-checkbox-row:not(.path-already-ignored)').forEach(row => {
-                    const cb = row.querySelector('.path-cb');
-                    if (!cb || !cb.checked) return;
-                    const topDep = row.dataset.topDep || '';
-                    const depPath = row.querySelector('.path-deppath')?.textContent || '';
-                    const idx = cb.dataset.idx;
-                    const reason = document.getElementById(`reason-${cardId}-${idx}`)?.value?.trim() || '';
+                group.querySelectorAll('.path-checkbox-row:not(.path-already-ignored)').forEach(row => {
+                    const cb = row.querySelector('input[type="checkbox"]');
+                    if (!cb?.checked) return;
+                    const snykFile = row.querySelector('.s3-file-badge')?.textContent || '';
+                    const depPath  = row.querySelector('.path-deppath')?.textContent  || '';
+                    const topDep   = row.dataset.topDep || '';
+                    row.className = 'path-checkbox-row path-already-ignored';
+                    row.dataset.topDep = topDep;
+                    row.innerHTML = `<span class="path-already-ignored-check">&#x2713;</span>`
+                        + `<span class="s3-file-badge">${esc(snykFile)}</span>`
+                        + `<span class="path-deppath">${esc(depPath)}</span>`
+                        + `<input type="text" class="ignore-form-input already-ignored-reason-input" value="${esc(reason)}" placeholder="Reason&hellip;" data-snyk-file="${esc(snykFile)}" data-vuln-id="${esc(vulnId)}" data-dep-path="${esc(depPath)}">`
+                        + `<button class="btn btn-sm btn-outline" data-action="update-ignore-reason" data-snyk-file="${esc(snykFile)}" data-vuln-id="${esc(vulnId)}" data-dep-path="${esc(depPath)}">Update</button>`
+                        + `<span class="already-ignored-badge">Already in .snyk</span>`;
+                });
+
+                group.querySelector('.s3-dep-group-reason-row')?.remove();
+                group.classList.add('s3-dep-group--done');
+                btn.remove();
+
+                const card = group.closest('.s3-vuln-card');
+                if (card) {
+                    updateCardCountBadge(card);
+                    card.querySelector('.s3-card-header')?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+                }
+            }
+
+            async function handleAddFileGroup(btn) {
+                const { groupId, vulnId, snykFile } = btn.dataset;
+                const group = document.getElementById(groupId);
+                const expires = document.getElementById('expiry-s3')?.value?.trim() || '';
+                const reason = group?.querySelector('.s3-dep-reason')?.value?.trim() || '';
+                if (!expires) { alert('Please enter an expiry date.'); return; }
+                if (!reason)  { alert('Please enter a reason.'); return; }
+
+                const toAdd = [];
+                group.querySelectorAll('.path-checkbox-row:not(.path-already-ignored)').forEach(row => {
+                    const cb = row.querySelector('input[type="checkbox"]');
+                    if (!cb?.checked) return;
+                    toAdd.push({ depPath: row.querySelector('.path-deppath')?.textContent || '' });
+                });
+                if (!toAdd.length) { alert('No checked paths.'); return; }
+
+                btn.disabled = true;
+                for (let i = 0; i < toAdd.length; i++) {
+                    btn.textContent = `Adding ${i + 1}/${toAdd.length}\u2026`;
+                    const { depPath } = toAdd[i];
+                    const r = await fetch('/add-snyk-ignore', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ snykFile, vulnId, path: depPath, reason, expires }),
+                    });
+                    const data = await r.json();
+                    if (!data.ok) {
+                        btn.disabled = false;
+                        btn.textContent = `Add ${toAdd.length} path${toAdd.length !== 1 ? 's' : ''} to .snyk`;
+                        alert('Failed: ' + data.error); return;
+                    }
+                }
+                btn.textContent = '\u2713 Added';
+
+                for (const { depPath } of toAdd) {
+                    if (!localAddedPatterns[snykFile]) localAddedPatterns[snykFile] = {};
+                    if (!localAddedPatterns[snykFile][vulnId]) localAddedPatterns[snykFile][vulnId] = [];
+                    localAddedPatterns[snykFile][vulnId].push({ path: depPath, reason });
+                }
+                recomputeProgress();
+
+                group.querySelectorAll('.path-checkbox-row:not(.path-already-ignored)').forEach(row => {
+                    const cb = row.querySelector('input[type="checkbox"]');
+                    if (!cb?.checked) return;
+                    const depPath  = row.querySelector('.path-deppath')?.textContent || '';
+                    const topDep   = row.dataset.topDep || '';
                     row.className = 'path-checkbox-row path-already-ignored';
                     row.dataset.topDep = topDep;
                     row.innerHTML = `<span class="path-already-ignored-check">&#x2713;</span>`
@@ -849,36 +893,24 @@
                         + `<span class="already-ignored-badge">Already in .snyk</span>`;
                 });
 
-                subgroup.removeAttribute('open');
-                subgroup.classList.add('batch-file-subgroup--done');
-                const heading = subgroup.querySelector('.batch-file-subgroup-heading');
-                if (heading && !heading.querySelector('.batch-file-done-badge')) {
-                    const badge = document.createElement('span');
-                    badge.className = 'batch-file-done-badge';
-                    badge.textContent = '\u2713 Added';
-                    heading.appendChild(badge);
+                group.querySelector('.s3-dep-group-reason-row')?.remove();
+                group.classList.add('s3-dep-group--done');
+                btn.remove();
+
+                const card = group.closest('.s3-vuln-card');
+                if (card) {
+                    updateCardCountBadge(card);
+                    card.querySelector('.s3-card-header')?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
                 }
-
-                updateCardCountBadge(card);
-
-                // If all paths across all subgroups are now resolved, mark the whole card
-                const cardAllIgnored = !card.querySelector('.path-checkbox-row:not(.path-already-ignored)');
-                if (cardAllIgnored) {
-                    card.classList.add('s3-card-all-ignored');
-                    card.removeAttribute('open');
-                }
-
-                card.querySelector('.s3-card-header')?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-                setTimeout(() => { btn.disabled = false; btn.textContent = `Add to ${snykFile}`; }, 2000);
             }
 
-            // Preset dropdown — fills the prefill text box, not the reason inputs directly
+            // Preset dropdown — fills the dep-group reason input
             container.addEventListener('change', function (e) {
-                if (!e.target.classList.contains('preset-select')) return;
+                if (!e.target.classList.contains('s3-dep-preset')) return;
                 const val = e.target.value;
                 if (!val) return;
-                const prefillInput = e.target.closest('.prefill-row')?.querySelector('.prefill-text');
-                if (prefillInput) prefillInput.value = val;
+                const input = document.getElementById(e.target.dataset.targetInput);
+                if (input) { input.value = val; input.dispatchEvent(new Event('input')); }
                 e.target.value = '';
             });
 
@@ -888,18 +920,7 @@
                 e.stopPropagation();
                 const action = btn.dataset.action;
 
-                if (action === 'prefill-reasons') {
-                    const vulnIdx = btn.dataset.vulnIdx;
-                    const snykFile = btn.dataset.snykFile;
-                    const prefillInput = btn.closest('.prefill-row')?.querySelector('.prefill-text');
-                    const val = prefillInput?.value?.trim() || '';
-                    if (!val) return;
-                    const card = document.getElementById(`s3-card-${vulnIdx}`);
-                    const subgroup = card?.querySelector(`.batch-file-subgroup[data-snyk-file="${CSS.escape(snykFile)}"]`);
-                    if (!subgroup) return;
-                    subgroup.querySelectorAll('.batch-ignore-reason').forEach(inp => { inp.value = val; });
-                    if (vulnIdx !== undefined && snykFile) rebuildFileYaml(parseInt(vulnIdx), snykFile);
-                } else if (action === 'select-version') {
+                if (action === 'select-version') {
                     const version = btn.dataset.version;
                     const row = btn.closest('.dep-card-file-row');
                     if (!row) return;
@@ -920,10 +941,23 @@
                     handleRemoveDep(btn);
                 } else if (action === 'apply-resolution') {
                     handleApplyResolution(btn);
+                } else if (action === 'toggle-s3-view') {
+                    s3ViewMode = s3ViewMode === 'by-dep' ? 'by-file' : 'by-dep';
+                    const openSections = new Set(
+                        [...document.querySelectorAll('.tool-section')].map((el, i) => el.open ? i : -1).filter(i => i !== -1)
+                    );
+                    const openCards = new Set(
+                        [...document.querySelectorAll('.s3-vuln-card')].map((el, i) => el.open ? i : -1).filter(i => i !== -1)
+                    );
+                    renderReviewQueueTab();
+                    document.querySelectorAll('.tool-section').forEach((el, i) => { if (openSections.has(i)) el.open = true; });
+                    document.querySelectorAll('.s3-vuln-card').forEach((el, i) => { if (openCards.has(i)) el.open = true; });
                 } else if (action === 'update-ignore-reason') {
                     handleUpdateIgnoreReason(btn);
-                } else if (action === 'add-file-snyk-ignore') {
-                    handleAddFileSnykIgnore(btn);
+                } else if (action === 'add-dep-group') {
+                    handleAddDepGroup(btn);
+                } else if (action === 'add-file-group') {
+                    handleAddFileGroup(btn);
                 } else if (action === 'add-snyk-ignore') {
                     handleAddSnykIgnore(btn);
                 } else if (action === 'update-snyk') {
@@ -949,35 +983,20 @@
                     const dep = btn.dataset.dep;
                     if (skipState.deps.has(dep)) skipState.deps.delete(dep);
                     else skipState.deps.add(dep);
-                    // Toggle checkboxes for this dep and collect affected (vulnIdx, snykFile) pairs
-                    const toRebuild = new Set();
-                    container.querySelectorAll(`.path-checkbox-row[data-top-dep="${CSS.escape(dep)}"]`).forEach(row => {
-                        const cb = row.querySelector('input[type="checkbox"]');
-                        if (cb) {
-                            cb.checked = !skipState.deps.has(dep);
-                            const vi = cb.dataset.vulnIdx;
-                            const sf = row.closest('.batch-file-subgroup')?.dataset.snykFile;
-                            if (vi !== undefined && sf) toRebuild.add(`${vi}\0${sf}`);
-                        }
-                    });
-                    // Toggle button style
-                    container.querySelectorAll(`[data-action="skip-dep"][data-dep="${CSS.escape(dep)}"]`).forEach(b => {
-                        b.classList.toggle('skipped', skipState.deps.has(dep));
-                    });
-                    // Rebuild YAML previews for affected vuln+file pairs
-                    toRebuild.forEach(key => {
-                        const sep = key.indexOf('\0');
-                        rebuildFileYaml(parseInt(key.slice(0, sep)), key.slice(sep + 1));
-                    });
-                } else if (action === 'copy-file-yaml') {
-                    const vi = btn.dataset.vulnIdx;
-                    const snykFile = btn.dataset.snykFile;
-                    const fileId = snykFile.replace(/[^a-z0-9]/gi, '-');
-                    const yamlEl = document.getElementById(`batch-yaml-s3-${vi}-${fileId}`);
-                    if (yamlEl) navigator.clipboard.writeText(yamlEl.textContent).then(() => {
-                        const orig = btn.textContent; btn.textContent = '\u2713 Copied';
-                        setTimeout(() => { btn.textContent = orig; }, 1500);
-                    });
+                    const isSkipped = skipState.deps.has(dep);
+                    if (s3ViewMode === 'by-dep') {
+                        container.querySelectorAll(`.s3-dep-group[data-dep="${CSS.escape(dep)}"]`)
+                            .forEach(g => g.classList.toggle('s3-dep-group--skipped', isSkipped));
+                    } else {
+                        container.querySelectorAll(`.path-checkbox-row[data-top-dep="${CSS.escape(dep)}"]`)
+                            .forEach(row => {
+                                row.classList.toggle('dep-skipped', isSkipped);
+                                const cb = row.querySelector('input[type="checkbox"]');
+                                if (cb && !row.classList.contains('path-already-ignored')) cb.checked = !isSkipped;
+                            });
+                    }
+                    container.querySelectorAll(`[data-action="skip-dep"][data-dep="${CSS.escape(dep)}"]`)
+                        .forEach(b => b.classList.toggle('skipped', isSkipped));
                 } else if (action === 'resolve') {
                     const ids = btn.dataset.ids.split(',').filter(Boolean);
                     applyDecision(ids, 'resolved', { resolution: btn.dataset.resolution, note: btn.dataset.note });
@@ -993,35 +1012,6 @@
                     if (yaml) navigator.clipboard.writeText(yaml.textContent).then(() => {
                         const orig = btn.textContent; btn.textContent = '\u2713 Copied';
                         setTimeout(() => { btn.textContent = orig; }, 1500);
-                    });
-                }
-            });
-
-            // Live YAML preview updates
-            container.addEventListener('input', function (e) {
-                if (e.target.classList.contains('batch-ignore-reason')) {
-                    const vulnIdx = parseInt(e.target.dataset.vulnIdx);
-                    const snykFile = e.target.dataset.snykFile;
-                    if (!isNaN(vulnIdx) && snykFile) rebuildFileYaml(vulnIdx, snykFile);
-                }
-                if (e.target.classList.contains('batch-ignore-expiry')) {
-                    const cardId = e.target.dataset.card;
-                    if (!cardId) return;
-                    // Rebuild all file YAML previews
-                    container.querySelectorAll('[id^="batch-yaml-s3-"]').forEach(yamlEl => {
-                        const m = yamlEl.id.match(/^batch-yaml-s3-(\d+)-(.+)$/);
-                        if (!m) return;
-                        const vi = parseInt(m[1]);
-                        const fileId = m[2];
-                        // Find snyk file from matching subgroup
-                        const card = document.getElementById(`s3-card-${vi}`);
-                        if (!card) return;
-                        card.querySelectorAll('.batch-file-subgroup').forEach(sg => {
-                            const sf = sg.dataset.snykFile;
-                            if (sf && sf.replace(/[^a-z0-9]/gi, '-') === fileId) {
-                                rebuildFileYaml(vi, sf);
-                            }
-                        });
                     });
                 }
             });

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -339,7 +339,7 @@
                     }
                 }
                 const updateAllBtn = allNearUpdates.length
-                    ? `<button class="btn btn-sm btn-warn" data-action="update-all-near"
+                    ? `<button class="btn btn-sm btn-warn" style="margin-left:auto" data-action="update-all-near"
                             data-updates="${esc(JSON.stringify(allNearUpdates))}">Update All .snyk Files</button>`
                     : '';
                 const nearGroupsHtml = [...nearItems.entries()].map(([sf, items]) => renderCatDGroup(sf, items)).join('');
@@ -581,7 +581,7 @@
                     newPath: (entry.vuln.from?.slice(1) || []).join(' > '),
                 }));
                 const updateAllVulnBtn = vulnUpdates.length > 1
-                    ? `<button class="btn btn-sm btn-warn" data-action="update-all-near"
+                    ? `<button class="btn btn-sm btn-warn" style="margin-left:auto" data-action="update-all-near"
                             data-updates="${esc(JSON.stringify(vulnUpdates))}">Update all paths</button>`
                     : '';
                 const pathsHtml = unresolvedVulnItems.map(({ entry, nearMatch }) =>
@@ -608,7 +608,7 @@
             const resolvedPill = allResolved ? '<span class="near-group-resolved-pill">&#x2713; Resolved</span>' : '';
             const toggleArrow = `<span class="near-toggle-arrow">${allResolved ? '&#x25B6;' : '&#x25BC;'}</span>`;
             const updateAllBtn = !allResolved
-                ? `<button class="btn btn-sm btn-warn" data-action="update-all-near"
+                ? `<button class="btn btn-sm btn-warn" style="margin-left:auto" data-action="update-all-near"
                         data-updates="${esc(JSON.stringify(allUpdates))}">Update All in This File</button>`
                 : '';
 
@@ -711,7 +711,6 @@
             }
 
             document.getElementById('rq-content').innerHTML = html;
-            attachEvents();
         }
 
         // ── Event handling (delegated) ──
@@ -1179,9 +1178,14 @@
         }
 
         function refreshIgnorePatterns() {
+            document.querySelector('.s3-near-panel')?.classList.add('refreshing');
+            const openSectionIndices = new Set(
+                [...document.querySelectorAll('.tool-section')].map((el, i) => el.open ? i : -1).filter(i => i !== -1)
+            );
             return fetch('/data').then(r => r.json()).then(data => {
                 ignorePatternsByFile = data.ignorePatternsByFile || {};
                 renderReviewQueueTab();
+                document.querySelectorAll('.tool-section').forEach((el, i) => { if (openSectionIndices.has(i)) el.open = true; });
                 document.getElementById('rq-resolved-section')?.classList.add('open');
             });
         }
@@ -1199,7 +1203,7 @@
                     btn.textContent = '\u2713 Updated';
                     btn.classList.replace('btn-warn', 'btn-primary');
                     applyNearUpdatesToLocalPatterns([{ snykFile, vulnId, newPath }]);
-                    setTimeout(refreshIgnorePatterns, 700);
+                    refreshIgnorePatterns();
                 } else { btn.disabled = false; btn.textContent = 'Update .snyk'; alert('Failed: ' + data.error); }
             }).catch(err => { btn.disabled = false; btn.textContent = 'Update .snyk'; alert('Request failed: ' + err.message); });
         }
@@ -1219,7 +1223,7 @@
                     btn.textContent = '\u2713 All Updated';
                     btn.classList.replace('btn-warn', 'btn-primary');
                     applyNearUpdatesToLocalPatterns(updates);
-                    setTimeout(refreshIgnorePatterns, 700);
+                    refreshIgnorePatterns();
                 } else { btn.disabled = false; btn.textContent = 'Update All in This File'; alert('Failed: ' + data.error); }
             }).catch(err => { btn.disabled = false; btn.textContent = 'Update All in This File'; alert('Request failed: ' + err.message); });
         }
@@ -1259,5 +1263,6 @@
         }
 
         renderReviewQueueTab();
+        attachEvents();
     };
 })();

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -344,7 +344,7 @@
                 const nearGroupsHtml = [...nearItems.entries()].map(([sf, items]) => renderCatDGroup(sf, items)).join('');
                 nearHtml = `<details class="s3-near-panel" open>
                     <summary class="s3-near-summary">
-                        <span>&#x26A1; Near-ignored &#x2014; stale .snyk paths</span>
+                        <span>&#x26A1; Outdated versions &#x2014; stale .snyk paths</span>
                         <span class="s3-near-count">${nearItems.size} file${nearItems.size !== 1 ? 's' : ''}</span>
                         ${updateAllBtn}
                     </summary>

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -382,11 +382,18 @@
                             ${esc(snykFile)}
                             <span class="s3-file-path-count">${fps.length} path${fps.length !== 1 ? 's' : ''}</span>
                         </div>
-                        <select class="ignore-form-input preset-select cat-a-preset"
-                            data-card="${cardId}" data-vuln-idx="${vi}" data-snyk-file="${esc(snykFile)}">
-                            <option value="">Fill reasons for this file&#x2026;</option>
-                            ${presetOptionsHtml}
-                        </select>
+                        <div class="prefill-row">
+                            <select class="ignore-form-input preset-select cat-a-preset"
+                                data-card="${cardId}" data-vuln-idx="${vi}" data-snyk-file="${esc(snykFile)}">
+                                <option value="">Preset&#x2026;</option>
+                                ${presetOptionsHtml}
+                            </select>
+                            <input type="text" class="ignore-form-input prefill-text"
+                                data-card="${cardId}" data-vuln-idx="${vi}" data-snyk-file="${esc(snykFile)}"
+                                placeholder="Prefill reason&#x2026;">
+                            <button class="btn btn-sm btn-outline" data-action="prefill-reasons"
+                                data-card="${cardId}" data-vuln-idx="${vi}" data-snyk-file="${esc(snykFile)}">Apply to all</button>
+                        </div>
                         ${rowsHtml}
                         <details class="batch-yaml-details">
                             <summary class="batch-yaml-summary">
@@ -695,21 +702,14 @@
                 setTimeout(() => { btn.disabled = false; btn.textContent = `Add to ${snykFile}`; }, 2000);
             }
 
-            // Preset dropdown
+            // Preset dropdown — fills the prefill text box, not the reason inputs directly
             container.addEventListener('change', function (e) {
                 if (!e.target.classList.contains('preset-select')) return;
-                const vulnIdx = e.target.dataset.vulnIdx;
-                const snykFile = e.target.dataset.snykFile;
                 const val = e.target.value;
                 if (!val) return;
-                const card = document.getElementById(`s3-card-${vulnIdx}`);
-                const subgroup = card?.querySelector(`.batch-file-subgroup[data-snyk-file="${CSS.escape(snykFile)}"]`);
-                if (!subgroup) return;
-                subgroup.querySelectorAll('.batch-ignore-reason').forEach(inp => {
-                    inp.value = val;
-                });
+                const prefillInput = e.target.closest('.prefill-row')?.querySelector('.prefill-text');
+                if (prefillInput) prefillInput.value = val;
                 e.target.value = '';
-                if (vulnIdx !== undefined && snykFile) rebuildFileYaml(parseInt(vulnIdx), snykFile);
             });
 
             container.addEventListener('click', function (e) {
@@ -718,7 +718,18 @@
                 e.stopPropagation();
                 const action = btn.dataset.action;
 
-                if (action === 'check-versions') {
+                if (action === 'prefill-reasons') {
+                    const vulnIdx = btn.dataset.vulnIdx;
+                    const snykFile = btn.dataset.snykFile;
+                    const prefillInput = btn.closest('.prefill-row')?.querySelector('.prefill-text');
+                    const val = prefillInput?.value?.trim() || '';
+                    if (!val) return;
+                    const card = document.getElementById(`s3-card-${vulnIdx}`);
+                    const subgroup = card?.querySelector(`.batch-file-subgroup[data-snyk-file="${CSS.escape(snykFile)}"]`);
+                    if (!subgroup) return;
+                    subgroup.querySelectorAll('.batch-ignore-reason').forEach(inp => { inp.value = val; });
+                    if (vulnIdx !== undefined && snykFile) rebuildFileYaml(parseInt(vulnIdx), snykFile);
+                } else if (action === 'check-versions') {
                     handleCheckVersions(btn);
                 } else if (action === 'check-dep-field') {
                     handleCheckDepField(btn);

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -674,7 +674,7 @@
                                 <a class="vuln-id-link" href="https://security.snyk.io/vuln/${esc(id)}" target="_blank" rel="noopener">${esc(id)}</a>
                                 ${sevBadge(vuln)}
                                 <span class="rq-resolved-note">${esc(vuln.title || '')}</span>
-                                ${decision.note ? `<span class="rq-resolved-note" style="color:var(--c-fix)">${esc(decision.note)}</span>` : ''}
+                                ${decision.note ? `<span class="rq-resolved-decision-note">${esc(decision.note)}</span>` : ''}
                                 <span class="rq-resolved-ts">${esc(ts)}</span>
                             </div>`;
                         }).join('')}

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -64,17 +64,11 @@
         function buildSections() {
             const decisions = localRS.decisions;
 
-            // Mark resolved vulns that reappeared as reopened
-            const activeIds = new Set(allVulnEntries.map(e => e.vuln.id));
-            for (const [id, dec] of Object.entries(decisions)) {
-                if (dec.status === 'resolved' && activeIds.has(id)) {
-                    decisions[id] = { ...dec, status: 'reopened' };
-                }
-            }
-
             // Section 1: Dep groups — Map: depName → { depName, vulns: Map<id,{id,vuln}>, files: Map<pkgPath,version> }
             const depGroups = new Map();
             for (const { vuln, project } of allVulnEntries) {
+                const dec = decisions[vuln.id];
+                if (dec?.status === 'resolved' || dec?.status === 'skipped') continue;
                 const topDep = vuln.from?.[1] || '';
                 if (!topDep) continue;
                 const depName = stripVer(topDep);
@@ -89,6 +83,8 @@
             // Section 2: Resolution groups — Map: pkgName → { fixVersion, items: [{id,vuln,entries}] }
             const resGroups = new Map();
             for (const { vuln, project } of allVulnEntries) {
+                const dec = decisions[vuln.id];
+                if (dec?.status === 'resolved' || dec?.status === 'skipped') continue;
                 const fix = sameMajorFixVersion(vuln);
                 if (!fix) continue;
                 const pkg = vuln.name || vuln.packageName || '';
@@ -111,7 +107,7 @@
             for (const { vuln, project } of allVulnEntries) {
                 const id = vuln.id;
                 const decision = decisions[id];
-                if (decision?.status === 'resolved') continue;
+                if (decision?.status === 'resolved' || decision?.status === 'skipped') continue;
 
                 // Near-ignored check
                 const near = getNear(vuln, project);

--- a/external/ag-shared/scripts/snyk-viewer/ui-styles.css
+++ b/external/ag-shared/scripts/snyk-viewer/ui-styles.css
@@ -1,0 +1,1696 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+    --c-bg: #0f1117;
+    --c-surface: #1a1d27;
+    --c-surface2: #22263a;
+    --c-border: #2e3348;
+    --c-text: #e2e8f0;
+    --c-text-muted: #8892a4;
+    --c-critical: #ff4d4d;
+    --c-high: #ff8c42;
+    --c-medium: #ffc107;
+    --c-low: #6fa8dc;
+    --c-fix: #4caf82;
+    --c-accent: #7c83f5;
+    --radius: 6px;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--c-bg);
+    color: var(--c-text);
+    font-size: 14px;
+    line-height: 1.5;
+    min-height: 100vh;
+}
+
+a { color: var(--c-accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* ── Layout ── */
+#app { max-width: 1400px; margin: 0 auto; padding: 24px 20px; }
+
+/* ── Header ── */
+#header {
+    background: var(--c-surface);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    padding: 20px 24px;
+    margin-bottom: 0;
+    border-bottom: none;
+    border-radius: var(--radius) var(--radius) 0 0;
+}
+#header h1 {
+    font-size: 20px;
+    font-weight: 700;
+    margin-bottom: 12px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+#header h1 span.icon { font-size: 24px; }
+
+.summary-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+}
+.summary-stat {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    color: var(--c-text-muted);
+}
+.summary-stat strong { color: var(--c-text); }
+
+.sev-pills { display: flex; gap: 8px; flex-wrap: wrap; }
+.sev-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 3px 10px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+}
+.sev-pill.critical { background: rgba(255,77,77,0.15); color: var(--c-critical); border: 1px solid rgba(255,77,77,0.3); }
+.sev-pill.high     { background: rgba(255,140,66,0.15); color: var(--c-high);     border: 1px solid rgba(255,140,66,0.3); }
+.sev-pill.medium   { background: rgba(255,193,7,0.12);  color: var(--c-medium);   border: 1px solid rgba(255,193,7,0.3); }
+.sev-pill.low      { background: rgba(111,168,220,0.12);color: var(--c-low);      border: 1px solid rgba(111,168,220,0.3); }
+
+/* ── Tab bar ── */
+#tab-bar {
+    background: var(--c-surface);
+    border: 1px solid var(--c-border);
+    border-top: none;
+    border-radius: 0 0 0 0;
+    display: flex;
+    align-items: center;
+    padding: 0 8px;
+    margin-bottom: 16px;
+    border-bottom: 2px solid var(--c-border);
+}
+.tab-bar-run {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 0 4px;
+}
+.tab-btn {
+    padding: 10px 18px;
+    background: none;
+    border: none;
+    color: var(--c-text-muted);
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 600;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -2px;
+    transition: all 0.15s;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.tab-btn:hover { color: var(--c-text); }
+.tab-btn.active { color: var(--c-accent); border-bottom-color: var(--c-accent); }
+.tab-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    height: 20px;
+    padding: 0 6px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 700;
+    background: rgba(124,131,245,0.15);
+    color: var(--c-accent);
+}
+.tab-btn.active .tab-badge { background: var(--c-accent); color: #fff; }
+
+/* ── Controls (Browse All) ── */
+#controls {
+    background: var(--c-surface);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    padding: 14px 20px;
+    margin-bottom: 16px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+    align-items: center;
+}
+
+.ctrl-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.ctrl-label {
+    font-size: 12px;
+    color: var(--c-text-muted);
+    white-space: nowrap;
+}
+
+#search {
+    background: var(--c-bg);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    color: var(--c-text);
+    padding: 6px 10px;
+    font-size: 13px;
+    width: 240px;
+    outline: none;
+    transition: border-color 0.15s;
+}
+#search:focus { border-color: var(--c-accent); }
+#search::placeholder { color: var(--c-text-muted); }
+
+.filter-chips { display: flex; gap: 6px; }
+.chip {
+    padding: 4px 12px;
+    border-radius: 12px;
+    border: 1px solid var(--c-border);
+    background: var(--c-bg);
+    color: var(--c-text-muted);
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 600;
+    transition: all 0.15s;
+}
+.chip:hover { border-color: var(--c-accent); color: var(--c-text); }
+.chip.active { background: var(--c-accent); border-color: var(--c-accent); color: #fff; }
+.chip.active.critical { background: var(--c-critical); border-color: var(--c-critical); }
+.chip.active.high     { background: var(--c-high);     border-color: var(--c-high); }
+.chip.active.medium   { background: var(--c-medium);   border-color: var(--c-medium); color: #000; }
+.chip.active.low      { background: var(--c-low);      border-color: var(--c-low); }
+
+.seg-btn-group { display: flex; border: 1px solid var(--c-border); border-radius: var(--radius); overflow: hidden; }
+.seg-btn {
+    padding: 5px 14px;
+    background: var(--c-bg);
+    border: none;
+    color: var(--c-text-muted);
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 600;
+    transition: all 0.15s;
+    border-right: 1px solid var(--c-border);
+}
+.seg-btn:last-child { border-right: none; }
+.seg-btn:hover { background: var(--c-surface2); color: var(--c-text); }
+.seg-btn.active { background: var(--c-accent); color: #fff; }
+
+.toggle-label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    font-size: 12px;
+    color: var(--c-text-muted);
+}
+.toggle-label input { cursor: pointer; accent-color: var(--c-accent); }
+
+/* ── Projects popover ── */
+#stat-projects { position: relative; cursor: pointer; user-select: none; }
+#stat-projects:hover strong { text-decoration: underline; }
+#projects-popover {
+    display: none;
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 0;
+    background: var(--c-surface2);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    padding: 6px 0;
+    min-width: 280px;
+    max-height: 320px;
+    overflow-y: auto;
+    z-index: 100;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.5);
+    font-weight: normal;
+}
+#projects-popover.open { display: block; }
+.popover-project {
+    padding: 5px 14px;
+    font-size: 12px;
+    color: var(--c-text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* ── Vulnerabilities popover ── */
+#stat-packages { position: relative; cursor: pointer; user-select: none; }
+#stat-packages:hover strong { text-decoration: underline; }
+#vulns-popover {
+    display: none;
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 0;
+    background: var(--c-surface2);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    padding: 6px 0;
+    min-width: 460px;
+    max-height: 360px;
+    overflow-y: auto;
+    z-index: 100;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.5);
+    font-weight: normal;
+}
+#vulns-popover.open { display: block; }
+.popover-vuln {
+    display: flex;
+    align-items: baseline;
+    gap: 7px;
+    padding: 5px 14px;
+    font-size: 12px;
+}
+.popover-vuln-id {
+    font-family: monospace;
+    color: var(--c-accent);
+    text-decoration: none;
+    flex-shrink: 0;
+}
+.popover-vuln-id:hover { text-decoration: underline; }
+.popover-vuln-title {
+    color: var(--c-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* ── Count bar ── */
+#count-bar {
+    font-size: 12px;
+    color: var(--c-text-muted);
+    padding: 0 4px;
+    margin-bottom: 10px;
+}
+
+/* ── Vuln List (Browse All) ── */
+#vuln-list { display: flex; flex-direction: column; gap: 4px; }
+
+.group-header {
+    background: var(--c-surface2);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    padding: 10px 16px;
+    font-weight: 700;
+    color: var(--c-text-muted);
+    margin-top: 10px;
+    margin-bottom: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 11px;
+}
+
+.vuln-row {
+    background: var(--c-surface);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    overflow: hidden;
+    transition: border-color 0.15s;
+}
+.vuln-row:hover { border-color: var(--c-accent); }
+.vuln-row.critical { border-left: 3px solid var(--c-critical); }
+.vuln-row.high     { border-left: 3px solid var(--c-high); }
+.vuln-row.medium   { border-left: 3px solid var(--c-medium); }
+.vuln-row.low      { border-left: 3px solid var(--c-low); }
+.vuln-row.has-near-ignored {
+    border-left-color: var(--c-medium) !important;
+    background: rgba(255, 193, 7, 0.04);
+}
+
+.vuln-summary {
+    display: grid;
+    grid-template-columns: 90px 1fr auto auto auto auto;
+    gap: 12px;
+    align-items: center;
+    padding: 10px 14px;
+    cursor: pointer;
+    user-select: none;
+}
+.vuln-summary:hover { background: var(--c-surface2); }
+
+.sev-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    text-align: center;
+}
+.sev-badge.critical { background: rgba(255,77,77,0.2);  color: var(--c-critical); }
+.sev-badge.high     { background: rgba(255,140,66,0.2); color: var(--c-high); }
+.sev-badge.medium   { background: rgba(255,193,7,0.15); color: var(--c-medium); }
+.sev-badge.low      { background: rgba(111,168,220,0.15); color: var(--c-low); }
+
+.vuln-main { min-width: 0; }
+.vuln-title { font-weight: 600; font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.vuln-meta { font-size: 11px; color: var(--c-text-muted); margin-top: 2px; display: flex; gap: 12px; flex-wrap: wrap; }
+.vuln-id-link { font-family: monospace; font-size: 11px; color: var(--c-accent); white-space: nowrap; }
+.vuln-id-wrap { display: flex; align-items: center; gap: 5px; }
+.copy-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--c-text-muted);
+    padding: 0 2px;
+    font-size: 12px;
+    line-height: 1;
+    opacity: 0;
+    transition: opacity 0.15s, color 0.15s;
+}
+.vuln-summary:hover .copy-btn { opacity: 1; }
+.copy-btn:hover { color: var(--c-text); }
+.copy-btn.copied { color: var(--c-fix); opacity: 1; }
+.cve-links { display: flex; gap: 5px; flex-wrap: wrap; }
+.cve-link { font-family: monospace; font-size: 11px; color: var(--c-text-muted); }
+.cve-link:hover { color: var(--c-accent); }
+
+.proj-count { font-size: 11px; color: var(--c-text-muted); white-space: nowrap; }
+.near-ignored-row-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 7px;
+    border-radius: 10px;
+    font-size: 10px;
+    font-weight: 700;
+    background: rgba(255, 193, 7, 0.15);
+    border: 1px solid rgba(255, 193, 7, 0.4);
+    color: var(--c-medium);
+    white-space: nowrap;
+    vertical-align: middle;
+}
+.near-ignored-badge {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 10px;
+    font-size: 10px;
+    font-weight: 600;
+    background: rgba(255, 193, 7, 0.1);
+    border: 1px solid rgba(255, 193, 7, 0.35);
+    color: var(--c-medium);
+    margin-left: 6px;
+    vertical-align: middle;
+}
+.project-entry.near-ignored {
+    border-left: 2px solid var(--c-medium);
+    background: rgba(255, 193, 7, 0.04);
+}
+.snyk-ignore-reason {
+    margin-top: 6px;
+    padding-top: 6px;
+    border-top: 1px solid var(--c-border);
+    font-size: 11px;
+    color: var(--c-text-muted);
+    font-style: italic;
+}
+.snyk-ignore-reason strong {
+    font-style: normal;
+    font-weight: 600;
+    color: var(--c-medium);
+    margin-right: 4px;
+}
+
+.fix-status { white-space: nowrap; font-size: 12px; display: flex; align-items: center; gap: 4px; }
+.fix-yes { color: var(--c-fix); }
+.fix-no  { color: var(--c-text-muted); }
+
+.expand-icon {
+    color: var(--c-text-muted);
+    font-size: 14px;
+    transition: transform 0.2s;
+    width: 20px;
+    text-align: center;
+}
+.vuln-row.expanded .expand-icon { transform: rotate(180deg); }
+
+/* ── Expanded details ── */
+.vuln-detail {
+    display: none;
+    border-top: 1px solid var(--c-border);
+    background: var(--c-bg);
+    padding: 14px 16px;
+}
+.vuln-row.expanded .vuln-detail { display: block; }
+
+.detail-section { margin-bottom: 12px; }
+.detail-section:last-child { margin-bottom: 0; }
+.detail-label {
+    font-size: 11px;
+    color: var(--c-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 700;
+    margin-bottom: 6px;
+}
+
+.project-entry {
+    background: var(--c-surface);
+    border: 1px solid var(--c-border);
+    border-radius: 4px;
+    padding: 8px 12px;
+    margin-bottom: 6px;
+    font-size: 12px;
+}
+.project-entry:last-child { margin-bottom: 0; }
+.project-name {
+    font-weight: 600;
+    color: var(--c-text);
+    margin-bottom: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+.project-name-actions { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
+.resolve-btn {
+    padding: 2px 8px;
+    background: rgba(255, 193, 7, 0.08);
+    border: 1px solid rgba(255, 193, 7, 0.35);
+    border-radius: 3px;
+    color: var(--c-medium);
+    font-size: 10px;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.15s;
+}
+.resolve-btn:hover { background: rgba(255, 193, 7, 0.2); }
+.resolve-btn:disabled { opacity: 0.5; cursor: default; }
+.near-actions { display: flex; justify-content: flex-end; margin: -4px 0 8px; }
+.update-all-btn {
+    padding: 5px 12px;
+    background: rgba(255, 193, 7, 0.1);
+    border: 1px solid rgba(255, 193, 7, 0.4);
+    border-radius: var(--radius);
+    color: var(--c-medium);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+.update-all-btn:hover { background: rgba(255, 193, 7, 0.22); }
+.update-all-btn:disabled { opacity: 0.5; cursor: default; }
+.dep-paths { display: flex; flex-direction: column; gap: 6px; }
+.dep-path { display: flex; align-items: center; flex-wrap: wrap; gap: 4px; }
+.dep-path-row { display: flex; align-items: flex-start; gap: 8px; }
+.dep-path-label {
+    font-size: 10px;
+    font-weight: 700;
+    font-family: monospace;
+    white-space: nowrap;
+    padding: 1px 5px;
+    border-radius: 3px;
+    margin-top: 1px;
+    flex-shrink: 0;
+}
+.dep-path-label.label-snyk {
+    background: rgba(255, 193, 7, 0.1);
+    border: 1px solid rgba(255, 193, 7, 0.3);
+    color: var(--c-medium);
+}
+.dep-path-label.label-active {
+    background: rgba(124, 131, 245, 0.1);
+    border: 1px solid rgba(124, 131, 245, 0.3);
+    color: var(--c-accent);
+}
+.dep-path.snyk-path .dep-crumb { color: rgba(255, 193, 7, 0.65); }
+.dep-path.snyk-path .dep-crumb:hover { background: var(--c-surface2); color: var(--c-medium); }
+.dep-path.snyk-path .dep-crumb.target { color: var(--c-medium); }
+.dep-crumb .ver-changed { font-weight: 700; }
+.dep-path:not(.snyk-path) .dep-crumb .ver-changed { color: var(--c-fix); }
+.dep-path.snyk-path .dep-crumb .ver-changed { color: var(--c-medium); }
+.dep-crumb {
+    color: var(--c-text-muted);
+    font-family: monospace;
+    font-size: 11px;
+    cursor: pointer;
+    border-radius: 3px;
+    padding: 0 2px;
+    transition: background 0.1s, color 0.1s;
+}
+.dep-crumb:hover { background: var(--c-surface2); color: var(--c-text); }
+.dep-crumb.target { color: var(--c-medium); font-weight: 600; }
+.dep-crumb.target:hover { color: var(--c-medium); }
+.dep-crumb.flash { background: rgba(76,175,130,0.2); color: var(--c-fix) !important; }
+.dep-arrow { color: var(--c-border); font-size: 10px; }
+.dep-path-copy {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--c-text-muted);
+    font-size: 11px;
+    padding: 0 3px;
+    opacity: 0;
+    transition: opacity 0.15s, color 0.15s;
+    line-height: 1;
+    margin-left: 2px;
+}
+.dep-path:hover .dep-path-copy { opacity: 1; }
+.dep-path-copy:hover { color: var(--c-text); }
+.dep-path-copy.copied { color: var(--c-fix); opacity: 1; }
+
+.fix-versions { display: flex; gap: 6px; flex-wrap: wrap; }
+.fix-version {
+    background: rgba(76,175,130,0.1);
+    border: 1px solid rgba(76,175,130,0.3);
+    color: var(--c-fix);
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-family: monospace;
+}
+
+/* ── Ignored section ── */
+#ignored-section { margin-top: 20px; }
+.section-toggle {
+    width: 100%;
+    text-align: left;
+    background: var(--c-surface2);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    padding: 10px 16px;
+    cursor: pointer;
+    color: var(--c-text-muted);
+    font-size: 13px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    transition: background 0.15s;
+}
+.section-toggle:hover { background: var(--c-surface); color: var(--c-text); }
+.section-toggle .toggle-arrow { margin-left: auto; transition: transform 0.2s; }
+#ignored-section.open .toggle-arrow { transform: rotate(180deg); }
+#ignored-list { display: none; margin-top: 4px; }
+#ignored-section.open #ignored-list { display: flex; flex-direction: column; gap: 4px; }
+
+.ignored-row {
+    background: var(--c-surface);
+    border: 1px solid var(--c-border);
+    border-left: 3px solid var(--c-text-muted);
+    border-radius: var(--radius);
+    padding: 10px 14px;
+    font-size: 12px;
+    opacity: 0.75;
+}
+.ignored-reason { color: var(--c-text-muted); font-style: italic; margin-top: 4px; }
+.ignored-expiry { font-size: 11px; color: var(--c-text-muted); margin-top: 2px; }
+
+/* ── Reason summary panel ── */
+.reason-summary {
+    background: rgba(255, 193, 7, 0.04);
+    border: 1px solid rgba(255, 193, 7, 0.2);
+    border-radius: var(--radius);
+    padding: 12px 14px;
+    margin-bottom: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+.reason-summary-label {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--c-medium);
+}
+.reason-entry { display: flex; flex-direction: column; gap: 5px; }
+.reason-entry + .reason-entry { padding-top: 10px; border-top: 1px solid rgba(255,193,7,0.15); }
+.reason-text { font-size: 12px; color: var(--c-text); font-style: italic; }
+.reason-refs { display: flex; align-items: center; gap: 5px; flex-wrap: wrap; }
+.reason-refs-label { font-size: 10px; color: var(--c-text-muted); white-space: nowrap; }
+.reason-ref {
+    font-size: 10px;
+    font-family: monospace;
+    background: var(--c-surface2);
+    border: 1px solid var(--c-border);
+    border-radius: 3px;
+    padding: 1px 6px;
+    color: var(--c-text-muted);
+}
+
+/* ── Section dividers ── */
+.section-divider {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 16px 0 8px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--c-text-muted);
+}
+.section-divider::after { content: ''; flex: 1; height: 1px; background: var(--c-border); }
+.section-divider:first-child { margin-top: 0; }
+.section-divider.near { color: var(--c-medium); }
+.section-divider.near::after { background: rgba(255,193,7,0.3); }
+
+/* ── Empty state ── */
+#empty-state { text-align: center; padding: 60px 20px; color: var(--c-text-muted); }
+#empty-state .empty-icon { font-size: 48px; margin-bottom: 12px; }
+
+/* ── Run controls ── */
+.run-snyk-btn {
+    background: var(--c-accent);
+    color: #fff;
+    border: none;
+    border-radius: var(--radius);
+    padding: 6px 14px;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity 0.15s;
+    white-space: nowrap;
+}
+.run-snyk-btn:hover { opacity: 0.85; }
+.run-snyk-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* ── Run log panel ── */
+#run-log-panel {
+    background: #0a0c10;
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    margin-bottom: 16px;
+    overflow: hidden;
+    scroll-margin-top: 8px;
+}
+.run-log-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--c-border);
+    font-size: 13px;
+    font-weight: 600;
+}
+.run-log-title { display: flex; align-items: center; gap: 8px; }
+.run-log-spinner {
+    width: 14px; height: 14px;
+    border: 2px solid var(--c-border);
+    border-top-color: var(--c-accent);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+    flex-shrink: 0;
+}
+.run-log-body {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 12px;
+    line-height: 1.5;
+    padding: 12px 16px;
+    max-height: 300px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+    color: #c8d3e8;
+    margin: 0;
+}
+
+/* ── Loading spinner ── */
+#loading {
+    position: fixed;
+    inset: 0;
+    background: var(--c-bg);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 20px;
+    z-index: 999;
+}
+#loading .spinner {
+    width: 48px;
+    height: 48px;
+    border: 4px solid var(--c-border);
+    border-top-color: var(--c-accent);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+#loading .loading-text { color: var(--c-text-muted); font-size: 14px; }
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ── Scrollbar ── */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: var(--c-bg); }
+::-webkit-scrollbar-thumb { background: var(--c-border); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: var(--c-text-muted); }
+
+/* ════════════════════════════════════════════
+   REVIEW QUEUE
+   ════════════════════════════════════════════ */
+
+/* ── RQ header / progress ── */
+.rq-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+.rq-progress {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex: 1;
+    min-width: 200px;
+}
+.rq-progress-label { font-size: 13px; font-weight: 600; color: var(--c-text-muted); white-space: nowrap; }
+.rq-progress-bar-wrap {
+    flex: 1;
+    height: 8px;
+    background: var(--c-border);
+    border-radius: 4px;
+    overflow: hidden;
+    min-width: 80px;
+}
+.rq-progress-bar-fill {
+    height: 100%;
+    background: var(--c-fix);
+    border-radius: 4px;
+    transition: width 0.3s;
+}
+.rq-progress-text { font-size: 12px; color: var(--c-text-muted); white-space: nowrap; }
+.reset-review-btn {
+    padding: 5px 12px;
+    background: none;
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    color: var(--c-text-muted);
+    font-size: 12px;
+    cursor: pointer;
+    transition: all 0.15s;
+    white-space: nowrap;
+}
+.reset-review-btn:hover { border-color: var(--c-critical); color: var(--c-critical); }
+
+/* ── Category labels ── */
+.rq-category-section { margin-bottom: 20px; }
+.rq-category-label {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 8px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--c-text-muted);
+}
+.rq-category-label::after { content: ''; flex: 1; height: 1px; background: var(--c-border); }
+.near-update-all-files-btn { margin-left: auto; margin-right: 0; flex-shrink: 0; }
+
+.cat-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 700;
+    white-space: nowrap;
+}
+.cat-a { background: rgba(76,175,130,0.15); color: var(--c-fix); border: 1px solid rgba(76,175,130,0.3); }
+.cat-b { background: rgba(124,131,245,0.15); color: var(--c-accent); border: 1px solid rgba(124,131,245,0.3); }
+.cat-c { background: rgba(255,140,66,0.15); color: var(--c-high); border: 1px solid rgba(255,140,66,0.3); }
+.cat-d { background: rgba(255,193,7,0.15); color: var(--c-medium); border: 1px solid rgba(255,193,7,0.3); }
+
+/* ── Review cards ── */
+.rq-card {
+    background: var(--c-surface);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    margin-bottom: 8px;
+    overflow: hidden;
+}
+.rq-card-header {
+    padding: 10px 14px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    border-bottom: 1px solid var(--c-border);
+    background: var(--c-surface2);
+}
+.rq-card-title { font-weight: 600; font-size: 13px; }
+.rq-card-title code {
+    font-family: monospace;
+    background: var(--c-bg);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 12px;
+}
+.rq-card-body { padding: 12px 14px; }
+
+/* ── Affected folders ── */
+.rq-affected-folders { display: flex; flex-wrap: wrap; gap: 5px; margin-bottom: 12px; }
+.folder-tag {
+    font-family: monospace;
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 4px;
+    background: rgba(124,131,245,0.08);
+    border: 1px solid rgba(124,131,245,0.25);
+    color: var(--c-accent);
+}
+
+/* ── Vuln list within card ── */
+.rq-vuln-list { display: flex; flex-direction: column; gap: 5px; margin-bottom: 12px; }
+.rq-vuln-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    flex-wrap: wrap;
+}
+.rq-vuln-title { color: var(--c-text-muted); flex: 1; min-width: 160px; }
+
+/* ── Steps ── */
+.rq-steps { display: flex; flex-direction: column; gap: 8px; margin-bottom: 12px; }
+.rq-step { display: flex; gap: 10px; align-items: flex-start; }
+.step-num {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    background: var(--c-surface2);
+    border: 1px solid var(--c-border);
+    border-radius: 50%;
+    font-size: 10px;
+    font-weight: 700;
+    color: var(--c-text-muted);
+    flex-shrink: 0;
+    margin-top: 2px;
+}
+.step-content { flex: 1; }
+.step-label { font-size: 11px; color: var(--c-text-muted); margin-bottom: 5px; display: block; }
+.step-code-line {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-family: monospace;
+    font-size: 12px;
+    background: var(--c-bg);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    padding: 5px 10px;
+    color: var(--c-fix);
+}
+.step-note { display: block; font-size: 11px; color: var(--c-text-muted); margin-top: 4px; }
+.step-note code { font-family: monospace; background: var(--c-bg); padding: 1px 4px; border-radius: 3px; }
+
+/* ── Resolution snippet ── */
+.resolution-snippet {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    background: var(--c-bg);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    padding: 6px 10px;
+    font-family: monospace;
+    font-size: 12px;
+    color: var(--c-fix);
+    margin-bottom: 6px;
+}
+
+/* ── Versions panel ── */
+.versions-panel {
+    margin-top: 7px;
+    padding: 9px 11px;
+    background: var(--c-bg);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+}
+.versions-panel-title { font-size: 11px; color: var(--c-text-muted); margin-bottom: 6px; font-weight: 600; }
+.versions-list { display: flex; flex-wrap: wrap; gap: 4px; max-height: 100px; overflow-y: auto; }
+.version-tag {
+    padding: 2px 7px;
+    border-radius: 3px;
+    font-family: monospace;
+    font-size: 11px;
+    background: var(--c-surface2);
+    border: 1px solid var(--c-border);
+    color: var(--c-text-muted);
+}
+.version-tag.recommended {
+    background: rgba(76,175,130,0.15);
+    border-color: rgba(76,175,130,0.4);
+    color: var(--c-fix);
+    font-weight: 700;
+}
+.version-tag.recommended::after { content: ' ✓'; }
+
+/* ── Shared action buttons ── */
+.rq-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    padding-top: 10px;
+    border-top: 1px solid var(--c-border);
+}
+.btn {
+    padding: 5px 13px;
+    border-radius: var(--radius);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s;
+    border: 1px solid;
+    white-space: nowrap;
+}
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn-primary { background: rgba(76,175,130,0.15); border-color: rgba(76,175,130,0.4); color: var(--c-fix); }
+.btn-primary:hover:not(:disabled) { background: rgba(76,175,130,0.25); }
+.btn-accent { background: rgba(124,131,245,0.15); border-color: rgba(124,131,245,0.4); color: var(--c-accent); }
+.btn-accent:hover:not(:disabled) { background: rgba(124,131,245,0.25); }
+.btn-outline { background: none; border-color: var(--c-border); color: var(--c-text-muted); }
+.btn-outline:hover:not(:disabled) { border-color: var(--c-text); color: var(--c-text); }
+.btn-warn { background: rgba(255,193,7,0.1); border-color: rgba(255,193,7,0.4); color: var(--c-medium); }
+.btn-warn:hover:not(:disabled) { background: rgba(255,193,7,0.2); }
+.btn-sm { padding: 3px 9px; font-size: 11px; }
+.btn-inline { padding: 3px 9px; font-size: 11px; }
+
+/* ── Category C: Ignore form ── */
+.rq-ignore-inline {
+    padding: 12px 14px;
+    border-top: 1px solid var(--c-border);
+    background: rgba(255,140,66,0.03);
+}
+.rq-ignore-inline-title {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--c-high);
+    margin-bottom: 10px;
+}
+.ignore-form-row {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 8px;
+    flex-wrap: wrap;
+    align-items: flex-start;
+}
+.ignore-form-label { font-size: 11px; color: var(--c-text-muted); margin-bottom: 3px; display: block; }
+.ignore-form-input {
+    background: var(--c-bg);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    color: var(--c-text);
+    padding: 5px 10px;
+    font-size: 12px;
+    outline: none;
+    transition: border-color 0.15s;
+    width: 100%;
+}
+.ignore-form-input:focus { border-color: var(--c-accent); }
+.ignore-reason-wrap { flex: 1; min-width: 200px; }
+.ignore-expiry-wrap { width: 240px; }
+.ignore-snyk-file { font-size: 11px; color: var(--c-text-muted); margin-bottom: 8px; }
+.ignore-snyk-file code { font-family: monospace; background: var(--c-bg); padding: 1px 5px; border-radius: 3px; color: var(--c-accent); }
+.yaml-preview-wrap {
+    background: var(--c-bg);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    overflow: hidden;
+    margin-bottom: 10px;
+}
+.yaml-preview-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 5px 10px;
+    border-bottom: 1px solid var(--c-border);
+    background: var(--c-surface2);
+    font-size: 11px;
+    color: var(--c-text-muted);
+}
+.yaml-snippet {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 11px;
+    color: var(--c-text);
+    padding: 9px 12px;
+    margin: 0;
+    overflow-x: auto;
+    white-space: pre;
+    line-height: 1.6;
+}
+
+/* ── Category D: Near-ignored groups ── */
+.near-group {
+    background: var(--c-surface);
+    border: 1px solid rgba(255,193,7,0.35);
+    border-radius: var(--radius);
+    margin-bottom: 8px;
+    overflow: hidden;
+}
+.near-group-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 9px 13px;
+    background: rgba(255,193,7,0.05);
+    border-bottom: 1px solid rgba(255,193,7,0.2);
+    gap: 10px;
+}
+.near-group-toggle {
+    cursor: pointer;
+    user-select: none;
+}
+.near-group-toggle:hover { background: rgba(255,193,7,0.1); }
+.near-toggle-arrow-wrap { flex-shrink: 0; font-size: 10px; color: var(--c-text-muted); }
+.near-toggle-arrow { font-size: 10px; }
+.near-group-file {
+    font-family: monospace;
+    font-size: 12px;
+    color: var(--c-medium);
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.near-group-count {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--c-text-muted);
+    background: var(--c-surface2);
+    border: 1px solid var(--c-border);
+    padding: 1px 7px;
+    border-radius: 10px;
+    flex-shrink: 0;
+}
+.near-group-resolved-pill {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--c-fix);
+    background: rgba(74,222,128,0.08);
+    border: 1px solid rgba(74,222,128,0.3);
+    padding: 1px 8px;
+    border-radius: 10px;
+    flex-shrink: 0;
+}
+.near-resolved-pill {
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--c-fix);
+    background: rgba(74,222,128,0.08);
+    border: 1px solid rgba(74,222,128,0.3);
+    padding: 1px 6px;
+    border-radius: 8px;
+}
+.near-item {
+    padding: 10px 13px;
+    border-bottom: 1px solid var(--c-border);
+    font-size: 12px;
+}
+.near-item:last-child { border-bottom: none; }
+.near-item-header { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; flex-wrap: wrap; }
+.near-item-resolved .near-item-header { margin-bottom: 0; }
+.near-paths { display: flex; flex-direction: column; gap: 5px; }
+.near-path-row { display: flex; align-items: flex-start; gap: 8px; }
+.near-path-lbl {
+    font-size: 10px;
+    font-weight: 700;
+    font-family: monospace;
+    padding: 1px 5px;
+    border-radius: 3px;
+    flex-shrink: 0;
+    margin-top: 2px;
+}
+.near-path-lbl.lbl-snyk { background: rgba(255,193,7,0.1); border: 1px solid rgba(255,193,7,0.3); color: var(--c-medium); }
+.near-path-lbl.lbl-active { background: rgba(124,131,245,0.1); border: 1px solid rgba(124,131,245,0.3); color: var(--c-accent); }
+.near-path-text { font-family: monospace; font-size: 11px; color: var(--c-text-muted); }
+.near-path-text .changed { font-weight: 700; color: var(--c-fix); }
+.near-path-text.snyk-side .changed { color: var(--c-medium); }
+
+/* ── Resolved accordion ── */
+.rq-resolved-section { margin-top: 20px; }
+.rq-resolved-toggle {
+    width: 100%;
+    text-align: left;
+    background: var(--c-surface2);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    padding: 10px 16px;
+    cursor: pointer;
+    color: var(--c-text-muted);
+    font-size: 13px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    transition: background 0.15s;
+}
+.rq-resolved-toggle:hover { background: var(--c-surface); color: var(--c-text); }
+.rq-resolved-toggle .toggle-arrow { margin-left: auto; transition: transform 0.2s; }
+.rq-resolved-section.open .toggle-arrow { transform: rotate(180deg); }
+.rq-resolved-list { display: none; margin-top: 4px; flex-direction: column; gap: 4px; }
+.rq-resolved-section.open .rq-resolved-list { display: flex; }
+.rq-resolved-item {
+    background: var(--c-surface);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    padding: 8px 14px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 12px;
+    opacity: 0.8;
+}
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 7px;
+    border-radius: 10px;
+    font-size: 10px;
+    font-weight: 700;
+    white-space: nowrap;
+}
+.status-resolved { background: rgba(76,175,130,0.15); color: var(--c-fix); border: 1px solid rgba(76,175,130,0.3); }
+.status-skipped { background: rgba(142,160,188,0.1); color: var(--c-text-muted); border: 1px solid var(--c-border); }
+.status-reopened { background: rgba(255,77,77,0.12); color: var(--c-critical); border: 1px solid rgba(255,77,77,0.3); }
+.rq-resolved-note { font-size: 11px; color: var(--c-text-muted); flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rq-resolved-ts { font-size: 11px; color: var(--c-text-muted); margin-left: auto; white-space: nowrap; flex-shrink: 0; }
+
+/* ── Empty queue ── */
+.rq-empty { text-align: center; padding: 48px 20px; color: var(--c-text-muted); }
+.rq-empty .empty-icon { font-size: 40px; margin-bottom: 12px; }
+
+/* ── Tool sections (new three-section layout) ── */
+.tool-section {
+    background: var(--c-surface);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    margin-bottom: 16px;
+    overflow: hidden;
+}
+.tool-section-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 16px;
+    background: var(--c-surface2);
+    border-bottom: 1px solid var(--c-border);
+    flex-wrap: wrap;
+}
+.tool-section-num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: var(--c-accent);
+    color: #fff;
+    font-size: 11px;
+    font-weight: 700;
+    flex-shrink: 0;
+}
+.tool-section-title {
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--c-text);
+}
+.tool-section-desc {
+    font-size: 11px;
+    color: var(--c-text-muted);
+    flex: 1;
+}
+.tool-section-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 22px;
+    height: 20px;
+    padding: 0 7px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 700;
+    background: rgba(124,131,245,0.15);
+    color: var(--c-accent);
+    border: 1px solid rgba(124,131,245,0.3);
+}
+/* Make <details> summary behave like a normal clickable header */
+summary.tool-section-header {
+    list-style: none;
+    cursor: pointer;
+}
+summary.tool-section-header::-webkit-details-marker { display: none; }
+.tool-section-chevron {
+    display: inline-block;
+    font-size: 10px;
+    color: var(--c-text-muted);
+    margin-right: 4px;
+    transition: transform 0.2s;
+}
+details.tool-section:not([open]) .tool-section-chevron {
+    transform: rotate(-90deg);
+}
+.tool-section-body {
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+/* ── Section 1: Dep cards ── */
+.dep-card {
+    background: var(--c-bg);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+.dep-card-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    background: var(--c-surface2);
+    border-bottom: 1px solid var(--c-border);
+    flex-wrap: wrap;
+}
+.dep-card-name {
+    font-family: monospace;
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--c-text);
+    flex-shrink: 0;
+}
+.dep-card-vulns {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    flex: 1;
+}
+.vuln-tag-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    text-decoration: none;
+    padding: 1px 6px;
+    border-radius: 4px;
+    background: var(--c-surface);
+    border: 1px solid var(--c-border);
+    transition: border-color 0.15s;
+}
+.vuln-tag-link:hover { border-color: var(--c-accent); text-decoration: none; }
+.dep-card-body {
+    padding: 8px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.dep-card-file-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    flex-wrap: wrap;
+    padding: 8px 10px;
+    background: var(--c-surface);
+    border: 1px solid var(--c-border);
+    border-radius: 4px;
+}
+.dep-file-path {
+    font-family: monospace;
+    font-size: 11px;
+    color: var(--c-accent);
+    flex: 1;
+    min-width: 160px;
+    word-break: break-all;
+}
+.dep-file-version {
+    font-family: monospace;
+    font-size: 11px;
+    color: var(--c-text-muted);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+.dep-file-actions {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    flex-wrap: wrap;
+    flex-shrink: 0;
+}
+
+/* ── Section 3: Near-ignored panel ── */
+.s3-near-panel {
+    background: rgba(255,193,7,0.03);
+    border: 1px solid rgba(255,193,7,0.3);
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+.s3-near-summary {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 13px;
+    background: rgba(255,193,7,0.06);
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--c-medium);
+    list-style: none;
+    user-select: none;
+}
+.s3-near-summary::-webkit-details-marker { display: none; }
+.s3-near-count {
+    font-size: 11px;
+    background: rgba(255,193,7,0.12);
+    border: 1px solid rgba(255,193,7,0.3);
+    color: var(--c-medium);
+    padding: 1px 7px;
+    border-radius: 10px;
+}
+.s3-near-body { padding: 8px; }
+
+/* ── Section 3: Shared expiry row ── */
+.s3-expiry-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+/* ── Section 3: Vuln cards ── */
+.s3-vuln-card.s3-card-skipped {
+    opacity: 0.55;
+}
+/* Collapsible vuln cards */
+summary.rq-card-header {
+    list-style: none;
+    cursor: pointer;
+}
+summary.rq-card-header::-webkit-details-marker { display: none; }
+.s3-card-chevron {
+    display: inline-block;
+    font-size: 10px;
+    color: var(--c-text-muted);
+    flex-shrink: 0;
+    transition: transform 0.2s;
+}
+details.s3-vuln-card:not([open]) .s3-card-chevron {
+    transform: rotate(-90deg);
+}
+
+.rq-card-header.s3-card-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 5px;
+}
+.s3-card-header-main {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+    width: 100%;
+}
+.s3-card-header-right {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+.s3-path-count-badge {
+    font-size: 10px;
+    color: var(--c-text-muted);
+    background: rgba(255,255,255,0.05);
+    border: 1px solid var(--c-border);
+    border-radius: 10px;
+    padding: 1px 7px;
+    white-space: nowrap;
+}
+.s3-file-path-count {
+    font-size: 10px;
+    color: var(--c-text-muted);
+    margin-left: 6px;
+}
+.s3-via-label {
+    font-size: 11px;
+    color: var(--c-text-muted);
+}
+.s3-skipped-overlay {
+    padding: 10px 14px;
+    font-size: 12px;
+    color: var(--c-text-muted);
+    font-style: italic;
+}
+.s3-global-actions {
+    margin-top: 4px;
+    padding-top: 12px;
+    border-top: 1px solid var(--c-border);
+}
+
+/* ── Skip controls ── */
+.skip-btn {
+    padding: 2px 8px;
+    background: none;
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    color: var(--c-text-muted);
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s;
+    white-space: nowrap;
+}
+.skip-btn:hover { border-color: var(--c-critical); color: var(--c-critical); }
+.skip-btn.active { background: rgba(255,77,77,0.1); border-color: rgba(255,77,77,0.4); color: var(--c-critical); }
+
+.skip-dep-tag {
+    padding: 2px 8px;
+    background: rgba(124,131,245,0.08);
+    border: 1px solid rgba(124,131,245,0.25);
+    border-radius: 12px;
+    color: var(--c-accent);
+    font-size: 11px;
+    font-family: monospace;
+    cursor: pointer;
+    transition: all 0.15s;
+    white-space: nowrap;
+}
+.skip-dep-tag:hover { background: rgba(124,131,245,0.18); }
+.skip-dep-tag.skipped {
+    background: rgba(255,77,77,0.08);
+    border-color: rgba(255,77,77,0.3);
+    color: var(--c-critical);
+    text-decoration: line-through;
+}
+
+/* ── Path checkbox rows ── */
+.path-checkbox-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 6px 8px;
+    background: rgba(255,255,255,0.02);
+    border: 1px solid var(--c-border);
+    border-radius: 4px;
+    margin-bottom: 5px;
+}
+.path-checkbox-row.dep-skipped { opacity: 0.45; }
+.path-checkbox-row input[type="checkbox"] {
+    margin-top: 3px;
+    flex-shrink: 0;
+    accent-color: var(--c-accent);
+    cursor: pointer;
+}
+.path-deppath {
+    font-family: monospace;
+    font-size: 11px;
+    color: var(--c-text);
+    flex: 1;
+    word-break: break-word;
+    min-width: 0;
+}
+.path-checkbox-row .batch-ignore-reason {
+    width: 240px;
+    flex-shrink: 0;
+}
+
+/* ── Category A: Batch ignore section ── */
+.batch-ignore-section {
+    border: 1px solid rgba(76,175,130,0.2);
+    border-radius: var(--radius);
+    background: rgba(76,175,130,0.03);
+    padding: 12px 14px;
+    margin-bottom: 12px;
+}
+.batch-ignore-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+    flex-wrap: wrap;
+}
+.batch-ignore-title {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--c-fix);
+    flex: 1;
+}
+
+/* ── Dep-type badge ── */
+.dep-type-badge {
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 8px;
+    font-weight: 600;
+}
+.dep-type-badge.devDependencies {
+    color: var(--c-fix);
+    background: rgba(74,222,128,0.08);
+    border: 1px solid rgba(74,222,128,0.3);
+}
+.dep-type-badge.dependencies {
+    color: var(--c-high);
+    background: rgba(255,140,66,0.08);
+    border: 1px solid rgba(255,140,66,0.3);
+}
+.dep-type-badge.peerDependencies {
+    color: var(--c-accent);
+    background: rgba(124,131,245,0.08);
+    border: 1px solid rgba(124,131,245,0.25);
+}
+.dep-type-badge.optionalDependencies {
+    color: var(--c-text-muted);
+    background: rgba(142,160,188,0.1);
+    border: 1px solid var(--c-border);
+}
+
+/* ── Batch ignore: shared expiry row ── */
+.batch-ignore-shared-row {
+    display: flex;
+    gap: 12px;
+    align-items: flex-end;
+    flex-wrap: wrap;
+    margin-bottom: 12px;
+}
+.batch-ignore-shared-row .ignore-expiry-wrap {
+    flex: 1;
+    min-width: 180px;
+}
+
+/* ── Per-path reason rows ── */
+.batch-path-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    margin-bottom: 12px;
+}
+
+/* ── Per-.snyk-file subgroup inside a vuln card ── */
+.batch-file-subgroup {
+    margin-bottom: 10px;
+}
+.batch-file-subgroup-heading {
+    font-family: monospace;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--c-accent);
+    padding: 4px 0 6px;
+    margin-bottom: 6px;
+}
+.batch-path-row {
+    background: rgba(255,255,255,0.02);
+    border: 1px solid var(--c-border);
+    border-radius: 6px;
+    padding: 8px 10px;
+    margin-bottom: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.batch-path-deppath {
+    font-family: monospace;
+    font-size: 11px;
+    color: var(--c-text);
+    word-break: break-word;
+}
+
+/* ── Cat A: preset select inside each file card ── */
+.cat-a-preset {
+    width: 100%;
+    margin-bottom: 8px;
+    cursor: pointer;
+}
+
+/* ── Collapsible YAML preview inside group ── */
+.batch-yaml-details {
+    margin: 8px 0;
+}
+.batch-yaml-summary {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 11px;
+    color: var(--c-text-muted);
+    list-style: none;
+    user-select: none;
+    padding: 4px 0;
+}
+.batch-yaml-summary::-webkit-details-marker { display: none; }
+.batch-yaml-summary::before {
+    content: '\25B6';
+    font-size: 9px;
+    transition: transform 0.15s;
+}
+details[open] > .batch-yaml-summary::before { transform: rotate(90deg); }
+
+/* ── Cat A: shared expiry row (above file cards) ── */
+.cat-a-expiry-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+.cat-a-expiry-row .ignore-form-input { width: 280px; flex-shrink: 0; }
+
+/* ── Cat A: upgrade options section (collapsed <details>) ── */
+.cat-a-upgrade-section {
+    margin-top: 12px;
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+.cat-a-upgrade-summary {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--c-text-muted);
+    list-style: none;
+    user-select: none;
+    padding: 9px 13px;
+    background: var(--c-surface2);
+}
+.cat-a-upgrade-summary::-webkit-details-marker { display: none; }
+.cat-a-upgrade-summary::before {
+    content: '\25B6';
+    font-size: 9px;
+    transition: transform 0.15s;
+}
+.cat-a-upgrade-section[open] > .cat-a-upgrade-summary::before { transform: rotate(90deg); }
+.cat-a-upgrade-body {
+    padding: 12px 14px;
+}

--- a/external/ag-shared/scripts/snyk-viewer/ui-styles.css
+++ b/external/ag-shared/scripts/snyk-viewer/ui-styles.css
@@ -790,6 +790,23 @@ a:hover { text-decoration: underline; }
     transition: width 0.3s;
 }
 .rq-progress-text { font-size: 12px; color: var(--c-text-muted); white-space: nowrap; }
+.rq-refresh-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(15,17,23,0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+.rq-refresh-spinner {
+    width: 32px;
+    height: 32px;
+    border: 3px solid var(--c-border);
+    border-top-color: var(--c-accent);
+    border-radius: 50%;
+    animation: spin 0.7s linear infinite;
+}
 .reset-review-btn {
     padding: 5px 12px;
     background: none;

--- a/external/ag-shared/scripts/snyk-viewer/ui-styles.css
+++ b/external/ag-shared/scripts/snyk-viewer/ui-styles.css
@@ -952,7 +952,9 @@ a:hover { text-decoration: underline; }
     background: var(--c-surface2);
     border: 1px solid var(--c-border);
     color: var(--c-text-muted);
+    cursor: pointer;
 }
+.version-tag:hover { border-color: var(--c-accent); color: var(--c-text); }
 .version-tag.recommended {
     background: rgba(76,175,130,0.15);
     border-color: rgba(76,175,130,0.4);
@@ -960,6 +962,13 @@ a:hover { text-decoration: underline; }
     font-weight: 700;
 }
 .version-tag.recommended::after { content: ' ✓'; }
+.version-tag.selected {
+    background: rgba(100,160,255,0.15);
+    border-color: var(--c-accent);
+    color: var(--c-accent);
+    font-weight: 700;
+}
+.version-tag.selected::after { content: ' ←'; }
 
 /* ── Shared action buttons ── */
 .rq-actions {

--- a/external/ag-shared/scripts/snyk-viewer/ui-styles.css
+++ b/external/ag-shared/scripts/snyk-viewer/ui-styles.css
@@ -1289,6 +1289,7 @@ summary.tool-section-header {
     z-index: 20;
 }
 summary.tool-section-header::-webkit-details-marker { display: none; }
+.s3-view-seg { font-size: 11px; }
 .tool-section-chevron {
     display: inline-block;
     font-size: 10px;

--- a/external/ag-shared/scripts/snyk-viewer/ui-styles.css
+++ b/external/ag-shared/scripts/snyk-viewer/ui-styles.css
@@ -1127,6 +1127,8 @@ a:hover { text-decoration: underline; }
 .near-item:last-child { border-bottom: none; }
 .near-item-header { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; flex-wrap: wrap; }
 .near-item-resolved .near-item-header { margin-bottom: 0; }
+.near-path-entry { padding: 8px 0 4px; border-top: 1px dashed var(--c-border); margin-top: 4px; }
+.near-path-entry:first-child { border-top: none; margin-top: 0; padding-top: 0; }
 .near-paths { display: flex; flex-direction: column; gap: 5px; }
 .near-path-row { display: flex; align-items: flex-start; gap: 8px; }
 .near-path-lbl {

--- a/external/ag-shared/scripts/snyk-viewer/ui-styles.css
+++ b/external/ag-shared/scripts/snyk-viewer/ui-styles.css
@@ -81,6 +81,7 @@ a:hover { text-decoration: underline; }
 .sev-pill.high     { background: rgba(255,140,66,0.15); color: var(--c-high);     border: 1px solid rgba(255,140,66,0.3); }
 .sev-pill.medium   { background: rgba(255,193,7,0.12);  color: var(--c-medium);   border: 1px solid rgba(255,193,7,0.3); }
 .sev-pill.low      { background: rgba(111,168,220,0.12);color: var(--c-low);      border: 1px solid rgba(111,168,220,0.3); }
+.sev-pill.sev-pill-zero { opacity: 0.35; }
 
 /* ── Tab bar ── */
 #tab-bar {
@@ -1190,7 +1191,8 @@ a:hover { text-decoration: underline; }
 .status-skipped { background: rgba(142,160,188,0.1); color: var(--c-text-muted); border: 1px solid var(--c-border); }
 .status-reopened { background: rgba(255,77,77,0.12); color: var(--c-critical); border: 1px solid rgba(255,77,77,0.3); }
 .rq-resolved-note { font-size: 11px; color: var(--c-text-muted); flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.rq-resolved-ts { font-size: 11px; color: var(--c-text-muted); margin-left: auto; white-space: nowrap; flex-shrink: 0; }
+.rq-resolved-decision-note { font-size: 11px; color: var(--c-fix); margin-left: auto; white-space: nowrap; flex-shrink: 0; }
+.rq-resolved-ts { font-size: 11px; color: var(--c-text-muted); white-space: nowrap; flex-shrink: 0; }
 
 /* ── Empty queue ── */
 .rq-empty { text-align: center; padding: 48px 20px; color: var(--c-text-muted); }

--- a/external/ag-shared/scripts/snyk-viewer/ui-styles.css
+++ b/external/ag-shared/scripts/snyk-viewer/ui-styles.css
@@ -1419,7 +1419,11 @@ details.tool-section:not([open]) .tool-section-chevron {
 .s3-dep-group { margin-bottom: 10px; border: 1px solid var(--c-border); border-radius: var(--radius); background: rgba(255,255,255,0.02); padding: 10px 12px; }
 .s3-dep-group--done { border-color: rgba(76,175,130,0.3); background: rgba(76,175,130,0.03); }
 .s3-dep-group--skipped { display: none; }
-.s3-dep-group-header { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+.s3-dep-group-header { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; cursor: pointer; user-select: none; }
+.s3-dep-group-header:hover .s3-dep-group-name { text-decoration: underline; }
+.s3-dep-group-chevron { font-size: 10px; color: var(--c-text-muted); transition: transform 0.2s; flex-shrink: 0; }
+.s3-dep-group--collapsed .s3-dep-group-chevron { transform: rotate(-90deg); }
+.s3-dep-group--collapsed .s3-dep-group-body { display: none; }
 .s3-dep-group-name { font-family: monospace; font-size: 12px; font-weight: 700; color: var(--c-accent); }
 .s3-dep-group-count { font-size: 10px; color: var(--c-text-muted); }
 .s3-dep-group-reason-row { display: flex; align-items: center; gap: 6px; margin-bottom: 8px; }

--- a/external/ag-shared/scripts/snyk-viewer/ui-styles.css
+++ b/external/ag-shared/scripts/snyk-viewer/ui-styles.css
@@ -99,7 +99,6 @@ a:hover { text-decoration: underline; }
     display: flex;
     align-items: center;
     gap: 10px;
-    padding: 0 17px 0 0;
 }
 .tab-btn {
     padding: 10px 18px;

--- a/external/ag-shared/scripts/snyk-viewer/ui-styles.css
+++ b/external/ag-shared/scripts/snyk-viewer/ui-styles.css
@@ -759,6 +759,12 @@ a:hover { text-decoration: underline; }
     margin-bottom: 16px;
     gap: 16px;
     flex-wrap: wrap;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: var(--c-bg);
+    padding: 10px 0;
+    margin-top: -10px;
 }
 .rq-progress {
     display: flex;

--- a/external/ag-shared/scripts/snyk-viewer/ui-styles.css
+++ b/external/ag-shared/scripts/snyk-viewer/ui-styles.css
@@ -1625,6 +1625,26 @@ details.s3-vuln-card:not([open]) .s3-card-chevron {
     word-break: break-word;
 }
 
+/* ── Prefill row: preset dropdown + text box + apply button ── */
+.prefill-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 8px;
+}
+.prefill-row .cat-a-preset {
+    flex: 0 0 auto;
+    width: auto;
+    min-width: 120px;
+    max-width: 220px;
+    margin-bottom: 0;
+    cursor: pointer;
+}
+.prefill-row .prefill-text {
+    flex: 1;
+    min-width: 0;
+}
+
 /* ── Cat A: preset select inside each file card ── */
 .cat-a-preset {
     width: 100%;

--- a/external/ag-shared/scripts/snyk-viewer/ui-styles.css
+++ b/external/ag-shared/scripts/snyk-viewer/ui-styles.css
@@ -1415,6 +1415,22 @@ details.tool-section:not([open]) .tool-section-chevron {
 }
 .s3-near-body { padding: 8px; }
 
+/* ── Section 3: Dep groups ── */
+.s3-dep-group { margin-bottom: 10px; border: 1px solid var(--c-border); border-radius: var(--radius); background: rgba(255,255,255,0.02); padding: 10px 12px; }
+.s3-dep-group--done { border-color: rgba(76,175,130,0.3); background: rgba(76,175,130,0.03); }
+.s3-dep-group--skipped { display: none; }
+.s3-dep-group-header { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+.s3-dep-group-name { font-family: monospace; font-size: 12px; font-weight: 700; color: var(--c-accent); }
+.s3-dep-group-count { font-size: 10px; color: var(--c-text-muted); }
+.s3-dep-group-reason-row { display: flex; align-items: center; gap: 6px; margin-bottom: 8px; }
+.s3-dep-reason { flex: 1; min-width: 0; }
+.s3-dep-preset { flex: 0 0 auto; max-width: 160px; cursor: pointer; }
+.s3-dep-add-btn { display: block; margin-top: 8px; margin-left: auto; }
+.s3-file-badge { font-family: monospace; font-size: 10px; color: var(--c-text-muted); background: rgba(255,255,255,0.05); border: 1px solid var(--c-border); border-radius: 3px; padding: 1px 5px; white-space: nowrap; flex-shrink: 0; }
+
+/* ── Section 3: View toggle button ── */
+.s3-view-toggle { margin-left: auto; flex-shrink: 0; }
+
 /* ── Section 3: Shared expiry row ── */
 .s3-expiry-row {
     display: flex;
@@ -1506,12 +1522,6 @@ details.s3-vuln-card:not([open]) .s3-card-chevron {
     border-top: 1px solid var(--c-border);
     justify-content: flex-end;
 }
-.batch-file-subgroup > .btn {
-    display: block;
-    margin-left: auto;
-    width: fit-content;
-}
-
 /* ── Skip controls ── */
 .skip-btn {
     padding: 2px 8px;
@@ -1574,11 +1584,6 @@ details.s3-vuln-card:not([open]) .s3-card-chevron {
     word-break: break-word;
     min-width: 0;
 }
-.path-checkbox-row .batch-ignore-reason {
-    width: 240px;
-    flex-shrink: 0;
-}
-
 /* ── Category A: Batch ignore section ── */
 .batch-ignore-section {
     border: 1px solid rgba(76,175,130,0.2);
@@ -1652,37 +1657,6 @@ details.s3-vuln-card:not([open]) .s3-card-chevron {
     margin-bottom: 12px;
 }
 
-/* ── Per-.snyk-file subgroup inside a vuln card ── */
-.batch-file-subgroup {
-    margin-bottom: 10px;
-}
-.batch-file-subgroup-heading {
-    font-family: monospace;
-    font-size: 11px;
-    font-weight: 600;
-    color: var(--c-accent);
-    padding: 4px 0 6px;
-    margin-bottom: 6px;
-    cursor: pointer;
-    list-style: none;
-    display: flex;
-    align-items: center;
-    gap: 5px;
-    user-select: none;
-}
-.batch-file-subgroup-heading::-webkit-details-marker { display: none; }
-.batch-file-subgroup-chevron {
-    font-size: 9px;
-    color: var(--c-text-muted);
-    transition: transform 0.15s;
-    flex-shrink: 0;
-}
-.batch-file-subgroup[open] > .batch-file-subgroup-heading .batch-file-subgroup-chevron {
-    transform: rotate(0deg);
-}
-.batch-file-subgroup:not([open]) > .batch-file-subgroup-heading .batch-file-subgroup-chevron {
-    transform: rotate(-90deg);
-}
 /* ── Already-ignored path rows ── */
 .path-already-ignored {
     opacity: 0.6;
@@ -1723,87 +1697,6 @@ details.s3-vuln-card:not([open]) .s3-card-chevron {
 .s3-card-all-ignored > .s3-card-header .s3-card-chevron {
     color: var(--c-fix);
 }
-
-.batch-file-subgroup--done > .batch-file-subgroup-heading {
-    color: var(--c-fix);
-}
-.batch-file-done-badge {
-    font-size: 10px;
-    font-weight: 700;
-    color: var(--c-fix);
-    background: rgba(76, 175, 130, 0.12);
-    border: 1px solid rgba(76, 175, 130, 0.3);
-    border-radius: 3px;
-    padding: 1px 5px;
-    margin-left: auto;
-    flex-shrink: 0;
-}
-.batch-path-row {
-    background: rgba(255,255,255,0.02);
-    border: 1px solid var(--c-border);
-    border-radius: 6px;
-    padding: 8px 10px;
-    margin-bottom: 6px;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-}
-.batch-path-deppath {
-    font-family: monospace;
-    font-size: 11px;
-    color: var(--c-text);
-    word-break: break-word;
-}
-
-/* ── Prefill row: preset dropdown + text box + apply button ── */
-.prefill-row {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    margin-bottom: 8px;
-}
-.prefill-row .cat-a-preset {
-    flex: 0 0 auto;
-    width: auto;
-    min-width: 120px;
-    max-width: 220px;
-    margin-bottom: 0;
-    cursor: pointer;
-}
-.prefill-row .prefill-text {
-    flex: 1;
-    min-width: 0;
-}
-
-/* ── Cat A: preset select inside each file card ── */
-.cat-a-preset {
-    width: 100%;
-    margin-bottom: 8px;
-    cursor: pointer;
-}
-
-/* ── Collapsible YAML preview inside group ── */
-.batch-yaml-details {
-    margin: 8px 0;
-}
-.batch-yaml-summary {
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 11px;
-    color: var(--c-text-muted);
-    list-style: none;
-    user-select: none;
-    padding: 4px 0;
-}
-.batch-yaml-summary::-webkit-details-marker { display: none; }
-.batch-yaml-summary::before {
-    content: '\25B6';
-    font-size: 9px;
-    transition: transform 0.15s;
-}
-details[open] > .batch-yaml-summary::before { transform: rotate(90deg); }
 
 /* ── Cat A: shared expiry row (above file cards) ── */
 .cat-a-expiry-row {

--- a/external/ag-shared/scripts/snyk-viewer/ui-styles.css
+++ b/external/ag-shared/scripts/snyk-viewer/ui-styles.css
@@ -1670,6 +1670,15 @@ details.s3-vuln-card:not([open]) .s3-card-chevron {
     margin-left: auto;
     flex-shrink: 0;
 }
+.already-ignored-reason-input {
+    flex: 1;
+    min-width: 0;
+    font-size: 12px;
+    opacity: 0.6;
+}
+.already-ignored-reason-input:focus {
+    opacity: 1;
+}
 
 /* ── All-paths-ignored vuln card ── */
 .s3-card-all-ignored > .s3-card-header {

--- a/external/ag-shared/scripts/snyk-viewer/ui-styles.css
+++ b/external/ag-shared/scripts/snyk-viewer/ui-styles.css
@@ -1364,6 +1364,7 @@ details.tool-section:not([open]) .tool-section-chevron {
     border-radius: var(--radius);
     overflow: hidden;
 }
+.s3-near-panel.refreshing { opacity: 0.5; pointer-events: none; }
 .s3-near-summary {
     cursor: pointer;
     display: flex;

--- a/external/ag-shared/scripts/snyk-viewer/ui-styles.css
+++ b/external/ag-shared/scripts/snyk-viewer/ui-styles.css
@@ -1607,6 +1607,71 @@ details.s3-vuln-card:not([open]) .s3-card-chevron {
     color: var(--c-accent);
     padding: 4px 0 6px;
     margin-bottom: 6px;
+    cursor: pointer;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    user-select: none;
+}
+.batch-file-subgroup-heading::-webkit-details-marker { display: none; }
+.batch-file-subgroup-chevron {
+    font-size: 9px;
+    color: var(--c-text-muted);
+    transition: transform 0.15s;
+    flex-shrink: 0;
+}
+.batch-file-subgroup[open] > .batch-file-subgroup-heading .batch-file-subgroup-chevron {
+    transform: rotate(0deg);
+}
+.batch-file-subgroup:not([open]) > .batch-file-subgroup-heading .batch-file-subgroup-chevron {
+    transform: rotate(-90deg);
+}
+/* ── Already-ignored path rows ── */
+.path-already-ignored {
+    opacity: 0.6;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.path-already-ignored-check {
+    color: var(--c-fix);
+    font-weight: 700;
+    flex-shrink: 0;
+}
+.already-ignored-badge {
+    font-size: 10px;
+    color: var(--c-fix);
+    background: rgba(76, 175, 130, 0.12);
+    border: 1px solid rgba(76, 175, 130, 0.3);
+    border-radius: 3px;
+    padding: 1px 5px;
+    white-space: nowrap;
+    margin-left: auto;
+    flex-shrink: 0;
+}
+
+/* ── All-paths-ignored vuln card ── */
+.s3-card-all-ignored > .s3-card-header {
+    opacity: 0.65;
+}
+.s3-card-all-ignored > .s3-card-header .s3-card-chevron {
+    color: var(--c-fix);
+}
+
+.batch-file-subgroup--done > .batch-file-subgroup-heading {
+    color: var(--c-fix);
+}
+.batch-file-done-badge {
+    font-size: 10px;
+    font-weight: 700;
+    color: var(--c-fix);
+    background: rgba(76, 175, 130, 0.12);
+    border: 1px solid rgba(76, 175, 130, 0.3);
+    border-radius: 3px;
+    padding: 1px 5px;
+    margin-left: auto;
+    flex-shrink: 0;
 }
 .batch-path-row {
     background: rgba(255,255,255,0.02);

--- a/external/ag-shared/scripts/snyk-viewer/ui-styles.css
+++ b/external/ag-shared/scripts/snyk-viewer/ui-styles.css
@@ -1435,6 +1435,20 @@ details.s3-vuln-card:not([open]) .s3-card-chevron {
     padding: 1px 7px;
     white-space: nowrap;
 }
+.s3-resolved-count {
+    color: var(--c-fix);
+    font-weight: 600;
+}
+.s3-all-resolved-badge {
+    font-size: 10px;
+    color: var(--c-fix);
+    background: rgba(76, 175, 130, 0.12);
+    border: 1px solid rgba(76, 175, 130, 0.3);
+    border-radius: 10px;
+    padding: 1px 7px;
+    white-space: nowrap;
+    font-weight: 600;
+}
 .s3-file-path-count {
     font-size: 10px;
     color: var(--c-text-muted);

--- a/external/ag-shared/scripts/snyk-viewer/ui-styles.css
+++ b/external/ag-shared/scripts/snyk-viewer/ui-styles.css
@@ -1454,6 +1454,12 @@ details.s3-vuln-card:not([open]) .s3-card-chevron {
     margin-top: 4px;
     padding-top: 12px;
     border-top: 1px solid var(--c-border);
+    justify-content: flex-end;
+}
+.batch-file-subgroup > .btn {
+    display: block;
+    margin-left: auto;
+    width: fit-content;
 }
 
 /* ── Skip controls ── */

--- a/external/ag-shared/scripts/snyk-viewer/ui-styles.css
+++ b/external/ag-shared/scripts/snyk-viewer/ui-styles.css
@@ -856,7 +856,7 @@ a:hover { text-decoration: underline; }
     border: 1px solid var(--c-border);
     border-radius: var(--radius);
     margin-bottom: 8px;
-    overflow: hidden;
+    overflow: clip;
 }
 .rq-card-header {
     padding: 10px 14px;
@@ -1232,7 +1232,7 @@ a:hover { text-decoration: underline; }
     border: 1px solid var(--c-border);
     border-radius: var(--radius);
     margin-bottom: 16px;
-    overflow: hidden;
+    overflow: clip;
 }
 .tool-section-header {
     display: flex;
@@ -1284,6 +1284,9 @@ a:hover { text-decoration: underline; }
 summary.tool-section-header {
     list-style: none;
     cursor: pointer;
+    position: sticky;
+    top: 0;
+    z-index: 20;
 }
 summary.tool-section-header::-webkit-details-marker { display: none; }
 .tool-section-chevron {
@@ -1451,6 +1454,9 @@ details.tool-section:not([open]) .tool-section-chevron {
 summary.rq-card-header {
     list-style: none;
     cursor: pointer;
+    position: sticky;
+    top: 43px;
+    z-index: 19;
 }
 summary.rq-card-header::-webkit-details-marker { display: none; }
 .s3-card-chevron {

--- a/external/ag-shared/scripts/snyk-viewer/ui-styles.css
+++ b/external/ag-shared/scripts/snyk-viewer/ui-styles.css
@@ -99,7 +99,7 @@ a:hover { text-decoration: underline; }
     display: flex;
     align-items: center;
     gap: 10px;
-    padding: 0 4px;
+    padding: 0 17px 0 0;
 }
 .tab-btn {
     padding: 10px 18px;

--- a/external/ag-shared/scripts/snyk-viewer/ui.html
+++ b/external/ag-shared/scripts/snyk-viewer/ui.html
@@ -26,6 +26,7 @@
             <div class="summary-stat" id="stat-projects"></div>
             <div class="summary-stat" id="stat-deps"></div>
             <div class="summary-stat" id="stat-packages"></div>
+            <div class="summary-stat" id="stat-scan-date"></div>
             <button id="copy-summary-btn" class="btn btn-sm btn-outline" style="margin-left:auto" title="Copy summary to clipboard">&#x2398; Copy summary</button>
         </div>
     </div>
@@ -120,7 +121,7 @@
     ]).then(function (results) {
         var data = results[0], rs = results[1];
         document.getElementById('loading').remove();
-        window.initBrowseAll(data.projects, data.ignorePatternsByFile || {});
+        window.initBrowseAll(data.projects, data.ignorePatternsByFile || {}, data.scanDate || null);
         window.initReviewQueue(data.projects, data.ignorePatternsByFile || {}, rs, data.sharedExpiry || null, data.rootPackageName || null);
         initTabs();
     }).catch(function (err) {

--- a/external/ag-shared/scripts/snyk-viewer/ui.html
+++ b/external/ag-shared/scripts/snyk-viewer/ui.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Snyk Vulnerability Viewer</title>
+<link rel="stylesheet" href="/ui-styles.css">
+</head>
+<body>
+<div id="loading">
+    <div class="spinner"></div>
+    <div class="loading-text">Loading vulnerability data…</div>
+</div>
+<div id="app">
+    <div id="header">
+        <h1><span class="icon">🔒</span> Snyk Vulnerability Viewer</h1>
+        <div class="summary-row">
+            <div class="sev-pills" id="sev-pills"></div>
+            <div class="summary-stat" id="stat-projects"></div>
+            <div class="summary-stat" id="stat-deps"></div>
+            <div class="summary-stat" id="stat-packages"></div>
+        </div>
+    </div>
+
+    <div id="tab-bar">
+        <button class="tab-btn active" data-tab="review-queue">
+            Review Queue <span class="tab-badge" id="queue-badge">0</span>
+        </button>
+        <button class="tab-btn" data-tab="browse-all">Browse All</button>
+        <div class="tab-bar-run">
+            <label class="toggle-label">
+                <input type="checkbox" id="backup-cb"> Backup old results
+            </label>
+            <button id="run-snyk-btn" class="run-snyk-btn">&#x21BB; Re-run Snyk scan</button>
+        </div>
+    </div>
+
+    <div id="run-log-panel" style="display:none"></div>
+
+    <!-- Review Queue Tab -->
+    <div id="tab-review-queue" class="tab-panel">
+        <div class="rq-header">
+            <div class="rq-progress">
+                <span class="rq-progress-label">Progress</span>
+                <div class="rq-progress-bar-wrap">
+                    <div class="rq-progress-bar-fill" id="rq-progress-fill" style="width:0%"></div>
+                </div>
+                <span class="rq-progress-text" id="rq-progress-text">0 / 0 reviewed</span>
+            </div>
+            <button class="reset-review-btn" id="reset-review-btn">Reset review state</button>
+        </div>
+        <div id="rq-content"></div>
+    </div>
+
+    <!-- Browse All Tab -->
+    <div id="tab-browse-all" class="tab-panel" style="display:none">
+        <div id="controls">
+            <div class="ctrl-group">
+                <input id="search" type="text" placeholder="Search package, vuln ID, CVE…">
+            </div>
+            <div class="ctrl-group">
+                <span class="ctrl-label">Severity:</span>
+                <div class="filter-chips">
+                    <div class="chip active" data-sev="all">All</div>
+                    <div class="chip critical" data-sev="critical">Critical</div>
+                    <div class="chip high" data-sev="high">High</div>
+                    <div class="chip medium" data-sev="medium">Medium</div>
+                    <div class="chip low" data-sev="low">Low</div>
+                </div>
+            </div>
+            <div class="ctrl-group">
+                <span class="ctrl-label">Group by:</span>
+                <div class="seg-btn-group">
+                    <button class="seg-btn" data-group="vuln">Vulnerability</button>
+                    <button class="seg-btn" data-group="package">Package</button>
+                    <button class="seg-btn active" data-group="project">Project</button>
+                </div>
+            </div>
+            <div class="ctrl-group">
+                <label class="toggle-label">
+                    <input type="checkbox" id="show-ignored"> Show ignored
+                </label>
+            </div>
+
+        </div>
+        <div id="count-bar"></div>
+        <div id="vuln-list"></div>
+        <div id="ignored-section">
+            <button class="section-toggle" id="ignored-toggle">
+                <span>🚫 Ignored Vulnerabilities</span>
+                <span class="ignored-count-badge"></span>
+                <span class="toggle-arrow">▼</span>
+            </button>
+            <div id="ignored-list"></div>
+        </div>
+    </div>
+</div>
+
+<script src="/ui-browse.js"></script>
+<script src="/ui-review.js"></script>
+<script>
+(function () {
+    function initTabs() {
+        document.querySelectorAll('.tab-btn').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var tab = btn.dataset.tab;
+                document.querySelectorAll('.tab-btn').forEach(function (b) { b.classList.remove('active'); });
+                document.querySelectorAll('.tab-panel').forEach(function (p) { p.style.display = 'none'; });
+                btn.classList.add('active');
+                document.getElementById('tab-' + tab).style.display = 'block';
+            });
+        });
+    }
+
+    Promise.all([
+        fetch('/data').then(function (r) { return r.json(); }),
+        fetch('/review-state').then(function (r) { return r.json(); }),
+    ]).then(function (results) {
+        var data = results[0], rs = results[1];
+        document.getElementById('loading').remove();
+        window.initBrowseAll(data.projects, data.ignorePatternsByFile || {});
+        window.initReviewQueue(data.projects, data.ignorePatternsByFile || {}, rs, data.sharedExpiry || null, data.rootPackageName || null);
+        initTabs();
+    }).catch(function (err) {
+        document.getElementById('loading').remove();
+        document.getElementById('app').innerHTML =
+            '<div id="empty-state"><div class="empty-icon">&#x26A0;&#xFE0F;</div><div>Failed to load data: ' + err.message + '</div></div>';
+    });
+}());
+</script>
+</body>
+</html>

--- a/external/ag-shared/scripts/snyk-viewer/ui.html
+++ b/external/ag-shared/scripts/snyk-viewer/ui.html
@@ -19,6 +19,7 @@
             <div class="summary-stat" id="stat-projects"></div>
             <div class="summary-stat" id="stat-deps"></div>
             <div class="summary-stat" id="stat-packages"></div>
+            <button id="copy-summary-btn" class="btn btn-sm btn-outline" style="margin-left:auto" title="Copy summary to clipboard">&#x2398; Copy summary</button>
         </div>
     </div>
 

--- a/external/ag-shared/scripts/snyk-viewer/ui.html
+++ b/external/ag-shared/scripts/snyk-viewer/ui.html
@@ -13,7 +13,14 @@
 </div>
 <div id="app">
     <div id="header">
-        <h1><span class="icon">🔒</span> Snyk Vulnerability Viewer</h1>
+        <h1><span class="icon">🔒</span> Snyk Vulnerability Viewer
+            <div class="tab-bar-run">
+                <label class="toggle-label">
+                    <input type="checkbox" id="backup-cb"> Backup old results
+                </label>
+                <button id="run-snyk-btn" class="run-snyk-btn">&#x21BB; Re-run Snyk scan</button>
+            </div>
+        </h1>
         <div class="summary-row">
             <div class="sev-pills" id="sev-pills"></div>
             <div class="summary-stat" id="stat-projects"></div>
@@ -28,12 +35,6 @@
             Review Queue <span class="tab-badge" id="queue-badge">0</span>
         </button>
         <button class="tab-btn" data-tab="browse-all">Browse All</button>
-        <div class="tab-bar-run">
-            <label class="toggle-label">
-                <input type="checkbox" id="backup-cb"> Backup old results
-            </label>
-            <button id="run-snyk-btn" class="run-snyk-btn">&#x21BB; Re-run Snyk scan</button>
-        </div>
     </div>
 
     <div id="run-log-panel" style="display:none"></div>

--- a/package.json
+++ b/package.json
@@ -143,6 +143,8 @@
     "**/jpeg-js": "0.4.0",
     "**/tough-cookie": "^4.1.3",
     "dependency-cruiser/**/cross-spawn": "7.0.6",
-    "@modelcontextprotocol/sdk": "1.26.0"
+    "@modelcontextprotocol/sdk": "1.26.0",
+    "@nx/devkit/**/ejs": "3.1.10",
+    "@nx/devkit/**/ejs/jake": "10.9.4"
   }
 }

--- a/testing/angular-tests/.snyk
+++ b/testing/angular-tests/.snyk
@@ -1,0 +1,27 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.1
+
+ignore:
+    SNYK-JS-MINIMATCH-15353389:
+        - jest@29.7.0 > @jest/core@29.7.0 > @jest/reporters@29.7.0 > @jest/transform@29.7.0 > babel-plugin-istanbul@6.1.1 > test-exclude@6.0.0 > glob@7.2.3 > minimatch@3.1.2:
+              reason: >-
+                  Test dependency - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-03T16:54:45.813Z
+        - jest@29.7.0 > @jest/core@29.7.0 > @jest/reporters@29.7.0 > @jest/transform@29.7.0 > babel-plugin-istanbul@6.1.1 > test-exclude@6.0.0 > minimatch@3.1.2:
+              reason: >-
+                  Test dependency - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-03T16:54:45.798Z
+    SNYK-JS-MINIMATCH-15309438:
+        - jest@29.7.0 > @jest/core@29.7.0 > @jest/reporters@29.7.0 > @jest/transform@29.7.0 > babel-plugin-istanbul@6.1.1 > test-exclude@6.0.0 > glob@7.2.3 > minimatch@3.1.2:
+              reason: >-
+                  Test dependency - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-03T16:54:29.838Z
+        - jest@29.7.0 > @jest/core@29.7.0 > @jest/reporters@29.7.0 > @jest/transform@29.7.0 > babel-plugin-istanbul@6.1.1 > test-exclude@6.0.0 > minimatch@3.1.2:
+              reason: >-
+                  Test dependency - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-03T16:54:29.834Z
+patch: {}

--- a/utilities/all/project.json
+++ b/utilities/all/project.json
@@ -225,7 +225,7 @@
       "command": "./scripts/removeLocalDeps.sh"
     },
     "snyk:test": {
-      "command": "npx snyk test --yarn-workspaces --dev --strict-out-of-sync=false --severity-threshold=high --exclude=.nx,project.json,dist --remote-repo-url=https://github.com/ag-grid/ag-grid",
+      "command": "npx snyk test --yarn-workspaces --dev --strict-out-of-sync=false --severity-threshold=high --exclude=.nx,project.json,dist,.claude --remote-repo-url=https://github.com/ag-grid/ag-grid",
       "options": {
         "cwd": "{workspaceRoot}"
       }
@@ -240,6 +240,28 @@
       "command": "node ./external/ag-shared/scripts/snyk/getSnykIgnore.mjs",
       "options": {
         "cwd": "{workspaceRoot}"
+      }
+    },
+    "snyk:test:json": {
+      "command": "npx snyk test --yarn-workspaces --dev --strict-out-of-sync=false --severity-threshold=high --exclude=.nx,project.json,dist,.claude --remote-repo-url=https://github.com/ag-grid/ag-grid --json > tmp/snyk.json; true",
+      "cache": true,
+      "inputs": ["{workspaceRoot}/yarn.lock"],
+      "outputs": ["{workspaceRoot}/tmp/snyk.json"],
+      "options": {
+        "cwd": "{workspaceRoot}"
+      }
+    },
+    "snyk:view": {
+      "command": "node ./external/ag-shared/scripts/snyk-viewer/index.mjs {args.file}",
+      "dependsOn": ["snyk:test:json"],
+      "options": {
+        "cwd": "{workspaceRoot}",
+        "file": "tmp/snyk.json"
+      },
+      "configurations": {
+        "open": {
+          "args": ["--open"]
+        }
       }
     }
   },

--- a/utilities/all/project.json
+++ b/utilities/all/project.json
@@ -243,7 +243,7 @@
       }
     },
     "snyk:test:json": {
-      "command": "npx snyk test --yarn-workspaces --dev --strict-out-of-sync=false --severity-threshold=high --exclude=.nx,project.json,dist,.claude --remote-repo-url=https://github.com/ag-grid/ag-grid --json > tmp/snyk.json; true",
+      "command": "mkdir -p tmp && { npx snyk test --yarn-workspaces --dev --strict-out-of-sync=false --severity-threshold=high --exclude=.nx,project.json,dist,.claude --remote-repo-url=https://github.com/ag-grid/ag-grid --json > tmp/snyk.json; code=$?; [ $code -le 1 ]; }",
       "cache": true,
       "inputs": ["{workspaceRoot}/yarn.lock"],
       "outputs": ["{workspaceRoot}/tmp/snyk.json"],

--- a/utilities/all/project.json
+++ b/utilities/all/project.json
@@ -252,11 +252,12 @@
       }
     },
     "snyk:view": {
-      "command": "node ./external/ag-shared/scripts/snyk-viewer/index.mjs {args.file}",
+      "command": "node ./external/ag-shared/scripts/snyk-viewer/index.mjs {args.file} --port {args.port}",
       "dependsOn": ["snyk:test:json"],
       "options": {
         "cwd": "{workspaceRoot}",
-        "file": "tmp/snyk.json"
+        "file": "tmp/snyk.json",
+        "port": 4615
       },
       "configurations": {
         "open": {

--- a/utilities/all/project.json
+++ b/utilities/all/project.json
@@ -252,12 +252,13 @@
       }
     },
     "snyk:view": {
-      "command": "node ./external/ag-shared/scripts/snyk-viewer/index.mjs {args.file} --port {args.port}",
+      "command": "node ./external/ag-shared/scripts/snyk-viewer/index.mjs {args.file} --port {args.port} --name \"{args.name}\"",
       "dependsOn": ["snyk:test:json"],
       "options": {
         "cwd": "{workspaceRoot}",
         "file": "tmp/snyk.json",
-        "port": 4615
+        "port": 4615,
+        "name": "AG Grid"
       },
       "configurations": {
         "open": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5515,9 +5515,9 @@
     tmp "~0.2.1"
     tslib "^2.3.0"
 
-"@nx/devkit@18.3.5", "@nx/devkit@^18.3.4":
+"@nx/devkit@18.3.5", "@nx/devkit@^18.3.5":
   version "18.3.5"
-  resolved "http://52.50.158.57:4873/@nx/devkit/-/devkit-18.3.5.tgz#6ea0306e9658ae59a3728108b0d1a75b8d51d928"
+  resolved "https://registry.ag-grid.com/@nx/devkit/-/devkit-18.3.5.tgz#6ea0306e9658ae59a3728108b0d1a75b8d51d928"
   integrity sha512-9I0L17t0MN87fL4m4MjDiBxJIx7h5RQY/pTYtt5TBjye0ANb165JeE4oh3ibzfjMzXv42Aej2Gm+cOuSPwzT9g==
   dependencies:
     "@nrwl/devkit" "18.3.5"
@@ -12772,9 +12772,9 @@ effect@3.19.16:
     "@standard-schema/spec" "^1.0.0"
     fast-check "^3.23.1"
 
-ejs@^3.1.5, ejs@^3.1.7:
+ejs@3.1.10, ejs@^3.1.5, ejs@^3.1.7:
   version "3.1.10"
-  resolved "http://52.50.158.57:4873/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
+  resolved "https://registry.ag-grid.com/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
   integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
   dependencies:
     jake "^10.8.5"
@@ -16482,7 +16482,7 @@ jackspeak@^4.1.1:
   dependencies:
     "@isaacs/cliui" "^8.0.2"
 
-jake@^10.8.5:
+jake@10.9.4, jake@^10.8.5:
   version "10.9.4"
   resolved "http://52.50.158.57:4873/jake/-/jake-10.9.4.tgz#d626da108c63d5cfb00ab5c25fadc7e0084af8e6"
   integrity sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==


### PR DESCRIPTION
## Summary

Adds an interactive local web app (`external/ag-shared/scripts/snyk-viewer/`) for reviewing and resolving Snyk vulnerabilities in the monorepo. The tool reads a Snyk JSON output file, serves a browser UI, and provides one-click actions to apply fixes directly to repository source files.

## Features

- **Browse All tab** — filterable/searchable list of all vulnerabilities with severity, dep paths, and CVE links
- **Review Queue tab** — structured triage workflow with three sections:
  - Section 1: Dependency Upgrades — update `package.json` versions directly from the UI
  - Section 2: Yarn Resolutions — apply `resolutions` entries to root `package.json`
  - Section 3: Snyk Ignores — add/update `.snyk` ignore rules with YAML preview; "Outdated versions" panel updates stale dep paths in `.snyk` files
- **Re-run Snyk scan** — streams `yarn nx snyk:test:json` output and reloads data without a page refresh
- **Persistent review state** — decisions saved to `tmp/snyk-review-state.json`

## Test plan

- Run `node external/ag-shared/scripts/snyk-viewer/index.mjs <snyk-output.json>`
- Verify Browse All tab filters and grouping work
- Verify Review Queue sections 1, 2, 3 render and actions (update dep, apply resolution, add to .snyk) work
- Verify Outdated versions panel update buttons dim the panel during fetch and restore open section state after re-render