### PR TITLE
AG-17016 - Reduce robots size (#13445)

### DIFF
--- a/documentation/ag-grid-docs/.env.build
+++ b/documentation/ag-grid-docs/.env.build
@@ -15,3 +15,5 @@ PUBLIC_GTM_PREVIEW=env-55
 LIVE_SITEMAP_URL=https://grid-staging.ag-grid.com/sitemap-0.xml
 CHARTS_SITEMAP_INDEX_URL=https://www.ag-grid.com/charts/sitemap-index.xml
 CHARTS_ROBOTS_DISALLOW_JSON_URL=https://www.ag-grid.com/charts/robots-disallow.json
+STUDIO_SITEMAP_INDEX_URL=https://www.ag-grid.com/studio/sitemap-index.xml
+STUDIO_ROBOTS_DISALLOW_JSON_URL=https://www.ag-grid.com/studio/robots-disallow.json

--- a/documentation/ag-grid-docs/.env.build.staging
+++ b/documentation/ag-grid-docs/.env.build.staging
@@ -6,6 +6,7 @@ PUBLIC_TRIAL_LICENCE_FORM_URL=https://us-central1-stripe-testing-19784.cloudfunc
 
 # Use staging sitemap
 CHARTS_SITEMAP_INDEX_URL=https://charts-staging.ag-grid.com/sitemap-index.xml
+STUDIO_SITEMAP_INDEX_URL=https://studio-staging.ag-grid.com/sitemap-index.xml
 LIVE_SITEMAP_URL=https://grid-staging.ag-grid.com/sitemap-0.xml
 
 # No robots disallow required, as staging is disallow all

--- a/documentation/ag-grid-docs/.env.dev
+++ b/documentation/ag-grid-docs/.env.dev
@@ -10,6 +10,7 @@ LIVE_SITEMAP_URL=https://grid-staging.ag-grid.com/sitemap-0.xml
 
 # Use production robots disallow
 CHARTS_ROBOTS_DISALLOW_JSON_URL=https://www.ag-grid.com/charts/robots-disallow.json
+STUDIO_ROBOTS_DISALLOW_JSON_URL=https://www.ag-grid.com/studio/robots-disallow.json
 
 #############################################################################
 # To use local dev sitemap/robots disallow, put the following in a .env.local
@@ -17,7 +18,8 @@ CHARTS_ROBOTS_DISALLOW_JSON_URL=https://www.ag-grid.com/charts/robots-disallow.j
 # NOTE: Using charts local build url, as sitemap is only generated on build
 # CHARTS_SITEMAP_INDEX_URL=https://localhost:4601/charts/sitemap-index.xml
 
-# NOTE: Using charts local dev url
+# NOTE: Using local dev url
 # CHARTS_ROBOTS_DISALLOW_JSON_URL="https://localhost:4600/charts/robots-disallow.json"
-# NOTE: Require bypass of HTTPS checks on localhost for `CHARTS_ROBOTS_DISALLOW_JSON_URL`
+# STUDIO_ROBOTS_DISALLOW_JSON_URL=http://localhost:4621/studio/robots-disallow.json
+# NOTE: Require bypass of HTTPS checks on localhost for `*_ROBOTS_DISALLOW_JSON_URL`
 # NODE_TLS_REJECT_UNAUTHORIZED=0

--- a/documentation/ag-grid-docs/astro.config.mjs
+++ b/documentation/ag-grid-docs/astro.config.mjs
@@ -111,6 +111,16 @@ const {
      * Charts robots.txt disallow json url to merge
      */
     CHARTS_ROBOTS_DISALLOW_JSON_URL,
+
+    /**
+     * Studio sitemap index to merge
+     */
+    STUDIO_SITEMAP_INDEX_URL,
+
+    /**
+     * Studio robots.txt disallow json url to merge
+     */
+    STUDIO_ROBOTS_DISALLOW_JSON_URL,
 } = dotenvExpand.expand(dotenv).parsed;
 console.log(
     'Astro configuration',
@@ -130,6 +140,8 @@ console.log(
             DISABLE_EXAMPLE_RUNNER,
             CHARTS_SITEMAP_INDEX_URL,
             CHARTS_ROBOTS_DISALLOW_JSON_URL,
+            STUDIO_SITEMAP_INDEX_URL,
+            STUDIO_ROBOTS_DISALLOW_JSON_URL,
         },
         null,
         2
@@ -199,7 +211,7 @@ export default defineConfig({
         buildTime(),
         react(),
         markdoc(),
-        sitemap(getSitemapConfig({ chartsSitemap: CHARTS_SITEMAP_INDEX_URL })),
+        sitemap(getSitemapConfig({ chartsSitemap: CHARTS_SITEMAP_INDEX_URL, studioSitemap: STUDIO_SITEMAP_INDEX_URL })),
         agHtaccessGen({ include: HTACCESS === 'true' }),
         agRedirectsChecker({
             skip: CHECK_REDIRECTS !== 'true',

--- a/documentation/ag-grid-docs/src/constants.ts
+++ b/documentation/ag-grid-docs/src/constants.ts
@@ -133,6 +133,11 @@ export const FRAMEWORK_REDIRECT_PATH = 'data-grid';
  */
 export const CHARTS_ROBOTS_DISALLOW_JSON_URL = import.meta.env?.CHARTS_ROBOTS_DISALLOW_JSON_URL;
 
+/**
+ * Studio robots disallow json url for merging with grid
+ */
+export const STUDIO_ROBOTS_DISALLOW_JSON_URL = import.meta.env?.STUDIO_ROBOTS_DISALLOW_JSON_URL;
+
 export const PRODUCTION_CHARTS_SITE_URL = 'https://www.ag-grid.com/charts';
 export const LEGACY_CHARTS_SITE_URL = 'https://charts.ag-grid.com';
 

--- a/documentation/ag-grid-docs/src/pages/robots.txt.ts
+++ b/documentation/ag-grid-docs/src/pages/robots.txt.ts
@@ -1,4 +1,4 @@
-import { CHARTS_ROBOTS_DISALLOW_JSON_URL, SITE_URL } from '@constants';
+import { CHARTS_ROBOTS_DISALLOW_JSON_URL, SITE_URL, STUDIO_ROBOTS_DISALLOW_JSON_URL } from '@constants';
 import { getIsDev, getIsProduction } from '@utils/env';
 import { pathJoin } from '@utils/pathJoin';
 import { getSitemapIgnorePaths } from '@utils/sitemapPages';
@@ -7,6 +7,9 @@ import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 const disallowAllRobotsTxt = () => 'User-agent: * Disallow: /';
 
 const productionRobotsTxt = (disallowPaths: string[] = []) => `User-agent: *
+Allow: ${urlWithBaseUrl('/')}
+Allow: ${urlWithBaseUrl('/charts/')}
+Allow: ${urlWithBaseUrl('/studio/')}
 ${disallowPaths
     .map((path) => {
         return `Disallow: ${path}`;
@@ -16,16 +19,43 @@ ${disallowPaths
 Sitemap: ${pathJoin(SITE_URL, urlWithBaseUrl('/sitemap-index.xml'))}
 `;
 
+const fetchRobotsDisallow = async (urls: string[]) => {
+    const fetches = urls.map((url) =>
+        fetch(url)
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch ${url}: ${response.statusText}`);
+                }
+                return response.json();
+            })
+            .catch((error) => {
+                // eslint-disable-next-line no-console
+                console.error(`Error fetching ${url}:`, error);
+                throw error;
+            })
+    );
+
+    const results = await Promise.all(fetches);
+
+    return results.flat();
+};
+
 export async function GET() {
     // NOTE: /archive is ignored in `ignorePaths` on production
     const disallowAll = !getIsDev() && !getIsProduction();
 
-    const gridIgnorePaths = await getSitemapIgnorePaths();
-
-    const chartsIgnorePaths = await fetch(CHARTS_ROBOTS_DISALLOW_JSON_URL).then((resp) => resp.json());
-    const ignorePaths = gridIgnorePaths.concat(chartsIgnorePaths);
-
-    const output = disallowAll ? disallowAllRobotsTxt() : productionRobotsTxt(ignorePaths);
+    let output;
+    if (disallowAll) {
+        output = disallowAllRobotsTxt();
+    } else {
+        const gridIgnorePaths = await getSitemapIgnorePaths();
+        const otherIgnorePaths = await fetchRobotsDisallow([
+            CHARTS_ROBOTS_DISALLOW_JSON_URL,
+            STUDIO_ROBOTS_DISALLOW_JSON_URL,
+        ]);
+        const ignorePaths = gridIgnorePaths.concat(otherIgnorePaths);
+        output = productionRobotsTxt(ignorePaths);
+    }
 
     return new Response(output, {
         status: 200,

--- a/documentation/ag-grid-docs/src/utils/sitemap.ts
+++ b/documentation/ag-grid-docs/src/utils/sitemap.ts
@@ -65,9 +65,11 @@ const filterIgnoredPages = (page: string) => {
     );
 };
 
-export function getSitemapConfig({ chartsSitemap }: { chartsSitemap?: string }) {
+export function getSitemapConfig({ chartsSitemap, studioSitemap }: { chartsSitemap?: string; studioSitemap?: string }) {
+    const customSitemaps = [...(chartsSitemap ? [chartsSitemap] : []), ...(studioSitemap ? [studioSitemap] : [])];
+
     return {
-        customSitemaps: chartsSitemap ? [chartsSitemap] : [],
+        customSitemaps,
         filter: filterIgnoredPages,
         changefreq: 'daily',
         priority: 0.7,

--- a/documentation/ag-grid-docs/src/utils/sitemapPages.ts
+++ b/documentation/ag-grid-docs/src/utils/sitemapPages.ts
@@ -1,26 +1,10 @@
-import { getDocsPages } from '@components/docs/utils/pageData';
-import { getExamplePageUrl } from '@components/docs/utils/urlPaths';
 import { FRAMEWORK_REDIRECT_PATH } from '@constants';
-import { getCollection } from 'astro:content';
 
-import { isTestPage } from './sitemap';
 import { urlWithBaseUrl } from './urlWithBaseUrl';
 
 function addTrailingSlash(path: string) {
     return path.slice(-1) === '/' ? path : `${path}/`;
 }
-
-const getTestPages = async () => {
-    const pages = await getCollection('docs');
-    const docsTestPages = getDocsPages(pages)
-        .map(({ params }) => {
-            const { framework, pageName } = params;
-            return getExamplePageUrl({ framework, path: pageName });
-        })
-        .filter(isTestPage);
-
-    return docsTestPages;
-};
 
 export async function getSitemapIgnorePaths() {
     const ignorePaths = [
@@ -30,9 +14,11 @@ export async function getSitemapIgnorePaths() {
         urlWithBaseUrl('/campaigns'),
         // Redirects
         urlWithBaseUrl(`/${FRAMEWORK_REDIRECT_PATH}`),
+
+        // Test pages
+        urlWithBaseUrl('/*-data-grid/*-test'),
     ];
-    const testPages = await getTestPages();
-    const folderPaths = ignorePaths.concat(testPages).map(addTrailingSlash);
+    const folderPaths = ignorePaths.map(addTrailingSlash);
 
     return folderPaths.concat(urlWithBaseUrl('/404'));
 }


### PR DESCRIPTION
* AG-17016 - Simplify robots.txt generation with wildcard

* AG-17016 - Update with studio sitemap and robots.txt

* AG-17016 - Allow homepage in robots.txt

* AG-17016 - Explicitly allow charts and studio homepages

* AG-17016 - Allow printing to console if there is an error

* AG-17016 - Only fetch ignore paths if required

Port of https://github.com/ag-grid/ag-grid/pull/13445