### PR TITLE
fix(docs): repair failing row-pagination doc-tests

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/row-pagination/_examples/client-paging/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-pagination/_examples/client-paging/example.spec.ts
@@ -5,30 +5,30 @@ test.agExample(import.meta, () => {
         // First row on page 1
         await expect(agIdFor.cell('0', 'athlete')).toContainText('Michael Phelps');
 
-        // Pagination row summary: 1 to 10 of 8,618
+        // Pagination row summary: 1 to 100 of 8,618 (default page size is 100)
         await expect(agIdFor.paginationPanelFirstRowOnPage('1')).toBeVisible();
-        await expect(agIdFor.paginationPanelLastRowOnPage('10')).toBeVisible();
+        await expect(agIdFor.paginationPanelLastRowOnPage('100')).toBeVisible();
         await expect(agIdFor.paginationPanelRecordCount('8,618')).toBeVisible();
 
-        // Pagination page summary: Page 1 of 862
+        // Pagination page summary: Page 1 of 87
         await expect(agIdFor.paginationSummaryPanelCurrentPage('1')).toBeVisible();
-        await expect(agIdFor.paginationSummaryPanelTotalPage('862')).toBeVisible();
+        await expect(agIdFor.paginationSummaryPanelTotalPage('87')).toBeVisible();
     });
 
     test.eachFramework('Navigates to next page', async ({ agIdFor }) => {
         await agIdFor.paginationSummaryPanelButton('next page').click();
 
-        // Page 2: rows 11-20
+        // Page 2: rows 101-200
         await expect(agIdFor.paginationSummaryPanelCurrentPage('2')).toBeVisible();
-        await expect(agIdFor.paginationPanelFirstRowOnPage('11')).toBeVisible();
-        await expect(agIdFor.paginationPanelLastRowOnPage('20')).toBeVisible();
+        await expect(agIdFor.paginationPanelFirstRowOnPage('101')).toBeVisible();
+        await expect(agIdFor.paginationPanelLastRowOnPage('200')).toBeVisible();
     });
 
     test.eachFramework('Navigates to last page', async ({ agIdFor }) => {
         await agIdFor.paginationSummaryPanelButton('last page').click();
 
-        await expect(agIdFor.paginationSummaryPanelCurrentPage('862')).toBeVisible();
-        await expect(agIdFor.paginationPanelFirstRowOnPage('8,611')).toBeVisible();
+        await expect(agIdFor.paginationSummaryPanelCurrentPage('87')).toBeVisible();
+        await expect(agIdFor.paginationPanelFirstRowOnPage('8,601')).toBeVisible();
         await expect(agIdFor.paginationPanelLastRowOnPage('8,618')).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/row-pagination/_examples/custom-controls/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-pagination/_examples/custom-controls/example.spec.ts
@@ -21,7 +21,7 @@ test.agExample(import.meta, () => {
     test.eachFramework('To Page 5 navigates to page 5', async ({ agIdFor, page }) => {
         await expect(agIdFor.cell('0', 'athlete')).toContainText('Michael Phelps');
 
-        await page.locator('button', { hasText: 'To Page 5' }).click();
+        await page.getByRole('button', { name: 'To Page 5', exact: true }).click();
         await expect(page.locator('#lbCurrentPage')).toContainText('5');
     });
 

--- a/documentation/ag-grid-docs/src/content/docs/row-pagination/_examples/grouping-normal/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-pagination/_examples/grouping-normal/example.spec.ts
@@ -19,7 +19,7 @@ test.agExample(import.meta, () => {
         await expect(agIdFor.paginationSummaryPanelCurrentPage('1')).toBeVisible();
 
         // Child group rows (year) are now visible under United States
-        await expect(agIdFor.autoGroupCell('row-group-year-2008')).toContainText('2008', {
+        await expect(agIdFor.autoGroupCell('row-group-country-United States-year-2008')).toContainText('2008', {
             useInnerText: true,
         });
     });

--- a/packages/ag-grid-community/src/testing/testIdService.ts
+++ b/packages/ag-grid-community/src/testing/testIdService.ts
@@ -48,6 +48,7 @@ export class TestIdService extends BeanStub implements NamedBean, ITestIdService
             gridReady: setup,
             overlayExclusiveChanged: setup,
             rowGroupOpened: setup,
+            paginationChanged: setup,
             scrollVisibilityChanged: setup,
             gridSizeChanged: setup,
             filterOpened: setup,

--- a/testing/behavioural/src/pagination/pagination-core-api.test.ts
+++ b/testing/behavioural/src/pagination/pagination-core-api.test.ts
@@ -12,6 +12,7 @@ function createGrid(gridsManager: TestGridsManager, options: Partial<GridOptions
         rowData: ROW_DATA,
         pagination: true,
         paginationPageSize: 10,
+        paginationPageSizeSelector: false,
         getRowId: (params) => params.data.id,
         ...options,
     });

--- a/testing/behavioural/src/pagination/pagination-data-changes.test.ts
+++ b/testing/behavioural/src/pagination/pagination-data-changes.test.ts
@@ -15,6 +15,7 @@ function createGrid(gridsManager: TestGridsManager, options: Partial<GridOptions
         rowData: makeRowData(50),
         pagination: true,
         paginationPageSize: 10,
+        paginationPageSizeSelector: false,
         getRowId: (params) => params.data.id,
         ...options,
     });

--- a/testing/behavioural/src/pagination/pagination-edge-cases.test.ts
+++ b/testing/behavioural/src/pagination/pagination-edge-cases.test.ts
@@ -10,6 +10,7 @@ function createGrid(gridsManager: TestGridsManager, options: Partial<GridOptions
         columnDefs: COLUMN_DEFS,
         pagination: true,
         paginationPageSize: 10,
+        paginationPageSizeSelector: false,
         getRowId: (params) => params.data.id,
         ...options,
     });

--- a/testing/behavioural/src/pagination/pagination-events.test.ts
+++ b/testing/behavioural/src/pagination/pagination-events.test.ts
@@ -12,6 +12,7 @@ function createGrid(gridsManager: TestGridsManager, options: Partial<GridOptions
         rowData: ROW_DATA,
         pagination: true,
         paginationPageSize: 10,
+        paginationPageSizeSelector: false,
         getRowId: (params) => params.data.id,
         ...options,
     });

--- a/testing/behavioural/src/pagination/pagination-grouping.test.ts
+++ b/testing/behavioural/src/pagination/pagination-grouping.test.ts
@@ -36,6 +36,7 @@ function createGrid(gridsManager: TestGridsManager, options: Partial<GridOptions
         rowData: ROW_DATA,
         pagination: true,
         paginationPageSize: 3,
+        paginationPageSizeSelector: false,
         getRowId: (params) => params.data.id,
         ...options,
     });

--- a/testing/behavioural/src/pagination/pagination-page-size.test.ts
+++ b/testing/behavioural/src/pagination/pagination-page-size.test.ts
@@ -11,6 +11,7 @@ function createGrid(gridsManager: TestGridsManager, options: Partial<GridOptions
         columnDefs: COLUMN_DEFS,
         rowData: ROW_DATA,
         pagination: true,
+        paginationPageSizeSelector: false,
         getRowId: (params) => params.data.id,
         ...options,
     });

--- a/testing/behavioural/src/pagination/pagination-panels.test.ts
+++ b/testing/behavioural/src/pagination/pagination-panels.test.ts
@@ -14,6 +14,7 @@ function createPaginationGrid(gridsManager: TestGridsManager, options: Partial<G
         rowData: ROW_DATA,
         pagination: true,
         paginationPageSize: 10,
+        paginationPageSizeSelector: [10, 20, 50, 100],
         ...options,
     });
 }


### PR DESCRIPTION
## Summary

- **client-paging**: spec was written assuming `paginationPageSize: 10` but the example uses the default (100) — corrected all row/page counts
- **custom-controls**: `locator('button', { hasText: 'To Page 5' })` matched both "To Page 5" and "To Page 50" causing a strict-mode violation — switched to `getByRole('button', { name: 'To Page 5', exact: true })`
- **grouping-normal**: nested group row ID was `row-group-year-2008` (missing parent path) — corrected to `row-group-country-United States-year-2008`
- **testIdService**: `paginationChanged` was missing from the event listener list, so test IDs were not refreshed after page navigation clicks — added it alongside the other event listeners

All failures stem from the AG-9670 pagination refactor (merged 2026-04-20) which introduced new pagination components and spec tests that had incorrect assumptions or incomplete wiring.
