### PR TITLE
AG-17026 Fix snippet transformer crash on NewExpression

### DIFF
--- a/documentation/ag-grid-docs/src/components/snippet/__snapshots__/snippetTransformer.test.ts.snap
+++ b/documentation/ag-grid-docs/src/components/snippet/__snapshots__/snippetTransformer.test.ts.snap
@@ -772,7 +772,7 @@ this.getDataPath = (data) => data.path;"
 
 exports[`Snippet Component > given api statements > it should create 'angular' snippets 1`] = `
 "// save the columns state
-const savedState = this.gridApi.getColumnState(); 
+const savedState = this.gridApi.getColumnState();
 
 // restore the column state
 this.gridApi.applyColumnState({ state: savedState });
@@ -783,7 +783,7 @@ const rowNode = this.gridApi.getRowNode('55');"
 
 exports[`Snippet Component > given api statements > it should create 'angular' snippets with space between properties 1`] = `
 "// save the columns state
-const savedState = this.gridApi.getColumnState(); 
+const savedState = this.gridApi.getColumnState();
 
 // restore the column state
 this.gridApi.applyColumnState({ state: savedState });
@@ -794,7 +794,7 @@ const rowNode = this.gridApi.getRowNode('55');"
 
 exports[`Snippet Component > given api statements > it should create 'angular' snippets without framework context 1`] = `
 "// save the columns state
-const savedState = this.gridApi.getColumnState(); 
+const savedState = this.gridApi.getColumnState();
 
 // restore the column state
 this.gridApi.applyColumnState({ state: savedState });
@@ -805,7 +805,7 @@ const rowNode = this.gridApi.getRowNode('55');"
 
 exports[`Snippet Component > given api statements > it should create 'angular' snippets without framework context and space between properties 1`] = `
 "// save the columns state
-const savedState = this.gridApi.getColumnState(); 
+const savedState = this.gridApi.getColumnState();
 
 // restore the column state
 this.gridApi.applyColumnState({ state: savedState });
@@ -816,7 +816,7 @@ const rowNode = this.gridApi.getRowNode('55');"
 
 exports[`Snippet Component > given api statements > it should create 'javascript' snippets 1`] = `
 "// save the columns state
-const savedState = api.getColumnState(); 
+const savedState = api.getColumnState();
 
 // restore the column state
 api.applyColumnState({ state: savedState });
@@ -827,7 +827,7 @@ const rowNode = api.getRowNode('55');"
 
 exports[`Snippet Component > given api statements > it should create 'javascript' snippets with space between properties 1`] = `
 "// save the columns state
-const savedState = api.getColumnState(); 
+const savedState = api.getColumnState();
 
 // restore the column state
 api.applyColumnState({ state: savedState });
@@ -838,7 +838,7 @@ const rowNode = api.getRowNode('55');"
 
 exports[`Snippet Component > given api statements > it should create 'javascript' snippets without framework context 1`] = `
 "// save the columns state
-const savedState = api.getColumnState(); 
+const savedState = api.getColumnState();
 
 // restore the column state
 api.applyColumnState({ state: savedState });
@@ -849,7 +849,7 @@ const rowNode = api.getRowNode('55');"
 
 exports[`Snippet Component > given api statements > it should create 'javascript' snippets without framework context and space between properties 1`] = `
 "// save the columns state
-const savedState = api.getColumnState(); 
+const savedState = api.getColumnState();
 
 // restore the column state
 api.applyColumnState({ state: savedState });
@@ -860,7 +860,7 @@ const rowNode = api.getRowNode('55');"
 
 exports[`Snippet Component > given api statements > it should create 'react' snippets 1`] = `
 "// save the columns state
-const savedState = gridApi.getColumnState(); 
+const savedState = gridApi.getColumnState();
 
 // restore the column state
 gridApi.applyColumnState({ state: savedState });
@@ -871,7 +871,7 @@ const rowNode = gridApi.getRowNode('55');"
 
 exports[`Snippet Component > given api statements > it should create 'react' snippets with space between properties 1`] = `
 "// save the columns state
-const savedState = gridApi.getColumnState(); 
+const savedState = gridApi.getColumnState();
 
 // restore the column state
 gridApi.applyColumnState({ state: savedState });
@@ -882,7 +882,7 @@ const rowNode = gridApi.getRowNode('55');"
 
 exports[`Snippet Component > given api statements > it should create 'react' snippets without framework context 1`] = `
 "// save the columns state
-const savedState = gridApi.getColumnState(); 
+const savedState = gridApi.getColumnState();
 
 // restore the column state
 gridApi.applyColumnState({ state: savedState });
@@ -893,7 +893,7 @@ const rowNode = gridApi.getRowNode('55');"
 
 exports[`Snippet Component > given api statements > it should create 'react' snippets without framework context and space between properties 1`] = `
 "// save the columns state
-const savedState = gridApi.getColumnState(); 
+const savedState = gridApi.getColumnState();
 
 // restore the column state
 gridApi.applyColumnState({ state: savedState });
@@ -904,7 +904,7 @@ const rowNode = gridApi.getRowNode('55');"
 
 exports[`Snippet Component > given api statements > it should create 'vue' snippets 1`] = `
 "// save the columns state
-const savedState = this.gridApi.getColumnState(); 
+const savedState = this.gridApi.getColumnState();
 
 // restore the column state
 this.gridApi.applyColumnState({ state: savedState });
@@ -915,7 +915,7 @@ const rowNode = this.gridApi.getRowNode('55');"
 
 exports[`Snippet Component > given api statements > it should create 'vue' snippets with space between properties 1`] = `
 "// save the columns state
-const savedState = this.gridApi.getColumnState(); 
+const savedState = this.gridApi.getColumnState();
 
 // restore the column state
 this.gridApi.applyColumnState({ state: savedState });
@@ -926,7 +926,7 @@ const rowNode = this.gridApi.getRowNode('55');"
 
 exports[`Snippet Component > given api statements > it should create 'vue' snippets without framework context 1`] = `
 "// save the columns state
-const savedState = this.gridApi.getColumnState(); 
+const savedState = this.gridApi.getColumnState();
 
 // restore the column state
 this.gridApi.applyColumnState({ state: savedState });
@@ -937,7 +937,7 @@ const rowNode = this.gridApi.getRowNode('55');"
 
 exports[`Snippet Component > given api statements > it should create 'vue' snippets without framework context and space between properties 1`] = `
 "// save the columns state
-const savedState = this.gridApi.getColumnState(); 
+const savedState = this.gridApi.getColumnState();
 
 // restore the column state
 this.gridApi.applyColumnState({ state: savedState });
@@ -2040,6 +2040,398 @@ exports[`Snippet Component > given complex column definition with array property
         ]
     }
 ];"
+`;
+
+exports[`Snippet Component > given const with new expression > it should create 'angular' snippets 1`] = `
+"<ag-grid-angular
+    [columnDefs]="columnDefs"
+    [formulaDataSource]="formulaDataSource"
+    /* other grid options ... */ />
+
+const formulaStore = new Map();
+const formulaKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+this.columnDefs = [
+    { field: 'sales' },
+    { field: 'tax', allowFormula: true },
+];
+this.formulaDataSource = {
+    getFormula: ({ column, rowNode }) => formulaStore.get(formulaKey(rowNode.id, column.getColId())),
+    setFormula: ({ column, rowNode, formula }) => {
+        const key = formulaKey(rowNode.id, column.getColId());
+        if (formula === undefined) {
+            formulaStore.delete(key);
+        } else {
+            formulaStore.set(key, formula);
+        }
+    },
+};"
+`;
+
+exports[`Snippet Component > given const with new expression > it should create 'angular' snippets with space between properties 1`] = `
+"<ag-grid-angular
+    [columnDefs]="columnDefs"
+    [formulaDataSource]="formulaDataSource"
+    /* other grid options ... */ />
+
+const formulaStore = new Map();
+const formulaKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+this.columnDefs = [
+    { field: 'sales' },
+    { field: 'tax', allowFormula: true },
+];
+
+this.formulaDataSource = {
+    getFormula: ({ column, rowNode }) => formulaStore.get(formulaKey(rowNode.id, column.getColId())),
+    setFormula: ({ column, rowNode, formula }) => {
+        const key = formulaKey(rowNode.id, column.getColId());
+        if (formula === undefined) {
+            formulaStore.delete(key);
+        } else {
+            formulaStore.set(key, formula);
+        }
+    },
+};"
+`;
+
+exports[`Snippet Component > given const with new expression > it should create 'angular' snippets without framework context 1`] = `
+"const formulaStore = new Map();
+const formulaKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+this.columnDefs = [
+    { field: 'sales' },
+    { field: 'tax', allowFormula: true },
+];
+this.formulaDataSource = {
+    getFormula: ({ column, rowNode }) => formulaStore.get(formulaKey(rowNode.id, column.getColId())),
+    setFormula: ({ column, rowNode, formula }) => {
+        const key = formulaKey(rowNode.id, column.getColId());
+        if (formula === undefined) {
+            formulaStore.delete(key);
+        } else {
+            formulaStore.set(key, formula);
+        }
+    },
+};"
+`;
+
+exports[`Snippet Component > given const with new expression > it should create 'angular' snippets without framework context and space between properties 1`] = `
+"const formulaStore = new Map();
+const formulaKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+this.columnDefs = [
+    { field: 'sales' },
+    { field: 'tax', allowFormula: true },
+];
+
+this.formulaDataSource = {
+    getFormula: ({ column, rowNode }) => formulaStore.get(formulaKey(rowNode.id, column.getColId())),
+    setFormula: ({ column, rowNode, formula }) => {
+        const key = formulaKey(rowNode.id, column.getColId());
+        if (formula === undefined) {
+            formulaStore.delete(key);
+        } else {
+            formulaStore.set(key, formula);
+        }
+    },
+};"
+`;
+
+exports[`Snippet Component > given const with new expression > it should create 'javascript' snippets 1`] = `
+"const formulaStore = new Map();
+const formulaKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+const gridOptions = {
+    columnDefs: [
+        { field: 'sales' },
+        { field: 'tax', allowFormula: true },
+    ],
+    formulaDataSource: {
+        getFormula: ({ column, rowNode }) => formulaStore.get(formulaKey(rowNode.id, column.getColId())),
+        setFormula: ({ column, rowNode, formula }) => {
+            const key = formulaKey(rowNode.id, column.getColId());
+            if (formula === undefined) {
+                formulaStore.delete(key);
+            } else {
+                formulaStore.set(key, formula);
+            }
+        },
+    },
+
+    // other grid options ...
+}"
+`;
+
+exports[`Snippet Component > given const with new expression > it should create 'javascript' snippets with space between properties 1`] = `
+"const formulaStore = new Map();
+const formulaKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+const gridOptions = {
+    columnDefs: [
+        { field: 'sales' },
+        { field: 'tax', allowFormula: true },
+    ],
+
+    formulaDataSource: {
+        getFormula: ({ column, rowNode }) => formulaStore.get(formulaKey(rowNode.id, column.getColId())),
+        setFormula: ({ column, rowNode, formula }) => {
+            const key = formulaKey(rowNode.id, column.getColId());
+            if (formula === undefined) {
+                formulaStore.delete(key);
+            } else {
+                formulaStore.set(key, formula);
+            }
+        },
+    },
+
+    // other grid options ...
+}"
+`;
+
+exports[`Snippet Component > given const with new expression > it should create 'javascript' snippets without framework context 1`] = `
+"const formulaStore = new Map();
+const formulaKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+
+columnDefs: [
+    { field: 'sales' },
+    { field: 'tax', allowFormula: true },
+],
+formulaDataSource: {
+    getFormula: ({ column, rowNode }) => formulaStore.get(formulaKey(rowNode.id, column.getColId())),
+    setFormula: ({ column, rowNode, formula }) => {
+        const key = formulaKey(rowNode.id, column.getColId());
+        if (formula === undefined) {
+            formulaStore.delete(key);
+        } else {
+            formulaStore.set(key, formula);
+        }
+    },
+},"
+`;
+
+exports[`Snippet Component > given const with new expression > it should create 'javascript' snippets without framework context and space between properties 1`] = `
+"const formulaStore = new Map();
+const formulaKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+
+columnDefs: [
+    { field: 'sales' },
+    { field: 'tax', allowFormula: true },
+],
+
+formulaDataSource: {
+    getFormula: ({ column, rowNode }) => formulaStore.get(formulaKey(rowNode.id, column.getColId())),
+    setFormula: ({ column, rowNode, formula }) => {
+        const key = formulaKey(rowNode.id, column.getColId());
+        if (formula === undefined) {
+            formulaStore.delete(key);
+        } else {
+            formulaStore.set(key, formula);
+        }
+    },
+},"
+`;
+
+exports[`Snippet Component > given const with new expression > it should create 'react' snippets 1`] = `
+"const formulaStore = new Map();
+const formulaKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+const [columnDefs, setColumnDefs] = useState([
+    { field: 'sales' },
+    { field: 'tax', allowFormula: true },
+]);
+const formulaDataSource = {
+    getFormula: ({ column, rowNode }) => formulaStore.get(formulaKey(rowNode.id, column.getColId())),
+    setFormula: ({ column, rowNode, formula }) => {
+        const key = formulaKey(rowNode.id, column.getColId());
+        if (formula === undefined) {
+            formulaStore.delete(key);
+        } else {
+            formulaStore.set(key, formula);
+        }
+    },
+};
+
+<AgGridReact
+    columnDefs={columnDefs}
+    formulaDataSource={formulaDataSource}
+/>"
+`;
+
+exports[`Snippet Component > given const with new expression > it should create 'react' snippets with space between properties 1`] = `
+"const formulaStore = new Map();
+const formulaKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+const [columnDefs, setColumnDefs] = useState([
+    { field: 'sales' },
+    { field: 'tax', allowFormula: true },
+]);
+
+const formulaDataSource = {
+    getFormula: ({ column, rowNode }) => formulaStore.get(formulaKey(rowNode.id, column.getColId())),
+    setFormula: ({ column, rowNode, formula }) => {
+        const key = formulaKey(rowNode.id, column.getColId());
+        if (formula === undefined) {
+            formulaStore.delete(key);
+        } else {
+            formulaStore.set(key, formula);
+        }
+    },
+};
+
+<AgGridReact
+    columnDefs={columnDefs}
+    formulaDataSource={formulaDataSource}
+/>"
+`;
+
+exports[`Snippet Component > given const with new expression > it should create 'react' snippets without framework context 1`] = `
+"const formulaStore = new Map();
+const formulaKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+const [columnDefs, setColumnDefs] = useState([
+    { field: 'sales' },
+    { field: 'tax', allowFormula: true },
+]);
+const formulaDataSource = {
+    getFormula: ({ column, rowNode }) => formulaStore.get(formulaKey(rowNode.id, column.getColId())),
+    setFormula: ({ column, rowNode, formula }) => {
+        const key = formulaKey(rowNode.id, column.getColId());
+        if (formula === undefined) {
+            formulaStore.delete(key);
+        } else {
+            formulaStore.set(key, formula);
+        }
+    },
+};
+
+<AgGridReact
+    columnDefs={columnDefs}
+    formulaDataSource={formulaDataSource}
+/>"
+`;
+
+exports[`Snippet Component > given const with new expression > it should create 'react' snippets without framework context and space between properties 1`] = `
+"const formulaStore = new Map();
+const formulaKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+const [columnDefs, setColumnDefs] = useState([
+    { field: 'sales' },
+    { field: 'tax', allowFormula: true },
+]);
+
+const formulaDataSource = {
+    getFormula: ({ column, rowNode }) => formulaStore.get(formulaKey(rowNode.id, column.getColId())),
+    setFormula: ({ column, rowNode, formula }) => {
+        const key = formulaKey(rowNode.id, column.getColId());
+        if (formula === undefined) {
+            formulaStore.delete(key);
+        } else {
+            formulaStore.set(key, formula);
+        }
+    },
+};
+
+<AgGridReact
+    columnDefs={columnDefs}
+    formulaDataSource={formulaDataSource}
+/>"
+`;
+
+exports[`Snippet Component > given const with new expression > it should create 'vue' snippets 1`] = `
+"<ag-grid-vue
+    :columnDefs="columnDefs"
+    :formulaDataSource="formulaDataSource"
+    /* other grid options ... */>
+</ag-grid-vue>
+
+const formulaStore = new Map();
+const formulaKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+this.columnDefs = [
+    { field: 'sales' },
+    { field: 'tax', allowFormula: true },
+];
+this.formulaDataSource = {
+    getFormula: ({ column, rowNode }) => formulaStore.get(formulaKey(rowNode.id, column.getColId())),
+    setFormula: ({ column, rowNode, formula }) => {
+        const key = formulaKey(rowNode.id, column.getColId());
+        if (formula === undefined) {
+            formulaStore.delete(key);
+        } else {
+            formulaStore.set(key, formula);
+        }
+    },
+};"
+`;
+
+exports[`Snippet Component > given const with new expression > it should create 'vue' snippets with space between properties 1`] = `
+"<ag-grid-vue
+    :columnDefs="columnDefs"
+    :formulaDataSource="formulaDataSource"
+    /* other grid options ... */>
+</ag-grid-vue>
+
+const formulaStore = new Map();
+const formulaKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+this.columnDefs = [
+    { field: 'sales' },
+    { field: 'tax', allowFormula: true },
+];
+
+this.formulaDataSource = {
+    getFormula: ({ column, rowNode }) => formulaStore.get(formulaKey(rowNode.id, column.getColId())),
+    setFormula: ({ column, rowNode, formula }) => {
+        const key = formulaKey(rowNode.id, column.getColId());
+        if (formula === undefined) {
+            formulaStore.delete(key);
+        } else {
+            formulaStore.set(key, formula);
+        }
+    },
+};"
+`;
+
+exports[`Snippet Component > given const with new expression > it should create 'vue' snippets without framework context 1`] = `
+"const formulaStore = new Map();
+const formulaKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+this.columnDefs = [
+    { field: 'sales' },
+    { field: 'tax', allowFormula: true },
+];
+this.formulaDataSource = {
+    getFormula: ({ column, rowNode }) => formulaStore.get(formulaKey(rowNode.id, column.getColId())),
+    setFormula: ({ column, rowNode, formula }) => {
+        const key = formulaKey(rowNode.id, column.getColId());
+        if (formula === undefined) {
+            formulaStore.delete(key);
+        } else {
+            formulaStore.set(key, formula);
+        }
+    },
+};"
+`;
+
+exports[`Snippet Component > given const with new expression > it should create 'vue' snippets without framework context and space between properties 1`] = `
+"const formulaStore = new Map();
+const formulaKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+this.columnDefs = [
+    { field: 'sales' },
+    { field: 'tax', allowFormula: true },
+];
+
+this.formulaDataSource = {
+    getFormula: ({ column, rowNode }) => formulaStore.get(formulaKey(rowNode.id, column.getColId())),
+    setFormula: ({ column, rowNode, formula }) => {
+        const key = formulaKey(rowNode.id, column.getColId());
+        if (formula === undefined) {
+            formulaStore.delete(key);
+        } else {
+            formulaStore.set(key, formula);
+        }
+    },
+};"
 `;
 
 exports[`Snippet Component > given function declaration > it should create 'angular' snippets 1`] = `

--- a/documentation/ag-grid-docs/src/components/snippet/snippetTransformer.test.ts
+++ b/documentation/ag-grid-docs/src/components/snippet/snippetTransformer.test.ts
@@ -198,6 +198,31 @@ const rowNode = api.getRowNode('55');`
         );
     });
 
+    describe('given const with new expression', () => {
+        runSnippetFrameworkTests(
+            `const formulaStore = new Map();
+const formulaKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+const gridOptions = {
+    columnDefs: [
+        { field: 'sales' },
+        { field: 'tax', allowFormula: true },
+    ],
+    formulaDataSource: {
+        getFormula: ({ column, rowNode }) => formulaStore.get(formulaKey(rowNode.id, column.getColId())),
+        setFormula: ({ column, rowNode, formula }) => {
+            const key = formulaKey(rowNode.id, column.getColId());
+            if (formula === undefined) {
+                formulaStore.delete(key);
+            } else {
+                formulaStore.set(key, formula);
+            }
+        },
+    },
+}`
+        );
+    });
+
     describe('given useMemo and useCallback properties with JS literals does not add useMemo or useCallback', () => {
         runSnippetFrameworkTests(`const gridOptions = {
             popupParent: -Infinity,

--- a/documentation/ag-grid-docs/src/components/snippet/snippetTransformer.ts
+++ b/documentation/ag-grid-docs/src/components/snippet/snippetTransformer.ts
@@ -17,6 +17,7 @@ class SnippetTransformer {
 
     // used when adding framework context
     propertiesVisited = [];
+    expressions = [];
 
     constructor(snippet, options) {
         this.options = options;
@@ -29,8 +30,12 @@ class SnippetTransformer {
             // create a syntax tree from the supplied snippet (also contains separated comments)
             parsedSyntaxTreeResults = parseScript(this.snippet, { comment: true, loc: true, range: true });
         } catch (error) {
-            const errorMsg = "To troubleshoot paste snippet here: 'https://esprima.org/demo/parse.html'";
-            return `${error}\n\n${errorMsg}\n\n${this.snippet}`;
+            throw new Error(
+                `Snippet transformation failed (parse error).\n` +
+                    `To troubleshoot paste snippet here: 'https://esprima.org/demo/parse.html'\n\n` +
+                    `Snippet:\n${this.snippet}`,
+                { cause: error }
+            );
         }
 
         // associate comments with each node
@@ -41,7 +46,7 @@ class SnippetTransformer {
             // parse syntax tree to produce main snippet body
             snippetBody = this.parse(tree, this.initialDepth);
         } catch (error) {
-            return `${error}\n\n${this.snippet}`;
+            throw new Error(`Snippet transformation failed.\n\nSnippet:\n${this.snippet}`, { cause: error });
         }
 
         // wrap snippet body with framework context
@@ -97,18 +102,21 @@ class JavascriptTransformer extends SnippetTransformer {
     }
 
     parseExpression(expression, variableExpression) {
-        const comment = this.addComment(expression, 0);
+        const extraLine = expression.comment && this.expressions.length > 0 ? '\n' : '';
+        const comment = expression.comment ? `//${expression.comment}\n` : '';
         const exprPrefix = variableExpression ? 'const ' : '';
-        const exprPostfix = variableExpression ? '; ' : '';
+        const exprPostfix = variableExpression ? ';' : '';
         const [start, end] = expression.range;
-        return `\n${comment}${exprPrefix}${this.snippet.slice(start, end)}${exprPostfix}`;
+        this.expressions.push(`${extraLine}${comment}${exprPrefix}${this.snippet.slice(start, end)}${exprPostfix}`);
+        return '';
     }
 
     addFrameworkContext(result) {
+        const expressionSnippet = this.expressions.length > 0 ? this.expressions.join('\n') + '\n\n' : '';
         if (this.options.suppressFrameworkContext || this.propertiesVisited.length === 0) {
-            return result.trim();
+            return (expressionSnippet + result).trim();
         }
-        return `const gridOptions = {${result}` + `\n\n${tab(1)}// other grid options ...` + '\n}';
+        return expressionSnippet + `const gridOptions = {${result}` + `\n\n${tab(1)}// other grid options ...` + '\n}';
     }
 
     addComment(property, depth) {
@@ -130,22 +138,27 @@ class AngularTransformer extends SnippetTransformer {
     }
 
     parseExpression(expression, variableExpression) {
-        const comment = this.addComment(expression, 0);
+        const extraLine = expression.comment && this.expressions.length > 0 ? '\n' : '';
+        const comment = expression.comment ? `//${expression.comment}\n` : '';
         const exprPrefix = variableExpression ? 'const ' : '';
-        const exprPostfix = variableExpression ? '; ' : '';
+        const exprPostfix = variableExpression ? ';' : '';
         const [start, end] = expression.range;
-        return `\n${comment}${exprPrefix}${this.snippet.slice(start, end)}${exprPostfix}`.replace(
-            'api',
-            'this.gridApi'
+        this.expressions.push(
+            `${extraLine}${comment}${exprPrefix}${this.snippet.slice(start, end)}${exprPostfix}`.replace(
+                'api',
+                'this.gridApi'
+            )
         );
+        return '';
     }
 
     addFrameworkContext(result) {
+        const expressionSnippet = this.expressions.length > 0 ? '\n' + this.expressions.join('\n') + '\n' : '';
         if (this.options.suppressFrameworkContext || this.propertiesVisited.length === 0) {
-            return result.trim();
+            return (expressionSnippet + result).trim();
         }
         const props = this.propertiesVisited.map((property) => `${tab(1)}[${property}]="${property}"`).join('\n');
-        return '<ag-grid-angular\n' + props + '\n    /* other grid options ... */ />\n' + result;
+        return '<ag-grid-angular\n' + props + '\n    /* other grid options ... */ />\n' + expressionSnippet + result;
     }
 
     addComment(property) {
@@ -155,16 +168,23 @@ class AngularTransformer extends SnippetTransformer {
 
 class VueTransformer extends AngularTransformer {
     addFrameworkContext(result) {
+        const expressionSnippet = this.expressions.length > 0 ? '\n' + this.expressions.join('\n') + '\n' : '';
         if (this.options.suppressFrameworkContext || this.propertiesVisited.length === 0) {
-            return result.trim();
+            return (expressionSnippet + result).trim();
         }
         const props = this.propertiesVisited.map((property) => `${tab(1)}:${property}="${property}"`).join('\n');
-        return '<ag-grid-vue\n' + props + '\n    /* other grid options ... */>\n' + '</ag-grid-vue>\n' + result;
+        return (
+            '<ag-grid-vue\n' +
+            props +
+            '\n    /* other grid options ... */>\n' +
+            '</ag-grid-vue>\n' +
+            expressionSnippet +
+            result
+        );
     }
 }
 
 class ReactTransformer extends SnippetTransformer {
-    expressionSnippet = false;
     externalisedProperties = [];
     inlineProperties = [];
     inlinePropertiesWithValues = [];
@@ -185,12 +205,18 @@ class ReactTransformer extends SnippetTransformer {
     }
 
     parseExpression(expression, variableExpression) {
-        this.expressionSnippet = true;
-        const comment = this.getComment(expression, 0);
+        const extraLine = expression.comment && this.externalisedProperties.length > 0 ? '\n' : '';
+        const comment = expression.comment ? `//${expression.comment}\n` : '';
         const exprPrefix = variableExpression ? 'const ' : '';
-        const exprPostfix = variableExpression ? '; ' : '';
+        const exprPostfix = variableExpression ? ';' : '';
         const [start, end] = expression.range;
-        return `\n${comment}${exprPrefix}${this.snippet.slice(start, end)}${exprPostfix}`.replace('api', 'gridApi');
+        this.externalisedProperties.push(
+            `${extraLine}${comment}${exprPrefix}${this.snippet.slice(start, end)}${exprPostfix}`.replace(
+                'api',
+                'gridApi'
+            )
+        );
+        return '';
     }
 
     extractExternalProperty(property) {
@@ -216,20 +242,16 @@ class ReactTransformer extends SnippetTransformer {
     }
 
     addFrameworkContext(result) {
-        const externalProperties = this.externalisedProperties.length > 0;
-        const externalSnippet = externalProperties ? this.externalisedProperties.join('\n').trim() + '\n\n' : '';
+        const externalSnippet =
+            this.externalisedProperties.length > 0 ? this.externalisedProperties.join('\n').trim() + '\n\n' : '';
 
-        if (this.expressionSnippet) {
-            return result.trim();
-        }
-        if (this.options.suppressFrameworkContext && this.propertiesVisited.length === 0) {
-            // framework context is only hidden if no grid options exists (columnDefs excluded)
-            return decreaseIndent(result.trim());
+        if (this.propertiesVisited.length === 0) {
+            return externalSnippet.trim() || decreaseIndent(result.trim());
         }
 
         if (this.options.inlineReactProperties && this.inlinePropertiesWithValues.length > 0) {
             const space = this.inlinePropertiesWithValues.length > 0 ? ' ' : '';
-            return `<AgGridReact${space}${this.inlinePropertiesWithValues.join(' ')} />`;
+            return externalSnippet + `<AgGridReact${space}${this.inlinePropertiesWithValues.join(' ')} />`;
         }
 
         if (this.inlineProperties.length > 1) {
@@ -370,5 +392,5 @@ const isVarDeclarator = (node) => node.type === 'VariableDeclarator';
 const isExprStatement = (node) => node.type === 'ExpressionStatement';
 const isLabelStatement = (node) => node.type === 'LabeledStatement';
 const isBlockStatement = (node) => node.type === 'BlockStatement';
-const isCallableExpr = (node) => node.init.type === 'CallExpression';
+const isCallableExpr = (node) => node.init.type === 'CallExpression' || node.init.type === 'NewExpression';
 const isArrowFunctionExpr = (node) => node.init.type === 'ArrowFunctionExpression';


### PR DESCRIPTION
## Summary

- Fix `isCallableExpr` to handle `NewExpression` (e.g. `new Map()`) which was crashing the snippet transformer with `TypeError: Cannot read properties of undefined (reading 'map')`
- Collect expressions separately from grid properties so they are placed correctly per framework: before `gridOptions` (JS), after the template (Angular/Vue), or into `externalisedProperties` (React)
- Throw proper errors with cause chain instead of returning error strings from `transform()`
- Add test case covering the formulas documentation snippet with mixed `const` declarations and `gridOptions`

## Test plan

- [x] All 160 existing snippet transformer tests pass
- [x] New test case covers `const formulaStore = new Map()` + `const formulaKey = ...` + `gridOptions` for all frameworks and option combinations

Fixes AG-17026