### PR TITLE
AG-13677 AG-16877 Note CellStyleModule required for provided column types

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/column-definitions/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-definitions/index.mdoc
@@ -98,6 +98,10 @@ const gridOptions = {
 }
 ```
 
+{% note %}
+The provided column types use cell classes to apply styling. The `CellStyleModule` is required for these types to work correctly.
+{% /note %}
+
 ## Updating Columns
 
 Columns can be controlled by updating the column state, or updating the column definition.


### PR DESCRIPTION
Fix AG-13677, AG-16877

Adds a note to the Provided Column Types section of the Column Definitions docs page indicating that the `CellStyleModule` is required, as the provided column types internally use cell classes for styling.