### PR TITLE
AG-9654 Support reactive pivotComparator

### DIFF
--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
@@ -165,7 +165,9 @@ import type {
     PasteStartEvent,
     PinnedRowDataChangedEvent,
     PinnedRowsChangedEvent,
+    PivotColumnGroupTotals,
     PivotMaxColumnsExceededEvent,
+    PivotRowTotals,
     PostProcessPopup,
     PostSortRows,
     ProcessCellForClipboard,
@@ -1144,11 +1146,11 @@ export class AgGridAngular<TData = any, TColDef extends ColDef<TData> = ColDef<a
     /** When set and the grid is in pivot mode, automatically calculated totals will appear within the Pivot Column Groups, in the position specified.
      * @agModule `PivotModule`
      */
-    @Input() public pivotColumnGroupTotals: 'before' | 'after' | undefined = undefined;
+    @Input() public pivotColumnGroupTotals: PivotColumnGroupTotals | undefined = undefined;
     /** When set and the grid is in pivot mode, automatically calculated totals will appear for each value column in the position specified.
      * @agModule `PivotModule`
      */
-    @Input() public pivotRowTotals: 'before' | 'after' | undefined = undefined;
+    @Input() public pivotRowTotals: PivotRowTotals | undefined = undefined;
     /** If `true`, the grid will not swap in the grouping column when pivoting. Useful if pivoting using Server Side Row Model or Viewport Row Model and you want full control of all columns including the group column.
      * @default false
      * @initial

--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
@@ -626,7 +626,7 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
                 this.doFilter(changedPath);
             case 'pivot':
                 // Pivot may signal that columns changed, requiring full traversal for subsequent stages.
-                if (this.doPivot(changedPath)) {
+                if (this.doPivot(changedPath, params.changedProps)) {
                     changedPath = undefined;
                     params.changedPath = undefined;
                 }
@@ -1008,8 +1008,8 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
     }
 
     /** Returns `true` if pivot columns changed and changedPath should be deactivated. */
-    private doPivot(changedPath: ChangedPath | undefined): boolean {
-        return this.beans.pivotStage?.execute(changedPath) ?? false;
+    private doPivot(changedPath: ChangedPath | undefined, changedProps: Set<keyof GridOptions> | undefined): boolean {
+        return this.beans.pivotStage?.execute(changedPath, changedProps) ?? false;
     }
 
     public getRowNode(id: string): RowNode | undefined {

--- a/packages/ag-grid-community/src/entities/gridOptions.ts
+++ b/packages/ag-grid-community/src/entities/gridOptions.ts
@@ -1144,12 +1144,12 @@ export interface GridOptions<TData = any> {
      * When set and the grid is in pivot mode, automatically calculated totals will appear within the Pivot Column Groups, in the position specified.
      * @agModule `PivotModule`
      */
-    pivotColumnGroupTotals?: 'before' | 'after';
+    pivotColumnGroupTotals?: PivotColumnGroupTotals;
     /**
      * When set and the grid is in pivot mode, automatically calculated totals will appear for each value column in the position specified.
      * @agModule `PivotModule`
      */
-    pivotRowTotals?: 'before' | 'after';
+    pivotRowTotals?: PivotRowTotals;
     /**
      * If `true`, the grid will not swap in the grouping column when pivoting. Useful if pivoting using Server Side Row Model or Viewport Row Model and you want full control of all columns including the group column.
      * @default false
@@ -3281,3 +3281,6 @@ export type AgPublicEventHandlerType = `on${Capitalize<AgPublicEventType>}` & ke
 
 export type ProcessPivotResultColDef<TData = any, TValue = any> = (colDef: ColDef<TData, TValue>) => void;
 export type ProcessPivotResultColGroupDef<TData = any> = (colDef: ColGroupDef<TData>) => void;
+
+export type PivotColumnGroupTotals = 'before' | 'after';
+export type PivotRowTotals = 'before' | 'after';

--- a/packages/ag-grid-community/src/interfaces/iRowNodeStage.ts
+++ b/packages/ag-grid-community/src/interfaces/iRowNodeStage.ts
@@ -20,7 +20,7 @@ export interface IRowNodeFilterStage<TData = any> extends IRowNodeStage<TData> {
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface IRowNodePivotStage<TData = any> extends IRowNodeStage<TData> {
     /** Returns `true` if the changedPath should be deactivated (e.g. pivot columns changed). */
-    execute(changedPath: ChangedPath | undefined): boolean;
+    execute(changedPath: ChangedPath | undefined, changedProps: Set<keyof GridOptions> | undefined): boolean;
 }
 
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */

--- a/packages/ag-grid-community/src/main.ts
+++ b/packages/ag-grid-community/src/main.ts
@@ -769,6 +769,8 @@ export type {
     LocaleText,
     MasterSelectionMode,
     MultiRowSelectionOptions,
+    PivotColumnGroupTotals,
+    PivotRowTotals,
     ProcessPivotResultColDef,
     ProcessPivotResultColGroupDef,
     RangeHandleOptions,

--- a/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
@@ -120,10 +120,10 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
         this.groupColumnsHashLastTime = groupColumnsHash;
 
         const pivotColumns = pivotColsSvc?.columns ?? [];
-        const anyComparators =
+        const shouldTrackPivotOrder =
             gos.get('enableStrictPivotColumnOrder') && pivotColumns.some((col) => col.getColDef().pivotComparator);
-        const pivotOrder = anyComparators ? computePivotOrder(this.uniqueValues, pivotColumns, 0) : [];
-        const pivotComparatorsChanged = !_areEqual(pivotOrder, this.pivotOrderLastTime);
+        const pivotOrder = shouldTrackPivotOrder ? computePivotOrder(this.uniqueValues, pivotColumns, 0) : [];
+        const pivotOrderChanged = !_areEqual(pivotOrder, this.pivotOrderLastTime);
         this.pivotOrderLastTime = pivotOrder;
 
         const anyGridOptionsChanged = this.refreshProps.some((p) => changedProps?.has(p));
@@ -134,7 +134,7 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
             aggregationColumnsChanged ||
             groupColumnsChanged ||
             aggregationFuncsChanged ||
-            pivotComparatorsChanged ||
+            pivotOrderChanged ||
             anyGridOptionsChanged
         ) {
             const pivotColumnGroupDefs = this.pivotColDefSvc.createPivotColumnDefs(this.uniqueValues);

--- a/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
@@ -3,13 +3,10 @@ import type {
     BeanCollection,
     ChangedPath,
     ClientSideRowModelStage,
-    ColumnModel,
     GridOptions,
-    IColsService,
     IPivotResultColsService,
     NamedBean,
     RowNode,
-    ValueService,
     _IRowNodePivotStage,
 } from 'ag-grid-community';
 import { BeanStub, _forEachChangedGroupDepthFirst, _jsonEquals, _missing } from 'ag-grid-community';
@@ -28,7 +25,7 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
     beanName = 'pivotStage' as const;
 
     public readonly step: ClientSideRowModelStage = 'pivot';
-    public readonly refreshProps: (keyof GridOptions<any>)[] = [
+    public readonly refreshProps: (keyof GridOptions)[] = [
         'removePivotHeaderRowWhenSingleValueColumn',
         'pivotRowTotals',
         'pivotColumnGroupTotals',
@@ -36,21 +33,11 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
         'enableStrictPivotColumnOrder',
     ];
 
-    private valueSvc: ValueService;
-    private colModel: ColumnModel;
     private pivotResultCols: IPivotResultColsService;
-    private rowGroupColsSvc?: IColsService;
-    private valueColsSvc?: IColsService;
-    private pivotColsSvc?: IColsService;
     private pivotColDefSvc: PivotColDefService;
 
     public wireBeans(beans: BeanCollection) {
-        this.valueSvc = beans.valueSvc;
-        this.colModel = beans.colModel;
         this.pivotResultCols = beans.pivotResultCols!;
-        this.rowGroupColsSvc = beans.rowGroupColsSvc;
-        this.valueColsSvc = beans.valueColsSvc;
-        this.pivotColsSvc = beans.pivotColsSvc;
         this.pivotColDefSvc = beans.pivotColDefSvc as PivotColDefService;
     }
 
@@ -58,15 +45,11 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
 
     private aggregationColumnsHashLastTime: string | null;
     private aggregationFuncsHashLastTime: string;
-    private enableStrictPivotColumnOrderLastTime: GridOptions['enableStrictPivotColumnOrder'];
     private pivotComparatorsHashLastTime: string = '';
 
     private groupColumnsHashLastTime: string | null;
 
-    private pivotRowTotalsLastTime: GridOptions['pivotRowTotals'];
-    private pivotColumnGroupTotalsLastTime: GridOptions['pivotColumnGroupTotals'];
-    private suppressExpandablePivotGroupsLastTime: GridOptions['suppressExpandablePivotGroups'];
-    private removePivotHeaderRowWhenSingleValueColumnLastTime: GridOptions['removePivotHeaderRowWhenSingleValueColumn'];
+    private gridOptionsHashLastTime: string = '';
 
     private lastTimeFailed = false;
 
@@ -74,7 +57,7 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
 
     /** Returns `true` if the changedPath should be deactivated (e.g. pivot columns changed). */
     public execute(changedPath: ChangedPath | undefined): boolean {
-        if (this.colModel.isPivotActive()) {
+        if (this.beans.colModel.isPivotActive()) {
             return this.executePivotOn(changedPath);
         } else {
             return this.executePivotOff();
@@ -93,7 +76,7 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
     }
 
     private executePivotOn(changedPath: ChangedPath | undefined): boolean {
-        const { valueColsSvc, gos } = this;
+        const { valueColsSvc, gos, rowGroupColsSvc, pivotColsSvc } = this.beans;
         const numberOfAggregationColumns = valueColsSvc?.columns.length ?? 1;
 
         // As unique values creates one column per aggregation column, divide max columns by number of aggregation columns
@@ -131,34 +114,28 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
         this.aggregationColumnsHashLastTime = aggregationColumnsHash;
         this.aggregationFuncsHashLastTime = aggregationFuncsHash;
 
-        const groupColumnsHash = (this.rowGroupColsSvc?.columns ?? []).map((column) => column.getId()).join('#');
+        const groupColumnsHash = (rowGroupColsSvc?.columns ?? []).map((column) => column.getId()).join('#');
         const groupColumnsChanged = groupColumnsHash !== this.groupColumnsHashLastTime;
         this.groupColumnsHashLastTime = groupColumnsHash;
 
-        const pivotComparatorsHash = (this.pivotColsSvc?.columns ?? [])
+        const pivotComparatorsHash = (pivotColsSvc?.columns ?? [])
             .map((column) => `${column.getId()}-${column.getColDef().pivotComparator?.toString() ?? ''}`)
             .join('#');
         const pivotComparatorsChanged = pivotComparatorsHash !== this.pivotComparatorsHashLastTime;
         this.pivotComparatorsHashLastTime = pivotComparatorsHash;
 
-        const pivotRowTotals = gos.get('pivotRowTotals');
-        const pivotColumnGroupTotals = gos.get('pivotColumnGroupTotals');
-        const suppressExpandablePivotGroups = gos.get('suppressExpandablePivotGroups');
-        const removePivotHeaderRowWhenSingleValueColumn = gos.get('removePivotHeaderRowWhenSingleValueColumn');
-        const enableStrictPivotColumnOrder = gos.get('enableStrictPivotColumnOrder');
-
-        const anyGridOptionsChanged =
-            pivotRowTotals !== this.pivotRowTotalsLastTime ||
-            pivotColumnGroupTotals !== this.pivotColumnGroupTotalsLastTime ||
-            suppressExpandablePivotGroups !== this.suppressExpandablePivotGroupsLastTime ||
-            removePivotHeaderRowWhenSingleValueColumn !== this.removePivotHeaderRowWhenSingleValueColumnLastTime ||
-            enableStrictPivotColumnOrder !== this.enableStrictPivotColumnOrderLastTime;
-
-        this.pivotRowTotalsLastTime = pivotRowTotals;
-        this.pivotColumnGroupTotalsLastTime = pivotColumnGroupTotals;
-        this.suppressExpandablePivotGroupsLastTime = suppressExpandablePivotGroups;
-        this.removePivotHeaderRowWhenSingleValueColumnLastTime = removePivotHeaderRowWhenSingleValueColumn;
-        this.enableStrictPivotColumnOrderLastTime = enableStrictPivotColumnOrder;
+        const gridOptionsHash =
+            gos.get('pivotRowTotals') +
+            '-' +
+            gos.get('pivotColumnGroupTotals') +
+            '-' +
+            gos.get('suppressExpandablePivotGroups') +
+            '-' +
+            gos.get('removePivotHeaderRowWhenSingleValueColumn') +
+            '-' +
+            gos.get('enableStrictPivotColumnOrder');
+        const anyGridOptionsChanged = gridOptionsHash !== this.gridOptionsHashLastTime;
+        this.gridOptionsHashLastTime = gridOptionsHash;
 
         if (
             this.lastTimeFailed ||
@@ -193,21 +170,17 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
 
     private currentUniqueCount = 0;
     private bucketUpRowNodes(changedPath: ChangedPath | undefined): Map<string, any> {
+        const rowModel = this.beans.rowModel;
         this.currentUniqueCount = 0;
         // accessed from inside inner function
         const uniqueValues: Map<string, any> = new Map();
 
         // ensure childrenMapped is cleared, as if a node has been filtered out it should not have mapped children.
-        _forEachChangedGroupDepthFirst(
-            this.beans.rowModel.rootNode,
-            this.beans.rowModel.hierarchical,
-            changedPath,
-            (node) => {
-                if (node.leafGroup) {
-                    node.childrenMapped = null;
-                }
+        _forEachChangedGroupDepthFirst(rowModel.rootNode, rowModel.hierarchical, changedPath, (node) => {
+            if (node.leafGroup) {
+                node.childrenMapped = null;
             }
-        );
+        });
 
         const recursivelyBucketFilteredChildren = (node: RowNode) => {
             if (node.leafGroup) {
@@ -222,13 +195,13 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
             }
         };
 
-        recursivelyBucketFilteredChildren(this.beans.rowModel.rootNode!);
+        recursivelyBucketFilteredChildren(rowModel.rootNode!);
 
         return uniqueValues;
     }
 
     private bucketRowNode(rowNode: RowNode, uniqueValues: Map<string, any>): void {
-        const pivotColumns = this.pivotColsSvc?.columns;
+        const pivotColumns = this.beans.pivotColsSvc?.columns;
 
         if (pivotColumns?.length === 0) {
             rowNode.childrenMapped = null;
@@ -256,7 +229,7 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
         // map the children out based on the pivot column
         for (let i = 0, len = children.length; i < len; ++i) {
             const child = children[i];
-            let key: string | null | undefined = this.valueSvc.getKeyForNode(pivotColumn, child);
+            let key: string | null | undefined = this.beans.valueSvc.getKeyForNode(pivotColumn, child);
 
             if (_missing(key)) {
                 key = '';

--- a/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
@@ -9,7 +9,7 @@ import type {
     RowNode,
     _IRowNodePivotStage,
 } from 'ag-grid-community';
-import { BeanStub, _forEachChangedGroupDepthFirst, _jsonEquals, _missing } from 'ag-grid-community';
+import { BeanStub, _areEqual, _forEachChangedGroupDepthFirst, _jsonEquals, _missing } from 'ag-grid-community';
 
 import type { PivotColDefService } from './pivotColDefService';
 
@@ -45,7 +45,7 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
 
     private aggregationColumnsHashLastTime: string | null;
     private aggregationFuncsHashLastTime: string;
-    private pivotComparatorsHashLastTime: string = '';
+    private pivotOrderLastTime: string[] = [];
 
     private groupColumnsHashLastTime: string | null;
 
@@ -66,7 +66,7 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
 
     private executePivotOff(): boolean {
         this.aggregationColumnsHashLastTime = null;
-        this.pivotComparatorsHashLastTime = '';
+        this.pivotOrderLastTime = [];
         this.uniqueValues = new Map();
         if (this.pivotResultCols.isPivotResultColsPresent()) {
             this.pivotResultCols.setPivotResultCols(null, 'rowModelUpdated');
@@ -118,11 +118,12 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
         const groupColumnsChanged = groupColumnsHash !== this.groupColumnsHashLastTime;
         this.groupColumnsHashLastTime = groupColumnsHash;
 
-        const pivotComparatorsHash = (pivotColsSvc?.columns ?? [])
-            .map((column) => `${column.getId()}-${column.getColDef().pivotComparator?.toString() ?? ''}`)
-            .join('#');
-        const pivotComparatorsChanged = pivotComparatorsHash !== this.pivotComparatorsHashLastTime;
-        this.pivotComparatorsHashLastTime = pivotComparatorsHash;
+        const pivotColumns = pivotColsSvc?.columns ?? [];
+        const anyComparators =
+            gos.get('enableStrictPivotColumnOrder') && pivotColumns.some((col) => col.getColDef().pivotComparator);
+        const pivotOrder = anyComparators ? computePivotOrder(this.uniqueValues, pivotColumns, 0) : [];
+        const pivotComparatorsChanged = !_areEqual(pivotOrder, this.pivotOrderLastTime);
+        this.pivotOrderLastTime = pivotOrder;
 
         const gridOptionsHash =
             gos.get('pivotRowTotals') +
@@ -268,4 +269,21 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
 
         return result;
     }
+}
+
+/**
+ * Returns a flat depth-first array of pivot value keys sorted at each level by their column's pivotComparator.
+ * Used to detect when a comparator's output changes (e.g. due to closure mutation) without relying on
+ * function reference or source equality.
+ */
+function computePivotOrder(values: Map<string, any>, pivotColumns: AgColumn[], depth: number): string[] {
+    const comparator = pivotColumns[depth]?.getColDef().pivotComparator;
+    const keys = [...values.keys()];
+    if (comparator) {
+        keys.sort(comparator);
+    }
+    if (depth === pivotColumns.length - 1) {
+        return keys;
+    }
+    return keys.flatMap((key) => [key, ...computePivotOrder(values.get(key), pivotColumns, depth + 1)]);
 }

--- a/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
@@ -33,6 +33,7 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
         'pivotRowTotals',
         'pivotColumnGroupTotals',
         'suppressExpandablePivotGroups',
+        'enableStrictPivotColumnOrder',
     ];
 
     private valueSvc: ValueService;
@@ -57,6 +58,8 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
 
     private aggregationColumnsHashLastTime: string | null;
     private aggregationFuncsHashLastTime: string;
+    private enableStrictPivotColumnOrderLastTime: GridOptions['enableStrictPivotColumnOrder'];
+    private pivotComparatorsHashLastTime: string = '';
 
     private groupColumnsHashLastTime: string | null;
 
@@ -80,6 +83,7 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
 
     private executePivotOff(): boolean {
         this.aggregationColumnsHashLastTime = null;
+        this.pivotComparatorsHashLastTime = '';
         this.uniqueValues = new Map();
         if (this.pivotResultCols.isPivotResultColsPresent()) {
             this.pivotResultCols.setPivotResultCols(null, 'rowModelUpdated');
@@ -89,11 +93,12 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
     }
 
     private executePivotOn(changedPath: ChangedPath | undefined): boolean {
-        const numberOfAggregationColumns = this.valueColsSvc?.columns.length ?? 1;
+        const { valueColsSvc, gos } = this;
+        const numberOfAggregationColumns = valueColsSvc?.columns.length ?? 1;
 
         // As unique values creates one column per aggregation column, divide max columns by number of aggregation columns
         // to get the max number of unique values.
-        const configuredMaxCols = this.gos.get('pivotMaxGeneratedColumns');
+        const configuredMaxCols = gos.get('pivotMaxGeneratedColumns');
         this.maxUniqueValues = configuredMaxCols === -1 ? -1 : configuredMaxCols / numberOfAggregationColumns;
         let uniqueValues: Map<string, any>;
         try {
@@ -115,7 +120,7 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
 
         const uniqueValuesChanged = this.setUniqueValues(uniqueValues);
 
-        const aggregationColumns = this.valueColsSvc?.columns ?? [];
+        const aggregationColumns = valueColsSvc?.columns ?? [];
         const aggregationColumnsHash = aggregationColumns
             .map((column) => `${column.getId()}-${column.getColDef().headerName}`)
             .join('#');
@@ -130,21 +135,30 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
         const groupColumnsChanged = groupColumnsHash !== this.groupColumnsHashLastTime;
         this.groupColumnsHashLastTime = groupColumnsHash;
 
-        const pivotRowTotals = this.gos.get('pivotRowTotals');
-        const pivotColumnGroupTotals = this.gos.get('pivotColumnGroupTotals');
-        const suppressExpandablePivotGroups = this.gos.get('suppressExpandablePivotGroups');
-        const removePivotHeaderRowWhenSingleValueColumn = this.gos.get('removePivotHeaderRowWhenSingleValueColumn');
+        const pivotComparatorsHash = (this.pivotColsSvc?.columns ?? [])
+            .map((column) => `${column.getId()}-${column.getColDef().pivotComparator?.toString() ?? ''}`)
+            .join('#');
+        const pivotComparatorsChanged = pivotComparatorsHash !== this.pivotComparatorsHashLastTime;
+        this.pivotComparatorsHashLastTime = pivotComparatorsHash;
+
+        const pivotRowTotals = gos.get('pivotRowTotals');
+        const pivotColumnGroupTotals = gos.get('pivotColumnGroupTotals');
+        const suppressExpandablePivotGroups = gos.get('suppressExpandablePivotGroups');
+        const removePivotHeaderRowWhenSingleValueColumn = gos.get('removePivotHeaderRowWhenSingleValueColumn');
+        const enableStrictPivotColumnOrder = gos.get('enableStrictPivotColumnOrder');
 
         const anyGridOptionsChanged =
             pivotRowTotals !== this.pivotRowTotalsLastTime ||
             pivotColumnGroupTotals !== this.pivotColumnGroupTotalsLastTime ||
             suppressExpandablePivotGroups !== this.suppressExpandablePivotGroupsLastTime ||
-            removePivotHeaderRowWhenSingleValueColumn !== this.removePivotHeaderRowWhenSingleValueColumnLastTime;
+            removePivotHeaderRowWhenSingleValueColumn !== this.removePivotHeaderRowWhenSingleValueColumnLastTime ||
+            enableStrictPivotColumnOrder !== this.enableStrictPivotColumnOrderLastTime;
 
         this.pivotRowTotalsLastTime = pivotRowTotals;
         this.pivotColumnGroupTotalsLastTime = pivotColumnGroupTotals;
         this.suppressExpandablePivotGroupsLastTime = suppressExpandablePivotGroups;
         this.removePivotHeaderRowWhenSingleValueColumnLastTime = removePivotHeaderRowWhenSingleValueColumn;
+        this.enableStrictPivotColumnOrderLastTime = enableStrictPivotColumnOrder;
 
         if (
             this.lastTimeFailed ||
@@ -152,6 +166,7 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
             aggregationColumnsChanged ||
             groupColumnsChanged ||
             aggregationFuncsChanged ||
+            pivotComparatorsChanged ||
             anyGridOptionsChanged
         ) {
             const pivotColumnGroupDefs = this.pivotColDefSvc.createPivotColumnDefs(this.uniqueValues);

--- a/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
@@ -275,12 +275,18 @@ function computePivotOrder(values: Map<string, any>, pivotColumns: AgColumn[], d
     if (depth === pivotColumns.length - 1) {
         return keys;
     }
-    return keys.flatMap((key) => {
+    const result: string[] = [];
+    for (let i = 0; i < keys.length; i++) {
+        const key = keys[i];
+        result.push(key);
         const child = values.get(key);
         // child is a nested Map at non-leaf levels; if absent (sparse map), skip its subtree.
-        if (!(child instanceof Map)) {
-            return [key];
+        if (child instanceof Map) {
+            const childKeys = computePivotOrder(child, pivotColumns, depth + 1);
+            for (let j = 0; j < childKeys.length; j++) {
+                result.push(childKeys[j]);
+            }
         }
-        return [key, ...computePivotOrder(child, pivotColumns, depth + 1)];
-    });
+    }
+    return result;
 }

--- a/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
@@ -49,16 +49,14 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
 
     private groupColumnsHashLastTime: string | null;
 
-    private gridOptionsHashLastTime: string = '';
-
     private lastTimeFailed = false;
 
     private maxUniqueValues: number = -1;
 
     /** Returns `true` if the changedPath should be deactivated (e.g. pivot columns changed). */
-    public execute(changedPath: ChangedPath | undefined): boolean {
+    public execute(changedPath: ChangedPath | undefined, changedProps: Set<keyof GridOptions> | undefined): boolean {
         if (this.beans.colModel.isPivotActive()) {
-            return this.executePivotOn(changedPath);
+            return this.executePivotOn(changedPath, changedProps);
         } else {
             return this.executePivotOff();
         }
@@ -75,7 +73,10 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
         return false;
     }
 
-    private executePivotOn(changedPath: ChangedPath | undefined): boolean {
+    private executePivotOn(
+        changedPath: ChangedPath | undefined,
+        changedProps: Set<keyof GridOptions> | undefined
+    ): boolean {
         const { valueColsSvc, gos, rowGroupColsSvc, pivotColsSvc } = this.beans;
         const numberOfAggregationColumns = valueColsSvc?.columns.length ?? 1;
 
@@ -125,18 +126,7 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
         const pivotComparatorsChanged = !_areEqual(pivotOrder, this.pivotOrderLastTime);
         this.pivotOrderLastTime = pivotOrder;
 
-        const gridOptionsHash =
-            gos.get('pivotRowTotals') +
-            '-' +
-            gos.get('pivotColumnGroupTotals') +
-            '-' +
-            gos.get('suppressExpandablePivotGroups') +
-            '-' +
-            gos.get('removePivotHeaderRowWhenSingleValueColumn') +
-            '-' +
-            gos.get('enableStrictPivotColumnOrder');
-        const anyGridOptionsChanged = gridOptionsHash !== this.gridOptionsHashLastTime;
-        this.gridOptionsHashLastTime = gridOptionsHash;
+        const anyGridOptionsChanged = this.refreshProps.some((p) => changedProps?.has(p));
 
         if (
             this.lastTimeFailed ||
@@ -285,5 +275,12 @@ function computePivotOrder(values: Map<string, any>, pivotColumns: AgColumn[], d
     if (depth === pivotColumns.length - 1) {
         return keys;
     }
-    return keys.flatMap((key) => [key, ...computePivotOrder(values.get(key), pivotColumns, depth + 1)]);
+    return keys.flatMap((key) => {
+        const child = values.get(key);
+        // child is a nested Map at non-leaf levels; if absent (sparse map), skip its subtree.
+        if (!(child instanceof Map)) {
+            return [key];
+        }
+        return [key, ...computePivotOrder(child, pivotColumns, depth + 1)];
+    });
 }

--- a/packages/ag-grid-vue3/src/components/utils.ts
+++ b/packages/ag-grid-vue3/src/components/utils.ts
@@ -75,6 +75,8 @@ import type {
     OverlaySelectorFunc,
     OverlayType,
     PaginationNumberFormatter,
+    PivotColumnGroupTotals,
+    PivotRowTotals,
     PostProcessPopup,
     PostSortRows,
     ProcessCellForClipboard,
@@ -968,11 +970,11 @@ export interface Props<TData> {
     /** When set and the grid is in pivot mode, automatically calculated totals will appear within the Pivot Column Groups, in the position specified.
          * @agModule `PivotModule`
          */
-    pivotColumnGroupTotals?: 'before' | 'after',
+    pivotColumnGroupTotals?: PivotColumnGroupTotals,
     /** When set and the grid is in pivot mode, automatically calculated totals will appear for each value column in the position specified.
          * @agModule `PivotModule`
          */
-    pivotRowTotals?: 'before' | 'after',
+    pivotRowTotals?: PivotRowTotals,
     /** If `true`, the grid will not swap in the grouping column when pivoting. Useful if pivoting using Server Side Row Model or Viewport Row Model and you want full control of all columns including the group column.
          * @default false
          * @initial

--- a/testing/behavioural/src/columns/order/pivot.test.ts
+++ b/testing/behavioural/src/columns/order/pivot.test.ts
@@ -398,6 +398,95 @@ describe('pivotMode=true', () => {
             expect(getColumnOrder(gridApi, 'center')).toEqual(initialExpected);
         });
 
+        test('stale closure pivotComparator is detected and re-sorts columns with enableStrictPivotColumnOrder=true', () => {
+            let direction = 1;
+            const comparator = (a: string, b: string) => direction * a.localeCompare(b);
+
+            const columnDefs: (ColDef | ColGroupDef)[] = [
+                { field: 'a', rowGroup: true },
+                { field: 'b', pivot: true, pivotComparator: comparator },
+                { field: 'c', aggFunc: 'sum' },
+            ];
+
+            const gridApi = gridsManager.createGrid('myGrid', {
+                columnDefs,
+                rowData,
+                pivotMode: true,
+                enableStrictPivotColumnOrder: true,
+                getRowId: ({ data }) => `${data.a}-${data.b}`,
+            });
+
+            const groupColIds = getAutoGroupColumnIds(columnDefs, 'singleColumn', true);
+            expect(getColumnOrder(gridApi, 'center')).toEqual([
+                ...groupColIds,
+                'pivot_b_1_c',
+                'pivot_b_2_c',
+                'pivot_b_3_c',
+            ]);
+
+            // Mutate the closure variable without changing the function reference
+            direction = -1;
+            // Trigger the pivot stage via a data update that keeps the same set of pivot values
+            applyTransactionChecked(gridApi, { update: [{ a: '1', b: '1', c: 99 }] });
+
+            expect(getColumnOrder(gridApi, 'center')).toEqual([
+                ...groupColIds,
+                'pivot_b_3_c',
+                'pivot_b_2_c',
+                'pivot_b_1_c',
+            ]);
+        });
+
+        test('stale closure pivotComparator changes are detected at each level in multi-level pivot with enableStrictPivotColumnOrder=true', () => {
+            const multiLevelRowData = [
+                { a: 'x', b: '1', c: 1 },
+                { a: 'x', b: '2', c: 1 },
+                { a: 'y', b: '1', c: 1 },
+                { a: 'y', b: '2', c: 1 },
+            ];
+
+            let levelBDirection = 1;
+            const comparatorB = (a: string, b: string) => levelBDirection * a.localeCompare(b);
+
+            const columnDefs: (ColDef | ColGroupDef)[] = [
+                { field: 'a', pivot: true },
+                { field: 'b', pivot: true, pivotComparator: comparatorB },
+                { field: 'c', aggFunc: 'sum' },
+            ];
+
+            const gridApi = gridsManager.createGrid('myGrid', {
+                columnDefs,
+                rowData: multiLevelRowData,
+                pivotMode: true,
+                enableStrictPivotColumnOrder: true,
+                // suppressExpandablePivotGroups ensures leaf columns are always visible
+                // (without it, collapsed outer groups show only their summary column)
+                suppressExpandablePivotGroups: true,
+                getRowId: ({ data }) => `${data.a}-${data.b}`,
+            });
+
+            // Level-A default (ascending: x, y), level-B ascending (1, 2)
+            expect(getColumnOrder(gridApi, 'center')).toEqual([
+                'pivot_a-b_x-1_c',
+                'pivot_a-b_x-2_c',
+                'pivot_a-b_y-1_c',
+                'pivot_a-b_y-2_c',
+            ]);
+
+            // Mutate the level-B comparator closure without changing the function reference
+            levelBDirection = -1;
+            // Trigger the pivot stage via a data update that keeps the same set of pivot values
+            applyTransactionChecked(gridApi, { update: [{ a: 'x', b: '1', c: 99 }] });
+
+            // Level-B now descending (2, 1) within each level-A group
+            expect(getColumnOrder(gridApi, 'center')).toEqual([
+                'pivot_a-b_x-2_c',
+                'pivot_a-b_x-1_c',
+                'pivot_a-b_y-2_c',
+                'pivot_a-b_y-1_c',
+            ]);
+        });
+
         test('toggling enableStrictPivotColumnOrder from false to true re-sorts columns', () => {
             const columnDefs: (ColDef | ColGroupDef)[] = [
                 { field: 'a', rowGroup: true },

--- a/testing/behavioural/src/columns/order/pivot.test.ts
+++ b/testing/behavioural/src/columns/order/pivot.test.ts
@@ -398,6 +398,35 @@ describe('pivotMode=true', () => {
             expect(getColumnOrder(gridApi, 'center')).toEqual(initialExpected);
         });
 
+        test('changing pivotComparator via setColumnDefs has no effect when enableStrictPivotColumnOrder=false', () => {
+            const columnDefs: (ColDef | ColGroupDef)[] = [
+                { field: 'a', rowGroup: true },
+                { field: 'b', pivot: true, pivotComparator: (a, b) => -a.localeCompare(b) },
+                { field: 'c', aggFunc: 'sum' },
+            ];
+
+            const gridApi = gridsManager.createGrid('myGrid', {
+                columnDefs,
+                rowData,
+                pivotMode: true,
+                enableStrictPivotColumnOrder: false,
+            });
+
+            const groupColIds = getAutoGroupColumnIds(columnDefs, 'singleColumn', true);
+            // Initial order sorted by reverse comparator
+            const initialExpected = [...groupColIds, 'pivot_b_3_c', 'pivot_b_2_c', 'pivot_b_1_c'];
+            expect(getColumnOrder(gridApi, 'center')).toEqual(initialExpected);
+
+            // Switch to a forward (ascending) comparator — with strict mode off this should have no effect
+            gridApi.setGridOption('columnDefs', [
+                { field: 'a', rowGroup: true },
+                { field: 'b', pivot: true, pivotComparator: (a, b) => a.localeCompare(b) },
+                { field: 'c', aggFunc: 'sum' },
+            ]);
+
+            expect(getColumnOrder(gridApi, 'center')).toEqual(initialExpected);
+        });
+
         test('stale closure pivotComparator is detected and re-sorts columns with enableStrictPivotColumnOrder=true', () => {
             let direction = 1;
             const comparator = (a: string, b: string) => direction * a.localeCompare(b);
@@ -570,6 +599,84 @@ describe('pivotMode=true', () => {
 
                 const reorderedExpected = [...groupColIds, 'pivot_b_1_c', 'pivot_b_2_c', 'pivot_b_3_c', 'pivot_b_0_c'];
                 expect(getColumnOrder(gridApi, 'center')).toEqual(reorderedExpected);
+            });
+
+            test('multiple new pivot result columns introduced by a transaction are appended at the end ordered by pivotComparator', () => {
+                // New columns are appended after all existing columns, but are ordered among themselves
+                // by the pivotComparator.
+                const columnDefs: (ColDef | ColGroupDef)[] = [
+                    { field: 'a', rowGroup: true },
+                    // Reverse comparator: initial order is 3, 2, 1
+                    { field: 'b', pivot: true, pivotComparator: (a, b) => -a.localeCompare(b) },
+                    { field: 'c', aggFunc: 'sum' },
+                ];
+
+                const gridApi = gridsManager.createGrid('myGrid', {
+                    columnDefs,
+                    rowData,
+                    pivotMode: true,
+                    enableStrictPivotColumnOrder: false,
+                });
+
+                const groupColIds = getAutoGroupColumnIds(columnDefs, 'singleColumn', true);
+
+                // Add two new pivot values simultaneously — '4' and '5', added in ascending order
+                applyTransactionChecked(gridApi, {
+                    add: [
+                        { a: '1', b: '5', c: 3 },
+                        { a: '1', b: '4', c: 3 },
+                    ],
+                });
+
+                // Existing columns [3, 2, 1] keep their positions; new columns [5, 4] are appended
+                // at the end, ordered among themselves by the reverse comparator (5 before 4)
+                expect(getColumnOrder(gridApi, 'center')).toEqual([
+                    ...groupColIds,
+                    'pivot_b_3_c',
+                    'pivot_b_2_c',
+                    'pivot_b_1_c',
+                    'pivot_b_5_c',
+                    'pivot_b_4_c',
+                ]);
+            });
+
+            test('new pivot result column introduced by a transaction is appended at the end even with a pivotComparator', () => {
+                // With enableStrictPivotColumnOrder=false, new columns are always appended at the end of their
+                // parent group to preserve any order changes the user may have made — the pivotComparator does
+                // not control placement of new columns.
+                const columnDefs: (ColDef | ColGroupDef)[] = [
+                    { field: 'a', rowGroup: true },
+                    // Reverse comparator: initial order is 3, 2, 1
+                    { field: 'b', pivot: true, pivotComparator: (a, b) => -a.localeCompare(b) },
+                    { field: 'c', aggFunc: 'sum' },
+                ];
+
+                const gridApi = gridsManager.createGrid('myGrid', {
+                    columnDefs,
+                    rowData,
+                    pivotMode: true,
+                    enableStrictPivotColumnOrder: false,
+                });
+
+                const groupColIds = getAutoGroupColumnIds(columnDefs, 'singleColumn', true);
+                expect(getColumnOrder(gridApi, 'center')).toEqual([
+                    ...groupColIds,
+                    'pivot_b_3_c',
+                    'pivot_b_2_c',
+                    'pivot_b_1_c',
+                ]);
+
+                // Add '4' — the reverse comparator would place it before '3', but with
+                // enableStrictPivotColumnOrder=false it is appended at the end instead
+                applyTransactionChecked(gridApi, { add: [{ a: '1', b: '4', c: 3 }] });
+
+                expect(getColumnOrder(gridApi, 'center')).toEqual([
+                    ...groupColIds,
+                    'pivot_b_3_c',
+                    'pivot_b_2_c',
+                    'pivot_b_1_c',
+                    'pivot_b_4_c',
+                ]);
             });
         });
 

--- a/testing/behavioural/src/columns/order/pivot.test.ts
+++ b/testing/behavioural/src/columns/order/pivot.test.ts
@@ -341,6 +341,92 @@ describe('pivotMode=true', () => {
             }
         );
 
+        test('runtime pivotComparator change re-sorts columns with enableStrictPivotColumnOrder=true', () => {
+            const columnDefs: (ColDef | ColGroupDef)[] = [
+                { field: 'a', rowGroup: true },
+                { field: 'b', pivot: true },
+                { field: 'c', aggFunc: 'sum' },
+            ];
+
+            const gridApi = gridsManager.createGrid('myGrid', {
+                columnDefs,
+                rowData,
+                pivotMode: true,
+                enableStrictPivotColumnOrder: true,
+            });
+
+            const groupColIds = getAutoGroupColumnIds(columnDefs, 'singleColumn', true);
+            const initialExpected = [...groupColIds, 'pivot_b_1_c', 'pivot_b_2_c', 'pivot_b_3_c'];
+            expect(getColumnOrder(gridApi, 'center')).toEqual(initialExpected);
+
+            // Update with a reverse comparator
+            gridApi.setGridOption('columnDefs', [
+                { field: 'a', rowGroup: true },
+                { field: 'b', pivot: true, pivotComparator: (a, b) => -a.localeCompare(b) },
+                { field: 'c', aggFunc: 'sum' },
+            ]);
+
+            const reversedExpected = [...groupColIds, 'pivot_b_3_c', 'pivot_b_2_c', 'pivot_b_1_c'];
+            expect(getColumnOrder(gridApi, 'center')).toEqual(reversedExpected);
+        });
+
+        test('runtime pivotComparator change preserves column order with enableStrictPivotColumnOrder=false', () => {
+            const columnDefs: (ColDef | ColGroupDef)[] = [
+                { field: 'a', rowGroup: true },
+                { field: 'b', pivot: true },
+                { field: 'c', aggFunc: 'sum' },
+            ];
+
+            const gridApi = gridsManager.createGrid('myGrid', {
+                columnDefs,
+                rowData,
+                pivotMode: true,
+                enableStrictPivotColumnOrder: false,
+            });
+
+            const groupColIds = getAutoGroupColumnIds(columnDefs, 'singleColumn', true);
+            const initialExpected = [...groupColIds, 'pivot_b_1_c', 'pivot_b_2_c', 'pivot_b_3_c'];
+            expect(getColumnOrder(gridApi, 'center')).toEqual(initialExpected);
+
+            // Update with a reverse comparator — existing columns keep their order
+            gridApi.setGridOption('columnDefs', [
+                { field: 'a', rowGroup: true },
+                { field: 'b', pivot: true, pivotComparator: (a, b) => -a.localeCompare(b) },
+                { field: 'c', aggFunc: 'sum' },
+            ]);
+
+            expect(getColumnOrder(gridApi, 'center')).toEqual(initialExpected);
+        });
+
+        test('toggling enableStrictPivotColumnOrder from false to true re-sorts columns', () => {
+            const columnDefs: (ColDef | ColGroupDef)[] = [
+                { field: 'a', rowGroup: true },
+                { field: 'b', pivot: true, pivotComparator: (a, b) => -a.localeCompare(b) },
+                { field: 'c', aggFunc: 'sum' },
+            ];
+
+            const gridApi = gridsManager.createGrid('myGrid', {
+                columnDefs,
+                rowData,
+                pivotMode: true,
+                enableStrictPivotColumnOrder: false,
+            });
+
+            const groupColIds = getAutoGroupColumnIds(columnDefs, 'singleColumn', true);
+            // Initial order uses comparator for creation, but restoreColOrder may reorder
+            const reversedExpected = [...groupColIds, 'pivot_b_3_c', 'pivot_b_2_c', 'pivot_b_1_c'];
+            expect(getColumnOrder(gridApi, 'center')).toEqual(reversedExpected);
+
+            // Move a column to disrupt the sorted order
+            gridApi.moveColumns(['pivot_b_1_c'], 1);
+            const movedExpected = [...groupColIds, 'pivot_b_1_c', 'pivot_b_3_c', 'pivot_b_2_c'];
+            expect(getColumnOrder(gridApi, 'center')).toEqual(movedExpected);
+
+            // Toggle to strict — columns should re-sort
+            gridApi.setGridOption('enableStrictPivotColumnOrder', true);
+            expect(getColumnOrder(gridApi, 'center')).toEqual(reversedExpected);
+        });
+
         describe('with enableStrictPivotColumnOrder=false', () => {
             test('new pivot result columns are added at the end when a pivot column filter is removed', () => {
                 const columnDefs: (ColDef | ColGroupDef)[] = [

--- a/testing/behavioural/src/grouping-data/benchmarks/pivot-aggregation.bench.ts
+++ b/testing/behavioural/src/grouping-data/benchmarks/pivot-aggregation.bench.ts
@@ -106,6 +106,92 @@ function buildPivotColumnDefs(): ColDef[] {
     return defs;
 }
 
+function buildPivotColumnDefsWithComparator(): ColDef[] {
+    const defs: ColDef[] = [
+        { field: 'group1', rowGroup: true, hide: true },
+        { field: 'group2', rowGroup: true, hide: true },
+        { field: 'year', pivot: true, hide: true, pivotComparator: (a, b) => a.localeCompare(b) },
+    ];
+    for (let v = 0; v < VALUE_COL_COUNT; ++v) {
+        defs.push({ field: `v${v}`, aggFunc: 'sum', hide: true });
+    }
+    return defs;
+}
+
+// ── High-cardinality pivot data ───────────────────────────────────────────────
+// 333 unique pivot values × 3 value columns = 999 result cols — near a 1000-col limit.
+// Exercises computePivotOrder with 333 keys per pipeline run (worst-case overhead).
+
+const HIGH_CARDINALITY_PIVOT_VALUES = 333;
+
+interface HighCardinalityRow {
+    id: string;
+    group1: string;
+    pivot: string;
+    [key: string]: string | number;
+}
+
+function buildHighCardinalityData(count: number, prng = new SimplePRNG(0xe7f8a9b0)): HighCardinalityRow[] {
+    const g1 = ['Dept A', 'Dept B', 'Dept C', 'Dept D', 'Dept E'];
+    const pivotValues = Array.from(
+        { length: HIGH_CARDINALITY_PIVOT_VALUES },
+        (_, i) => `pv${String(i).padStart(3, '0')}`
+    );
+    const rows: HighCardinalityRow[] = [];
+    for (let i = 0; i < count; ++i) {
+        const row: HighCardinalityRow = {
+            id: `h${i}`,
+            group1: prng.pick(g1)!,
+            pivot: prng.pick(pivotValues)!,
+        };
+        for (let v = 0; v < VALUE_COL_COUNT; ++v) {
+            row[`v${v}`] = prng.nextFloat(1, 1000);
+        }
+        rows.push(row);
+    }
+    return rows;
+}
+
+function buildHighCardinalityEdits(rows: HighCardinalityRow[], prng = new SimplePRNG(0xf8a9b0c1)) {
+    const forward: HighCardinalityRow[] = [];
+    const reverse: HighCardinalityRow[] = [];
+    const changeCount = Math.floor(rows.length * UPDATE_FRACTION);
+    const indices = new Set<number>();
+    while (indices.size < changeCount) {
+        indices.add(prng.nextInt(0, rows.length - 1));
+    }
+    for (const idx of indices) {
+        const original = rows[idx];
+        const modified = { ...original };
+        for (let v = 0; v < VALUE_COL_COUNT; ++v) {
+            modified[`v${v}`] = (modified[`v${v}`] as number) * prng.nextFloat(0.5, 1.5);
+        }
+        forward.push(modified);
+        reverse.push(original);
+    }
+    return { forward, reverse };
+}
+
+function buildHighCardinalityColumnDefs(withComparator: boolean): ColDef[] {
+    const defs: ColDef[] = [
+        { field: 'group1', rowGroup: true, hide: true },
+        {
+            field: 'pivot',
+            pivot: true,
+            hide: true,
+            ...(withComparator ? { pivotComparator: (a: string, b: string) => a.localeCompare(b) } : {}),
+        },
+    ];
+    for (let v = 0; v < VALUE_COL_COUNT; ++v) {
+        defs.push({ field: `v${v}`, aggFunc: 'sum', hide: true });
+    }
+    return defs;
+}
+
+const highCardinalityData = buildHighCardinalityData(ROW_COUNT);
+const highCardinalityEdits = buildHighCardinalityEdits(highCardinalityData);
+const highCardinalityResultCols = HIGH_CARDINALITY_PIVOT_VALUES * VALUE_COL_COUNT;
+
 // ── Pre-built data ───────────────────────────────────────────────────────────
 
 const dataA = buildPivotData(ROW_COUNT);
@@ -181,3 +267,115 @@ suite(desc, () => {
         dataA
     );
 });
+
+// ── pivotComparator overhead ─────────────────────────────────────────────────
+// Measures the cost of computePivotOrder running on every pipeline execution
+// when enableStrictPivotColumnOrder=true and a pivotComparator is present.
+// Compare transaction update timings against the baseline suite above.
+
+const gridOptionsWithComparator: GridOptions = {
+    columnDefs: buildPivotColumnDefsWithComparator(),
+    pivotMode: true,
+    autoGroupColumnDef: { headerName: 'Group' },
+    groupDefaultExpanded: -1,
+    suppressAggFuncInHeader: true,
+    enableStrictPivotColumnOrder: true,
+    getRowId: ({ data }: { data: { id: string } }) => data.id,
+};
+
+const descComparator = `pivot aggregation with pivotComparator — ${ROW_COUNT} rows, ${resultCols} result cols, ${updateCount} updated rows`;
+
+suite(descComparator, () => {
+    let gridId = 0;
+
+    const benchMode = (name: string, fn: (api: GridApi) => void, initialData: PivotRow[]) => {
+        const id = `PC${++gridId}`;
+        const gridsManager = new TestGridsManager({ benchmark: true, modules });
+        let api!: GridApi;
+
+        bench(name, () => fn(api), {
+            throws: true,
+            setup: () => {
+                gridsManager.reset();
+                api = gridsManager.createGrid(id, { ...gridOptionsWithComparator, rowData: initialData });
+            },
+        });
+    };
+
+    // Full refresh: cold path — pivot col defs rebuilt regardless, comparator overhead is minimal
+    benchMode(
+        'full refresh',
+        (api) => {
+            api.setGridOption('rowData', []);
+            api.setGridOption('rowData', dataA);
+        },
+        []
+    );
+
+    // Immutable update: computePivotOrder runs on each iteration to detect comparator output changes
+    benchMode(
+        `immutable update (${updateCount} rows)`,
+        (api) => {
+            api.setGridOption('rowData', immutableB);
+            api.setGridOption('rowData', immutableA);
+        },
+        immutableA
+    );
+
+    // Transaction update: hot path — computePivotOrder traverses uniqueValues on every transaction
+    benchMode(
+        `transaction update (${updateCount} rows)`,
+        (api) => {
+            api.applyTransaction({ update: edits.forward });
+            api.applyTransaction({ update: edits.reverse });
+        },
+        dataA
+    );
+});
+
+// ── High-cardinality pivot: baseline vs pivotComparator ───────────────────────
+// 333 unique pivot values × 3 value cols = 999 result cols (near a 1000-col limit).
+// Transactions only update value columns, so unique pivot values never change —
+// computePivotOrder runs on every iteration but never triggers a rebuild.
+// This isolates the detection overhead at scale.
+
+for (const withComparator of [false, true] as const) {
+    const hcOptions: GridOptions = {
+        columnDefs: buildHighCardinalityColumnDefs(withComparator),
+        pivotMode: true,
+        autoGroupColumnDef: { headerName: 'Group' },
+        groupDefaultExpanded: -1,
+        suppressAggFuncInHeader: true,
+        enableStrictPivotColumnOrder: true,
+        pivotMaxGeneratedColumns: 1000,
+        getRowId: ({ data }: { data: { id: string } }) => data.id,
+    };
+
+    const label = withComparator ? 'with pivotComparator' : 'no comparator (baseline)';
+    const hcDesc = `high-cardinality pivot ${label} — ${ROW_COUNT} rows, ${highCardinalityResultCols} result cols, ${updateCount} updated rows`;
+
+    suite(hcDesc, () => {
+        let gridId = 0;
+        const benchMode = (name: string, fn: (api: GridApi) => void, initialData: HighCardinalityRow[]) => {
+            const id = `HC${withComparator ? 'C' : 'B'}${++gridId}`;
+            const gridsManager = new TestGridsManager({ benchmark: true, modules });
+            let api!: GridApi;
+            bench(name, () => fn(api), {
+                throws: true,
+                setup: () => {
+                    gridsManager.reset();
+                    api = gridsManager.createGrid(id, { ...hcOptions, rowData: initialData });
+                },
+            });
+        };
+
+        benchMode(
+            `transaction update (${updateCount} rows)`,
+            (api) => {
+                api.applyTransaction({ update: highCardinalityEdits.forward });
+                api.applyTransaction({ update: highCardinalityEdits.reverse });
+            },
+            highCardinalityData
+        );
+    });
+}


### PR DESCRIPTION
Fix [AG-9654](https://ag-grid.atlassian.net/browse/AG-9654)

## Overview

- **Reactive `pivotComparator`**: `PivotStage` now includes `pivotComparator` in its change detection, so updating a column's `pivotComparator` via `applyColumnState` / `setColumnDefs` triggers a pivot rebuild without requiring a full grid refresh.
- **Named types for pivot options**: Introduced `PivotRowTotals` and `PivotColumnGroupTotals` string union types in `GridOptions` (exported from community `main.ts`), replacing ad-hoc `GridOptions['...']` indexed lookups.
- **Simplified grid options change detection**: The five separate `*LastTime` fields for pivot grid options are replaced with a single `gridOptionsHashLastTime` string, consistent with the existing hash-based change detection pattern used for aggregation columns, group columns, and pivot comparators.