### PR TITLE
Stop nx format temporarily updating tsconfig

### DIFF
--- a/.rulesync/rules/ag-grid.md
+++ b/.rulesync/rules/ag-grid.md
@@ -12,7 +12,7 @@ This file provides guidance to AI Agents when working with code in this reposito
 ### Quick Reference
 
 -   **Main branch:** `latest`
--   **Format:** `yarn nx format` (run before commits)
+-   **Format:** `yarn nx format --sort-root-tsconfig-paths=false` (run before commits)
 -   **Type-check:** `yarn nx build:types <package>` (run before commits)
 -   **Lint:** `yarn nx lint <package>` (run before commits)
 -   **Build:** `yarn nx build <package>`
@@ -34,7 +34,7 @@ This file provides guidance to AI Agents when working with code in this reposito
 -   **Main constraint:** Community and enterprise runtime bundles stay dependency-free beyond AG Grid code.
 -   **Default branch:** Target `latest`; follow release/JIRA naming conventions below for topic branches.
 -   **Build monitoring:** Check `node_modules/.cache/ag-watch-status.json` to monitor watch state (`yarn nx dev`) and build health (see [Development Server Guide](.rulesync/rules/dev-server.md)).
--   **Formatting:** Run `yarn nx format` from the repo root before proposing commits.
+-   **Formatting:** Run `yarn nx format --sort-root-tsconfig-paths=false` from the repo root before proposing commits.
 -   **Typechecking:** Run `yarn nx build:types <package>` from the repo root before proposing commits.
 -   **Linting:** Run `yarn nx lint <package>` from the repo root before proposing commits.
 -   **Baseline verification:** Expect to run `yarn nx test ag-grid-community`, `yarn nx test ag-grid-enterprise`, and `yarn nx e2e ag-grid-docs` after meaningful grid changes.
@@ -75,7 +75,7 @@ For detailed information about preferred technologies and architectural constrai
 -   `yarn install` – install dependencies after cloning or when the Yarn lockfile changes.
     -   `./external/ag-shared/scripts/install-for-cloud/install-for-cloud.sh` – install dependencies and tooling in a remote environment - use this in preference to `yarn install` to ensure all global tools are installed.
 -   `yarn nx clean` – purge all dist folders when switching branches or before packaging releases.
--   `yarn nx format` – format repo files; run from the project root before committing.
+-   `yarn nx format --sort-root-tsconfig-paths=false` – format repo files; run from the project root before committing.
 -   `yarn nx build <package>` – compile a specific package after code edits.
 -   `yarn nx build:types <package>` – regenerate declaration files when touching exported APIs.
 -   `yarn nx build:package <package>` – create ESM/CJS bundles to validate publishable output.
@@ -154,7 +154,7 @@ For code quality guidelines, see [Code Quality Guide](.rulesync/rules/code-quali
 
 Essential practices:
 
--   Run `yarn nx format` before committing
+-   Run `yarn nx format --sort-root-tsconfig-paths=false` before committing
 -   Self-review your changes before proposing commits
 -   Ensure tests exercise real implementations, not test helpers
 

--- a/.rulesync/skills/technology-stack/SKILL.md
+++ b/.rulesync/skills/technology-stack/SKILL.md
@@ -51,7 +51,7 @@ The core grid logic is framework-agnostic. Framework-specific wrappers (`ag-grid
 ## Code Style
 
 -   **ESLint**: Linting with custom rules
--   **Prettier**: Code formatting (via `yarn nx format`)
+-   **Prettier**: Code formatting (via `yarn nx format --sort-root-tsconfig-paths=false`)
 -   **TypeScript Strict Mode**: Enforced across all packages
 
 ## Browser Support

--- a/external/ag-shared/prompts/skills/batch-lint-cleanup/SKILL.md
+++ b/external/ag-shared/prompts/skills/batch-lint-cleanup/SKILL.md
@@ -134,7 +134,7 @@ grep -c "<rule-name>" /tmp/lint-fix.txt || echo "0"
 
 ```bash
 # Format all changes
-yarn nx format
+yarn nx format --sort-root-tsconfig-paths=false
 
 # Run full lint to ensure no new issues
 yarn nx lint <affected-packages>
@@ -178,7 +178,7 @@ For non-auto-fixable rules or remaining violations after auto-fix:
 5. **When complete:**
 
     ```bash
-    yarn nx format
+    yarn nx format --sort-root-tsconfig-paths=false
     yarn nx lint <affected-packages>
     yarn nx build:types <affected-packages>
 
@@ -206,7 +206,7 @@ For non-auto-fixable rules or remaining violations after auto-fix:
 
 **Before ANY commit:**
 
-1. ✅ `yarn nx format` passes
+1. ✅ `yarn nx format --sort-root-tsconfig-paths=false` passes
 2. ✅ `yarn nx lint <affected-packages>` passes
 3. ✅ `yarn nx build:types <affected-packages>` passes
 4. ✅ Only files related to the rule are changed

--- a/external/ag-shared/prompts/skills/sync-ag-shared/SKILL.md
+++ b/external/ag-shared/prompts/skills/sync-ag-shared/SKILL.md
@@ -214,7 +214,7 @@ Common companion tasks:
 -   Update `.rulesync/` symlinks if skills/rules were added, renamed, or removed.
 -   Update product-specific configurations if ag-shared scripts changed.
 -   Run verification: `./external/ag-shared/scripts/setup-prompts/verify-rulesync.sh`.
--   **Run `npx nx format` (or equivalent formatter) before committing** to avoid CI formatting check failures.
+-   **Run `npx nx format --sort-root-tsconfig-paths=false` (or equivalent formatter) before committing** to avoid CI formatting check failures.
 
 ### Iterative Push/Pull (if needed)
 


### PR DESCRIPTION
## Summary

- Add `--sort-root-tsconfig-paths=false` flag to all `yarn nx format` references in docs and skills to prevent nx format from reordering tsconfig paths during formatting