### PR TITLE
AG-16878 reduce formula data service calls

### DIFF
--- a/documentation/ag-grid-docs/src/content/api-documentation/grid-api/api.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/grid-api/api.json
@@ -332,6 +332,12 @@
             }
         },
         "refreshHeader": {},
+        "refreshFormulas": {
+            "more": {
+                "name": "Formula Caching",
+                "url": "./formulas/#caching"
+            }
+        },
         "flashCells": {
             "more": {
                 "name": "Flashing Cells",

--- a/documentation/ag-grid-docs/src/content/docs/formulas/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/formulas/index.mdoc
@@ -9,7 +9,7 @@ Formulas let users enter spreadsheet-style expressions into grid cells so values
 
 ## Enabling Formulas
 
-To enable formulas, set the column property `allowFormula: true` on one or more columns and ensure your rows have [Row IDs](./row-ids/#row-ids).
+To enable formulas, set the column property `allowFormula: true` on one or more columns and ensure rows have [Row IDs](./row-ids/#row-ids).
 
 ```{% frameworkTransform=true %}
 const gridOptions = {
@@ -34,7 +34,7 @@ const gridOptions = {
 
 ## Formula Editor Component
 
-The Formula Cell Editor is the default editor for `allowFormula: true` columns unless you provide a custom `cellEditor`. It tokenises references, highlights ranges, and provides function autocomplete while typing.
+The Formula Cell Editor is the default editor for `allowFormula: true` columns unless a custom `cellEditor` is provided. It tokenises references, highlights ranges, and provides function autocomplete while typing.
 
 To opt out, set a `cellEditor` on the column. Formulas still evaluate, but the formula editor features are disabled.
 
@@ -62,9 +62,9 @@ Relative references move as the grid changes. Absolute references stay fixed usi
 
 #### Long-Form References
 
-The grid stores formulas in a long-hand format using column and row IDs to preserve references across row/column changes while the grid is not open. The editor converts that back to shorthand when users edit a cell.
+The grid stores formulas in a long-hand format using column and row IDs so references remain valid across row and column changes that happen while the grid is not displaying the data. The editor converts them back to shorthand when users edit a cell.
 
-If you supply formulas directly in data, use the long-hand format to avoid row position drift. See the notes in [Formula Reference](./formula-reference/) for the conversion rules.
+If formulas are supplied directly in data, use the long-hand format to avoid row position drift. See the notes in [Formula Reference](./formula-reference/) for the conversion rules.
 
 ### Cell Ranges
 
@@ -72,7 +72,7 @@ Ranges refer to a block of cells using a top-left and bottom-right reference sep
 
 ### Functions
 
-Formulas support built-in functions such as `SUM`, `AVERAGE`, and `CONCAT`. See [Formula Reference](./formula-reference/) for the full list of supported functions, errors and operators.
+Formulas support built-in functions such as `SUM`, `AVERAGE`, and `CONCAT`. See [Formula Reference](./formula-reference/) for the full list of supported functions, errors, and operators.
 
 ## Feature Interactions / Compatibility
 
@@ -89,7 +89,7 @@ Formulas support built-in functions such as `SUM`, `AVERAGE`, and `CONCAT`. See 
 
 ## Formula Data Source
 
-You can back formulas with a custom data source. This example uses a Map-based store for formula values:
+Formulas can be backed by a custom data source. This example uses a Map-based store for formula values:
 
 ```{% frameworkTransform=true %}
 const formulaStore = new Map();
@@ -116,16 +116,26 @@ const gridOptions = {
 
 {% gridExampleRunner title="Formula Data Source" name="formulas-formula-data-source" exampleHeight=440 /%}
 
-A user-provided data source should provide the following interface:
+A user-provided data source should implement the following interface:
 
 {% interfaceDocumentation interfaceName="FormulaDataSource" config={ "description": "" } /%}
 
+### Caching
+
+When a data source is configured, `getFormula` is called lazily and the result is cached per cell. The cache is invalidated automatically when:
+
+-   A cell in the row is edited through the grid (cell editor, `rowNode.setDataValue`, or any update that dispatches `cellValueChanged`).
+-   The Client-Side Row Model refreshes the row (add, remove, update, reorder).
+-   Columns are added, removed, or reordered.
+
+If the formula store is mutated outside the grid (for example, syncing from a backend), call `api.refreshFormulas()` to invalidate every cached formula, or `api.refreshFormulas(rowNode)` / `api.refreshFormulas(rowId)` to invalidate a single row. Changes written only to the external store are not picked up until the cache is invalidated by one of the events above or by an explicit call.
+
 ## Exporting
 
-When performing a [CSV Export](./csv-export), the grid exports the evaluated values of any formulas. When performing an [Excel Export](./excel-export), the grid exports the formulas themselves so Excel can evaluate them.
+During a [CSV Export](./csv-export), the grid exports the evaluated values of any formulas. During an [Excel Export](./excel-export), the grid exports the formulas themselves so Excel can evaluate them.
 
 ## See also
 
 -   [Formula Editor Component](./formula-editor-component/) – The rich editing experience for formula cells, including autocomplete and range selection tools.
--   [Formula Reference](./formula-reference/) – Full reference for operators (+, -, \*, /, ^, &, comparisons), provided functions and errors.
+-   [Formula Reference](./formula-reference/) – Full reference for operators (+, -, \*, /, ^, &, comparisons), provided functions, and errors.
 -   [Custom Functions](./formula-custom-functions/) – How to register and implement custom functions for formulas.

--- a/packages/ag-grid-community/src/api/gridApi.ts
+++ b/packages/ag-grid-community/src/api/gridApi.ts
@@ -1742,6 +1742,31 @@ export interface _ColumnChooserGridApi {
 }
 
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
+export interface _FormulaGridApi<TData = any> {
+    /**
+     * Invalidate the grid's formula cache so the next render re-queries
+     * `formulaDataSource.getFormula` and re-evaluates affected formulas.
+     *
+     * Call this when the formula store has been mutated outside the grid (e.g. synced from
+     * a backend). In-grid edits and Client-Side Row Model updates invalidate automatically.
+     *
+     * - No argument: invalidates every cached formula.
+     * - `RowNode`: invalidates that row and its pinned / group-footer siblings.
+     * - `string` (row id): resolved against the main row model, pinned-top and pinned-bottom.
+     *   Every match is invalidated — so if a statically-pinned row shares an id with a body
+     *   row, both are refreshed. An unknown id is a silent no-op.
+     *
+     * @returns `true` when a refresh was actually performed — i.e. the full cache was cleared
+     * (no-arg call) or at least one cache entry was dropped for any resolved row or its
+     * siblings. Returns `false` for no-op cases: formulas inactive, an unknown row id,
+     * or a row whose entire sibling chain had no cached formulas.
+     *
+     * @agModule `FormulaModule`
+     */
+    refreshFormulas(rowNode?: IRowNode<TData> | string): boolean;
+}
+
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export interface _MasterDetailGridApi {
     /**
      * Register a detail grid with the master grid when it is created.
@@ -1996,6 +2021,7 @@ export interface GridApi<TData = any>
         _ContextMenuGridApi,
         _ColumnChooserGridApi,
         _MasterDetailGridApi,
+        _FormulaGridApi<TData>,
         _ExcelExportGridApi,
         _ClipboardGridApi,
         _GridChartsGridApi,

--- a/packages/ag-grid-community/src/api/gridApiFunctions.ts
+++ b/packages/ag-grid-community/src/api/gridApiFunctions.ts
@@ -27,6 +27,7 @@ import type {
     _ExcelExportGridApi,
     _FilterGridApi,
     _FindApi,
+    _FormulaGridApi,
     _GridChartsGridApi,
     _HighlightChangesGridApi,
     _InfiniteRowModelGridApi,
@@ -369,6 +370,10 @@ export const gridApiFunctionsMap: Record<keyof GridApi, ValidationModuleName> = 
         removeDetailGridInfo: 0,
         getDetailGridInfo: 0,
         forEachDetailGridInfo: 0,
+    }),
+
+    ...mod<_FormulaGridApi<any>>('Formula', {
+        refreshFormulas: 0,
     }),
 
     ...mod<_ContextMenuGridApi>('ContextMenu', {

--- a/packages/ag-grid-community/src/interfaces/formulas.ts
+++ b/packages/ag-grid-community/src/interfaces/formulas.ts
@@ -74,9 +74,11 @@ export interface IFormulaDataService extends Bean {
 
 export interface IFormulaService extends Bean {
     active: boolean;
+    hasCachedRows(): boolean;
     isFormula(value: unknown): value is `=${string}`;
     setFormulasActive(cols: ColumnCollections): void;
     resolveValue(col: AgColumn, row: RowNode): unknown;
+    getDataSourceFormula(row: RowNode, col: AgColumn): string | undefined;
     getFormulaError(col: AgColumn, row: RowNode): Error | null;
     normaliseFormula(value: string, shorthand: boolean): string | null;
     getColByRef(ref: string): AgColumn | null;
@@ -88,6 +90,13 @@ export interface IFormulaService extends Bean {
         useRefFormat?: boolean;
     }): string;
     refreshFormulas(refreshRows: boolean): void;
+    /**
+     * Drop a row's formula cache (including pinned / group-footer siblings) and repaint.
+     * Accepts a `RowNode` directly, or a row id string — in which case the main row model,
+     * pinned-top and pinned-bottom row models are all consulted and every matching chain is
+     * invalidated. Returns `true` when at least one entry was dropped.
+     */
+    refreshRow(row: RowNode | string): boolean;
     /**
      * Called by CSRM after every model refresh so the service can evict cache entries for destroyed
      * rows and, if the row order or set changed, drop stale computed values while keeping parsed ASTs.

--- a/packages/ag-grid-community/src/main-internal.ts
+++ b/packages/ag-grid-community/src/main-internal.ts
@@ -204,6 +204,7 @@ export type {
     _CsvExportGridApi,
     _ExcelExportGridApi,
     _FindApi,
+    _FormulaGridApi,
     _GridChartsGridApi,
     _InfiniteRowModelGridApi,
     _MasterDetailGridApi,

--- a/packages/ag-grid-community/src/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.ts
@@ -262,11 +262,10 @@ export class ValueService extends BeanStub implements NamedBean {
         const colDef = column.colDef;
         const colId = column.colId;
 
-        // Formula datasource is skipped for group rows — formulas and row grouping are not supported together.
-        const formulaDataSvc = !isGroup && this.formulaDataSvc;
-        if (formulaDataSvc && formulaDataSvc.hasDataSource() && colDef.allowFormula === true) {
-            const formula = formulaDataSvc.getFormula({ column, rowNode });
-            if (_isExpressionString(formula)) {
+        // Skipped for group rows — formulas + row grouping are not supported together.
+        if (!isGroup && colDef.allowFormula) {
+            const formula = this.beans.formula?.getDataSourceFormula(rowNode as RowNode, column);
+            if (formula !== undefined) {
                 return formula;
             }
         }

--- a/packages/ag-grid-enterprise/src/formula/cellFormula.ts
+++ b/packages/ag-grid-enterprise/src/formula/cellFormula.ts
@@ -44,23 +44,10 @@ export class CellFormula {
         public readonly rowNode: RowNode,
         public readonly column: AgColumn,
         public formulaString: string,
+        public readonly fromDataSource: boolean,
         private readonly beans: BeanCollection,
         private readonly service: FormulaService
     ) {}
-
-    public setFormulaString(next: string) {
-        if (this.formulaString === next) {
-            return;
-        }
-        this.formulaString = next;
-        this.astStale = true;
-        this._valueVersion = -1;
-        // inline _clearError: drop the stale error fields
-        this.errorType = null;
-        this.errorId = null;
-        this.errorMessage = '';
-        this.errorVariableValues = null;
-    }
 
     /** Cache write: store a fresh computed value (and clear previous error). */
     public setComputedValue(v: unknown) {

--- a/packages/ag-grid-enterprise/src/formula/formulaApi.ts
+++ b/packages/ag-grid-enterprise/src/formula/formulaApi.ts
@@ -1,0 +1,21 @@
+import type { BeanCollection, IRowNode, RowNode } from 'ag-grid-community';
+
+export function refreshFormulas(beans: BeanCollection, rowNode?: IRowNode | string): boolean {
+    const formulaSvc = beans.formula;
+    if (!formulaSvc?.active) {
+        return false; // No-op if formulas are not active
+    }
+
+    if (rowNode === undefined) {
+        if (!formulaSvc.hasCachedRows()) {
+            return false; // No-op if nothing is cached
+        }
+        formulaSvc.refreshFormulas(true);
+        return true;
+    }
+
+    // Both the RowNode overload and the string-id overload are handled by `refreshRow` — the
+    // string path consults every row-model source (body, pinned-top, pinned-bottom) and drops
+    // each matching chain. An unknown id is a silent no-op.
+    return formulaSvc.refreshRow(rowNode as RowNode | string);
+}

--- a/packages/ag-grid-enterprise/src/formula/formulaModule.ts
+++ b/packages/ag-grid-enterprise/src/formula/formulaModule.ts
@@ -1,9 +1,10 @@
-import type { _ModuleWithoutApi } from 'ag-grid-community';
+import type { _FormulaGridApi, _ModuleWithApi } from 'ag-grid-community';
 
 import { RowNumbersModule } from '../rowNumbers/rowNumbersModule';
 import { VERSION } from '../version';
 import { FormulaCellEditor } from './editor/formulaCellEditor';
 import formulaCSS from './formula.css';
+import { refreshFormulas } from './formulaApi';
 import { FormulaDataService } from './formulaDataService';
 import { FormulaInputManagerService } from './formulaInputManagerService';
 import { FormulaService } from './formulaService';
@@ -11,11 +12,14 @@ import { FormulaService } from './formulaService';
 /**
  * @feature Formulas
  */
-export const FormulaModule: _ModuleWithoutApi = {
+export const FormulaModule: _ModuleWithApi<_FormulaGridApi<any>> = {
     moduleName: 'Formula',
     version: VERSION,
     userComponents: { agFormulaCellEditor: FormulaCellEditor },
     beans: [FormulaService, FormulaDataService, FormulaInputManagerService],
+    apiFunctions: {
+        refreshFormulas,
+    },
     dependsOn: [RowNumbersModule],
     css: [formulaCSS],
 };

--- a/packages/ag-grid-enterprise/src/formula/formulaService.ts
+++ b/packages/ag-grid-enterprise/src/formula/formulaService.ts
@@ -1,5 +1,6 @@
 import type {
     AgColumn,
+    CellValueChangedEvent,
     FormulaFunctionParams,
     IFormulaDataService,
     IFormulaService,
@@ -8,15 +9,21 @@ import type {
     _ChangedRowNodes,
     _ColumnCollections,
 } from 'ag-grid-community';
-import { BeanStub, _convertColumnEventSourceType, _isExpressionString, _warn } from 'ag-grid-community';
+import {
+    BeanStub,
+    _convertColumnEventSourceType,
+    _isExpressionString,
+    _parseBigIntOrNull,
+    _warn,
+} from 'ag-grid-community';
 
 import { parseFormula } from './ast/parsers';
 import { serializeFormula } from './ast/serializer';
 import type { FormulaNode } from './ast/utils';
 import { FormulaError } from './ast/utils';
 import { CellFormula } from './cellFormula';
-import type { Addr } from './functions/resolver';
-import { evalAst, unresolvedDeps } from './functions/resolver';
+import type { Addr, FormulaResolver, FormulaVisitorContext } from './functions/resolver';
+import { evalAst, formulaVisitorSetVisited, formulaVisitorSetVisiting, unresolvedDeps } from './functions/resolver';
 import SUPPORTED_FUNCTIONS from './functions/supportedFuncs';
 import { shiftNode } from './functions/utils';
 import type { FormulaErrorId, FormulaErrorType } from './i18n';
@@ -25,13 +32,17 @@ import { isValidFunctionName } from './refUtils';
 /** Shared params object for `rowRenderer.refreshCells`, hoisted to avoid per-call allocation. */
 const REFRESH_CELLS_PARAMS = { suppressFlash: true, force: true } as const;
 
+/** A1-style column-label alphabet and its length (base 26). */
+const COL_REF_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const COL_REF_BASE = COL_REF_ALPHABET.length;
+
 interface FormulaFrame {
     address: Addr;
     ast: FormulaNode;
     unresolvedDepIterator: Generator<Addr>;
 }
 
-export class FormulaService extends BeanStub implements IFormulaService, NamedBean {
+export class FormulaService extends BeanStub implements IFormulaService, NamedBean, FormulaResolver {
     public readonly beanName = 'formula' as const;
 
     /**
@@ -56,50 +67,17 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
      * bounded because every destructive event purges destroyed entries explicitly
      * (`onRowsChanged`) or wipes the whole map (`refreshFormulas`).
      */
-    private readonly cachedResult: Map<RowNode, Map<AgColumn, CellFormula>> = new Map();
+    private readonly cachedResult: Map<RowNode, Map<AgColumn, CellFormula | null>> = new Map();
 
     /**
      * Stored at the class level so a `valueGetter` that resolves another formula cell (e.g. via
      * `api.getCellValue`) reuses the same cycle-detection state instead of hitting a false
      * positive. Read at the top of every `resolveValue` call; null outside of an active eval.
      */
-    private activeCtx: {
-        setVisiting: (r: RowNode, c: AgColumn) => void;
-        setVisited: (r: RowNode, c: AgColumn) => void;
-        errorAllVisitors: (source: unknown) => FormulaErrorType;
-    } | null = null;
+    private activeCtx: FormulaVisitorContext | null = null;
 
     /** Built-in operations (extendable via gridOptions.formulaFuncs). Read per function call. */
     private supportedOperations: Map<string, (params: FormulaFunctionParams) => unknown>;
-
-    /**
-     * Pre-bound view of `ensureCellFormula` that `unresolvedDeps` can invoke without allocating
-     * a fresh bound function for every frame push. Bound once during field init.
-     */
-    private readonly ensureCellFormulaBound = this.ensureCellFormula.bind(this);
-
-    /**
-     * Pre-bound callback passed to `evalAst` to resolve an `Addr` into a raw value (or throw a
-     * FormulaError if the referenced cell is not ready / errored). Defined as an arrow field so
-     * one closure exists per service instance instead of per-frame allocation.
-     */
-    private readonly resolveAddrRef = (addr: Addr): unknown => {
-        const { row, column } = addr;
-        const cachedRefFormula = this.ensureCellFormula(row, column);
-        if (cachedRefFormula) {
-            if (!cachedRefFormula.isValueReady()) {
-                throw new FormulaError(53);
-            }
-            // Cell is fresh; `buildError` skips the version check and allocates a FormulaError
-            // only if this cell actually holds an error.
-            const error = this.buildError(cachedRefFormula);
-            if (error) {
-                throw error;
-            }
-            return cachedRefFormula.getValue();
-        }
-        return this.fetchRawValue(column, row);
-    };
 
     /** Map "A", "B", ..., "AA" -> actual AgColumn. */
     private readonly colRefMap: Map<string, AgColumn> = new Map();
@@ -120,6 +98,10 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
      * enableCellExpressions toggle.
      */
     private formulaColumnsPresent = false;
+
+    public hasCachedRows(): boolean {
+        return this.cachedResult.size > 0;
+    }
 
     /**
      * Recompute `active`, the `formulaColumnsPresent` cache, and trigger a full formula refresh
@@ -183,10 +165,22 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
         this.setupFunctions();
         this.formulaDataSvc = this.beans.formulaDataSvc;
 
-        const refreshFormulas = () => {
-            if (this.active) {
-                this.refreshFormulas(true);
+        const onCellValueChanged = (event: CellValueChangedEvent) => {
+            if (!this.active) {
+                return;
             }
+            // valueService fires this once for the edited node and once for its pinnedSibling.
+            // Skip the pinned-side event: refreshCells is sync, so running both repaints twice.
+            const node = event.node as RowNode;
+            if (node.rowPinned != null && node.pinnedSibling) {
+                return;
+            }
+            // Always bump: a formula in another row may REF a non-formula column here, whose
+            // cells never enter this cache — only the version bump invalidates those computed
+            // values. `dropRow` additionally evicts this row's and its pinned sibling's own
+            // CellFormula entries so their captured `formulaString` re-queries `getFormula`.
+            this.dropRow(node);
+            this.bumpValueCacheAndRefresh();
         };
         const onNewColumnsLoaded = () => {
             if (!this.active) {
@@ -208,7 +202,7 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
             if (this.cachedResult.size === 0) {
                 return;
             }
-            // Column instances are stable across a reorder - only their positions changed. Parsed
+            // Column instances are stable across a reorder — only their positions changed. Parsed
             // ASTs keep referring to the right colIds; only absolute `COLUMN("A",true)` refs pick
             // up different columns via colRefMap. Bumping the value version re-evaluates surviving
             // cells while preserving their parsed ASTs.
@@ -219,6 +213,9 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
             if (!this.active || cache.size === 0) {
                 return;
             }
+            // Do NOT use `dropRow` here: a pinned row's `pinnedSibling` points back to the
+            // unpinned main whose cache entry is still valid (absolute refs resolve via CSRM only).
+            // Drop only pinned entries and their group-footer sibling.
             let dropped = false;
             for (const row of cache.keys()) {
                 if (row.rowPinned) {
@@ -244,7 +241,7 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
         });
 
         this.addManagedListeners(this.beans.eventSvc, {
-            cellValueChanged: refreshFormulas,
+            cellValueChanged: onCellValueChanged,
             newColumnsLoaded: onNewColumnsLoaded,
             columnMoved: onColumnMoved,
             pinnedRowDataChanged: onPinnedRowsChanged,
@@ -265,26 +262,25 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
         this.formulaDataSvc = undefined;
     }
 
-    /**
-     * Evict a row from the cache. Pinned rows and group-feature siblings share the row's `data`
-     * object but live as distinct entries, each with its own captured formulaString — drop them
-     * all together.
-     */
-    private dropRow(row: RowNode): void {
+    /** Evict a row and its pinned / group-footer siblings from the cache. */
+    private dropRow(row: RowNode): boolean {
         const cache = this.cachedResult;
-        cache.delete(row);
+        let dropped = cache.delete(row);
         const sibling = row.sibling;
         if (sibling) {
-            cache.delete(sibling);
+            if (cache.delete(sibling)) {
+                dropped = true;
+            }
             const siblingPinnedSibling = sibling.pinnedSibling;
-            if (siblingPinnedSibling) {
-                cache.delete(siblingPinnedSibling);
+            if (siblingPinnedSibling && cache.delete(siblingPinnedSibling)) {
+                dropped = true;
             }
         }
         const pinnedSibling = row.pinnedSibling;
-        if (pinnedSibling) {
-            cache.delete(pinnedSibling);
+        if (pinnedSibling && cache.delete(pinnedSibling)) {
+            dropped = true;
         }
+        return dropped;
     }
 
     /**
@@ -329,8 +325,8 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
     }
 
     /**
-     * Bulk-invalidate every cached value (ASTs preserved) and repaint. Cheap O(1): just bumps the
-     * version counter so every entry becomes implicitly stale on next read.
+     * Bulk-invalidate every cached value via a version bump (ASTs preserved) and repaint.
+     * O(1); entries become stale on next read.
      */
     private bumpValueCacheAndRefresh(): void {
         this.valueCacheVersion++;
@@ -420,9 +416,6 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
             return;
         }
 
-        const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-        const base = alphabet.length;
-
         let idx = 0;
         for (let i = 0, len = list.length; i < len; ++i) {
             const col = list[i];
@@ -433,11 +426,11 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
             let n = idx++;
             // generate a column label (A, B, C, ..., Z, AA, AB, ...)
             while (true) {
-                label = alphabet[n % base] + label;
-                if (n < base) {
+                label = COL_REF_ALPHABET[n % COL_REF_BASE] + label;
+                if (n < COL_REF_BASE) {
                     break;
                 }
-                n = Math.floor(n / base) - 1;
+                n = Math.floor(n / COL_REF_BASE) - 1;
             }
             if (col.formulaRef !== label) {
                 col.formulaRef = label;
@@ -459,7 +452,7 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
     }
 
     /** Clear all cached results and re-render cells. */
-    public refreshFormulas(refreshCells: boolean) {
+    public refreshFormulas(refreshCells: boolean): void {
         this.cachedResult.clear();
         if (refreshCells) {
             this.beans.rowRenderer.refreshCells(REFRESH_CELLS_PARAMS);
@@ -467,8 +460,40 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
     }
 
     /**
-     * Is a value a formula string (starts with '=')
-     **/
+     * Drop a row's formula cache (with its sibling chain) and repaint. When given a string id,
+     * body / pinned-top / pinned-bottom are all consulted and every match is evicted. Returns
+     * `true` if anything was dropped.
+     */
+    public refreshRow(row: RowNode | string): boolean {
+        if (!this.active) {
+            return false;
+        }
+
+        let dropped = false;
+        if (typeof row === 'string') {
+            const { rowModel, pinnedRowModel } = this.beans;
+            const body = rowModel.getRowNode(row) as RowNode | undefined;
+            if (body && this.dropRow(body)) {
+                dropped = true;
+            }
+            const pinnedTop = pinnedRowModel?.getPinnedRowById(row, 'top');
+            if (pinnedTop && this.dropRow(pinnedTop)) {
+                dropped = true;
+            }
+            const pinnedBottom = pinnedRowModel?.getPinnedRowById(row, 'bottom');
+            if (pinnedBottom && this.dropRow(pinnedBottom)) {
+                dropped = true;
+            }
+        } else {
+            dropped = this.dropRow(row);
+        }
+
+        if (dropped) {
+            this.bumpValueCacheAndRefresh();
+        }
+        return dropped;
+    }
+
     public isFormula(value: unknown): value is `=${string}` {
         return this.active && _isExpressionString(value);
     }
@@ -487,72 +512,91 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
     }
 
     /**
-     * Return the current formula error for a cell, recomputing if the cached entry is stale.
-     *
-     * Called from rendering/tooltips where callers want the up-to-date error state. Delegates to
-     * `resolveValue` which is a no-op when the cell is already fresh (isValueReady check inside).
+     * Return the `formulaDataSource` formula for (row, col), or undefined. Raw-data `"=..."`
+     * values take a separate path via the standard field lookup + `isFormula` check.
      */
-    public getFormulaError(column: AgColumn, node: RowNode): FormulaError | null {
-        this.resolveValue(column, node);
-        const cell = this.cachedResult.get(node)?.get(column);
-        return cell ? this.buildError(cell) : null;
+    public getDataSourceFormula(row: RowNode, col: AgColumn): string | undefined {
+        if (!this.active || !this.formulaDataSvc?.hasDataSource()) {
+            return undefined;
+        }
+        const cf = this.ensureCellFormula(row, col);
+        return cf?.fromDataSource ? cf.formulaString : undefined;
     }
 
     /**
-     * Construct a FormulaError from a freshly-evaluated cell's stored error fields. The caller is
-     * responsible for having verified freshness (via `isValueReady()` or a prior `resolveValue`) -
-     * this method does not check the version. Returns null if the cell has no error.
-     *
-     * Lives on the service (not on CellFormula) so CellFormula stays a lean data holder and the
-     * FormulaError allocation is co-located with the other error-shaping logic.
+     * Return the current formula error for a cell, or null. Recomputes if the cached entry is
+     * stale. Short-circuits for non-formula cells (common in mostly-plain allowFormula columns).
      */
-    private buildError(cell: CellFormula): FormulaError | null {
+    public getFormulaError(column: AgColumn, node: RowNode): FormulaError | null {
+        const cell = this.ensureCellFormula(node, column);
+        if (!cell) {
+            return null;
+        }
+        if (!cell.isValueReady()) {
+            this.resolveValue(column, node);
+        }
         const errorType = cell.errorType;
         if (!errorType) {
             return null;
         }
         const errorId = cell.errorId;
-        if (errorId != null) {
-            return new FormulaError(errorId, cell.errorVariableValues ?? undefined, errorType);
-        }
-        return new FormulaError(cell.errorMessage, errorType);
+        return errorId != null
+            ? new FormulaError(errorId, cell.errorVariableValues ?? undefined, errorType)
+            : new FormulaError(cell.errorMessage, errorType);
     }
 
     /** Get a registered function by name (used by the evaluator). */
     public getFunction(name: string) {
-        return this.supportedOperations.get(name.toUpperCase());
+        const supportedOperations = this.supportedOperations;
+        return supportedOperations.get(name) ?? supportedOperations.get(name.toUpperCase());
     }
 
-    /** Ensure a CellFormula exists for (row,col) if it's a formula cell; returns null for non-formula. */
-    private ensureCellFormula(row: RowNode, col: AgColumn): CellFormula | null {
+    /**
+     * Ensure a `CellFormula` exists for (row, col), or null if the cell isn't a formula.
+     * Non-formula results are negatively cached (as `null`) so N dependent formulas referencing
+     * the same plain cell trigger one `getFormula` + `fetchRawValue` pair, not N.
+     */
+    public ensureCellFormula(row: RowNode, col: AgColumn): CellFormula | null {
+        if (!this.active || !col.isAllowFormula()) {
+            return null;
+        }
         const cache = this.cachedResult;
         let rowMap = cache.get(row);
         const cached = rowMap?.get(col);
-        if (cached) {
+        if (cached !== undefined) {
             return cached;
         }
-
-        const str = this.getFormulaFromDataSource(row, col) ?? this.fetchRawValue(col, row);
-        if (typeof str !== 'string' || str[0] !== '=') {
-            return null;
-        }
-
-        const cf = new CellFormula(row, col, str, this.beans, this);
         if (!rowMap) {
-            rowMap = new Map<AgColumn, CellFormula>();
+            rowMap = new Map<AgColumn, CellFormula | null>();
             cache.set(row, rowMap);
         }
-        rowMap.set(col, cf);
 
-        return cf;
-    }
+        // Block re-entry for this (row, col) while `ds.getFormula` / `fetchRawValue` runs —
+        // either may synchronously call back via api (e.g. a valueGetter hitting `api.getCellValue`).
+        rowMap.set(col, null);
 
-    private getFormulaFromDataSource(row: RowNode, col: AgColumn): string | undefined {
-        const dataSource = this.formulaDataSvc;
-        if (!dataSource?.hasDataSource()) {
-            return undefined;
+        try {
+            const dataSvc = this.formulaDataSvc;
+
+            const fromSource = dataSvc?.hasDataSource() ? dataSvc.getFormula({ column: col, rowNode: row }) : undefined;
+            if (_isExpressionString(fromSource)) {
+                const cellFormula = new CellFormula(row, col, fromSource, true, this.beans, this);
+                rowMap.set(col, cellFormula);
+                return cellFormula;
+            }
+
+            const str = this.fetchRawValue(col, row);
+            if (_isExpressionString(str)) {
+                const cellFormula = new CellFormula(row, col, str, false, this.beans, this);
+                rowMap.set(col, cellFormula);
+                return cellFormula;
+            }
+
+            return null;
+        } catch (e) {
+            rowMap.delete(col); // clear the negative cache to retry next time
+            throw e;
         }
-        return dataSource.getFormula({ column: col, rowNode: row });
     }
 
     private coerceFormulaValue(cell: CellFormula, value: unknown): unknown {
@@ -562,8 +606,7 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
             cell.baseDataType = baseDataType;
         }
         if (baseDataType === 'bigint') {
-            const bigintValue = this.toBigIntValue(value);
-            return bigintValue ?? value;
+            return _parseBigIntOrNull(value) ?? value;
         }
         if (baseDataType === 'number' && typeof value === 'bigint') {
             const asNumber = Number(value);
@@ -572,102 +615,29 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
         return value;
     }
 
-    private toBigIntValue(value: unknown): bigint | null {
-        if (typeof value === 'bigint') {
-            return value;
-        }
-        if (typeof value === 'number') {
-            if (!Number.isFinite(value) || !Number.isInteger(value)) {
-                return null;
-            }
-            return BigInt(value);
-        }
-        return null;
-    }
-
     /** Fetch a non-formula value from the grid without triggering nested formula calc. */
     private fetchRawValue(col: AgColumn, row: RowNode): unknown {
         return this.beans.valueSvc.getValue(col, row, 'data');
     }
 
     /**
-     * Lazily build (or reuse) the per-evaluation cycle-detection / error-propagation context.
-     * Reusing the existing `activeCtx` when nested evaluations occur (e.g. a `valueGetter`
-     * calling `api.getCellValue`) keeps one shared visiting set per outer call, so we don't
-     * raise false-positive cycle errors across nested eval boundaries.
+     * Resolve an `Addr` for `evalAst`. Throws a FormulaError if the cell isn't ready, or the
+     * `CellFormula` itself if it holds an error — the outer catch decomposes it, avoiding a
+     * FormulaError allocation on the eval hot path.
      */
-    private getVisitorContext() {
-        if (this.activeCtx) {
-            return this.activeCtx;
+    public resolveAddrRef(addr: Addr): unknown {
+        const { row, column } = addr;
+        const cachedRefFormula = this.ensureCellFormula(row, column);
+        if (cachedRefFormula) {
+            if (!cachedRefFormula.isValueReady()) {
+                throw new FormulaError(53);
+            }
+            if (cachedRefFormula.errorType) {
+                throw cachedRefFormula;
+            }
+            return cachedRefFormula.getValue();
         }
-        const stateByCell = new Map<RowNode, Set<AgColumn>>();
-        const setVisiting = (r: RowNode, c: AgColumn): void => {
-            let colSet = stateByCell.get(r);
-
-            const isVisiting = colSet?.has(c);
-            if (isVisiting) {
-                // already visiting, so we have a cycle.
-                throw new FormulaError(51);
-            }
-
-            if (!colSet) {
-                colSet = new Set<AgColumn>();
-                stateByCell.set(r, colSet);
-            }
-            colSet.add(c);
-        };
-
-        const setVisited = (r: RowNode, c: AgColumn): void => {
-            const colSet = stateByCell.get(r);
-            if (colSet) {
-                colSet.delete(c);
-                if (colSet.size === 0) {
-                    stateByCell.delete(r);
-                }
-            }
-        };
-
-        /**
-         * Stamp every still-visiting cell with the final error fields decomposed from `source`.
-         * Accepts the thrown value directly (CellFormula, FormulaError, or anything else) so the
-         * catch site stays a single call and decomposition happens exactly once per eval cycle.
-         * Returns the error type so the catch can use it as the return value.
-         */
-        const errorAllVisitors = (source: unknown): FormulaErrorType => {
-            let type: FormulaErrorType;
-            let errorId: FormulaErrorId | null;
-            let message: string;
-            let variableValues: string[] | null;
-            if (source instanceof CellFormula) {
-                // Throw sites only raise a CellFormula after stamping errorType; fall back to
-                // the generic error type rather than `null` if that invariant is ever violated.
-                type = source.errorType ?? '#ERROR!';
-                errorId = source.errorId;
-                message = source.errorMessage;
-                variableValues = source.errorVariableValues;
-            } else if (source instanceof FormulaError) {
-                type = source.type;
-                errorId = source.errorId;
-                message = source.message;
-                variableValues = source.variableValues ?? null;
-            } else {
-                type = '#ERROR!';
-                errorId = null;
-                message = String((source as { message?: unknown } | null | undefined)?.message ?? source);
-                variableValues = null;
-            }
-            // forEach on Map/Set avoids the per-step iterator/entry allocations that destructuring
-            // `for...of [row, cells]` pays. Hot on grids with many cascading errors.
-            stateByCell.forEach((cells, row) => {
-                cells.forEach((col) => {
-                    const cache = this.ensureCellFormula(row, col);
-                    cache?.setErrorFields(type, errorId, message, variableValues);
-                });
-            });
-            return type;
-        };
-
-        return (this.activeCtx = { setVisited, setVisiting, errorAllVisitors });
+        return this.fetchRawValue(column, row);
     }
 
     private makeFormulaFrame(address: Addr): FormulaFrame {
@@ -679,24 +649,20 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
             throw new FormulaError(52);
         }
 
-        const unresolvedDepIterator = unresolvedDeps(this.beans, ast, this.ensureCellFormulaBound);
+        const unresolvedDepIterator = unresolvedDeps(this.beans, ast, this);
 
         return { address, ast, unresolvedDepIterator };
     }
 
     /**
-     * Evaluate a single cell's formula **iteratively** (no recursion to avoid large stack traces),
-     * caching dependency results into their own CellFormula entries.
-     *
+     * Evaluate a cell's formula iteratively (no recursion), caching dependency results.
      * Returns the computed value, or a '#...' string on error.
      */
     public resolveValue(column: AgColumn, node: RowNode): unknown {
-        // If start cell isn't a formula, return raw value.
+        // If start cell isn't a formula, return raw value. We don't route through the
+        // formatter here — that could loop back through the formula engine.
         const rootCachedCellFormula = this.ensureCellFormula(node, column);
         if (!rootCachedCellFormula) {
-            // if this isn't a formula shouldn't be resolving here.
-            // we don't try to return the formatted value as that could
-            // endlessly loop
             return this.fetchRawValue(column, node);
         }
 
@@ -705,16 +671,18 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
             return rootCachedCellFormula.getValue();
         }
 
-        const hadCtx = !!this.activeCtx; // top level call
-        const { setVisited, setVisiting, errorAllVisitors } = this.getVisitorContext();
+        // Reuse an existing ctx for nested evals (e.g. a valueGetter calling `api.getCellValue`)
+        // so they share the visiting set and don't raise false-positive cycle errors.
+        const existingCtx = this.activeCtx;
+        const ctx = existingCtx ?? (this.activeCtx = new Map());
 
         const evalStack: FormulaFrame[] = [];
 
         try {
-            // Seed the stack with the root formula cell.
-            // Dependencies will be added to tail, and the last item is picked each pass
-            // As items are removed from the tail, items at the head should become resolvable.
-            setVisiting(node, column);
+            // Seed the stack with the root formula cell. Dependencies are added to the tail and
+            // the last item is picked each pass — as items are removed from the tail, items at
+            // the head should become resolvable.
+            formulaVisitorSetVisiting(ctx, node, column);
             evalStack.push(this.makeFormulaFrame({ row: node, column }));
 
             while (evalStack.length) {
@@ -724,11 +692,9 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
                 // formula is guaranteed to exist for frames; check cache/error each pass.
                 const cachedCellFormula = this.ensureCellFormula(row, col)!;
 
-                // if not stale and cache ready, short circuit
                 if (cachedCellFormula.isValueReady()) {
-                    // value is ready, so set complete
                     evalStack.pop();
-                    setVisited(row, col);
+                    formulaVisitorSetVisited(ctx, row, col);
 
                     // Up-to-date but errored: rethrow the cell as its own error carrier. The outer
                     // catch reads the error fields directly off CellFormula so we avoid allocating
@@ -739,37 +705,36 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
                     continue;
                 }
 
-                // pull next unresolved dependency
                 const depStep = unresolvedDepIterator.next();
                 if (!depStep.done) {
                     const depAddr = depStep.value;
                     const depCachedCellFormula = this.ensureCellFormula(depAddr.row, depAddr.column);
                     if (!depCachedCellFormula || depCachedCellFormula.isValueReady()) {
-                        continue; // skip if not formula or value ready
+                        continue;
                     }
 
-                    // value not ready, so mark as visiting before adding any dependencies to the stack
-                    setVisiting(depAddr.row, depAddr.column);
-                    evalStack.push(this.makeFormulaFrame(depAddr)); // push dependency to be resolved
+                    // value not ready — mark visiting before pushing so cycle detection fires on
+                    // the next setVisiting for this cell.
+                    formulaVisitorSetVisiting(ctx, depAddr.row, depAddr.column);
+                    evalStack.push(this.makeFormulaFrame(depAddr));
                     continue;
                 }
 
-                // all deps ready, evaluate this frame. Reuse the frame's `address` as the
+                // All deps ready — evaluate this frame. Reuse the frame's `address` as the
                 // current-cell arg rather than allocating a fresh `{ row, column }` each iteration.
-                const computed = evalAst(this.beans, ast, this.resolveAddrRef, address);
+                const computed = evalAst(this.beans, ast, this, address);
                 const coerced = this.coerceFormulaValue(cachedCellFormula, computed);
 
-                // An inner valueGetter might have errored via errorAllVisitors during evalAst above,
-                // which would have stamped errorType with the current cacheVersion. If so, rethrow
-                // the cell itself (no FormulaError allocation) instead of overwriting with the coerced value.
+                // An inner valueGetter might have errored via `errorAllVisitors` during evalAst
+                // above, stamping errorType at the current cacheVersion. If so, rethrow the cell
+                // itself (no FormulaError allocation) instead of overwriting with the coerced value.
                 if (cachedCellFormula.errorType && cachedCellFormula.isValueReady()) {
-                    setVisited(row, col);
+                    formulaVisitorSetVisited(ctx, row, col);
                     throw cachedCellFormula;
                 }
 
-                // cache result and mark as completed
                 cachedCellFormula.setComputedValue(coerced);
-                setVisited(row, col);
+                formulaVisitorSetVisited(ctx, row, col);
                 evalStack.pop();
             }
 
@@ -779,12 +744,46 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
 
             return rootCachedCellFormula.getValue();
         } catch (e) {
-            return errorAllVisitors(e);
+            return this.errorAllVisitors(ctx, e);
         } finally {
-            // clear out the active ctx to ensure fresh visiting tree
-            if (!hadCtx) {
+            // Only the outermost call clears the ctx, so nested evals keep sharing it.
+            if (!existingCtx) {
                 this.activeCtx = null;
             }
         }
+    }
+
+    /**
+     * Stamp every still-visiting cell with the final error fields decomposed from `source`.
+     * Accepts the thrown value directly (CellFormula, FormulaError, or anything else) so the
+     * catch site stays a single call and decomposition happens exactly once per eval cycle.
+     * Returns the error type so the catch can use it as the return value.
+     */
+    private errorAllVisitors(ctx: FormulaVisitorContext, source: unknown): FormulaErrorType {
+        let type: FormulaErrorType = '#ERROR!';
+        let errorId: FormulaErrorId | null = null;
+        let message: string;
+        let variableValues: string[] | null = null;
+        if (source instanceof CellFormula) {
+            // Throw sites only raise a CellFormula after stamping errorType; fall back to the
+            // generic error type rather than `null` if that invariant is ever violated.
+            type = source.errorType ?? '#ERROR!';
+            errorId = source.errorId;
+            message = source.errorMessage;
+            variableValues = source.errorVariableValues;
+        } else if (source instanceof FormulaError) {
+            type = source.type;
+            errorId = source.errorId;
+            message = source.message;
+            variableValues = source.variableValues ?? null;
+        } else {
+            message = String((source as { message?: unknown } | null | undefined)?.message ?? source);
+        }
+        ctx.forEach((cells, row) => {
+            for (const col of cells) {
+                this.ensureCellFormula(row, col)?.setErrorFields(type, errorId, message, variableValues);
+            }
+        });
+        return type;
     }
 }

--- a/packages/ag-grid-enterprise/src/formula/functions/resolver.ts
+++ b/packages/ag-grid-enterprise/src/formula/functions/resolver.ts
@@ -9,6 +9,47 @@ import type { CellFormula } from '../cellFormula';
  * This file contains utils for resolving formula AST to values
  */
 
+/**
+ * Per-eval cycle-detection state. Tracked as row -> set-of-visiting-columns so push/pop of an
+ * eval frame maps to a single add/remove on a cell's set. A fresh map is allocated at the
+ * outermost `resolveValue` call and reused across nested evals (so a valueGetter that chains
+ * into another formula shares the visiting set and doesn't raise false-positive cycles).
+ */
+export type FormulaVisitorContext = Map<RowNode, Set<AgColumn>>;
+
+/**
+ * Contract the eval loop (`evalAst`, `unresolvedDeps`, error propagation) needs. FormulaService
+ * implements this directly so we pass `this` and avoid allocating bound callbacks.
+ */
+export interface FormulaResolver {
+    ensureCellFormula(row: RowNode, col: AgColumn): CellFormula | null;
+    resolveAddrRef(addr: Addr): unknown;
+}
+
+/** Mark `(r, c)` as visiting. Throws FormulaError(51) if already visiting (cycle). */
+export function formulaVisitorSetVisiting(ctx: FormulaVisitorContext, r: RowNode, c: AgColumn): void {
+    let colSet = ctx.get(r);
+    if (colSet?.has(c)) {
+        throw new FormulaError(51);
+    }
+    if (!colSet) {
+        colSet = new Set<AgColumn>();
+        ctx.set(r, colSet);
+    }
+    colSet.add(c);
+}
+
+/** Mark `(r, c)` as visited. Cleans up the row's entry when its column set becomes empty. */
+export function formulaVisitorSetVisited(ctx: FormulaVisitorContext, r: RowNode, c: AgColumn): void {
+    const colSet = ctx.get(r);
+    if (colSet) {
+        colSet.delete(c);
+        if (colSet.size === 0) {
+            ctx.delete(r);
+        }
+    }
+}
+
 function isRangeCell(cell: Cell): boolean {
     return !!(cell.endColumn && cell.endRow);
 }
@@ -35,7 +76,7 @@ function resolveRefToAddress(beans: BeanCollection, cell: Cell): CellAddress | n
 export function evalAst(
     beans: BeanCollection,
     node: FormulaNode,
-    getCellValue: (addr: { row: RowNode; column: AgColumn }) => unknown,
+    resolver: FormulaResolver,
     caller: { row: RowNode; column: AgColumn }
 ): unknown {
     if (node.type === 'operand') {
@@ -53,7 +94,7 @@ export function evalAst(
         if (!addr) {
             throw new FormulaError(26);
         }
-        return getCellValue(addr);
+        return resolver.resolveAddrRef(addr);
     }
 
     const fn = beans.formula?.getFunction(node.operation);
@@ -61,14 +102,14 @@ export function evalAst(
         throw new FormulaError(27, [node.operation]);
     }
 
-    const { args, values } = makeArgIterables(beans, node.operands, getCellValue, caller);
+    const { args, values } = makeArgIterables(beans, node.operands, resolver, caller);
     return fn({ row: caller.row, column: caller.column, args, values });
 }
 
 function operandToArg(
     beans: BeanCollection,
     node: FormulaNode,
-    getCellValue: (addr: { row: RowNode; column: AgColumn }) => unknown,
+    resolver: FormulaResolver,
     caller: { row: RowNode; column: AgColumn }
 ): FormulaParam {
     if (node.type === 'operand') {
@@ -79,18 +120,18 @@ function operandToArg(
 
         if (isRangeCell(v)) {
             // return a range iterable with range context
-            return buildRangeArgLazy(beans, v, getCellValue);
+            return buildRangeArgLazy(beans, v, resolver);
         }
 
         const addr = resolveRefToAddress(beans, v);
         if (!addr) {
             throw new FormulaError(26);
         }
-        return { kind: 'value', value: getCellValue(addr) };
+        return { kind: 'value', value: resolver.resolveAddrRef(addr) };
     }
 
     // nested op -> scalar
-    const val = evalAst(beans, node, getCellValue, caller);
+    const val = evalAst(beans, node, resolver, caller);
     return { kind: 'value', value: val };
 }
 
@@ -104,7 +145,7 @@ class ParamsIterator implements Iterator<FormulaParam> {
     constructor(
         private readonly beans: BeanCollection,
         private readonly operandNodes: FormulaNode[],
-        private readonly getCellValue: (addr: { row: RowNode; column: AgColumn }) => unknown,
+        private readonly resolver: FormulaResolver,
         private readonly caller: { row: RowNode; column: AgColumn }
     ) {}
 
@@ -115,7 +156,7 @@ class ParamsIterator implements Iterator<FormulaParam> {
             return this.res;
         }
         this.res.done = false;
-        this.res.value = operandToArg(this.beans, this.operandNodes[this.i++], this.getCellValue, this.caller);
+        this.res.value = operandToArg(this.beans, this.operandNodes[this.i++], this.resolver, this.caller);
         return this.res;
     }
 
@@ -133,7 +174,7 @@ class ValuesIterator implements Iterator<unknown> {
     constructor(
         private readonly beans: BeanCollection,
         private readonly operandNodes: FormulaNode[],
-        private readonly getCellValue: (addr: { row: RowNode; column: AgColumn }) => unknown,
+        private readonly resolver: FormulaResolver,
         private readonly caller: { row: RowNode; column: AgColumn }
     ) {}
 
@@ -156,7 +197,7 @@ class ValuesIterator implements Iterator<unknown> {
                 return this.res;
             }
 
-            const arg = operandToArg(this.beans, this.operandNodes[this.i++], this.getCellValue, this.caller);
+            const arg = operandToArg(this.beans, this.operandNodes[this.i++], this.resolver, this.caller);
 
             if (arg.kind === 'value') {
                 this.res.done = false;
@@ -181,17 +222,17 @@ class ValuesIterator implements Iterator<unknown> {
 function makeArgIterables(
     beans: BeanCollection,
     operandNodes: FormulaNode[],
-    getCellValue: (addr: { row: RowNode; column: AgColumn }) => unknown,
+    resolver: FormulaResolver,
     caller: { row: RowNode; column: AgColumn }
 ): { args: Iterable<FormulaParam>; values: Iterable<unknown> } {
     const args: Iterable<FormulaParam> = {
         [Symbol.iterator](): Iterator<FormulaParam> {
-            return new ParamsIterator(beans, operandNodes, getCellValue, caller);
+            return new ParamsIterator(beans, operandNodes, resolver, caller);
         },
     };
     const values: Iterable<unknown> = {
         [Symbol.iterator](): Iterator<unknown> {
-            return new ValuesIterator(beans, operandNodes, getCellValue, caller);
+            return new ValuesIterator(beans, operandNodes, resolver, caller);
         },
     };
     return { args, values };
@@ -244,7 +285,7 @@ class RangeValuesIterator implements Iterator<unknown> {
         private readonly rowEndIndex: number,
         private readonly colStart: AgColumn,
         private readonly colEnd: AgColumn,
-        private readonly getCellValue: (addr: { row: RowNode; column: AgColumn }) => unknown
+        private readonly resolver: FormulaResolver
     ) {}
 
     private initColsOnce() {
@@ -290,7 +331,7 @@ class RangeValuesIterator implements Iterator<unknown> {
                 this.currentRowIndex++;
             }
 
-            this.res.value = this.getCellValue({ row, column: col });
+            this.res.value = this.resolver.resolveAddrRef({ row, column: col });
             return this.res;
         }
 
@@ -300,11 +341,7 @@ class RangeValuesIterator implements Iterator<unknown> {
     }
 }
 
-function buildRangeArgLazy(
-    beans: BeanCollection,
-    cell: Cell,
-    getCellValue: (addr: { row: RowNode; column: AgColumn }) => unknown
-): RangeParam {
+function buildRangeArgLazy(beans: BeanCollection, cell: Cell, resolver: FormulaResolver): RangeParam {
     const r1 = resolveRowIndex(beans, cell.row);
     const r2 = cell.endRow ? resolveRowIndex(beans, cell.endRow) : r1;
     const rowStart = Math.min(r1, r2);
@@ -320,7 +357,7 @@ function buildRangeArgLazy(
         colStart: c1,
         colEnd: c2,
         [Symbol.iterator](): Iterator<unknown> {
-            return new RangeValuesIterator(beans, rowStart, rowEnd, c1, c2, getCellValue);
+            return new RangeValuesIterator(beans, rowStart, rowEnd, c1, c2, resolver);
         },
     };
 }
@@ -387,11 +424,7 @@ function* rangeAddrs(
  * Streams uncached formula dependencies from an AST in traversal order.
  * Skips primitives, non-formula cells, cached formula cells, and already-done cells.
  */
-export function* unresolvedDeps(
-    beans: BeanCollection,
-    root: FormulaNode,
-    ensureFormulaCache: (row: RowNode, col: AgColumn) => CellFormula | null
-): Generator<Addr> {
+export function* unresolvedDeps(beans: BeanCollection, root: FormulaNode, resolver: FormulaResolver): Generator<Addr> {
     const astStack: FormulaNode[] = [root];
 
     while (astStack.length) {
@@ -412,7 +445,7 @@ export function* unresolvedDeps(
                     throw new FormulaError(33);
                 }
 
-                const cachedCellFormula = ensureFormulaCache(cellAddress.row, cellAddress.column);
+                const cachedCellFormula = resolver.ensureCellFormula(cellAddress.row, cellAddress.column);
                 if (!cachedCellFormula || cachedCellFormula.isValueReady()) {
                     continue; // skip non-formula or already computed
                 }
@@ -435,7 +468,7 @@ export function* unresolvedDeps(
             const endCol = resolveCol(beans, operandValue.endColumn);
 
             for (const cellAddress of rangeAddrs(beans, rowStartIndex, rowEndIndex, startCol, endCol)) {
-                const cachedCellFormula = ensureFormulaCache(cellAddress.row, cellAddress.column);
+                const cachedCellFormula = resolver.ensureCellFormula(cellAddress.row, cellAddress.column);
                 if (!cachedCellFormula || cachedCellFormula.isValueReady()) {
                     continue; // skip non-formula or already computed
                 }

--- a/testing/behavioural/src/benchmarks/bench-compare.mjs
+++ b/testing/behavioural/src/benchmarks/bench-compare.mjs
@@ -538,15 +538,24 @@ function round(v, decimals) {
     return Math.round(v * f) / f;
 }
 
-// Sort by conservative delta magnitude
-comparisons.sort((a, b) => {
-    const ac = Math.abs(a.deltaConservative);
-    const bc = Math.abs(b.deltaConservative);
-    if (ac !== bc) {
-        return bc - ac;
+/**
+ * Sort worst-first, best-last. Uses the signed conservative delta as the primary key so
+ * confidence-interval-aware regressions rank above noisy non-changes, which rank above
+ * confidence-interval-aware improvements. Falls back to the signed raw delta, then name.
+ */
+function bySignedDeltaAsc(a, b) {
+    const diff = a.deltaConservative - b.deltaConservative;
+    if (diff !== 0) {
+        return diff;
     }
-    return Math.abs(b.delta) - Math.abs(a.delta);
-});
+    const rawDiff = a.delta - b.delta;
+    if (rawDiff !== 0) {
+        return rawDiff;
+    }
+    return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+}
+
+comparisons.sort(bySignedDeltaAsc);
 
 // ── Output ──
 
@@ -640,12 +649,8 @@ md += `rme = max(run-to-run std, mean within-run rme).\n\n`;
 //             delta is large enough to warrant investigation.
 const notableCertain = comparisons
     .filter((c) => !isNoisy(c) && Math.abs(c.deltaConservative) >= CERTAIN_MIN_PCT)
-    .slice()
-    .sort((a, b) => Math.abs(b.deltaConservative) - Math.abs(a.deltaConservative));
-const notableNoisy = comparisons
-    .filter((c) => isNoisy(c) && Math.abs(c.delta) >= NOISY_MIN_PCT)
-    .slice()
-    .sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta));
+    .sort(bySignedDeltaAsc);
+const notableNoisy = comparisons.filter((c) => isNoisy(c) && Math.abs(c.delta) >= NOISY_MIN_PCT).sort(bySignedDeltaAsc);
 const notable = [...notableCertain, ...notableNoisy];
 
 function writeNotableTable(header, rows) {

--- a/testing/behavioural/src/formulas/formulas-edge-cases.test.ts
+++ b/testing/behavioural/src/formulas/formulas-edge-cases.test.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 
-import type { FormulaDataSource, FormulaFunctionParams, GridOptions, Module } from 'ag-grid-community';
-import { ClientSideRowModelModule, TextEditorModule, UndoRedoEditModule } from 'ag-grid-community';
+import type { FormulaDataSource, FormulaFunctionParams, GridOptions, Module, RowNode } from 'ag-grid-community';
+import { ClientSideRowModelModule, PinnedRowModule, TextEditorModule, UndoRedoEditModule } from 'ag-grid-community';
 import { FormulaModule } from 'ag-grid-enterprise';
 
 import { GridRows, TestGridsManager, applyTransactionChecked, asyncSetTimeout, waitForEvent } from '../test-utils';
@@ -11,7 +11,13 @@ describe('ag-grid formulas edge cases', () => {
     const gridRowsOpts = { useFormatter: false } as const;
 
     const gridsManager = new TestGridsManager({
-        modules: [ClientSideRowModelModule, FormulaModule, TextEditorModule, UndoRedoEditModule] as Module[],
+        modules: [
+            ClientSideRowModelModule,
+            FormulaModule,
+            PinnedRowModule,
+            TextEditorModule,
+            UndoRedoEditModule,
+        ] as Module[],
     });
 
     beforeEach(() => {
@@ -505,11 +511,6 @@ describe('ag-grid formulas edge cases', () => {
     });
 
     test('serializer output covers operand types, precedence and parens branches', async () => {
-        // Commits an A1 formula via the editor and reads back the normalised REF-format string
-        // written to row data. This exercises the full parse -> serialize pipeline and pins down
-        // the exact serializer output so regressions in `needsParensInBinary`,
-        // `needsParensForUnaryMinus`, operand emission (string/number/boolean/cell) and range
-        // formatting are caught.
         const api = createGrid('edge-serializer-shapes', {
             rowData: [
                 { id: 'r1', a: 1, b: 2, c: 3, x: null },
@@ -698,5 +699,426 @@ describe('ag-grid formulas edge cases', () => {
         `);
 
         expect(getFormula).toHaveBeenCalled();
+    });
+
+    test('formulaDataSource.getFormula is only called for columns with allowFormula=true', async () => {
+        const getFormula = vi.fn(({ rowNode, column }) =>
+            rowNode.id === 'r1' && column.getColId() === 'a' ? '=1+2' : undefined
+        );
+        const setFormula = vi.fn();
+        const dataSource: FormulaDataSource = { getFormula, setFormula };
+
+        gridsManager.createGrid('edge-formula-datasource-allowformula-gated', {
+            getRowId: (params) => params.data?.id,
+            rowData: [
+                { id: 'r1', a: 1, b: 2, c: 3 },
+                { id: 'r2', a: 4, b: 5, c: 6 },
+            ],
+            columnDefs: [
+                { field: 'a', allowFormula: true },
+                { field: 'b' }, // no allowFormula
+                { field: 'c', allowFormula: false },
+            ],
+            formulaDataSource: dataSource,
+        });
+        await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+        const columnsQueried = new Set(getFormula.mock.calls.map(([p]) => p.column.getColId()));
+        expect(columnsQueried.has('a')).toBe(true);
+        expect(columnsQueried.has('b')).toBe(false);
+        expect(columnsQueried.has('c')).toBe(false);
+    });
+
+    test('formulas can reference non-allowFormula columns without triggering getFormula on them', async () => {
+        const getFormula = vi.fn(({ rowNode, column }) =>
+            rowNode.id === 'r1' && column.getColId() === 'out' ? '=REF(COLUMN("plain"),ROW("r1"))*2' : undefined
+        );
+        const setFormula = vi.fn();
+        const dataSource: FormulaDataSource = { getFormula, setFormula };
+
+        const api = gridsManager.createGrid('edge-formula-refs-plain-col', {
+            getRowId: (params) => params.data?.id,
+            rowData: [{ id: 'r1', plain: 7, out: null }],
+            columnDefs: [
+                { field: 'plain' }, // NOT allowFormula — only read by REF, never queried via getFormula
+                { field: 'out', allowFormula: true },
+            ],
+            formulaDataSource: dataSource,
+        });
+        await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+        await new GridRows(api, 'formula reads raw value from non-formula column', gridRowsOpts).check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 row-number:"1" plain:7 out:14
+        `);
+
+        const columnsQueried = new Set(getFormula.mock.calls.map(([p]) => p.column.getColId()));
+        expect(columnsQueried.has('out')).toBe(true);
+        expect(columnsQueried.has('plain')).toBe(false);
+    });
+
+    test('plain-value cells in allowFormula columns cache their "not a formula" result (no re-query per dep lookup)', async () => {
+        const getFormula = vi.fn(({ rowNode, column }) => {
+            const colId = column.getColId();
+            if (colId === 'b1' && rowNode.id === 'r1') {
+                return '=REF(COLUMN("a"),ROW("r1"))*2';
+            }
+            if (colId === 'b2' && rowNode.id === 'r1') {
+                return '=REF(COLUMN("a"),ROW("r1"))+10';
+            }
+            if (colId === 'b3' && rowNode.id === 'r1') {
+                return '=REF(COLUMN("a"),ROW("r1"))-5';
+            }
+            return undefined;
+        });
+        const dataSource: FormulaDataSource = { getFormula, setFormula: vi.fn() };
+
+        const api = gridsManager.createGrid('edge-negative-cache', {
+            getRowId: (params) => params.data?.id,
+            rowData: [{ id: 'r1', a: 7, b1: null, b2: null, b3: null }],
+            columnDefs: [
+                { field: 'a', allowFormula: true },
+                { field: 'b1', allowFormula: true },
+                { field: 'b2', allowFormula: true },
+                { field: 'b3', allowFormula: true },
+            ],
+            formulaDataSource: dataSource,
+        });
+        await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+        await new GridRows(api, 'shared plain-value reference', gridRowsOpts).check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 row-number:"1" a:7 b1:14 b2:17 b3:2
+        `);
+
+        const aR1Calls = getFormula.mock.calls.filter(([p]) => p.column.getColId() === 'a' && p.rowNode.id === 'r1');
+        expect(aR1Calls.length).toBe(1);
+    });
+
+    test('plain-text "=..." values on non-formula columns are not parsed as formulas', async () => {
+        const api = gridsManager.createGrid('edge-plain-text-equals-on-non-formula-col', {
+            getRowId: (params) => params.data?.id,
+            rowData: [{ id: 'r1', formulaCol: '=1+2', textCol: '=1+2' }],
+            columnDefs: [
+                { field: 'formulaCol', allowFormula: true },
+                { field: 'textCol' }, // no allowFormula — the `=` prefix must NOT be interpreted
+            ],
+        });
+        await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+        await new GridRows(api, 'non-formula column preserves "=" prefix', gridRowsOpts).check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 row-number:"1" formulaCol:3 textCol:"=1+2"
+        `);
+    });
+
+    test('REF into a non-allowFormula column with a "=..." raw value returns the literal string', async () => {
+        const api = gridsManager.createGrid('edge-ref-non-allowformula-col-equals-text', {
+            getRowId: (params) => params.data?.id,
+            rowData: [{ id: 'r1', textCol: '=1+2', out: '=REF(COLUMN("textCol"),ROW("r1"))' }],
+            columnDefs: [
+                { field: 'textCol' }, // NOT allowFormula — "=1+2" must NOT be re-parsed
+                { field: 'out', allowFormula: true },
+            ],
+        });
+        await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+        await new GridRows(api, 'REF reads raw string from non-formula column', gridRowsOpts).check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 row-number:"1" textCol:"=1+2" out:"=1+2"
+        `);
+    });
+
+    describe('api.refreshFormulas', () => {
+        type StoreKey = `${string}:${string}`;
+        const k = (rowId: string, colId: string): StoreKey => `${rowId}:${colId}`;
+
+        /**
+         * Build a grid whose `out` column formula comes from an external store. Mutating the
+         * store alone does not reach the grid until `refreshFormulas` (or another invalidation
+         * event) runs — that's exactly what these tests exercise.
+         */
+        function createRefreshFixture(testId: string, initial: Record<StoreKey, string>) {
+            const store = new Map<string, string>(Object.entries(initial));
+            const getFormula = vi.fn(({ rowNode, column }) => store.get(k(rowNode.id!, column.getColId())));
+            const dataSource: FormulaDataSource = { getFormula, setFormula: vi.fn() };
+
+            const api = gridsManager.createGrid(testId, {
+                getRowId: (params) => params.data?.id,
+                rowData: [
+                    { id: 'r1', out: null },
+                    { id: 'r2', out: null },
+                ],
+                columnDefs: [{ field: 'out', allowFormula: true }],
+                formulaDataSource: dataSource,
+            });
+            return { api, store, getFormula };
+        }
+
+        test('no-arg call invalidates the whole cache and re-queries every cell', async () => {
+            const { api, store, getFormula } = createRefreshFixture('api-refresh-all', {
+                [k('r1', 'out')]: '=1+2',
+                [k('r2', 'out')]: '=10+20',
+            });
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            await new GridRows(api, 'initial formulas', gridRowsOpts).check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:r1 row-number:"1" out:3
+                └── LEAF id:r2 row-number:"2" out:30
+            `);
+
+            getFormula.mockClear();
+            store.set(k('r1', 'out'), '=100+1');
+            store.set(k('r2', 'out'), '=200+2');
+            expect(api.refreshFormulas()).toBe(true);
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            await new GridRows(api, 'after refreshFormulas()', gridRowsOpts).check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:r1 row-number:"1" out:101
+                └── LEAF id:r2 row-number:"2" out:202
+            `);
+
+            const refreshedRows = new Set(getFormula.mock.calls.map(([p]) => p.rowNode.id));
+            expect(refreshedRows.has('r1')).toBe(true);
+            expect(refreshedRows.has('r2')).toBe(true);
+        });
+
+        test('passing a RowNode invalidates only that row', async () => {
+            const { api, store, getFormula } = createRefreshFixture('api-refresh-rownode', {
+                [k('r1', 'out')]: '=1+2',
+                [k('r2', 'out')]: '=10+20',
+            });
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            getFormula.mockClear();
+            store.set(k('r1', 'out'), '=100+1');
+            store.set(k('r2', 'out'), '=200+2'); // updated but NOT invalidated
+            const r1 = api.getRowNode('r1')!;
+            expect(api.refreshFormulas(r1)).toBe(true);
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            await new GridRows(api, 'only r1 refreshed', gridRowsOpts).check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:r1 row-number:"1" out:101
+                └── LEAF id:r2 row-number:"2" out:30
+            `);
+
+            const refreshedRows = new Set(getFormula.mock.calls.map(([p]) => p.rowNode.id));
+            expect(refreshedRows.has('r1')).toBe(true);
+            expect(refreshedRows.has('r2')).toBe(false);
+        });
+
+        test('passing a row id string resolves via the row model', async () => {
+            const { api, store, getFormula } = createRefreshFixture('api-refresh-rowid', {
+                [k('r1', 'out')]: '=1+2',
+                [k('r2', 'out')]: '=10+20',
+            });
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            getFormula.mockClear();
+            store.set(k('r1', 'out'), '=100+1');
+            store.set(k('r2', 'out'), '=200+2');
+            expect(api.refreshFormulas('r2')).toBe(true);
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            await new GridRows(api, 'only r2 refreshed', gridRowsOpts).check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:r1 row-number:"1" out:3
+                └── LEAF id:r2 row-number:"2" out:202
+            `);
+
+            const refreshedRows = new Set(getFormula.mock.calls.map(([p]) => p.rowNode.id));
+            expect(refreshedRows.has('r1')).toBe(false);
+            expect(refreshedRows.has('r2')).toBe(true);
+        });
+
+        test('unknown row id is a silent no-op — cached values remain stale', async () => {
+            const { api, store, getFormula } = createRefreshFixture('api-refresh-unknown-id', {
+                [k('r1', 'out')]: '=1+2',
+                [k('r2', 'out')]: '=10+20',
+            });
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            getFormula.mockClear();
+            store.set(k('r1', 'out'), '=100+1');
+            store.set(k('r2', 'out'), '=200+2');
+            expect(api.refreshFormulas('does-not-exist')).toBe(false);
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            await new GridRows(api, 'unknown id: no rows refreshed', gridRowsOpts).check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:r1 row-number:"1" out:3
+                └── LEAF id:r2 row-number:"2" out:30
+            `);
+            expect(getFormula).not.toHaveBeenCalled();
+        });
+
+        test('returns false when the formula service is inactive', async () => {
+            const api = gridsManager.createGrid('api-refresh-inactive', {
+                getRowId: (params) => params.data?.id,
+                rowData: [{ id: 'r1', value: 1 }],
+                columnDefs: [{ field: 'value' }], // no allowFormula anywhere
+            });
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            const r1 = api.getRowNode('r1')!;
+            expect(api.refreshFormulas(r1)).toBe(false);
+            expect(api.refreshFormulas('r1')).toBe(false);
+        });
+
+        test('cellValueChanged walks the sibling chain — pinned cache does not diverge after a body edit', async () => {
+            const store = { template: (plain: number) => `=${plain}+2` };
+            const getFormula = vi.fn(({ rowNode, column }) => {
+                if (column.getColId() !== 'out') {
+                    return undefined;
+                }
+                const plainValue = Number(rowNode.data?.plain ?? 0);
+                return store.template(plainValue);
+            });
+
+            const api = gridsManager.createGrid('api-cell-edit-sibling-invalidation', {
+                getRowId: (params) => params.data?.id,
+                rowData: [{ id: 'r1', plain: 2, out: null }],
+                columnDefs: [{ field: 'plain' }, { field: 'out', allowFormula: true }],
+                enableRowPinning: true,
+                isRowPinned: () => 'top',
+                formulaDataSource: { getFormula, setFormula: vi.fn() },
+            });
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            // Initial: plain=2, getFormula returns "=2+2" → out=4 on both sides.
+            await new GridRows(api, 'initial', gridRowsOpts).check(`
+                PINNED_TOP id:t-top-r1 row-number:"1" plain:2 out:4
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:r1 row-number:"1" plain:2 out:4
+            `);
+
+            const r1 = api.getRowNode('r1')!;
+            r1.setDataValue('plain', 10);
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            await new GridRows(api, 'after body edit — pinned matches body', gridRowsOpts).check(`
+                PINNED_TOP id:t-top-r1 row-number:"1" plain:10 out:12
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:r1 row-number:"1" plain:10 out:12
+            `);
+        });
+
+        test('cellValueChanged invalidates formulas that REF a non-formula column — downstream rows are not left stale', async () => {
+            const api = gridsManager.createGrid('api-cell-edit-cross-row-non-formula-ref', {
+                getRowId: (params) => params.data?.id,
+                rowData: [
+                    { id: 'a', plain: 5 },
+                    { id: 'b', out: '=REF(COLUMN("plain"),ROW("a"))*2' },
+                ],
+                columnDefs: [{ field: 'plain' }, { field: 'out', allowFormula: true }],
+            });
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            await new GridRows(api, 'initial: b.out reads a.plain', gridRowsOpts).check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:a row-number:"1" plain:5
+                └── LEAF id:b row-number:"2" out:10
+            `);
+
+            const a = api.getRowNode('a')!;
+            a.setDataValue('plain', 20);
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            await new GridRows(api, 'after a.plain edit: b.out refreshed', gridRowsOpts).check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:a row-number:"1" plain:20
+                └── LEAF id:b row-number:"2" out:40
+            `);
+        });
+
+        test('cellValueChanged does not double-refresh when valueService fires both body and pinned events', async () => {
+            const getFormula = vi.fn(({ rowNode, column }) => {
+                if (column.getColId() !== 'out') {
+                    return undefined;
+                }
+                return `=${Number(rowNode.data?.plain ?? 0)}+2`;
+            });
+
+            const api = gridsManager.createGrid('api-cell-edit-no-double-refresh', {
+                getRowId: (params) => params.data?.id,
+                rowData: [{ id: 'r1', plain: 2, out: null }],
+                columnDefs: [{ field: 'plain' }, { field: 'out', allowFormula: true }],
+                enableRowPinning: true,
+                isRowPinned: () => 'top',
+                formulaDataSource: { getFormula, setFormula: vi.fn() },
+            });
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            // Clear the spy after initial render populates both caches.
+            getFormula.mockClear();
+
+            const r1 = api.getRowNode('r1')!;
+            r1.setDataValue('plain', 10);
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            // After the edit: cache for body and pinned each cleared once (by the first event),
+            // then re-populated once each by the repaint. With the old always-bump handler the
+            // second event would wipe + refresh again, doubling the getFormula calls.
+            const outCalls = getFormula.mock.calls.filter(([p]) => p.column.getColId() === 'out');
+            expect(outCalls.length).toBe(2); // one for body, one for pinned sibling
+        });
+
+        test('refreshFormulas propagates through the pinned-sibling chain from either side', async () => {
+            const store = new Map<string, string>([['r1:out', '=1+2']]);
+            const getFormula = vi.fn(({ rowNode, column }) => {
+                const bodyId = rowNode.id!.replace(/^t-top-/, '');
+                return store.get(`${bodyId}:${column.getColId()}`);
+            });
+
+            const api = gridsManager.createGrid('api-refresh-pinned-sibling-chain', {
+                getRowId: (params) => params.data?.id,
+                rowData: [{ id: 'r1', out: null }],
+                columnDefs: [{ field: 'out', allowFormula: true }],
+                enableRowPinning: true,
+                isRowPinned: () => 'top',
+                formulaDataSource: { getFormula, setFormula: vi.fn() },
+            });
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            await new GridRows(api, 'initial: body and pinned both cached', gridRowsOpts).check(`
+                PINNED_TOP id:t-top-r1 row-number:"1" out:3
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:r1 row-number:"1" out:3
+            `);
+
+            store.set('r1:out', '=100+1');
+            const pinnedRow = api.getPinnedTopRow(0) as RowNode;
+            expect(api.refreshFormulas(pinnedRow)).toBe(true);
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            await new GridRows(api, 'after refresh via pinned node', gridRowsOpts).check(`
+                PINNED_TOP id:t-top-r1 row-number:"1" out:101
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:r1 row-number:"1" out:101
+            `);
+
+            store.set('r1:out', '=999-1');
+            expect(api.refreshFormulas('r1')).toBe(true);
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            await new GridRows(api, 'after refresh via body id', gridRowsOpts).check(`
+                PINNED_TOP id:t-top-r1 row-number:"1" out:998
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:r1 row-number:"1" out:998
+            `);
+
+            store.set('r1:out', '=42+0');
+            expect(api.refreshFormulas(pinnedRow.id!)).toBe(true);
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            await new GridRows(api, 'after refresh via pinned id string', gridRowsOpts).check(`
+                PINNED_TOP id:t-top-r1 row-number:"1" out:42
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:r1 row-number:"1" out:42
+            `);
+        });
     });
 });


### PR DESCRIPTION
## Summary

Reduces redundant calls to `formulaDataSource.getFormula` and `valueService.getValue` from the formula engine, narrows `cellValueChanged` invalidation from a full cache wipe to a row-local eviction, and adds a grid API to invalidate the formula cache explicitly when the external store is mutated out-of-band.

I won't really define the new caching mechanism as a breaking change as I doubt users expected the data source to be automatically reflected without a grid refresh / edit / setData, but, providing the new API gives them an option to do this.
The right behaviour is to cache the data source results, so this is a bug fix more than a breaking change - and providing this new API as an escape hatch if the user would ever need to.

## New API: `api.refreshFormulas`

In-grid edits and CSRM updates already auto-invalidate the formula cache. Users who mutate the external formula store out-of-band (e.g. backend sync) previously had no way to tell the grid to re-query. New grid API:

- `api.refreshFormulas()` — invalidates every cached formula.
- `api.refreshFormulas(rowNode)` — invalidates a single row (plus pinned / group-footer siblings) given an `IRowNode`.
- `api.refreshFormulas(rowId)` — same, but resolves the row via `rowModel.getRowNode(id)`; unknown id is a silent no-op.

Documented under the Formula Data Source / Caching section in the Formulas docs.

## Changes

- **Single source of truth for per-cell lookups.** `ensureCellFormula` is now the only place that queries `dataSource.getFormula` or reads the raw cell value. `valueService` (for the column-value path), `getDataSourceFormula`, `getFormulaError`, `resolveValue`, and the eval loop all route through it.
- Changes the lookup in value service for non formulas and formulas, the new implementation make the performance critical getValue a bit faster, as benchmarks shows too.
- **Negative caching.** Plain-value cells in `allowFormula` columns cache a `null` result, so N dependent formulas referencing the same plain cell trigger one lookup, not N.
- **Re-entry guard.** `ensureCellFormula` writes a `null` sentinel before calling out, so a `valueGetter` that synchronously calls back via `api.getCellValue` for the same cell sees "not a formula" instead of recursing. On throw the sentinel is cleared so the next read retries.
- **`fromDataSource` flag on `CellFormula`.** Lets `getDataSourceFormula` distinguish formulas produced by the data source from `"=..."` strings in raw row data without re-querying the data source.
- **Row-local cache eviction on `cellValueChanged`.** Drops the edited row's map and bumps the value-version counter instead of wiping the whole cache. Relies on `valueService.finishValueChange` already firing the event for both the row and its pinned sibling.
- **Resolver refactor.** `FormulaService` implements a new `FormulaResolver` interface (`ensureCellFormula` + `resolveAddrRef`) so `evalAst` / `unresolvedDeps` / range iterators take the service directly, eliminating per-frame bound-callback allocations and the `activeCtx` arrow-field closures. Cycle-detection state moves to a plain `Map<RowNode, Set<AgColumn>>`.
- **Error propagation.** `resolveAddrRef` now throws the `CellFormula` itself for errored dependencies; the outer catch decomposes it, avoiding a `FormulaError` allocation on the eval hot path.
- **Shared helpers.** A1-column alphabet is hoisted to a module-level constant; bigint coercion is delegated to the shared `_parseBigIntOrNull`.
- Improved documentation grammar and wording and avoid "you".

## Behaviour changes

- `cellValueChanged` no longer wipes the entire formula cache; only the edited row's entry (and its pinned sibling, via the separate event `valueService` already dispatches) is dropped. Cross-row `getFormula` dependencies that relied on the old full-wipe behaviour will see stale formula text — these now need `api.refreshFormulas()`.
- `getFormulaError` no longer calls `resolveValue` for cells that aren't formulas;

## Tests

Eight new behavioural tests in `formulas-edge-cases.test.ts`:

- `getFormula` is only called for `allowFormula` columns.
- Formulas can `REF` into non-`allowFormula` columns without triggering `getFormula` there.
- Plain-value cells cache their "not a formula" result (one `getFormula` call shared across N references).
- `"=..."` raw values on non-`allowFormula` columns are not parsed as formulas (also via `REF`).
- `api.refreshFormulas()` invalidates the whole cache and re-queries every cell.
- `api.refreshFormulas(rowNode)` invalidates only that row.
- `api.refreshFormulas(rowId)` resolves string ids via the row model.
- `api.refreshFormulas(unknownId)` is a silent no-op; cached values stay as-is.

## Benchmarks 

compared to the version before the prev AG-16878 PR, so, before the work on this ticket started:

↑ 3.89x faster [formulas] cold: invalidate then evaluate sum/product/branch for 3000 rows (16.48 → 64.08 ops/s)
↑ 2.40x faster [formulas] update source -> re-eval 200 chained + 1500 fan-out dependents (148.0 → 355.3 ops/s)
↑ 1.30x faster [grouping-aggregation] immutable (5/50 cols) — CellsPath (75.23 → 97.44 ops/s)
↑ 1.28x faster [grouping-aggregation] transaction (5/50 cols) — RowsPath (79.42 → 101.3 ops/s)
↑ 1.27x faster [grouping-aggregation] immutable (all 50 cols) — RowsPath (72.65 → 92.44 ops/s)
↑ 1.27x faster [grouping-aggregation] transaction (5/50 cols) — CellsPath (79.27 → 100.5 ops/s)
↑ 1.22x faster [formulas] cold: invalidate then SUM over 100000 cells (48.97 → 59.92 ops/s)
↑ 1.21x faster [flat-sorting] sort 30000 rows (26.13 → 31.66 ops/s)
↑ 1.12x faster [tree-data-path] build from scratch 20884 rows (7.381 → 8.244 ops/s)
↑ 1.10x faster [delta-sort-transaction] applyTransaction (deltaSort: false) - 1 update (7.194 → 7.911 ops/s)
↑ 1.09x faster [getvalue] getCellValue by string (last of 100 cols) (9373.8 → 10,256 ops/s)
↑ 1.09x faster [flat-pipeline] filter + sort 30000 rows (18.13 → 19.70 ops/s)
↑ 1.08x faster [getvalue] getDataValue by Column object (first col) (12,630 → 13,608 ops/s)
↑ 1.06x faster [delta-sort-transaction] applyTransaction (deltaSort: true) - 1 update (60.78 → 64.69 ops/s)

FIX AG-16878