### PR TITLE
[AG-17127] Feature(toolbar): add support for tooltip separate from label

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/built-in-items/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/built-in-items/main.ts
@@ -56,7 +56,7 @@ const gridOptions: GridOptions<IOlympicData> = {
             },
             {
                 key: 'resetColumns',
-                label: 'Reset Columns',
+                tooltip: 'Reset Columns',
                 icon: 'minimize',
                 action: (params) => params.api.resetColumnState(),
             },

--- a/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/built-in-items/provided/reactFunctionalTs/index.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/built-in-items/provided/reactFunctionalTs/index.tsx
@@ -73,7 +73,7 @@ const GridExample = () => {
                 },
                 {
                     key: 'resetColumns',
-                    label: 'Reset Columns',
+                    tooltip: 'Reset Columns',
                     icon: 'minimize',
                     action: (params) => params.api.resetColumnState(),
                 },

--- a/documentation/ag-grid-docs/src/content/docs/toolbar/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/index.mdoc
@@ -26,7 +26,7 @@ const gridOptions = {
             },
             {
                 key: 'resetColumns',
-                label: 'Reset Columns',
+                tooltip: 'Reset Columns',
                 icon: 'minimize',
                 action: (params) => params.api.resetColumnState(),
             },
@@ -60,7 +60,7 @@ An item object supports the following properties:
 -   `alignment`: `'left'` or `'right'`. See [Default Alignment](#default-alignment).
 -   `toolbarItem`: a built-in item name or a reference to a [Custom Component](#custom-components).
 -   `toolbarItemParams`: additional props forwarded to the component.
--   `label`, `icon`, `action`: shorthand for rendering an [Action Button](#action-buttons) without a component.
+-   `label`, `tooltip`, `icon`, `action`: shorthand for rendering an [Action Button](#action-buttons) without a component.
 
 ```{% frameworkTransform=true %}
 const gridOptions = {
@@ -102,7 +102,7 @@ The Toolbar accepts two kinds of user-defined items: [Action Buttons](#action-bu
 
 ### Action Buttons
 
-Set `label`, `icon` and `action` on an item to render a button inline, without writing a component. The `action` callback fires on click and receives the grid `api`, `context`, and the item `key`.
+Set `label`, `tooltip`, `icon` and `action` on an item to render a button inline, without writing a component. The `action` callback fires on click and receives the grid `api`, `context`, and the item `key`.
 
 ```{% frameworkTransform=true %}
 const gridOptions = {
@@ -116,7 +116,7 @@ const gridOptions = {
             },
             {
                 key: 'excelExport',
-                label: 'Excel Export',
+                tooltip: 'Excel Export',
                 icon: 'excel',
                 action: (params) => params.api.exportDataAsExcel(),
             },
@@ -125,7 +125,7 @@ const gridOptions = {
 }
 ```
 
-Buttons render the `icon` and `label` side by side when both are provided; the `label` is also used as the tooltip and `aria-label`.
+`label` is the visible text rendered next to the icon; omit it to render an icon-only button. `tooltip` sets the hover tooltip and `aria-label`, and falls back to `label` when omitted.
 
 ### Custom Component
 

--- a/packages/ag-grid-community/src/interfaces/iToolbar.ts
+++ b/packages/ag-grid-community/src/interfaces/iToolbar.ts
@@ -44,8 +44,10 @@ interface ToolbarItemDefBase {
  * without requiring a component reference. Provide at least one of `label`, `icon` or `action`.
  */
 export interface ToolbarButtonItemDef<TData = any, TContext = any> extends ToolbarItemDefBase {
-    /** Text used for the button label, tooltip and `aria-label`. */
+    /** Visible text rendered next to the icon. Omit to render an icon-only button. */
     label?: string;
+    /** Hover tooltip and `aria-label`. Falls back to `label` when omitted. */
+    tooltip?: string;
     /** Icon displayed on the default button. */
     icon?: IconName;
     /** Function invoked when the default button is clicked. */

--- a/packages/ag-grid-enterprise/src/toolbar/agToolbar.ts
+++ b/packages/ag-grid-enterprise/src/toolbar/agToolbar.ts
@@ -46,10 +46,10 @@ function normaliseItem(item: ToolbarItemDef | string, nextKey: () => string): No
     let toolbarItemParams: any = item.toolbarItemParams;
 
     if (toolbarItem == null) {
-        const { label, icon, action } = item as ToolbarButtonItemDef;
+        const { label, tooltip, icon, action } = item as ToolbarButtonItemDef;
         if (action != null || label != null || icon != null) {
             toolbarItem = 'agButtonToolbarItem';
-            toolbarItemParams = { ...(toolbarItemParams ?? {}), label, icon, action };
+            toolbarItemParams = { ...(toolbarItemParams ?? {}), label, tooltip, icon, action };
         }
     }
 

--- a/packages/ag-grid-enterprise/src/toolbar/providedItems/buttonToolbarItem.ts
+++ b/packages/ag-grid-enterprise/src/toolbar/providedItems/buttonToolbarItem.ts
@@ -18,6 +18,7 @@ import {
 
 interface ButtonToolbarItemParams extends IToolbarItemParams {
     label?: string;
+    tooltip?: string;
     icon?: IconName;
     action?: (params: ToolbarItemActionParams) => void;
 }
@@ -71,8 +72,9 @@ export class ButtonToolbarItem extends Component implements IToolbarItemComp {
         this.eLabel.textContent = params.label ?? '';
         _setDisplayed(this.eLabel, hasLabel);
 
-        _setAriaLabel(eGui, params.label);
-        _addOrRemoveAttribute(eGui, 'title', params.label);
+        const hoverText = params.tooltip ?? params.label;
+        _setAriaLabel(eGui, hoverText);
+        _addOrRemoveAttribute(eGui, 'title', hoverText);
     }
 
     private invokeAction(): void {

--- a/testing/behavioural/src/toolbar/toolbar-action-button.test.ts
+++ b/testing/behavioural/src/toolbar/toolbar-action-button.test.ts
@@ -12,8 +12,8 @@ describe('Toolbar action button item', () => {
         gridMgr.reset();
     });
 
-    test('renders a button with icon, label and tooltip', async () => {
-        const api = gridMgr.createGrid('action-button-render', {
+    test('label-only: renders visible label, title and aria-label fall back to label', async () => {
+        const api = gridMgr.createGrid('action-button-label-only', {
             columnDefs: [{ field: 'name' }],
             rowData: [{ name: 'Alice' }],
             toolbar: {
@@ -31,18 +31,71 @@ describe('Toolbar action button item', () => {
         await waitForEvent('firstDataRendered', api);
 
         const gridDiv = TestGridsManager.getHTMLElement(api)!;
-        const button = gridDiv.querySelector<HTMLButtonElement>('.ag-toolbar-button');
-        expect(button).not.toBeNull();
-        expect(button!.getAttribute('title')).toBe('Auto Size All');
-        expect(button!.getAttribute('aria-label')).toBe('Auto Size All');
-        expect(button!.querySelector('.ag-icon')).not.toBeNull();
-        const label = button!.querySelector<HTMLElement>('.ag-toolbar-button-label')!;
+        const button = gridDiv.querySelector<HTMLButtonElement>('.ag-toolbar-button')!;
+        expect(button.getAttribute('title')).toBe('Auto Size All');
+        expect(button.getAttribute('aria-label')).toBe('Auto Size All');
+        expect(button.querySelector('.ag-icon')).not.toBeNull();
+        const label = button.querySelector<HTMLElement>('.ag-toolbar-button-label')!;
         expect(label.classList.contains('ag-hidden')).toBe(false);
         expect(label.textContent).toBe('Auto Size All');
     });
 
-    test('hides label when not provided', async () => {
-        const api = gridMgr.createGrid('action-button-no-label', {
+    test('tooltip-only: renders icon-only button with tooltip and aria-label from tooltip', async () => {
+        const api = gridMgr.createGrid('action-button-tooltip-only', {
+            columnDefs: [{ field: 'name' }],
+            rowData: [{ name: 'Alice' }],
+            toolbar: {
+                items: [
+                    {
+                        key: 'resetColumns',
+                        tooltip: 'Reset Columns',
+                        icon: 'minimize',
+                        action: () => {},
+                    },
+                ],
+            },
+        });
+
+        await waitForEvent('firstDataRendered', api);
+
+        const gridDiv = TestGridsManager.getHTMLElement(api)!;
+        const button = gridDiv.querySelector<HTMLButtonElement>('.ag-toolbar-button')!;
+        expect(button.getAttribute('title')).toBe('Reset Columns');
+        expect(button.getAttribute('aria-label')).toBe('Reset Columns');
+        const label = button.querySelector<HTMLElement>('.ag-toolbar-button-label')!;
+        expect(label.classList.contains('ag-hidden')).toBe(true);
+    });
+
+    test('label and tooltip: tooltip wins for title and aria-label; label is still shown', async () => {
+        const api = gridMgr.createGrid('action-button-label-and-tooltip', {
+            columnDefs: [{ field: 'name' }],
+            rowData: [{ name: 'Alice' }],
+            toolbar: {
+                items: [
+                    {
+                        key: 'autoSizeAll',
+                        label: 'Auto Size',
+                        tooltip: 'Auto-size all columns',
+                        icon: 'maximize',
+                        action: () => {},
+                    },
+                ],
+            },
+        });
+
+        await waitForEvent('firstDataRendered', api);
+
+        const gridDiv = TestGridsManager.getHTMLElement(api)!;
+        const button = gridDiv.querySelector<HTMLButtonElement>('.ag-toolbar-button')!;
+        expect(button.getAttribute('title')).toBe('Auto-size all columns');
+        expect(button.getAttribute('aria-label')).toBe('Auto-size all columns');
+        const label = button.querySelector<HTMLElement>('.ag-toolbar-button-label')!;
+        expect(label.classList.contains('ag-hidden')).toBe(false);
+        expect(label.textContent).toBe('Auto Size');
+    });
+
+    test('neither label nor tooltip: icon-only with no title or aria-label', async () => {
+        const api = gridMgr.createGrid('action-button-no-text', {
             columnDefs: [{ field: 'name' }],
             rowData: [{ name: 'Alice' }],
             toolbar: {
@@ -59,7 +112,10 @@ describe('Toolbar action button item', () => {
         await waitForEvent('firstDataRendered', api);
 
         const gridDiv = TestGridsManager.getHTMLElement(api)!;
-        const label = gridDiv.querySelector<HTMLElement>('.ag-toolbar-button-label')!;
+        const button = gridDiv.querySelector<HTMLButtonElement>('.ag-toolbar-button')!;
+        expect(button.hasAttribute('title')).toBe(false);
+        expect(button.hasAttribute('aria-label')).toBe(false);
+        const label = button.querySelector<HTMLElement>('.ag-toolbar-button-label')!;
         expect(label.classList.contains('ag-hidden')).toBe(true);
     });
 


### PR DESCRIPTION
- Add `tooltip?: string` to `ToolbarButtonItemDef`
- `label` is now strictly the visible text next to the icon; omit to render an icon-only button
- `tooltip` drives the button's `title` and `aria-label`, and falls back to `label` when omitted
- `ButtonToolbarItem` and `agToolbar` updated to thread `tooltip` through to the rendered button
- `built-in-items` example demonstrates both modes: one button with visible label, one icon-only with tooltip
- Toolbar docs updated to describe the `label` / `tooltip` split
- Behavioural tests cover label-only, tooltip-only, both, and neither

Fix [AG-17127](https://ag-grid.atlassian.net/browse/AG-17127)