### PR TITLE
Fix(columns): staged state equivalent to current still shows apply button as active

### DIFF
--- a/packages/ag-grid-enterprise/src/columnToolPanel/updates/columnStateUpdateExecutionStrategy.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/updates/columnStateUpdateExecutionStrategy.ts
@@ -275,13 +275,19 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
         if (columnOrder && !_areEqual(columnOrder.colIds, getPrimaryColumnIds(beans))) {
             return true;
         }
-        if (rowGroup && !_areEqual(rowGroup.colIds, getColIds(beans.rowGroupColsSvc?.columns))) {
+        if (
+            rowGroup &&
+            !_areEqual([...rowGroup.colIds].sort(), [...getColIds(beans.rowGroupColsSvc?.columns)].sort())
+        ) {
             return true;
         }
-        if (aggregation && !_areEqual(aggregation.colIds, getColIds(beans.valueColsSvc?.columns))) {
+        if (
+            aggregation &&
+            !_areEqual([...aggregation.colIds].sort(), [...getColIds(beans.valueColsSvc?.columns)].sort())
+        ) {
             return true;
         }
-        if (pivot && !_areEqual(pivot.colIds, getColIds(beans.pivotColsSvc?.columns))) {
+        if (pivot && !_areEqual([...pivot.colIds].sort(), [...getColIds(beans.pivotColsSvc?.columns)].sort())) {
             return true;
         }
         if (pivotMode && pivotMode.pivotMode !== beans.colModel.isPivotMode()) {

--- a/testing/behavioural/src/columnToolPanel/deferred-pivot-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-pivot-mode.test.ts
@@ -1674,6 +1674,54 @@ describe('deferred column tool panel pivot mode', () => {
         expect(getApplyButton(toolPanelGui).disabled).toBe(false);
     });
 
+    test('apply button is disabled after reverting a staged row group change', async () => {
+        const { gridApi, toolPanel, toolPanelGui } = await createDeferredNonPivotGrid([
+            { field: 'country', enableRowGroup: true, rowGroup: true },
+            { field: 'athlete' },
+            { field: 'gold' },
+        ]);
+        const country = gridApi.getColumn('country')! as AgColumn;
+
+        expect(getApplyButton(toolPanelGui).disabled).toBe(true);
+
+        // Remove country from row groups
+        getUpdateStrategy(toolPanel).setRowGroupColumns(true, [], 'toolPanelUi');
+        toolPanel.refreshDeferredUi();
+
+        expect(getApplyButton(toolPanelGui).disabled).toBe(false);
+
+        // Add country back to row groups (revert to original state)
+        getUpdateStrategy(toolPanel).setRowGroupColumns(true, [country], 'toolPanelUi');
+        toolPanel.refreshDeferredUi();
+
+        expect(getApplyButton(toolPanelGui).disabled).toBe(true);
+    });
+
+    test('apply button is disabled after removing then re-adding a row group column via drop zone in pivot mode', async () => {
+        const { gridApi, toolPanel, toolPanelGui } = await createDeferredPivotModeGrid();
+        const strategy = getUpdateStrategy(toolPanel);
+        const country = gridApi.getColumn('country')! as AgColumn;
+
+        expect(getApplyButton(toolPanelGui).disabled).toBe(true);
+
+        // Remove country from row groups via the drop zone (simulates removing pill)
+        // This goes through pillDropZonePanel.removeItems → updateItems → setRowGroupColumns
+        const rowGroupPanel = toolPanel.rowGroupDropZonePanel;
+        const existingRowGroupCols = rowGroupPanel.getExistingItems();
+        const withoutCountry = existingRowGroupCols.filter((c: AgColumn) => c !== country);
+        rowGroupPanel['updateItems'](withoutCountry);
+        toolPanel.refreshDeferredUi();
+
+        expect(getApplyButton(toolPanelGui).disabled).toBe(false);
+
+        // Add country back via the drop zone (simulates dragging from columns list)
+        const currentRowGroupCols = rowGroupPanel.getExistingItems();
+        rowGroupPanel['updateItems']([...currentRowGroupCols, country]);
+        toolPanel.refreshDeferredUi();
+
+        expect(getApplyButton(toolPanelGui).disabled).toBe(true);
+    });
+
     test('apply button becomes enabled when a value column aggregation function is changed', async () => {
         const { gridApi, toolPanel, toolPanelGui } = await createDeferredPivotModeGrid();
         const silver = gridApi.getColumn('silver')! as AgColumn;

--- a/testing/behavioural/src/columnToolPanel/deferred-pivot-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-pivot-mode.test.ts
@@ -1699,7 +1699,6 @@ describe('deferred column tool panel pivot mode', () => {
 
     test('apply button is disabled after removing then re-adding a row group column via drop zone in pivot mode', async () => {
         const { gridApi, toolPanel, toolPanelGui } = await createDeferredPivotModeGrid();
-        const strategy = getUpdateStrategy(toolPanel);
         const country = gridApi.getColumn('country')! as AgColumn;
 
         expect(getApplyButton(toolPanelGui).disabled).toBe(true);


### PR DESCRIPTION
When removing a column from row groups and dragging it back, it gets appended at the end, creating a different order from the original. hasPendingChanges now sorts column IDs before comparing so that the same set of columns in a different order is not treated as a pending change. Applies to row groups, pivot columns, and value columns.

Fixes [RTI-3260](https://ag-grid.atlassian.net/browse/RTI-3260)