### PR TITLE
[RTI-3309] Fix(docs): restructure ctp deferred updates example and align csrm ssrm content

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/deferred-apply-mode/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/deferred-apply-mode/example.spec.ts
@@ -1,0 +1,11 @@
+import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+
+test.agExample(import.meta, () => {
+    test.eachFramework('Example', async ({ page }) => {
+        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+        await clickAllButtons(page);
+        // END PLACEHOLDER
+    });
+});

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/deferred-apply-mode/fakeServer.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/deferred-apply-mode/fakeServer.ts
@@ -1,0 +1,254 @@
+import type { IServerSideDatasource, IServerSideGetRowsRequest } from 'ag-grid-community';
+
+type ServerResponse = {
+    success: boolean;
+    rows: IOlympicData[];
+    lastRow: number;
+    pivotResultFields?: string[];
+};
+
+export function createServerSideDatasource(server: {
+    getData: (request: IServerSideGetRowsRequest) => ServerResponse;
+}): IServerSideDatasource {
+    return {
+        getRows: (params) => {
+            console.log('server request', {
+                rowGroups: params.request.rowGroupCols?.map((col) => col.id) ?? [],
+                groupKeys: params.request.groupKeys ?? [],
+                pivots: params.request.pivotCols?.map((col) => col.id) ?? [],
+                values: params.request.valueCols?.map((col) => `${col.id}:${col.aggFunc ?? 'sum'}`) ?? [],
+                sortModel: params.request.sortModel ?? [],
+            });
+            const response = server.getData(params.request);
+
+            setTimeout(() => {
+                if (response.success) {
+                    params.success({
+                        rowData: response.rows,
+                        rowCount: response.lastRow,
+                        pivotResultFields: response.pivotResultFields,
+                    });
+                } else {
+                    params.fail();
+                }
+            }, Math.random() * 1000);
+        },
+    };
+}
+
+export function createFakeServer(allData: IOlympicData[]) {
+    const matchesPivotKey = (row: IOlympicData, pivotColIds: string[], pivotKey: string[]) => {
+        for (let i = 0; i < pivotColIds.length; i++) {
+            if (String((row as any)[pivotColIds[i]]) !== pivotKey[i]) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    const createPivotField = (pivotKey: string[], valueColId: string) => `${pivotKey.join('_')}_${valueColId}`;
+
+    const toNumber = (value: unknown): number | null => {
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            return value;
+        }
+        if (typeof value === 'string') {
+            const parsed = Number(value);
+            return Number.isFinite(parsed) ? parsed : null;
+        }
+        return null;
+    };
+
+    const aggregateValues = (rows: IOlympicData[], field: string, aggFunc: string): number | string | null => {
+        const values = rows.map((row) => (row as any)[field]);
+
+        switch (aggFunc) {
+            case 'sum': {
+                return values.reduce((sum, value) => sum + (toNumber(value) ?? 0), 0);
+            }
+            case 'min': {
+                let min: number | null = null;
+                for (const value of values) {
+                    const num = toNumber(value);
+                    if (num == null) {
+                        continue;
+                    }
+                    min = min == null ? num : Math.min(min, num);
+                }
+                return min;
+            }
+            case 'max': {
+                let max: number | null = null;
+                for (const value of values) {
+                    const num = toNumber(value);
+                    if (num == null) {
+                        continue;
+                    }
+                    max = max == null ? num : Math.max(max, num);
+                }
+                return max;
+            }
+            case 'avg': {
+                let sum = 0;
+                let count = 0;
+                for (const value of values) {
+                    const num = toNumber(value);
+                    if (num == null) {
+                        continue;
+                    }
+                    sum += num;
+                    count++;
+                }
+                return count > 0 ? sum / count : null;
+            }
+            case 'count': {
+                return values.length;
+            }
+            case 'first': {
+                return values.length ? (values[0] as any) ?? null : null;
+            }
+            case 'last': {
+                return values.length ? (values[values.length - 1] as any) ?? null : null;
+            }
+            default:
+                return values.reduce((sum, value) => sum + (toNumber(value) ?? 0), 0);
+        }
+    };
+
+    const sortRows = (rows: IOlympicData[], sortModel: IServerSideGetRowsRequest['sortModel']) => {
+        if (!sortModel?.length) {
+            return rows;
+        }
+
+        return [...rows].sort((a: any, b: any) => {
+            for (const sort of sortModel) {
+                const left = a[sort.colId];
+                const right = b[sort.colId];
+
+                if (left === right) {
+                    continue;
+                }
+
+                const compare = left > right ? 1 : -1;
+                return sort.sort === 'asc' ? compare : -compare;
+            }
+            return 0;
+        });
+    };
+
+    const compareKeys = (left: string, right: string): number => {
+        const leftNum = toNumber(left);
+        const rightNum = toNumber(right);
+        if (leftNum != null && rightNum != null) {
+            return leftNum - rightNum;
+        }
+        return left.localeCompare(right, undefined, { numeric: true, sensitivity: 'base' });
+    };
+
+    return {
+        getData: (request: IServerSideGetRowsRequest): ServerResponse => {
+            let rows = allData;
+            const { rowGroupCols = [], pivotCols = [], groupKeys = [], valueCols = [], sortModel = [] } = request;
+
+            for (let i = 0; i < groupKeys.length; i++) {
+                const key = groupKeys[i];
+                const rowGroupCol = rowGroupCols[i];
+                if (!rowGroupCol) {
+                    continue;
+                }
+                rows = rows.filter((row) => String((row as any)[rowGroupCol.id]) === String(key));
+            }
+
+            const isGrouping = rowGroupCols.length > groupKeys.length;
+            let resultRows: IOlympicData[];
+            let pivotResultFields: string[] | undefined;
+
+            const hasPivot = pivotCols.length > 0 && valueCols.length > 0;
+            const pivotColIds = pivotCols.map((col) => col.id);
+            const pivotKeys = hasPivot
+                ? Array.from(new Set(rows.map((row) => pivotColIds.map((id) => String((row as any)[id])).join('|'))))
+                      .map((key) => key.split('|'))
+                      .sort((a, b) => {
+                          const len = Math.max(a.length, b.length);
+                          for (let i = 0; i < len; i++) {
+                              const cmp = compareKeys(a[i] ?? '', b[i] ?? '');
+                              if (cmp !== 0) {
+                                  return cmp;
+                              }
+                          }
+                          return 0;
+                      })
+                : [];
+
+            const buildPivotedRow = (targetRows: IOlympicData[], base: any = {}) => {
+                const result: any = { ...base };
+                for (const pivotKey of pivotKeys) {
+                    const matchingRows = targetRows.filter((row) => matchesPivotKey(row, pivotColIds, pivotKey));
+                    for (const valueCol of valueCols) {
+                        const field = createPivotField(pivotKey, valueCol.id);
+                        result[field] = aggregateValues(matchingRows, valueCol.id, valueCol.aggFunc!);
+                    }
+                }
+                return result as IOlympicData;
+            };
+
+            if (isGrouping) {
+                const rowGroupCol = rowGroupCols[groupKeys.length];
+                const groupField = rowGroupCol.id;
+                const grouped = new Map<string, IOlympicData[]>();
+
+                for (const row of rows) {
+                    const key = String((row as any)[groupField]);
+                    const bucket = grouped.get(key);
+                    if (bucket) {
+                        bucket.push(row);
+                    } else {
+                        grouped.set(key, [row]);
+                    }
+                }
+
+                resultRows = Array.from(grouped.entries())
+                    .sort(([leftKey, leftRows], [rightKey, rightRows]) => {
+                        if (groupField === 'country') {
+                            const countDiff = rightRows.length - leftRows.length;
+                            if (countDiff !== 0) {
+                                return countDiff;
+                            }
+                        }
+                        return compareKeys(leftKey, rightKey);
+                    })
+                    .map(([key, groupRows]) => {
+                        if (hasPivot) {
+                            return buildPivotedRow(groupRows, { [groupField]: key, childCount: groupRows.length });
+                        }
+
+                        const groupRow: any = { [groupField]: key, childCount: groupRows.length };
+                        for (const valueCol of valueCols) {
+                            groupRow[valueCol.id] = aggregateValues(groupRows, valueCol.id, valueCol.aggFunc!);
+                        }
+                        return groupRow as IOlympicData;
+                    });
+            } else {
+                resultRows = hasPivot ? [buildPivotedRow(rows)] : [...rows];
+            }
+
+            if (hasPivot) {
+                pivotResultFields = pivotKeys.flatMap((pivotKey) =>
+                    valueCols.map((valueCol) => createPivotField(pivotKey, valueCol.id))
+                );
+            }
+
+            const sortedRows = sortRows(resultRows, sortModel);
+            const start = request.startRow ?? 0;
+            const end = request.endRow ?? sortedRows.length;
+            const requestedRows = sortedRows.slice(start, end);
+
+            return {
+                success: true,
+                rows: requestedRows,
+                lastRow: sortedRows.length,
+                pivotResultFields,
+            };
+        },
+    };
+}

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/deferred-apply-mode/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/deferred-apply-mode/index.html
@@ -1,0 +1,3 @@
+<div class="example-wrapper">
+    <div id="myGrid"></div>
+</div>

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/deferred-apply-mode/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/deferred-apply-mode/main.ts
@@ -1,0 +1,110 @@
+import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
+import { ModuleRegistry, ValidationModule, createGrid } from 'ag-grid-community';
+import {
+    ColumnMenuModule,
+    ColumnsToolPanelModule,
+    ContextMenuModule,
+    PivotModule,
+    RowGroupingPanelModule,
+    ServerSideRowModelModule,
+} from 'ag-grid-enterprise';
+
+import { createFakeServer, createServerSideDatasource } from './fakeServer';
+
+ModuleRegistry.registerModules([
+    ColumnsToolPanelModule,
+    ColumnMenuModule,
+    ContextMenuModule,
+    PivotModule,
+    RowGroupingPanelModule,
+    ServerSideRowModelModule,
+    ...(process.env.NODE_ENV !== 'production' ? [ValidationModule] : []),
+]);
+
+const columnDefs: ColDef[] = [
+    {
+        field: 'athlete',
+        minWidth: 200,
+        enableRowGroup: true,
+        enablePivot: true,
+    },
+    {
+        field: 'age',
+        enableValue: true,
+    },
+    {
+        field: 'country',
+        minWidth: 200,
+        enableRowGroup: true,
+        enablePivot: true,
+        rowGroupIndex: 1,
+    },
+    {
+        field: 'year',
+        enableRowGroup: true,
+        enablePivot: true,
+    },
+    {
+        field: 'date',
+        minWidth: 180,
+        enableRowGroup: true,
+        enablePivot: true,
+    },
+    {
+        field: 'sport',
+        minWidth: 200,
+        enableRowGroup: true,
+        enablePivot: true,
+        rowGroupIndex: 2,
+    },
+    { field: 'gold', hide: true, enableValue: true },
+    { field: 'silver', hide: true, enableValue: true, aggFunc: 'sum' },
+    { field: 'bronze', hide: true, enableValue: true, aggFunc: 'sum' },
+    { headerName: 'Total', field: 'total', enableValue: true },
+];
+
+let gridApi: GridApi<IOlympicData>;
+
+const gridOptions: GridOptions<IOlympicData> = {
+    columnDefs,
+    defaultColDef: {
+        flex: 1,
+        minWidth: 150,
+    },
+    autoGroupColumnDef: {
+        minWidth: 250,
+    },
+    rowModelType: 'serverSide',
+    rowGroupPanelShow: 'always',
+    pivotPanelShow: 'always',
+    sideBar: {
+        toolPanels: [
+            {
+                id: 'columns',
+                labelDefault: 'Columns',
+                labelKey: 'columns',
+                iconKey: 'columns',
+                toolPanel: 'agColumnsToolPanel',
+                toolPanelParams: {
+                    buttons: ['cancel', 'apply'],
+                },
+            },
+        ],
+        defaultToolPanel: 'columns',
+    },
+    getChildCount: (data: any) => (typeof data?.childCount === 'number' ? data.childCount : undefined),
+};
+
+// setup the grid after the page has finished loading
+document.addEventListener('DOMContentLoaded', function () {
+    const gridDiv = document.querySelector<HTMLElement>('#myGrid')!;
+    gridApi = createGrid(gridDiv, gridOptions);
+
+    fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
+        .then((response) => response.json())
+        .then((data: IOlympicData[]) => {
+            const fakeServer = createFakeServer(data);
+            const datasource = createServerSideDatasource(fakeServer);
+            gridApi!.setGridOption('serverSideDatasource', datasource);
+        });
+});

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/deferred-apply-mode/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/deferred-apply-mode/styles.css
@@ -1,0 +1,10 @@
+.example-wrapper {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+#myGrid {
+    flex: 1 1 0px;
+    width: 100%;
+}

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/index.mdoc
@@ -218,6 +218,38 @@ In the example below, note the following:
 
 ## Batching Data Requests
 
-You can stage multiple data requests by using the Columns Tool Panel (see: [Deferred Updates](./tool-panel-columns/#deferred-updates)). This allows multiple configuration changes to be applied in a single update, avoiding unnecessary intermediate recomputations or server requests.
+You can configure the Columns Tool Panel to stage changes and require an explicit **Apply** action before they are committed. This allows multiple configuration changes to be made and applied in a single update, avoiding unnecessary intermediate recomputations or requests.
+
+Deferred Updates are enabled by including the **Apply** button in `toolPanelParams.buttons`.
+
+Note that in the example below:
+
+-   Changes made in the Columns Tool Panel are staged as pending changes.
+-   **Apply** commits all pending changes in a single operation.
+-   **Cancel** discards all pending changes and restores the last applied state.
 
 {% gridExampleRunner title="Deferred Updates" name="deferred-apply-mode"  exampleHeight=830 /%}
+
+```{% frameworkTransform=true %}
+const gridOptions = {
+    sideBar: {
+        toolPanels: [
+            {
+                id: 'columns',
+                labelDefault: 'Columns',
+                labelKey: 'columns',
+                iconKey: 'columns',
+                toolPanel: 'agColumnsToolPanel',
+                toolPanelParams: {
+                    buttons: ['cancel', 'apply'],
+                },
+            },
+        ],
+        defaultToolPanel: 'columns',
+    },
+};
+```
+
+{% note %}
+Changes made outside the Columns Tool Panel — such as dragging columns into the Row Group or Pivot Panels, using the Column Menu, or calling the Grid / Column API — are applied immediately and clear any pending changes. Column pinning, resizing, and group expansion do not clear pending changes.
+{% /note %}

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/index.mdoc
@@ -219,3 +219,5 @@ In the example below, note the following:
 ## Batching Data Requests
 
 You can stage multiple data requests by using the Columns Tool Panel (see: [Deferred Updates](./tool-panel-columns/#deferred-updates)). This allows multiple configuration changes to be applied in a single update, avoiding unnecessary intermediate recomputations or server requests.
+
+{% gridExampleRunner title="Deferred Updates" name="deferred-apply-mode"  exampleHeight=830 /%}

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/index.mdoc
@@ -212,4 +212,4 @@ The example demonstrates the following:
 
 ## Batching Data Requests
 
-You can stage multiple data requests by using the Columns Tool Panel (see: [Batching Data Requests](./server-side-model-grouping/#batching-data-requests) under SSRM Row Grouping). This allows multiple configuration changes to be applied in a single update, avoiding unnecessary intermediate recomputations or server requests.
+You can stage multiple data requests by using the Columns Tool Panel. This allows multiple configuration changes to be applied in a single update, avoiding unnecessary intermediate recomputations or server requests. See [SSRM Row Grouping — Batching Data Requests](./server-side-model-grouping/#batching-data-requests) for a detailed example.

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/index.mdoc
@@ -212,4 +212,4 @@ The example demonstrates the following:
 
 ## Batching Data Requests
 
-You can stage multiple data requests by using the Columns Tool Panel (see: [Deferred Updates](./tool-panel-columns/#deferred-updates)). This allows multiple configuration changes to be applied in a single update, avoiding unnecessary intermediate recomputations or server requests.
+You can stage multiple data requests by using the Columns Tool Panel (see: [Batching Data Requests](./server-side-model-grouping/#batching-data-requests) under SSRM Row Grouping). This allows multiple configuration changes to be applied in a single update, avoiding unnecessary intermediate recomputations or server requests.

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode-csrm/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode-csrm/example.spec.ts
@@ -1,0 +1,11 @@
+import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+
+test.agExample(import.meta, () => {
+    test.eachFramework('Example', async ({ page }) => {
+        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+        await clickAllButtons(page);
+        // END PLACEHOLDER
+    });
+});

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode-csrm/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode-csrm/index.html
@@ -1,0 +1,3 @@
+<div class="example-wrapper">
+    <div id="myGrid"></div>
+</div>

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode-csrm/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode-csrm/main.ts
@@ -1,0 +1,72 @@
+import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
+import { ClientSideRowModelModule, ModuleRegistry, ValidationModule, createGrid } from 'ag-grid-community';
+import {
+    ColumnMenuModule,
+    ColumnsToolPanelModule,
+    ContextMenuModule,
+    PivotModule,
+    RowGroupingPanelModule,
+} from 'ag-grid-enterprise';
+
+ModuleRegistry.registerModules([
+    ClientSideRowModelModule,
+    ColumnsToolPanelModule,
+    ColumnMenuModule,
+    ContextMenuModule,
+    PivotModule,
+    RowGroupingPanelModule,
+    ...(process.env.NODE_ENV !== 'production' ? [ValidationModule] : []),
+]);
+
+const columnDefs: ColDef[] = [
+    { field: 'athlete', minWidth: 200, enableRowGroup: true, enablePivot: true },
+    { field: 'age', enableValue: true },
+    { field: 'country', minWidth: 200, enableRowGroup: true, enablePivot: true, rowGroup: true },
+    { field: 'year', enableRowGroup: true, enablePivot: true },
+    { field: 'date', minWidth: 180, enableRowGroup: true, enablePivot: true },
+    { field: 'sport', minWidth: 200, enableRowGroup: true, enablePivot: true },
+    { field: 'gold', hide: true, enableValue: true },
+    { field: 'silver', hide: true, enableValue: true, aggFunc: 'sum' },
+    { field: 'bronze', hide: true, enableValue: true, aggFunc: 'sum' },
+    { headerName: 'Total', field: 'total', enableValue: true },
+];
+
+let gridApi: GridApi<IOlympicData>;
+
+const gridOptions: GridOptions<IOlympicData> = {
+    columnDefs,
+    defaultColDef: {
+        flex: 1,
+        minWidth: 150,
+    },
+    autoGroupColumnDef: {
+        minWidth: 250,
+    },
+    rowGroupPanelShow: 'always',
+    pivotPanelShow: 'always',
+    sideBar: {
+        toolPanels: [
+            {
+                id: 'columns',
+                labelDefault: 'Columns',
+                labelKey: 'columns',
+                iconKey: 'columns',
+                toolPanel: 'agColumnsToolPanel',
+                toolPanelParams: {
+                    buttons: ['cancel', 'apply'],
+                },
+            },
+        ],
+        defaultToolPanel: 'columns',
+    },
+};
+
+// setup the grid after the page has finished loading
+document.addEventListener('DOMContentLoaded', function () {
+    const gridDiv = document.querySelector<HTMLElement>('#myGrid')!;
+    gridApi = createGrid(gridDiv, gridOptions);
+
+    fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
+        .then((response) => response.json())
+        .then((data: IOlympicData[]) => gridApi!.setGridOption('rowData', data));
+});

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode-csrm/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/_examples/deferred-apply-mode-csrm/styles.css
@@ -1,0 +1,10 @@
+.example-wrapper {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+#myGrid {
+    flex: 1 1 0px;
+    width: 100%;
+}

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/index.mdoc
@@ -249,6 +249,8 @@ const gridOptions = {
 Changes made outside the Columns Tool Panel — such as dragging columns into the Row Group or Pivot Panels, using the Column Menu, or calling the Grid / Column API — are applied immediately and clear any pending changes. Column pinning, resizing, and group expansion do not clear pending changes.
 {% /note %}
 
+When using the [Server-Side Row Model](./server-side-model/), Deferred Updates can be used to batch multiple configuration changes into a single server request. See [Batching Data Requests](./server-side-model-grouping/#batching-data-requests) for an SSRM-specific example.
+
 ## Custom Column Layout
 
 The order of columns in the Columns Tool Panel is derived from the `columnDefs` supplied in the grid options, and is kept in sync with the grid when columns are moved by default. However custom column layouts can also be defined by invoking the following method on the Columns Tool Panel Instance:

--- a/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/tool-panel-columns/index.mdoc
@@ -24,44 +24,6 @@ Selecting columns means different things depending on whether the grid is in piv
 -   **Pivot Mode Off**: When pivot mode is off, selecting a column toggles the visibility of the column. A selected column is visible and an unselected column is hidden. With `allowDragFromColumnsToolPanel=true`, you can drag a column from the tool panel onto the grid and it will become visible.
 -   **Pivot Mode On**: When pivot mode is on, selecting a column will trigger the column to be either aggregated, grouped or pivoted depending on what is allowed for that column.
 
-## Deferred Updates
-
-You can configure the Columns Tool Panel to stage changes and require an explicit **Apply** action before they are committed. This allows multiple configuration changes to be made and applied in a single update, avoiding unnecessary intermediate recomputations or requests.
-
-Deferred Updates are enabled by including the **Apply** button in `toolPanelParams.buttons`.
-
-The example below uses the Server-Side Row Model. Note that in the example below:
-
--   Changes made in the Columns Tool Panel are staged as pending changes.
--   **Apply** commits all pending changes in a single operation.
--   **Cancel** discards all pending changes and restores the last applied state.
-
-{% gridExampleRunner title="Deferred Updates" name="deferred-apply-mode"  exampleHeight=830 /%}
-
-```{% frameworkTransform=true %}
-const gridOptions = {
-    sideBar: {
-        toolPanels: [
-            {
-                id: 'columns',
-                labelDefault: 'Columns',
-                labelKey: 'columns',
-                iconKey: 'columns',
-                toolPanel: 'agColumnsToolPanel',
-                toolPanelParams: {
-                    buttons: ['cancel', 'apply'],
-                },
-            },
-        ],
-        defaultToolPanel: 'columns',
-    },
-};
-```
-
-{% note %}
-Changes made outside the Columns Tool Panel — such as dragging columns into the Row Group or Pivot Panels, using the Column Menu, or calling the Grid / Column API — are applied immediately and clear any pending changes. Column pinning, resizing, and group expansion do not clear pending changes.
-{% /note %}
-
 ## Columns Tool Panel Sections
 
 The Columns Tool Panel is split into different sections as described from the top:
@@ -248,6 +210,44 @@ The example below demonstrates these methods in action. Note the following:
 -   Clicking **Collapse Competition** collapses only the 'Competition' column group using `collapseColumnGroups(['competitionGroupId'])`.
 
 {% gridExampleRunner title="Expand / Collapse Column Groups" name="expand-collapse"  exampleHeight=640 /%}
+
+## Deferred Updates
+
+You can configure the Columns Tool Panel to stage changes and require an explicit **Apply** action before they are committed. This allows multiple configuration changes to be made and applied in a single update, avoiding unnecessary intermediate recomputations or requests.
+
+Deferred Updates are enabled by including the **Apply** button in `toolPanelParams.buttons`.
+
+Note that in the example below:
+
+-   Changes made in the Columns Tool Panel are staged as pending changes.
+-   **Apply** commits all pending changes in a single operation.
+-   **Cancel** discards all pending changes and restores the last applied state.
+
+{% gridExampleRunner title="Deferred Updates" name="deferred-apply-mode-csrm"  exampleHeight=830 /%}
+
+```{% frameworkTransform=true %}
+const gridOptions = {
+    sideBar: {
+        toolPanels: [
+            {
+                id: 'columns',
+                labelDefault: 'Columns',
+                labelKey: 'columns',
+                iconKey: 'columns',
+                toolPanel: 'agColumnsToolPanel',
+                toolPanelParams: {
+                    buttons: ['cancel', 'apply'],
+                },
+            },
+        ],
+        defaultToolPanel: 'columns',
+    },
+};
+```
+
+{% note %}
+Changes made outside the Columns Tool Panel — such as dragging columns into the Row Group or Pivot Panels, using the Column Menu, or calling the Grid / Column API — are applied immediately and clear any pending changes. Column pinning, resizing, and group expansion do not clear pending changes.
+{% /note %}
 
 ## Custom Column Layout
 


### PR DESCRIPTION
- Added new CSRM example for the CTP Deferred Updates section
- Moved Deferred Updates section below Expand/Collapse Column Groups
- Removed "uses Server-Side Row Model" copy from CTP page
- Moved existing SSRM example to SSRM Row Grouping → Batching Data Requests
- Updated SSRM Pivoting → Batching Data Requests link to point to SSRM Row Grouping

Fixes [RTI-3309](https://ag-grid.atlassian.net/browse/RTI-3309)