### PR TITLE
[AG-17161] Feature(toolbar): design followups

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_toolbar.scss
+++ b/community-modules/styles/src/internal/base/parts/_toolbar.scss
@@ -25,7 +25,7 @@
         display: inline-flex;
         align-items: center;
         gap: var(--ag-spacing);
-        padding: var(--ag-spacing);
+        padding: calc(var(--ag-spacing) * 2.5);
         border: 0;
         border-radius: var(--ag-border-radius);
         background: transparent;
@@ -44,7 +44,11 @@
     }
 
     .ag-toolbar-button:focus-visible {
+        outline: solid calc(var(--ag-border-width) * 2) var(--ag-accent-color);
+        outline-offset: calc(var(--ag-border-width) * -2);
         box-shadow: var(--ag-focus-shadow);
+        position: relative;
+        z-index: 1;
     }
 
     .ag-toolbar-button:disabled {
@@ -115,21 +119,19 @@
     }
 
     .ag-toolbar-separator {
-        align-self: stretch;
-        width: 0;
-        margin: 0 var(--ag-spacing);
-        @include ag.unthemed-rtl(
-            (
-                border-left: solid var(--ag-border-width) var(--ag-border-color),
-            )
-        );
+        width: var(--ag-border-width);
+        height: calc(var(--ag-spacing) * 5);
+        align-self: center;
+        background: var(--ag-border-color);
+        flex-shrink: 0;
+        margin: 0 calc(var(--ag-spacing) * 0.5);
     }
 
     .ag-toolbar-find {
         gap: calc(var(--ag-spacing) * 0.5);
         border: solid var(--ag-border-width) var(--ag-border-color);
         border-radius: var(--ag-border-radius);
-        width: 240px;
+        min-width: 240px;
     }
 
     .ag-toolbar-find:focus-within {

--- a/community-modules/styles/src/internal/base/parts/_toolbar.scss
+++ b/community-modules/styles/src/internal/base/parts/_toolbar.scss
@@ -120,11 +120,10 @@
 
     .ag-toolbar-separator {
         width: var(--ag-border-width);
-        height: calc(var(--ag-spacing) * 5);
-        align-self: center;
+        align-self: stretch;
         background: var(--ag-border-color);
         flex-shrink: 0;
-        margin: 0 calc(var(--ag-spacing) * 0.5);
+        margin: calc(var(--ag-spacing) * 2) calc(var(--ag-spacing) * 0.5);
     }
 
     .ag-toolbar-find {

--- a/packages/ag-grid-enterprise/src/toolbar/agToolbar.css
+++ b/packages/ag-grid-enterprise/src/toolbar/agToolbar.css
@@ -108,11 +108,10 @@
 
 .ag-toolbar-separator {
     width: var(--ag-border-width);
-    height: calc(var(--ag-spacing) * 5);
-    align-self: center;
+    align-self: stretch;
     background: var(--ag-border-color);
     flex-shrink: 0;
-    margin: 0 calc(var(--ag-spacing) * 0.5);
+    margin: calc(var(--ag-spacing) * 2) calc(var(--ag-spacing) * 0.5);
 }
 
 .ag-toolbar-find {

--- a/packages/ag-grid-enterprise/src/toolbar/agToolbar.css
+++ b/packages/ag-grid-enterprise/src/toolbar/agToolbar.css
@@ -22,7 +22,7 @@
     display: inline-flex;
     align-items: center;
     gap: var(--ag-spacing);
-    padding: var(--ag-spacing);
+    padding: calc(var(--ag-spacing) * 2.5);
     border: 0;
     border-radius: var(--ag-border-radius);
     background: transparent;
@@ -41,7 +41,11 @@
 }
 
 .ag-toolbar-button:focus-visible {
+    outline: solid calc(var(--ag-border-width) * 2) var(--ag-accent-color);
+    outline-offset: calc(var(--ag-border-width) * -2);
     box-shadow: var(--ag-focus-shadow);
+    position: relative;
+    z-index: 1;
 }
 
 .ag-toolbar-button:disabled {
@@ -103,17 +107,19 @@
 }
 
 .ag-toolbar-separator {
-    align-self: stretch;
-    width: 0;
-    margin: 0 var(--ag-spacing);
-    border-left: solid var(--ag-border-width) var(--ag-border-color);
+    width: var(--ag-border-width);
+    height: calc(var(--ag-spacing) * 5);
+    align-self: center;
+    background: var(--ag-border-color);
+    flex-shrink: 0;
+    margin: 0 calc(var(--ag-spacing) * 0.5);
 }
 
 .ag-toolbar-find {
     gap: calc(var(--ag-spacing) * 0.5);
     border: solid var(--ag-border-width) var(--ag-border-color);
     border-radius: var(--ag-border-radius);
-    width: 240px;
+    min-width: 240px;
 }
 
 .ag-toolbar-find:focus-within {


### PR DESCRIPTION
## Changes

- `.ag-toolbar-find`: `width: 240px` → `min-width: 240px`
- `.ag-toolbar-button`: padding `var(--ag-spacing)` → `calc(var(--ag-spacing) * 2.5)`
- `.ag-toolbar-button:focus-visible`: added inset accent outline (`2 * --ag-border-width`, `-2 * --ag-border-width` offset), kept `var(--ag-focus-shadow)` halo, added `position: relative` + `z-index: 1`
- `.ag-toolbar-separator`: switched from `border-left` on a 0-width stretched element to a centered 1px × `calc(var(--ag-spacing) * 5)` bar with `background: var(--ag-border-color)` and `margin: 0 calc(var(--ag-spacing) * 0.5)`

Applied identically to:
- `packages/ag-grid-enterprise/src/toolbar/agToolbar.css` (Theming API)
- `community-modules/styles/src/internal/base/parts/_toolbar.scss` (Legacy Themes)