### PR TITLE
[RTI-3272] Fix(aggregation): throws an error on changing type

### DIFF
--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/dropZoneColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/dropZoneColumnComp.ts
@@ -360,11 +360,13 @@ export class DropZoneColumnComp extends PillDragComp<AgColumn> {
                 value,
                 'toolPanelDragAndDrop'
             );
-            const eText = this.getGui().querySelector<HTMLElement>('.ag-column-drop-cell-text');
-            if (eText) {
-                eText.textContent = this.getDisplayValue();
+            if (this.column) {
+                const eText = this.getGui().querySelector<HTMLElement>('.ag-column-drop-cell-text');
+                if (eText) {
+                    eText.textContent = this.getDisplayValue();
+                }
+                this.setupAria();
             }
-            this.setupAria();
             refreshDeferredToolPanelUi(this.beans, this.updateParams);
         };
 

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/dropZoneColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/dropZoneColumnComp.ts
@@ -360,6 +360,7 @@ export class DropZoneColumnComp extends PillDragComp<AgColumn> {
                 value,
                 'toolPanelDragAndDrop'
             );
+            // In synchronous mode, setColumnAggFunc dispatches events that can destroy this component, nulling this.column
             if (this.column) {
                 const eText = this.getGui().querySelector<HTMLElement>('.ag-column-drop-cell-text');
                 if (eText) {


### PR DESCRIPTION
- Fixes `TypeError: Cannot read properties of null (reading 'getAggFunc')` when switching aggregation function type in the columns tool panel (non-deferred mode)
- In synchronous mode, `setColumnAggFunc` dispatches events that destroy and recreate `DropZoneColumnComp`, nulling `this.column`. The subsequent DOM update and aria setup now guard against this.

Fixes [RTI-3272](https://ag-grid.atlassian.net/browse/RTI-3272)