### PR TITLE
AG-17009 Add horizontal scroll to row group panel

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -755,7 +755,9 @@
 
     .ag-column-drop.ag-column-drop-horizontal {
         white-space: nowrap;
-        overflow: hidden;
+        overflow-x: auto;
+        overflow-y: hidden;
+        scrollbar-width: thin;
     }
 
     .ag-column-drop-cell-button {

--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -755,8 +755,7 @@
 
     .ag-column-drop.ag-column-drop-horizontal {
         white-space: nowrap;
-        overflow-x: auto;
-        overflow-y: hidden;
+        overflow: auto hidden;
         scrollbar-width: thin;
     }
 

--- a/packages/ag-grid-enterprise/src/widgets/pillDropZonePanel.css
+++ b/packages/ag-grid-enterprise/src/widgets/pillDropZonePanel.css
@@ -98,7 +98,9 @@
 
 .ag-column-drop-horizontal {
     white-space: nowrap;
-    overflow: hidden;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: thin;
     height: var(--ag-header-height);
     padding-left: var(--ag-cell-horizontal-padding);
     gap: var(--ag-cell-widget-spacing);

--- a/packages/ag-grid-enterprise/src/widgets/pillDropZonePanel.css
+++ b/packages/ag-grid-enterprise/src/widgets/pillDropZonePanel.css
@@ -98,8 +98,7 @@
 
 .ag-column-drop-horizontal {
     white-space: nowrap;
-    overflow-x: auto;
-    overflow-y: hidden;
+    overflow: auto hidden;
     scrollbar-width: thin;
     height: var(--ag-header-height);
     padding-left: var(--ag-cell-horizontal-padding);


### PR DESCRIPTION
Fix [AG-17009](https://ag-grid.atlassian.net/browse/AG-17009)

Add a thin scrollbar when there are too many items to fit in the horizontal column drop component

<img width="757" height="319" alt="image" src="https://github.com/user-attachments/assets/68bfa7e5-776f-4a05-8067-fbee9d50c45e" />