### PR TITLE
AG-16980 Fix set filter popup resizer width bug

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_menu.scss
+++ b/community-modules/styles/src/internal/base/parts/_menu.scss
@@ -217,7 +217,7 @@
     }
 
     .ag-filter-menu .ag-set-filter-list {
-        min-width: 200px;
+        min-width: max(200px, 100%);
     }
 
     @include ag.keyboard-focus((ag-filter-virtual-list-item), 1px);

--- a/community-modules/styles/stylelint-config-css.js
+++ b/community-modules/styles/stylelint-config-css.js
@@ -3,6 +3,7 @@ module.exports = {
     rules: {
         'csstree/validator': {
             ignoreProperties: ['container-type'],
+            ignoreValue: /\bmax\(/,
         },
     },
 };

--- a/packages/ag-grid-community/src/filter/column-filters.css
+++ b/packages/ag-grid-community/src/filter/column-filters.css
@@ -176,7 +176,7 @@
 }
 
 :where(.ag-filter-menu) .ag-set-filter-list {
-    min-width: 200px;
+    min-width: max(200px, 100%);
 }
 
 .ag-filter-virtual-list-item:focus-visible {

--- a/testing/manual/template/vite.config.ts
+++ b/testing/manual/template/vite.config.ts
@@ -100,6 +100,7 @@ function cssFileDefaultImport(): Plugin {
         async load(id) {
             if (id.endsWith('.css?inline')) {
                 const realPath = id.slice(0, -'?inline'.length);
+                this.addWatchFile(realPath);
                 const raw = fs.readFileSync(realPath, 'utf-8');
                 const result = await postcss(postcssPlugins).process(raw, {
                     from: realPath,


### PR DESCRIPTION
FIX [AG-16980](https://ag-grid.atlassian.net/browse/AG-16980)

Prevent the set filter list in the filter menu being resized smaller than the menu's minimum width.

Also fix an issue preventing CSS files triggering hot reload in the manual testing template.