### PR TITLE
Only call clearTimeout if required

### DIFF
--- a/packages/ag-grid-community/src/widgets/touchListener.ts
+++ b/packages/ag-grid-community/src/widgets/touchListener.ts
@@ -174,8 +174,10 @@ export class TouchListener implements IEventEmitter<TouchListenerEvent> {
     }
 
     private clearLongPress(): void {
-        window.clearTimeout(this.longPressTimer);
-        this.longPressTimer = 0;
+        if (this.longPressTimer !== 0) {
+            window.clearTimeout(this.longPressTimer);
+            this.longPressTimer = 0;
+        }
         this.moved = false;
     }
 


### PR DESCRIPTION
Matching the pattern for all other clearTimeout to avoid the expense of the browser clearTimeout when it is not required.

This appeared in performance profiling for a separate item.