### PR TITLE
Fix rulesync-fetch GIT_AUTH_ARGS unbound on bash 3.2

### DIFF
--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = acdddd72ce03eef8dab38c0d3895fc7861e04200
-	parent = 189c58cc6ce5a0ec98c36b56f17fed0c43c42b18
+	commit = 1fe2eb4c7ad2e6281ff67e873844b6798e3e1cb5
+	parent = 3328f741edf4475775d02e4465f37bd935b32619
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = 327f0da9410123e3b792b23d163ef5c917b14f33
+	commit = acdddd72ce03eef8dab38c0d3895fc7861e04200
 	parent = 189c58cc6ce5a0ec98c36b56f17fed0c43c42b18
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/github/actions/codex-pr-review/action.yml
+++ b/external/ag-shared/github/actions/codex-pr-review/action.yml
@@ -330,8 +330,43 @@ runs:
               LINES_ADDED=$(git diff --numstat "${DIFF_BASE}" | awk '{ s += $1 } END { print s+0 }')
               LINES_REMOVED=$(git diff --numstat "${DIFF_BASE}" | awk '{ s += $2 } END { print s+0 }')
 
-              # Write the raw diff to a standalone file (avoids Markdown escaping issues)
-              git diff "${DIFF_BASE}" > "${diff_file}"
+              # Write the raw diff to a standalone file (avoids Markdown escaping issues).
+              # Apply per-file-type size caps so a single churn-heavy file (typically generated
+              # snapshots or lockfiles) cannot blow Codex's 1 MiB turn input limit.
+              DEFAULT_FILE_CAP_BYTES=204800   # 200 KiB for regular source files
+              SNAPSHOT_FILE_CAP_BYTES=10240   # 10 KiB for *.snap (generated snapshots)
+              : > "${diff_file}"
+              TRUNCATED_COUNT=0
+              TRUNCATED_BYTES_SAVED=0
+              per_file_tmp=$(mktemp)
+              while IFS= read -r path; do
+                  [ -z "$path" ] && continue
+                  case "$path" in
+                      *.snap) cap="$SNAPSHOT_FILE_CAP_BYTES" ;;
+                      *)      cap="$DEFAULT_FILE_CAP_BYTES" ;;
+                  esac
+                  git diff "${DIFF_BASE}" -- "$path" > "$per_file_tmp"
+                  file_size=$(wc -c < "$per_file_tmp" | tr -d ' ')
+                  if [ "$file_size" -gt "$cap" ]; then
+                      numstat=$(git diff --numstat "${DIFF_BASE}" -- "$path")
+                      added=$(echo "$numstat" | awk '{print $1}')
+                      removed=$(echo "$numstat" | awk '{print $2}')
+                      {
+                          echo ""
+                          echo "diff --git a/${path} b/${path}"
+                          printf '[truncated by codex-pr-review: diff is %s bytes, exceeds %s-byte cap for this file type; +%s / -%s lines]\n' \
+                              "$file_size" "$cap" "$added" "$removed"
+                      } >> "${diff_file}"
+                      TRUNCATED_COUNT=$((TRUNCATED_COUNT + 1))
+                      TRUNCATED_BYTES_SAVED=$((TRUNCATED_BYTES_SAVED + file_size - cap))
+                  else
+                      cat "$per_file_tmp" >> "${diff_file}"
+                  fi
+              done < <(git diff --name-only "${DIFF_BASE}")
+              rm -f "$per_file_tmp"
+              if [ "$TRUNCATED_COUNT" -gt 0 ]; then
+                  echo "Truncated ${TRUNCATED_COUNT} file(s) in diff (~${TRUNCATED_BYTES_SAVED} bytes elided) to stay under Codex input limits."
+              fi
 
               # Build the context file (metadata only, no embedded diff).
               # Uses printf instead of a heredoc to keep content indented within the

--- a/external/ag-shared/scripts/rulesync-fetch/fetch.sh
+++ b/external/ag-shared/scripts/rulesync-fetch/fetch.sh
@@ -45,6 +45,9 @@ fi
 # embedding credentials in the remote URL, so nothing secret lands in
 # .git/config. Assignment happens at top level (not inside a subshell) so the
 # array is visible to the git invocations below.
+#
+# Callers MUST expand with the ${arr[@]+"${arr[@]}"} idiom — under `set -u`,
+# macOS's system bash 3.2 treats "${empty_array[@]}" as an unbound variable.
 GIT_AUTH_ARGS=()
 if [[ "$AUTH_MODE" == "token" || "$AUTH_MODE" == "gh" ]]; then
     _basic=$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')
@@ -163,12 +166,12 @@ REPO_URL=$(resolve_repo_url)
 mkdir -p "$CACHE_ROOT"
 
 if [[ ! -d "$REPO_DIR/.git" ]]; then
-    git "${GIT_AUTH_ARGS[@]}" clone --depth=1 --filter=blob:none --branch "$REF" "$REPO_URL" "$REPO_DIR" >&2
+    git ${GIT_AUTH_ARGS[@]+"${GIT_AUTH_ARGS[@]}"} clone --depth=1 --filter=blob:none --branch "$REF" "$REPO_URL" "$REPO_DIR" >&2
 else
     # Keep the remote URL in sync (no credentials embedded) in case the slug or
     # AG_DEV_PROMPTS_REPO changed between runs.
     git -C "$REPO_DIR" remote set-url origin "$REPO_URL"
-    git "${GIT_AUTH_ARGS[@]}" -C "$REPO_DIR" fetch --depth=1 --quiet origin "$REF" >&2
+    git ${GIT_AUTH_ARGS[@]+"${GIT_AUTH_ARGS[@]}"} -C "$REPO_DIR" fetch --depth=1 --quiet origin "$REF" >&2
     git -C "$REPO_DIR" reset --hard --quiet FETCH_HEAD >&2
 fi
 

--- a/external/ag-shared/scripts/setup-prompts/setup-prompts.sh
+++ b/external/ag-shared/scripts/setup-prompts/setup-prompts.sh
@@ -255,24 +255,27 @@ copy_extra_configs() {
     local claude_settings_dest="$REPO_ROOT/.claude/settings.json"
 
     if [[ -f "$REPO_ROOT/$claude_settings_template" ]] && [[ "$targets" == *"claudecode"* || "$targets" == "*" ]]; then
+        # Detect product via AG_PRODUCT env var or by reading package.json .name.
+        # Fall back gracefully when neither source yields a match: skipping the
+        # render leaves any existing .claude/settings.json in place and lets
+        # the rest of postinstall complete. Failing here would otherwise abort
+        # `yarn install` on environments missing jq or on unknown checkouts.
         local product="${AG_PRODUCT:-}"
-        if [[ -z "$product" && -f "$REPO_ROOT/package.json" ]]; then
+        if [[ -z "$product" && -f "$REPO_ROOT/package.json" ]] && command -v jq >/dev/null 2>&1; then
             product=$(jq -r '.name // empty' "$REPO_ROOT/package.json" 2>/dev/null)
         fi
 
         if [[ -z "$product" ]]; then
-            echo -e "${RED}✗${NC} Cannot render .claude/settings.json: no product detected."
-            echo -e "${YELLOW}  Expected workspace root package.json .name to be one of: ag-charts | ag-grid | ag-studio.${NC}"
-            echo -e "${YELLOW}  Override with AG_PRODUCT env var if running from a non-standard checkout.${NC}"
-            return 1
+            echo -e "${YELLOW}!${NC} Skipping .claude/settings.json render: no product detected" >&2
+            echo -e "${YELLOW}  Set AG_PRODUCT (ag-charts | ag-grid | ag-studio) or ensure jq is installed + package.json .name is set.${NC}" >&2
+            return 0
         fi
 
         case "$product" in
             ag-charts|ag-grid|ag-studio) ;;
             *)
-                echo -e "${RED}✗${NC} Unknown product '$product' (expected: ag-charts | ag-grid | ag-studio)"
-                echo -e "${YELLOW}  Detected from package.json .name; override with AG_PRODUCT if needed.${NC}"
-                return 1
+                echo -e "${YELLOW}!${NC} Skipping .claude/settings.json render: unknown product '$product' (expected: ag-charts | ag-grid | ag-studio). Override with AG_PRODUCT if needed." >&2
+                return 0
                 ;;
         esac
 
@@ -455,13 +458,15 @@ generate_config() {
     # items. If it does, rulesync would regenerate them in .claude/skills
     # alongside the same skill delivered by the plugin — duplicate content and
     # ambiguous trigger behaviour. Fail fast if stale symlinks exist.
+    # Cleanup requires python3; skip with a warning when it's unavailable so
+    # postinstall still succeeds on environments without it.
     local cleanup_script="$REPO_ROOT/external/ag-shared/scripts/setup-prompts/cleanup-plugin-delivered.py"
-    if [[ -f "$cleanup_script" ]] && [[ -f "$cache_manifest" ]]; then
+    if [[ -f "$cleanup_script" ]] && [[ -f "$cache_manifest" ]] && command -v python3 >/dev/null 2>&1; then
         if ! python3 "$cleanup_script" --verify >/dev/null 2>&1; then
             echo -e "${YELLOW}Warning: .rulesync/ contains symlinks for plugin-delivered items${NC}"
             python3 "$cleanup_script" --verify || true
             echo -e "${YELLOW}Removing stale symlinks...${NC}"
-            python3 "$cleanup_script"
+            python3 "$cleanup_script" || true
         fi
     fi
 


### PR DESCRIPTION
## Summary

- Fix `external/ag-shared/scripts/rulesync-fetch/fetch.sh` so it survives execution under macOS's system bash (3.2), which treats empty-array expansion as an unbound variable under `set -u`.
- Pull latest `external/ag-shared` upstream (brings in `setup-prompts.sh` and `codex-pr-review` action updates alongside the fix).

## Root cause

`fetch.sh` runs under `set -euo pipefail` and declares `GIT_AUTH_ARGS=()`. When no token is available (`AUTH_MODE=https`) the array stays empty, and expanding it at the clone/fetch call sites fails on bash 3.2:

```
fetch.sh: line 166: GIT_AUTH_ARGS[@]: unbound variable
```

Bash 4.4+ fixed this quirk. The shebang is `#!/usr/bin/env bash`, so any user with Homebrew bash on PATH dodges the issue — which is why this landed green in review but bit the first developer whose `/usr/bin/env bash` resolved to Apple's `/bin/bash`. A cold `~/.cache/ag-dev-prompts` is also required to hit the clone branch.

## Fix

- Switch both expansions to the bash-3.2-safe `${arr[@]+"${arr[@]}"}` idiom.
- Add a short note on the `GIT_AUTH_ARGS=()` declaration so the workaround is not "simplified" back to the broken form.
- Verified by syntax-checking and running the script end-to-end under `/bin/bash` (3.2.57) against a cold cache and a warm cache.

## Immediate workarounds for anyone blocked before this merges

- `brew install bash` (makes `env bash` find 5.x), or
- `export GITHUB_TOKEN=$(gh auth token)` before running `yarn` (populates the array).

## Follow-up

- This change needs to be pulled into `ag-charts` and `ag-studio` via the usual ag-shared sync workflow.