### PR TITLE
AG-16674 Respect transaction rowCount for add/update, not just removals

### DIFF
--- a/packages/ag-grid-community/src/interfaces/serverSideTransaction.ts
+++ b/packages/ag-grid-community/src/interfaces/serverSideTransaction.ts
@@ -15,7 +15,7 @@ export interface ServerSideTransaction<TData = any> {
     remove?: TData[];
     /** Rows to update */
     update?: TData[];
-    /** Optional new total row count. Use this when a transaction deletes rows that are not currently in cache. */
+    /** Optional new total row count. Applied after the transaction to override the store's row count. */
     rowCount?: number;
 }
 

--- a/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyCache.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyCache.ts
@@ -1073,7 +1073,7 @@ export class LazyCache extends BeanStub {
     /**
      * Transaction Support here
      */
-    public updateRowNodes(updates: any[]): RowNode[] {
+    public updateRowNodes(updates: any[], newRowCount?: number): RowNode[] {
         const updatedNodes: RowNode[] = [];
         updates.forEach((data) => {
             const id = this.getRowId(data);
@@ -1083,10 +1083,17 @@ export class LazyCache extends BeanStub {
                 updatedNodes.push(lazyNode.node);
             }
         });
+
+        const isNewRowCountValid = newRowCount != null && newRowCount >= 0;
+        if (isNewRowCountValid) {
+            this.numberOfRows = newRowCount;
+            this.isLastRowKnown = true;
+        }
+
         return updatedNodes;
     }
 
-    public insertRowNodes(inserts: any[], indexToAdd?: number): RowNode[] {
+    public insertRowNodes(inserts: any[], indexToAdd?: number, newRowCount?: number): RowNode[] {
         // adjust row count to allow for footer row
         const realRowCount = this.store.getRowCount() - (this.store.getParentNode().sibling ? 1 : 0);
 
@@ -1128,8 +1135,14 @@ export class LazyCache extends BeanStub {
             });
         });
 
-        // increase the store size to accommodate
-        this.numberOfRows += numberOfInserts;
+        const isNewRowCountValid = newRowCount != null && newRowCount >= 0;
+        if (isNewRowCountValid) {
+            this.numberOfRows = newRowCount;
+            this.isLastRowKnown = true;
+        } else {
+            // increase the store size to accommodate
+            this.numberOfRows += numberOfInserts;
+        }
 
         // finally insert the new rows
         return uniqueInserts.map((data, uniqueInsertOffset) =>

--- a/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyStore.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyStore.ts
@@ -149,7 +149,7 @@ export class LazyStore extends BeanStub implements IServerSideStore {
 
         let updatedNodes: RowNode[] | undefined = undefined;
         if (transaction.update?.length) {
-            updatedNodes = this.cache.updateRowNodes(transaction.update);
+            updatedNodes = this.cache.updateRowNodes(transaction.update, transaction.rowCount);
         }
 
         let insertedNodes: RowNode[] | undefined = undefined;
@@ -158,7 +158,7 @@ export class LazyStore extends BeanStub implements IServerSideStore {
             if (addIndex != null && addIndex < 0) {
                 addIndex = undefined;
             }
-            insertedNodes = this.cache.insertRowNodes(transaction.add, addIndex);
+            insertedNodes = this.cache.insertRowNodes(transaction.add, addIndex, transaction.rowCount);
         }
 
         let removedNodes: RowNode[] | undefined = undefined;

--- a/testing/behavioural/src/row-data/server-side-row-model-transactions.test.ts
+++ b/testing/behavioural/src/row-data/server-side-row-model-transactions.test.ts
@@ -77,6 +77,65 @@ describe('Server Side Row Model Transactions', () => {
         expect(api.getDisplayedRowAtIndex(0)?.data.id).toBe(2);
     });
 
+    test('add transaction honours supplied rowCount', async () => {
+        const totalRows = 100;
+        const rowData = Array.from({ length: totalRows }, (_, i) => ({ id: i, value: `Row ${i}` }));
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide' as const,
+            getRowId: (params: any) => params.data.id.toString(),
+            serverSideDatasource: {
+                getRows: (params: any) => {
+                    const rowDataS = rowData.slice(params.request.startRow, params.request.endRow);
+                    params.success({ rowData: rowDataS, rowCount: rowData.length });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+
+        await waitForEvent('firstDataRendered', api);
+        expect(api.getDisplayedRowCount()).toBe(100);
+
+        api.applyServerSideTransaction({
+            add: [{ id: 200, value: 'Row 200' }],
+            rowCount: 150,
+        });
+
+        expect(api.getDisplayedRowCount()).toBe(150);
+    });
+
+    test('update transaction honours supplied rowCount', async () => {
+        const totalRows = 100;
+        const rowData = Array.from({ length: totalRows }, (_, i) => ({ id: i, value: `Row ${i}` }));
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide' as const,
+            getRowId: (params: any) => params.data.id.toString(),
+            serverSideDatasource: {
+                getRows: (params: any) => {
+                    const rowDataS = rowData.slice(params.request.startRow, params.request.endRow);
+                    params.success({ rowData: rowDataS, rowCount: rowData.length });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+
+        await waitForEvent('firstDataRendered', api);
+        expect(api.getDisplayedRowCount()).toBe(100);
+
+        api.applyServerSideTransaction({
+            update: [{ id: 0, value: 'Updated Row 0' }],
+            rowCount: 200,
+        });
+
+        expect(api.getDisplayedRowCount()).toBe(200);
+        expect(api.getDisplayedRowAtIndex(0)?.data.value).toBe('Updated Row 0');
+    });
+
     test('removing cached and uncached rows marks non-contiguous rows for refresh', async () => {
         const totalRows = 300;
         const rowData = Array.from({ length: totalRows }, (_, i) => ({ id: i, value: `Row ${i}` }));


### PR DESCRIPTION
 
- Extend `ServerSideTransaction.rowCount` support to add and update transactions (previously only applied during removals)
- When `rowCount` is provided on an add-only or update-only transaction, the store's row count is now overridden via the existing `setRowCount` method
- Added behavioural tests for both add and update transactions honouring supplied`rowCount` 

Fix [AG-16674](https://ag-grid.atlassian.net/browse/AG-16674)