### PR TITLE
AG-17093 Prevent raf accumulation in background tab

### DIFF
--- a/packages/ag-grid-community/src/interfaces/iCellRangeFeature.ts
+++ b/packages/ag-grid-community/src/interfaces/iCellRangeFeature.ts
@@ -4,7 +4,7 @@ import type { ICellComp } from '../rendering/cell/cellCtrl';
 export interface ICellRangeFeature {
     setComp(cellComp: ICellComp): void;
     unsetComp(): void;
-    refreshRangeStyleAndHandle(): void;
+    scheduleRefreshRangeStyleAndHandle(): void;
     updateRangeBordersIfRangeCount(): void;
     onCellSelectionChanged(): void;
     destroy(): void;

--- a/packages/ag-grid-community/src/navigation/cellNavigationService.ts
+++ b/packages/ag-grid-community/src/navigation/cellNavigationService.ts
@@ -4,24 +4,16 @@ import { _missing } from '../agStack/utils/generic';
 import { isRowNumberCol } from '../columns/columnUtils';
 import type { NamedBean } from '../context/bean';
 import { BeanStub } from '../context/beanStub';
-import type { BeanCollection } from '../context/context';
 import type { AgColumn } from '../entities/agColumn';
 import { _getRowAbove, _getRowBelow } from '../entities/positionUtils';
 import type { RowNode } from '../entities/rowNode';
 import type { CellPosition } from '../interfaces/iCellPosition';
 import type { IRowNode } from '../interfaces/iRowNode';
-import type { RowSpanService } from '../rendering/spanning/rowSpanService';
 import { _warn } from '../validation/logging';
 
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class CellNavigationService extends BeanStub implements NamedBean {
     beanName = 'cellNavigation' as const;
-
-    private rowSpanSvc: RowSpanService | undefined;
-
-    public wireBeans(beans: BeanCollection) {
-        this.rowSpanSvc = beans.rowSpanSvc;
-    }
 
     // returns null if no cell to focus on, ie at the end of the grid
     public getNextCellToFocus(
@@ -190,10 +182,11 @@ export class CellNavigationService extends BeanStub implements NamedBean {
             return null;
         }
 
+        const { beans } = this;
         // adjust spanned cell so when moving down asserts use of last row in cell
-        const adjustedLastCell = this.rowSpanSvc?.getCellEnd(lastCell) ?? lastCell;
+        const adjustedLastCell = beans.rowSpanSvc?.getCellEnd(lastCell) ?? lastCell;
 
-        const rowBelow = _getRowBelow(this.beans, adjustedLastCell, true);
+        const rowBelow = _getRowBelow(beans, adjustedLastCell, true);
         if (rowBelow) {
             return {
                 rowIndex: rowBelow.rowIndex,
@@ -210,11 +203,12 @@ export class CellNavigationService extends BeanStub implements NamedBean {
             return null;
         }
 
+        const { beans } = this;
         // adjust spanned cell so when moving up asserts use of first row in cell
-        const adjustedLastCell = this.rowSpanSvc?.getCellStart(lastCell) ?? lastCell;
+        const adjustedLastCell = beans.rowSpanSvc?.getCellStart(lastCell) ?? lastCell;
 
         const rowAbove = _getRowAbove(
-            this.beans,
+            beans,
             {
                 rowIndex: adjustedLastCell.rowIndex,
                 rowPinned: adjustedLastCell.rowPinned,

--- a/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
@@ -1,7 +1,7 @@
 import { KeyCode } from '../../agStack/constants/keyCode';
 import { _setAriaColIndex, _setAriaRowIndex } from '../../agStack/utils/aria';
 import { _getActiveDomElement } from '../../agStack/utils/document';
-import { _addOrRemoveAttribute, _placeCaretAtEnd, _requestAnimationFrame } from '../../agStack/utils/dom';
+import { _addOrRemoveAttribute, _placeCaretAtEnd } from '../../agStack/utils/dom';
 import { _findFocusableElements } from '../../agStack/utils/focus';
 import { _makeNull } from '../../agStack/utils/generic';
 import { AgPromise } from '../../agStack/utils/promise';
@@ -419,9 +419,9 @@ export class CellCtrl extends BeanStub {
 
         this.customRowDragComp?.refreshVisibility();
 
-        // Don't call expensive _requestAnimationFrame if we don't have to
         if (!skipRangeHandleRefresh && rangeFeature) {
-            _requestAnimationFrame(beans, () => rangeFeature?.refreshRangeStyleAndHandle());
+            // Don't call expensive _requestAnimationFrame if we don't have to
+            rangeFeature.scheduleRefreshRangeStyleAndHandle();
         }
 
         this.rowResizeFeature?.refreshRowResizer();

--- a/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
@@ -838,7 +838,7 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
             columnMoved: () => this.updateColumnLists(),
         });
 
-        if (rowSpanSvc) {
+        if (rowSpanSvc?.active) {
             // when spans change, need to verify that cells are correctly skipped/rendered
             this.addManagedListeners(rowSpanSvc, {
                 spannedCellsUpdated: ({ pinned }) => {

--- a/packages/ag-grid-community/src/rendering/spanning/rowSpanService.ts
+++ b/packages/ag-grid-community/src/rendering/spanning/rowSpanService.ts
@@ -11,9 +11,17 @@ import { RowSpanCache } from './rowSpanCache';
 export class RowSpanService extends BeanStub<'spannedCellsUpdated'> implements NamedBean {
     beanName = 'rowSpanSvc' as const;
 
+    /** Active only if `enableCellSpan=true` */
+    public active: boolean = false;
     private readonly spanningColumns: Map<AgColumn, RowSpanCache> = new Map();
 
     public postConstruct(): void {
+        if (!this.gos.get('enableCellSpan')) {
+            // Don't setup listeners when the feature is not configured.
+            return;
+        }
+        this.active = true;
+
         const onRowDataUpdated = this.onRowDataUpdated.bind(this);
         const buildPinnedCaches = this.buildPinnedCaches.bind(this);
         this.addManagedEventListeners({
@@ -30,13 +38,10 @@ export class RowSpanService extends BeanStub<'spannedCellsUpdated'> implements N
      * @param column column that is now spanning
      */
     public register(column: AgColumn): void {
-        const { gos } = this.beans;
-        if (!gos.get('enableCellSpan')) {
+        if (!this.active || this.spanningColumns.has(column)) {
             return;
         }
-        if (this.spanningColumns.has(column)) {
-            return;
-        }
+
         const cache = this.createManagedBean(new RowSpanCache(column));
         this.spanningColumns.set(column, cache);
 
@@ -122,6 +127,9 @@ export class RowSpanService extends BeanStub<'spannedCellsUpdated'> implements N
     }
 
     public isCellSpanning(col: AgColumn, rowNode: RowNode): boolean {
+        if (!this.active) {
+            return false;
+        }
         const cache = this.spanningColumns.get(col);
         if (!cache) {
             return false;
@@ -131,25 +139,24 @@ export class RowSpanService extends BeanStub<'spannedCellsUpdated'> implements N
     }
 
     public getCellSpanByPosition(position: CellPosition): CellSpan | undefined {
-        const { pinnedRowModel, rowModel } = this.beans;
-        const col = position.column;
-        const index = position.rowIndex;
-
-        const cache = this.spanningColumns.get(col as AgColumn);
+        const { column, rowIndex } = position;
+        const cache = this.spanningColumns.get(column as AgColumn);
         if (!cache) {
             return undefined;
         }
 
+        const { pinnedRowModel, rowModel } = this.beans;
+
         let node;
         switch (position.rowPinned) {
             case 'top':
-                node = pinnedRowModel?.getPinnedTopRow(index);
+                node = pinnedRowModel?.getPinnedTopRow(rowIndex);
                 break;
             case 'bottom':
-                node = pinnedRowModel?.getPinnedBottomRow(index);
+                node = pinnedRowModel?.getPinnedBottomRow(rowIndex);
                 break;
             default:
-                node = rowModel.getRow(index);
+                node = rowModel.getRow(rowIndex);
         }
 
         if (!node) {

--- a/packages/ag-grid-enterprise/src/find/findService.ts
+++ b/packages/ag-grid-enterprise/src/find/findService.ts
@@ -148,7 +148,7 @@ export class FindService extends BeanStub implements NamedBean, IFindService {
             batchEditingStopped: refreshAndKeepActiveDebounced,
         });
         const rowSpanSvc = this.beans.rowSpanSvc;
-        if (rowSpanSvc) {
+        if (rowSpanSvc?.active) {
             this.addManagedListeners(rowSpanSvc, { spannedCellsUpdated: refreshAndKeepActiveDebounced });
         }
 

--- a/packages/ag-grid-enterprise/src/rangeSelection/cellRangeFeature.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/cellRangeFeature.ts
@@ -8,7 +8,14 @@ import type {
     ICellRangeFeature,
     IRangeService,
 } from 'ag-grid-community';
-import { CellRangeType, _isSameRow, _last, _missing, _setAriaSelected } from 'ag-grid-community';
+import {
+    CellRangeType,
+    _isSameRow,
+    _last,
+    _missing,
+    _requestAnimationFrame,
+    _setAriaSelected,
+} from 'ag-grid-community';
 
 import { SelectionHandleType } from './abstractSelectionHandle';
 import type { AgFillHandle } from './agFillHandle';
@@ -56,6 +63,7 @@ export class CellRangeFeature implements ICellRangeFeature {
     private handleColorClass: string | null = null;
 
     private selectionHandle: AgFillHandle | AgRangeHandle | null | undefined;
+    private refreshScheduled = false;
 
     constructor(
         private readonly beans: BeanCollection,
@@ -222,7 +230,7 @@ export class CellRangeFeature implements ICellRangeFeature {
         return { top, right, bottom, left };
     }
 
-    public refreshRangeStyleAndHandle(): void {
+    private refreshRangeStyleAndHandle(): void {
         const { context } = this.beans;
         if (context.isDestroyed()) {
             return;
@@ -242,6 +250,17 @@ export class CellRangeFeature implements ICellRangeFeature {
 
         this.refreshHandleColor(rangeForHandle);
         this.cellComp.toggleCss(CSS_CELL_RANGE_HANDLE, !!this.selectionHandle);
+    }
+
+    public scheduleRefreshRangeStyleAndHandle(): void {
+        if (this.refreshScheduled) {
+            return;
+        }
+        this.refreshScheduled = true;
+        _requestAnimationFrame(this.beans, () => {
+            this.refreshScheduled = false;
+            this.refreshRangeStyleAndHandle();
+        });
     }
 
     private styleCellForRangeType(): void {
@@ -361,24 +380,24 @@ export class CellRangeFeature implements ICellRangeFeature {
     }
 
     private addSelectionHandle(cellRange: CellRange) {
-        const { beans } = this;
-        const isRangeSelectionEnabledWhileEditing = beans.editSvc?.isRangeSelectionEnabledWhileEditing();
+        const { editSvc, gos, context, registry } = this.beans;
+        const isRangeSelectionEnabledWhileEditing = editSvc?.isRangeSelectionEnabledWhileEditing();
         const cellRangeType = cellRange.type;
         const selectionHandleFill =
-            !isRangeSelectionEnabledWhileEditing && _isFillHandleEnabled(beans.gos) && _missing(cellRangeType);
+            !isRangeSelectionEnabledWhileEditing && _isFillHandleEnabled(gos) && _missing(cellRangeType);
         const type = selectionHandleFill ? SelectionHandleType.FILL : SelectionHandleType.RANGE;
 
         if (this.selectionHandle && this.selectionHandle.getType() !== type) {
-            this.selectionHandle = beans.context.destroyBean(this.selectionHandle);
+            this.selectionHandle = context.destroyBean(this.selectionHandle);
         }
 
         if (!this.selectionHandle) {
-            const selectionHandle = beans.registry.createDynamicBean<AgFillHandle | AgRangeHandle>(
+            const selectionHandle = registry.createDynamicBean<AgFillHandle | AgRangeHandle>(
                 type === SelectionHandleType.FILL ? 'fillHandle' : 'rangeHandle',
                 false
             );
             if (selectionHandle) {
-                this.selectionHandle = beans.context.createBean(selectionHandle);
+                this.selectionHandle = context.createBean(selectionHandle);
             }
         }
 

--- a/testing/behavioural/src/selection/cell-selection-raf.test.ts
+++ b/testing/behavioural/src/selection/cell-selection-raf.test.ts
@@ -1,0 +1,226 @@
+import type { MockInstance } from 'vitest';
+
+import type { GridApi, GridOptions } from 'ag-grid-community';
+import { CellSpanModule, ClientSideRowModelModule, RenderApiModule } from 'ag-grid-community';
+import { CellSelectionModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout, waitForEvent } from '../test-utils';
+
+describe('Cell Selection RAF Deduplication', () => {
+    let consoleWarnSpy: MockInstance;
+    let rafSpy: MockInstance;
+
+    const gridMgr = new TestGridsManager({
+        modules: [ClientSideRowModelModule, CellSelectionModule, RenderApiModule],
+    });
+
+    async function createGrid(go: GridOptions): Promise<GridApi> {
+        const api = gridMgr.createGrid('myGrid', go);
+
+        await waitForEvent('firstDataRendered', api);
+        await asyncSetTimeout(0);
+
+        return api;
+    }
+
+    const columnDefs = [{ field: 'name' }, { field: 'value' }];
+    const rowData = [
+        { name: 'a', value: 1 },
+        { name: 'b', value: 2 },
+        { name: 'c', value: 3 },
+        { name: 'd', value: 4 },
+    ];
+
+    beforeEach(() => {
+        gridMgr.reset();
+        consoleWarnSpy = vitest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        gridMgr.reset();
+        consoleWarnSpy.mockRestore();
+        rafSpy?.mockRestore();
+    });
+
+    test('repeated refreshCells does not accumulate RAF callbacks when cell selection is active', async () => {
+        const api = await createGrid({
+            columnDefs,
+            rowData,
+            cellSelection: true,
+        });
+
+        // Add a cell range so the range feature is active on cells
+        api.addCellRange({
+            columns: ['name', 'value'],
+            rowStartIndex: 0,
+            rowEndIndex: 3,
+        });
+        await asyncSetTimeout(0);
+
+        // Spy on requestAnimationFrame to count scheduling calls.
+        // Using a non-executing spy so callbacks are queued but never fire,
+        // simulating a hidden tab where RAF callbacks accumulate.
+        let rafId = 1000;
+        rafSpy = vitest.spyOn(window, 'requestAnimationFrame').mockImplementation(() => ++rafId);
+
+        const rafCountBefore = rafSpy.mock.calls.length;
+
+        // Call refreshCells many times to simulate rapid updates (e.g. backgrounded tab)
+        for (let i = 0; i < 20; i++) {
+            api.refreshCells({ force: true, suppressFlash: true });
+        }
+
+        const rafScheduled = rafSpy.mock.calls.length - rafCountBefore;
+
+        // With deduplication, the number of RAF calls should be bounded to at most
+        // one per CellRangeFeature instance (8 cells in the range).
+        // Without the fix, we'd see 20 * 8 = 160 RAF calls.
+        expect(rafScheduled).toBeLessThanOrEqual(8);
+    });
+
+    test('scheduled range refresh resets after RAF fires allowing new scheduling', async () => {
+        const api = await createGrid({
+            columnDefs,
+            rowData,
+            cellSelection: true,
+        });
+
+        api.addCellRange({
+            columns: ['name', 'value'],
+            rowStartIndex: 0,
+            rowEndIndex: 1,
+        });
+        await asyncSetTimeout(0);
+
+        // Capture callbacks instead of executing them
+        const rafCallbacks: FrameRequestCallback[] = [];
+        let rafId = 2000;
+        rafSpy = vitest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+            rafCallbacks.push(cb);
+            return ++rafId;
+        });
+
+        // First batch of refreshCells
+        api.refreshCells({ force: true, suppressFlash: true });
+        const firstBatchCount = rafCallbacks.length;
+        expect(firstBatchCount).toBeGreaterThan(0);
+
+        // Execute all pending RAF callbacks (simulates frame firing when tab becomes visible)
+        for (const cb of [...rafCallbacks]) {
+            cb(performance.now());
+        }
+        rafCallbacks.length = 0;
+
+        // Second batch — should be able to schedule again since the flags were reset
+        api.refreshCells({ force: true, suppressFlash: true });
+
+        expect(rafCallbacks.length).toBeGreaterThan(0);
+        expect(rafCallbacks.length).toBe(firstBatchCount);
+    });
+});
+
+describe('RowSpanService does not register listeners when enableCellSpan is not configured', () => {
+    let consoleWarnSpy: MockInstance;
+    let rafSpy: MockInstance;
+
+    const gridMgr = new TestGridsManager({
+        modules: [ClientSideRowModelModule, CellSpanModule, CellSelectionModule, RenderApiModule],
+    });
+
+    beforeEach(() => {
+        gridMgr.reset();
+        consoleWarnSpy = vitest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        gridMgr.reset();
+        consoleWarnSpy.mockRestore();
+        rafSpy?.mockRestore();
+    });
+
+    const columnDefs = [{ field: 'name' }, { field: 'value' }];
+    const rowData = [
+        { name: 'a', value: 1 },
+        { name: 'b', value: 2 },
+        { name: 'c', value: 3 },
+    ];
+
+    test('data updates with cell selection do not accumulate RAF callbacks without enableCellSpan', async () => {
+        const api = gridMgr.createGrid('myGrid', {
+            columnDefs,
+            rowData,
+            cellSelection: true,
+            getRowId: (params) => params.data.name,
+        });
+
+        await waitForEvent('firstDataRendered', api);
+        await asyncSetTimeout(0);
+
+        // Add a cell range to activate the range feature
+        api.addCellRange({
+            columns: ['name', 'value'],
+            rowStartIndex: 0,
+            rowEndIndex: 2,
+        });
+        await asyncSetTimeout(0);
+
+        // Spy on RAF — don't execute callbacks (simulates hidden tab)
+        let rafId = 3000;
+        rafSpy = vitest.spyOn(window, 'requestAnimationFrame').mockImplementation(() => ++rafId);
+
+        // Simulate the real-world scenario: repeated data updates interleaved with
+        // flushAllAnimationFrames (which happens during scroll/focus operations).
+        // Each flush resets AnimationFrameService.ticking = false, allowing the
+        // next spannedCellsUpdated cycle to schedule a fresh RAF — which then
+        // accumulates because the old RAF is never cancelled.
+        for (let i = 0; i < 10; i++) {
+            api.applyTransaction({
+                update: [{ name: 'a', value: i }],
+            });
+            // Allow debounced RowSpanService timeouts to dispatch spannedCellsUpdated
+            await asyncSetTimeout(5);
+            // Flush animation frame tasks (simulates what happens during scroll/focus)
+            api.flushAllAnimationFrames();
+        }
+
+        const rafCount = rafSpy.mock.calls.length;
+
+        // Without the RowSpanService fix, each flush+update cycle schedules a new RAF
+        // via spannedCellsUpdated → updateColumnLists → AnimationFrameService, even when
+        // no columns are spanning. This causes ~10+ orphaned RAFs.
+        // With the fix, RowSpanService doesn't register listeners, so no extra RAFs accumulate.
+        expect(rafCount).toBeLessThanOrEqual(5);
+    });
+
+    test('data updates with enableCellSpan respond to span changes', async () => {
+        let spanValue = 1;
+        const api = gridMgr.createGrid('myGrid', {
+            columnDefs: [
+                { field: 'name' },
+                {
+                    field: 'value',
+                    rowSpan: () => spanValue,
+                },
+            ],
+            rowData,
+            enableCellSpan: true,
+            cellSelection: true,
+            getRowId: (params) => params.data.name,
+        });
+
+        await waitForEvent('firstDataRendered', api);
+        await asyncSetTimeout(0);
+
+        // Update data — with enableCellSpan active, RowSpanService should be processing events
+        spanValue = 2;
+        api.applyTransaction({
+            update: [{ name: 'a', value: 999 }],
+        });
+
+        // Allow RowSpanService timeouts and events to process
+        await asyncSetTimeout(50);
+
+        // The grid should not have errored — spans are being processed
+        expect(api.getDisplayedRowCount()).toBe(3);
+    });
+});


### PR DESCRIPTION
Fix [AG-17093](https://ag-grid.atlassian.net/browse/AG-17093)

Prevents unbounded requestAnimationFrame cellSelection refreshes from accumulating when tab in the background. Able to only keep the latest raf as the callback always takes the latest data.

Also made an optimisation so that the RowSpanService does not register event listeners which result in further raf calls, even when this feature is not used. 