### PR TITLE
Disable sort-root-tsconfig-paths in nx format commands

### DIFF
--- a/utilities/all/project.json
+++ b/utilities/all/project.json
@@ -166,12 +166,15 @@
         "commands": ["node external/ag-shared/scripts/watch/watch.js grid", "nx run ag-grid-docs:dev"]
       }
     },
+    "format-write": {
+      "command": "nx format:write --sort-root-tsconfig-paths=false"
+    },
     "format-check": {
       "executor": "nx:run-commands",
       "options": {
         "commands": [
           {
-            "command": "nx format:check --all"
+            "command": "nx format:check --all --sort-root-tsconfig-paths=false"
           }
         ]
       }

--- a/utilities/all/project.json
+++ b/utilities/all/project.json
@@ -167,7 +167,7 @@
       }
     },
     "format-write": {
-      "command": "nx format:write --sort-root-tsconfig-paths=false"
+      "command": "nx format:write --all --sort-root-tsconfig-paths=false"
     },
     "format-check": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
Add `--sort-root-tsconfig-paths=false` to `format-write` and `format-check` targets so the flag doesn't need to be passed on the command line. Nx defaults this to `true` which causes comments in tsconfig to be lost.