### PR TITLE
AG-16757 Remove updateEditCount from batch editing examples

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/cell-editing-batch/_examples/batch-editing-api/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/cell-editing-batch/_examples/batch-editing-api/main.ts
@@ -66,28 +66,16 @@ const gridOptions: GridOptions = {
     onRowEditingStopped: (_event: RowEditingStoppedEvent) => {
         console.log('rowEditingStopped');
     },
-    onCellEditingStarted: (event: CellEditingStartedEvent) => {
+    onCellEditingStarted: (_event: CellEditingStartedEvent) => {
         console.log('cellEditingStarted');
-        updateEditCount(event.api);
     },
-    onCellEditingStopped: (event: CellEditingStoppedEvent) => {
+    onCellEditingStopped: (_event: CellEditingStoppedEvent) => {
         console.log('cellEditingStopped');
-        updateEditCount(event.api);
     },
     onCellValueChanged: (_event: CellValueChangedEvent) => {
         console.log('Cell value changed');
     },
 };
-
-function updateEditCount(api: GridApi) {
-    if (api.isBatchEditing()) {
-        const pendingEditCount = api.getEditingCells().length;
-        const el = document.querySelector<HTMLElement>('#batchStatusValue');
-        if (el) {
-            el.textContent = `Active (${pendingEditCount} edit${pendingEditCount !== 1 ? 's' : ''})`;
-        }
-    }
-}
 
 function getEditingCells() {
     const cells = gridApi!.getEditingCells();
@@ -97,7 +85,7 @@ function getEditingCells() {
 function startBatchEdit() {
     gridApi!.startBatchEdit();
     const el = document.querySelector<HTMLElement>('#batchStatusValue');
-    if (el) el.textContent = 'Active (0 edits)';
+    if (el) el.textContent = 'Active';
 }
 
 function commitBatchEdit() {

--- a/documentation/ag-grid-docs/src/content/docs/cell-editing-batch/_examples/batch-editing-custom/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/cell-editing-batch/_examples/batch-editing-custom/example.spec.ts
@@ -21,7 +21,7 @@ test.agExample(import.meta, () => {
 
         // Start batch editing
         await page.locator('button', { hasText: 'Start Batch' }).click();
-        await expect(page.locator('#batchStatusValue')).toHaveText('Active (0 edits)');
+        await expect(page.locator('#batchStatusValue')).toHaveText('Active');
 
         // Double-click to edit first_name cell
         await firstNameCell.dblclick();

--- a/documentation/ag-grid-docs/src/content/docs/cell-editing-batch/_examples/batch-editing-custom/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/cell-editing-batch/_examples/batch-editing-custom/main.ts
@@ -1,4 +1,4 @@
-import type { CellEditingStartedEvent, CellEditingStoppedEvent, ColDef, GridApi, GridOptions } from 'ag-grid-community';
+import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     CustomEditorModule,
@@ -68,23 +68,7 @@ const gridOptions: GridOptions = {
         flex: 1,
         minWidth: 100,
     },
-    onCellEditingStarted: (event: CellEditingStartedEvent) => {
-        updateEditCount(event.api);
-    },
-    onCellEditingStopped: (event: CellEditingStoppedEvent) => {
-        updateEditCount(event.api);
-    },
 };
-
-function updateEditCount(api: GridApi) {
-    if (api.isBatchEditing()) {
-        const pendingEditCount = api.getEditingCells().length;
-        const el = document.querySelector<HTMLElement>('#batchStatusValue');
-        if (el) {
-            el.textContent = `Active (${pendingEditCount} edit${pendingEditCount !== 1 ? 's' : ''})`;
-        }
-    }
-}
 
 function getEditingCells() {
     const cells = gridApi!.getEditingCells();
@@ -94,7 +78,7 @@ function getEditingCells() {
 function startBatchEdit() {
     gridApi!.startBatchEdit();
     const el = document.querySelector<HTMLElement>('#batchStatusValue');
-    if (el) el.textContent = 'Active (0 edits)';
+    if (el) el.textContent = 'Active';
 }
 
 function commitBatchEdit() {

--- a/documentation/ag-grid-docs/src/content/docs/cell-editing-batch/_examples/batch-editing-fullrow/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/cell-editing-batch/_examples/batch-editing-fullrow/main.ts
@@ -54,29 +54,17 @@ const gridOptions: GridOptions = {
     onRowEditingStopped: (_event: RowEditingStoppedEvent) => {
         console.log('rowEditingStopped');
     },
-    onCellEditingStarted: (event: CellEditingStartedEvent) => {
+    onCellEditingStarted: (_event: CellEditingStartedEvent) => {
         console.log('cellEditingStarted');
-        updateEditCount(event.api);
     },
-    onCellEditingStopped: (event: CellEditingStoppedEvent) => {
+    onCellEditingStopped: (_event: CellEditingStoppedEvent) => {
         console.log('cellEditingStopped');
-        updateEditCount(event.api);
     },
     onCellValueChanged: (_event: CellValueChangedEvent) => {
         console.log('Cell value changed');
     },
     editType: 'fullRow',
 };
-
-function updateEditCount(api: GridApi) {
-    if (api.isBatchEditing()) {
-        const pendingEditCount = api.getEditingCells().length;
-        const el = document.querySelector<HTMLElement>('#batchStatusValue');
-        if (el) {
-            el.textContent = `Active (${pendingEditCount} edit${pendingEditCount !== 1 ? 's' : ''})`;
-        }
-    }
-}
 
 function getEditingCells() {
     const cells = gridApi!.getEditingCells();
@@ -86,7 +74,7 @@ function getEditingCells() {
 function startBatchEdit() {
     gridApi!.startBatchEdit();
     const el = document.querySelector<HTMLElement>('#batchStatusValue');
-    if (el) el.textContent = 'Active (0 edits)';
+    if (el) el.textContent = 'Active';
 }
 
 function commitBatchEdit() {

--- a/documentation/ag-grid-docs/src/content/docs/cell-editing-batch/_examples/batch-editing-styles/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/cell-editing-batch/_examples/batch-editing-styles/example.spec.ts
@@ -23,8 +23,8 @@ test.agExample(import.meta, () => {
         const lastNameCell = agIdFor.cell('0', 'lastName');
         await expect(lastNameCell).not.toHaveClass(/ag-cell-batch-edit/);
 
-        // Status indicator should reflect active batch with 2 pending edits
-        await expect(page.locator('#batchStatusValue')).toHaveText('Active (2 edits)');
+        // Status indicator should reflect active batch
+        await expect(page.locator('#batchStatusValue')).toHaveText('Active');
     });
 
     test.eachFramework('Commit batch applies values and removes styling', async ({ page, agIdFor }) => {

--- a/documentation/ag-grid-docs/src/content/docs/cell-editing-batch/_examples/batch-editing-styles/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/cell-editing-batch/_examples/batch-editing-styles/main.ts
@@ -56,13 +56,11 @@ const gridOptions: GridOptions = {
     onRowEditingStopped: (_event: RowEditingStoppedEvent) => {
         console.log('rowEditingStopped');
     },
-    onCellEditingStarted: (event: CellEditingStartedEvent) => {
+    onCellEditingStarted: (_event: CellEditingStartedEvent) => {
         console.log('cellEditingStarted');
-        updateEditCount(event.api);
     },
-    onCellEditingStopped: (event: CellEditingStoppedEvent) => {
+    onCellEditingStopped: (_event: CellEditingStoppedEvent) => {
         console.log('cellEditingStopped');
-        updateEditCount(event.api);
     },
     onCellValueChanged: (_event: CellValueChangedEvent) => {
         console.log('Cell value changed');
@@ -75,19 +73,10 @@ const gridOptions: GridOptions = {
         gridApi.getDisplayedRowAtIndex(0)?.setDataValue('firstName', 'Justine');
         gridApi.getDisplayedRowAtIndex(1)?.setDataValue('age', 101);
 
-        updateEditCount(params.api);
+        const el = document.querySelector<HTMLElement>('#batchStatusValue');
+        if (el) el.textContent = 'Active';
     },
 };
-
-function updateEditCount(api: GridApi) {
-    if (api.isBatchEditing()) {
-        const pendingEditCount = api.getEditingCells().length;
-        const el = document.querySelector<HTMLElement>('#batchStatusValue');
-        if (el) {
-            el.textContent = `Active (${pendingEditCount} edit${pendingEditCount !== 1 ? 's' : ''})`;
-        }
-    }
-}
 
 function getEditingCells() {
     const cells = gridApi!.getEditingCells();
@@ -97,7 +86,7 @@ function getEditingCells() {
 function startBatchEdit() {
     gridApi!.startBatchEdit();
     const el = document.querySelector<HTMLElement>('#batchStatusValue');
-    if (el) el.textContent = 'Active (0 edits)';
+    if (el) el.textContent = 'Active';
 }
 
 function commitBatchEdit() {


### PR DESCRIPTION
Simplify batch editing examples by removing the `updateEditCount` logic. The batch status indicator now shows only "Active" or "Inactive" instead of tracking the number of editing cells.

Fix AG-16757