### PR TITLE
Fix JIRA transition applying move/mention per-ticket instead of globally

### DIFF
--- a/.github/workflows/update-jira-ticket.yml
+++ b/.github/workflows/update-jira-ticket.yml
@@ -107,8 +107,13 @@ jobs:
                 }
                 const matches = pr.body?.match(regex);
                 if (matches) {
-                    const isMove = !!pr.body.match(/fix(es)? \[?((AG|RTI)-\d{3,})/gi);
-                    matches.map(m => m.match(/(AG|RTI)-\d{3,}/i)[0].toUpperCase()).forEach(ticket => issue_keys[ticket] = isMove ? 'move' : 'mention');
+                    matches.forEach(m => {
+                        const ticket = m.match(/(AG|RTI)-\d{3,}/i)[0].toUpperCase();
+                        const isFix = !!m.match(/fix(es)?/i);
+                        if (isFix || !issue_keys[ticket]) {
+                            issue_keys[ticket] = isFix ? 'move' : 'mention';
+                        }
+                    });
                 }
                 if (!Object.keys(issue_keys).length) {
                     throw new Error('No JIRA ticket found in PR body.');

--- a/.github/workflows/update-jira-ticket.yml
+++ b/.github/workflows/update-jira-ticket.yml
@@ -14,6 +14,11 @@ on:
         type: string
         default: ''
         required: false
+      debug_skip_merge_check:
+        description: 'Skip the merged check (used for debugging this workflow)'
+        type: boolean
+        default: false
+        required: false
 
 permissions:
   contents: read
@@ -36,6 +41,7 @@ jobs:
         env:
           PR_ID: ${{ github.event.inputs.debug_pr_id || github.event.pull_request.number }}
           DEBUG_JIRA_TICKET: ${{ github.event.inputs.debug_jira_ticket }}
+          DEBUG_SKIP_MERGE_CHECK: ${{ github.event.inputs.debug_skip_merge_check }}
           JIRA_API_AUTH: ${{ secrets.JIRA_API_AUTH }}
           GH_USER_JIRA_MAPPING: ${{ secrets.GH_USER_JIRA_MAPPING }}
           JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -97,7 +103,7 @@ jobs:
                 }
                 const pr = pull_number ? (await github.rest.pulls.get({owner, repo, pull_number})).data : {};
                 const is_merged = !!pr.merged_at;
-                if (!is_merged) {
+                if (!is_merged && process.env.DEBUG_SKIP_MERGE_CHECK !== 'true') {
                     console.log(`PR #${pull_number} is not merged, skipping JIRA ticket update.`);
                     return;
                 }

--- a/.github/workflows/update-jira-ticket.yml
+++ b/.github/workflows/update-jira-ticket.yml
@@ -16,8 +16,8 @@ on:
         required: false
       debug_skip_merge_check:
         description: 'Skip the merged check (used for debugging this workflow)'
-        type: boolean
-        default: false
+        type: string
+        default: ''
         required: false
 
 permissions:
@@ -103,7 +103,7 @@ jobs:
                 }
                 const pr = pull_number ? (await github.rest.pulls.get({owner, repo, pull_number})).data : {};
                 const is_merged = !!pr.merged_at;
-                if (!is_merged && process.env.DEBUG_SKIP_MERGE_CHECK !== 'true') {
+                if (!is_merged && !process.env.DEBUG_SKIP_MERGE_CHECK) {
                     console.log(`PR #${pull_number} is not merged, skipping JIRA ticket update.`);
                     return;
                 }


### PR DESCRIPTION
Previously, if any ticket in the PR body had a "Fix" prefix, all mentioned tickets were transitioned. Now each ticket is independently classified based on whether its own reference includes "Fix".

Fix [AG-16866](https://ag-grid.atlassian.net/browse/AG-16866)

Additionally, AG-16867 should receive a comment when tis PR is merged