### PR TITLE
AG-17168 standardise-get-data-value-and-comparator

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/cell-editing-batch/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/cell-editing-batch/index.mdoc
@@ -62,6 +62,11 @@ The table below shows the impact of the `from` parameter on the value that is re
 -   **`'value'`** — same as `'data'`, but unwraps the aggregation result returned by `avg` and `count` to its scalar value.
 -   **`'data-raw'`** — same as `'data'` but skips aggregation results (`rowNode.aggData`). For group rows the valueGetter or field value is returned instead, which is typically `undefined` since group rows do not hold leaf data.
 
+**Formula Cells (`allowFormula: true`)**
+
+-   **`'data'` / `'value'`** — return the computed result.
+-   **`'edit'` / `'batch'` / `'data-raw'`** — return the raw formula string (e.g. `"=A1*2"`).
+
 ### Example getDataValue()
 
 ```js

--- a/packages/ag-grid-community/src/agStack/utils/generic.test.ts
+++ b/packages/ag-grid-community/src/agStack/utils/generic.test.ts
@@ -15,7 +15,15 @@ describe('_makeNull', () => {
 });
 
 describe('_defaultComparator', () => {
-    const sign = (n: number) => (n > 0 ? 1 : n < 0 ? -1 : 0);
+    const sign = (n: number) => {
+        if (n > 0) {
+            return 1;
+        }
+        if (n < 0) {
+            return -1;
+        }
+        return 0;
+    };
 
     describe('nullish handling', () => {
         it('returns 0 when both values are null', () => {
@@ -72,44 +80,42 @@ describe('_defaultComparator', () => {
             expect(sign(_defaultComparator(nine, ten))).toBe(-1); // numeric, not lexicographic
         });
 
-        it('unwraps a wrapper with only .value (custom aggFunc style)', () => {
-            // Custom aggregation functions may return `{ value: N, ...extra }` without toNumber.
-            // Previously `_defaultComparator` compared these as objects (>/< on objects => false),
-            // effectively breaking sort on those columns.
-            const a = { value: 5, label: 'a' };
-            const b = { value: 50, label: 'b' };
-            const c = { value: 9, label: 'c' };
-
-            expect(sign(_defaultComparator(a, b))).toBe(-1);
-            expect(sign(_defaultComparator(b, a))).toBe(1);
-            // numeric (9 < 50) — not lexicographic (where "50" < "9")
-            expect(sign(_defaultComparator(c, b))).toBe(-1);
-        });
-
-        it('prefers toNumber() over .value when both are present', () => {
-            // If both are defined and disagree, toNumber() wins — matches the priority ordering in
-            // dataTypeService's scalar-resolution logic.
-            const a = { toNumber: () => 1, value: 999, toString: () => '1' };
-            const b = { toNumber: () => 2, value: 0, toString: () => '2' };
-
-            expect(sign(_defaultComparator(a, b))).toBe(-1);
-        });
-
-        it('leaves plain objects without toNumber or .value unchanged', () => {
-            // A bare object with neither shape should not be unwrapped — `<`/`>` on objects coerces
-            // via `toString()`, yielding "[object Object]" on both sides → 0.
-            const a = { foo: 1 };
-            const b = { foo: 2 };
-            expect(_defaultComparator(a, b)).toBe(0);
-        });
-
-        it('handles a mix of wrapped and unwrapped values', () => {
-            // Group-level agg cell compared against a leaf scalar — common when sorting a column where
-            // only some rows have aggregated values.
-            const wrapped = { value: 10 };
+        it('compares wrapper against bare scalar via toNumber()', () => {
+            // Group-level agg cell compared against a leaf scalar — common when sorting a column
+            // where only some rows have aggregated values.
+            const wrapped = { toNumber: () => 10 };
             expect(sign(_defaultComparator(wrapped, 5))).toBe(1);
             expect(sign(_defaultComparator(5, wrapped))).toBe(-1);
             expect(_defaultComparator(wrapped, 10)).toBe(0);
+        });
+
+        it('does not unwrap arbitrary objects without toNumber()', () => {
+            // Domain objects exposed via valueGetter (e.g. `{ value: 5, label: 'High' }`) must NOT
+            // be silently unwrapped — they're treated as opaque, and `>`/`<` on objects coerces via
+            // toString to `"[object Object]"` on both sides, returning 0. Sort stability for such
+            // objects is the user's responsibility (custom comparator).
+            const a = { value: 5, label: 'High' };
+            const b = { value: 50, label: 'Low' };
+            expect(_defaultComparator(a, b)).toBe(0);
+        });
+
+        it('ignores a non-function `toNumber` property (defensive against truthy collisions)', () => {
+            // A user object where `toNumber` is a truthy non-function (e.g. a stale string) must not
+            // be invoked; treat the wrapper as opaque instead of throwing.
+            const a = { toNumber: 'oops', value: 1 };
+            const b = { toNumber: 'oops', value: 2 };
+            expect(_defaultComparator(a, b)).toBe(0);
+        });
+
+        it('treats wrapper whose toNumber() yields null as nullish (sorts before non-null)', () => {
+            // Empty groups commonly produce `{ toNumber: () => null, ... }`. Without the post-unwrap
+            // nullish recheck, the unwrapped null would be coerced to 0 by `<`/`>` and sort after
+            // negative numbers. The recheck restores the standard null-sorts-first ordering.
+            const wrapped = { toNumber: () => null, toString: () => '' };
+            expect(_defaultComparator(wrapped, null)).toBe(0);
+            expect(sign(_defaultComparator(wrapped, 5))).toBe(-1);
+            expect(sign(_defaultComparator(wrapped, -10))).toBe(-1);
+            expect(sign(_defaultComparator(wrapped, 0))).toBe(-1);
         });
     });
 });

--- a/packages/ag-grid-community/src/agStack/utils/generic.test.ts
+++ b/packages/ag-grid-community/src/agStack/utils/generic.test.ts
@@ -1,4 +1,4 @@
-import { _makeNull } from './generic';
+import { _defaultComparator, _makeNull } from './generic';
 
 describe('_makeNull', () => {
     it.each([4, 'string', new Date()])('returns value if not null: %s', (value) => {
@@ -11,5 +11,105 @@ describe('_makeNull', () => {
 
     it('converts empty string to null', () => {
         expect(_makeNull('')).toBeNull();
+    });
+});
+
+describe('_defaultComparator', () => {
+    const sign = (n: number) => (n > 0 ? 1 : n < 0 ? -1 : 0);
+
+    describe('nullish handling', () => {
+        it('returns 0 when both values are null', () => {
+            expect(_defaultComparator(null, null)).toBe(0);
+        });
+
+        it('returns 0 when both values are undefined', () => {
+            expect(_defaultComparator(undefined, undefined)).toBe(0);
+        });
+
+        it('treats null and undefined as equivalent', () => {
+            expect(_defaultComparator(null, undefined)).toBe(0);
+            expect(_defaultComparator(undefined, null)).toBe(0);
+        });
+
+        it('sorts null before non-null', () => {
+            expect(_defaultComparator(null, 5)).toBe(-1);
+            expect(_defaultComparator(5, null)).toBe(1);
+        });
+    });
+
+    describe('primitive comparison', () => {
+        it('compares numbers in ascending order', () => {
+            expect(sign(_defaultComparator(1, 2))).toBe(-1);
+            expect(sign(_defaultComparator(2, 1))).toBe(1);
+            expect(_defaultComparator(2, 2)).toBe(0);
+        });
+
+        it('compares strings lexicographically by default', () => {
+            expect(sign(_defaultComparator('a', 'b'))).toBe(-1);
+            expect(sign(_defaultComparator('b', 'a'))).toBe(1);
+            expect(_defaultComparator('a', 'a')).toBe(0);
+        });
+
+        it('uses localeCompare when accentedCompare is enabled for strings', () => {
+            // accentedCompare delegates to localeCompare which handles collation (e.g. "é" vs "e")
+            expect(sign(_defaultComparator('a', 'b', true))).toBe(-1);
+            expect(_defaultComparator('é', 'é', true)).toBe(0);
+        });
+    });
+
+    describe('aggregation wrapper unwrapping', () => {
+        it('unwraps a wrapper with toNumber() (built-in avg/count style)', () => {
+            const a = { toNumber: () => 10, toString: () => '10' };
+            const b = { toNumber: () => 20, toString: () => '20' };
+
+            // Without unwrap, string comparison on "10"/"20" would also give -1 here, so also check
+            // a case where string and numeric comparison disagree ("9" > "10" as strings).
+            const nine = { toNumber: () => 9, toString: () => '9' };
+            const ten = { toNumber: () => 10, toString: () => '10' };
+
+            expect(sign(_defaultComparator(a, b))).toBe(-1);
+            expect(sign(_defaultComparator(b, a))).toBe(1);
+            expect(sign(_defaultComparator(nine, ten))).toBe(-1); // numeric, not lexicographic
+        });
+
+        it('unwraps a wrapper with only .value (custom aggFunc style)', () => {
+            // Custom aggregation functions may return `{ value: N, ...extra }` without toNumber.
+            // Previously `_defaultComparator` compared these as objects (>/< on objects => false),
+            // effectively breaking sort on those columns.
+            const a = { value: 5, label: 'a' };
+            const b = { value: 50, label: 'b' };
+            const c = { value: 9, label: 'c' };
+
+            expect(sign(_defaultComparator(a, b))).toBe(-1);
+            expect(sign(_defaultComparator(b, a))).toBe(1);
+            // numeric (9 < 50) — not lexicographic (where "50" < "9")
+            expect(sign(_defaultComparator(c, b))).toBe(-1);
+        });
+
+        it('prefers toNumber() over .value when both are present', () => {
+            // If both are defined and disagree, toNumber() wins — matches the priority ordering in
+            // dataTypeService's scalar-resolution logic.
+            const a = { toNumber: () => 1, value: 999, toString: () => '1' };
+            const b = { toNumber: () => 2, value: 0, toString: () => '2' };
+
+            expect(sign(_defaultComparator(a, b))).toBe(-1);
+        });
+
+        it('leaves plain objects without toNumber or .value unchanged', () => {
+            // A bare object with neither shape should not be unwrapped — `<`/`>` on objects coerces
+            // via `toString()`, yielding "[object Object]" on both sides → 0.
+            const a = { foo: 1 };
+            const b = { foo: 2 };
+            expect(_defaultComparator(a, b)).toBe(0);
+        });
+
+        it('handles a mix of wrapped and unwrapped values', () => {
+            // Group-level agg cell compared against a leaf scalar — common when sorting a column where
+            // only some rows have aggregated values.
+            const wrapped = { value: 10 };
+            expect(sign(_defaultComparator(wrapped, 5))).toBe(1);
+            expect(sign(_defaultComparator(5, wrapped))).toBe(-1);
+            expect(_defaultComparator(wrapped, 10)).toBe(0);
+        });
     });
 });

--- a/packages/ag-grid-community/src/agStack/utils/generic.ts
+++ b/packages/ag-grid-community/src/agStack/utils/generic.ts
@@ -38,35 +38,26 @@ export const _jsonEquals = <T1, T2>(val1: T1, val2: T2): boolean => {
 };
 
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
+// PERFORMANCE CRITICAL — called per comparison during sort (O(n log n)). Any change here can have
+// a large impact across grouping, filtering, and rendering. Run the sort benchmark to verify.
 export const _defaultComparator = (valueA: any, valueB: any, accentedCompare: boolean = false): number => {
+    // Unwrap `IAggFuncResult`-shaped wrappers (e.g. built-in `avg` / `count`) BEFORE the nullish
+    // check so wrappers carrying a nullish payload (`toNumber() => null` for empty aggregations)
+    // sort with bare nullish instead of being coerced to `0` by the `<` / `>` path.
+    // - `valueA !== null` is required because `typeof null === 'object'`.
+    // - Strict `typeof === 'function'` guards against truthy non-function `toNumber` properties.
+    if (typeof valueA === 'object' && valueA !== null && typeof valueA.toNumber === 'function') {
+        valueA = valueA.toNumber();
+    }
+    if (typeof valueB === 'object' && valueB !== null && typeof valueB.toNumber === 'function') {
+        valueB = valueB.toNumber();
+    }
+
     if (valueA == null) {
         return valueB == null ? 0 : -1;
     }
-
     if (valueB == null) {
         return 1;
-    }
-
-    // Unwrap `IAggFuncResult`-shaped objects (built-in avg/count as well as custom aggFuncs) so we
-    // compare the underlying scalar. Without this, `>`/`<` on objects returns false and the column
-    // silently fails to sort. `toNumber()` is preferred — avg/count provide it and it preserves
-    // precision. Fall back to `.value` for custom aggregation results that expose only the scalar
-    // property (e.g. `{ value: 300, label: '...' }`).
-    // Null / undefined are already short-circuited above, so `typeof === 'object'` is enough here.
-    if (typeof valueA === 'object') {
-        if (typeof valueA.toNumber === 'function') {
-            valueA = valueA.toNumber();
-        } else if ('value' in valueA) {
-            valueA = valueA.value;
-        }
-    }
-
-    if (typeof valueB === 'object') {
-        if (typeof valueB.toNumber === 'function') {
-            valueB = valueB.toNumber();
-        } else if ('value' in valueB) {
-            valueB = valueB.value;
-        }
     }
 
     if (!accentedCompare || typeof valueA !== 'string') {
@@ -79,6 +70,6 @@ export const _defaultComparator = (valueA: any, valueB: any, accentedCompare: bo
         return 0;
     }
 
-    // using locale compare also allows chinese comparisons
+    // localeCompare also handles Chinese / accented collation.
     return valueA.localeCompare(valueB);
 };

--- a/packages/ag-grid-community/src/agStack/utils/generic.ts
+++ b/packages/ag-grid-community/src/agStack/utils/generic.ts
@@ -47,15 +47,26 @@ export const _defaultComparator = (valueA: any, valueB: any, accentedCompare: bo
         return 1;
     }
 
-    // this is for aggregations sum and avg, where the result can be a number that is wrapped.
-    // if we didn't do this, then the toString() value would be used, which would result in
-    // the strings getting used instead of the numbers.
-    if (typeof valueA === 'object' && valueA.toNumber) {
-        valueA = valueA.toNumber();
+    // Unwrap `IAggFuncResult`-shaped objects (built-in avg/count as well as custom aggFuncs) so we
+    // compare the underlying scalar. Without this, `>`/`<` on objects returns false and the column
+    // silently fails to sort. `toNumber()` is preferred — avg/count provide it and it preserves
+    // precision. Fall back to `.value` for custom aggregation results that expose only the scalar
+    // property (e.g. `{ value: 300, label: '...' }`).
+    // Null / undefined are already short-circuited above, so `typeof === 'object'` is enough here.
+    if (typeof valueA === 'object') {
+        if (typeof valueA.toNumber === 'function') {
+            valueA = valueA.toNumber();
+        } else if ('value' in valueA) {
+            valueA = valueA.value;
+        }
     }
 
-    if (typeof valueB === 'object' && valueB.toNumber) {
-        valueB = valueB.toNumber();
+    if (typeof valueB === 'object') {
+        if (typeof valueB.toNumber === 'function') {
+            valueB = valueB.toNumber();
+        } else if ('value' in valueB) {
+            valueB = valueB.value;
+        }
     }
 
     if (!accentedCompare || typeof valueA !== 'string') {

--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -183,7 +183,15 @@ export interface IAggFuncResult<TAggValue = number | bigint | null> {
     count?: number;
     /** Returns a string representation of the aggregated value */
     toString(): string;
-    /** Returns the numeric representation of the aggregated value */
+    /**
+     * Returns the numeric representation of the aggregated value.
+     *
+     * **Required for sorting:** the grid's default comparator unwraps `IAggFuncResult` wrappers via
+     * this method to compare the underlying scalar. Custom aggregation functions that omit
+     * `toNumber()` will not sort correctly under the default comparator — the wrapper is treated as
+     * an opaque object (`>` / `<` returns `false`), so the column appears unsorted. Either provide
+     * `toNumber()` or supply a custom `colDef.comparator`.
+     */
     toNumber?(): TAggValue;
 }
 

--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -168,30 +168,24 @@ export type IAggFunc<TData = any, TValue = any, TContext = any> = (
 export type IAggFuncs<TData = any, TValue = any, TContext = any> = { [key: string]: IAggFunc<TData, TValue, TContext> };
 
 /**
- * Wrapper object returned by built-in aggregation functions `avg` and `count` on group rows.
+ * Wrapper returned by the built-in `avg` and `count` aggregation functions, and the recommended
+ * shape for custom agg functions that expose a scalar value alongside metadata (e.g. a count, used
+ * when re-aggregating across nested groups).
  *
- * - `avg` returns `{ value: number | bigint | null, count: number, toString(), toNumber() }`
- * - `count` returns `{ value: number, toString(), toNumber() }`
+ * - `avg` returns `{ value, count, toString(), toNumber() }`
+ * - `count` returns `{ value, toString(), toNumber() }`
  *
- * Other built-in agg functions (`sum`, `min`, `max`, `first`, `last`) return plain scalar values.
- * Custom aggregation functions may return any value.
+ * Other built-ins (`sum`, `min`, `max`, `first`, `last`) return plain scalars.
  */
 export interface IAggFuncResult<TAggValue = number | bigint | null> {
-    /** The aggregated scalar value */
+    /** The aggregated scalar value. */
     value?: TAggValue;
     /** The count of aggregated values. Present on `avg` results. */
     count?: number;
-    /** Returns a string representation of the aggregated value */
+    /** Returns a string representation of the aggregated value. Used also for sorting. */
     toString(): string;
-    /**
-     * Returns the numeric representation of the aggregated value.
-     *
-     * **Required for sorting:** the grid's default comparator unwraps `IAggFuncResult` wrappers via
-     * this method to compare the underlying scalar. Custom aggregation functions that omit
-     * `toNumber()` will not sort correctly under the default comparator — the wrapper is treated as
-     * an opaque object (`>` / `<` returns `false`), so the column appears unsorted. Either provide
-     * `toNumber()` or supply a custom `colDef.comparator`.
-     */
+
+    /** Returns the numeric representation of the aggregated value. Used also for sorting. */
     toNumber?(): TAggValue;
 }
 

--- a/packages/ag-grid-community/src/entities/rowNode.ts
+++ b/packages/ag-grid-community/src/entities/rowNode.ts
@@ -628,41 +628,61 @@ export class RowNode<TData = any>
     ): TValue | IAggFuncResult<TValue> | null | undefined;
     public getDataValue<TValue = any>(
         colKey: ColKey<TValue>,
-        from: DataValueFrom = 'data'
+        from: DataValueFrom | undefined
     ): TValue | IAggFuncResult<TValue> | null | undefined {
-        const { colModel, valueSvc, formula } = this.beans;
+        // PERFORMANCE CRITICAL
 
-        if (colKey == null) {
-            return undefined;
-        }
+        const beans = this.beans;
 
-        const column = colModel.getColOrColDefCol(colKey);
+        const column = beans.colModel.getColOrColDefCol(colKey);
         if (!column) {
             return undefined;
         }
 
-        // 'data-raw' skips aggData (aggregation results) and formula resolution, but still calls valueGetters
-        // 'value' reads committed data like 'data' but resolves agg wrappers (handled below)
-        const dataRaw = from === 'data-raw';
-        const resolvedFrom = dataRaw || from === 'value' ? 'data' : from;
-        let value = valueSvc.getValue(column, this, resolvedFrom, dataRaw);
-
-        if (!dataRaw) {
-            // Resolve formulas to their computed value (skip for 'data-raw')
-            if (formula && column.isAllowFormula() && formula.isFormula(value)) {
-                value = formula.resolveValue(column, this);
+        let value: any;
+        if (from === 'data' || !from) {
+            value = beans.valueSvc.getValue(column, this, 'data', false);
+            if (value == null) {
+                return value;
+            }
+        } else {
+            // 'data-raw' skips aggData (aggregation results) and formula resolution, but still calls valueGetters
+            // 'value' reads committed data like 'data' but resolves agg wrappers (handled below)
+            const dataRaw = from === 'data-raw';
+            const resolvedFrom = dataRaw || from === 'value' ? 'data' : from;
+            value = beans.valueSvc.getValue(column, this, resolvedFrom, dataRaw);
+            if (dataRaw || value == null) {
+                return value;
             }
 
-            // For 'value', 'edit', and 'batch' modes, resolve aggregation wrapper objects to their scalar value
-            // on agg columns. Matches the resolution pattern in dataTypeService:
-            // first try toNumber(), then fall back to .value property.
-            if (from !== 'data' && column.getAggFunc() && typeof value === 'object' && value != null) {
+            // For 'value', 'edit', and 'batch' modes, resolve aggregation wrapper objects to their scalar
+            // value on agg columns. Matches the resolution pattern in dataTypeService: first try toNumber(),
+            // then fall back to .value property. `typeof` check precedes `aggFunc` to cheaply skip primitives.
+            if (typeof value === 'object' && column.aggFunc) {
                 if (typeof value.toNumber === 'function') {
                     return value.toNumber();
                 }
                 if ('value' in value) {
                     return value.value;
                 }
+            }
+
+            // 'edit' and 'batch' mirror the edit-pipeline buffer, which stores the raw formula string
+            // (see editService / editModelService `sourceValue` handling). Resolving formulas here would
+            // break symmetry between the read side and the write side: callers couldn't round-trip the
+            // formula through edits. Only 'value' continues to the formula tail — it is the "computed
+            // value" variant of 'data'.
+            if (from !== 'value') {
+                return value;
+            }
+        }
+
+        // `isFormula` short-circuits on non-string values in a single typeof check — cheaper than
+        // the `isAllowFormula()` method call for the vast majority of cells.
+        if (column.colDef.allowFormula) {
+            const formula = beans.formula;
+            if (formula?.isFormula(value) && column.isAllowFormula()) {
+                value = formula.resolveValue(column, this);
             }
         }
 

--- a/packages/ag-grid-community/src/entities/rowNode.ts
+++ b/packages/ag-grid-community/src/entities/rowNode.ts
@@ -677,8 +677,6 @@ export class RowNode<TData = any>
             }
         }
 
-        // `isFormula` short-circuits on non-string values in a single typeof check — cheaper than
-        // the `isAllowFormula()` method call for the vast majority of cells.
         if (column.colDef.allowFormula) {
             const formula = beans.formula;
             if (formula?.isFormula(value) && column.isAllowFormula()) {

--- a/packages/ag-grid-community/src/filter/filterValueService.ts
+++ b/packages/ag-grid-community/src/filter/filterValueService.ts
@@ -44,9 +44,11 @@ export class FilterValueService extends BeanStub implements NamedBean {
         }
 
         const value = valueSvc.getValue(column, rowNode, 'data');
-        const formula = beans.formula;
-        if (formula && column.isAllowFormula() && formula.isFormula(value)) {
-            return formula.resolveValue(column, rowNode as RowNode);
+        if (column.colDef.allowFormula) {
+            const formula = beans.formula;
+            if (formula?.isFormula(value)) {
+                return formula.resolveValue(column, rowNode as RowNode);
+            }
         }
         return value;
     }

--- a/packages/ag-grid-community/src/interfaces/iRowNode.ts
+++ b/packages/ag-grid-community/src/interfaces/iRowNode.ts
@@ -377,7 +377,9 @@ export interface IRowNode<TData = any> extends BaseRowNode<TData>, GroupRowNode<
      * Returns the data value from the `rowNode` for the specified column.
      *
      * By default, returns committed data ignoring any pending edits. For group rows, returns
-     * aggregated values or the group key. For formula cells, returns the computed result.
+     * aggregated values or the group key. For formula cells in `'data'` / `'value'` modes,
+     * returns the **computed result**; in `'edit'` / `'batch'` / `'data-raw'` modes, returns
+     * the **raw formula string** (so the edit pipeline can round-trip it).
      *
      * To get the **displayed** value (with formatting and value formatter applied), use `api.getCellValue()` instead.
      *
@@ -387,12 +389,16 @@ export interface IRowNode<TData = any> extends BaseRowNode<TData>, GroupRowNode<
      *
      * - `'data'` (default) — Returns the aggregated value for group rows, otherwise committed data.
      *   May return an `IAggFuncResult<TValue>` wrapper for aggregation columns; use `'value'` to unwrap.
+     *   Formulas are resolved to their computed value.
      * - `'edit'` — Returns the active editor's value if editing, or the pending batch value if not editing,
-     *   then falls back to aggregation and committed data.
-     * - `'batch'` — Returns the pending batch value if batching, then falls back to aggregation and committed data.
-     * - `'value'` — Same as `'data'` but unwraps `IAggFuncResult` (e.g. from `avg` or `count`) to its scalar value.
-     * - `'data-raw'` — Always returns committed data, skipping aggregation results (`rowNode.aggData`).
-     *   For group rows this is typically `undefined` since group rows do not hold leaf data.
+     *   then falls back to aggregation and committed data. **Formulas are NOT resolved** — returns the raw
+     *   formula string to mirror the edit-pipeline buffer.
+     * - `'batch'` — Returns the pending batch value if batching, then falls back to aggregation and committed
+     *   data. **Formulas are NOT resolved** — returns the raw formula string to mirror the edit-pipeline buffer.
+     * - `'value'` — Same as `'data'` but unwraps `IAggFuncResult` (e.g. from `avg` or `count`) to its scalar
+     *   value. Formulas are resolved to their computed value.
+     * - `'data-raw'` — Always returns committed data, skipping aggregation results (`rowNode.aggData`) and
+     *   formula resolution. For group rows this is typically `undefined` since group rows do not hold leaf data.
      *
      * @param colKey The column to read (field name, `colId`, or `Column` object)
      * @param from Controls value resolution. Defaults to `'data'`.

--- a/packages/ag-grid-community/src/sort/rowNodeSorter.ts
+++ b/packages/ag-grid-community/src/sort/rowNodeSorter.ts
@@ -153,7 +153,7 @@ export class RowNodeSorter extends BeanStub implements NamedBean {
         }
 
         const value = beans.valueSvc.getValue(column, node, 'data');
-        if (column.isAllowFormula()) {
+        if (column.colDef.allowFormula) {
             const formula = beans.formula;
             if (formula?.isFormula(value)) {
                 return formula.resolveValue(column, node);
@@ -165,6 +165,7 @@ export class RowNodeSorter extends BeanStub implements NamedBean {
     private getGroupDataValue(node: RowNode, column: AgColumn): any {
         // because they're group rows, no display cols exist, so groupData never populated.
         // instead delegate to getting value from leaf child.
+        // Formulas are currently not supported on row-group columns, so no formula resolution is needed here.
         if (_isGroupUseEntireRow(this.gos, this.pivotActive)) {
             const leafChild = this.firstLeaf(node);
             return leafChild && this.beans.valueSvc.getValue(column, leafChild, 'data');

--- a/packages/ag-grid-community/src/tooltip/tooltipService.ts
+++ b/packages/ag-grid-community/src/tooltip/tooltipService.ts
@@ -131,9 +131,10 @@ const resolveCellTooltip = ({
 }): ResolvedCellTooltip | null => {
     const { editSvc, formula, gos } = beans;
     const { column, rowNode } = ctrl;
+    const colDef = column.colDef;
 
     // 1) formula error tooltip has highest priority.
-    if (formula?.active && column.isAllowFormula()) {
+    if (colDef.allowFormula && formula?.active) {
         const error = formula.getFormulaError(column, rowNode);
         if (error) {
             return {
@@ -164,7 +165,6 @@ const resolveCellTooltip = ({
         return { value, location: 'cell', shouldDisplay: shouldDisplayCustomTooltip };
     }
 
-    const colDef = column.colDef;
     const data = rowNode.data;
 
     // 4) column tooltip field/valueGetter is the final fallback.

--- a/packages/ag-grid-community/src/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.ts
@@ -112,14 +112,13 @@ export class ValueService extends BeanStub implements NamedBean {
         const node = params.node;
         const showRowGroupColValueSvc = beans.showRowGroupColValueSvc;
         const isFullWidthGroup = !column && node.group;
-        const isGroupCol = column?.colDef.showRowGroup;
 
         // Tree data auto col acts as a traditional column, with the exception of footers, so only process footers with
         // showRowGroupColValueSvc
         const processTreeDataAsGroup = !this.isTreeData || node.footer;
 
         // handle group cell value
-        if (showRowGroupColValueSvc && processTreeDataAsGroup && (isFullWidthGroup || isGroupCol)) {
+        if (showRowGroupColValueSvc && processTreeDataAsGroup && (isFullWidthGroup || column?.colDef.showRowGroup)) {
             const groupValue = showRowGroupColValueSvc.getGroupValue(node, column, this.displayIgnoresAggData(node));
             if (groupValue == null) {
                 return {
@@ -148,7 +147,8 @@ export class ValueService extends BeanStub implements NamedBean {
         let valueToFormat = value;
 
         const formula = beans.formula;
-        if (column.isAllowFormula() && formula?.isFormula(value)) {
+        const colDef = column.colDef;
+        if (colDef.allowFormula && formula?.isFormula(value)) {
             if (params.useRawFormula) {
                 value = formula.normaliseFormula(value, true);
                 valueToFormat = formula.resolveValue(column, node as RowNode);
@@ -159,7 +159,7 @@ export class ValueService extends BeanStub implements NamedBean {
         }
 
         const format =
-            params.includeValueFormatted && !(params.exporting && column.colDef.useValueFormatterForExport === false);
+            params.includeValueFormatted && !(params.exporting && colDef.useValueFormatterForExport === false);
         return {
             value,
             valueFormatted: format ? this.formatValue(column, node, valueToFormat) : null,
@@ -571,7 +571,7 @@ export class ValueService extends BeanStub implements NamedBean {
         const { field, valueSetter } = colDef;
 
         const formulaSvc = this.beans.formula;
-        const isFormulaValue = column.isAllowFormula() && formulaSvc?.isFormula(newValue);
+        const isFormulaValue = column.colDef.allowFormula && formulaSvc?.isFormula(newValue);
         const hasExternalFormulaData = !!this.formulaDataSvc?.hasDataSource();
 
         if (_missing(field) && _missing(valueSetter) && !(hasExternalFormulaData && isFormulaValue)) {
@@ -602,7 +602,7 @@ export class ValueService extends BeanStub implements NamedBean {
         const { column, rowNode, newValue, eventSource, setterParams } = args;
         const formulaSvc = this.beans.formula;
         const formulaDataSvc = this.formulaDataSvc;
-        if (!formulaDataSvc?.hasDataSource() || !column.isAllowFormula()) {
+        if (!column.colDef.allowFormula || !formulaDataSvc?.hasDataSource()) {
             return null;
         }
 

--- a/packages/ag-grid-enterprise/src/clipboard/clipboardService.ts
+++ b/packages/ag-grid-enterprise/src/clipboard/clipboardService.ts
@@ -563,7 +563,7 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
                             return;
                         }
 
-                        const isFormula = column.isAllowFormula() && formula?.isFormula(firstRowValues[index]);
+                        const isFormula = column.colDef.allowFormula && formula?.isFormula(firstRowValues[index]);
 
                         if (isFormula) {
                             firstRowValues[index] = formula?.updateFormulaByOffset({

--- a/packages/ag-grid-enterprise/src/excelExport/excelSerializingSession.ts
+++ b/packages/ag-grid-enterprise/src/excelExport/excelSerializingSession.ts
@@ -438,7 +438,7 @@ export class ExcelSerializingSession extends BaseGridSerializingSession<ExcelRow
                     )
                 );
             } else {
-                const isFormula = column.isAllowFormula() && this.formulaSvc?.isFormula(valueForCellString);
+                const isFormula = column.colDef.allowFormula && this.formulaSvc?.isFormula(valueForCellString);
                 const cell = this.createCell(
                     excelStyleId,
                     isFormula ? 'f' : this.getDataTypeForValue(rawValueForCell),

--- a/packages/ag-grid-enterprise/src/statusBar/providedPanels/aggregationComp.test.ts
+++ b/packages/ag-grid-enterprise/src/statusBar/providedPanels/aggregationComp.test.ts
@@ -37,7 +37,7 @@ const createAggregationSnapshot = (
     (comp as any).avgAggregationComp = avgAggregationComp;
     (comp as any).countAggregationComp = countAggregationComp;
 
-    const column = { getId: () => 'value' };
+    const column = { getId: () => 'value', colDef: {} };
     const rowNodes = values.map((value, index) => ({ data: { value }, rowIndex: index }));
 
     const rowModel = {

--- a/packages/ag-grid-enterprise/src/statusBar/providedPanels/aggregationComp.ts
+++ b/packages/ag-grid-enterprise/src/statusBar/providedPanels/aggregationComp.ts
@@ -160,6 +160,8 @@ export class AggregationComp extends Component implements IStatusPanelComp {
      */
     private onCellSelectionChanged(): void {
         const beans = this.beans;
+        const valueSvc = beans.valueSvc;
+        const formulaSvc = beans.formula;
         const rangeSvc = beans.rangeSvc;
         const cellRanges = rangeSvc?.getCellRanges();
 
@@ -254,7 +256,13 @@ export class AggregationComp extends Component implements IStatusPanelComp {
                             return;
                         }
 
-                        let value = rowNode.getDataValue(col, 'data');
+                        // Direct `valueSvc.getValue` + inline formula resolution — `rowNode.getDataValue`
+                        // would pay an extra `colModel.getColOrColDefCol` lookup per cell on this hot
+                        // path (called for every cell across the selected ranges on each selection change).
+                        let value: any = valueSvc.getValue(col, rowNode, 'data');
+                        if (col.colDef.allowFormula && formulaSvc?.isFormula(value)) {
+                            value = formulaSvc.resolveValue(col, rowNode);
+                        }
 
                         // if empty cell, skip it, doesn't impact count or anything
                         if (_missing(value) || value === '') {

--- a/packages/ag-grid-enterprise/src/statusBar/providedPanels/aggregationComp.ts
+++ b/packages/ag-grid-enterprise/src/statusBar/providedPanels/aggregationComp.ts
@@ -160,7 +160,7 @@ export class AggregationComp extends Component implements IStatusPanelComp {
      */
     private onCellSelectionChanged(): void {
         const beans = this.beans;
-        const { rangeSvc, valueSvc } = beans;
+        const rangeSvc = beans.rangeSvc;
         const cellRanges = rangeSvc?.getCellRanges();
 
         let sum = 0;
@@ -254,7 +254,7 @@ export class AggregationComp extends Component implements IStatusPanelComp {
                             return;
                         }
 
-                        let value = valueSvc.getValue(col, rowNode, 'data');
+                        let value = rowNode.getDataValue(col, 'data');
 
                         // if empty cell, skip it, doesn't impact count or anything
                         if (_missing(value) || value === '') {

--- a/testing/behavioural/src/row-data/row-node-get-data-value.test.ts
+++ b/testing/behavioural/src/row-data/row-node-get-data-value.test.ts
@@ -510,6 +510,199 @@ describe('RowNode.getDataValue', () => {
             expect(formulaNode.getDataValue('value')).toBe(50);
             expect(formulaNode.getDataValue('value')).toBe(api.getCellValue({ rowNode: formulaNode, colKey: 'value' }));
         });
+
+        test("getDataValue returns raw formula string for 'edit' and 'batch' (mirrors edit-pipeline buffer)", async () => {
+            const formulaString = '=REF(COLUMN("value"),ROW("raw"))*3';
+            const api = await gridsManager.createGridAndWait('formula-edit-batch-raw', {
+                defaultColDef: { allowFormula: true },
+                rowNumbers: true,
+                columnDefs: [{ field: 'value' }],
+                rowData: [
+                    { id: 'raw', value: 7 },
+                    { id: 'formula', value: formulaString },
+                ],
+                getRowId: (params) => params.data.id,
+            });
+
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            const formulaNode = api.getRowNode('formula')!;
+
+            // 'data' / 'value' / default: resolved — computed value
+            expect(formulaNode.getDataValue('value')).toBe(21); // 7 * 3
+            expect(formulaNode.getDataValue('value', 'data')).toBe(21);
+            expect(formulaNode.getDataValue('value', 'value')).toBe(21);
+
+            // 'edit' / 'batch': raw formula string (edit pipeline round-trips the formula as-is)
+            expect(formulaNode.getDataValue('value', 'edit')).toBe(formulaString);
+            expect(formulaNode.getDataValue('value', 'batch')).toBe(formulaString);
+
+            // 'data-raw': already documented as raw (no formula resolution)
+            expect(formulaNode.getDataValue('value', 'data-raw')).toBe(formulaString);
+        });
+
+        test('getDataValue does NOT evaluate "=..." when allowFormula is false', async () => {
+            const notAFormula = '=1+2';
+            const api = await gridsManager.createGridAndWait('formula-disabled', {
+                // allowFormula omitted — defaults to false
+                columnDefs: [{ field: 'value' }],
+                rowData: [{ id: 'row1', value: notAFormula }],
+                getRowId: (params) => params.data.id,
+            });
+
+            const node = api.getRowNode('row1')!;
+
+            // Every `from` must return the raw string; no evaluation gate must fire without allowFormula.
+            expect(node.getDataValue('value')).toBe(notAFormula);
+            expect(node.getDataValue('value', 'data')).toBe(notAFormula);
+            expect(node.getDataValue('value', 'value')).toBe(notAFormula);
+            expect(node.getDataValue('value', 'edit')).toBe(notAFormula);
+            expect(node.getDataValue('value', 'batch')).toBe(notAFormula);
+            expect(node.getDataValue('value', 'data-raw')).toBe(notAFormula);
+        });
+
+        test('getDataValue returns error string when formula evaluation fails', async () => {
+            const api = await gridsManager.createGridAndWait('formula-error', {
+                defaultColDef: { allowFormula: true },
+                rowNumbers: true,
+                columnDefs: [{ field: 'value' }],
+                rowData: [
+                    // Reference a non-existent column — evaluator returns a "#REF!"-style error string
+                    { id: 'bad', value: '=REF(COLUMN("nonexistent"),ROW("bad"))' },
+                ],
+                getRowId: (params) => params.data.id,
+            });
+
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            const node = api.getRowNode('bad')!;
+            const resolved = node.getDataValue('value');
+
+            // Formula evaluation error surfaces as a string beginning with '#' — not the raw "=..." source
+            expect(typeof resolved).toBe('string');
+            expect(resolved as string).toMatch(/^#/);
+            expect(resolved).not.toBe(node.data!.value);
+        });
+
+        test('getDataValue round-trips formula through setDataValue', async () => {
+            const api = await gridsManager.createGridAndWait('formula-roundtrip', {
+                defaultColDef: { allowFormula: true, editable: true },
+                rowNumbers: true,
+                columnDefs: [{ field: 'value' }],
+                rowData: [
+                    { id: 'source', value: 10 },
+                    { id: 'target', value: 1 },
+                ],
+                getRowId: (params) => params.data.id,
+            });
+
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            const target = api.getRowNode('target')!;
+
+            // Write a formula via setDataValue
+            const formulaString = '=REF(COLUMN("value"),ROW("source"))*4';
+            target.setDataValue('value', formulaString);
+
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            // 'data' resolves to computed value; 'edit'/'batch'/'data-raw' preserve the raw string
+            expect(target.getDataValue('value')).toBe(40); // 10 * 4
+            expect(target.getDataValue('value', 'edit')).toBe(formulaString);
+            expect(target.getDataValue('value', 'batch')).toBe(formulaString);
+            expect(target.getDataValue('value', 'data-raw')).toBe(formulaString);
+        });
+
+        test('getDataValue during batch edit of a formula column', async () => {
+            const originalFormula = '=REF(COLUMN("value"),ROW("a"))+1';
+            const api = await gridsManager.createGridAndWait('formula-batch-edit', {
+                defaultColDef: { allowFormula: true, editable: true },
+                rowNumbers: true,
+                columnDefs: [{ field: 'value' }],
+                rowData: [
+                    { id: 'a', value: 5 },
+                    { id: 'b', value: originalFormula },
+                ],
+                getRowId: (params) => params.data.id,
+            });
+
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            const b = api.getRowNode('b')!;
+
+            // Baseline: formula evaluates to 6
+            expect(b.getDataValue('value')).toBe(6);
+            expect(b.getDataValue('value', 'edit')).toBe(originalFormula);
+
+            // Stage a new formula via batch edit
+            const newFormula = '=REF(COLUMN("value"),ROW("a"))*10';
+            api.startBatchEdit();
+            try {
+                b.setDataValue('value', newFormula, 'batch');
+
+                // 'data' still sees the committed (original) formula resolved
+                expect(b.getDataValue('value', 'data')).toBe(6);
+                expect(b.getDataValue('value', 'data-raw')).toBe(originalFormula);
+
+                // 'batch' returns the staged raw formula string (not evaluated)
+                expect(b.getDataValue('value', 'batch')).toBe(newFormula);
+            } finally {
+                api.cancelBatchEdit();
+            }
+
+            // After cancelling, state reverts to the original formula
+            expect(b.getDataValue('value')).toBe(6);
+            expect(b.getDataValue('value', 'batch')).toBe(originalFormula);
+        });
+
+        test('getDataValue evaluates chained formula references', async () => {
+            const api = await gridsManager.createGridAndWait('formula-chain', {
+                defaultColDef: { allowFormula: true },
+                rowNumbers: true,
+                columnDefs: [{ field: 'value' }],
+                rowData: [
+                    { id: 'a', value: 2 },
+                    { id: 'b', value: '=REF(COLUMN("value"),ROW("a"))*3' }, // 6
+                    { id: 'c', value: '=REF(COLUMN("value"),ROW("b"))+1' }, // 7
+                ],
+                getRowId: (params) => params.data.id,
+            });
+
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            // Each formula in the chain is resolved via the previous one's computed value.
+            expect(api.getRowNode('a')!.getDataValue('value')).toBe(2);
+            expect(api.getRowNode('b')!.getDataValue('value')).toBe(6);
+            expect(api.getRowNode('c')!.getDataValue('value')).toBe(7);
+        });
+
+        test('getDataValue on formula returning null/undefined operands', async () => {
+            const api = await gridsManager.createGridAndWait('formula-null', {
+                defaultColDef: { allowFormula: true },
+                rowNumbers: true,
+                columnDefs: [{ field: 'value' }],
+                rowData: [
+                    { id: 'nullCell', value: null },
+                    // Summing null with 5 — result depends on evaluator coercion rules; at minimum, should not
+                    // throw and should return a defined result (scalar or a '#...' error marker).
+                    { id: 'sum', value: '=REF(COLUMN("value"),ROW("nullCell"))+5' },
+                ],
+                getRowId: (params) => params.data.id,
+            });
+
+            await asyncSetTimeout(rowNumberRefreshBufferMs);
+
+            const nullNode = api.getRowNode('nullCell')!;
+            const sumNode = api.getRowNode('sum')!;
+
+            // Raw null passes through unchanged on the nullCell row
+            expect(nullNode.getDataValue('value')).toBeNull();
+
+            // The formula resolves without throwing — exact value depends on the evaluator's null handling,
+            // but it must not be the raw formula string (i.e. resolution did run).
+            const sumResolved = sumNode.getDataValue('value');
+            expect(sumResolved).not.toBe(sumNode.data!.value);
+        });
     });
 
     describe('pivot mode', () => {

--- a/testing/behavioural/src/row-data/row-node-get-data-value.test.ts
+++ b/testing/behavioural/src/row-data/row-node-get-data-value.test.ts
@@ -66,6 +66,27 @@ describe('RowNode.getDataValue', () => {
             expect(rowNode.getDataValue('nonexistent')).toBeUndefined();
         });
 
+        test('getDataValue returns undefined for nullish colKey', async () => {
+            // Defensive call sites pass `colKey` from configuration that may be null/undefined.
+            // The implementation relies on `colModel.getColOrColDefCol`'s internal `key == null`
+            // short-circuit rather than re-checking — this test pins that contract so any future
+            // change to the lookup surface fails loudly here instead of in a runtime error path.
+            const api = await gridsManager.createGridAndWait('nullish-colkey', {
+                columnDefs: [{ field: 'name' }],
+                rowData: [{ id: '1', name: 'Alice' }],
+                getRowId: (params) => params.data.id,
+            });
+
+            const rowNode = api.getRowNode('1')!;
+            expect(rowNode.getDataValue(null as any)).toBeUndefined();
+            expect(rowNode.getDataValue(undefined as any)).toBeUndefined();
+            // Same for non-default `from` modes — the lookup happens before the from-branching.
+            expect(rowNode.getDataValue(null as any, 'edit')).toBeUndefined();
+            expect(rowNode.getDataValue(null as any, 'batch')).toBeUndefined();
+            expect(rowNode.getDataValue(null as any, 'value')).toBeUndefined();
+            expect(rowNode.getDataValue(null as any, 'data-raw')).toBeUndefined();
+        });
+
         test('getDataValue returns null for null cell value', async () => {
             const api = await gridsManager.createGridAndWait('null-value', {
                 columnDefs: [{ field: 'name' }, { field: 'value' }],


### PR DESCRIPTION
rowNode.getDataValue with formulas when from = edit or batch should return the formula string, not the resolved value.

before accessing the formula service is faster in general to access column.colDef.allowFormula as is already in the CPU cache before accessing the formula svc

also:
- minor optimizations in _defaultComparator (no change in behaviour)
- minor optimizations in getDataValue


FIX AG-17168