### PR TITLE
AG-17007 refresh Multi Filter siblings on floating filter change

### DIFF
--- a/packages/ag-grid-enterprise/src/multiFilter/multiFilterHandler.ts
+++ b/packages/ag-grid-enterprise/src/multiFilter/multiFilterHandler.ts
@@ -78,7 +78,10 @@ export class MultiFilterHandler
         if (params.source !== 'floating' && params.source !== 'ui') {
             this.resetActiveList(params.model);
         }
-        if (params.additionalEventAttributes?.fromButtons) {
+        // Floating filter changes bypass MultiFilterUi (whose onModelChange triggers sibling
+        // notification for the 'ui' source). Cross-column onAnyFilterChanged notification skips
+        // the active column, so siblings within this Multi Filter would otherwise never refresh.
+        if (params.additionalEventAttributes?.fromButtons || params.source === 'floating') {
             this.onAnyFilterChanged();
         }
     }

--- a/testing/behavioural/src/filters/multi-filter-set-filter-refresh.test.ts
+++ b/testing/behavioural/src/filters/multi-filter-set-filter-refresh.test.ts
@@ -1,0 +1,105 @@
+import { getByTestId, waitFor } from '@testing-library/dom';
+
+import type { GridApi, GridOptions } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    TextFilterModule,
+    agTestIdFor,
+    getGridElement,
+    setupAgTestIds,
+} from 'ag-grid-community';
+import type { MultiFilter, SetFilter } from 'ag-grid-enterprise';
+import { ColumnMenuModule, MultiFilterModule, SetFilterModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+
+interface Row {
+    name: string;
+}
+
+const ROW_DATA: Row[] = [{ name: 'michael' }, { name: 'michelle' }, { name: 'bob' }, { name: 'alice' }];
+
+describe('Multi Filter + Set Filter list refresh on floating filter change', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, MultiFilterModule, SetFilterModule, TextFilterModule, ColumnMenuModule],
+    });
+
+    beforeAll(() => setupAgTestIds());
+    afterEach(() => gridsManager.reset());
+
+    async function createGrid(overrides?: Partial<GridOptions<Row>>): Promise<GridApi<Row>> {
+        return gridsManager.createGridAndWait('grid1', {
+            enableFilterHandlers: true,
+            columnDefs: [
+                {
+                    field: 'name',
+                    filter: 'agMultiColumnFilter',
+                    floatingFilter: true,
+                },
+            ],
+            rowData: ROW_DATA,
+            ...overrides,
+        });
+    }
+
+    async function typeInFloatingFilter(api: GridApi<Row>, text: string): Promise<void> {
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const input = getByTestId<HTMLInputElement>(
+            gridDiv,
+            agTestIdFor.textFilterInstanceInput({ source: 'floating-filter', colId: 'name', index: 0 })
+        );
+        input.value = text;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        // Filters are debounced; wait enough for debounce + async handler refresh.
+        await asyncSetTimeout(600);
+    }
+
+    /**
+     * Keys that will be rendered in the open Set Filter list — read from the display value model
+     * the Set Filter populates in `setParams`. Same pattern as set-filter-complex-objects.test.ts.
+     * Needed because jsdom does not lay out the VirtualList, so the rendered DOM is empty.
+     */
+    async function openPopupAndGetDisplayedSetFilterKeys(api: GridApi<Row>): Promise<string[]> {
+        api.showColumnFilter('name');
+        await asyncSetTimeout(0);
+        const multiFilter = (await api.getColumnFilterInstance('name')) as MultiFilter | null | undefined;
+        const setFilter = multiFilter?.getChildFilterInstance<SetFilter>(1);
+        if (!setFilter) {
+            throw new Error('Expected SetFilter child instance at index 1 of Multi Filter');
+        }
+        const displayedKeys = (setFilter as any).displayValueModel.getDisplayedKeys() as (string | null)[];
+        return displayedKeys.filter((k): k is string => k != null).sort();
+    }
+
+    test('Scenario A: no popup opened — reopening popup shows filtered Set Filter list', async () => {
+        const api = await createGrid();
+        await asyncSetTimeout(0);
+
+        await typeInFloatingFilter(api, 'michael');
+
+        expect(api.getDisplayedRowCount()).toBe(1);
+
+        await waitFor(async () => {
+            expect(await openPopupAndGetDisplayedSetFilterKeys(api)).toEqual(['michael']);
+        });
+    });
+
+    test('Scenario B: popup opened+closed before floating filter — reopening popup shows filtered Set Filter list', async () => {
+        const api = await createGrid();
+        await asyncSetTimeout(0);
+
+        api.showColumnFilter('name');
+        await asyncSetTimeout(10);
+        api.hideColumnFilter();
+        await asyncSetTimeout(10);
+
+        await typeInFloatingFilter(api, 'michael');
+
+        expect(api.getDisplayedRowCount()).toBe(1);
+
+        await waitFor(async () => {
+            expect(await openPopupAndGetDisplayedSetFilterKeys(api)).toEqual(['michael']);
+        });
+    });
+});


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17007

When a Multi Filter column uses `enableFilterHandlers` with floating filters, changing a child filter via the floating filter did not refresh its siblings inside the Multi Filter. The symptom: a Set Filter sibling list shown in the popup did not filter down to the currently-visible values after typing in the text filter's floating input — but only if the popup had been opened once before the floating filter was used.

Fix: in `MultiFilterHandler.refresh`, call `onAnyFilterChanged()` when `source === 'floating'`, mirroring the existing `fromButtons` behaviour.

Fix [AG-17007](https://ag-grid.atlassian.net/browse/AG-17007)