### PR TITLE
AG-8814: Add datasize URL param and modernise URL param handling

### DIFF
--- a/documentation/ag-grid-docs/src/components/example-grid/Example.tsx
+++ b/documentation/ag-grid-docs/src/components/example-grid/Example.tsx
@@ -137,7 +137,17 @@ const staticGridOptions: GridOptions = {
     ),
 };
 
-const ExampleInner = ({ darkMode, theme, isSmall }: { darkMode: boolean; theme: string; isSmall: boolean }) => {
+const ExampleInner = ({
+    darkMode,
+    theme,
+    isSmall,
+    datasizeStr,
+}: {
+    darkMode: boolean;
+    theme: string;
+    datasizeStr: string | undefined;
+    isSmall: boolean;
+}) => {
     const gridRef = useRef(null);
     const loadInstance = useRef(0);
     const [gridThemeStr, setGridThemeStr] = useState(theme);
@@ -288,9 +298,15 @@ const ExampleInner = ({ darkMode, theme, isSmall }: { darkMode: boolean; theme: 
             newRowsCols.push([10_000, 100], [50_000, defaultColCount], [100_000, defaultColCount]);
         }
 
-        setDataSize(createDataSizeValue(newRowsCols[1][0], newRowsCols[1][1]));
+        const defaultDataSize = datasizeStr
+            ? newRowsCols.find(([r, c]) => createDataSizeValue(r, c) === datasizeStr)
+                ? datasizeStr
+                : createDataSizeValue(newRowsCols[1][0], newRowsCols[1][1])
+            : createDataSizeValue(newRowsCols[1][0], newRowsCols[1][1]);
+
+        setDataSize(defaultDataSize);
         setRowCols(newRowsCols);
-    }, [isSmall]);
+    }, [isSmall, datasizeStr]);
 
     useEffect(() => {
         const flags: Record<string, any> = {};
@@ -430,11 +446,14 @@ const ExampleInner = ({ darkMode, theme, isSmall }: { darkMode: boolean; theme: 
 const Example = () => {
     const [darkMode] = useDarkmode();
     const [gridThemeStr] = useState<string>(() => new URLSearchParams(window.location.search).get('theme') ?? 'quartz');
+    const [datasizeStr] = useState<string | undefined>(
+        () => new URLSearchParams(window.location.search).get('datasize') ?? undefined
+    );
     const [small] = useState(() =>
         IS_SSR ? false : document.documentElement.clientHeight <= 415 || document.documentElement.clientWidth < 768
     );
 
-    return <ExampleInner darkMode={darkMode ?? false} theme={gridThemeStr} isSmall={small} />;
+    return <ExampleInner darkMode={darkMode ?? false} theme={gridThemeStr} datasizeStr={datasizeStr} isSmall={small} />;
 };
 
 export default memo(Example);

--- a/documentation/ag-grid-docs/src/components/example-grid/Example.tsx
+++ b/documentation/ag-grid-docs/src/components/example-grid/Example.tsx
@@ -445,9 +445,11 @@ const ExampleInner = ({
 
 const Example = () => {
     const [darkMode] = useDarkmode();
-    const [gridThemeStr] = useState<string>(() => new URLSearchParams(window.location.search).get('theme') ?? 'quartz');
-    const [datasizeStr] = useState<string | undefined>(
-        () => new URLSearchParams(window.location.search).get('datasize') ?? undefined
+    const [gridThemeStr] = useState<string>(() =>
+        IS_SSR ? 'quartz' : new URLSearchParams(window.location.search).get('theme') ?? 'quartz'
+    );
+    const [datasizeStr] = useState<string | undefined>(() =>
+        IS_SSR ? undefined : new URLSearchParams(window.location.search).get('datasize') ?? undefined
     );
     const [small] = useState(() =>
         IS_SSR ? false : document.documentElement.clientHeight <= 415 || document.documentElement.clientWidth < 768

--- a/documentation/ag-grid-docs/src/components/example-grid/Example.tsx
+++ b/documentation/ag-grid-docs/src/components/example-grid/Example.tsx
@@ -141,11 +141,11 @@ const ExampleInner = ({
     darkMode,
     theme,
     isSmall,
-    datasizeStr,
+    dataSizeStr,
 }: {
     darkMode: boolean;
     theme: string;
-    datasizeStr: string | undefined;
+    dataSizeStr: string | undefined;
     isSmall: boolean;
 }) => {
     const gridRef = useRef(null);
@@ -298,15 +298,15 @@ const ExampleInner = ({
             newRowsCols.push([10_000, 100], [50_000, defaultColCount], [100_000, defaultColCount]);
         }
 
-        const defaultDataSize = datasizeStr
-            ? newRowsCols.find(([r, c]) => createDataSizeValue(r, c) === datasizeStr)
-                ? datasizeStr
+        const defaultDataSize = dataSizeStr
+            ? newRowsCols.find(([r, c]) => createDataSizeValue(r, c) === dataSizeStr)
+                ? dataSizeStr
                 : createDataSizeValue(newRowsCols[1][0], newRowsCols[1][1])
             : createDataSizeValue(newRowsCols[1][0], newRowsCols[1][1]);
 
         setDataSize(defaultDataSize);
         setRowCols(newRowsCols);
-    }, [isSmall, datasizeStr]);
+    }, [isSmall, dataSizeStr]);
 
     useEffect(() => {
         const flags: Record<string, any> = {};
@@ -448,14 +448,14 @@ const Example = () => {
     const [gridThemeStr] = useState<string>(() =>
         IS_SSR ? 'quartz' : new URLSearchParams(window.location.search).get('theme') ?? 'quartz'
     );
-    const [datasizeStr] = useState<string | undefined>(() =>
-        IS_SSR ? undefined : new URLSearchParams(window.location.search).get('datasize') ?? undefined
+    const [dataSizeStr] = useState<string | undefined>(() =>
+        IS_SSR ? undefined : new URLSearchParams(window.location.search).get('dataSize') ?? undefined
     );
     const [small] = useState(() =>
         IS_SSR ? false : document.documentElement.clientHeight <= 415 || document.documentElement.clientWidth < 768
     );
 
-    return <ExampleInner darkMode={darkMode ?? false} theme={gridThemeStr} datasizeStr={datasizeStr} isSmall={small} />;
+    return <ExampleInner darkMode={darkMode ?? false} theme={gridThemeStr} dataSizeStr={dataSizeStr} isSmall={small} />;
 };
 
 export default memo(Example);

--- a/documentation/ag-grid-docs/src/components/example-grid/Toolbar.tsx
+++ b/documentation/ag-grid-docs/src/components/example-grid/Toolbar.tsx
@@ -58,7 +58,7 @@ export const Toolbar = ({
             value,
         });
 
-        updateUrlParam('datasize', value);
+        updateUrlParam('dataSize', value);
     }
 
     function onThemeChanged(newValue: SelectOption) {

--- a/documentation/ag-grid-docs/src/components/example-grid/Toolbar.tsx
+++ b/documentation/ag-grid-docs/src/components/example-grid/Toolbar.tsx
@@ -8,7 +8,11 @@ import type { GridApi } from 'ag-grid-community';
 import styles from './Toolbar.module.scss';
 import { createDataSizeValue } from './utils';
 
-const IS_SSR = typeof window === 'undefined';
+function updateUrlParam(key: string, value: string) {
+    const url = new URL(window.location.href);
+    url.searchParams.set(key, value);
+    history.replaceState({}, '', url);
+}
 
 interface SelectOption {
     label: string;
@@ -48,6 +52,8 @@ export const Toolbar = ({
             type: 'dataSize',
             value,
         });
+
+        updateUrlParam('datasize', value);
     }
 
     function onThemeChanged(newValue: SelectOption) {
@@ -63,16 +69,7 @@ export const Toolbar = ({
             value: newTheme,
         });
 
-        if (!IS_SSR) {
-            let url = window.location.href;
-            if (url.indexOf('?theme=') !== -1) {
-                url = url.replace(/\?theme=[\w:-]+/, `?theme=${newTheme}`);
-            } else {
-                const sep = url.indexOf('?') === -1 ? '?' : '&';
-                url += `${sep}theme=${newTheme}`;
-            }
-            history.replaceState({}, '', url);
-        }
+        updateUrlParam('theme', newTheme);
     }
 
     const [quickFilterText, setQuickFilterText] = useState('');

--- a/documentation/ag-grid-docs/src/components/example-grid/Toolbar.tsx
+++ b/documentation/ag-grid-docs/src/components/example-grid/Toolbar.tsx
@@ -8,7 +8,10 @@ import type { GridApi } from 'ag-grid-community';
 import styles from './Toolbar.module.scss';
 import { createDataSizeValue } from './utils';
 
+const IS_SSR = typeof window === 'undefined';
+
 function updateUrlParam(key: string, value: string) {
+    if (IS_SSR) return;
     const url = new URL(window.location.href);
     url.searchParams.set(key, value);
     history.replaceState({}, '', url);

--- a/documentation/ag-grid-docs/src/components/example-grid/Toolbar.tsx
+++ b/documentation/ag-grid-docs/src/components/example-grid/Toolbar.tsx
@@ -11,7 +11,9 @@ import { createDataSizeValue } from './utils';
 const IS_SSR = typeof window === 'undefined';
 
 function updateUrlParam(key: string, value: string) {
-    if (IS_SSR) return;
+    if (IS_SSR) {
+        return;
+    }
     const url = new URL(window.location.href);
     url.searchParams.set(key, value);
     history.replaceState({}, '', url);

--- a/documentation/ag-grid-docs/src/components/example-grid/config/colDefs.ts
+++ b/documentation/ag-grid-docs/src/components/example-grid/config/colDefs.ts
@@ -309,12 +309,13 @@ const desktopDefaultCols: (ColDef<RowItem> | ColGroupDef<RowItem>)[] = [
     },
     {
         headerName: 'Monthly Breakdown',
-        openByDefault: false,
+        openByDefault: true,
         children: [
             {
                 headerName: 'Winning Trends',
                 colId: 'winningTrends',
                 sortable: false,
+                columnGroupShow: 'closed',
                 cellRenderer: 'agSparklineCellRenderer',
                 cellRendererParams: {
                     deferRender: true,


### PR DESCRIPTION
## Summary
- Read `datasize` from URL query params on page load to restore the previously selected data size (matching existing `theme` param behaviour)
- Replace fragile manual string manipulation with `URL`/`URLSearchParams` API for updating both `theme` and `datasize` URL params
- Open Monthly Breakdown column group by default with sparkline column visible when collapsed

## Test plan
- [ ] Load the example grid page — verify default data size (1,000 rows) loads
- [ ] Change data size via dropdown — verify URL updates with `?datasize=` param
- [ ] Reload the page with a `?datasize=` param — verify the correct data size is selected
- [ ] Change theme via dropdown — verify URL updates with `?theme=` param
- [ ] Verify both params coexist correctly in the URL (e.g. `?theme=balham&datasize=10000x100`)
- [ ] Verify Monthly Breakdown column group is open by default with sparkline visible when collapsed

Fix AG-8814