### PR TITLE
AG-17086 guard setTooltip against destroyed header controllers

### DIFF
--- a/packages/ag-grid-community/src/tooltip/tooltipService.ts
+++ b/packages/ag-grid-community/src/tooltip/tooltipService.ts
@@ -213,6 +213,10 @@ export class TooltipService extends BeanStub implements NamedBean {
             ctrl.destroyBean(existingTooltipFeature);
         }
 
+        if (!ctrl.isAlive()) {
+            return;
+        }
+
         const gos = this.gos;
         const isTooltipWhenTruncated = _isShowTooltipWhenTruncated(gos);
         const { column, eGui } = ctrl;
@@ -259,6 +263,9 @@ export class TooltipService extends BeanStub implements NamedBean {
     ): TooltipFeature | undefined {
         if (existingTooltipFeature) {
             ctrl.destroyBean(existingTooltipFeature);
+        }
+        if (!ctrl.isAlive()) {
+            return;
         }
         const gos = this.gos;
         const isTooltipWhenTruncated = _isShowTooltipWhenTruncated(gos);

--- a/testing/behavioural/src/columns/column-custom-renderers.test.ts
+++ b/testing/behavioural/src/columns/column-custom-renderers.test.ts
@@ -4,7 +4,7 @@
  */
 import { vitest } from 'vitest';
 
-import type { ColDef, IHeaderComp, IHeaderGroupComp, IHeaderParams } from 'ag-grid-community';
+import type { ColDef, IHeaderComp, IHeaderGroupComp, IHeaderGroupParams, IHeaderParams } from 'ag-grid-community';
 import { ClientSideRowModelModule, TooltipModule, getGridElement } from 'ag-grid-community';
 import { RowGroupingModule } from 'ag-grid-enterprise';
 
@@ -235,6 +235,73 @@ describe('Column Custom Renderers', () => {
                 ├── a width:200
                 └── b width:200
             `);
+        });
+
+        test('AG-17086 setTooltip does not throw after HeaderCellCtrl is destroyed', async () => {
+            let capturedSetTooltip: IHeaderParams['setTooltip'] | null = null;
+
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [
+                    {
+                        colId: 'a',
+                        headerTooltip: 'Tooltip A',
+                        headerComponent: class implements IHeaderComp {
+                            private eGui!: HTMLDivElement;
+                            init(params: IHeaderParams): void {
+                                capturedSetTooltip = params.setTooltip;
+                                this.eGui = document.createElement('div');
+                                this.eGui.textContent = params.displayName;
+                            }
+                            getGui(): HTMLElement {
+                                return this.eGui;
+                            }
+                        },
+                    },
+                    { colId: 'b' },
+                ],
+                rowData: [{ a: 1, b: 2 }],
+            });
+
+            expect(capturedSetTooltip).not.toBeNull();
+
+            // Remove the column, which destroys its HeaderCellCtrl and nullifies this.column
+            api.setGridOption('columnDefs', [{ colId: 'b' }]);
+
+            // Calling setTooltip after destruction should be a no-op, not a crash
+            expect(() => capturedSetTooltip!('late tooltip', () => true)).not.toThrow();
+        });
+
+        test('AG-17086 setTooltip does not throw after HeaderGroupCellCtrl is destroyed', async () => {
+            let capturedSetTooltip: IHeaderGroupParams['setTooltip'] | null = null;
+
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [
+                    {
+                        headerName: 'Group',
+                        headerGroupComponent: class implements IHeaderGroupComp {
+                            private eGui!: HTMLDivElement;
+                            init(params: IHeaderGroupParams): void {
+                                capturedSetTooltip = params.setTooltip;
+                                this.eGui = document.createElement('div');
+                                this.eGui.textContent = params.displayName;
+                            }
+                            getGui(): HTMLElement {
+                                return this.eGui;
+                            }
+                        },
+                        children: [{ colId: 'a' }, { colId: 'b' }],
+                    },
+                ],
+                rowData: [{ a: 1, b: 2 }],
+            });
+
+            expect(capturedSetTooltip).not.toBeNull();
+
+            // Replace columns, destroying the group header and its controller
+            api.setGridOption('columnDefs', [{ colId: 'c' }]);
+
+            // Calling setTooltip after destruction should be a no-op, not a crash
+            expect(() => capturedSetTooltip!('late tooltip', () => true)).not.toThrow();
         });
     });
 


### PR DESCRIPTION
## Summary

- Add `isAlive()` guard in `TooltipService.setupHeaderTooltip()` and `setupHeaderGroupTooltip()` to prevent crash when `setTooltip` is called on a destroyed header controller
- When columns virtualize quickly, `HeaderCellCtrl` is destroyed (`this.column` set to null) before React's portal manager flushes — a `useEffect` calling `setTooltip` then throws `TypeError: Cannot read properties of null (reading 'getColDef')`
- Add behavioural tests for both `HeaderCellCtrl` and `HeaderGroupCellCtrl` confirming `setTooltip` is a no-op after destruction

Fix [AG-17086](https://ag-grid.atlassian.net/browse/AG-17086)