### PR TITLE
AG-16463 Fix deferred column panel background color compounding

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_columns-tool-panel.scss
+++ b/community-modules/styles/src/internal/base/parts/_columns-tool-panel.scss
@@ -1,11 +1,7 @@
 @use 'ag';
 
 @mixin output {
-    :where(.ag-column-panel.ag-column-panel-deferred),
-    :where(.ag-column-panel.ag-column-panel-deferred) :where(.ag-column-panel-column-select),
-    :where(.ag-column-panel.ag-column-panel-deferred) :where(.ag-column-drop-vertical),
-    :where(.ag-column-panel.ag-column-panel-deferred) :where(.ag-column-panel-defer-mode-toggle),
-    :where(.ag-column-panel.ag-column-panel-deferred) :where(.ag-column-panel-buttons) {
+    :where(.ag-column-panel.ag-column-panel-deferred) {
         background-color: var(--ag-cell-batch-edit-background-color);
     }
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.css
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.css
@@ -5,11 +5,7 @@
     flex: 1 1 auto;
 }
 
-:where(.ag-column-panel.ag-column-panel-deferred),
-:where(.ag-column-panel.ag-column-panel-deferred) :where(.ag-column-panel-column-select),
-:where(.ag-column-panel.ag-column-panel-deferred) :where(.ag-column-drop-vertical),
-:where(.ag-column-panel.ag-column-panel-deferred) :where(.ag-column-panel-defer-mode-toggle),
-:where(.ag-column-panel.ag-column-panel-deferred) :where(.ag-column-panel-buttons) {
+:where(.ag-column-panel.ag-column-panel-deferred) {
     background-color: var(--ag-cell-batch-edit-background-color);
 }
 


### PR DESCRIPTION
Apply background-color only to the parent .ag-column-panel-deferred container instead of also on child elements, which caused the color to stack and appear darker than intended.