### PR TITLE
fix fill handle TypeError when cell.comp is undefined (gh #13504)

### DIFF
--- a/packages/ag-grid-enterprise/src/rangeSelection/agFillHandle.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/agFillHandle.ts
@@ -555,6 +555,9 @@ export class AgFillHandle extends AbstractSelectionHandle {
                 continue;
             }
             const { comp } = cell;
+            if (!comp) {
+                continue;
+            }
             comp.toggleCss('ag-selection-fill-top', false);
             comp.toggleCss('ag-selection-fill-right', false);
             comp.toggleCss('ag-selection-fill-bottom', false);
@@ -648,8 +651,11 @@ export class AgFillHandle extends AbstractSelectionHandle {
                     const cell = _getCellByPosition(beans, cellPos);
 
                     if (cell) {
-                        this.markedCells.push(cell);
                         const cellComp = cell.comp;
+                        if (!cellComp) {
+                            continue;
+                        }
+                        this.markedCells.push(cell);
 
                         if (!cellInRange) {
                             cellComp.toggleCss('ag-selection-fill-left', i === 0);
@@ -688,9 +694,13 @@ export class AgFillHandle extends AbstractSelectionHandle {
                 const cell = _getCellByPosition(beans, celPos);
 
                 if (cell) {
+                    const cellComp = cell.comp;
+                    if (!cellComp) {
+                        continue;
+                    }
                     this.markedCells.push(cell);
 
-                    cell.comp.toggleCss('ag-selection-fill-bottom', _isSameRow(row, endPosition));
+                    cellComp.toggleCss('ag-selection-fill-bottom', _isSameRow(row, endPosition));
                 }
             }
             if (isLastRow) {
@@ -724,8 +734,11 @@ export class AgFillHandle extends AbstractSelectionHandle {
                 });
 
                 if (cell) {
-                    this.markedCells.push(cell);
                     const cellComp = cell.comp;
+                    if (!cellComp) {
+                        continue;
+                    }
+                    this.markedCells.push(cell);
 
                     cellComp.toggleCss('ag-selection-fill-top', _isSameRow(row, rangeStartRow));
                     cellComp.toggleCss('ag-selection-fill-bottom', _isSameRow(row, rangeEndRow));
@@ -765,8 +778,12 @@ export class AgFillHandle extends AbstractSelectionHandle {
                 });
 
                 if (cell) {
+                    const cellComp = cell.comp;
+                    if (!cellComp) {
+                        continue;
+                    }
                     this.markedCells.push(cell);
-                    cell.comp.toggleCss('ag-selection-fill-right', column === colsToMark[0]);
+                    cellComp.toggleCss('ag-selection-fill-right', column === colsToMark[0]);
                 }
 
                 row = _getRowBelow(beans, row)!;

--- a/testing/behavioural/src/selection/cell-selection.test.ts
+++ b/testing/behavioural/src/selection/cell-selection.test.ts
@@ -12,7 +12,7 @@ import {
     getGridElement,
     setupAgTestIds,
 } from 'ag-grid-community';
-import { CellSelectionModule } from 'ag-grid-enterprise';
+import { CellSelectionModule, RowGroupingModule } from 'ag-grid-enterprise';
 
 import {
     GridRows,
@@ -29,7 +29,14 @@ describe('Cell Selection', () => {
     let consoleWarnSpy: MockInstance;
 
     const gridMgr = new TestGridsManager({
-        modules: [ClientSideRowModelModule, CellSelectionModule, PaginationModule, PinnedRowModule, TextEditorModule],
+        modules: [
+            ClientSideRowModelModule,
+            CellSelectionModule,
+            PaginationModule,
+            PinnedRowModule,
+            TextEditorModule,
+            RowGroupingModule,
+        ],
     });
 
     async function createGrid(go: GridOptions): Promise<[GridApi, GridActions]> {
@@ -124,6 +131,54 @@ describe('Cell Selection', () => {
             });
 
             expect(sports).toEqual(['football', 'rugby', 'tennis', 'tennis', 'tennis', 'tennis', 'tennis']);
+        });
+
+        test('Fill handle works with custom group display type', async () => {
+            const [api] = await createGrid({
+                columnDefs: [
+                    { field: 'sport', rowGroup: true, hide: true },
+                    { field: 'year', editable: true },
+                    { field: 'amount', editable: true },
+                ],
+                rowData,
+                groupDisplayType: 'custom',
+                groupDefaultExpanded: -1,
+                cellSelection: {
+                    handle: {
+                        mode: 'fill',
+                    },
+                },
+                getRowId(params) {
+                    return params.data?.sport;
+                },
+            });
+
+            const gridDiv = getGridElement(api)! as HTMLElement;
+
+            await asyncSetTimeout(1);
+
+            // Select a leaf cell in the first leaf row
+            const cell = getByTestId(gridDiv, agTestIdFor.cell('football', 'year'));
+
+            const cellSelectionChanged = waitForEvent('cellSelectionChanged', api);
+            cell.dispatchEvent(new MouseEvent('touchstart', { bubbles: true }));
+
+            await cellSelectionChanged;
+            await asyncSetTimeout(1);
+
+            const fillHandle = getByTestId(gridDiv, agTestIdFor.fillHandle());
+            const fillEnd = waitForEvent('fillEnd', api);
+            await userEvent.dblClick(fillHandle);
+            await fillEnd;
+
+            // Verify fill completed without TypeError and propagated values
+            const years: number[] = [];
+            api.forEachLeafNode((node) => {
+                years.push(api.getCellValue({ rowNode: node, colKey: 'year' }));
+            });
+
+            // All leaf rows in the same group should have the filled value
+            expect(years[0]).toBe(2021);
         });
     });
 


### PR DESCRIPTION

## Summary

Fixes #13504

## Link to reproducible scenario

https://codesandbox.io/p/sandbox/wfmc4z

## Describe the bug

### Steps to reproduce
1. Configure grid with:
   - `groupDisplayType="custom"` (group rows render individual cells, not a single full-width cell)
   - `cellSelection={{ handle: { mode: "fill" } }}`
   - Enough columns that horizontal scrolling is needed
2. Select a cell on a leaf row (non-group row)
3. Drag the fill handle vertically downward, scrolling far enough that the originally selected cell is scrolled out of the horizontal viewport (unmounted by DOM virtualisation)
4. Two TypeErrors appear in the console

### Actual behaviour

Two TypeErrors are thrown:

**Error 1** — `extendVertical` accesses `cell.comp` without null-checking after getting the cell via `_getCellByPosition`:
```js
const cell = _getCellByPosition2(beans, cellPos);
if (cell) {
  this.markedCells.push(cell);
  const cellComp = cell.comp;       // undefined for virtualised group-row cells
  cellComp.toggleCss(...)            // TypeError
```
Error 2 — clearMarkedPath iterates markedCells but doesn't check cell.comp:
```for (const cell of this.markedCells) {
  if (!cell.isAlive()) continue;
  const { comp } = cell;
  comp.toggleCss(...)                // TypeError — comp is undefined
```
Error 1 also poisons state: the cell is pushed to markedCells (line before the crash) but CSS was never applied. Error 2 then fires on cleanup because markedCells.length = 0 is never reached.

### More information
- HARD to replicate at first try — the easiest way is to select a leaf row cell and drag the fill handle down to just before the total row at the bottom, triggering auto-scroll while hovering
- Does NOT reproduce with the default groupDisplayType (full-width group rows) — only with "custom" which renders individual cells per column on group rows
- Root cause: _getCellByPosition returns cell controllers for group-row cells that exist in the internal model but whose DOM component has been virtualised out (horizontal scroll moves them out of the rendered viewport)
- In production, this cascades: Error 1 leaves stale entries in markedCells, causing Error 2 on every subsequent fill operation until the grid is re-mounted

### Root cause

_getCellByPosition() returns CellCtrl objects for cells that exist in the internal model but whose DOM component (comp) has been removed by column virtualisation. The fill handle code assumed comp was always present. This is an expected condition in the codebase —
CellCtrl itself already has ~10 defensive guards like if (!this.comp) { return; }.

### Fix

- Guard cell.comp in all 5 methods that access it in agFillHandle.ts: clearMarkedPath, extendVertical, extendHorizontal, reduceVertical, reduceHorizontal
- Only push cells to markedCells if comp exists — cells without a DOM component cannot show CSS highlights
- Added defence-in-depth guard in clearMarkedPath in case comp becomes undefined between push and cleanup

### Files changed

- packages/ag-grid-enterprise/src/rangeSelection/agFillHandle.ts — null guards
- testing/behavioural/src/selection/cell-selection.test.ts — regression test with groupDisplayType: "custom" + fill handle

### Test plan

- ./behave.sh "cell-selection" — 23/23 tests pass (including new regression test)
- nx build:types ag-grid-enterprise — clean
- nx lint ag-grid-enterprise — clean
- Manual: reproduce the scenario from #13504 (custom group display + fill handle + horizontal scroll) and verify no TypeError