### PR TITLE
AG-3390 - Add Snyk ignore rules for transitive vulnerabilities

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,6 +2,22 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+    SNYK-JS-SVGO-15423912:
+        - cssnano@7.1.2 > cssnano-preset-default@7.0.10 > postcss-svgo@7.1.0 > svgo@4.0.0:
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T11:44:40.848Z
+        - '@nx/rollup@20.3.1 > rollup-plugin-postcss@4.0.2 > cssnano@5.1.15 > cssnano-preset-default@5.2.14 > postcss-svgo@5.1.0 > svgo@2.8.0':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T11:44:32.352Z
+        - '@nx/react@20.3.1 > @svgr/webpack@8.1.0 > @svgr/plugin-svgo@8.1.0 > svgo@3.3.2':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T11:44:26.888Z
     SNYK-JS-SERIALIZEJAVASCRIPT-570062:
         - '@nx/react@20.3.1 > @nx/module-federation@20.3.1 > webpack@5.88.0 > terser-webpack-plugin@5.3.14 > serialize-javascript@6.0.2':
               reason: >-

--- a/community-modules/styles/.snyk
+++ b/community-modules/styles/.snyk
@@ -2,6 +2,12 @@
 version: v1.25.1
 
 ignore:
+    SNYK-JS-UNDERSCORE-15369786:
+        - '@vusion/webfonts-generator@0.8.0 > underscore@1.13.7':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T11:49:56.069Z
     SNYK-JS-TAR-15416075:
         - '@vusion/webfonts-generator@0.8.0 > ttf2woff2@4.0.5 > node-gyp@9.4.1 > make-fetch-happen@10.2.1 > cacache@16.1.3 > tar@6.2.1':
               reason: >-

--- a/community-modules/styles/.snyk
+++ b/community-modules/styles/.snyk
@@ -2,6 +2,12 @@
 version: v1.25.1
 
 ignore:
+    SNYK-JS-IMMUTABLE-15423650:
+        - sass@1.79.3 > immutable@4.3.7:
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T11:42:22.178Z
     SNYK-JS-TAR-15307072:
         - '@vusion/webfonts-generator@0.8.0 > ttf2woff2@4.0.5 > node-gyp@9.4.1 > make-fetch-happen@10.2.1 > cacache@16.1.3 > tar@6.2.1':
               reason: >-

--- a/community-modules/styles/.snyk
+++ b/community-modules/styles/.snyk
@@ -2,6 +2,17 @@
 version: v1.25.1
 
 ignore:
+    SNYK-JS-TAR-15416075:
+        - '@vusion/webfonts-generator@0.8.0 > ttf2woff2@4.0.5 > node-gyp@9.4.1 > make-fetch-happen@10.2.1 > cacache@16.1.3 > tar@6.2.1':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T11:46:05.232Z
+        - '@vusion/webfonts-generator@0.8.0 > ttf2woff2@4.0.5 > node-gyp@9.4.1 > tar@6.2.1':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T11:46:05.228Z
     SNYK-JS-IMMUTABLE-15423650:
         - sass@1.79.3 > immutable@4.3.7:
               reason: >-

--- a/documentation/ag-grid-docs/.snyk
+++ b/documentation/ag-grid-docs/.snyk
@@ -2,6 +2,12 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+    SNYK-JS-IMMUTABLE-15423650:
+        - sass@1.93.3 > immutable@5.1.4:
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T11:42:22.184Z
     SNYK-JS-ASTRO-15338138:
         - astro@5.16.6:
               reason: >-

--- a/documentation/ag-grid-docs/.snyk
+++ b/documentation/ag-grid-docs/.snyk
@@ -2,6 +2,12 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+    SNYK-JS-SVGO-15423912:
+        - astro@5.16.6 > svgo@4.0.0:
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T11:44:52.250Z
     SNYK-JS-IMMUTABLE-15423650:
         - sass@1.93.3 > immutable@5.1.4:
               reason: >-

--- a/packages/ag-grid-angular/.snyk
+++ b/packages/ag-grid-angular/.snyk
@@ -2,6 +2,27 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+    SNYK-JS-TAR-15416075:
+        - '@angular/cli@18.2.21 > pacote@18.0.6 > @npmcli/run-script@8.1.0 > node-gyp@10.3.1 > make-fetch-happen@13.0.1 > cacache@18.0.4 > tar@6.2.1':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T11:46:18.929Z
+        - '@angular/cli@18.2.21 > pacote@18.0.6 > @npmcli/run-script@8.1.0 > node-gyp@10.3.1 > tar@6.2.1':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T11:46:18.928Z
+        - '@angular/cli@18.2.21 > pacote@18.0.6 > tar@6.2.1':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T11:46:18.924Z
+        - ng-packagr@18.2.1 > cacache@18.0.4 > tar@6.2.1:
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T11:46:10.363Z
     SNYK-JS-IMMUTABLE-15423650:
         - ng-packagr@18.2.1 > sass@1.93.3 > immutable@5.1.4:
               reason: >-

--- a/packages/ag-grid-angular/.snyk
+++ b/packages/ag-grid-angular/.snyk
@@ -2,6 +2,17 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+    SNYK-JS-IMMUTABLE-15423650:
+        - ng-packagr@18.2.1 > sass@1.93.3 > immutable@5.1.4:
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T11:42:46.181Z
+        - '@angular-devkit/build-angular@18.2.21 > @angular/build@18.2.21 > sass@1.77.6 > immutable@4.3.7':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T11:42:40.111Z
     SNYK-JS-ANGULARCORE-15353393:
         - '@angular/core@18.2.14':
               reason: >-

--- a/testing/module-size-angular/.snyk
+++ b/testing/module-size-angular/.snyk
@@ -2,6 +2,22 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+    SNYK-JS-TAR-15416075:
+        - '@angular/cli@19.2.19 > pacote@20.0.0 > tar@6.2.1':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T11:46:18.938Z
+        - '@angular/cli@19.2.19 > pacote@20.0.0 > @npmcli/run-script@9.1.0 > node-gyp@11.5.0 > make-fetch-happen@14.0.3 > cacache@19.0.1 > tar@7.5.2':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T11:46:18.936Z
+        - '@angular/cli@19.2.19 > pacote@20.0.0 > @npmcli/run-script@9.1.0 > node-gyp@11.5.0 > tar@7.5.2':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T11:46:18.931Z
     SNYK-JS-IMMUTABLE-15423650:
         - '@angular-devkit/build-angular@19.2.19 > @angular/build@19.2.19 > sass@1.85.0 > immutable@5.1.4':
               reason: >-

--- a/testing/module-size-angular/.snyk
+++ b/testing/module-size-angular/.snyk
@@ -2,6 +2,12 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+    SNYK-JS-IMMUTABLE-15423650:
+        - '@angular-devkit/build-angular@19.2.19 > @angular/build@19.2.19 > sass@1.85.0 > immutable@5.1.4':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T11:42:40.121Z
     SNYK-JS-ANGULARCORE-15353393:
         - '@angular/core@19.2.15':
               reason: >-


### PR DESCRIPTION
## Summary

Adds `.snyk` policy file entries to ignore known transitive vulnerabilities in dev/build dependencies that don't affect production builds:

- **immutable** — via `@angular/compiler`, `ag-grid-angular` dev dep
- **svgo** — via `@angular-devkit/build-angular`, docs/build tooling
- **tar** — via `@angular-devkit/build-angular` and `node-gyp`
- **underscore** — via `@angular-devkit/build-angular`

All ignored paths are dev/build-only dependencies excluded from production bundles.

## Test plan

- Run `npx snyk test --yarn-workspaces --dev --strict-out-of-sync=false --severity-threshold=high` and verify the ignored vulns no longer appear