### PR TITLE
AG-14831 Add wrapperBackgroundColor theme param

### DIFF
--- a/community-modules/styles/src/internal/base/_base-variables.scss
+++ b/community-modules/styles/src/internal/base/_base-variables.scss
@@ -16,6 +16,8 @@
 
         --ag-background-color: #fff;
 
+        --ag-wrapper-background-color: var(--ag-background-color);
+
         --ag-header-background-color: transparent;
 
         --ag-tooltip-background-color: transparent;

--- a/community-modules/styles/src/internal/base/parts/_root.scss
+++ b/community-modules/styles/src/internal/base/parts/_root.scss
@@ -1,7 +1,7 @@
 @mixin output {
     .ag-root-wrapper,
     .ag-dnd-ghost {
-        background-color: var(--ag-background-color);
+        background-color: var(--ag-wrapper-background-color);
     }
 
     .ag-sticky-top,

--- a/documentation/ag-grid-docs/src/content/api-documentation/theming-api/properties.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/theming-api/properties.json
@@ -59,6 +59,7 @@
         "borderColor": {},
         "borderWidth": {},
         "borderRadius": {},
+        "wrapperBackgroundColor": {},
         "wrapperBorder": {},
         "wrapperBorderRadius": {},
         "columnBorder": {},

--- a/packages/ag-grid-community/src/agStack/theming/shared/css/_root.css
+++ b/packages/ag-grid-community/src/agStack/theming/shared/css/_root.css
@@ -14,7 +14,7 @@
     font-weight: var(--ag-font-weight);
     color-scheme: var(--ag-browser-color-scheme);
     color: var(--ag-text-color);
-    background-color: var(--ag-background-color);
+    background-color: var(--ag-wrapper-background-color);
 
     --ag-indentation-level: 0;
 }

--- a/packages/ag-grid-community/src/theming/core/core-css.ts
+++ b/packages/ag-grid-community/src/theming/core/core-css.ts
@@ -596,6 +596,11 @@ export interface CoreParams extends SharedThemeParams {
     valueChangeValueHighlightBackgroundColor: ColorValue;
 
     /**
+     * Background color of the outermost container around the grid.
+     */
+    wrapperBackgroundColor: ColorValue;
+
+    /**
      * Borders around the outside of the grid
      */
     wrapperBorder: BorderValue;
@@ -699,6 +704,7 @@ export const coreDefaults: Readonly<Omit<CoreParams, keyof SharedThemeParams>> =
     },
     dataBackgroundColor: backgroundColor,
     oddRowBackgroundColor: { ref: 'dataBackgroundColor' },
+    wrapperBackgroundColor: backgroundColor,
     wrapperBorderRadius: 8,
     cellHorizontalPadding: {
         calc: 'spacing * 2 * cellHorizontalPaddingScale',


### PR DESCRIPTION
Fix [AG-14831](https://ag-grid.atlassian.net/browse/AG-14831)

Add a new `wrapperBackgroundColor` theme param (`--ag-wrapper-background-color` CSS variable) so users can change the grid wrapper's visual background without affecting the mixed greys derived from `backgroundColor`