### PR TITLE
AG-17053 Clean up Column Chooser popup on grid destroy

### DIFF
--- a/packages/ag-grid-enterprise/src/menu/columnChooserFactory.ts
+++ b/packages/ag-grid-enterprise/src/menu/columnChooserFactory.ts
@@ -120,7 +120,12 @@ export class ColumnChooserFactory extends BeanStub implements NamedBean {
     }
 
     public hideActiveColumnChooser(): void {
-        this.destroyBean(this.activeColumnChooserDialog);
+        this.activeColumnChooserDialog = this.destroyBean(this.activeColumnChooserDialog);
+    }
+
+    public override destroy(): void {
+        this.hideActiveColumnChooser();
+        super.destroy();
     }
 
     private dispatchVisibleChangedEvent(visible: boolean, column?: AgColumn | null): void {

--- a/testing/behavioural/src/services/popup-cleanup-on-destroy.test.ts
+++ b/testing/behavioural/src/services/popup-cleanup-on-destroy.test.ts
@@ -3,20 +3,33 @@ import { ColumnMenuModule } from 'ag-grid-enterprise';
 
 import { TestGridsManager } from '../test-utils';
 
-// jsdom has no layout engine, so offsetParent and dimensions are all 0.
-// The column chooser dialog needs these to position itself.
-Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
-    get() {
-        return this.parentNode;
-    },
-});
-
 const columnDefs: ColDef[] = [{ field: 'a' }, { field: 'b' }];
 const rowData = [{ a: 1, b: 2 }];
 
 describe('ag-grid popup cleanup on destroy', () => {
     const gridsManager = new TestGridsManager({
         modules: [ColumnMenuModule],
+    });
+
+    // jsdom has no layout engine, so offsetParent and dimensions are all 0.
+    // The column chooser dialog needs these to position itself.
+    const originalOffsetParent = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetParent');
+
+    beforeAll(() => {
+        Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+            get() {
+                return this.parentNode;
+            },
+            configurable: true,
+        });
+    });
+
+    afterAll(() => {
+        if (originalOffsetParent) {
+            Object.defineProperty(HTMLElement.prototype, 'offsetParent', originalOffsetParent);
+        } else {
+            delete (HTMLElement.prototype as any).offsetParent;
+        }
     });
 
     afterEach(() => {

--- a/testing/behavioural/src/services/popup-cleanup-on-destroy.test.ts
+++ b/testing/behavioural/src/services/popup-cleanup-on-destroy.test.ts
@@ -1,0 +1,82 @@
+import type { ColDef, GridOptions } from 'ag-grid-community';
+import { ColumnMenuModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager } from '../test-utils';
+
+// jsdom has no layout engine, so offsetParent and dimensions are all 0.
+// The column chooser dialog needs these to position itself.
+Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+    get() {
+        return this.parentNode;
+    },
+});
+
+const columnDefs: ColDef[] = [{ field: 'a' }, { field: 'b' }];
+const rowData = [{ a: 1, b: 2 }];
+
+describe('ag-grid popup cleanup on destroy', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ColumnMenuModule],
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    test('popups are removed from DOM when grid is destroyed', () => {
+        const popupParent = document.createElement('div');
+        document.body.appendChild(popupParent);
+
+        const gridOptions: GridOptions = {
+            columnDefs,
+            rowData,
+            popupParent,
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+
+        // Open the column chooser popup
+        api.showColumnChooser();
+
+        expect(popupParent.querySelectorAll('.ag-popup').length).toBeGreaterThan(0);
+
+        // Destroy the grid
+        api.destroy();
+
+        // All popup elements should have been removed from the popup parent
+        expect(popupParent.querySelectorAll('.ag-popup').length).toBe(0);
+
+        popupParent.remove();
+    });
+
+    test('no duplicate popups after grid remount', () => {
+        const popupParent = document.createElement('div');
+        document.body.appendChild(popupParent);
+
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+
+        const gridOptions: GridOptions = {
+            columnDefs,
+            rowData,
+            popupParent,
+        };
+
+        // First grid: open column chooser then destroy
+        const api1 = gridsManager.createGrid(container, gridOptions);
+        api1.showColumnChooser();
+        expect(popupParent.querySelectorAll('.ag-popup').length).toBeGreaterThan(0);
+        api1.destroy();
+
+        // Second grid: open column chooser
+        const api2 = gridsManager.createGrid(container, gridOptions);
+        api2.showColumnChooser();
+
+        // Should only have popups from the second grid, not leftover from the first
+        expect(popupParent.querySelectorAll('.ag-popup').length).toBe(1);
+
+        api2.destroy();
+        popupParent.remove();
+        container.remove();
+    });
+});


### PR DESCRIPTION

- `ColumnChooserFactory` was the only Dialog owner missing a `destroy()` override — when the grid was unmounted with the Column Chooser open, the popup wrapper remained in the DOM and duplicate popups appeared on remount

Fix [AG-17053](https://ag-grid.atlassian.net/browse/AG-17053)