### PR TITLE
AG-17009 Fix pill drop zone scroll on focus entry and exit

### DIFF
--- a/packages/ag-grid-enterprise/src/widgets/pillDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/widgets/pillDropZonePanel.ts
@@ -135,6 +135,10 @@ export abstract class PillDropZonePanel<TPill extends PillDragComp<TItem>, TItem
 
         this.refreshGui();
         _setAriaLabel(this.ePillDropList, this.getAriaLabel());
+
+        this.addManagedElementListeners(this.getFocusableElement(), {
+            focusin: this.onFocusIn.bind(this),
+        });
     }
 
     private onTabKeyDown(e: KeyboardEvent): void {
@@ -153,8 +157,19 @@ export abstract class PillDropZonePanel<TPill extends PillDragComp<TItem>, TItem
         const shouldAllowDefaultTab = len === 1 || (isFirstFocused && shiftKey) || (isLastFocused && !shiftKey);
 
         if (!shouldAllowDefaultTab) {
-            focusableElements[shiftKey ? 0 : len - 1].focus();
+            // We want tab to jump out of the container, not select the next item, so focus the last item
+            focusableElements[shiftKey ? 0 : len - 1].focus({ preventScroll: true });
         }
+    }
+
+    private onFocusIn(e: FocusEvent): void {
+        const root = this.getFocusableElement();
+        if (root.contains(e.relatedTarget as Node | null)) {
+            // don't scroll when we focus the last item item in order to tab out of the container
+            return;
+        }
+        const target = e.target as HTMLElement | null;
+        target?.scrollIntoView();
     }
 
     private onKeyDown(e: KeyboardEvent) {
@@ -183,6 +198,7 @@ export abstract class PillDropZonePanel<TPill extends PillDragComp<TItem>, TItem
 
             if (el) {
                 el.focus();
+                el.scrollIntoView();
             }
         }
     }


### PR DESCRIPTION
Fix [AG-17009](https://ag-grid.atlassian.net/browse/AG-17009)

The horizontal overflow added by #13441 exposed two focus-scroll issues
in the row grouping panel:

1. When tabbing out of the panel, don't scroll to the end

2. When tabbing in to the panel, scroll to to show the focussed pill (first if tabbing from above, last if Shift+tabbing from below)