### PR TITLE
AG-17115 Sync ag-shared: adopt canary-ref template placeholder

### DIFF
--- a/external/ag-shared/.claude-settings.template.json
+++ b/external/ag-shared/.claude-settings.template.json
@@ -150,7 +150,7 @@
     "ag-dev": {
       "source": {
         "source": "github",
-        "repo": "ag-grid/ag-dev-prompts"
+        "repo": "ag-grid/ag-dev-prompts${AG_DEV_PROMPTS_REF_SUFFIX}"
       }
     },
     "openai-codex": {

--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = 7bcc8a9de0d72a49d17622a5ebefd291a67ec0f4
-	parent = 773dd043270b6eecece777c41fe48510af9e2bb5
+	commit = 327f0da9410123e3b792b23d163ef5c917b14f33
+	parent = 189c58cc6ce5a0ec98c36b56f17fed0c43c42b18
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -7,6 +7,6 @@
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
 	commit = 7bcc8a9de0d72a49d17622a5ebefd291a67ec0f4
-	parent = 789eb246b4a332c46d4f469d0ec6e26f47ba5663
+	parent = 773dd043270b6eecece777c41fe48510af9e2bb5
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/scripts/setup-prompts/setup-prompts.sh
+++ b/external/ag-shared/scripts/setup-prompts/setup-prompts.sh
@@ -276,14 +276,30 @@ copy_extra_configs() {
                 ;;
         esac
 
+        # Derive marketplace ref suffix from AG_DEV_PROMPTS_REF. An unset or
+        # 'latest' value leaves the source unqualified (Claude picks the default
+        # branch); any other value pins the marketplace to that branch/tag via
+        # the `repo#ref` syntax. This lets a single consumer opt into the
+        # canary track without changing settings for the other products.
+        local dev_prompts_ref="${AG_DEV_PROMPTS_REF:-}"
+        local ref_suffix=""
+        if [[ -n "$dev_prompts_ref" && "$dev_prompts_ref" != "latest" ]]; then
+            ref_suffix="#$dev_prompts_ref"
+        fi
+
         mkdir -p "$REPO_ROOT/.claude"
         # Atomic render via temp file + mv. Drop any stale symlink first.
         local tmp_file="$claude_settings_dest.tmp.$$"
-        sed "s|\${PRODUCT}|$product|g" "$REPO_ROOT/$claude_settings_template" > "$tmp_file"
+        sed \
+            -e "s|\${PRODUCT}|$product|g" \
+            -e "s|\${AG_DEV_PROMPTS_REF_SUFFIX}|$ref_suffix|g" \
+            "$REPO_ROOT/$claude_settings_template" > "$tmp_file"
         rm -f "$claude_settings_dest"
         mv "$tmp_file" "$claude_settings_dest"
         if [[ "$verbose" == "true" ]]; then
-            echo -e "${GREEN}✓${NC} Rendered Claude Code settings for product: $product"
+            local track_note=""
+            [[ -n "$ref_suffix" ]] && track_note=" (marketplace pinned to ${dev_prompts_ref})"
+            echo -e "${GREEN}✓${NC} Rendered Claude Code settings for product: ${product}${track_note}"
         fi
     fi
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17115

Sync the ag-shared subrepo to pick up the canary-track template placeholder landed in [ag-grid/ag-charts#6640](https://github.com/ag-grid/ag-charts/pull/6640) (AG-17085 close-out).

## What changes

- `external/ag-shared/.claude-settings.template.json` — adds \`\${AG_DEV_PROMPTS_REF_SUFFIX}\` placeholder on the marketplace \`source\` entry.
- `external/ag-shared/scripts/setup-prompts/setup-prompts.sh` — renders that placeholder from the \`AG_DEV_PROMPTS_REF\` env var (unset or \`latest\` → empty suffix; any other value → \`#<ref>\` pin).

ag-grid does **not** set \`AG_DEV_PROMPTS_REF\`, so the rendered \`.claude/settings.json\` remains byte-identical to before — the marketplace still resolves to \`ag-grid/ag-dev-prompts\` on the default (\`latest\`) branch. This PR is pure upstream sync; no ag-grid behaviour change.

## Why

The ag-dev-prompts repo now runs a two-track release model (\`canary\` → 24h soak → \`latest\`). ag-charts opts into canary so early regressions surface there before reaching the broader org. This subrepo sync gives every consumer the same escape hatch — ag-grid can flip tracks in future by setting the env var, without another ag-shared change.

## Commits

1. \`WIP: fix ag-shared subrepo parent for recovery\` — points the \`.gitrepo\` \`parent\` at a commit that's still reachable after upstream rebases. git-subrepo's own suggested remediation (it computed the recovery SHA and printed it in its failure message).
2. \`git subrepo pull external/ag-shared\` — the actual sync, 3 files touched (template, setup-prompts.sh, .gitrepo).

The two commits are kept separate rather than squashed so the recovery step is auditable.

## Test plan

- [x] \`git subrepo pull\` completes cleanly after parent recovery.
- [ ] \`yarn install\` runs setup-prompts successfully on this branch.
- [ ] Rendered \`.claude/settings.json\` still points at \`ag-grid/ag-dev-prompts\` (no \`#ref\`).
- [ ] No skill-resolution regressions.