### PR TITLE
Cancel stale cell selection refresh animation frames

### DIFF
--- a/packages/ag-grid-community/src/agStack/utils/dom.ts
+++ b/packages/ag-grid-community/src/agStack/utils/dom.ts
@@ -443,15 +443,32 @@ export function _observeResize(
 }
 
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
-export function _requestAnimationFrame(beans: UtilBeanCollection, callback: any) {
+export function _requestAnimationFrame(beans: UtilBeanCollection, callback: any): number {
     const win = _getWindow(beans);
 
     if (win.requestAnimationFrame) {
-        win.requestAnimationFrame(callback);
+        return win.requestAnimationFrame(callback);
     } else if ((win as any).webkitRequestAnimationFrame) {
-        (win as any).webkitRequestAnimationFrame(callback);
+        return (win as any).webkitRequestAnimationFrame(callback);
     } else {
-        win.setTimeout(callback, 0);
+        return win.setTimeout(callback, 0);
+    }
+}
+
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
+export function _cancelAnimationFrame(beans: UtilBeanCollection, requestId: number | null | undefined): void {
+    if (requestId == null) {
+        return;
+    }
+
+    const win = _getWindow(beans);
+
+    if (win.cancelAnimationFrame) {
+        win.cancelAnimationFrame(requestId);
+    } else if ((win as any).webkitCancelAnimationFrame) {
+        (win as any).webkitCancelAnimationFrame(requestId);
+    } else {
+        win.clearTimeout(requestId);
     }
 }
 

--- a/packages/ag-grid-community/src/rendering/cell/cellCtrl.test.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellCtrl.test.ts
@@ -42,4 +42,124 @@ describe('CellCtrl', () => {
 
         expect(ctrl.isCellNoteHoverSuppressed()).toBe(false);
     });
+
+    describe('range refresh scheduling', () => {
+        const originalRequestAnimationFrame = window.requestAnimationFrame;
+        const originalCancelAnimationFrame = window.cancelAnimationFrame;
+
+        const createRangeRefreshCtrl = () => {
+            const ctrl = Object.create(CellCtrl.prototype) as CellCtrl & {
+                rangeHandleRefreshFrameId: number | null;
+                scheduleRangeHandleRefresh: () => void;
+                clearPendingRangeHandleRefresh: () => void;
+                beans: Partial<BeanCollection>;
+                rangeFeature: { refreshRangeStyleAndHandle: jest.Mock };
+                isAlive: () => boolean;
+                onCompAttachedFuncs: (() => void)[];
+                onEditorAttachedFuncs: (() => void)[];
+                cellPosition: any;
+            };
+
+            ctrl.beans = {
+                eRootDiv: document.createElement('div'),
+                gos: { get: jest.fn() } as any,
+                focusSvc: {
+                    isCellFocused: jest.fn(() => false),
+                    attemptToRecoverFocus: jest.fn(),
+                } as any,
+            };
+            ctrl.rangeFeature = {
+                refreshRangeStyleAndHandle: jest.fn(),
+            };
+            ctrl.rangeHandleRefreshFrameId = null;
+            ctrl.isAlive = () => !(ctrl as any).destroyed;
+            ctrl.onCompAttachedFuncs = [];
+            ctrl.onEditorAttachedFuncs = [];
+            ctrl.cellPosition = {} as any;
+
+            (ctrl as any).destroyFunctions = [];
+            (ctrl as any).destroyed = false;
+
+            return ctrl;
+        };
+
+        afterEach(() => {
+            window.requestAnimationFrame = originalRequestAnimationFrame;
+            window.cancelAnimationFrame = originalCancelAnimationFrame;
+            jest.restoreAllMocks();
+        });
+
+        it('cancels the previous range refresh frame before scheduling another one', () => {
+            const callbacks = new Map<number, FrameRequestCallback>();
+            let nextFrameId = 0;
+
+            window.requestAnimationFrame = jest.fn((callback: FrameRequestCallback) => {
+                const frameId = ++nextFrameId;
+                callbacks.set(frameId, callback);
+                return frameId;
+            });
+            window.cancelAnimationFrame = jest.fn((frameId: number) => {
+                callbacks.delete(frameId);
+            });
+
+            const ctrl = createRangeRefreshCtrl();
+
+            ctrl.scheduleRangeHandleRefresh();
+            ctrl.scheduleRangeHandleRefresh();
+
+            expect(window.cancelAnimationFrame).toHaveBeenCalledWith(1);
+            expect(window.requestAnimationFrame).toHaveBeenCalledTimes(2);
+            expect(callbacks.has(1)).toBe(false);
+            expect(callbacks.has(2)).toBe(true);
+
+            callbacks.get(2)?.(0);
+
+            expect(ctrl.rangeFeature.refreshRangeStyleAndHandle).toHaveBeenCalledTimes(1);
+            expect(ctrl.rangeHandleRefreshFrameId).toBeNull();
+        });
+
+        it('clears the pending range refresh frame without running it', () => {
+            window.requestAnimationFrame = jest.fn(() => 7);
+            window.cancelAnimationFrame = jest.fn();
+
+            const ctrl = createRangeRefreshCtrl();
+
+            ctrl.scheduleRangeHandleRefresh();
+            ctrl.clearPendingRangeHandleRefresh();
+
+            expect(window.cancelAnimationFrame).toHaveBeenCalledWith(7);
+            expect(ctrl.rangeFeature.refreshRangeStyleAndHandle).not.toHaveBeenCalled();
+            expect(ctrl.rangeHandleRefreshFrameId).toBeNull();
+        });
+
+        it('clears the pending range refresh frame when the cell is destroyed', () => {
+            const callbacks = new Map<number, FrameRequestCallback>();
+            let nextFrameId = 0;
+
+            window.requestAnimationFrame = jest.fn((callback: FrameRequestCallback) => {
+                const frameId = ++nextFrameId;
+                callbacks.set(frameId, callback);
+                return frameId;
+            });
+            window.cancelAnimationFrame = jest.fn((frameId: number) => {
+                callbacks.delete(frameId);
+            });
+
+            const ctrl = createRangeRefreshCtrl();
+
+            ctrl.scheduleRangeHandleRefresh();
+            const queuedCallback = callbacks.get(1);
+
+            ctrl.destroy();
+
+            expect(window.cancelAnimationFrame).toHaveBeenCalledWith(1);
+            expect(callbacks.has(1)).toBe(false);
+            expect(ctrl.rangeFeature.refreshRangeStyleAndHandle).not.toHaveBeenCalled();
+
+            queuedCallback?.(0);
+
+            expect(ctrl.rangeFeature.refreshRangeStyleAndHandle).not.toHaveBeenCalled();
+            expect(ctrl.rangeHandleRefreshFrameId).toBeNull();
+        });
+    });
 });

--- a/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
@@ -1,7 +1,12 @@
 import { KeyCode } from '../../agStack/constants/keyCode';
 import { _setAriaColIndex, _setAriaRowIndex } from '../../agStack/utils/aria';
 import { _getActiveDomElement } from '../../agStack/utils/document';
-import { _addOrRemoveAttribute, _placeCaretAtEnd, _requestAnimationFrame } from '../../agStack/utils/dom';
+import {
+    _addOrRemoveAttribute,
+    _cancelAnimationFrame,
+    _placeCaretAtEnd,
+    _requestAnimationFrame,
+} from '../../agStack/utils/dom';
 import { _findFocusableElements } from '../../agStack/utils/focus';
 import { _makeNull } from '../../agStack/utils/generic';
 import { AgPromise } from '../../agStack/utils/promise';
@@ -134,6 +139,7 @@ export class CellCtrl extends BeanStub {
     private focusEventWhileNotReady: CellFocusedEvent | null = null;
     // if cell has been focused, check if it's focused when destroyed
     private hasBeenFocused = false;
+    private rangeHandleRefreshFrameId: number | null = null;
 
     private readonly editSvc?: EditService;
     private readonly hasEdit: boolean = false;
@@ -419,9 +425,11 @@ export class CellCtrl extends BeanStub {
 
         this.customRowDragComp?.refreshVisibility();
 
-        // Don't call expensive _requestAnimationFrame if we don't have to
+        // Don't call expensive _requestAnimationFrame if we don't have to.
+        // If another refresh comes in before the frame runs, cancel the stale callback
+        // so hidden tabs do not accumulate background range refresh work.
         if (!skipRangeHandleRefresh && rangeFeature) {
-            _requestAnimationFrame(beans, () => rangeFeature?.refreshRangeStyleAndHandle());
+            this.scheduleRangeHandleRefresh();
         }
 
         this.rowResizeFeature?.refreshRowResizer();
@@ -1042,6 +1050,7 @@ export class CellCtrl extends BeanStub {
     }
 
     public override destroy(): void {
+        this.clearPendingRangeHandleRefresh();
         this.onCompAttachedFuncs = [];
         this.onEditorAttachedFuncs = [];
 
@@ -1051,6 +1060,23 @@ export class CellCtrl extends BeanStub {
         }
 
         super.destroy();
+    }
+
+    private scheduleRangeHandleRefresh(): void {
+        this.clearPendingRangeHandleRefresh();
+
+        this.rangeHandleRefreshFrameId = _requestAnimationFrame(this.beans, () => {
+            this.rangeHandleRefreshFrameId = null;
+            if (!this.isAlive()) {
+                return;
+            }
+            this.rangeFeature?.refreshRangeStyleAndHandle();
+        });
+    }
+
+    private clearPendingRangeHandleRefresh(): void {
+        _cancelAnimationFrame(this.beans, this.rangeHandleRefreshFrameId);
+        this.rangeHandleRefreshFrameId = null;
     }
 
     public hasBrowserFocus(): boolean {


### PR DESCRIPTION
Fixes #13502

Cancel pending cell selection refresh animation frames before scheduling a new one and when destroying a cell.

This prevents hidden tabs from accumulating stale cell selection refresh callbacks that all flush when the tab becomes visible again.

Adds unit coverage for rescheduling, explicit clearing, and destroy cleanup.