### PR TITLE
AG-16656: Add Viewport Row Model support for advanced filters

### DIFF
--- a/packages/ag-grid-community/src/gridOptionsUtils.ts
+++ b/packages/ag-grid-community/src/gridOptionsUtils.ts
@@ -37,6 +37,7 @@ import type { AgGridCommon, WithoutGridCommon } from './interfaces/iCommon';
 import type { IRowModel, RowModelType } from './interfaces/iRowModel';
 import type { IRowNode } from './interfaces/iRowNode';
 import type { IServerSideRowModel } from './interfaces/iServerSideRowModel';
+import type { iViewportRowModel } from './interfaces/iViewportRowModel';
 import { _warn } from './validation/logging';
 
 function isRowModelType(gos: GridOptionsService, rowModelType: RowModelType): boolean {
@@ -51,6 +52,11 @@ export function _isClientSideRowModel(gos: GridOptionsService, rowModel?: IRowMo
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isServerSideRowModel(gos: GridOptionsService, rowModel?: IRowModel): rowModel is IServerSideRowModel {
     return isRowModelType(gos, 'serverSide');
+}
+
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
+export function _isViewportRowModel(gos: GridOptionsService, rowModel?: IRowModel): rowModel is iViewportRowModel {
+    return isRowModelType(gos, 'viewport');
 }
 
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */

--- a/packages/ag-grid-community/src/main-internal.ts
+++ b/packages/ag-grid-community/src/main-internal.ts
@@ -382,6 +382,7 @@ export {
     _isRowSelection,
     _isServerSideRowModel,
     _isSetFilterByDefault,
+    _isViewportRowModel,
     _isUsingNewCellSelectionAPI,
     _isUsingNewRowSelectionAPI,
     _processOnChange,

--- a/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
+++ b/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
@@ -407,7 +407,8 @@ export const AG_GRID_ERRORS = {
     121: () =>
         'a column you are grouping or pivoting by has objects as values. If you want to group by complex objects then either a) use a colDef.keyCreator (see AG Grid docs) or b) to toString() on the object to return a key' as const,
     122: () => 'could not find the document, document is empty' as const,
-    123: () => 'Advanced Filter is only supported with the Client-Side Row Model or Server-Side Row Model.' as const,
+    123: () =>
+        'Advanced Filter is only supported with the Client-Side Row Model, Server-Side Row Model, or Viewport Row Model.' as const,
     124: () => 'No active charts to update.' as const,
     125: ({ chartId }: { chartId: string }) =>
         `Unable to update chart. No active chart found with ID: ${chartId}.` as const,

--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterService.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterService.ts
@@ -11,7 +11,14 @@ import type {
     NewColumnsLoadedEvent,
     ValueService,
 } from 'ag-grid-community';
-import { BeanStub, _exists, _isClientSideRowModel, _isServerSideRowModel, _warn } from 'ag-grid-community';
+import {
+    BeanStub,
+    _exists,
+    _isClientSideRowModel,
+    _isServerSideRowModel,
+    _isViewportRowModel,
+    _warn,
+} from 'ag-grid-community';
 
 import { AdvancedFilterCtrl } from './advancedFilterCtrl';
 import type { AdvancedFilterExpressionService } from './advancedFilterExpressionService';
@@ -164,7 +171,8 @@ export class AdvancedFilterService extends BeanStub implements NamedBean, IAdvan
 
     private setEnabled(enabled: boolean, silent?: boolean): void {
         const previousValue = this.enabled;
-        const isValidRowModel = _isClientSideRowModel(this.gos) || _isServerSideRowModel(this.gos);
+        const isValidRowModel =
+            _isClientSideRowModel(this.gos) || _isServerSideRowModel(this.gos) || _isViewportRowModel(this.gos);
         if (enabled && !isValidRowModel) {
             _warn(123);
         }


### PR DESCRIPTION
- Add _isViewportRowModel helper to gridOptionsUtils.ts
- Export _isViewportRowModel from main-internal.ts
- Update advancedFilterService to check for viewport row model
- Update error message 123 to include Viewport Row Model
- Fixes AG-16656
