### PR TITLE
RTI-3287 Fix legacy theme CSS postcss-rtlcss double-wrapping

### DIFF
--- a/esbuild.config.cjs
+++ b/esbuild.config.cjs
@@ -10,21 +10,24 @@ const cssPlugin = {
     name: 'css-plugin',
     setup(build) {
         build.onLoad({ filter: /\.css$/ }, async (args) => {
-            const css = await require('fs').promises.readFile(args.path, 'utf8');
-            const result = await postcss(postcssPlugins).process(css, {
-                from: args.path,
-                to: args.path,
-            });
+            const rawCSS = await fs.readFile(args.path, 'utf8');
+            const isLegacyCSS = !args.path.includes('/src/');
+
+            // Legacy theme CSS is already processed through Sass, only source
+            // CSS (Theming API) needs PostCSS.
+            const outputCSS = isLegacyCSS
+                ? rawCSS
+                : (await postcss(postcssPlugins).process(rawCSS, { from: args.path, to: args.path })).css;
 
             // UMD builds: non-source CSS (legacy themes) gets injected as <style> tags
             const isUmd = /:(umd|umd:watch)$/.test(process.env.NX_TASK_TARGET_TARGET ?? '');
-            if (isUmd && !args.path.includes('/src/')) {
+            if (isUmd && isLegacyCSS) {
                 return {
-                    contents: `(function(){if(typeof document!=="undefined"){var s=document.createElement("style");s.setAttribute("data-ag-scope","legacy");s.textContent=${JSON.stringify(result.css)};document.head.appendChild(s);}})();`,
+                    contents: `(function(){if(typeof document!=="undefined"){var s=document.createElement("style");s.setAttribute("data-ag-scope","legacy");s.textContent=${JSON.stringify(outputCSS)};document.head.appendChild(s);}})();`,
                     loader: 'js',
                 };
             }
-            return { contents: result.css, loader: 'text' };
+            return { contents: outputCSS, loader: 'text' };
         });
     },
 };

--- a/testing/manual/template/vite.config.ts
+++ b/testing/manual/template/vite.config.ts
@@ -15,9 +15,10 @@ const agGridRoot = path.resolve(__dirname, '../../..');
 export default defineConfig(async () => {
     const plugins = [cssFileDefaultImport(), ...(angularEnabled ? [] : [serveAngularDisabledPage()]), react(), vue()];
     const aliases: Record<string, string> = {
-        'ag-grid-community/styles': path.join(agGridRoot, 'packages/ag-grid-community/styles'),
         'ag-grid-community': path.join(agGridRoot, 'packages/ag-grid-community/src/main.ts'),
+        'ag-grid-community/styles': path.join(agGridRoot, 'packages/ag-grid-community/styles'),
         'ag-grid-enterprise': path.join(agGridRoot, 'packages/ag-grid-enterprise/src/main.ts'),
+        'ag-grid-enterprise/styles': path.join(agGridRoot, 'packages/ag-grid-enterprise/styles'),
         'ag-grid-react': path.join(agGridRoot, 'packages/ag-grid-react/src/index.ts'),
         'ag-grid-vue3': path.join(agGridRoot, 'packages/ag-grid-vue3/src/main.ts'),
         '@': path.join(agGridRoot, 'packages/ag-grid-vue3/src'), // resolves @/ imports within ag-grid-vue3 source

--- a/testing/manual/template/vite.config.ts
+++ b/testing/manual/template/vite.config.ts
@@ -15,6 +15,7 @@ const agGridRoot = path.resolve(__dirname, '../../..');
 export default defineConfig(async () => {
     const plugins = [cssFileDefaultImport(), ...(angularEnabled ? [] : [serveAngularDisabledPage()]), react(), vue()];
     const aliases: Record<string, string> = {
+        'ag-grid-community/styles': path.join(agGridRoot, 'packages/ag-grid-community/styles'),
         'ag-grid-community': path.join(agGridRoot, 'packages/ag-grid-community/src/main.ts'),
         'ag-grid-enterprise': path.join(agGridRoot, 'packages/ag-grid-enterprise/src/main.ts'),
         'ag-grid-react': path.join(agGridRoot, 'packages/ag-grid-react/src/index.ts'),

--- a/testing/manual/template/vite.config.ts
+++ b/testing/manual/template/vite.config.ts
@@ -43,11 +43,8 @@ export default defineConfig(async () => {
         console.log('\x1b[33m%s\x1b[0m', 'Angular disabled. Run with ANGULAR=1 yarn dev to enable.');
     }
 
-    const postcssPlugins = require(path.join(agGridRoot, 'postcss-plugins.cjs'));
-
     return {
         plugins,
-        css: { postcss: { plugins: postcssPlugins } },
         resolve: { alias: aliases },
         build: {
             target: 'esnext',
@@ -79,10 +76,14 @@ function serveAngularDisabledPage(): Plugin {
 }
 
 // AG Grid source uses `import css from './foo.css'` (default imports of CSS
-// strings). Vite requires `?inline` after the CSS file to get this behaviour.
-// This plugin appends ?inline to all imported CSS files.
+// strings). This plugin:
+// 1. Appends ?inline so Vite returns the CSS as a string (default export)
+// 2. Runs PostCSS on the CSS content (for RTL support etc) before Vite sees it
 function cssFileDefaultImport(): Plugin {
     const agGridSrc = path.join(agGridRoot, 'packages');
+    const postcssPlugins = require(path.join(agGridRoot, 'postcss-plugins.cjs'));
+    const postcss = require('postcss');
+
     return {
         name: 'ag-grid-css-inline',
         enforce: 'pre',
@@ -92,6 +93,17 @@ function cssFileDefaultImport(): Plugin {
                 if (resolved) {
                     return resolved.id + '?inline';
                 }
+            }
+        },
+        async load(id) {
+            if (id.endsWith('.css?inline')) {
+                const realPath = id.slice(0, -'?inline'.length);
+                const raw = fs.readFileSync(realPath, 'utf-8');
+                const result = await postcss(postcssPlugins).process(raw, {
+                    from: realPath,
+                    to: realPath,
+                });
+                return result.css;
             }
         },
     };


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/RTI-3287

Legacy theme CSS already handles RTL via SCSS mixins. The esbuild and Vite build configs were running these files through `postcss-rtlcss` which double-wrapped selectors (e.g. `.ag-ltr` became `:where(.ag-ltr) .ag-ltr`), breaking borders, spacing and padding in the columns tool panel and other components.