### PR TITLE
RTI-3270 Add note about Angular 21 zoneless default to NgZone docs

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/angular-ngzone/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/angular-ngzone/index.mdoc
@@ -5,6 +5,10 @@ frameworks: ["angular"]
 
 Recommended NgZoneOptions and details of AG Grid's performance optimisations to avoid [Zone Pollution](https://angular.dev/best-practices/zone-pollution).
 
+{% note %}
+From Angular 21, new applications are zoneless by default. The optimisations on this page only apply to Zone based applications. See [Angular Zoneless](https://angular.dev/guide/zoneless) for more details.
+{% /note %}
+
 ## Recommended NgZoneOptions
 
 Angular supports coalescing of change detection cycles via [NgZoneOptions](https://angular.dev/api/core/NgZoneOptions). This can be set via `provideZoneChangeDetection` when bootstrapping your application. We recommend enabling `eventCoalescing` and `runCoalescing` for optimal AG Grid performance.


### PR DESCRIPTION
Fix [RTI-3270](https://ag-grid.atlassian.net/browse/RTI-3270)