### PR TITLE
Fix sparkline error in Finance demo caused by duplicate ag-charts-core

### DIFF
--- a/documentation/ag-grid-docs/astro.config.mjs
+++ b/documentation/ag-grid-docs/astro.config.mjs
@@ -191,8 +191,23 @@ export default defineConfig({
             },
         },
         optimizeDeps: {
-            // Prevent vite from importing in content/docs folder
-            exclude: ['vue', '@angular/common/http', '@angular/forms', '@angular/common', '@angular/platform-browser'],
+            // Prevent vite from importing in content/docs folder.
+            // ag-charts-community and ag-charts-enterprise are excluded so Vite serves them as
+            // raw ESM rather than pre-bundling them. When pre-bundled, each package inlines its
+            // own copy of ag-charts-core, producing two separate ModuleRegistry singletons.
+            // Serving them as raw ESM lets both packages reference the same pre-bundled
+            // ag-charts-core.js, keeping the ModuleRegistry truly singular and fixing the
+            // "No modules have been registered" sparkline error in the Finance demo.
+            exclude: [
+                'vue',
+                '@angular/common/http',
+                '@angular/forms',
+                '@angular/common',
+                '@angular/platform-browser',
+                'ag-charts-community',
+                'ag-charts-enterprise',
+            ],
+            include: ['ag-charts-core'],
         },
     },
     integrations: [


### PR DESCRIPTION
Vite's dep pre-bundler was inlining `ag-charts-core` separately into both `ag-charts-community` and `ag-charts-enterprise`, producing two distinct `ModuleRegistry` singletons. When `SparklinesModule.with()` called `setup()`, modules were registered on the enterprise bundle's registry, but `AgCharts.create()` checked the community bundle's registry — which was empty — throwing "No modules have been registered".

Excluding `ag-charts-community` and `ag-charts-enterprise` from `optimizeDeps` causes Vite to serve them as raw ESM. Both packages then resolve `ag-charts-core` to the same pre-bundled `ag-charts-core.js`, restoring the shared singleton and fixing the sparkline error in the Finance demo page.

Fix [AG-8814](https://ag-grid.atlassian.net/browse/AG-8814)