### PR TITLE
RTI-3268 fix change detection example

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-filter-sort-group/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-filter-sort-group/main.ts
@@ -68,8 +68,15 @@ const gridOptions: GridOptions = {
     groupDefaultExpanded: 1,
     suppressAggFuncInHeader: true,
     allowShowChangeAfterFilter: true,
-    refreshAfterGroupEdit: true,
+    onCellValueChanged: onCellValueChanged,
 };
+
+function onCellValueChanged(params: CellValueChangedEvent) {
+    const data = params.data;
+    if (data) {
+        params.api.applyTransaction({ update: [data] });
+    }
+}
 
 function getRowData() {
     const rowData = [];


### PR DESCRIPTION
The example was doing more than what refreshAfterGroupEdit handles (that handles only when a group column is updated)

In the future maybe we should add a refreshAfterEdit flag together with refreshAfterGroupEdit, however, the solution here is to just use the old implementation of the example.

Verified there are no other examples to fix.

FIX RTI-3268