### PR TITLE
AG-17003 Optimise validation checks to avoid repeated work

### DIFF
--- a/packages/ag-grid-community/src/validation/rules/colDefValidations.ts
+++ b/packages/ag-grid-community/src/validation/rules/colDefValidations.ts
@@ -2,6 +2,7 @@ import type { UserComponentName } from '../../context/context';
 import { _isSortDefValid, _isSortDirectionValid } from '../../entities/agColumn';
 import type { AbstractColDef, ColDef, ColGroupDef, ColumnMenuTab } from '../../entities/colDef';
 import { _errMsg, toStringWithNullUndefined } from '../logging';
+import { buildAllValidNames } from '../validationTypes';
 import type { Deprecations, ModuleValidation, OptionsValidator, Validations } from '../validationTypes';
 import { USER_COMP_MODULES } from './userCompValidations';
 
@@ -497,10 +498,17 @@ const colDefPropertyMap: Record<ColOrGroupKey, undefined> = {
 };
 const ALL_PROPERTIES: () => ColOrGroupKey[] = () => Object.keys(colDefPropertyMap) as ColOrGroupKey[];
 
-export const COL_DEF_VALIDATORS: () => OptionsValidator<ColDef | ColGroupDef> = () => ({
-    objectName: 'colDef',
-    allProperties: ALL_PROPERTIES(),
-    docsUrl: 'column-properties/',
-    deprecations: COLUMN_DEFINITION_DEPRECATIONS(),
-    validations: COLUMN_DEFINITION_VALIDATIONS(),
-});
+let _colDefValidatorsCache: OptionsValidator<ColDef | ColGroupDef> | undefined;
+export const COL_DEF_VALIDATORS: () => OptionsValidator<ColDef | ColGroupDef> = () =>
+    (_colDefValidatorsCache ??= (() => {
+        const allProperties = ALL_PROPERTIES();
+        const deprecations = COLUMN_DEFINITION_DEPRECATIONS();
+        return {
+            objectName: 'colDef',
+            allProperties,
+            allValidNames: buildAllValidNames(allProperties, deprecations),
+            docsUrl: 'column-properties/',
+            deprecations,
+            validations: COLUMN_DEFINITION_VALIDATIONS(),
+        };
+    })());

--- a/packages/ag-grid-community/src/validation/rules/gridOptionsValidations.ts
+++ b/packages/ag-grid-community/src/validation/rules/gridOptionsValidations.ts
@@ -4,6 +4,7 @@ import { _BOOLEAN_GRID_OPTIONS, _GET_ALL_GRID_OPTIONS, _NUMBER_GRID_OPTIONS } fr
 import { _PUBLIC_EVENT_HANDLERS_MAP } from '../../publicEventHandlersMap';
 import { _mergeDeep } from '../../utils/mergeDeep';
 import { _errMsg, toStringWithNullUndefined } from '../logging';
+import { buildAllValidNames } from '../validationTypes';
 import type { Deprecations, OptionsValidator, RequiredModule, Validations } from '../validationTypes';
 
 /**
@@ -586,11 +587,19 @@ const GRID_OPTION_VALIDATIONS: () => Validations<GridOptions> = () => {
     return validations;
 };
 
-export const GRID_OPTIONS_VALIDATORS: () => Required<OptionsValidator<GridOptions>> = () => ({
-    objectName: 'gridOptions',
-    allProperties: [..._GET_ALL_GRID_OPTIONS(), ...Object.values(_PUBLIC_EVENT_HANDLERS_MAP)],
-    propertyExceptions: ['api'],
-    docsUrl: 'grid-options/',
-    deprecations: GRID_OPTION_DEPRECATIONS(),
-    validations: GRID_OPTION_VALIDATIONS(),
-});
+let _gridOptionsValidatorsCache: Required<OptionsValidator<GridOptions>> | undefined;
+export const GRID_OPTIONS_VALIDATORS: () => Required<OptionsValidator<GridOptions>> = () =>
+    (_gridOptionsValidatorsCache ??= (() => {
+        const allProperties = [..._GET_ALL_GRID_OPTIONS(), ...Object.values(_PUBLIC_EVENT_HANDLERS_MAP)];
+        const deprecations = GRID_OPTION_DEPRECATIONS();
+        const propertyExceptions = ['api'];
+        return {
+            objectName: 'gridOptions',
+            allProperties,
+            allValidNames: buildAllValidNames(allProperties, deprecations, propertyExceptions),
+            propertyExceptions,
+            docsUrl: 'grid-options/',
+            deprecations,
+            validations: GRID_OPTION_VALIDATIONS(),
+        };
+    })());

--- a/packages/ag-grid-community/src/validation/validationService.ts
+++ b/packages/ag-grid-community/src/validation/validationService.ts
@@ -28,6 +28,8 @@ export class ValidationService extends BeanStub implements NamedBean {
     private gridOptions: GridOptions;
     /** Property names already checked via checkProperties, keyed by objectName. */
     private checkedPropertyNames: Map<string, Set<string>> = new Map();
+    /** Property names whose supportedRowModels check failed, keyed by objectName. */
+    private unsupportedRowModelProperties: Map<string, Set<string>> = new Map();
 
     public wireBeans(beans: BeanCollection): void {
         this.gridOptions = beans.gridOptions;
@@ -151,12 +153,18 @@ export class ValidationService extends BeanStub implements NamedBean {
 
                 const rules = validations[name as keyof T];
                 if (rules?.supportedRowModels && !rules.supportedRowModels.includes(rowModel)) {
+                    let unsupported = this.unsupportedRowModelProperties.get(objectName);
+                    if (!unsupported) {
+                        unsupported = new Set();
+                        this.unsupportedRowModelProperties.set(objectName, unsupported);
+                    }
+                    unsupported.add(name);
                     _warnOnce(
                         `${name} is not supported with the '${rowModel}' row model. It is only valid with: ${rules.supportedRowModels.join(', ')}.`
                     );
                 }
 
-                if (!deprecation && checkPropertyNames && !allValidNames.has(name)) {
+                if (checkPropertyNames && !allValidNames.has(name)) {
                     const suggestions = _fuzzySuggestions({
                         inputValue: name,
                         allSuggestions: allProperties,
@@ -177,11 +185,17 @@ export class ValidationService extends BeanStub implements NamedBean {
         }
 
         const warnings = new Set<string>();
+        const unsupported = this.unsupportedRowModelProperties.get(objectName);
 
         optionKeys.forEach((key: keyof T) => {
             const value = options[key];
             if (value == null || value === false) {
                 // false implies feature is disabled, don't validate.
+                return;
+            }
+
+            // Skip dependencies/validate for properties not supported by the current row model
+            if (unsupported?.has(key as string)) {
                 return;
             }
 

--- a/packages/ag-grid-community/src/validation/validationService.ts
+++ b/packages/ag-grid-community/src/validation/validationService.ts
@@ -26,10 +26,13 @@ export class ValidationService extends BeanStub implements NamedBean {
     beanName = 'validation' as const;
 
     private gridOptions: GridOptions;
-    /** Property names already checked via checkProperties, keyed by objectName. */
-    private checkedPropertyNames: Map<string, Set<string>> = new Map();
-    /** Property names whose supportedRowModels check failed, keyed by objectName. */
-    private unsupportedRowModelProperties: Map<string, Set<string>> = new Map();
+    /**
+     * Caches per-property-name validation results keyed by objectName.
+     * Each inner map records: property name → true if valid for runtime checks, false if not.
+     * A property is invalid if it has an unsupported row model, or is an unrecognised name.
+     * Deprecation warnings and fuzzy suggestions are emitted once when first encountered.
+     */
+    private propertyNameCache: Map<string, Map<string, boolean>> = new Map();
 
     public wireBeans(beans: BeanCollection): void {
         this.gridOptions = beans.gridOptions;
@@ -128,74 +131,69 @@ export class ValidationService extends BeanStub implements NamedBean {
         const { validations, deprecations, allProperties, allValidNames, objectName, docsUrl } = validator;
 
         const optionKeys = Object.keys(options) as (keyof T & string)[];
-        const checked = this.checkedPropertyNames.get(objectName);
-        const uncheckedNames = checked ? optionKeys.filter((name) => !checked.has(name)) : optionKeys;
-
-        if (uncheckedNames.length > 0) {
-            const target = checked ?? new Set<string>();
-            if (!checked) {
-                this.checkedPropertyNames.set(objectName, target);
-            }
-
-            const checkPropertyNames = this.gridOptions.suppressPropertyNamesCheck !== true;
-            let hasInvalid = false;
-
-            const rowModel = this.gridOptions.rowModelType ?? 'clientSide';
-
-            for (const name of uncheckedNames) {
-                target.add(name);
-
-                const deprecation = deprecations[name as keyof T];
-                if (deprecation) {
-                    const { message, version } = deprecation;
-                    _warnOnce(`As of v${version}, ${name} is deprecated. ${message ?? ''}`);
-                }
-
-                const rules = validations[name as keyof T];
-                if (rules?.supportedRowModels && !rules.supportedRowModels.includes(rowModel)) {
-                    let unsupported = this.unsupportedRowModelProperties.get(objectName);
-                    if (!unsupported) {
-                        unsupported = new Set();
-                        this.unsupportedRowModelProperties.set(objectName, unsupported);
-                    }
-                    unsupported.add(name);
-                    _warnOnce(
-                        `${name} is not supported with the '${rowModel}' row model. It is only valid with: ${rules.supportedRowModels.join(', ')}.`
-                    );
-                }
-
-                if (checkPropertyNames && !allValidNames.has(name)) {
-                    const suggestions = _fuzzySuggestions({
-                        inputValue: name,
-                        allSuggestions: allProperties,
-                    }).values;
-                    let message = `invalid ${objectName} property '${name}' did you mean any of these: ${suggestions.slice(0, 8).join(', ')}.`;
-                    if (allValidNames.has('context')) {
-                        message += `\nIf you are trying to annotate ${objectName} with application data, use the '${objectName}.context' property instead.`;
-                    }
-                    _warnOnce(message);
-                    hasInvalid = true;
-                }
-            }
-
-            if (hasInvalid && docsUrl) {
-                const url = this.beans.frameworkOverrides.getDocLink(docsUrl);
-                _warnOnce(`to see all the valid ${objectName} properties please check: ${url}`);
-            }
+        let cache = this.propertyNameCache.get(objectName);
+        if (!cache) {
+            cache = new Map();
+            this.propertyNameCache.set(objectName, cache);
         }
 
+        // Check uncached property names: emit one-time warnings and record validity
+        let hasInvalidName = false;
+        for (const name of optionKeys) {
+            if (cache.has(name)) {
+                continue;
+            }
+
+            const deprecation = deprecations[name as keyof T];
+            if (deprecation) {
+                const { message, version } = deprecation;
+                _warnOnce(`As of v${version}, ${name} is deprecated. ${message ?? ''}`);
+            }
+
+            const rules = validations[name as keyof T];
+            const rowModel = this.gridOptions.rowModelType ?? 'clientSide';
+            if (rules?.supportedRowModels && !rules.supportedRowModels.includes(rowModel)) {
+                _warnOnce(
+                    `${name} is not supported with the '${rowModel}' row model. It is only valid with: ${rules.supportedRowModels.join(', ')}.`
+                );
+                cache.set(name, false);
+                continue;
+            }
+
+            if (this.gridOptions.suppressPropertyNamesCheck !== true && !allValidNames.has(name)) {
+                const suggestions = _fuzzySuggestions({
+                    inputValue: name,
+                    allSuggestions: allProperties,
+                }).values;
+                let message = `invalid ${objectName} property '${name}' did you mean any of these: ${suggestions.slice(0, 8).join(', ')}.`;
+                if (allValidNames.has('context')) {
+                    message += `\nIf you are trying to annotate ${objectName} with application data, use the '${objectName}.context' property instead.`;
+                }
+                _warnOnce(message);
+                hasInvalidName = true;
+                cache.set(name, false);
+                continue;
+            }
+
+            cache.set(name, true);
+        }
+
+        if (hasInvalidName && docsUrl) {
+            const url = this.beans.frameworkOverrides.getDocLink(docsUrl);
+            _warnOnce(`to see all the valid ${objectName} properties please check: ${url}`);
+        }
+
+        // Run value-level validation only for properties marked valid
         const warnings = new Set<string>();
-        const unsupported = this.unsupportedRowModelProperties.get(objectName);
 
         optionKeys.forEach((key: keyof T) => {
-            const value = options[key];
-            if (value == null || value === false) {
-                // false implies feature is disabled, don't validate.
+            if (!cache!.get(key as string)) {
                 return;
             }
 
-            // Skip dependencies/validate for properties not supported by the current row model
-            if (unsupported?.has(key as string)) {
+            const value = options[key];
+            if (value == null || value === false) {
+                // false implies feature is disabled, don't validate.
                 return;
             }
 

--- a/packages/ag-grid-community/src/validation/validationService.ts
+++ b/packages/ag-grid-community/src/validation/validationService.ts
@@ -26,6 +26,8 @@ export class ValidationService extends BeanStub implements NamedBean {
     beanName = 'validation' as const;
 
     private gridOptions: GridOptions;
+    /** Property names already checked via checkProperties, keyed by objectName. */
+    private checkedPropertyNames: Map<string, Set<string>> = new Map();
 
     public wireBeans(beans: BeanCollection): void {
         this.gridOptions = beans.gridOptions;
@@ -121,28 +123,62 @@ export class ValidationService extends BeanStub implements NamedBean {
     }
 
     private processOptions<T extends object>(options: T, validator: OptionsValidator<T>): void {
-        const { validations, deprecations, allProperties, propertyExceptions, objectName, docsUrl } = validator;
+        const { validations, deprecations, allProperties, allValidNames, objectName, docsUrl } = validator;
 
-        if (allProperties && this.gridOptions.suppressPropertyNamesCheck !== true) {
-            this.checkProperties(
-                options,
-                [...(propertyExceptions ?? []), ...Object.keys(deprecations)],
-                allProperties,
-                objectName,
-                docsUrl
-            );
+        const optionKeys = Object.keys(options) as (keyof T & string)[];
+        const checked = this.checkedPropertyNames.get(objectName);
+        const uncheckedNames = checked ? optionKeys.filter((name) => !checked.has(name)) : optionKeys;
+
+        if (uncheckedNames.length > 0) {
+            const target = checked ?? new Set<string>();
+            if (!checked) {
+                this.checkedPropertyNames.set(objectName, target);
+            }
+
+            const checkPropertyNames = this.gridOptions.suppressPropertyNamesCheck !== true;
+            let hasInvalid = false;
+
+            const rowModel = this.gridOptions.rowModelType ?? 'clientSide';
+
+            for (const name of uncheckedNames) {
+                target.add(name);
+
+                const deprecation = deprecations[name as keyof T];
+                if (deprecation) {
+                    const { message, version } = deprecation;
+                    _warnOnce(`As of v${version}, ${name} is deprecated. ${message ?? ''}`);
+                }
+
+                const rules = validations[name as keyof T];
+                if (rules?.supportedRowModels && !rules.supportedRowModels.includes(rowModel)) {
+                    _warnOnce(
+                        `${name} is not supported with the '${rowModel}' row model. It is only valid with: ${rules.supportedRowModels.join(', ')}.`
+                    );
+                }
+
+                if (!deprecation && checkPropertyNames && !allValidNames.has(name)) {
+                    const suggestions = _fuzzySuggestions({
+                        inputValue: name,
+                        allSuggestions: allProperties,
+                    }).values;
+                    let message = `invalid ${objectName} property '${name}' did you mean any of these: ${suggestions.slice(0, 8).join(', ')}.`;
+                    if (allValidNames.has('context')) {
+                        message += `\nIf you are trying to annotate ${objectName} with application data, use the '${objectName}.context' property instead.`;
+                    }
+                    _warnOnce(message);
+                    hasInvalid = true;
+                }
+            }
+
+            if (hasInvalid && docsUrl) {
+                const url = this.beans.frameworkOverrides.getDocLink(docsUrl);
+                _warnOnce(`to see all the valid ${objectName} properties please check: ${url}`);
+            }
         }
 
         const warnings = new Set<string>();
 
-        const optionKeys = Object.keys(options) as (keyof T)[];
         optionKeys.forEach((key: keyof T) => {
-            const deprecation = deprecations[key];
-            if (deprecation) {
-                const { message, version } = deprecation;
-                warnings.add(`As of v${version}, ${String(key)} is deprecated. ${message ?? ''}`);
-            }
-
             const value = options[key];
             if (value == null || value === false) {
                 // false implies feature is disabled, don't validate.
@@ -154,23 +190,13 @@ export class ValidationService extends BeanStub implements NamedBean {
                 return;
             }
 
-            const { dependencies, validate, supportedRowModels, expectedType } = rules;
+            const { dependencies, validate, expectedType } = rules;
 
             if (expectedType) {
                 const actualType = typeof value;
                 if (actualType !== expectedType) {
                     warnings.add(
                         `${String(key)} should be of type '${expectedType}' but received '${actualType}' (${value}).`
-                    );
-                    return;
-                }
-            }
-
-            if (supportedRowModels) {
-                const rowModel = this.gridOptions.rowModelType ?? 'clientSide';
-                if (!supportedRowModels.includes(rowModel)) {
-                    warnings.add(
-                        `${String(key)} is not supported with the '${rowModel}' row model. It is only valid with: ${supportedRowModels.join(', ')}.`
                     );
                     return;
                 }
@@ -230,58 +256,6 @@ export class ValidationService extends BeanStub implements NamedBean {
             )
             .join('\n           '); // make multiple messages easier to read
     }
-
-    private checkProperties<K extends string, O extends Record<K, any>>(
-        object: O,
-        exceptions: string[], // deprecated properties generally
-        validProperties: string[], // properties to recommend
-        containerName: string,
-        docsUrl?: string
-    ) {
-        // Vue adds these properties to all objects, so we ignore them when checking for invalid properties
-        const VUE_FRAMEWORK_PROPS = ['__ob__', '__v_skip', '__metadata__'];
-
-        const invalidProperties = _fuzzyCheckStrings(
-            Object.getOwnPropertyNames(object) as K[],
-            [...VUE_FRAMEWORK_PROPS, ...exceptions, ...validProperties],
-            validProperties
-        );
-
-        const invalidPropertiesKeys = Object.keys(invalidProperties) as K[];
-
-        for (const key of invalidPropertiesKeys) {
-            const value = invalidProperties[key];
-            let message = `invalid ${containerName} property '${key as string}' did you mean any of these: ${value.slice(0, 8).join(', ')}.`;
-            if (validProperties.includes('context')) {
-                message += `\nIf you are trying to annotate ${containerName} with application data, use the '${containerName}.context' property instead.`;
-            }
-            _warnOnce(message);
-        }
-
-        if (invalidPropertiesKeys.length > 0 && docsUrl) {
-            const url = this.beans.frameworkOverrides.getDocLink(docsUrl);
-            _warnOnce(`to see all the valid ${containerName} properties please check: ${url}`);
-        }
-    }
-}
-
-function _fuzzyCheckStrings<V extends string>(
-    inputValues: V[],
-    validValues: string[],
-    allSuggestions: string[]
-): { [p in V]: string[] } {
-    const fuzzyMatches = {} as { [p in V]: string[] };
-    const invalidInputs = inputValues.filter(
-        (inputValue) => !validValues.some((validValue) => validValue === inputValue)
-    );
-
-    if (invalidInputs.length > 0) {
-        for (const invalidInput of invalidInputs) {
-            fuzzyMatches[invalidInput] = _fuzzySuggestions({ inputValue: invalidInput, allSuggestions }).values;
-        }
-    }
-
-    return fuzzyMatches;
 }
 
 const DEPRECATED_ROW_NODE_EVENTS: Set<RowNodeEventType> = new Set([

--- a/packages/ag-grid-community/src/validation/validationService.ts
+++ b/packages/ag-grid-community/src/validation/validationService.ts
@@ -131,16 +131,17 @@ export class ValidationService extends BeanStub implements NamedBean {
         const { validations, deprecations, allProperties, allValidNames, objectName, docsUrl } = validator;
 
         const optionKeys = Object.keys(options) as (keyof T & string)[];
-        let cache = this.propertyNameCache.get(objectName);
-        if (!cache) {
-            cache = new Map();
-            this.propertyNameCache.set(objectName, cache);
+        let isValidMap = this.propertyNameCache.get(objectName);
+        if (!isValidMap) {
+            isValidMap = new Map();
+            this.propertyNameCache.set(objectName, isValidMap);
         }
 
         // Check uncached property names: emit one-time warnings and record validity
         let hasInvalidName = false;
         for (const name of optionKeys) {
-            if (cache.has(name)) {
+            if (isValidMap.has(name)) {
+                // Already validated this property name
                 continue;
             }
 
@@ -156,7 +157,7 @@ export class ValidationService extends BeanStub implements NamedBean {
                 _warnOnce(
                     `${name} is not supported with the '${rowModel}' row model. It is only valid with: ${rules.supportedRowModels.join(', ')}.`
                 );
-                cache.set(name, false);
+                isValidMap.set(name, false);
                 continue;
             }
 
@@ -173,11 +174,11 @@ export class ValidationService extends BeanStub implements NamedBean {
                     _warnOnce(message);
                 }
                 hasInvalidName = true;
-                cache.set(name, false);
+                isValidMap.set(name, false);
                 continue;
             }
 
-            cache.set(name, true);
+            isValidMap.set(name, true);
         }
 
         if (hasInvalidName && docsUrl) {
@@ -189,7 +190,8 @@ export class ValidationService extends BeanStub implements NamedBean {
         const warnings = new Set<string>();
 
         optionKeys.forEach((key: keyof T) => {
-            if (!cache!.get(key as string)) {
+            if (isValidMap.get(key as string) === false) {
+                // Don't perform runtime validations on invalid properties
                 return;
             }
 

--- a/packages/ag-grid-community/src/validation/validationService.ts
+++ b/packages/ag-grid-community/src/validation/validationService.ts
@@ -32,7 +32,7 @@ export class ValidationService extends BeanStub implements NamedBean {
      * A property is invalid if it has an unsupported row model, or is an unrecognised name.
      * Deprecation warnings and fuzzy suggestions are emitted once when first encountered.
      */
-    private propertyNameCache: Map<string, Map<string, boolean>> = new Map();
+    private readonly propertyNameCache: Map<string, Map<string, boolean>> = new Map();
 
     public wireBeans(beans: BeanCollection): void {
         this.gridOptions = beans.gridOptions;

--- a/packages/ag-grid-community/src/validation/validationService.ts
+++ b/packages/ag-grid-community/src/validation/validationService.ts
@@ -138,6 +138,7 @@ export class ValidationService extends BeanStub implements NamedBean {
         }
 
         // Check uncached property names: emit one-time warnings and record validity
+        const checkPropertyNames = this.gridOptions.suppressPropertyNamesCheck !== true;
         let hasInvalidName = false;
         for (const name of optionKeys) {
             if (isValidMap.has(name)) {
@@ -162,7 +163,7 @@ export class ValidationService extends BeanStub implements NamedBean {
             }
 
             if (!allValidNames.has(name)) {
-                if (this.gridOptions.suppressPropertyNamesCheck !== true) {
+                if (checkPropertyNames) {
                     const suggestions = _fuzzySuggestions({
                         inputValue: name,
                         allSuggestions: allProperties,
@@ -172,8 +173,8 @@ export class ValidationService extends BeanStub implements NamedBean {
                         message += `\nIf you are trying to annotate ${objectName} with application data, use the '${objectName}.context' property instead.`;
                     }
                     _warnOnce(message);
-                    hasInvalidName = true;
                 }
+                hasInvalidName = true;
                 isValidMap.set(name, false);
                 continue;
             }
@@ -181,7 +182,7 @@ export class ValidationService extends BeanStub implements NamedBean {
             isValidMap.set(name, true);
         }
 
-        if (hasInvalidName && docsUrl) {
+        if (hasInvalidName && docsUrl && checkPropertyNames) {
             const url = this.beans.frameworkOverrides.getDocLink(docsUrl);
             _warnOnce(`to see all the valid ${objectName} properties please check: ${url}`);
         }

--- a/packages/ag-grid-community/src/validation/validationService.ts
+++ b/packages/ag-grid-community/src/validation/validationService.ts
@@ -172,8 +172,8 @@ export class ValidationService extends BeanStub implements NamedBean {
                         message += `\nIf you are trying to annotate ${objectName} with application data, use the '${objectName}.context' property instead.`;
                     }
                     _warnOnce(message);
+                    hasInvalidName = true;
                 }
-                hasInvalidName = true;
                 isValidMap.set(name, false);
                 continue;
             }

--- a/packages/ag-grid-community/src/validation/validationService.ts
+++ b/packages/ag-grid-community/src/validation/validationService.ts
@@ -160,16 +160,18 @@ export class ValidationService extends BeanStub implements NamedBean {
                 continue;
             }
 
-            if (this.gridOptions.suppressPropertyNamesCheck !== true && !allValidNames.has(name)) {
-                const suggestions = _fuzzySuggestions({
-                    inputValue: name,
-                    allSuggestions: allProperties,
-                }).values;
-                let message = `invalid ${objectName} property '${name}' did you mean any of these: ${suggestions.slice(0, 8).join(', ')}.`;
-                if (allValidNames.has('context')) {
-                    message += `\nIf you are trying to annotate ${objectName} with application data, use the '${objectName}.context' property instead.`;
+            if (!allValidNames.has(name)) {
+                if (this.gridOptions.suppressPropertyNamesCheck !== true) {
+                    const suggestions = _fuzzySuggestions({
+                        inputValue: name,
+                        allSuggestions: allProperties,
+                    }).values;
+                    let message = `invalid ${objectName} property '${name}' did you mean any of these: ${suggestions.slice(0, 8).join(', ')}.`;
+                    if (allValidNames.has('context')) {
+                        message += `\nIf you are trying to annotate ${objectName} with application data, use the '${objectName}.context' property instead.`;
+                    }
+                    _warnOnce(message);
                 }
-                _warnOnce(message);
                 hasInvalidName = true;
                 cache.set(name, false);
                 continue;

--- a/packages/ag-grid-community/src/validation/validationTypes.ts
+++ b/packages/ag-grid-community/src/validation/validationTypes.ts
@@ -3,10 +3,28 @@ import type { GridOptions } from '../entities/gridOptions';
 import type { ValidationModuleName } from '../interfaces/iModule';
 import type { RowModelType } from '../interfaces/iRowModel';
 
+// Vue adds these properties to all objects, so we ignore them when checking for invalid properties
+const VUE_FRAMEWORK_PROPS = ['__ob__', '__v_skip', '__metadata__'];
+
+/** Build the set of all property names that should be accepted without warning. */
+export function buildAllValidNames<T extends object>(
+    allProperties: string[],
+    deprecations: Deprecations<T>,
+    propertyExceptions?: string[]
+): Set<string> {
+    return new Set([
+        ...VUE_FRAMEWORK_PROPS,
+        ...(propertyExceptions ?? []),
+        ...Object.keys(deprecations),
+        ...allProperties,
+    ]);
+}
+
 export interface OptionsValidator<T extends object> {
     objectName: string;
-    allProperties?: string[];
-    propertyExceptions?: string[];
+    allProperties: string[];
+    /** Pre-computed set of all accepted property names (valid + deprecated + exceptions + Vue). */
+    allValidNames: Set<string>;
     docsUrl?: `${string}/`;
     deprecations: Deprecations<T>;
     validations: Validations<T>;

--- a/testing/behavioural/src/validation/validation-warnings.test.ts
+++ b/testing/behavioural/src/validation/validation-warnings.test.ts
@@ -1,0 +1,209 @@
+import type { MockInstance } from 'vitest';
+
+import type { GridOptions } from 'ag-grid-community';
+import { ClientSideRowModelModule, ValidationModule } from 'ag-grid-community';
+
+import { TestGridsManager } from '../test-utils';
+
+describe('ag-grid validation warnings', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, ValidationModule],
+    });
+    let consoleWarnSpy: MockInstance;
+
+    beforeEach(() => {
+        consoleWarnSpy = vitest.spyOn(console, 'warn').mockImplementation(() => {});
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+        consoleWarnSpy.mockRestore();
+    });
+
+    describe('invalid property names', () => {
+        test('warns for unknown gridOptions properties', () => {
+            gridsManager.createGrid('myGrid', {
+                columnDefs: [],
+                rowData: [],
+                ['notARealOption' as any]: true,
+            });
+
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                expect.stringContaining("invalid gridOptions property 'notARealOption'")
+            );
+        });
+
+        test('includes docs URL after invalid property warning', () => {
+            gridsManager.createGrid('myGrid', {
+                columnDefs: [],
+                rowData: [],
+                ['notARealOption' as any]: true,
+            });
+
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                expect.stringContaining('to see all the valid gridOptions properties please check:')
+            );
+        });
+
+        test('warns for unknown colDef properties', () => {
+            gridsManager.createGrid('myGrid', {
+                defaultColDef: { cellDataType: false },
+                columnDefs: [{ field: 'a', ['notAColProp' as any]: true }],
+                rowData: [{ a: 1 }],
+            });
+
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                expect.stringContaining("invalid colDef property 'notAColProp'")
+            );
+        });
+
+        test('warns only once per property name across multiple calls', () => {
+            const api = gridsManager.createGrid('myGrid', {
+                defaultColDef: { cellDataType: false },
+                columnDefs: [{ field: 'a', ['fakeColProp' as any]: 1 }],
+                rowData: [{ a: 1 }],
+            });
+
+            const invalidPropWarnings = () =>
+                consoleWarnSpy.mock.calls.filter((args) =>
+                    String(args[0]).includes("invalid colDef property 'fakeColProp'")
+                );
+
+            expect(invalidPropWarnings()).toHaveLength(1);
+
+            // Update colDefs with the same unknown property — should not warn again
+            api.setGridOption('columnDefs', [{ field: 'a', ['fakeColProp' as any]: 2 }]);
+
+            expect(invalidPropWarnings()).toHaveLength(1);
+        });
+    });
+
+    describe('suppressPropertyNamesCheck', () => {
+        test('suppresses invalid property name warnings', () => {
+            gridsManager.createGrid('myGrid', {
+                columnDefs: [],
+                rowData: [],
+                suppressPropertyNamesCheck: true,
+                ['notARealOption' as any]: true,
+            } as GridOptions);
+
+            const invalidPropWarnings = consoleWarnSpy.mock.calls.filter((args) =>
+                String(args[0]).includes("invalid gridOptions property 'notARealOption'")
+            );
+            expect(invalidPropWarnings).toHaveLength(0);
+        });
+
+        test('suppresses docs URL warning', () => {
+            gridsManager.createGrid('myGrid', {
+                columnDefs: [],
+                rowData: [],
+                suppressPropertyNamesCheck: true,
+                ['notARealOption' as any]: true,
+            } as GridOptions);
+
+            const docsWarnings = consoleWarnSpy.mock.calls.filter((args) =>
+                String(args[0]).includes('to see all the valid gridOptions properties please check:')
+            );
+            expect(docsWarnings).toHaveLength(0);
+        });
+
+        test('does not suppress deprecation warnings', () => {
+            gridsManager.createGrid('myGrid', {
+                columnDefs: [],
+                rowData: [],
+                suppressPropertyNamesCheck: true,
+                suppressLoadingOverlay: true,
+            } as GridOptions);
+
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                expect.stringContaining('suppressLoadingOverlay is deprecated')
+            );
+        });
+    });
+
+    describe('deprecation warnings', () => {
+        test('warns for deprecated gridOptions properties', () => {
+            gridsManager.createGrid('myGrid', {
+                columnDefs: [],
+                rowData: [],
+                suppressLoadingOverlay: true,
+            } as GridOptions);
+
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                expect.stringContaining('suppressLoadingOverlay is deprecated')
+            );
+        });
+
+        test('warns only once for same deprecated property', () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [],
+                rowData: [],
+                suppressLoadingOverlay: true,
+            } as GridOptions);
+
+            const deprecationWarnings = () =>
+                consoleWarnSpy.mock.calls.filter((args) =>
+                    String(args[0]).includes('suppressLoadingOverlay is deprecated')
+                );
+
+            expect(deprecationWarnings()).toHaveLength(1);
+
+            // Re-process with same option — should not warn again
+            api.updateGridOptions({ suppressLoadingOverlay: true } as GridOptions);
+
+            expect(deprecationWarnings()).toHaveLength(1);
+        });
+    });
+
+    describe('unsupported row model warnings', () => {
+        test('warns when gridOption is not supported by current row model', () => {
+            gridsManager.createGrid('myGrid', {
+                columnDefs: [],
+                rowData: [],
+                serverSideInitialRowCount: 5,
+            });
+
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                expect.stringContaining("serverSideInitialRowCount is not supported with the 'clientSide' row model")
+            );
+        });
+
+        test('warns only once for same unsupported row model property', () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [],
+                rowData: [],
+                serverSideInitialRowCount: 5,
+            });
+
+            const rowModelWarnings = () =>
+                consoleWarnSpy.mock.calls.filter((args) =>
+                    String(args[0]).includes('serverSideInitialRowCount is not supported')
+                );
+
+            expect(rowModelWarnings()).toHaveLength(1);
+
+            api.updateGridOptions({ serverSideInitialRowCount: 10 } as any);
+
+            expect(rowModelWarnings()).toHaveLength(1);
+        });
+
+        test('skips value-level validation for unsupported row model properties', () => {
+            // serverSideInitialRowCount has supportedRowModels: ['serverSide']
+            // Setting it on clientSide should only produce the row model warning,
+            // not any type/dependency validation warnings for the value itself.
+            gridsManager.createGrid('myGrid', {
+                columnDefs: [],
+                rowData: [],
+                serverSideInitialRowCount: 5,
+            });
+
+            const allWarnings = consoleWarnSpy.mock.calls.map((args) => String(args[0]));
+            const serverSideWarnings = allWarnings.filter((w) => w.includes('serverSideInitialRowCount'));
+
+            // Should only have the "not supported with row model" warning
+            expect(serverSideWarnings).toHaveLength(1);
+            expect(serverSideWarnings[0]).toContain("not supported with the 'clientSide' row model");
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Cache property name checks (deprecations, fuzzy string matching, row model support) per `objectName` so they run once per unique property name, not on every `processOptions` call. This avoids repeated Levenshtein distance calculations for gridOptions updates and grids with many identically-shaped colDefs.
- Pre-compute a `Set` of all valid property names (`allValidNames`) in each validator definition for O(1) lookups instead of rebuilding arrays and doing linear scans each time.
- Inline and remove `checkProperties` / `_fuzzyCheckStrings` helpers — the single cached loop now handles deprecation warnings, property name validation, and row model checks in one pass.

Fix [AG-17003](https://ag-grid.atlassian.net/browse/AG-17003)