### PR TITLE
RTI-3282-more-docs-fixes-for-group-edit

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/grouping-edit/_examples/distribute-group-value-all-agg/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grouping-edit/_examples/distribute-group-value-all-agg/main.ts
@@ -64,23 +64,23 @@ const sumOfSquaresValueSetter: GroupRowValueSetterFunc<MetricsRecord> = ({ newVa
 };
 
 /**
- * Cross-column groupRowValueSetter: editing the group row's "Bonus Rate"
+ * Cross-column groupRowValueSetter: editing the group row's "Rate %"
  * sets each leaf child's bonus to a percentage of their individual salary.
  *
- * Uses allLeafChildren to reach all descendant data rows directly,
- * since intermediate group rows don't have salary data.
+ * Uses getAggregatedChildren with recursive=true to reach all descendant
+ * leaf rows, since intermediate group rows don't have salary data.
  *
  * For example, entering 20 on the Engineering group sets each engineer's
  * bonus to 20% of their salary: Alice (salary 90) gets bonus 18,
  * Dave (salary 95) gets bonus 19, etc.
  */
-const bonusRateSetter: GroupRowValueSetterFunc<MetricsRecord> = ({ newValue, node }) => {
+const bonusRateSetter: GroupRowValueSetterFunc<MetricsRecord> = ({ newValue, node, column }) => {
     const rate = Number(newValue) / 100;
     if (!Number.isFinite(rate)) {
         return false;
     }
-    const leaves = node.allLeafChildren;
-    if (!leaves?.length) {
+    const leaves = node.getAggregatedChildren(column, true);
+    if (!leaves.length) {
         return false;
     }
     let changed = false;
@@ -107,7 +107,11 @@ const gridOptions: GridOptions<MetricsRecord> = {
         },
 
         // avg: default strategy is 'overwrite' — sets every child to the edited value
-        { field: 'bonus', aggFunc: 'avg' },
+        {
+            field: 'bonus',
+            aggFunc: 'avg',
+            valueFormatter: ({ value }) => (value != null ? Number(value).toFixed(2) : ''),
+        },
 
         // No aggFunc: the default strategy is 'overwrite', writing the edited
         // value to every child. The group cell is blank (no aggregation) but
@@ -118,7 +122,8 @@ const gridOptions: GridOptions<MetricsRecord> = {
         // reads each child's salary and writes a computed bonus.
         {
             headerName: 'Rate %',
-            valueGetter: ({ data }) => (data ? Math.round((data.bonus / data.salary) * 100) : null),
+            valueGetter: ({ data }) => (data ? (data.bonus / data.salary) * 100 : null),
+            valueFormatter: ({ value }) => (value != null ? Number(value).toFixed(2) : ''),
             aggFunc: 'avg',
             editable: false,
             groupRowEditable: true,

--- a/documentation/ag-grid-docs/src/content/docs/grouping-edit/_examples/distribute-group-value-all-agg/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grouping-edit/_examples/distribute-group-value-all-agg/main.ts
@@ -63,6 +63,29 @@ const sumOfSquaresValueSetter: GroupRowValueSetterFunc<MetricsRecord> = ({ newVa
     return changed;
 };
 
+/**
+ * Cross-column groupRowValueSetter: editing the group row's "Bonus Rate (%)"
+ * sets each child's bonus to a percentage of their individual salary.
+ *
+ * For example, entering 20 on the Engineering group sets each engineer's
+ * bonus to 20% of their salary: Alice (salary 90) gets bonus 18,
+ * Dave (salary 95) gets bonus 19, etc.
+ */
+const bonusRateSetter: GroupRowValueSetterFunc<MetricsRecord> = ({ newValue, aggregatedChildren, eventSource }) => {
+    const rate = Number(newValue) / 100;
+    if (!Number.isFinite(rate) || !aggregatedChildren.length) {
+        return false;
+    }
+    let changed = false;
+    for (const child of aggregatedChildren) {
+        const salary = child.data?.salary ?? 0;
+        if (child.setDataValue('bonus', Math.round(salary * rate), eventSource)) {
+            changed = true;
+        }
+    }
+    return changed;
+};
+
 const gridOptions: GridOptions<MetricsRecord> = {
     columnDefs: [
         { field: 'department', rowGroup: true, hide: true },
@@ -78,6 +101,22 @@ const gridOptions: GridOptions<MetricsRecord> = {
 
         // avg: overwrites every child with the edited value
         { field: 'bonus', aggFunc: 'avg' },
+
+        // No aggFunc: the default strategy is 'overwrite', writing the edited
+        // value to every child. The group cell is blank (no aggregation) but
+        // still editable via groupRowEditable.
+        { field: 'projects' },
+
+        // Cross-column custom callback: editing the group row's "Bonus Rate"
+        // reads each child's salary and writes a computed bonus.
+        {
+            headerName: 'Bonus Rate (%)',
+            valueGetter: ({ data }) => (data ? Math.round((data.bonus / data.salary) * 100) : null),
+            aggFunc: 'avg',
+            editable: false,
+            groupRowEditable: true,
+            groupRowValueSetter: bonusRateSetter,
+        },
 
         // Custom aggregation function with a custom groupRowValueSetter
         {

--- a/documentation/ag-grid-docs/src/content/docs/grouping-edit/_examples/distribute-group-value-all-agg/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grouping-edit/_examples/distribute-group-value-all-agg/main.ts
@@ -64,22 +64,29 @@ const sumOfSquaresValueSetter: GroupRowValueSetterFunc<MetricsRecord> = ({ newVa
 };
 
 /**
- * Cross-column groupRowValueSetter: editing the group row's "Bonus Rate (%)"
- * sets each child's bonus to a percentage of their individual salary.
+ * Cross-column groupRowValueSetter: editing the group row's "Bonus Rate"
+ * sets each leaf child's bonus to a percentage of their individual salary.
+ *
+ * Uses allLeafChildren to reach all descendant data rows directly,
+ * since intermediate group rows don't have salary data.
  *
  * For example, entering 20 on the Engineering group sets each engineer's
  * bonus to 20% of their salary: Alice (salary 90) gets bonus 18,
  * Dave (salary 95) gets bonus 19, etc.
  */
-const bonusRateSetter: GroupRowValueSetterFunc<MetricsRecord> = ({ newValue, aggregatedChildren, eventSource }) => {
+const bonusRateSetter: GroupRowValueSetterFunc<MetricsRecord> = ({ newValue, node }) => {
     const rate = Number(newValue) / 100;
-    if (!Number.isFinite(rate) || !aggregatedChildren.length) {
+    if (!Number.isFinite(rate)) {
+        return false;
+    }
+    const leaves = node.allLeafChildren;
+    if (!leaves?.length) {
         return false;
     }
     let changed = false;
-    for (const child of aggregatedChildren) {
+    for (const child of leaves) {
         const salary = child.data?.salary ?? 0;
-        if (child.setDataValue('bonus', Math.round(salary * rate), eventSource)) {
+        if (child.setDataValue('bonus', Math.round(salary * rate), 'data')) {
             changed = true;
         }
     }
@@ -99,7 +106,7 @@ const gridOptions: GridOptions<MetricsRecord> = {
             groupRowValueSetter: { precision: 0 },
         },
 
-        // avg: overwrites every child with the edited value
+        // avg: default strategy is 'overwrite' — sets every child to the edited value
         { field: 'bonus', aggFunc: 'avg' },
 
         // No aggFunc: the default strategy is 'overwrite', writing the edited
@@ -107,10 +114,10 @@ const gridOptions: GridOptions<MetricsRecord> = {
         // still editable via groupRowEditable.
         { field: 'projects' },
 
-        // Cross-column custom callback: editing the group row's "Bonus Rate"
+        // Cross-column custom callback: editing the group row's "Rate"
         // reads each child's salary and writes a computed bonus.
         {
-            headerName: 'Bonus Rate (%)',
+            headerName: 'Rate %',
             valueGetter: ({ data }) => (data ? Math.round((data.bonus / data.salary) * 100) : null),
             aggFunc: 'avg',
             editable: false,
@@ -120,7 +127,7 @@ const gridOptions: GridOptions<MetricsRecord> = {
 
         // Custom aggregation function with a custom groupRowValueSetter
         {
-            headerName: 'sumSq(score)',
+            headerName: 'SumSq',
             field: 'score',
             aggFunc: 'sumOfSquares',
             groupRowValueSetter: sumOfSquaresValueSetter,
@@ -128,7 +135,7 @@ const gridOptions: GridOptions<MetricsRecord> = {
     ],
     defaultColDef: {
         flex: 1,
-        minWidth: 150,
+        minWidth: 120,
         sortable: true,
         filter: true,
         resizable: true,

--- a/documentation/ag-grid-docs/src/content/docs/grouping-edit/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/grouping-edit/index.mdoc
@@ -9,9 +9,9 @@ and refreshing the grouping hierarchy after edits.
 
 ## Editing Group Row Cells
 
-In the example below, double-click any group row's `Sales` cell to edit it. The new value is
-distributed equally among the group's children, rounding to integers. When a child is itself a
-group, the cascade recurses through the full hierarchy.
+Double-click any group row's `Sales` cell to edit it. The new value is distributed equally among
+the group's children, rounding to integers. When a child is itself a group, the cascade recurses
+through the full hierarchy.
 
 {% gridExampleRunner title="Built-in Sum Distribution" name="distribute-group-value-sum" exampleHeight=540 /%}
 
@@ -159,19 +159,22 @@ Deep merging only applies when both the `defaultColDef` and the column define `g
 as plain objects. If the column defines a callback function, it replaces the default entirely.
 {% /note %}
 
-### All Aggregation Functions
+### Multiple Aggregation Functions
 
 The built-in distribution handles standard aggregation functions. The following example
-demonstrates a mix of built-in strategies and a custom aggregation function:
+demonstrates a mix of built-in strategies, non-aggregated columns, and custom callbacks:
 
 -   **Distributable columns** (`sum`, `avg`) use the automatic defaults via `groupRowEditable: true`.
     The `Salary (sum)` column overrides with `precision: 0` to show per-column configuration.
--   **Non-distributable columns** (`first`, `last`) use explicit `distribution: 'overwrite'` at
-    the top level to enable editing, which writes the new value to all children.
--   **Custom column** (`sumOfSquares`) uses a custom `groupRowValueSetter` callback that distributes
-    by computing `√(newValue / count)` per child — the correct inverse of sum-of-squares.
+-   **Non-aggregated column** (`projects`) has no `aggFunc`. The default strategy for columns without
+    aggregation is `'overwrite'` — editing the group cell writes the value to all children.
+-   **Cross-column callback** (`Bonus Rate`) uses a custom `groupRowValueSetter` that reads each
+    child's salary and computes their bonus as `salary × rate / 100`. This demonstrates editing
+    one column to affect values in another.
+-   **Custom aggregation** (`sumOfSquares`) uses a custom `groupRowValueSetter` callback that
+    distributes by computing `√(newValue / count)` per child — the correct inverse of sum-of-squares.
 
-{% gridExampleRunner title="All Aggregation Functions" name="distribute-group-value-all-agg" exampleHeight=540 /%}
+{% gridExampleRunner title="Multiple Aggregation Functions" name="distribute-group-value-all-agg" exampleHeight=540 /%}
 
 ### Per-Aggregation Strategies
 
@@ -222,26 +225,81 @@ const gridOptions = {
 }
 ```
 
+Custom aggregation functions are disabled by default. To enable editing, add an explicit entry in
+the `distribution` record — either a strategy string, an options object, or a custom callback
+function that implements the inverse of the aggregation logic:
+
+```{% frameworkTransform=true %}
+const gridOptions = {
+    defaultColDef: {
+        editable: true,
+        groupRowEditable: true,
+        groupRowValueSetter: {
+            precision: 0,
+            distribution: {
+                sum: 'percentage',
+                avg: 'increment',
+                count: 'overwrite',
+                // Custom aggFunc: provide a callback that reverses the aggregation
+                myCustomAgg: (params) => {
+                    for (const child of params.aggregatedChildren) {
+                        child.setDataValue(params.column, params.newValue, 'data');
+                    }
+                    return true;
+                },
+            },
+        },
+    },
+}
+```
+
 Aggregation functions not listed in the record fall through to the `default` fallback, then to
-the built-in defaults (see the strategy table above). Custom aggregation functions require an
-explicit entry or `default` to be editable.
+the built-in defaults (see the strategy table above).
+
+### The default Fallback
+
+When multiple custom aggregation functions share the same distribution logic, the `default`
+property avoids repeating entries for each one. It applies to any aggregation function not
+explicitly listed in the `distribution` record — including custom aggregation functions (which are
+disabled without it) and columns without an `aggFunc` (which already default to `'overwrite'` via
+built-in defaults). Non-distributable functions (`count`, `min`, `max`, `first`, `last`) are
+**not** affected by `default` and must always be listed explicitly.
+
+```{% frameworkTransform=true %}
+const gridOptions = {
+    defaultColDef: {
+        editable: true,
+        groupRowEditable: true,
+        groupRowValueSetter: {
+            precision: 0,
+            distribution: {
+                sum: 'percentage',
+                count: 'overwrite',
+            },
+            // Fallback for unlisted custom aggFuncs and no-aggFunc columns.
+            default: 'overwrite',
+        },
+    },
+}
+```
 
 ## Custom Distribution with a Callback
 
 For full control over how group-level edits cascade, assign a function to `groupRowValueSetter`.
-The callback receives a `GroupRowValueSetterParams` object and should return `true` if any child value was changed.
+The callback receives a `GroupRowValueSetterParams` object and should return `true` if any child
+value was changed.
+
+The following example demonstrates a custom function that distributes the edited total equally
+among children, rounding child values to integers (largest remainder method). The function calls
+`setDataValue` on each child, which triggers aggregation to refresh parent totals automatically.
 
 {% gridExampleRunner title="Custom Editable Group Totals" name="group-editable-totals-custom" exampleHeight=620 /%}
-
-In this example, a custom function distributes the edited total equally among children, rounding
-child values to integers (largest remainder method). The function calls `setDataValue` on each
-child, which triggers aggregation to refresh parent totals automatically.
 
 ### GroupRowValueSetterParams
 
 {% interfaceDocumentation interfaceName="GroupRowValueSetterParams" /%}
 
-### The aggregatedChildren Parameter
+### Aggregated Children
 
 The `groupRowValueSetter` callback receives an `aggregatedChildren` array containing the immediate children
 that contribute to the [Aggregation](./aggregation/) for the edited column. This array makes it easy to
@@ -267,20 +325,19 @@ See [Retrieving Aggregated Children](./aggregation/#retrieving-aggregated-childr
 
 Key points for implementing cascading edits:
 
--   Calling `rowNode.setDataValue` on each child pushes updated figures down. This triggers normal
-    aggregation to refresh parent totals. When working with large datasets or frequent edits,
-    consider using [Batch Editing](./cell-editing-batch/) to group multiple `setDataValue` calls
-    into a single transaction for better performance.
+-   Calling `rowNode.setDataValue` on each child pushes updated figures down.
 -   When a child is also a group that defines its own `groupRowValueSetter`, the cascade recurses further.
 -   Parent aggregates refresh automatically because child `data` changes re-run the column `aggFunc`,
     so editing a group row total instantly rebalances the children to reach that value.
+-   Aggregation is batched automatically — all `setDataValue` calls within a single `groupRowValueSetter`
+    invocation are processed before re-aggregation runs.
 
 {% note %}
 The `aggregatedChildren` parameter and `rowNode.getAggregatedChildren()` method are only supported
 with the Client-Side Row Model. For other row models, `aggregatedChildren` is an empty array.
 {% /note %}
 
-### Using distributeGroupValue Directly
+### Calling distributeGroupValue
 
 The built-in distribution function `distributeGroupValue` is exported from `ag-grid-enterprise`
 and can be called directly inside a custom `groupRowValueSetter` callback. This is useful when
@@ -304,7 +361,7 @@ import { distributeGroupValue } from 'ag-grid-enterprise';
 colDef.groupRowValueSetter = distributeGroupValue;
 ```
 
-### Custom Read/Write with getValue and setValue
+### Custom getValue and setValue
 
 The `getValue` and `setValue` callbacks let you override how the built-in distributor reads from
 and writes to child rows. By default, the distributor uses `node.getDataValue(column, 'value')`
@@ -346,17 +403,16 @@ distributed uniformly among the children matching that pivot column's keys.
 
 {% gridExampleRunner title="Built-in Pivot Editing" name="pivot-editable-builtin" exampleHeight=500 /%}
 
-For full control over pivot editing, use a custom `groupRowValueSetter` callback:
-
-{% gridExampleRunner title="Custom Editable Pivot Totals" name="pivot-editable-totals-custom" exampleHeight=500 /%}
-
-In this example:
+For full control over pivot editing, use a custom `groupRowValueSetter` callback.
+In the following example:
 
 -   The grid is pivoted by `product` (Electronics, Clothing, Food), grouped by `region` and `country`.
 -   Double-clicking on any pivot column cell opens the editor for the aggregated value.
 -   When editing a pivot cell (e.g., "Electronics" column on "Europe" row), the `aggregatedChildren` array
     contains only the European rows selling Electronics — not all European rows.
 -   The edit is distributed equally among just those matching children, leaving other product categories unchanged.
+
+{% gridExampleRunner title="Custom Editable Pivot Totals" name="pivot-editable-totals-custom" exampleHeight=500 /%}
 
 This behaviour ensures that edits on pivot columns affect only the data that contributes to that specific
 pivot value, making cascading edits work correctly with pivoted data.
@@ -367,27 +423,25 @@ The `groupRowEditable` and `groupRowValueSetter` features also work with [Tree D
 In tree data mode, parent nodes act as group rows — editing a parent's aggregated value
 cascades the change down to its children, just like with row grouping.
 
-{% gridExampleRunner title="Tree Data Editable" name="tree-data-editable" exampleHeight=500 /%}
+The following example shows a company's budget organised as a tree: departments contain teams, and
+teams contain employees. Editing a department's or team's budget distributes the new total equally
+among its members, rounding to integers. The cascade recurses through the full hierarchy automatically.
 
-In this example, a company's budget is organised as a tree: departments contain teams, and teams
-contain employees. Editing a department's or team's budget distributes the new total equally among
-its members, rounding to integers. The cascade recurses through the full hierarchy automatically.
+{% gridExampleRunner title="Tree Data Editable" name="tree-data-editable" exampleHeight=500 /%}
 
 ## Refreshing Groups After Editing
 
 When grouped columns are editable, setting `refreshAfterGroupEdit=true` causes the grid to update row data
-and recalculate the grouping after every committed edit.
-
-{% gridExampleRunner title="Refresh After Group Edit" name="refresh-after-group-edit" exampleHeight=600 /%}
-
-In the example above, changing the `department` or `team` causes the grid to re-evaluate the grouping and move
-the row to the correct group instantly. Double-click on a `department` or `team` cell to edit it.
-
-By default, without `refreshAfterGroupEdit` enabled, the row data updates but the grouping does not
-get updated until the next full refresh.
+and recalculate the grouping after every committed edit. Without this option, the row data updates but the
+grouping does not get updated until the next full refresh.
 
 When enabling `refreshAfterGroupEdit`, also provide `getRowId` so that the grid can track rows by
 stable IDs while rebuilding the grouping hierarchy.
+
+The following example demonstrates this behaviour. Double-click on a `department` or `team` cell to edit
+it — the grid re-evaluates the grouping and moves the row to the correct group instantly.
+
+{% gridExampleRunner title="Refresh After Group Edit" name="refresh-after-group-edit" exampleHeight=600 /%}
 
 See also [Read Only Edit](./value-setters/#read-only-edit) for configuring immutable grouped data or
 connecting the grid with a store.

--- a/documentation/ag-grid-docs/src/content/docs/grouping-edit/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/grouping-edit/index.mdoc
@@ -162,17 +162,20 @@ as plain objects. If the column defines a callback function, it replaces the def
 ### Multiple Aggregation Functions
 
 The built-in distribution handles standard aggregation functions. The following example
-demonstrates a mix of built-in strategies, non-aggregated columns, and custom callbacks:
+demonstrates a mix of built-in strategies, non-aggregated columns, and custom callbacks.
+Double-click any group row cell to edit it:
 
--   **Distributable columns** (`sum`, `avg`) use the automatic defaults via `groupRowEditable: true`.
-    The `Salary (sum)` column overrides with `precision: 0` to show per-column configuration.
--   **Non-aggregated column** (`projects`) has no `aggFunc`. The default strategy for columns without
-    aggregation is `'overwrite'` — editing the group cell writes the value to all children.
--   **Cross-column callback** (`Bonus Rate`) uses a custom `groupRowValueSetter` that reads each
-    child's salary and computes their bonus as `salary × rate / 100`. This demonstrates editing
-    one column to affect values in another.
--   **Custom aggregation** (`sumOfSquares`) uses a custom `groupRowValueSetter` callback that
-    distributes by computing `√(newValue / count)` per child — the correct inverse of sum-of-squares.
+-   **Salary** (`sum`): divides the new total equally among children, rounding to integers
+    (`precision: 0`). For example, editing a group total of 300 across 3 children produces 100 each.
+-   **Bonus** (`avg`): overwrites every child with the edited value (the default for `avg`).
+    For example, editing the group average to 15 sets all children's bonus to 15.
+-   **Projects** (no `aggFunc`): overwrites every child with the edited value (the default when
+    there is no aggregation). The group cell is blank but still editable.
+-   **Rate %** (custom callback): reads each leaf child's salary and computes their bonus as
+    `salary × rate / 100`. For example, entering 20 sets each child's bonus to 20% of their
+    individual salary. Uses `allLeafChildren` to reach all descendant data rows directly.
+-   **SumSq** (custom `sumOfSquares` aggFunc): uses a custom callback that computes
+    `√(newValue / count)` per child — the correct inverse of sum-of-squares.
 
 {% gridExampleRunner title="Multiple Aggregation Functions" name="distribute-group-value-all-agg" exampleHeight=540 /%}
 

--- a/documentation/ag-grid-docs/src/content/docs/grouping-edit/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/grouping-edit/index.mdoc
@@ -259,7 +259,7 @@ const gridOptions = {
 Aggregation functions not listed in the record fall through to the `default` fallback, then to
 the built-in defaults (see the strategy table above).
 
-### The default Fallback
+### Default Fallback
 
 When multiple custom aggregation functions share the same distribution logic, the `default`
 property avoids repeating entries for each one. It applies to any aggregation function not

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
@@ -1270,10 +1270,11 @@ export class AgGridAngular<TData = any, TColDef extends ColDef<TData> = ColDef<a
      * @agModule `RowDragModule`
      */
     @Input({ transform: booleanAttribute }) public rowDragManaged: boolean | undefined = undefined;
-    /** When `true`, managed row dragging updates grouped column values so rows can move between groups. When `false`,
-     * managed dragging only reorders rows inside their existing group.
+    /** When `true`, the grid re-evaluates the grouping hierarchy after editing a grouped column value,
+     * moving the row to the correct group instantly. Also enables managed row dragging to update
+     * grouped column values so rows can move between groups.
      * @default false
-     * @agModule `RowDragModule`
+     * @agModule `RowGroupingModule` / `TreeDataModule`
      */
     @Input({ transform: booleanAttribute }) public refreshAfterGroupEdit: boolean | undefined = undefined;
     /** Used if rowDragManaged is enabled and treeData is enabled,

--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -433,19 +433,21 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
      */
     editable?: boolean | EditableCallback<TData, TValue>;
     /**
-     * Works like `editable`, but is evaluated only for group rows. When provided, group rows use this property instead of `editable`.
-     * Set to `true` if this column is editable, otherwise `false`. Can also be a function to have different rows editable.
+     * Works like `editable`, but is evaluated only for group rows. When provided, group rows use
+     * this property instead of `editable`. Set to `true` to make group row cells editable, or use
+     * a callback to control editability per row.
      *
      * When `groupRowEditable` is defined and no explicit `groupRowValueSetter` is provided,
      * the built-in {@link distributeGroupValue | distributeGroupValue} is used automatically.
-     * Set `groupRowValueSetter: false` to disable distribution while keeping group rows editable.
      *
-     * Note: if `groupRowValueSetter` uses `distribution: false` (or `null`), the cell is
-     * treated as not editable even when `groupRowEditable` is `true`. This also applies to per-aggFunc
-     * records when the column's aggregation function maps to `false` or `null`.
+     * Columns with `groupRowEditable` or `groupRowValueSetter` do not require `field` or
+     * `valueSetter` — the group row value setter handles the edit entirely.
+     *
+     * Note: if `groupRowValueSetter` resolves to `false` or `null` (via `distribution: false`,
+     * a per-aggFunc record entry, or `groupRowValueSetter: false`), the cell is treated as not
+     * editable even when `groupRowEditable` is `true`.
      *
      * @agModule `RowGroupingEditModule`
-     *
      */
     groupRowEditable?: boolean | GroupRowEditableCallback<TData, TValue>;
     /**
@@ -453,12 +455,14 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
      *
      * - **`true`**: Uses the built-in {@link distributeGroupValue | distributeGroupValue} with default settings.
      *   Also enabled implicitly when `groupRowEditable` is defined and `groupRowValueSetter` is not set.
-     * - **`false`**: Explicitly disables group row value distribution, even if `groupRowEditable` is defined.
+     * - **`false`**: Explicitly disables group row value distribution and makes the cell not editable,
+     *   even if `groupRowEditable` is defined.
      * - **Function**: A custom callback that receives a {@link GroupRowValueSetterParams} and pushes
-     *   edits down to descendants. The grid always commits the group row value afterwards.
+     *   edits down to descendants. The column does not need `field` or `valueSetter` — the callback
+     *   handles the edit entirely.
      * - **Options object**: Uses the built-in distribution logic with a {@link GroupRowValueSetterOptions}
-     *   configuration. When `distribution` is set to `false` or `null`, the cell is treated
-     *   as not editable (overriding `groupRowEditable`).
+     *   configuration. When `distribution` resolves to `false` or `null` for the column's aggFunc,
+     *   the cell is treated as not editable (overriding `groupRowEditable`).
      *
      * Fires for every `setDataValue` call when active, regardless of `groupRowEditable`.
      *

--- a/packages/ag-grid-community/src/entities/gridOptions.ts
+++ b/packages/ag-grid-community/src/entities/gridOptions.ts
@@ -1304,10 +1304,11 @@ export interface GridOptions<TData = any> {
      */
     rowDragManaged?: boolean;
     /**
-     * When `true`, managed row dragging updates grouped column values so rows can move between groups. When `false`,
-     * managed dragging only reorders rows inside their existing group.
+     * When `true`, the grid re-evaluates the grouping hierarchy after editing a grouped column value,
+     * moving the row to the correct group instantly. Also enables managed row dragging to update
+     * grouped column values so rows can move between groups.
      * @default false
-     * @agModule `RowDragModule`
+     * @agModule `RowGroupingModule` / `TreeDataModule`
      */
     refreshAfterGroupEdit?: boolean;
     /**

--- a/packages/ag-grid-community/src/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.ts
@@ -583,7 +583,7 @@ export class ValueService extends BeanStub implements NamedBean {
         if (_missing(field) && _missing(valueSetter) && !(hasExternalFormulaData && isFormulaValue)) {
             // Group rows with groupRowValueSetter or groupRowEditable don't need field or valueSetter —
             // the groupRowValueSetter handles the edit entirely.
-            if (rowNode.group && (colDef.groupRowValueSetter || colDef.groupRowEditable != null)) {
+            if (rowNode.group && (colDef.groupRowValueSetter || colDef.groupRowEditable)) {
                 return true;
             }
             _warn(17);

--- a/packages/ag-grid-community/src/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.ts
@@ -434,7 +434,7 @@ export class ValueService extends BeanStub implements NamedBean {
             rowNode.data = {}; // enableGroupEdit allows editing group rows without data.
         }
 
-        if (!this.isSetValueSupported({ column, newValue, colDef })) {
+        if (!this.isSetValueSupported(column, rowNode, newValue, colDef)) {
             return false;
         }
 
@@ -568,12 +568,12 @@ export class ValueService extends BeanStub implements NamedBean {
         return true;
     }
 
-    private isSetValueSupported(params: {
-        column: AgColumn;
-        newValue: any;
-        colDef: ReturnType<AgColumn['getColDef']>;
-    }): boolean {
-        const { column, newValue, colDef } = params;
+    private isSetValueSupported(
+        column: AgColumn,
+        rowNode: IRowNode,
+        newValue: any,
+        colDef: ReturnType<AgColumn['getColDef']>
+    ): boolean {
         const { field, valueSetter } = colDef;
 
         const formulaSvc = this.beans.formula;
@@ -581,6 +581,11 @@ export class ValueService extends BeanStub implements NamedBean {
         const hasExternalFormulaData = !!this.formulaDataSvc?.hasDataSource();
 
         if (_missing(field) && _missing(valueSetter) && !(hasExternalFormulaData && isFormulaValue)) {
+            // Group rows with groupRowValueSetter or groupRowEditable don't need field or valueSetter —
+            // the groupRowValueSetter handles the edit entirely.
+            if (rowNode.group && (colDef.groupRowValueSetter || colDef.groupRowEditable != null)) {
+                return true;
+            }
             _warn(17);
             return false;
         }

--- a/packages/ag-grid-vue3/src/components/utils.ts
+++ b/packages/ag-grid-vue3/src/components/utils.ts
@@ -1093,10 +1093,11 @@ export interface Props<TData> {
          * @agModule `RowDragModule`
          */
     rowDragManaged?: boolean,
-    /** When `true`, managed row dragging updates grouped column values so rows can move between groups. When `false`,
-         * managed dragging only reorders rows inside their existing group.
+    /** When `true`, the grid re-evaluates the grouping hierarchy after editing a grouped column value,
+         * moving the row to the correct group instantly. Also enables managed row dragging to update
+         * grouped column values so rows can move between groups.
          * @default false
-         * @agModule `RowDragModule`
+         * @agModule `RowGroupingModule` / `TreeDataModule`
          */
     refreshAfterGroupEdit?: boolean,
     /** Used if rowDragManaged is enabled and treeData is enabled,

--- a/testing/behavioural/src/cell-editing/group-edit/group-row-editable.test.ts
+++ b/testing/behavioural/src/cell-editing/group-edit/group-row-editable.test.ts
@@ -875,3 +875,189 @@ describe('suppressDoubleClickExpand with groupRowEditable', () => {
         expect(groupNode.expanded).toBe(true);
     });
 });
+
+describe('groupRowValueSetter on columns without field or valueSetter', () => {
+    test('column with valueGetter and groupRowValueSetter (no field/valueSetter) allows group editing', async () => {
+        const groupRowValueSetterCalls: any[] = [];
+
+        const api = gridsManager.createGrid('no-field-groupRowValueSetter', {
+            columnDefs: [
+                { field: 'category', rowGroup: true, hide: true },
+                { field: 'amount', aggFunc: 'sum', editable: true },
+                {
+                    colId: 'computed',
+                    headerName: 'Computed',
+                    valueGetter: ({ data }) => (data ? data.amount * 2 : null),
+                    aggFunc: 'sum',
+                    editable: false,
+                    groupRowEditable: true,
+                    groupRowValueSetter: (params) => {
+                        groupRowValueSetterCalls.push(params);
+                        const value = Number(params.newValue);
+                        if (!Number.isFinite(value)) return false;
+                        let changed = false;
+                        for (const child of params.aggregatedChildren) {
+                            if (child.setDataValue('amount', value, 'data')) {
+                                changed = true;
+                            }
+                        }
+                        return changed;
+                    },
+                },
+            ],
+            rowData: [
+                { id: '1', category: 'A', amount: 10 },
+                { id: '2', category: 'A', amount: 20 },
+            ],
+            groupDefaultExpanded: -1,
+            getRowId: (params) => params.data.id,
+        });
+        await asyncSetTimeout(0);
+
+        const groupNode = api.getDisplayedRowAtIndex(0)!;
+        expect(groupNode.group).toBe(true);
+
+        // Edit the computed column on the group row via UI
+        await editCell(api, groupNode, 'computed', '50');
+
+        // groupRowValueSetter should have been called
+        expect(groupRowValueSetterCalls).toHaveLength(1);
+        expect(groupRowValueSetterCalls[0].newValue).toBe('50');
+
+        // Children should have been updated
+        const child1 = api.getRowNode('1')!;
+        const child2 = api.getRowNode('2')!;
+        expect(child1.data.amount).toBe(50);
+        expect(child2.data.amount).toBe(50);
+    });
+
+    test('column with valueGetter, valueSetter, and groupRowValueSetter allows group editing', async () => {
+        const valueSetterCalls: any[] = [];
+        const groupRowValueSetterCalls: any[] = [];
+
+        const api = gridsManager.createGrid('valueSetter-groupRowValueSetter', {
+            columnDefs: [
+                { field: 'category', rowGroup: true, hide: true },
+                { field: 'amount', editable: true },
+                {
+                    colId: 'computed',
+                    headerName: 'Computed',
+                    valueGetter: ({ data }) => (data ? data.amount * 2 : null),
+                    valueSetter: (params) => {
+                        valueSetterCalls.push(params);
+                        return true;
+                    },
+                    aggFunc: 'sum',
+                    editable: true,
+                    groupRowEditable: true,
+                    groupRowValueSetter: (params) => {
+                        groupRowValueSetterCalls.push(params);
+                        const value = Number(params.newValue);
+                        if (!Number.isFinite(value)) return false;
+                        let changed = false;
+                        for (const child of params.aggregatedChildren) {
+                            if (child.setDataValue('amount', value, 'data')) {
+                                changed = true;
+                            }
+                        }
+                        return changed;
+                    },
+                },
+            ],
+            rowData: [
+                { id: '1', category: 'A', amount: 10 },
+                { id: '2', category: 'A', amount: 20 },
+            ],
+            groupDefaultExpanded: -1,
+            getRowId: (params) => params.data.id,
+        });
+        await asyncSetTimeout(0);
+
+        const groupNode = api.getDisplayedRowAtIndex(0)!;
+        expect(groupNode.group).toBe(true);
+
+        // Edit the computed column on the group row
+        await editCell(api, groupNode, 'computed', '50');
+
+        // groupRowValueSetter should have been called, not valueSetter (group row)
+        expect(groupRowValueSetterCalls).toHaveLength(1);
+
+        // Children should have been updated
+        const child1 = api.getRowNode('1')!;
+        const child2 = api.getRowNode('2')!;
+        expect(child1.data.amount).toBe(50);
+        expect(child2.data.amount).toBe(50);
+
+        // Now edit a leaf row — should use valueSetter
+        valueSetterCalls.length = 0;
+        groupRowValueSetterCalls.length = 0;
+        await editCell(api, child1, 'computed', '99');
+
+        expect(valueSetterCalls).toHaveLength(1);
+        expect(groupRowValueSetterCalls).toHaveLength(0);
+    });
+
+    test('group row with null data does not call valueSetter, only groupRowValueSetter', async () => {
+        const valueSetterCalls: any[] = [];
+        const groupRowValueSetterCalls: any[] = [];
+
+        const api = gridsManager.createGrid('null-data-group', {
+            columnDefs: [
+                { field: 'category', rowGroup: true, hide: true },
+                {
+                    colId: 'amount',
+                    field: 'amount',
+                    aggFunc: 'sum',
+                    editable: true,
+                    valueSetter: (params) => {
+                        valueSetterCalls.push(params);
+                        if (params.data && params.colDef.field) {
+                            (params.data as Record<string, any>)[params.colDef.field] = params.newValue;
+                        }
+                        return true;
+                    },
+                    groupRowEditable: true,
+                    groupRowValueSetter: (params) => {
+                        groupRowValueSetterCalls.push(params);
+                        const value = Number(params.newValue);
+                        if (!Number.isFinite(value)) return false;
+                        let changed = false;
+                        for (const child of params.aggregatedChildren) {
+                            if (child.setDataValue(params.column, value, 'data')) {
+                                changed = true;
+                            }
+                        }
+                        return changed;
+                    },
+                },
+            ],
+            rowData: [
+                { id: '1', category: 'A', amount: 10 },
+                { id: '2', category: 'A', amount: 20 },
+            ],
+            groupDefaultExpanded: -1,
+            getRowId: (params) => params.data.id,
+        });
+        await asyncSetTimeout(0);
+
+        const groupNode = api.getDisplayedRowAtIndex(0)!;
+        expect(groupNode.group).toBe(true);
+        expect(groupNode.data).toBeUndefined();
+
+        // Edit the group row
+        await editCell(api, groupNode, 'amount', '50');
+
+        // groupRowValueSetter called, valueSetter NOT called for the group row
+        expect(groupRowValueSetterCalls).toHaveLength(1);
+        const groupValueSetterCallNodeIds = valueSetterCalls
+            .filter((c: any) => c.node?.group)
+            .map((c: any) => c.node.id);
+        expect(groupValueSetterCallNodeIds).toHaveLength(0);
+
+        // Children should have been updated
+        const child1 = api.getRowNode('1')!;
+        const child2 = api.getRowNode('2')!;
+        expect(child1.data.amount).toBe(50);
+        expect(child2.data.amount).toBe(50);
+    });
+});

--- a/testing/behavioural/src/cell-editing/group-edit/group-row-editable.test.ts
+++ b/testing/behavioural/src/cell-editing/group-edit/group-row-editable.test.ts
@@ -894,7 +894,9 @@ describe('groupRowValueSetter on columns without field or valueSetter', () => {
                     groupRowValueSetter: (params) => {
                         groupRowValueSetterCalls.push(params);
                         const value = Number(params.newValue);
-                        if (!Number.isFinite(value)) return false;
+                        if (!Number.isFinite(value)) {
+                            return false;
+                        }
                         let changed = false;
                         for (const child of params.aggregatedChildren) {
                             if (child.setDataValue('amount', value, 'data')) {
@@ -953,7 +955,9 @@ describe('groupRowValueSetter on columns without field or valueSetter', () => {
                     groupRowValueSetter: (params) => {
                         groupRowValueSetterCalls.push(params);
                         const value = Number(params.newValue);
-                        if (!Number.isFinite(value)) return false;
+                        if (!Number.isFinite(value)) {
+                            return false;
+                        }
                         let changed = false;
                         for (const child of params.aggregatedChildren) {
                             if (child.setDataValue('amount', value, 'data')) {
@@ -1020,7 +1024,9 @@ describe('groupRowValueSetter on columns without field or valueSetter', () => {
                     groupRowValueSetter: (params) => {
                         groupRowValueSetterCalls.push(params);
                         const value = Number(params.newValue);
-                        if (!Number.isFinite(value)) return false;
+                        if (!Number.isFinite(value)) {
+                            return false;
+                        }
                         let changed = false;
                         for (const child of params.aggregatedChildren) {
                             if (child.setDataValue(params.column, value, 'data')) {


### PR DESCRIPTION
- improves the documentation
- improves the example by providing a case of a computed column with a valueGetter where the group cell is editable
- fixes a bug where the edit was blocked if a valueGetter + rowGroupValueSetter was defined but NO valueSetter is defined in isSetValueSupported

FIX RTI-3282