### PR TITLE
[RTI-3265] Fix(sidebar): opening columns tool panel results in empty panel

### DIFF
--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
@@ -323,6 +323,7 @@ class AgSideBar extends Component implements ISideBar, FocusableContainer {
         let wrapper: ToolPanelWrapper;
         if (existingToolPanelWrapper) {
             wrapper = existingToolPanelWrapper;
+            wrapper.setDefParent(def.parent ?? null);
         } else {
             wrapper = this.createBean(new ToolPanelWrapper());
 

--- a/packages/ag-grid-enterprise/src/sideBar/toolPanelWrapper.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/toolPanelWrapper.ts
@@ -68,6 +68,10 @@ export class ToolPanelWrapper extends Component {
         return this.defParent;
     }
 
+    public setDefParent(parent: HTMLElement | null): void {
+        this.defParent = parent;
+    }
+
     public setToolPanelDef(toolPanelDef: ToolPanelDef, params: IToolPanelParams): boolean {
         const { id, minWidth, maxWidth, width, parent } = toolPanelDef;
 


### PR DESCRIPTION
When React/Vue re-renders the sidebar with updated refs, setState reuses existing tool panel wrappers without updating their defParent. The original defParent was null (from the first render before refs were assigned), so openToolPanel couldn't find the correct external parent and the panel rendered empty inside the hidden sidebar instead of the external container.

Now updates defParent on the wrapper when reusing it during setState.

Fixes [RTI-3265](https://ag-grid.atlassian.net/browse/RTI-3265)
 
<img width="738" height="519" alt="Screenshot 2026-03-23 at 16 26 49" src="https://github.com/user-attachments/assets/ec26e9a8-3fa7-40f6-9894-0da3071b5738" />

