### PR TITLE
[RTI-3259] Fix(columns): tool panel drag interaction shows pin icon instead of reorder indicator

### DIFF
--- a/.run/BigInt support.run.xml
+++ b/.run/BigInt support.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="BigInt support" type="JavascriptDebugType" engineId="98ca6316-2f89-46d9-a9e5-fa9e2b0625b3" uri="https://plnkr.co/edit/PRzRdjaX4KUkiGPm?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/Column Tool Panel Icon bug.run.xml
+++ b/.run/Column Tool Panel Icon bug.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Column Tool Panel Icon bug" type="JavascriptDebugType" engineId="98ca6316-2f89-46d9-a9e5-fa9e2b0625b3" uri="https://plnkr.co/edit/Kh56rmKKhKWuUmYB?open=main.js">
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Column Tool Panel Icon bug.run.xml
+++ b/.run/Column Tool Panel Icon bug.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Column Tool Panel Icon bug" type="JavascriptDebugType" engineId="98ca6316-2f89-46d9-a9e5-fa9e2b0625b3" uri="https://plnkr.co/edit/Kh56rmKKhKWuUmYB?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/Mini filter value formatter.run.xml
+++ b/.run/Mini filter value formatter.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Mini filter value formatter" type="JavascriptDebugType" engineId="98ca6316-2f89-46d9-a9e5-fa9e2b0625b3" uri="https://plnkr.co/edit/4MC5MKLtNjTb0bEG?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
@@ -263,7 +263,10 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
 
         const pivotModeActive = this.colModel.isPivotMode();
         const deferApply = isDeferredMode(params);
-        const shouldSyncColumnLayoutWithGrid = (!params.suppressSyncLayoutWithGrid || deferApply) && !pivotModeActive;
+        const hasDeferredColumnOrder =
+            deferApply && this.beans.columnStateUpdateStrategy.hasDeferredColumnOrder(deferApply);
+        const shouldSyncColumnLayoutWithGrid =
+            ((!params.suppressSyncLayoutWithGrid || deferApply) && !pivotModeActive) || hasDeferredColumnOrder;
 
         if (shouldSyncColumnLayoutWithGrid) {
             this.buildTreeFromWhatGridIsDisplaying();

--- a/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
@@ -176,7 +176,7 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
                 getCurrentDragValue: (listItemDragStartEvent: ColumnPanelItemDragStartEvent) =>
                     getCurrentDragValue(listItemDragStartEvent),
                 isMoveBlocked: (currentDragValue: AgColumn | AgProvidedColumnGroup | null) =>
-                    isMoveBlocked(gos, beans, getCurrentColumnsBeingMoved(currentDragValue)),
+                    isMoveBlocked(gos, beans, getCurrentColumnsBeingMoved(currentDragValue), this.params),
                 getNumRows: (comp: AgPrimaryColsList) => comp.getDisplayedColsList().length,
                 moveItem: (
                     currentDragValue: AgColumn | AgProvidedColumnGroup | null,
@@ -192,7 +192,7 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
         const { group, columnGroup, column, expanded } = modelItem;
         const currentColumns = getCurrentColumnsBeingMoved(group ? columnGroup : column);
 
-        if (isMoveBlocked(gos, beans, currentColumns)) {
+        if (isMoveBlocked(gos, beans, currentColumns, this.params)) {
             return;
         }
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnMoveUtils.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnMoveUtils.ts
@@ -53,8 +53,14 @@ const getMoveDiff = (allColumns: AgColumn[], currentColumns: AgColumn[] | null, 
     return 0;
 };
 
-export const isMoveBlocked = (gos: GridOptionsService, beans: BeanCollection, currentColumns: AgColumn[]): boolean => {
-    const preventMoving = gos.get('suppressMovableColumns') || beans.colModel.isPivotMode();
+export const isMoveBlocked = (
+    gos: GridOptionsService,
+    beans: BeanCollection,
+    currentColumns: AgColumn[],
+    params: ColumnStateUpdateParams
+): boolean => {
+    const deferMode = isDeferredMode(params);
+    const preventMoving = gos.get('suppressMovableColumns') || beans.columnStateUpdateStrategy.getPivotMode(deferMode);
 
     if (preventMoving) {
         return true;


### PR DESCRIPTION
Two fixes for drag interaction in deferred columns tool panel:

1. isMoveBlocked was reading pivot mode from the live grid state, so toggling pivot off in deferred mode without applying still blocked column moves and showed pin icon instead of reorder indicator.

2. After fixing the icon, column reordering still didn't work because onColumnsChanged used buildTreeFromProvidedColumnDefs when pivot mode was active (live), ignoring the deferred column order. Now falls through to buildTreeFromWhatGridIsDisplaying when a deferred column order exists.

Fixes [RTI-3259](https://ag-grid.atlassian.net/browse/RTI-3259)