### PR TITLE
AG-3471 Fix deferred apply mode example and docs

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode/main.ts
@@ -43,7 +43,6 @@ const columnDefs: ColDef[] = [
         field: 'year',
         enableRowGroup: true,
         enablePivot: true,
-        pivotIndex: 1,
     },
     {
         field: 'date',
@@ -75,7 +74,6 @@ const gridOptions: GridOptions<IOlympicData> = {
     autoGroupColumnDef: {
         minWidth: 250,
     },
-    pivotMode: true,
     rowModelType: 'serverSide',
     rowGroupPanelShow: 'always',
     pivotPanelShow: 'always',

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/index.mdoc
@@ -32,7 +32,7 @@ Deferred Updates are enabled by including the **Apply** button in `toolPanelPara
 
 The example below uses the Server-Side Row Model. Note that in the example below:
 
--   Changes made in the Columns Tool Panel (CTP) are staged as pending changes.
+-   Changes made in the Columns Tool Panel are staged as pending changes.
 -   **Apply** commits all pending changes in a single operation.
 -   **Cancel** discards all pending changes and restores the last applied state.
 

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/index.mdoc
@@ -117,9 +117,9 @@ The example below demonstrates the suppress options / methods described above. N
 -   The following sections are not present in the tool panel: Row Groups, Values, Column Labels, Pivot Mode, Side Buttons, Column Filter, Select / Unselect All, Expand / Collapse All.
 -   The date column is hidden from the tool panel using: `colDef.suppressColumnsToolPanel=true`.
 -   Clicking **Show Pivot Mode Section** invokes `setPivotModeSectionVisible(true)` on the Columns Tool Panel instance.
--   Clicking **Show Row Groups Section** invokes `showRowGroupsSection(true)` on the Columns Tool Panel instance.
--   Clicking **Show Values Section** invokes `showValuesSection(true)` on the Columns Tool Panel instance.
--   Clicking **Show Pivot Section** invokes `showPivotSection(true)` on the Columns Tool Panel instance.
+-   Clicking **Show Row Groups Section** invokes `setRowGroupsSectionVisible(true)` on the Columns Tool Panel instance.
+-   Clicking **Show Values Section** invokes `setValuesSectionVisible(true)` on the Columns Tool Panel instance.
+-   Clicking **Show Pivot Section** invokes `setPivotSectionVisible(true)` on the Columns Tool Panel instance.
 
 {% gridExampleRunner title="Section Visibility" name="section-visibility"  exampleHeight=630 /%}
 
@@ -234,7 +234,7 @@ columnsToolPanel.collapseColumnGroups();
 columnsToolPanel.expandColumnGroups(['athleteGroupId', 'competitionGroupId']);
 
 // collapses the 'Competition' column group in the Columns Tool Panel
-columnsToolPanel.collapseFilters(['age', 'sport']);
+columnsToolPanel.collapseColumnGroups(['competitionGroupId']);
 ```
 
 Notice in the snippet above that it's possible to target individual column groups by supplying `groupId`s.


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-3471

- Remove `pivotMode: true` and `pivotIndex: 1` from the deferred apply mode example
- Expand "CTP" abbreviation to "Columns Tool Panel" in docs