### PR TITLE
fix: use RTL-aware scroll helpers in getHScrollPosition and header se…

### DIFF
--- a/packages/ag-grid-community/src/gridBodyComp/rowContainer/rowContainerCtrl.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/rowContainer/rowContainerCtrl.ts
@@ -489,8 +489,8 @@ export class RowContainerCtrl extends BeanStub implements ScrollPartner {
 
     public getHScrollPosition(): { left: number; right: number } {
         const res = {
-            left: this.eViewport.scrollLeft,
-            right: this.eViewport.scrollLeft + this.eViewport.offsetWidth,
+            left: _getScrollLeft(this.eViewport, this.enableRtl),
+            right: _getScrollLeft(this.eViewport, this.enableRtl) + this.eViewport.offsetWidth,
         };
         return res;
     }

--- a/packages/ag-grid-community/src/headerRendering/rowContainer/headerRowContainerComp.ts
+++ b/packages/ag-grid-community/src/headerRendering/rowContainer/headerRowContainerComp.ts
@@ -1,5 +1,5 @@
 import { RefPlaceholder } from '../../agStack/interfaces/agComponent';
-import { _ensureDomOrder } from '../../agStack/utils/dom';
+import { _ensureDomOrder, _setScrollLeft } from '../../agStack/utils/dom';
 import type { ColumnPinnedType } from '../../interfaces/iColumn';
 import type { ElementParams } from '../../utils/element';
 import { Component } from '../../widgets/component';
@@ -36,13 +36,15 @@ export class HeaderRowContainerComp extends Component {
     public postConstruct(): void {
         this.selectAndSetTemplate();
 
+        const enableRtl = this.gos.get('enableRtl');
+
         const compProxy: IHeaderRowContainerComp = {
             setDisplayed: (displayed) => this.setDisplayed(displayed),
             setCtrls: (ctrls) => this.setCtrls(ctrls),
 
             // only gets called for center section
             setCenterWidth: (width) => (this.eCenterContainer.style.width = width),
-            setViewportScrollLeft: (left) => (this.getGui().scrollLeft = left),
+            setViewportScrollLeft: (left) => _setScrollLeft(this.getGui(), left, enableRtl),
 
             // only gets called for pinned sections
             setPinnedContainerWidth: (width) => {


### PR DESCRIPTION
## Problem

When `enableRtl` is set to `true`, horizontal scrolling can cause the header and body viewports to desynchronize — the header scrolls but the body cells don't follow (or vice versa).

This happens because two places in the scroll sync chain read/write `scrollLeft` directly without using the RTL-aware helpers (`getScrollLeft` / `setScrollLeft`), which handle cross-browser differences in how `scrollLeft` behaves under RTL:
- Chrome/Safari use negative `scrollLeft` values in RTL
- Firefox uses positive (inverted) values
- The helpers normalize these to a consistent positive value

## Root Cause

**1. `RowContainerCtrl.getHScrollPosition()`** reads raw `this.eViewport.scrollLeft` instead of `_getScrollLeft(this.eViewport, this.enableRtl)`.

This returns browser-specific values to callers (e.g. `getHorizontalPixelRange()` API, drag-and-drop positioning) that expect normalized values.

**2. `HeaderRowContainerComp.setViewportScrollLeft()`** writes directly to `this.getGui().scrollLeft = left` instead of using `_setScrollLeft(this.getGui(), left, enableRtl)`.

The header receives a normalized scroll offset from the body's scroll handler, but writes it as a raw `scrollLeft` value. In Chrome RTL, the browser expects a negative value, but receives a positive one — causing the header to scroll to the wrong position.

## Fix

- `rowContainerCtrl.ts`: `getHScrollPosition()` now uses `_getScrollLeft(this.eViewport, this.enableRtl)`, consistent with `getCenterViewportScrollLeft()` and `getViewportScrollLeft()` in the same class.
- `headerRowContainerComp.ts`: `setViewportScrollLeft` now uses `_setScrollLeft(this.getGui(), left, enableRtl)`, consistent with `setCenterViewportScrollLeft()` in `RowContainerCtrl`.

Both fixes use the same RTL-aware helpers that are already correctly used everywhere else in the scroll sync chain.

## How to reproduce

1. Set `enableRtl: true` on the grid
2. Add enough columns so horizontal scrolling is required
3. Scroll horizontally — observe header and body cells become misaligned

Particularly reproducible in Chrome, where `scrollLeft` is negative in RTL mode.
