### PR TITLE
AG-17003 Skip unsupported row model warning for null/undefined values

### DIFF
--- a/packages/ag-grid-community/src/validation/validationService.ts
+++ b/packages/ag-grid-community/src/validation/validationService.ts
@@ -155,6 +155,12 @@ export class ValidationService extends BeanStub implements NamedBean {
             const rules = validations[name as keyof T];
             const rowModel = this.gridOptions.rowModelType ?? 'clientSide';
             if (rules?.supportedRowModels && !rules.supportedRowModels.includes(rowModel)) {
+                const value = options[name as keyof T];
+                if (value == null || value === false) {
+                    // Value is disabled (e.g. Vue wrapper passes rowData: null) — don't cache
+                    // so the check runs again if a real value is provided later
+                    continue;
+                }
                 _warnOnce(
                     `${name} is not supported with the '${rowModel}' row model. It is only valid with: ${rules.supportedRowModels.join(', ')}.`
                 );

--- a/testing/behavioural/src/validation/validation-warnings.test.ts
+++ b/testing/behavioural/src/validation/validation-warnings.test.ts
@@ -188,6 +188,41 @@ describe('ag-grid validation warnings', () => {
             expect(rowModelWarnings()).toHaveLength(1);
         });
 
+        test('does not warn when unsupported row model property has null value', () => {
+            // Vue wrapper passes rowData: null even for serverSide row model grids
+            gridsManager.createGrid('myGrid', {
+                columnDefs: [],
+                rowData: null as any,
+                serverSideInitialRowCount: null as any,
+            });
+
+            const rowModelWarnings = consoleWarnSpy.mock.calls.filter((args) =>
+                String(args[0]).includes('not supported with')
+            );
+            expect(rowModelWarnings).toHaveLength(0);
+        });
+
+        test('warns when unsupported row model property is later set to a real value', () => {
+            // Initially null (no warning), then updated to a real value (should warn)
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [],
+                rowData: null as any,
+                serverSideInitialRowCount: null as any,
+            });
+
+            const rowModelWarnings = () =>
+                consoleWarnSpy.mock.calls.filter((args) =>
+                    String(args[0]).includes('serverSideInitialRowCount is not supported')
+                );
+
+            expect(rowModelWarnings()).toHaveLength(0);
+
+            // Now set a real value — should produce a warning
+            api.updateGridOptions({ serverSideInitialRowCount: 5 } as any);
+
+            expect(rowModelWarnings()).toHaveLength(1);
+        });
+
         test('skips value-level validation for unsupported row model properties', () => {
             // serverSideInitialRowCount has supportedRowModels: ['serverSide']
             // Setting it on clientSide should only produce the row model warning,


### PR DESCRIPTION
Fix [AG-17003](https://ag-grid.atlassian.net/browse/AG-17003)

- Fix regression from  validation caching where the `supportedRowModels` check moved to the property-name phase, firing regardless of value
- The Vue3 wrapper always passes `rowData: null` even for serverSide row model grids, triggering a spurious `rowData is not supported with the 'serverSide' row model` warning
- Skip the warning and don't cache the result for `null`/`undefined`/`false` values so the check re-runs correctly if a real value is provided later via `updateGridOptions`
