### PR TITLE
AG-12304 Add vertical scroll to sidebar buttons when they overflow

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_sidebar.scss
+++ b/community-modules/styles/src/internal/base/parts/_sidebar.scss
@@ -41,7 +41,8 @@
         padding-top: calc(var(--ag-grid-size) * 4);
         width: calc(var(--ag-icon-size) + 4px);
         position: relative;
-        overflow: hidden;
+        overflow: hidden auto;
+        scrollbar-width: thin;
     }
 
     button.ag-side-button-button {

--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.css
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.css
@@ -76,6 +76,8 @@
     background-color: var(--ag-side-button-bar-background-color);
     position: relative;
     padding-top: var(--ag-side-button-bar-top-padding);
+    overflow: hidden auto;
+    scrollbar-width: thin;
 }
 
 .ag-side-button {


### PR DESCRIPTION
Fix [AG-12304](https://ag-grid.atlassian.net/browse/AG-12304)

Add `overflow: hidden auto` and `scrollbar-width: thin` to `.ag-side-buttons` so that
sidebar tool panel buttons become scrollable when they overflow the available height.