### PR TITLE
[AG-3471] Block CTP-to-external drag side effects in deferred apply mode

### DIFF
--- a/packages/ag-grid-enterprise/project.json
+++ b/packages/ag-grid-enterprise/project.json
@@ -122,7 +122,7 @@
     },
     "build:package": {
       "executor": "@nx/esbuild:esbuild",
-      "dependsOn": ["^build:types", "chartsPackages"],
+      "dependsOn": ["^build:types", "^build:package", "chartsPackages"],
       "inputs": [
         "{projectRoot}/package.json",
         "{projectRoot}/src/**/*",

--- a/packages/ag-grid-enterprise/project.json
+++ b/packages/ag-grid-enterprise/project.json
@@ -122,7 +122,7 @@
     },
     "build:package": {
       "executor": "@nx/esbuild:esbuild",
-      "dependsOn": ["^build:types", "^build:package", "chartsPackages"],
+      "dependsOn": ["^build:types", "chartsPackages"],
       "inputs": [
         "{projectRoot}/package.json",
         "{projectRoot}/src/**/*",

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
@@ -231,6 +231,10 @@ export class ToolPanelColumnComp extends Component {
         const beans = this.beans;
         const { gos, eventSvc, dragAndDrop } = beans;
 
+        if (isDeferredMode(this.params)) {
+            eDragHandle.setAttribute('data-column-tool-panel-deferred', '');
+        }
+
         let hideColumnOnExit = !gos.get('suppressDragLeaveHidesColumns');
         const dragSource: GridDragSource = {
             type: DragSourceType.ToolPanel,

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
@@ -251,7 +251,7 @@ export class ToolPanelColumnComp extends Component {
                 });
             },
             onGridEnter: (dragItem: DragItem | null) => {
-                if (hideColumnOnExit) {
+                if (hideColumnOnExit && !isDeferredMode(this.params)) {
                     // when dragged into the grid, restore the state that was active pre-drag
                     updateColumns(beans, {
                         columns: [this.column],
@@ -263,7 +263,7 @@ export class ToolPanelColumnComp extends Component {
                 }
             },
             onGridExit: () => {
-                if (hideColumnOnExit) {
+                if (hideColumnOnExit && !isDeferredMode(this.params)) {
                     // when dragged outside of the grid, mimic what happens when checkbox is disabled
                     // this handles the behaviour for pivot which is different to just hiding a column.
                     this.onChangeCommon(false);

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/baseDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/baseDropZonePanel.ts
@@ -9,8 +9,6 @@ import { DropZoneColumnComp } from './dropZoneColumnComp';
 
 export type TDropZone = 'rowGroup' | 'pivot' | 'aggregation';
 
-const DEFERRED_TOOL_PANEL_CLASS = 'ag-column-panel-deferred';
-
 export abstract class BaseDropZonePanel extends PillDropZonePanel<DropZoneColumnComp, AgColumn> {
     constructor(
         horizontal: boolean,
@@ -49,7 +47,7 @@ export abstract class BaseDropZonePanel extends PillDropZonePanel<DropZoneColumn
             return true;
         }
 
-        return !sourceElement.closest(`.${DEFERRED_TOOL_PANEL_CLASS}`);
+        return !sourceElement.hasAttribute('data-column-tool-panel-deferred');
     }
 
     protected override minimumAllowedNewInsertIndex(): number {

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/dropZoneColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/dropZoneColumnComp.ts
@@ -61,6 +61,10 @@ export class DropZoneColumnComp extends PillDragComp<AgColumn> {
 
         super.postConstruct();
 
+        if (this.deferApply) {
+            this.eDragHandle.classList.add('ag-column-panel-deferred');
+        }
+
         if (sortSvc) {
             this.setupSort();
 

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/dropZoneColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/dropZoneColumnComp.ts
@@ -62,7 +62,7 @@ export class DropZoneColumnComp extends PillDragComp<AgColumn> {
         super.postConstruct();
 
         if (this.deferApply) {
-            this.eDragHandle.classList.add('ag-column-panel-deferred');
+            this.eDragHandle.setAttribute('data-column-tool-panel-deferred', '');
         }
 
         if (sortSvc) {

--- a/packages/ag-grid-enterprise/src/widgets/pillDragComp.ts
+++ b/packages/ag-grid-enterprise/src/widgets/pillDragComp.ts
@@ -38,7 +38,7 @@ const PillDragCompElement: ElementParams = {
 };
 export abstract class PillDragComp<TItem> extends Component<PillDragCompEvent> {
     private readonly eText: HTMLElement = RefPlaceholder;
-    private readonly eDragHandle: HTMLElement = RefPlaceholder;
+    protected readonly eDragHandle: HTMLElement = RefPlaceholder;
     private readonly eButton: HTMLElement = RefPlaceholder;
 
     public abstract getItem(): TItem;

--- a/testing/behavioural/src/columnToolPanel/deferred-pivot-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-pivot-mode.test.ts
@@ -859,7 +859,7 @@ describe('deferred column tool panel pivot mode', () => {
         parent.removeChild(pillDragHandle);
         expect(pillDragHandle.isConnected).toBe(false);
 
-        // Even when detached, should still be blocked (pill has ag-column-panel-deferred class)
+        // Even when detached, should still be blocked (pill has data-column-tool-panel-deferred attribute)
         expect(headerDropZones.rowGroupComp.isInterestedIn(DragSourceType.ToolPanel, pillDragHandle)).toBe(false);
         expect(headerDropZones.pivotComp.isInterestedIn(DragSourceType.ToolPanel, pillDragHandle)).toBe(false);
     });

--- a/testing/behavioural/src/columnToolPanel/deferred-pivot-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-pivot-mode.test.ts
@@ -838,6 +838,32 @@ describe('deferred column tool panel pivot mode', () => {
         expect(headerDropZones.pivotComp.isInterestedIn(DragSourceType.ToolPanel, dragHandle)).toBe(false);
     });
 
+    test('dragging a pill from a deferred CTP drop zone into header drop zones should be prohibited even when detached', async () => {
+        const { gridApi, toolPanel } = await createDeferredPivotModeGrid();
+        const country = gridApi.getColumn('country')! as any;
+        const HeaderDropZones = AgGridHeaderDropZonesSelector.component as any;
+        const headerDropZones = country.createBean(new HeaderDropZones()) as any;
+
+        // Get a pill drag handle from the CTP's row group drop zone
+        const pillDragHandle = toolPanel.rowGroupDropZonePanel
+            .getGui()
+            .querySelector('.ag-column-drop-cell-drag-handle') as Element;
+        expect(pillDragHandle).toBeTruthy();
+
+        // While attached: should be blocked
+        expect(headerDropZones.rowGroupComp.isInterestedIn(DragSourceType.ToolPanel, pillDragHandle)).toBe(false);
+
+        // Simulate what happens during drag: the pill gets detached from the DOM
+        // (source panel's onDragLeave -> removeItems -> refreshGui -> destroyGui)
+        const parent = pillDragHandle.parentElement!;
+        parent.removeChild(pillDragHandle);
+        expect(pillDragHandle.isConnected).toBe(false);
+
+        // Even when detached, should still be blocked (pill has ag-column-panel-deferred class)
+        expect(headerDropZones.rowGroupComp.isInterestedIn(DragSourceType.ToolPanel, pillDragHandle)).toBe(false);
+        expect(headerDropZones.pivotComp.isInterestedIn(DragSourceType.ToolPanel, pillDragHandle)).toBe(false);
+    });
+
     test('dragging a CTP column to the header pivot panel in deferred mode should not apply changes', async () => {
         const { gridApi, toolPanel, toolPanelGui } = await createDeferredPivotModeGrid();
 

--- a/testing/behavioural/src/columnToolPanel/deferred-pivot-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-pivot-mode.test.ts
@@ -838,6 +838,65 @@ describe('deferred column tool panel pivot mode', () => {
         expect(headerDropZones.pivotComp.isInterestedIn(DragSourceType.ToolPanel, dragHandle)).toBe(false);
     });
 
+    test('dragging a CTP column to the header pivot panel in deferred mode should not apply changes', async () => {
+        const { gridApi, toolPanel, toolPanelGui } = await createDeferredPivotModeGrid();
+
+        // Athlete is not a pivot column initially
+        expect(gridApi.getPivotColumns().map((col) => col.getColId())).toEqual(['year']);
+
+        // Get the header (horizontal) pivot drop zone GUI from the grid DOM
+        const gridEl = getGridElement(gridApi)!;
+        const headerPivotDropZone = gridEl.querySelector('.ag-column-drop-horizontal-pivot') as HTMLElement;
+        expect(headerPivotDropZone).toBeTruthy();
+
+        // Simulate full drag from CTP column list to header pivot panel
+        await dragRenderedPrimaryColumnToRowGroups(toolPanel, toolPanelGui, 'Athlete', headerPivotDropZone);
+
+        // Grid pivot columns should remain unchanged (no immediate apply)
+        expect(gridApi.getPivotColumns().map((col) => col.getColId())).toEqual(['year']);
+
+        // Deferred state should also remain unchanged (drag should be fully rejected)
+        expect(
+            getUpdateStrategy(toolPanel)
+                .getPivotColumns(true)
+                .map((col) => col.getColId())
+        ).toEqual(['year']);
+    });
+
+    test('onGridExit and onGridEnter drag callbacks should be no-ops in deferred mode', async () => {
+        const { gridApi, toolPanel } = await createDeferredPivotModeGrid();
+
+        // Country is an active row group
+        expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual(['country', 'sport']);
+
+        // Create a Country column comp (which registers drag source with onGridExit/onGridEnter)
+        const countryComp = createPrimaryColumnComp(toolPanel, 'Country');
+        const onChangeCommonSpy = vi.spyOn(countryComp, 'onChangeCommon');
+
+        // Find the drag source via dragSourceAndParamsList
+        const dragAndDrop = countryComp.beans.dragAndDrop;
+        const entry = dragAndDrop['dragSourceAndParamsList'].find(
+            (e: any) => e.dragSource.eElement === countryComp.eDragHandle
+        );
+        expect(entry).toBeTruthy();
+        const dragSource = entry.dragSource;
+
+        // Trigger onGridExit — should not call onChangeCommon in deferred mode
+        dragSource.onGridExit(null);
+
+        expect(onChangeCommonSpy).not.toHaveBeenCalled();
+
+        // Deferred state should remain unchanged
+        expect(
+            getUpdateStrategy(toolPanel)
+                .getRowGroupColumns(true)
+                .map((col) => col.getColId())
+        ).toEqual(['country', 'sport']);
+
+        // Grid state should remain unchanged
+        expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual(['country', 'sport']);
+    });
+
     test('dragging from the non-deferred tool panel into external header drop zones should remain allowed', async () => {
         const { gridApi, toolPanel } = await createNonDeferredPivotModeGrid();
         const country = gridApi.getColumn('country')! as any;


### PR DESCRIPTION
- Guard `onGridExit` and `onGridEnter` drag callbacks in `toolPanelColumnComp.ts` with `isDeferredMode` check to prevent external drag interactions from staging unintended column state changes
- Add e2e drag test verifying CTP-to-header-pivot-panel drag is fully blocked in deferred mode
- Add unit test verifying `onGridExit` does not call `onChangeCommon` in deferred mode