### PR TITLE
AG-17129 fix missing bottom row border in auto-height mode

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_grid-layout.scss
+++ b/community-modules/styles/src/internal/base/parts/_grid-layout.scss
@@ -303,8 +303,7 @@
 
     .ag-layout-auto-height,
     .ag-layout-print {
-        .ag-center-cols-viewport,
-        .ag-center-cols-container {
+        .ag-center-cols-viewport {
             min-height: 50px;
         }
     }

--- a/community-modules/styles/src/internal/themes/alpine/_index.scss
+++ b/community-modules/styles/src/internal/themes/alpine/_index.scss
@@ -284,8 +284,7 @@
 
     .ag-layout-auto-height,
     .ag-layout-print {
-        .ag-center-cols-viewport,
-        .ag-center-cols-container {
+        .ag-center-cols-viewport {
             min-height: 150px;
         }
     }

--- a/community-modules/styles/src/internal/themes/material/_index.scss
+++ b/community-modules/styles/src/internal/themes/material/_index.scss
@@ -217,8 +217,7 @@
 
     .ag-layout-auto-height,
     .ag-layout-print {
-        .ag-center-cols-viewport,
-        .ag-center-cols-container {
+        .ag-center-cols-viewport {
             min-height: 150px;
         }
     }

--- a/community-modules/styles/src/internal/themes/quartz/_index.scss
+++ b/community-modules/styles/src/internal/themes/quartz/_index.scss
@@ -598,8 +598,7 @@
 
     .ag-layout-auto-height,
     .ag-layout-print {
-        .ag-center-cols-viewport,
-        .ag-center-cols-container {
+        .ag-center-cols-viewport {
             min-height: 150px;
         }
     }

--- a/packages/ag-grid-community/src/theming/core/css/_grid-layout.css
+++ b/packages/ag-grid-community/src/theming/core/css/_grid-layout.css
@@ -346,8 +346,7 @@
 
 .ag-layout-auto-height,
 .ag-layout-print {
-    .ag-center-cols-viewport,
-    .ag-center-cols-container {
+    .ag-center-cols-viewport {
         min-height: 150px;
     }
 }

--- a/testing/manual/template/vite.config.ts
+++ b/testing/manual/template/vite.config.ts
@@ -106,6 +106,12 @@ function cssFileDefaultImport(): Plugin {
                     from: realPath,
                     to: realPath,
                 });
+                // Register each as a watched dependency for HMR
+                for (const msg of result.messages) {
+                    if (msg.type === 'dependency' && typeof msg.file === 'string') {
+                        this.addWatchFile(msg.file);
+                    }
+                }
                 return result.css;
             }
         },


### PR DESCRIPTION
Fix [AG-17129](https://ag-grid.atlassian.net/browse/AG-17129)

In `domLayout: 'autoHeight'`, when the total row content is shorter than the CSS minimum (150px), the last row's bottom border disappears even though there is a visible empty strip below it.

### Root cause

`hasVerticalScrollGap()` in `rowContainerCtrl.ts` decides whether a gap exists by comparing `eContainer.clientHeight` to `eViewport.clientHeight` — a negative delta means the rows are shorter than the viewport, so a gap exists and the last row border should be drawn.

The CSS in auto-height mode applied `min-height: 150px` to **both** `.ag-center-cols-viewport` **and** `.ag-center-cols-container`.

### Fix

Restrict the min-height to the viewport only.

### Also...

Fixed a bug in CSS live reload for the manual testing harness