### PR TITLE
AG-166000 improve avg percentage distribution

### DIFF
--- a/packages/ag-grid-enterprise/src/rowGrouping/distributeGroupValue/distributorNumber.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/distributeGroupValue/distributorNumber.ts
@@ -11,6 +11,11 @@ import type {
 import type { DistributionStrategy } from './valueConversion';
 import { detectPrecision, isNumericLike, resolveStrategy, toNumber } from './valueConversion';
 
+interface ValueAndCount {
+    readonly value: number;
+    readonly count: number;
+}
+
 /** Distributes a numeric value to children using the chosen strategy. */
 export class DistributorNumber {
     private readonly children: readonly IRowNode[];
@@ -107,18 +112,39 @@ export class DistributorNumber {
             case 'increment':
                 return this.distributeIncrement();
             default:
-                return this.distributePercentage();
+                return this.isAvg ? this.distributePercentageAvg() : this.distributePercentage();
         }
     }
 
-    private readOne(index: number): number {
+    /** Reads the raw value of a child via custom getter or getDataValue. */
+    private readRaw(index: number): unknown {
         const { children, column, getVal } = this;
-        const node = children[index];
+        const child = children[index];
         if (getVal) {
             const { colDef, api, context } = this.params;
-            return toNumber(getVal({ node, data: node.data, column, colDef, api, context, groupParams: this.params }));
+            return getVal({ node: child, data: child.data, column, colDef, api, context, groupParams: this.params });
         }
-        return toNumber(node.getDataValue(column, 'value'));
+        return child.getDataValue(column);
+    }
+
+    private readOne(index: number): number {
+        return toNumber(this.readRaw(index));
+    }
+
+    /**
+     * Reads a child's value and leaf count in a single call.
+     * If the raw value is already an avg agg object { value, count }, returns it directly.
+     * Otherwise wraps the value with the node's allLeafChildren count.
+     */
+    private readValueAndCount(index: number): ValueAndCount {
+        const raw = this.readRaw(index);
+        if (raw != null && typeof raw === 'object') {
+            const { value, count } = raw as ValueAndCount;
+            if (value != null && typeof count === 'number' && count > 0) {
+                return typeof value === 'number' ? (raw as ValueAndCount) : { value: toNumber(raw), count };
+            }
+        }
+        return { value: toNumber(raw), count: this.children[index].allLeafChildren?.length || 1 };
     }
 
     private writeOne(index: number, value: unknown): boolean {
@@ -132,9 +158,8 @@ export class DistributorNumber {
     }
 
     private writeAll(value: unknown): boolean {
-        const { count } = this;
         let changed = false;
-        for (let i = 0; i < count; ++i) {
+        for (let i = 0; i < this.count; ++i) {
             if (this.writeOne(i, value)) {
                 changed = true;
             }
@@ -158,13 +183,9 @@ export class DistributorNumber {
 
     private distributeUniform(): boolean {
         const { count, target, precision } = this;
-
-        // No rounding — write same float to every child
         if (precision === undefined) {
             return this.writeAll(target / count);
         }
-
-        // Scaled integer division with remainder spread to first N children
         const scale = 10 ** precision;
         const intTarget = Math.round(target * scale);
         const base = Math.trunc(intTarget / count);
@@ -182,8 +203,6 @@ export class DistributorNumber {
 
     private distributeIncrement(): boolean {
         const { count, target, oldTarget, precision } = this;
-
-        // No rounding — add delta / count to each child
         if (precision === undefined) {
             const add = (target - oldTarget) / count;
             let changed = false;
@@ -194,8 +213,6 @@ export class DistributorNumber {
             }
             return changed;
         }
-
-        // Scaled integer delta with remainder spread to first N children
         const scale = 10 ** precision;
         const intDelta = Math.round(target * scale) - Math.round(oldTarget * scale);
         const base = Math.trunc(intDelta / count);
@@ -212,65 +229,114 @@ export class DistributorNumber {
         return changed;
     }
 
+    /**
+     * Scales each child's value proportionally so they sum to the target.
+     * Each child keeps its relative share: newValue[i] = oldValue[i] × (target / oldTotal).
+     * With precision rounding, uses scaled integers and spreads the remainder across the first N children.
+     */
     private distributePercentage(): boolean {
-        const { count, target, precision, children, column, isAvg } = this;
+        const { count, target, precision } = this;
+
         const values = new Array<number>(count);
         let total = 0;
-        let childCounts: number[] | null = null;
-
-        // For avg, read each child's leaf count from the raw aggregation object.
-        // Leaf rows have no { value, count } wrapper, so they default to 1.
-        if (isAvg) {
-            childCounts = new Array<number>(count);
-            for (let i = 0; i < count; ++i) {
-                const raw = children[i].getDataValue(column);
-                childCounts[i] =
-                    (raw != null && typeof raw === 'object' && (raw as { readonly count?: number }).count) || 1;
-            }
-        }
-
-        // Read child values (via custom getter or default) and compute total.
-        // For avg with sub-group children, convert to sum contributions (avg × leafCount).
         for (let i = 0; i < count; ++i) {
-            let v = this.readOne(i);
-            if (childCounts) {
-                v *= childCounts[i];
-            }
+            const v = this.readOne(i);
             values[i] = v;
             total += v;
         }
 
-        // Zero total — fall back to uniform
+        // All children are zero — can't compute proportions, fall back to equal split
         if (total === 0) {
             return this.distributeUniform();
         }
 
-        // For avg with sub-group children, adjust target from avg-based (newAvg * childGroupCount)
-        // to sum-based (newAvg * totalLeafCount) so proportional scaling produces correct sums.
-        let effectiveTarget = target;
-        if (childCounts) {
-            let totalLeafCount = 0;
-            for (let i = 0; i < count; i++) {
-                totalLeafCount += childCounts[i];
-            }
-            effectiveTarget = (target / count) * totalLeafCount;
-        }
-
-        // No rounding — direct float proportional scaling
+        // No precision — scale each value by the same ratio
         if (precision === undefined) {
-            const ratio = effectiveTarget / total;
+            const ratio = target / total;
             let changed = false;
             for (let i = 0; i < count; ++i) {
-                const v = values[i] * ratio;
-                if (this.writeOne(i, childCounts ? v / childCounts[i] : v)) {
+                if (this.writeOne(i, values[i] * ratio)) {
                     changed = true;
                 }
             }
             return changed;
         }
 
-        // Rounding — scaled integer proportional distribution.
-        // (v / total) * intTarget avoids overflow from v * intTarget for large values.
+        // With precision — work in scaled integers to avoid floating-point drift.
+        // Round each child's share individually, then fix the remainder.
+        const scale = 10 ** precision;
+        const intTarget = Math.round(target * scale);
+        let roundedSum = 0;
+        for (let i = 0; i < count; ++i) {
+            const r = Math.round((values[i] / total) * intTarget);
+            values[i] = r;
+            roundedSum += r;
+        }
+
+        // Spread rounding remainder (±1) across the first N children so the total is exact
+        const rem = intTarget - roundedSum;
+        const absRem = Math.abs(rem);
+        const step = rem >= 0 ? 1 : -1;
+        let changed = false;
+        for (let i = 0; i < count; ++i) {
+            if (this.writeOne(i, (values[i] + (i < absRem ? step : 0)) / scale)) {
+                changed = true;
+            }
+        }
+        return changed;
+    }
+
+    /**
+     * Percentage distribution for avg aggregation.
+     *
+     * Avg group children may themselves be groups with different leaf counts,
+     * so we can't scale avg values directly — a group averaging 2 leaves contributes
+     * twice as much to the parent avg as a group averaging 1 leaf.
+     *
+     * Instead, we convert each child's avg to its sum contribution (avg × leafCount),
+     * scale those sums proportionally, then convert back to avg for writing.
+     *
+     * The target is also converted: constructor stores target = newAvg × childGroupCount,
+     * but we need effectiveTarget = newAvg × totalLeafCount for sum-space scaling.
+     */
+    private distributePercentageAvg(): boolean {
+        const { count, target, precision } = this;
+
+        // Read each child's avg and leaf count in one call, convert to sum contributions
+        const values = new Array<number>(count);
+        const leafCounts = new Array<number>(count);
+        let total = 0;
+        let totalLeafCount = 0;
+        for (let i = 0; i < count; ++i) {
+            const vc = this.readValueAndCount(i);
+            const lc = vc.count;
+            leafCounts[i] = lc;
+            totalLeafCount += lc;
+            const v = toNumber(vc.value) * lc;
+            values[i] = v;
+            total += v;
+        }
+
+        if (total === 0) {
+            return this.distributeUniform();
+        }
+
+        // Convert target from avg-space to sum-space
+        const effectiveTarget = (target / count) * totalLeafCount;
+
+        // No precision — scale sums proportionally, convert back to avg by dividing by leafCount
+        if (precision === undefined) {
+            const ratio = effectiveTarget / total;
+            let changed = false;
+            for (let i = 0; i < count; ++i) {
+                if (this.writeOne(i, (values[i] * ratio) / leafCounts[i])) {
+                    changed = true;
+                }
+            }
+            return changed;
+        }
+
+        // With precision — scaled integer proportional distribution in sum-space
         const scale = 10 ** precision;
         const intTarget = Math.round(effectiveTarget * scale);
         let roundedSum = 0;
@@ -280,14 +346,13 @@ export class DistributorNumber {
             roundedSum += r;
         }
 
-        // Spread rounding remainder to first N children so the total is exact
         const rem = intTarget - roundedSum;
         const absRem = Math.abs(rem);
         const step = rem >= 0 ? 1 : -1;
         let changed = false;
         for (let i = 0; i < count; ++i) {
-            const intVal = values[i] + (i < absRem ? step : 0);
-            if (this.writeOne(i, childCounts ? intVal / (scale * childCounts[i]) : intVal / scale)) {
+            // Convert scaled integer sum back to avg: intSum / (scale × leafCount)
+            if (this.writeOne(i, (values[i] + (i < absRem ? step : 0)) / (scale * leafCounts[i]))) {
                 changed = true;
             }
         }

--- a/packages/ag-grid-enterprise/src/rowGrouping/distributeGroupValue/distributorNumber.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/distributeGroupValue/distributorNumber.ts
@@ -23,6 +23,7 @@ export class DistributorNumber {
     private readonly strategy: DistributionStrategy;
     private readonly getVal: ((params: DistributionGetValueParams) => unknown) | undefined;
     private readonly setVal: ((params: DistributionSetValueParams) => boolean) | undefined;
+    private readonly isAvg: boolean;
 
     constructor(
         private readonly params: GroupRowValueSetterParams,
@@ -33,12 +34,14 @@ export class DistributorNumber {
         const { aggregatedChildren: children, column, colDef, newValue } = params;
         const newNumber = toNumber(newValue);
         const count = children.length;
+        const isAvg = aggFunc === 'avg';
         this.children = children;
         this.column = column;
         this.count = count;
         this.newValue = newValue;
         this.strategy = resolveStrategy(aggFunc, opts?.distribution);
-        if (aggFunc === 'avg') {
+        this.isAvg = isAvg;
+        if (isAvg) {
             this.target = newNumber * count;
             this.oldTarget = toNumber(params.oldValue) * count;
         } else {
@@ -210,13 +213,29 @@ export class DistributorNumber {
     }
 
     private distributePercentage(): boolean {
-        const { count, target, precision } = this;
-
-        // Read all child values and compute total
+        const { count, target, precision, children, column, isAvg } = this;
         const values = new Array<number>(count);
         let total = 0;
+        let childCounts: number[] | null = null;
+
+        // For avg, read each child's leaf count from the raw aggregation object.
+        // Leaf rows have no { value, count } wrapper, so they default to 1.
+        if (isAvg) {
+            childCounts = new Array<number>(count);
+            for (let i = 0; i < count; ++i) {
+                const raw = children[i].getDataValue(column);
+                childCounts[i] =
+                    (raw != null && typeof raw === 'object' && (raw as { readonly count?: number }).count) || 1;
+            }
+        }
+
+        // Read child values (via custom getter or default) and compute total.
+        // For avg with sub-group children, convert to sum contributions (avg × leafCount).
         for (let i = 0; i < count; ++i) {
-            const v = this.readOne(i);
+            let v = this.readOne(i);
+            if (childCounts) {
+                v *= childCounts[i];
+            }
             values[i] = v;
             total += v;
         }
@@ -226,12 +245,24 @@ export class DistributorNumber {
             return this.distributeUniform();
         }
 
+        // For avg with sub-group children, adjust target from avg-based (newAvg * childGroupCount)
+        // to sum-based (newAvg * totalLeafCount) so proportional scaling produces correct sums.
+        let effectiveTarget = target;
+        if (childCounts) {
+            let totalLeafCount = 0;
+            for (let i = 0; i < count; i++) {
+                totalLeafCount += childCounts[i];
+            }
+            effectiveTarget = (target / count) * totalLeafCount;
+        }
+
         // No rounding — direct float proportional scaling
         if (precision === undefined) {
-            const ratio = target / total;
+            const ratio = effectiveTarget / total;
             let changed = false;
             for (let i = 0; i < count; ++i) {
-                if (this.writeOne(i, values[i] * ratio)) {
+                const v = values[i] * ratio;
+                if (this.writeOne(i, childCounts ? v / childCounts[i] : v)) {
                     changed = true;
                 }
             }
@@ -241,7 +272,7 @@ export class DistributorNumber {
         // Rounding — scaled integer proportional distribution.
         // (v / total) * intTarget avoids overflow from v * intTarget for large values.
         const scale = 10 ** precision;
-        const intTarget = Math.round(target * scale);
+        const intTarget = Math.round(effectiveTarget * scale);
         let roundedSum = 0;
         for (let i = 0; i < count; ++i) {
             const r = Math.round((values[i] / total) * intTarget);
@@ -255,7 +286,8 @@ export class DistributorNumber {
         const step = rem >= 0 ? 1 : -1;
         let changed = false;
         for (let i = 0; i < count; ++i) {
-            if (this.writeOne(i, (values[i] + (i < absRem ? step : 0)) / scale)) {
+            const intVal = values[i] + (i < absRem ? step : 0);
+            if (this.writeOne(i, childCounts ? intVal / (scale * childCounts[i]) : intVal / scale)) {
                 changed = true;
             }
         }

--- a/testing/behavioural/src/cell-editing/group-edit/distribute-group-value/distribute-aggfunc.test.ts
+++ b/testing/behavioural/src/cell-editing/group-edit/distribute-group-value/distribute-aggfunc.test.ts
@@ -393,3 +393,106 @@ describe('overriding built-in aggFunc with a custom function', () => {
         `);
     });
 });
+
+describe('avg percentage distribution on non-leaf groups', () => {
+    // Norway has 2 sub-groups: 2010 (2 leaves: 23, 19) and 2002 (1 leaf: 19)
+    // avg = (23+19+19)/3 = 20.333..., sum = 61
+    const norwayRowData = () => [
+        { id: 'n1', country: 'Norway', year: '2010', total: 23 },
+        { id: 'n2', country: 'Norway', year: '2010', total: 19 },
+        { id: 'n3', country: 'Norway', year: '2002', total: 19 },
+    ];
+
+    test('editing avg on non-leaf group with percentage distribution produces correct avg', async () => {
+        const api = await gridsManager.createGridAndWait('avg-pct-nested', {
+            defaultColDef: { cellEditor: 'agTextCellEditor' },
+            groupDisplayType: 'custom',
+            columnDefs: [
+                { colId: 'group', headerName: 'Group', cellRenderer: 'agGroupCellRenderer' },
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', rowGroup: true, hide: true },
+                {
+                    colId: 'total',
+                    field: 'total',
+                    aggFunc: 'avg',
+                    editable: true,
+                    groupRowEditable: true,
+                    groupRowValueSetter: { distribution: 'percentage', precision: 0 },
+                },
+            ],
+            rowData: norwayRowData(),
+            groupDefaultExpanded: -1,
+            getRowId: (params) => params.data?.id,
+        });
+
+        const norwayNode = api.getRowNode('row-group-country-Norway')!;
+        expect(norwayNode.aggData?.total).toMatchObject({ value: expect.closeTo(20.333, 2), count: 3 });
+
+        // Edit Norway avg to 20
+        norwayNode.setDataValue('total', 20, 'ui');
+        await asyncSetTimeout(0);
+
+        // Desired sum = 20 * 3 = 60. Old sums: 2010=42, 2002=19, total=61.
+        // Percentage distributes sum proportionally: 2010 gets round(42/61*60)=41, 2002 gets round(19/61*60)=19.
+        // 2010 avg = 41/2 = 20.5, cascades to leaves: [round(23/42*41)=22, round(19/42*41)=19]
+        // 2002 avg = 19, leaf unchanged.
+        // Final: [22, 19, 19], sum=60, avg=20
+        expect(api.getRowNode('n1')?.data?.total).toBe(22);
+        expect(api.getRowNode('n2')?.data?.total).toBe(19);
+        expect(api.getRowNode('n3')?.data?.total).toBe(19);
+        expect(norwayNode.aggData?.total).toMatchObject({ value: 20, count: 3 });
+    });
+
+    test('editing avg on 3-level group hierarchy distributes correctly through all levels', async () => {
+        // Region > Country > Year, 3-level hierarchy
+        // Europe: France > 2010: [10, 20], France > 2011: [30], Germany > 2010: [40, 50]
+        // France avg = 60/3 = 20, Germany avg = 90/2 = 45, Europe avg = 150/5 = 30
+        const api = await gridsManager.createGridAndWait('avg-pct-3-level', {
+            defaultColDef: { cellEditor: 'agTextCellEditor' },
+            groupDisplayType: 'custom',
+            columnDefs: [
+                { colId: 'group', headerName: 'Group', cellRenderer: 'agGroupCellRenderer' },
+                { field: 'region', rowGroup: true, hide: true },
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', rowGroup: true, hide: true },
+                {
+                    colId: 'amount',
+                    field: 'amount',
+                    aggFunc: 'avg',
+                    editable: true,
+                    groupRowEditable: true,
+                    groupRowValueSetter: { distribution: 'percentage', precision: 0 },
+                },
+            ],
+            rowData: [
+                { id: 'f1', region: 'Europe', country: 'France', year: '2010', amount: 10 },
+                { id: 'f2', region: 'Europe', country: 'France', year: '2010', amount: 20 },
+                { id: 'f3', region: 'Europe', country: 'France', year: '2011', amount: 30 },
+                { id: 'g1', region: 'Europe', country: 'Germany', year: '2010', amount: 40 },
+                { id: 'g2', region: 'Europe', country: 'Germany', year: '2010', amount: 50 },
+            ],
+            groupDefaultExpanded: -1,
+            getRowId: (params) => params.data?.id,
+        });
+
+        const europeNode = api.getRowNode('row-group-region-Europe')!;
+        expect(europeNode.aggData?.amount).toMatchObject({ value: 30, count: 5 });
+
+        // Edit Europe avg from 30 to 20 (desired sum = 100, old sum = 150)
+        europeNode.setDataValue('amount', 20, 'ui');
+        await asyncSetTimeout(0);
+
+        // Level 1: France sum 60→40, Germany sum 90→60 (proportional by sum contributions)
+        // Level 2: France>2010 sum 30→20 (avg=10), France>2011 sum 30→20 (avg=20)
+        //          Germany>2010 sum 90→60 (avg=30)
+        // Level 3: France>2010 leaves [10,20]→[7,13], France>2011 [30]→[20]
+        //          Germany>2010 leaves [40,50]→[27,33]
+        // Final: [7, 13, 20, 27, 33], sum=100, avg=20
+        expect(api.getRowNode('f1')?.data?.amount).toBe(7);
+        expect(api.getRowNode('f2')?.data?.amount).toBe(13);
+        expect(api.getRowNode('f3')?.data?.amount).toBe(20);
+        expect(api.getRowNode('g1')?.data?.amount).toBe(27);
+        expect(api.getRowNode('g2')?.data?.amount).toBe(33);
+        expect(europeNode.aggData?.amount).toMatchObject({ value: 20, count: 5 });
+    });
+});

--- a/testing/behavioural/src/filters/set-filter-complex-objects.test.ts
+++ b/testing/behavioural/src/filters/set-filter-complex-objects.test.ts
@@ -1,5 +1,5 @@
 import type { GridApi, GridOptions, ISetFilterParams, KeyCreatorParams, ValueFormatterParams } from 'ag-grid-community';
-import { ClientSideRowModelModule } from 'ag-grid-community';
+import { ClientSideRowModelModule, TextEditorModule } from 'ag-grid-community';
 import { SetFilterModule } from 'ag-grid-enterprise';
 import type { SetFilter } from 'ag-grid-enterprise';
 
@@ -35,7 +35,7 @@ const ROW_DATA: RowData[] = [
 
 describe('Set Filter Complex Objects', () => {
     const gridsManager = new TestGridsManager({
-        modules: [ClientSideRowModelModule, SetFilterModule],
+        modules: [ClientSideRowModelModule, SetFilterModule, TextEditorModule],
     });
 
     afterEach(() => gridsManager.reset());


### PR DESCRIPTION
Fixed distributePercentage in DistributorNumber to correctly handle avg aggregation when children are sub-groups and not just leafs. Previously, percentage distribution on avg groups with nested sub-groups produced incorrect results because it treated child avg values as raw numbers without accounting for their differing leaf counts.
