### PR TITLE
AG-16643 Reset ready flag on unmount to preserve prop changes during Suspense

### DIFF
--- a/packages/ag-grid-react/src/reactUi/agGridReactUi.tsx
+++ b/packages/ag-grid-react/src/reactUi/agGridReactUi.tsx
@@ -132,6 +132,7 @@ export const AgGridReactUi = <TData,>(props: InternalAgGridReactProps<TData>) =>
         eGui.current = eRef;
         updateClassName(props.className);
         if (!eRef) {
+            ready.current = false;
             for (const f of destroyFuncs.current) {
                 f();
             }

--- a/testing/behavioural/src/suspense/react-suspense.test.tsx
+++ b/testing/behavioural/src/suspense/react-suspense.test.tsx
@@ -1,12 +1,13 @@
-import { cleanup, render } from '@testing-library/react';
-import React, { Suspense, act, useState } from 'react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import React, { Suspense, act, useMemo, useState } from 'react';
 
-import { ClientSideRowModelModule, ModuleRegistry } from 'ag-grid-community';
+import type { ColDef, GridApi } from 'ag-grid-community';
+import { ClientSideRowModelModule, ColumnApiModule, ModuleRegistry, RowApiModule } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
 
 describe('React Suspense', () => {
     beforeAll(() => {
-        ModuleRegistry.registerModules([ClientSideRowModelModule]);
+        ModuleRegistry.registerModules([ClientSideRowModelModule, ColumnApiModule, RowApiModule]);
     });
 
     beforeEach(() => {
@@ -74,5 +75,552 @@ describe('React Suspense', () => {
 
         expect(await findByText('foo')).toBeVisible();
         expect(await findByText('bar')).toBeVisible();
+    });
+
+    test('Should maintain pinned columns after Suspense unmount/remount with columnDefs change', async () => {
+        let gridApi: GridApi | null = null;
+        let resolveSuspense: (() => void) | null = null;
+
+        const rowData = [
+            { id: 1, name: 'Row A', value: 'Value A' },
+            { id: 2, name: 'Row B', value: 'Value B' },
+        ];
+
+        const GridComponent = ({ lang, onReady }: { lang: 'en' | 'fr'; onReady: (api: GridApi) => void }) => {
+            const columnDefs = useMemo<ColDef[]>(
+                () => [
+                    { field: 'name', pinned: 'left', width: 200 },
+                    { field: 'value', headerName: lang === 'fr' ? 'Valeur' : 'Value', flex: 1 },
+                ],
+                [lang]
+            );
+            return (
+                <AgGridReact
+                    rowData={rowData}
+                    columnDefs={columnDefs}
+                    onGridReady={({ api }: { api: GridApi }) => onReady(api)}
+                />
+            );
+        };
+
+        const SuspendingWrapper = ({
+            suspendPromise,
+            lang,
+            onReady,
+        }: {
+            suspendPromise: Promise<void> | null;
+            lang: 'en' | 'fr';
+            onReady: (api: GridApi) => void;
+        }) => {
+            if (suspendPromise) throw suspendPromise;
+            return <GridComponent lang={lang} onReady={onReady} />;
+        };
+
+        const Wrapper = () => {
+            const [lang, setLang] = useState<'en' | 'fr'>('en');
+            const [suspendPromise, setSuspendPromise] = useState<Promise<void> | null>(null);
+
+            return (
+                <div>
+                    <button
+                        type="button"
+                        onClick={() => {
+                            const promise = new Promise<void>((resolve) => {
+                                resolveSuspense = resolve;
+                            });
+                            setSuspendPromise(promise);
+                        }}
+                    >
+                        trigger-suspense
+                    </button>
+                    <button type="button" onClick={() => setLang('fr')}>
+                        change-lang
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => {
+                            resolveSuspense?.();
+                            setSuspendPromise(null);
+                        }}
+                    >
+                        resolve-suspense
+                    </button>
+                    <Suspense fallback={<span>loading...</span>}>
+                        <SuspendingWrapper
+                            suspendPromise={suspendPromise}
+                            lang={lang}
+                            onReady={(api) => {
+                                gridApi = api;
+                            }}
+                        />
+                    </Suspense>
+                </div>
+            );
+        };
+
+        const { getByText } = render(<Wrapper />);
+
+        // Wait for the grid to be ready
+        await waitFor(() => expect(gridApi).not.toBeNull());
+
+        // Verify pinned column exists on initial render
+        const initialColState = gridApi!.getColumnState();
+        expect(initialColState.find((s) => s.colId === 'name')?.pinned).toBe('left');
+
+        // Step 1: Trigger suspense to unmount the grid
+        act(() => {
+            getByText('trigger-suspense').click();
+        });
+
+        await screen.findByText('loading...');
+        gridApi = null;
+
+        // Step 2: Change language while grid is suspended (this changes columnDefs)
+        act(() => {
+            getByText('change-lang').click();
+        });
+
+        // Step 3: Resolve suspense to remount the grid with new columnDefs
+        act(() => {
+            getByText('resolve-suspense').click();
+        });
+
+        // Wait for the grid to be ready after remount
+        await waitFor(() => expect(gridApi).not.toBeNull());
+
+        // The pinned column should still be pinned after Suspense remount with changed columnDefs
+        const colStateAfterRemount = gridApi!.getColumnState();
+        expect(colStateAfterRemount.find((s) => s.colId === 'name')?.pinned).toBe('left');
+
+        // The column should be rendered in the left (pinned) display area
+        const leftCols = gridApi!.getDisplayedLeftColumns();
+        expect(leftCols).toHaveLength(1);
+        expect(leftCols[0].getColId()).toBe('name');
+    });
+
+    test('Should maintain pinned columns after Suspense unmount/remount with no prop changes', async () => {
+        let gridApi: GridApi | null = null;
+        let resolveSuspense: (() => void) | null = null;
+
+        const rowData = [
+            { id: 1, name: 'Row A', value: 'Value A' },
+            { id: 2, name: 'Row B', value: 'Value B' },
+        ];
+
+        const columnDefs: ColDef[] = [
+            { field: 'name', pinned: 'left', width: 200 },
+            { field: 'value', flex: 1 },
+        ];
+
+        const SuspendingWrapper = ({
+            suspendPromise,
+            onReady,
+        }: {
+            suspendPromise: Promise<void> | null;
+            onReady: (api: GridApi) => void;
+        }) => {
+            if (suspendPromise) throw suspendPromise;
+            return (
+                <AgGridReact
+                    rowData={rowData}
+                    columnDefs={columnDefs}
+                    onGridReady={({ api }: { api: GridApi }) => onReady(api)}
+                />
+            );
+        };
+
+        const Wrapper = () => {
+            const [suspendPromise, setSuspendPromise] = useState<Promise<void> | null>(null);
+
+            return (
+                <div>
+                    <button
+                        type="button"
+                        onClick={() => {
+                            const promise = new Promise<void>((resolve) => {
+                                resolveSuspense = resolve;
+                            });
+                            setSuspendPromise(promise);
+                        }}
+                    >
+                        trigger-suspense
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => {
+                            resolveSuspense?.();
+                            setSuspendPromise(null);
+                        }}
+                    >
+                        resolve-suspense
+                    </button>
+                    <Suspense fallback={<span>loading...</span>}>
+                        <SuspendingWrapper
+                            suspendPromise={suspendPromise}
+                            onReady={(api) => {
+                                gridApi = api;
+                            }}
+                        />
+                    </Suspense>
+                </div>
+            );
+        };
+
+        const { getByText } = render(<Wrapper />);
+
+        await waitFor(() => expect(gridApi).not.toBeNull());
+        expect(gridApi!.getColumnState().find((s) => s.colId === 'name')?.pinned).toBe('left');
+
+        // Trigger suspense to unmount the grid
+        act(() => {
+            getByText('trigger-suspense').click();
+        });
+
+        await screen.findByText('loading...');
+        gridApi = null;
+
+        // Resolve suspense with no prop changes
+        act(() => {
+            getByText('resolve-suspense').click();
+        });
+
+        await waitFor(() => expect(gridApi).not.toBeNull());
+
+        // Pinned column should still be intact after unmount/remount with no prop changes
+        expect(gridApi!.getColumnState().find((s) => s.colId === 'name')?.pinned).toBe('left');
+        const leftCols = gridApi!.getDisplayedLeftColumns();
+        expect(leftCols).toHaveLength(1);
+        expect(leftCols[0].getColId()).toBe('name');
+    });
+
+    test('Should apply rowData change made during Suspense suspension', async () => {
+        let gridApi: GridApi | null = null;
+        let resolveSuspense: (() => void) | null = null;
+
+        const initialRowData = [
+            { id: 1, name: 'Row A' },
+            { id: 2, name: 'Row B' },
+        ];
+        const updatedRowData = [
+            { id: 1, name: 'Row A' },
+            { id: 2, name: 'Row B' },
+            { id: 3, name: 'Row C' },
+        ];
+
+        const SuspendingWrapper = ({
+            suspendPromise,
+            rowData,
+            onReady,
+        }: {
+            suspendPromise: Promise<void> | null;
+            rowData: { id: number; name: string }[];
+            onReady: (api: GridApi) => void;
+        }) => {
+            if (suspendPromise) throw suspendPromise;
+            return (
+                <AgGridReact
+                    rowData={rowData}
+                    columnDefs={[{ field: 'name' }]}
+                    getRowId={({ data }) => String(data.id)}
+                    onGridReady={({ api }: { api: GridApi }) => onReady(api)}
+                />
+            );
+        };
+
+        const Wrapper = () => {
+            const [rowData, setRowData] = useState(initialRowData);
+            const [suspendPromise, setSuspendPromise] = useState<Promise<void> | null>(null);
+
+            return (
+                <div>
+                    <button
+                        type="button"
+                        onClick={() => {
+                            const promise = new Promise<void>((resolve) => {
+                                resolveSuspense = resolve;
+                            });
+                            setSuspendPromise(promise);
+                        }}
+                    >
+                        trigger-suspense
+                    </button>
+                    <button type="button" onClick={() => setRowData(updatedRowData)}>
+                        add-row
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => {
+                            resolveSuspense?.();
+                            setSuspendPromise(null);
+                        }}
+                    >
+                        resolve-suspense
+                    </button>
+                    <Suspense fallback={<span>loading...</span>}>
+                        <SuspendingWrapper
+                            suspendPromise={suspendPromise}
+                            rowData={rowData}
+                            onReady={(api) => {
+                                gridApi = api;
+                            }}
+                        />
+                    </Suspense>
+                </div>
+            );
+        };
+
+        const { getByText } = render(<Wrapper />);
+
+        await waitFor(() => expect(gridApi).not.toBeNull());
+        expect(gridApi!.getDisplayedRowCount()).toBe(2);
+
+        // Trigger suspense to unmount the grid
+        act(() => {
+            getByText('trigger-suspense').click();
+        });
+
+        await screen.findByText('loading...');
+        gridApi = null;
+
+        // Add a row while grid is suspended
+        act(() => {
+            getByText('add-row').click();
+        });
+
+        // Resolve suspense to remount the grid
+        act(() => {
+            getByText('resolve-suspense').click();
+        });
+
+        await waitFor(() => expect(gridApi).not.toBeNull());
+
+        // The new row should be present after remount
+        expect(gridApi!.getDisplayedRowCount()).toBe(3);
+        expect(gridApi!.getDisplayedRowAtIndex(2)!.data.name).toBe('Row C');
+    });
+
+    test('Should handle multiple Suspense cycles correctly', async () => {
+        let gridApi: GridApi | null = null;
+        let resolveSuspense: (() => void) | null = null;
+
+        const SuspendingWrapper = ({
+            suspendPromise,
+            label,
+            onReady,
+        }: {
+            suspendPromise: Promise<void> | null;
+            label: string;
+            onReady: (api: GridApi) => void;
+        }) => {
+            if (suspendPromise) throw suspendPromise;
+            return (
+                <AgGridReact
+                    rowData={[{ value: label }]}
+                    columnDefs={[{ field: 'value', pinned: 'left' }]}
+                    onGridReady={({ api }: { api: GridApi }) => onReady(api)}
+                />
+            );
+        };
+
+        const Wrapper = () => {
+            const [label, setLabel] = useState('initial');
+            const [suspendPromise, setSuspendPromise] = useState<Promise<void> | null>(null);
+
+            return (
+                <div>
+                    <button
+                        type="button"
+                        onClick={() => {
+                            const promise = new Promise<void>((resolve) => {
+                                resolveSuspense = resolve;
+                            });
+                            setSuspendPromise(promise);
+                        }}
+                    >
+                        trigger-suspense
+                    </button>
+                    <button type="button" onClick={() => setLabel((l) => l + '-updated')}>
+                        update-label
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => {
+                            resolveSuspense?.();
+                            setSuspendPromise(null);
+                        }}
+                    >
+                        resolve-suspense
+                    </button>
+                    <Suspense fallback={<span>loading...</span>}>
+                        <SuspendingWrapper
+                            suspendPromise={suspendPromise}
+                            label={label}
+                            onReady={(api) => {
+                                gridApi = api;
+                            }}
+                        />
+                    </Suspense>
+                </div>
+            );
+        };
+
+        const { getByText } = render(<Wrapper />);
+        await waitFor(() => expect(gridApi).not.toBeNull());
+        expect(gridApi!.getColumnState().find((s) => s.colId === 'value')?.pinned).toBe('left');
+
+        // --- First Suspense cycle ---
+        act(() => {
+            getByText('trigger-suspense').click();
+        });
+        await screen.findByText('loading...');
+        gridApi = null;
+
+        act(() => {
+            getByText('update-label').click();
+        });
+        act(() => {
+            getByText('resolve-suspense').click();
+        });
+
+        await waitFor(() => expect(gridApi).not.toBeNull());
+        expect(gridApi!.getColumnState().find((s) => s.colId === 'value')?.pinned).toBe('left');
+        gridApi = null;
+
+        // --- Second Suspense cycle ---
+        act(() => {
+            getByText('trigger-suspense').click();
+        });
+        await screen.findByText('loading...');
+
+        act(() => {
+            getByText('update-label').click();
+        });
+        act(() => {
+            getByText('resolve-suspense').click();
+        });
+
+        await waitFor(() => expect(gridApi).not.toBeNull());
+
+        // Pinned column intact after second cycle
+        expect(gridApi!.getColumnState().find((s) => s.colId === 'value')?.pinned).toBe('left');
+    });
+
+    test('Should apply multiple prop changes made during Suspense suspension', async () => {
+        let gridApi: GridApi | null = null;
+        let resolveSuspense: (() => void) | null = null;
+
+        const initialRowData = [{ id: 1, name: 'Row A', value: 'Value A' }];
+        const updatedRowData = [
+            { id: 1, name: 'Row A', value: 'Value A' },
+            { id: 2, name: 'Row B', value: 'Value B' },
+        ];
+
+        const SuspendingWrapper = ({
+            suspendPromise,
+            rowData,
+            lang,
+            onReady,
+        }: {
+            suspendPromise: Promise<void> | null;
+            rowData: { id: number; name: string; value: string }[];
+            lang: 'en' | 'fr';
+            onReady: (api: GridApi) => void;
+        }) => {
+            if (suspendPromise) throw suspendPromise;
+            const columnDefs = useMemo<ColDef[]>(
+                () => [
+                    { field: 'name', pinned: 'left', width: 200 },
+                    { field: 'value', headerName: lang === 'fr' ? 'Valeur' : 'Value', flex: 1 },
+                ],
+                [lang]
+            );
+            return (
+                <AgGridReact
+                    rowData={rowData}
+                    columnDefs={columnDefs}
+                    getRowId={({ data }) => String(data.id)}
+                    onGridReady={({ api }: { api: GridApi }) => onReady(api)}
+                />
+            );
+        };
+
+        const Wrapper = () => {
+            const [lang, setLang] = useState<'en' | 'fr'>('en');
+            const [rowData, setRowData] = useState(initialRowData);
+            const [suspendPromise, setSuspendPromise] = useState<Promise<void> | null>(null);
+
+            return (
+                <div>
+                    <button
+                        type="button"
+                        onClick={() => {
+                            const promise = new Promise<void>((resolve) => {
+                                resolveSuspense = resolve;
+                            });
+                            setSuspendPromise(promise);
+                        }}
+                    >
+                        trigger-suspense
+                    </button>
+                    <button type="button" onClick={() => setLang('fr')}>
+                        change-lang
+                    </button>
+                    <button type="button" onClick={() => setRowData(updatedRowData)}>
+                        add-row
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => {
+                            resolveSuspense?.();
+                            setSuspendPromise(null);
+                        }}
+                    >
+                        resolve-suspense
+                    </button>
+                    <Suspense fallback={<span>loading...</span>}>
+                        <SuspendingWrapper
+                            suspendPromise={suspendPromise}
+                            rowData={rowData}
+                            lang={lang}
+                            onReady={(api) => {
+                                gridApi = api;
+                            }}
+                        />
+                    </Suspense>
+                </div>
+            );
+        };
+
+        const { getByText } = render(<Wrapper />);
+        await waitFor(() => expect(gridApi).not.toBeNull());
+        expect(gridApi!.getDisplayedRowCount()).toBe(1);
+        expect(gridApi!.getColumnState().find((s) => s.colId === 'name')?.pinned).toBe('left');
+
+        // Trigger suspense
+        act(() => {
+            getByText('trigger-suspense').click();
+        });
+        await screen.findByText('loading...');
+        gridApi = null;
+
+        // Change both columnDefs (via lang) and rowData while suspended
+        act(() => {
+            getByText('change-lang').click();
+        });
+        act(() => {
+            getByText('add-row').click();
+        });
+
+        // Resolve suspense
+        act(() => {
+            getByText('resolve-suspense').click();
+        });
+
+        await waitFor(() => expect(gridApi).not.toBeNull());
+
+        // Both prop changes should be reflected after remount
+        expect(gridApi!.getDisplayedRowCount()).toBe(2);
+        expect(gridApi!.getColumnState().find((s) => s.colId === 'name')?.pinned).toBe('left');
+        expect(gridApi!.getColumn('value')!.getColDef().headerName).toBe('Valeur');
     });
 });

--- a/testing/behavioural/src/suspense/react-suspense.test.tsx
+++ b/testing/behavioural/src/suspense/react-suspense.test.tsx
@@ -112,7 +112,9 @@ describe('React Suspense', () => {
             lang: 'en' | 'fr';
             onReady: (api: GridApi) => void;
         }) => {
-            if (suspendPromise) throw suspendPromise;
+            if (suspendPromise) {
+                throw suspendPromise;
+            }
             return <GridComponent lang={lang} onReady={onReady} />;
         };
 
@@ -219,7 +221,9 @@ describe('React Suspense', () => {
             suspendPromise: Promise<void> | null;
             onReady: (api: GridApi) => void;
         }) => {
-            if (suspendPromise) throw suspendPromise;
+            if (suspendPromise) {
+                throw suspendPromise;
+            }
             return (
                 <AgGridReact
                     rowData={rowData}
@@ -316,7 +320,9 @@ describe('React Suspense', () => {
             rowData: { id: number; name: string }[];
             onReady: (api: GridApi) => void;
         }) => {
-            if (suspendPromise) throw suspendPromise;
+            if (suspendPromise) {
+                throw suspendPromise;
+            }
             return (
                 <AgGridReact
                     rowData={rowData}
@@ -412,7 +418,9 @@ describe('React Suspense', () => {
             label: string;
             onReady: (api: GridApi) => void;
         }) => {
-            if (suspendPromise) throw suspendPromise;
+            if (suspendPromise) {
+                throw suspendPromise;
+            }
             return (
                 <AgGridReact
                     rowData={[{ value: label }]}
@@ -526,7 +534,9 @@ describe('React Suspense', () => {
             lang: 'en' | 'fr';
             onReady: (api: GridApi) => void;
         }) => {
-            if (suspendPromise) throw suspendPromise;
+            if (suspendPromise) {
+                throw suspendPromise;
+            }
             const columnDefs = useMemo<ColDef[]>(
                 () => [
                     { field: 'name', pinned: 'left', width: 200 },


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16643

When a React Suspense boundary unmounts the grid, `ready.current` was left as `true`. Any prop changes arriving during suspension were immediately dispatched via `processWhenReady` against a destroyed API and silently dropped — causing pinned columns (and any other prop state) to be lost on remount.

Setting `ready.current = false` on unmount queues those changes in `whenReadyFuncs` so they are correctly applied once the grid finishes reinitialising after remount.

Adds behavioural tests covering:
- `columnDefs` change during suspension (original bug scenario)
- No-prop-change regression guard
- `rowData` change during suspension
- Multiple Suspense cycles in sequence
- Multiple simultaneous prop changes during suspension

Fix [AG-16643](https://ag-grid.atlassian.net/browse/AG-16643)