### PR TITLE
AG-16845 Correct filter docs: Set/Multi unsupported with custom logic

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/component-filter/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/component-filter/index.mdoc
@@ -225,6 +225,10 @@ The grid-provided handlers are:
 -   `'agBigIntColumnFilterHandler'` - [BigInt Filter](./filter-bigint/) handler.
 -   `'agDateColumnFilterHandler'` - [Date Filter](./filter-date/) handler.
 
+{% note %}
+[Set Filter](./filter-set/) and [Multi Filter](./filter-multi/) are not supported when using custom filters with grid-provided filter logic.
+{% /note %}
+
 The example below demonstrates using the Number Filter handler with a custom filter component:
 
 {% gridExampleRunner title="Use Grid Handlers" name="use-grid-handlers" /%}

--- a/packages/ag-grid-community/src/interfaces/iFilter.ts
+++ b/packages/ag-grid-community/src/interfaces/iFilter.ts
@@ -95,7 +95,7 @@ export type FilterHandlers<TData = any, TValue = any, TContext = any, TModel = a
 export interface ColumnFilter<TData = any, TValue = any, TContext = any, TModel = any, TCustomParams = any> {
     /**
      * Filter component to use for this column.
-     * - Set to the name of a provided filter: `agNumberColumnFilter`, `agBigIntColumnFilter`, `agTextColumnFilter`, `agDateColumnFilter`, `agMultiColumnFilter`, `agSetColumnFilter`.
+     * - Set to the name of a provided filter: `agNumberColumnFilter`, `agBigIntColumnFilter`, `agTextColumnFilter`, `agDateColumnFilter`.
      * - Set to a custom filter `FilterDisplay`
      */
     component: any;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16845

The `ColumnFilter` object (custom filter component + custom filter logic) does not support `agSetColumnFilter` or `agMultiColumnFilter` as the `component` — these are composite filters that own their own UI and logic and cannot be wrapped this way. Using them with custom filter logic leads to a runtime `TypeError: e.addEventListener is not a function`.

Changes:
- Removed `agMultiColumnFilter` / `agSetColumnFilter` from the JSDoc on `ColumnFilter.component` in `iFilter.ts`, so the generated interface docs no longer list them as valid values.
- Added a note under the four provided filter handlers in `component-filter/index.mdoc` explicitly stating Set Filter and Multi Filter are not supported when using custom filters with grid-provided filter logic.

Fix [AG-16845](https://ag-grid.atlassian.net/browse/AG-16845)