### PR TITLE
AG-17114 Correct behaviour for suppressShowOnUngroup

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/grouping-group-panel/_examples/keep-columns-visible/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grouping-group-panel/_examples/keep-columns-visible/example.spec.ts
@@ -1,11 +1,63 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
+
+type SuppressValue = 'false' | 'true' | 'suppressHideOnGroup' | 'suppressShowOnUngroup';
+
+interface Case {
+    value: SuppressValue;
+    hiddenAfterGroup: boolean;
+    hiddenAfterUngroup: boolean;
+}
+
+// The four combinations documented for `suppressGroupChangesColumnVisibility`,
+// plus the default `'false'`. After grouping the column should be hidden unless
+// hiding is suppressed; after ungrouping it should be visible again unless
+// showing is suppressed.
+const cases: Case[] = [
+    { value: 'false', hiddenAfterGroup: true, hiddenAfterUngroup: false },
+    { value: 'true', hiddenAfterGroup: false, hiddenAfterUngroup: false },
+    { value: 'suppressHideOnGroup', hiddenAfterGroup: false, hiddenAfterUngroup: false },
+    { value: 'suppressShowOnUngroup', hiddenAfterGroup: true, hiddenAfterUngroup: true },
+];
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Example', async ({ agIdFor, page, remoteGrid }) => {
+        const remoteApi = remoteGrid(page, '1');
+        const dropdown = page.locator('#visibility-behaviour');
+        const resetButton = page.getByRole('button', { name: 'Reset Column Visibility' });
+        const countryHeader = agIdFor.headerCell('country');
+
+        await expect(countryHeader).toBeVisible();
+
+        for (const { value, hiddenAfterGroup, hiddenAfterUngroup } of cases) {
+            await dropdown.selectOption(value);
+
+            await remoteApi.addRowGroupColumns(['country']);
+            if (hiddenAfterGroup) {
+                await expect(countryHeader, `${value}: country header should be hidden after grouping`).toBeHidden();
+            } else {
+                await expect(
+                    countryHeader,
+                    `${value}: country header should stay visible after grouping`
+                ).toBeVisible();
+            }
+
+            await remoteApi.removeRowGroupColumns(['country']);
+            if (hiddenAfterUngroup) {
+                await expect(
+                    countryHeader,
+                    `${value}: country header should stay hidden after ungrouping`
+                ).toBeHidden();
+            } else {
+                await expect(
+                    countryHeader,
+                    `${value}: country header should be visible again after ungrouping`
+                ).toBeVisible();
+            }
+
+            // Reset replaces `columnDefs` with all columns visible and ungrouped,
+            // giving each case a clean starting state.
+            await resetButton.click();
+            await expect(countryHeader).toBeVisible();
+        }
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/grouping-group-panel/_examples/prevent-group-order-changes/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grouping-group-panel/_examples/prevent-group-order-changes/example.spec.ts
@@ -1,11 +1,26 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Example', async ({ agIdFor }) => {
+        const rowGroupsArea = agIdFor.columnDropArea('panel', 'Row Groups');
+        const pills = rowGroupsArea.locator('.ag-column-drop-cell');
+
+        // Both initial row group columns show as pills.
+        await expect(pills).toHaveCount(2);
+        await expect(rowGroupsArea.getByText('Country', { exact: true })).toBeVisible();
+        await expect(rowGroupsArea.getByText('Year', { exact: true })).toBeVisible();
+
+        // `groupLockGroupColumns: -1` locks every pill — the remove (X) button must not
+        // be shown, and the drag handle carries the readonly class so the pill cannot be
+        // dragged out of the panel.
+        const removeButtons = pills.locator('.ag-column-drop-cell-button');
+        const count = await removeButtons.count();
+        for (let i = 0; i < count; i++) {
+            await expect(removeButtons.nth(i)).toBeHidden();
+        }
+
+        const dragHandles = pills.locator('.ag-column-drop-cell-drag-handle');
+        await expect(dragHandles.first()).toHaveClass(/ag-column-select-column-readonly/);
+        await expect(dragHandles.last()).toHaveClass(/ag-column-select-column-readonly/);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/grouping-group-panel/_examples/prevent-panel-sorting/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grouping-group-panel/_examples/prevent-panel-sorting/example.spec.ts
@@ -1,11 +1,29 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Example', async ({ agIdFor, page }) => {
+        const rowGroupsArea = agIdFor.columnDropArea('panel', 'Row Groups');
+        const countryPill = rowGroupsArea.locator('.ag-column-drop-cell').filter({ hasText: 'Country' }).first();
+        const yearPill = rowGroupsArea.locator('.ag-column-drop-cell').filter({ hasText: 'Year' }).first();
+        const suppressSortCheckbox = page.locator('#rowGroupPanelSuppressSort');
+
+        // The pill's sort direction is exposed via its aria-label
+        // (e.g. "Country, ascending. Press ENTER to sort. Press DELETE to remove").
+        const countryLabel = async () => (await countryPill.getAttribute('aria-label')) ?? '';
+        const yearLabel = async () => (await yearPill.getAttribute('aria-label')) ?? '';
+
+        // Sort is enabled by default — clicking the Country pill cycles Country's sort
+        // and the direction appears in the aria-label.
+        const countryLabelBefore = await countryLabel();
+        await countryPill.click();
+        const countryLabelAfter = await countryLabel();
+        expect(countryLabelAfter).not.toBe(countryLabelBefore);
+
+        // Enable `rowGroupPanelSuppressSort`; clicking a pill must now be a no-op.
+        await suppressSortCheckbox.check();
+        const yearLabelBefore = await yearLabel();
+        await yearPill.click();
+        const yearLabelAfter = await yearLabel();
+        expect(yearLabelAfter).toBe(yearLabelBefore);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/grouping-group-panel/_examples/row-group-panel/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grouping-group-panel/_examples/row-group-panel/example.spec.ts
@@ -1,11 +1,20 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Example', async ({ agIdFor, page }) => {
+        const rowGroupsArea = agIdFor.columnDropArea('panel', 'Row Groups');
+
+        // Row group panel shows the two pills configured with `rowGroup: true`.
+        await expect(rowGroupsArea).toBeVisible();
+        await expect(rowGroupsArea.locator('.ag-column-drop-cell')).toHaveCount(2);
+        await expect(rowGroupsArea.getByText('Country', { exact: true })).toBeVisible();
+        await expect(rowGroupsArea.getByText('Year', { exact: true })).toBeVisible();
+
+        // Auto group column renders country groups; drill into United States -> 2008.
+        const usRowId = 'row-group-country-United States';
+        await expect(agIdFor.autoGroupCell(usRowId)).toContainText('United States', { useInnerText: true });
+
+        await agIdFor.autoGroupContracted(usRowId).click();
+        await expect(agIdFor.autoGroupCell(`${usRowId}-year-2008`)).toContainText('2008', { useInnerText: true });
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/grouping-group-panel/_examples/side-bar-row-group-panel/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grouping-group-panel/_examples/side-bar-row-group-panel/example.spec.ts
@@ -1,11 +1,19 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Example', async ({ agIdFor }) => {
+        // Side bar is displaying the columns tool panel with its own Row Groups drop area.
+        await expect(agIdFor.columnToolPanel()).toBeVisible();
+
+        const panelRowGroups = agIdFor.columnDropArea('toolbar', 'Row Groups');
+        await expect(panelRowGroups).toBeVisible();
+        await expect(panelRowGroups.locator('.ag-column-drop-cell')).toHaveCount(2);
+        await expect(panelRowGroups.getByText('Country', { exact: true })).toBeVisible();
+        await expect(panelRowGroups.getByText('Year', { exact: true })).toBeVisible();
+
+        // Aggregated Total is rendered on the country group row.
+        const usRowId = 'row-group-country-United States';
+        await expect(agIdFor.autoGroupCell(usRowId)).toContainText('United States', { useInnerText: true });
+        await expect(agIdFor.cell(usRowId, 'total')).not.toHaveText('');
     });
 });

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/baseDropZonePanel.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/baseDropZonePanel.ts
@@ -60,16 +60,16 @@ export abstract class BaseDropZonePanel extends PillDropZonePanel<DropZoneColumn
         return Math.min(numberOfLockedCols, numberOfGroupCols);
     }
 
-    private showOrHideColumnOnExit(draggingEvent: GridDraggingEvent): boolean {
+    private shouldToggleColumnVisibility(draggingEvent: GridDraggingEvent, isGrouped: boolean): boolean {
         return (
-            this.isRowGroupPanel() && _shouldUpdateColVisibilityAfterGroup(this.gos, true) && !draggingEvent.fromNudge
+            this.isRowGroupPanel() &&
+            _shouldUpdateColVisibilityAfterGroup(this.gos, isGrouped) &&
+            !draggingEvent.fromNudge
         );
     }
 
     protected override handleDragEnterEnd(draggingEvent: GridDraggingEvent): void {
-        const hideColumnOnExit = this.showOrHideColumnOnExit(draggingEvent);
-
-        if (hideColumnOnExit) {
+        if (this.shouldToggleColumnVisibility(draggingEvent, true)) {
             const dragItem = draggingEvent.dragSource.getDragItem();
             const columns = dragItem.columns as AgColumn[];
             this.setColumnsVisible(columns, false, 'uiColumnDragged');
@@ -77,9 +77,7 @@ export abstract class BaseDropZonePanel extends PillDropZonePanel<DropZoneColumn
     }
 
     protected override handleDragLeaveEnd(draggingEvent: GridDraggingEvent): void {
-        const showColumnOnExit = this.showOrHideColumnOnExit(draggingEvent);
-
-        if (showColumnOnExit) {
+        if (this.shouldToggleColumnVisibility(draggingEvent, false)) {
             const dragItem = draggingEvent.dragSource.getDragItem();
 
             this.setColumnsVisible(dragItem.columns as AgColumn[], true, 'uiColumnDragged');

--- a/testing/behavioural/src/grouping-data/suppress-group-changes-column-visibility.test.ts
+++ b/testing/behavioural/src/grouping-data/suppress-group-changes-column-visibility.test.ts
@@ -1,0 +1,122 @@
+import type { AgColumn, GridApi, GridOptions } from 'ag-grid-community';
+import { ClientSideRowModelModule } from 'ag-grid-community';
+import { RowGroupingModule, RowGroupingPanelModule } from 'ag-grid-enterprise';
+
+import { AgGridHeaderDropZonesSelector } from '../../../../packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/agGridHeaderDropZones';
+import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+
+type SuppressValue = GridOptions['suppressGroupChangesColumnVisibility'];
+
+describe('suppressGroupChangesColumnVisibility', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule, RowGroupingPanelModule],
+    });
+
+    beforeEach(() => gridsManager.reset());
+    afterEach(() => gridsManager.reset());
+
+    async function createGrid(suppressGroupChangesColumnVisibility: SuppressValue): Promise<GridApi> {
+        return gridsManager.createGridAndWait('myGrid', {
+            columnDefs: [{ field: 'athlete' }, { field: 'country', enableRowGroup: true }, { field: 'year' }],
+            rowData: [
+                { athlete: 'Michael Phelps', country: 'United States', year: 2008 },
+                { athlete: 'Julian Weber', country: 'Romania', year: 2000 },
+            ],
+            rowGroupPanelShow: 'always',
+            suppressGroupChangesColumnVisibility,
+        });
+    }
+
+    function getRowGroupDropZonePanel(gridApi: GridApi): any {
+        const country = gridApi.getColumn('country') as any;
+        const HeaderDropZones = AgGridHeaderDropZonesSelector.component as any;
+        const headerDropZones = country.createBean(new HeaderDropZones()) as any;
+        return headerDropZones.rowGroupComp;
+    }
+
+    function makeSyntheticDragEvent(columns: AgColumn[]): any {
+        return {
+            dragSource: {
+                getDragItem: () => ({ columns }),
+            },
+            fromNudge: false,
+        };
+    }
+
+    /**
+     * Expected column visibility after each grouping transition, for each supported value of
+     * `suppressGroupChangesColumnVisibility`. `hiddenAfterGroup` is the expected visibility
+     * after the column is added to the row groups; `hiddenAfterUngroup` is the expected
+     * visibility after the column is subsequently removed from the row groups.
+     */
+    const cases: Array<{
+        label: string;
+        value: SuppressValue;
+        hiddenAfterGroup: boolean;
+        hiddenAfterUngroup: boolean;
+    }> = [
+        { label: 'default (undefined)', value: undefined, hiddenAfterGroup: true, hiddenAfterUngroup: false },
+        { label: 'true', value: true, hiddenAfterGroup: false, hiddenAfterUngroup: false },
+        {
+            label: '"suppressHideOnGroup"',
+            value: 'suppressHideOnGroup',
+            hiddenAfterGroup: false,
+            hiddenAfterUngroup: false,
+        },
+        {
+            label: '"suppressShowOnUngroup"',
+            value: 'suppressShowOnUngroup',
+            hiddenAfterGroup: true,
+            hiddenAfterUngroup: true,
+        },
+    ];
+
+    describe.each(cases)('$label', ({ value, hiddenAfterGroup, hiddenAfterUngroup }) => {
+        test('grid API: add then remove row group column', async () => {
+            const api = await createGrid(value);
+            const country = api.getColumn('country')!;
+
+            expect(country.isVisible()).toBe(true);
+
+            api.addRowGroupColumns(['country']);
+            expect(country.isVisible()).toBe(!hiddenAfterGroup);
+
+            api.removeRowGroupColumns(['country']);
+            expect(country.isVisible()).toBe(!hiddenAfterUngroup);
+        });
+
+        test('drag: column dragged into the row group panel', async () => {
+            const api = await createGrid(value);
+            const country = api.getColumn('country')! as unknown as AgColumn;
+            const panel = getRowGroupDropZonePanel(api);
+
+            expect(country.isVisible()).toBe(true);
+
+            // Simulates the final phase of `onDragEnter` on the row group drop zone,
+            // which fires when a column header is dragged over the panel.
+            panel['handleDragEnterEnd'](makeSyntheticDragEvent([country]));
+            await asyncSetTimeout(0);
+
+            expect(country.isVisible()).toBe(!hiddenAfterGroup);
+        });
+
+        test('drag: pill dragged out of the row group panel', async () => {
+            const api = await createGrid(value);
+            const country = api.getColumn('country')! as unknown as AgColumn;
+            const panel = getRowGroupDropZonePanel(api);
+
+            api.addRowGroupColumns(['country']);
+            expect(country.isVisible()).toBe(!hiddenAfterGroup);
+
+            // `onDragLeave` in the real flow first removes the column from row groups (via
+            // `updateItems` -> `setRowGroupColumns`), then calls `handleDragLeaveEnd`. The
+            // two together must respect the suppress setting — `handleDragLeaveEnd` must
+            // not re-show a column the first step correctly left hidden.
+            api.removeRowGroupColumns(['country']);
+            panel['handleDragLeaveEnd'](makeSyntheticDragEvent([country]));
+            await asyncSetTimeout(0);
+
+            expect(country.isVisible()).toBe(!hiddenAfterUngroup);
+        });
+    });
+});


### PR DESCRIPTION
Fix [AG-17114](https://ag-grid.atlassian.net/browse/AG-17114)

PR is mainly tests for the different combination of the flags and removing one hardcoded true value which meant the flag went down the wrong code path.
