### PR TITLE
RTI-3280 Fix print complex example dark mode appearance

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/printing/_examples/for-print-complex/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/printing/_examples/for-print-complex/styles.css
@@ -9,5 +9,11 @@
 @media print {
     body {
         overflow: visible;
+
+        --ag-border-color: #bbb;
+    }
+
+    * {
+        color: black !important;
     }
 }


### PR DESCRIPTION
Suppress dark mode on the print complex example and add white background with padding so the example renders correctly regardless of theme.