### PR TITLE
[AG-3471] Support suppressSyncLayoutWithGrid in deferred apply mode

### DIFF
--- a/packages/ag-grid-community/src/interfaces/iColumnStateUpdateStrategy.ts
+++ b/packages/ag-grid-community/src/interfaces/iColumnStateUpdateStrategy.ts
@@ -15,6 +15,7 @@ export interface IColumnStateUpdateStrategy {
     setRowGroupColumns(deferMode: boolean, columns: AgColumn[], eventType: ColumnEventType): void;
     getRowGroupColumns(deferMode: boolean): AgColumn[];
     getPrimaryColumns(deferMode: boolean): AgColumn[];
+    hasDeferredColumnOrder(deferMode: boolean): boolean;
     setValueColumns(deferMode: boolean, columns: AgColumn[], eventType: ColumnEventType): void;
     getValueColumns(deferMode: boolean): AgColumn[];
     setColumnAggFunc(

--- a/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
@@ -121,7 +121,7 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
 
         this.expandGroupsByDefault = !contractColumnSelection;
 
-        const isPreventMove = suppressColumnMove || suppressSyncLayoutWithGrid;
+        const isPreventMove = suppressColumnMove || (suppressSyncLayoutWithGrid && !isDeferredMode(params));
 
         const virtualList = this.createManagedBean(
             new VirtualList<ToolPanelColumnGroupComp | ToolPanelColumnComp, ColumnModelItem>({
@@ -262,7 +262,8 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
         const expandedStates = this.getExpandedStates();
 
         const pivotModeActive = this.colModel.isPivotMode();
-        const shouldSyncColumnLayoutWithGrid = !params.suppressSyncLayoutWithGrid && !pivotModeActive;
+        const deferApply = isDeferredMode(params);
+        const shouldSyncColumnLayoutWithGrid = (!params.suppressSyncLayoutWithGrid || deferApply) && !pivotModeActive;
 
         if (shouldSyncColumnLayoutWithGrid) {
             this.buildTreeFromWhatGridIsDisplaying();
@@ -335,13 +336,17 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
 
     private buildTreeFromWhatGridIsDisplaying(): void {
         const deferApply = isDeferredMode(this.params);
-        const columnOrder = this.beans.columnStateUpdateStrategy.getPrimaryColumns(deferApply);
-
-        if (deferApply && columnOrder.length > 0) {
-            syncLayoutWithColumns(columnOrder, this.setColumnLayout.bind(this));
+        if (deferApply && this.beans.columnStateUpdateStrategy.hasDeferredColumnOrder(deferApply)) {
+            const columnOrder = this.beans.columnStateUpdateStrategy.getPrimaryColumns(deferApply);
+            if (columnOrder.length > 0) {
+                syncLayoutWithColumns(columnOrder, this.setColumnLayout.bind(this));
+                return;
+            }
+        }
+        if (this.params.suppressSyncLayoutWithGrid) {
+            this.buildTreeFromProvidedColumnDefs();
             return;
         }
-
         syncLayoutWithGrid(this.colModel, this.setColumnLayout.bind(this));
     }
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -226,8 +226,12 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
     };
 
     private readonly onExternalGridChange = (): void => {
-        if (!this.isDeferModeEnabled || this.isCommitting) return;
-        if (!this.beans.columnStateUpdateStrategy.hasPendingChanges(this.isDeferModeEnabled)) return;
+        if (!this.isDeferModeEnabled || this.isCommitting) {
+            return;
+        }
+        if (!this.beans.columnStateUpdateStrategy.hasPendingChanges(this.isDeferModeEnabled)) {
+            return;
+        }
         this.beans.columnStateUpdateStrategy.reset(this.isDeferModeEnabled);
         this.deferredButtonsComp?.updateValidity(false);
         this.refreshToolPanelLayouts();

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -133,34 +133,18 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
 
         if (this.isDeferModeEnabled) {
             const resetListener = this.onExternalGridChange;
-            const [
-                sortChangedDestroy,
-                columnVisibleDestroy,
-                columnRowGroupChangedDestroy,
-                columnValueChangedDestroy,
-                columnPivotChangedDestroy,
-                columnPivotModeChangedDestroy,
-                newColumnsLoadedDestroy,
-                columnMovedDestroy,
-            ] = this.addManagedEventListeners({
-                sortChanged: resetListener,
-                columnVisible: resetListener,
-                columnRowGroupChanged: resetListener,
-                columnValueChanged: resetListener,
-                columnPivotChanged: resetListener,
-                columnPivotModeChanged: resetListener,
-                newColumnsLoaded: resetListener,
-                ...(mergedParams.suppressSyncLayoutWithGrid ? {} : { columnMoved: resetListener }),
-            });
+
             childDestroyFuncs.push(
-                () => sortChangedDestroy(),
-                () => columnVisibleDestroy(),
-                () => columnRowGroupChangedDestroy(),
-                () => columnValueChangedDestroy(),
-                () => columnPivotChangedDestroy(),
-                () => columnPivotModeChangedDestroy(),
-                () => newColumnsLoadedDestroy(),
-                () => columnMovedDestroy?.()
+                ...this.addManagedEventListeners({
+                    sortChanged: resetListener,
+                    columnVisible: resetListener,
+                    columnRowGroupChanged: resetListener,
+                    columnValueChanged: resetListener,
+                    columnPivotChanged: resetListener,
+                    columnPivotModeChanged: resetListener,
+                    newColumnsLoaded: resetListener,
+                    ...(mergedParams.suppressSyncLayoutWithGrid ? {} : { columnMoved: resetListener }),
+                })
             );
         }
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -40,6 +40,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
     private colToolPanelFactory?: ColumnToolPanelFactory;
     private deferredButtonsComp?: FilterButtonComp;
     private isDeferModeEnabled = false;
+    private isCommitting = false;
 
     constructor() {
         super({ tag: 'div', cls: 'ag-column-panel' });
@@ -130,6 +131,39 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             childDestroyFuncs.push(() => pivotModeListener());
         }
 
+        if (this.isDeferModeEnabled) {
+            const resetListener = this.onExternalGridChange;
+            const [
+                sortChangedDestroy,
+                columnVisibleDestroy,
+                columnRowGroupChangedDestroy,
+                columnValueChangedDestroy,
+                columnPivotChangedDestroy,
+                columnPivotModeChangedDestroy,
+                newColumnsLoadedDestroy,
+                columnMovedDestroy,
+            ] = this.addManagedEventListeners({
+                sortChanged: resetListener,
+                columnVisible: resetListener,
+                columnRowGroupChanged: resetListener,
+                columnValueChanged: resetListener,
+                columnPivotChanged: resetListener,
+                columnPivotModeChanged: resetListener,
+                newColumnsLoaded: resetListener,
+                ...(mergedParams.suppressSyncLayoutWithGrid ? {} : { columnMoved: resetListener }),
+            });
+            childDestroyFuncs.push(
+                () => sortChangedDestroy(),
+                () => columnVisibleDestroy(),
+                () => columnRowGroupChangedDestroy(),
+                () => columnValueChangedDestroy(),
+                () => columnPivotChangedDestroy(),
+                () => columnPivotModeChangedDestroy(),
+                () => newColumnsLoadedDestroy(),
+                () => columnMovedDestroy?.()
+            );
+        }
+
         if (mergedParams.buttons?.length) {
             if (!mergedParams.buttons.includes('apply')) {
                 _warn(298);
@@ -167,7 +201,12 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
     }
 
     private readonly onDeferredApply = (): void => {
-        this.beans.columnStateUpdateStrategy.commit(this.isDeferModeEnabled);
+        this.isCommitting = true;
+        try {
+            this.beans.columnStateUpdateStrategy.commit(this.isDeferModeEnabled);
+        } finally {
+            this.isCommitting = false;
+        }
         this.deferredButtonsComp?.updateValidity(false);
     };
 
@@ -184,6 +223,15 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         this.deferredButtonsComp?.updateValidity(
             this.beans.columnStateUpdateStrategy.hasPendingChanges(this.isDeferModeEnabled)
         );
+    };
+
+    private readonly onExternalGridChange = (): void => {
+        if (!this.isDeferModeEnabled || this.isCommitting) return;
+        if (!this.beans.columnStateUpdateStrategy.hasPendingChanges(this.isDeferModeEnabled)) return;
+        this.beans.columnStateUpdateStrategy.reset(this.isDeferModeEnabled);
+        this.deferredButtonsComp?.updateValidity(false);
+        this.refreshToolPanelLayouts();
+        this.pivotModePanel?.refreshEditStrategy();
     };
 
     public refreshDeferredUi(): void {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/updates/columnStateUpdateExecutionStrategy.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/updates/columnStateUpdateExecutionStrategy.ts
@@ -59,6 +59,9 @@ export class ColumnStateUpdateExecutionStrategy extends BeanStub implements ICol
     public getPrimaryColumns(deferMode: boolean): AgColumn[] {
         return this.getUpdateStrategy(deferMode).getPrimaryColumns();
     }
+    public hasDeferredColumnOrder(deferMode: boolean): boolean {
+        return this.getUpdateStrategy(deferMode).hasDeferredColumnOrder();
+    }
     public setValueColumns(deferMode: boolean, columns: AgColumn[], eventType: ColumnEventType): void {
         this.getUpdateStrategy(deferMode).setValueColumns(columns, eventType);
     }
@@ -119,6 +122,7 @@ export class SynchronousColumnStateUpdateStrategy implements ColumnStateConcrete
     public reset = noop;
     public commit = noop;
     public hasPendingChanges = () => false;
+    public hasDeferredColumnOrder = () => false;
 
     public applyColumnState(state: ColumnState[], eventType: ColumnEventType): void {
         if (state.length === 0) {
@@ -619,6 +623,10 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
 
     public getPrimaryColumns(): AgColumn[] {
         return getDraftColumns(this.beans, this.state.columnOrder?.colIds ?? getPrimaryColumnIds(this.beans));
+    }
+
+    public hasDeferredColumnOrder(): boolean {
+        return !!this.state.columnOrder;
     }
 
     public getValueColumns(): AgColumn[] {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/updates/columnStateUpdateStrategy.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/updates/columnStateUpdateStrategy.ts
@@ -59,6 +59,10 @@ export class ColumnStateUpdateStrategy extends BeanStub implements IColumnStateU
         return this.delegate('getPrimaryColumns', deferMode);
     }
 
+    public hasDeferredColumnOrder(deferMode: boolean): boolean {
+        return this.delegate('hasDeferredColumnOrder', deferMode);
+    }
+
     public setValueColumns(deferMode: boolean, columns: AgColumn[], eventType: ColumnEventType): void {
         this.delegate('setValueColumns', deferMode, columns, eventType);
     }

--- a/packages/ag-grid-enterprise/src/columnToolPanel/updates/columnStateUpdateTypes.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/updates/columnStateUpdateTypes.ts
@@ -13,6 +13,7 @@ export interface ColumnStateConcreteUpdateStrategy {
     setRowGroupColumns(columns: AgColumn[], eventType: ColumnEventType): void;
     getRowGroupColumns(): AgColumn[];
     getPrimaryColumns(): AgColumn[];
+    hasDeferredColumnOrder(): boolean;
     setValueColumns(columns: AgColumn[], eventType: ColumnEventType): void;
     getValueColumns(): AgColumn[];
     setColumnAggFunc(column: AgColumn, aggFunc: string | IAggFunc | null | undefined, eventType: ColumnEventType): void;

--- a/testing/behavioural/src/columnToolPanel/deferred-suppress-sync-layout.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-suppress-sync-layout.test.ts
@@ -1,0 +1,377 @@
+import type { AgColumn, ColDef, GridApi, IColumnStateUpdateStrategy } from 'ag-grid-community';
+import { setupAgTestIds } from 'ag-grid-community';
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
+
+import { moveItem } from '../../../../packages/ag-grid-enterprise/src/columnToolPanel/columnMoveUtils';
+import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+
+describe('deferred column tool panel with suppressSyncLayoutWithGrid', () => {
+    const gridMgr = new TestGridsManager({
+        modules: [AllEnterpriseModule],
+    });
+
+    const rowData = [
+        { athlete: 'Michael Phelps', age: 23, country: 'United States', sport: 'Swimming', gold: 8 },
+        { athlete: 'Julian Weber', age: 24, country: 'Romania', sport: 'Gymnastics', gold: 2 },
+    ];
+
+    const baseColumnDefs: ColDef[] = [
+        { field: 'athlete' },
+        { field: 'age' },
+        { field: 'country' },
+        { field: 'sport' },
+        { field: 'gold' },
+    ];
+
+    beforeAll(() => {
+        setupAgTestIds();
+    });
+
+    afterEach(() => {
+        gridMgr.reset();
+    });
+
+    async function createGrid(params: { suppressSyncLayoutWithGrid?: boolean; columnDefs?: ColDef[] } = {}): Promise<{
+        gridApi: GridApi;
+        toolPanel: any;
+        toolPanelGui: HTMLElement;
+    }> {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: params.columnDefs ?? baseColumnDefs,
+            rowData,
+            sideBar: {
+                toolPanels: [
+                    {
+                        id: 'columns',
+                        labelDefault: 'Columns',
+                        labelKey: 'columns',
+                        iconKey: 'columns',
+                        toolPanel: 'agColumnsToolPanel',
+                        toolPanelParams: {
+                            buttons: ['apply', 'cancel'] as const,
+                            suppressSyncLayoutWithGrid: params.suppressSyncLayoutWithGrid ?? true,
+                        },
+                    },
+                ],
+                defaultToolPanel: 'columns',
+            },
+        });
+
+        await asyncSetTimeout(50);
+
+        const toolPanel = gridApi.getToolPanelInstance('columns') as any;
+        return {
+            gridApi,
+            toolPanel,
+            toolPanelGui: toolPanel.getGui(),
+        };
+    }
+
+    function getUpdateStrategy(toolPanel: any): IColumnStateUpdateStrategy {
+        return toolPanel.beans.columnStateUpdateStrategy;
+    }
+
+    function isDeferred(toolPanel: any): boolean {
+        return !!toolPanel['isDeferModeEnabled'];
+    }
+
+    function getApplyButton(toolPanelGui: HTMLElement): HTMLButtonElement {
+        return Array.from(toolPanelGui.querySelectorAll<HTMLButtonElement>('.ag-column-panel-buttons-button')).find(
+            (button) => button.textContent?.trim() === 'Apply'
+        )!;
+    }
+
+    function getCancelButton(toolPanelGui: HTMLElement): HTMLButtonElement {
+        return Array.from(toolPanelGui.querySelectorAll<HTMLButtonElement>('.ag-column-panel-buttons-button')).find(
+            (button) => button.textContent?.trim() === 'Cancel'
+        )!;
+    }
+
+    function getDisplayedPrimaryColumnOrder(toolPanel: any): string[] {
+        return toolPanel.primaryColsPanel.primaryColsListPanel
+            .getDisplayedColsList()
+            .filter((item: any) => !item.group)
+            .map((item: any) => item.column.getColId());
+    }
+
+    function getPrimaryColumnOrder(toolPanel: any): string[] {
+        return toolPanel.beans.colModel.getColDefCols().map((col: any) => col.getColId());
+    }
+
+    async function dragColumnToEnd(toolPanel: any, label: string): Promise<void> {
+        const listPanel = toolPanel.primaryColsPanel.primaryColsListPanel;
+        const virtualList = listPanel['virtualList'];
+        const displayedColsList = listPanel.getDisplayedColsList() as any[];
+        const lastIndex = displayedColsList.length - 1;
+        const movingItem = displayedColsList.find((item: any) => item.displayName === label);
+
+        expect(movingItem).toBeTruthy();
+
+        virtualList.ensureIndexVisible(lastIndex);
+        await asyncSetTimeout(50);
+
+        let component = virtualList.getComponentAt(lastIndex) as any;
+        if (!component) {
+            component = listPanel['createComponentFromItem'](
+                displayedColsList[lastIndex],
+                document.createElement('div')
+            );
+        }
+
+        moveItem(
+            toolPanel.beans,
+            [movingItem.column as AgColumn],
+            {
+                rowIndex: lastIndex,
+                position: 'bottom',
+                component,
+            },
+            {
+                buttons: ['apply', 'cancel'] as const,
+                suppressSyncLayoutWithGrid: true,
+            }
+        );
+        await asyncSetTimeout(50);
+    }
+
+    describe('column reordering', () => {
+        test('allows column reordering in CTP when suppressSyncLayoutWithGrid and deferred mode', async () => {
+            const { toolPanel } = await createGrid({ suppressSyncLayoutWithGrid: true });
+
+            const initialOrder = getDisplayedPrimaryColumnOrder(toolPanel);
+            expect(initialOrder).toEqual(['athlete', 'age', 'country', 'sport', 'gold']);
+
+            await dragColumnToEnd(toolPanel, 'Athlete');
+
+            const newOrder = getDisplayedPrimaryColumnOrder(toolPanel);
+            expect(newOrder).toEqual(['age', 'country', 'sport', 'gold', 'athlete']);
+        });
+
+        test('shows deferred column order after drag and reverts on cancel', async () => {
+            const { toolPanel, toolPanelGui } = await createGrid({ suppressSyncLayoutWithGrid: true });
+
+            await dragColumnToEnd(toolPanel, 'Athlete');
+
+            expect(getDisplayedPrimaryColumnOrder(toolPanel)).toEqual(['age', 'country', 'sport', 'gold', 'athlete']);
+
+            // Grid column order is unchanged
+            expect(getPrimaryColumnOrder(toolPanel)).toEqual(['athlete', 'age', 'country', 'sport', 'gold']);
+
+            getCancelButton(toolPanelGui).click();
+            await asyncSetTimeout(50);
+
+            // Reverts to colDef order
+            expect(getDisplayedPrimaryColumnOrder(toolPanel)).toEqual(['athlete', 'age', 'country', 'sport', 'gold']);
+        });
+
+        test('applies deferred column order on commit', async () => {
+            const { toolPanel, toolPanelGui } = await createGrid({ suppressSyncLayoutWithGrid: true });
+
+            await dragColumnToEnd(toolPanel, 'Athlete');
+
+            expect(getDisplayedPrimaryColumnOrder(toolPanel)).toEqual(['age', 'country', 'sport', 'gold', 'athlete']);
+
+            getApplyButton(toolPanelGui).click();
+            await asyncSetTimeout(50);
+
+            // After apply, colDef order should be updated
+            expect(getPrimaryColumnOrder(toolPanel)).toEqual(['age', 'country', 'sport', 'gold', 'athlete']);
+        });
+    });
+
+    describe('external change resets staged changes', () => {
+        test('external sort change resets staged changes', async () => {
+            const { gridApi, toolPanel, toolPanelGui } = await createGrid({ suppressSyncLayoutWithGrid: true });
+            const athlete = gridApi.getColumn('athlete')! as AgColumn;
+
+            // Stage a visibility change
+            getUpdateStrategy(toolPanel).setColumnsVisible(true, [athlete], false, 'toolPanelUi');
+            toolPanel.refreshDeferredUi();
+
+            expect(getApplyButton(toolPanelGui).disabled).toBe(false);
+
+            // External sort change
+            gridApi.applyColumnState({ state: [{ colId: 'age', sort: 'asc' }] });
+            await asyncSetTimeout(50);
+
+            // Staged changes should be reset
+            expect(getUpdateStrategy(toolPanel).hasPendingChanges(isDeferred(toolPanel))).toBe(false);
+            expect(getApplyButton(toolPanelGui).disabled).toBe(true);
+        });
+
+        test('external column visibility change resets staged changes', async () => {
+            const { gridApi, toolPanel, toolPanelGui } = await createGrid({ suppressSyncLayoutWithGrid: true });
+            const age = gridApi.getColumn('age')! as AgColumn;
+
+            // Stage a sort change
+            getUpdateStrategy(toolPanel).progressSortFromEvent(true, age, new MouseEvent('click'));
+            toolPanel.refreshDeferredUi();
+
+            expect(getApplyButton(toolPanelGui).disabled).toBe(false);
+
+            // External visibility change
+            gridApi.setColumnsVisible(['gold'], false);
+            await asyncSetTimeout(50);
+
+            expect(getUpdateStrategy(toolPanel).hasPendingChanges(isDeferred(toolPanel))).toBe(false);
+            expect(getApplyButton(toolPanelGui).disabled).toBe(true);
+        });
+
+        test('external column move does NOT reset staged changes when suppressSyncLayoutWithGrid is true', async () => {
+            const { gridApi, toolPanel, toolPanelGui } = await createGrid({ suppressSyncLayoutWithGrid: true });
+            const athlete = gridApi.getColumn('athlete')! as AgColumn;
+
+            // Stage a visibility change
+            getUpdateStrategy(toolPanel).setColumnsVisible(true, [athlete], false, 'toolPanelUi');
+            toolPanel.refreshDeferredUi();
+
+            expect(getApplyButton(toolPanelGui).disabled).toBe(false);
+
+            // External column move
+            gridApi.moveColumns(['gold'], 0);
+            await asyncSetTimeout(50);
+
+            // Staged changes should NOT be reset because suppressSyncLayoutWithGrid is true
+            expect(getUpdateStrategy(toolPanel).hasPendingChanges(isDeferred(toolPanel))).toBe(true);
+            expect(getApplyButton(toolPanelGui).disabled).toBe(false);
+        });
+
+        test('external column move DOES reset staged changes when suppressSyncLayoutWithGrid is false', async () => {
+            const { gridApi, toolPanel, toolPanelGui } = await createGrid({ suppressSyncLayoutWithGrid: false });
+            const athlete = gridApi.getColumn('athlete')! as AgColumn;
+
+            // Stage a visibility change
+            getUpdateStrategy(toolPanel).setColumnsVisible(true, [athlete], false, 'toolPanelUi');
+            toolPanel.refreshDeferredUi();
+
+            expect(getApplyButton(toolPanelGui).disabled).toBe(false);
+
+            // External column move
+            gridApi.moveColumns(['gold'], 0);
+            await asyncSetTimeout(50);
+
+            // Staged changes SHOULD be reset
+            expect(getUpdateStrategy(toolPanel).hasPendingChanges(isDeferred(toolPanel))).toBe(false);
+            expect(getApplyButton(toolPanelGui).disabled).toBe(true);
+        });
+
+        test('external newColumnsLoaded resets staged changes', async () => {
+            const { gridApi, toolPanel, toolPanelGui } = await createGrid({ suppressSyncLayoutWithGrid: true });
+            const athlete = gridApi.getColumn('athlete')! as AgColumn;
+
+            getUpdateStrategy(toolPanel).setColumnsVisible(true, [athlete], false, 'toolPanelUi');
+            toolPanel.refreshDeferredUi();
+
+            expect(getApplyButton(toolPanelGui).disabled).toBe(false);
+
+            // setColumnDefs triggers newColumnsLoaded
+            gridApi.setGridOption('columnDefs', baseColumnDefs);
+            await asyncSetTimeout(50);
+
+            expect(getUpdateStrategy(toolPanel).hasPendingChanges(isDeferred(toolPanel))).toBe(false);
+            expect(getApplyButton(toolPanelGui).disabled).toBe(true);
+        });
+
+        test('commit does not trigger external reset (isCommitting guard)', async () => {
+            const { gridApi, toolPanel, toolPanelGui } = await createGrid({ suppressSyncLayoutWithGrid: false });
+            const athlete = gridApi.getColumn('athlete')! as AgColumn;
+
+            // Stage a visibility change
+            getUpdateStrategy(toolPanel).setColumnsVisible(true, [athlete], false, 'toolPanelUi');
+            toolPanel.refreshDeferredUi();
+
+            expect(getApplyButton(toolPanelGui).disabled).toBe(false);
+            expect(gridApi.getColumn('athlete')!.isVisible()).toBe(true);
+
+            // Apply commits staged changes — this fires grid events, but should NOT reset
+            getApplyButton(toolPanelGui).click();
+            await asyncSetTimeout(50);
+
+            // The change should have been applied
+            expect(gridApi.getColumn('athlete')!.isVisible()).toBe(false);
+            // Apply button should now be disabled (no pending changes)
+            expect(getApplyButton(toolPanelGui).disabled).toBe(true);
+        });
+
+        test('pinning does not reset staged changes', async () => {
+            const { gridApi, toolPanel, toolPanelGui } = await createGrid({ suppressSyncLayoutWithGrid: true });
+            const athlete = gridApi.getColumn('athlete')! as AgColumn;
+
+            getUpdateStrategy(toolPanel).setColumnsVisible(true, [athlete], false, 'toolPanelUi');
+            toolPanel.refreshDeferredUi();
+
+            expect(getApplyButton(toolPanelGui).disabled).toBe(false);
+
+            // External pinning
+            gridApi.setColumnsPinned(['age'], 'left');
+            await asyncSetTimeout(50);
+
+            // Staged changes should NOT be reset
+            expect(getUpdateStrategy(toolPanel).hasPendingChanges(isDeferred(toolPanel))).toBe(true);
+            expect(getApplyButton(toolPanelGui).disabled).toBe(false);
+        });
+
+        test('resizing does not reset staged changes', async () => {
+            const { gridApi, toolPanel, toolPanelGui } = await createGrid({ suppressSyncLayoutWithGrid: true });
+            const athlete = gridApi.getColumn('athlete')! as AgColumn;
+
+            getUpdateStrategy(toolPanel).setColumnsVisible(true, [athlete], false, 'toolPanelUi');
+            toolPanel.refreshDeferredUi();
+
+            expect(getApplyButton(toolPanelGui).disabled).toBe(false);
+
+            // External resize
+            gridApi.setColumnWidths([{ key: 'age', newWidth: 200 }]);
+            await asyncSetTimeout(50);
+
+            // Staged changes should NOT be reset
+            expect(getUpdateStrategy(toolPanel).hasPendingChanges(isDeferred(toolPanel))).toBe(true);
+            expect(getApplyButton(toolPanelGui).disabled).toBe(false);
+        });
+
+        test('no reset if no pending changes', async () => {
+            const { gridApi, toolPanel } = await createGrid({ suppressSyncLayoutWithGrid: true });
+            const resetSpy = vi.spyOn(getUpdateStrategy(toolPanel), 'reset');
+
+            // External sort change with no pending changes
+            gridApi.applyColumnState({ state: [{ colId: 'age', sort: 'asc' }] });
+            await asyncSetTimeout(50);
+
+            // reset should not have been called since there were no pending changes
+            expect(resetSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('initial state and fallback', () => {
+        test('initial render shows colDef order when suppressSyncLayoutWithGrid is true', async () => {
+            const { toolPanel } = await createGrid({ suppressSyncLayoutWithGrid: true });
+
+            expect(getDisplayedPrimaryColumnOrder(toolPanel)).toEqual(['athlete', 'age', 'country', 'sport', 'gold']);
+        });
+
+        test('after cancel, CTP reverts to colDef order', async () => {
+            const { toolPanel, toolPanelGui } = await createGrid({ suppressSyncLayoutWithGrid: true });
+
+            await dragColumnToEnd(toolPanel, 'Athlete');
+            expect(getDisplayedPrimaryColumnOrder(toolPanel)).toEqual(['age', 'country', 'sport', 'gold', 'athlete']);
+
+            getCancelButton(toolPanelGui).click();
+            await asyncSetTimeout(50);
+
+            expect(getDisplayedPrimaryColumnOrder(toolPanel)).toEqual(['athlete', 'age', 'country', 'sport', 'gold']);
+        });
+
+        test('after apply, CTP shows colDef order matching applied state', async () => {
+            const { toolPanel, toolPanelGui } = await createGrid({ suppressSyncLayoutWithGrid: true });
+
+            await dragColumnToEnd(toolPanel, 'Athlete');
+
+            getApplyButton(toolPanelGui).click();
+            await asyncSetTimeout(50);
+
+            // After apply, the colDef order was updated by commit, and the CTP shows it
+            expect(getDisplayedPrimaryColumnOrder(toolPanel)).toEqual(['age', 'country', 'sport', 'gold', 'athlete']);
+            expect(getPrimaryColumnOrder(toolPanel)).toEqual(['age', 'country', 'sport', 'gold', 'athlete']);
+        });
+    });
+});


### PR DESCRIPTION
- Enable column reordering in CTP when `suppressSyncLayoutWithGrid` is active with deferred mode
- Add `hasDeferredColumnOrder` to strategy interface to distinguish draft column order from live fallback
- Reset staged changes on external grid events (sort, visibility, row group, value, pivot, new columns loaded) with an exception for column moves when `suppressSyncLayoutWithGrid` is true

relates to [AG-3471](https://ag-grid.atlassian.net/browse/AG-3471)