### PR TITLE
Sync ag-shared: detect-base-branch improvements

### DIFF
--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = 4010a1312164ee54ebb7b9076c0a7955b4d4b47a
-	parent = d0d058059e38acc51bd4484e3861c57d6cada8b7
+	commit = 579ba2b0ad83f9f67a5fe6bd8543001a48a70d49
+	parent = 3429cdd73e00f8772bfc3ca3c1ed162b1031453f
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/prompts/skills/git-conventions/detect-base-branch.sh
+++ b/external/ag-shared/prompts/skills/git-conventions/detect-base-branch.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 
 git fetch origin --quiet
 
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+
 LATEST_MB=$(git merge-base origin/latest HEAD 2>/dev/null) || LATEST_MB=""
 if [ -n "$LATEST_MB" ]; then
   LATEST_DIST=$(git rev-list --count "$LATEST_MB..HEAD")
@@ -26,9 +28,23 @@ else
 fi
 echo "latest $LATEST_DIST"
 
+# Short circuit: if HEAD is on latest (distance 0), skip release branch scan.
+# If current branch is a release branch, it's a tie — prefer current branch.
+# Note: caller is expected to create a topic branch before opening a PR.
+if [ "$LATEST_DIST" -eq 0 ]; then
+  if [[ "$CURRENT_BRANCH" == b[0-9]* ]]; then
+    echo "BASE_BRANCH=$CURRENT_BRANCH"
+  else
+    echo "BASE_BRANCH=latest"
+  fi
+  return 0 2>/dev/null || exit 0
+fi
+
 PREV_DIST=""
 PREV_REF=""
 PARENT=""
+BEST_DIST=""
+BEST_REF=""
 
 # List all release branches sorted by version number, newest first.
 # No date cutoff — active release branches may be older than expected.
@@ -37,6 +53,19 @@ for ref in $(git branch -r --list 'origin/b[0-9]*' --sort=-version:refname \
   mb=$(git merge-base "$ref" HEAD 2>/dev/null) || continue
   count=$(git rev-list --count "$mb..HEAD")
   echo "$ref $count"
+
+  # Track closest release branch for tie-breaking at the end.
+  if [ -z "$BEST_DIST" ] || [ "$count" -lt "$BEST_DIST" ]; then
+    BEST_DIST="$count"
+    BEST_REF="$ref"
+  fi
+
+  # Short circuit: distance 0 to a release branch (latest is > 0 here).
+  if [ "$count" -eq 0 ]; then
+    PARENT="$ref"
+    echo "PARENT: $PARENT (distance 0)"
+    break
+  fi
 
   if [ -n "$PREV_DIST" ] && [ "$count" -gt "$PREV_DIST" ] && [ "$PREV_DIST" -lt "$LATEST_DIST" ]; then
     PARENT="$PREV_REF"
@@ -57,6 +86,13 @@ fi
 
 if [ -n "$PARENT" ]; then
   BASE_BRANCH="${PARENT#origin/}"
+elif [ -n "$BEST_REF" ] && [ "$BEST_DIST" -eq "$LATEST_DIST" ]; then
+  # Tie between latest and a release branch — prefer current branch.
+  if [[ "$CURRENT_BRANCH" == b[0-9]* ]]; then
+    BASE_BRANCH="$CURRENT_BRANCH"
+  else
+    BASE_BRANCH="latest"
+  fi
 else
   BASE_BRANCH="latest"
 fi


### PR DESCRIPTION
## Summary
- Fix `detect-base-branch.sh`: short-circuit when HEAD distance to latest is 0, prefer current release branch on ties, track closest release branch for better fallback logic
- Push updated ag-shared subrepo

## Cross-repo PRs
- ag-charts: https://github.com/ag-grid/ag-charts/pull/6522
- ag-studio: https://github.com/ag-grid/ag-studio/pull/1147

## Test plan
- [x] Verify ag-shared content matches across all repos
- [x] Run setup-prompts verification