### PR TITLE
Identify the use of AgGridProvider in React

### DIFF
--- a/packages/ag-grid-community/src/grid.ts
+++ b/packages/ag-grid-community/src/grid.ts
@@ -135,7 +135,12 @@ export class GridCoreCreator {
 
         const registeredModules = this.getRegisteredModules(params, gridId, gridOptions.rowModelType);
 
-        const beanClasses = this.createBeansList(gridOptions.rowModelType, registeredModules, gridId);
+        const beanClasses = this.createBeansList(
+            gridOptions.rowModelType,
+            registeredModules,
+            gridId,
+            params?.frameworkOverrides?.usesAgGridProvider
+        );
         const providedBeanInstances = this.createProvidedBeans(eGridDiv, gridOptions, params);
 
         if (!beanClasses) {
@@ -247,7 +252,8 @@ export class GridCoreCreator {
     private createBeansList(
         userProvidedRowModelType: RowModelType | undefined,
         registeredModules: Module[],
-        gridId: string
+        gridId: string,
+        usesAgGridProvider?: boolean
     ): SingletonBean[] | undefined {
         // assert that the relevant module has been loaded
         const rowModelModuleNames: Record<RowModelType, CommunityModuleName | EnterpriseModuleName> = {
@@ -266,7 +272,7 @@ export class GridCoreCreator {
         }
 
         if (!_hasUserRegistered()) {
-            _logPreInitErr(272, undefined, NoModulesRegisteredError());
+            _logPreInitErr(272, undefined, NoModulesRegisteredError(usesAgGridProvider));
             return;
         }
 

--- a/packages/ag-grid-community/src/gridOptionsService.ts
+++ b/packages/ag-grid-community/src/gridOptionsService.ts
@@ -347,12 +347,14 @@ export class GridOptionsService
         gridId: string;
         rowModelType: RowModelType;
         isUmd: boolean;
+        usesAgGridProvider: boolean;
     } {
         return {
             gridId: this.gridId,
             gridScoped: _areModulesGridScoped(),
             rowModelType: this.get('rowModelType'),
             isUmd: _isUmd(),
+            usesAgGridProvider: this.beans.frameworkOverrides.usesAgGridProvider ?? false,
         };
     }
 

--- a/packages/ag-grid-community/src/interfaces/iFrameworkOverrides.ts
+++ b/packages/ag-grid-community/src/interfaces/iFrameworkOverrides.ts
@@ -51,4 +51,7 @@ export interface IFrameworkOverrides extends AgFrameworkOverrides {
      * Required for React to work with StrictMode from v19 with the current implementation of the CtrlsService.
      */
     runWhenReadyAsync?(): boolean;
+
+    /** True when modules are provided via AgGridProvider React context, used for accurate missing module error messages */
+    readonly usesAgGridProvider?: boolean;
 }

--- a/packages/ag-grid-community/src/validation/errorMessages/errorText.test.ts
+++ b/packages/ag-grid-community/src/validation/errorMessages/errorText.test.ts
@@ -9,3 +9,35 @@ describe('Validate AG_GRID_ERRORS', () => {
         }
     );
 });
+
+describe('error 260 (missing user component)', () => {
+    test('formats missing component error with usesAgGridProvider', () => {
+        const result = AG_GRID_ERRORS[260]({
+            propName: 'cellEditor',
+            compName: 'agRichSelectCellEditor',
+            gridScoped: false,
+            gridId: 'myGrid',
+            rowModelType: 'clientSide',
+            usesAgGridProvider: true,
+        });
+
+        expect(result).toContain('RichSelectModule');
+        expect(result).toContain('AgGridProvider');
+        expect(result).not.toContain('ModuleRegistry.registerModules');
+    });
+
+    test('formats missing component error without usesAgGridProvider', () => {
+        const result = AG_GRID_ERRORS[260]({
+            propName: 'cellEditor',
+            compName: 'agRichSelectCellEditor',
+            gridScoped: false,
+            gridId: 'myGrid',
+            rowModelType: 'clientSide',
+            usesAgGridProvider: false,
+        });
+
+        expect(result).toContain('RichSelectModule');
+        expect(result).toContain('ModuleRegistry.registerModules');
+        expect(result).not.toContain('AgGridProvider');
+    });
+});

--- a/packages/ag-grid-community/src/validation/errorMessages/errorText.test.ts
+++ b/packages/ag-grid-community/src/validation/errorMessages/errorText.test.ts
@@ -1,4 +1,4 @@
-import { AG_GRID_ERRORS } from './errorText';
+import { AG_GRID_ERRORS, NoModulesRegisteredError } from './errorText';
 
 describe('Validate AG_GRID_ERRORS', () => {
     // eslint-disable-next-line no-restricted-properties
@@ -8,6 +8,63 @@ describe('Validate AG_GRID_ERRORS', () => {
             errorTextFn({} as any);
         }
     );
+});
+
+describe('NoModulesRegisteredError', () => {
+    test('shows AgGridProvider snippet when usesAgGridProvider is true', () => {
+        const result = NoModulesRegisteredError(true);
+
+        expect(result).toContain('AgGridProvider');
+        expect(result).toContain('AllCommunityModule');
+        expect(result).not.toContain('ModuleRegistry.registerModules');
+    });
+
+    test('shows ModuleRegistry snippet when usesAgGridProvider is false', () => {
+        const result = NoModulesRegisteredError(false);
+
+        expect(result).toContain('ModuleRegistry.registerModules');
+        expect(result).toContain('AllCommunityModule');
+        expect(result).not.toContain('AgGridProvider');
+    });
+
+    test('shows ModuleRegistry snippet when usesAgGridProvider is undefined', () => {
+        const result = NoModulesRegisteredError();
+
+        expect(result).toContain('ModuleRegistry.registerModules');
+        expect(result).not.toContain('AgGridProvider');
+    });
+});
+
+describe('error 200 (missing module)', () => {
+    test('shows AgGridProvider snippet when usesAgGridProvider is true', () => {
+        const result = AG_GRID_ERRORS[200]({
+            reasonOrId: 'Test feature',
+            moduleName: 'RowSelection',
+            gridScoped: false,
+            gridId: 'myGrid',
+            rowModelType: 'clientSide',
+            usesAgGridProvider: true,
+        });
+
+        expect(result).toContain('RowSelectionModule');
+        expect(result).toContain('AgGridProvider');
+        expect(result).not.toContain('ModuleRegistry.registerModules');
+    });
+
+    test('shows ModuleRegistry snippet when usesAgGridProvider is false', () => {
+        const result = AG_GRID_ERRORS[200]({
+            reasonOrId: 'Test feature',
+            moduleName: 'RowSelection',
+            gridScoped: false,
+            gridId: 'myGrid',
+            rowModelType: 'clientSide',
+            usesAgGridProvider: false,
+        });
+
+        expect(result).toContain('RowSelectionModule');
+        expect(result).toContain('ModuleRegistry.registerModules');
+        expect(result).not.toContain('AgGridProvider');
+    });
 });
 
 describe('error 260 (missing user component)', () => {

--- a/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
+++ b/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
@@ -26,7 +26,7 @@ const moduleRegistrationSnippet = (imports: string[], moduleList: string, usesAg
 
 export const NoModulesRegisteredError = (usesAgGridProvider?: boolean) => {
     const imports = [
-        `import { ${!usesAgGridProvider ? 'ModuleRegistry, ' : ''} AllCommunityModule } from 'ag-grid-community';`,
+        `import { ${usesAgGridProvider ? '' : 'ModuleRegistry, '}AllCommunityModule } from 'ag-grid-community';`,
     ];
 
     return `No AG Grid modules are registered! It is recommended to start with all Community features via the AllCommunityModule:\n\n${moduleRegistrationSnippet(imports, 'AllCommunityModule', usesAgGridProvider)}\n`;

--- a/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
+++ b/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
@@ -14,15 +14,25 @@ import { baseDocLink, getErrorLink } from '../logging';
 import { resolveModuleNames } from '../resolvableModuleNames';
 import { USER_COMP_MODULES } from '../rules/userCompValidations';
 
-export const NoModulesRegisteredError = () =>
-    `No AG Grid modules are registered! It is recommended to start with all Community features via the AllCommunityModule:
-                    
-    import { ModuleRegistry, AllCommunityModule } from 'ag-grid-community';
-    
-    ModuleRegistry.registerModules([ AllCommunityModule ]);
-    ` as const;
+/** Formats a code snippet showing how to register modules — via AgGridProvider for React, or ModuleRegistry otherwise. */
+const moduleRegistrationSnippet = (imports: string[], moduleList: string, usesAgGridProvider?: boolean): string => {
+    if (usesAgGridProvider) {
+        const allImports = ["import { AgGridProvider, AgGridReact } from 'ag-grid-react';", ...imports];
+        return `${allImports.join(' \n')} \n\nconst modules = [ ${moduleList} ]; \n\nfunction App() { \n    return ( \n        <AgGridProvider modules={modules}> \n            <AgGridReact /* ... props */ /> \n        </AgGridProvider> \n    ); \n}`;
+    }
 
-const moduleImportMsg = (moduleNames: ModuleName[]) => {
+    return `${imports.join(' \n')} \n\nModuleRegistry.registerModules([ ${moduleList} ]);`;
+};
+
+export const NoModulesRegisteredError = (usesAgGridProvider?: boolean) => {
+    const imports = [
+        `import { ${!usesAgGridProvider ? 'ModuleRegistry, ' : ''} AllCommunityModule } from 'ag-grid-community';`,
+    ];
+
+    return `No AG Grid modules are registered! It is recommended to start with all Community features via the AllCommunityModule:\n\n${moduleRegistrationSnippet(imports, 'AllCommunityModule', usesAgGridProvider)}\n`;
+};
+
+const moduleImportMsg = (moduleNames: ModuleName[], usesAgGridProvider?: boolean) => {
     const imports = moduleNames.map(
         (moduleName) =>
             `import { ${convertToUserModuleName(moduleName)} } from '${ENTERPRISE_MODULE_NAMES[moduleName as EnterpriseModuleName] ? 'ag-grid-enterprise' : 'ag-grid-community'}';`
@@ -33,7 +43,13 @@ const moduleImportMsg = (moduleNames: ModuleName[]) => {
         const chartImport = `import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';`;
         imports.push(chartImport);
     }
-    return `import { ModuleRegistry } from 'ag-grid-community'; \n${imports.join(' \n')} \n\nModuleRegistry.registerModules([ ${moduleNames.map((m) => convertToUserModuleName(m, true)).join(', ')} ]); \n\nFor more info see: ${baseDocLink}/modules/`;
+
+    const moduleList = moduleNames.map((m) => convertToUserModuleName(m, true)).join(', ');
+
+    if (usesAgGridProvider) {
+        return `${moduleRegistrationSnippet(imports, moduleList, true)} \n\nFor more info see: ${baseDocLink}/modules/`;
+    }
+    return `import { ModuleRegistry } from 'ag-grid-community'; \n${imports.join(' \n')} \n\nModuleRegistry.registerModules([ ${moduleList} ]); \n\nFor more info see: ${baseDocLink}/modules/`;
 };
 
 function convertToUserModuleName(moduleName: ModuleName, inModuleRegistration = false) {
@@ -81,6 +97,7 @@ const missingModule = ({
     rowModelType,
     additionalText,
     isUmd,
+    usesAgGridProvider,
 }: {
     reasonOrId: string | keyof MissingModuleErrors;
     moduleName: ValidationModuleName | ValidationModuleName[];
@@ -89,6 +106,7 @@ const missingModule = ({
     rowModelType: RowModelType;
     additionalText?: string;
     isUmd?: boolean;
+    usesAgGridProvider?: boolean;
 }) => {
     const resolvedModuleNames = resolveModuleNames(moduleName, rowModelType);
     const reason = typeof reasonOrId === 'string' ? reasonOrId : MISSING_MODULE_REASONS[reasonOrId];
@@ -107,7 +125,7 @@ const missingModule = ({
 
     return (
         `${explanation}
-${moduleImportMsg(resolvedModuleNames)}` + (additionalText ? ` \n\n${additionalText}` : '')
+${moduleImportMsg(resolvedModuleNames, usesAgGridProvider)}` + (additionalText ? ` \n\n${additionalText}` : '')
     );
 };
 
@@ -645,12 +663,14 @@ export const AG_GRID_ERRORS = {
         gridScoped,
         gridId,
         rowModelType,
+        usesAgGridProvider,
     }: {
         propName: string;
         compName: string;
         gridScoped: boolean;
         gridId: string;
         rowModelType: RowModelType;
+        usesAgGridProvider?: boolean;
     }) =>
         missingModule({
             reasonOrId: `AG Grid '${propName}' component: ${compName}`,
@@ -658,6 +678,7 @@ export const AG_GRID_ERRORS = {
             gridId,
             gridScoped,
             rowModelType,
+            usesAgGridProvider,
         }),
     261: () => 'As of v33, `column.isHovered()` is deprecated. Use `api.isColumnHovered(column)` instead.' as const,
     262: () =>

--- a/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
+++ b/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
@@ -46,10 +46,10 @@ const moduleImportMsg = (moduleNames: ModuleName[], usesAgGridProvider?: boolean
 
     const moduleList = moduleNames.map((m) => convertToUserModuleName(m, true)).join(', ');
 
-    if (usesAgGridProvider) {
-        return `${moduleRegistrationSnippet(imports, moduleList, true)} \n\nFor more info see: ${baseDocLink}/modules/`;
+    if (!usesAgGridProvider) {
+        imports.unshift("import { ModuleRegistry } from 'ag-grid-community';");
     }
-    return `import { ModuleRegistry } from 'ag-grid-community'; \n${imports.join(' \n')} \n\nModuleRegistry.registerModules([ ${moduleList} ]); \n\nFor more info see: ${baseDocLink}/modules/`;
+    return `${moduleRegistrationSnippet(imports, moduleList, usesAgGridProvider)} \n\nFor more info see: ${baseDocLink}/modules/`;
 };
 
 function convertToUserModuleName(moduleName: ModuleName, inModuleRegistration = false) {

--- a/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
+++ b/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
@@ -18,10 +18,22 @@ import { USER_COMP_MODULES } from '../rules/userCompValidations';
 const moduleRegistrationSnippet = (imports: string[], moduleList: string, usesAgGridProvider?: boolean): string => {
     if (usesAgGridProvider) {
         const allImports = ["import { AgGridProvider, AgGridReact } from 'ag-grid-react';", ...imports];
-        return `${allImports.join(' \n')} \n\nconst modules = [ ${moduleList} ]; \n\nfunction App() { \n    return ( \n        <AgGridProvider modules={modules}> \n            <AgGridReact /* ... props */ /> \n        </AgGridProvider> \n    ); \n}`;
+        return `${allImports.join(' \n')}
+
+const modules = [ ${moduleList} ];
+
+function App() {
+    return (
+        <AgGridProvider modules={modules}>
+            <AgGridReact /* ... props */ />
+        </AgGridProvider>
+    );
+}`;
     }
 
-    return `${imports.join(' \n')} \n\nModuleRegistry.registerModules([ ${moduleList} ]);`;
+    return `${imports.join(' \n')}
+
+ModuleRegistry.registerModules([ ${moduleList} ]);`;
 };
 
 export const NoModulesRegisteredError = (usesAgGridProvider?: boolean) => {
@@ -29,7 +41,10 @@ export const NoModulesRegisteredError = (usesAgGridProvider?: boolean) => {
         `import { ${usesAgGridProvider ? '' : 'ModuleRegistry, '}AllCommunityModule } from 'ag-grid-community';`,
     ];
 
-    return `No AG Grid modules are registered! It is recommended to start with all Community features via the AllCommunityModule:\n\n${moduleRegistrationSnippet(imports, 'AllCommunityModule', usesAgGridProvider)}\n`;
+    return `No AG Grid modules are registered! It is recommended to start with all Community features via the AllCommunityModule:
+
+${moduleRegistrationSnippet(imports, 'AllCommunityModule', usesAgGridProvider)}
+`;
 };
 
 const moduleImportMsg = (moduleNames: ModuleName[], usesAgGridProvider?: boolean) => {
@@ -49,7 +64,9 @@ const moduleImportMsg = (moduleNames: ModuleName[], usesAgGridProvider?: boolean
     if (!usesAgGridProvider) {
         imports.unshift("import { ModuleRegistry } from 'ag-grid-community';");
     }
-    return `${moduleRegistrationSnippet(imports, moduleList, usesAgGridProvider)} \n\nFor more info see: ${baseDocLink}/modules/`;
+    return `${moduleRegistrationSnippet(imports, moduleList, usesAgGridProvider)}
+
+For more info see: ${baseDocLink}/modules/`;
 };
 
 function convertToUserModuleName(moduleName: ModuleName, inModuleRegistration = false) {

--- a/packages/ag-grid-community/src/vanillaFrameworkOverrides.ts
+++ b/packages/ag-grid-community/src/vanillaFrameworkOverrides.ts
@@ -10,6 +10,7 @@ import { setValidationDocLink } from './validation/logging';
 export class VanillaFrameworkOverrides implements IFrameworkOverrides {
     public readonly renderingEngine: 'vanilla' | 'react' = 'vanilla';
     public readonly batchFrameworkComps: boolean = false;
+    public readonly usesAgGridProvider: boolean = false;
     private readonly baseDocLink: string;
 
     constructor(private readonly frameworkName: 'javascript' | 'angular' | 'react' | 'vue' = 'javascript') {

--- a/packages/ag-grid-react/src/reactUi/agGridProvider.tsx
+++ b/packages/ag-grid-react/src/reactUi/agGridProvider.tsx
@@ -18,7 +18,8 @@ export interface AgGridProviderProps {
     children: React.ReactNode;
 }
 
-export const ModulesContext = React.createContext<Module[]>([]);
+/** Defaults to null (no AgGridProvider in the tree). When an AgGridProvider is present, it provides Module[] (possibly empty). */
+export const ModulesContext = React.createContext<Module[] | null>(null);
 export const LicenseContext = React.createContext<string | undefined>(undefined);
 
 /**
@@ -29,7 +30,8 @@ export const LicenseContext = React.createContext<string | undefined>(undefined)
  * This is an alternative to providing modules globally via `ModuleRegistry.registerModules()` and setting the license key via `LicenseManager.setLicenseKey()`.
  */
 export function AgGridProvider({ modules, licenseKey, children }: Readonly<AgGridProviderProps>) {
-    const parentModules = useContext(ModulesContext);
+    const parentModulesRaw = useContext(ModulesContext);
+    const parentModules = parentModulesRaw ?? [];
     const parentLicenseKey = useContext(LicenseContext);
 
     const modulesRef = useRef<Module[]>(modules);

--- a/packages/ag-grid-react/src/reactUi/agGridReactUi.tsx
+++ b/packages/ag-grid-react/src/reactUi/agGridReactUi.tsx
@@ -177,7 +177,7 @@ export const AgGridReactUi = <TData,>(props: InternalAgGridReactProps<TData>) =>
             }
         };
 
-        const frameworkOverrides = new ReactFrameworkOverrides(processQueuedUpdates);
+        const frameworkOverrides = new ReactFrameworkOverrides(processQueuedUpdates, modulesFromContext.length > 0);
         frameworkOverridesRef.current = frameworkOverrides;
         const renderStatus = new RenderStatusService();
         const gridParams: GridParams = {
@@ -503,8 +503,12 @@ class ReactFrameworkOverrides extends VanillaFrameworkOverrides {
     private queueUpdates = false;
     public override readonly renderingEngine = 'react';
 
-    constructor(private readonly processQueuedUpdates: () => void) {
+    constructor(
+        private readonly processQueuedUpdates: () => void,
+        public override readonly usesAgGridProvider: boolean
+    ) {
         super('react');
+        this.usesAgGridProvider = usesAgGridProvider;
     }
 
     private readonly frameworkComponents: any = {

--- a/packages/ag-grid-react/src/reactUi/agGridReactUi.tsx
+++ b/packages/ag-grid-react/src/reactUi/agGridReactUi.tsx
@@ -509,7 +509,6 @@ class ReactFrameworkOverrides extends VanillaFrameworkOverrides {
         public override readonly usesAgGridProvider: boolean
     ) {
         super('react');
-        this.usesAgGridProvider = usesAgGridProvider;
     }
 
     private readonly frameworkComponents: any = {

--- a/packages/ag-grid-react/src/reactUi/agGridReactUi.tsx
+++ b/packages/ag-grid-react/src/reactUi/agGridReactUi.tsx
@@ -85,6 +85,7 @@ const deprecatedReactCompProps = new Set(Object.keys(deprecatedProps));
 export const AgGridReactUi = <TData,>(props: InternalAgGridReactProps<TData>) => {
     const modulesFromContext = useContext(ModulesContext);
     const licenseKeyFromContext = useContext(LicenseContext);
+    const usesAgGridProvider = modulesFromContext !== null;
 
     const apiRef = useRef<GridApi<TData>>();
     const eGui = useRef<HTMLDivElement | null>(null);
@@ -177,7 +178,7 @@ export const AgGridReactUi = <TData,>(props: InternalAgGridReactProps<TData>) =>
             }
         };
 
-        const frameworkOverrides = new ReactFrameworkOverrides(processQueuedUpdates, modulesFromContext.length > 0);
+        const frameworkOverrides = new ReactFrameworkOverrides(processQueuedUpdates, usesAgGridProvider);
         frameworkOverridesRef.current = frameworkOverrides;
         const renderStatus = new RenderStatusService();
         const gridParams: GridParams = {


### PR DESCRIPTION
## Summary
- Adds `usesAgGridProvider` property to framework overrides, set to `true` when modules are provided via `AgGridProvider` React context
- Missing module error messages now show `AgGridProvider`-based code snippets instead of `ModuleRegistry.registerModules` when appropriate
- Passes `usesAgGridProvider` through grid creation (`grid.ts`) and runtime validation (`gridOptionsService.ts`) so both pre-init and runtime errors produce accurate guidance

Fix [AG-17057](https://ag-grid.atlassian.net/browse/AG-17057)
