### PR TITLE
AG-16467 Add @internal JSDoc tags to main-internal.ts exports

### DIFF
--- a/.rulesync/README.md
+++ b/.rulesync/README.md
@@ -57,8 +57,8 @@ Quick-reference for all AI agent commands, skills, sub-agents, and rules availab
 
 | Type  | Name          | Invoke             | What it does                                       |
 | ----- | ------------- | ------------------ | -------------------------------------------------- |
-| Skill | 🔵 `remember`  | `/remember` (user) | Save branch context or project learnings as memory |
-| Skill | 🔵 `recall`    | `/recall` (user)   | Load branch context, browse project memories       |
+| Skill | 🔵 `remember` | `/remember` (user) | Save branch context or project learnings as memory |
+| Skill | 🔵 `recall`   | `/recall` (user)   | Load branch context, browse project memories       |
 
 ## Documentation Review
 

--- a/packages/ag-grid-community/src/agStack/constants/direction.ts
+++ b/packages/ag-grid-community/src/agStack/constants/direction.ts
@@ -1,7 +1,9 @@
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export enum Direction {
     Vertical,
     Horizontal,
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type VerticalDirection = 'up' | 'down';
 export type HorizontalDirection = 'left' | 'right';

--- a/packages/ag-grid-community/src/agStack/core/agBeanStub.ts
+++ b/packages/ag-grid-community/src/agStack/core/agBeanStub.ts
@@ -19,11 +19,13 @@ import type {
 import { _addSafePassiveEventListener } from '../utils/event';
 import { _getLocaleTextFunc } from '../utils/locale';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type AgBeanStubEvent = 'destroyed';
 type AgEventOrDestroyed<TEventType extends string> = TEventType | AgBeanStubEvent;
 
 type EventHandlers<TEventKey extends string, TEvent = any> = { [K in TEventKey]?: (event?: TEvent) => void };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export abstract class AgBeanStub<
         TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
         TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/core/agComponentStub.ts
+++ b/packages/ag-grid-community/src/agStack/core/agComponentStub.ts
@@ -24,6 +24,7 @@ import { AgBeanStub } from './agBeanStub';
 
 let compIdSequence = 0;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgComponentStub<
         TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
         TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/core/agContext.ts
+++ b/packages/ag-grid-community/src/agStack/core/agContext.ts
@@ -29,6 +29,7 @@ export interface AgContextParams<
     destroyCallback?: () => void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type AgSingletonBeanClass<TBeanCollection> = new () => AgSingletonBean<TBeanCollection>;
 
 interface DerivedBean<TBeanCollection, K extends keyof TBeanCollection> {
@@ -39,6 +40,7 @@ interface DerivedBean<TBeanCollection, K extends keyof TBeanCollection> {
 /** Instance Id used by React to reset the state of a component tree when the context changes. */
 let contextId = 1;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgContext<
     TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
     TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/core/baseDragAndDropService.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseDragAndDropService.ts
@@ -26,6 +26,7 @@ interface DragSourceAndParams<
     dragSource: TDragSource;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export abstract class BaseDragAndDropService<
         TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
         TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/core/baseDragService.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseDragService.ts
@@ -45,6 +45,7 @@ const addHandledDragEvent = (event: Event): boolean => {
     return true;
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class BaseDragService<
         TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
         TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/core/baseEnvironment.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseEnvironment.ts
@@ -22,6 +22,7 @@ const LIST_ITEM_HEIGHT: CssVariable<BaseCssChangeKeys> = {
     defaultValue: 24,
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export abstract class BaseEnvironment<
         TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
         TProperties extends BaseProperties,
@@ -301,6 +302,7 @@ export abstract class BaseEnvironment<
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type CssVariable<TChangeKeys extends BaseCssChangeKeys> = {
     changeKey: keyof TChangeKeys & string;
     type: ParamType;
@@ -309,6 +311,7 @@ export type CssVariable<TChangeKeys extends BaseCssChangeKeys> = {
     cacheDefault?: boolean;
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface BaseCssChangeKeys {
     theme: true;
     listItemHeight: true;

--- a/packages/ag-grid-community/src/agStack/core/baseRegistry.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseRegistry.ts
@@ -6,6 +6,7 @@ import type { IPropertiesService } from '../interfaces/iProperties';
 import type { IRegistry } from '../interfaces/iRegistry';
 import { AgBeanStub } from './agBeanStub';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export abstract class BaseRegistry<
         TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
         TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/events/baseEventService.ts
+++ b/packages/ag-grid-community/src/agStack/events/baseEventService.ts
@@ -11,6 +11,7 @@ import type {
 import type { IPropertiesService } from '../interfaces/iProperties';
 import { LocalEventService } from './localEventService';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class BaseEventService<
         TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
         TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/events/localEventService.ts
+++ b/packages/ag-grid-community/src/agStack/events/localEventService.ts
@@ -2,6 +2,7 @@ import type { AgEvent } from '../interfaces/agEvent';
 import type { AgFrameworkOverrides } from '../interfaces/agFrameworkOverrides';
 import type { IEventEmitter, IEventListener, IGlobalEventListener } from '../interfaces/iEventEmitter';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class LocalEventService<TEventType extends string> implements IEventEmitter<TEventType> {
     private readonly allSyncListeners = new Map<TEventType, Set<IEventListener<TEventType>>>();
     private readonly allAsyncListeners = new Map<TEventType, Set<IEventListener<TEventType>>>();

--- a/packages/ag-grid-community/src/agStack/focus/agManagedFocusFeature.ts
+++ b/packages/ag-grid-community/src/agStack/focus/agManagedFocusFeature.ts
@@ -6,6 +6,7 @@ import type { BaseProperties } from '../interfaces/baseProperties';
 import type { IPropertiesService } from '../interfaces/iProperties';
 import { _findNextFocusableElement } from '../utils/focus';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface ManagedFocusCallbacks {
     shouldStopEventPropagation?: (e: KeyboardEvent) => boolean;
     onTabKeyDown?: (e: KeyboardEvent) => void;
@@ -14,8 +15,10 @@ export interface ManagedFocusCallbacks {
     onFocusOut?: (e: FocusEvent) => void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const FOCUS_MANAGED_CLASS = 'ag-focus-managed';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface StopPropagationCallbacks {
     isStopPropagation: (e: Event) => boolean;
     stopPropagation: (e: Event) => void;

--- a/packages/ag-grid-community/src/agStack/focus/agTabGuardComp.ts
+++ b/packages/ag-grid-community/src/agStack/focus/agTabGuardComp.ts
@@ -8,6 +8,7 @@ import type { StopPropagationCallbacks } from './agManagedFocusFeature';
 import type { AgTabGuardParams } from './agTabGuardFeature';
 import { AgTabGuardFeature } from './agTabGuardFeature';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgTabGuardComp<
     TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
     TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/focus/agTabGuardFeature.ts
+++ b/packages/ag-grid-community/src/agStack/focus/agTabGuardFeature.ts
@@ -11,6 +11,7 @@ import type { StopPropagationCallbacks } from './agManagedFocusFeature';
 import type { ITabGuard } from './tabGuardCtrl';
 import { AgTabGuardCtrl, TabGuardClassNames } from './tabGuardCtrl';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgTabGuardParams {
     focusInnerElement?: (fromBottom: boolean) => boolean;
     shouldStopEventPropagation?: () => boolean;
@@ -40,6 +41,7 @@ export interface AgTabGuardParams {
     isFocusableContainer?: boolean;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgTabGuardFeature<
     TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
     TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/focus/tabGuardCtrl.ts
+++ b/packages/ag-grid-community/src/agStack/focus/tabGuardCtrl.ts
@@ -8,12 +8,14 @@ import { _findFocusableElements, _findNextFocusableElement } from '../utils/focu
 import type { StopPropagationCallbacks } from './agManagedFocusFeature';
 import { AgManagedFocusFeature } from './agManagedFocusFeature';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const TabGuardClassNames = {
     TAB_GUARD: 'ag-tab-guard',
     TAB_GUARD_TOP: 'ag-tab-guard-top',
     TAB_GUARD_BOTTOM: 'ag-tab-guard-bottom',
 } as const;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface ITabGuard {
     setTabIndex(tabIndex?: string): void;
 }

--- a/packages/ag-grid-community/src/agStack/interfaces/agComponent.ts
+++ b/packages/ag-grid-community/src/agStack/interfaces/agComponent.ts
@@ -5,10 +5,12 @@ import type { AgEvent } from './agEvent';
 import type { BaseEvents } from './baseEvents';
 import type { BaseProperties } from './baseProperties';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgBaseComponent<TBeanCollection> extends AgBaseBean<TBeanCollection> {
     getGui(): HTMLElement;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgComponent<
     TBeanCollection,
     TProperties extends BaseProperties,
@@ -45,21 +47,25 @@ export interface AgComponent<
     toggleCss(className: string, addOrRemove: boolean): void;
 }
 
-/** The RefPlaceholder is used to control when data-ref attribute should be applied to the component
+/**
+ * The RefPlaceholder is used to control when data-ref attribute should be applied to the component
  * There are hanging data-refs in the DOM that are not being used internally by the component which we don't want to apply to the component.
  * There is also the case where data-refs are solely used for passing parameters to the component and should not be applied to the component.
  * It also enables validation to catch typo errors in the data-ref attribute vs component name.
  * The value is `null` so that it can be identified in the component and distinguished from just missing with undefined.
  * The `null` value also allows for existing falsy checks to work as expected when code can be run before the template is setup.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
-
 export const RefPlaceholder: any = null;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type AgComponentEvent = 'displayChanged' | AgBeanStubEvent;
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface VisibleChangedEvent extends AgEvent<'displayChanged'> {
     visible: boolean;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type AgComponentSelector<
     TComponentSelectorType extends string,
     TBeanCollection = any,
@@ -69,6 +75,7 @@ export type AgComponentSelector<
     selector: TComponentSelectorType;
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isComponent<TBeanCollection>(item: any): item is AgBaseComponent<TBeanCollection> {
     return typeof (item as AgBaseComponent<TBeanCollection>)?.getGui === 'function';
 }

--- a/packages/ag-grid-community/src/agStack/interfaces/agCoreBean.ts
+++ b/packages/ag-grid-community/src/agStack/interfaces/agCoreBean.ts
@@ -5,7 +5,10 @@ export interface AgSingletonBean<TBeanCollection> extends AgBaseBean<TBeanCollec
     /** AG Grid internal - do not use */
     beanName?: keyof TBeanCollection & string;
 }
-/** Includes bean creation and destruction logic */
+/**
+ * Includes bean creation and destruction logic
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 
 export interface AgCoreBean<TBeanCollection> extends AgBaseBean<TBeanCollection> {
     isAlive(): boolean;

--- a/packages/ag-grid-community/src/agStack/interfaces/agCoreBeanCollection.ts
+++ b/packages/ag-grid-community/src/agStack/interfaces/agCoreBeanCollection.ts
@@ -13,6 +13,7 @@ import type { IPopupService } from './iPopupService';
 import type { IPropertiesService } from './iProperties';
 import type { IRegistry } from './iRegistry';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgCoreBeanCollection<
     TProperties extends BaseProperties,
     TGlobalEvents extends BaseEvents,

--- a/packages/ag-grid-community/src/agStack/interfaces/agFrameworkOverrides.ts
+++ b/packages/ag-grid-community/src/agStack/interfaces/agFrameworkOverrides.ts
@@ -1,5 +1,7 @@
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type FrameworkOverridesIncomingSource = 'resize-observer' | 'ensureVisible' | 'popupPositioning';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgFrameworkOverrides {
     /**
      * This method is to cater for Angular's change detection.

--- a/packages/ag-grid-community/src/agStack/interfaces/baseEvents.ts
+++ b/packages/ag-grid-community/src/agStack/interfaces/baseEvents.ts
@@ -34,12 +34,16 @@ interface AgTooltipShowEvent extends AgTooltipEvent<'tooltipShow'> {
 
 interface AgTooltipHideEvent extends AgTooltipEvent<'tooltipHide'> {}
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgStylesChangedEvent extends AgEvent<'stylesChanged'> {
     themeChanged?: boolean;
     listItemHeightChanged?: boolean;
 }
 
-/** Events required by AG Stack */
+/**
+ * Events required by AG Stack
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export interface BaseEvents {
     checkboxChanged: AgCheckboxChangedEvent;
     bodyScroll: AgBodyScrollEvent;

--- a/packages/ag-grid-community/src/agStack/interfaces/baseProperties.ts
+++ b/packages/ag-grid-community/src/agStack/interfaces/baseProperties.ts
@@ -1,6 +1,9 @@
 import type { Theme } from '../theming/theme';
 
-/** Properties required by AG Stack */
+/**
+ * Properties required by AG Stack
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export interface BaseProperties {
     tabIndex?: number;
     suppressScrollWhenPopupsAreOpen?: boolean;

--- a/packages/ag-grid-community/src/agStack/interfaces/iAfterGuiAttachedParams.ts
+++ b/packages/ag-grid-community/src/agStack/interfaces/iAfterGuiAttachedParams.ts
@@ -1,3 +1,4 @@
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AfterGuiAttachedParams<TContainerType extends string> {
     /** Where this component is attached to. */
     container?: TContainerType;

--- a/packages/ag-grid-community/src/agStack/interfaces/iAriaAnnouncementService.ts
+++ b/packages/ag-grid-community/src/agStack/interfaces/iAriaAnnouncementService.ts
@@ -1,3 +1,4 @@
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IAriaAnnouncementService {
     readonly beanName: 'ariaAnnounce';
     announceValue(value: string, key: string): void;

--- a/packages/ag-grid-community/src/agStack/interfaces/iDrag.ts
+++ b/packages/ag-grid-community/src/agStack/interfaces/iDrag.ts
@@ -1,3 +1,4 @@
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IDragService {
     readonly beanName: 'dragSvc';
 

--- a/packages/ag-grid-community/src/agStack/interfaces/iDragAndDrop.ts
+++ b/packages/ag-grid-community/src/agStack/interfaces/iDragAndDrop.ts
@@ -1,5 +1,6 @@
 import type { HorizontalDirection, VerticalDirection } from '../constants/direction';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IDragAndDropService<
     TDragSourceType extends number,
     TDragItem,
@@ -28,6 +29,7 @@ export interface IDragAndDropService<
     ): AgDropTarget<TDragSourceType, TDragItem, TDragAndDropIcon, TDraggingEvent> | null;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgDragSource<
     TDragSourceType extends number,
     TDragItem,
@@ -58,6 +60,7 @@ export interface AgDragSource<
     onDragCancelled?: () => void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgDraggingEvent<
     TDragSourceType extends number,
     TDragItem,
@@ -92,6 +95,7 @@ export interface AgDraggingEvent<
     changed: boolean;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgDropTarget<
     TDragSourceType extends number,
     TDragItem,
@@ -128,6 +132,7 @@ export interface AgDropTarget<
     external?: boolean;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IDragAndDropImage {
     setIcon(iconName: string | null, shake: boolean): void;
     setLabel(label: string): void;

--- a/packages/ag-grid-community/src/agStack/interfaces/iEvent.ts
+++ b/packages/ag-grid-community/src/agStack/interfaces/iEvent.ts
@@ -10,12 +10,14 @@ export type AgEventServiceListener<TGlobalEvents, TEventType extends keyof TGlob
     params: TGlobalEvents[TEventType]
 ) => void;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type WithoutCommon<TCommon, T> = Omit<T, keyof TCommon>;
 
 export type AgRawEvents<TGlobalEvents extends BaseEvents, TCommon> = {
     [K in keyof TGlobalEvents]: WithoutCommon<TCommon, TGlobalEvents[K]>;
 }[keyof TGlobalEvents];
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgEventService<TGlobalEvents extends BaseEvents, TCommon> {
     readonly eventServiceType: 'global';
     readonly beanName: 'eventSvc';

--- a/packages/ag-grid-community/src/agStack/interfaces/iIcon.ts
+++ b/packages/ag-grid-community/src/agStack/interfaces/iIcon.ts
@@ -1,3 +1,4 @@
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type IconValue =
     | 'expanded'
     | 'contracted'

--- a/packages/ag-grid-community/src/agStack/interfaces/iIconService.ts
+++ b/packages/ag-grid-community/src/agStack/interfaces/iIconService.ts
@@ -1,3 +1,4 @@
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IIconService<TIconName extends string, TParams> {
     readonly beanName: 'iconSvc';
 

--- a/packages/ag-grid-community/src/agStack/interfaces/iLocaleService.ts
+++ b/packages/ag-grid-community/src/agStack/interfaces/iLocaleService.ts
@@ -1,9 +1,11 @@
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface ILocaleService<TKey extends string = string> {
     readonly beanName: 'localeSvc';
 
     getLocaleTextFunc(): LocaleTextFunc<TKey>;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type LocaleTextFunc<TKey extends string = string> = (
     key: TKey,
     defaultValue: string,

--- a/packages/ag-grid-community/src/agStack/interfaces/iPopup.ts
+++ b/packages/ag-grid-community/src/agStack/interfaces/iPopup.ts
@@ -1,5 +1,6 @@
 import type { AfterGuiAttachedParams } from './iAfterGuiAttachedParams';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type AddPopupParams<TContainerType extends string> =
     | LabelAddPopupParams<TContainerType>
     | OwnsAddPopupParams<TContainerType>;
@@ -49,6 +50,7 @@ export interface PopupEventParams {
     forceHide?: boolean;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AddPopupResult {
     hideFunc: (params?: PopupEventParams) => void;
 }

--- a/packages/ag-grid-community/src/agStack/interfaces/iPopupService.ts
+++ b/packages/ag-grid-community/src/agStack/interfaces/iPopupService.ts
@@ -7,6 +7,7 @@ import type {
     AgPopupPositionParams,
 } from './iPopup';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IPopupService<TPopupPositionParams> {
     readonly beanName: 'popupSvc';
 

--- a/packages/ag-grid-community/src/agStack/interfaces/iProperties.ts
+++ b/packages/ag-grid-community/src/agStack/interfaces/iProperties.ts
@@ -2,8 +2,10 @@ import type { AgEvent } from './agEvent';
 import type { BaseProperties } from './baseProperties';
 import type { WithoutCommon } from './iEvent';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type AgPropertyChangedSource = 'api' | 'optionsUpdated';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgPropertyChangeSet<TProperties extends BaseProperties> {
     /** Unique id which can be used to link changes of multiple properties that were updated together.
      * i.e a user updated multiple properties at the same time.
@@ -18,8 +20,10 @@ export interface AgPropertyChangedEvent<TProperties extends BaseProperties> exte
     source: AgPropertyChangedSource;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type AgPropertyKey<TProperties extends BaseProperties> = keyof TProperties & string;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgPropertyValueChangedEvent<TProperties extends BaseProperties, K extends AgPropertyKey<TProperties>>
     extends AgEvent {
     type: K;
@@ -33,10 +37,12 @@ export type AgPropertyChangedListener<TProperties extends BaseProperties> = (
     event: AgPropertyChangedEvent<TProperties>
 ) => void;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type AgPropertyValueChangedListener<TProperties extends BaseProperties, K extends AgPropertyKey<TProperties>> = (
     event: AgPropertyValueChangedEvent<TProperties, K>
 ) => void;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IPropertiesService<TProperties extends BaseProperties, TCommon> {
     readonly beanName: 'gos';
 

--- a/packages/ag-grid-community/src/agStack/interfaces/iTooltip.ts
+++ b/packages/ag-grid-community/src/agStack/interfaces/iTooltip.ts
@@ -1,3 +1,4 @@
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface ITooltipFeature {
     setTooltipAndRefresh(tooltip: any): void;
 
@@ -10,6 +11,7 @@ export interface ITooltipFeature {
     destroy(): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface TooltipCtrl<TLocation extends string, TParams> {
     getTooltipValue?(): any;
     getGui(): HTMLElement;

--- a/packages/ag-grid-community/src/agStack/popup/agPopupComponent.ts
+++ b/packages/ag-grid-community/src/agStack/popup/agPopupComponent.ts
@@ -6,6 +6,7 @@ import type { BaseProperties } from '../interfaces/baseProperties';
 import type { IPopupComponent } from '../interfaces/iPopupComponent';
 import type { IPropertiesService } from '../interfaces/iProperties';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgPopupComponent<
         TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
         TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/popup/basePopupService.ts
+++ b/packages/ag-grid-community/src/agStack/popup/basePopupService.ts
@@ -49,6 +49,7 @@ interface Position {
     direction: Direction;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export abstract class BasePopupService<
         TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
         TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/rendering/agPositionableFeature.ts
+++ b/packages/ag-grid-community/src/agStack/rendering/agPositionableFeature.ts
@@ -49,6 +49,7 @@ const RESIZE_TEMPLATE: AgElementParams<string> = {
     ],
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface PositionableOptions {
     popup?: boolean;
     minWidth?: number | null;
@@ -67,6 +68,7 @@ export interface PositionableOptions {
     y?: number | null;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type ResizableSides =
     | 'topLeft'
     | 'top'
@@ -77,6 +79,7 @@ export type ResizableSides =
     | 'bottomLeft'
     | 'left';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type ResizableStructure = {
     [key in ResizableSides]?: boolean;
 };
@@ -86,6 +89,7 @@ interface MappedResizer {
 }
 type PositionableFeatureEvent = 'resize';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgPositionableFeature<
     TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
     TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/rendering/autoScrollService.ts
+++ b/packages/ag-grid-community/src/agStack/rendering/autoScrollService.ts
@@ -1,3 +1,4 @@
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AutoScrollService {
     private tickingInterval: number | null = null;
 

--- a/packages/ag-grid-community/src/agStack/rendering/cssClassManager.ts
+++ b/packages/ag-grid-community/src/agStack/rendering/cssClassManager.ts
@@ -1,3 +1,4 @@
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class CssClassManager {
     private readonly getGui: () => HTMLElement | undefined | null;
 

--- a/packages/ag-grid-community/src/agStack/theming/shared/shared-css.ts
+++ b/packages/ag-grid-community/src/agStack/theming/shared/shared-css.ts
@@ -17,6 +17,7 @@ import {
     foregroundMix,
 } from '../themeUtils';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface SharedThemeParams {
     /**
      * The 'brand color' for the grid, used wherever a non-neutral color is required. Selections, focus outlines and checkboxes use the accent color by default.
@@ -362,6 +363,7 @@ export const defaultLightColorSchemeParams = {
     browserColorScheme: 'light',
 } as const;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const sharedDefaults: Readonly<SharedThemeParams> = {
     ...defaultLightColorSchemeParams,
     textColor: foregroundColor,

--- a/packages/ag-grid-community/src/agStack/theming/themeImpl.ts
+++ b/packages/ag-grid-community/src/agStack/theming/themeImpl.ts
@@ -9,6 +9,7 @@ import { paramValueToCss } from './themeTypeUtils';
 import type { WithParamTypes } from './themeTypes';
 import { paramToVariableName } from './themeUtils';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const _asThemeImpl = <TParams>(theme: Theme<TParams>): ThemeImpl => {
     if (!(theme instanceof ThemeImpl)) {
         throw new Error('theme is not an object created by createTheme');
@@ -16,6 +17,7 @@ export const _asThemeImpl = <TParams>(theme: Theme<TParams>): ThemeImpl => {
     return theme;
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const createSharedTheme = <TParams extends SharedThemeParams>(
     themeLogger: ThemeLogger,
     overridePrefix?: string

--- a/packages/ag-grid-community/src/agStack/theming/themeLogger.ts
+++ b/packages/ag-grid-community/src/agStack/theming/themeLogger.ts
@@ -19,6 +19,7 @@ type ThemeErrorValue<TId extends ThemeErrorId | null> = TId extends ThemeErrorId
 type GetThemeErrorParams<TId extends ThemeErrorId> =
     ThemeErrorValue<TId> extends (params: infer P) => any ? (P extends Record<string, any> ? P : undefined) : never;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type ThemeLogger = {
     error: <
         TId extends ThemeErrorId,

--- a/packages/ag-grid-community/src/agStack/theming/themeTypeUtils.ts
+++ b/packages/ag-grid-community/src/agStack/theming/themeTypeUtils.ts
@@ -29,6 +29,7 @@ export type ParamType = (typeof paramTypes)[number];
 
 /**
  * Return the ParamType for a given param name,
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const getParamType = memoize((param: string): ParamType => {
     param = param.toLowerCase();
@@ -222,6 +223,7 @@ const paramValidators: Record<ParamType, (value: unknown, param: string, themeLo
         duration: durationValueToCss,
     };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const paramValueToCss = (param: string, value: unknown, themeLogger: ThemeLogger): string | false => {
     const type = getParamType(param);
     return paramValidators[type](value, param, themeLogger);

--- a/packages/ag-grid-community/src/agStack/theming/themeUtils.ts
+++ b/packages/ag-grid-community/src/agStack/theming/themeUtils.ts
@@ -2,6 +2,7 @@ import type { ColorValue } from './themeTypes';
 
 const kebabCase = (str: string) => str.replace(/[A-Z]|\d+/g, (m) => `-${m}`).toLowerCase();
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const paramToVariableName = (paramName: string) => `--ag-${kebabCase(paramName)}`;
 
 export const paramToVariableExpression = (paramName: string) => `var(${paramToVariableName(paramName)})`;

--- a/packages/ag-grid-community/src/agStack/tooltip/agHighlightTooltipFeature.ts
+++ b/packages/ag-grid-community/src/agStack/tooltip/agHighlightTooltipFeature.ts
@@ -9,6 +9,7 @@ import { AgTooltipFeature } from './agTooltipFeature';
 import type { BaseTooltipParams } from './baseTooltipStateManager';
 import { TooltipTrigger } from './baseTooltipStateManager';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type HighlightTooltipEventType = 'itemHighlighted';
 export interface HighlightTooltipEvent extends AgEvent<HighlightTooltipEventType> {
     highlighted: boolean;

--- a/packages/ag-grid-community/src/agStack/tooltip/agTooltipComponent.ts
+++ b/packages/ag-grid-community/src/agStack/tooltip/agTooltipComponent.ts
@@ -7,6 +7,7 @@ import { AgPopupComponent } from '../popup/agPopupComponent';
 import { _toString } from '../utils/string';
 import type { BaseTooltipParams } from './baseTooltipStateManager';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgTooltipComponent<
         TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
         TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/tooltip/agTooltipFeature.ts
+++ b/packages/ag-grid-community/src/agStack/tooltip/agTooltipFeature.ts
@@ -6,6 +6,7 @@ import type { IPropertiesService } from '../interfaces/iProperties';
 import type { ITooltipFeature, TooltipCtrl } from '../interfaces/iTooltip';
 import type { BaseTooltipParams, BaseTooltipStateManager } from './baseTooltipStateManager';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgTooltipFeature<
         TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
         TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/tooltip/baseTooltipStateManager.ts
+++ b/packages/ag-grid-community/src/agStack/tooltip/baseTooltipStateManager.ts
@@ -29,6 +29,7 @@ const INTERACTIVE_HIDE_DELAY = 100;
 let lastTooltipHideTime: number;
 let isLocked = false;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface BaseTooltipParams<TLocation extends string, TValue = any> {
     location: TLocation;
     /** The value to be rendered by the tooltip. */
@@ -37,6 +38,7 @@ export interface BaseTooltipParams<TLocation extends string, TValue = any> {
     hideTooltipCallback?: () => void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export abstract class BaseTooltipStateManager<
     TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
     TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/utils/aria.ts
+++ b/packages/ag-grid-community/src/agStack/utils/aria.ts
@@ -1,6 +1,9 @@
 import type { LocaleTextFunc } from '../interfaces/iLocaleService';
 
-/** Per https://www.w3.org/TR/wai-aria/#aria-sort](https://www.w3.org/TR/wai-aria/#aria-sort:~:text=integer-,aria%2Dsort%20property,-Indicates%20if%20items */
+/**
+ * Per https://www.w3.org/TR/wai-aria/#aria-sort](https://www.w3.org/TR/wai-aria/#aria-sort:~:text=integer-,aria%2Dsort%20property,-Indicates%20if%20items
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export type AriaSortState = 'ascending' | 'descending' | 'other' | 'none';
 
 export type DisplaySortDef =
@@ -40,6 +43,7 @@ function _ariaAttributeName(attribute: string) {
     return `aria-${attribute}`;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaRole(element: Element, role?: string | null) {
     if (role) {
         element.setAttribute('role', role);
@@ -63,6 +67,7 @@ export function _getAriaSortState(directionOrDef: DisplaySortDef | null): AriaSo
 }
 
 // ARIA ATTRIBUTE GETTERS
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getAriaPosInSet(element: Element): number {
     return Number.parseInt(element.getAttribute('aria-posinset')!, 10);
 }
@@ -72,14 +77,17 @@ export function _getAriaLabel(element: Element): string | null {
 }
 
 // ARIA ATTRIBUTE SETTERS
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaLabel(element: Element, label?: string | null): void {
     _toggleAriaAttribute(element, 'label', label);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaLabelledBy(element: Element, labelledBy?: string): void {
     _toggleAriaAttribute(element, 'labelledby', labelledBy);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaDescribedBy(element: Element, describedby?: string): void {
     _toggleAriaAttribute(element, 'describedby', describedby);
 }
@@ -99,38 +107,47 @@ export function _setAriaRelevant(
     _toggleAriaAttribute(element, 'relevant', relevant);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaInvalid(element: Element, invalid: boolean) {
     _toggleAriaAttribute(element, 'invalid', invalid);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaLevel(element: Element, level: number): void {
     _toggleAriaAttribute(element, 'level', level);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaDisabled(element: Element, disabled: boolean): void {
     _toggleAriaAttribute(element, 'disabled', disabled);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaHidden(element: Element, hidden: boolean): void {
     _toggleAriaAttribute(element, 'hidden', hidden);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaActiveDescendant(element: Element, descendantId: string | null): void {
     _toggleAriaAttribute(element, 'activedescendant', descendantId);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaExpanded(element: Element, expanded: boolean): void {
     _setAriaAttribute(element, 'expanded', expanded);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _removeAriaExpanded(element: Element): void {
     _removeAriaAttribute(element, 'expanded');
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaSetSize(element: Element, setsize: number): void {
     _setAriaAttribute(element, 'setsize', setsize);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaPosInSet(element: Element, position: number): void {
     _setAriaAttribute(element, 'posinset', position);
 }
@@ -139,10 +156,12 @@ export function _setAriaMultiSelectable(element: Element, multiSelectable: boole
     _setAriaAttribute(element, 'multiselectable', multiSelectable);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaRowCount(element: Element, rowCount: number): void {
     _setAriaAttribute(element, 'rowcount', rowCount);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaRowIndex(element: Element, rowIndex: number): void {
     _setAriaAttribute(element, 'rowindex', rowIndex);
 }
@@ -151,38 +170,47 @@ export function _setAriaRowSpan(element: Element, spanCount: number): void {
     _setAriaAttribute(element, 'rowspan', spanCount);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaColCount(element: Element, colCount: number): void {
     _setAriaAttribute(element, 'colcount', colCount);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaColIndex(element: Element, colIndex: number): void {
     _setAriaAttribute(element, 'colindex', colIndex);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaColSpan(element: Element, colSpan: number): void {
     _setAriaAttribute(element, 'colspan', colSpan);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaSort(element: Element, sort: AriaSortState): void {
     _setAriaAttribute(element, 'sort', sort);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _removeAriaSort(element: Element): void {
     _removeAriaAttribute(element, 'sort');
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaSelected(element: Element, selected?: boolean): void {
     _toggleAriaAttribute(element, 'selected', selected);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaChecked(element: Element, checked?: boolean) {
     _setAriaAttribute(element, 'checked', checked === undefined ? 'mixed' : checked);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaControls(controllerElement: Element, controlledId?: string | null) {
     _toggleAriaAttribute(controllerElement, 'controls', controlledId);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaControlsAndLabel(controllerElement: Element, controlledElement: Element) {
     _setAriaControls(controllerElement, controlledElement.id);
     _setAriaLabelledBy(controlledElement, controllerElement.id);
@@ -192,6 +220,7 @@ export function _setAriaOwns(ownerElement: Element, ownedId?: string | null) {
     _toggleAriaAttribute(ownerElement, 'owns', ownedId);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaHasPopup(
     element: Element,
     hasPopup: 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog' | boolean
@@ -207,6 +236,7 @@ export function _getAriaCheckboxStateName(translate: LocaleTextFunc, state?: boo
           : translate('ariaUnchecked', 'unchecked');
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setAriaOrientation(element: Element, orientation?: 'horizontal' | 'vertical'): void {
     if (orientation) {
         _setAriaAttribute(element, 'orientation', orientation);

--- a/packages/ag-grid-community/src/agStack/utils/array.ts
+++ b/packages/ag-grid-community/src/agStack/utils/array.ts
@@ -1,6 +1,10 @@
-/** An array that is always empty and that cannot be modified */
+/**
+ * An array that is always empty and that cannot be modified
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export const _EmptyArray = Object.freeze([]) as unknown as any[];
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _last<T>(arr: readonly T[]): T;
 export function _last<T extends Node>(arr: NodeListOf<T>): T;
 export function _last(arr: any): any {
@@ -11,6 +15,7 @@ export function _last(arr: any): any {
     return arr[arr.length - 1];
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _areEqual<T>(
     a: readonly T[] | null | undefined,
     b: readonly T[] | null | undefined,
@@ -51,6 +56,7 @@ export function _forAll<T>(array: T[] | undefined, callback: (value: T) => boole
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _removeFromArray<T>(array: T[], object: T): void {
     const index = array.indexOf(object);
 
@@ -63,6 +69,7 @@ export function _removeFromArray<T>(array: T[], object: T): void {
  * O(N+M) way to remove M elements from an array of size N. Better than calling _removeFromArray in a loop
  *
  * Note: this implementation removes _any_ instances of the `elementsToRemove`
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _removeAllFromArray<T>(array: T[], elementsToRemove: readonly T[]): void {
     let i = 0;
@@ -96,6 +103,7 @@ export function _moveInArray<T>(array: T[], objectsToMove: T[], toIndex: number)
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _flatten<T>(arrays: Array<T[]>): T[] {
     // Currently the fastest way to flatten an array according to https://jsbench.me/adlib26t2y/2
     return ([] as T[]).concat.apply([], arrays);

--- a/packages/ag-grid-community/src/agStack/utils/bigInt.ts
+++ b/packages/ag-grid-community/src/agStack/utils/bigInt.ts
@@ -1,3 +1,4 @@
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const _parseBigIntOrNull = (value: unknown): bigint | null => {
     if (typeof value === 'bigint') {
         return value;

--- a/packages/ag-grid-community/src/agStack/utils/browser.ts
+++ b/packages/ag-grid-community/src/agStack/utils/browser.ts
@@ -10,6 +10,7 @@ let invisibleScrollbar: boolean;
 let browserScrollbarWidth: number;
 let maxDivHeight: number;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isBrowserSafari(): boolean {
     if (isSafari === undefined) {
         isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
@@ -17,6 +18,7 @@ export function _isBrowserSafari(): boolean {
     return isSafari;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isBrowserFirefox(): boolean {
     if (isFirefox === undefined) {
         isFirefox = /(firefox)/i.test(navigator.userAgent);
@@ -33,6 +35,7 @@ export function _isMacOsUserAgent(): boolean {
     return isMacOs;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isIOSUserAgent(): boolean {
     if (isIOS === undefined) {
         isIOS =

--- a/packages/ag-grid-community/src/agStack/utils/date.ts
+++ b/packages/ag-grid-community/src/agStack/utils/date.ts
@@ -19,6 +19,7 @@ function _padStartWidthZeros(value: number, totalStringSize: number): string {
  * @param date The date to serialise
  * @param includeTime Whether to include the time in the serialised string
  * @param separator The separator to use between date and time parts (default 'T')
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 
 export function _serialiseDate(date: Date | null, includeTime = true, separator = DATE_TIME_SEPARATOR): string | null {
@@ -46,6 +47,7 @@ export function _serialiseDate(date: Date | null, includeTime = true, separator 
  * @param d The date to get the parts from
  * @param includeTime Whether to include the time in the returned array
  * @returns The date parts as an array of strings or null if the date is null or undefined
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _getDateParts(d: Date | null | undefined, includeTime: boolean = true): null | string[] {
     if (!d) {
@@ -82,6 +84,7 @@ const calculateOrdinal = (value: number) => {
     return 'th';
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const MONTHS = [
     'January',
     'February',
@@ -157,6 +160,7 @@ export function _isValidDateTime(value?: string | null): boolean {
  * Per MDN:
  *   When the time zone offset is absent, **date-only** forms are interpreted as a UTC time and **date-time** forms are interpreted as a local time.
  *   The interpretation as a UTC time is due to a historical spec error that was not consistent with ISO 8601 but could not be changed due to web compatibility.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _parseDateTimeFromString(
     value?: string | null,

--- a/packages/ag-grid-community/src/agStack/utils/document.ts
+++ b/packages/ag-grid-community/src/agStack/utils/document.ts
@@ -1,14 +1,17 @@
 import type { UtilBeanCollection } from '../interfaces/agCoreBeanCollection';
 import { _exists } from './generic';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getRootNode(beans: UtilBeanCollection): Document | ShadowRoot {
     return beans.eRootDiv.getRootNode() as Document | ShadowRoot;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getActiveDomElement(beans: UtilBeanCollection): Element | null {
     return _getRootNode(beans).activeElement;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getDocument(beans: UtilBeanCollection): Document {
     // if user is providing document, we use the users one,
     // otherwise we use the document on the global namespace.
@@ -28,17 +31,20 @@ export function _getDocument(beans: UtilBeanCollection): Document {
     return document;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isNothingFocused(beans: UtilBeanCollection): boolean {
     const activeEl = _getActiveDomElement(beans);
 
     return activeEl === null || activeEl === _getDocument(beans).body;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getWindow(beans: UtilBeanCollection) {
     const eDocument = _getDocument(beans);
     return eDocument.defaultView || window;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getPageBody(beans: UtilBeanCollection): HTMLElement | ShadowRoot {
     let rootNode: Document | ShadowRoot | HTMLElement | null = null;
     let targetEl: HTMLElement | ShadowRoot | null = null;

--- a/packages/ag-grid-community/src/agStack/utils/dom.ts
+++ b/packages/ag-grid-community/src/agStack/utils/dom.ts
@@ -8,6 +8,7 @@ import { _getDocument, _getWindow } from './document';
  * @param {HTMLElement} element The element to receive the class
  * @param {string} elementClass The class to be assigned to the element
  * @param {boolean} otherElementClass The class to be assigned to siblings of the element, but not the element itself
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _radioCssClass(element: HTMLElement, elementClass: string | null, otherElementClass?: string | null) {
     const parent = element.parentElement;
@@ -27,6 +28,7 @@ export function _radioCssClass(element: HTMLElement, elementClass: string | null
 export const FOCUSABLE_SELECTOR = '[tabindex], input, select, button, textarea, [href]';
 export const FOCUSABLE_EXCLUDE = '[disabled], .ag-disabled:not(.ag-button), .ag-disabled *';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isFocusableFormField(element: Element | null): boolean {
     if (!element) {
         return false;
@@ -42,6 +44,7 @@ export function _isFocusableFormField(element: Element | null): boolean {
     return _isVisible(element);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setDisplayed(element: Element, displayed: boolean, options: { skipAriaHidden?: boolean } = {}) {
     const { skipAriaHidden } = options;
     element.classList.toggle('ag-hidden', !displayed);
@@ -50,6 +53,7 @@ export function _setDisplayed(element: Element, displayed: boolean, options: { s
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setVisible(element: HTMLElement, visible: boolean, options: { skipAriaHidden?: boolean } = {}) {
     const { skipAriaHidden } = options;
     element.classList.toggle('ag-invisible', !visible);
@@ -58,6 +62,7 @@ export function _setVisible(element: HTMLElement, visible: boolean, options: { s
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setDisabled(element: HTMLElement, disabled: boolean) {
     const attributeName = 'disabled';
     const addOrRemoveDisabledAttribute = disabled
@@ -157,6 +162,7 @@ export function _getElementSize(el: HTMLElement): {
     };
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getInnerHeight(el: HTMLElement): number {
     const size = _getElementSize(el);
 
@@ -167,6 +173,7 @@ export function _getInnerHeight(el: HTMLElement): number {
     return size.height;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getInnerWidth(el: HTMLElement): number {
     const size = _getElementSize(el);
 
@@ -177,12 +184,14 @@ export function _getInnerWidth(el: HTMLElement): number {
     return size.width;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getAbsoluteHeight(el: HTMLElement): number {
     const { height, marginBottom, marginTop } = _getElementSize(el);
 
     return Math.floor(height + marginBottom + marginTop);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getAbsoluteWidth(el: HTMLElement): number {
     const { width, marginLeft, marginRight } = _getElementSize(el);
 
@@ -216,6 +225,7 @@ export function _getScrollLeft(element: HTMLElement, rtl: boolean): number {
     return scrollLeft;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setScrollLeft(element: HTMLElement, value: number, rtl: boolean): void {
     if (rtl) {
         value *= -1;
@@ -223,12 +233,14 @@ export function _setScrollLeft(element: HTMLElement, value: number, rtl: boolean
     element.scrollLeft = value;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _clearElement(el: HTMLElement | null | undefined): void {
     while (el?.firstChild) {
         el.firstChild.remove();
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _removeFromParent(node: Element | null | undefined): void {
     if (node?.parentNode) {
         node.remove();
@@ -239,6 +251,7 @@ export function _isInDOM(element: Element): element is HTMLElement {
     return !!(element as HTMLElement).offsetParent;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isVisible(element: Element) {
     if (element.checkVisibility) {
         return element.checkVisibility({ checkVisibilityCSS: true });
@@ -252,6 +265,7 @@ export function _isVisible(element: Element) {
  * NOTE: Prefer _createElement
  * @param {string} template
  * @returns {HTMLElement}
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _loadTemplate(template: string | undefined | null): HTMLElement {
     const tempDiv = document.createElement('div');
@@ -333,6 +347,7 @@ export function _addStylesToElement(
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isElementOverflowingCallback(getElement: () => HTMLElement | undefined): () => boolean {
     return () => {
         const element = getElement();
@@ -363,6 +378,7 @@ export function _setElementWidth(element: HTMLElement, width: string | number) {
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setFixedWidth(element: HTMLElement, width: string | number) {
     width = _formatSize(width);
     element.style.width = width;
@@ -381,10 +397,12 @@ export function _formatSize(size: number | string) {
     return typeof size === 'number' ? `${size}px` : size;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isNodeOrElement(o: any): o is Node | Element {
     return o instanceof Node || o instanceof HTMLElement;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _addOrRemoveAttribute(element: HTMLElement, name: string, value: string | number | null | undefined) {
     if (value == null || value === '') {
         element.removeAttribute(name);
@@ -393,6 +411,7 @@ export function _addOrRemoveAttribute(element: HTMLElement, name: string, value:
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _placeCaretAtEnd(beans: UtilBeanCollection, contentElement: HTMLElement): void {
     if (!contentElement.isContentEditable) {
         return;
@@ -410,6 +429,7 @@ export function _placeCaretAtEnd(beans: UtilBeanCollection, contentElement: HTML
     selection.addRange(range);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _observeResize(
     beans: UtilBeanCollection,
     element: HTMLElement,
@@ -422,6 +442,7 @@ export function _observeResize(
     return () => resizeObserver?.disconnect();
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _requestAnimationFrame(beans: UtilBeanCollection, callback: any) {
     const win = _getWindow(beans);
 
@@ -455,6 +476,7 @@ type RoleType =
     | 'tabpanel'
     | 'treeitem';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type AgElementParams<SelectorType extends string> = {
     /** The tag name to use for the element, either browser tag or one of the AG Grid components such as ag-checkbox
      */
@@ -500,6 +522,7 @@ function getWhitespaceNode() {
     whitespaceNode ??= document.createTextNode(' ');
     return whitespaceNode.cloneNode();
 }
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _createAgElement<T extends HTMLElement = HTMLElement, TComponentSelector extends string = string>(
     params: AgElementParams<TComponentSelector>
 ): T {

--- a/packages/ag-grid-community/src/agStack/utils/event.ts
+++ b/packages/ag-grid-community/src/agStack/utils/event.ts
@@ -31,6 +31,7 @@ export const _isEventSupported = (() => {
     return eventChecker;
 })();
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isElementInEventPath(element: HTMLElement, event: Event): boolean {
     if (!event || !element) {
         return false;
@@ -143,6 +144,7 @@ export function _isEventFromThisInstance(beans: UtilBeanCollection, event: UIEve
     return beans.gos.isElementInThisInstance(event.target as HTMLElement);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _anchorElementToMouseMoveEvent(
     element: HTMLElement,
     mouseMoveEvent: MouseEvent | Touch,

--- a/packages/ag-grid-community/src/agStack/utils/focus.ts
+++ b/packages/ag-grid-community/src/agStack/utils/focus.ts
@@ -52,10 +52,12 @@ export function _registerKeyboardFocusEvents(beans: UtilBeanCollection): () => v
     };
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isKeyboardMode(): boolean {
     return keyboardModeActive;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _findFocusableElements(
     rootNode: HTMLElement,
     exclude?: string | null,
@@ -87,6 +89,7 @@ export function _findFocusableElements(
     return diff(nodes, excludeNodes);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _focusInto(
     rootNode: HTMLElement,
     up = false,
@@ -108,6 +111,7 @@ export function _focusInto(
     return false;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _findNextFocusableElement(
     beans: UtilBeanCollection,
     rootNode: HTMLElement,
@@ -133,6 +137,7 @@ export function _findNextFocusableElement(
     return focusable[nextIndex];
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _findTabbableParent(node: HTMLElement | null, limit: number = 5): HTMLElement | null {
     let counter = 0;
 

--- a/packages/ag-grid-community/src/agStack/utils/function.ts
+++ b/packages/ag-grid-community/src/agStack/utils/function.ts
@@ -31,11 +31,11 @@ const batchedCallsRaf: BatchedCalls = {
     funcs: [],
 };
 
-/*
+/**
  * Batch calls to execute after the next macro task (mode = setTimeout) / or in the next requestAnimationFrame.
  * @param {Function} func The function to be batched
+ *  @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
-/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _batchCall(func: () => void): void;
 export function _batchCall(func: () => void, mode: 'raf', beans: UtilBeanCollection): void;
 export function _batchCall(

--- a/packages/ag-grid-community/src/agStack/utils/function.ts
+++ b/packages/ag-grid-community/src/agStack/utils/function.ts
@@ -3,7 +3,10 @@ import { _requestAnimationFrame } from './dom';
 
 const doOnceSet = new Set<string>();
 
-/** If the key was passed before, then doesn't execute the func */
+/**
+ * If the key was passed before, then doesn't execute the func
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export const _doOnce = (func: () => void, key: string) => {
     if (!doOnceSet.has(key)) {
         doOnceSet.add(key);
@@ -32,6 +35,7 @@ const batchedCallsRaf: BatchedCalls = {
  * Batch calls to execute after the next macro task (mode = setTimeout) / or in the next requestAnimationFrame.
  * @param {Function} func The function to be batched
  */
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _batchCall(func: () => void): void;
 export function _batchCall(func: () => void, mode: 'raf', beans: UtilBeanCollection): void;
 export function _batchCall(
@@ -69,6 +73,7 @@ export function _batchCall(
  * @param {Function} func The function to be debounced
  * @param {number} delay The time in ms to debounce
  * @returns {Function} The debounced function
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _debounce<TArgs extends any[], TContext>(
     bean: { isAlive(): boolean },
@@ -118,6 +123,7 @@ export function _throttle(func: (...args: any[]) => void, wait: number): (...arg
     };
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _waitUntil(
     bean: { addDestroyFunc(func: () => void): void },
     condition: () => boolean,

--- a/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
+++ b/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
@@ -1,5 +1,6 @@
 /**
  * This function provides fuzzy matching suggestions based on the input value and a list of all suggestions.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _fuzzySuggestions(params: {
     inputValue: string;

--- a/packages/ag-grid-community/src/agStack/utils/generic.ts
+++ b/packages/ag-grid-community/src/agStack/utils/generic.ts
@@ -2,6 +2,7 @@
  * If value is undefined, null or blank, returns null, otherwise returns the value
  * @param {T} value
  * @returns {T | null}
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const _makeNull = <T>(value?: T): T | null => {
     if (value == null || value === '') {
@@ -10,21 +11,25 @@ export const _makeNull = <T>(value?: T): T | null => {
     return value;
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _exists(value: string | null | undefined): value is string;
 export function _exists<T>(value: T): value is NonNullable<T>;
 export function _exists(value: any): boolean {
     return value != null && value !== '';
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _missing<T>(value: T | null | undefined): value is Exclude<undefined | null, T>;
 export function _missing(value: any): boolean {
     return !_exists(value);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const _toStringOrNull = (value: any): string | null => {
     return value != null && typeof value.toString === 'function' ? value.toString() : null;
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const _jsonEquals = <T1, T2>(val1: T1, val2: T2): boolean => {
     const val1Json = val1 ? JSON.stringify(val1) : null;
     const val2Json = val2 ? JSON.stringify(val2) : null;
@@ -32,6 +37,7 @@ export const _jsonEquals = <T1, T2>(val1: T1, val2: T2): boolean => {
     return val1Json === val2Json;
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const _defaultComparator = (valueA: any, valueB: any, accentedCompare: boolean = false): number => {
     if (valueA == null) {
         return valueB == null ? 0 : -1;

--- a/packages/ag-grid-community/src/agStack/utils/keyboard.ts
+++ b/packages/ag-grid-community/src/agStack/utils/keyboard.ts
@@ -1,3 +1,4 @@
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isEventFromPrintableCharacter(event: KeyboardEvent): boolean {
     // no allowed printable chars have alt or ctrl key combinations
     if (event.altKey || event.ctrlKey || event.metaKey) {

--- a/packages/ag-grid-community/src/agStack/utils/locale.ts
+++ b/packages/ag-grid-community/src/agStack/utils/locale.ts
@@ -4,12 +4,14 @@ function defaultLocaleTextFunc(_key: string, defaultValue: string): string {
     return defaultValue;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getLocaleTextFunc<TKey extends string = string>(
     localeSvc?: ILocaleService<TKey>
 ): LocaleTextFunc<TKey> {
     return localeSvc?.getLocaleTextFunc() ?? defaultLocaleTextFunc;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _translate<T extends Record<string, string | ((variableValues: string[]) => string)>>(
     bean: { getLocaleTextFunc(): LocaleTextFunc },
     localeValues: T,
@@ -24,6 +26,7 @@ export function _translate<T extends Record<string, string | ((variableValues: s
     );
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getLocaleTextFromFunc(
     getLocaleText: (params: { key: string; defaultValue: string; variableValues?: string[] }) => string
 ): LocaleTextFunc {
@@ -36,6 +39,7 @@ export function _getLocaleTextFromFunc(
     };
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getLocaleTextFromMap(localeText?: { [key: string]: string }): LocaleTextFunc {
     return (key: string, defaultValue: string, variableValues?: string[]) => {
         let localisedText = localeText?.[key];

--- a/packages/ag-grid-community/src/agStack/utils/promise.ts
+++ b/packages/ag-grid-community/src/agStack/utils/promise.ts
@@ -1,3 +1,4 @@
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isPromise<T>(fn: any): fn is Promise<T> {
     return typeof fn.then === 'function';
 }

--- a/packages/ag-grid-community/src/agStack/utils/string.ts
+++ b/packages/ag-grid-community/src/agStack/utils/string.ts
@@ -14,17 +14,20 @@ const HTML_ESCAPES: { [id: string]: string } = {
 /**
  * Calls toString() twice, in case value is an object, where user provides a toString() method.
  * The first call to toString() returns back something other than a string (eg a number to render)
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 
 export function _toString(toEscape?: string | null): string | null {
     return toEscape?.toString().toString() ?? null;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _escapeString(toEscape?: string | null): string | null {
     // in react we don't need to escape html characters, as it's done by the framework
     return _toString(toEscape)?.replace(reUnescapedHtml, (chr) => HTML_ESCAPES[chr]) ?? null;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isExpressionString(value: unknown): value is `=${string}` {
     return typeof value === 'string' && value.startsWith('=') && value.length > 1;
 }
@@ -33,6 +36,7 @@ export function _isExpressionString(value: unknown): value is `=${string}` {
  * Converts a camelCase string into startCase
  * @param {string} camelCase
  * @returns {string}
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _camelCaseToHumanText(camelCase: string | undefined): string | null {
     if (!camelCase || camelCase == null) {

--- a/packages/ag-grid-community/src/agStack/widgets/agAbstractInputField.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agAbstractInputField.ts
@@ -30,6 +30,7 @@ function buildTemplate<TComponentSelectorType extends string>(
 }
 
 export type AgAbstractInputFieldEvent = AgAbstractFieldEvent;
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export abstract class AgAbstractInputField<
     TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
     TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/widgets/agAbstractLabel.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agAbstractLabel.ts
@@ -11,6 +11,7 @@ import { agAbstractLabelCSS } from './agAbstractLabel.css-GENERATED';
 import type { AgLabelParams, LabelAlignment } from './agFieldParams';
 
 type AgAbstractLabelEvent = AgComponentEvent;
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export abstract class AgAbstractLabel<
     TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
     TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/widgets/agCheckbox.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agCheckbox.ts
@@ -7,6 +7,7 @@ import { AgAbstractInputField } from './agAbstractInputField';
 import type { AgCheckboxParams, LabelAlignment } from './agFieldParams';
 import type { AgWidgetSelectorType } from './agWidgetSelectorType';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgCheckbox<
     TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
     TProperties extends BaseProperties,
@@ -165,6 +166,7 @@ export class AgCheckbox<
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const AgCheckboxSelector: AgComponentSelector<AgWidgetSelectorType> = {
     selector: 'AG-CHECKBOX',
     component: AgCheckbox,

--- a/packages/ag-grid-community/src/agStack/widgets/agContentEditableField.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agContentEditableField.ts
@@ -38,6 +38,7 @@ const AgContentEditableFieldElement: AgElementParams<any> = {
     ],
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgContentEditableField<
     TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
     TProperties extends BaseProperties,
@@ -138,6 +139,7 @@ export class AgContentEditableField<
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const AgContentEditableFieldSelector: AgComponentSelector<AgWidgetSelectorType> = {
     selector: 'AG-CONTENT-EDITABLE-FIELD',
     component: AgContentEditableField,

--- a/packages/ag-grid-community/src/agStack/widgets/agFieldParams.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agFieldParams.ts
@@ -1,7 +1,9 @@
 import type { AgElementParams } from '../utils/dom';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type LabelAlignment = 'left' | 'right' | 'top';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgLabelParams {
     label?: HTMLElement | string;
     labelWidth?: number | 'flex';
@@ -11,6 +13,7 @@ export interface AgLabelParams {
     labelEllipsis?: boolean;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgFieldParams extends AgLabelParams {
     value?: any;
     width?: number;
@@ -18,6 +21,7 @@ export interface AgFieldParams extends AgLabelParams {
     ariaLabel?: string | null;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgInputFieldParams<TComponentSelectorType extends string> extends AgFieldParams {
     inputName?: string;
     inputWidth?: number | 'flex';
@@ -27,6 +31,7 @@ export interface AgInputFieldParams<TComponentSelectorType extends string> exten
     tabIndex?: number;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgCheckboxParams<TComponentSelectorType extends string>
     extends AgInputFieldParams<TComponentSelectorType> {
     readOnly?: boolean;

--- a/packages/ag-grid-community/src/agStack/widgets/agInputDateField.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agInputDateField.ts
@@ -11,6 +11,7 @@ import type { AgInputTextFieldParams } from './agInputTextField';
 import { AgInputTextField } from './agInputTextField';
 import type { AgWidgetSelectorType } from './agWidgetSelectorType';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgInputDateField<
     TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
     TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/widgets/agInputNumberField.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agInputNumberField.ts
@@ -10,6 +10,7 @@ import type { AgInputTextFieldParams } from './agInputTextField';
 import { AgInputTextField } from './agInputTextField';
 import type { AgWidgetSelectorType } from './agWidgetSelectorType';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgInputNumberFieldParams<TComponentSelectorType extends string>
     extends AgInputTextFieldParams<TComponentSelectorType> {
     precision?: number;
@@ -18,6 +19,7 @@ export interface AgInputNumberFieldParams<TComponentSelectorType extends string>
     max?: number;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgInputNumberField<
     TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
     TProperties extends BaseProperties,
@@ -219,6 +221,7 @@ export class AgInputNumberField<
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const AgInputNumberFieldSelector: AgComponentSelector<AgWidgetSelectorType> = {
     selector: 'AG-INPUT-NUMBER-FIELD',
     component: AgInputNumberField,

--- a/packages/ag-grid-community/src/agStack/widgets/agInputTextArea.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agInputTextArea.ts
@@ -7,6 +7,7 @@ import { AgAbstractInputField } from './agAbstractInputField';
 import type { AgInputFieldParams } from './agFieldParams';
 import type { AgWidgetSelectorType } from './agWidgetSelectorType';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgInputTextArea<
     TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
     TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/widgets/agInputTextField.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agInputTextField.ts
@@ -11,11 +11,13 @@ import { AgAbstractInputField } from './agAbstractInputField';
 import type { AgInputFieldParams } from './agFieldParams';
 import type { AgWidgetSelectorType } from './agWidgetSelectorType';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgInputTextFieldParams<TComponentSelectorType extends string>
     extends AgInputFieldParams<TComponentSelectorType> {
     allowedCharPattern?: string;
 }
 export type AgInputTextFieldEvent = AgAbstractInputFieldEvent;
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgInputTextField<
     TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
     TProperties extends BaseProperties,
@@ -103,6 +105,7 @@ export class AgInputTextField<
         });
     }
 }
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const AgInputTextFieldSelector: AgComponentSelector<AgWidgetSelectorType> = {
     selector: 'AG-INPUT-TEXT-FIELD',
     component: AgInputTextField,

--- a/packages/ag-grid-community/src/agStack/widgets/agList.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agList.ts
@@ -10,6 +10,7 @@ import { _clearElement, _isVisible } from '../utils/dom';
 import { agListCSS } from './agList.css-GENERATED';
 import { AgListItem } from './agListItem';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface ListOption<TValue = string> {
     value: TValue;
     text?: string;

--- a/packages/ag-grid-community/src/agStack/widgets/agPickerField.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agPickerField.ts
@@ -35,6 +35,7 @@ const AgPickerFieldElement: AgElementParams<any> = {
     ],
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export abstract class AgPickerField<
     TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
     TProperties extends BaseProperties,

--- a/packages/ag-grid-community/src/agStack/widgets/agPickerFieldParams.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agPickerFieldParams.ts
@@ -2,6 +2,7 @@ import type { AgComponentSelector } from '../interfaces/agComponent';
 import type { AgElementParams } from '../utils/dom';
 import type { AgFieldParams } from './agFieldParams';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgPickerFieldParams<TComponentSelectorType extends string> extends AgFieldParams {
     pickerType: string;
     pickerGap?: number;

--- a/packages/ag-grid-community/src/agStack/widgets/agRadioButton.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agRadioButton.ts
@@ -7,9 +7,11 @@ import { AgCheckbox } from './agCheckbox';
 import type { AgCheckboxParams } from './agFieldParams';
 import type { AgWidgetSelectorType } from './agWidgetSelectorType';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgRadioButtonParams<TComponentSelectorType extends string>
     extends AgCheckboxParams<TComponentSelectorType> {}
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgRadioButton<
     TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
     TProperties extends BaseProperties,
@@ -72,6 +74,7 @@ export class AgRadioButton<
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const AgRadioButtonSelector: AgComponentSelector<AgWidgetSelectorType> = {
     selector: 'AG-RADIO-BUTTON',
     component: AgRadioButton,

--- a/packages/ag-grid-community/src/agStack/widgets/agSelect.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agSelect.ts
@@ -15,6 +15,7 @@ import type { AgPickerFieldParams } from './agPickerFieldParams';
 import { agSelectCSS } from './agSelect.css-GENERATED';
 import type { AgWidgetSelectorType } from './agWidgetSelectorType';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgSelectParams<TComponentSelectorType extends string, TValue = string>
     extends Omit<
         AgPickerFieldParams<TComponentSelectorType>,
@@ -27,6 +28,7 @@ export interface AgSelectParams<TComponentSelectorType extends string, TValue = 
     placeholder?: string;
 }
 type AgSelectEvent = 'selectedItem';
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgSelect<
     TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
     TProperties extends BaseProperties,
@@ -285,6 +287,7 @@ export class AgSelect<
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const AgSelectSelector: AgComponentSelector<AgWidgetSelectorType> = {
     selector: 'AG-SELECT',
     component: AgSelect,

--- a/packages/ag-grid-community/src/agStack/widgets/agToggleButton.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agToggleButton.ts
@@ -8,9 +8,11 @@ import type { AgCheckboxParams } from './agFieldParams';
 import { agToggleButtonCSS } from './agToggleButton.css-GENERATED';
 import type { AgWidgetSelectorType } from './agWidgetSelectorType';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface AgToggleButtonParams<TComponentSelectorType extends string>
     extends AgCheckboxParams<TComponentSelectorType> {}
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgToggleButton<
     TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
     TProperties extends BaseProperties,
@@ -40,6 +42,7 @@ export class AgToggleButton<
         return this;
     }
 }
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const AgToggleButtonSelector: AgComponentSelector<AgWidgetSelectorType> = {
     selector: 'AG-TOGGLE-BUTTON',
     component: AgToggleButton,

--- a/packages/ag-grid-community/src/agStack/widgets/agWidgetSelectorType.ts
+++ b/packages/ag-grid-community/src/agStack/widgets/agWidgetSelectorType.ts
@@ -1,3 +1,4 @@
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type AgWidgetSelectorType =
     | 'AG-CHECKBOX'
     | 'AG-COLOR-INPUT'

--- a/packages/ag-grid-community/src/api/gridApi.ts
+++ b/packages/ag-grid-community/src/api/gridApi.ts
@@ -433,6 +433,7 @@ export interface _SortGridApi {
     onSortChanged(): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _ClientSideRowModelGridApi<TData> extends _RowModelSharedApi {
     /**
      * Informs the grid that row group expanded state has changed and it needs to rerender the group nodes.
@@ -881,6 +882,7 @@ export interface _EditGridApi<TData> {
     validateEdit(): ICellEditorValidationError[] | null;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _BatchEditApi {
     /**
      * Starts a batch editing session. While batch editing is active, cell edits are accumulated
@@ -1083,6 +1085,7 @@ export interface _QuickFilterGridApi {
     resetQuickFilter(): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _FindApi<TData> {
     /**
      * Go to the next match.
@@ -1222,6 +1225,7 @@ export interface _PaginationGridApi {
     paginationGoToPage(page: number): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _PinnedRowGridApi {
     /**
      * Gets the number of top pinned rows.
@@ -1314,6 +1318,7 @@ export interface _HighlightChangesGridApi<TData> {
     flashCells(params?: FlashCellsParams<TData>): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _SideBarGridApi<TData> {
     /**
      * Returns `true` if the side bar is visible.
@@ -1381,6 +1386,7 @@ export interface _SideBarGridApi<TData> {
     getSideBar(): SideBarDef | undefined;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _StatusBarGridApi<TData = any> {
     /**
      * Gets the status panel instance corresponding to the supplied `id`.
@@ -1388,6 +1394,7 @@ export interface _StatusBarGridApi<TData = any> {
     getStatusPanel<TStatusPanel = IStatusPanel<TData>>(key: string): TStatusPanel | undefined;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _InfiniteRowModelGridApi {
     /**
      * Marks all the currently loaded blocks in the cache for reload.
@@ -1412,6 +1419,7 @@ export interface _InfiniteRowModelGridApi {
     getInfiniteRowCount(): number | undefined;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _CsvExportGridApi {
     /**
      * Similar to `exportDataAsCsv`, except returns the result as a string rather than download it.
@@ -1426,6 +1434,7 @@ export interface _CsvExportGridApi {
     exportDataAsCsv(params?: CsvExportParams): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _RowGroupingGridApi {
     /**
      * Set the row group columns.
@@ -1458,6 +1467,7 @@ export interface _RowGroupingGridApi {
     getRowGroupColumns(): Column[];
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _AggregationGridApi<TData> {
     /**
      * Add aggregations function with the specified keys.
@@ -1481,6 +1491,7 @@ export interface _AggregationGridApi<TData> {
     ): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _PivotGridApi<TData> {
     /**
      * Returns whether pivot mode is currently active.
@@ -1555,6 +1566,7 @@ export interface _PivotGridApi<TData> {
     getPivotResultColumns(): Column[] | null;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _CellSelectionGridApi {
     /**
      * Returns the list of selected cell ranges.
@@ -1586,6 +1598,7 @@ export interface _CellSelectionGridApi {
     clearCellSelection(): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _ServerSideRowModelGridApi<TData> extends _RowModelSharedApi {
     /**
      * Returns an object containing rules matching the selected rows in the SSRM.
@@ -1658,6 +1671,7 @@ export interface _ServerSideRowModelGridApi<TData> extends _RowModelSharedApi {
     getServerSideGroupLevelState(): ServerSideGroupLevelState[];
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _ContextMenuGridApi {
     /**
      * Displays the AG Grid context menu
@@ -1666,6 +1680,7 @@ export interface _ContextMenuGridApi {
     showContextMenu(params?: IContextMenuParams): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _ColumnChooserGridApi {
     /**
      * Show the column chooser.
@@ -1680,6 +1695,7 @@ export interface _ColumnChooserGridApi {
     hideColumnChooser(): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _MasterDetailGridApi {
     /**
      * Register a detail grid with the master grid when it is created.
@@ -1706,6 +1722,7 @@ export interface _MasterDetailGridApi {
     forEachDetailGridInfo(callback: (gridInfo: DetailGridInfo, index: number) => void): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _ExcelExportGridApi {
     /**
      * Similar to `exportDataAsExcel`, except instead of downloading a file, it will return a [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob) to be processed by the user.
@@ -1738,6 +1755,7 @@ export interface _ExcelExportGridApi {
     exportMultipleSheetsAsExcel(params: ExcelExportMultipleSheetParams): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _ClipboardGridApi {
     /**
      * Copies data to clipboard by following the same rules as pressing Ctrl+C.
@@ -1776,6 +1794,7 @@ export interface _ClipboardGridApi {
     pasteFromClipboard(): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _GridChartsGridApi {
     /**
      * Returns a list of models with information about the charts that are currently rendered from the grid.
@@ -1844,6 +1863,7 @@ export interface _GridChartsGridApi {
     restoreChart(chartModel: ChartModel, chartContainer?: HTMLElement): ChartRef | undefined;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _AdvancedFilterGridApi {
     /**
      * Get the state of the Advanced Filter. Used for saving Advanced Filter state
@@ -1873,6 +1893,7 @@ export interface _AdvancedFilterGridApi {
     hideAdvancedFilterBuilder(): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _AiToolkitGridApi {
     /**
      * Returns the structured schema of the grid, which includes information about columns, data types, and relationships.

--- a/packages/ag-grid-community/src/api/rowModelApiUtils.ts
+++ b/packages/ag-grid-community/src/api/rowModelApiUtils.ts
@@ -4,6 +4,7 @@ import type { IClientSideRowModel } from '../interfaces/iClientSideRowModel';
 import type { IServerSideRowModel } from '../interfaces/iServerSideRowModel';
 import type { iViewportRowModel } from '../interfaces/iViewportRowModel';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getClientSideRowModel(beans: BeanCollection): IClientSideRowModel | undefined {
     const rowModel = beans.rowModel;
     return rowModel.getType() === 'clientSide' ? (rowModel as IClientSideRowModel) : undefined;
@@ -14,11 +15,13 @@ export function _getInfiniteRowModel(beans: BeanCollection): InfiniteRowModel | 
     return rowModel.getType() === 'infinite' ? (rowModel as InfiniteRowModel) : undefined;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getServerSideRowModel(beans: BeanCollection): IServerSideRowModel | undefined {
     const rowModel = beans.rowModel;
     return rowModel.getType() === 'serverSide' ? (rowModel as IServerSideRowModel) : undefined;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getViewportRowModel(beans: BeanCollection): iViewportRowModel | undefined {
     const rowModel = beans.rowModel;
     return rowModel.getType() === 'viewport' ? (rowModel as iViewportRowModel) : undefined;

--- a/packages/ag-grid-community/src/api/rowModelSharedApi.ts
+++ b/packages/ag-grid-community/src/api/rowModelSharedApi.ts
@@ -9,10 +9,12 @@ export function collapseAll(beans: BeanCollection) {
     beans.expansionSvc?.expandAll(false);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function onRowHeightChanged(beans: BeanCollection) {
     beans.rowModel?.onRowHeightChanged();
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function resetRowHeights(beans: BeanCollection) {
     if (beans.rowAutoHeight?.active) {
         _warn(3);

--- a/packages/ag-grid-community/src/api/sharedApiModule.ts
+++ b/packages/ag-grid-community/src/api/sharedApiModule.ts
@@ -7,7 +7,7 @@ import { getCacheBlockState, isLastRowIndexKnown, setRowCount } from './ssrmInfi
 // these modules are not used in core, but are shared between multiple other modules
 
 /**
- * @internal
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const CsrmSsrmSharedApiModule: _ModuleWithApi<_CsrmSsrmSharedGridApi> = {
     moduleName: 'CsrmSsrmSharedApi',
@@ -16,7 +16,7 @@ export const CsrmSsrmSharedApiModule: _ModuleWithApi<_CsrmSsrmSharedGridApi> = {
 };
 
 /**
- * @internal
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const RowModelSharedApiModule: _ModuleWithApi<_RowModelSharedApi> = {
     moduleName: 'RowModelSharedApi',
@@ -25,7 +25,7 @@ export const RowModelSharedApiModule: _ModuleWithApi<_RowModelSharedApi> = {
 };
 
 /**
- * @internal
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const SsrmInfiniteSharedApiModule: _ModuleWithApi<_SsrmInfiniteSharedGridApi> = {
     moduleName: 'SsrmInfiniteSharedApi',

--- a/packages/ag-grid-community/src/clientSideRowModel/changedRowNodes.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/changedRowNodes.ts
@@ -1,5 +1,6 @@
 import type { RowNode } from '../entities/rowNode';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class ChangedRowNodes<TData = any> {
     public reordered = false;
     public readonly removals: RowNode<TData>[] = [];

--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModelUtils.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModelUtils.ts
@@ -1,6 +1,7 @@
 import type { RowNode } from '../entities/rowNode';
 import type { IRowNode } from '../interfaces/iRowNode';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const _csrmFirstLeaf = (node: IRowNode): RowNode | undefined => {
     let childrenAfterGroup = node.childrenAfterGroup;
     while (childrenAfterGroup?.length) {
@@ -12,13 +13,15 @@ export const _csrmFirstLeaf = (node: IRowNode): RowNode | undefined => {
     }
 };
 
-/** Reorders the children of the root node, so that the rows to move are in the correct order.
+/**
+ * Reorders the children of the root node, so that the rows to move are in the correct order.
  * @param allLeafs The list of all leaf rows of the root node
  * @param leafsToMove The valid set of rows to move, as returned by getValidRowsToMove
  * @param firstAffectedLeafIdx The first index of the rows to move
  * @param targetPositionIdx The target index, where the rows will be moved
  * @param lastAffectedLeafIndex The last index of the rows to move
  * @returns True if the order of the rows changed, false otherwise
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const _csrmReorderAllLeafs = (
     allLeafs: RowNode[] | null | undefined,

--- a/packages/ag-grid-community/src/columnMove/columnMoveModule.ts
+++ b/packages/ag-grid-community/src/columnMove/columnMoveModule.ts
@@ -9,6 +9,7 @@ import { ColumnMoveService } from './columnMoveService';
 
 /**
  * @feature Columns -> Column Moving
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const ColumnMoveModule: _ModuleWithApi<_ColumnMoveApi> = {
     moduleName: 'ColumnMove',

--- a/packages/ag-grid-community/src/columns/baseColsService.ts
+++ b/packages/ag-grid-community/src/columns/baseColsService.ts
@@ -20,6 +20,7 @@ import type { ColumnModel, Maybe } from './columnModel';
 import type { ColumnState, ColumnStateParams } from './columnStateUtils';
 import type { VisibleColsService } from './visibleColsService';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export abstract class BaseColsService extends BeanStub implements IColsService {
     protected colModel: ColumnModel;
     protected aggFuncSvc?: IAggFuncService;

--- a/packages/ag-grid-community/src/columns/columnFactoryUtils.ts
+++ b/packages/ag-grid-community/src/columns/columnFactoryUtils.ts
@@ -24,6 +24,7 @@ const depthFirstCallback = (child: AgColumn | AgProvidedColumnGroup, parent: AgP
 /**
  * A performant approach to _createColumnTree where the function assumes all defs have an ID.
  * Used for Pivoting.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _createColumnTreeWithIds(
     beans: BeanCollection,
@@ -92,6 +93,7 @@ export function _createColumnTreeWithIds(
     };
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _createColumnTree(
     beans: BeanCollection,
     defs: (ColDef | ColGroupDef)[] | null | undefined = null,
@@ -267,6 +269,7 @@ export function updateSomeColumnState(
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _updateColumnState(
     beans: BeanCollection,
     column: AgColumn,
@@ -339,6 +342,7 @@ function findExistingColumn(
     return undefined;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _addColumnDefaultAndTypes(
     beans: BeanCollection,
     colDef: ColDef,

--- a/packages/ag-grid-community/src/columns/columnGroups/columnGroupModule.ts
+++ b/packages/ag-grid-community/src/columns/columnGroups/columnGroupModule.ts
@@ -20,6 +20,7 @@ import { ColumnGroupService } from './columnGroupService';
 /**
  * @feature Columns -> Column Groups
  * @colGroupDef
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const ColumnGroupModule: _ModuleWithApi<_ColumnGroupGridApi> = {
     moduleName: 'ColumnGroup',

--- a/packages/ag-grid-community/src/columns/columnKeyCreator.ts
+++ b/packages/ag-grid-community/src/columns/columnKeyCreator.ts
@@ -9,6 +9,7 @@ export type IColumnKeyCreator = {
     getUniqueKey(colId?: string | null, colField?: string | null): string;
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class ColumnKeyCreator implements IColumnKeyCreator {
     private existingKeys: { [key: string]: boolean } = {};
 

--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -26,6 +26,7 @@ import {
 
 export type Maybe<T> = T | null | undefined;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface ColumnCollections {
     // columns in a tree, leaf levels are columns, everything above is group column
     tree: (AgColumn | AgProvidedColumnGroup)[];
@@ -36,6 +37,7 @@ export interface ColumnCollections {
     map: { [id: string]: AgColumn };
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class ColumnModel extends BeanStub implements NamedBean {
     beanName = 'colModel' as const;
 

--- a/packages/ag-grid-community/src/columns/columnNameService.ts
+++ b/packages/ag-grid-community/src/columns/columnNameService.ts
@@ -7,6 +7,7 @@ import type { AgProvidedColumnGroup } from '../entities/agProvidedColumnGroup';
 import type { AbstractColDef, ColDef, HeaderLocation, HeaderValueGetterParams } from '../entities/colDef';
 import { _addGridCommonParams } from '../gridOptionsUtils';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class ColumnNameService extends BeanStub implements NamedBean {
     beanName = 'colNames' as const;
 

--- a/packages/ag-grid-community/src/columns/columnStateUtils.ts
+++ b/packages/ag-grid-community/src/columns/columnStateUtils.ts
@@ -70,6 +70,7 @@ export interface ApplyColumnStateParams {
     defaultState?: ColumnStateParams;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _applyColumnState(
     beans: BeanCollection,
     params: ApplyColumnStateParams,
@@ -282,6 +283,7 @@ export function _applyColumnState(
     return unmatchedCount === 0; // Successful if no states unaccounted for
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _resetColumnState(beans: BeanCollection, source: ColumnEventType): void {
     const { colModel, autoColSvc, selectionColSvc, eventSvc, gos } = beans;
 
@@ -461,6 +463,7 @@ export function _compareColumnStatesAndDispatchEvents(beans: BeanCollection, sou
     };
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getColumnState(beans: BeanCollection): ColumnState[] {
     const { colModel, rowGroupColsSvc, pivotColsSvc } = beans;
     const primaryCols = colModel.getColDefCols();

--- a/packages/ag-grid-community/src/columns/columnUtils.ts
+++ b/packages/ag-grid-community/src/columns/columnUtils.ts
@@ -19,6 +19,7 @@ export const ROW_NUMBERS_COLUMN_ID = 'ag-Grid-RowNumbersColumn';
 export const GROUP_HIERARCHY_COLUMN_ID_PREFIX = 'ag-Grid-HierarchyColumn';
 
 // Possible candidate for reuse (alot of recursive traversal duplication)
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getColumnsFromTree(rootColumns: (AgColumn | AgProvidedColumnGroup)[]): AgColumn[] {
     const result: AgColumn[] = [];
 
@@ -42,6 +43,7 @@ export function getWidthOfColsInList(columnList: AgColumn[]) {
     return columnList.reduce((width, col) => width + col.getActualWidth(), 0);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _destroyColumnTree(
     beans: BeanCollection,
     oldTree: (AgColumn | AgProvidedColumnGroup)[] | null | undefined,
@@ -70,21 +72,25 @@ export function _destroyColumnTree(
     beans.context.destroyBeans(colsToDestroy);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function isColumnGroupAutoCol(col: AgColumn): boolean {
     const colId = col.getId();
     return colId.startsWith(GROUP_AUTO_COLUMN_ID);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function isColumnSelectionCol(col: ColKey): boolean {
     const id = typeof col === 'string' ? col : 'getColId' in col ? col.getColId() : col.colId;
     return id?.startsWith(SELECTION_COLUMN_ID) ?? false;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function isRowNumberCol(col: ColKey): boolean {
     const id = typeof col === 'string' ? col : 'getColId' in col ? col.getColId() : col.colId;
     return id?.startsWith(ROW_NUMBERS_COLUMN_ID) ?? false;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function isSpecialCol(col: ColKey): boolean {
     return isColumnSelectionCol(col) || isRowNumberCol(col);
 }
@@ -100,10 +106,12 @@ export function convertColumnTypes(type: string | string[]): string[] {
     return typeKeys;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _areColIdsEqual(colsA: AgColumn[] | null, colsB: AgColumn[] | null): boolean {
     return _areEqual(colsA, colsB, (a, b) => a.getColId() === b.getColId());
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _updateColsMap(cols: ColumnCollections): void {
     cols.map = {};
     for (const col of cols.list) {
@@ -111,11 +119,13 @@ export function _updateColsMap(cols: ColumnCollections): void {
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _convertColumnEventSourceType(source: AgPropertyChangedSource): ColumnEventType {
     // unfortunately they do not match so need to perform conversion
     return source === 'optionsUpdated' ? 'gridOptionsChanged' : source;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _columnsMatch(column: AgColumn, key: ColKey): boolean {
     return column === key || column.colId == key || column.getColDef() === key;
 }
@@ -155,6 +165,7 @@ export const getValueFactory =
         return obj;
     };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getColumnStateFromColDef(colDef: ColDef, colId: string): ColumnState {
     const state: ColumnState = {
         ...colDef,
@@ -170,6 +181,7 @@ export function _getColumnStateFromColDef(colDef: ColDef, colId: string): Column
     return state;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getSortDefFromColDef(colDef: ColDef) {
     const { sort, initialSort } = colDef;
     const sortIsValid = _isSortDefValid(sort) || _isSortDirectionValid(sort);

--- a/packages/ag-grid-community/src/columns/dataTypeService.ts
+++ b/packages/ag-grid-community/src/columns/dataTypeService.ts
@@ -56,6 +56,7 @@ const SORTED_CELL_DATA_TYPES_FOR_MATCHING: readonly Exclude<BaseCellDataType, 'd
     'date',
 ] as const;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class DataTypeService extends BeanStub implements NamedBean {
     beanName = 'dataTypeSvc' as const;
 

--- a/packages/ag-grid-community/src/columns/groupInstanceIdCreator.ts
+++ b/packages/ag-grid-community/src/columns/groupInstanceIdCreator.ts
@@ -8,6 +8,7 @@
 // getInstanceIdForKey('age') => 0
 // getInstanceIdForKey('age') => 1
 // getInstanceIdForKey('country') => 4
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class GroupInstanceIdCreator {
     // this map contains keys to numbers, so we remember what the last call was
     private existingIds: any = {};

--- a/packages/ag-grid-community/src/columns/visibleColsService.ts
+++ b/packages/ag-grid-community/src/columns/visibleColsService.ts
@@ -26,6 +26,7 @@ function _removeAllFromUnorderedArray<T>(array: T[], toRemove: T[]) {
 }
 
 // takes in a list of columns, as specified by the column definitions, and returns column groups
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class VisibleColsService extends BeanStub implements NamedBean {
     beanName = 'visibleCols' as const;
 

--- a/packages/ag-grid-community/src/components/emptyBean.ts
+++ b/packages/ag-grid-community/src/components/emptyBean.ts
@@ -6,6 +6,7 @@ import type { Context } from '../context/context';
  * Used in React to avoid duplicating listeners and setup logic while React is running in StrictMode where setComp will be called multiple times.
  * This is only required for the Components where the ctrl is managed by AG Grid and passed into the React component.
  * Both React and the Ctrl can decide to destroy the EmptyBean which will clean up listeners setup against it.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export class EmptyBean extends BeanStub {}
 

--- a/packages/ag-grid-community/src/components/framework/frameworkComponentWrapper.ts
+++ b/packages/ag-grid-community/src/components/framework/frameworkComponentWrapper.ts
@@ -5,6 +5,7 @@ import { _warn } from '../../validation/logging';
 /**
  * B the business interface (ie IHeader)
  * A the agGridComponent interface (ie IHeaderComp). The final object acceptable by ag-grid
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export interface FrameworkComponentWrapper {
     wrap<A extends IComponent<any>>(
@@ -15,6 +16,7 @@ export interface FrameworkComponentWrapper {
     ): A;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface WrappableInterface {
     hasMethod(name: string): boolean;
 
@@ -23,6 +25,7 @@ export interface WrappableInterface {
     addMethod(name: string, callback: (...args: any[]) => any): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export abstract class BaseComponentWrapper<F extends WrappableInterface> implements FrameworkComponentWrapper {
     public wrap<A extends IComponent<any>>(
         OriginalConstructor: new () => any,

--- a/packages/ag-grid-community/src/components/framework/registry.ts
+++ b/packages/ag-grid-community/src/components/framework/registry.ts
@@ -13,6 +13,7 @@ import type { IconName } from '../../utils/icon';
 import { _errMsg } from '../../validation/logging';
 import type { AgComponentSelectorType, ComponentSelector } from '../../widgets/component';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class Registry
     extends BaseRegistry<
         BeanCollection,

--- a/packages/ag-grid-community/src/components/framework/unwrapUserComp.ts
+++ b/packages/ag-grid-community/src/components/framework/unwrapUserComp.ts
@@ -1,3 +1,4 @@
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _unwrapUserComp<T>(comp: T): T {
     const compAsAny = comp as any;
     const isProxy = compAsAny?.getFrameworkComponentInstance != null;

--- a/packages/ag-grid-community/src/components/framework/userCompUtils.ts
+++ b/packages/ag-grid-community/src/components/framework/userCompUtils.ts
@@ -125,6 +125,7 @@ export function _getDragAndDropImageCompDetails(
     return userCompFactory.getCompDetailsFromGridOptions(DragAndDropImageComponent, 'agDragAndDropImage', params, true);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getInnerCellRendererDetails<TDefinition = any>(
     userCompFactory: UserComponentFactory,
     def: TDefinition,
@@ -196,6 +197,7 @@ export function _getFullWidthDetailCellRendererDetails(
 }
 // CELL RENDERER
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getCellRendererDetails<
     TDefinition = ColDef,
     TParams extends AgGridCommon<any, any> = ICellRendererParams,
@@ -207,6 +209,7 @@ export function _getCellRendererDetails<
     return userCompFactory.getCompDetails(def, CellRendererComponent, undefined, params);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getEditorRendererDetails<TDefinition, TEditorParams extends AgGridCommon<any, any>>(
     userCompFactory: UserComponentFactory,
     def: TDefinition,
@@ -240,6 +243,7 @@ export function _getCellEditorDetails(
 
 /**
  * @param defaultFilter provided filters only
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _getFilterDetails<TFilter extends SharedFilterUi & IComponent<SharedFilterParams> = IFilterComp>(
     userCompFactory: UserComponentFactory,
@@ -274,6 +278,7 @@ export function _getTooltipCompDetails(
 
 /**
  * @param defaultFloatingFilter provided floating filters only
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _getFloatingFilterCompDetails(
     userCompFactory: UserComponentFactory,

--- a/packages/ag-grid-community/src/components/framework/userComponentFactory.ts
+++ b/packages/ag-grid-community/src/components/framework/userComponentFactory.ts
@@ -84,6 +84,7 @@ export function _getUserCompKeys<TDefinition>(
     return { compName, jsComp, fwComp, paramsFromSelector, popupFromSelector, popupPositionFromSelector };
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class UserComponentFactory extends BeanStub implements NamedBean {
     beanName = 'userCompFactory' as const;
 

--- a/packages/ag-grid-community/src/context/bean.ts
+++ b/packages/ag-grid-community/src/context/bean.ts
@@ -1,7 +1,11 @@
 import type { AgSingletonBean } from '../agStack/interfaces/agCoreBean';
 import type { BeanCollection } from './context';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface Bean extends AgSingletonBean<BeanCollection> {}
 
-/** For any Bean that is required via auto wired or extracted by name from the Context must have a beanName */
+/**
+ * For any Bean that is required via auto wired or extracted by name from the Context must have a beanName
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export type NamedBean = Required<Pick<Bean, 'beanName'>>;

--- a/packages/ag-grid-community/src/context/beanStub.ts
+++ b/packages/ag-grid-community/src/context/beanStub.ts
@@ -6,6 +6,7 @@ import type { GridOptionsService } from '../gridOptionsService';
 import type { AgGridCommon } from '../interfaces/iCommon';
 import type { BeanCollection } from './context';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export abstract class BeanStub<TEventType extends string = AgBeanStubEvent> extends AgBeanStub<
     BeanCollection,
     GridOptionsWithDefaults,

--- a/packages/ag-grid-community/src/context/context.ts
+++ b/packages/ag-grid-community/src/context/context.ts
@@ -131,6 +131,7 @@ import type { ValueCache } from '../valueService/valueCache';
 import type { ValueService } from '../valueService/valueService';
 import type { PopupService } from '../widgets/popupService';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface SingletonBean extends AgSingletonBeanClass<BeanCollection> {}
 
 export type DynamicBeanName =
@@ -156,6 +157,7 @@ export type DynamicBeanName =
     | 'agDateColumnFilterHandler'
     | 'agTextColumnFilterHandler';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type StatusPanelComponentName =
     | 'agAggregationComponent'
     | 'agSelectedRowCountComponent'
@@ -379,13 +381,16 @@ interface CoreBeanCollection
     formulaInputManager?: IFormulaInputManagerService;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type BeanCollection = CoreBeanCollection & {
     // `unknown | undefined` to make sure the type is handled correctly when used
     [key in UntypedBeanNames]?: unknown;
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type Context = IContext<BeanCollection>;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type BeanName = keyof BeanCollection;
 
 /** Things used in enterprise or elsewhere that we haven't created interfaces for */

--- a/packages/ag-grid-community/src/ctrlsService.ts
+++ b/packages/ag-grid-community/src/ctrlsService.ts
@@ -56,6 +56,7 @@ type BeanDestroyFunc = Pick<BeanStub<any>, 'addDestroyFunc'>;
 
 // for all controllers that are singletons, they can register here so other parts
 // of the application can access them.
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class CtrlsService extends BeanStub<'ready'> implements NamedBean {
     beanName = 'ctrlsSvc' as const;
 

--- a/packages/ag-grid-community/src/dragAndDrop/dragAndDropService.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/dragAndDropService.ts
@@ -59,6 +59,7 @@ export type DragAndDropIcon =
     | 'notAllowed'
     | 'hide';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class DragAndDropService extends BaseDragAndDropService<
     BeanCollection,
     GridOptionsWithDefaults,

--- a/packages/ag-grid-community/src/dragAndDrop/dragModule.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/dragModule.ts
@@ -17,7 +17,7 @@ import { RowDragService } from './rowDragService';
 import { RowDropHighlightService } from './rowDropHighlightService';
 
 /**
- * @internal
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const DragModule: _ModuleWithoutApi = {
     moduleName: 'Drag',
@@ -42,7 +42,7 @@ export const DragAndDropModule: _ModuleWithoutApi = {
 };
 
 /**
- * @internal
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const SharedDragAndDropModule: _ModuleWithoutApi = {
     moduleName: 'SharedDragAndDrop',
@@ -96,7 +96,7 @@ export const RowDragModule: _ModuleWithApi<_DragGridApi<any>> = {
 };
 
 /**
- * @internal
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const HorizontalResizeModule: _ModuleWithoutApi = {
     moduleName: 'HorizontalResize',

--- a/packages/ag-grid-community/src/dragAndDrop/dragService.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/dragService.ts
@@ -5,7 +5,9 @@ import type { GridOptionsWithDefaults } from '../gridOptionsDefault';
 import type { GridOptionsService } from '../gridOptionsService';
 import type { AgGridCommon } from '../interfaces/iCommon';
 
-/** Adds drag listening onto an element. In AG Grid this is used twice, first is resizing columns,
+/**
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ * Adds drag listening onto an element. In AG Grid this is used twice, first is resizing columns,
  * second is moving the columns and column groups around (ie the 'drag' part of Drag and Drop. */
 export class DragService extends BaseDragService<
     BeanCollection,

--- a/packages/ag-grid-community/src/dragAndDrop/horizontalResizeService.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/horizontalResizeService.ts
@@ -11,6 +11,7 @@ interface HorizontalResizeParams {
     onResizeEnd: (delta: number) => void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class HorizontalResizeService extends BeanStub implements NamedBean {
     beanName = 'horizontalResizeSvc' as const;
 

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
@@ -18,6 +18,7 @@ const RowDragElement: ElementParams = {
 
 const SKIP_ARIA_HIDDEN = { skipAriaHidden: true };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class RowDragComp extends Component {
     private dragSource: GridDragSource<RowDraggingEvent> | null = null;
     private mouseDownListener: (() => void) | undefined;

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragService.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragService.ts
@@ -7,6 +7,7 @@ import { RowDragComp } from './rowDragComp';
 import { RowDragFeature } from './rowDragFeature';
 import type { RowDragVisibility } from './rowDragTypes';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class RowDragService extends BeanStub implements NamedBean {
     beanName = 'rowDragSvc' as const;
 

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragTypes.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragTypes.ts
@@ -137,7 +137,10 @@ export interface RowDraggingEvent<TData = any, TContext = any>
     extends AgDraggingEvent<DragSourceType, DragItem, DragAndDropIcon, RowDraggingEvent, RowsDrop<TData, TContext>>,
         AgGridCommon<TData, TContext> {}
 
-/** This is only used internally */
+/**
+ * This is only used internally
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export interface RowsDrop<TData = any, TContext = any>
     extends Omit<IsRowValidDropPositionParams<TData, TContext>, 'draggingEvent'> {
     /** The dragging event that originated this drop operation */

--- a/packages/ag-grid-community/src/edit/editModule.ts
+++ b/packages/ag-grid-community/src/edit/editModule.ts
@@ -31,7 +31,7 @@ import { SingleCellEditStrategy } from './strategy/singleCellEditStrategy';
 import { getCellEditorInstances } from './utils/editors';
 
 /**
- * @internal
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const EditCoreModule: _ModuleWithApi<_EditGridApi<any>> = {
     moduleName: 'EditCore',

--- a/packages/ag-grid-community/src/entities/agColumn.ts
+++ b/packages/ag-grid-community/src/entities/agColumn.ts
@@ -65,6 +65,7 @@ const DEFAULT_ABSOLUTE_SORTING_ORDER: (SortDef | SortDirection)[] = [
 // appear as a child of either the original tree or the displayed tree. However the relevant group classes
 // for each type only implements one, as each group can only appear in it's associated tree (eg ProvidedColumnGroup
 // can only appear in OriginalColumn tree).
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgColumn<TValue = any>
     extends BeanStub<ColumnEventName>
     implements Column, IAgEventEmitter<ColumnEventName>
@@ -804,6 +805,7 @@ export class AgColumn<TValue = any>
  *
  * If input is already a valid SortDef, we pluck the direction and type from it.
  * Otherwise, we normalise the direction and type from input.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _getSortDefFromInput(input?: unknown): SortDef {
     if (_isSortDefValid(input)) {
@@ -812,10 +814,12 @@ export function _getSortDefFromInput(input?: unknown): SortDef {
     return { direction: _normalizeSortDirection(input), type: _normalizeSortType(input) };
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isSortDirectionValid(maybeSortDir: unknown): maybeSortDir is SortDirection {
     return maybeSortDir === 'asc' || maybeSortDir === 'desc' || maybeSortDir === null;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isSortTypeValid(maybeSortType: unknown): maybeSortType is SortType {
     return maybeSortType === 'default' || maybeSortType === 'absolute';
 }
@@ -829,6 +833,7 @@ export function _isSortDefValid(maybeSortDef: unknown): maybeSortDef is SortDef 
     return _isSortTypeValid(maybeSortDefT.type) && _isSortDirectionValid(maybeSortDefT.direction);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _areSortDefsEqual(sortDef1: SortDef | null | undefined, sortDef2: SortDef | null | undefined): boolean {
     if (!sortDef1) {
         return sortDef2 ? sortDef2.direction === null : true;
@@ -840,14 +845,17 @@ export function _areSortDefsEqual(sortDef1: SortDef | null | undefined, sortDef2
     return sortDef1.type === sortDef2.type && sortDef1.direction === sortDef2.direction;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _normalizeSortDirection(sortDirectionLike?: unknown): SortDirection {
     return _isSortDirectionValid(sortDirectionLike) ? sortDirectionLike : null;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _normalizeSortType(sortTypeLike?: unknown): SortType {
     return _isSortTypeValid(sortTypeLike) ? sortTypeLike : 'default';
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getDisplaySortForColumn(column: AgColumn, beans: BeanCollection) {
     const sortDef = beans.sortSvc!.getDisplaySortForColumn(column);
     const type = _normalizeSortType(sortDef?.type);

--- a/packages/ag-grid-community/src/entities/agColumnGroup.ts
+++ b/packages/ag-grid-community/src/entities/agColumnGroup.ts
@@ -22,6 +22,7 @@ export function isColumnGroup(col: Column | ColumnGroup | string): col is AgColu
     return col instanceof AgColumnGroup;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgColumnGroup<TValue = any> extends BeanStub<AgColumnGroupEvent> implements ColumnGroup<TValue> {
     public readonly isColumn = false as const;
 

--- a/packages/ag-grid-community/src/entities/agProvidedColumnGroup.ts
+++ b/packages/ag-grid-community/src/entities/agProvidedColumnGroup.ts
@@ -9,6 +9,7 @@ export function isProvidedColumnGroup(col: Column | ProvidedColumnGroup | string
 }
 
 export type AgProvidedColumnGroupEvent = 'expandedChanged' | 'expandableChanged';
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AgProvidedColumnGroup extends BeanStub<AgProvidedColumnGroupEvent> implements ProvidedColumnGroup {
     public readonly isColumn = false as const;
 

--- a/packages/ag-grid-community/src/entities/positionUtils.ts
+++ b/packages/ag-grid-community/src/entities/positionUtils.ts
@@ -9,11 +9,13 @@ import type { RowCtrl } from '../rendering/row/rowCtrl';
 import type { AgColumn } from './agColumn';
 import type { RowNode } from './rowNode';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _createCellId(cellPosition: CellPosition): string {
     const { rowIndex, rowPinned, column } = cellPosition;
     return `${rowIndex}.${rowPinned == null ? 'null' : rowPinned}.${column.getId()}`;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _areCellsEqual(cellA: CellPosition, cellB: CellPosition): boolean {
     const colsMatch = cellA.column === cellB.column;
     const floatingMatch = cellA.rowPinned === cellB.rowPinned;
@@ -23,6 +25,7 @@ export function _areCellsEqual(cellA: CellPosition, cellB: CellPosition): boolea
 
 /**
  * True if `rowA` appears before `rowB`
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _isRowBefore(rowA: RowPosition, rowB: RowPosition): boolean {
     switch (rowA.rowPinned) {
@@ -48,6 +51,7 @@ export function _isRowBefore(rowA: RowPosition, rowB: RowPosition): boolean {
     return rowA.rowIndex < rowB.rowIndex;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isSameRow(rowA: RowPosition | undefined, rowB: RowPosition | undefined): boolean {
     // if both missing
     if (!rowA && !rowB) {
@@ -61,6 +65,7 @@ export function _isSameRow(rowA: RowPosition | undefined, rowB: RowPosition | un
     return rowA.rowIndex === rowB.rowIndex && rowA.rowPinned == rowB.rowPinned;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getFirstRow(beans: BeanCollection): RowPosition | null {
     let rowIndex = 0;
     let rowPinned: RowPinnedType;
@@ -79,6 +84,7 @@ export function _getFirstRow(beans: BeanCollection): RowPosition | null {
     return rowPinned === undefined ? null : { rowIndex, rowPinned };
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getLastRow(beans: BeanCollection): RowPosition | null {
     let rowIndex;
     let rowPinned: RowPinnedType = null;
@@ -101,6 +107,7 @@ export function _getLastRow(beans: BeanCollection): RowPosition | null {
     return rowIndex === undefined ? null : { rowIndex, rowPinned };
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getRowNode(beans: BeanCollection, gridRow: RowPosition): RowNode | undefined {
     switch (gridRow.rowPinned) {
         case 'top':
@@ -112,6 +119,7 @@ export function _getRowNode(beans: BeanCollection, gridRow: RowPosition): RowNod
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getCellByPosition(beans: BeanCollection, cellPosition: CellPosition): CellCtrl | null {
     // if spanned, return cell ctrl from spanned renderer
     const spannedCellCtrl = beans.spannedRowRenderer?.getCellByPosition(cellPosition);
@@ -147,6 +155,7 @@ export function _getRowById(beans: BeanCollection, rowId: string, rowPinned?: Ro
 /**
  * Gets the row position above the given row position. Considers pinned and sticky rows for navigation.
  * RowModel.getRow() is expensive, so it is only called if `checkSticky` is true.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _getRowAbove(beans: BeanCollection, rowPosition: RowPosition, checkSticky = false): RowPosition | null {
     const { rowIndex: index, rowPinned: pinned } = rowPosition;
@@ -173,6 +182,7 @@ export function _getRowAbove(beans: BeanCollection, rowPosition: RowPosition, ch
     return { rowIndex: index - 1, rowPinned: pinned };
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getAbsoluteRowIndex(beans: BeanCollection, rowPosition: RowPosition): number {
     const { pinnedRowModel, rowModel } = beans;
     const pinnedTopRowCount = pinnedRowModel?.getPinnedTopRowCount() ?? 0;
@@ -193,6 +203,7 @@ export function _getAbsoluteRowIndex(beans: BeanCollection, rowPosition: RowPosi
 /**
  * Returns the row position below the given row position. Considers pinned and sticky rows for navigation.
  * RowModel.getRow() is expensive, so it is only called if `checkSticky` is true.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _getRowBelow(beans: BeanCollection, rowPosition: RowPosition, checkSticky = false): RowPosition | null {
     const { rowIndex: index, rowPinned: pinned } = rowPosition;

--- a/packages/ag-grid-community/src/entities/rowNode.ts
+++ b/packages/ag-grid-community/src/entities/rowNode.ts
@@ -19,12 +19,16 @@ import { _error, _warn } from '../validation/logging';
 import type { AgColumn } from './agColumn';
 import type { ColKey } from './colDef';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const ROW_ID_PREFIX_ROW_GROUP = 'row-group-';
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const ROW_ID_PREFIX_TOP_PINNED = 't-';
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const ROW_ID_PREFIX_BOTTOM_PINNED = 'b-';
 
 let OBJECT_ID_SEQUENCE = 0;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class RowNode<TData = any>
     implements IEventEmitter<RowNodeEventType>, IAgEventEmitter<RowNodeEventType>, IRowNode<TData>
 {

--- a/packages/ag-grid-community/src/entities/rowNodeUtils.ts
+++ b/packages/ag-grid-community/src/entities/rowNodeUtils.ts
@@ -7,6 +7,7 @@ import type { IRowModel } from '../interfaces/iRowModel';
 import type { IRowNode } from '../interfaces/iRowNode';
 import { RowNode } from './rowNode';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _createGlobalRowEvent<T extends AgEventType>(
     rowNode: RowNode,
     gos: GridOptionsService,
@@ -46,6 +47,7 @@ const IGNORED_SIBLING_PROPERTIES = new Set<
     'treeParent',
 ]);
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const _createRowNodeSibling = (rowNode: RowNode, beans: BeanCollection): RowNode => {
     const sibling = new RowNode(beans);
 
@@ -63,7 +65,10 @@ export const _createRowNodeSibling = (rowNode: RowNode, beans: BeanCollection): 
     return sibling;
 };
 
-/** When dragging multiple rows, we want the user to be able to drag to the prev or next in the group if dragging on one of the selected rows. */
+/**
+ * When dragging multiple rows, we want the user to be able to drag to the prev or next in the group if dragging on one of the selected rows.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export const _prevOrNextDisplayedRow = (
     rowModel: IRowModel,
     direction: -1 | 1,

--- a/packages/ag-grid-community/src/environment.ts
+++ b/packages/ag-grid-community/src/environment.ts
@@ -32,6 +32,7 @@ const ROW_BORDER_WIDTH = cssVariable('rowBorderWidth', 'border', 1);
 const PINNED_BORDER_WIDTH = cssVariable('pinnedRowBorderWidth', 'border', 1);
 const HEADER_ROW_BORDER_WIDTH = cssVariable('headerRowBorderWidth', 'border', 1);
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _addAdditionalCss(cssMap: Map<string, string[]>, modules: Module[]): void {
     for (const module of modules.sort((a, b) => a.moduleName.localeCompare(b.moduleName))) {
         const moduleCss = module.css;
@@ -41,6 +42,7 @@ export function _addAdditionalCss(cssMap: Map<string, string[]>, modules: Module
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class Environment
     extends BaseEnvironment<
         BeanCollection,

--- a/packages/ag-grid-community/src/eventTypes.ts
+++ b/packages/ag-grid-community/src/eventTypes.ts
@@ -1,7 +1,10 @@
 // events that are available for use by users of AG Grid and so should be documented
 import type { AgEvent } from './agStack/interfaces/agEvent';
 
-/** EVENTS that should be exposed via code generation for the framework components.  */
+/**
+ * EVENTS that should be exposed via code generation for the framework components.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export const _PUBLIC_EVENTS = [
     'columnEverythingChanged',
     'newColumnsLoaded',
@@ -174,12 +177,14 @@ const _INTERNAL_EVENTS = [
 ] as const;
 
 // We define as a callback to help with tree shaking (esbuild)
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const _GET_ALL_EVENTS = () => [..._PUBLIC_EVENTS, ..._INTERNAL_EVENTS] as const;
 
 export type AgPublicEventType = (typeof _PUBLIC_EVENTS)[number];
 export type AgInternalEventType = (typeof _INTERNAL_EVENTS)[number];
 export type AgEventType = AgPublicEventType | AgInternalEventType;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const ALWAYS_SYNC_GLOBAL_EVENTS: Set<AgEventType> = new Set(['gridPreDestroyed', 'fillStart', 'pasteStart']);
 
 export type BuildEventTypeMap<TEventTypes extends string, T extends { [K in TEventTypes]: AgEvent<K> }> = T;

--- a/packages/ag-grid-community/src/export/baseCreator.ts
+++ b/packages/ag-grid-community/src/export/baseCreator.ts
@@ -2,6 +2,7 @@ import { BeanStub } from '../context/beanStub';
 import type { ExportParams } from '../interfaces/exportParams';
 import type { GridSerializingSession } from './iGridSerializer';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export abstract class BaseCreator<T, S extends GridSerializingSession<T>, P extends ExportParams<T>> extends BeanStub {
     protected abstract export(userParams?: P, compress?: boolean): void;
 

--- a/packages/ag-grid-community/src/export/baseGridSerializingSession.ts
+++ b/packages/ag-grid-community/src/export/baseGridSerializingSession.ts
@@ -20,6 +20,7 @@ import type {
     RowSpanningAccumulator,
 } from './iGridSerializer';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export abstract class BaseGridSerializingSession<T> implements GridSerializingSession<T> {
     public colModel: ColumnModel;
     private readonly colNames: ColumnNameService;

--- a/packages/ag-grid-community/src/export/downloader.ts
+++ b/packages/ag-grid-community/src/export/downloader.ts
@@ -1,5 +1,6 @@
 import { _warn } from '../validation/logging';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _downloadFile(fileName: string, content: Blob) {
     const win = document.defaultView || window;
 

--- a/packages/ag-grid-community/src/export/exportModule.ts
+++ b/packages/ag-grid-community/src/export/exportModule.ts
@@ -4,7 +4,7 @@ import { GridSerializer } from './gridSerializer';
 
 // Shared CSV and Excel logic
 /**
- * @internal
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const SharedExportModule: _ModuleWithoutApi = {
     moduleName: 'SharedExport',

--- a/packages/ag-grid-community/src/export/iGridSerializer.ts
+++ b/packages/ag-grid-community/src/export/iGridSerializer.ts
@@ -14,10 +14,12 @@ import type { ColumnGroup } from '../interfaces/iColumn';
 import type { CellValueResolveFrom } from '../interfaces/iEditService';
 import type { ValueService } from '../valueService/valueService';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface RowAccumulator {
     onColumn(column: AgColumn, index: number, node?: RowNode): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface RowSpanningAccumulator {
     onColumn(
         columnGroup: ColumnGroup,
@@ -28,6 +30,7 @@ export interface RowSpanningAccumulator {
     ): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface GridSerializingParams {
     colModel: ColumnModel;
     rowGroupColsSvc?: IColsService;

--- a/packages/ag-grid-community/src/filter/columnFilterUtils.ts
+++ b/packages/ag-grid-community/src/filter/columnFilterUtils.ts
@@ -101,6 +101,7 @@ export function getFilterUiFromWrapper<TComp extends IFilterComp | FilterDisplay
     return promise;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _refreshHandlerAndUi(
     getFilterUi: () => AgPromise<{ filter: FilterDisplayComp; filterParams: FilterDisplayParams } | undefined>,
     handler: FilterHandler,
@@ -120,6 +121,7 @@ export function _refreshHandlerAndUi(
     });
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _refreshFilterUi(
     filter: FilterDisplayComp | null | undefined,
     filterParams: FilterDisplayParams,
@@ -159,6 +161,7 @@ export function getAndRefreshFilterUi(
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _updateFilterModel(params: {
     action: FilterAction;
     filterParams?: FilterWrapperParams;
@@ -229,6 +232,7 @@ export function _updateFilterModel(params: {
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getFilterModel<TModel = any>(model: FilterModel, colId: string): TModel | null {
     return model[colId] ?? null;
 }

--- a/packages/ag-grid-community/src/filter/filterButtonComp.ts
+++ b/packages/ag-grid-community/src/filter/filterButtonComp.ts
@@ -13,10 +13,12 @@ interface FilterButtonCompParams {
     className?: string;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface FilterButtonEvent extends AgEvent<FilterAction> {
     event?: Event;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface FilterButton {
     type: FilterAction;
     label: string;
@@ -29,6 +31,7 @@ function getElement(className: string): ElementParams {
     };
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class FilterButtonComp extends Component<FilterAction> {
     private buttons: FilterButton[];
     private listeners: (() => void)[] = [];
@@ -158,6 +161,7 @@ export class FilterButtonComp extends Component<FilterAction> {
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const AgFilterButtonSelector: ComponentSelector = {
     selector: 'AG-FILTER-BUTTON',
     component: FilterButtonComp,

--- a/packages/ag-grid-community/src/filter/filterComp.ts
+++ b/packages/ag-grid-community/src/filter/filterComp.ts
@@ -15,7 +15,10 @@ import { legacyFilterCSS } from './legacyFilter.css-GENERATED';
 
 const FilterElement: ElementParams = { tag: 'div', cls: 'ag-filter' };
 
-/** Wraps column filters for use in menus, tool panel etc. */
+/**
+ * Wraps column filters for use in menus, tool panel etc.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export class FilterComp extends Component {
     private wrapper: AgPromise<FilterDisplayWrapper> | null = null;
     private comp?: FilterWrapperComp;

--- a/packages/ag-grid-community/src/filter/filterDataTypeUtils.ts
+++ b/packages/ag-grid-community/src/filter/filterDataTypeUtils.ts
@@ -209,6 +209,7 @@ const setFilterParamsForEachDataType: FilterParamsDefMap = {
     text: () => undefined,
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getFilterParamsForDataType(
     filter: string,
     existingFilterParams: any,
@@ -262,6 +263,7 @@ const defaultFloatingFilters: Record<BaseCellDataType, UserComponentName> = {
     text: 'agTextColumnFloatingFilter',
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getDefaultSimpleFilter(cellDataType?: BaseCellDataType, isFloating: boolean = false): string {
     const filterSet = isFloating ? defaultFloatingFilters : defaultFilters;
     return filterSet[cellDataType ?? 'text'];

--- a/packages/ag-grid-community/src/filter/filterLocaleText.ts
+++ b/packages/ag-grid-community/src/filter/filterLocaleText.ts
@@ -83,6 +83,7 @@ const FILTER_LOCALE_TEXT = {
 
 export type FilterLocaleTextKey = keyof typeof FILTER_LOCALE_TEXT;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function translateForFilter(
     bean: { getLocaleTextFunc(): LocaleTextFunc },
     key: keyof typeof FILTER_LOCALE_TEXT,

--- a/packages/ag-grid-community/src/filter/filterManager.ts
+++ b/packages/ag-grid-community/src/filter/filterManager.ts
@@ -16,6 +16,7 @@ import { _warn } from '../validation/logging';
 import type { ColumnFilterService } from './columnFilterService';
 import type { QuickFilterService } from './quickFilterService';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class FilterManager extends BeanStub implements NamedBean {
     beanName = 'filterManager' as const;
 

--- a/packages/ag-grid-community/src/filter/filterModule.ts
+++ b/packages/ag-grid-community/src/filter/filterModule.ts
@@ -53,7 +53,7 @@ const ClientSideRowModelFilterModule: _ModuleWithoutApi = {
 };
 
 /**
- * @internal
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const FilterCoreModule: _ModuleWithApi<_FilterGridApi> = {
     moduleName: 'FilterCore',
@@ -68,7 +68,7 @@ export const FilterCoreModule: _ModuleWithApi<_FilterGridApi> = {
 };
 
 /**
- * @internal
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const FilterValueModule: _ModuleWithoutApi = {
     moduleName: 'FilterValue',
@@ -77,7 +77,7 @@ export const FilterValueModule: _ModuleWithoutApi = {
 };
 
 /**
- * @internal
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const ColumnFilterModule: _ModuleWithApi<_ColumnFilterGridApi> = {
     moduleName: 'ColumnFilter',

--- a/packages/ag-grid-community/src/filter/filterValueService.ts
+++ b/packages/ag-grid-community/src/filter/filterValueService.ts
@@ -7,6 +7,7 @@ import type { RowNode } from '../entities/rowNode';
 import { _addGridCommonParams } from '../gridOptionsUtils';
 import type { IRowNode } from '../interfaces/iRowNode';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class FilterValueService extends BeanStub implements NamedBean {
     beanName: BeanName = 'filterValueSvc';
 

--- a/packages/ag-grid-community/src/filter/filterWrapperComp.ts
+++ b/packages/ag-grid-community/src/filter/filterWrapperComp.ts
@@ -19,7 +19,8 @@ import { FilterButtonComp } from './filterButtonComp';
 import { translateForFilter } from './filterLocaleText';
 import { _isUseApplyButton } from './provided/providedFilterUtils';
 
-/** Used with filter handlers. This adds filter buttons. */
+/** Used with filter handlers. This adds filter buttons.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class FilterWrapperComp extends Component {
     private eButtons?: FilterButtonComp;
     private params?: FilterWrapperParams;

--- a/packages/ag-grid-community/src/filter/floating/floatingFilterMapper.ts
+++ b/packages/ag-grid-community/src/filter/floating/floatingFilterMapper.ts
@@ -2,6 +2,7 @@ import { _getFilterCompKeys } from '../../components/framework/userCompUtils';
 import type { IFilterDef } from '../../interfaces/iFilter';
 import type { IFrameworkOverrides } from '../../interfaces/iFrameworkOverrides';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getDefaultFloatingFilterType(
     frameworkOverrides: IFrameworkOverrides,
     def: IFilterDef,

--- a/packages/ag-grid-community/src/filter/provided/providedFilterUtils.ts
+++ b/packages/ag-grid-community/src/filter/provided/providedFilterUtils.ts
@@ -19,6 +19,7 @@ export function getDebounceMs(params: IProvidedFilterParams, debounceDefault: nu
     return debounceMs ?? debounceDefault;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isUseApplyButton(params: FilterWrapperParams): boolean {
     return (params.buttons?.indexOf('apply') ?? -1) >= 0;
 }

--- a/packages/ag-grid-community/src/focusService.ts
+++ b/packages/ag-grid-community/src/focusService.ts
@@ -41,6 +41,7 @@ import {
 
 type FocusDirection = 'Before' | 'After' | null;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class FocusService extends BeanStub implements NamedBean {
     beanName = 'focusSvc' as const;
 

--- a/packages/ag-grid-community/src/globalGridOptions.ts
+++ b/packages/ag-grid-community/src/globalGridOptions.ts
@@ -86,6 +86,7 @@ export function provideGlobalGridOptions(
     GlobalGridOptions.mergeStrategy = mergeStrategy;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getGlobalGridOption<K extends keyof GridOptions>(gridOption: K): GridOptions[K] {
     return GlobalGridOptions.gridOptions?.[gridOption];
 }

--- a/packages/ag-grid-community/src/grid.ts
+++ b/packages/ag-grid-community/src/grid.ts
@@ -37,6 +37,7 @@ import { NoModulesRegisteredError, missingRowModelTypeError } from './validation
 import { _error, _logPreInitErr } from './validation/logging';
 import { VanillaFrameworkOverrides } from './vanillaFrameworkOverrides';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface GridParams {
     // INTERNAL - used by Web Components
     globalListener?: (...args: any[]) => any;
@@ -117,6 +118,7 @@ let nextGridId = 1;
 
 // creates services of grid only, no UI, so frameworks can use this if providing
 // their own UI
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class GridCoreCreator {
     public create(
         eGridDiv: HTMLElement,

--- a/packages/ag-grid-community/src/gridBodyComp/fakeHScrollComp.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/fakeHScrollComp.ts
@@ -23,6 +23,7 @@ const FakeHScrollElement: ElementParams = {
         { tag: 'div', ref: 'eRightSpacer', cls: 'ag-horizontal-right-spacer' },
     ],
 };
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class FakeHScrollComp extends AbstractFakeScrollComp {
     private visibleCols: VisibleColsService;
     private scrollVisibleSvc: ScrollVisibleService;

--- a/packages/ag-grid-community/src/gridBodyComp/fakeVScrollComp.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/fakeVScrollComp.ts
@@ -18,6 +18,7 @@ const FakeVScrollElement: ElementParams = {
         },
     ],
 };
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class FakeVScrollComp extends AbstractFakeScrollComp {
     constructor() {
         super(FakeVScrollElement, 'vertical');

--- a/packages/ag-grid-community/src/gridBodyComp/gridBodyCtrl.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/gridBodyCtrl.ts
@@ -18,6 +18,7 @@ import { _getRowContainerClass, _getRowViewportClass } from './rowContainer/rowC
 import type { ScrollVisibleService } from './scrollVisibleService';
 import { _shouldShowVerticalScroll } from './scrollbarVisibilityHelper';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type RowAnimationCssClasses = 'ag-row-animation' | 'ag-row-no-animation';
 
 export const CSS_CLASS_FORCE_VERTICAL_SCROLL = 'ag-force-vertical-scroll';
@@ -25,6 +26,7 @@ export const CSS_CLASS_FORCE_VERTICAL_SCROLL = 'ag-force-vertical-scroll';
 const CSS_CLASS_CELL_SELECTABLE = 'ag-selectable';
 const CSS_CLASS_COLUMN_MOVING = 'ag-column-moving';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IGridBodyComp extends LayoutView {
     setColumnMovingCss(cssClass: string, on: boolean): void;
     setCellSelectableCss(cssClass: string | null, on: boolean): void;
@@ -48,6 +50,7 @@ export interface IGridBodyComp extends LayoutView {
     setGridRootRole(role: 'grid' | 'treegrid'): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class GridBodyCtrl extends BeanStub {
     private ctrlsSvc: CtrlsService;
     private colModel: ColumnModel;

--- a/packages/ag-grid-community/src/gridBodyComp/mouseEventUtils.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/mouseEventUtils.ts
@@ -4,6 +4,7 @@ import { _isDomLayout } from '../gridOptionsUtils';
 import type { CellPosition } from '../interfaces/iCellPosition';
 import { _getCellCtrlForEventTarget } from '../rendering/renderUtils';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getCellPositionForEvent(
     gos: GridOptionsService,
     event: MouseEvent | KeyboardEvent | Touch
@@ -11,6 +12,7 @@ export function _getCellPositionForEvent(
     return _getCellCtrlForEventTarget(gos, event.target)?.getFocusedCellPosition() ?? null;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getNormalisedMousePosition(
     beans: BeanCollection,
     event: MouseEvent | { x: number; y: number }

--- a/packages/ag-grid-community/src/gridBodyComp/rowContainer/rowContainerCtrl.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/rowContainer/rowContainerCtrl.ts
@@ -14,6 +14,7 @@ import { RowContainerEventsFeature } from './rowContainerEventsFeature';
 import { SetHeightFeature } from './setHeightFeature';
 import type { SetPinnedWidthFeature } from './setPinnedWidthFeature';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type RowContainerName =
     | 'left'
     | 'right'
@@ -36,10 +37,12 @@ export type RowContainerName =
     | 'bottomCenter'
     | 'bottomFullWidth';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type RowContainerType = 'left' | 'right' | 'center' | 'fullWidth';
 
 type GetRowCtrls = (renderer: RowRenderer) => RowCtrl[];
 type GetSpannedRowCtrls = (renderer: SpannedRowRenderer) => RowCtrl[];
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type RowContainerOptions = {
     type: RowContainerType;
     name: string;
@@ -198,18 +201,22 @@ const ContainerCssClasses: Record<RowContainerName, RowContainerOptions> = {
         getRowCtrls: getBottomRowCtrls,
     },
 };
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getRowViewportClass(name: RowContainerName): `ag-${string}-viewport` {
     const options = _getRowContainerOptions(name);
     return `ag-${options.name}-viewport`;
 }
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getRowContainerClass(name: RowContainerName): `ag-${string}` {
     const options = _getRowContainerOptions(name);
     return options.container ?? `ag-${options.name}-container`;
 }
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getRowSpanContainerClass(name: RowContainerName): `ag-${string}-spanned-cells-container` {
     const options = _getRowContainerOptions(name);
     return `ag-${options.name}-spanned-cells-container`;
 }
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getRowContainerOptions(name: RowContainerName): RowContainerOptions {
     return ContainerCssClasses[name];
 }
@@ -240,6 +247,7 @@ const allNoFW: RowContainerName[] = [
     ...allStickyBottomNoFW,
 ];
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IRowContainerComp {
     setViewportHeight(height: string): void;
     setHorizontalScroll(offset: number): void;
@@ -250,6 +258,7 @@ export interface IRowContainerComp {
     setOffsetTop(offset: string): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class RowContainerCtrl extends BeanStub implements ScrollPartner {
     private readonly options: RowContainerOptions;
 

--- a/packages/ag-grid-community/src/gridBodyComp/scrollVisibleService.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/scrollVisibleService.ts
@@ -10,6 +10,7 @@ export interface SetScrollsVisibleParams {
     verticalScrollShowing: boolean;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class ScrollVisibleService extends BeanStub implements NamedBean {
     beanName = 'scrollVisibleSvc' as const;
 

--- a/packages/ag-grid-community/src/gridComp/gridCtrl.ts
+++ b/packages/ag-grid-community/src/gridComp/gridCtrl.ts
@@ -13,6 +13,7 @@ import { _isCellFocusSuppressed, _isHeaderFocusSuppressed, _runWithContainerFocu
 import { _consoleWarn } from '../utils/log';
 import type { Component, ComponentSelector } from '../widgets/component';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IGridComp extends LayoutView {
     setRtlClass(cssClass: string): void;
     destroyGridUi(): void;
@@ -46,6 +47,7 @@ const getDefaultTabToNextGridContainerTargetName = (target: TabToNextGridContain
     return typeof target === 'string' ? target : 'gridBody';
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class GridCtrl extends BeanStub {
     private view: IGridComp;
     private eGridHostDiv: HTMLElement;

--- a/packages/ag-grid-community/src/gridOptionsUtils.ts
+++ b/packages/ag-grid-community/src/gridOptionsUtils.ts
@@ -43,22 +43,27 @@ function isRowModelType(gos: GridOptionsService, rowModelType: RowModelType): bo
     return gos.get('rowModelType') === rowModelType;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isClientSideRowModel(gos: GridOptionsService, rowModel?: IRowModel): rowModel is IClientSideRowModel {
     return isRowModelType(gos, 'clientSide');
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isServerSideRowModel(gos: GridOptionsService, rowModel?: IRowModel): rowModel is IServerSideRowModel {
     return isRowModelType(gos, 'serverSide');
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isDomLayout(gos: GridOptionsService, domLayout: DomLayoutType) {
     return gos.get('domLayout') === domLayout;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isRowSelection(gos: GridOptionsService): boolean {
     return _getRowSelectionMode(gos) !== undefined;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isGetRowHeightFunction(gos: GridOptionsService): boolean {
     return typeof gos.get('getRowHeight') === 'function';
 }
@@ -70,11 +75,13 @@ export function _shouldMaintainColumnOrder(gos: GridOptionsService, isPivotColum
     return gos.get('maintainColumnOrder');
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isRowNumbers({ gos, formula }: BeanCollection) {
     const rowNumbers = gos.get('rowNumbers');
     return rowNumbers || (!!formula?.active && rowNumbers !== false);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getRowHeightForNode(
     beans: BeanCollection,
     rowNode: IRowNode,
@@ -139,6 +146,7 @@ function getMasterDetailRowHeight(gos: GridOptionsService): { height: number; es
 }
 
 // we don't allow dynamic row height for virtual paging
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getRowHeightAsNumber(beans: BeanCollection): number {
     const { environment, gos } = beans;
     const gridOptionsRowHeight = gos.get('rowHeight');
@@ -178,6 +186,7 @@ export function _setDomData(gos: GridOptionsService, element: Element, key: stri
     domData[key] = value;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isAnimateRows(gos: GridOptionsService) {
     // never allow animating if enforcing the row order
     if (gos.get('ensureDomOrder')) {
@@ -187,15 +196,18 @@ export function _isAnimateRows(gos: GridOptionsService) {
     return gos.get('animateRows');
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isGroupRowsSticky(gos: GridOptionsService): boolean {
     return !(gos.get('paginateChildRows') || gos.get('groupHideOpenParents') || _isDomLayout(gos, 'print'));
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isColumnsSortingCoupledToGroup(gos: GridOptionsService): boolean {
     const autoGroupColumnDef = gos.get('autoGroupColumnDef');
     return !autoGroupColumnDef?.comparator && !gos.get('treeData');
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getGroupAggFiltering(
     gos: GridOptionsService
 ): ((params: WithoutGridCommon<GetGroupAggFilteringParams>) => boolean) | undefined {
@@ -212,10 +224,12 @@ export function _getGroupAggFiltering(
     return undefined;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getGrandTotalRow(gos: GridOptionsService): GridOptions['grandTotalRow'] {
     return gos.get('grandTotalRow');
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getGroupTotalRowCallback(
     gos: GridOptionsService
 ): (params: WithoutGridCommon<GetGroupIncludeFooterParams>) => 'top' | 'bottom' | undefined {
@@ -228,6 +242,7 @@ export function _getGroupTotalRowCallback(
     return () => userValue ?? undefined;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isGroupMultiAutoColumn(gos: GridOptionsService) {
     const isHideOpenParents = !!gos.get('groupHideOpenParents');
     if (isHideOpenParents) {
@@ -236,10 +251,12 @@ export function _isGroupMultiAutoColumn(gos: GridOptionsService) {
     return gos.get('groupDisplayType') === 'multipleColumns';
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isGroupHideColumnsUntilExpanded(gos: GridOptionsService) {
     return _isGroupMultiAutoColumn(gos) && gos.get('groupHideColumnsUntilExpanded') && _isClientSideRowModel(gos);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isGroupUseEntireRow(gos: GridOptionsService, pivotMode: boolean): boolean {
     // we never allow groupDisplayType = 'groupRows' if in pivot mode, otherwise we won't see the pivot values.
     if (pivotMode) {
@@ -249,11 +266,13 @@ export function _isGroupUseEntireRow(gos: GridOptionsService, pivotMode: boolean
     return gos.get('groupDisplayType') === 'groupRows';
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isFullWidthGroupRow(gos: GridOptionsService, node: RowNode, pivotMode: boolean): boolean {
     return !!node.group && !node.footer && _isGroupUseEntireRow(gos, pivotMode);
 }
 
 // AG-9259 Can't use `WrappedCallback<'getRowId', ...>` here because of a strange typescript bug
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getRowIdCallback<TData = any>(
     gos: GridOptionsService
 ):
@@ -280,6 +299,7 @@ export function _getRowIdCallback<TData = any>(
     };
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _canSkipShowingRowGroup(gos: GridOptionsService, node: RowNode): boolean {
     const isSkippingGroups = gos.get('groupHideParentOfSingleChild');
     if (isSkippingGroups === true) {
@@ -298,12 +318,14 @@ export function _canSkipShowingRowGroup(gos: GridOptionsService, node: RowNode):
     return false;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getMaxConcurrentDatasourceRequests(gos: GridOptionsService): number | undefined {
     const res = gos.get('maxConcurrentDatasourceRequests');
     // negative number, eg -1, means no max restriction
     return res > 0 ? res : undefined;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _shouldUpdateColVisibilityAfterGroup(gos: GridOptionsService, isGrouped: boolean): boolean {
     const preventVisibilityChanges = gos.get('suppressGroupChangesColumnVisibility');
     if (preventVisibilityChanges === true) {
@@ -329,18 +351,25 @@ export function _shouldUpdateColVisibilityAfterGroup(gos: GridOptionsService, is
     return true;
 }
 
-/** Get the selection checkbox configuration. Defaults to enabled. */
+/**
+ * Get the selection checkbox configuration. Defaults to enabled.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export function _getCheckboxes(
     selection: RowSelectionOptions
 ): NonNullable<SingleRowSelectionOptions['checkboxes']> | NonNullable<MultiRowSelectionOptions['checkboxes']> {
     return selection?.checkboxes ?? true;
 }
 
-/** Get the header checkbox configuration. Defaults to enabled in `multiRow`, otherwise disabled. */
+/**
+ * Get the header checkbox configuration. Defaults to enabled in `multiRow`, otherwise disabled.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export function _getHeaderCheckbox(selection: RowSelectionOptions): boolean {
     return selection?.mode === 'multiRow' && (selection.headerCheckbox ?? true);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getCheckboxLocation(rowSelection: GridOptions['rowSelection']): CheckboxLocation | undefined {
     if (typeof rowSelection !== 'object') {
         return undefined;
@@ -353,15 +382,18 @@ export function _getHideDisabledCheckboxes(selection: RowSelectionOptions): bool
     return selection?.hideDisabledCheckboxes ?? false;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isUsingNewRowSelectionAPI(gos: GridOptionsService): boolean {
     const rowSelection = gos.get('rowSelection');
     return typeof rowSelection !== 'string';
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isUsingNewCellSelectionAPI(gos: GridOptionsService): boolean {
     return gos.get('cellSelection') !== undefined;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getSuppressMultiRanges(gos: GridOptionsService): boolean {
     const selection = gos.get('cellSelection');
     const useNewAPI = selection !== undefined;
@@ -373,6 +405,7 @@ export function _getSuppressMultiRanges(gos: GridOptionsService): boolean {
     return typeof selection !== 'boolean' ? selection?.suppressMultiRanges ?? false : false;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isCellSelectionEnabled(gos: GridOptionsService): boolean {
     const selection = gos.get('cellSelection');
     const useNewAPI = selection !== undefined;
@@ -380,6 +413,7 @@ export function _isCellSelectionEnabled(gos: GridOptionsService): boolean {
     return useNewAPI ? !!selection : gos.get('enableRangeSelection');
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getFillHandle(gos: GridOptionsService): FillHandleOptions | undefined {
     const selection = gos.get('cellSelection');
     const useNewAPI = selection !== undefined;
@@ -396,6 +430,7 @@ export function _getFillHandle(gos: GridOptionsService): FillHandleOptions | und
     return typeof selection !== 'boolean' && selection.handle?.mode === 'fill' ? selection.handle : undefined;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getEnableColumnSelection(gos: GridOptionsService): boolean {
     const cellSelection = gos.get('cellSelection') ?? false;
     return (typeof cellSelection === 'object' && cellSelection.enableColumnSelection) ?? false;
@@ -434,6 +469,7 @@ export function _getEnableDeselection(gos: GridOptionsService): boolean {
     return enableClickSelection === true || enableClickSelection === 'enableDeselection';
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getIsRowSelectable(gos: GridOptionsService): IsRowSelectable | undefined {
     const selection = gos.get('rowSelection');
 
@@ -444,6 +480,7 @@ export function _getIsRowSelectable(gos: GridOptionsService): IsRowSelectable | 
     return selection?.isRowSelectable;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getRowSelectionMode(gridOptions: GridOptions): RowSelectionMode | undefined;
 export function _getRowSelectionMode(gos: GridOptionsService): RowSelectionMode | undefined;
 export function _getRowSelectionMode(arg: object): RowSelectionMode | undefined {
@@ -473,6 +510,7 @@ export function _getRowSelectionMode(arg: object): RowSelectionMode | undefined 
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isMultiRowSelection(gridOptions: GridOptions): boolean;
 export function _isMultiRowSelection(gos: GridOptionsService): boolean;
 export function _isMultiRowSelection(arg: object): boolean {
@@ -490,6 +528,7 @@ export function _getEnableSelectionWithoutKeys(gos: GridOptionsService): boolean
     return selection?.enableSelectionWithoutKeys ?? false;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getGroupSelection(gos: GridOptionsService): GroupSelectionMode | undefined {
     const selection = gos.get('rowSelection');
 
@@ -527,6 +566,7 @@ export function _getCtrlASelectsRows(gos: GridOptionsService): boolean {
     return rowSelection?.mode === 'multiRow' ? rowSelection.ctrlASelectsRows ?? false : false;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getGroupSelectsDescendants(gos: GridOptionsService): boolean {
     const groupSelection = _getGroupSelection(gos);
     return groupSelection === 'descendants' || groupSelection === 'filteredDescendants';
@@ -537,18 +577,22 @@ export function _getMasterSelects(gos: GridOptionsService): MasterSelectionMode 
     return (typeof rowSelection === 'object' && rowSelection.masterSelects) || 'self';
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isSetFilterByDefault(gos: GridOptionsService): boolean {
     return gos.isModuleRegistered('SetFilter') && !gos.get('suppressSetFilterByDefault');
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isLegacyMenuEnabled(gos: GridOptionsService): boolean {
     return gos.get('columnMenu') === 'legacy';
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isColumnMenuAnchoringEnabled(gos: GridOptionsService): boolean {
     return !_isLegacyMenuEnabled(gos);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getCallbackForEvent(eventName: string): string {
     if (!eventName || eventName.length < 2) {
         return eventName;
@@ -556,7 +600,10 @@ export function _getCallbackForEvent(eventName: string): string {
     return 'on' + eventName[0].toUpperCase() + eventName.substring(1);
 }
 
-/** Combines component props / attributes with the provided gridOptions returning a new combined gridOptions object */
+/**
+ * Combines component props / attributes with the provided gridOptions returning a new combined gridOptions object
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export function _combineAttributesAndGridOptions(
     gridOptions: GridOptions | undefined,
     component: any,
@@ -578,6 +625,7 @@ export function _combineAttributesAndGridOptions(
     return mergedOptions;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _processOnChange(changes: any, api: GridApi): void {
     if (!changes) {
         return;
@@ -609,6 +657,7 @@ export function _processOnChange(changes: any, api: GridApi): void {
     api.dispatchEvent(event);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _addGridCommonParams<T extends AgGridCommon<TData, TContext>, TData = any, TContext = any>(
     gos: GridOptionsService,
     params: WithoutGridCommon<T>
@@ -616,7 +665,10 @@ export function _addGridCommonParams<T extends AgGridCommon<TData, TContext>, TD
     return gos.addCommon(params);
 }
 
-/** Used for before GridOptionsService is initialised */
+/**
+ * Used for before GridOptionsService is initialised
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export function _getGridOption<K extends keyof GridOptions>(
     providedGridOptions: GridOptions,
     gridOption: K
@@ -629,6 +681,7 @@ export function _getGridOption<K extends keyof GridOptions>(
     );
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _interpretAsRightClick({ gos }: BeanCollection, event: MouseEvent): boolean {
     return event.button === 2 || (event.ctrlKey && gos.get('allowContextMenuWithControlKey'));
 }

--- a/packages/ag-grid-community/src/headerRendering/cells/abstractCell/abstractHeaderCellCtrl.ts
+++ b/packages/ag-grid-community/src/headerRendering/cells/abstractCell/abstractHeaderCellCtrl.ts
@@ -19,6 +19,7 @@ import { refreshFirstAndLastStyles } from '../cssClassApplier';
 
 let instanceIdSequence = 0;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IAbstractHeaderCellComp {
     toggleCss(cssClassName: string, on: boolean): void;
     setUserStyles(styles: HeaderStyle): void;
@@ -32,6 +33,7 @@ export type HeaderCellCtrlInstanceId = BrandedType<string, 'HeaderCellCtrlInstan
 
 export const DOM_DATA_KEY_HEADER_CTRL = 'headerCtrl';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export abstract class AbstractHeaderCellCtrl<
     TComp extends IAbstractHeaderCellComp = IAbstractHeaderCellComp,
     TColumn extends AgColumn | AgColumnGroup = AgColumn | AgColumnGroup,

--- a/packages/ag-grid-community/src/headerRendering/cells/column/headerCellCtrl.ts
+++ b/packages/ag-grid-community/src/headerRendering/cells/column/headerCellCtrl.ts
@@ -26,6 +26,7 @@ import { AbstractHeaderCellCtrl } from '../abstractCell/abstractHeaderCellCtrl';
 import { _getHeaderClassesFromColDef } from '../cssClassApplier';
 import type { HeaderComp } from './headerComp';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IHeaderCellComp extends IAbstractHeaderCellComp {
     setWidth(width: string): void;
     setAriaSort(sort?: AriaSortState): void;
@@ -45,6 +46,7 @@ type RefreshFunction =
     | 'measuring'
     | 'resize';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class HeaderCellCtrl extends AbstractHeaderCellCtrl<IHeaderCellComp, AgColumn, ResizeFeature> {
     private refreshFunctions: { [key in RefreshFunction]?: () => void } = {};
     private selectAllFeature?: SelectAllFeature;

--- a/packages/ag-grid-community/src/headerRendering/cells/column/headerComp.ts
+++ b/packages/ag-grid-community/src/headerRendering/cells/column/headerComp.ts
@@ -54,6 +54,7 @@ function getHeaderCompElementParams(includeColumnRefIndicator: boolean, includeS
     };
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class HeaderComp extends Component implements IHeaderComp {
     // All the elements are optional, as they are not guaranteed to be present if the user provides a custom template
     private readonly eFilter?: HTMLElement = RefPlaceholder;

--- a/packages/ag-grid-community/src/headerRendering/cells/columnGroup/headerGroupCellCtrl.ts
+++ b/packages/ag-grid-community/src/headerRendering/cells/columnGroup/headerGroupCellCtrl.ts
@@ -21,6 +21,7 @@ import { _getHeaderClassesFromColDef } from '../cssClassApplier';
 import { GroupWidthFeature } from './groupWidthFeature';
 import type { IHeaderGroupComp, IHeaderGroupParams } from './headerGroupComp';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IHeaderGroupCellComp extends IAbstractHeaderCellComp {
     setResizableDisplayed(displayed: boolean): void;
     setWidth(width: string): void;
@@ -31,6 +32,7 @@ export interface IHeaderGroupCellComp extends IAbstractHeaderCellComp {
     getUserCompInstance(): IHeaderGroupComp | undefined;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class HeaderGroupCellCtrl extends AbstractHeaderCellCtrl<
     IHeaderGroupCellComp,
     AgColumnGroup,

--- a/packages/ag-grid-community/src/headerRendering/cells/cssClassApplier.ts
+++ b/packages/ag-grid-community/src/headerRendering/cells/cssClassApplier.ts
@@ -13,6 +13,7 @@ import type { IAbstractHeaderCellComp } from './abstractCell/abstractHeaderCellC
 const CSS_FIRST_COLUMN = 'ag-column-first';
 const CSS_LAST_COLUMN = 'ag-column-last';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getHeaderClassesFromColDef(
     abstractColDef: AbstractColDef | null,
     gos: GridOptionsService,
@@ -26,6 +27,7 @@ export function _getHeaderClassesFromColDef(
     return getColumnClassesFromCollDef(abstractColDef.headerClass, abstractColDef, gos, column, columnGroup);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getToolPanelClassesFromColDef(
     abstractColDef: AbstractColDef | null,
     gos: GridOptionsService,

--- a/packages/ag-grid-community/src/headerRendering/cells/floatingFilter/headerFilterCellCtrl.ts
+++ b/packages/ag-grid-community/src/headerRendering/cells/floatingFilter/headerFilterCellCtrl.ts
@@ -18,6 +18,7 @@ import { ManagedFocusFeature } from '../../../widgets/managedFocusFeature';
 import { AbstractHeaderCellCtrl } from '../abstractCell/abstractHeaderCellCtrl';
 import type { IHeaderFilterCellComp } from './iHeaderFilterCellComp';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class HeaderFilterCellCtrl extends AbstractHeaderCellCtrl<IHeaderFilterCellComp, AgColumn> {
     private eButtonShowMainFilter: HTMLElement;
     private eFloatingFilterBody: HTMLElement;

--- a/packages/ag-grid-community/src/headerRendering/cells/floatingFilter/iHeaderFilterCellComp.ts
+++ b/packages/ag-grid-community/src/headerRendering/cells/floatingFilter/iHeaderFilterCellComp.ts
@@ -3,6 +3,7 @@ import type { IFloatingFilter } from '../../../filter/floating/floatingFilter';
 import type { UserCompDetails } from '../../../interfaces/iUserCompDetails';
 import type { IAbstractHeaderCellComp } from '../abstractCell/abstractHeaderCellCtrl';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IHeaderFilterCellComp extends IAbstractHeaderCellComp {
     addOrRemoveBodyCssClass(cssClassName: string, on: boolean): void;
     setButtonWrapperDisplayed(displayed: boolean): void;

--- a/packages/ag-grid-community/src/headerRendering/gridHeaderCtrl.ts
+++ b/packages/ag-grid-community/src/headerRendering/gridHeaderCtrl.ts
@@ -8,11 +8,13 @@ import type { HeaderNavigationDirection } from '../navigation/headerNavigationSe
 import { ManagedFocusFeature } from '../widgets/managedFocusFeature';
 import { getColumnHeaderRowHeight, getFloatingFiltersHeight, getGroupRowsHeight } from './headerUtils';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IGridHeaderComp {
     toggleCss(cssClassName: string, on: boolean): void;
     setHeightAndMinHeight(height: string): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class GridHeaderCtrl extends BeanStub {
     private comp: IGridHeaderComp;
     public eGui: HTMLElement;

--- a/packages/ag-grid-community/src/headerRendering/headerUtils.ts
+++ b/packages/ag-grid-community/src/headerRendering/headerUtils.ts
@@ -4,6 +4,7 @@ import type { HeaderPosition } from '../interfaces/iHeaderPosition';
 import type { HeaderRowCtrl } from './row/headerRowCtrl';
 
 // + gridPanel -> for resizing the body and setting top margin
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function getHeaderRowCount(colModel: ColumnModel): number {
     if (!colModel.cols) {
         return -1;
@@ -73,6 +74,7 @@ export function getHeaderHeight(beans: BeanCollection): number {
     return beans.gos.get('headerHeight') ?? beans.environment.getDefaultHeaderHeight();
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function getFloatingFiltersHeight(beans: BeanCollection): number {
     return beans.gos.get('floatingFiltersHeight') ?? getHeaderHeight(beans);
 }

--- a/packages/ag-grid-community/src/headerRendering/row/headerRowCtrl.ts
+++ b/packages/ag-grid-community/src/headerRendering/row/headerRowCtrl.ts
@@ -12,6 +12,7 @@ import type { HeaderFilterCellCtrl } from '../cells/floatingFilter/headerFilterC
 import { getColumnHeaderRowHeight, getFloatingFiltersHeight, getGroupRowsHeight } from '../headerUtils';
 import type { HeaderRowType } from './headerRowComp';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IHeaderRowComp {
     setTop(top: string): void;
     setHeight(height: string): void;
@@ -23,6 +24,7 @@ export interface IHeaderRowComp {
 let instanceIdSequence = 0;
 export type HeaderRowCtrlInstanceId = BrandedType<number, 'HeaderRowCtrlInstanceId'>;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class HeaderRowCtrl extends BeanStub {
     public readonly instanceId: HeaderRowCtrlInstanceId = instanceIdSequence++ as HeaderRowCtrlInstanceId;
 

--- a/packages/ag-grid-community/src/headerRendering/rowContainer/headerRowContainerCtrl.ts
+++ b/packages/ag-grid-community/src/headerRendering/rowContainer/headerRowContainerCtrl.ts
@@ -12,6 +12,7 @@ import type { AbstractHeaderCellCtrl } from '../cells/abstractCell/abstractHeade
 import type { HeaderRowType } from '../row/headerRowComp';
 import { HeaderRowCtrl } from '../row/headerRowCtrl';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IHeaderRowContainerComp {
     setCenterWidth(width: string): void;
     setViewportScrollLeft(left: number): void;
@@ -20,6 +21,7 @@ export interface IHeaderRowContainerComp {
     setCtrls(ctrls: HeaderRowCtrl[]): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class HeaderRowContainerCtrl extends BeanStub implements ScrollPartner {
     public comp: IHeaderRowContainerComp;
     public hidden: boolean = false;

--- a/packages/ag-grid-community/src/interfaces/IRangeService.ts
+++ b/packages/ag-grid-community/src/interfaces/IRangeService.ts
@@ -10,6 +10,7 @@ import type { CellPosition } from './iCellPosition';
 import type { ICellRangeFeature } from './iCellRangeFeature';
 import type { RowPosition } from './iRowPosition';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IRangeService {
     readonly autoScrollService: AutoScrollService;
     isEmpty(): boolean;

--- a/packages/ag-grid-community/src/interfaces/iAdvancedFilterCtrl.ts
+++ b/packages/ag-grid-community/src/interfaces/iAdvancedFilterCtrl.ts
@@ -1,3 +1,4 @@
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IAdvancedFilterCtrl {
     setupHeaderComp(eCompToInsertBefore: HTMLElement): void;
 

--- a/packages/ag-grid-community/src/interfaces/iAdvancedFilterService.ts
+++ b/packages/ag-grid-community/src/interfaces/iAdvancedFilterService.ts
@@ -2,6 +2,7 @@ import type { AdvancedFilterModel } from './advancedFilterModel';
 import type { IAdvancedFilterCtrl } from './iAdvancedFilterCtrl';
 import type { IRowNode } from './iRowNode';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IAdvancedFilterService {
     isEnabled(): boolean;
 

--- a/packages/ag-grid-community/src/interfaces/iAggColumnNameService.ts
+++ b/packages/ag-grid-community/src/interfaces/iAggColumnNameService.ts
@@ -1,5 +1,6 @@
 import type { AgColumn } from '../entities/agColumn';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IAggColumnNameService {
     getHeaderName(column: AgColumn, headerName: string | null): string | null;
 }

--- a/packages/ag-grid-community/src/interfaces/iAggFuncService.ts
+++ b/packages/ag-grid-community/src/interfaces/iAggFuncService.ts
@@ -1,6 +1,7 @@
 import type { AgColumn } from '../entities/agColumn';
 import type { IAggFunc } from '../entities/colDef';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IAggFuncService {
     addAggFuncs(aggFuncs: { [key: string]: IAggFunc }): void;
     clear(): void;

--- a/packages/ag-grid-community/src/interfaces/iCellRangeFeature.ts
+++ b/packages/ag-grid-community/src/interfaces/iCellRangeFeature.ts
@@ -1,5 +1,6 @@
 import type { ICellComp } from '../rendering/cell/cellCtrl';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface ICellRangeFeature {
     setComp(cellComp: ICellComp): void;
     unsetComp(): void;

--- a/packages/ag-grid-community/src/interfaces/iClipboardService.ts
+++ b/packages/ag-grid-community/src/interfaces/iClipboardService.ts
@@ -7,6 +7,7 @@ export interface IClipboardCopyParams {
 export interface IClipboardCopyRowsParams extends IClipboardCopyParams {
     columnKeys?: (string | Column)[];
 }
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IClipboardService {
     pasteFromClipboard(): void;
     copyToClipboard(params?: IClipboardCopyParams): void;

--- a/packages/ag-grid-community/src/interfaces/iColsService.ts
+++ b/packages/ag-grid-community/src/interfaces/iColsService.ts
@@ -24,6 +24,7 @@ export type ColumnExtractors = {
     getInitialValueFunc: (colDef: ColDef) => boolean | undefined;
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IColsService {
     columns: AgColumn[];
     eventName: ColumnChangedEventType;

--- a/packages/ag-grid-community/src/interfaces/iColumnCollectionService.ts
+++ b/packages/ag-grid-community/src/interfaces/iColumnCollectionService.ts
@@ -5,6 +5,7 @@ import type { GridOptions } from '../entities/gridOptions';
 import type { ColumnEventType } from '../events';
 import type { PropertyChangedEvent, PropertyValueChangedEvent } from '../gridOptionsService';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IColumnCollectionService {
     columns: ColumnCollections | null;
 

--- a/packages/ag-grid-community/src/interfaces/iEventService.ts
+++ b/packages/ag-grid-community/src/interfaces/iEventService.ts
@@ -2,4 +2,5 @@ import type { AgEventService } from '../agStack/interfaces/iEvent';
 import type { AgEventTypeParams } from '../events';
 import type { AgGridCommon } from './iCommon';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type IEventService = AgEventService<AgEventTypeParams, AgGridCommon<any, any>>;

--- a/packages/ag-grid-community/src/interfaces/iExpansionService.ts
+++ b/packages/ag-grid-community/src/interfaces/iExpansionService.ts
@@ -25,6 +25,7 @@ export interface RowGroupBulkExpansionState {
     invertedRowGroupIds: string[];
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IExpansionService<
     T extends RowGroupExpansionState | RowGroupBulkExpansionState = RowGroupExpansionState,
 > {

--- a/packages/ag-grid-community/src/interfaces/iFocusableContainer.ts
+++ b/packages/ag-grid-community/src/interfaces/iFocusableContainer.ts
@@ -7,6 +7,7 @@ export type FocusableContainerName =
     | 'sideBar'
     | 'statusBar';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface FocusableContainer {
     getGui(): HTMLElement;
     getFocusableContainerName(): FocusableContainerName;

--- a/packages/ag-grid-community/src/interfaces/iFooterService.ts
+++ b/packages/ag-grid-community/src/interfaces/iFooterService.ts
@@ -2,6 +2,7 @@ import type { RowNode } from '../entities/rowNode';
 import type { Column } from './iColumn';
 import type { IRowNode } from './iRowNode';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IFooterService {
     addTotalRows(
         startIndex: number,

--- a/packages/ag-grid-community/src/interfaces/iFrameworkEventListenerService.ts
+++ b/packages/ag-grid-community/src/interfaces/iFrameworkEventListenerService.ts
@@ -4,6 +4,7 @@ import type { RowNodeEventType } from './iRowNode';
 
 type EventType = AgEventType | RowNodeEventType | ColumnEventName;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IFrameworkEventListenerService<
     TEventListener extends (e: any) => void,
     TGlobalEventListener extends (name: string, e: any) => void,

--- a/packages/ag-grid-community/src/interfaces/iFrameworkOverrides.ts
+++ b/packages/ag-grid-community/src/interfaces/iFrameworkOverrides.ts
@@ -2,6 +2,7 @@ import type { LocalEventService } from '../agStack/events/localEventService';
 import type { AgFrameworkOverrides } from '../agStack/interfaces/agFrameworkOverrides';
 import type { IFrameworkEventListenerService } from './iFrameworkEventListenerService';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IFrameworkOverrides extends AgFrameworkOverrides {
     /** Used for Angular event listener wrapping */
     createLocalEventListenerWrapper?(

--- a/packages/ag-grid-community/src/interfaces/iGroupEditService.ts
+++ b/packages/ag-grid-community/src/interfaces/iGroupEditService.ts
@@ -1,6 +1,7 @@
 import type { RowsDrop } from '../dragAndDrop/rowDragTypes';
 import type { IRowNode } from './iRowNode';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IGroupEditService {
     canSetParent(rowsDrop: RowsDrop): boolean;
     isGroupingDrop(rowsDrop: RowsDrop): boolean;

--- a/packages/ag-grid-community/src/interfaces/iGroupFilterService.ts
+++ b/packages/ag-grid-community/src/interfaces/iGroupFilterService.ts
@@ -1,6 +1,7 @@
 import type { AgColumn } from '../entities/agColumn';
 import type { ColumnEventType } from '../events';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IGroupFilterService {
     isGroupFilter(column: AgColumn): boolean;
 

--- a/packages/ag-grid-community/src/interfaces/iGroupHierarchyColService.ts
+++ b/packages/ag-grid-community/src/interfaces/iGroupHierarchyColService.ts
@@ -1,6 +1,7 @@
 import type { AgColumn } from '../entities/agColumn';
 import type { IColumnCollectionService } from './iColumnCollectionService';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IGroupHierarchyColService extends IColumnCollectionService {
     /**
      * Mutates the `target` parameter, adding any virtual columns associated with the given source column, as well as the source column itself (last in the array)

--- a/packages/ag-grid-community/src/interfaces/iMenuFactory.ts
+++ b/packages/ag-grid-community/src/interfaces/iMenuFactory.ts
@@ -4,6 +4,7 @@ import type { ContainerType } from './iAfterGuiAttachedParams';
 
 type MenuColumn = AgColumn | AgProvidedColumnGroup | undefined;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IMenuFactory {
     showMenuAfterButtonClick(
         column: MenuColumn,

--- a/packages/ag-grid-community/src/interfaces/iModule.ts
+++ b/packages/ag-grid-community/src/interfaces/iModule.ts
@@ -16,6 +16,7 @@ type ModuleValidationInvalidResult = {
     message: string;
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type ModuleValidationResult = ModuleValidationValidResult | ModuleValidationInvalidResult;
 
 /** A Module contains all the code related to this feature to enable tree shaking when this module is not used. */
@@ -48,16 +49,25 @@ export interface Module {
     css?: string[];
 }
 
-/** Used to define a module that contains api functions. */
+/**
+ * Used to define a module that contains api functions.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export type _ModuleWithApi<TGridApi extends Readonly<Partial<GridApi>>> = Omit<Module, 'rowModels'> & {
     apiFunctions?: { [K in ApiFunctionName & keyof TGridApi]: ApiFunction<K> };
 };
-/** Used to define a module that does not contain api functions. */
+/**
+ * Used to define a module that does not contain api functions.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export type _ModuleWithoutApi = Module & {
     apiFunctions?: never;
 };
 
-/** Used by React to set the license key via React context if an enterprise module has been provided. */
+/**
+ * Used by React to set the license key via React context if an enterprise module has been provided.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export type _ModuleWithLicenseManager = {
     setLicenseKey: (licenseKey: string) => void;
 };
@@ -294,7 +304,10 @@ type ModuleTypesEquivalent = ValidateTheSame | ValidateTheSame2 extends never ? 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const validateTheSame: ModuleTypesEquivalent = true;
 
-/** INTERNAL: All public and internal module names */
+/**
+ * INTERNAL: All public and internal module names
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export type ModuleName = InternalModuleName | CommunityModuleName | EnterpriseModuleName;
 
 /** These are the internal modules that we have mappings for to convert into exported modules */
@@ -334,5 +347,8 @@ export type ResolvableModuleName = Extract<
     | 'SharedTreeData'
 >;
 
-/** These are the types that we can display validations for */
+/**
+ * These are the types that we can display validations for
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export type ValidationModuleName = CommunityModuleName | EnterpriseModuleName | ResolvableModuleName;

--- a/packages/ag-grid-community/src/interfaces/iMultiFilterService.ts
+++ b/packages/ag-grid-community/src/interfaces/iMultiFilterService.ts
@@ -2,6 +2,7 @@ import type { ValueGetterFunc } from '../entities/colDef';
 import type { CoreDataTypeDefinition, DataTypeFormatValueFunc } from '../entities/dataType';
 import type { IMultiFilterParams } from './iMultiFilter';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IMultiFilterService {
     getParamsForDataType(
         existingFilterParams: IMultiFilterParams | undefined,

--- a/packages/ag-grid-community/src/interfaces/iPinnedRowModel.ts
+++ b/packages/ag-grid-community/src/interfaces/iPinnedRowModel.ts
@@ -3,6 +3,7 @@ import type { RowNode } from '../entities/rowNode';
 import type { RowPinningState } from './gridState';
 import type { RowPinnedType } from './iRowNode';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IPinnedRowModel {
     /** Reset the pinned row state. This is a no-op for the static pinned row model. */
     reset(): void;

--- a/packages/ag-grid-community/src/interfaces/iPivotColDefService.ts
+++ b/packages/ag-grid-community/src/interfaces/iPivotColDefService.ts
@@ -1,5 +1,6 @@
 import type { ColDef, ColGroupDef } from '../entities/colDef';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IPivotColDefService {
     createColDefsFromFields: (fields: string[]) => (ColDef | ColGroupDef)[];
     recreateColDef(colDef: ColDef): ColDef;

--- a/packages/ag-grid-community/src/interfaces/iPivotResultColsService.ts
+++ b/packages/ag-grid-community/src/interfaces/iPivotResultColsService.ts
@@ -3,6 +3,7 @@ import type { AgColumn } from '../entities/agColumn';
 import type { ColDef, ColGroupDef, ColKey } from '../entities/colDef';
 import type { ColumnEventType } from '../events';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IPivotResultColsService {
     isPivotResultColsPresent(): boolean;
 

--- a/packages/ag-grid-community/src/interfaces/iRowChildrenService.ts
+++ b/packages/ag-grid-community/src/interfaces/iRowChildrenService.ts
@@ -1,5 +1,6 @@
 import type { RowNode } from '../entities/rowNode';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IRowChildrenService {
     getHasChildrenValue(rowNode: RowNode): boolean | null;
 }

--- a/packages/ag-grid-community/src/interfaces/iRowNodeStage.ts
+++ b/packages/ag-grid-community/src/interfaces/iRowNodeStage.ts
@@ -18,10 +18,12 @@ export interface IRowNodeFilterStage<TData = any> extends IRowNodeStage<TData> {
     execute(changedPath: ChangedPath): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IRowNodePivotStage<TData = any> extends IRowNodeStage<TData> {
     execute(changedPath: ChangedPath): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IRowNodeAggregationStage<TData = any> extends IRowNodeStage<TData> {
     execute(changedPath: ChangedPath): void;
 
@@ -35,16 +37,20 @@ export interface IRowNodeAggregationStage<TData = any> extends IRowNodeStage<TDa
     ): RowNode<TData>[];
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IRowNodeFilterAggregateStage<TData = any> extends IRowNodeStage<TData> {
     execute(changedPath: ChangedPath): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IRowNodeFlattenStage<TData = any> extends IRowNodeStage<TData> {
     execute(): RowNode<TData>[];
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type NestedDataGetter<TData = any> = (data: TData) => TData[] | null | undefined;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IRowNodeGroupStage<TData = any> extends IRowNodeStage<TData> {
     readonly treeData: boolean;
 

--- a/packages/ag-grid-community/src/interfaces/iSelectionService.ts
+++ b/packages/ag-grid-community/src/interfaces/iSelectionService.ts
@@ -10,6 +10,7 @@ import type { ChangedPath } from '../utils/changedPath';
 import type { IRowNode } from './iRowNode';
 import type { ServerSideRowGroupSelectionState, ServerSideRowSelectionState } from './selectionState';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface ISelectionService {
     getSelectionState(): string[] | ServerSideRowSelectionState | ServerSideRowGroupSelectionState | null;
     setSelectionState(
@@ -51,6 +52,7 @@ export interface ISelectionService {
     setDetailSelectionState(masterNode: RowNode, option: GridOptions, detailApi: GridApi): void;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface ISetNodesSelectedParams {
     /** nodes to change selection of */
     nodes: readonly RowNode[];

--- a/packages/ag-grid-community/src/interfaces/iShowRowGroupColsService.ts
+++ b/packages/ag-grid-community/src/interfaces/iShowRowGroupColsService.ts
@@ -1,5 +1,6 @@
 import type { AgColumn } from '../entities/agColumn';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IShowRowGroupColsService {
     readonly columns: AgColumn[];
 

--- a/packages/ag-grid-community/src/interfaces/iShowRowGroupColsValueService.ts
+++ b/packages/ag-grid-community/src/interfaces/iShowRowGroupColsValueService.ts
@@ -1,11 +1,13 @@
 import type { AgColumn } from '../entities/agColumn';
 import type { IRowNode } from './iRowNode';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface GroupValueResult {
     displayedNode: IRowNode;
     value: any;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IShowRowGroupColsValueService {
     getGroupValue(node: IRowNode, column: AgColumn | undefined, ignoreAggData: boolean): GroupValueResult | null;
     formatAndPrefixGroupColValue(groupValue: GroupValueResult, column?: AgColumn, exporting?: boolean): string | null;

--- a/packages/ag-grid-community/src/interfaces/iSideBar.ts
+++ b/packages/ag-grid-community/src/interfaces/iSideBar.ts
@@ -2,11 +2,13 @@ import type { Component, ComponentSelector } from '../widgets/component';
 import type { SideBarState } from './gridState';
 import type { IToolPanel } from './iToolPanel';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface ISideBarService {
     comp: ISideBar;
     getSelector(): ComponentSelector<Component>;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface ISideBar {
     refresh(): void;
     setDisplayed(show: boolean): void;

--- a/packages/ag-grid-community/src/interfaces/iSortOption.ts
+++ b/packages/ag-grid-community/src/interfaces/iSortOption.ts
@@ -1,6 +1,7 @@
 import type { SortDirection, SortType } from '../entities/colDef';
 import type { Column } from './iColumn';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface SortOption {
     sort: NonNullable<SortDirection>;
     type: SortType;

--- a/packages/ag-grid-community/src/interfaces/iStickyRows.ts
+++ b/packages/ag-grid-community/src/interfaces/iStickyRows.ts
@@ -2,6 +2,7 @@ import type { BeanStub } from '../context/beanStub';
 import type { RowNode } from '../entities/rowNode';
 import type { RowCtrl } from '../rendering/row/rowCtrl';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IStickyRowFeature {
     stickyTopRowCtrls: RowCtrl[];
 
@@ -22,6 +23,7 @@ export interface IStickyRowFeature {
     ensureRowHeightsValid(): boolean;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IStickyRowService {
     createStickyRowFeature(
         ctrl: BeanStub,

--- a/packages/ag-grid-community/src/interfaces/iUserCompDetails.ts
+++ b/packages/ag-grid-community/src/interfaces/iUserCompDetails.ts
@@ -1,6 +1,7 @@
 import type { IComponent } from '../agStack/interfaces/iComponent';
 import type { AgPromise } from '../agStack/utils/promise';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface UserCompDetails<TComp extends IComponent<any> = any> {
     componentClass: any;
     componentFromFramework: boolean;
@@ -11,6 +12,7 @@ export interface UserCompDetails<TComp extends IComponent<any> = any> {
     newAgStackInstance: () => AgPromise<TComp>;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface ComponentType<TComp = any> {
     name: string;
     cellRenderer?: boolean;

--- a/packages/ag-grid-community/src/interfaces/iWatermark.ts
+++ b/packages/ag-grid-community/src/interfaces/iWatermark.ts
@@ -1,5 +1,6 @@
 import type { Component, ComponentSelector } from '../widgets/component';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IWatermark {
     getWatermarkSelector(): ComponentSelector<Component>;
 }

--- a/packages/ag-grid-community/src/interfaces/iXmlFactory.ts
+++ b/packages/ag-grid-community/src/interfaces/iXmlFactory.ts
@@ -1,3 +1,4 @@
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface XmlElement {
     name: string;
     properties?: XmlAttributes;
@@ -5,6 +6,7 @@ export interface XmlElement {
     textNode?: string | null;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface HeaderElement {
     [key: string]: string | undefined;
     version?: string;
@@ -12,11 +14,13 @@ export interface HeaderElement {
     encoding?: string;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface XmlAttributes {
     prefixedAttributes?: PrefixedXmlAttributes[];
     rawMap?: any;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface PrefixedXmlAttributes {
     prefix: string;
     map: any;

--- a/packages/ag-grid-community/src/interfaces/renderStatusService.ts
+++ b/packages/ag-grid-community/src/interfaces/renderStatusService.ts
@@ -1,3 +1,4 @@
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IRenderStatusService {
     /** Checks that every header cell that is currently visible has been rendered.
      * Can only be false under some circumstances when using React.

--- a/packages/ag-grid-community/src/interfaces/rowNumbers.ts
+++ b/packages/ag-grid-community/src/interfaces/rowNumbers.ts
@@ -60,6 +60,7 @@ export interface RowNumbersOptions
     resizable?: boolean;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IRowNumbersService extends IColumnCollectionService {
     setupForHeader(comp: HeaderComp): void;
     handleMouseDownOnCell(cell: CellPosition, mouseEvent: MouseEvent): boolean;

--- a/packages/ag-grid-community/src/main-internal.test.ts
+++ b/packages/ag-grid-community/src/main-internal.test.ts
@@ -1,0 +1,216 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as ts from 'typescript';
+
+const COMMUNITY_SRC = path.resolve(__dirname);
+const MAIN_INTERNAL_PATH = path.join(COMMUNITY_SRC, 'main-internal.ts');
+
+interface SymbolInfo {
+    originalName: string;
+    sourceFilePath: string;
+    relativeSourcePath: string;
+}
+
+// Cache parsed source files for performance
+const sourceFileCache = new Map<string, { text: string; sourceFile: ts.SourceFile }>();
+
+function getSourceFile(filePath: string) {
+    if (!sourceFileCache.has(filePath)) {
+        const text = fs.readFileSync(filePath, 'utf-8');
+        const sourceFile = ts.createSourceFile(path.basename(filePath), text, ts.ScriptTarget.Latest, true);
+        sourceFileCache.set(filePath, { text, sourceFile });
+    }
+    return sourceFileCache.get(filePath)!;
+}
+
+function getExportedNamesFromFile(filePath: string): string[] {
+    const { sourceFile } = getSourceFile(filePath);
+    const names: string[] = [];
+
+    for (const stmt of sourceFile.statements) {
+        const mods = ts.canHaveModifiers(stmt) ? ts.getModifiers(stmt) : undefined;
+        const isExported = mods?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+        if (!isExported) {
+            continue;
+        }
+
+        if (
+            ts.isClassDeclaration(stmt) ||
+            ts.isInterfaceDeclaration(stmt) ||
+            ts.isTypeAliasDeclaration(stmt) ||
+            ts.isEnumDeclaration(stmt) ||
+            ts.isFunctionDeclaration(stmt)
+        ) {
+            if (stmt.name) {
+                names.push(stmt.name.text);
+            }
+        } else if (ts.isVariableStatement(stmt)) {
+            for (const decl of stmt.declarationList.declarations) {
+                if (ts.isIdentifier(decl.name)) {
+                    names.push(decl.name.text);
+                }
+            }
+        }
+    }
+
+    return names;
+}
+
+function parseMainInternalExports(): SymbolInfo[] {
+    const { sourceFile } = getSourceFile(MAIN_INTERNAL_PATH);
+    const symbols: SymbolInfo[] = [];
+
+    for (const stmt of sourceFile.statements) {
+        if (!ts.isExportDeclaration(stmt) || !stmt.moduleSpecifier) {
+            continue;
+        }
+        if (!ts.isStringLiteral(stmt.moduleSpecifier)) {
+            continue;
+        }
+
+        const modulePath = stmt.moduleSpecifier.text;
+        const resolvedPath = path.resolve(COMMUNITY_SRC, modulePath + '.ts');
+        const relativePath = path.relative(COMMUNITY_SRC, resolvedPath);
+
+        if (stmt.exportClause && ts.isNamedExports(stmt.exportClause)) {
+            for (const element of stmt.exportClause.elements) {
+                const originalName = (element.propertyName || element.name).text;
+                symbols.push({ originalName, sourceFilePath: resolvedPath, relativeSourcePath: relativePath });
+            }
+        } else if (!stmt.exportClause) {
+            // Wildcard: export * from '...'
+            const wildcardNames = getExportedNamesFromFile(resolvedPath);
+            for (const name of wildcardNames) {
+                symbols.push({ originalName: name, sourceFilePath: resolvedPath, relativeSourcePath: relativePath });
+            }
+        }
+    }
+
+    return symbols;
+}
+
+function findDeclarationNode(sourceFile: ts.SourceFile, symbolName: string): ts.Node | null {
+    for (const stmt of sourceFile.statements) {
+        if (
+            ts.isClassDeclaration(stmt) ||
+            ts.isInterfaceDeclaration(stmt) ||
+            ts.isTypeAliasDeclaration(stmt) ||
+            ts.isEnumDeclaration(stmt) ||
+            ts.isFunctionDeclaration(stmt)
+        ) {
+            if (stmt.name?.text === symbolName) {
+                return stmt;
+            }
+        }
+
+        if (ts.isVariableStatement(stmt)) {
+            for (const decl of stmt.declarationList.declarations) {
+                if (ts.isIdentifier(decl.name) && decl.name.text === symbolName) {
+                    return stmt; // VariableStatement, not the individual declarator
+                }
+            }
+        }
+    }
+
+    return null;
+}
+
+function getJSDocForSymbol(filePath: string, symbolName: string): string | null {
+    const { text, sourceFile } = getSourceFile(filePath);
+    const node = findDeclarationNode(sourceFile, symbolName);
+    if (!node) {
+        return null;
+    }
+
+    const fullStart = node.getFullStart();
+    const comments = ts.getLeadingCommentRanges(text, fullStart);
+    if (!comments) {
+        return null;
+    }
+
+    // Find the last JSDoc comment (/** ... */) before the declaration
+    for (let i = comments.length - 1; i >= 0; i--) {
+        const comment = comments[i];
+        if (comment.kind === ts.SyntaxKind.MultiLineCommentTrivia) {
+            const commentText = text.substring(comment.pos, comment.end);
+            if (commentText.startsWith('/**')) {
+                return commentText;
+            }
+        }
+    }
+
+    return null;
+}
+
+const MAIN_PATH = path.join(COMMUNITY_SRC, 'main.ts');
+
+/**
+ * Collects all exported names from a module entry-point file by examining
+ * its export declarations.
+ *
+ * - Named re-exports (`export { Foo as Bar } from '...'`): adds the exported alias `Bar`.
+ * - Wildcard re-exports (`export * from '...'`): expands the target file's direct declarations.
+ * - Modules listed in `excludeModules` are skipped.
+ */
+function getExportedNamesFromModule(filePath: string, excludeModules: string[] = []): string[] {
+    const { sourceFile } = getSourceFile(filePath);
+    const names: string[] = [];
+    const dir = path.dirname(filePath);
+
+    for (const stmt of sourceFile.statements) {
+        if (!ts.isExportDeclaration(stmt) || !stmt.moduleSpecifier) {
+            continue;
+        }
+        if (!ts.isStringLiteral(stmt.moduleSpecifier)) {
+            continue;
+        }
+
+        const modulePath = stmt.moduleSpecifier.text;
+        if (excludeModules.includes(modulePath)) {
+            continue;
+        }
+
+        if (stmt.exportClause && ts.isNamedExports(stmt.exportClause)) {
+            for (const element of stmt.exportClause.elements) {
+                names.push(element.name.text);
+            }
+        } else if (!stmt.exportClause) {
+            // Wildcard re-export: expand the target file's direct declarations
+            const resolvedPath = path.resolve(dir, modulePath + '.ts');
+            names.push(...getExportedNamesFromFile(resolvedPath));
+        }
+    }
+
+    return names;
+}
+
+const symbols = parseMainInternalExports();
+
+describe('main-internal.ts JSDoc validation', () => {
+    test('should have at least 500 symbols to validate', () => {
+        expect(symbols.length).toBeGreaterThan(500);
+    });
+
+    test.each(symbols)(
+        '$originalName ($relativeSourcePath) should have AG_GRID_INTERNAL or @internal JSDoc',
+        ({ originalName, sourceFilePath }) => {
+            const jsDoc = getJSDocForSymbol(sourceFilePath, originalName);
+            expect(jsDoc).toBeTruthy();
+            expect(jsDoc!.includes('AG_GRID_INTERNAL') && jsDoc!.includes('@internal')).toBe(true);
+        }
+    );
+});
+
+describe('main.ts and main-internal.ts exports do not overlap', () => {
+    // main.ts re-exports everything from main-internal.ts at the bottom, so we exclude
+    // that re-export when collecting main.ts names to avoid false positives.
+    const mainExportNames = getExportedNamesFromModule(MAIN_PATH, ['./main-internal']);
+    const internalExportNames = getExportedNamesFromModule(MAIN_INTERNAL_PATH);
+
+    const internalNamesSet = new Set(internalExportNames);
+    const overlapping = mainExportNames.filter((name) => internalNamesSet.has(name));
+
+    test('should have no overlapping exports between main.ts and main-internal.ts', () => {
+        expect(overlapping).toEqual([]);
+    });
+});

--- a/packages/ag-grid-community/src/main-internal.ts
+++ b/packages/ag-grid-community/src/main-internal.ts
@@ -17,9 +17,9 @@ export { BaseRegistry as _BaseRegistry } from './agStack/core/baseRegistry';
 export { BaseEventService as _BaseEventService } from './agStack/events/baseEventService';
 export { LocalEventService } from './agStack/events/localEventService';
 export {
-    ManagedFocusCallbacks,
     FOCUS_MANAGED_CLASS as _FOCUS_MANAGED_CLASS,
     StopPropagationCallbacks as _StopPropagationCallbacks,
+    ManagedFocusCallbacks,
 } from './agStack/focus/agManagedFocusFeature';
 export { AgTabGuardComp as _AgTabGuardComp } from './agStack/focus/agTabGuardComp';
 export {
@@ -28,19 +28,19 @@ export {
 } from './agStack/focus/agTabGuardFeature';
 export { ITabGuard, TabGuardClassNames } from './agStack/focus/tabGuardCtrl';
 export {
-    AgBaseComponent,
-    RefPlaceholder,
-    VisibleChangedEvent,
     AgComponent as _AgComponent,
     AgComponentEvent as _AgComponentEvent,
     AgComponentSelector as _AgComponentSelector,
     _isComponent,
+    AgBaseComponent,
+    RefPlaceholder,
+    VisibleChangedEvent,
 } from './agStack/interfaces/agComponent';
 export { AgCoreBean as _AgCoreBean } from './agStack/interfaces/agCoreBean';
 export { AgCoreBeanCollection as _AgCoreBeanCollection } from './agStack/interfaces/agCoreBeanCollection';
 export {
-    FrameworkOverridesIncomingSource,
     AgFrameworkOverrides as _AgFrameworkOverrides,
+    FrameworkOverridesIncomingSource,
 } from './agStack/interfaces/agFrameworkOverrides';
 export {
     AgStylesChangedEvent as _AgStylesChangedEvent,
@@ -51,21 +51,21 @@ export { AfterGuiAttachedParams as _AfterGuiAttachedParams } from './agStack/int
 export { IAriaAnnouncementService } from './agStack/interfaces/iAriaAnnouncementService';
 export { IDragService as _IDragService } from './agStack/interfaces/iDrag';
 export {
-    IDragAndDropImage,
-    AgDragSource as _AgDragSource,
     AgDraggingEvent as _AgDraggingEvent,
+    AgDragSource as _AgDragSource,
     AgDropTarget as _AgDropTarget,
     IDragAndDropService as _IDragAndDropService,
+    IDragAndDropImage,
 } from './agStack/interfaces/iDragAndDrop';
 export { AgEventService as _AgEventService, WithoutCommon as _WithoutCommon } from './agStack/interfaces/iEvent';
 export { IconValue as _IconValue } from './agStack/interfaces/iIcon';
 export { IIconService as _IIconService } from './agStack/interfaces/iIconService';
-export { LocaleTextFunc, ILocaleService as _ILocaleService } from './agStack/interfaces/iLocaleService';
+export { ILocaleService as _ILocaleService, LocaleTextFunc } from './agStack/interfaces/iLocaleService';
 export { AddPopupParams as _AddPopupParams, AddPopupResult as _AddPopupResult } from './agStack/interfaces/iPopup';
 export { IPopupService as _IPopupService } from './agStack/interfaces/iPopupService';
 export {
-    AgPropertyChangeSet as _AgPropertyChangeSet,
     AgPropertyChangedSource as _AgPropertyChangedSource,
+    AgPropertyChangeSet as _AgPropertyChangeSet,
     AgPropertyKey as _AgPropertyKey,
     AgPropertyValueChangedEvent as _AgPropertyValueChangedEvent,
     AgPropertyValueChangedListener as _AgPropertyValueChangedListener,
@@ -75,16 +75,16 @@ export { ITooltipFeature as _ITooltipFeature, TooltipCtrl as _TooltipCtrl } from
 export { AgPopupComponent } from './agStack/popup/agPopupComponent';
 export { BasePopupService as _BasePopupService } from './agStack/popup/basePopupService';
 export {
+    AgPositionableFeature as _AgPositionableFeature,
     PositionableOptions,
     ResizableSides,
     ResizableStructure,
-    AgPositionableFeature as _AgPositionableFeature,
 } from './agStack/rendering/agPositionableFeature';
 export { AutoScrollService } from './agStack/rendering/autoScrollService';
 export { CssClassManager } from './agStack/rendering/cssClassManager';
 export {
-    SharedThemeParams as _SharedThemeParams,
     sharedDefaults as _sharedThemeDefaults,
+    SharedThemeParams as _SharedThemeParams,
 } from './agStack/theming/shared/shared-css';
 export { _asThemeImpl, createSharedTheme as _createSharedTheme } from './agStack/theming/themeImpl';
 export { ThemeLogger as _ThemeLogger } from './agStack/theming/themeLogger';
@@ -98,7 +98,6 @@ export {
     BaseTooltipStateManager as _BaseTooltipStateManager,
 } from './agStack/tooltip/baseTooltipStateManager';
 export {
-    AriaSortState,
     _getAriaPosInSet,
     _removeAriaExpanded,
     _removeAriaSort,
@@ -118,6 +117,7 @@ export {
     _setAriaLabel,
     _setAriaLabelledBy,
     _setAriaLevel,
+    _setAriaOrientation,
     _setAriaPosInSet,
     _setAriaRole,
     _setAriaRowCount,
@@ -125,34 +125,36 @@ export {
     _setAriaSelected,
     _setAriaSetSize,
     _setAriaSort,
-    _setAriaOrientation,
+    AriaSortState,
 } from './agStack/utils/aria';
-export { _EmptyArray, _areEqual, _flatten, _last, _removeAllFromArray, _removeFromArray } from './agStack/utils/array';
-export { _isBrowserFirefox, _isBrowserSafari, _isIOSUserAgent } from './agStack/utils/browser';
+export { _areEqual, _EmptyArray, _flatten, _last, _removeAllFromArray, _removeFromArray } from './agStack/utils/array';
 export { _parseBigIntOrNull } from './agStack/utils/bigInt';
-export { MONTHS as _MONTHS, _getDateParts, _parseDateTimeFromString, _serialiseDate } from './agStack/utils/date';
+export { _isBrowserFirefox, _isBrowserSafari, _isIOSUserAgent } from './agStack/utils/browser';
+export { _getDateParts, MONTHS as _MONTHS, _parseDateTimeFromString, _serialiseDate } from './agStack/utils/date';
 export {
     _getActiveDomElement,
     _getDocument,
-    _getWindow,
     _getPageBody,
     _getRootNode,
+    _getWindow,
     _isNothingFocused,
 } from './agStack/utils/document';
 export {
+    _addOrRemoveAttribute,
     AgElementParams as _AgElementParams,
     _clearElement,
     _createAgElement,
-    _addOrRemoveAttribute,
     _getAbsoluteHeight,
     _getAbsoluteWidth,
     _getInnerHeight,
     _getInnerWidth,
     _isElementOverflowingCallback,
+    _isFocusableFormField,
     _isNodeOrElement,
     _isVisible,
     _loadTemplate,
     _observeResize,
+    _placeCaretAtEnd,
     _radioCssClass,
     _removeFromParent,
     _requestAnimationFrame,
@@ -161,8 +163,6 @@ export {
     _setFixedWidth,
     _setScrollLeft,
     _setVisible,
-    _isFocusableFormField,
-    _placeCaretAtEnd,
 } from './agStack/utils/dom';
 export { _anchorElementToMouseMoveEvent, _isElementInEventPath } from './agStack/utils/event';
 export {
@@ -185,7 +185,7 @@ export {
 export { _isEventFromPrintableCharacter } from './agStack/utils/keyboard';
 export { _getLocaleTextFromFunc, _getLocaleTextFromMap, _getLocaleTextFunc, _translate } from './agStack/utils/locale';
 export { _isPromise } from './agStack/utils/promise';
-export { _escapeString, _isExpressionString, _toString, _camelCaseToHumanText } from './agStack/utils/string';
+export { _camelCaseToHumanText, _escapeString, _isExpressionString, _toString } from './agStack/utils/string';
 export { AgWidgetSelectorType as _AgWidgetSelectorType } from './agStack/widgets/agWidgetSelectorType';
 export {
     _AdvancedFilterGridApi,
@@ -221,7 +221,6 @@ export {
     _updateColumnState,
 } from './columns/columnFactoryUtils';
 export { ColumnKeyCreator } from './columns/columnKeyCreator';
-export { GroupInstanceIdCreator } from './columns/groupInstanceIdCreator';
 export { ColumnCollections as _ColumnCollections } from './columns/columnModel';
 export type { ColumnModel } from './columns/columnModel';
 export type { ColumnNameService } from './columns/columnNameService';
@@ -231,8 +230,8 @@ export {
     _columnsMatch,
     _convertColumnEventSourceType,
     _destroyColumnTree,
-    _getColumnStateFromColDef,
     _getColumnsFromTree,
+    _getColumnStateFromColDef,
     _getSortDefFromColDef,
     _updateColsMap,
     isColumnGroupAutoCol,
@@ -241,6 +240,7 @@ export {
     isSpecialCol,
 } from './columns/columnUtils';
 export type { DataTypeService } from './columns/dataTypeService';
+export { GroupInstanceIdCreator } from './columns/groupInstanceIdCreator';
 export type { VisibleColsService } from './columns/visibleColsService';
 export { EmptyBean as _EmptyBean } from './components/emptyBean';
 export {
@@ -250,6 +250,7 @@ export {
 } from './components/framework/frameworkComponentWrapper';
 export type { Registry } from './components/framework/registry';
 export { _unwrapUserComp } from './components/framework/unwrapUserComp';
+export type { UserComponentFactory } from './components/framework/userComponentFactory';
 export {
     _getCellRendererDetails,
     _getEditorRendererDetails,
@@ -257,7 +258,6 @@ export {
     _getFloatingFilterCompDetails,
     _getInnerCellRendererDetails,
 } from './components/framework/userCompUtils';
-export type { UserComponentFactory } from './components/framework/userComponentFactory';
 export { Bean, NamedBean } from './context/bean';
 export { BeanStub } from './context/beanStub';
 export { BeanCollection, BeanName, SingletonBean, StatusPanelComponentName } from './context/context';
@@ -266,17 +266,18 @@ export type { CtrlsService } from './ctrlsService';
 export type { DragAndDropService } from './dragAndDrop/dragAndDropService';
 export type { DragService } from './dragAndDrop/dragService';
 export type { HorizontalResizeService } from './dragAndDrop/horizontalResizeService';
+export type { RowDragComp } from './dragAndDrop/rowDragComp';
 export type { RowDragService } from './dragAndDrop/rowDragService';
 export type { RowsDrop as _RowsDrop } from './dragAndDrop/rowDragTypes';
 export {
-    AgColumn,
     _areSortDefsEqual,
+    _getDisplaySortForColumn,
     _getSortDefFromInput,
     _isSortDirectionValid,
     _isSortTypeValid,
     _normalizeSortDirection,
     _normalizeSortType,
-    _getDisplaySortForColumn,
+    AgColumn,
 } from './entities/agColumn';
 export { AgColumnGroup } from './entities/agColumnGroup';
 export { AgProvidedColumnGroup } from './entities/agProvidedColumnGroup';
@@ -294,15 +295,15 @@ export {
     _isSameRow,
 } from './entities/positionUtils';
 export {
-    RowNode,
     ROW_ID_PREFIX_BOTTOM_PINNED as _ROW_ID_PREFIX_BOTTOM_PINNED,
     ROW_ID_PREFIX_ROW_GROUP as _ROW_ID_PREFIX_ROW_GROUP,
     ROW_ID_PREFIX_TOP_PINNED as _ROW_ID_PREFIX_TOP_PINNED,
+    RowNode,
 } from './entities/rowNode';
 export { _createGlobalRowEvent, _createRowNodeSibling, _prevOrNextDisplayedRow } from './entities/rowNodeUtils';
 export { _addAdditionalCss } from './environment';
 export type { Environment } from './environment';
-export { ALWAYS_SYNC_GLOBAL_EVENTS, _GET_ALL_EVENTS, _PUBLIC_EVENTS } from './eventTypes';
+export { _GET_ALL_EVENTS, _PUBLIC_EVENTS, ALWAYS_SYNC_GLOBAL_EVENTS } from './eventTypes';
 export { BaseCreator } from './export/baseCreator';
 export { BaseGridSerializingSession } from './export/baseGridSerializingSession';
 export { _downloadFile } from './export/downloader';
@@ -312,10 +313,13 @@ export {
     _refreshHandlerAndUi,
     _updateFilterModel,
 } from './filter/columnFilterUtils';
+export { AgFilterButtonSelector, FilterButton, FilterButtonComp, FilterButtonEvent } from './filter/filterButtonComp';
+export { FilterComp } from './filter/filterComp';
 export { _getDefaultSimpleFilter, _getFilterParamsForDataType } from './filter/filterDataTypeUtils';
 export { translateForFilter as _translateForFilter } from './filter/filterLocaleText';
 export type { FilterManager } from './filter/filterManager';
 export type { FilterValueService } from './filter/filterValueService';
+export { FilterWrapperComp } from './filter/filterWrapperComp';
 export { _getDefaultFloatingFilterType } from './filter/floating/floatingFilterMapper';
 export { _isUseApplyButton } from './filter/provided/providedFilterUtils';
 export type { FocusService } from './focusService';
@@ -326,15 +330,15 @@ export { FakeVScrollComp } from './gridBodyComp/fakeVScrollComp';
 export { GridBodyCtrl, IGridBodyComp, RowAnimationCssClasses } from './gridBodyComp/gridBodyCtrl';
 export { _getCellPositionForEvent, _getNormalisedMousePosition } from './gridBodyComp/mouseEventUtils';
 export {
+    _getRowContainerClass,
+    _getRowContainerOptions,
+    _getRowSpanContainerClass,
+    _getRowViewportClass,
     IRowContainerComp,
     RowContainerCtrl,
     RowContainerName,
     RowContainerOptions,
     RowContainerType,
-    _getRowContainerClass,
-    _getRowContainerOptions,
-    _getRowSpanContainerClass,
-    _getRowViewportClass,
 } from './gridBodyComp/rowContainer/rowContainerCtrl';
 export type { ScrollVisibleService } from './gridBodyComp/scrollVisibleService';
 export { GridCtrl, IGridComp } from './gridComp/gridCtrl';
@@ -343,8 +347,8 @@ export {
     _canSkipShowingRowGroup,
     _combineAttributesAndGridOptions,
     _getCallbackForEvent,
-    _getCheckboxLocation,
     _getCheckboxes,
+    _getCheckboxLocation,
     _getEnableColumnSelection,
     _getFillHandle,
     _getGrandTotalRow,
@@ -370,8 +374,8 @@ export {
     _isDomLayout,
     _isFullWidthGroupRow,
     _isGetRowHeightFunction,
-    _isGroupMultiAutoColumn,
     _isGroupHideColumnsUntilExpanded,
+    _isGroupMultiAutoColumn,
     _isGroupRowsSticky,
     _isGroupUseEntireRow,
     _isLegacyMenuEnabled,
@@ -385,13 +389,26 @@ export {
     _processOnChange,
     _shouldUpdateColVisibilityAfterGroup,
 } from './gridOptionsUtils';
+export type {
+    AbstractHeaderCellCtrl,
+    IAbstractHeaderCellComp,
+} from './headerRendering/cells/abstractCell/abstractHeaderCellCtrl';
+export type { HeaderCellCtrl, IHeaderCellComp } from './headerRendering/cells/column/headerCellCtrl';
 export { HeaderComp as _HeaderComp } from './headerRendering/cells/column/headerComp';
+export type {
+    HeaderGroupCellCtrl,
+    IHeaderGroupCellComp,
+} from './headerRendering/cells/columnGroup/headerGroupCellCtrl';
 export { _getHeaderClassesFromColDef, _getToolPanelClassesFromColDef } from './headerRendering/cells/cssClassApplier';
+export type { HeaderFilterCellCtrl } from './headerRendering/cells/floatingFilter/headerFilterCellCtrl';
+export { IHeaderFilterCellComp } from './headerRendering/cells/floatingFilter/iHeaderFilterCellComp';
+export { GridHeaderCtrl, IGridHeaderComp } from './headerRendering/gridHeaderCtrl';
 export {
     getFloatingFiltersHeight as _getFloatingFiltersHeight,
     getHeaderRowCount as _getHeaderRowCount,
 } from './headerRendering/headerUtils';
-export { IRangeService } from './interfaces/IRangeService';
+export type { HeaderRowCtrl, IHeaderRowComp } from './headerRendering/row/headerRowCtrl';
+export { HeaderRowContainerCtrl, IHeaderRowContainerComp } from './headerRendering/rowContainer/headerRowContainerCtrl';
 export { IAdvancedFilterCtrl } from './interfaces/iAdvancedFilterCtrl';
 export { IAdvancedFilterService } from './interfaces/iAdvancedFilterService';
 export { IAggColumnNameService } from './interfaces/iAggColumnNameService';
@@ -414,14 +431,15 @@ export { IMultiFilterService } from './interfaces/iMultiFilterService';
 export { IPinnedRowModel } from './interfaces/iPinnedRowModel';
 export { IPivotColDefService } from './interfaces/iPivotColDefService';
 export { IPivotResultColsService } from './interfaces/iPivotResultColsService';
+export { IRangeService } from './interfaces/IRangeService';
 export { IRowChildrenService } from './interfaces/iRowChildrenService';
 export type {
-    NestedDataGetter,
     IRowNodeAggregationStage as _IRowNodeAggregationStage,
     IRowNodeFilterAggregateStage as _IRowNodeFilterAggregateStage,
     IRowNodeFlattenStage as _IRowNodeFlattenStage,
     IRowNodeGroupStage as _IRowNodeGroupStage,
     IRowNodePivotStage as _IRowNodePivotStage,
+    NestedDataGetter,
 } from './interfaces/iRowNodeStage';
 export { ISelectionService, ISetNodesSelectedParams } from './interfaces/iSelectionService';
 export { IShowRowGroupColsService } from './interfaces/iShowRowGroupColsService';
@@ -431,6 +449,7 @@ export { SortOption } from './interfaces/iSortOption';
 export { IStickyRowFeature, IStickyRowService } from './interfaces/iStickyRows';
 export { ComponentType, UserCompDetails } from './interfaces/iUserCompDetails';
 export { IWatermark } from './interfaces/iWatermark';
+export { HeaderElement, PrefixedXmlAttributes, XmlAttributes, XmlElement } from './interfaces/iXmlFactory';
 export { IRenderStatusService } from './interfaces/renderStatusService';
 export type { IRowNumbersService } from './interfaces/rowNumbers';
 export type { AnimationFrameService } from './misc/animationFrameService';
@@ -438,10 +457,10 @@ export { LocaleService } from './misc/locale/localeService';
 export { _setColMenuVisible } from './misc/menu/menuService';
 export type { MenuService } from './misc/menu/menuService';
 export {
+    _findEnterpriseCoreModule,
     _getGridRegisteredModules,
     _registerModule,
     _setUmd,
-    _findEnterpriseCoreModule,
 } from './modules/moduleRegistry';
 export type { CellNavigationService } from './navigation/cellNavigationService';
 export type { HeaderNavigationService } from './navigation/headerNavigationService';
@@ -465,8 +484,8 @@ export type { RowRangeSelectionContext } from './selection/rowRangeSelectionCont
 export type { RowNodeSorter } from './sort/rowNodeSorter';
 export type { SortService } from './sort/sortService';
 export type { CellStyleService } from './styling/cellStyleService';
-export { gridThemeLogger as _gridThemeLogger } from './theming/createTheme';
 export { coreDefaults as _coreThemeDefaults } from './theming/core/core-css';
+export { gridThemeLogger as _gridThemeLogger } from './theming/createTheme';
 export {
     themeAlpineParams as _themeAlpineParams,
     themeBalhamParams as _themeBalhamParams,
@@ -474,14 +493,14 @@ export {
     themeQuartzParams as _themeQuartzParams,
 } from './theming/parts/theme/themes';
 export {
+    _getShouldDisplayTooltip,
+    _isShowTooltipWhenTruncated,
     ITooltipCtrl,
     ITooltipCtrlParams,
     TooltipFeature,
-    _getShouldDisplayTooltip,
-    _isShowTooltipWhenTruncated,
 } from './tooltip/tooltipFeature';
 export { ChangedPath } from './utils/changedPath';
-export { ElementParams, _createElement } from './utils/element';
+export { _createElement, ElementParams } from './utils/element';
 export { _isStopPropagationForAgGrid, _stopPropagationForAgGrid } from './utils/gridEvent';
 export {
     _addFocusableContainerListener,
@@ -490,7 +509,7 @@ export {
     _focusNextGridCoreContainer,
 } from './utils/gridFocus';
 export { _createIcon, _createIconNoSpan } from './utils/icon';
-export { _warnOnce, _consoleError } from './utils/log';
+export { _consoleError, _warnOnce } from './utils/log';
 export { _mergeDeep } from './utils/mergeDeep';
 export { _formatNumberCommas } from './utils/number';
 export { _selectAllCells } from './utils/selection';
@@ -502,8 +521,8 @@ export { VanillaFrameworkOverrides } from './vanillaFrameworkOverrides';
 export { AgComponentSelectorType, Component, ComponentEvent, ComponentSelector } from './widgets/component';
 export * from './widgets/gridWidgetTypes';
 export {
-    ManagedFocusFeature,
     STOP_PROPAGATION_CALLBACKS as _STOP_PROPAGATION_CALLBACKS,
+    ManagedFocusFeature,
 } from './widgets/managedFocusFeature';
 export type { PopupService } from './widgets/popupService';
 export { TabGuardCtrl, TabGuardFeature } from './widgets/tabGuard';
@@ -537,6 +556,7 @@ export { AgPickerFieldParams } from './agStack/widgets/agPickerFieldParams';
 export { AgRadioButton, AgRadioButtonParams, AgRadioButtonSelector } from './agStack/widgets/agRadioButton';
 export { AgSelect, AgSelectParams, AgSelectSelector } from './agStack/widgets/agSelect';
 export { AgToggleButton, AgToggleButtonParams, AgToggleButtonSelector } from './agStack/widgets/agToggleButton';
+export { GridSerializingParams, RowAccumulator, RowSpanningAccumulator } from './export/iGridSerializer';
 
 // These should have been exported with _ as only used in SSRM and end users should be using them via the gridApi
 export { onRowHeightChanged, resetRowHeights } from './api/rowModelSharedApi';
@@ -562,12 +582,12 @@ export {
     FilterValueModule as _FilterValueModule,
 } from './filter/filterModule';
 export {
-    ModuleName,
-    ModuleValidationResult,
     _ModuleWithApi,
+    _ModuleWithLicenseManager,
     _ModuleWithoutApi,
     ValidationModuleName as _ValidationModuleName,
-    _ModuleWithLicenseManager,
+    ModuleName,
+    ModuleValidationResult,
 } from './interfaces/iModule';
 export { SharedMenuModule as _SharedMenuModule } from './misc/menu/sharedMenuModule';
 export { KeyboardNavigationModule as _KeyboardNavigationModule } from './navigation/navigationModule';

--- a/packages/ag-grid-community/src/main.ts
+++ b/packages/ag-grid-community/src/main.ts
@@ -67,7 +67,6 @@ export {
 } from './agStack/interfaces/iPopup';
 export { AgPromise } from './agStack/utils/promise';
 export { IDragAndDropImageComponent, IDragAndDropImageParams } from './dragAndDrop/dragAndDropImageComponent';
-export type { RowDragComp } from './dragAndDrop/rowDragComp';
 export type {
     DropIndicatorPosition,
     RowDropPositionIndicator,
@@ -75,7 +74,6 @@ export type {
 } from './dragAndDrop/rowDropHighlightService';
 
 // Excel Export
-export { GridSerializingParams, RowAccumulator, RowSpanningAccumulator } from './export/iGridSerializer';
 export {
     ColumnWidthCallbackParams,
     ExcelAlignment,
@@ -146,9 +144,6 @@ export { DragItem } from './interfaces/iDragItem';
 export { IRowDragItem, RowDragTextFunc } from './interfaces/iRowDragItem';
 
 // Filtering
-export { AgFilterButtonSelector, FilterButton, FilterButtonComp, FilterButtonEvent } from './filter/filterButtonComp';
-export { FilterComp } from './filter/filterComp';
-export { FilterWrapperComp } from './filter/filterWrapperComp';
 export {
     BaseFloatingFilter,
     FloatingFilterDisplay,
@@ -318,21 +313,7 @@ export {
 } from './interfaces/iFind';
 
 // Headers
-export type {
-    AbstractHeaderCellCtrl,
-    IAbstractHeaderCellComp,
-} from './headerRendering/cells/abstractCell/abstractHeaderCellCtrl';
-export type { HeaderCellCtrl, IHeaderCellComp } from './headerRendering/cells/column/headerCellCtrl';
-export type {
-    HeaderGroupCellCtrl,
-    IHeaderGroupCellComp,
-} from './headerRendering/cells/columnGroup/headerGroupCellCtrl';
-export type { HeaderFilterCellCtrl } from './headerRendering/cells/floatingFilter/headerFilterCellCtrl';
-export { IHeaderFilterCellComp } from './headerRendering/cells/floatingFilter/iHeaderFilterCellComp';
-export { GridHeaderCtrl, IGridHeaderComp } from './headerRendering/gridHeaderCtrl';
 export { HeaderRowType } from './headerRendering/row/headerRowComp';
-export type { HeaderRowCtrl, IHeaderRowComp } from './headerRendering/row/headerRowCtrl';
-export { HeaderRowContainerCtrl, IHeaderRowContainerComp } from './headerRendering/rowContainer/headerRowContainerCtrl';
 export type { SortIndicatorComp } from './sort/sortIndicatorComp';
 
 // AlignedGrid
@@ -571,7 +552,6 @@ export {
     ShouldRowBeSkippedParams,
 } from './interfaces/exportParams';
 export { ICsvCreator } from './interfaces/iCsvCreator';
-export { HeaderElement, PrefixedXmlAttributes, XmlAttributes, XmlElement } from './interfaces/iXmlFactory';
 
 // Clipboard
 export { IClipboardCopyParams, IClipboardCopyRowsParams } from './interfaces/iClipboardService';

--- a/packages/ag-grid-community/src/misc/animationFrameService.ts
+++ b/packages/ag-grid-community/src/misc/animationFrameService.ts
@@ -15,6 +15,7 @@ interface TaskList {
     sorted: boolean;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class AnimationFrameService extends BeanStub implements NamedBean {
     beanName = 'animationFrameSvc' as const;
 

--- a/packages/ag-grid-community/src/misc/locale/localeService.ts
+++ b/packages/ag-grid-community/src/misc/locale/localeService.ts
@@ -3,6 +3,7 @@ import { _getLocaleTextFromFunc, _getLocaleTextFromMap } from '../../agStack/uti
 import type { NamedBean } from '../../context/bean';
 import { BeanStub } from '../../context/beanStub';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class LocaleService extends BeanStub implements NamedBean, ILocaleService {
     beanName = 'localeSvc' as const;
 

--- a/packages/ag-grid-community/src/misc/menu/menuService.ts
+++ b/packages/ag-grid-community/src/misc/menu/menuService.ts
@@ -43,6 +43,7 @@ type ShowColumnMenuParams = (MouseShowMenuParams | ButtonShowMenuParams | AutoSh
 type ShowFilterMenuParams = (MouseShowMenuParams | ButtonShowMenuParams | AutoShowMenuParams) &
     BaseShowFilterMenuParams;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class MenuService extends BeanStub implements NamedBean {
     beanName = 'menuSvc' as const;
 
@@ -188,6 +189,7 @@ export class MenuService extends BeanStub implements NamedBean {
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _setColMenuVisible(column: AgColumn, visible: boolean, source: ColumnEventType): void {
     if (column.menuVisible !== visible) {
         column.menuVisible = visible;

--- a/packages/ag-grid-community/src/misc/menu/sharedMenuModule.ts
+++ b/packages/ag-grid-community/src/misc/menu/sharedMenuModule.ts
@@ -5,7 +5,7 @@ import { hidePopupMenu, showColumnMenu } from './menuApi';
 import { MenuService } from './menuService';
 
 /**
- * @internal
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const SharedMenuModule: _ModuleWithApi<_CommunityMenuGridApi> = {
     moduleName: 'SharedMenu',

--- a/packages/ag-grid-community/src/modules/moduleRegistry.ts
+++ b/packages/ag-grid-community/src/modules/moduleRegistry.ts
@@ -47,6 +47,7 @@ function runVersionChecks(module: Module) {
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _registerModule(module: Module, gridId: string | undefined, isInternalRegistration = false): void {
     if (!isInternalRegistration) {
         userHasRegistered = true;
@@ -109,6 +110,7 @@ export function _getAllRegisteredModules(): Set<Module> {
     return new Set(allRegisteredModules);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getGridRegisteredModules(gridId: string, rowModel: RowModelType): Module[] {
     const gridModules = gridModulesMap[gridId] ?? {};
     return [...Object.values(gridModules['all'] ?? {}), ...Object.values(gridModules[rowModel] ?? {})];
@@ -123,7 +125,10 @@ export function _isUmd(): boolean {
     return isUmd;
 }
 
-/** Internal use to provide clear error messages for UMD users. */
+/**
+ * Internal use to provide clear error messages for UMD users.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export function _setUmd(): void {
     isUmd = true;
 }
@@ -146,6 +151,7 @@ export class ModuleRegistry {
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _findEnterpriseCoreModule(modules: Module[]): _ModuleWithLicenseManager | undefined {
     for (const module of modules) {
         if ('setLicenseKey' in module) {

--- a/packages/ag-grid-community/src/navigation/cellNavigationService.ts
+++ b/packages/ag-grid-community/src/navigation/cellNavigationService.ts
@@ -13,6 +13,7 @@ import type { IRowNode } from '../interfaces/iRowNode';
 import type { RowSpanService } from '../rendering/spanning/rowSpanService';
 import { _warn } from '../validation/logging';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class CellNavigationService extends BeanStub implements NamedBean {
     beanName = 'cellNavigation' as const;
 

--- a/packages/ag-grid-community/src/navigation/headerNavigationService.ts
+++ b/packages/ag-grid-community/src/navigation/headerNavigationService.ts
@@ -52,6 +52,7 @@ export function getHeaderIndexToFocus(beans: BeanCollection, column: AgColumn, l
     };
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class HeaderNavigationService extends BeanStub implements NamedBean {
     beanName = 'headerNavigation' as const;
 

--- a/packages/ag-grid-community/src/navigation/navigationModule.ts
+++ b/packages/ag-grid-community/src/navigation/navigationModule.ts
@@ -15,6 +15,7 @@ import { NavigationService } from './navigationService';
 
 /**
  * @feature Interactivity -> Keyboard Navigation
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const KeyboardNavigationModule: _ModuleWithApi<_KeyboardNavigationGridApi> = {
     moduleName: 'KeyboardNavigation',

--- a/packages/ag-grid-community/src/navigation/navigationService.ts
+++ b/packages/ag-grid-community/src/navigation/navigationService.ts
@@ -42,6 +42,7 @@ type FindNextCellToFocusOnParams = {
     skipToNextEditableCell?: boolean;
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class NavigationService extends BeanStub implements NamedBean {
     beanName = 'navigation' as const;
 

--- a/packages/ag-grid-community/src/pagination/pageBoundsService.ts
+++ b/packages/ag-grid-community/src/pagination/pageBoundsService.ts
@@ -3,6 +3,7 @@ import { BeanStub } from '../context/beanStub';
 import type { RowBounds } from '../interfaces/iRowModel';
 
 // note that everything in this service is used even when pagination is off
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class PageBoundsService extends BeanStub implements NamedBean {
     beanName = 'pageBounds' as const;
 

--- a/packages/ag-grid-community/src/propertyKeys.ts
+++ b/packages/ag-grid-community/src/propertyKeys.ts
@@ -175,6 +175,7 @@ const OTHER_GRID_OPTIONS: GridOptionKey[] = ['theme', 'rowSelection'];
 // Used by Angular to support the user setting these
 // as plain HTML attributes and us correctly mapping that to true
 // These are all of type boolean | something else
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const _BOOLEAN_MIXED_GRID_OPTIONS: KeysWithType<boolean>[] = [
     'cellSelection',
     'sideBar',
@@ -412,6 +413,7 @@ export const _FUNCTION_GRID_OPTIONS: (CallbackKeys | FunctionKeys)[] = [
 // Vue Runtime prop changes
 // example generation
 // We define as a callback to help with tree shaking (esbuild)
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const _GET_ALL_GRID_OPTIONS: () => GridOptionKey[] = () => [
     ...ARRAY_GRID_OPTIONS,
     ...OBJECT_GRID_OPTIONS,
@@ -424,6 +426,7 @@ export const _GET_ALL_GRID_OPTIONS: () => GridOptionKey[] = () => [
 ];
 
 // Options that only need shallow (reference) watching (only Vue atm) — primitives and functions
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const _GET_SHALLOW_GRID_OPTIONS: () => GridOptionKey[] = () => [
     ...STRING_GRID_OPTIONS,
     ..._NUMBER_GRID_OPTIONS,

--- a/packages/ag-grid-community/src/publicEventHandlersMap.ts
+++ b/packages/ag-grid-community/src/publicEventHandlersMap.ts
@@ -3,7 +3,10 @@ import type { AgPublicEventType } from './eventTypes';
 import { _PUBLIC_EVENTS } from './eventTypes';
 import { _getCallbackForEvent } from './gridOptionsUtils';
 
-/** Map of public events to their handler names in GridOptions */
+/**
+ * Map of public events to their handler names in GridOptions
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export const _PUBLIC_EVENT_HANDLERS_MAP = _PUBLIC_EVENTS.reduce(
     (mem, ev) => {
         mem[ev] = _getCallbackForEvent(ev) as AgPublicEventHandlerType;

--- a/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
@@ -60,6 +60,7 @@ const CSS_CELL_LAST_LEFT_PINNED = 'ag-cell-last-left-pinned';
 const CSS_CELL_NOT_INLINE_EDITING = 'ag-cell-not-inline-editing';
 const CSS_CELL_WRAP_TEXT = 'ag-cell-wrap-text';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface ICellComp {
     toggleCss(cssClassName: string, on: boolean): void;
     setUserStyles(styles: CellStyle): void;
@@ -91,6 +92,7 @@ export interface ICellComp {
 let instanceIdSequence = 0;
 export type CellCtrlInstanceId = BrandedType<string, 'CellCtrlInstanceId'>;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class CellCtrl extends BeanStub {
     public readonly instanceId: CellCtrlInstanceId;
 

--- a/packages/ag-grid-community/src/rendering/cellRenderers/checkboxCellRenderer.ts
+++ b/packages/ag-grid-community/src/rendering/cellRenderers/checkboxCellRenderer.ts
@@ -30,6 +30,7 @@ const CheckboxCellRendererElement: ElementParams = {
     ],
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class CheckboxCellRenderer extends Component implements ICellRenderer {
     private readonly eCheckbox: GridCheckbox = RefPlaceholder;
     private params: ICheckboxCellRendererParams;

--- a/packages/ag-grid-community/src/rendering/features/positionableFeature.ts
+++ b/packages/ag-grid-community/src/rendering/features/positionableFeature.ts
@@ -5,6 +5,7 @@ import type { GridOptionsWithDefaults } from '../../gridOptionsDefault';
 import type { GridOptionsService } from '../../gridOptionsService';
 import type { AgGridCommon } from '../../interfaces/iCommon';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class PositionableFeature extends AgPositionableFeature<
     BeanCollection,
     GridOptionsWithDefaults,

--- a/packages/ag-grid-community/src/rendering/renderUtils.ts
+++ b/packages/ag-grid-community/src/rendering/renderUtils.ts
@@ -10,6 +10,7 @@ import type {
 } from './cellRenderers/iCellRenderer';
 import type { RowCtrl } from './row/rowCtrl';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _suppressCellMouseEvent(
     gos: GridOptionsService,
     column: Column,
@@ -68,12 +69,14 @@ function _getCtrlForEventTarget<T>(gos: GridOptionsService, eventTarget: EventTa
 
 export const DOM_DATA_KEY_CELL_CTRL = 'cellCtrl';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getCellCtrlForEventTarget(gos: GridOptionsService, eventTarget: EventTarget | null): CellCtrl | null {
     return _getCtrlForEventTarget(gos, eventTarget, DOM_DATA_KEY_CELL_CTRL);
 }
 
 export const DOM_DATA_KEY_ROW_CTRL = 'renderedRow';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getRowCtrlForEventTarget(gos: GridOptionsService, eventTarget: EventTarget | null): RowCtrl | null {
     return _getCtrlForEventTarget(gos, eventTarget, DOM_DATA_KEY_ROW_CTRL);
 }

--- a/packages/ag-grid-community/src/rendering/row/rowAutoHeightService.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowAutoHeightService.ts
@@ -11,6 +11,7 @@ import type { IClientSideRowModel } from '../../interfaces/iClientSideRowModel';
 import type { IServerSideRowModel } from '../../interfaces/iServerSideRowModel';
 import type { CellCtrl } from '../cell/cellCtrl';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class RowAutoHeightService extends BeanStub implements NamedBean {
     beanName = 'rowAutoHeight' as const;
 

--- a/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
@@ -70,6 +70,7 @@ type RowType = 'Normal' | 'FullWidth' | 'FullWidthLoading' | 'FullWidthGroup' | 
 let instanceIdSequence = 0;
 export type RowCtrlInstanceId = BrandedType<string, 'RowCtrlInstanceId'>;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IRowComp {
     setDomOrder(domOrder: boolean): void;
     toggleCss(cssClassName: string, on: boolean): void;
@@ -99,6 +100,7 @@ interface CellCtrlListAndMap {
 }
 
 type RowCtrlEvent = RenderedRowEvent;
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class RowCtrl extends BeanStub<RowCtrlEvent> {
     public readonly instanceId: RowCtrlInstanceId;
 

--- a/packages/ag-grid-community/src/rendering/rowRenderer.ts
+++ b/packages/ag-grid-community/src/rendering/rowRenderer.ts
@@ -47,6 +47,7 @@ interface RowNodeMap {
 
 const ROW_ANIMATION_TIMEOUT = 400;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class RowRenderer extends BeanStub implements NamedBean {
     beanName = 'rowRenderer' as const;
 

--- a/packages/ag-grid-community/src/selection/baseSelectionService.ts
+++ b/packages/ag-grid-community/src/selection/baseSelectionService.ts
@@ -28,6 +28,7 @@ import { CheckboxSelectionComponent } from './checkboxSelectionComponent';
 import { RowRangeSelectionContext } from './rowRangeSelectionContext';
 import { SelectAllFeature, isCheckboxSelection } from './selectAllFeature';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export abstract class BaseSelectionService extends BeanStub {
     protected isRowSelectable?: IsRowSelectable;
     protected selectionCtx: RowRangeSelectionContext;

--- a/packages/ag-grid-community/src/selection/rowRangeSelectionContext.ts
+++ b/packages/ag-grid-community/src/selection/rowRangeSelectionContext.ts
@@ -16,6 +16,7 @@ interface RangePartition {
  * represents the "root" of a selection range, and subsequent selections are based off that root.
  *
  * See AG-9620 for more
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export class RowRangeSelectionContext {
     /** Whether the user is currently selecting all nodes either via the header checkbox or API */

--- a/packages/ag-grid-community/src/selection/rowSelectionModule.ts
+++ b/packages/ag-grid-community/src/selection/rowSelectionModule.ts
@@ -17,7 +17,7 @@ import {
 import { SelectionService } from './selectionService';
 
 /**
- * @internal
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const SharedRowSelectionModule: _ModuleWithApi<_RowSelectionGridApi> = {
     moduleName: 'SharedRowSelection',

--- a/packages/ag-grid-community/src/sort/rowNodeSorter.ts
+++ b/packages/ag-grid-community/src/sort/rowNodeSorter.ts
@@ -11,6 +11,7 @@ import type { SortOption } from '../interfaces/iSortOption';
 
 // this logic is used by both SSRM and CSRM
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class RowNodeSorter extends BeanStub implements NamedBean {
     beanName = 'rowNodeSorter' as const;
 

--- a/packages/ag-grid-community/src/sort/sortModule.ts
+++ b/packages/ag-grid-community/src/sort/sortModule.ts
@@ -9,6 +9,7 @@ import { SortService } from './sortService';
 /**
  * @feature Rows -> Row Sorting
  * @colDef sortable, sort, sortIndex
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const SortModule: _ModuleWithApi<_SortGridApi> = {
     moduleName: 'Sort',

--- a/packages/ag-grid-community/src/sort/sortService.ts
+++ b/packages/ag-grid-community/src/sort/sortService.ts
@@ -12,6 +12,7 @@ import type { SortOption } from '../interfaces/iSortOption';
 import type { Component, ComponentSelector } from '../widgets/component';
 import { SortIndicatorComp, SortIndicatorSelector } from './sortIndicatorComp';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class SortService extends BeanStub implements NamedBean {
     beanName = 'sortSvc' as const;
 

--- a/packages/ag-grid-community/src/styling/cellStyleService.ts
+++ b/packages/ag-grid-community/src/styling/cellStyleService.ts
@@ -5,6 +5,7 @@ import type { CellCtrl } from '../rendering/cell/cellCtrl';
 import { CellCustomStyleFeature } from './cellCustomStyleFeature';
 import { processClassRules } from './stylingUtils';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class CellStyleService extends BeanStub implements NamedBean {
     beanName = 'cellStyles' as const;
 

--- a/packages/ag-grid-community/src/theming/core/core-css.ts
+++ b/packages/ag-grid-community/src/theming/core/core-css.ts
@@ -616,6 +616,7 @@ export interface CoreParams extends SharedThemeParams {
     statusBarValueFontWeight: FontWeightValue;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const coreDefaults: Readonly<Omit<CoreParams, keyof SharedThemeParams>> = {
     wrapperBorder: true,
     rowBorder: true,

--- a/packages/ag-grid-community/src/theming/createTheme.ts
+++ b/packages/ag-grid-community/src/theming/createTheme.ts
@@ -11,6 +11,7 @@ import type { ButtonStyleParams } from './parts/button-style/button-styles';
 import { columnDropStyleBordered } from './parts/column-drop-style/column-drop-styles';
 import { formulaStyleBase } from './parts/formula-style/formula-styles';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const gridThemeLogger: ThemeLogger = {
     warn: (...args) => {
         // temp typing needed here to link theme error type and grid error type

--- a/packages/ag-grid-community/src/theming/parts/theme/themes.ts
+++ b/packages/ag-grid-community/src/theming/parts/theme/themes.ts
@@ -42,6 +42,7 @@ export type ThemeDefaultParams = CoreParams &
  */
 export type AllThemeParamsForAPIDocumentation = ThemeDefaultParams & FormulaStyleParams;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const themeQuartzParams = () => ({
     fontFamily: [
         { googleFont: 'IBM Plex Sans' },
@@ -68,6 +69,7 @@ export const themeQuartz: Theme<ThemeDefaultParams> =
     /*#__PURE__*/
     makeThemeQuartzTreeShakeable();
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const themeAlpineParams = () => ({
     accentColor: '#2196f3',
     selectedRowBackgroundColor: accentMix(0.3),
@@ -125,6 +127,7 @@ export const themeAlpine: Theme<ThemeDefaultParams> =
     /*#__PURE__*/
     makeThemeAlpineTreeShakeable();
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const themeBalhamParams = () => ({
     accentColor: '#0091ea',
     borderColor: foregroundMix(0.2),
@@ -300,6 +303,7 @@ const makeStyleMaterialTreeShakeable = () => {
 
 export const styleMaterial = /*#__PURE__*/ makeStyleMaterialTreeShakeable();
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const themeMaterialParams = () => ({
     rowHeight: {
         calc: 'max(iconSize, cellFontSize) + spacing * 3.75 * rowVerticalPaddingScale',

--- a/packages/ag-grid-community/src/tooltip/tooltipFeature.ts
+++ b/packages/ag-grid-community/src/tooltip/tooltipFeature.ts
@@ -12,6 +12,7 @@ import type { GridOptionsService } from '../gridOptionsService';
 import type { AgGridCommon } from '../interfaces/iCommon';
 import type { ITooltipParams, TooltipLocation } from './tooltipComponent';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface ITooltipCtrlParams {
     column?: AgColumn | AgColumnGroup;
     colDef?: ColDef | ColGroupDef;
@@ -21,12 +22,15 @@ export interface ITooltipCtrlParams {
     valueFormatted?: string;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface ITooltipCtrl extends TooltipCtrl<TooltipLocation, ITooltipCtrlParams> {}
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isShowTooltipWhenTruncated(gos: GridOptionsService): boolean {
     return gos.get('tooltipShowMode') === 'whenTruncated';
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getShouldDisplayTooltip(
     gos: GridOptionsService,
     getElement: () => HTMLElement | undefined
@@ -34,6 +38,7 @@ export function _getShouldDisplayTooltip(
     return _isShowTooltipWhenTruncated(gos) ? _isElementOverflowingCallback(getElement) : undefined;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type TooltipFeature = AgTooltipFeature<
     BeanCollection,
     GridOptionsWithDefaults,

--- a/packages/ag-grid-community/src/utils/changedPath.ts
+++ b/packages/ag-grid-community/src/utils/changedPath.ts
@@ -14,6 +14,7 @@ interface PathItem {
 // this class keeps track of all groups that were impacted by a transaction.
 // the the different CSRM operations (filter, sort etc) use the forEach method
 // to visit each group that was changed.
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class ChangedPath {
     // we keep columns when doing changed detection after user edits.
     // when a user edits, we only need to re-aggregate the column

--- a/packages/ag-grid-community/src/utils/element.ts
+++ b/packages/ag-grid-community/src/utils/element.ts
@@ -2,8 +2,10 @@ import type { AgElementParams } from '../agStack/utils/dom';
 import { _createAgElement } from '../agStack/utils/dom';
 import type { AgComponentSelectorType } from '../widgets/component';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type ElementParams = AgElementParams<AgComponentSelectorType>;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _createElement<T extends HTMLElement = HTMLElement>(
     params: AgElementParams<AgComponentSelectorType>
 ): T {

--- a/packages/ag-grid-community/src/utils/gridEvent.ts
+++ b/packages/ag-grid-community/src/utils/gridEvent.ts
@@ -8,11 +8,13 @@ const AG_GRID_STOP_PROPAGATION = '__ag_Grid_Stop_Propagation';
  * to get around this, we have a pattern to stop propagation for the purposes of AG Grid,
  * but we still let the event pass back to the body.
  * @param {Event} event
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _stopPropagationForAgGrid(event: Event): void {
     (event as any)[AG_GRID_STOP_PROPAGATION] = true;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isStopPropagationForAgGrid(event: Event): boolean {
     return (event as any)[AG_GRID_STOP_PROPAGATION] === true;
 }

--- a/packages/ag-grid-community/src/utils/gridFocus.ts
+++ b/packages/ag-grid-community/src/utils/gridFocus.ts
@@ -9,6 +9,7 @@ import type { FocusableContainer } from '../interfaces/iFocusableContainer';
 import type { Component } from '../widgets/component';
 import { _isStopPropagationForAgGrid } from './gridEvent';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _addFocusableContainerListener(beans: BeanCollection, comp: Component, eGui: HTMLElement): void {
     comp.addManagedElementListeners(eGui, {
         keydown: (e: KeyboardEvent) => {
@@ -24,6 +25,7 @@ export function _addFocusableContainerListener(beans: BeanCollection, comp: Comp
     });
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _focusGridInnerElement(beans: BeanCollection, fromBottom?: boolean): boolean {
     return beans.ctrlsSvc.get('gridCtrl').focusInnerElement(fromBottom);
 }
@@ -36,6 +38,7 @@ export function _isCellFocusSuppressed(beans: BeanCollection): boolean {
     return beans.gos.get('suppressCellFocus') || !!beans.overlays?.exclusive;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _focusNextGridCoreContainer(
     beans: BeanCollection,
     backwards: boolean,
@@ -60,6 +63,7 @@ export function _focusNextGridCoreContainer(
     return false;
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _attemptToRestoreCellFocus(beans: BeanCollection, focusedCell: CellPosition | null): void {
     const focusSvc = beans.focusSvc;
     const currentFocusedCell = focusSvc.getFocusedCell();

--- a/packages/ag-grid-community/src/utils/icon.ts
+++ b/packages/ag-grid-community/src/utils/icon.ts
@@ -129,6 +129,7 @@ export type Icons = { [key: string]: ((...args: any[]) => any) | string };
  * if not, then use the default icon from the theme.
  * Technically `iconName` could be any string, if using user-provided icons map.
  * However, in most cases we're providing a specific icon name, so better to have type-checking.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _createIcon(iconName: IconName, beans: BeanCollection, column: AgColumn | null): Element {
     const iconContents = _createIconNoSpan(iconName, beans, column);
@@ -152,6 +153,7 @@ export function _createIcon(iconName: IconName, beans: BeanCollection, column: A
 /**
  * Technically `iconName` could be any string, if using user-provided icons map.
  * However, in most cases we're providing a specific icon name, so better to have type-checking.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _createIconNoSpan(
     iconName: IconName,

--- a/packages/ag-grid-community/src/utils/log.ts
+++ b/packages/ag-grid-community/src/utils/log.ts
@@ -8,6 +8,7 @@ export function _logIfDebug(gos: GridOptionsService, message: string, ...args: a
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _warnOnce(msg: string, ...args: any[]) {
     _doOnce(() => _consoleWarn(msg, ...args), msg + args?.join(''));
 }
@@ -15,6 +16,7 @@ export function _errorOnce(msg: string, ...args: any[]) {
     _doOnce(() => _consoleError(msg, ...args), msg + args?.join(''));
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _consoleError(msg: string, ...args: any[]) {
     // eslint-disable-next-line no-console
     console.error('AG Grid: ' + msg, ...args);

--- a/packages/ag-grid-community/src/utils/mergeDeep.ts
+++ b/packages/ag-grid-community/src/utils/mergeDeep.ts
@@ -23,6 +23,7 @@ function _iterateObject<T>(
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _mergeDeep(dest: any, source: any, copyUndefined = true, makeCopyOfSimpleObjects = false): void {
     if (!_exists(source)) {
         return;

--- a/packages/ag-grid-community/src/utils/number.ts
+++ b/packages/ag-grid-community/src/utils/number.ts
@@ -6,6 +6,7 @@ import type { LocaleTextFunc } from '../agStack/interfaces/iLocaleService';
  * from: http://blog.tompawlak.org/number-currency-formatting-javascript
  * @param {number} value
  * @returns {string}
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export function _formatNumberCommas(value: number | null, getLocaleTextFunc: () => LocaleTextFunc): string {
     if (typeof value !== 'number') {

--- a/packages/ag-grid-community/src/utils/selection.ts
+++ b/packages/ag-grid-community/src/utils/selection.ts
@@ -1,6 +1,7 @@
 import type { BeanCollection } from '../context/context';
 import type { RowPinnedType } from '../interfaces/iRowNode';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _selectAllCells(beans: BeanCollection) {
     const { pinnedRowModel, rowModel, rangeSvc, visibleCols } = beans;
 

--- a/packages/ag-grid-community/src/validation/logging.ts
+++ b/packages/ag-grid-community/src/validation/logging.ts
@@ -133,6 +133,7 @@ const minifiedLog = (errorNum: ErrorId, args: GetErrorParams<any>, defaultMessag
     return `${prefix}${defaultMessage ? '' : ' \n  Alternatively register the ValidationModule to see the full message in the console.'}`;
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _warn<
     TId extends ErrorId,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -141,6 +142,7 @@ export function _warn<
     getMsgOrDefault(_warnOnce, args[0], args[1] as any, true);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _error<
     TId extends ErrorId,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -158,6 +160,7 @@ export function _logPreInitErr<
     getMsgOrDefault(_errorOnce, id, args as any, false, defaultMessage);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _logPreInitWarn<
     TId extends ErrorId,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -174,6 +177,7 @@ function getErrMsg<TId extends ErrorId>(
     return `error #${id} ` + getErrorParts(id, args[1] as any, defaultMessage).join(' ');
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _errMsg<
     TId extends ErrorId,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -182,7 +186,10 @@ export function _errMsg<
     return getErrMsg(undefined, args);
 }
 
-/** Used for messages before the ValidationService has been created */
+/**
+ * Used for messages before the ValidationService has been created
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export function _preInitErrMsg<
     TId extends ErrorId,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/ag-grid-community/src/valueService/expressionService.ts
+++ b/packages/ag-grid-community/src/valueService/expressionService.ts
@@ -2,6 +2,7 @@ import type { NamedBean } from '../context/bean';
 import { BeanStub } from '../context/beanStub';
 import { _error } from '../validation/logging';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class ExpressionService extends BeanStub implements NamedBean {
     beanName = 'expressionSvc' as const;
 

--- a/packages/ag-grid-community/src/valueService/valueCache.ts
+++ b/packages/ag-grid-community/src/valueService/valueCache.ts
@@ -2,6 +2,7 @@ import type { NamedBean } from '../context/bean';
 import { BeanStub } from '../context/beanStub';
 import type { RowNode } from '../entities/rowNode';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class ValueCache extends BeanStub implements NamedBean {
     beanName = 'valueCache' as const;
 

--- a/packages/ag-grid-community/src/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.ts
@@ -26,6 +26,7 @@ import { _warn } from '../validation/logging';
 import type { ExpressionService } from './expressionService';
 import type { ValueCache } from './valueCache';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class ValueService extends BeanStub implements NamedBean {
     beanName = 'valueSvc' as const;
 

--- a/packages/ag-grid-community/src/vanillaFrameworkOverrides.ts
+++ b/packages/ag-grid-community/src/vanillaFrameworkOverrides.ts
@@ -3,7 +3,10 @@ import { BASE_URL } from './baseUrl';
 import type { IFrameworkOverrides } from './interfaces/iFrameworkOverrides';
 import { setValidationDocLink } from './validation/logging';
 
-/** The base frameworks, eg React & Angular, override this bean with implementations specific to their requirement. */
+/**
+ * The base frameworks, eg React & Angular, override this bean with implementations specific to their requirement.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export class VanillaFrameworkOverrides implements IFrameworkOverrides {
     public readonly renderingEngine: 'vanilla' | 'react' = 'vanilla';
     public readonly batchFrameworkComps: boolean = false;

--- a/packages/ag-grid-community/src/widgets/component.ts
+++ b/packages/ag-grid-community/src/widgets/component.ts
@@ -7,12 +7,17 @@ import type { GridOptionsWithDefaults } from '../gridOptionsDefault';
 import type { GridOptionsService } from '../gridOptionsService';
 import type { AgGridCommon } from '../interfaces/iCommon';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type ComponentEvent = AgComponentEvent;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type ComponentSelector<TComponent extends AgBaseComponent<BeanCollection> = AgBaseComponent<BeanCollection>> =
     AgComponentSelector<AgComponentSelectorType, BeanCollection, TComponent>;
 
-/** All the AG Grid components that are used within internal templates via <ag-autocomplete> syntax */
+/**
+ * All the AG Grid components that are used within internal templates via <ag-autocomplete> syntax
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
 export type AgComponentSelectorType =
     | AgWidgetSelectorType
     | 'AG-AUTOCOMPLETE'
@@ -38,6 +43,7 @@ export type AgComponentSelectorType =
     | 'AG-WATERMARK'
     | 'AG-FORMULA-INPUT-FIELD';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class Component<TLocalEvent extends string = AgComponentEvent> extends AgComponentStub<
     BeanCollection,
     GridOptionsWithDefaults,

--- a/packages/ag-grid-community/src/widgets/gridWidgetTypes.ts
+++ b/packages/ag-grid-community/src/widgets/gridWidgetTypes.ts
@@ -18,6 +18,7 @@ import type { GridOptionsService } from '../gridOptionsService';
 import type { AgGridCommon } from '../interfaces/iCommon';
 import type { AgComponentSelectorType } from './component';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type GridInputTextArea = AgInputTextArea<
     BeanCollection,
     GridOptionsWithDefaults,
@@ -27,6 +28,7 @@ export type GridInputTextArea = AgInputTextArea<
     AgComponentSelectorType
 >;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type GridInputTextField<
     TConfig extends AgInputTextFieldParams<AgComponentSelectorType> = AgInputTextFieldParams<AgComponentSelectorType>,
     TEventType extends string = AgInputTextFieldEvent,
@@ -41,6 +43,7 @@ export type GridInputTextField<
     TEventType
 >;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type GridInputNumberField = AgInputNumberField<
     BeanCollection,
     GridOptionsWithDefaults,
@@ -50,6 +53,7 @@ export type GridInputNumberField = AgInputNumberField<
     AgComponentSelectorType
 >;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type GridInputDateField = AgInputDateField<
     BeanCollection,
     GridOptionsWithDefaults,
@@ -59,6 +63,7 @@ export type GridInputDateField = AgInputDateField<
     AgComponentSelectorType
 >;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type GridCheckbox<
     TConfig extends AgCheckboxParams<AgComponentSelectorType> = AgCheckboxParams<AgComponentSelectorType>,
 > = AgCheckbox<
@@ -71,6 +76,7 @@ export type GridCheckbox<
     TConfig
 >;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type GridRadioButton = AgRadioButton<
     BeanCollection,
     GridOptionsWithDefaults,
@@ -80,6 +86,7 @@ export type GridRadioButton = AgRadioButton<
     AgComponentSelectorType
 >;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type GridToggleButton = AgToggleButton<
     BeanCollection,
     GridOptionsWithDefaults,
@@ -89,6 +96,7 @@ export type GridToggleButton = AgToggleButton<
     AgComponentSelectorType
 >;
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type GridSelect<TValue = string | null> = AgSelect<
     BeanCollection,
     GridOptionsWithDefaults,

--- a/packages/ag-grid-community/src/widgets/managedFocusFeature.ts
+++ b/packages/ag-grid-community/src/widgets/managedFocusFeature.ts
@@ -7,11 +7,13 @@ import type { GridOptionsService } from '../gridOptionsService';
 import type { AgGridCommon } from '../interfaces/iCommon';
 import { _isStopPropagationForAgGrid, _stopPropagationForAgGrid } from '../utils/gridEvent';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const STOP_PROPAGATION_CALLBACKS: StopPropagationCallbacks = {
     isStopPropagation: _isStopPropagationForAgGrid,
     stopPropagation: _stopPropagationForAgGrid,
 };
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class ManagedFocusFeature extends AgManagedFocusFeature<
     BeanCollection,
     GridOptionsWithDefaults,

--- a/packages/ag-grid-community/src/widgets/popupModule.ts
+++ b/packages/ag-grid-community/src/widgets/popupModule.ts
@@ -3,7 +3,7 @@ import { VERSION } from '../version';
 import { PopupService } from './popupService';
 
 /**
- * @internal
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
  */
 export const PopupModule: _ModuleWithoutApi = {
     moduleName: 'Popup',

--- a/packages/ag-grid-community/src/widgets/popupService.ts
+++ b/packages/ag-grid-community/src/widgets/popupService.ts
@@ -10,6 +10,7 @@ import type { AgGridCommon, WithoutGridCommon } from '../interfaces/iCommon';
 import type { PopupPositionParams } from '../interfaces/iPopupPositionParams';
 import { _isStopPropagationForAgGrid } from '../utils/gridEvent';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class PopupService
     extends BasePopupService<
         BeanCollection,

--- a/packages/ag-grid-community/src/widgets/tabGuard.ts
+++ b/packages/ag-grid-community/src/widgets/tabGuard.ts
@@ -9,6 +9,7 @@ import type { AgGridCommon } from '../interfaces/iCommon';
 import type { Component } from './component';
 import { STOP_PROPAGATION_CALLBACKS } from './managedFocusFeature';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class TabGuardCtrl extends AgTabGuardCtrl<
     BeanCollection,
     GridOptionsWithDefaults,
@@ -21,6 +22,7 @@ export class TabGuardCtrl extends AgTabGuardCtrl<
     }
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class TabGuardFeature extends AgTabGuardFeature<
     BeanCollection,
     GridOptionsWithDefaults,

--- a/packages/ag-grid-community/src/widgets/tabGuardComp.ts
+++ b/packages/ag-grid-community/src/widgets/tabGuardComp.ts
@@ -8,6 +8,7 @@ import type { AgGridCommon } from '../interfaces/iCommon';
 import type { AgComponentSelectorType, ComponentEvent } from './component';
 import { STOP_PROPAGATION_CALLBACKS } from './managedFocusFeature';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class TabGuardComp<TLocalEvent extends string = ComponentEvent> extends AgTabGuardComp<
     BeanCollection,
     GridOptionsWithDefaults,

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
@@ -61,10 +61,8 @@ export function getFunctionName(code: string): string {
 export const convertFunctionToProperty = (code: string) =>
     code.replace(/function\s+([^(\s]+)\s*\(([^)]*)\)(:[^{]+)?/, '$1 = ($2)$3 =>');
 
-export const convertFunctionToConstProperty = (code: string) =>
-    code.replace(/function\s+([^(\s]+)\s*\(([^)]*)\)/, 'const $1 = ($2) =>');
 export const convertFunctionToConstPropertyTs = (code: string) => {
-    return code.replace(/function\s+([^(\s]+)\s*\(([^)]*)\):(\s+[^{]*)/, 'const $1: ($2) => $3 = ($2) =>');
+    return code.replace(/(async\s+)?function\s+([^(\s]+)\s*\(([^)]*)\):(\s+[^{]*)/, 'const $2: ($3) => $4 = $1($3) =>');
 };
 
 export function isInstanceMethod(methods: string[], property: any): boolean {


### PR DESCRIPTION
Add `@internal AG_GRID_INTERNAL` JSDoc tags to all ~571 symbols exported from `main-internal.ts` across 234 source files. This ensures IDE users see a clear warning when hovering over internal APIs.

Also adds a validation test (`main-internal.test.ts`) that prevents regressions by verifying every exported symbol carries the `AG_GRID_INTERNAL` tag, and that `main.ts` and `main-internal.ts` exports do not overlap.

Fix [AG-16467](https://ag-grid.atlassian.net/browse/AG-16467)