### PR TITLE
Fix demo examples e2e test strict mode violation

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/example-demos.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/example-demos.spec.ts
@@ -22,7 +22,7 @@ test.describe(`Demo Examples`, async () => {
         await page.waitForTimeout(1000);
 
         await page.locator('button').filter({ hasText: 'Rows, 22 Cols' }).click();
-        await page.getByText('1,000 Rows, 22 Cols').click();
+        await page.getByRole('option', { name: '1,000 Rows, 22 Cols' }).click();
         await page.locator('button').filter({ hasText: 'Quartz' }).click();
         await page.getByText('Balham').click();
         await page.getByRole('textbox', { name: 'Filter:' }).click();


### PR DESCRIPTION
Use `getByRole('option')` instead of `getByText()` for the Radix Select dropdown item in the demo examples Playwright test, fixing a strict mode violation where the selector matched both the trigger button and the dropdown option.