### PR TITLE
Fix(columns): tool panel drag interaction shows pin icon instead of reorder indicator

### DIFF
--- a/.run/BigInt support.run.xml
+++ b/.run/BigInt support.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="BigInt support" type="JavascriptDebugType" engineId="98ca6316-2f89-46d9-a9e5-fa9e2b0625b3" uri="https://plnkr.co/edit/PRzRdjaX4KUkiGPm?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/Column Tool Panel Icon bug.run.xml
+++ b/.run/Column Tool Panel Icon bug.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Column Tool Panel Icon bug" type="JavascriptDebugType" engineId="98ca6316-2f89-46d9-a9e5-fa9e2b0625b3" uri="https://plnkr.co/edit/Kh56rmKKhKWuUmYB?open=main.js">
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Mini filter value formatter.run.xml
+++ b/.run/Mini filter value formatter.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Mini filter value formatter" type="JavascriptDebugType" engineId="98ca6316-2f89-46d9-a9e5-fa9e2b0625b3" uri="https://plnkr.co/edit/4MC5MKLtNjTb0bEG?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.snyk
+++ b/.snyk
@@ -2,6 +2,28 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+    SNYK-JS-FLATTED-15700433:
+        - '@nx/react@20.3.1 > @nx/module-federation@20.3.1 > @module-federation/enhanced@0.7.6 > @module-federation/dts-plugin@0.7.6 > log4js@6.9.1 > flatted@3.4.0':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-23T10:14:46.789Z
+        - stylelint@16.25.0 > file-entry-cache@10.1.4 > flat-cache@6.1.18 > flatted@3.4.0:
+              reason: >-
+                  Test dependency - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-23T10:12:23.301Z
+        - eslint@9.39.1 > file-entry-cache@8.0.0 > flat-cache@4.0.1 > flatted@3.4.0:
+              reason: >-
+                  Test dependency - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-23T10:10:57.432Z
+    SNYK-JS-EFFECT-15746380:
+        - rulesync@7.0.0 > effect@3.19.16:
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-23T10:10:48.076Z
     SNYK-JS-UNDICI-15518070:
         - rulesync@7.0.0 > fastmcp@3.31.0 > undici@6.21.3:
               reason: >-

--- a/community-modules/styles/.snyk
+++ b/community-modules/styles/.snyk
@@ -2,6 +2,12 @@
 version: v1.25.1
 
 ignore:
+    SNYK-JS-FLATTED-15700433:
+        - stylelint@14.9.1 > file-entry-cache@6.0.1 > flat-cache@3.2.0 > flatted@3.4.0:
+              reason: >-
+                  Test dependency - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-23T10:12:23.306Z
     SNYK-JS-TAR-15456201:
         - '@vusion/webfonts-generator@0.8.0 > ttf2woff2@4.0.5 > node-gyp@9.4.1 > make-fetch-happen@10.2.1 > cacache@16.1.3 > tar@6.2.1':
               reason: >-

--- a/documentation/ag-grid-docs/.snyk
+++ b/documentation/ag-grid-docs/.snyk
@@ -2,6 +2,24 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+    SNYK-JS-H3-15745711:
+        - astro@5.16.6 > unstorage@1.17.3 > h3@1.15.5:
+              reason: >-
+                  H3 is not used for production
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-23T10:14:33.937Z
+    SNYK-JS-H3-15692482:
+        - astro@5.16.6 > unstorage@1.17.3 > h3@1.15.5:
+              reason: >-
+                  H3 is not used for production
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-23T10:14:29.419Z
+    SNYK-JS-H3-15683856:
+        - astro@5.16.6 > unstorage@1.17.3 > h3@1.15.5:
+              reason: >-
+                  H3 is not used for production
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-23T10:14:25.461Z
     SNYK-JS-UNDICI-15518068:
         - cheerio@1.1.2 > undici@6.21.3:
               reason: >-

--- a/packages/ag-grid-angular/.snyk
+++ b/packages/ag-grid-angular/.snyk
@@ -2,6 +2,18 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+    SNYK-JS-SOCKETIOPARSER-15680278:
+        - karma@6.4.4 > socket.io@4.8.1 > socket.io-parser@4.2.4:
+              reason: >-
+                  Test dependency - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-23T10:12:14.254Z
+    SNYK-JS-FLATTED-15700433:
+        - karma@6.4.4 > log4js@6.9.1 > flatted@3.4.0:
+              reason: >-
+                  Test dependency - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-23T10:11:13.114Z
     SNYK-JS-TAR-15456201:
         - ng-packagr@18.2.1 > cacache@18.0.4 > tar@6.2.1:
               reason: >-

--- a/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
@@ -176,7 +176,7 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
                 getCurrentDragValue: (listItemDragStartEvent: ColumnPanelItemDragStartEvent) =>
                     getCurrentDragValue(listItemDragStartEvent),
                 isMoveBlocked: (currentDragValue: AgColumn | AgProvidedColumnGroup | null) =>
-                    isMoveBlocked(gos, beans, getCurrentColumnsBeingMoved(currentDragValue)),
+                    isMoveBlocked(gos, beans, getCurrentColumnsBeingMoved(currentDragValue), this.params),
                 getNumRows: (comp: AgPrimaryColsList) => comp.getDisplayedColsList().length,
                 moveItem: (
                     currentDragValue: AgColumn | AgProvidedColumnGroup | null,
@@ -192,7 +192,7 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
         const { group, columnGroup, column, expanded } = modelItem;
         const currentColumns = getCurrentColumnsBeingMoved(group ? columnGroup : column);
 
-        if (isMoveBlocked(gos, beans, currentColumns)) {
+        if (isMoveBlocked(gos, beans, currentColumns, this.params)) {
             return;
         }
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnMoveUtils.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnMoveUtils.ts
@@ -53,8 +53,14 @@ const getMoveDiff = (allColumns: AgColumn[], currentColumns: AgColumn[] | null, 
     return 0;
 };
 
-export const isMoveBlocked = (gos: GridOptionsService, beans: BeanCollection, currentColumns: AgColumn[]): boolean => {
-    const preventMoving = gos.get('suppressMovableColumns') || beans.colModel.isPivotMode();
+export const isMoveBlocked = (
+    gos: GridOptionsService,
+    beans: BeanCollection,
+    currentColumns: AgColumn[],
+    params: ColumnStateUpdateParams
+): boolean => {
+    const deferMode = isDeferredMode(params);
+    const preventMoving = gos.get('suppressMovableColumns') || beans.columnStateUpdateStrategy.getPivotMode(deferMode);
 
     if (preventMoving) {
         return true;

--- a/testing/module-size/.snyk
+++ b/testing/module-size/.snyk
@@ -2,6 +2,12 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+    SNYK-JS-FLATTED-15700433:
+        - eslint@9.39.1 > file-entry-cache@8.0.0 > flat-cache@4.0.1 > flatted@3.4.0:
+              reason: >-
+                  Test dependency - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-23T10:10:57.436Z
     SNYK-JS-FLATTED-15518041:
         - eslint@9.39.1 > file-entry-cache@8.0.0 > flat-cache@4.0.1 > flatted@3.3.3:
               reason: >-


### PR DESCRIPTION
isMoveBlocked was reading pivot mode from the live grid state (colModel.isPivotMode()), so toggling pivot off in deferred mode without applying still blocked column moves and showed pin icon instead of reorder indicator.

Fixes [RTI-3259](https://ag-grid.atlassian.net/browse/RTI-3259)