### PR TITLE
Include .rulesync/README.md in nx format checks

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,5 +1,6 @@
-# Needed to avoid nx format failing on symlinks.
-.rulesync/
+# Ignore .rulesync symlinks as nx format doesn't handle these well.
+.rulesync/**
+!.rulesync/README.md
 .patches/
 patches/
 


### PR DESCRIPTION
## Summary
- `.rulesync/` was fully excluded in `.nxignore`, so `nx format:check` in CI never caught formatting drift on `README.md`
- Changed `.rulesync/` to `.rulesync/**` with `!.rulesync/README.md` negation, so the README is formatted while symlinks remain ignored