### PR TITLE
Only flag breaking changes against released versions in PR review

### DIFF
--- a/external/ag-shared/prompts/skills/pr-review/_review-core.md
+++ b/external/ag-shared/prompts/skills/pr-review/_review-core.md
@@ -107,10 +107,12 @@ PAGER='' gh pr view $ARGUMENTS --json title,author,headRefOid,baseRefName,headRe
 
 | Priority | Meaning                          | Examples                                                       |
 | -------- | -------------------------------- | -------------------------------------------------------------- |
-| **P0**   | Critical - Must fix before merge | Security vulnerabilities, data loss, crashes, breaking changes |
+| **P0**   | Critical - Must fix before merge | Security vulnerabilities, data loss, crashes, breaking changes (see note below) |
 | **P1**   | High - Should fix before merge   | Logic errors, significant bugs, missing error handling         |
 | **P2**   | Medium - Consider fixing         | Minor bugs, performance concerns, maintainability issues       |
 | **P3**   | Low - Optional (count only)      | Documentation, minor style, suggestions                        |
+
+**Breaking change note:** Only flag something as a breaking change if the affected API or behaviour exists in a **published release** — i.e., present on a `bX.Y.Z` release branch or published npm package. Changes that exist only on the unreleased `latest` branch are not breaking changes for consumers.
 
 ## 6. Confidence Score Guidelines
 

--- a/external/ag-shared/prompts/skills/pr-review/agents/devils-advocate.md
+++ b/external/ag-shared/prompts/skills/pr-review/agents/devils-advocate.md
@@ -46,6 +46,7 @@ You operate as a sub-agent spawned after the standard review pass. The standard 
 - Are there breaking changes that are not obvious from the diff alone (e.g., subtle behaviour changes, type narrowing)?
 - Would a consumer need to migrate or update their code? Is that migration path clear?
 - Does this change alter any public API surface (types, events, callbacks, CSS classes)?
+- **Only flag something as a breaking change if the affected API or behaviour exists in a published release** (a `bX.Y.Z` branch or npm package). Changes that exist only on the unreleased `latest` branch are not breaking changes for consumers.
 
 ### 6. Play the Adversary
 


### PR DESCRIPTION
Update the PR review skill to clarify that breaking changes should only be flagged when the affected API or behaviour exists in a published release (a `bX.Y.Z` branch or npm package). Changes that exist only on the unreleased `latest` branch are not breaking changes for consumers.

Changes:
- `_review-core.md`: added a breaking change note below the P0 priority definition
- `agents/devils-advocate.md`: added the same qualifier to the "Consider the Consumer" section