### PR TITLE
Fix js example generator stripping "export" inside string literals

### DIFF
--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
@@ -15,7 +15,7 @@ export function readAsJsFile(srcFile, internalFramework: InternalFramework) {
         tsFile = tsFile.replace(/import {((.|\n)*?)} from(?!(\s['"]\.\/)).*\n/g, '');
     } else {
         tsFile = tsFile.replace(/import ((.|\n)*?)from.*\n/g, '');
-        tsFile = tsFile.replace(/export /g, '');
+        tsFile = tsFile.replace(/^export /gm, '');
     }
 
     const jsFile = transform(tsFile, { transforms: ['typescript'], disableESTransforms: true }).code;


### PR DESCRIPTION
## Summary

`readAsJsFile` in the example generator stripped every occurrence of `export ` with `tsFile.replace(/export /g, '')`. Because that regex is unanchored, it also mangled text inside string literals and comments — e.g. the Excel-notes customisation example's note text `'This note is added only during export through ExcelCell.note.'` became `'This note is added only during through ExcelCell.note.'` in the generated JavaScript version.

This change anchors the regex to line-start with `/^export /gm`, so only top-level ES module `export` keywords get removed while string-literal and comment occurrences are preserved.
