### PR TITLE
fix: floating filter input intermittently reverts typed characters (#13176)

### DIFF
--- a/packages/ag-grid-community/src/filter/floating/provided/textInputFloatingFilter.ts
+++ b/packages/ag-grid-community/src/filter/floating/provided/textInputFloatingFilter.ts
@@ -46,7 +46,7 @@ export abstract class TextInputFloatingFilter<
     protected onModelUpdated(model: M): void {
         this.setLastTypeFromModel(model);
         this.setEditable(this.canWeEditAfterModelFromParentFilter(model));
-        this.inputSvc.setValue(this.filterModelFormatter.getModelAsString(model));
+        this.inputSvc.setValue(this.filterModelFormatter.getModelAsString(model), true);
     }
 
     protected override setParams(params: TParams): void {

--- a/testing/behavioural/src/filters/floating-filters.test.ts
+++ b/testing/behavioural/src/filters/floating-filters.test.ts
@@ -1,4 +1,5 @@
-import { getByTestId } from '@testing-library/dom';
+import { getByTestId, waitFor } from '@testing-library/dom';
+import { userEvent } from '@testing-library/user-event';
 
 import {
     ClientSideRowModelModule,
@@ -124,6 +125,129 @@ describe('Floating Filters', () => {
             const textFilter = getByTestId(gridDiv, getTestId({ source: 'floating-filter', colId: 'country' }));
 
             expect(textFilter.getAttribute('placeholder')).toBe('Filter...');
+        });
+    });
+
+    describe('Text input behaviour', () => {
+        test('Floating filter input retains typed characters after model sync-back', async () => {
+            const userSession = userEvent.setup();
+
+            const api = await gridsManager.createGridAndWait('grid1', {
+                columnDefs: [
+                    {
+                        field: 'country',
+                        filter: 'agTextColumnFilter',
+                    },
+                ],
+                defaultColDef: {
+                    floatingFilter: true,
+                },
+                rowData: [
+                    { country: 'ALPHA' },
+                    { country: 'GLAM' },
+                    { country: 'GLIDE' },
+                    { country: 'GLOW' },
+                    { country: 'GLOOM' },
+                ],
+            });
+
+            const gridDiv = getGridElement(api)! as HTMLElement;
+
+            // Wait for next tick, filters are async
+            await asyncSetTimeout(0);
+
+            const filterInput = getByTestId<HTMLInputElement>(
+                gridDiv,
+                agTestIdFor.textFilterInstanceInput({ source: 'floating-filter', colId: 'country' })
+            );
+
+            // Type into the floating filter and verify input value is preserved
+            await userSession.type(filterInput, 'GLAM');
+
+            // Input should retain all typed characters, not revert mid-typing
+            expect(filterInput.value).toBe('GLAM');
+
+            // Wait for debounce to complete and filter model to apply
+            await waitFor(() => {
+                expect(api.getFilterModel()).toEqual({
+                    country: {
+                        filter: 'GLAM',
+                        filterType: 'text',
+                        type: 'contains',
+                    },
+                });
+            });
+
+            // After model sync-back, input should still show the typed value
+            expect(filterInput.value).toBe('GLAM');
+        });
+
+        test('Floating filter input value persists through rapid typing', async () => {
+            const userSession = userEvent.setup({ delay: 20 });
+
+            const api = await gridsManager.createGridAndWait('grid1', {
+                columnDefs: [
+                    {
+                        field: 'country',
+                        filter: 'agTextColumnFilter',
+                        filterParams: {
+                            debounceMs: 50,
+                        },
+                    },
+                ],
+                defaultColDef: {
+                    floatingFilter: true,
+                },
+                rowData: [
+                    { country: 'ALPHA' },
+                    { country: 'GLAM' },
+                    { country: 'GLIDE' },
+                    { country: 'GLOW' },
+                    { country: 'GLOOM' },
+                ],
+            });
+
+            const gridDiv = getGridElement(api)! as HTMLElement;
+
+            await asyncSetTimeout(0);
+
+            const filterInput = getByTestId<HTMLInputElement>(
+                gridDiv,
+                agTestIdFor.textFilterInstanceInput({ source: 'floating-filter', colId: 'country' })
+            );
+
+            // Type rapidly with short debounce to maximise chance of hitting the sync-back race
+            await userSession.type(filterInput, 'GL');
+
+            expect(filterInput.value).toBe('GL');
+
+            // Wait for debounce + model update cycle
+            await waitFor(() => {
+                expect(api.getFilterModel()).toEqual({
+                    country: {
+                        filter: 'GL',
+                        filterType: 'text',
+                        type: 'contains',
+                    },
+                });
+            });
+
+            // Continue typing after first debounce cycle
+            await userSession.type(filterInput, 'OOM');
+
+            expect(filterInput.value).toBe('GLOOM');
+
+            await waitFor(() => {
+                expect(api.getFilterModel()).toEqual({
+                    country: {
+                        filter: 'GLOOM',
+                        filterType: 'text',
+                        type: 'contains',
+                    },
+                });
+            });
+
+            expect(filterInput.value).toBe('GLOOM');
         });
     });
 });


### PR DESCRIPTION
## Summary

Addresses #13176 — floating filter text input can intermittently revert typed characters.

## Analysis

The reporter identified this as a 35.1.0 regression vs 35.0.1. After reviewing the diff between `release-35.0.1` and `release-35.1.0`, the floating filter text input code path (`textInputFloatingFilter.ts`, `simpleFloatingFilter.ts`, `floatingFilterTextInputService.ts`) is functionally unchanged between the two versions. The missing `silent=true` parameter exists in both.

The changes between versions in the filter area are: BigInt filter support, date preset ranges, `isTypeEditable` refactor (no behavioral change for text filters), `onModelAsStringChange` (enterprise set filter only), and CSS/theming performance improvements. None of these directly alter the text floating filter input path.

This suggests either the regression is caused by an indirect change (e.g. CSS relayout timing making the race more observable), or the issue is intermittent enough to have been present but unnoticed in 35.0.1.

Regardless, the fix is correct — `onModelUpdated` should pass `silent=true` to `setValue` to prevent re-triggering the debounced input listener during the model sync-back, consistent with the existing pattern used elsewhere in the same file.

## Root Cause

In `textInputFloatingFilter.ts`, the `onModelUpdated` method calls `inputSvc.setValue()` **without** the `silent=true` parameter. This allows the debounced input change listener to re-fire during the model sync-back loop:

1. User types characters → debounced `syncUpWithParentFilter` fires
2. Parent filter model updates → `onModelUpdated` called on floating filter
3. `setValue()` without `silent` triggers the input change listener again
4. Within the debounce window, this can reset the input to the stale model value

## Fix

Pass `silent=true` to `setValue` in `onModelUpdated`, consistent with the existing pattern used in `recreateFloatingFilterInputService` (line 99) and `syncUpWithParentFilter` (line 120) in the same file.

## Changes

- `packages/ag-grid-community/src/filter/floating/provided/textInputFloatingFilter.ts` — add `silent=true` to `setValue` call in `onModelUpdated`
- `testing/behavioural/src/filters/floating-filters.test.ts` — add behavioural tests for floating filter input retention during debounce cycle

## Validation

- `yarn nx build:types ag-grid-community` — pass
- `yarn nx lint ag-grid-community` — pass
- `yarn nx test ag-grid-community` — 1141 tests pass
- `./behave.sh "floating-filters"` — 8 tests pass (6 existing + 2 new)
- `yarn nx format` — clean

## CLA

I agree to the retention of intellectual property rights as described in the AG Grid CONTRIBUTING.md. All software rights for this contribution are granted to AG Grid Ltd.