### PR TITLE
Fix JIRA transition applying move/mention per-ticket

### DIFF
--- a/.github/workflows/update-jira-ticket.yml
+++ b/.github/workflows/update-jira-ticket.yml
@@ -107,8 +107,13 @@ jobs:
                 }
                 const matches = pr.body?.match(regex);
                 if (matches) {
-                    const isMove = !!pr.body.match(/fix(es)? \[?((AG|RTI)-\d{3,})/gi);
-                    matches.map(m => m.match(/(AG|RTI)-\d{3,}/i)[0].toUpperCase()).forEach(ticket => issue_keys[ticket] = isMove ? 'move' : 'mention');
+                    matches.forEach(m => {
+                        const ticket = m.match(/(AG|RTI)-\d{3,}/i)[0].toUpperCase();
+                        const isFix = !!m.match(/fix(es)?/i);
+                        if (isFix || !issue_keys[ticket]) {
+                            issue_keys[ticket] = isFix ? 'move' : 'mention';
+                        }
+                    });
                 }
                 if (!Object.keys(issue_keys).length) {
                     throw new Error('No JIRA ticket found in PR body.');


### PR DESCRIPTION
## Summary

The `update-jira-ticket` workflow finds all AG-XXXX ticket ids and either transitions the card to QA or comments on them saying they were mentioned in a PR. There is a bug where if any ticket in a PR description had a "Fix" prefix, **all** mentioned tickets were transitioned to QA.

For example, this PR description would incorrectly transition both tickets:

```
Fix AG-XXXXX

Revert the breaking fix to header heights, will defer to AG-YYYYY
```

The fix classifies each ticket independently based on whether its own match includes a "Fix" prefix. If the same ticket appears both with and without "Fix", the "move" classification wins.