### PR TITLE
RTI-3293 group-to-leaf demotion must update count

### DIFF
--- a/packages/ag-grid-enterprise/src/aggregation/filterAggregatesStage.ts
+++ b/packages/ag-grid-enterprise/src/aggregation/filterAggregatesStage.ts
@@ -61,6 +61,7 @@ export class FilterAggregatesStage extends BeanStub implements NamedBean, _IRowN
                     setAllChildrenCount(node);
                 } else {
                     node.setAllChildrenCount(null);
+                    node.pinnedSibling?.setAllChildrenCount(null);
                 }
             }
 
@@ -89,6 +90,7 @@ export class FilterAggregatesStage extends BeanStub implements NamedBean, _IRowN
                 setAllChildrenCount(node);
             } else {
                 node.setAllChildrenCount(null);
+                node.pinnedSibling?.setAllChildrenCount(null);
             }
             if (node.sibling) {
                 node.sibling.childrenAfterAggFilter = node.childrenAfterAggFilter;
@@ -114,12 +116,13 @@ export class FilterAggregatesStage extends BeanStub implements NamedBean, _IRowN
                 allChildrenCount += childrenAfterAggFilter[i].allChildrenCount ?? 0; // include children of children
             }
         }
-        rowNode.setAllChildrenCount(
+        const count =
             // Maintain the historical behaviour:
             // - allChildrenCount is 0 in the root if there are no children
             // - allChildrenCount is null in any non-root row if there are no children
-            allChildrenCount === 0 && rowNode.level >= 0 ? null : allChildrenCount
-        );
+            allChildrenCount === 0 && rowNode.level >= 0 ? null : allChildrenCount;
+        rowNode.setAllChildrenCount(count);
+        rowNode.pinnedSibling?.setAllChildrenCount(count);
     };
 
     /* for grid data, we only count the leafs */
@@ -135,5 +138,6 @@ export class FilterAggregatesStage extends BeanStub implements NamedBean, _IRowN
             }
         }
         rowNode.setAllChildrenCount(allChildrenCount);
+        rowNode.pinnedSibling?.setAllChildrenCount(allChildrenCount);
     };
 }

--- a/packages/ag-grid-enterprise/src/rowGrouping/rowGroupingUtils.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/rowGroupingUtils.ts
@@ -27,31 +27,33 @@ export const setRowNodeGroupValue = (
     rowNode.dispatchCellChangedEvent(column, newValue, oldValue);
 };
 
-/** Invoked when demoting a group to a leaf node */
-const demoteGroup = (rowNode: RowNode, colModel: ColumnModel) => {
-    setAggData(rowNode, null, colModel);
-    rowNode.setAllChildrenCount(null);
-};
-
-export const setRowNodeGroup = (rowNode: RowNode, beans: BeanCollection, group: boolean): void => {
-    if (rowNode.group === group) {
+const doSetRowNodeGroup = (rowNode: RowNode | null | undefined, beans: BeanCollection, group: boolean): void => {
+    if (!rowNode) {
         return;
     }
-
-    // if we used to be a group, and no longer, then close the node
-    if (rowNode.group && !group) {
-        const colModel = beans.colModel;
-        demoteGroup(rowNode, beans.colModel);
-        const pinnedSibling = rowNode.pinnedSibling;
-        if (pinnedSibling) {
-            demoteGroup(pinnedSibling, colModel);
-        }
+    const oldGroup = rowNode.group;
+    if (oldGroup === group) {
+        return;
     }
 
     rowNode.group = group;
     rowNode.updateHasChildren();
+
+    // Clear stale aggData and allChildrenCount when demoting from group to leaf.
+    // These must be cleared here because downstream stages (filterAggregatesStage)
+    // won't visit this node via changedPath since it's no longer a group.
+    if (oldGroup && !group) {
+        setAggData(rowNode, null, beans.colModel);
+        rowNode.setAllChildrenCount(null);
+    }
+
     beans.selectionSvc?.updateRowSelectable(rowNode);
     rowNode.dispatchRowEvent('groupChanged');
+};
+
+export const setRowNodeGroup = (rowNode: RowNode, beans: BeanCollection, group: boolean): void => {
+    doSetRowNodeGroup(rowNode, beans, group);
+    doSetRowNodeGroup(rowNode.pinnedSibling, beans, group);
 };
 
 export const isRowGroupColLocked = (column: AgColumn | undefined | null, beans: BeanCollection): boolean => {

--- a/packages/ag-grid-enterprise/src/rowGrouping/rowGroupingUtils.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/rowGroupingUtils.ts
@@ -2,12 +2,12 @@ import type { AgColumn, BeanCollection, ColumnModel, LocaleTextFunc, RowNode } f
 
 import { setAggData } from '../aggregation/aggDataUtils';
 
-export function setRowNodeGroupValue(
+export const setRowNodeGroupValue = (
     rowNode: RowNode,
     colModel: ColumnModel,
     colKey: string | AgColumn,
     newValue: any
-): void {
+): void => {
     const column = colModel.getCol(colKey)!;
 
     let groupData = rowNode._groupData;
@@ -25,21 +25,26 @@ export function setRowNodeGroupValue(
 
     groupData[columnId] = newValue;
     rowNode.dispatchCellChangedEvent(column, newValue, oldValue);
-}
+};
 
-export function setRowNodeGroup(rowNode: RowNode, beans: BeanCollection, group: boolean): void {
+/** Invoked when demoting a group to a leaf node */
+const demoteGroup = (rowNode: RowNode, colModel: ColumnModel) => {
+    setAggData(rowNode, null, colModel);
+    rowNode.setAllChildrenCount(null);
+};
+
+export const setRowNodeGroup = (rowNode: RowNode, beans: BeanCollection, group: boolean): void => {
     if (rowNode.group === group) {
         return;
     }
 
     // if we used to be a group, and no longer, then close the node
     if (rowNode.group && !group) {
-        // Clear stale aggData when demoting from group to leaf.
         const colModel = beans.colModel;
-        setAggData(rowNode, null, colModel);
+        demoteGroup(rowNode, beans.colModel);
         const pinnedSibling = rowNode.pinnedSibling;
         if (pinnedSibling) {
-            setAggData(pinnedSibling, null, colModel);
+            demoteGroup(pinnedSibling, colModel);
         }
     }
 
@@ -47,9 +52,9 @@ export function setRowNodeGroup(rowNode: RowNode, beans: BeanCollection, group: 
     rowNode.updateHasChildren();
     beans.selectionSvc?.updateRowSelectable(rowNode);
     rowNode.dispatchRowEvent('groupChanged');
-}
+};
 
-export function isRowGroupColLocked(column: AgColumn | undefined | null, beans: BeanCollection): boolean {
+export const isRowGroupColLocked = (column: AgColumn | undefined | null, beans: BeanCollection): boolean => {
     const { gos, rowGroupColsSvc } = beans;
 
     if (!rowGroupColsSvc || !column) {
@@ -67,17 +72,17 @@ export function isRowGroupColLocked(column: AgColumn | undefined | null, beans: 
 
     const colIndex = rowGroupColsSvc.columns.findIndex((groupCol) => groupCol.getColId() === column.getColId());
     return groupLockGroupColumns > colIndex;
-}
+};
 
 /**
  * In AG-16700 the locale introduced a ${variable} and stopped concatenating the column name in the code
  * To avoid a breaking change we need to check if the variable is present and if not fallback to the old way of concatenating the column name.
  */
-export function getGroupingLocaleText(
+export const getGroupingLocaleText = (
     localeTextFunc: LocaleTextFunc,
     key: 'groupBy' | 'ungroupBy',
     displayName: string
-): string {
+): string => {
     const prefix = key === 'groupBy' ? 'Group by' : 'Un-Group by';
 
     const localStr = localeTextFunc(key, `${prefix} ${displayName}`, [displayName]);
@@ -88,4 +93,4 @@ export function getGroupingLocaleText(
     } else {
         return `${localStr} ${displayName}`;
     }
-}
+};

--- a/testing/behavioural/src/drag-n-drop/tree-data/tree-data-managed-row-drag-basic.test.ts
+++ b/testing/behavioural/src/drag-n-drop/tree-data/tree-data-managed-row-drag-basic.test.ts
@@ -31,7 +31,7 @@ describe.each([false, true])('tree data drag basics (suppress move %s)', (suppre
         treeDataChildrenField: 'children',
         rowDragManaged: true,
         suppressMoveWhenRowDragging,
-        rowDragInsertDelay: 30,
+        rowDragInsertDelay: 1,
         groupDefaultExpanded: -1,
         getRowId: ({ data }) => data.id,
     };
@@ -358,5 +358,66 @@ describe.each([false, true])('tree data drag basics (suppress move %s)', (suppre
         expect(api.getRowNode('projects')?.parent?.id).toBe('storage');
         expect(api.getRowNode('project-alpha')?.parent?.id).toBe('projects');
         expect(api.getRowNode('alpha-design')?.parent?.id).toBe('project-alpha');
+    });
+
+    test('clears child count when dragging the only child out of a group', async () => {
+        const rowData = [
+            {
+                id: 'backend',
+                name: 'Backend',
+                type: 'folder',
+                children: [
+                    { id: 'payment', name: 'Payment Integration', type: 'folder', children: [] },
+                    { id: 'user-auth', name: 'User Auth', type: 'folder', children: [] },
+                ],
+            },
+        ];
+
+        const api = createGrid('tree-managed-child-count', rowData);
+
+        const initialRows = new GridRows(api, 'initial');
+        await initialRows.check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ backend GROUP id:backend ag-Grid-AutoColumn:"Backend" type:"folder"
+            · ├── payment LEAF id:payment ag-Grid-AutoColumn:"Payment Integration" type:"folder"
+            · └── user-auth LEAF id:user-auth ag-Grid-AutoColumn:"User Auth" type:"folder"
+        `);
+
+        // Step 1: Drag 'User Auth' into 'Payment Integration' (making it a child)
+        const dispatcher1 = new RowDragDispatcher({ api });
+        await dispatcher1.start('user-auth');
+        await waitFor(() => expect(dispatcher1.getDragGhostLabel()).toBe('User Auth'));
+        await dispatcher1.move('payment', { center: true });
+        await asyncSetTimeout(10); // Wait for rowDragInsertDelay timer to fire and nudge
+        await dispatcher1.finish();
+        await asyncSetTimeout(0);
+
+        const afterDragIn = new GridRows(api, 'after drag into Payment');
+        await afterDragIn.check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ backend GROUP id:backend ag-Grid-AutoColumn:"Backend" type:"folder"
+            · └─┬ payment GROUP id:payment ag-Grid-AutoColumn:"Payment Integration" type:"folder"
+            · · └── user-auth LEAF id:user-auth ag-Grid-AutoColumn:"User Auth" type:"folder"
+        `);
+        expect(api.getRowNode('user-auth')?.parent?.id).toBe('payment');
+        expect(api.getRowNode('payment')?.allChildrenCount).toBe(1);
+
+        // Step 2: Drag 'User Auth' back out alongside 'Payment Integration'
+        const dispatcher2 = new RowDragDispatcher({ api });
+        await dispatcher2.start('user-auth');
+        await waitFor(() => expect(dispatcher2.getDragGhostLabel()).toBe('User Auth'));
+        await dispatcher2.move('payment', { yOffsetPercent: 0.05 });
+        await dispatcher2.finish();
+        await asyncSetTimeout(0);
+
+        const afterDragOut = new GridRows(api, 'after drag out of Payment');
+        await afterDragOut.check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ backend GROUP id:backend ag-Grid-AutoColumn:"Backend" type:"folder"
+            · ├── user-auth LEAF id:user-auth ag-Grid-AutoColumn:"User Auth" type:"folder"
+            · └── payment LEAF id:payment ag-Grid-AutoColumn:"Payment Integration" type:"folder"
+        `);
+        expect(api.getRowNode('user-auth')?.parent?.id).toBe('backend');
+        expect(api.getRowNode('payment')?.allChildrenCount).toBeNull();
     });
 });

--- a/testing/behavioural/src/test-utils/gridRows/rows-validation/gridRowsValidator.ts
+++ b/testing/behavioural/src/test-utils/gridRows/rows-validation/gridRowsValidator.ts
@@ -219,6 +219,7 @@ export class GridRowsValidator {
         );
 
         this.validateSibling(rowErrors, row);
+        this.validatePinnedSibling(rowErrors, row);
 
         if (csrm) {
             const childrenAfterGroupSet = this.validateChildren(state, row, 'childrenAfterGroup', null);
@@ -334,6 +335,22 @@ export class GridRowsValidator {
         );
         rowErrors.add(sibling.childrenAfterSort !== row.childrenAfterSort && 'Sibling childrenAfterSort is different');
         rowErrors.add(sibling.allLeafChildren !== row.allLeafChildren && 'Sibling allLeafChildren is different');
+    }
+
+    private validatePinnedSibling(rowErrors: GridRowErrors, row: RowNode<any>) {
+        const pinnedSibling = row.pinnedSibling;
+        if (!pinnedSibling) {
+            return;
+        }
+        rowErrors.add(pinnedSibling === row && 'Row references itself as pinnedSibling');
+        rowErrors.add(
+            pinnedSibling.pinnedSibling !== row && 'PinnedSibling does not reference back to the original row'
+        );
+        rowErrors.add(pinnedSibling.group !== row.group && 'PinnedSibling group is different');
+        rowErrors.add(pinnedSibling.hasChildren() !== row.hasChildren() && 'PinnedSibling hasChildren() is different');
+        rowErrors.add(
+            pinnedSibling.allChildrenCount !== row.allChildrenCount && 'PinnedSibling allChildrenCount is different'
+        );
     }
 
     private validateChildren(

--- a/testing/behavioural/src/tree-data/hierarchical/hierarchical-immutable-tree-data.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/hierarchical-immutable-tree-data.test.ts
@@ -888,6 +888,105 @@ describe('ag-grid hierarchical immutable tree data', () => {
         }
     });
 
+    test('allChildrenCount updates correctly through setRowData (0→1→2→1→0)', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'v' }],
+            treeData: true,
+            treeDataChildrenField: 'children',
+            animateRows: false,
+            groupDefaultExpanded: -1,
+            rowData: cachedJSONObjects.array([
+                { id: 'parent', v: 'parent' },
+                { id: 'sibling', v: 'sibling' },
+            ]),
+            getRowId: ({ data }) => data.id,
+        });
+
+        // Initial: parent is a LEAF with no children (allChildrenCount = null)
+        let gridRows = new GridRows(api, '0 children');
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├── parent LEAF id:parent ag-Grid-AutoColumn:"parent" v:"parent"
+            └── sibling LEAF id:sibling ag-Grid-AutoColumn:"sibling" v:"sibling"
+        `);
+        expect(api.getRowNode('parent')?.allChildrenCount).toBeNull();
+
+        // Add first child via setRowData: parent becomes GROUP with allChildrenCount = 1
+        setRowDataChecked(
+            api,
+            cachedJSONObjects.array([
+                { id: 'parent', v: 'parent', children: [{ id: 'child-1', v: 'child-1' }] },
+                { id: 'sibling', v: 'sibling' },
+            ])
+        );
+        gridRows = new GridRows(api, '1 child');
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ parent GROUP id:parent ag-Grid-AutoColumn:"parent" v:"parent"
+            │ └── child-1 LEAF id:child-1 ag-Grid-AutoColumn:"child-1" v:"child-1"
+            └── sibling LEAF id:sibling ag-Grid-AutoColumn:"sibling" v:"sibling"
+        `);
+        expect(api.getRowNode('parent')?.allChildrenCount).toBe(1);
+
+        // Add second child: allChildrenCount = 2
+        setRowDataChecked(
+            api,
+            cachedJSONObjects.array([
+                {
+                    id: 'parent',
+                    v: 'parent',
+                    children: [
+                        { id: 'child-1', v: 'child-1' },
+                        { id: 'child-2', v: 'child-2' },
+                    ],
+                },
+                { id: 'sibling', v: 'sibling' },
+            ])
+        );
+        gridRows = new GridRows(api, '2 children');
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ parent GROUP id:parent ag-Grid-AutoColumn:"parent" v:"parent"
+            │ ├── child-1 LEAF id:child-1 ag-Grid-AutoColumn:"child-1" v:"child-1"
+            │ └── child-2 LEAF id:child-2 ag-Grid-AutoColumn:"child-2" v:"child-2"
+            └── sibling LEAF id:sibling ag-Grid-AutoColumn:"sibling" v:"sibling"
+        `);
+        expect(api.getRowNode('parent')?.allChildrenCount).toBe(2);
+
+        // Remove first child: allChildrenCount = 1
+        setRowDataChecked(
+            api,
+            cachedJSONObjects.array([
+                { id: 'parent', v: 'parent', children: [{ id: 'child-2', v: 'child-2' }] },
+                { id: 'sibling', v: 'sibling' },
+            ])
+        );
+        gridRows = new GridRows(api, '1 child again');
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ parent GROUP id:parent ag-Grid-AutoColumn:"parent" v:"parent"
+            │ └── child-2 LEAF id:child-2 ag-Grid-AutoColumn:"child-2" v:"child-2"
+            └── sibling LEAF id:sibling ag-Grid-AutoColumn:"sibling" v:"sibling"
+        `);
+        expect(api.getRowNode('parent')?.allChildrenCount).toBe(1);
+
+        // Remove last child: parent becomes LEAF, allChildrenCount = null
+        setRowDataChecked(
+            api,
+            cachedJSONObjects.array([
+                { id: 'parent', v: 'parent' },
+                { id: 'sibling', v: 'sibling' },
+            ])
+        );
+        gridRows = new GridRows(api, '0 children again');
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├── parent LEAF id:parent ag-Grid-AutoColumn:"parent" v:"parent"
+            └── sibling LEAF id:sibling ag-Grid-AutoColumn:"sibling" v:"sibling"
+        `);
+        expect(api.getRowNode('parent')?.allChildrenCount).toBeNull();
+    });
+
     test('suppressMaintainUnsortedOrder is respected', async () => {
         const rowData1 = cachedJSONObjects.array([
             {

--- a/testing/behavioural/src/tree-data/parentid/parentid-tree-transactions.test.ts
+++ b/testing/behavioural/src/tree-data/parentid/parentid-tree-transactions.test.ts
@@ -104,6 +104,75 @@ describe('ag-grid tree transactions', () => {
         expect(gridRows.rootAllLeafChildren.map((row) => row.data)).toEqual([row0, row3, row4, row5b]);
     });
 
+    test('allChildrenCount updates correctly through add/remove transactions (0→1→2→1→0)', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'x' }],
+            autoGroupColumnDef: { headerName: 'Hierarchy' },
+            treeData: true,
+            animateRows: false,
+            groupDefaultExpanded: -1,
+            rowData: [
+                { id: 'parent', x: 'parent' },
+                { id: 'sibling', x: 'sibling' },
+            ],
+            getRowId: (params) => params.data.id,
+            treeDataParentIdField: 'parentId',
+        });
+
+        // Initial: parent is a LEAF with no children (allChildrenCount = null)
+        let gridRows = new GridRows(api, '0 children');
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├── parent LEAF id:parent ag-Grid-AutoColumn:"parent" x:"parent"
+            └── sibling LEAF id:sibling ag-Grid-AutoColumn:"sibling" x:"sibling"
+        `);
+        expect(api.getRowNode('parent')?.allChildrenCount).toBeNull();
+
+        // Add first child: parent becomes GROUP with allChildrenCount = 1
+        applyTransactionChecked(api, { add: [{ id: 'child-1', x: 'child-1', parentId: 'parent' }] });
+        gridRows = new GridRows(api, '1 child');
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ parent GROUP id:parent ag-Grid-AutoColumn:"parent" x:"parent"
+            │ └── child-1 LEAF id:child-1 ag-Grid-AutoColumn:"child-1" x:"child-1"
+            └── sibling LEAF id:sibling ag-Grid-AutoColumn:"sibling" x:"sibling"
+        `);
+        expect(api.getRowNode('parent')?.allChildrenCount).toBe(1);
+
+        // Add second child: allChildrenCount = 2
+        applyTransactionChecked(api, { add: [{ id: 'child-2', x: 'child-2', parentId: 'parent' }] });
+        gridRows = new GridRows(api, '2 children');
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ parent GROUP id:parent ag-Grid-AutoColumn:"parent" x:"parent"
+            │ ├── child-1 LEAF id:child-1 ag-Grid-AutoColumn:"child-1" x:"child-1"
+            │ └── child-2 LEAF id:child-2 ag-Grid-AutoColumn:"child-2" x:"child-2"
+            └── sibling LEAF id:sibling ag-Grid-AutoColumn:"sibling" x:"sibling"
+        `);
+        expect(api.getRowNode('parent')?.allChildrenCount).toBe(2);
+
+        // Remove first child: allChildrenCount = 1
+        applyTransactionChecked(api, { remove: [{ id: 'child-1' }] });
+        gridRows = new GridRows(api, '1 child again');
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ parent GROUP id:parent ag-Grid-AutoColumn:"parent" x:"parent"
+            │ └── child-2 LEAF id:child-2 ag-Grid-AutoColumn:"child-2" x:"child-2"
+            └── sibling LEAF id:sibling ag-Grid-AutoColumn:"sibling" x:"sibling"
+        `);
+        expect(api.getRowNode('parent')?.allChildrenCount).toBe(1);
+
+        // Remove last child: parent becomes LEAF, allChildrenCount = null
+        applyTransactionChecked(api, { remove: [{ id: 'child-2' }] });
+        gridRows = new GridRows(api, '0 children again');
+        await gridRows.check(`
+            ROOT id:ROOT_NODE_ID
+            ├── parent LEAF id:parent ag-Grid-AutoColumn:"parent" x:"parent"
+            └── sibling LEAF id:sibling ag-Grid-AutoColumn:"sibling" x:"sibling"
+        `);
+        expect(api.getRowNode('parent')?.allChildrenCount).toBeNull();
+    });
+
     test('ag-grid parentId tree async complex transaction', async () => {
         const row0 = { id: '0', x: '0', parentId: null };
         const row1a = { id: '1', x: '1a', parentId: null };


### PR DESCRIPTION
We standardised ChangedPath to be able to contain and iterate only groups.
In the previous PR we updated the code to update the required fields during demotion, instead of including them in the depth first search - for performance and consistency
However, setAllChildrenCount was forgotten in this case.

This PR fix the issue

Also, working on this noticed that pinnedSibling setAllChildrenCount is not kept up to date and the pinnedSibling holds the value that was present on construction never updating it - this fixes the issue too.

Verified that there are no other fields that need to be updated.

Also, add tests for drag and drop and transactions and pinned siblings.

FIX [RTI-3293](https://ag-grid.atlassian.net/browse/RTI-3293)