### PR TITLE
AG-17102 sizeColumnsToFit respects pinned column viewport limit

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/column-pinning/_examples/column-pinning/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-pinning/_examples/column-pinning/example.spec.ts
@@ -66,7 +66,7 @@ test.agExample(import.meta, () => {
         test.use({ agModules: ['ColumnAutoSize'] });
 
         test.vanilla(
-            'sizeColumnsToFit should not reverse pinned left column order when hidden column exists',
+            'sizeColumnsToFit should not unpin left-pinned columns when no center columns exist',
             async ({ page, remoteGrid }) => {
                 const remoteApi = remoteGrid(page, '1');
 
@@ -77,24 +77,78 @@ test.agExample(import.meta, () => {
                 ]);
                 await waitForGridContent(page);
 
-                // Verify initial pinned left header order
                 const headersBefore = await getPinnedHeaderColIds(page, '.ag-pinned-left-header');
                 expect(headersBefore).toEqual(['athlete', 'age']);
 
-                // Call sizeColumnsToFit and wait for any async layout changes
                 await remoteApi.sizeColumnsToFit({});
                 await page.waitForTimeout(600);
 
-                // Verify pinned left header order is preserved
                 const headersAfter = await getPinnedHeaderColIds(page, '.ag-pinned-left-header');
                 expect(headersAfter).toEqual(['athlete', 'age']);
 
-                // Verify both columns are still pinned left
-                const pinnedState = (await remoteApi.getColumnState()) as any[];
-                const athleteState = pinnedState.find((s) => s.colId === 'athlete');
-                const ageState = pinnedState.find((s) => s.colId === 'age');
-                expect(athleteState.pinned).toBe('left');
-                expect(ageState.pinned).toBe('left');
+                const state = (await remoteApi.getColumnState()) as any[];
+                expect(state.find((s) => s.colId === 'athlete').pinned).toBe('left');
+                expect(state.find((s) => s.colId === 'age').pinned).toBe('left');
+            }
+        );
+
+        test.vanilla(
+            'sizeColumnsToFit should not unpin right-pinned columns when no center columns exist',
+            async ({ page, remoteGrid }) => {
+                const remoteApi = remoteGrid(page, '1');
+
+                await remoteApi.setGridOption('columnDefs', [
+                    { field: 'gold', pinned: 'right' },
+                    { field: 'silver', pinned: 'right' },
+                    { colId: 'bronze', field: 'bronze', hide: true },
+                ]);
+                await waitForGridContent(page);
+
+                const headersBefore = await getPinnedHeaderColIds(page, '.ag-pinned-right-header');
+                expect(headersBefore).toEqual(['gold', 'silver']);
+
+                await remoteApi.sizeColumnsToFit({});
+                await page.waitForTimeout(600);
+
+                const headersAfter = await getPinnedHeaderColIds(page, '.ag-pinned-right-header');
+                expect(headersAfter).toEqual(['gold', 'silver']);
+
+                const state = (await remoteApi.getColumnState()) as any[];
+                expect(state.find((s) => s.colId === 'gold').pinned).toBe('right');
+                expect(state.find((s) => s.colId === 'silver').pinned).toBe('right');
+            }
+        );
+
+        test.vanilla(
+            'sizeColumnsToFit should not unpin mixed left+right columns when no center columns exist',
+            async ({ page, remoteGrid }) => {
+                const remoteApi = remoteGrid(page, '1');
+
+                await remoteApi.setGridOption('columnDefs', [
+                    { field: 'athlete', pinned: 'left' },
+                    { field: 'age', pinned: 'left' },
+                    { field: 'gold', pinned: 'right' },
+                    { colId: 'country', field: 'country', hide: true },
+                ]);
+                await waitForGridContent(page);
+
+                const leftBefore = await getPinnedHeaderColIds(page, '.ag-pinned-left-header');
+                expect(leftBefore).toEqual(['athlete', 'age']);
+                const rightBefore = await getPinnedHeaderColIds(page, '.ag-pinned-right-header');
+                expect(rightBefore).toEqual(['gold']);
+
+                await remoteApi.sizeColumnsToFit({});
+                await page.waitForTimeout(600);
+
+                const leftAfter = await getPinnedHeaderColIds(page, '.ag-pinned-left-header');
+                expect(leftAfter).toEqual(['athlete', 'age']);
+                const rightAfter = await getPinnedHeaderColIds(page, '.ag-pinned-right-header');
+                expect(rightAfter).toEqual(['gold']);
+
+                const state = (await remoteApi.getColumnState()) as any[];
+                expect(state.find((s) => s.colId === 'athlete').pinned).toBe('left');
+                expect(state.find((s) => s.colId === 'age').pinned).toBe('left');
+                expect(state.find((s) => s.colId === 'gold').pinned).toBe('right');
             }
         );
     });

--- a/documentation/ag-grid-docs/src/content/docs/column-pinning/_examples/column-pinning/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-pinning/_examples/column-pinning/example.spec.ts
@@ -1,11 +1,101 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
+
+/** Returns col-ids of header cells inside the given container selector, ordered by aria-colindex. */
+async function getPinnedHeaderColIds(page: import('playwright/test').Page, containerSelector: string) {
+    return page.evaluate((selector) => {
+        const cells = document.querySelectorAll(`${selector} .ag-header-cell`);
+        return Array.from(cells)
+            .sort(
+                (a, b) =>
+                    parseInt(a.getAttribute('aria-colindex') || '0') - parseInt(b.getAttribute('aria-colindex') || '0')
+            )
+            .map((c) => c.getAttribute('col-id'));
+    }, containerSelector);
+}
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('initial pinned layout', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const leftHeaders = await getPinnedHeaderColIds(page, '.ag-pinned-left-header');
+        expect(leftHeaders).toEqual(['rowNum', 'athlete', 'age']);
+
+        const rightHeaders = await getPinnedHeaderColIds(page, '.ag-pinned-right-header');
+        expect(rightHeaders).toEqual(['total']);
+    });
+
+    test.eachFramework('Clear Pinned removes all pinning', async ({ page }) => {
+        await waitForGridContent(page);
+
+        await page.locator('button:text("Clear Pinned")').click();
+
+        const leftHeaders = await getPinnedHeaderColIds(page, '.ag-pinned-left-header');
+        expect(leftHeaders).toEqual([]);
+
+        const rightHeaders = await getPinnedHeaderColIds(page, '.ag-pinned-right-header');
+        expect(rightHeaders).toEqual([]);
+    });
+
+    test.eachFramework('Reset Pinned restores original layout', async ({ page }) => {
+        await waitForGridContent(page);
+
+        // Clear first, then reset
+        await page.locator('button:text("Clear Pinned")').click();
+        await page.locator('button:text-is("Left = #, Athlete, Age; Right = Total")').click();
+
+        const leftHeaders = await getPinnedHeaderColIds(page, '.ag-pinned-left-header');
+        expect(leftHeaders).toEqual(['rowNum', 'athlete', 'age']);
+
+        const rightHeaders = await getPinnedHeaderColIds(page, '.ag-pinned-right-header');
+        expect(rightHeaders).toEqual(['total']);
+    });
+
+    test.eachFramework('Pin Country moves only country to left', async ({ page }) => {
+        await waitForGridContent(page);
+
+        await page.locator('button:text("Left = Country")').click();
+
+        const leftHeaders = await getPinnedHeaderColIds(page, '.ag-pinned-left-header');
+        expect(leftHeaders).toEqual(['country']);
+
+        const rightHeaders = await getPinnedHeaderColIds(page, '.ag-pinned-right-header');
+        expect(rightHeaders).toEqual([]);
+    });
+
+    test.describe('sizeColumnsToFit with pinned columns', () => {
+        test.use({ agModules: ['ColumnAutoSize'] });
+
+        test.vanilla(
+            'sizeColumnsToFit should not reverse pinned left column order when hidden column exists',
+            async ({ page, remoteGrid }) => {
+                const remoteApi = remoteGrid(page, '1');
+
+                await remoteApi.setGridOption('columnDefs', [
+                    { field: 'athlete', pinned: 'left' },
+                    { field: 'age', pinned: 'left' },
+                    { colId: 'country', field: 'country', hide: true },
+                ]);
+                await waitForGridContent(page);
+
+                // Verify initial pinned left header order
+                const headersBefore = await getPinnedHeaderColIds(page, '.ag-pinned-left-header');
+                expect(headersBefore).toEqual(['athlete', 'age']);
+
+                // Call sizeColumnsToFit and wait for any async layout changes
+                await remoteApi.sizeColumnsToFit({});
+                await page.waitForTimeout(600);
+
+                // Verify pinned left header order is preserved
+                const headersAfter = await getPinnedHeaderColIds(page, '.ag-pinned-left-header');
+                expect(headersAfter).toEqual(['athlete', 'age']);
+
+                // Verify both columns are still pinned left
+                const pinnedState = (await remoteApi.getColumnState()) as any[];
+                const athleteState = pinnedState.find((s) => s.colId === 'athlete');
+                const ageState = pinnedState.find((s) => s.colId === 'age');
+                expect(athleteState.pinned).toBe('left');
+                expect(ageState.pinned).toBe('left');
+            }
+        );
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/column-pinning/_examples/lock-pinned/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-pinning/_examples/lock-pinned/example.spec.ts
@@ -1,11 +1,39 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('lockPinned athlete stays pinned left', async ({ page, agIdFor }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const athleteHeader = agIdFor.headerCell('athlete');
+        await expect(athleteHeader).toBeVisible();
+
+        // Athlete should be in the pinned left header
+        const pinnedLeftHeader = page.locator('.ag-pinned-left-header');
+        await expect(pinnedLeftHeader.locator('.ag-header-cell[col-id="athlete"]')).toBeVisible();
+    });
+
+    test.eachFramework('lockPinned age stays in center (not pinnable)', async ({ page, agIdFor }) => {
+        await waitForGridContent(page);
+
+        const ageHeader = agIdFor.headerCell('age');
+        await expect(ageHeader).toBeVisible();
+
+        // Age should be in the center header, not pinned
+        const centerHeader = page.locator('.ag-header-viewport');
+        await expect(centerHeader.locator('.ag-header-cell[col-id="age"]')).toBeVisible();
+    });
+
+    test.eachFramework('locked cells have lock-pinned class', async ({ page }) => {
+        await waitForGridContent(page);
+
+        // First row athlete cell should have lock-pinned class
+        const athleteCell = page.locator(
+            '.ag-pinned-left-cols-container .ag-row:first-child .ag-cell[col-id="athlete"]'
+        );
+        await expect(athleteCell).toHaveClass(/lock-pinned/);
+
+        // First row age cell should have lock-pinned class
+        const ageCell = page.locator('.ag-center-cols-container .ag-row:first-child .ag-cell[col-id="age"]');
+        await expect(ageCell).toHaveClass(/lock-pinned/);
     });
 });

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
@@ -315,7 +315,14 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
             return;
         }
 
-        const availableWidth = getAvailableWidth(this.beans);
+        let availableWidth = getAvailableWidth(this.beans);
+
+        // When all visible columns are pinned, cap the available width so the pinned sections
+        // don't fill the entire viewport. Without this, the processUnpinnedColumns callback is triggered
+        // and would asynchronously unpin columns — visually reversing their order.
+        if (availableWidth > 0 && this.beans.visibleCols.centerCols.length === 0) {
+            availableWidth = Math.max(availableWidth - MIN_CENTER_VIEWPORT_WIDTH, 0);
+        }
 
         if (availableWidth > 0) {
             this.sizeColumnsToFit(availableWidth, 'sizeColumnsToFit', false, params);
@@ -366,18 +373,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
         // avoid divide by zero
         const allDisplayedColumns = beans.visibleCols.allCols;
 
-        if (!allDisplayedColumns.length) {
-            return;
-        }
-
-        // When all visible columns are pinned, cap the available width so the pinned sections
-        // don't fill the entire viewport. Without this, the processUnpinnedColumns callback is triggered
-        // and would asynchronously unpin columns — visually reversing their order.
-        if (allDisplayedColumns.every((col) => col.getPinned())) {
-            gridWidth = Math.max(gridWidth - MIN_CENTER_VIEWPORT_WIDTH, 0);
-        }
-
-        if (gridWidth <= 0) {
+        if (gridWidth <= 0 || !allDisplayedColumns.length) {
             return;
         }
 

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
@@ -17,6 +17,7 @@ import type {
     SizeColumnsToContentColumnLimits,
     SizeColumnsToContentStrategy,
 } from '../interfaces/autoSize';
+import { MIN_CENTER_VIEWPORT_WIDTH } from '../pinnedColumns/pinnedColumnService';
 import { _warn } from '../validation/logging';
 import { TouchListener } from '../widgets/touchListener';
 
@@ -365,7 +366,18 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
         // avoid divide by zero
         const allDisplayedColumns = beans.visibleCols.allCols;
 
-        if (gridWidth <= 0 || !allDisplayedColumns.length) {
+        if (!allDisplayedColumns.length) {
+            return;
+        }
+
+        // When all visible columns are pinned, cap the available width so the pinned sections
+        // don't fill the entire viewport. Without this, the processUnpinnedColumns callback is triggered
+        // and would asynchronously unpin columns — visually reversing their order.
+        if (allDisplayedColumns.every((col) => col.getPinned())) {
+            gridWidth = Math.max(gridWidth - MIN_CENTER_VIEWPORT_WIDTH, 0);
+        }
+
+        if (gridWidth <= 0) {
             return;
         }
 

--- a/packages/ag-grid-community/src/pinnedColumns/pinnedColumnService.ts
+++ b/packages/ag-grid-community/src/pinnedColumns/pinnedColumnService.ts
@@ -16,6 +16,9 @@ import type { ColumnPinnedType } from '../interfaces/iColumn';
 import type { WithoutGridCommon } from '../interfaces/iCommon';
 import { _warn } from '../validation/logging';
 
+/** Minimum center viewport width (in px) reserved when pinned columns are present. */
+export const MIN_CENTER_VIEWPORT_WIDTH = 50;
+
 export class PinnedColumnService extends BeanStub implements NamedBean {
     beanName = 'pinnedCols' as const;
 
@@ -58,12 +61,13 @@ export class PinnedColumnService extends BeanStub implements NamedBean {
         const eBodyViewport = this.gridBodyCtrl.eBodyViewport;
         const bodyWidth = _getInnerWidth(eBodyViewport);
 
-        if (bodyWidth <= 50) {
+        if (bodyWidth <= MIN_CENTER_VIEWPORT_WIDTH) {
             return;
         }
 
-        // remove 50px from the bodyWidth to give some margin
-        const processedColumnsToRemove = this.getPinnedColumnsOverflowingViewport(bodyWidth - 50);
+        const processedColumnsToRemove = this.getPinnedColumnsOverflowingViewport(
+            bodyWidth - MIN_CENTER_VIEWPORT_WIDTH
+        );
         const processUnpinnedColumns = this.gos.getCallback('processUnpinnedColumns');
         const { columns, hasLockedPinned } = processedColumnsToRemove;
 
@@ -214,7 +218,8 @@ export class PinnedColumnService extends BeanStub implements NamedBean {
         const pinned = column.getPinned();
         if (pinned) {
             const { leftWidth, rightWidth } = this;
-            const bodyWidth = _getInnerWidth(this.beans.ctrlsSvc.getGridBodyCtrl().eBodyViewport) - 50;
+            const bodyWidth =
+                _getInnerWidth(this.beans.ctrlsSvc.getGridBodyCtrl().eBodyViewport) - MIN_CENTER_VIEWPORT_WIDTH;
 
             if (leftWidth + rightWidth + diff > bodyWidth) {
                 if (bodyWidth > leftWidth + rightWidth) {


### PR DESCRIPTION
## Summary

- Fix `sizeColumnsToFit` reversing pinned column order when all visible columns are pinned
- When all displayed columns are pinned, cap available width by `MIN_CENTER_VIEWPORT_WIDTH` (50px) so pinned sections don't fill the entire viewport
- Extract shared `MIN_CENTER_VIEWPORT_WIDTH` constant from the three inline `50` usages in `pinnedColumnService`
- Add E2E tests for both column-pinning examples (replacing placeholders)

## Root Cause

`sizeColumnsToFit` distributes the full grid body width across all visible columns, including pinned ones. When all visible columns are pinned (e.g. 2 pinned left + 1 hidden), pinned columns expand to fill the entire viewport. A `ResizeObserver` then fires on the shrunk center viewport, triggering `keepPinnedColumnsNarrowerThanViewport()` which unpins the first column — visually reversing the order.

Bug has existed since v31.0.0 when `keepPinnedColumnsNarrowerThanViewport` was introduced (AG-3915).

Fix [AG-17102](https://ag-grid.atlassian.net/browse/AG-17102)