### PR TITLE
AG-16880 Add row spanning row model validation and update comparison table

### DIFF
--- a/documentation/ag-grid-docs/src/content/matrix-table/row-models.json
+++ b/documentation/ag-grid-docs/src/content/matrix-table/row-models.json
@@ -114,9 +114,9 @@
     {
         "feature": "[Row Spanning](./row-spanning)",
         "clientSide": true,
-        "infinite": true,
+        "infinite": false,
         "serverSide": true,
-        "viewport": true
+        "viewport": false
     },
     {
         "feature": "[Column Pinning](./column-pinning)",

--- a/packages/ag-grid-community/src/validation/rules/gridOptionsValidations.ts
+++ b/packages/ag-grid-community/src/validation/rules/gridOptionsValidations.ts
@@ -204,6 +204,9 @@ const GRID_OPTION_VALIDATIONS: () => Validations<GridOptions> = () => {
                 enableRangeSelection: { required: [true] },
             },
         },
+        enableCellSpan: {
+            supportedRowModels: ['clientSide', 'serverSide'],
+        },
         enableRangeSelection: {
             dependencies: {
                 rowDragEntireRow: { required: [false, undefined] },


### PR DESCRIPTION
- Add `supportedRowModels` validation for `enableCellSpan` restricting it to client-side and server-side row models
- Update row models comparison table to mark Row Spanning as unsupported for Infinite and Viewport row models

Fix [AG-16880](https://ag-grid.atlassian.net/browse/AG-16880)