### PR TITLE
AG-17026 Replace esprima with esprima-next for ES2020+ snippet support

### DIFF
--- a/documentation/ag-grid-docs/package.json
+++ b/documentation/ag-grid-docs/package.json
@@ -70,6 +70,7 @@
     "classnames": "^2.5.1",
     "codesandbox-import-utils": "2.2.3",
     "dompurify": "^3.2.6",
+    "esprima-next": "^5.8.4",
     "downshift": "^9.0.6",
     "gif-frames": "^1.0.1",
     "he": "^1.2.0",

--- a/documentation/ag-grid-docs/src/components/snippet/__snapshots__/snippetTransformer.test.ts.snap
+++ b/documentation/ag-grid-docs/src/components/snippet/__snapshots__/snippetTransformer.test.ts.snap
@@ -2546,6 +2546,478 @@ const myValueFormatter = params => {
 };"
 `;
 
+exports[`Snippet Component > given optional chaining and nullish coalescing > it should create 'angular' snippets 1`] = `
+"<ag-grid-angular
+    [getRowId]="getRowId"
+    [notesDataSource]="notesDataSource"
+    /* other grid options ... */ />
+
+const noteStore = new Map();
+const noteKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+this.getRowId = (params) => String(params.data.id);
+this.notesDataSource = {
+    getNote: ({ rowNode, column }) => noteStore.get(noteKey(rowNode.id, column.getColId())),
+    setNote: ({ rowNode, column, note }) => {
+        const key = noteKey(rowNode.id, column.getColId());
+        const existingNote = noteStore.get(key);
+
+        if (note === undefined) {
+            noteStore.delete(key);
+        } else {
+            noteStore.set(key, {
+                ...existingNote,
+                ...note,
+                author: getCurrentUser(),
+                createdAt: existingNote?.createdAt ?? getDisplayTimestamp(),
+                updatedAt: getDisplayTimestamp(),
+            });
+        }
+    },
+};"
+`;
+
+exports[`Snippet Component > given optional chaining and nullish coalescing > it should create 'angular' snippets with space between properties 1`] = `
+"<ag-grid-angular
+    [getRowId]="getRowId"
+    [notesDataSource]="notesDataSource"
+    /* other grid options ... */ />
+
+const noteStore = new Map();
+const noteKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+this.getRowId = (params) => String(params.data.id);
+
+this.notesDataSource = {
+    getNote: ({ rowNode, column }) => noteStore.get(noteKey(rowNode.id, column.getColId())),
+    setNote: ({ rowNode, column, note }) => {
+        const key = noteKey(rowNode.id, column.getColId());
+        const existingNote = noteStore.get(key);
+
+        if (note === undefined) {
+            noteStore.delete(key);
+        } else {
+            noteStore.set(key, {
+                ...existingNote,
+                ...note,
+                author: getCurrentUser(),
+                createdAt: existingNote?.createdAt ?? getDisplayTimestamp(),
+                updatedAt: getDisplayTimestamp(),
+            });
+        }
+    },
+};"
+`;
+
+exports[`Snippet Component > given optional chaining and nullish coalescing > it should create 'angular' snippets without framework context 1`] = `
+"const noteStore = new Map();
+const noteKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+this.getRowId = (params) => String(params.data.id);
+this.notesDataSource = {
+    getNote: ({ rowNode, column }) => noteStore.get(noteKey(rowNode.id, column.getColId())),
+    setNote: ({ rowNode, column, note }) => {
+        const key = noteKey(rowNode.id, column.getColId());
+        const existingNote = noteStore.get(key);
+
+        if (note === undefined) {
+            noteStore.delete(key);
+        } else {
+            noteStore.set(key, {
+                ...existingNote,
+                ...note,
+                author: getCurrentUser(),
+                createdAt: existingNote?.createdAt ?? getDisplayTimestamp(),
+                updatedAt: getDisplayTimestamp(),
+            });
+        }
+    },
+};"
+`;
+
+exports[`Snippet Component > given optional chaining and nullish coalescing > it should create 'angular' snippets without framework context and space between properties 1`] = `
+"const noteStore = new Map();
+const noteKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+this.getRowId = (params) => String(params.data.id);
+
+this.notesDataSource = {
+    getNote: ({ rowNode, column }) => noteStore.get(noteKey(rowNode.id, column.getColId())),
+    setNote: ({ rowNode, column, note }) => {
+        const key = noteKey(rowNode.id, column.getColId());
+        const existingNote = noteStore.get(key);
+
+        if (note === undefined) {
+            noteStore.delete(key);
+        } else {
+            noteStore.set(key, {
+                ...existingNote,
+                ...note,
+                author: getCurrentUser(),
+                createdAt: existingNote?.createdAt ?? getDisplayTimestamp(),
+                updatedAt: getDisplayTimestamp(),
+            });
+        }
+    },
+};"
+`;
+
+exports[`Snippet Component > given optional chaining and nullish coalescing > it should create 'javascript' snippets 1`] = `
+"const noteStore = new Map();
+const noteKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+const gridOptions = {
+    getRowId: (params) => String(params.data.id),
+    notesDataSource: {
+        getNote: ({ rowNode, column }) => noteStore.get(noteKey(rowNode.id, column.getColId())),
+        setNote: ({ rowNode, column, note }) => {
+            const key = noteKey(rowNode.id, column.getColId());
+            const existingNote = noteStore.get(key);
+
+            if (note === undefined) {
+                noteStore.delete(key);
+            } else {
+                noteStore.set(key, {
+                    ...existingNote,
+                    ...note,
+                    author: getCurrentUser(),
+                    createdAt: existingNote?.createdAt ?? getDisplayTimestamp(),
+                    updatedAt: getDisplayTimestamp(),
+                });
+            }
+        },
+    },
+
+    // other grid options ...
+}"
+`;
+
+exports[`Snippet Component > given optional chaining and nullish coalescing > it should create 'javascript' snippets with space between properties 1`] = `
+"const noteStore = new Map();
+const noteKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+const gridOptions = {
+    getRowId: (params) => String(params.data.id),
+
+    notesDataSource: {
+        getNote: ({ rowNode, column }) => noteStore.get(noteKey(rowNode.id, column.getColId())),
+        setNote: ({ rowNode, column, note }) => {
+            const key = noteKey(rowNode.id, column.getColId());
+            const existingNote = noteStore.get(key);
+
+            if (note === undefined) {
+                noteStore.delete(key);
+            } else {
+                noteStore.set(key, {
+                    ...existingNote,
+                    ...note,
+                    author: getCurrentUser(),
+                    createdAt: existingNote?.createdAt ?? getDisplayTimestamp(),
+                    updatedAt: getDisplayTimestamp(),
+                });
+            }
+        },
+    },
+
+    // other grid options ...
+}"
+`;
+
+exports[`Snippet Component > given optional chaining and nullish coalescing > it should create 'javascript' snippets without framework context 1`] = `
+"const noteStore = new Map();
+const noteKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+
+getRowId: (params) => String(params.data.id),
+notesDataSource: {
+    getNote: ({ rowNode, column }) => noteStore.get(noteKey(rowNode.id, column.getColId())),
+    setNote: ({ rowNode, column, note }) => {
+        const key = noteKey(rowNode.id, column.getColId());
+        const existingNote = noteStore.get(key);
+
+        if (note === undefined) {
+            noteStore.delete(key);
+        } else {
+            noteStore.set(key, {
+                ...existingNote,
+                ...note,
+                author: getCurrentUser(),
+                createdAt: existingNote?.createdAt ?? getDisplayTimestamp(),
+                updatedAt: getDisplayTimestamp(),
+            });
+        }
+    },
+},"
+`;
+
+exports[`Snippet Component > given optional chaining and nullish coalescing > it should create 'javascript' snippets without framework context and space between properties 1`] = `
+"const noteStore = new Map();
+const noteKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+
+getRowId: (params) => String(params.data.id),
+
+notesDataSource: {
+    getNote: ({ rowNode, column }) => noteStore.get(noteKey(rowNode.id, column.getColId())),
+    setNote: ({ rowNode, column, note }) => {
+        const key = noteKey(rowNode.id, column.getColId());
+        const existingNote = noteStore.get(key);
+
+        if (note === undefined) {
+            noteStore.delete(key);
+        } else {
+            noteStore.set(key, {
+                ...existingNote,
+                ...note,
+                author: getCurrentUser(),
+                createdAt: existingNote?.createdAt ?? getDisplayTimestamp(),
+                updatedAt: getDisplayTimestamp(),
+            });
+        }
+    },
+},"
+`;
+
+exports[`Snippet Component > given optional chaining and nullish coalescing > it should create 'react' snippets 1`] = `
+"const noteStore = new Map();
+const noteKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+const getRowId = useCallback((params) => String(params.data.id), []);
+const notesDataSource = {
+    getNote: ({ rowNode, column }) => noteStore.get(noteKey(rowNode.id, column.getColId())),
+    setNote: ({ rowNode, column, note }) => {
+        const key = noteKey(rowNode.id, column.getColId());
+        const existingNote = noteStore.get(key);
+
+        if (note === undefined) {
+            noteStore.delete(key);
+        } else {
+            noteStore.set(key, {
+                ...existingNote,
+                ...note,
+                author: getCurrentUser(),
+                createdAt: existingNote?.createdAt ?? getDisplayTimestamp(),
+                updatedAt: getDisplayTimestamp(),
+            });
+        }
+    },
+};
+
+<AgGridReact
+    getRowId={getRowId}
+    notesDataSource={notesDataSource}
+/>"
+`;
+
+exports[`Snippet Component > given optional chaining and nullish coalescing > it should create 'react' snippets with space between properties 1`] = `
+"const noteStore = new Map();
+const noteKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+const getRowId = useCallback((params) => String(params.data.id), []);
+
+const notesDataSource = {
+    getNote: ({ rowNode, column }) => noteStore.get(noteKey(rowNode.id, column.getColId())),
+    setNote: ({ rowNode, column, note }) => {
+        const key = noteKey(rowNode.id, column.getColId());
+        const existingNote = noteStore.get(key);
+
+        if (note === undefined) {
+            noteStore.delete(key);
+        } else {
+            noteStore.set(key, {
+                ...existingNote,
+                ...note,
+                author: getCurrentUser(),
+                createdAt: existingNote?.createdAt ?? getDisplayTimestamp(),
+                updatedAt: getDisplayTimestamp(),
+            });
+        }
+    },
+};
+
+<AgGridReact
+    getRowId={getRowId}
+    notesDataSource={notesDataSource}
+/>"
+`;
+
+exports[`Snippet Component > given optional chaining and nullish coalescing > it should create 'react' snippets without framework context 1`] = `
+"const noteStore = new Map();
+const noteKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+const getRowId = useCallback((params) => String(params.data.id), []);
+const notesDataSource = {
+    getNote: ({ rowNode, column }) => noteStore.get(noteKey(rowNode.id, column.getColId())),
+    setNote: ({ rowNode, column, note }) => {
+        const key = noteKey(rowNode.id, column.getColId());
+        const existingNote = noteStore.get(key);
+
+        if (note === undefined) {
+            noteStore.delete(key);
+        } else {
+            noteStore.set(key, {
+                ...existingNote,
+                ...note,
+                author: getCurrentUser(),
+                createdAt: existingNote?.createdAt ?? getDisplayTimestamp(),
+                updatedAt: getDisplayTimestamp(),
+            });
+        }
+    },
+};
+
+<AgGridReact
+    getRowId={getRowId}
+    notesDataSource={notesDataSource}
+/>"
+`;
+
+exports[`Snippet Component > given optional chaining and nullish coalescing > it should create 'react' snippets without framework context and space between properties 1`] = `
+"const noteStore = new Map();
+const noteKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+const getRowId = useCallback((params) => String(params.data.id), []);
+
+const notesDataSource = {
+    getNote: ({ rowNode, column }) => noteStore.get(noteKey(rowNode.id, column.getColId())),
+    setNote: ({ rowNode, column, note }) => {
+        const key = noteKey(rowNode.id, column.getColId());
+        const existingNote = noteStore.get(key);
+
+        if (note === undefined) {
+            noteStore.delete(key);
+        } else {
+            noteStore.set(key, {
+                ...existingNote,
+                ...note,
+                author: getCurrentUser(),
+                createdAt: existingNote?.createdAt ?? getDisplayTimestamp(),
+                updatedAt: getDisplayTimestamp(),
+            });
+        }
+    },
+};
+
+<AgGridReact
+    getRowId={getRowId}
+    notesDataSource={notesDataSource}
+/>"
+`;
+
+exports[`Snippet Component > given optional chaining and nullish coalescing > it should create 'vue' snippets 1`] = `
+"<ag-grid-vue
+    :getRowId="getRowId"
+    :notesDataSource="notesDataSource"
+    /* other grid options ... */>
+</ag-grid-vue>
+
+const noteStore = new Map();
+const noteKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+this.getRowId = (params) => String(params.data.id);
+this.notesDataSource = {
+    getNote: ({ rowNode, column }) => noteStore.get(noteKey(rowNode.id, column.getColId())),
+    setNote: ({ rowNode, column, note }) => {
+        const key = noteKey(rowNode.id, column.getColId());
+        const existingNote = noteStore.get(key);
+
+        if (note === undefined) {
+            noteStore.delete(key);
+        } else {
+            noteStore.set(key, {
+                ...existingNote,
+                ...note,
+                author: getCurrentUser(),
+                createdAt: existingNote?.createdAt ?? getDisplayTimestamp(),
+                updatedAt: getDisplayTimestamp(),
+            });
+        }
+    },
+};"
+`;
+
+exports[`Snippet Component > given optional chaining and nullish coalescing > it should create 'vue' snippets with space between properties 1`] = `
+"<ag-grid-vue
+    :getRowId="getRowId"
+    :notesDataSource="notesDataSource"
+    /* other grid options ... */>
+</ag-grid-vue>
+
+const noteStore = new Map();
+const noteKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+this.getRowId = (params) => String(params.data.id);
+
+this.notesDataSource = {
+    getNote: ({ rowNode, column }) => noteStore.get(noteKey(rowNode.id, column.getColId())),
+    setNote: ({ rowNode, column, note }) => {
+        const key = noteKey(rowNode.id, column.getColId());
+        const existingNote = noteStore.get(key);
+
+        if (note === undefined) {
+            noteStore.delete(key);
+        } else {
+            noteStore.set(key, {
+                ...existingNote,
+                ...note,
+                author: getCurrentUser(),
+                createdAt: existingNote?.createdAt ?? getDisplayTimestamp(),
+                updatedAt: getDisplayTimestamp(),
+            });
+        }
+    },
+};"
+`;
+
+exports[`Snippet Component > given optional chaining and nullish coalescing > it should create 'vue' snippets without framework context 1`] = `
+"const noteStore = new Map();
+const noteKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+this.getRowId = (params) => String(params.data.id);
+this.notesDataSource = {
+    getNote: ({ rowNode, column }) => noteStore.get(noteKey(rowNode.id, column.getColId())),
+    setNote: ({ rowNode, column, note }) => {
+        const key = noteKey(rowNode.id, column.getColId());
+        const existingNote = noteStore.get(key);
+
+        if (note === undefined) {
+            noteStore.delete(key);
+        } else {
+            noteStore.set(key, {
+                ...existingNote,
+                ...note,
+                author: getCurrentUser(),
+                createdAt: existingNote?.createdAt ?? getDisplayTimestamp(),
+                updatedAt: getDisplayTimestamp(),
+            });
+        }
+    },
+};"
+`;
+
+exports[`Snippet Component > given optional chaining and nullish coalescing > it should create 'vue' snippets without framework context and space between properties 1`] = `
+"const noteStore = new Map();
+const noteKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+this.getRowId = (params) => String(params.data.id);
+
+this.notesDataSource = {
+    getNote: ({ rowNode, column }) => noteStore.get(noteKey(rowNode.id, column.getColId())),
+    setNote: ({ rowNode, column, note }) => {
+        const key = noteKey(rowNode.id, column.getColId());
+        const existingNote = noteStore.get(key);
+
+        if (note === undefined) {
+            noteStore.delete(key);
+        } else {
+            noteStore.set(key, {
+                ...existingNote,
+                ...note,
+                author: getCurrentUser(),
+                createdAt: existingNote?.createdAt ?? getDisplayTimestamp(),
+                updatedAt: getDisplayTimestamp(),
+            });
+        }
+    },
+};"
+`;
+
 exports[`Snippet Component > given simple column definitions > it should create 'angular' snippets 1`] = `
 "<ag-grid-angular
     [columnDefs]="columnDefs"

--- a/documentation/ag-grid-docs/src/components/snippet/snippetTransformer.test.ts
+++ b/documentation/ag-grid-docs/src/components/snippet/snippetTransformer.test.ts
@@ -223,6 +223,36 @@ const gridOptions = {
         );
     });
 
+    describe('given optional chaining and nullish coalescing', () => {
+        runSnippetFrameworkTests(
+            `const noteStore = new Map();
+const noteKey = (rowId, colId) => \`\${rowId}-\${colId}\`;
+
+const gridOptions = {
+    getRowId: (params) => String(params.data.id),
+    notesDataSource: {
+        getNote: ({ rowNode, column }) => noteStore.get(noteKey(rowNode.id, column.getColId())),
+        setNote: ({ rowNode, column, note }) => {
+            const key = noteKey(rowNode.id, column.getColId());
+            const existingNote = noteStore.get(key);
+
+            if (note === undefined) {
+                noteStore.delete(key);
+            } else {
+                noteStore.set(key, {
+                    ...existingNote,
+                    ...note,
+                    author: getCurrentUser(),
+                    createdAt: existingNote?.createdAt ?? getDisplayTimestamp(),
+                    updatedAt: getDisplayTimestamp(),
+                });
+            }
+        },
+    },
+}`
+        );
+    });
+
     describe('given useMemo and useCallback properties with JS literals does not add useMemo or useCallback', () => {
         runSnippetFrameworkTests(`const gridOptions = {
             popupParent: -Infinity,

--- a/documentation/ag-grid-docs/src/components/snippet/snippetTransformer.ts
+++ b/documentation/ag-grid-docs/src/components/snippet/snippetTransformer.ts
@@ -1,4 +1,4 @@
-import { parseScript } from 'esprima';
+import { parseScript } from 'esprima-next';
 
 export const transform = (snippet, framework, options) => {
     const transforms = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13080,6 +13080,11 @@ espree@^9.0.0:
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.4.1"
 
+esprima-next@^5.8.4:
+  version "5.8.4"
+  resolved "https://registry.yarnpkg.com/esprima-next/-/esprima-next-5.8.4.tgz#9f82c8093a33da7207a4e8621e997c66878c145a"
+  integrity sha512-8nYVZ4ioIH4Msjb/XmhnBdz5WRRBaYqevKa1cv9nGJdCehMbzZCPNEEnqfLCZVetUVrUPEcb5IYyu1GG4hFqgg==
+
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "http://52.50.158.57:4873/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17026

Replace `esprima` with `esprima-next` in the snippet transformer so that
modern JS syntax (optional chaining `?.`, nullish coalescing `??`) works
in `frameworkTransform` doc snippets. Esprima 4.0.1 only supports ES2017
and is unmaintained; esprima-next is a drop-in fork with ES2020+ support.

- Swap import from `esprima` to `esprima-next` (same API, same AST shape)
- Add `esprima-next` dependency to `ag-grid-docs` package.json
- Add test case covering optional chaining and nullish coalescing in snippets

Fix [AG-17026](https://ag-grid.atlassian.net/browse/AG-17026)