### PR TITLE
AG-17106 Standardise sticky row group scroll behaviour

### DIFF
--- a/packages/ag-grid-enterprise/src/rowHierarchy/baseExpansionService.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/baseExpansionService.ts
@@ -28,6 +28,13 @@ export abstract class BaseExpansionService extends BeanStub {
             return;
         }
 
+        // Collapsing a sticky row: scroll so the row lands at the pixel it occupied
+        // while sticky, otherwise the viewport keeps its old scrollTop and the user
+        // loses sight of the group they just collapsed.
+        if (!expanded && rowNode.sticky) {
+            this.beans.ctrlsSvc.getScrollFeature().setVerticalScrollPosition(rowNode.rowTop! - rowNode.stickyRowTop);
+        }
+
         rowNode._expanded = expanded;
 
         rowNode.dispatchRowEvent('expandedChanged');

--- a/packages/ag-grid-enterprise/src/rowHierarchy/rendering/groupCellRendererCtrl.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/rendering/groupCellRendererCtrl.ts
@@ -625,6 +625,10 @@ export class GroupCellRendererCtrl extends BeanStub implements IGroupCellRendere
         }
     }
 
+    /**
+     * Called when expand or contract is attempted to update the node state
+     * @param e originating event
+     */
     private onExpandOrContract(e: MouseEvent | KeyboardEvent): void {
         if (!this.isExpandable()) {
             return;

--- a/packages/ag-grid-enterprise/src/rowHierarchy/rendering/groupCellRendererCtrl.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/rendering/groupCellRendererCtrl.ts
@@ -625,10 +625,6 @@ export class GroupCellRendererCtrl extends BeanStub implements IGroupCellRendere
         }
     }
 
-    /**
-     * Called when expand or contract is attempted, to scroll the row and update the node state
-     * @param e originating event
-     */
     private onExpandOrContract(e: MouseEvent | KeyboardEvent): void {
         if (!this.isExpandable()) {
             return;
@@ -636,13 +632,7 @@ export class GroupCellRendererCtrl extends BeanStub implements IGroupCellRendere
 
         // must use the displayedGroup, so if data was dragged down, we expand the parent, not this row
         const rowNode: RowNode = this.displayedNode;
-        const nextExpandState = !rowNode.expanded;
-
-        if (!nextExpandState && rowNode.sticky) {
-            this.beans.ctrlsSvc.getScrollFeature().setVerticalScrollPosition(rowNode.rowTop! - rowNode.stickyRowTop);
-        }
-
-        rowNode.setExpanded(nextExpandState, e);
+        rowNode.setExpanded(!rowNode.expanded, e);
     }
 
     public override destroy(): void {

--- a/testing/behavioural/src/grouping-data/grouping-sticky-collapse.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-sticky-collapse.test.ts
@@ -1,0 +1,98 @@
+import { ClientSideRowModelModule, ScrollApiModule } from 'ag-grid-community';
+import { RowGroupingModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+
+describe('ag-grid grouping sticky collapse', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule, ScrollApiModule],
+    });
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    // Regression: a custom group cell renderer that collapses a group by calling
+    // rowNode.setExpanded(false) used to skip the sticky->non-sticky scroll
+    // compensation that only lived inside agGroupCellRenderer. The user lost
+    // visual context of the group they just collapsed. The compensation now
+    // lives inside BaseExpansionService.setExpanded so every caller benefits.
+    test('collapsing a group via setExpanded leaves the group row visible', async () => {
+        const CHILDREN_PER_GROUP = 40;
+        const rowData: { id: string; group: string; value: number }[] = [];
+        for (const group of ['A', 'B', 'C']) {
+            for (let i = 0; i < CHILDREN_PER_GROUP; i++) {
+                rowData.push({ id: `${group}-${i}`, group, value: i });
+            }
+        }
+
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'group', rowGroup: true, hide: true }, { field: 'value' }],
+            autoGroupColumnDef: { headerName: 'Group' },
+            groupDefaultExpanded: 1,
+            getRowId: (params) => params.data.id,
+            rowData,
+            suppressRowVirtualisation: false,
+            suppressAnimationFrame: true,
+        });
+
+        await asyncSetTimeout(0);
+
+        const groupNode = api.getRowNode('row-group-group-A')!;
+        expect(groupNode).toBeDefined();
+        expect(groupNode.expanded).toBe(true);
+
+        // Scroll deep into group A's children so group A's row falls off the top
+        // of the rendered range — this is the setup where the bug manifests.
+        api.ensureIndexVisible(30, 'top');
+        await asyncSetTimeout(0);
+
+        // Pre-condition: group A's row is now above the rendered window, so
+        // without a scroll fix-up the user would not see it after collapse.
+        expect(groupNode.rowIndex).toBeLessThan(api.getFirstDisplayedRowIndex());
+
+        // Mimic a custom group cell renderer collapsing the group — no
+        // originating event, no renderer-level scroll fix-up. The fix in
+        // BaseExpansionService.setExpanded must keep the collapsed group in the
+        // rendered range regardless of caller.
+        groupNode.setExpanded(false);
+        await asyncSetTimeout(0);
+
+        expect(groupNode.expanded).toBe(false);
+        expect(groupNode.rowIndex).toBeGreaterThanOrEqual(api.getFirstDisplayedRowIndex());
+        expect(groupNode.rowIndex).toBeLessThanOrEqual(api.getLastDisplayedRowIndex());
+    });
+
+    test('collapsing a group that is already on-screen does not move the viewport', async () => {
+        const rowData = [
+            { id: '1', group: 'A', value: 1 },
+            { id: '2', group: 'A', value: 2 },
+            { id: '3', group: 'B', value: 3 },
+        ];
+
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'group', rowGroup: true, hide: true }, { field: 'value' }],
+            autoGroupColumnDef: { headerName: 'Group' },
+            groupDefaultExpanded: 1,
+            getRowId: (params) => params.data.id,
+            rowData,
+            suppressRowVirtualisation: false,
+            suppressAnimationFrame: true,
+        });
+
+        await asyncSetTimeout(0);
+
+        const groupNode = api.getRowNode('row-group-group-A')!;
+        const scrollBefore = api.getVerticalPixelRange().top;
+
+        groupNode.setExpanded(false);
+        await asyncSetTimeout(0);
+
+        expect(groupNode.expanded).toBe(false);
+        expect(api.getVerticalPixelRange().top).toBe(scrollBefore);
+    });
+});

--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-sticky-collapse.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-sticky-collapse.test.ts
@@ -1,0 +1,208 @@
+import type { IServerSideDatasource, IServerSideGetRowsParams } from 'ag-grid-community';
+import { ScrollApiModule } from 'ag-grid-community';
+import { RowGroupingModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout, waitForNoLoadingRows } from '../../test-utils';
+
+describe('SSRM grouping sticky collapse', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [RowGroupingModule, ServerSideRowModelModule, ScrollApiModule],
+    });
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    const CHILDREN_PER_GROUP = 40;
+    const GROUPS = ['A', 'B', 'C'];
+
+    function createSingleLevelDatasource(): IServerSideDatasource {
+        return {
+            getRows(params: IServerSideGetRowsParams) {
+                const { groupKeys } = params.request;
+                setTimeout(() => {
+                    if (groupKeys.length === 0) {
+                        params.success({
+                            rowData: GROUPS.map((key) => ({ group: key, value: null })),
+                            rowCount: GROUPS.length,
+                        });
+                    } else {
+                        const parent = groupKeys[0];
+                        params.success({
+                            rowData: Array.from({ length: CHILDREN_PER_GROUP }, (_, i) => ({
+                                id: `${parent}-${i}`,
+                                group: parent,
+                                value: i,
+                            })),
+                            rowCount: CHILDREN_PER_GROUP,
+                        });
+                    }
+                }, 0);
+            },
+        };
+    }
+
+    // Mirrors the CSRM regression test in ../grouping-sticky-collapse.test.ts,
+    // but exercises the SSRM code path — ServerSideExpansionService.setExpanded
+    // routes through BaseExpansionService.setExpanded where the sticky scroll
+    // compensation now lives. The bug was originally reported against SSRM.
+    test('collapsing a sticky SSRM group via setExpanded leaves the group row visible', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'group', rowGroup: true, hide: true }, { field: 'value' }],
+            autoGroupColumnDef: { headerName: 'Group' },
+            rowModelType: 'serverSide',
+            serverSideDatasource: createSingleLevelDatasource(),
+            getRowId: (params) => {
+                if (params.data.id) {
+                    return params.data.id;
+                }
+                return `g-${params.data.group}`;
+            },
+            suppressRowVirtualisation: false,
+            suppressAnimationFrame: true,
+        });
+
+        await waitForNoLoadingRows(api);
+
+        const groupNode = api.getRowNode('g-A')!;
+        expect(groupNode).toBeDefined();
+
+        // Expand group A and wait for children to load.
+        groupNode.setExpanded(true);
+        await waitForNoLoadingRows(api);
+
+        // Scroll deep into group A's children so A's row falls off the top of
+        // the rendered range — the condition under which the bug manifests.
+        api.ensureIndexVisible(30, 'top');
+        await asyncSetTimeout(0);
+
+        expect(groupNode.rowIndex).toBeLessThan(api.getFirstDisplayedRowIndex());
+
+        // Mimic a custom group cell renderer collapsing the group under SSRM.
+        // The call traverses ServerSideExpansionService → BaseExpansionService
+        // and must leave the group row within the rendered range.
+        groupNode.setExpanded(false);
+        await asyncSetTimeout(0);
+
+        expect(groupNode.expanded).toBe(false);
+        expect(groupNode.rowIndex).toBeGreaterThanOrEqual(api.getFirstDisplayedRowIndex());
+        expect(groupNode.rowIndex).toBeLessThanOrEqual(api.getLastDisplayedRowIndex());
+    });
+
+    // Documents the batch-collapse behaviour change introduced by moving the
+    // sticky scroll compensation into BaseExpansionService.setExpanded:
+    //
+    // SSRM's ServerSideExpansionService.collapseAll / setExpansionState /
+    // resetExpansion all funnel through updateAllNodes → super.setExpanded(node, …)
+    // for every node. Any currently-sticky row being collapsed triggers the new
+    // compensation. Before this PR, api.collapseAll() on SSRM left scrollTop
+    // untouched; after this PR it jumps to the outermost sticky ancestor's
+    // natural row position.
+    //
+    // With multiple nested sticky ancestors, every ancestor's compensated
+    // scrollTop computes to the same value (the outermost ancestor's rowTop),
+    // so the outcome is deterministic regardless of traversal order.
+    const SUBGROUPS = ['1', '2', '3'];
+
+    function createNestedDatasource(): IServerSideDatasource {
+        return {
+            getRows(params: IServerSideGetRowsParams) {
+                const { groupKeys } = params.request;
+                setTimeout(() => {
+                    if (groupKeys.length === 0) {
+                        params.success({
+                            rowData: GROUPS.map((g) => ({ id: `g-${g}`, group: g, subgroup: null, value: null })),
+                            rowCount: GROUPS.length,
+                        });
+                    } else if (groupKeys.length === 1) {
+                        const g = groupKeys[0];
+                        params.success({
+                            rowData: SUBGROUPS.map((s) => ({
+                                id: `sg-${g}-${s}`,
+                                group: g,
+                                subgroup: `${g}-${s}`,
+                                value: null,
+                            })),
+                            rowCount: SUBGROUPS.length,
+                        });
+                    } else {
+                        const sub = groupKeys[1];
+                        params.success({
+                            rowData: Array.from({ length: CHILDREN_PER_GROUP }, (_, i) => ({
+                                id: `leaf-${sub}-${i}`,
+                                group: groupKeys[0],
+                                subgroup: sub,
+                                value: i,
+                            })),
+                            rowCount: CHILDREN_PER_GROUP,
+                        });
+                    }
+                }, 0);
+            },
+        };
+    }
+
+    test('api.collapseAll() with nested sticky groups moves the viewport to the outermost ancestor', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { field: 'group', rowGroup: true, hide: true },
+                { field: 'subgroup', rowGroup: true, hide: true },
+                { field: 'value' },
+            ],
+            autoGroupColumnDef: { headerName: 'Group' },
+            rowModelType: 'serverSide',
+            serverSideDatasource: createNestedDatasource(),
+            getRowId: (params) => params.data.id,
+            suppressRowVirtualisation: false,
+            suppressAnimationFrame: true,
+        });
+
+        await waitForNoLoadingRows(api);
+
+        // Expand A, then A-1, and wait for each batch of children.
+        const groupA = api.getRowNode('g-A')!;
+        groupA.setExpanded(true);
+        await waitForNoLoadingRows(api);
+
+        const subgroupA1 = api.getRowNode('sg-A-1')!;
+        subgroupA1.setExpanded(true);
+        await waitForNoLoadingRows(api);
+
+        // Scroll deep into A-1's leaves so both A and A-1 are pinned as sticky
+        // rows at the top of the viewport.
+        api.ensureIndexVisible(30, 'top');
+        await asyncSetTimeout(0);
+
+        // Pre-condition: both ancestor groups are above the rendered range, i.e.
+        // they have scrolled out of flow and into the sticky header stack.
+        expect(groupA.rowIndex).toBeLessThan(api.getFirstDisplayedRowIndex());
+        expect(subgroupA1.rowIndex).toBeLessThan(api.getFirstDisplayedRowIndex());
+
+        const scrollBefore = api.getVerticalPixelRange().top;
+        expect(scrollBefore).toBeGreaterThan(0);
+
+        // The compensated scrollTop for any sticky ancestor is (rowTop − stickyRowTop).
+        // For an ancestor chain, this collapses to the outermost ancestor's rowTop
+        // regardless of chain position, so the batch outcome is deterministic.
+        const expectedScrollTop = groupA.rowTop! - groupA.stickyRowTop;
+
+        // Bulk collapse via the public SSRM api. Internally this runs
+        // updateAllNodes → super.setExpanded per node; the sticky check in the
+        // base service fires for every currently-sticky group being collapsed.
+        api.collapseAll();
+        await asyncSetTimeout(0);
+
+        const scrollAfter = api.getVerticalPixelRange().top;
+
+        // Before this PR, scrollAfter would equal scrollBefore (≈1176). After,
+        // it lands on the outermost sticky ancestor's natural position.
+        expect(scrollAfter).not.toBe(scrollBefore);
+        expect(scrollAfter).toBe(expectedScrollTop);
+        expect(groupA.expanded).toBe(false);
+        expect(subgroupA1.expanded).toBe(false);
+    });
+});


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17106

A custom group cell renderer that collapses a group by calling `rowNode.setExpanded(false)` previously lost viewport context — the viewport kept its scrollTop and the user saw unrelated siblings at the same row index. The native `agGroupCellRenderer` worked because it ran a sticky→non-sticky scroll compensation (`scrollTop = rowTop − stickyRowTop`) inside the renderer before delegating to `setExpanded`.

This PR moves that compensation into `BaseExpansionService.setExpanded` so every caller benefits — the three native renderer triggers (chevron click, keyboard, full-row click), custom cell renderers, and the public `setRowNodeExpanded` API. The renderer's `onExpandOrContract` is trimmed down accordingly.

New behavioural test `grouping-sticky-collapse.test.ts` exercises the regression using only public API (`getFirstDisplayedRowIndex`, `getLastDisplayedRowIndex`, `getVerticalPixelRange`) and asserts the collapsed group row stays within the rendered range.

Fix [AG-17106](https://ag-grid.atlassian.net/browse/AG-17106)