### PR TITLE
AG-16977 Align datetime-filter example display with filter input

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/filter-date/_examples/date-filter/data.ts
+++ b/documentation/ag-grid-docs/src/content/docs/filter-date/_examples/date-filter/data.ts
@@ -7,7 +7,8 @@ export function getData(): any[] {
             startDate: `20${i}-${pad(m, 2)}-${pad(getRandom(28), 2)}`,
             endDate: `20${i}-${pad(m + 1, 2)}-${pad(getRandom(28), 2)}`,
             startDateTime: new Date(13e11 + getRandom(5e8) * 1e3),
-            endDateTime: new Date(13e11 + getRandom(5e8) * 1e3).toISOString(),
+            // ISO string format without milliseconds
+            endDateTime: new Date(13e11 + getRandom(5e8) * 1e3).toISOString().slice(0, 19),
         });
     }
 

--- a/documentation/ag-grid-docs/src/content/docs/filter-date/_examples/date-filter/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/filter-date/_examples/date-filter/example.spec.ts
@@ -12,7 +12,6 @@ test.agExample(import.meta, () => {
         const filterInput = agIdFor.dateFilterInstanceInput({ source: 'column-filter' });
         await expect(filterInput).toBeVisible();
 
-        // Built-in dateTime formatter outputs "YYYY-MM-DDTHH:mm:ss" (local time, T separator already present)
         await filterInput.fill(cellText);
         await filterInput.dispatchEvent('input');
 
@@ -70,9 +69,7 @@ test.agExample(import.meta, () => {
         const filterInput = agIdFor.dateFilterInstanceInput({ source: 'column-filter' });
         await expect(filterInput).toBeVisible();
 
-        // valueFormatter outputs "YYYY-MM-DD HH:mm:ss"; convert to datetime-local format "YYYY-MM-DDTHH:mm:ss"
-        const datetimeValue = cellText.replace(' ', 'T');
-        await filterInput.fill(datetimeValue);
+        await filterInput.fill(cellText);
         await filterInput.dispatchEvent('input');
 
         const otherCell = agIdFor.cell('0', 'startDate');

--- a/documentation/ag-grid-docs/src/content/docs/filter-date/_examples/date-filter/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/filter-date/_examples/date-filter/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridApi, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     DateFilterModule,
@@ -24,14 +24,15 @@ const columnDefs: ColDef[] = [
         filter: 'agDateColumnFilter',
     },
     {
+        // Data contains a Date object
         field: 'startDateTime',
         filter: 'agDateColumnFilter',
         cellDataType: 'dateTime',
     },
     {
+        // Data contains an ISO string format
         field: 'endDateTime',
         filter: 'agDateColumnFilter',
-        valueFormatter: (params: ValueFormatterParams) => params.value.replace(/[TZ]/g, ' ').trim().slice(0, -4),
     },
 ];
 


### PR DESCRIPTION
QA follow-up on the TC1 failure from the previous round: `startDateTime` cell was rendering with a `T` separator while `endDateTime` rendered space-separated, making the example look inconsistent.

Unify both date-time columns on the native `YYYY-MM-DDTHH:mm:ss` format that `datetime-local` filter inputs natively use — so the displayed cell value and the filter input format match exactly (which is the property the original AG-16977 bug was about).

- `startDateTime`: no `valueFormatter` (the built-in `cellDataType: 'dateTime'` already produces this format in local time).
- `endDateTime`: strip milliseconds + `Z` at the data source (`.toISOString().slice(0, 19)`) so the raw ISO string renders cleanly without needing a `valueFormatter`.
- Drop the now-unneeded space-to-`T` conversion from the `endDateTime` e2e spec.

Fix [AG-16977](https://ag-grid.atlassian.net/browse/AG-16977)
