### PR TITLE
feat: add api.applyAutoSizeStrategy() for runtime reapplication (#13525)

### DIFF
--- a/documentation/ag-grid-docs/src/content/api-documentation/grid-api/api.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/grid-api/api.json
@@ -75,6 +75,12 @@
                 "name": "Auto-Size Columns to Fit Cell Contents",
                 "url": "./column-sizing/#auto-size-columns-to-fit-cell-contents"
             }
+        },
+        "applyAutoSizeStrategy": {
+            "more": {
+                "name": "Reapplying the Auto-Size Strategy at Runtime",
+                "url": "./column-sizing/#reapplying-the-auto-size-strategy-at-runtime"
+            }
         }
     },
     "columnMoving": {

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/apply-auto-size-strategy/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/apply-auto-size-strategy/example.spec.ts
@@ -1,0 +1,74 @@
+import { type AgGridFixtures, expect, test, waitForGridContent } from '@utils/grid/test-utils';
+import type { Locator, Page } from 'playwright/test';
+
+async function getWidth(locator: Locator): Promise<number | undefined> {
+    return (await locator.boundingBox())?.width;
+}
+
+const COL_IDS = ['athlete', 'age', 'country', 'year', 'date', 'sport'] as const;
+
+type ColIds = (typeof COL_IDS)[number];
+
+function getHeaders(agIdFor: AgGridFixtures['agIdFor']): Record<ColIds, Locator> {
+    return Object.fromEntries(COL_IDS.map((colId) => [colId, agIdFor.headerCell(colId)])) as Record<ColIds, Locator>;
+}
+
+async function totalHeaderWidth(headers: Record<ColIds, Locator>): Promise<number> {
+    const widths = await Promise.all(Object.values(headers).map(getWidth));
+    return widths.reduce<number>((acc, w) => acc + (w ?? 0), 0);
+}
+
+// wait twice as long as animation so we know widths have settled
+async function waitForAnimation(page: Page): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    await expect(page.locator('.ag-animate-autosize')).not.toBeVisible();
+}
+
+test.agExample(import.meta, () => {
+    test.eachFramework('override: fitProvidedWidth sizes columns to total width', async ({ page, agIdFor }) => {
+        await waitForGridContent(page);
+        await waitForAnimation(page);
+
+        const headers = getHeaders(agIdFor);
+
+        await page.getByRole('button', { name: /fitProvidedWidth/ }).click();
+        await waitForAnimation(page);
+
+        // All columns must sum to 600 (allowing 1px tolerance for sub-pixel rounding).
+        const total = await totalHeaderWidth(headers);
+        expect(total).toBeGreaterThanOrEqual(599);
+        expect(total).toBeLessThanOrEqual(601);
+    });
+
+    test.eachFramework('override: fitGridWidth fills the viewport', async ({ page, agIdFor }) => {
+        await waitForGridContent(page);
+        await waitForAnimation(page);
+
+        const headers = getHeaders(agIdFor);
+
+        // First shrink with fitProvidedWidth so we can verify fitGridWidth grows.
+        await page.getByRole('button', { name: /fitProvidedWidth/ }).click();
+        await waitForAnimation(page);
+        const shrunkTotal = await totalHeaderWidth(headers);
+
+        await page.getByRole('button', { name: /fitGridWidth/ }).click();
+        await waitForAnimation(page);
+
+        const grownTotal = await totalHeaderWidth(headers);
+        expect(grownTotal).toBeGreaterThan(shrunkTotal);
+    });
+
+    test.eachFramework('re-apply configured strategy is idempotent', async ({ page, agIdFor }) => {
+        await waitForGridContent(page);
+        await waitForAnimation(page);
+
+        const headers = getHeaders(agIdFor);
+        const beforeTotal = await totalHeaderWidth(headers);
+
+        await page.getByRole('button', { name: /Re-apply Configured Strategy/ }).click();
+        await waitForAnimation(page);
+
+        const afterTotal = await totalHeaderWidth(headers);
+        expect(Math.abs(afterTotal - beforeTotal)).toBeLessThanOrEqual(2);
+    });
+});

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/apply-auto-size-strategy/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/apply-auto-size-strategy/index.html
@@ -1,0 +1,11 @@
+<div class="outer-div">
+    <div class="button-bar">
+        <button onclick="applyConfigured()">Re-apply Configured Strategy</button>
+        <button onclick="applyFitCellContents()">Override: fitCellContents</button>
+        <button onclick="applyFitGridWidth()">Override: fitGridWidth</button>
+        <button onclick="applyFitProvidedWidth()">Override: fitProvidedWidth (600px)</button>
+    </div>
+    <div class="grid-wrapper">
+        <div id="myGrid" style="height: 100%"></div>
+    </div>
+</div>

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/apply-auto-size-strategy/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/apply-auto-size-strategy/main.ts
@@ -1,0 +1,63 @@
+import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    ColumnAutoSizeModule,
+    ModuleRegistry,
+    ValidationModule,
+    createGrid,
+} from 'ag-grid-community';
+
+ModuleRegistry.registerModules([
+    ColumnAutoSizeModule,
+    ClientSideRowModelModule,
+    ...(process.env.NODE_ENV !== 'production' ? [ValidationModule] : []),
+]);
+
+const columnDefs: ColDef[] = [
+    { field: 'athlete', width: 150 },
+    { field: 'age', width: 90 },
+    { field: 'country', width: 120 },
+    { field: 'year', width: 90 },
+    { field: 'date', width: 110 },
+    { field: 'sport', width: 110 },
+];
+
+let gridApi: GridApi<IOlympicData>;
+
+const gridOptions: GridOptions<IOlympicData> = {
+    columnDefs: columnDefs,
+    // The configured strategy is used when api.applyAutoSizeStrategy() is called with no arguments.
+    autoSizeStrategy: {
+        type: 'fitCellContents',
+        defaultMinWidth: 80,
+    },
+};
+
+// Re-apply the strategy configured on gridOptions. Useful from a ResizeObserver on the grid's
+// container, after rows are refreshed, or any time layout inputs change.
+function applyConfigured() {
+    gridApi!.applyAutoSizeStrategy();
+}
+
+// Pass any strategy as an override — the grid option value is ignored for this call.
+function applyFitCellContents() {
+    gridApi!.applyAutoSizeStrategy({ type: 'fitCellContents', defaultMinWidth: 80 });
+}
+
+function applyFitGridWidth() {
+    gridApi!.applyAutoSizeStrategy({ type: 'fitGridWidth', defaultMinWidth: 100 });
+}
+
+function applyFitProvidedWidth() {
+    gridApi!.applyAutoSizeStrategy({ type: 'fitProvidedWidth', width: 600 });
+}
+
+// setup the grid after the page has finished loading
+document.addEventListener('DOMContentLoaded', () => {
+    const gridDiv = document.querySelector<HTMLElement>('#myGrid')!;
+    gridApi = createGrid(gridDiv, gridOptions);
+
+    fetch('https://www.ag-grid.com/example-assets/small-olympic-winners.json')
+        .then((response) => response.json())
+        .then((data: IOlympicData[]) => gridApi!.setGridOption('rowData', data));
+});

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/apply-auto-size-strategy/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/apply-auto-size-strategy/styles.css
@@ -1,0 +1,16 @@
+.outer-div {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.button-bar {
+    margin-bottom: 1rem;
+    display: flex;
+    gap: 0.5em;
+    flex-wrap: wrap;
+}
+
+.grid-wrapper {
+    flex: 1 1 auto;
+}

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
@@ -179,6 +179,22 @@ Just like Excel, each column can also be auto-resized by double clicking the rig
 
 {% /note %}
 
+### Reapplying the Auto-Size Strategy at Runtime
+
+The `autoSizeStrategy` grid option is applied once when the grid is first loaded. To reapply the configured strategy later — for example in response to a container resize or after rows are refreshed — call `api.applyAutoSizeStrategy()`. The method runs the same dispatch that is used at init time, so a single call handles whichever variant is configured (`fitGridWidth`, `fitProvidedWidth`, or `fitCellContents`, including `scaleUpToFitGridWidth`).
+
+```{% frameworkTransform=true %}
+// Use the strategy configured on gridOptions.autoSizeStrategy
+api.applyAutoSizeStrategy();
+
+// Or pass an explicit strategy to override the configured one
+api.applyAutoSizeStrategy({ type: 'fitCellContents', scaleUpToFitGridWidth: true });
+```
+
+If no strategy is configured on `gridOptions.autoSizeStrategy` and no override is provided, the call is a no-op. Columns resized by this call fire the `columnResized` event with `source: 'autoSizeStrategy'`.
+
+{% apiDocumentation source="grid-api/api.json" section="columnSizing" names=["applyAutoSizeStrategy"] /%}
+
 ## Resize via Keyboard
 
 Column headers can be resized using the keyboard. When a column header is focused, press {% kbd "⌥ Alt" /%} + {% kbd "←" /%} / {% kbd "→" /%} to resize the column in that direction.

--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/index.mdoc
@@ -193,6 +193,10 @@ api.applyAutoSizeStrategy({ type: 'fitCellContents', scaleUpToFitGridWidth: true
 
 If no strategy is configured on `gridOptions.autoSizeStrategy` and no override is provided, the call is a no-op. Columns resized by this call fire the `columnResized` event with `source: 'autoSizeStrategy'`.
 
+The example below configures `fitCellContents` on `gridOptions.autoSizeStrategy` and exposes four buttons: one to re-apply the configured strategy, and three to override with each of the built-in variants.
+
+{% gridExampleRunner title="Applying the Auto-Size Strategy at Runtime" name="apply-auto-size-strategy" /%}
+
 {% apiDocumentation source="grid-api/api.json" section="columnSizing" names=["applyAutoSizeStrategy"] /%}
 
 ## Resize via Keyboard

--- a/packages/ag-grid-community/src/api/gridApi.ts
+++ b/packages/ag-grid-community/src/api/gridApi.ts
@@ -31,6 +31,7 @@ import type { CellRange, CellRangeParams } from '../interfaces/IRangeService';
 import type { ServerSideGroupLevelState } from '../interfaces/IServerSideStore';
 import type { AdvancedFilterModel } from '../interfaces/advancedFilterModel';
 import type {
+    AutoSizeStrategy,
     ISizeAllColumnsToContentParams,
     ISizeColumnsToContentParams,
     ISizeColumnsToFitParams,
@@ -635,6 +636,25 @@ export interface _ColumnAutosizeApi {
      * @agModule `ColumnAutoSizeModule`
      */
     autoSizeAllColumns(params: ISizeAllColumnsToContentParams): void;
+
+    /**
+     * Applies the configured `autoSizeStrategy` to the current columns. This runs the same logic
+     * that is applied on initial grid load, but can be called at any time — for example from a
+     * `ResizeObserver` on the grid's container when the user wants columns to respond to layout changes.
+     *
+     * If no strategy is configured via `gridOptions.autoSizeStrategy` and no `strategyOverride`
+     * is provided, this is a no-op.
+     *
+     * For best results with the `fitCellContents` strategy, call this after rows have rendered so
+     * that cell contents can be measured. If called before any rows are present, sizing will fall
+     * back to header text widths.
+     *
+     * Columns resized by this call fire `columnResized` with `source: 'autoSizeStrategy'`.
+     *
+     * @param strategyOverride Optional strategy to apply instead of the one configured on `gridOptions.autoSizeStrategy`.
+     * @agModule `ColumnAutoSizeModule`
+     */
+    applyAutoSizeStrategy(strategyOverride?: AutoSizeStrategy): void;
 }
 
 export interface _ColumnResizeApi {

--- a/packages/ag-grid-community/src/api/gridApiFunctions.ts
+++ b/packages/ag-grid-community/src/api/gridApiFunctions.ts
@@ -194,6 +194,7 @@ export const gridApiFunctionsMap: Record<keyof GridApi, ValidationModuleName> = 
         sizeColumnsToFit: 0,
         autoSizeColumns: 0,
         autoSizeAllColumns: 0,
+        applyAutoSizeStrategy: 0,
     }),
     ...mod<_ColumnGroupGridApi>('ColumnGroup', {
         setColumnGroupOpened: 0,

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeApi.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeApi.ts
@@ -1,6 +1,7 @@
 import type { BeanCollection } from '../context/context';
 import type { ColKey } from '../entities/colDef';
 import type {
+    AutoSizeStrategy,
     ISizeAllColumnsToContentParams,
     ISizeColumnsToContentParams,
     ISizeColumnsToFitParams,
@@ -43,4 +44,8 @@ export function autoSizeAllColumns(
     } else {
         beans.colAutosize?.autoSizeAllColumns({ source: 'api', skipHeader: paramsOrSkipHeader });
     }
+}
+
+export function applyAutoSizeStrategy(beans: BeanCollection, strategyOverride?: AutoSizeStrategy): void {
+    beans.colAutosize?.applyAutoSizeStrategy(strategyOverride);
 }

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeModule.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeModule.ts
@@ -3,7 +3,7 @@ import type { _ModuleWithApi } from '../interfaces/iModule';
 import { AutoWidthModule } from '../rendering/autoWidthModule';
 import { VERSION } from '../version';
 import columnAutoSizeCSS from './columnAutoSize.css';
-import { autoSizeAllColumns, autoSizeColumns, sizeColumnsToFit } from './columnAutosizeApi';
+import { applyAutoSizeStrategy, autoSizeAllColumns, autoSizeColumns, sizeColumnsToFit } from './columnAutosizeApi';
 import { ColumnAutosizeService } from './columnAutosizeService';
 
 /**
@@ -18,6 +18,7 @@ export const ColumnAutoSizeModule: _ModuleWithApi<_ColumnAutosizeApi> = {
         sizeColumnsToFit,
         autoSizeColumns,
         autoSizeAllColumns,
+        applyAutoSizeStrategy,
     },
     dependsOn: [AutoWidthModule],
     css: [columnAutoSizeCSS],

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
@@ -12,6 +12,7 @@ import type { ColumnEventType } from '../events';
 import { _isClientSideRowModel } from '../gridOptionsUtils';
 import type { HeaderGroupCellCtrl } from '../headerRendering/cells/columnGroup/headerGroupCellCtrl';
 import type {
+    AutoSizeStrategy,
     IColumnLimit,
     ISizeColumnsToFitParams,
     SizeColumnsToContentColumnLimits,
@@ -31,6 +32,13 @@ interface AutoSizeColumnParams {
     columnLimits?: SizeColumnsToContentColumnLimits[];
     scaleUpToFitGridWidth?: boolean;
     source?: ColumnEventType;
+    /**
+     * Source for the final batched `columnResized` event fired after all columns have been
+     * sized. Defaults to `'autosizeColumns'`. Separate from `source` so that callers using
+     * `autoSizeCols` as a building block (e.g. `applyAutoSizeStrategy`) can surface their own
+     * higher-level source without affecting per-column events or legacy behaviour.
+     */
+    eventSource?: ColumnEventType;
 }
 
 export class ColumnAutosizeService extends BeanStub implements NamedBean {
@@ -70,8 +78,9 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
         setWidthAnimation(this.beans, true);
 
         this.innerAutoSizeCols(params).then((columnsAutoSized) => {
+            const dispatchSource = params.eventSource ?? 'autosizeColumns';
             const dispatch = (cols: Set<AgColumn>) =>
-                dispatchColumnResizedEvent(eventSvc, Array.from(cols), true, 'autosizeColumns');
+                dispatchColumnResizedEvent(eventSvc, Array.from(cols), true, dispatchSource);
 
             if (!params.scaleUpToFitGridWidth) {
                 setWidthAnimation(this.beans, false);
@@ -250,6 +259,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
         defaultMaxWidth?: number;
         columnLimits?: SizeColumnsToContentColumnLimits[];
         source?: ColumnEventType;
+        eventSource?: ColumnEventType;
     }): void {
         if (this.shouldQueueResizeOperations) {
             this.pushResizeOperation(() => this.autoSizeAllColumns(params));
@@ -310,7 +320,11 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
 
     // method will call itself if no available width. this covers if the grid
     // isn't visible, but is just about to be visible.
-    public sizeColumnsToFitGridBody(params?: ISizeColumnsToFitParams, nextTimeout?: number): void {
+    public sizeColumnsToFitGridBody(
+        params?: ISizeColumnsToFitParams,
+        source: ColumnEventType = 'sizeColumnsToFit',
+        nextTimeout?: number
+    ): void {
         if (!this.isAlive()) {
             return;
         }
@@ -325,21 +339,21 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
         }
 
         if (availableWidth > 0) {
-            this.sizeColumnsToFit(availableWidth, 'sizeColumnsToFit', false, params);
+            this.sizeColumnsToFit(availableWidth, source, false, params);
             return;
         }
 
         if (nextTimeout === undefined) {
             window.setTimeout(() => {
-                this.sizeColumnsToFitGridBody(params, 100);
+                this.sizeColumnsToFitGridBody(params, source, 100);
             }, 0);
         } else if (nextTimeout === 100) {
             window.setTimeout(() => {
-                this.sizeColumnsToFitGridBody(params, 500);
+                this.sizeColumnsToFitGridBody(params, source, 500);
             }, 100);
         } else if (nextTimeout === 500) {
             window.setTimeout(() => {
-                this.sizeColumnsToFitGridBody(params, -1);
+                this.sizeColumnsToFitGridBody(params, source, -1);
             }, 500);
         } else {
             // Grid coming back with zero width, maybe the grid is not visible yet on the screen?
@@ -519,51 +533,86 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
     }
 
     public applyAutosizeStrategy(): void {
-        const { gos, colDelayRenderSvc } = this.beans;
-        const autoSizeStrategy = gos.get('autoSizeStrategy');
+        const autoSizeStrategy = this.beans.gos.get('autoSizeStrategy');
+        // fitCellContents is applied separately via the firstDataRendered listener registered in postConstruct.
         if (autoSizeStrategy?.type !== 'fitGridWidth' && autoSizeStrategy?.type !== 'fitProvidedWidth') {
             return;
         }
-
         // ensure things like aligned grids have linked first
+        this.dispatchAutoSizeStrategy(autoSizeStrategy, 'sizeColumnsToFit', true);
+    }
+
+    /**
+     * Public API entrypoint for `api.applyAutoSizeStrategy()`.
+     *
+     * Applies the configured `autoSizeStrategy` (or a caller-supplied override) to the current columns,
+     * without the init-time column hide/reveal dance (columns are already visible at this point).
+     * Emits `columnResized` with `source: 'autoSizeStrategy'`.
+     *
+     * Note the casing difference vs. `applyAutosizeStrategy` above — this method matches the public
+     * `api.applyAutoSizeStrategy` and the grid option name `autoSizeStrategy`, whereas the legacy
+     * init-only method keeps its historical one-word-"autosize" spelling.
+     */
+    public applyAutoSizeStrategy(strategyOverride?: AutoSizeStrategy): void {
+        const strategy = strategyOverride ?? this.beans.gos.get('autoSizeStrategy');
+        if (!strategy) {
+            return;
+        }
+        this.dispatchAutoSizeStrategy(strategy, 'autoSizeStrategy', false);
+    }
+
+    private onFirstDataRendered(strategy: SizeColumnsToContentStrategy): void {
+        this.dispatchAutoSizeStrategy(strategy, 'autosizeColumns', true);
+    }
+
+    /**
+     * Shared dispatch for applying an `AutoSizeStrategy`. Used both by the initial grid load path
+     * (via `applyAutosizeStrategy` and `onFirstDataRendered`) and by the public runtime API.
+     *
+     * The `setTimeout` wrapper defers to the next tick so that things like aligned grids or the
+     * initial render pass have a chance to settle before we measure/resize.
+     */
+    private dispatchAutoSizeStrategy(
+        strategy: AutoSizeStrategy,
+        source: ColumnEventType,
+        revealColumnsAfter: boolean
+    ): void {
         setTimeout(() => {
             if (!this.isAlive()) {
                 return;
             }
-            const type = autoSizeStrategy.type;
+            const type = strategy.type;
             if (type === 'fitGridWidth') {
-                const { columnLimits: propColumnLimits, defaultMinWidth, defaultMaxWidth } = autoSizeStrategy;
+                const { columnLimits: propColumnLimits, defaultMinWidth, defaultMaxWidth } = strategy;
                 const columnLimits = propColumnLimits?.map(({ colId: key, minWidth, maxWidth }) => ({
                     key,
                     minWidth,
                     maxWidth,
                 }));
-                this.sizeColumnsToFitGridBody({
-                    defaultMinWidth,
-                    defaultMaxWidth,
-                    columnLimits,
-                });
+                this.sizeColumnsToFitGridBody(
+                    {
+                        defaultMinWidth,
+                        defaultMaxWidth,
+                        columnLimits,
+                    },
+                    source
+                );
             } else if (type === 'fitProvidedWidth') {
-                this.sizeColumnsToFit(autoSizeStrategy.width, 'sizeColumnsToFit');
+                this.sizeColumnsToFit(strategy.width, source);
+            } else if (type === 'fitCellContents') {
+                const { colIds: colKeys, ...params } = strategy;
+                // `eventSource` ensures the final batched columnResized event surfaces the caller's
+                // source (e.g. 'autoSizeStrategy') rather than the default 'autosizeColumns' used by
+                // other entrypoints that build on `autoSizeCols`.
+                if (colKeys) {
+                    this.autoSizeCols({ ...params, source, eventSource: source, colKeys });
+                } else {
+                    this.autoSizeAllColumns({ ...params, source, eventSource: source });
+                }
             }
-            colDelayRenderSvc?.revealColumns(type);
-        });
-    }
-
-    private onFirstDataRendered({ colIds: colKeys, ...params }: SizeColumnsToContentStrategy): void {
-        // ensure render has finished
-        setTimeout(() => {
-            if (!this.isAlive()) {
-                return;
+            if (revealColumnsAfter) {
+                this.beans.colDelayRenderSvc?.revealColumns(type);
             }
-            const source = 'autosizeColumns';
-
-            if (colKeys) {
-                this.autoSizeCols({ ...params, source, colKeys });
-            } else {
-                this.autoSizeAllColumns({ ...params, source });
-            }
-            this.beans.colDelayRenderSvc?.revealColumns(params.type);
         });
     }
 

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
@@ -32,12 +32,7 @@ interface AutoSizeColumnParams {
     columnLimits?: SizeColumnsToContentColumnLimits[];
     scaleUpToFitGridWidth?: boolean;
     source?: ColumnEventType;
-    /**
-     * Source for the final batched `columnResized` event fired after all columns have been
-     * sized. Defaults to `'autosizeColumns'`. Separate from `source` so that callers using
-     * `autoSizeCols` as a building block (e.g. `applyAutoSizeStrategy`) can surface their own
-     * higher-level source without affecting per-column events or legacy behaviour.
-     */
+    /** Override for the final batched `columnResized` event. Defaults to `'autosizeColumns'` to preserve pre-existing behaviour for `uiColumnResized`/`api` callers. */
     eventSource?: ColumnEventType;
 }
 
@@ -532,27 +527,15 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
         }
     }
 
-    public applyAutosizeStrategy(): void {
+    public applyInitialAutoSizeStrategy(): void {
         const autoSizeStrategy = this.beans.gos.get('autoSizeStrategy');
         // fitCellContents is applied separately via the firstDataRendered listener registered in postConstruct.
         if (autoSizeStrategy?.type !== 'fitGridWidth' && autoSizeStrategy?.type !== 'fitProvidedWidth') {
             return;
         }
-        // ensure things like aligned grids have linked first
         this.dispatchAutoSizeStrategy(autoSizeStrategy, 'sizeColumnsToFit', true);
     }
 
-    /**
-     * Public API entrypoint for `api.applyAutoSizeStrategy()`.
-     *
-     * Applies the configured `autoSizeStrategy` (or a caller-supplied override) to the current columns,
-     * without the init-time column hide/reveal dance (columns are already visible at this point).
-     * Emits `columnResized` with `source: 'autoSizeStrategy'`.
-     *
-     * Note the casing difference vs. `applyAutosizeStrategy` above — this method matches the public
-     * `api.applyAutoSizeStrategy` and the grid option name `autoSizeStrategy`, whereas the legacy
-     * init-only method keeps its historical one-word-"autosize" spelling.
-     */
     public applyAutoSizeStrategy(strategyOverride?: AutoSizeStrategy): void {
         const strategy = strategyOverride ?? this.beans.gos.get('autoSizeStrategy');
         if (!strategy) {
@@ -565,13 +548,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
         this.dispatchAutoSizeStrategy(strategy, 'autosizeColumns', true);
     }
 
-    /**
-     * Shared dispatch for applying an `AutoSizeStrategy`. Used both by the initial grid load path
-     * (via `applyAutosizeStrategy` and `onFirstDataRendered`) and by the public runtime API.
-     *
-     * The `setTimeout` wrapper defers to the next tick so that things like aligned grids or the
-     * initial render pass have a chance to settle before we measure/resize.
-     */
+    // setTimeout defers to the next tick so aligned grids / initial render can settle before we measure.
     private dispatchAutoSizeStrategy(
         strategy: AutoSizeStrategy,
         source: ColumnEventType,
@@ -601,9 +578,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
                 this.sizeColumnsToFit(strategy.width, source);
             } else if (type === 'fitCellContents') {
                 const { colIds: colKeys, ...params } = strategy;
-                // `eventSource` ensures the final batched columnResized event surfaces the caller's
-                // source (e.g. 'autoSizeStrategy') rather than the default 'autosizeColumns' used by
-                // other entrypoints that build on `autoSizeCols`.
+                // eventSource overrides the batched dispatch so the caller's source reaches consumers.
                 if (colKeys) {
                     this.autoSizeCols({ ...params, source, eventSource: source, colKeys });
                 } else {

--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -165,7 +165,7 @@ export class ColumnModel extends BeanStub implements NamedBean {
         });
 
         if (source === 'gridInitializing') {
-            colAutosize?.applyAutosizeStrategy();
+            colAutosize?.applyInitialAutoSizeStrategy();
         }
     }
 

--- a/packages/ag-grid-community/src/events.ts
+++ b/packages/ag-grid-community/src/events.ts
@@ -787,6 +787,7 @@ export interface ExpandOrCollapseAllEvent<TData = any, TContext = any>
 export type ColumnEventType =
     | 'sizeColumnsToFit'
     | 'autosizeColumns'
+    | 'autoSizeStrategy'
     | 'autosizeColumnHeaderHeight'
     | 'alignedGridChanged'
     | 'filterChanged'

--- a/testing/behavioural/src/columns/apply-auto-size-strategy.test.ts
+++ b/testing/behavioural/src/columns/apply-auto-size-strategy.test.ts
@@ -1,20 +1,3 @@
-/**
- * Tests for the `api.applyAutoSizeStrategy()` grid API method. Covers:
- * - No-op when no strategy is configured and no override is passed
- * - Applies `fitProvidedWidth` configured on `gridOptions.autoSizeStrategy`
- * - Applies a strategy passed as the override argument
- * - Override argument takes precedence over the configured strategy
- * - Applies `fitGridWidth`
- * - Applies `fitCellContents` (autoSizeAllColumns path)
- * - Applies `fitCellContents` with `colIds` (autoSizeCols path)
- * - Is callable repeatedly (no one-shot guards)
- * - `columnResized` fires with `source: 'autoSizeStrategy'`
- *
- * Note: jsdom has no real layout engine. `mockGridLayout` (applied by
- * `TestGridsManager` by default) gives the grid a simulated width of 1000px
- * and simulated column widths of 150px. These tests assert behaviour that
- * does not depend on real cell content measurement.
- */
 import { ClientSideRowModelModule, ColumnAutoSizeModule } from 'ag-grid-community';
 
 import { TestGridsManager, asyncSetTimeout } from '../test-utils';
@@ -189,15 +172,14 @@ describe('applyAutoSizeStrategy API', () => {
         api.applyAutoSizeStrategy({ type: 'fitCellContents', colIds: ['a', 'b'] });
         await asyncSetTimeout(5);
 
-        // Expect only columns a and b to appear in resize events; c should not be targeted.
+        expect(listener).toHaveBeenCalled();
         const resizedColIds = new Set<string>();
         for (const [ev] of listener.mock.calls) {
             for (const col of ev.columns ?? []) {
                 resizedColIds.add(col.getColId());
             }
         }
-        // At least one of the targeted columns should show up in the events,
-        // and 'c' should not appear as a target.
+        expect(resizedColIds.has('a') || resizedColIds.has('b')).toBe(true);
         expect(resizedColIds.has('c')).toBe(false);
 
         api.removeEventListener('columnResized', listener);

--- a/testing/behavioural/src/columns/apply-auto-size-strategy.test.ts
+++ b/testing/behavioural/src/columns/apply-auto-size-strategy.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for the `api.applyAutoSizeStrategy()` grid API method. Covers:
+ * - No-op when no strategy is configured and no override is passed
+ * - Applies `fitProvidedWidth` configured on `gridOptions.autoSizeStrategy`
+ * - Applies a strategy passed as the override argument
+ * - Override argument takes precedence over the configured strategy
+ * - Applies `fitGridWidth`
+ * - Applies `fitCellContents` (autoSizeAllColumns path)
+ * - Applies `fitCellContents` with `colIds` (autoSizeCols path)
+ * - Is callable repeatedly (no one-shot guards)
+ * - `columnResized` fires with `source: 'autoSizeStrategy'`
+ *
+ * Note: jsdom has no real layout engine. `mockGridLayout` (applied by
+ * `TestGridsManager` by default) gives the grid a simulated width of 1000px
+ * and simulated column widths of 150px. These tests assert behaviour that
+ * does not depend on real cell content measurement.
+ */
+import { ClientSideRowModelModule, ColumnAutoSizeModule } from 'ag-grid-community';
+
+import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+
+describe('applyAutoSizeStrategy API', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, ColumnAutoSizeModule],
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    test('is a no-op when no strategy is configured and no override is passed', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ colId: 'a' }, { colId: 'b' }],
+        });
+
+        // Let any init work settle.
+        await asyncSetTimeout(5);
+
+        const listener = vitest.fn();
+        api.addEventListener('columnResized', listener);
+
+        api.applyAutoSizeStrategy();
+        await asyncSetTimeout(5);
+
+        expect(listener).not.toHaveBeenCalled();
+        api.removeEventListener('columnResized', listener);
+    });
+
+    test('applies fitProvidedWidth configured on gridOptions.autoSizeStrategy', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { colId: 'a', width: 100 },
+                { colId: 'b', width: 100 },
+            ],
+            autoSizeStrategy: { type: 'fitProvidedWidth', width: 600 },
+        });
+
+        // Wait for the init-time application to complete so the subsequent API call is isolated from it.
+        await asyncSetTimeout(10);
+        expect(api.getColumn('a')!.getActualWidth() + api.getColumn('b')!.getActualWidth()).toBe(600);
+
+        // Force columns off the configured total so the no-arg re-application isn't a no-op.
+        // (`sizeColumnsToFit` correctly short-circuits when current widths already satisfy the target.)
+        api.applyAutoSizeStrategy({ type: 'fitProvidedWidth', width: 400 });
+        await asyncSetTimeout(10);
+        expect(api.getColumn('a')!.getActualWidth() + api.getColumn('b')!.getActualWidth()).toBe(400);
+
+        // Attach listener and verify the no-arg call re-applies the configured strategy (600) with the new source.
+        const listener = vitest.fn();
+        api.addEventListener('columnResized', listener);
+
+        api.applyAutoSizeStrategy();
+        await asyncSetTimeout(10);
+
+        expect(api.getColumn('a')!.getActualWidth() + api.getColumn('b')!.getActualWidth()).toBe(600);
+
+        const sources = listener.mock.calls.map(([ev]) => ev.source);
+        expect(sources).toContain('autoSizeStrategy');
+
+        api.removeEventListener('columnResized', listener);
+    });
+
+    test('applies the strategy passed as the override argument', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { colId: 'a', width: 100 },
+                { colId: 'b', width: 100 },
+            ],
+        });
+
+        await asyncSetTimeout(5);
+
+        api.applyAutoSizeStrategy({ type: 'fitProvidedWidth', width: 800 });
+        await asyncSetTimeout(5);
+
+        const totalWidth = api.getColumn('a')!.getActualWidth() + api.getColumn('b')!.getActualWidth();
+        expect(totalWidth).toBe(800);
+    });
+
+    test('override argument takes precedence over the configured strategy', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { colId: 'a', width: 100 },
+                { colId: 'b', width: 100 },
+            ],
+            autoSizeStrategy: { type: 'fitProvidedWidth', width: 400 },
+        });
+
+        // Let the init-time application complete (columns should now sum to 400).
+        await asyncSetTimeout(10);
+        expect(api.getColumn('a')!.getActualWidth() + api.getColumn('b')!.getActualWidth()).toBe(400);
+
+        // Override should win over the configured 400.
+        api.applyAutoSizeStrategy({ type: 'fitProvidedWidth', width: 800 });
+        await asyncSetTimeout(10);
+
+        expect(api.getColumn('a')!.getActualWidth() + api.getColumn('b')!.getActualWidth()).toBe(800);
+    });
+
+    test('applies fitGridWidth', async () => {
+        // mockGridLayout gives the grid a simulated width of 1000px.
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { colId: 'a', width: 100 },
+                { colId: 'b', width: 100 },
+            ],
+        });
+
+        await asyncSetTimeout(5);
+
+        const listener = vitest.fn();
+        api.addEventListener('columnResized', listener);
+
+        api.applyAutoSizeStrategy({ type: 'fitGridWidth' });
+        // sizeColumnsToFitGridBody defers on a zero-width check chain; give it room.
+        await asyncSetTimeout(50);
+
+        // Columns should have been resized (the exact widths depend on the mock layout).
+        const totalWidth = api.getColumn('a')!.getActualWidth() + api.getColumn('b')!.getActualWidth();
+        expect(totalWidth).toBeGreaterThan(200);
+
+        const sources = listener.mock.calls.map(([ev]) => ev.source);
+        expect(sources).toContain('autoSizeStrategy');
+
+        api.removeEventListener('columnResized', listener);
+    });
+
+    test('applies fitCellContents to all columns', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { colId: 'a', width: 100 },
+                { colId: 'b', width: 100 },
+            ],
+            rowData: [{ a: 'x', b: 'y' }],
+        });
+
+        await asyncSetTimeout(5);
+
+        const listener = vitest.fn();
+        api.addEventListener('columnResized', listener);
+
+        api.applyAutoSizeStrategy({ type: 'fitCellContents' });
+        await asyncSetTimeout(5);
+
+        // fitCellContents with no cell content in jsdom falls back to default widths,
+        // but the dispatch should still fire the event with the new source.
+        expect(listener).toHaveBeenCalled();
+        const sources = listener.mock.calls.map(([ev]) => ev.source);
+        expect(sources).toContain('autoSizeStrategy');
+
+        api.removeEventListener('columnResized', listener);
+    });
+
+    test('applies fitCellContents with colIds only to specified columns', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { colId: 'a', width: 100 },
+                { colId: 'b', width: 100 },
+                { colId: 'c', width: 100 },
+            ],
+            rowData: [{ a: 'x', b: 'y', c: 'z' }],
+        });
+
+        await asyncSetTimeout(5);
+
+        const listener = vitest.fn();
+        api.addEventListener('columnResized', listener);
+
+        api.applyAutoSizeStrategy({ type: 'fitCellContents', colIds: ['a', 'b'] });
+        await asyncSetTimeout(5);
+
+        // Expect only columns a and b to appear in resize events; c should not be targeted.
+        const resizedColIds = new Set<string>();
+        for (const [ev] of listener.mock.calls) {
+            for (const col of ev.columns ?? []) {
+                resizedColIds.add(col.getColId());
+            }
+        }
+        // At least one of the targeted columns should show up in the events,
+        // and 'c' should not appear as a target.
+        expect(resizedColIds.has('c')).toBe(false);
+
+        api.removeEventListener('columnResized', listener);
+    });
+
+    test('is callable repeatedly', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { colId: 'a', width: 100 },
+                { colId: 'b', width: 100 },
+            ],
+        });
+
+        await asyncSetTimeout(5);
+
+        api.applyAutoSizeStrategy({ type: 'fitProvidedWidth', width: 400 });
+        await asyncSetTimeout(5);
+        expect(api.getColumn('a')!.getActualWidth() + api.getColumn('b')!.getActualWidth()).toBe(400);
+
+        api.applyAutoSizeStrategy({ type: 'fitProvidedWidth', width: 700 });
+        await asyncSetTimeout(5);
+        expect(api.getColumn('a')!.getActualWidth() + api.getColumn('b')!.getActualWidth()).toBe(700);
+
+        api.applyAutoSizeStrategy({ type: 'fitProvidedWidth', width: 500 });
+        await asyncSetTimeout(5);
+        expect(api.getColumn('a')!.getActualWidth() + api.getColumn('b')!.getActualWidth()).toBe(500);
+    });
+});


### PR DESCRIPTION
Adds a public grid API method that reapplies the configured autoSizeStrategy (or an ad-hoc override) at any time after init — enabling column sizing in response to container resizes, filter changes, or other dynamic layout events without reloading the grid.

- New method: `api.applyAutoSizeStrategy(strategyOverride?)`
- Supports all three strategy variants (`fitGridWidth`, `fitProvidedWidth`, `fitCellContents`)
- No-op when neither override nor `gridOptions.autoSizeStrategy` is set
- Columns resized by this call fire `columnResized` with `source: 'autoSizeStrategy'`
- Init-time dispatch and runtime dispatch share a single helper
- `autoSizeCols` gains a narrow opt-in `eventSource` for the final batched dispatch so the strategy's source surfaces without disturbing existing autosize call sites
- Adds behavioural test coverage and a "Reapplying the Auto-Size Strategy at Runtime" subsection under Column Sizing with an interactive example

## Review follow-ups

- Renamed the init-only `applyAutosizeStrategy` to `applyInitialAutoSizeStrategy` to remove the confusing casing collision with the public API
- Trimmed multi-line JSDocs on internal autosize service methods
- Tightened the `fitCellContents` + `colIds` behavioural test to assert at least one targeted column appears in the resize events
- Added an interactive docs example with four buttons (re-apply configured, override with each built-in variant) and cross-framework Playwright coverage

Closes #13525