### PR TITLE
AG-17060 remove some getters indirection step-1

### DIFF
--- a/packages/ag-grid-community/src/alignedGrids/alignedGridsService.ts
+++ b/packages/ag-grid-community/src/alignedGrids/alignedGridsService.ts
@@ -141,7 +141,7 @@ export class AlignedGridsService extends BeanStub implements NamedBean {
     }
 
     public getColumnIds(event: ColumnEvent): string[] {
-        return this.extractDataFromEvent(event, (col) => col.getColId());
+        return this.extractDataFromEvent(event, (col) => col.colId);
     }
 
     public onColumnEvent(event: AgEvent): void {
@@ -246,7 +246,7 @@ export class AlignedGridsService extends BeanStub implements NamedBean {
                     };
                 } = {};
                 for (const column of masterColumns) {
-                    columnWidths[column.getId()] = { key: column.getColId(), newWidth: column.getActualWidth() };
+                    columnWidths[column.getId()] = { key: column.colId, newWidth: column.getActualWidth() };
                 }
                 // don't set flex columns width
                 for (const col of resizedEvent.flexColumns ?? []) {

--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
@@ -887,7 +887,7 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
 
     public forEachPivotNode(callback: ForEachNodeCallback, includeFooterNodes?: boolean, afterSort?: boolean): void {
         const { colModel, rowGroupColsSvc } = this.beans;
-        if (!colModel.isPivotMode()) {
+        if (!colModel.pivotMode) {
             return;
         }
 

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
@@ -85,7 +85,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
 
             // We exclude all pinned columns here, we only want columns in the main viewport to be scaled up
             const colKeys = params.colKeys.filter((col) => {
-                const allowAutoSize = !colModel.getCol(col)?.getColDef().suppressAutoSize;
+                const allowAutoSize = !colModel.getCol(col)?.colDef.suppressAutoSize;
                 return allowAutoSize && !isRowNumberCol(col) && !isLeftCol(col) && !isRightCol(col);
             });
 
@@ -176,7 +176,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
                     const column = colModel.getCol(key);
 
                     // if already autoSized or suppressed, skip it
-                    if (!column || columnsAutoSized.has(column) || column.getColDef().suppressAutoSize) {
+                    if (!column || columnsAutoSized.has(column) || column.colDef.suppressAutoSize) {
                         continue;
                     }
 
@@ -220,12 +220,12 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
         const columns = colModel.getColsForKeys(keys);
 
         for (const col of columns) {
-            let parent = col.getParent();
+            let parent = col.parent;
             while (parent && parent != stopAtGroup) {
                 if (!parent.isPadding()) {
                     columnGroups.add(parent);
                 }
-                parent = parent.getParent();
+                parent = parent.parent;
             }
         }
 
@@ -286,8 +286,8 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
 
             for (const column of leafCols) {
                 // not all cols in the group may be participating with auto-resize
-                if (!column.getColDef().suppressAutoSize) {
-                    keys.push(column.getColId());
+                if (!column.colDef.suppressAutoSize) {
+                    keys.push(column.colId);
                 }
             }
 
@@ -406,7 +406,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
 
         for (const column of allDisplayedColumns) {
             const isIncluded = params?.colKeys?.some((key) => _columnsMatch(column, key)) ?? true;
-            if (column.getColDef().suppressSizeToFit || !isIncluded) {
+            if (column.colDef.suppressSizeToFit || !isIncluded) {
                 colsToNotSpread.push(column);
             } else {
                 colsToSpread.push(column);
@@ -433,7 +433,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
             if (params?.onlyScaleUp) {
                 // When `onlyScaleUp`, we store the current widths to act as a true minimum because we don't
                 // want any columns to get smaller
-                currentWidths[column.getColId()] = column.getActualWidth();
+                currentWidths[column.colId] = column.getActualWidth();
             }
             column.resetActualWidth(source);
 
@@ -470,7 +470,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
                 for (let i = colsToSpread.length - 1; i >= 0; i--) {
                     const column = colsToSpread[i];
 
-                    const id = column.getColId();
+                    const id = column.colId;
                     const prevWidth = currentWidths[id];
                     const widthOverride = limitsMap?.[id];
                     const minOverride = widthOverride?.minWidth ?? params?.defaultMinWidth ?? prevWidth;

--- a/packages/ag-grid-community/src/columnMove/columnDrag/bodyDropPivotTarget.ts
+++ b/packages/ag-grid-community/src/columnMove/columnDrag/bodyDropPivotTarget.ts
@@ -30,7 +30,7 @@ export class BodyDropPivotTarget extends BeanStub implements DropListener {
 
         for (const column of dragColumns) {
             // we don't allow adding secondary columns
-            if (!column.isPrimary()) {
+            if (!column.primary) {
                 continue;
             }
 

--- a/packages/ag-grid-community/src/columnMove/columnDrag/bodyDropTarget.ts
+++ b/packages/ag-grid-community/src/columnMove/columnDrag/bodyDropTarget.ts
@@ -93,7 +93,7 @@ export class BodyDropTarget extends BeanStub implements DropTarget {
         // in pivot mode, then if moving a column (ie didn't come from toolpanel) then it's
         // a standard column move, however if it came from the toolpanel, then we are introducing
         // dimensions or values to the grid
-        return this.beans.colModel.isPivotMode() && draggingEvent.dragSource.type === DragSourceType.ToolPanel;
+        return this.beans.colModel.pivotMode && draggingEvent.dragSource.type === DragSourceType.ToolPanel;
     }
 
     public onDragEnter(draggingEvent: GridDraggingEvent): void {

--- a/packages/ag-grid-community/src/columnMove/columnDrag/moveColumnFeature.ts
+++ b/packages/ag-grid-community/src/columnMove/columnDrag/moveColumnFeature.ts
@@ -289,8 +289,7 @@ export class MoveColumnFeature extends BeanStub implements DropListener {
         // if locked return true only if both col and container are same pin type.
         // double equals (==) here on purpose so that null==undefined is true (for not pinned options)
         // if not pin locked, then always allowed to be in this container
-        const conditionCallback = (col: AgColumn) =>
-            col.getColDef().lockPinned ? col.getPinned() == this.pinned : true;
+        const conditionCallback = (col: AgColumn) => (col.colDef.lockPinned ? col.getPinned() == this.pinned : true);
 
         if (!columns) {
             return [];
@@ -358,7 +357,7 @@ export class MoveColumnFeature extends BeanStub implements DropListener {
             // (e.g. hovering an empty area of the column header beyond all columns)
             for (let i = consideredColumns.length - 1; i >= 0; i--) {
                 const currentColumn = consideredColumns[i];
-                const parent = consideredColumns[i].getParent();
+                const parent = consideredColumns[i].parent;
                 if (!parent) {
                     targetColumn = currentColumn;
                     break;
@@ -680,7 +679,7 @@ export class MoveColumnFeature extends BeanStub implements DropListener {
         pinned?: ColumnPinnedType,
         fromMoving: boolean = false
     ): number {
-        const allowedCols = (columns || []).filter((c) => !c.getColDef().lockPinned);
+        const allowedCols = (columns || []).filter((c) => !c.colDef.lockPinned);
 
         if (!allowedCols.length) {
             return 0;

--- a/packages/ag-grid-community/src/columnMove/columnMoveService.ts
+++ b/packages/ag-grid-community/src/columnMove/columnMoveService.ts
@@ -96,7 +96,7 @@ export class ColumnMoveService extends BeanStub implements NamedBean {
             let lastPlacement = isRtl ? MoveDirection.RIGHT : MoveDirection.LEFT;
             let rulePassed = true;
             for (const col of proposedColumnOrder) {
-                const placement = lockPositionToPlacement(col.getColDef().lockPosition);
+                const placement = lockPositionToPlacement(col.colDef.lockPosition);
                 if (isRtl) {
                     if (placement > lastPlacement) {
                         // If placement goes up, we're not in the correct order
@@ -185,7 +185,7 @@ export class ColumnMoveService extends BeanStub implements NamedBean {
                 if (!leafCols.length) {
                     return;
                 }
-                const parent = leafCols[0].getParent();
+                const parent = leafCols[0].parent;
                 if (!parent) {
                     return;
                 }
@@ -260,7 +260,7 @@ function findGroupWidthId(columnGroup: AgColumnGroup | null, id: any): AgColumnG
         if (columnGroup.getGroupId() === id) {
             return columnGroup;
         }
-        columnGroup = columnGroup.getParent();
+        columnGroup = columnGroup.parent;
     }
 
     return undefined;

--- a/packages/ag-grid-community/src/columnMove/columnMoveUtils.ts
+++ b/packages/ag-grid-community/src/columnMove/columnMoveUtils.ts
@@ -9,7 +9,7 @@ export function placeLockedColumns(cols: AgColumn[], gos: GridOptionsService): A
     const normal: AgColumn[] = [];
     const right: AgColumn[] = [];
     cols.forEach((col: AgColumn) => {
-        const position = col.getColDef().lockPosition;
+        const position = col.colDef.lockPosition;
         if (position === 'right') {
             right.push(col);
         } else if (position === 'left' || position === true) {

--- a/packages/ag-grid-community/src/columnMove/internalColumnMoveUtils.ts
+++ b/packages/ag-grid-community/src/columnMove/internalColumnMoveUtils.ts
@@ -52,10 +52,10 @@ function getColsToMove(allMovingColumns: AgColumn[]): AgColumn[] {
     for (const col of allMovingColumns) {
         let movingGroup: AgColumnGroup | null = null;
 
-        let parent = col.getParent();
+        let parent = col.parent;
         while (parent != null && parent.getDisplayedLeafColumns().length === 1) {
             movingGroup = parent;
-            parent = parent.getParent();
+            parent = parent.parent;
         }
         if (movingGroup != null) {
             const isMarryChildren = !!movingGroup.getColGroupDef()?.marryChildren;
@@ -269,8 +269,7 @@ function calculateValidMoves(params: {
     visibleCols: VisibleColsService;
 }): number[] {
     const { movingCols, draggingRight, xPosition, pinned, gos, colModel, visibleCols } = params;
-    const isMoveBlocked =
-        gos.get('suppressMovableColumns') || movingCols.some((col) => col.getColDef().suppressMovable);
+    const isMoveBlocked = gos.get('suppressMovableColumns') || movingCols.some((col) => col.colDef.suppressMovable);
 
     if (isMoveBlocked) {
         return [];

--- a/packages/ag-grid-community/src/columnResize/resizeFeature.ts
+++ b/packages/ag-grid-community/src/columnResize/resizeFeature.ts
@@ -57,7 +57,7 @@ export class ResizeFeature extends BeanStub implements IHeaderResizeFeature {
 
         const refresh = () => {
             const resize = this.column.isResizable();
-            const autoSize = !this.gos.get('suppressAutoSize') && !this.column.getColDef().suppressAutoSize;
+            const autoSize = !this.gos.get('suppressAutoSize') && !this.column.colDef.suppressAutoSize;
             const propertyChange = resize !== canResize || autoSize !== canAutosize;
             if (propertyChange) {
                 canResize = resize;

--- a/packages/ag-grid-community/src/columns/baseColsService.ts
+++ b/packages/ag-grid-community/src/columns/baseColsService.ts
@@ -216,7 +216,7 @@ export abstract class BaseColsService extends BeanStub implements IColsService {
         // if default only, change only if new
         for (const col of primaryCols ?? []) {
             const colIsNew = !oldProvidedCols.includes(col);
-            const colDef = col.getColDef();
+            const colDef = col.colDef;
 
             const value = getValueFunc(colDef);
             const initialValue = getInitialValueFunc(colDef);
@@ -268,7 +268,7 @@ export abstract class BaseColsService extends BeanStub implements IColsService {
         }
 
         const getIndexForCol = (col: AgColumn): number => {
-            const colDef = col.getColDef();
+            const colDef = col.colDef;
             return getIndexFunc(colDef) ?? getInitialIndexFunc(colDef)!;
         };
 
@@ -351,7 +351,7 @@ export abstract class BaseColsService extends BeanStub implements IColsService {
         const allColIds = new Set(
             colList
                 .map((column) => {
-                    const colId = column.getColId();
+                    const colId = column.colId;
                     newColIds.delete(colId);
                     return colId;
                 })
@@ -362,7 +362,7 @@ export abstract class BaseColsService extends BeanStub implements IColsService {
         const originalOrderMap: { [colId: string]: number } = {};
         let orderIndex = 0;
         for (let i = 0; i < primaryCols.length; i++) {
-            const colId = primaryCols[i].getColId();
+            const colId = primaryCols[i].colId;
             if (allColIds.has(colId)) {
                 colIdsInOriginalOrder.push(colId);
                 originalOrderMap[colId] = orderIndex++;
@@ -392,13 +392,13 @@ export abstract class BaseColsService extends BeanStub implements IColsService {
         };
 
         for (const column of colList) {
-            const colId = column.getColId();
+            const colId = column.colId;
             if (updatedColIds.has(colId)) {
                 // New col already exists. Add any other new cols that should be before it.
                 processPrecedingNewCols(colId);
                 incomingColumnState[colId][indexProp] = index++;
             } else {
-                const colDef = column.getColDef();
+                const colDef = column.colDef;
                 const missingIndex =
                     colDef[indexProp] === null || (colDef[indexProp] === undefined && colDef[initialIndexProp] == null);
                 if (missingIndex) {

--- a/packages/ag-grid-community/src/columns/columnApi.ts
+++ b/packages/ag-grid-community/src/columns/columnApi.ts
@@ -12,10 +12,7 @@ export function getColumnDef<TValue = any, TData = any>(
     key: string | Column<TValue>
 ): ColDef<TData, TValue> | null {
     const column = beans.colModel.getColDefCol(key);
-    if (column) {
-        return column.getColDef();
-    }
-    return null;
+    return column ? column.colDef : null;
 }
 
 export function getColumnDefs<TData = any>(beans: BeanCollection): (ColDef<TData> | ColGroupDef<TData>)[] | undefined {

--- a/packages/ag-grid-community/src/columns/columnDefFactory.ts
+++ b/packages/ag-grid-community/src/columns/columnDefFactory.ts
@@ -150,9 +150,9 @@ export class ColumnDefFactory extends BeanStub implements NamedBean {
     }
 
     private createDefFromColumn(col: AgColumn, rowGroupColumns: AgColumn[], pivotColumns: AgColumn[]): ColDef {
-        const colDefCloned = _deepCloneDefinition(col.getColDef())!;
+        const colDefCloned = _deepCloneDefinition(col.colDef)!;
 
-        colDefCloned.colId = col.getColId();
+        colDefCloned.colId = col.colId;
 
         colDefCloned.width = col.getActualWidth();
         colDefCloned.rowGroup = col.isRowGroupActive();

--- a/packages/ag-grid-community/src/columns/columnFactoryUtils.ts
+++ b/packages/ag-grid-community/src/columns/columnFactoryUtils.ts
@@ -63,7 +63,7 @@ export function _createColumnTreeWithIds(
         const colId = def.colId!;
 
         let column = colIdMap.get(colId);
-        const colDefMerged = _addColumnDefaultAndTypes(beans, def, column?.getColId() ?? colId);
+        const colDefMerged = _addColumnDefaultAndTypes(beans, def, column?.colId ?? colId);
         if (!column) {
             // no existing column, need to create one
             column = new AgColumn(colDefMerged, def, colId, primaryColumns);
@@ -219,7 +219,7 @@ function createColumn(
         column = new AgColumn(colDefMerged, colDef, colId, primaryColumns);
         beans.context.createBean(column);
     } else {
-        const colDefMerged = _addColumnDefaultAndTypes(beans, colDef, column.getColId());
+        const colDefMerged = _addColumnDefaultAndTypes(beans, colDef, column.colId);
         column.setColDef(colDefMerged, colDef, source);
         _updateColumnState(beans, column, colDefMerged, source);
     }

--- a/packages/ag-grid-community/src/columns/columnGroups/columnGroupService.ts
+++ b/packages/ag-grid-community/src/columns/columnGroups/columnGroupService.ts
@@ -167,7 +167,7 @@ export class ColumnGroupService extends BeanStub implements NamedBean {
 
     public getColGroupAtLevel(column: AgColumn, level: number): AgColumnGroup | null {
         // get group at same level as the one we are looking for
-        let groupPointer: AgColumnGroup = column.getParent()!;
+        let groupPointer: AgColumnGroup = column.parent!;
         let originalGroupLevel: number;
         let groupPointerLevel: number;
 
@@ -179,7 +179,7 @@ export class ColumnGroupService extends BeanStub implements NamedBean {
             if (originalGroupLevel + groupPointerLevel <= level) {
                 break;
             }
-            groupPointer = groupPointer.getParent()!;
+            groupPointer = groupPointer.parent!;
         }
 
         return groupPointer;

--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -53,7 +53,7 @@ export class ColumnModel extends BeanStub implements NamedBean {
     public cols?: ColumnCollections;
 
     // if pivotMode is on, however pivot results are NOT shown if no pivot columns are set
-    private pivotMode = false;
+    public pivotMode = false;
 
     // true when pivotResultCols are in cols
     private showingPivotResult: boolean;
@@ -272,7 +272,7 @@ export class ColumnModel extends BeanStub implements NamedBean {
             // If the current columns are the same or a subset of the previous
             // we keep the previous order, otherwise we go back to the order the pivot
             // cols are generated in
-            const hasSameColumns = pivotResultCols.list.some((col) => this.cols?.map[col.getColId()] !== undefined);
+            const hasSameColumns = pivotResultCols.list.some((col) => this.cols?.map[col.colId] !== undefined);
             if (!hasSameColumns) {
                 this.lastPivotOrder = null;
             }
@@ -289,7 +289,7 @@ export class ColumnModel extends BeanStub implements NamedBean {
         const { beans, showingPivotResult, cols } = this;
 
         const { valueColsSvc, selectionColSvc, gos } = beans;
-        const showAutoGroupAndValuesOnly = this.isPivotMode() && !showingPivotResult;
+        const showAutoGroupAndValuesOnly = this.pivotMode && !showingPivotResult;
         const showSelectionColumn = selectionColSvc?.isSelectionColumnEnabled();
         const showRowNumbers = _isRowNumbers(beans);
         const valueColumns = valueColsSvc?.columns;
@@ -328,7 +328,7 @@ export class ColumnModel extends BeanStub implements NamedBean {
             this.beans,
             {
                 state: keys.map<ColumnState>((key) => ({
-                    colId: typeof key === 'string' ? key : key.getColId(),
+                    colId: typeof key === 'string' ? key : key.colId,
                     hide: !visible,
                 })),
             },

--- a/packages/ag-grid-community/src/columns/columnStateUtils.ts
+++ b/packages/ag-grid-community/src/columns/columnStateUtils.ts
@@ -154,7 +154,7 @@ export function _applyColumnState(
         }
 
         // we do not do aggFunc, rowGroup or pivot for auto cols or secondary cols
-        if (autoCol || !column.isPrimary()) {
+        if (autoCol || !column.primary) {
             return;
         }
 
@@ -399,7 +399,7 @@ export function _compareColumnStatesAndDispatchEvents(beans: BeanCollection, sou
             const changedColumns: AgColumn[] = [];
 
             colModel.forAllCols((column) => {
-                const colStateBefore = columnStateBeforeMap[column.getColId()];
+                const colStateBefore = columnStateBeforeMap[column.colId];
                 if (colStateBefore && changedPredicate(colStateBefore, column)) {
                     changedColumns.push(column);
                 }
@@ -408,7 +408,7 @@ export function _compareColumnStatesAndDispatchEvents(beans: BeanCollection, sou
             return changedColumns;
         };
 
-        const columnIdMapper = (c: AgColumn) => c.getColId();
+        const columnIdMapper = (c: AgColumn) => c.colId;
 
         dispatchWhenListsDifferent(
             'columnRowGroupChanged',
@@ -484,7 +484,7 @@ export function _getColumnState(beans: BeanCollection): ColumnState[] {
         const sortIndex = column.getSortIndex() != null ? column.getSortIndex() : null;
 
         res.push({
-            colId: column.getColId(),
+            colId: column.colId,
             width: column.getActualWidth(),
             hide: !column.isVisible(),
             pinned: column.getPinned(),
@@ -502,9 +502,7 @@ export function _getColumnState(beans: BeanCollection): ColumnState[] {
     colModel.forAllCols((col) => createStateItemFromColumn(col));
 
     // for fast looking, store the index of each column
-    const colIdToGridIndexMap = new Map<string, number>(
-        colModel.getCols().map((col, index) => [col.getColId(), index])
-    );
+    const colIdToGridIndexMap = new Map<string, number>(colModel.getCols().map((col, index) => [col.colId, index]));
 
     res.sort((itemA: any, itemB: any) => {
         const posA = colIdToGridIndexMap.has(itemA.colId) ? colIdToGridIndexMap.get(itemA.colId) : -1;
@@ -518,7 +516,7 @@ export function _getColumnState(beans: BeanCollection): ColumnState[] {
 export function getColumnStateFromColDef(column: AgColumn): ColumnState {
     const getValueOrNull = <T>(a: T, b: T) => (a != null ? a : b != null ? b : null);
 
-    const colDef = column.getColDef();
+    const colDef = column.colDef;
     const sortDefFromColDef = _getSortDefFromInput(getValueOrNull(colDef.sort, colDef.initialSort));
     const sort = sortDefFromColDef.direction;
     const sortType = sortDefFromColDef.type;
@@ -548,7 +546,7 @@ export function getColumnStateFromColDef(column: AgColumn): ColumnState {
     const aggFunc = getValueOrNull(colDef.aggFunc, colDef.initialAggFunc);
 
     return {
-        colId: column.getColId(),
+        colId: column.colId,
         sort,
         sortType,
         sortIndex,
@@ -604,7 +602,7 @@ function sortColsLikeKeys(
     // add in all other columns
     let autoGroupInsertIndex = 0;
     for (const col of cols.list) {
-        const colId = col.getColId();
+        const colId = col.colId;
         const alreadyProcessed = processedColIds[colId] != null;
         if (alreadyProcessed) {
             continue;

--- a/packages/ag-grid-community/src/columns/columnUtils.ts
+++ b/packages/ag-grid-community/src/columns/columnUtils.ts
@@ -108,7 +108,7 @@ export function convertColumnTypes(type: string | string[]): string[] {
 
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _areColIdsEqual(colsA: AgColumn[] | null, colsB: AgColumn[] | null): boolean {
-    return _areEqual(colsA, colsB, (a, b) => a.getColId() === b.getColId());
+    return _areEqual(colsA, colsB, (a, b) => a.colId === b.colId);
 }
 
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
@@ -127,7 +127,7 @@ export function _convertColumnEventSourceType(source: AgPropertyChangedSource): 
 
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _columnsMatch(column: AgColumn, key: ColKey): boolean {
-    return column === key || column.colId == key || column.getColDef() === key;
+    return column === key || column.colId == key || column.colDef === key;
 }
 
 export const getValueFactory =

--- a/packages/ag-grid-community/src/columns/columnViewportService.ts
+++ b/packages/ag-grid-community/src/columns/columnViewportService.ts
@@ -233,7 +233,7 @@ export class ColumnViewportService extends BeanStub implements NamedBean {
             const groupsToRender: { [row: number]: AgColumnGroup[] } = {};
 
             for (const col of cols) {
-                let group = col.getParent();
+                let group = col.parent;
                 const skipFillers = col.isSpanHeaderHeight();
 
                 while (group) {
@@ -245,7 +245,7 @@ export class ColumnViewportService extends BeanStub implements NamedBean {
 
                     const skipFillerGroup = skipFillers && group.isPadding();
                     if (skipFillerGroup) {
-                        group = group.getParent();
+                        group = group.parent;
                         continue;
                     }
 
@@ -254,7 +254,7 @@ export class ColumnViewportService extends BeanStub implements NamedBean {
                     groupsToRender[level] ??= [];
                     groupsToRender[level].push(group);
                     groupsToRenderSet.add(group);
-                    group = group.getParent();
+                    group = group.parent;
                 }
             }
 
@@ -287,7 +287,7 @@ function isAnyParentAutoHeaderHeight(col: AgColumn | AgColumnGroup | null): bool
         if (col.isAutoHeaderHeight()) {
             return true;
         }
-        col = col.getParent();
+        col = col.parent;
     }
 
     return false;

--- a/packages/ag-grid-community/src/columns/dataTypeService.ts
+++ b/packages/ag-grid-community/src/columns/dataTypeService.ts
@@ -264,7 +264,7 @@ export class DataTypeService extends BeanStub implements NamedBean {
         if (!this.isPendingInference) {
             return;
         }
-        const columnStateUpdates = this.columnStateUpdatesPendingInference[column.getColId()];
+        const columnStateUpdates = this.columnStateUpdatesPendingInference[column.colId];
         if (!columnStateUpdates) {
             return;
         }
@@ -383,11 +383,11 @@ export class DataTypeService extends BeanStub implements NamedBean {
             if (!column) {
                 continue;
             }
-            const oldColDef = column.getColDef();
+            const oldColDef = column.colDef;
             if (!this.resetColDefIntoCol(column, 'cellDataTypeInferred')) {
                 continue;
             }
-            const newColDef = column.getColDef();
+            const newColDef = column.colDef;
             if (columnTypeOverridesExist && newColDef.type && newColDef.type !== oldColDef.type) {
                 const updatedColumnState = getUpdatedColumnState(column, columnStateUpdates);
                 if (updatedColumnState.rowGroup && updatedColumnState.rowGroupIndex == null) {
@@ -437,7 +437,7 @@ export class DataTypeService extends BeanStub implements NamedBean {
         if (!userColDef) {
             return false;
         }
-        const newColDef = _addColumnDefaultAndTypes(this.beans, userColDef, column.getColId());
+        const newColDef = _addColumnDefaultAndTypes(this.beans, userColDef, column.colId);
         column.setColDef(newColDef, userColDef, source);
         return true;
     }
@@ -463,7 +463,7 @@ export class DataTypeService extends BeanStub implements NamedBean {
     }
 
     public getDataTypeDefinition(column: AgColumn): DataTypeDefinition | CoreDataTypeDefinition | undefined {
-        const colDef = column.getColDef();
+        const colDef = column.colDef;
         if (!colDef.cellDataType) {
             return undefined;
         }
@@ -484,7 +484,7 @@ export class DataTypeService extends BeanStub implements NamedBean {
         }
 
         // skip type checking for formulas
-        if (column.getColDef().allowFormula && this.beans.formula?.isFormula(value)) {
+        if (column.colDef.allowFormula && this.beans.formula?.isFormula(value)) {
             return true;
         }
         return dataTypeMatcher(value);
@@ -587,7 +587,7 @@ export class DataTypeService extends BeanStub implements NamedBean {
                 },
                 comparator: (a: any, b: any) => {
                     const column = colModel.getColDefCol(colId);
-                    const colDef = column?.getColDef();
+                    const colDef = column?.colDef;
                     if (!column || !colDef) {
                         return 0;
                     }

--- a/packages/ag-grid-community/src/columns/visibleColsService.ts
+++ b/packages/ag-grid-community/src/columns/visibleColsService.ts
@@ -102,7 +102,7 @@ export class VisibleColsService extends BeanStub implements NamedBean {
 
         let headerGroupRowCount = 0;
         for (const col of this.allCols) {
-            let parent = col.getParent();
+            let parent = col.parent;
             while (parent) {
                 if (!parent.isPadding()) {
                     const level = parent.getProvidedColumnGroup().getLevel() + 1;
@@ -112,7 +112,7 @@ export class VisibleColsService extends BeanStub implements NamedBean {
                     break;
                 }
 
-                parent = parent.getParent();
+                parent = parent.parent;
             }
         }
 

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragService.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragService.ts
@@ -111,7 +111,7 @@ export class RowDragService extends BeanStub implements NamedBean {
             return 'visible';
         }
 
-        const pivoting = beans.colModel.isPivotMode();
+        const pivoting = beans.colModel.pivotMode;
 
         if ((pivoting || beans.rowGroupColsSvc?.columns?.length) && !gos.get('refreshAfterGroupEdit')) {
             return 'hidden';

--- a/packages/ag-grid-community/src/entities/agColumn.ts
+++ b/packages/ag-grid-community/src/entities/agColumn.ts
@@ -129,7 +129,7 @@ export class AgColumn<TValue = any>
         // This is used in ColumnFactory
         public userProvidedColDef: ColDef<any, TValue> | null,
         public readonly colId: string,
-        private readonly primary: boolean
+        public readonly primary: boolean
     ) {
         super();
         this.colIdSanitised = _escapeString(colId)!;
@@ -605,8 +605,7 @@ export class AgColumn<TValue = any>
     }
 
     public isSpanHeaderHeight(): boolean {
-        const colDef = this.getColDef();
-        return !colDef.suppressSpanHeaderHeight;
+        return !this.colDef.suppressSpanHeaderHeight;
     }
 
     /**
@@ -621,7 +620,7 @@ export class AgColumn<TValue = any>
     }
 
     public getColumnGroupPaddingInfo(): { numberOfParents: number; isSpanningTotal: boolean } {
-        let parent = this.getParent();
+        let parent = this.parent;
 
         if (!parent?.isPadding()) {
             return { numberOfParents: 0, isSpanningTotal: false };
@@ -635,7 +634,7 @@ export class AgColumn<TValue = any>
                 isSpanningTotal = false;
                 break;
             }
-            parent = parent.getParent();
+            parent = parent.parent;
         }
 
         return { numberOfParents, isSpanningTotal };

--- a/packages/ag-grid-community/src/entities/agColumnGroup.ts
+++ b/packages/ag-grid-community/src/entities/agColumnGroup.ts
@@ -262,7 +262,7 @@ export class AgColumnGroup<TValue = any> extends BeanStub<AgColumnGroupEvent> im
     }
 
     public getPaddingLevel(): number {
-        const parent = this.getParent();
+        const parent = this.parent;
 
         if (!this.isPadding() || !parent?.isPadding()) {
             return 0;
@@ -279,7 +279,7 @@ export class AgColumnGroup<TValue = any> extends BeanStub<AgColumnGroupEvent> im
         // groups, where the expandable is actually the first parent that is not a padding group.
         let parentWithExpansion: AgColumnGroup | null = this;
         while (parentWithExpansion?.isPadding()) {
-            parentWithExpansion = parentWithExpansion.getParent();
+            parentWithExpansion = parentWithExpansion.parent;
         }
 
         const isExpandable = parentWithExpansion ? parentWithExpansion.getProvidedColumnGroup().isExpandable() : false;

--- a/packages/ag-grid-community/src/export/baseGridSerializingSession.ts
+++ b/packages/ag-grid-community/src/export/baseGridSerializingSession.ts
@@ -84,11 +84,11 @@ export abstract class BaseGridSerializingSession<T> implements GridSerializingSe
     }): { value: any; valueFormatted?: string | null } {
         const { column, node, currentColumnIndex, accumulatedRowIndex, type, useRawFormula } = params;
         const isFullWidthGroup =
-            currentColumnIndex === 0 && _isFullWidthGroupRow(this.gos, node, this.colModel.isPivotMode());
+            currentColumnIndex === 0 && _isFullWidthGroupRow(this.gos, node, this.colModel.pivotMode);
         if (
             this.processRowGroupCallback &&
             (this.gos.get('treeData') || node.group) &&
-            (column.isRowGroupDisplayed(node.rowGroupColumn?.getColId() ?? '') || isFullWidthGroup)
+            (column.isRowGroupDisplayed(node.rowGroupColumn?.colId ?? '') || isFullWidthGroup)
         ) {
             return { value: this.processRowGroupCallback(_addGridCommonParams(this.gos, { column, node })) ?? '' };
         }

--- a/packages/ag-grid-community/src/export/gridSerializer.ts
+++ b/packages/ag-grid-community/src/export/gridSerializer.ts
@@ -78,7 +78,7 @@ export class GridSerializer extends BeanStub implements NamedBean {
         const isClipboardExport = params.rowPositions != null;
         const isExplicitExportSelection = isClipboardExport || !!params.onlySelected;
         const hideOpenParents = this.gos.get('groupHideOpenParents') && !isExplicitExportSelection;
-        const isLeafNode = this.colModel.isPivotMode() ? node.leafGroup : !node.group;
+        const isLeafNode = this.colModel.pivotMode ? node.leafGroup : !node.group;
         const isFooter = !!node.footer;
         const shouldSkipCurrentGroup =
             node.allChildrenCount === 1 &&
@@ -239,7 +239,7 @@ export class GridSerializer extends BeanStub implements NamedBean {
                     .sort((a, b) => a.rowIndex - b.rowIndex)
                     .map((position) => rowModel.getRow(position.rowIndex))
                     .forEach(processRow);
-            } else if (this.colModel.isPivotMode()) {
+            } else if (this.colModel.pivotMode) {
                 if (usingCsrm) {
                     rowModel.forEachPivotNode(processRow, true, exportedRows === 'filteredAndSorted');
                 } else if (usingSsrm) {
@@ -341,7 +341,7 @@ export class GridSerializer extends BeanStub implements NamedBean {
     }): AgColumn[] {
         const { allColumns = false, skipRowGroups = false, exportRowNumbers = false, columnKeys } = params;
         const { colModel, gos, visibleCols } = this;
-        const isPivotMode = colModel.isPivotMode();
+        const isPivotMode = colModel.pivotMode;
 
         const filterSpecialColumns = (col: AgColumn) => {
             if (isColumnSelectionCol(col)) {

--- a/packages/ag-grid-community/src/filter/filterManager.ts
+++ b/packages/ag-grid-community/src/filter/filterManager.ts
@@ -221,8 +221,7 @@ export class FilterManager extends BeanStub implements NamedBean {
 
     private shouldApplyQuickFilterAfterAgg(): boolean {
         return (
-            (this.aggFiltering || this.beans.colModel.isPivotMode()) &&
-            !this.gos.get('applyQuickFilterBeforePivotOrAgg')
+            (this.aggFiltering || this.beans.colModel.pivotMode) && !this.gos.get('applyQuickFilterBeforePivotOrAgg')
         );
     }
 

--- a/packages/ag-grid-community/src/filter/filterMenuFactory.ts
+++ b/packages/ag-grid-community/src/filter/filterMenuFactory.ts
@@ -215,7 +215,7 @@ export class FilterMenuFactory extends BeanStub implements NamedBean, IMenuFacto
 
     public isMenuEnabled(column: AgColumn): boolean {
         // for standard, we show menu if filter is enabled, and the menu is not suppressed by passing an empty array
-        return column.isFilterAllowed() && (column.getColDef().menuTabs ?? ['filterMenuTab']).includes('filterMenuTab');
+        return column.isFilterAllowed() && (column.colDef.menuTabs ?? ['filterMenuTab']).includes('filterMenuTab');
     }
 
     public showMenuAfterContextMenuEvent(): void {

--- a/packages/ag-grid-community/src/filter/filterValueService.ts
+++ b/packages/ag-grid-community/src/filter/filterValueService.ts
@@ -15,11 +15,11 @@ export class FilterValueService extends BeanStub implements NamedBean {
         if (!rowNode) {
             return;
         }
-        const colDef = column.getColDef();
+        const colDef = column.colDef;
         const { selectableFilter, valueSvc, formula } = this.beans;
         const filterValueGetter =
             filterValueGetterOverride ??
-            selectableFilter?.getFilterValueGetter(column.getColId()) ??
+            selectableFilter?.getFilterValueGetter(column.colId) ??
             colDef.filterValueGetter;
         if (filterValueGetter) {
             return this.executeFilterValueGetter(filterValueGetter, rowNode.data, column, rowNode, colDef);

--- a/packages/ag-grid-community/src/filter/quickFilterService.ts
+++ b/packages/ag-grid-community/src/filter/quickFilterService.ts
@@ -54,7 +54,7 @@ export class QuickFilterService extends BeanStub<QuickFilterServiceEvent> implem
     //    (tree data is a bit different, as parent rows can be filtered on, unlike row grouping)
     public refreshCols(): void {
         const { autoColSvc, colModel, gos, pivotResultCols } = this.beans;
-        const pivotMode = colModel.isPivotMode();
+        const pivotMode = colModel.pivotMode;
         const groupAutoCols = autoColSvc?.getColumns();
         const providedCols = colModel.getColDefCols();
 
@@ -181,7 +181,7 @@ export class QuickFilterService extends BeanStub<QuickFilterServiceEvent> implem
 
     private getTextForColumn(column: AgColumn, node: RowNode): string {
         let value = this.beans.filterValueSvc!.getValue(column, node);
-        const colDef = column.getColDef();
+        const colDef = column.colDef;
 
         if (colDef.getQuickFilterText) {
             const params: GetQuickFilterTextParams = _addGridCommonParams(this.gos, {

--- a/packages/ag-grid-community/src/gridBodyComp/gridBodyCtrl.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/gridBodyCtrl.ts
@@ -184,7 +184,7 @@ export class GridBodyCtrl extends BeanStub {
         let isTreeGrid = gos.get('treeData');
 
         if (!isTreeGrid) {
-            const isPivotActive = colModel.isPivotMode();
+            const isPivotActive = colModel.pivotMode;
             const rowGroupColumnLen = !rowGroupColsSvc ? 0 : rowGroupColsSvc.columns.length;
             const columnsNeededForGrouping = isPivotActive ? 2 : 1;
             isTreeGrid = rowGroupColumnLen >= columnsNeededForGrouping;

--- a/packages/ag-grid-community/src/headerRendering/cells/column/headerCellCtrl.ts
+++ b/packages/ag-grid-community/src/headerRendering/cells/column/headerCellCtrl.ts
@@ -340,7 +340,7 @@ export class HeaderCellCtrl extends AbstractHeaderCellCtrl<IHeaderCellComp, AgCo
 
     private setupClassesFromColDef(): void {
         const refreshHeaderClasses = () => {
-            const colDef = this.column.getColDef();
+            const colDef = this.column.colDef;
             const classes = _getHeaderClassesFromColDef(colDef, this.gos, this.column, null);
 
             const oldClasses = this.userHeaderClasses;
@@ -451,7 +451,7 @@ export class HeaderCellCtrl extends AbstractHeaderCellCtrl<IHeaderCellComp, AgCo
     }
 
     private workOutDraggable(): boolean {
-        const colDef = this.column.getColDef();
+        const colDef = this.column.colDef;
         const isSuppressMovableColumns = this.gos.get('suppressMovableColumns');
 
         const colCanMove = !isSuppressMovableColumns && !colDef.suppressMovable && !colDef.lockPosition;

--- a/packages/ag-grid-community/src/headerRendering/cells/columnGroup/headerGroupCellCtrl.ts
+++ b/packages/ag-grid-community/src/headerRendering/cells/columnGroup/headerGroupCellCtrl.ts
@@ -451,9 +451,7 @@ export class HeaderGroupCellCtrl extends AbstractHeaderCellCtrl<
         // if any child is fixed, then don't allow moving
         return (
             this.gos.get('suppressMovableColumns') ||
-            this.column
-                .getLeafColumns()
-                .some((column) => column.getColDef().suppressMovable || column.getColDef().lockPosition)
+            this.column.getLeafColumns().some((column) => column.colDef.suppressMovable || column.colDef.lockPosition)
         );
     }
 

--- a/packages/ag-grid-community/src/headerRendering/cells/floatingFilter/headerFilterCellCtrl.ts
+++ b/packages/ag-grid-community/src/headerRendering/cells/floatingFilter/headerFilterCellCtrl.ts
@@ -98,7 +98,7 @@ export class HeaderFilterCellCtrl extends AbstractHeaderCellCtrl<IHeaderFilterCe
     }
 
     private setupActive(): void {
-        const colDef = this.column.getColDef();
+        const colDef = this.column.colDef;
         const filterExists = !!colDef.filter;
         const floatingFilterExists = !!colDef.floatingFilter;
         this.active = filterExists && floatingFilterExists;
@@ -187,7 +187,7 @@ export class HeaderFilterCellCtrl extends AbstractHeaderCellCtrl<IHeaderFilterCe
             if (!nextCol) {
                 break;
             }
-        } while (!nextCol.getColDef().filter || !nextCol.getColDef().floatingFilter);
+        } while (!nextCol.colDef.filter || !nextCol.colDef.floatingFilter);
 
         return nextCol;
     }
@@ -435,7 +435,7 @@ export class HeaderFilterCellCtrl extends AbstractHeaderCellCtrl<IHeaderFilterCe
                 if (this.gos.get('enableFilterHandlers')) {
                     params = {
                         ...params,
-                        model: _getFilterModel(this.beans.colFilter?.model ?? {}, this.column.getColId()),
+                        model: _getFilterModel(this.beans.colFilter?.model ?? {}, this.column.colId),
                         source,
                     };
                 }

--- a/packages/ag-grid-community/src/headerRendering/gridHeaderCtrl.ts
+++ b/packages/ag-grid-community/src/headerRendering/gridHeaderCtrl.ts
@@ -112,7 +112,7 @@ export class GridHeaderCtrl extends BeanStub {
     }
 
     private onPivotModeChanged(beans: BeanCollection): void {
-        const pivotMode = beans.colModel.isPivotMode();
+        const pivotMode = beans.colModel.pivotMode;
 
         this.comp.toggleCss('ag-pivot-on', pivotMode);
         this.comp.toggleCss('ag-pivot-off', !pivotMode);

--- a/packages/ag-grid-community/src/headerRendering/headerUtils.ts
+++ b/packages/ag-grid-community/src/headerRendering/headerUtils.ts
@@ -45,7 +45,7 @@ export function getGroupRowsHeight(beans: BeanCollection): number[] {
 }
 
 function getColumnGroupHeaderRowHeight(beans: BeanCollection, headerRowCtrl: HeaderRowCtrl): number {
-    const defaultHeight = beans.colModel.isPivotMode() ? getPivotGroupHeaderHeight(beans) : getGroupHeaderHeight(beans);
+    const defaultHeight = beans.colModel.pivotMode ? getPivotGroupHeaderHeight(beans) : getGroupHeaderHeight(beans);
     let maxDisplayedHeight = defaultHeight;
     const headerRowCellCtrls = headerRowCtrl.getHeaderCellCtrls();
     for (const headerCellCtrl of headerRowCellCtrls) {
@@ -59,7 +59,7 @@ function getColumnGroupHeaderRowHeight(beans: BeanCollection, headerRowCtrl: Hea
 }
 
 export function getColumnHeaderRowHeight(beans: BeanCollection): number {
-    const defaultHeight = beans.colModel.isPivotMode() ? getPivotHeaderHeight(beans) : getHeaderHeight(beans);
+    const defaultHeight = beans.colModel.pivotMode ? getPivotHeaderHeight(beans) : getHeaderHeight(beans);
     let maxDisplayedHeight = defaultHeight;
     beans.colModel.forAllCols((col) => {
         const height = col.getAutoHeaderHeight();

--- a/packages/ag-grid-community/src/misc/menu/menuService.ts
+++ b/packages/ag-grid-community/src/misc/menu/menuService.ts
@@ -82,7 +82,7 @@ export class MenuService extends BeanStub implements NamedBean {
     }
 
     public isColumnMenuInHeaderEnabled(column: AgColumn): boolean {
-        const { suppressHeaderMenuButton } = column.getColDef();
+        const { suppressHeaderMenuButton } = column.colDef;
         return (
             !suppressHeaderMenuButton &&
             !!this.activeMenuFactory?.isMenuEnabled(column) &&
@@ -91,11 +91,11 @@ export class MenuService extends BeanStub implements NamedBean {
     }
 
     public isFilterMenuInHeaderEnabled(column: AgColumn): boolean {
-        return !column.getColDef().suppressHeaderFilterButton && !!this.beans.filterManager?.isFilterAllowed(column);
+        return !column.colDef.suppressHeaderFilterButton && !!this.beans.filterManager?.isFilterAllowed(column);
     }
 
     public isHeaderContextMenuEnabled(column?: AgColumn | AgProvidedColumnGroup): boolean {
-        const colDef = column && isColumn(column) ? column.getColDef() : column?.getColGroupDef();
+        const colDef = column && isColumn(column) ? column.colDef : column?.getColGroupDef();
         return !colDef?.suppressHeaderContextMenu && this.gos.get('columnMenu') === 'new';
     }
 

--- a/packages/ag-grid-community/src/misc/state/stateService.ts
+++ b/packages/ag-grid-community/src/misc/state/stateService.ts
@@ -380,7 +380,7 @@ export class StateService extends BeanStub implements NamedBean {
         columnOrder?: ColumnOrderState;
     } {
         const beans = this.beans;
-        return convertColumnState(_getColumnState(beans), beans.colModel.isPivotMode());
+        return convertColumnState(_getColumnState(beans), beans.colModel.pivotMode);
     }
 
     private setColumnState(

--- a/packages/ag-grid-community/src/navigation/headerNavigationService.ts
+++ b/packages/ag-grid-community/src/navigation/headerNavigationService.ts
@@ -31,9 +31,9 @@ export function getHeaderIndexToFocus(beans: BeanCollection, column: AgColumn, l
     }
 
     // if level is less, then find the group with the given level
-    let parent = column.getParent();
+    let parent = column.parent;
     while (parent && parent.getProvidedColumnGroup().getLevel() > level) {
-        parent = parent.getParent();
+        parent = parent.parent;
     }
 
     const isColSpanning = column.isSpanHeaderHeight();
@@ -104,7 +104,7 @@ export class HeaderNavigationService extends BeanStub implements NamedBean {
 
         while (col) {
             row++;
-            col = col.getParent();
+            col = col.parent;
         }
 
         let headerRowIndex = row;
@@ -361,14 +361,14 @@ function getColumnVisibleParent(
     const optimisticNextIndex = currentIndex - 1;
     if (currentRowType !== 'filter') {
         const isSpanningCol = currentColumn instanceof AgColumn && currentColumn.isSpanHeaderHeight();
-        let nextVisibleParent = currentColumn.getParent();
+        let nextVisibleParent = currentColumn.parent;
         while (
             nextVisibleParent &&
             // skip if row isn't visible or col is padding and spanned
             (nextVisibleParent.getProvidedColumnGroup().getLevel() > optimisticNextIndex ||
                 (isSpanningCol && nextVisibleParent.isPadding()))
         ) {
-            nextVisibleParent = nextVisibleParent.getParent();
+            nextVisibleParent = nextVisibleParent.parent;
         }
 
         if (nextVisibleParent) {

--- a/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
@@ -328,11 +328,11 @@ export class CellCtrl extends BeanStub {
     }
 
     public getCellAriaRole(): string {
-        return this.column.getColDef().cellAriaRole ?? 'gridcell';
+        return this.column.colDef.cellAriaRole ?? 'gridcell';
     }
 
     public isCellRenderer(): boolean {
-        const colDef = this.column.getColDef();
+        const colDef = this.column.colDef;
         return colDef.cellRenderer != null || colDef.cellRendererSelector != null;
     }
     public getValueToDisplay(): any {
@@ -346,7 +346,7 @@ export class CellCtrl extends BeanStub {
         const { beans, column } = this;
         const { userCompFactory, ctrlsSvc, eventSvc } = beans;
 
-        const colDef = column.getColDef();
+        const colDef = column.colDef;
         const params = this.createCellRendererParams() as ILoadingCellRendererParams;
         params.deferRender = true;
 
@@ -381,7 +381,7 @@ export class CellCtrl extends BeanStub {
 
         // if node is stub, and no group data for this node (groupSelectsChildren can populate group data)
         const isSsrmLoading = rowNode.stub && rowNode.groupData?.[column.getId()] == null;
-        const colDef = column.getColDef();
+        const colDef = column.colDef;
 
         if (isSsrmLoading || this.isCellRenderer()) {
             const params = this.createCellRendererParams();
@@ -395,7 +395,7 @@ export class CellCtrl extends BeanStub {
             const params = this.createCellRendererParams();
             compDetails = _getCellRendererDetails(
                 userCompFactory,
-                { ...column.getColDef(), cellRenderer: 'agFindCellRenderer' },
+                { ...column.colDef, cellRenderer: 'agFindCellRenderer' },
                 params
             );
         }
@@ -428,7 +428,7 @@ export class CellCtrl extends BeanStub {
     }
 
     private setupControlComps(): void {
-        const colDef = this.column.getColDef();
+        const colDef = this.column.colDef;
         this.includeSelection = this.isIncludeControl(this.isCheckboxSelection(colDef), true);
         this.includeRowDrag = this.isIncludeControl(colDef.rowDrag);
         this.includeDndSource = this.isIncludeControl(colDef.dndSource);
@@ -445,7 +445,7 @@ export class CellCtrl extends BeanStub {
 
     public getCellValueClass(): string {
         const prefix = 'ag-cell-value';
-        const isCheckboxRenderer = this.column.getColDef().cellRenderer === 'agCheckboxCellRenderer';
+        const isCheckboxRenderer = this.column.colDef.cellRenderer === 'agCheckboxCellRenderer';
         let suffix = '';
 
         if (isCheckboxRenderer) {
@@ -486,7 +486,7 @@ export class CellCtrl extends BeanStub {
     }
 
     private refreshShouldDestroy(): boolean {
-        const colDef = this.column.getColDef();
+        const colDef = this.column.colDef;
         const selectionChanged = this.includeSelection != this.isIncludeControl(this.isCheckboxSelection(colDef), true);
         const rowDragChanged = this.includeRowDrag != this.isIncludeControl(colDef.rowDrag);
         const dndSourceChanged = this.includeDndSource != this.isIncludeControl(colDef.dndSource);
@@ -551,7 +551,7 @@ export class CellCtrl extends BeanStub {
             data: rowNode.data,
             node: rowNode,
             pinned: column.getPinned() as any,
-            colDef: column.getColDef(),
+            colDef: column.colDef,
             column,
             refreshCell: this.refreshCell.bind(this),
             eGridCell: eGui,
@@ -622,7 +622,7 @@ export class CellCtrl extends BeanStub {
             return;
         }
 
-        const { field, valueGetter, showRowGroup, enableCellChangeFlash } = column.getColDef();
+        const { field, valueGetter, showRowGroup, enableCellChangeFlash } = column.colDef;
         // we always refresh if cell has no value - this can happen when user provides Cell Renderer and the
         // cell renderer doesn't rely on a value, instead it could be looking directly at the data, or maybe
         // printing the current time (which would be silly)???. Generally speaking
@@ -722,7 +722,7 @@ export class CellCtrl extends BeanStub {
 
     private valuesAreEqual(val1: any, val2: any): boolean {
         // if the user provided an equals method, use that, otherwise do simple comparison
-        const colDef = this.column.getColDef();
+        const colDef = this.column.colDef;
         return colDef.equals ? colDef.equals(val1, val2) : val1 === val2;
     }
 
@@ -1015,13 +1015,13 @@ export class CellCtrl extends BeanStub {
     }
 
     private setWrapText(): void {
-        const value = this.column.getColDef().wrapText == true;
+        const value = this.column.colDef.wrapText == true;
 
         this.comp.toggleCss(CSS_CELL_WRAP_TEXT, value);
     }
 
     public dispatchCellContextMenuEvent(event: Event | null) {
-        const colDef = this.column.getColDef();
+        const colDef = this.column.colDef;
         const cellContextMenuEvent: CellContextMenuEvent = this.createEvent(event, 'cellContextMenu');
 
         const { beans } = this;

--- a/packages/ag-grid-community/src/rendering/cell/cellMouseListenerFeature.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellMouseListenerFeature.ts
@@ -72,7 +72,7 @@ export class CellMouseListenerFeature extends BeanStub {
         cellClickedEvent.isEventHandlingSuppressed = suppressMouseEvent;
         eventSvc.dispatchEvent(cellClickedEvent);
 
-        const colDef = column.getColDef();
+        const colDef = column.colDef;
 
         if (colDef.onCellClicked) {
             // to make callback async, do in a timeout
@@ -121,7 +121,7 @@ export class CellMouseListenerFeature extends BeanStub {
 
         const suppressMouseEvent = _suppressCellMouseEvent(gos, cellCtrl.column, cellCtrl.rowNode, event);
 
-        const colDef = column.getColDef();
+        const colDef = column.colDef;
         // always dispatch event to eventService
         const cellDoubleClickedEvent: CellDoubleClickedEvent = cellCtrl.createEvent(
             event,

--- a/packages/ag-grid-community/src/rendering/cell/cellPositionFeature.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellPositionFeature.ts
@@ -101,7 +101,7 @@ export class CellPositionFeature extends BeanStub {
 
     private setupColSpan(): void {
         // if no col span is active, then we don't set it up, as it would be wasteful of CPU
-        if (this.column.getColDef().colSpan == null) {
+        if (this.column.colDef.colSpan == null) {
             return;
         }
 

--- a/packages/ag-grid-community/src/rendering/dndSourceComp.ts
+++ b/packages/ag-grid-community/src/rendering/dndSourceComp.ts
@@ -33,7 +33,7 @@ export class DndSourceComp extends Component {
 
     private onDragStart(dragEvent: DragEvent): void {
         const { rowNode, column, eCell, gos } = this;
-        const providedOnRowDrag = column.getColDef().dndSourceOnRowDrag;
+        const providedOnRowDrag = column.colDef.dndSourceOnRowDrag;
 
         const dataTransfer = dragEvent.dataTransfer!;
 

--- a/packages/ag-grid-community/src/rendering/row/rowAutoHeightService.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowAutoHeightService.ts
@@ -41,7 +41,7 @@ export class RowAutoHeightService extends BeanStub implements NamedBean {
 
             let newRowHeight = _getRowHeightForNode(this.beans, row).height;
             for (const col of displayedAutoHeightCols) {
-                let cellHeight = autoHeights?.[col.getColId()];
+                let cellHeight = autoHeights?.[col.colId];
 
                 const spannedCell = rowSpanSvc?.getCellSpan(col, row);
                 if (spannedCell) {
@@ -233,7 +233,7 @@ export class RowAutoHeightService extends BeanStub implements NamedBean {
             }
 
             for (const col of renderedAutoHeightCols) {
-                const cellHeight = rowNode.__autoHeights[col.getColId()];
+                const cellHeight = rowNode.__autoHeights[col.colId];
                 if (!cellHeight || rowNode.rowHeight! < cellHeight) {
                     return false;
                 }

--- a/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
@@ -459,7 +459,7 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         const isStub = rowNode.stub && !suppressFullWidthLoading && !groupHideOpenParents;
         const isFullWidthCell = this.isNodeFullWidthCell();
         const isDetailCell = gos.get('masterDetail') && rowNode.detail;
-        const pivotMode = colModel.isPivotMode();
+        const pivotMode = colModel.pivotMode;
         const isFullWidthGroup = _isFullWidthGroupRow(gos, rowNode, pivotMode);
         // When suppressServerSideFullWidthLoadingRow is set, stub group rows (groupDisplayType='groupRows')
         // fall through to Normal so they render per-cell skeletons, consistent with leaf row stubs.

--- a/packages/ag-grid-community/src/rendering/spanning/rowSpanCache.ts
+++ b/packages/ag-grid-community/src/rendering/spanning/rowSpanCache.ts
@@ -61,7 +61,7 @@ export class CellSpan {
      * needs applied to the last row in the span.
      */
     public getLastNodeAutoHeight(): number | undefined {
-        const autoHeight = this.firstNode.__autoHeights?.[this.col.getColId()];
+        const autoHeight = this.firstNode.__autoHeights?.[this.col.colId];
         if (autoHeight == null) {
             return undefined;
         }

--- a/packages/ag-grid-community/src/selection/checkboxSelectionComponent.ts
+++ b/packages/ag-grid-community/src/selection/checkboxSelectionComponent.ts
@@ -155,9 +155,7 @@ export class CheckboxSelectionComponent extends Component {
 
         const so = gos.get('rowSelection');
         const showDisabledCheckboxes =
-            so && typeof so !== 'string'
-                ? !_getHideDisabledCheckboxes(so)
-                : !!column?.getColDef().showDisabledCheckboxes;
+            so && typeof so !== 'string' ? !_getHideDisabledCheckboxes(so) : !!column?.colDef.showDisabledCheckboxes;
 
         this.setVisible(visible && (disabled ? showDisabledCheckboxes : true));
         this.setDisplayed(visible && (disabled ? showDisabledCheckboxes : true));
@@ -182,6 +180,6 @@ export class CheckboxSelectionComponent extends Component {
         }
 
         // column will be missing if groupDisplayType = 'groupRows'
-        return this.column?.getColDef()?.checkboxSelection;
+        return this.column?.colDef?.checkboxSelection;
     }
 }

--- a/packages/ag-grid-community/src/selection/selectAllFeature.ts
+++ b/packages/ag-grid-community/src/selection/selectAllFeature.ts
@@ -212,7 +212,7 @@ export class SelectAllFeature extends BeanStub {
         if (selectAll) {
             return selectAll;
         }
-        const { headerCheckboxSelectionCurrentPageOnly, headerCheckboxSelectionFilteredOnly } = this.column.getColDef();
+        const { headerCheckboxSelectionCurrentPageOnly, headerCheckboxSelectionFilteredOnly } = this.column.colDef;
         if (headerCheckboxSelectionCurrentPageOnly) {
             return 'currentPage';
         }
@@ -231,7 +231,7 @@ export class SelectAllFeature extends BeanStub {
 
 export function isCheckboxSelection({ gos, selectionColSvc }: BeanCollection, column: AgColumn): boolean {
     const rowSelection = gos.get('rowSelection');
-    const colDef = column.getColDef();
+    const colDef = column.colDef;
     const { headerCheckboxSelection } = colDef;
 
     let result = false;

--- a/packages/ag-grid-community/src/sort/rowNodeSorter.ts
+++ b/packages/ag-grid-community/src/sort/rowNodeSorter.ts
@@ -125,7 +125,7 @@ export class RowNodeSorter extends BeanStub implements NamedBean {
             return;
         }
         // comparator on col get preference over everything else
-        return this.getComparatorFromColDef(primaryColumn.getColDef(), sortOption);
+        return this.getComparatorFromColDef(primaryColumn.colDef, sortOption);
     }
 
     private getComparatorFromColDef(colDef: ColDef, sortOption: SortOption): SortComparatorFn | undefined {
@@ -147,7 +147,7 @@ export class RowNodeSorter extends BeanStub implements NamedBean {
                 return this.getGroupDataValue(node, column);
             }
 
-            if (node.group && column.getColDef().showRowGroup) {
+            if (node.group && column.colDef.showRowGroup) {
                 return undefined;
             }
         }

--- a/packages/ag-grid-community/src/sort/sortIndicatorComp.ts
+++ b/packages/ag-grid-community/src/sort/sortIndicatorComp.ts
@@ -80,7 +80,7 @@ export class SortIndicatorComp extends Component {
 
         this.setupMultiSortIndicator();
 
-        if (!column.isSortable() && !column.getColDef().showRowGroup) {
+        if (!column.isSortable() && !column.colDef.showRowGroup) {
             return;
         }
 
@@ -139,7 +139,7 @@ export class SortIndicatorComp extends Component {
         }
 
         if (eSortNone) {
-            const alwaysHideNoSort = !column.getColDef().unSortIcon && !gos.get('unSortIcon');
+            const alwaysHideNoSort = !column.colDef.unSortIcon && !gos.get('unSortIcon');
             _setDisplayed(eSortNone, !alwaysHideNoSort && !direction, { skipAriaHidden: true });
         }
 
@@ -160,7 +160,7 @@ export class SortIndicatorComp extends Component {
         const { eSortMixed, column, gos } = this;
         this.addInIcon('sortUnSort', eSortMixed, column);
 
-        const isColumnShowingRowGroup = column.getColDef().showRowGroup;
+        const isColumnShowingRowGroup = column.colDef.showRowGroup;
         const areGroupsCoupled = _isColumnsSortingCoupledToGroup(gos);
         if (areGroupsCoupled && isColumnShowingRowGroup) {
             this.addManagedEventListeners({

--- a/packages/ag-grid-community/src/sort/sortService.ts
+++ b/packages/ag-grid-community/src/sort/sortService.ts
@@ -33,7 +33,7 @@ export class SortService extends BeanStub implements NamedBean {
         const isColumnsSortingCoupledToGroup = _isColumnsSortingCoupledToGroup(gos);
         let columnsToUpdate = [column];
         if (isColumnsSortingCoupledToGroup) {
-            if (column.getColDef().showRowGroup) {
+            if (column.colDef.showRowGroup) {
                 const rowGroupColumns = showRowGroupCols?.getSourceColumnsForGroupColumn?.(column);
                 const sortableRowGroupColumns = rowGroupColumns?.filter((col) => col.isSortable());
 
@@ -74,7 +74,7 @@ export class SortService extends BeanStub implements NamedBean {
         colModel.forAllCols((col) => this.setColSortIndex(col, null));
 
         const allSortedColsWithoutChangesOrGroups = allSortedCols.filter((col) => {
-            if (isCoupled && col.getColDef().showRowGroup) {
+            if (isCoupled && col.colDef.showRowGroup) {
                 return false;
             }
             return col !== lastSortIndexCol;
@@ -161,14 +161,14 @@ export class SortService extends BeanStub implements NamedBean {
             }
         });
 
-        if (colModel.isPivotMode()) {
+        if (colModel.pivotMode) {
             const isSortingLinked = _isColumnsSortingCoupledToGroup(gos);
             allSortedCols = allSortedCols.filter((col) => {
-                const isAggregated = !!col.getAggFunc();
-                const isSecondary = !col.isPrimary();
+                const isAggregated = !!col.aggFunc;
+                const isSecondary = !col.primary;
                 const isGroup = isSortingLinked
                     ? showRowGroupCols?.getShowRowGroupCol(col.getId())
-                    : col.getColDef().showRowGroup;
+                    : col.colDef.showRowGroup;
                 return isAggregated || isSecondary || isGroup;
             });
         }
@@ -263,7 +263,7 @@ export class SortService extends BeanStub implements NamedBean {
 
     public canColumnDisplayMixedSort(column: AgColumn): boolean {
         const isColumnSortCouplingActive = _isColumnsSortingCoupledToGroup(this.gos);
-        const isGroupDisplayColumn = !!column.getColDef().showRowGroup;
+        const isGroupDisplayColumn = !!column.colDef.showRowGroup;
         return isColumnSortCouplingActive && isGroupDisplayColumn;
     }
 
@@ -274,7 +274,7 @@ export class SortService extends BeanStub implements NamedBean {
         }
 
         // if column has unique data, its sorting is independent - but can still be mixed
-        const columnHasUniqueData = column.getColDef().field != null || !!column.getColDef().valueGetter;
+        const columnHasUniqueData = column.colDef.field != null || !!column.colDef.valueGetter;
         const sortableColumns = columnHasUniqueData ? [column, ...linkedColumns] : linkedColumns;
 
         const firstSort = sortableColumns[0].getSortDef();

--- a/packages/ag-grid-community/src/tooltip/tooltipService.ts
+++ b/packages/ag-grid-community/src/tooltip/tooltipService.ts
@@ -64,7 +64,7 @@ const getCellTruncationCheck = (beans: BeanCollection, ctrl: CellCtrl): (() => b
     }
 
     if (ctrl.isCellRenderer()) {
-        const colDef = ctrl.column.getColDef();
+        const colDef = ctrl.column.colDef;
         // create rule for our internal group cell renderer
         const isGroupCellRenderer = !!colDef.showRowGroup || colDef.cellRenderer === 'agGroupCellRenderer';
         if (!isGroupCellRenderer) {
@@ -164,7 +164,7 @@ const resolveCellTooltip = ({
         return { value, location: 'cell', shouldDisplay: shouldDisplayCustomTooltip };
     }
 
-    const colDef = column.getColDef();
+    const colDef = column.colDef;
     const data = rowNode.data;
 
     // 4) column tooltip field/valueGetter is the final fallback.
@@ -183,7 +183,7 @@ const resolveCellTooltip = ({
             value: valueGetter(
                 _addGridCommonParams(gos, {
                     location: 'cell',
-                    colDef: column.getColDef(),
+                    colDef: column.colDef,
                     column: column,
                     rowIndex: ctrl.cellPosition.rowIndex,
                     node: rowNode,
@@ -220,7 +220,7 @@ export class TooltipService extends BeanStub implements NamedBean {
         const gos = this.gos;
         const isTooltipWhenTruncated = _isShowTooltipWhenTruncated(gos);
         const { column, eGui } = ctrl;
-        const colDef = column.getColDef();
+        const colDef = column.colDef;
 
         if (!shouldDisplayTooltip && isTooltipWhenTruncated && !colDef.headerComponent) {
             shouldDisplayTooltip = _isElementOverflowingCallback(
@@ -243,7 +243,7 @@ export class TooltipService extends BeanStub implements NamedBean {
             shouldDisplayTooltip,
             getAdditionalParams: () => ({
                 column,
-                colDef: column.getColDef(),
+                colDef: column.colDef,
             }),
         };
 
@@ -345,7 +345,7 @@ export class TooltipService extends BeanStub implements NamedBean {
             },
             getAdditionalParams: () => ({
                 column,
-                colDef: column.getColDef(),
+                colDef: column.colDef,
                 rowIndex: ctrl.cellPosition.rowIndex,
                 node: rowNode,
                 data: rowNode.data,

--- a/packages/ag-grid-community/src/utils/icon.ts
+++ b/packages/ag-grid-community/src/utils/icon.ts
@@ -171,7 +171,7 @@ export function _createIconNoSpan(
     }
 
     // check col for icon first
-    const icons: any = column?.getColDef().icons;
+    const icons: any = column?.colDef.icons;
 
     if (icons) {
         userProvidedIcon = icons[iconName];

--- a/packages/ag-grid-community/src/utils/keyboardEvent.ts
+++ b/packages/ag-grid-community/src/utils/keyboardEvent.ts
@@ -20,7 +20,7 @@ export function _isUserSuppressingKeyboardEvent(
     column: AgColumn,
     editing: boolean
 ): boolean {
-    const colDefFunc = column ? column.getColDef().suppressKeyboardEvent : undefined;
+    const colDefFunc = column ? column.colDef.suppressKeyboardEvent : undefined;
 
     // if no callbacks provided by user, then do nothing
     if (!colDefFunc) {
@@ -33,7 +33,7 @@ export function _isUserSuppressingKeyboardEvent(
         column,
         node: rowNode,
         data: rowNode.data,
-        colDef: column.getColDef(),
+        colDef: column.colDef,
     });
 
     // colDef get first preference on suppressing events

--- a/packages/ag-grid-community/src/valueService/valueService.test.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.test.ts
@@ -16,8 +16,8 @@ let valueSvc: ValueService;
 describe('formatValue', () => {
     beforeEach(() => {
         colDef = {};
-        column = mock<AgColumn>('getColDef');
-        column.getColDef.mockReturnValue(colDef);
+        column = mock<AgColumn>();
+        column.colDef = colDef;
 
         gos = mock<GridOptionsService>('get', 'addCommon');
         gos.addCommon.mockImplementation((params) => params as any);

--- a/packages/ag-grid-community/src/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.ts
@@ -246,7 +246,7 @@ export class ValueService extends BeanStub implements NamedBean {
             return false;
         }
         // When in pivot mode, leafGroups cannot be expanded
-        if (node.leafGroup && this.colModel.isPivotMode()) {
+        if (node.leafGroup && this.colModel.pivotMode) {
             return false;
         }
         // node.expanded (getter with side effects) evaluated last
@@ -332,7 +332,7 @@ export class ValueService extends BeanStub implements NamedBean {
         newValue: TValueNew,
         oldValue: TValueOld
     ): TValue {
-        const colDef = column.getColDef();
+        const colDef = column.colDef;
 
         // we do not allow parsing of formulas
         if (colDef.allowFormula && this.beans.formula?.isFormula(newValue)) {
@@ -359,7 +359,7 @@ export class ValueService extends BeanStub implements NamedBean {
     }
 
     public getDeleteValue(column: AgColumn, rowNode: IRowNode): any {
-        if (_exists(column.getColDef().valueParser)) {
+        if (_exists(column.colDef.valueParser)) {
             return (
                 this.parseValue(
                     column,
@@ -383,7 +383,7 @@ export class ValueService extends BeanStub implements NamedBean {
         let result: string | null = null;
         let formatter: ((value: any) => string) | string | undefined;
 
-        const colDef = column.getColDef();
+        const colDef = column.colDef;
 
         if (suppliedFormatter) {
             // use supplied formatter if provided, e.g. set filter items can have their own value formatters
@@ -428,7 +428,7 @@ export class ValueService extends BeanStub implements NamedBean {
      * @returns `true` if the value has been updated, otherwise `false`.
      */
     public setValue(rowNode: IRowNode, column: AgColumn, newValue: any, eventSource?: string): boolean {
-        const colDef = column.getColDef();
+        const colDef = column.colDef;
 
         if (!rowNode.data && this.canCreateRowNodeData(rowNode, colDef)) {
             rowNode.data = {}; // enableGroupEdit allows editing group rows without data.
@@ -568,12 +568,7 @@ export class ValueService extends BeanStub implements NamedBean {
         return true;
     }
 
-    private isSetValueSupported(
-        column: AgColumn,
-        rowNode: IRowNode,
-        newValue: any,
-        colDef: ReturnType<AgColumn['getColDef']>
-    ): boolean {
+    private isSetValueSupported(column: AgColumn, rowNode: IRowNode, newValue: any, colDef: ColDef): boolean {
         const { field, valueSetter } = colDef;
 
         const formulaSvc = this.beans.formula;
@@ -625,7 +620,7 @@ export class ValueService extends BeanStub implements NamedBean {
 
             // Store the computed value into rowData for consumers that do not understand formulas.
             const computedValue = formulaSvc?.resolveValue(column, rowNode as RowNode);
-            const colDef = column.getColDef();
+            const colDef = column.colDef;
             if (_exists(colDef.valueSetter) || !_missing(colDef.field)) {
                 const computedParams: ValueSetterParams = { ...setterParams, newValue: computedValue };
                 this.computeValueChange({
@@ -745,7 +740,7 @@ export class ValueService extends BeanStub implements NamedBean {
         column: AgColumn,
         rowNode: IRowNode
     ): any {
-        const colId = column.getColId();
+        const colId = column.colId;
 
         const valueFromCache = this.valueCache!.getValue(rowNode as RowNode, colId);
         if (valueFromCache !== undefined) {
@@ -770,7 +765,7 @@ export class ValueService extends BeanStub implements NamedBean {
             data: data,
             node: rowNode,
             column: column,
-            colDef: column.getColDef(),
+            colDef: column.colDef,
             getValue: (field) => this.getValueCallback(rowNode, field),
         });
 
@@ -799,13 +794,13 @@ export class ValueService extends BeanStub implements NamedBean {
         // Use 'data' - grouping keys should be based on committed data, not pending edits.
         // Row structure should remain stable during editing; rows only move groups when edits are committed.
         const value = this.getValue(col, rowNode, 'data');
-        const keyCreator = col.getColDef().keyCreator;
+        const keyCreator = col.colDef.keyCreator;
 
         let result = value;
         if (keyCreator) {
             const keyParams: KeyCreatorParams = _addGridCommonParams(this.gos, {
                 value: value,
-                colDef: col.getColDef(),
+                colDef: col.colDef,
                 column: col,
                 node: rowNode,
                 data: rowNode.data,

--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterExpressionService.ts
@@ -212,12 +212,9 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
         const entries: AutocompleteEntry[] = [];
         const includeHiddenColumns = this.gos.get('includeHiddenColumnsInAdvancedFilter');
         for (const column of columns) {
-            if (
-                column.getColDef().filter &&
-                (includeHiddenColumns || column.isVisible() || column.isRowGroupActive())
-            ) {
+            if (column.colDef.filter && (includeHiddenColumns || column.isVisible() || column.isRowGroupActive())) {
                 entries.push({
-                    key: column.getColId(),
+                    key: column.colId,
                     displayValue: this.colNames.getDisplayNameForColumn(column, 'advancedFilter')!,
                 });
             }
@@ -310,7 +307,7 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
                 break;
             case 'object':
                 // If there's a filter value getter, assume the value is already a string. Otherwise we need to format it.
-                if (column.getColDef().filterValueGetter) {
+                if (column.colDef.filterValueGetter) {
                     params = { valueConverter: (v: any) => v };
                 } else {
                     params = {
@@ -328,7 +325,7 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
                 params = { valueConverter: (v: any) => v };
                 break;
         }
-        const { filterParams } = column.getColDef();
+        const { filterParams } = column.colDef;
         if (filterParams) {
             ['caseSensitive', 'includeBlanksInEquals', 'includeBlanksInLessThan', 'includeBlanksInGreaterThan'].forEach(
                 (param: keyof FilterExpressionEvaluatorParams<ConvertedTValue, TValue>) => {
@@ -383,7 +380,7 @@ export class AdvancedFilterExpressionService extends BeanStub implements NamedBe
     }
 
     private getActiveOperators(column: AgColumn): string[] | undefined {
-        const filterOptions = column.getColDef().filterParams?.filterOptions;
+        const filterOptions = column.colDef.filterParams?.filterOptions;
         if (!filterOptions) {
             return undefined;
         }

--- a/packages/ag-grid-enterprise/src/aggregation/aggColumnNameService.ts
+++ b/packages/ag-grid-enterprise/src/aggregation/aggColumnNameService.ts
@@ -12,7 +12,7 @@ export class AggColumnNameService extends BeanStub implements NamedBean, IAggCol
         const { valueColsSvc, colModel, rowGroupColsSvc } = this.beans;
 
         // only columns with aggregation active can have aggregations
-        const pivotValueColumn = column.getColDef().pivotValueColumn;
+        const pivotValueColumn = column.colDef.pivotValueColumn;
         const pivotActiveOnThisColumn = _exists(pivotValueColumn);
         let aggFunc: string | IAggFunc | null | undefined = null;
         let aggFuncFound: boolean;
@@ -22,7 +22,7 @@ export class AggColumnNameService extends BeanStub implements NamedBean, IAggCol
             const valueColumns = valueColsSvc?.columns ?? [];
             const isCollapsedHeaderEnabled =
                 this.gos.get('removePivotHeaderRowWhenSingleValueColumn') && valueColumns.length === 1;
-            const isTotalColumn = column.getColDef().pivotTotalColumnIds !== undefined;
+            const isTotalColumn = column.colDef.pivotTotalColumnIds !== undefined;
             if (isCollapsedHeaderEnabled && !isTotalColumn) {
                 return headerName; // Skip decorating the header - in this case the label is the pivot key, not the value col
             }
@@ -31,7 +31,7 @@ export class AggColumnNameService extends BeanStub implements NamedBean, IAggCol
         } else {
             const measureActive = column.isValueActive();
             const isGrouping = rowGroupColsSvc?.columns.length !== 0;
-            const aggregationPresent = colModel.isPivotMode() || isGrouping || this.gos.get('treeData');
+            const aggregationPresent = colModel.pivotMode || isGrouping || this.gos.get('treeData');
 
             if (measureActive && aggregationPresent) {
                 aggFunc = column.getAggFunc();

--- a/packages/ag-grid-enterprise/src/aggregation/aggFuncService.ts
+++ b/packages/ag-grid-enterprise/src/aggregation/aggFuncService.ts
@@ -55,7 +55,7 @@ export class AggFuncService extends BeanStub implements NamedBean, IAggFuncServi
     }
 
     public getDefaultAggFunc(column: AgColumn): string | null {
-        const defaultAgg = column.getColDef().defaultAggFunc;
+        const defaultAgg = column.colDef.defaultAggFunc;
 
         if (_exists(defaultAgg) && this.isAggFuncPossible(column, defaultAgg)) {
             return defaultAgg;
@@ -87,7 +87,7 @@ export class AggFuncService extends BeanStub implements NamedBean, IAggFuncServi
     }
 
     public getFuncNames(column: AgColumn): string[] {
-        const userAllowedFuncs = column.getColDef().allowedAggFuncs;
+        const userAllowedFuncs = column.colDef.allowedAggFuncs;
 
         return userAllowedFuncs == null ? Object.keys(this.aggFuncsMap).sort() : userAllowedFuncs;
     }

--- a/packages/ag-grid-enterprise/src/aggregation/aggregationStage.ts
+++ b/packages/ag-grid-enterprise/src/aggregation/aggregationStage.ts
@@ -89,8 +89,7 @@ export class AggregationStage extends BeanStub implements NamedBean, _IRowNodeAg
 
         const colModel = beans.colModel;
         const aggFuncSvc = beans.aggFuncSvc;
-        const aggregateRoot =
-            gos.get('alwaysAggregateAtRootLevel') || !!_getGrandTotalRow(gos) || colModel.isPivotMode();
+        const aggregateRoot = gos.get('alwaysAggregateAtRootLevel') || !!_getGrandTotalRow(gos) || colModel.pivotMode;
         const filteredOnly = !_getGroupAggFiltering(gos) && !gos.get('suppressAggFilteredOnly');
 
         // Hoist service lookups once — they are accessed per-group inside the traversal callback.

--- a/packages/ag-grid-enterprise/src/aggregation/filterAggregatesStage.ts
+++ b/packages/ag-grid-enterprise/src/aggregation/filterAggregatesStage.ts
@@ -26,7 +26,7 @@ export class FilterAggregatesStage extends BeanStub implements NamedBean, _IRowN
         const { rowModel, colModel, groupStage } = this.beans;
         const { filterManager } = this;
 
-        const isPivotMode = colModel.isPivotMode();
+        const isPivotMode = colModel.pivotMode;
         const isAggFilterActive =
             filterManager?.isAggregateFilterPresent() || filterManager?.isAggregateQuickFilterPresent();
         const isTreeData = !!groupStage?.treeData;

--- a/packages/ag-grid-enterprise/src/aggregation/valueColsSvc.ts
+++ b/packages/ag-grid-enterprise/src/aggregation/valueColsSvc.ts
@@ -54,7 +54,7 @@ export class ValueColsSvc extends BaseColsService implements NamedBean, IColsSer
 
         // all new columns added will have aggFunc missing, so set it to what is in the colDef
         for (const col of this.columns) {
-            const colDef = col.getColDef();
+            const colDef = col.colDef;
             // if aggFunc provided, we always override, as reactive property
             if (colDef.aggFunc != null && colDef.aggFunc != '') {
                 this.setColAggFunc(col, colDef.aggFunc);

--- a/packages/ag-grid-enterprise/src/aiToolkit/features/aggregationFeatureSchema.ts
+++ b/packages/ag-grid-enterprise/src/aiToolkit/features/aggregationFeatureSchema.ts
@@ -22,7 +22,7 @@ export const buildAggregationFeatureSchema = (beans: BeanCollection) => {
                     s.union(
                         aggregatableColumns.map((col) =>
                             s.object({
-                                colId: s.literal(col.getColId(), 'Column identifier'),
+                                colId: s.literal(col.colId, 'Column identifier'),
                                 aggFunc: s.enum(beans.aggFuncSvc?.getFuncNames(col) || [], 'Aggregation function'),
                             })
                         )

--- a/packages/ag-grid-enterprise/src/aiToolkit/features/columnSizingFeatureSchema.ts
+++ b/packages/ag-grid-enterprise/src/aiToolkit/features/columnSizingFeatureSchema.ts
@@ -10,7 +10,7 @@ export const buildColumnSizingFeatureSchema = (beans: BeanCollection) => {
         return;
     }
 
-    const resizableColumnIds = resizableColumns.map((col) => col.getColId());
+    const resizableColumnIds = resizableColumns.map((col) => col.colId);
 
     return s
         .object(

--- a/packages/ag-grid-enterprise/src/aiToolkit/features/filterFeatureSchema.ts
+++ b/packages/ag-grid-enterprise/src/aiToolkit/features/filterFeatureSchema.ts
@@ -44,9 +44,9 @@ const buildColumnFilterFeatureSchema = (beans: BeanCollection, params?: Structur
     const enableFilterHandlers = gos.get('enableFilterHandlers');
 
     for (const column of filterableColumns) {
-        const columnParams = params?.columns ? params.columns[column.getColId()] : undefined;
+        const columnParams = params?.columns ? params.columns[column.colId] : undefined;
 
-        const colDef = column.getColDef();
+        const colDef = column.colDef;
         const defaultFilter = colFilter!.getDefaultFilter(column);
         const includeSetValues = columnParams?.includeSetValues ?? false;
 

--- a/packages/ag-grid-enterprise/src/aiToolkit/features/pivotFeatureSchema.ts
+++ b/packages/ag-grid-enterprise/src/aiToolkit/features/pivotFeatureSchema.ts
@@ -4,7 +4,7 @@ import { s } from '../schemaBuilder';
 
 export const buildPivotFeatureSchema = (beans: BeanCollection) => {
     const columns = beans.colModel.getCols();
-    const pivotableColumnIds = columns.filter((col) => col.isAllowPivot()).map((col) => col.getColId());
+    const pivotableColumnIds = columns.filter((col) => col.isAllowPivot()).map((col) => col.colId);
 
     if (pivotableColumnIds.length === 0) {
         return;

--- a/packages/ag-grid-enterprise/src/aiToolkit/features/rowGroupFeatureSchema.ts
+++ b/packages/ag-grid-enterprise/src/aiToolkit/features/rowGroupFeatureSchema.ts
@@ -10,7 +10,7 @@ export const buildRowGroupFeatureSchema = (beans: BeanCollection) => {
         return;
     }
 
-    const groupableColumnIds = groupableColumns.map((col) => col.getColId());
+    const groupableColumnIds = groupableColumns.map((col) => col.colId);
 
     return s.object(
         {

--- a/packages/ag-grid-enterprise/src/aiToolkit/features/sortFeatureSchema.ts
+++ b/packages/ag-grid-enterprise/src/aiToolkit/features/sortFeatureSchema.ts
@@ -15,7 +15,7 @@ export const buildSortFeatureSchema = (beans: BeanCollection) => {
         return;
     }
 
-    const sortableColumnIds = sortableColumns.map((col) => col.getColId());
+    const sortableColumnIds = sortableColumns.map((col) => col.colId);
 
     return s
         .object(

--- a/packages/ag-grid-enterprise/src/aiToolkit/structuredSchema.ts
+++ b/packages/ag-grid-enterprise/src/aiToolkit/structuredSchema.ts
@@ -26,7 +26,7 @@ const StructuredSchemaBuilderMap: Record<
 } as const;
 
 export function getStructuredSchema(beans: BeanCollection, params?: StructuredSchemaParams): JSONSchema | undefined {
-    const allColumnIds = beans.colModel.getCols().map((col) => col.getColId());
+    const allColumnIds = beans.colModel.getCols().map((col) => col.colId);
 
     const features: Record<string, SchemaBuilder> = {};
 

--- a/packages/ag-grid-enterprise/src/charts/chartComp/datasource/chartDatasource.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/datasource/chartDatasource.ts
@@ -141,13 +141,13 @@ export class ChartDatasource extends BeanStub {
                 let colNamesArr: string[] = [];
 
                 // pivot keys should be added first
-                const pivotKeys = col.getColDef().pivotKeys;
+                const pivotKeys = col.colDef.pivotKeys;
                 if (pivotKeys) {
                     colNamesArr = pivotKeys.slice();
                 }
 
                 // then add column header name to results
-                const headerName = col.getColDef().headerName;
+                const headerName = col.colDef.headerName;
                 if (headerName) {
                     colNamesArr.push(headerName);
                 }
@@ -234,7 +234,7 @@ export class ChartDatasource extends BeanStub {
 
             // then get data for value columns
             for (const col of valueCols) {
-                const colId = col.getColId();
+                const colId = col.colId;
                 if (crossFiltering) {
                     const filteredOutColId = colId + '-filtered-out';
 
@@ -360,7 +360,7 @@ export class ChartDatasource extends BeanStub {
 
             for (const groupItem of dataAggregated) {
                 for (const col of params.valueCols) {
-                    const colId = col.getColId();
+                    const colId = col.colId;
 
                     if (params.crossFiltering) {
                         // filtered data
@@ -442,10 +442,10 @@ export class ChartDatasource extends BeanStub {
         // the same logic can be used for CSRM and SSRM to extract legend names in extractRowsFromGridRowModel()
         for (const col of secondaryColumns) {
             if (pivotKeySeparator === '') {
-                col.getColDef().pivotKeys = [];
+                col.colDef.pivotKeys = [];
             } else {
-                const keys = col.getColId().split(pivotKeySeparator);
-                col.getColDef().pivotKeys = keys.slice(0, keys.length - 1);
+                const keys = col.colId.split(pivotKeySeparator);
+                col.colDef.pivotKeys = keys.slice(0, keys.length - 1);
             }
         }
     }
@@ -468,7 +468,7 @@ export class ChartDatasource extends BeanStub {
         if (firstSecondaryCol.getParent() == null) {
             return '';
         }
-        return extractSeparator(firstSecondaryCol.getParent()!, firstSecondaryCol.getColId());
+        return extractSeparator(firstSecondaryCol.getParent()!, firstSecondaryCol.colId);
     }
 
     private getGroupLabels(rowNode: RowNode | null, initialLabel: string): string[] {

--- a/packages/ag-grid-enterprise/src/charts/chartComp/model/chartDataModel.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/model/chartDataModel.ts
@@ -235,9 +235,7 @@ export class ChartDataModel extends BeanStub {
         // charts only group when the selected category is a group column
         const colIds = this.getSelectedDimensions().map(({ colId }) => colId);
         const displayedGroupCols = this.chartColSvc.getGroupDisplayColumns();
-        const groupDimensionSelected = displayedGroupCols
-            .map((col) => col.getColId())
-            .some((id) => colIds.includes(id));
+        const groupDimensionSelected = displayedGroupCols.map((col) => col.colId).some((id) => colIds.includes(id));
         return !!isGroupActive && groupDimensionSelected;
     }
 
@@ -285,7 +283,7 @@ export class ChartDataModel extends BeanStub {
         getDisplayName(column.getParent());
         if (attemptFallbackToColNames) {
             // one of the column groups doesn't have a name. Try and use the internal name map instead
-            const colNames = this.colNames[column.getColId()];
+            const colNames = this.colNames[column.colId];
             if (colNames) {
                 displayNames = colNames;
             }
@@ -303,7 +301,7 @@ export class ChartDataModel extends BeanStub {
 
     public getChartDataType(colId: string): string | undefined {
         const column = this.chartColSvc.getColumn(colId);
-        return column ? column.getColDef().chartDataType : undefined;
+        return column ? column.colDef.chartDataType : undefined;
     }
 
     public getConvertTime(colId: string): ((date: string | undefined) => Date | undefined) | undefined {
@@ -395,13 +393,13 @@ export class ChartDataModel extends BeanStub {
 
             const selected =
                 this.crossFiltering && this.aggFunc
-                    ? aggFuncDimension.getColId() === column.getColId()
+                    ? aggFuncDimension.getColId() === column.colId
                     : (this.useGroupColumnAsCategory && groupingActive && autoGroup) ||
                       ((!hasSelectedDimension || supportsMultipleDimensions) && allCols.has(column));
 
             this.dimensionColState.push({
                 column,
-                colId: column.getColId(),
+                colId: column.colId,
                 displayName: this.getColDisplayName(column),
                 selected,
                 order: order++,
@@ -433,7 +431,7 @@ export class ChartDataModel extends BeanStub {
 
             this.valueColState.push({
                 column,
-                colId: column.getColId(),
+                colId: column.colId,
                 displayName: this.getColDisplayName(column),
                 selected: allCols.has(column),
                 order: order++,
@@ -564,7 +562,7 @@ export class ChartDataModel extends BeanStub {
                     selectedValueCols.push(col);
                     numSelected++;
                 }
-            } else if (this.valueColState.some((colState) => colState.selected && colState.colId === col.getColId())) {
+            } else if (this.valueColState.some((colState) => colState.selected && colState.colId === col.colId)) {
                 selectedValueCols.push(col);
             }
         });
@@ -575,10 +573,10 @@ export class ChartDataModel extends BeanStub {
             if (this.valueColState.length > 0) {
                 orderedColIds = this.valueColState.map((c) => c.colId);
             } else {
-                colsInRange.forEach((c) => orderedColIds.push(c.getColId()));
+                colsInRange.forEach((c) => orderedColIds.push(c.colId));
             }
 
-            selectedValueCols.sort((a, b) => orderedColIds.indexOf(a.getColId()) - orderedColIds.indexOf(b.getColId()));
+            selectedValueCols.sort((a, b) => orderedColIds.indexOf(a.colId) - orderedColIds.indexOf(b.colId));
 
             this.valueCellRange = this.createCellRange(CellRangeType.VALUE, ...selectedValueCols);
         }
@@ -599,7 +597,7 @@ export class ChartDataModel extends BeanStub {
     }
 
     private updateSelectedDimensions(columns: AgColumn[]): void {
-        const colIdSet = new Set(columns.map((column) => column.getColId()));
+        const colIdSet = new Set(columns.map((column) => column.colId));
 
         // For non-hierarchical chart types, only one dimension can be selected
         const supportsMultipleDimensions = isHierarchical(getSeriesType(this.chartType));

--- a/packages/ag-grid-enterprise/src/charts/chartComp/services/chartColumnService.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/services/chartColumnService.ts
@@ -55,7 +55,7 @@ export class ChartColumnService extends BeanStub {
     }
 
     public isPivotMode(): boolean {
-        return this.colModel.isPivotMode();
+        return this.colModel.pivotMode;
     }
 
     public isPivotActive(): boolean {
@@ -69,7 +69,7 @@ export class ChartColumnService extends BeanStub {
         const valueCols = new Set<AgColumn>();
 
         for (const col of gridCols) {
-            const colDef = col.getColDef();
+            const colDef = col.colDef;
             const chartDataType = colDef.chartDataType;
 
             if (chartDataType) {
@@ -95,7 +95,7 @@ export class ChartColumnService extends BeanStub {
                 continue;
             }
 
-            if (!col.isPrimary()) {
+            if (!col.primary) {
                 valueCols.add(col);
                 continue;
             }
@@ -108,7 +108,7 @@ export class ChartColumnService extends BeanStub {
     }
 
     private isInferredValueCol(col: AgColumn): boolean {
-        const colId = col.getColId();
+        const colId = col.colId;
         if (colId === 'ag-Grid-AutoColumn') {
             return false;
         }

--- a/packages/ag-grid-enterprise/src/charts/chartService.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartService.ts
@@ -419,7 +419,7 @@ export class ChartService extends BeanStub implements NamedBean, IChartService {
                   rowStartPinned: undefined,
                   rowEndIndex: null,
                   rowEndPinned: undefined,
-                  columns: this.visibleCols.allCols.map((col) => col.getColId()),
+                  columns: this.visibleCols.allCols.map((col) => col.colId),
               }
             : cellRangeParams;
         const cellRange =

--- a/packages/ag-grid-enterprise/src/clipboard/clipboardService.ts
+++ b/packages/ag-grid-enterprise/src/clipboard/clipboardService.ts
@@ -1169,11 +1169,11 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
             return func(params);
         }
 
-        if (canParse && column.getColDef().useValueParserForImport !== false) {
+        if (canParse && column.colDef.useValueParserForImport !== false) {
             return valueSvc.parseValue(column, rowNode ?? null, value, valueSvc.getValue(column, rowNode, 'edit'));
         }
 
-        if (canFormat && column.getColDef().useValueFormatterForExport !== false) {
+        if (canFormat && column.colDef.useValueFormatterForExport !== false) {
             if (formula?.isFormula(value)) {
                 return value;
             }

--- a/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
@@ -261,7 +261,7 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
 
         const expandedStates = this.getExpandedStates();
 
-        const pivotModeActive = this.colModel.isPivotMode();
+        const pivotModeActive = this.colModel.pivotMode;
         const deferApply = isDeferredMode(params);
         const hasDeferredColumnOrder =
             deferApply && this.beans.columnStateUpdateStrategy.hasDeferredColumnOrder(deferApply);
@@ -428,7 +428,7 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
         };
 
         const createColumnItem = (column: AgColumn, depth: number, parentList: ColumnModelItem[]): void => {
-            const skipThisColumn = column.getColDef()?.suppressColumnsToolPanel;
+            const skipThisColumn = column.colDef?.suppressColumnsToolPanel;
 
             if (skipThisColumn) {
                 return;
@@ -609,7 +609,7 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
             }
 
             const column = item.column;
-            const colDef = column.getColDef();
+            const colDef = column.colDef;
 
             let checked: boolean;
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -280,18 +280,18 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
             rowGroupColIds: getColIds(beans.rowGroupColsSvc?.columns),
             valueColIds: getColIds(beans.valueColsSvc?.columns),
             pivotColIds: getColIds(beans.pivotColsSvc?.columns),
-            pivotMode: beans.colModel.isPivotMode(),
-            columnOrder: beans.colModel.getCols().map((c) => c.getColId()),
+            pivotMode: beans.colModel.pivotMode,
+            columnOrder: beans.colModel.getCols().map((c) => c.colId),
             visibleColIds: beans.colModel
                 .getCols()
                 .filter((c) => c.isVisible())
-                .map((c) => c.getColId()),
+                .map((c) => c.colId),
             sortState: beans.colModel
                 .getCols()
                 .filter((c) => c.getSort())
-                .map((c) => `${c.getColId()}:${c.getSort()}:${c.getSortIndex()}`),
+                .map((c) => `${c.colId}:${c.getSort()}:${c.getSortIndex()}`),
             aggFuncState: (beans.valueColsSvc?.columns ?? []).map((c) => c.getAggFunc()),
-            widthState: beans.colModel.getCols().map((c) => `${c.getColId()}:${c.getActualWidth()}`),
+            widthState: beans.colModel.getCols().map((c) => `${c.colId}:${c.getActualWidth()}`),
         };
     }
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/modelItemUtils.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/modelItemUtils.ts
@@ -71,7 +71,7 @@ function setAllVisible(
     const colStateItems: ColumnState[] = [];
 
     for (const col of columns) {
-        if (col.getColDef().lockVisible) {
+        if (col.colDef.lockVisible) {
             continue;
         }
         if (updateStrategy.isColumnVisibleInToolPanel(isDeferredMode(params), col) !== visible) {
@@ -171,7 +171,7 @@ export function updateColumns(
     const updateStrategy = beans.columnStateUpdateStrategy;
     const isPivotMode = updateStrategy.getPivotMode(isDeferredMode(params));
     const state: ColumnState[] = columns.map((column) => {
-        const colId = column.getColId();
+        const colId = column.colId;
         if (isPivotMode) {
             const pivotStateForColumn = pivotState?.[colId];
             return {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnComp.ts
@@ -101,7 +101,7 @@ export class ToolPanelColumnComp extends Component {
                 getLocation: () => 'columnToolPanelColumn',
                 shouldDisplayTooltip: _getShouldDisplayTooltip(gos, () => eLabel),
                 getAdditionalParams: () => ({
-                    colDef: column.getColDef(),
+                    colDef: column.colDef,
                 }),
             } as ITooltipCtrl)
         );
@@ -138,7 +138,7 @@ export class ToolPanelColumnComp extends Component {
 
         this.setupTooltip();
 
-        const classes = _getToolPanelClassesFromColDef(column.getColDef(), gos, column, null);
+        const classes = _getToolPanelClassesFromColDef(column.colDef, gos, column, null);
         for (const c of classes) {
             this.toggleCss(c, true);
         }
@@ -149,7 +149,7 @@ export class ToolPanelColumnComp extends Component {
     }
 
     private setupTooltip(): void {
-        const refresh = () => this.tooltipFeature?.setTooltipAndRefresh(this.column.getColDef().headerTooltip);
+        const refresh = () => this.tooltipFeature?.setTooltipAndRefresh(this.column.colDef.headerTooltip);
         refresh();
 
         this.addManagedEventListeners({ newColumnsLoaded: refresh });
@@ -280,7 +280,7 @@ export class ToolPanelColumnComp extends Component {
     }
 
     private createDragItem() {
-        const colId = this.column.getColId();
+        const colId = this.column.colId;
         const visibleState = { [colId]: this.column.isVisible() };
         const updateStrategy = this.beans.columnStateUpdateStrategy;
         const pivotState = {
@@ -320,7 +320,7 @@ export class ToolPanelColumnComp extends Component {
             canBeToggled = !functionsReadOnly && !noFunctionsAllowed;
             canBeDragged = canBeToggled;
         } else {
-            const { enableRowGroup, enableValue, lockPosition, suppressMovable, lockVisible } = this.column.getColDef();
+            const { enableRowGroup, enableValue, lockPosition, suppressMovable, lockVisible } = this.column.colDef;
             const forceDraggable = !!enableRowGroup || !!enableValue;
             const disableDraggable = !!lockPosition || !!suppressMovable;
             canBeToggled = !lockVisible;

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnGroupComp.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelColumnGroupComp.ts
@@ -378,7 +378,7 @@ export class ToolPanelColumnGroupComp extends Component {
         let uncheckedCount = 0;
 
         for (const column of visibleLeafColumns) {
-            if (pivotMode || !column.getColDef().lockVisible) {
+            if (pivotMode || !column.colDef.lockVisible) {
                 if (this.isColumnChecked(column)) {
                     checkedCount++;
                 } else {
@@ -404,7 +404,7 @@ export class ToolPanelColumnGroupComp extends Component {
                 if (col.isAnyFunctionAllowed()) {
                     colsThatCanAction++;
                 }
-            } else if (!col.getColDef().lockVisible) {
+            } else if (!col.colDef.lockVisible) {
                 colsThatCanAction++;
             }
         }

--- a/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelContextMenu.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/toolPanelContextMenu.ts
@@ -81,8 +81,8 @@ export class ToolPanelContextMenu extends Component {
         const isPivotMode = updateStrategy.getPivotMode(isDeferredMode(this.params));
 
         this.allowScrollIntoView = !isPivotMode && columns.some(this.isColumnValidForScrollIntoView);
-        this.allowGrouping = columns.some((col) => col.isPrimary() && col.isAllowRowGroup());
-        this.allowValues = columns.some((col) => col.isPrimary() && col.isAllowValue());
+        this.allowGrouping = columns.some((col) => col.primary && col.isAllowRowGroup());
+        this.allowValues = columns.some((col) => col.primary && col.isAllowValue());
         this.allowPivoting = isPivotMode && columns.some((col) => col.isPrimary() && col.isAllowPivot());
     }
 
@@ -97,10 +97,10 @@ export class ToolPanelContextMenu extends Component {
         const deferMode = isDeferredMode(this.params);
         const isPivotMode = updateStrategy.getPivotMode(deferMode);
         const rowGroupColIdSet = new Set(
-            updateStrategy.getRowGroupColumns(deferMode).map((col: AgColumn) => col.getColId())
+            updateStrategy.getRowGroupColumns(deferMode).map((col: AgColumn) => col.colId)
         );
-        const valueColIdSet = new Set(updateStrategy.getValueColumns(deferMode).map((col: AgColumn) => col.getColId()));
-        const pivotColIdSet = new Set(updateStrategy.getPivotColumns(deferMode).map((col: AgColumn) => col.getColId()));
+        const valueColIdSet = new Set(updateStrategy.getValueColumns(deferMode).map((col: AgColumn) => col.colId));
+        const pivotColIdSet = new Set(updateStrategy.getPivotColumns(deferMode).map((col: AgColumn) => col.colId));
 
         menuItemMap.set('scrollIntoView', {
             allowedFunction: (col) => !col.isPinned() && !isPivotMode && this.isColumnValidForScrollIntoView(col),
@@ -119,10 +119,10 @@ export class ToolPanelContextMenu extends Component {
         });
 
         const rowGroupAllowed = (col: AgColumn) =>
-            col.isPrimary() && col.isAllowRowGroup() && !isRowGroupColLocked(col, beans);
+            col.primary && col.isAllowRowGroup() && !isRowGroupColLocked(col, beans);
         menuItemMap.set('rowGroup', {
             allowedFunction: rowGroupAllowed,
-            activeFunction: (col) => rowGroupColIdSet.has(col.getColId()),
+            activeFunction: (col) => rowGroupColIdSet.has(col.colId),
             activateLabel: () => getGroupingLocaleText(localeTextFunc, 'groupBy', displayName!),
             deactivateLabel: () => getGroupingLocaleText(localeTextFunc, 'ungroupBy', displayName!),
             activateFunction: () => {
@@ -142,10 +142,10 @@ export class ToolPanelContextMenu extends Component {
             removeIcon: 'menuRemoveRowGroup',
         });
 
-        const valueAllowed = (col: AgColumn) => col.isPrimary() && col.isAllowValue();
+        const valueAllowed = (col: AgColumn) => col.primary && col.isAllowValue();
         menuItemMap.set('value', {
             allowedFunction: valueAllowed,
-            activeFunction: (col) => valueColIdSet.has(col.getColId()),
+            activeFunction: (col) => valueColIdSet.has(col.colId),
             activateLabel: () => localeTextFunc('addToValues', `Add ${displayName} to values`, [displayName!]),
             deactivateLabel: () =>
                 localeTextFunc('removeFromValues', `Remove ${displayName} from values`, [displayName!]),
@@ -163,10 +163,10 @@ export class ToolPanelContextMenu extends Component {
             removeIcon: 'valuePanel',
         });
 
-        const pivotAllowed = (col: AgColumn) => isPivotMode && col.isPrimary() && col.isAllowPivot();
+        const pivotAllowed = (col: AgColumn) => isPivotMode && col.primary && col.isAllowPivot();
         menuItemMap.set('pivot', {
             allowedFunction: pivotAllowed,
-            activeFunction: (col) => pivotColIdSet.has(col.getColId()),
+            activeFunction: (col) => pivotColIdSet.has(col.colId),
             activateLabel: () => localeTextFunc('addToLabels', `Add ${displayName} to labels`, [displayName!]),
             deactivateLabel: () =>
                 localeTextFunc('removeFromLabels', `Remove ${displayName} from labels`, [displayName!]),

--- a/packages/ag-grid-enterprise/src/columnToolPanel/updates/columnStateUpdateExecutionStrategy.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/updates/columnStateUpdateExecutionStrategy.ts
@@ -138,7 +138,7 @@ export class SynchronousColumnStateUpdateStrategy implements ColumnStateConcrete
     }
 
     public setColumnsVisible(columns: AgColumn[], visible: boolean, eventType: ColumnEventType): void {
-        const allowedCols = columns.filter((column) => !column.getColDef().lockVisible);
+        const allowedCols = columns.filter((column) => !column.colDef.lockVisible);
         this.beans.colModel.setColsVisible(allowedCols, visible, eventType); // apply column state
     }
 
@@ -175,7 +175,7 @@ export class SynchronousColumnStateUpdateStrategy implements ColumnStateConcrete
     }
 
     public setPivotColumns(columns: AgColumn[], eventType: ColumnEventType): void {
-        this.lastPivotColIds = columns.map((column) => column.getColId());
+        this.lastPivotColIds = columns.map((column) => column.colId);
         this.beans.pivotColsSvc?.setColumns(columns, eventType); // computes which columns actually changed + dispatchEvent
     }
 
@@ -185,11 +185,11 @@ export class SynchronousColumnStateUpdateStrategy implements ColumnStateConcrete
 
     public setPivotMode(pivotMode: boolean, eventType: ColumnEventType): void {
         const { colModel, gos, ctrlsSvc } = this.beans;
-        if (pivotMode === colModel.isPivotMode()) {
+        if (pivotMode === colModel.pivotMode) {
             return;
         }
 
-        const currentPivotColIds = this.beans.pivotColsSvc?.columns.map((col) => col.getColId()) ?? [];
+        const currentPivotColIds = this.beans.pivotColsSvc?.columns.map((col) => col.colId) ?? [];
         if (currentPivotColIds.length > 0) {
             this.lastPivotColIds = currentPivotColIds;
         }
@@ -200,7 +200,7 @@ export class SynchronousColumnStateUpdateStrategy implements ColumnStateConcrete
                 this.beans,
                 {
                     state: cols.map((col) => ({
-                        colId: col.getColId(),
+                        colId: col.colId,
                         pivot: false,
                         pivotIndex: null,
                     })),
@@ -230,7 +230,7 @@ export class SynchronousColumnStateUpdateStrategy implements ColumnStateConcrete
     }
 
     public getPivotMode(): boolean {
-        return this.beans.colModel.isPivotMode();
+        return this.beans.colModel.pivotMode;
     }
 
     public getSortDef(column: AgColumn): SortDef | null {
@@ -253,7 +253,7 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
     public hasPendingChanges(): boolean {
         const { state, beans } = this;
         const { columnState, columnOrder, rowGroup, aggregation, pivot, pivotMode, sort, aggFuncs } = state;
-        const getColIds = (cols: AgColumn[] | undefined) => (cols ?? []).map((c) => c.getColId());
+        const getColIds = (cols: AgColumn[] | undefined) => (cols ?? []).map((c) => c.colId);
 
         if (columnState) {
             for (const [colId, patch] of columnState.patches) {
@@ -284,7 +284,7 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
         if (pivot && !_areEqual(pivot.colIds, getColIds(beans.pivotColsSvc?.columns))) {
             return true;
         }
-        if (pivotMode && pivotMode.pivotMode !== beans.colModel.isPivotMode()) {
+        if (pivotMode && pivotMode.pivotMode !== beans.colModel.pivotMode) {
             return true;
         }
 
@@ -301,7 +301,7 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
             if (sort.baselineCleared) {
                 const primaryColumns = getPrimaryColumns(beans);
                 for (const col of primaryColumns) {
-                    if (!sort.sortDefsByColId.has(col.getColId()) && col.getSortDef() !== null) {
+                    if (!sort.sortDefsByColId.has(col.colId) && col.getSortDef() !== null) {
                         return true;
                     }
                 }
@@ -344,7 +344,7 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
                     const orderedColumns = operation.colIds
                         .map((colId) => beans.colModel.getColDefCol(colId))
                         .filter((column): column is AgColumn => !!column && isPrimaryColDefColumn(column));
-                    if (!beans.colModel.isPivotMode()) {
+                    if (!beans.colModel.pivotMode) {
                         for (let i = 0; i < orderedColumns.length; i++) {
                             const column = orderedColumns[i];
                             const allColumns = beans.colModel.getCols();
@@ -373,8 +373,8 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
                 }
                 case 'pivotMode': {
                     const { colModel, ctrlsSvc, gos, stateSvc } = beans;
-                    if (operation.pivotMode !== colModel.isPivotMode()) {
-                        const currentPivotColIds = beans.pivotColsSvc?.columns.map((col) => col.getColId()) ?? [];
+                    if (operation.pivotMode !== colModel.pivotMode) {
+                        const currentPivotColIds = beans.pivotColsSvc?.columns.map((col) => col.colId) ?? [];
                         if (currentPivotColIds.length > 0) {
                             this.lastPivotColIds = currentPivotColIds;
                         }
@@ -399,7 +399,7 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
                                 beans,
                                 {
                                     state: cols.map((col) => ({
-                                        colId: col.getColId(),
+                                        colId: col.colId,
                                         pivot: false,
                                         pivotIndex: null,
                                     })),
@@ -472,11 +472,11 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
     }
 
     public moveColumns(columns: AgColumn[], targetIndex: number, eventType: ColumnEventType): void {
-        const movingColIds = new Set(columns.map((column) => column.getColId()));
+        const movingColIds = new Set(columns.map((column) => column.colId));
         const orderedColIds = this.state.columnOrder?.colIds ?? getPrimaryColumnIds(this.beans);
 
         const remaining = orderedColIds.filter((colId) => !movingColIds.has(colId));
-        const movedIds = columns.map((column) => column.getColId());
+        const movedIds = columns.map((column) => column.colId);
         const seq = nextSeq(this.sequence);
         this.sequence = seq;
 
@@ -489,10 +489,10 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
 
     public setColumnsVisible(columns: AgColumn[], visible: boolean, eventType: ColumnEventType): void {
         for (const column of columns) {
-            if (column.getColDef().lockVisible) {
+            if (column.colDef.lockVisible) {
                 continue;
             }
-            mergeColumnStatePatch(this.state, { colId: column.getColId(), hide: !visible });
+            mergeColumnStatePatch(this.state, { colId: column.colId, hide: !visible });
         }
         const columnState = ensureColumnStateDraft(this.state);
         columnState.seq = nextSeq(this.sequence);
@@ -505,7 +505,7 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
         const seq = nextSeq(this.sequence);
         this.sequence = seq;
         this.state.rowGroup = {
-            colIds: columns.map((column) => column.getColId()),
+            colIds: columns.map((column) => column.colId),
             eventType,
             seq,
         };
@@ -513,15 +513,15 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
 
     public setValueColumns(columns: AgColumn[], eventType: ColumnEventType): void {
         clearDeferredFunctionPatches(this.state, 'aggFunc');
-        const liveValueColIds = new Set((this.beans.valueColsSvc?.columns ?? []).map((col) => col.getColId()));
+        const liveValueColIds = new Set((this.beans.valueColsSvc?.columns ?? []).map((col) => col.colId));
         const aggFuncs = ensureAggFuncsDraft(this.state);
         for (const col of columns) {
-            if (!liveValueColIds.has(col.getColId()) && !aggFuncs.values.has(col.getColId())) {
+            if (!liveValueColIds.has(col.colId) && !aggFuncs.values.has(col.colId)) {
                 const existingAggFunc = col.getAggFunc();
                 const aggFunc =
                     existingAggFunc != null ? existingAggFunc : this.beans.aggFuncSvc?.getDefaultAggFunc(col);
                 if (aggFunc != null) {
-                    aggFuncs.values.set(col.getColId(), aggFunc);
+                    aggFuncs.values.set(col.colId, aggFunc);
                 }
             }
         }
@@ -530,7 +530,7 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
         aggFuncs.seq = seq;
         aggFuncs.eventType = eventType;
         this.state.aggregation = {
-            colIds: columns.map((column) => column.getColId()),
+            colIds: columns.map((column) => column.colId),
             eventType,
             seq,
         };
@@ -541,7 +541,7 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
         aggFunc: string | IAggFunc | null | undefined,
         eventType: ColumnEventType
     ): void {
-        mergeColumnStatePatch(this.state, { colId: column.getColId(), aggFunc });
+        mergeColumnStatePatch(this.state, { colId: column.colId, aggFunc });
         const columnState = ensureColumnStateDraft(this.state);
         columnState.seq = nextSeq(this.sequence);
         this.sequence = columnState.seq;
@@ -549,11 +549,11 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
         const aggFuncs = ensureAggFuncsDraft(this.state);
         aggFuncs.seq = columnState.seq;
         aggFuncs.eventType = eventType;
-        aggFuncs.values.set(column.getColId(), aggFunc);
+        aggFuncs.values.set(column.colId, aggFunc);
     }
 
     public getColumnAggFunc(column: AgColumn): string | IAggFunc | null | undefined {
-        const colId = column.getColId();
+        const colId = column.colId;
         if (this.state.aggFuncs?.values.has(colId)) {
             return this.state.aggFuncs.values.get(colId);
         }
@@ -561,7 +561,7 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
     }
 
     public isColumnVisibleInToolPanel(column: AgColumn): boolean {
-        const columnState = this.state.columnState?.patches.get(column.getColId());
+        const columnState = this.state.columnState?.patches.get(column.colId);
         if (columnState?.hide !== undefined) {
             return !columnState.hide;
         }
@@ -569,7 +569,7 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
     }
 
     public isColumnSelectedInPivotModeToolPanel(column: AgColumn): boolean {
-        const colId = column.getColId();
+        const colId = column.colId;
         const columnState = this.state.columnState?.patches.get(colId);
 
         let rowGroupActive: boolean;
@@ -607,7 +607,7 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
         const seq = nextSeq(this.sequence);
         this.sequence = seq;
         this.state.pivot = {
-            colIds: columns.map((column) => column.getColId()),
+            colIds: columns.map((column) => column.colId),
             eventType,
             seq,
         };
@@ -677,12 +677,12 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
     }
 
     public getPivotMode(): boolean {
-        return this.state.pivotMode?.pivotMode ?? this.beans.colModel.isPivotMode();
+        return this.state.pivotMode?.pivotMode ?? this.beans.colModel.pivotMode;
     }
 
     public getSortDef(column: AgColumn): SortDef | null {
         const draftSortState = this.state.sort;
-        const colId = column.getColId();
+        const colId = column.colId;
         const sortDefsByColId = draftSortState?.sortDefsByColId;
         if (sortDefsByColId?.has(colId)) {
             return sortDefsByColId.get(colId) ?? null;
@@ -701,7 +701,7 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
             eventType: 'toolPanelUi',
         };
         const { sortSvc } = this.beans;
-        const colId = column.getColId();
+        const colId = column.colId;
         let currentSortDef: SortDef | null | undefined;
         if (currentDraft.sortDefsByColId.has(colId)) {
             currentSortDef = currentDraft.sortDefsByColId.get(colId);
@@ -745,7 +745,7 @@ function getDraftFunctionColumnIds(
     columnStatePatches: Map<string, ColumnState> | undefined,
     getPatchState: (patch: ColumnState) => boolean | undefined
 ): string[] {
-    const colIds = [...(draftColIds ?? liveColumns?.map((column) => column.getColId()) ?? [])];
+    const colIds = [...(draftColIds ?? liveColumns?.map((column) => column.colId) ?? [])];
 
     if (!columnStatePatches?.size) {
         return colIds;
@@ -784,7 +784,7 @@ function syncPrimaryColDefOrderFromCurrentColumns(beans: BeanStub['beans']): voi
     const orderedPrimaryColumns = beans.colModel
         .getCols()
         .filter((column) => isPrimaryColDefColumn(column))
-        .map((column) => beans.colModel.getColDefCol(column.getColId()))
+        .map((column) => beans.colModel.getColDefCol(column.colId))
         .filter((column): column is AgColumn => !!column);
     syncPrimaryColDefOrder(beans, orderedPrimaryColumns);
 }
@@ -803,7 +803,7 @@ function syncPrimaryColDefOrder(beans: BeanStub['beans'], orderedPrimaryColumns:
 }
 
 function getPrimaryColumnIds(beans: BeanStub['beans']): string[] {
-    return getPrimaryColumns(beans).map((column) => column.getColId());
+    return getPrimaryColumns(beans).map((column) => column.colId);
 }
 
 function getPrimaryColumns(beans: BeanStub['beans']): AgColumn[] {
@@ -824,7 +824,7 @@ function getMutablePrimaryColDefCollection(beans: BeanStub['beans']): { list: Ag
 }
 
 function isPrimaryColDefColumn(column: AgColumn): boolean {
-    if (!column.isPrimary()) {
+    if (!column.primary) {
         return false;
     }
     return !isColumnGroupAutoCol(column) && !isSpecialCol(column);

--- a/packages/ag-grid-enterprise/src/filterToolPanel/agFiltersToolPanelList.ts
+++ b/packages/ag-grid-enterprise/src/filterToolPanel/agFiltersToolPanelList.ts
@@ -96,7 +96,7 @@ export class AgFiltersToolPanelList extends Component<AgFiltersToolPanelListEven
             this.onColumnsChangedPending = true;
             return;
         }
-        const pivotModeActive = this.colModel.isPivotMode();
+        const pivotModeActive = this.colModel.pivotMode;
         const shouldSyncColumnLayoutWithGrid = !this.params.suppressSyncLayoutWithGrid && !pivotModeActive;
         if (shouldSyncColumnLayoutWithGrid) {
             this.syncFilterLayout();
@@ -280,7 +280,7 @@ export class AgFiltersToolPanelList extends Component<AgFiltersToolPanelListEven
     }
 
     private shouldDisplayFilter(column: AgColumn) {
-        const suppressFiltersToolPanel = column.getColDef()?.suppressFiltersToolPanel;
+        const suppressFiltersToolPanel = column.colDef?.suppressFiltersToolPanel;
         return column.isFilterAllowed() && !suppressFiltersToolPanel;
     }
 
@@ -384,7 +384,7 @@ export class AgFiltersToolPanelList extends Component<AgFiltersToolPanelListEven
                 return anyChildrenChanged;
             }
 
-            const colId = filterComp.getColumn().getColId();
+            const colId = filterComp.getColumn().colId;
             const updateFilterExpandState = !colIds || colIds.includes(colId);
 
             if (updateFilterExpandState) {
@@ -558,7 +558,7 @@ export class AgFiltersToolPanelList extends Component<AgFiltersToolPanelListEven
                     expandedGroupIds.push(groupId);
                 }
             } else if (filterComp.isExpanded()) {
-                expandedColIds.add(filterComp.getColumn().getColId());
+                expandedColIds.add(filterComp.getColumn().colId);
             }
         };
 

--- a/packages/ag-grid-enterprise/src/filterToolPanel/newFilterToolPanel/filterPanelService.ts
+++ b/packages/ag-grid-enterprise/src/filterToolPanel/newFilterToolPanel/filterPanelService.ts
@@ -61,7 +61,7 @@ export class FilterPanelService
             filterClosed: updateApplyButton,
         });
         const refreshForColumn = ({ column }: { column: AgColumn }) => {
-            this.states.get(column.getColId())?.refresh?.();
+            this.states.get(column.colId)?.refresh?.();
             updateApplyButton();
         };
         this.addManagedListeners(this.beans.colFilter!, {
@@ -106,7 +106,7 @@ export class FilterPanelService
         const beans = this.beans;
         const availableFilters: { id: string; name: string }[] = [];
         for (const column of beans.colModel.getColDefCols() ?? []) {
-            const id = column.getColId();
+            const id = column.colId;
             if (column.isFilterAllowed() && !column.colDef.suppressFiltersToolPanel && !this.states.get(id)) {
                 availableFilters.push({
                     id,
@@ -303,7 +303,7 @@ export class FilterPanelService
         const beans = this.beans;
         const { colFilter, selectableFilter } = beans;
         const name = getDisplayName(beans, column);
-        const colId = column.getColId();
+        const colId = column.colId;
         const getIsEditing = () => !!this.params?.buttons && colFilter!.hasUnappliedModel(colId);
         const isEditing = getIsEditing();
         if (expanded) {
@@ -329,7 +329,7 @@ export class FilterPanelService
                 destroy: () => this.destroyBean(filterComp),
             };
         } else {
-            const colId = column.getColId();
+            const colId = column.colId;
             const getSummary = () =>
                 handler.getModelAsString?.(colFilter!.getStateForColumn(colId).model, 'filterToolPanel') ?? '';
             return {
@@ -408,5 +408,5 @@ export class FilterPanelService
 }
 
 function getDisplayName(beans: BeanCollection, column: AgColumn): string {
-    return beans.colNames.getDisplayNameForColumn(column, 'filterToolPanel') ?? column.getColId();
+    return beans.colNames.getDisplayNameForColumn(column, 'filterToolPanel') ?? column.colId;
 }

--- a/packages/ag-grid-enterprise/src/filterToolPanel/newFilterToolPanel/selectableFilterService.ts
+++ b/packages/ag-grid-enterprise/src/filterToolPanel/newFilterToolPanel/selectableFilterService.ts
@@ -110,7 +110,7 @@ export class SelectableFilterService
                 if (typeof filterString === 'string') {
                     updatedName = translateForFilterPanel(this, `${filterString as ProvidedFilterType}DisplayName`);
                 } else {
-                    _warn(280, { colId: column.getColId() });
+                    _warn(280, { colId: column.colId });
                     updatedName = '';
                 }
             }
@@ -129,7 +129,7 @@ export class SelectableFilterService
 
         let index =
             overrideIndex ?? // provided override
-            this.selectedFilters.get(column.getColId()) ?? // UI selected value
+            this.selectedFilters.get(column.colId) ?? // UI selected value
             defaultFilterIndex ?? // col def value
             (!filters && _isSetFilterByDefault(gos) ? 1 : 0); // if using defaults, then respect set filter by default setting, else choose first
 

--- a/packages/ag-grid-enterprise/src/filterToolPanel/toolPanelFilterGroupComp.ts
+++ b/packages/ag-grid-enterprise/src/filterToolPanel/toolPanelFilterGroupComp.ts
@@ -78,7 +78,7 @@ export class ToolPanelFilterGroupComp extends Component {
                     () => filterGroupComp.getGui().querySelector('.ag-group-title') as HTMLElement | undefined
                 ),
                 getAdditionalParams: () => ({
-                    colDef: column?.getColDef(),
+                    colDef: column?.colDef,
                     column,
                 }),
             } as ITooltipCtrl)
@@ -101,7 +101,7 @@ export class ToolPanelFilterGroupComp extends Component {
         }
 
         const refresh = () => {
-            this.tooltipFeature?.setTooltipAndRefresh((this.columnGroup as AgColumn).getColDef().headerTooltip);
+            this.tooltipFeature?.setTooltipAndRefresh((this.columnGroup as AgColumn).colDef.headerTooltip);
         };
 
         refresh();

--- a/packages/ag-grid-enterprise/src/find/findService.ts
+++ b/packages/ag-grid-enterprise/src/find/findService.ts
@@ -370,7 +370,7 @@ export class FindService extends BeanStub implements NamedBean, IFindService {
         const fullWidthCellRendererParams = gos.get('fullWidthCellRendererParams');
         const groupRowRendererParams = gos.get('groupRowRendererParams');
         const flattenDetails = _getFlattenDetails(gos);
-        const pivotMode = colModel.isPivotMode();
+        const pivotMode = colModel.pivotMode;
 
         let containerNumMatches = 0;
         let matches: Matches;

--- a/packages/ag-grid-enterprise/src/formula/formulaService.ts
+++ b/packages/ag-grid-enterprise/src/formula/formulaService.ts
@@ -253,7 +253,7 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
 
         let idx = 0;
         list?.forEach((col) => {
-            if (!col.isPrimary()) {
+            if (!col.primary) {
                 return;
             }
             let label = '';

--- a/packages/ag-grid-enterprise/src/groupHierarchy/groupHierarchyColService.ts
+++ b/packages/ag-grid-enterprise/src/groupHierarchy/groupHierarchyColService.ts
@@ -43,7 +43,7 @@ export class GroupHierarchyColService extends BeanStub implements NamedBean, IGr
         }
 
         cols.list = groupHierarchyCols.list
-            .filter((col) => !cols.list.some((c) => c.getColId() === col.getColId()))
+            .filter((col) => !cols.list.some((c) => c.colId === col.colId))
             .concat(cols.list);
 
         cols.tree = groupHierarchyCols.tree
@@ -94,7 +94,7 @@ export class GroupHierarchyColService extends BeanStub implements NamedBean, IGr
     public expandColumnInto(target: AgColumn[], col: AgColumn): void {
         const expanded = this.getVirtualColumnsForColumn(col).concat(col);
         for (const expandedCol of expanded) {
-            if (!target.some((_c) => _columnsMatch(_c, expandedCol) || _c.getColId() === expandedCol.getColId())) {
+            if (!target.some((_c) => _columnsMatch(_c, expandedCol) || _c.colId === expandedCol.colId)) {
                 target.push(expandedCol);
             }
         }
@@ -153,7 +153,7 @@ export class GroupHierarchyColService extends BeanStub implements NamedBean, IGr
     }
 
     private isGroupHierarchyColsEnabledForCol(col: AgColumn): boolean {
-        const def = col.getColDef();
+        const def = col.colDef;
         const groupHierarchy = _getGroupHierarchy(def);
         return !!(
             groupHierarchy &&
@@ -168,7 +168,7 @@ export class GroupHierarchyColService extends BeanStub implements NamedBean, IGr
 
     private createGroupHierarchyColDefs(sourceCol: AgColumn): ColDef[] {
         const colDefs: ColDef[] = [];
-        const sourceColDef = sourceCol.getColDef();
+        const sourceColDef = sourceCol.colDef;
         const groupHierarchy = _getGroupHierarchy(sourceColDef);
 
         if (!groupHierarchy) {
@@ -223,7 +223,7 @@ export class GroupHierarchyColService extends BeanStub implements NamedBean, IGr
     private createColDefForPart(part: string, sourceCol: AgColumn, sourceColDef: ColDef): ColDef | null {
         const { beans, gos } = this;
 
-        const colId = `${GROUP_HIERARCHY_COLUMN_ID_PREFIX}-${sourceCol.getColId()}-${part}`;
+        const colId = `${GROUP_HIERARCHY_COLUMN_ID_PREFIX}-${sourceCol.colId}-${part}`;
         const defaults: Partial<ColDef> = {
             enableRowGroup: sourceColDef.enableRowGroup,
             rowGroup: sourceColDef.rowGroup,

--- a/packages/ag-grid-enterprise/src/menu/columnChooserFactory.ts
+++ b/packages/ag-grid-enterprise/src/menu/columnChooserFactory.ts
@@ -26,7 +26,7 @@ export class ColumnChooserFactory extends BeanStub implements NamedBean {
     ): AgPrimaryCols {
         const columnSelectPanel = parent.createManagedBean(new AgPrimaryCols());
 
-        const columnChooserParams = params ?? column?.getColDef().columnChooserParams ?? {};
+        const columnChooserParams = params ?? column?.colDef.columnChooserParams ?? {};
 
         const {
             contractColumnSelection,

--- a/packages/ag-grid-enterprise/src/menu/columnMenuFactory.ts
+++ b/packages/ag-grid-enterprise/src/menu/columnMenuFactory.ts
@@ -51,7 +51,7 @@ export class ColumnMenuFactory extends BeanStub implements NamedBean {
         const defaultItems = this.getDefaultMenuOptions(column);
         let result: (DefaultMenuItem | MenuItemDef)[];
 
-        const columnMainMenuItems = (column?.getColDef() ?? columnGroup?.getColGroupDef())?.mainMenuItems;
+        const columnMainMenuItems = (column?.colDef ?? columnGroup?.getColGroupDef())?.mainMenuItems;
         if (Array.isArray(columnMainMenuItems)) {
             result = columnMainMenuItems;
         } else if (typeof columnMainMenuItems === 'function') {
@@ -119,7 +119,7 @@ export class ColumnMenuFactory extends BeanStub implements NamedBean {
         const grandTotalRow = _getGrandTotalRow(gos);
         const treeData = gos.get('treeData');
 
-        const isPrimary = column.isPrimary();
+        const isPrimary = column.primary;
 
         // 1. secondary columns can always have aggValue, as it means it's a pivot value column
         // 2. otherwise, only allow aggValue if it's a value column and we're grouping or have a grand total row
@@ -210,7 +210,7 @@ export class ColumnMenuFactory extends BeanStub implements NamedBean {
         if (
             expansionSvc &&
             (_isClientSideRowModel(gos) || gos.get('ssrmExpandAllAffectsAllRows')) &&
-            (treeData || rowGroupCount > (colModel.isPivotMode() ? 1 : 0))
+            (treeData || rowGroupCount > (colModel.pivotMode ? 1 : 0))
         ) {
             result.push('expandAll');
             result.push('contractAll');

--- a/packages/ag-grid-enterprise/src/menu/contextMenu.ts
+++ b/packages/ag-grid-enterprise/src/menu/contextMenu.ts
@@ -108,7 +108,7 @@ export class ContextMenuService extends BeanStub implements NamedBean, IContextM
         }
 
         if (gos.get('enableCharts') && chartSvc) {
-            if (colModel.isPivotMode()) {
+            if (colModel.pivotMode) {
                 defaultMenuOptions.push('pivotChart');
             }
 

--- a/packages/ag-grid-enterprise/src/menu/enterpriseMenu.ts
+++ b/packages/ag-grid-enterprise/src/menu/enterpriseMenu.ts
@@ -343,7 +343,7 @@ export class EnterpriseMenuFactory extends BeanStub implements NamedBean, IMenuF
         }
         // Determine whether there are any tabs to show in the menu, given that the filter tab may be hidden
         const isFilterDisabled = !this.beans.filterManager?.isFilterAllowed(column);
-        const tabs = column.getColDef().menuTabs ?? TABS_DEFAULT;
+        const tabs = column.colDef.menuTabs ?? TABS_DEFAULT;
         const numActiveTabs = isFilterDisabled && tabs.includes(TAB_FILTER) ? tabs.length - 1 : tabs.length;
         return numActiveTabs > 0;
     }
@@ -419,7 +419,7 @@ class TabbedColumnMenu extends BeanStub<TabbedColumnMenuEvent> implements Enterp
             return this.restrictTo;
         }
 
-        return (this.column?.getColDef().menuTabs ?? TABS_DEFAULT).filter(
+        return (this.column?.colDef.menuTabs ?? TABS_DEFAULT).filter(
             (tabName) => this.isValidMenuTabItem(tabName) && this.isNotSuppressed(tabName)
         );
     }

--- a/packages/ag-grid-enterprise/src/menu/menuItemMapper.ts
+++ b/packages/ag-grid-enterprise/src/menu/menuItemMapper.ts
@@ -213,7 +213,7 @@ export class MenuItemMapper extends BeanStub implements NamedBean {
                           }
                         : null;
                 case 'valueAggSubMenu':
-                    if (aggFuncSvc && valueColsSvc && (column?.isPrimary() || column?.getColDef().pivotValueColumn)) {
+                    if (aggFuncSvc && valueColsSvc && (column?.primary || column?.colDef.pivotValueColumn)) {
                         return {
                             name: localeTextFunc('valueAggregation', 'Value Aggregation'),
                             icon: _createIconNoSpan('menuValue', beans, null),
@@ -253,14 +253,14 @@ export class MenuItemMapper extends BeanStub implements NamedBean {
                               disabled:
                                   gos.get('functionsReadOnly') ||
                                   column?.isRowGroupActive() ||
-                                  !column?.getColDef().enableRowGroup,
+                                  !column?.colDef.enableRowGroup,
                               action: () => rowGroupColsSvc.addColumns([column], source),
                               icon: _createIconNoSpan('menuAddRowGroup', beans, null),
                           }
                         : null;
                 case 'rowUnGroup': {
                     if (rowGroupColsSvc && gos.isModuleRegistered('SharedRowGrouping')) {
-                        const showRowGroup = column?.getColDef().showRowGroup;
+                        const showRowGroup = column?.colDef.showRowGroup;
                         const lockedGroups = gos.get('groupLockGroupColumns');
                         let name: string;
                         let disabled: boolean;
@@ -296,7 +296,7 @@ export class MenuItemMapper extends BeanStub implements NamedBean {
                             disabled =
                                 gos.get('functionsReadOnly') ||
                                 !column?.isRowGroupActive() ||
-                                !column?.getColDef().enableRowGroup ||
+                                !column?.colDef.enableRowGroup ||
                                 isRowGroupColLocked(column, beans);
                             action = () => rowGroupColsSvc.removeColumns([column], source);
                         }
@@ -617,10 +617,10 @@ function createAggregationSubMenu(
     localeTextFunc: LocaleTextFunc
 ): MenuItemDef[] {
     let columnToUse: AgColumn | undefined;
-    if (column.isPrimary()) {
+    if (column.primary) {
         columnToUse = column;
     } else {
-        const pivotValueColumn = column.getColDef().pivotValueColumn as AgColumn;
+        const pivotValueColumn = column.colDef.pivotValueColumn as AgColumn;
         columnToUse = _exists(pivotValueColumn) ? pivotValueColumn : undefined;
     }
 

--- a/packages/ag-grid-enterprise/src/notes/notesService.test.ts
+++ b/packages/ag-grid-enterprise/src/notes/notesService.test.ts
@@ -29,6 +29,8 @@ describe('NotesService', () => {
         };
 
         column = {
+            colId: 'athlete',
+            colDef,
             getColId: () => 'athlete',
             getColDef: () => colDef,
             isColumnFunc: (_rowNode: IRowNode, value?: boolean | ((params: any) => boolean) | null) => {

--- a/packages/ag-grid-enterprise/src/notes/notesService.ts
+++ b/packages/ag-grid-enterprise/src/notes/notesService.ts
@@ -84,7 +84,7 @@ export class NotesService extends BeanStub implements INotesService, INotesFeatu
             return undefined;
         }
 
-        const isSuppressed = column.isColumnFunc(params.rowNode, column.getColDef().suppressNoteActions ?? null);
+        const isSuppressed = column.isColumnFunc(params.rowNode, column.colDef.suppressNoteActions ?? null);
         const isReadOnly = !!note?.readOnly;
 
         return {

--- a/packages/ag-grid-enterprise/src/pivot/pivotApi.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotApi.ts
@@ -1,7 +1,7 @@
 import type { BeanCollection, ColDef, ColGroupDef, ColKey, Column } from 'ag-grid-community';
 
 export function isPivotMode(beans: BeanCollection): boolean {
-    return beans.colModel.isPivotMode();
+    return beans.colModel.pivotMode;
 }
 
 export function getPivotResultColumn<TValue = any, TData = any>(

--- a/packages/ag-grid-enterprise/src/pivot/pivotColDefService.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotColDefService.ts
@@ -125,7 +125,7 @@ export class PivotColDefService extends BeanStub implements NamedBean, IPivotCol
         }
 
         // sort by either user provided comparator, or our own one
-        const { pivotComparator } = primaryPivotColumns[index].getColDef();
+        const { pivotComparator } = primaryPivotColumns[index].colDef;
         const comparator = pivotComparator ? convertToHeaderNameComparator(pivotComparator) : headerNameComparator;
 
         const measureColumns = this.valueColsSvc?.columns;
@@ -216,7 +216,7 @@ export class PivotColDefService extends BeanStub implements NamedBean, IPivotCol
                 for (const valueColumn of valueCols) {
                     const columnName: string | null = this.colNames.getDisplayNameForColumn(valueColumn, 'header');
                     const totalColDef = this.createColDef(valueColumn, columnName, def.pivotKeys);
-                    totalColDef.pivotTotalColumnIds = childAcc.get(valueColumn.getColId());
+                    totalColDef.pivotTotalColumnIds = childAcc.get(valueColumn.colId);
 
                     totalColDef.columnGroupShow = !isSuppressExpand ? 'closed' : 'open';
 
@@ -365,7 +365,7 @@ export class PivotColDefService extends BeanStub implements NamedBean, IPivotCol
                 ? {
                       children: [colDef],
                       pivotKeys: [],
-                      groupId: `${PIVOT_ROW_TOTAL_PREFIX}_pivotGroup_${valueCol.getColId()}`,
+                      groupId: `${PIVOT_ROW_TOTAL_PREFIX}_pivotGroup_${valueCol.colId}`,
                   }
                 : colDef;
 
@@ -422,7 +422,7 @@ export class PivotColDefService extends BeanStub implements NamedBean, IPivotCol
 
         // This is null when there are no measure columns and we're creating placeholder columns
         if (valueColumn) {
-            const colDefToCopy = valueColumn.getColDef();
+            const colDefToCopy = valueColumn.colDef;
             Object.assign(colDef, colDefToCopy);
 
             // even if original column was hidden, we always show the pivot value column, otherwise it would be
@@ -431,10 +431,7 @@ export class PivotColDefService extends BeanStub implements NamedBean, IPivotCol
         }
 
         colDef.headerName = headerName;
-        colDef.colId = this.generateColumnId(
-            pivotKeys || [],
-            valueColumn && !totalColumn ? valueColumn.getColId() : ''
-        );
+        colDef.colId = this.generateColumnId(pivotKeys || [], valueColumn && !totalColumn ? valueColumn.colId : '');
 
         // pivot columns repeat over field, so it makes sense to use the unique id instead. For example if you want to
         // assign values to pinned bottom rows using setPinnedBottomRowData the value service will use this colId.
@@ -474,12 +471,12 @@ export class PivotColDefService extends BeanStub implements NamedBean, IPivotCol
     }
 
     private generateColumnGroupId(pivotKeys: string[]): string {
-        const pivotCols = (this.pivotColsSvc?.columns ?? []).map((col) => col.getColId());
+        const pivotCols = (this.pivotColsSvc?.columns ?? []).map((col) => col.colId);
         return `pivotGroup_${pivotCols.join('-')}_${pivotKeys.join('-')}`;
     }
 
     private generateColumnId(pivotKeys: string[], measureColumnId: string) {
-        const pivotCols = (this.pivotColsSvc?.columns ?? []).map((col) => col.getColId());
+        const pivotCols = (this.pivotColsSvc?.columns ?? []).map((col) => col.colId);
         return `pivot_${pivotCols.join('-')}_${pivotKeys.join('-')}_${measureColumnId}`;
     }
 

--- a/packages/ag-grid-enterprise/src/pivot/pivotResultColsService.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotResultColsService.ts
@@ -63,8 +63,9 @@ export class PivotResultColsService extends BeanStub implements NamedBean, IPivo
         let foundColumn: AgColumn | null = null;
 
         for (const column of this.pivotResultCols.list) {
-            const thisPivotKeys = column.getColDef().pivotKeys;
-            const pivotValueColumn = column.getColDef().pivotValueColumn;
+            const colDef = column.colDef;
+            const thisPivotKeys = colDef.pivotKeys;
+            const pivotValueColumn = colDef.pivotValueColumn;
 
             const pivotKeyMatches = _areEqual(thisPivotKeys, pivotKeys);
             const pivotValueMatches = pivotValueColumn === valueColumnToFind;
@@ -102,7 +103,8 @@ export class PivotResultColsService extends BeanStub implements NamedBean, IPivo
         // Aggregation requires this order because total columns read from already-computed regular results.
         let hasAnyTotals = false;
         for (let i = 0; i < list.length; ++i) {
-            if (list[i].getColDef().pivotTotalColumnIds != null) {
+            const colDef = list[i].colDef;
+            if (colDef.pivotTotalColumnIds != null) {
                 hasAnyTotals = true;
                 break;
             }
@@ -115,7 +117,7 @@ export class PivotResultColsService extends BeanStub implements NamedBean, IPivo
             const totals: AgColumn[] = [];
             for (let i = 0; i < list.length; ++i) {
                 const col = list[i];
-                if (col.getColDef().pivotTotalColumnIds != null) {
+                if (col.colDef.pivotTotalColumnIds != null) {
                     totals.push(col);
                 } else {
                     regular.push(col);

--- a/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
@@ -106,7 +106,7 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
 
         const aggregationColumns = valueColsSvc?.columns ?? [];
         const aggregationColumnsHash = aggregationColumns
-            .map((column) => `${column.getId()}-${column.getColDef().headerName}`)
+            .map((column) => `${column.getId()}-${column.colDef.headerName}`)
             .join('#');
         const aggregationFuncsHash = aggregationColumns.map((column) => column.getAggFunc()!.toString()).join('#');
 
@@ -121,7 +121,7 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
 
         const pivotColumns = pivotColsSvc?.columns ?? [];
         const shouldTrackPivotOrder =
-            gos.get('enableStrictPivotColumnOrder') && pivotColumns.some((col) => col.getColDef().pivotComparator);
+            gos.get('enableStrictPivotColumnOrder') && pivotColumns.some((col) => col.colDef.pivotComparator);
         const pivotOrder = shouldTrackPivotOrder ? computePivotOrder(this.uniqueValues, pivotColumns, 0) : [];
         const pivotOrderChanged = !_areEqual(pivotOrder, this.pivotOrderLastTime);
         this.pivotOrderLastTime = pivotOrder;
@@ -267,7 +267,7 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
  * function reference or source equality.
  */
 function computePivotOrder(values: Map<string, any>, pivotColumns: AgColumn[], depth: number): string[] {
-    const comparator = pivotColumns[depth]?.getColDef().pivotComparator;
+    const comparator = pivotColumns[depth]?.colDef.pivotComparator;
     const keys = [...values.keys()];
     if (comparator) {
         keys.sort(comparator);

--- a/packages/ag-grid-enterprise/src/rangeSelection/agFillHandle.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/agFillHandle.ts
@@ -375,7 +375,7 @@ export class AgFillHandle extends AbstractSelectionHandle {
 
                     if (!fromUserFunction) {
                         if (sourceCol) {
-                            const sourceColDef = sourceCol.getColDef();
+                            const sourceColDef = sourceCol.colDef;
                             if (sourceColDef.useValueFormatterForExport !== false && sourceColDef.valueFormatter) {
                                 const formattedValue = valueSvc.getValueForDisplay({
                                     column: sourceCol,
@@ -389,7 +389,7 @@ export class AgFillHandle extends AbstractSelectionHandle {
                                 }
                             }
                         }
-                        if (col.getColDef().useValueParserForImport !== false) {
+                        if (col.colDef.useValueParserForImport !== false) {
                             currentValue = valueSvc.parseValue(
                                 col,
                                 rowNode,

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/baseDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/baseDropZonePanel.ts
@@ -96,7 +96,7 @@ export abstract class BaseDropZonePanel extends PillDropZonePanel<DropZoneColumn
         if (isDeferredMode(this.updateParams)) {
             return;
         }
-        const allowedCols = columns.filter((c) => !c.getColDef().lockVisible);
+        const allowedCols = columns.filter((c) => !c.colDef.lockVisible);
         this.beans.columnStateUpdateStrategy.setColumnsVisible(false, allowedCols, visible, source);
     }
 

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/dropZoneColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/dropZoneColumnComp.ts
@@ -93,7 +93,7 @@ export class DropZoneColumnComp extends PillDragComp<AgColumn> {
     }
 
     protected getTooltip(): string | null | undefined {
-        return this.column.getColDef().headerTooltip;
+        return this.column.colDef.headerTooltip;
     }
 
     protected override addAdditionalAriaInstructions(

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/pivotDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/pivotDropZonePanel.ts
@@ -48,7 +48,7 @@ export class PivotDropZonePanel extends BaseDropZonePanel implements FocusableCo
 
     private checkVisibility(): void {
         const colModel = this.beans.colModel;
-        const pivotMode = colModel.isPivotMode();
+        const pivotMode = colModel.pivotMode;
 
         if (this.horizontal) {
             // what we do for horizontal (ie the pivot panel at the top) depends
@@ -75,7 +75,7 @@ export class PivotDropZonePanel extends BaseDropZonePanel implements FocusableCo
 
     protected isItemDroppable(column: AgColumn, draggingEvent: GridDraggingEvent): boolean {
         // we never allow grouping of secondary columns
-        if (this.gos.get('functionsReadOnly') || !column.isPrimary()) {
+        if (this.gos.get('functionsReadOnly') || !column.primary) {
             return false;
         }
 

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/rowGroupDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/rowGroupDropZonePanel.ts
@@ -38,7 +38,7 @@ export class RowGroupDropZonePanel extends BaseDropZonePanel implements Focusabl
 
     protected isItemDroppable(column: AgColumn, draggingEvent: GridDraggingEvent): boolean {
         // we never allow grouping of secondary columns or already-grouped columns
-        if (this.gos.get('functionsReadOnly') || !column.isPrimary() || column.colDef.showRowGroup) {
+        if (this.gos.get('functionsReadOnly') || !column.primary || column.colDef.showRowGroup) {
             return false;
         }
 

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/valueDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/valueDropZonePanel.ts
@@ -37,7 +37,7 @@ export class ValuesDropZonePanel extends BaseDropZonePanel {
 
     protected isItemDroppable(column: AgColumn, draggingEvent: GridDraggingEvent): boolean {
         // we never allow grouping of secondary columns
-        if (this.gos.get('functionsReadOnly') || !column.isPrimary()) {
+        if (this.gos.get('functionsReadOnly') || !column.primary) {
             return false;
         }
 

--- a/packages/ag-grid-enterprise/src/rowGrouping/groupFilter/groupFilter.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/groupFilter/groupFilter.ts
@@ -163,11 +163,11 @@ export class GroupFilter extends TabGuardComp<GroupFilterEvent> implements IFilt
         eGroupFieldSelect.setLabelAlignment('top');
         eGroupFieldSelect.addOptions(
             sourceColumns.map((sourceColumn) => ({
-                value: sourceColumn.getColId(),
+                value: sourceColumn.colId,
                 text: this.beans.colNames.getDisplayNameForColumn(sourceColumn, 'groupFilter', false) ?? undefined,
             }))
         );
-        eGroupFieldSelect.setValue(selectedColumn.getColId());
+        eGroupFieldSelect.setValue(selectedColumn.colId);
         eGroupFieldSelect.onValueChange((newValue) => this.updateSelectedColumn(newValue));
         eGroupFieldSelect.addCss('ag-group-filter-field-select-wrapper');
         if (sourceColumns.length === 1) {
@@ -198,7 +198,7 @@ export class GroupFilter extends TabGuardComp<GroupFilterEvent> implements IFilt
                                 column,
                             });
                         }
-                        if (column.getColId() === selectedColumn!.getColId()) {
+                        if (column.colId === selectedColumn!.colId) {
                             this.selectedFilter = filter ?? undefined;
                         }
                     })
@@ -291,6 +291,6 @@ export class GroupFilter extends TabGuardComp<GroupFilterEvent> implements IFilt
         if (!columnId) {
             return undefined;
         }
-        return this.filterColumnPairs?.find(({ column }) => column.getColId() === columnId);
+        return this.filterColumnPairs?.find(({ column }) => column.colId === columnId);
     }
 }

--- a/packages/ag-grid-enterprise/src/rowGrouping/groupFilter/groupFilterHandler.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/groupFilter/groupFilterHandler.ts
@@ -98,7 +98,7 @@ export class GroupFilterHandler
             return;
         }
         const colId = eventColumn.getColId();
-        if (this.sourceColumns?.some((column) => column.getColId() === colId)) {
+        if (this.sourceColumns?.some((column) => column.colId === colId)) {
             // filter may already be getting recreated, so wait before updating
             setTimeout(() => {
                 if (this.isAlive()) {

--- a/packages/ag-grid-enterprise/src/rowGrouping/groupFilter/groupFilterService.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/groupFilter/groupFilterService.ts
@@ -11,7 +11,7 @@ export class GroupFilterService extends BeanStub implements NamedBean, IGroupFil
     }
 
     public isGroupFilter(column: AgColumn): boolean {
-        return column.getColDef().filter === 'agGroupColumnFilter';
+        return column.colDef.filter === 'agGroupColumnFilter';
     }
 
     public isFilterAllowed(column: AgColumn): boolean {

--- a/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/groupColumns.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/groupColumns.ts
@@ -17,7 +17,7 @@ export const makeGroupColumns = (columns: AgColumn[] | null | undefined, result:
     result.length = len;
     for (let i = 0; i < len; i++) {
         const col = columns[i];
-        const colDef = col.getColDef();
+        const colDef = col.colDef;
         result[i] = {
             col,
             field: colDef.field,
@@ -39,7 +39,7 @@ export const groupColumnsChanged = (groupColumns: GroupColumn[], columns: AgColu
         if (a.col !== b) {
             return true;
         }
-        const bColDef = b.getColDef();
+        const bColDef = b.colDef;
         if (
             a.field !== bColDef.field ||
             a.type !== bColDef.type ||

--- a/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/groupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/groupStrategy.ts
@@ -73,7 +73,7 @@ export class GroupStrategy extends BeanStub implements IRowGroupingStrategy {
             // if rowGroupColumn is present, then it's grid row grouping and we only include if configuration says so
             if (col.isRowGroupDisplayed(rowGroupColId)) {
                 // if maintain group value type, get the value from any leaf node.
-                groupData[col.getColId()] = valueSvc.getValue(rowGroupCol, leafNode, 'data');
+                groupData[col.colId] = valueSvc.getValue(rowGroupCol, leafNode, 'data');
             }
         }
 
@@ -140,7 +140,7 @@ export class GroupStrategy extends BeanStub implements IRowGroupingStrategy {
     private initRefresh(params: RefreshModelParams): 'skip' | 'refresh' | 'groupColsChanged' {
         const { rowGroupColsSvc, colModel, gos } = this.beans;
 
-        this.pivotMode = colModel.isPivotMode();
+        this.pivotMode = colModel.pivotMode;
         this.groupEmpty = this.pivotMode || !gos.get('groupAllowUnbalanced');
         const cols = rowGroupColsSvc?.columns;
         const groupCols = this.groupCols;
@@ -517,7 +517,7 @@ export class GroupStrategy extends BeanStub implements IRowGroupingStrategy {
         leafNode: RowNode
     ): RowNode {
         const col = groupCol.col;
-        const id = (parent.level >= 0 ? parent.id! + '-' : 'row-group-') + (col.getColId() + '-' + key);
+        const id = (parent.level >= 0 ? parent.id! + '-' : 'row-group-') + (col.colId + '-' + key);
 
         const groupsById = this.nonLeafsById;
         let node = groupsById.get(id);

--- a/packages/ag-grid-enterprise/src/rowGrouping/rowGroupingEditValueSvc.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/rowGroupingEditValueSvc.ts
@@ -15,7 +15,7 @@ export class RowGroupingEditValueSvc extends BeanStub implements NamedBean, _IRo
     beanName = 'rowGroupingEditValueSvc' as const;
 
     public isGroupCellEditable(rowNode: IRowNode, column: AgColumn): boolean {
-        const colDef = column.getColDef();
+        const colDef = column.colDef;
 
         if (!column.isColumnFunc(rowNode, colDef.groupRowEditable)) {
             return false;
@@ -51,7 +51,7 @@ export class RowGroupingEditValueSvc extends BeanStub implements NamedBean, _IRo
         eventSource: string | undefined,
         valueChanged: boolean
     ): boolean | undefined {
-        const colDef = column.getColDef();
+        const colDef = column.colDef;
 
         // Resolve groupRowValueSetter: true or groupRowEditable → built-in distributeGroupValue,
         // false → explicitly disabled, function/object → as-is.

--- a/packages/ag-grid-enterprise/src/rowGrouping/rowGroupingUtils.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/rowGroupingUtils.ts
@@ -16,7 +16,7 @@ export const setRowNodeGroupValue = (
         rowNode._groupData = groupData;
     }
 
-    const columnId = column.getColId();
+    const columnId = column.colId;
     const oldValue = groupData[columnId];
 
     if (oldValue === newValue) {
@@ -72,7 +72,7 @@ export const isRowGroupColLocked = (column: AgColumn | undefined | null, beans: 
         return true;
     }
 
-    const colIndex = rowGroupColsSvc.columns.findIndex((groupCol) => groupCol.getColId() === column.getColId());
+    const colIndex = rowGroupColsSvc.columns.findIndex((groupCol) => groupCol.colId === column.colId);
     return groupLockGroupColumns > colIndex;
 };
 

--- a/packages/ag-grid-enterprise/src/rowHierarchy/autoColService.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/autoColService.ts
@@ -72,7 +72,7 @@ export class AutoColService extends BeanStub implements NamedBean, IColumnCollec
     ): void {
         const beans = this.beans;
         const { colModel, gos, rowGroupColsSvc, colGroupSvc } = beans;
-        const isPivotMode = colModel.isPivotMode();
+        const isPivotMode = colModel.pivotMode;
         const groupFullWidthRow = _isGroupUseEntireRow(gos, isPivotMode);
         // we need to allow suppressing auto-column separately for group and pivot as the normal situation
         // is CSRM and user provides group column themselves for normal view, but when they go into pivot the
@@ -115,7 +115,7 @@ export class AutoColService extends BeanStub implements NamedBean, IColumnCollec
             for (const col of this.columns?.list ?? []) {
                 const newDef = colsMap.get(col.getId());
                 if (newDef) {
-                    col.setColDef(newDef.getColDef(), null, source);
+                    col.setColDef(newDef.colDef, null, source);
                 }
             }
             return;
@@ -215,7 +215,7 @@ export class AutoColService extends BeanStub implements NamedBean, IColumnCollec
      * Refreshes an auto group col to load changes from defaultColDef or autoGroupColDef
      */
     private updateOneAutoCol(colToUpdate: AgColumn, index: number, source: ColumnEventType) {
-        const oldColDef = colToUpdate.getColDef();
+        const oldColDef = colToUpdate.colDef;
         const underlyingColId = typeof oldColDef.showRowGroup == 'string' ? oldColDef.showRowGroup : undefined;
         const beans = this.beans;
         const underlyingColumn = underlyingColId != null ? beans.colModel.getColDefCol(underlyingColId) : undefined;
@@ -284,7 +284,7 @@ export class AutoColService extends BeanStub implements NamedBean, IColumnCollec
 
         const res: ColDef = {
             headerName: localeTextFunc('group', 'Group'),
-            showRowGroup: rowGroupCol?.getColId() ?? true,
+            showRowGroup: rowGroupCol?.colId ?? true,
         };
 
         const userHasProvidedGroupCellRenderer = userDef && (userDef.cellRenderer || userDef.cellRendererSelector);

--- a/packages/ag-grid-enterprise/src/rowHierarchy/baseExpansionService.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/baseExpansionService.ts
@@ -63,7 +63,7 @@ export abstract class BaseExpansionService extends BeanStub {
             return false;
         }
 
-        if (this.beans.colModel.isPivotMode()) {
+        if (this.beans.colModel.pivotMode) {
             // master detail and leaf groups aren't expandable in pivot mode.
             return rowNode.hasChildren() && !rowNode.leafGroup;
         }

--- a/packages/ag-grid-enterprise/src/rowHierarchy/csrmExpansionService.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/csrmExpansionService.ts
@@ -68,7 +68,7 @@ export class CsrmExpansionService
         if (rowNode.footer) {
             return !!rowNode._expanded;
         }
-        if (!(rowNode.group || rowNode.master) || (rowNode.leafGroup && this.beans.colModel.isPivotMode())) {
+        if (!(rowNode.group || rowNode.master) || (rowNode.leafGroup && this.beans.colModel.pivotMode)) {
             return false; // Not expandable, so always return false
         }
         let value = rowNode._expanded;

--- a/packages/ag-grid-enterprise/src/rowHierarchy/flattenStage.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/flattenStage.ts
@@ -40,7 +40,7 @@ export class FlattenStage extends BeanStub implements _IRowNodeFlattenStage, Nam
             return result; // destroyed
         }
 
-        const skipLeafNodes = beans.colModel.isPivotMode();
+        const skipLeafNodes = beans.colModel.pivotMode;
         // if we are reducing, and not grouping, then we want to show the root node, as that
         // is where the pivot values are
 

--- a/packages/ag-grid-enterprise/src/rowHierarchy/groupEditService.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/groupEditService.ts
@@ -48,7 +48,7 @@ export class GroupEditService extends BeanStub implements _IGroupEditService {
         if (!this.gos.get('refreshAfterGroupEdit')) {
             return false;
         }
-        return !!this.beans.rowGroupColsSvc?.columns?.length && !this.beans.colModel.isPivotMode();
+        return !!this.beans.rowGroupColsSvc?.columns?.length && !this.beans.colModel.pivotMode;
     }
 
     private initDraggingGroups(rowsDrop: _RowsDrop): void {
@@ -443,7 +443,7 @@ export class GroupEditService extends BeanStub implements _IGroupEditService {
         while (current && current.level >= 0) {
             const column: AgColumn | undefined = columns[current.level];
             if (column) {
-                const colId = column.getColId();
+                const colId = column.colId;
                 const level = current.level;
                 values[level] = current.groupData?.[colId] ?? current.key ?? undefined;
                 if (level > maxLevel) {

--- a/packages/ag-grid-enterprise/src/rowHierarchy/groupSortStage.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/groupSortStage.ts
@@ -41,7 +41,7 @@ export class GroupSortStage extends BeanStub implements NamedBean, _IRowNodeSort
         const groupColumnsPresent = colModel.getCols().some((c) => c.isRowGroupActive());
         const groupCols = rowGroupColsSvc?.columns;
 
-        const isPivotMode = colModel.isPivotMode();
+        const isPivotMode = colModel.pivotMode;
         const postSortFunc = gos.getCallback('postSortRows');
 
         let hasAnyFirstChildChanged = false;

--- a/packages/ag-grid-enterprise/src/rowHierarchy/groupStage.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/groupStage.ts
@@ -169,7 +169,7 @@ export class GroupStage<TData> extends BeanStub implements NamedBean, _IRowNodeG
 
     private getStrategy(): IRowGroupingStrategy<TData> | null {
         let strategy = this.strategy;
-        const pivotMode = this.beans.colModel.isPivotMode();
+        const pivotMode = this.beans.colModel.pivotMode;
         if (pivotMode !== this.pivotMode) {
             this.pivotMode = pivotMode;
             this.columnsInvalidated = true;

--- a/packages/ag-grid-enterprise/src/rowHierarchy/rendering/groupCellRendererCtrl.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/rendering/groupCellRendererCtrl.ts
@@ -223,10 +223,10 @@ export class GroupCellRendererCtrl extends BeanStub implements IGroupCellRendere
             comp.toggleCss('ag-row-group', expandable);
 
             // indent non-expandable cells so they correctly indent with expandable cells
-            const pivotModeAndLeaf = !expandable && colModel.isPivotMode();
+            const pivotModeAndLeaf = !expandable && colModel.pivotMode;
             comp.toggleCss('ag-pivot-leaf-group', pivotModeAndLeaf);
             const normalModeNotTotalFooter =
-                !colModel.isPivotMode() && (!this.displayedNode.footer || this.displayedNode.level !== -1);
+                !colModel.pivotMode && (!this.displayedNode.footer || this.displayedNode.level !== -1);
             comp.toggleCss('ag-row-group-leaf-indent', !expandable && normalModeNotTotalFooter);
 
             // update the child count component

--- a/packages/ag-grid-enterprise/src/rowHierarchy/showRowGroupColsService.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/showRowGroupColsService.ts
@@ -31,7 +31,7 @@ export class ShowRowGroupColsService extends BeanStub implements NamedBean, ISho
         const cols = colModel.getCols();
         for (let colIdx = 0, colsLen = cols.length; colIdx < colsLen; ++colIdx) {
             const col = cols[colIdx];
-            const colDef = col.getColDef();
+            const colDef = col.colDef;
             const showRowGroup = colDef.showRowGroup;
 
             if (typeof showRowGroup === 'string') {
@@ -68,7 +68,7 @@ export class ShowRowGroupColsService extends BeanStub implements NamedBean, ISho
     }
 
     public getSourceColumnsForGroupColumn(groupCol: AgColumn): AgColumn[] | null {
-        const sourceColumnId = groupCol.getColDef().showRowGroup;
+        const sourceColumnId = groupCol.colDef.showRowGroup;
         if (!sourceColumnId) {
             return null;
         }
@@ -83,7 +83,7 @@ export class ShowRowGroupColsService extends BeanStub implements NamedBean, ISho
     }
 
     public isRowGroupDisplayed(column: AgColumn, colId: string | null): boolean {
-        const showRowGroup = column.getColDef()?.showRowGroup;
+        const showRowGroup = column.colDef.showRowGroup;
         return showRowGroup === true || (showRowGroup != null && showRowGroup === colId);
     }
 }

--- a/packages/ag-grid-enterprise/src/rowNumbers/rowNumbersService.ts
+++ b/packages/ag-grid-enterprise/src/rowNumbers/rowNumbersService.ts
@@ -215,7 +215,7 @@ export class RowNumbersService extends BeanStub implements NamedBean, IRowNumber
             const colDef = this.createRowNumbersColDef();
             col.setColDef(colDef, null, source);
 
-            _applyColumnState(this.beans, { state: [_getColumnStateFromColDef(colDef, col.getColId())] }, source);
+            _applyColumnState(this.beans, { state: [_getColumnStateFromColDef(colDef, col.colId)] }, source);
         }
     }
 

--- a/packages/ag-grid-enterprise/src/serverSideRowModel/blocks/blockUtils.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/blocks/blockUtils.ts
@@ -252,11 +252,11 @@ export class BlockUtils extends BeanStub implements NamedBean {
                 rowNode._groupData = groupData;
             }
             if (usingTreeData) {
-                groupData[col.getColId()] = key;
+                groupData[col.colId] = key;
             } else if (col.isRowGroupDisplayed(rowNode.rowGroupColumn!.getId())) {
                 // Use 'data' - group keys should be based on committed data, not pending edits
                 const groupValue = this.valueSvc.getValue(rowNode.rowGroupColumn!, rowNode, 'data');
-                groupData[col.getColId()] = groupValue;
+                groupData[col.colId] = groupValue;
             }
         }
     }

--- a/packages/ag-grid-enterprise/src/serverSideRowModel/listeners/listenerUtils.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/listeners/listenerUtils.ts
@@ -13,7 +13,7 @@ export class ListenerUtils extends BeanStub implements NamedBean {
     }
 
     public isSortingWithValueColumn(changedColumnsInSort: string[]): boolean {
-        const valueColIds = (this.valueColsSvc?.columns ?? []).map((col) => col.getColId());
+        const valueColIds = (this.valueColsSvc?.columns ?? []).map((col) => col.colId);
 
         for (let i = 0; i < changedColumnsInSort.length; i++) {
             if (valueColIds.indexOf(changedColumnsInSort[i]) > -1) {
@@ -30,7 +30,7 @@ export class ListenerUtils extends BeanStub implements NamedBean {
             return false;
         }
 
-        const secondaryColIds = pivotResultCols.list.map((col) => col.getColId());
+        const secondaryColIds = pivotResultCols.list.map((col) => col.colId);
 
         for (let i = 0; i < changedColumnsInSort.length; i++) {
             if (secondaryColIds.indexOf(changedColumnsInSort[i]) > -1) {

--- a/packages/ag-grid-enterprise/src/serverSideRowModel/serverSideRowModel.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/serverSideRowModel.ts
@@ -376,7 +376,7 @@ export class ServerSideRowModel extends BeanStub implements NamedBean, IServerSi
                     id: col.getId(),
                     aggFunc: col.getAggFunc(),
                     displayName: this.colNames.getDisplayNameForColumn(col, 'model'),
-                    field: col.getColDef().field,
+                    field: col.colDef.field,
                 }) as ColumnVO
         );
     }
@@ -393,7 +393,7 @@ export class ServerSideRowModel extends BeanStub implements NamedBean, IServerSi
             valueCols: valueColumnVos,
             rowGroupCols: rowGroupColumnVos,
             pivotCols: pivotColumnVos,
-            pivotMode: this.colModel.isPivotMode(),
+            pivotMode: this.colModel.pivotMode,
 
             // sort and filter model
             filterModel: this.filterManager?.isAdvFilterEnabled()

--- a/packages/ag-grid-enterprise/src/serverSideRowModel/stores/storeFactory.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/stores/storeFactory.ts
@@ -100,7 +100,7 @@ export class StoreFactory extends BeanStub implements NamedBean {
             parentRowNode: parentNode.level >= 0 ? parentNode : undefined,
             rowGroupColumns: this.rowGroupColsSvc?.columns ?? [],
             pivotColumns: this.pivotColsSvc?.columns ?? [],
-            pivotMode: this.colModel.isPivotMode(),
+            pivotMode: this.colModel.pivotMode,
         };
 
         const res = callback(params);

--- a/packages/ag-grid-enterprise/src/serverSideRowModel/stores/storeUtils.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/stores/storeUtils.ts
@@ -80,8 +80,8 @@ export class StoreUtils extends BeanStub implements NamedBean {
         const allCols = this.colModel.getCols();
         const affectedGroupCols = allCols
             // find all impacted cols which also a group display column
-            .filter((col) => col.getColDef().showRowGroup && params.changedColumns.includes(col.getId()))
-            .map((col) => col.getColDef().showRowGroup)
+            .filter((col) => col.colDef.showRowGroup && params.changedColumns.includes(col.getId()))
+            .map((col) => col.colDef.showRowGroup)
             // if displaying all groups, or displaying the effected col for this group, refresh
             .some((group) => group === true || group === colIdThisGroup);
 

--- a/packages/ag-grid-enterprise/src/sideBar/common/toolPanelColDefService.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/common/toolPanelColDefService.ts
@@ -100,9 +100,9 @@ function getLeafPathTrees(columns: AgColumn[]): AbstractColDef[] {
                 leafPathTree = groupDef;
             }
         } else {
-            const colDef = Object.assign({}, node.getColDef());
+            const colDef = Object.assign({}, node.colDef);
             // ensure col contains colId
-            colDef.colId = node.getColId();
+            colDef.colId = node.colId;
             leafPathTree = colDef;
         }
 
@@ -118,12 +118,11 @@ function getLeafPathTrees(columns: AgColumn[]): AbstractColDef[] {
     };
 
     // construct a leaf path tree for each column
-    return columns.map((col) => getLeafPathTree(col, col.getColDef()));
+    return columns.map((col) => getLeafPathTree(col, col.colDef));
 }
 
 function getGridPrimaryColumns(colModel: ColumnModel): AgColumn[] {
     return colModel.getCols().filter((column) => {
-        const colDef = column.getColDef();
-        return column.isPrimary() && !colDef.showRowGroup;
+        return column.primary && !column.colDef.showRowGroup;
     });
 }

--- a/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
@@ -111,7 +111,7 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
         const groupDisplayCols = this.beans.showRowGroupCols?.columns;
         if (groupDisplayCols) {
             for (let i = 0, len = groupDisplayCols.length; i < len; ++i) {
-                groupData[groupDisplayCols[i].getColId()] = key;
+                groupData[groupDisplayCols[i].colId] = key;
             }
         }
         return groupData;


### PR DESCRIPTION
Accessing a field directly instead of getter function performs much better and makes the code simpler and bundle smaller.
V8 and in general engines cannot always inline methods especially in complex objects

First step of systematic replacement of getter methods => field access

- isPivotMode() from ColModel => pivotMode
- getColDef
- getColId
- column.getParent

| Benchmark | base (ops/s) | test (ops/s) | Result |
|-----------|-------------|-------------|--------|
| transaction update (500 rows) | 52.00 | 65.13 | **1.25x faster** |
| immutable (5/50 cols) — RowsPath | 78.48 | 86.92 | **1.11x faster** |
| getDataValue by string (last of 100 cols) | 9707.7 | 9043.0 | **1.07x slower** |
| transaction (5/50 cols) — CellsPath | 86.74 | 91.15 | **1.05x faster** |
| getDataValue by Column object (last of 100 cols) | 71.59 | 75.06 | **1.05x faster** |
| applyTransaction (deltaSort: false) - 1 update | 7.322 | 6.986 | **1.05x slower** |
