### PR TITLE
AG-8439 Gracefully handle numeric ids

### DIFF
--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
@@ -1014,6 +1014,9 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
     }
 
     public getRowNode(id: string): RowNode | undefined {
+        if (typeof id !== 'string') {
+            id = String(id);
+        }
         const found = this.nodeManager?.getRowNode(id);
         if (typeof found === 'object') {
             return found; // we check for typeof object to avoid returning things from Object.prototype
@@ -1026,9 +1029,6 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
     }
 
     private getSpecialRowNode(id: string): RowNode | undefined {
-        if (typeof id !== 'string') {
-            return undefined;
-        }
         if (id === ROOT_NODE_ID) {
             return this.rootNode ?? undefined;
         }

--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
@@ -1026,6 +1026,9 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
     }
 
     private getSpecialRowNode(id: string): RowNode | undefined {
+        if (typeof id !== 'string') {
+            return undefined;
+        }
         if (id === ROOT_NODE_ID) {
             return this.rootNode ?? undefined;
         }

--- a/packages/ag-grid-enterprise/src/serverSideRowModel/serverSideRowModel.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/serverSideRowModel.ts
@@ -661,6 +661,9 @@ export class ServerSideRowModel extends BeanStub implements NamedBean, IServerSi
     }
 
     public getRowNode(id: string): RowNode | undefined {
+        if (typeof id !== 'string') {
+            id = String(id);
+        }
         if (id === GRAND_TOTAL_ROW_ID) {
             return this.getRootStore()?.getGrandTotalNode();
         }
@@ -676,7 +679,7 @@ export class ServerSideRowModel extends BeanStub implements NamedBean, IServerSi
         if (id === ROOT_NODE_ID) {
             return this.rootNode;
         }
-        if (!result && typeof id === 'string' && id.startsWith(GROUP_TOTAL_ROW_ID_PREFIX)) {
+        if (!result && id.startsWith(GROUP_TOTAL_ROW_ID_PREFIX)) {
             const groupId = id.slice(GROUP_TOTAL_ROW_ID_PREFIX.length);
             const groupNode = this.getRowNode(groupId);
             result = groupNode?.sibling?.footer ? groupNode.sibling : undefined;

--- a/packages/ag-grid-enterprise/src/serverSideRowModel/serverSideRowModel.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/serverSideRowModel.ts
@@ -676,7 +676,7 @@ export class ServerSideRowModel extends BeanStub implements NamedBean, IServerSi
         if (id === ROOT_NODE_ID) {
             return this.rootNode;
         }
-        if (!result && id.startsWith(GROUP_TOTAL_ROW_ID_PREFIX)) {
+        if (!result && typeof id === 'string' && id.startsWith(GROUP_TOTAL_ROW_ID_PREFIX)) {
             const groupId = id.slice(GROUP_TOTAL_ROW_ID_PREFIX.length);
             const groupNode = this.getRowNode(groupId);
             result = groupNode?.sibling?.footer ? groupNode.sibling : undefined;

--- a/testing/behavioural/src/row-data/row-data.test.ts
+++ b/testing/behavioural/src/row-data/row-data.test.ts
@@ -1,6 +1,6 @@
 import type { MockInstance } from 'vitest';
 
-import { ClientSideRowModelModule, NumberFilterModule, TextFilterModule } from 'ag-grid-community';
+import { ClientSideRowModelModule, NumberFilterModule, RowApiModule, TextFilterModule } from 'ag-grid-community';
 import type { GridOptions, ModelUpdatedEvent } from 'ag-grid-community';
 
 import {
@@ -15,7 +15,7 @@ import {
 
 describe('ag-grid row data', () => {
     const gridsManager = new TestGridsManager({
-        modules: [TextFilterModule, NumberFilterModule, ClientSideRowModelModule],
+        modules: [TextFilterModule, NumberFilterModule, ClientSideRowModelModule, RowApiModule],
     });
     let consoleWarnSpy: MockInstance | undefined;
     let consoleErrorSpy: MockInstance | undefined;
@@ -371,6 +371,24 @@ describe('ag-grid row data', () => {
             ├── LEAF id:2 value:2 value_1:2
             └── LEAF id:3 value:3 value_1:3
         `);
+    });
+
+    test('getRowNode does not throw when passed a numeric id', async () => {
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'value' }],
+            rowData: [
+                { id: 1, value: 'a' },
+                { id: 2, value: 'b' },
+            ],
+            getRowId: (params) => String(params.data.id),
+        };
+
+        const api = gridsManager.createGrid('myGrid', gridOptions);
+        await asyncSetTimeout(1);
+
+        // Passing a number should not throw
+        expect(() => api.getRowNode(1 as any)).not.toThrow();
+        expect(() => api.getRowNode(999 as any)).not.toThrow();
     });
 
     describe('onModelUpdated event flags', () => {

--- a/testing/behavioural/src/row-data/row-data.test.ts
+++ b/testing/behavioural/src/row-data/row-data.test.ts
@@ -386,9 +386,9 @@ describe('ag-grid row data', () => {
         const api = gridsManager.createGrid('myGrid', gridOptions);
         await asyncSetTimeout(1);
 
-        // Passing a number should not throw
-        expect(() => api.getRowNode(1 as any)).not.toThrow();
-        expect(() => api.getRowNode(999 as any)).not.toThrow();
+        // Passing a number should not throw, and should still find the row via property key coercion
+        expect(api.getRowNode(1 as any)).toBeTruthy();
+        expect(api.getRowNode(999 as any)).toBeUndefined();
     });
 
     describe('onModelUpdated event flags', () => {

--- a/testing/behavioural/src/row-data/server-side-row-model-transactions.test.ts
+++ b/testing/behavioural/src/row-data/server-side-row-model-transactions.test.ts
@@ -114,4 +114,28 @@ describe('Server Side Row Model Transactions', () => {
         expect(farRow).toBeTruthy();
         expect((farRow as any).__needsRefreshWhenVisible).toBe(true);
     });
+
+    test('getRowNode does not throw when passed a numeric id', async () => {
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'value' }],
+            rowModelType: 'serverSide' as const,
+            getRowId: (params: any) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params: any) => {
+                    const rowData = [
+                        { id: 1, value: 'a' },
+                        { id: 2, value: 'b' },
+                    ];
+                    params.success({ rowData, rowCount: rowData.length });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await waitForEvent('firstDataRendered', api);
+
+        // Passing a number should not throw
+        expect(() => api.getRowNode(1 as any)).not.toThrow();
+        expect(() => api.getRowNode(999 as any)).not.toThrow();
+    });
 });

--- a/testing/behavioural/src/row-data/server-side-row-model-transactions.test.ts
+++ b/testing/behavioural/src/row-data/server-side-row-model-transactions.test.ts
@@ -134,8 +134,8 @@ describe('Server Side Row Model Transactions', () => {
         const api = gridsManager.createGrid(null, gridOptions);
         await waitForEvent('firstDataRendered', api);
 
-        // Passing a number should not throw
-        expect(() => api.getRowNode(1 as any)).not.toThrow();
-        expect(() => api.getRowNode(999 as any)).not.toThrow();
+        // Passing a number should not throw, and should find the row via toString coercion
+        expect(api.getRowNode(1 as any)).toBeTruthy();
+        expect(api.getRowNode(999 as any)).toBeUndefined();
     });
 });


### PR DESCRIPTION
Fix [AG-8439](https://ag-grid.atlassian.net/browse/AG-8439) 

getRowNode should take a string key but it should not throw if it is passed a numeric id.