### PR TITLE
[AG-3471] Fix drag pill no-op clearing staged deferred state

### DIFF
--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -165,7 +165,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
                     columnRowGroupChanged: resetListener,
                     columnValueChanged: resetListener,
                     columnPivotChanged: resetListener,
-                    columnPivotModeChanged: resetListener,
+                    columnPivotModeChanged: this.onExternalGridChangeNoSource,
                     newColumnsLoaded: resetListener,
                     ...(mergedParams.suppressSyncLayoutWithGrid ? {} : { columnMoved: resetListener }),
                 })
@@ -255,16 +255,30 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         this.resetDeferredState();
     };
 
-    private readonly onExternalGridChange = (): void => {
+    private readonly onExternalGridChange = (event: { source?: string }): void => {
         if (!this.isDeferModeEnabled || this.isCommitting) {
             return;
         }
+        if (event.source === 'toolPanelUi') {
+            return;
+        }
+        this.onExternalGridChangeCore();
+    };
+
+    private readonly onExternalGridChangeNoSource = (): void => {
+        if (!this.isDeferModeEnabled || this.isCommitting) {
+            return;
+        }
+        this.onExternalGridChangeCore();
+    };
+
+    private onExternalGridChangeCore(): void {
         if (!this.beans.columnStateUpdateStrategy.hasPendingChanges(this.isDeferModeEnabled)) {
             return;
         }
         this.resetDeferredState();
         this.lastKnownGridState = this.captureGridState();
-    };
+    }
 
     private resetDeferredState(): void {
         this.beans.columnStateUpdateStrategy.reset(this.isDeferModeEnabled);

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -259,7 +259,7 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         if (!this.isDeferModeEnabled || this.isCommitting) {
             return;
         }
-        if (event.source === 'toolPanelUi') {
+        if (event.source === 'toolPanelUi' || event.source === 'toolPanelDragAndDrop') {
             return;
         }
         this.onExternalGridChangeCore();

--- a/testing/behavioural/src/columnToolPanel/deferred-suppress-sync-layout.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-suppress-sync-layout.test.ts
@@ -377,6 +377,35 @@ describe('deferred column tool panel with suppressSyncLayoutWithGrid', () => {
             expect(getApplyButton(toolPanelGui).disabled).toBe(false);
         });
 
+        test('toolPanelDragAndDrop source does not reset staged changes', async () => {
+            const { gridApi, toolPanel, toolPanelGui } = await createGrid({
+                suppressSyncLayoutWithGrid: true,
+                columnDefs: [
+                    { field: 'athlete' },
+                    { field: 'age' },
+                    { field: 'country' },
+                    { field: 'sport', rowGroup: true },
+                    { field: 'gold' },
+                ],
+            });
+            const athlete = gridApi.getColumn('athlete')! as AgColumn;
+
+            // Stage a visibility change
+            getUpdateStrategy(toolPanel).setColumnsVisible(true, [athlete], false, 'toolPanelUi');
+            toolPanel.refreshDeferredUi();
+
+            expect(getApplyButton(toolPanelGui).disabled).toBe(false);
+
+            // Simulate drag from CTP onto grid body (source 'toolPanelDragAndDrop')
+            const rowGroupSvc = toolPanel.beans.rowGroupColsSvc!;
+            rowGroupSvc.setColumns([], 'toolPanelDragAndDrop');
+            await asyncSetTimeout(50);
+
+            // Staged changes should still be preserved
+            expect(getUpdateStrategy(toolPanel).hasPendingChanges(isDeferred(toolPanel))).toBe(true);
+            expect(getApplyButton(toolPanelGui).disabled).toBe(false);
+        });
+
         test('api source row group change still resets staged changes', async () => {
             const { gridApi, toolPanel, toolPanelGui } = await createGrid({
                 suppressSyncLayoutWithGrid: true,

--- a/testing/behavioural/src/columnToolPanel/deferred-suppress-sync-layout.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-suppress-sync-layout.test.ts
@@ -338,6 +338,73 @@ describe('deferred column tool panel with suppressSyncLayoutWithGrid', () => {
             expect(getApplyButton(toolPanelGui).disabled).toBe(true);
         });
 
+        test('toolPanelUi source does not reset staged changes (drag pill no-op)', async () => {
+            const { gridApi, toolPanel, toolPanelGui } = await createGrid({
+                suppressSyncLayoutWithGrid: true,
+                columnDefs: [
+                    { field: 'athlete' },
+                    { field: 'age' },
+                    { field: 'country' },
+                    { field: 'sport', rowGroup: true },
+                    { field: 'gold' },
+                ],
+            });
+            const athlete = gridApi.getColumn('athlete')! as AgColumn;
+
+            // Stage a visibility change
+            getUpdateStrategy(toolPanel).setColumnsVisible(true, [athlete], false, 'toolPanelUi');
+            toolPanel.refreshDeferredUi();
+
+            expect(getApplyButton(toolPanelGui).disabled).toBe(false);
+
+            // Simulate header Row Group panel drag: remove Sport then add it back
+            // This fires columnRowGroupChanged with source 'toolPanelUi'
+            const rowGroupSvc = toolPanel.beans.rowGroupColsSvc!;
+            const sportCol = gridApi.getColumn('sport')!;
+            rowGroupSvc.setColumns([], 'toolPanelUi');
+            await asyncSetTimeout(50);
+
+            // Staged changes should still be preserved
+            expect(getUpdateStrategy(toolPanel).hasPendingChanges(isDeferred(toolPanel))).toBe(true);
+            expect(getApplyButton(toolPanelGui).disabled).toBe(false);
+
+            // Add Sport back (completes the no-op drag)
+            rowGroupSvc.setColumns([sportCol], 'toolPanelUi');
+            await asyncSetTimeout(50);
+
+            // Staged changes should still be preserved
+            expect(getUpdateStrategy(toolPanel).hasPendingChanges(isDeferred(toolPanel))).toBe(true);
+            expect(getApplyButton(toolPanelGui).disabled).toBe(false);
+        });
+
+        test('api source row group change still resets staged changes', async () => {
+            const { gridApi, toolPanel, toolPanelGui } = await createGrid({
+                suppressSyncLayoutWithGrid: true,
+                columnDefs: [
+                    { field: 'athlete' },
+                    { field: 'age' },
+                    { field: 'country' },
+                    { field: 'sport', rowGroup: true },
+                    { field: 'gold' },
+                ],
+            });
+            const athlete = gridApi.getColumn('athlete')! as AgColumn;
+
+            // Stage a visibility change
+            getUpdateStrategy(toolPanel).setColumnsVisible(true, [athlete], false, 'toolPanelUi');
+            toolPanel.refreshDeferredUi();
+
+            expect(getApplyButton(toolPanelGui).disabled).toBe(false);
+
+            // API-driven row group change (source 'api', not 'toolPanelUi')
+            gridApi.setRowGroupColumns([]);
+            await asyncSetTimeout(50);
+
+            // Staged changes should be reset
+            expect(getUpdateStrategy(toolPanel).hasPendingChanges(isDeferred(toolPanel))).toBe(false);
+            expect(getApplyButton(toolPanelGui).disabled).toBe(true);
+        });
+
         test('external aggFunc change with custom function resets staged changes', async () => {
             const customSum = (params: any) => params.values.reduce((a: number, b: number) => a + b, 0);
             const customMax = (params: any) => Math.max(...params.values);


### PR DESCRIPTION
## Summary

- Ignore `toolPanelUi` and `toolPanelDragAndDrop` sourced events in `onExternalGridChange` so header Row Group panel drag-and-drop does not reset staged CTP changes
- Split handler for `columnPivotModeChanged` (no `source` field) via `onExternalGridChangeNoSource`
- Added tests for TC17 (drag pill no-op), toolPanelDragAndDrop source, and inverse test (API source still resets)

## Test plan

- [x] `./behave.sh "deferred-suppress-sync-layout"` — 20 tests pass
- [x] `NX_DAEMON=false yarn nx build:types ag-grid-enterprise` — passes