### PR TITLE
RTI-3267-fix-delta-sort-transaction

### DIFF
--- a/packages/ag-grid-community/src/clientSideRowModel/deltaSort.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/deltaSort.ts
@@ -62,7 +62,7 @@ export const doDeltaSort = (
     const touchedRows: RowNode[] = [];
     for (let i = 0; i < unsortedRowsLen; ++i) {
         const node = unsortedRows[i];
-        if (updates.has(node) || adds.has(node) || !changedPath || changedPath.hasRow(node)) {
+        if (updates.has(node) || adds.has(node) || changedPath?.hasRow(node)) {
             indexByNode.set(node, ~i); // Bitwise NOT for touched (negative)
             touchedRows.push(node);
         } else {

--- a/testing/behavioural/src/sorting/benchmarks/delta-sort-transaction.bench.ts
+++ b/testing/behavioural/src/sorting/benchmarks/delta-sort-transaction.bench.ts
@@ -1,0 +1,135 @@
+import type { BenchOptions } from 'vitest';
+import { bench, suite } from 'vitest';
+
+import type { GridApi } from 'ag-grid-community';
+import { ClientSideRowModelApiModule, ClientSideRowModelModule, ColumnApiModule } from 'ag-grid-community';
+
+import { SimplePRNG, TestGridsManager } from '../../test-utils';
+
+/**
+ * Benchmarks the delta-sorting example scenario:
+ * 100k rows, multi-column sort, applyTransaction with 1 add + 1 update.
+ *
+ * Mirrors: documentation/ag-grid-docs/src/content/docs/data-update-transactions/_examples/delta-sorting/
+ */
+
+interface IData {
+    id: number;
+    sort: number;
+    sort1: number;
+    sort2: number;
+}
+
+const ROW_COUNT = 100_000;
+
+function buildRowData(count: number, prng: SimplePRNG): IData[] {
+    const result = new Array<IData>(count);
+    for (let i = 0; i < count; i++) {
+        result[i] = {
+            id: i,
+            sort: prng.nextInt(2000, 2002),
+            sort1: prng.nextInt(2000, 2002),
+            sort2: prng.nextInt(2000, 102000),
+        };
+    }
+    return result;
+}
+
+suite('delta sort transactions (100k rows, multi-column sort)', () => {
+    const gridsManager = new TestGridsManager({
+        benchmark: true,
+        modules: [ClientSideRowModelModule, ClientSideRowModelApiModule, ColumnApiModule],
+    });
+
+    const prng = new SimplePRNG(0xde17a50);
+    const baseRowData = buildRowData(ROW_COUNT, prng);
+
+    let deltaSortApi!: GridApi<IData>;
+    let fullSortApi!: GridApi<IData>;
+    let nextId = ROW_COUNT;
+
+    const gridOptions = {
+        columnDefs: [
+            { field: 'id' as const },
+            { field: 'sort' as const, sortIndex: 0, sort: 'desc' as const },
+            { field: 'sort1' as const, sortIndex: 1, sort: 'desc' as const },
+            { field: 'sort2' as const, sortIndex: 2, sort: 'desc' as const },
+        ],
+        defaultColDef: { flex: 1 },
+        getRowId: ({ data }: { data: IData }) => String(data.id),
+    };
+
+    const benchOptions: BenchOptions = {
+        throws: true,
+        setup: () => {
+            nextId = ROW_COUNT;
+            deltaSortApi ??= gridsManager.createGrid('delta', {
+                ...gridOptions,
+                deltaSort: true,
+                rowData: baseRowData.slice(),
+            });
+            fullSortApi ??= gridsManager.createGrid('full', {
+                ...gridOptions,
+                deltaSort: false,
+                rowData: baseRowData.slice(),
+            });
+        },
+        teardown: () => {
+            gridsManager.reset();
+            deltaSortApi = undefined!;
+            fullSortApi = undefined!;
+        },
+    };
+
+    bench(
+        'applyTransaction (deltaSort: true) - 1 add + 1 update',
+        () => {
+            const id = nextId++;
+            deltaSortApi.applyTransaction({
+                add: [
+                    {
+                        id,
+                        sort: prng.nextInt(2000, 2002),
+                        sort1: prng.nextInt(2000, 2002),
+                        sort2: prng.nextInt(2000, 102000),
+                    },
+                ],
+                update: [
+                    {
+                        id: 1,
+                        sort: prng.nextInt(2000, 2002),
+                        sort1: prng.nextInt(2000, 2002),
+                        sort2: prng.nextInt(2000, 102000),
+                    },
+                ],
+            });
+        },
+        benchOptions
+    );
+
+    bench(
+        'applyTransaction (deltaSort: false) - 1 add + 1 update',
+        () => {
+            const id = nextId++;
+            fullSortApi.applyTransaction({
+                add: [
+                    {
+                        id,
+                        sort: prng.nextInt(2000, 2002),
+                        sort1: prng.nextInt(2000, 2002),
+                        sort2: prng.nextInt(2000, 102000),
+                    },
+                ],
+                update: [
+                    {
+                        id: 1,
+                        sort: prng.nextInt(2000, 2002),
+                        sort1: prng.nextInt(2000, 2002),
+                        sort2: prng.nextInt(2000, 102000),
+                    },
+                ],
+            });
+        },
+        benchOptions
+    );
+});


### PR DESCRIPTION
A wrong condition was making delta sort being slower than it supposed to be because was marking all rows as 


`applyTransaction` with 1 add + 1 update on 100k rows, 3-column descending sort new benchmark created in this PR:

| Version                  | deltaSort: true | deltaSort: false | Delta speedup |
| ------------------------ | --------------- | ---------------- | ------------- |
| **b35.1.0** (baseline)   | 85 ms           | 697 ms           | 8.2x faster   |
| **b35.2.0** (regression) | 410 ms          | 404 ms           | 1.0x (broken) |
| **b35.2.0 + fix**        | 78 ms           | 396 ms           | 5.1x faster   |

The regression is resolved.

For normal transactions, Version 35.2.0 is **1.7x** faster than version 35.1.0 because the recent improvements in ChangedPath in this release in https://github.com/ag-grid/ag-grid/pull/13276

For delta sorting and transactions the speed is almost identical, slightly faster.