### PR TITLE
AG-15609-batch-edit-full-row-not-clearing-styles

### DIFF
--- a/packages/ag-grid-community/src/edit/strategy/fullRowEditStrategy.ts
+++ b/packages/ag-grid-community/src/edit/strategy/fullRowEditStrategy.ts
@@ -127,7 +127,7 @@ export class FullRowEditStrategy extends BaseEditStrategy {
 
     public override stopCancelled(forceCancel: boolean): boolean {
         const { rowNode, model } = this;
-        if (rowNode && !model.hasRowEdits(rowNode)) {
+        if (rowNode && !model.hasEdits()) {
             return false;
         }
 
@@ -141,7 +141,7 @@ export class FullRowEditStrategy extends BaseEditStrategy {
 
     public override stopCommitted(event: Event | null, commit: boolean): boolean {
         const { rowNode, beans, model, editSvc } = this;
-        if (rowNode && !model.hasRowEdits(rowNode)) {
+        if (rowNode && !model.hasEdits()) {
             return false;
         }
 

--- a/testing/behavioural/src/cell-editing/cell-editing-full-row-batch-styles.test.ts
+++ b/testing/behavioural/src/cell-editing/cell-editing-full-row-batch-styles.test.ts
@@ -799,11 +799,7 @@ describe('Cell Editing: full-row batch styles', () => {
         });
     });
 
-    test('commitBatchEdit clears styles when Enter closed editors on an unchanged row (AG-15609)', async () => {
-        // Repro: after Enter closed editors on a row with no pending changes,
-        // `FullRowEditStrategy.stopCommitted` used to early-return because
-        // `this.rowNode` pointed at a row whose UNEDITED entries had just been
-        // purged — leaving stale batch styles on previously-edited rows.
+    test('commitBatchEdit clears styles when Enter closed editors on an unchanged row', async () => {
         const api = await createGrid();
         const eventTracker = new EditEventTracker(api);
         const gridDiv = getGridElement(api)! as HTMLElement;
@@ -867,7 +863,78 @@ describe('Cell Editing: full-row batch styles', () => {
         });
     });
 
-    test('cancelBatchEdit clears styles when Enter closed editors on an unchanged row (AG-15609)', async () => {
+    test('commitBatchEdit persists every pending row after Enter on an unchanged row', async () => {
+        const api = await createGrid();
+        const eventTracker = new EditEventTracker(api);
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const user = userEvent.setup({ skipHover: true });
+        await asyncSetTimeout(0);
+
+        api.startBatchEdit();
+
+        // Edit row 0, column a
+        const cellA0 = getByTestId(gridDiv, agTestIdFor.cell('ROW_0', 'a'));
+        await user.click(cellA0);
+        api.startEditingCell({ rowIndex: 0, colKey: 'a' });
+        let input = await waitForInput(gridDiv, cellA0);
+        await user.clear(input);
+        await user.type(input, 'R0_NEW');
+
+        // Tab through col b of row 0 into row 1 col a
+        await user.keyboard('{Tab}');
+        await asyncSetTimeout(0);
+        await user.keyboard('{Tab}');
+        await asyncSetTimeout(0);
+
+        // Edit row 1, column a
+        const cellA1 = getByTestId(gridDiv, agTestIdFor.cell('ROW_1', 'a'));
+        input = await waitForInput(gridDiv, cellA1);
+        await user.clear(input);
+        await user.type(input, 'R1_NEW');
+
+        // Tab through col b of row 1 into row 2 col a (no changes on row 2)
+        await user.keyboard('{Tab}');
+        await asyncSetTimeout(0);
+        await user.keyboard('{Tab}');
+        await asyncSetTimeout(0);
+
+        // Press Enter on row 2 — purges row 2's UNEDITED entries while leaving
+        // `this.rowNode` pointing at row 2.
+        await user.keyboard('{Enter}');
+        await asyncSetTimeout(0);
+
+        // Sanity: rows 0 and 1 still carry pending styles
+        expect(getByTestId(gridDiv, agTestIdFor.cell('ROW_0', 'a'))).toHaveClass(/ag-cell-batch-edit/);
+        expect(getByTestId(gridDiv, agTestIdFor.cell('ROW_1', 'a'))).toHaveClass(/ag-cell-batch-edit/);
+
+        api.commitBatchEdit();
+        await asyncSetTimeout(0);
+
+        // Both previously-edited rows must have styles cleared
+        const cellA0After = getByTestId(gridDiv, agTestIdFor.cell('ROW_0', 'a'));
+        expect(cellA0After).toHaveTextContent('R0_NEW');
+        expect(cellA0After).not.toHaveClass(/ag-cell-batch-edit/);
+        expect(cellA0After.closest('[row-index="0"]')).not.toHaveClass(/ag-row-batch-edit/);
+
+        const cellA1After = getByTestId(gridDiv, agTestIdFor.cell('ROW_1', 'a'));
+        expect(cellA1After).toHaveTextContent('R1_NEW');
+        expect(cellA1After).not.toHaveClass(/ag-cell-batch-edit/);
+        expect(cellA1After.closest('[row-index="1"]')).not.toHaveClass(/ag-row-batch-edit/);
+
+        // Data persisted for rows 0 and 1, row 2 untouched
+        const rowData = api.getGridOption('rowData')!;
+        expect(rowData[0].a).toBe('R0_NEW');
+        expect(rowData[1].a).toBe('R1_NEW');
+        expect(rowData[2].a).toBe('A2');
+
+        // rowValueChanged and cellValueChanged fire once per changed row
+        expect(eventTracker.counts.batchEditingStarted).toBe(1);
+        expect(eventTracker.counts.batchEditingStopped).toBe(1);
+        expect(eventTracker.counts.cellValueChanged).toBe(2);
+        expect(eventTracker.counts.rowValueChanged).toBe(2);
+    });
+
+    test('cancelBatchEdit clears styles when Enter closed editors on an unchanged row', async () => {
         // Symmetric case to the commit repro: after Enter purged the tracked row's UNEDITED
         // entries, cancelBatchEdit must still revert data and clear styles on previously-edited rows.
         const api = await createGrid();

--- a/testing/behavioural/src/cell-editing/cell-editing-full-row-batch-styles.test.ts
+++ b/testing/behavioural/src/cell-editing/cell-editing-full-row-batch-styles.test.ts
@@ -799,6 +799,125 @@ describe('Cell Editing: full-row batch styles', () => {
         });
     });
 
+    test('commitBatchEdit clears styles when Enter closed editors on an unchanged row (AG-15609)', async () => {
+        // Repro: after Enter closed editors on a row with no pending changes,
+        // `FullRowEditStrategy.stopCommitted` used to early-return because
+        // `this.rowNode` pointed at a row whose UNEDITED entries had just been
+        // purged — leaving stale batch styles on previously-edited rows.
+        const api = await createGrid();
+        const eventTracker = new EditEventTracker(api);
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const user = userEvent.setup({ skipHover: true });
+        await asyncSetTimeout(0);
+
+        api.startBatchEdit();
+
+        // Edit row 0, column a
+        const cellA0 = getByTestId(gridDiv, agTestIdFor.cell('ROW_0', 'a'));
+        await user.click(cellA0);
+        api.startEditingCell({ rowIndex: 0, colKey: 'a' });
+        const inputA0 = await waitForInput(gridDiv, cellA0);
+        await user.clear(inputA0);
+        await user.type(inputA0, 'CHANGED');
+
+        // Tab through col b of row 0 into row 1 col a (cross row boundary; row 0's
+        // pending edit is preserved, the rest of row 0 is purged)
+        await user.keyboard('{Tab}');
+        await asyncSetTimeout(0);
+        await user.keyboard('{Tab}');
+        await asyncSetTimeout(0);
+
+        // Press Enter on row 1 (no changes) — closes editors and purges row 1's
+        // UNEDITED entries, but leaves `this.rowNode` pointing at row 1.
+        await user.keyboard('{Enter}');
+        await asyncSetTimeout(0);
+
+        // Sanity: row 0 still has batch styles before commit
+        const cellA0Mid = getByTestId(gridDiv, agTestIdFor.cell('ROW_0', 'a'));
+        expect(cellA0Mid).toHaveClass(/ag-cell-batch-edit/);
+        expect(cellA0Mid.closest('[row-index="0"]')).toHaveClass(/ag-row-batch-edit/);
+
+        // Commit
+        api.commitBatchEdit();
+        await asyncSetTimeout(0);
+
+        // Row 0 styles must be cleared and value persisted
+        const cellA0After = getByTestId(gridDiv, agTestIdFor.cell('ROW_0', 'a'));
+        expect(cellA0After).toHaveTextContent('CHANGED');
+        expect(cellA0After).not.toHaveClass(/ag-cell-batch-edit/);
+        expect(cellA0After).not.toHaveClass(/ag-cell-editing/);
+
+        const row0 = cellA0After.closest('[row-index="0"]');
+        expect(row0).not.toHaveClass(/ag-row-batch-edit/);
+        expect(row0).not.toHaveClass(/ag-row-editing/);
+
+        const rowData = api.getGridOption('rowData')!;
+        expect(rowData[0].a).toBe('CHANGED');
+
+        expect(eventTracker.counts).toEqual({
+            cellEditingStarted: 5,
+            cellEditingStopped: 5,
+            cellValueChanged: 1,
+            rowValueChanged: 1,
+            cellEditRequest: 0,
+            bulkEditingStarted: 0,
+            bulkEditingStopped: 0,
+            batchEditingStarted: 1,
+            batchEditingStopped: 1,
+        });
+    });
+
+    test('cancelBatchEdit clears styles when Enter closed editors on an unchanged row (AG-15609)', async () => {
+        // Symmetric case to the commit repro: after Enter purged the tracked row's UNEDITED
+        // entries, cancelBatchEdit must still revert data and clear styles on previously-edited rows.
+        const api = await createGrid();
+        const eventTracker = new EditEventTracker(api);
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const user = userEvent.setup({ skipHover: true });
+        await asyncSetTimeout(0);
+
+        api.startBatchEdit();
+
+        const cellA0 = getByTestId(gridDiv, agTestIdFor.cell('ROW_0', 'a'));
+        await user.click(cellA0);
+        api.startEditingCell({ rowIndex: 0, colKey: 'a' });
+        const inputA0 = await waitForInput(gridDiv, cellA0);
+        await user.clear(inputA0);
+        await user.type(inputA0, 'CHANGED');
+
+        await user.keyboard('{Tab}');
+        await asyncSetTimeout(0);
+        await user.keyboard('{Tab}');
+        await asyncSetTimeout(0);
+
+        await user.keyboard('{Enter}');
+        await asyncSetTimeout(0);
+
+        // Sanity: row 0 still has batch styles before cancel
+        const cellA0Mid = getByTestId(gridDiv, agTestIdFor.cell('ROW_0', 'a'));
+        expect(cellA0Mid).toHaveClass(/ag-cell-batch-edit/);
+
+        api.cancelBatchEdit();
+        await asyncSetTimeout(0);
+
+        const cellA0After = getByTestId(gridDiv, agTestIdFor.cell('ROW_0', 'a'));
+        expect(cellA0After).toHaveTextContent('A0');
+        expect(cellA0After).not.toHaveClass(/ag-cell-batch-edit/);
+        expect(cellA0After).not.toHaveClass(/ag-cell-editing/);
+
+        const row0 = cellA0After.closest('[row-index="0"]');
+        expect(row0).not.toHaveClass(/ag-row-batch-edit/);
+        expect(row0).not.toHaveClass(/ag-row-editing/);
+
+        const rowData = api.getGridOption('rowData')!;
+        expect(rowData[0].a).toBe('A0');
+
+        expect(eventTracker.counts.batchEditingStarted).toBe(1);
+        expect(eventTracker.counts.batchEditingStopped).toBe(1);
+        expect(eventTracker.counts.cellValueChanged).toBe(0);
+        expect(eventTracker.counts.rowValueChanged).toBe(0);
+    });
+
     test('cancelBatchEdit removes cell and row styles and reverts values', async () => {
         const api = await createGrid();
         const eventTracker = new EditEventTracker(api);


### PR DESCRIPTION
the condition that invoked cleanupEditors was too restrictive and was not considering batch mode.
By checking if there is any editing in the grid instead of just the row solves the issue

FIX AG-15609