### PR TITLE
AG-3471 Add columnPanelApplyButtonColor to Theming API

### DIFF
--- a/documentation/ag-grid-docs/src/content/api-documentation/theming-api/properties.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/theming-api/properties.json
@@ -446,6 +446,17 @@
         "chartMenuLabelColor": {},
         "chartMenuPanelWidth": {}
     },
+    "columnPanel": {
+        "meta": {
+            "displayName": "Column Panel",
+            "page": {
+                "name": "Columns Tool Panel",
+                "url": "./tool-panel-columns/"
+            }
+        },
+        "columnPanelApplyButtonBackgroundColor": {},
+        "columnPanelApplyButtonColor": {}
+    },
     "filterPanel": {
         "meta": {
             "displayName": "Filter Panel",

--- a/packages/ag-grid-community/src/theming/core/core-css.ts
+++ b/packages/ag-grid-community/src/theming/core/core-css.ts
@@ -154,6 +154,16 @@ export interface CoreParams extends SharedThemeParams {
     filterPanelApplyButtonBackgroundColor: ColorValue;
 
     /**
+     * Color of Columns Tool Panel apply button
+     */
+    columnPanelApplyButtonColor: ColorValue;
+
+    /**
+     * Background color of Columns Tool Panel apply button
+     */
+    columnPanelApplyButtonBackgroundColor: ColorValue;
+
+    /**
      * Color of text and UI elements that should stand out less than the default in new Filters Tool Panel
      */
     filterPanelCardSubtleColor: ColorValue;
@@ -768,6 +778,8 @@ export const coreDefaults: Readonly<Omit<CoreParams, keyof SharedThemeParams>> =
     advancedFilterBuilderValuePillColor: '#85c0e4',
     filterPanelApplyButtonColor: backgroundColor,
     filterPanelApplyButtonBackgroundColor: accentColor,
+    columnPanelApplyButtonColor: backgroundColor,
+    columnPanelApplyButtonBackgroundColor: accentColor,
     filterPanelCardSubtleColor: {
         ref: 'textColor',
         mix: 0.7,

--- a/packages/ag-grid-community/src/theming/parts/color-scheme/color-schemes.ts
+++ b/packages/ag-grid-community/src/theming/parts/color-scheme/color-schemes.ts
@@ -59,6 +59,7 @@ const darkParams = () =>
         advancedFilterBuilderOptionPillColor: '#5a3168',
         advancedFilterBuilderValuePillColor: '#374c86',
         filterPanelApplyButtonColor: foregroundColor,
+        columnPanelApplyButtonColor: foregroundColor,
         findMatchColor: backgroundColor,
         findActiveMatchColor: backgroundColor,
         checkboxUncheckedBorderColor: foregroundBackgroundMix(0.4),

--- a/packages/ag-grid-community/src/theming/parts/theme/themes.ts
+++ b/packages/ag-grid-community/src/theming/parts/theme/themes.ts
@@ -256,6 +256,8 @@ const makeStyleMaterialTreeShakeable = () => {
         advancedFilterBuilderButtonBarBorder: false,
         filterPanelApplyButtonColor: { ref: 'buttonTextColor' },
         filterPanelApplyButtonBackgroundColor: { ref: 'buttonBackgroundColor' },
+        columnPanelApplyButtonColor: { ref: 'buttonTextColor' },
+        columnPanelApplyButtonBackgroundColor: { ref: 'buttonBackgroundColor' },
         colorPickerThumbSize: 13,
         colorPickerTrackSize: 11,
         colorPickerThumbBorderWidth: 2,


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-3471

The `columnPanelApplyButtonColor` and `columnPanelApplyButtonBackgroundColor` params were missing from the Theming API, so the Apply button in the Columns Tool Panel never turned blue when there were pending changes (unlike the Filters Tool Panel which already had its equivalent params).