### PR TITLE
AG-3390 - Fix nx format:check --base skipping .astro,.mdoc etc

### DIFF
--- a/patches/nx+20.3.1.patch
+++ b/patches/nx+20.3.1.patch
@@ -1,3 +1,16 @@
+diff --git a/node_modules/nx/src/command-line/format/format.js b/node_modules/nx/src/command-line/format/format.js
+index af23c46..b0f7d0c 100644
+--- a/node_modules/nx/src/command-line/format/format.js
++++ b/node_modules/nx/src/command-line/format/format.js
+@@ -90,7 +90,7 @@ async function getPatterns(args) {
+             // Prettier supports ".swcrc" as a file instead of an extension
+             // So we add ".swcrc" as a supported extension manually
+             // which allows it to be considered for calculating "patterns"
+-            .concat('.swcrc'));
++            .concat('.swcrc', '.mdoc', '.astro'));
+         const patterns = p.files
+             .map((f) => path.relative(workspace_root_1.workspaceRoot, f))
+             .filter((f) => (0, fileutils_1.fileExists)(f) && supportedExtensions.has(path.extname(f)));
 diff --git a/node_modules/nx/src/tasks-runner/forked-process-task-runner.js b/node_modules/nx/src/tasks-runner/forked-process-task-runner.js
 index aa01b52..7763f2f 100644
 --- a/node_modules/nx/src/tasks-runner/forked-process-task-runner.js


### PR DESCRIPTION
From https://github.com/ag-grid/ag-charts/commit/215b227d6d8a70645f280f44f97d60bd4ef4dc21