### PR TITLE
AG-17042 Fix(columns): reset columns restores original order after Column Chooser reorder

### DIFF
--- a/packages/ag-grid-community/src/columns/columnStateUtils.ts
+++ b/packages/ag-grid-community/src/columns/columnStateUtils.ts
@@ -330,7 +330,7 @@ export function _resetColumnState(beans: BeanCollection, source: ColumnEventType
 
     const autoCols = autoColSvc?.getColumns() ?? [];
     const selectionCols = selectionColSvc?.getColumns() ?? [];
-    const orderedCols = [...selectionCols, ...autoCols, ...primaryCols];
+    const orderedCols = [...selectionCols, ...autoCols, ...primaryColumns];
     const orderedColState = orderedCols.map((col) => ({ colId: col.colId }));
 
     // apply the new order when all the cols have been created & are available


### PR DESCRIPTION
- Fixes regression from 35.1.0 where "Reset Columns" did not restore original column order after reordering via Column Chooser
- `_resetColumnState()` was using `primaryCols` (from mutable `colDefCols.list`) for the ordering step — this list gets mutated by `syncPrimaryColDefOrderFromCurrentColumns()` when the Column Chooser reorders columns
- Changed to use `primaryColumns` (extracted from the immutable column tree), which always reflects the original columnDefs order

Fix [AG-17042](https://ag-grid.atlassian.net/browse/AG-17042)