### PR TITLE
Fix Rich Select fuzzy search selecting wrong value with long formatValue descriptions

### DIFF
--- a/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.test.ts
+++ b/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.test.ts
@@ -143,6 +143,34 @@ describe('fuzzyMatch.ts', () => {
             expect(values).toEqual(['abc', 'abd']);
         });
 
+        it('fuzzy search for "duct" ranks substring matches appropriately', () => {
+            // Rich Select scenario: equipment codes with descriptions, searching for 'duct'.
+            // Entries containing the exact substring 'DUCT' should rank above fuzzy matches.
+            const allSuggestions = [
+                'LCDD00 DUST DETECTOR',
+                'PSCI00 CONDUCTIVITY INDICATOR',
+                'ERCD01 RESIDUAL CURRENT DEVICE',
+                'TCID00 INTRUDER DETECTION',
+                'HAHAY00 HYDRAULIC HATCH',
+                'HVAC03 HVAC DUCT',
+                'HVAC07 HVAC DUCT FLOW SWITCH',
+            ];
+            const { values } = _fuzzySuggestions({
+                inputValue: 'duct',
+                allSuggestions,
+                hideIrrelevant: true,
+            });
+            expect(values).toEqual([
+                'PSCI00 CONDUCTIVITY INDICATOR',
+                'HVAC03 HVAC DUCT',
+                'HVAC07 HVAC DUCT FLOW SWITCH',
+                'LCDD00 DUST DETECTOR',
+                'TCID00 INTRUDER DETECTION',
+                'ERCD01 RESIDUAL CURRENT DEVICE',
+                'HAHAY00 HYDRAULIC HATCH',
+            ]);
+        });
+
         it('returns an empty result for an empty suggestion list', () => {
             const { values, indices } = _fuzzySuggestions({ inputValue: 'test', allSuggestions: [] });
             expect(values).toEqual([]);

--- a/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.test.ts
+++ b/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.test.ts
@@ -177,6 +177,81 @@ describe('fuzzyMatch.ts', () => {
             expect(indices).toEqual([]);
         });
 
+        it('returns all suggestions when inputValue is empty', () => {
+            const allSuggestions = ['apple', 'banana', 'cherry'];
+            const { values } = _fuzzySuggestions({ inputValue: '', allSuggestions });
+            expect(values).toHaveLength(3);
+        });
+
+        it('maxSuggestions of 0 returns all results', () => {
+            const allSuggestions = ['test', 'tester', 'testing'];
+            const { values } = _fuzzySuggestions({
+                inputValue: 'test',
+                allSuggestions,
+                maxSuggestions: 0,
+            });
+            expect(values).toHaveLength(3);
+        });
+
+        it('negative maxSuggestions returns all results', () => {
+            const allSuggestions = ['test', 'tester', 'testing'];
+            const { values } = _fuzzySuggestions({
+                inputValue: 'test',
+                allSuggestions,
+                maxSuggestions: -1,
+            });
+            expect(values).toHaveLength(3);
+        });
+
+        it('preserves input order for items with equal non-zero relevance', () => {
+            // 'xyz' and 'xyw' have similar edit distance from 'abc' — neither is a substring
+            // match, so they go through Levenshtein. With equal scores the original order
+            // should be preserved.
+            const allSuggestions = ['xyz', 'xyw'];
+            const { values } = _fuzzySuggestions({ inputValue: 'abc', allSuggestions });
+            expect(values).toEqual(['xyz', 'xyw']);
+        });
+
+        it('hideIrrelevant with a very short inputValue filters almost nothing', () => {
+            // Threshold is max(suggestion.value.length, 1). For longer suggestions the
+            // threshold is high, so they survive. Only a suggestion shorter than or equal
+            // to the input whose distance >= its own length would be removed.
+            const allSuggestions = ['apple', 'banana', 'cherry', 'a'];
+            const { values } = _fuzzySuggestions({
+                inputValue: 'a',
+                allSuggestions,
+                hideIrrelevant: true,
+            });
+            // 'a' is a prefix of 'apple' → distance 0, well under threshold
+            expect(values).toContain('apple');
+            expect(values).toContain('a');
+        });
+
+        it('indices are correct after hideIrrelevant filtering', () => {
+            const allSuggestions = ['test', 'zzz', 'tester'];
+            const { values, indices } = _fuzzySuggestions({
+                inputValue: 'test',
+                allSuggestions,
+                hideIrrelevant: true,
+            });
+            for (let i = 0; i < values.length; i++) {
+                expect(values[i]).toBe(allSuggestions[indices[i]]);
+            }
+        });
+
+        it('indices are correct after maxSuggestions truncation', () => {
+            const allSuggestions = ['banana', 'test', 'testing', 'tset', 'toast'];
+            const { values, indices } = _fuzzySuggestions({
+                inputValue: 'test',
+                allSuggestions,
+                maxSuggestions: 3,
+            });
+            expect(values).toHaveLength(3);
+            for (let i = 0; i < values.length; i++) {
+                expect(values[i]).toBe(allSuggestions[indices[i]]);
+            }
+        });
+
         it('exact match ranks first even when it appears late in a sorted value list (AG-14163)', () => {
             // Regression: when the value list was sorted alphabetically, 'CO' fell to
             // index 5 (after all 'BR Power...' entries). A bug caused one of the longer
@@ -340,6 +415,63 @@ describe('fuzzyMatch.ts', () => {
 
             expect(_getLevenshteinSimilarityDistance(searchTerm, correctFormatted)).toBeLessThan(
                 _getLevenshteinSimilarityDistance(searchTerm, wrongFormatted)
+            );
+        });
+
+        it('returns 0 for both strings empty', () => {
+            expect(_getLevenshteinSimilarityDistance('', '')).toBe(0);
+        });
+
+        it('returns source length for empty target', () => {
+            expect(_getLevenshteinSimilarityDistance('test', '')).toBe(4);
+            expect(_getLevenshteinSimilarityDistance('a', '')).toBe(1);
+        });
+
+        it('returns 0 for empty source (semi-global: empty pattern matches at position 0)', () => {
+            // With semi-global alignment an empty source matches any target at position 0
+            // with zero edits — the minimum across the initialised first row is always 0.
+            expect(_getLevenshteinSimilarityDistance('', 'hello')).toBe(0);
+            expect(_getLevenshteinSimilarityDistance('', 'a')).toBe(0);
+        });
+
+        it('non-prefix substring match scores based on position', () => {
+            // Substring at position 0 (prefix) → 0
+            expect(_getLevenshteinSimilarityDistance('duct', 'duct HVAC')).toBe(0);
+            // Substring at position 5 → 5 * 0.01 = 0.05
+            expect(_getLevenshteinSimilarityDistance('duct', 'HVAC DUCT')).toBeCloseTo(0.05, 5);
+            // A later position scores worse than an earlier one
+            expect(_getLevenshteinSimilarityDistance('test', 'atest')).toBeGreaterThan(
+                _getLevenshteinSimilarityDistance('test', 'testing')
+            );
+        });
+
+        it('transposition scores worse than exact match but better than fully different', () => {
+            const exact = _getLevenshteinSimilarityDistance('ab', 'ab');
+            const transposed = _getLevenshteinSimilarityDistance('ab', 'ba');
+            const different = _getLevenshteinSimilarityDistance('ab', 'zz');
+            expect(exact).toBeLessThan(transposed);
+            expect(transposed).toBeLessThan(different);
+        });
+
+        it('earlyMatchLimit bonus does not apply for short strings', () => {
+            // For sourceLength=4, earlyMatchLimit = 4/2 - 10 = -8, so the bonus never fires.
+            // Both should still produce valid scores without errors.
+            const score = _getLevenshteinSimilarityDistance('abcd', 'abxd');
+            expect(score).toBeGreaterThan(0);
+        });
+
+        it('earlyMatchLimit bonus applies for long strings', () => {
+            // For sourceLength=30, earlyMatchLimit = 30/2 - 10 = 5. The bonus fires for
+            // i < 5 (first 4 characters). Verify this by comparing two targets that differ
+            // only in whether their matching characters fall within the bonus window.
+            // Use a source where the early chars differ between the two targets.
+            const source = 'abcde' + 'x'.repeat(25);
+            // target1 matches the first 5 chars (within the bonus window) but diverges after
+            const target1 = 'abcde' + 'y'.repeat(25);
+            // target2 has the same number of matching characters but they appear later
+            const target2 = 'y'.repeat(25) + 'abcde';
+            expect(_getLevenshteinSimilarityDistance(source, target1)).toBeLessThan(
+                _getLevenshteinSimilarityDistance(source, target2)
             );
         });
 

--- a/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.test.ts
+++ b/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.test.ts
@@ -17,7 +17,7 @@ describe('fuzzyMatch.ts', () => {
                 allSuggestions: ['taste', 'test', 'tst', 'completely different'],
             });
             // Exact match must come first; completely different must come last
-            expect(values).toEqual(['test', 'taste', 'tst', 'completely different']);
+            expect(values).toEqual(['test', 'tst', 'taste', 'completely different']);
         });
 
         it('indices map each returned value back to its position in allSuggestions', () => {
@@ -167,7 +167,6 @@ describe('fuzzyMatch.ts', () => {
                 'LCDD00 DUST DETECTOR',
                 'TCID00 INTRUDER DETECTION',
                 'ERCD01 RESIDUAL CURRENT DEVICE',
-                'HAHAY00 HYDRAULIC HATCH',
             ]);
         });
 
@@ -344,9 +343,9 @@ describe('fuzzyMatch.ts', () => {
         });
 
         it('should return a max distance for non-matching strings', () => {
-            // 'exerci' (first 6 of 'exercise', after swap) shares no chars with 'banana'
-            // → all 6 cells in the final row equal 6, so minDist = 6, secondaryScore = 0
-            expect(_getLevenshteinSimilarityDistance('banana', 'exercise')).toBe(6);
+            // 'banana' (6) and 'exercise' (8) share no characters — the standard
+            // Levenshtein distance is 8 (6 replacements + 2 deletions), secondaryScore = 0.
+            expect(_getLevenshteinSimilarityDistance('banana', 'exercise')).toBe(8);
         });
 
         it('should handle different case', () => {
@@ -427,11 +426,10 @@ describe('fuzzyMatch.ts', () => {
             expect(_getLevenshteinSimilarityDistance('a', '')).toBe(1);
         });
 
-        it('returns 0 for empty source (semi-global: empty pattern matches at position 0)', () => {
-            // With semi-global alignment an empty source matches any target at position 0
-            // with zero edits — the minimum across the initialised first row is always 0.
-            expect(_getLevenshteinSimilarityDistance('', 'hello')).toBe(0);
-            expect(_getLevenshteinSimilarityDistance('', 'a')).toBe(0);
+        it('returns target length for empty source', () => {
+            // An empty source requires inserting every character of the target.
+            expect(_getLevenshteinSimilarityDistance('', 'hello')).toBe(5);
+            expect(_getLevenshteinSimilarityDistance('', 'a')).toBe(1);
         });
 
         it('non-prefix substring match scores based on position', () => {

--- a/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.test.ts
+++ b/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.test.ts
@@ -17,8 +17,7 @@ describe('fuzzyMatch.ts', () => {
                 allSuggestions: ['taste', 'test', 'tst', 'completely different'],
             });
             // Exact match must come first; completely different must come last
-            expect(values[0]).toBe('test');
-            expect(values[values.length - 1]).toBe('completely different');
+            expect(values).toEqual(['test', 'taste', 'tst', 'completely different']);
         });
 
         it('indices map each returned value back to its position in allSuggestions', () => {
@@ -41,6 +40,179 @@ describe('fuzzyMatch.ts', () => {
                 allSuggestions: ['CODE009 - Short', exactMatch],
             });
             expect(values[0]).toBe(exactMatch);
+        });
+
+        it('returns the exact prefix match when filterByPercentageOfBestMatch is set (AG-15499)', () => {
+            // Regression: the percentage filter incorrectly removed the best match when it
+            // scored 0 (exact prefix). It now correctly keeps only the exact prefix match and
+            // trims the unrelated 'ag*' suggestions entirely.
+            const allSuggestions = [
+                'agTextCellEditor',
+                'agTooltipComponent',
+                'agNumberCellEditor',
+                'agDateCellEditor',
+                'agDateStringCellEditor',
+                'agCheckboxCellEditor',
+                'agSelectCellEditor',
+                'agLargeTextCellEditor',
+                'agTextColumnFilter',
+                'agTextColumnFloatingFilter',
+                'agNumberColumnFilter',
+                'agNumberColumnFloatingFilter',
+                'agDateColumnFilter',
+                'agDateInput',
+                'agDateColumnFloatingFilter',
+                'agReadOnlyFloatingFilter',
+                'agDragAndDropImage',
+                'agAnimateShowChangeCellRenderer',
+                'agAnimateSlideCellRenderer',
+                'agGroupCellRenderer',
+                'agCheckboxCellRenderer',
+                'agColumnHeader',
+                'agColumnGroupHeader',
+                'agLoadingOverlay',
+                'agNoRowsOverlay',
+                'agSkeletonCellRenderer',
+                'noFilter1',
+            ];
+            // 'zz' and 'vv' share no characters with 'noFilter' — they score at the maximum
+            // possible distance (sourceLength = 8) so hideIrrelevant trims them because
+            // 8 is not < max(2, 8). The ag* strings are long enough that their thresholds
+            // are higher, so they survive hideIrrelevant.
+            const irrelevant = ['zz', 'vv'];
+            const allSuggestionsWithIrrelevant = [...allSuggestions, ...irrelevant];
+
+            // hideIrrelevant trims 'zz'/'vv'; without filterByPercentageOfBestMatch all
+            // remaining 27 suggestions are returned.
+            const hideOnly = _fuzzySuggestions({
+                inputValue: 'noFilter',
+                allSuggestions: allSuggestionsWithIrrelevant,
+                hideIrrelevant: true,
+            });
+            expect(hideOnly.values[0]).toBe('noFilter1');
+            expect(hideOnly.values).not.toContain('zz');
+            expect(hideOnly.values).not.toContain('vv');
+            expect(hideOnly.values.length).toBe(allSuggestions.length);
+
+            // filterByPercentageOfBestMatch with bestMatch = 0 keeps only exact prefix
+            // matches (limit = 0 / 0.8 = 0). The ag* strings all score > 0 so they are
+            // trimmed, leaving only 'noFilter1' regardless of hideIrrelevant.
+            const withPercentFilter = _fuzzySuggestions({
+                inputValue: 'noFilter',
+                allSuggestions: allSuggestionsWithIrrelevant,
+                hideIrrelevant: true,
+                filterByPercentageOfBestMatch: 0.8,
+            });
+            expect(withPercentFilter.values).toEqual(['noFilter1']);
+
+            const withPercentFilterNoHide = _fuzzySuggestions({
+                inputValue: 'noFilter',
+                allSuggestions: allSuggestionsWithIrrelevant,
+                hideIrrelevant: false,
+                filterByPercentageOfBestMatch: 0.8,
+            });
+            expect(withPercentFilterNoHide.values).toEqual(['noFilter1']);
+        });
+
+        it('filterByPercentageOfBestMatch trims far-off matches', () => {
+            // 'zzzzzzzzz' shares no characters with 'abc' so its score is much higher than
+            // 'abx'/'aby'. The filter keeps only suggestions within bestMatch / 0.8 of the
+            // best score, which excludes 'zzzzzzzzz'.
+            const allSuggestions = ['abx', 'aby', 'zzzzzzzzz'];
+            const withFilter = _fuzzySuggestions({
+                inputValue: 'abc',
+                allSuggestions,
+                filterByPercentageOfBestMatch: 0.8,
+            });
+            const withoutFilter = _fuzzySuggestions({ inputValue: 'abc', allSuggestions });
+            expect(withoutFilter.values).toContain('zzzzzzzzz');
+            expect(withFilter.values).not.toContain('zzzzzzzzz');
+        });
+
+        it('a higher percentage keeps fewer matches than a lower one', () => {
+            // Scores for input "abcd":
+            //   "abce"  ≈ 0.091  (1 edit, strong secondary score from shared "abc" prefix)
+            //   "abyz"  ≈ 0.286  (2 edits, weaker secondary score)
+            //   "wxyz"  = 4.0    (4 edits, no shared characters)
+            //
+            // limit = bestMatch / percentage, so a higher percentage produces a tighter limit:
+            //   0.50 → limit ≈ 0.182  → only "abce" passes          (1 result)
+            //   0.25 → limit ≈ 0.364  → "abce" and "abyz" pass      (2 results)
+            //   0.02 → limit ≈ 4.55   → all three pass              (3 results)
+            const allSuggestions = ['abce', 'abyz', 'wxyz'];
+            const strict = _fuzzySuggestions({
+                inputValue: 'abcd',
+                allSuggestions,
+                filterByPercentageOfBestMatch: 0.5,
+            });
+            const medium = _fuzzySuggestions({
+                inputValue: 'abcd',
+                allSuggestions,
+                filterByPercentageOfBestMatch: 0.25,
+            });
+            const lenient = _fuzzySuggestions({
+                inputValue: 'abcd',
+                allSuggestions,
+                filterByPercentageOfBestMatch: 0.02,
+            });
+
+            expect(strict.values).toEqual(['abce']);
+            expect(medium.values).toEqual(['abce', 'abyz']);
+            expect(lenient.values).toEqual(['abce', 'abyz', 'wxyz']);
+        });
+
+        it('higher percentage is stricter', () => {
+            const allSuggestions = [
+                'agTextCellEditor',
+                'agTooltipComponent',
+                'agNumberCellEditor',
+                'agDateCellEditor',
+                'agDateStringCellEditor',
+                'agCheckboxCellEditor',
+                'agSelectCellEditor',
+                'agLargeTextCellEditor',
+                'agTextColumnFilter',
+                'agTextColumnFloatingFilter',
+                'agNumberColumnFilter',
+                'agNumberColumnFloatingFilter',
+                'agDateColumnFilter',
+                'agDateInput',
+                'agDateColumnFloatingFilter',
+                'agReadOnlyFloatingFilter',
+                'agDragAndDropImage',
+                'agAnimateShowChangeCellRenderer',
+                'agAnimateSlideCellRenderer',
+                'agGroupCellRenderer',
+                'agCheckboxCellRenderer',
+                'agColumnHeader',
+                'agColumnGroupHeader',
+                'agLoadingOverlay',
+                'agNoRowsOverlay',
+                'agSkeletonCellRenderer',
+                'noFilter1',
+            ];
+
+            const fiftyPercent = _fuzzySuggestions({
+                inputValue: 'agCell',
+                allSuggestions,
+                filterByPercentageOfBestMatch: 0.5,
+            });
+
+            expect(fiftyPercent.values).toEqual([
+                'agSelectCellEditor',
+                'agColumnHeader',
+                'agColumnGroupHeader',
+                'agSkeletonCellRenderer',
+                'agCheckboxCellEditor',
+                'agCheckboxCellRenderer',
+            ]);
+
+            const ninetyPercent = _fuzzySuggestions({
+                inputValue: 'agCell',
+                allSuggestions,
+                filterByPercentageOfBestMatch: 0.9,
+            });
+            expect(ninetyPercent.values).toEqual(['agSelectCellEditor']);
         });
 
         it('returns an empty result for an empty suggestion list', () => {
@@ -141,6 +313,28 @@ describe('fuzzyMatch.ts', () => {
             expect(_getLevenshteinSimilarityDistance(searchTerm, correctFormatted)).toBeLessThan(
                 _getLevenshteinSimilarityDistance(searchTerm, wrongFormatted)
             );
+        });
+
+        it('an exact code match with different description lengths respects input order', () => {
+            const searchTerm = 'CODE001';
+            const longDescription = 'CODE001 - A long description';
+            const longerDescription = 'CODE001 - A very long description';
+            const shortDescription = 'CODE001 - Short';
+            const wrongFormatted = 'CODE111 - Wrong';
+
+            expect(
+                _fuzzySuggestions({
+                    inputValue: searchTerm,
+                    allSuggestions: [longDescription, shortDescription, wrongFormatted, longerDescription],
+                }).values
+            ).toEqual([longDescription, shortDescription, longerDescription, wrongFormatted]);
+
+            expect(
+                _fuzzySuggestions({
+                    inputValue: searchTerm,
+                    allSuggestions: [longerDescription, longDescription, wrongFormatted, shortDescription],
+                }).values
+            ).toEqual([longerDescription, longDescription, shortDescription, wrongFormatted]);
         });
     });
 });

--- a/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.test.ts
+++ b/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.test.ts
@@ -220,6 +220,78 @@ describe('fuzzyMatch.ts', () => {
             expect(values).toEqual([]);
             expect(indices).toEqual([]);
         });
+
+        it('exact match ranks first even when it appears late in a sorted value list (AG-14163)', () => {
+            // Regression: when the value list was sorted alphabetically, 'CO' fell to
+            // index 5 (after all 'BR Power...' entries). A bug caused one of the longer
+            // 'BR Power...' strings to score better than the exact match 'CO', so 'CO'
+            // was no longer the first highlighted result.
+            const allSuggestions = [
+                'CO',
+                'ETF',
+                'BR Power North East Con',
+                'BR Power South East Con',
+                'BR Power North Con',
+                'BR Power South Con',
+                'BR Power North East I50',
+            ].sort(); // sorts 'CO' to index 5, after all 'BR Power' entries
+
+            const { values } = _fuzzySuggestions({
+                inputValue: 'CO',
+                allSuggestions,
+                hideIrrelevant: true,
+            });
+            expect(values[0]).toBe('CO');
+        });
+
+        it('uppercase input ranks exact match first (AG-14560 TC1)', () => {
+            // Regression: searching 'CO' in uppercase showed 'C3' as the top result
+            // instead of the exact match 'CO'. Lowercase 'co' worked correctly.
+            const allSuggestions = [
+                'CO',
+                'ETF',
+                'C3',
+                'E3',
+                'BR Power North East Con',
+                'BR Power South East Con',
+                'BR Power North Con',
+                'BR Power South Con',
+                'BR Power North East I50',
+            ];
+            const { values: upperValues } = _fuzzySuggestions({
+                inputValue: 'CO',
+                allSuggestions,
+                hideIrrelevant: true,
+            });
+            expect(upperValues[0]).toBe('CO');
+
+            const { values: lowerValues } = _fuzzySuggestions({
+                inputValue: 'co',
+                allSuggestions,
+                hideIrrelevant: true,
+            });
+            expect(lowerValues[0]).toBe('CO');
+        });
+
+        it('uppercase input ranks exact match first (AG-14560 TC2)', () => {
+            // Regression: searching 'TEST' in uppercase showed 'DEF' before 'TEST'.
+            // Lowercase 'test' worked correctly.
+            const allSuggestions = ['TEST', 'ABC', 'DEF', 'GHI'];
+
+            const { values: upperValues } = _fuzzySuggestions({
+                inputValue: 'TEST',
+                allSuggestions,
+                hideIrrelevant: true,
+            });
+            expect(upperValues[0]).toBe('TEST');
+
+            const { values: lowerValues } = _fuzzySuggestions({
+                inputValue: 'test',
+                allSuggestions,
+                hideIrrelevant: true,
+            });
+            expect(lowerValues[0]).toBe('TEST');
+        });
     });
 
     describe('_getLevenshteinSimilarityDistance', () => {

--- a/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.test.ts
+++ b/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.test.ts
@@ -10,11 +10,56 @@ describe('fuzzyMatch.ts', () => {
             });
             expect(suggestions.values).toEqual(['test', 'tst', 'tst str']);
         });
+
+        it('returns values sorted from best to worst match', () => {
+            const { values } = _fuzzySuggestions({
+                inputValue: 'test',
+                allSuggestions: ['taste', 'test', 'tst', 'completely different'],
+            });
+            // Exact match must come first; completely different must come last
+            expect(values[0]).toBe('test');
+            expect(values[values.length - 1]).toBe('completely different');
+        });
+
+        it('indices map each returned value back to its position in allSuggestions', () => {
+            const allSuggestions = ['banana', 'test', 'testing', 'tset'];
+            const { values, indices } = _fuzzySuggestions({
+                inputValue: 'test',
+                allSuggestions,
+            });
+            for (let i = 0; i < values.length; i++) {
+                expect(values[i]).toBe(allSuggestions[indices[i]]);
+            }
+        });
+
+        it('exact code match ranks first regardless of description length', () => {
+            // Integration-level regression: the same scenario that exposed the underlying
+            // _getLevenshteinSimilarityDistance bug, exercised through _fuzzySuggestions.
+            const exactMatch = 'CODE001 - A very long description that should not penalise the score';
+            const { values } = _fuzzySuggestions({
+                inputValue: 'CODE001',
+                allSuggestions: ['CODE009 - Short', exactMatch],
+            });
+            expect(values[0]).toBe(exactMatch);
+        });
+
+        it('returns an empty result for an empty suggestion list', () => {
+            const { values, indices } = _fuzzySuggestions({ inputValue: 'test', allSuggestions: [] });
+            expect(values).toEqual([]);
+            expect(indices).toEqual([]);
+        });
     });
 
     describe('_getLevenshteinSimilarityDistance', () => {
         it('should return 0 for exact match', () => {
             expect(_getLevenshteinSimilarityDistance('test', 'test')).toBe(0);
+        });
+
+        it('returns 0 when input is an exact prefix of the target', () => {
+            // With semi-global alignment the trailing characters in the target are free,
+            // so "test" matching the start of "testing" scores identically to an exact match.
+            expect(_getLevenshteinSimilarityDistance('test', 'testing')).toBe(0);
+            expect(_getLevenshteinSimilarityDistance('CODE001', 'CODE001 - some description')).toBe(0);
         });
 
         it('should do simple fuzzy match', () => {
@@ -24,7 +69,9 @@ describe('fuzzyMatch.ts', () => {
         });
 
         it('should return a max distance for non-matching strings', () => {
-            expect(_getLevenshteinSimilarityDistance('banana', 'exercise')).toBe(8);
+            // 'exerci' (first 6 of 'exercise', after swap) shares no chars with 'banana'
+            // → all 6 cells in the final row equal 6, so minDist = 6, secondaryScore = 0
+            expect(_getLevenshteinSimilarityDistance('banana', 'exercise')).toBe(6);
         });
 
         it('should handle different case', () => {
@@ -49,6 +96,50 @@ describe('fuzzyMatch.ts', () => {
         it('favours consecutive matches', () => {
             expect(_getLevenshteinSimilarityDistance(' 12345', '12345')).toBeLessThan(
                 _getLevenshteinSimilarityDistance('123_45', '12345')
+            );
+        });
+
+        it('score increases monotonically with edit distance', () => {
+            const oneEdit = _getLevenshteinSimilarityDistance('test', 'text');
+            const twoEdits = _getLevenshteinSimilarityDistance('test', 'txxt');
+            const threeEdits = _getLevenshteinSimilarityDistance('test', 'xxxt');
+            expect(oneEdit).toBeLessThan(twoEdits);
+            expect(twoEdits).toBeLessThan(threeEdits);
+        });
+
+        it('prefix match of target scores better than a non-prefix match with the same edit distance', () => {
+            // "a" is a prefix of "ab" (0 edits) but not of "ba" (1 edit to reach "a").
+            expect(_getLevenshteinSimilarityDistance('a', 'ab')).toBeLessThan(
+                _getLevenshteinSimilarityDistance('a', 'ba')
+            );
+        });
+
+        it('exact code match scores 0 regardless of description length', () => {
+            // Key property introduced by the semi-global alignment fix: the length of the
+            // trailing description must not penalise an otherwise-perfect code prefix match.
+            const code = 'CODE001';
+            const descriptions = [
+                'Short',
+                'Medium length description',
+                'A moderately long description with several words in it',
+                'A very very very long description that spans many many characters here and keeps going',
+            ];
+            for (const desc of descriptions) {
+                expect(_getLevenshteinSimilarityDistance(code, `${code} - ${desc}`)).toBe(0);
+            }
+        });
+
+        it('an exact code match with a long description beats a near-code match with a short description', () => {
+            // Regression for: Rich Select fuzzy search selects wrong value when formatValue returns
+            // longer display strings. The correct value had an exact code match but its formatted
+            // string was longer, inflating the raw distance and making it lose to a shorter-formatted
+            // near-match.
+            const searchTerm = 'CODE001';
+            const correctFormatted = 'CODE001 - A very long description that should not penalise the score';
+            const wrongFormatted = 'CODE009 - Short'; // short description, different code
+
+            expect(_getLevenshteinSimilarityDistance(searchTerm, correctFormatted)).toBeLessThan(
+                _getLevenshteinSimilarityDistance(searchTerm, wrongFormatted)
             );
         });
     });

--- a/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.test.ts
+++ b/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.test.ts
@@ -42,10 +42,7 @@ describe('fuzzyMatch.ts', () => {
             expect(values[0]).toBe(exactMatch);
         });
 
-        it('returns the exact prefix match when filterByPercentageOfBestMatch is set (AG-15499)', () => {
-            // Regression: the percentage filter incorrectly removed the best match when it
-            // scored 0 (exact prefix). It now correctly keeps only the exact prefix match and
-            // trims the unrelated 'ag*' suggestions entirely.
+        it('exact prefix match ranks first with hideIrrelevant and maxSuggestions (AG-15499)', () => {
             const allSuggestions = [
                 'agTextCellEditor',
                 'agTooltipComponent',
@@ -82,7 +79,7 @@ describe('fuzzyMatch.ts', () => {
             const irrelevant = ['zz', 'vv'];
             const allSuggestionsWithIrrelevant = [...allSuggestions, ...irrelevant];
 
-            // hideIrrelevant trims 'zz'/'vv'; without filterByPercentageOfBestMatch all
+            // hideIrrelevant trims 'zz'/'vv'; without maxSuggestions all
             // remaining 27 suggestions are returned.
             const hideOnly = _fuzzySuggestions({
                 inputValue: 'noFilter',
@@ -94,125 +91,56 @@ describe('fuzzyMatch.ts', () => {
             expect(hideOnly.values).not.toContain('vv');
             expect(hideOnly.values.length).toBe(allSuggestions.length);
 
-            // filterByPercentageOfBestMatch with bestMatch = 0 keeps only exact prefix
-            // matches (limit = 0 / 0.8 = 0). The ag* strings all score > 0 so they are
-            // trimmed, leaving only 'noFilter1' regardless of hideIrrelevant.
-            const withPercentFilter = _fuzzySuggestions({
+            // maxSuggestions: 1 keeps only the best match ('noFilter1')
+            // regardless of hideIrrelevant.
+            const withMaxSuggestions = _fuzzySuggestions({
                 inputValue: 'noFilter',
                 allSuggestions: allSuggestionsWithIrrelevant,
                 hideIrrelevant: true,
-                filterByPercentageOfBestMatch: 0.8,
+                maxSuggestions: 1,
             });
-            expect(withPercentFilter.values).toEqual(['noFilter1']);
+            expect(withMaxSuggestions.values).toEqual(['noFilter1']);
 
-            const withPercentFilterNoHide = _fuzzySuggestions({
+            const withMaxSuggestionsNoHide = _fuzzySuggestions({
                 inputValue: 'noFilter',
                 allSuggestions: allSuggestionsWithIrrelevant,
                 hideIrrelevant: false,
-                filterByPercentageOfBestMatch: 0.8,
+                maxSuggestions: 1,
             });
-            expect(withPercentFilterNoHide.values).toEqual(['noFilter1']);
+            expect(withMaxSuggestionsNoHide.values).toEqual(['noFilter1']);
         });
 
-        it('filterByPercentageOfBestMatch trims far-off matches', () => {
-            // 'zzzzzzzzz' shares no characters with 'abc' so its score is much higher than
-            // 'abx'/'aby'. The filter keeps only suggestions within bestMatch / 0.8 of the
-            // best score, which excludes 'zzzzzzzzz'.
-            const allSuggestions = ['abx', 'aby', 'zzzzzzzzz'];
-            const withFilter = _fuzzySuggestions({
+        it('maxSuggestions limits the number of returned values', () => {
+            const allSuggestions = ['test', 'tester', 'testing', 'tested', 'toast'];
+            const { values } = _fuzzySuggestions({
+                inputValue: 'test',
+                allSuggestions,
+                maxSuggestions: 2,
+            });
+            expect(values).toHaveLength(2);
+            expect(values[0]).toBe('test');
+        });
+
+        it('maxSuggestions works together with hideIrrelevant', () => {
+            const allSuggestions = ['test', 'tester', 'zzz', 'testing'];
+            const { values } = _fuzzySuggestions({
+                inputValue: 'test',
+                allSuggestions,
+                hideIrrelevant: true,
+                maxSuggestions: 2,
+            });
+            expect(values).toHaveLength(2);
+            expect(values).not.toContain('zzz');
+        });
+
+        it('maxSuggestions returns all results when limit exceeds matches', () => {
+            const allSuggestions = ['abc', 'abd'];
+            const { values } = _fuzzySuggestions({
                 inputValue: 'abc',
                 allSuggestions,
-                filterByPercentageOfBestMatch: 0.8,
+                maxSuggestions: 10,
             });
-            const withoutFilter = _fuzzySuggestions({ inputValue: 'abc', allSuggestions });
-            expect(withoutFilter.values).toContain('zzzzzzzzz');
-            expect(withFilter.values).not.toContain('zzzzzzzzz');
-        });
-
-        it('a higher percentage keeps fewer matches than a lower one', () => {
-            // Scores for input "abcd":
-            //   "abce"  ≈ 0.091  (1 edit, strong secondary score from shared "abc" prefix)
-            //   "abyz"  ≈ 0.286  (2 edits, weaker secondary score)
-            //   "wxyz"  = 4.0    (4 edits, no shared characters)
-            //
-            // limit = bestMatch / percentage, so a higher percentage produces a tighter limit:
-            //   0.50 → limit ≈ 0.182  → only "abce" passes          (1 result)
-            //   0.25 → limit ≈ 0.364  → "abce" and "abyz" pass      (2 results)
-            //   0.02 → limit ≈ 4.55   → all three pass              (3 results)
-            const allSuggestions = ['abce', 'abyz', 'wxyz'];
-            const strict = _fuzzySuggestions({
-                inputValue: 'abcd',
-                allSuggestions,
-                filterByPercentageOfBestMatch: 0.5,
-            });
-            const medium = _fuzzySuggestions({
-                inputValue: 'abcd',
-                allSuggestions,
-                filterByPercentageOfBestMatch: 0.25,
-            });
-            const lenient = _fuzzySuggestions({
-                inputValue: 'abcd',
-                allSuggestions,
-                filterByPercentageOfBestMatch: 0.02,
-            });
-
-            expect(strict.values).toEqual(['abce']);
-            expect(medium.values).toEqual(['abce', 'abyz']);
-            expect(lenient.values).toEqual(['abce', 'abyz', 'wxyz']);
-        });
-
-        it('higher percentage is stricter', () => {
-            const allSuggestions = [
-                'agTextCellEditor',
-                'agTooltipComponent',
-                'agNumberCellEditor',
-                'agDateCellEditor',
-                'agDateStringCellEditor',
-                'agCheckboxCellEditor',
-                'agSelectCellEditor',
-                'agLargeTextCellEditor',
-                'agTextColumnFilter',
-                'agTextColumnFloatingFilter',
-                'agNumberColumnFilter',
-                'agNumberColumnFloatingFilter',
-                'agDateColumnFilter',
-                'agDateInput',
-                'agDateColumnFloatingFilter',
-                'agReadOnlyFloatingFilter',
-                'agDragAndDropImage',
-                'agAnimateShowChangeCellRenderer',
-                'agAnimateSlideCellRenderer',
-                'agGroupCellRenderer',
-                'agCheckboxCellRenderer',
-                'agColumnHeader',
-                'agColumnGroupHeader',
-                'agLoadingOverlay',
-                'agNoRowsOverlay',
-                'agSkeletonCellRenderer',
-                'noFilter1',
-            ];
-
-            const fiftyPercent = _fuzzySuggestions({
-                inputValue: 'agCell',
-                allSuggestions,
-                filterByPercentageOfBestMatch: 0.5,
-            });
-
-            expect(fiftyPercent.values).toEqual([
-                'agSelectCellEditor',
-                'agColumnHeader',
-                'agColumnGroupHeader',
-                'agSkeletonCellRenderer',
-                'agCheckboxCellEditor',
-                'agCheckboxCellRenderer',
-            ]);
-
-            const ninetyPercent = _fuzzySuggestions({
-                inputValue: 'agCell',
-                allSuggestions,
-                filterByPercentageOfBestMatch: 0.9,
-            });
-            expect(ninetyPercent.values).toEqual(['agSelectCellEditor']);
+            expect(values).toEqual(['abc', 'abd']);
         });
 
         it('returns an empty result for an empty suggestion list', () => {

--- a/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
+++ b/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
@@ -149,16 +149,5 @@ export function _getLevenshteinSimilarityDistance(source: string, target: string
         currentRow = swapTmp;
     }
 
-    // Use the minimum across the final row (prefix/semi-global alignment).
-    // This prevents long target strings (e.g. "code - description") from being
-    // penalised relative to short ones purely because of description length —
-    // the minimum naturally falls at the position where the input best matches
-    // a prefix of the target, ignoring any trailing characters beyond that point.
-    let minDist = previousRow[0];
-    for (let j = 1; j <= targetLength; j++) {
-        if (previousRow[j] < minDist) {
-            minDist = previousRow[j];
-        }
-    }
-    return minDist / (secondaryScore + 1); // positives divided by positives, ensure no division by zero
+    return previousRow[targetLength] / (secondaryScore + 1); // negatives divided by positives, ensure no division by zero
 }

--- a/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
+++ b/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
@@ -142,5 +142,16 @@ export function _getLevenshteinSimilarityDistance(source: string, target: string
         currentRow = swapTmp;
     }
 
-    return previousRow[targetLength] / (secondaryScore + 1); // negatives divided by positives, ensure no division by zero
+    // Use the minimum across the final row (prefix/semi-global alignment).
+    // This prevents long target strings (e.g. "code - description") from being
+    // penalised relative to short ones purely because of description length —
+    // the minimum naturally falls at the position where the input best matches
+    // a prefix of the target, ignoring any trailing characters beyond that point.
+    let minDist = previousRow[0];
+    for (let j = 1; j <= targetLength; j++) {
+        if (previousRow[j] < minDist) {
+            minDist = previousRow[j];
+        }
+    }
+    return minDist / (secondaryScore + 1); // positives divided by positives, ensure no division by zero
 }

--- a/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
+++ b/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
@@ -29,8 +29,11 @@ export function _fuzzySuggestions(params: {
 
     if (thisSuggestions.length > 0 && filterByPercentageOfBestMatch && filterByPercentageOfBestMatch > 0) {
         const bestMatch = thisSuggestions[0].relevance;
-        const limit = bestMatch * filterByPercentageOfBestMatch;
-        thisSuggestions = thisSuggestions.filter((suggestion) => limit - suggestion.relevance < 0);
+        // Lower scores are better. Keep only suggestions within a proportional distance of
+        // the best match: limit = bestMatch / percentage is the maximum allowed score.
+        // When bestMatch is 0 (exact prefix match), limit is also 0 so only perfect matches survive.
+        const limit = bestMatch / filterByPercentageOfBestMatch;
+        thisSuggestions = thisSuggestions.filter((suggestion) => suggestion.relevance <= limit);
     }
 
     const values: string[] = [];

--- a/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
+++ b/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
@@ -6,9 +6,9 @@ export function _fuzzySuggestions(params: {
     inputValue: string;
     allSuggestions: string[];
     hideIrrelevant?: boolean;
-    filterByPercentageOfBestMatch?: number;
+    maxSuggestions?: number;
 }): { values: string[]; indices: number[] } {
-    const { inputValue, allSuggestions, hideIrrelevant, filterByPercentageOfBestMatch } = params;
+    const { inputValue, allSuggestions, hideIrrelevant, maxSuggestions } = params;
 
     let thisSuggestions: { value: string; relevance: number; idx: number }[] = (allSuggestions ?? []).map(
         (text, idx) => ({
@@ -27,13 +27,8 @@ export function _fuzzySuggestions(params: {
         );
     }
 
-    if (thisSuggestions.length > 0 && filterByPercentageOfBestMatch && filterByPercentageOfBestMatch > 0) {
-        const bestMatch = thisSuggestions[0].relevance;
-        // Lower scores are better. Keep only suggestions within a proportional distance of
-        // the best match: limit = bestMatch / percentage is the maximum allowed score.
-        // When bestMatch is 0 (exact prefix match), limit is also 0 so only perfect matches survive.
-        const limit = bestMatch / filterByPercentageOfBestMatch;
-        thisSuggestions = thisSuggestions.filter((suggestion) => suggestion.relevance <= limit);
+    if (maxSuggestions != null && maxSuggestions > 0) {
+        thisSuggestions = thisSuggestions.slice(0, maxSuggestions);
     }
 
     const values: string[] = [];

--- a/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
+++ b/packages/ag-grid-community/src/agStack/utils/fuzzyMatch.ts
@@ -61,6 +61,15 @@ export function _getLevenshteinSimilarityDistance(source: string, target: string
     let targetLower = target.toLocaleLowerCase();
     let swapTmp;
 
+    // Substring match: if the input appears verbatim (case-insensitive)
+    // within the target, score based on position. Position 0 (prefix) = 0 (best).
+    if (sourceLength > 0) {
+        const substringPos = targetLower.indexOf(inputLower);
+        if (substringPos >= 0) {
+            return substringPos * 0.01;
+        }
+    }
+
     // Always use the shorter string for columns to reduce space
     if (source.length < target.length) {
         swapTmp = targetLower;

--- a/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
+++ b/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
@@ -355,7 +355,7 @@ export const AG_GRID_ERRORS = {
             inputValue: componentName,
             allSuggestions: validComponents,
             hideIrrelevant: true,
-            filterByPercentageOfBestMatch: 0.8,
+            maxSuggestions: 4,
         }).values;
 
         textOutput.push(
@@ -383,7 +383,7 @@ export const AG_GRID_ERRORS = {
             inputValue,
             allSuggestions,
             hideIrrelevant: true,
-            filterByPercentageOfBestMatch: 0.8,
+            maxSuggestions: 4,
         }).values;
         return [
             `Could not find '${inputValue}' aggregate function. It was configured as "aggFunc: '${inputValue}'" but it wasn't found in the list of registered aggregations.`,


### PR DESCRIPTION
Fix [AG-17046](https://ag-grid.atlassian.net/browse/AG-17046)

## Summary

- Added a shortcut for exact matches. This improves those case for the Rich Select and also correctly ranks exact matches with longer description tails.
- Replaced filter percentage with simpler maxSuggestions as this is really what we want from that usecase. Avoids returning an empty list
