### PR TITLE
AG-16677 fix(pivot): keep re-added pivotRowTotals groups adjacent

### DIFF
--- a/.run/Column Tool Panel Icon bug.run.xml
+++ b/.run/Column Tool Panel Icon bug.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Column Tool Panel Icon bug" type="JavascriptDebugType" engineId="98ca6316-2f89-46d9-a9e5-fa9e2b0625b3" uri="https://plnkr.co/edit/Kh56rmKKhKWuUmYB?open=main.js">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/Pivot totals position bug.run.xml
+++ b/.run/Pivot totals position bug.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Pivot totals position bug" type="JavascriptDebugType" engineId="98ca6316-2f89-46d9-a9e5-fa9e2b0625b3" uri="https://plnkr.co/edit/CIAKpYngoZwWnVha?open=main.js">
+    <method v="2" />
+  </configuration>
+</component>

--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -461,12 +461,15 @@ export class ColumnModel extends BeanStub implements NamedBean {
         const previousSiblingPosMap: Map<AgColumn, AgColumn | AgColumn[]> = new Map();
 
         const { pivotColDefSvc } = this.beans;
-        const freshListIndex = new Map<AgColumn, number>();
-        for (let i = 0; i < cols.list.length; i++) {
-            freshListIndex.set(cols.list[i], i);
-        }
+        let freshListIndex: Map<AgColumn, number> | null = null;
 
         const getPreviousColInFreshList = (col: AgColumn): AgColumn | null => {
+            if (freshListIndex == null) {
+                freshListIndex = new Map<AgColumn, number>();
+                for (let i = 0; i < cols.list.length; i++) {
+                    freshListIndex.set(cols.list[i], i);
+                }
+            }
             const idx = freshListIndex.get(col)!;
             for (let i = idx - 1; i >= 0; i--) {
                 const candidate = cols.list[i];

--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -174,7 +174,7 @@ export class ColumnModel extends BeanStub implements NamedBean {
     // setPivotMode, applyColumnState,
     // functionColsService.setPrimaryColList, functionColsService.updatePrimaryColList,
     // pivotResultCols.setPivotResultCols
-    public refreshCols(newColDefs: boolean, source: ColumnEventType): void {
+    public refreshCols(newColDefs: boolean, source: ColumnEventType, useGeneratedOrder: boolean = false): void {
         if (!this.colDefCols) {
             return;
         }
@@ -206,7 +206,7 @@ export class ColumnModel extends BeanStub implements NamedBean {
         this.createColumnsForService([autoColSvc, selectionColSvc, rowNumbersSvc], cols, source);
 
         const shouldSortNewColDefs = _shouldMaintainColumnOrder(this.gos, this.showingPivotResult);
-        if (!newColDefs || shouldSortNewColDefs) {
+        if (!useGeneratedOrder && (!newColDefs || shouldSortNewColDefs)) {
             this.restoreColOrder(cols);
         }
 

--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -453,18 +453,6 @@ export class ColumnModel extends BeanStub implements NamedBean {
             return highestSibling;
         };
 
-        /* In pivot mode, new cols with no preserved-order sibling follow their neighbour
-           in the fresh list rather than being pushed to the tail. */
-        const newListIndex = this.showingPivotResult ? new Map<AgColumn, number>() : null;
-        if (newListIndex) {
-            for (let i = 0; i < cols.list.length; i++) {
-                newListIndex.set(cols.list[i], i);
-            }
-        }
-
-        // pivot-mode bucket: new cols that sit before every preserved col in the new list.
-        const leadingOrphans: AgColumn[] = [];
-
         // array of cols that have no siblings in the last order, to be added at the tail of the results
         const noSiblingsAvailable: AgColumn[] = [];
 
@@ -472,27 +460,24 @@ export class ColumnModel extends BeanStub implements NamedBean {
         // in results array
         const previousSiblingPosMap: Map<AgColumn, AgColumn | AgColumn[]> = new Map();
 
-        // for each new col, find the col it needs inserted after and store for when array is constructed
-        for (const col of additionalCols) {
-            let anchor = getPreviousSibling(col, null);
-            if (anchor == null && newListIndex) {
-                const idx = newListIndex.get(col)!;
-                for (let j = idx - 1; j >= 0; j--) {
-                    const candidate = cols.list[j];
-                    if (colPositionMap.has(candidate)) {
-                        anchor = candidate;
-                        break;
-                    }
-                }
-                if (anchor == null) {
-                    leadingOrphans.push(col);
-                    continue;
-                }
-            } else if (anchor == null) {
-                noSiblingsAvailable.push(col);
-                continue;
-            }
+        const { pivotColDefSvc } = this.beans;
+        const freshListIndex = new Map<AgColumn, number>();
+        for (let i = 0; i < cols.list.length; i++) {
+            freshListIndex.set(cols.list[i], i);
+        }
 
+        const getPreviousColInFreshList = (col: AgColumn): AgColumn | null => {
+            const idx = freshListIndex.get(col)!;
+            for (let i = idx - 1; i >= 0; i--) {
+                const candidate = cols.list[i];
+                if (colPositionMap.has(candidate)) {
+                    return candidate;
+                }
+            }
+            return null;
+        };
+
+        const addColAfter = (anchor: AgColumn, col: AgColumn): void => {
             const prev = previousSiblingPosMap.get(anchor);
             if (prev === undefined) {
                 previousSiblingPosMap.set(anchor, col);
@@ -502,16 +487,37 @@ export class ColumnModel extends BeanStub implements NamedBean {
                 // if we have a single col, then we need to add the new col to the array
                 previousSiblingPosMap.set(anchor, [prev, col]);
             }
+        };
+
+        // for each new col, find the col it needs inserted after and store for when array is constructed
+        for (const col of additionalCols) {
+            if (pivotColDefSvc?.isPivotRowTotalColumn(col.colDef)) {
+                const anchor = getPreviousColInFreshList(col);
+                if (anchor == null) {
+                    noSiblingsAvailable.push(col);
+                } else {
+                    addColAfter(anchor, col);
+                }
+                continue;
+            }
+
+            const prevSiblingIdx = getPreviousSibling(col, null);
+            if (prevSiblingIdx == null) {
+                noSiblingsAvailable.push(col);
+                continue;
+            }
+
+            addColAfter(prevSiblingIdx, col);
         }
 
         // the following code starts at the tail of the array and works backwards.
         // first it applies all of the cols with no siblings (so no location in last order)
         // then it works backwards through the preserved order - when a col has siblings, it adds
         // them to the array and then adds the col itself.
-        // finally, any leadingOrphans (pivot-only) are written at the head of the array.
 
         const result = new Array(cols.list.length);
         let resultPointer = result.length - 1;
+
         // work backwards, first adding no siblings to end
         for (let i = noSiblingsAvailable.length - 1; i >= 0; i--) {
             result[resultPointer--] = noSiblingsAvailable[i];
@@ -534,9 +540,6 @@ export class ColumnModel extends BeanStub implements NamedBean {
             result[resultPointer--] = nextCol;
         }
 
-        for (let i = leadingOrphans.length - 1; i >= 0; i--) {
-            result[resultPointer--] = leadingOrphans[i];
-        }
         cols.list = result;
     }
 

--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -453,10 +453,8 @@ export class ColumnModel extends BeanStub implements NamedBean {
             return highestSibling;
         };
 
-        // In pivot mode the cols are regenerated each refresh, so an added col with no sibling
-        // in the preserved order (e.g. a freshly-created pivotRowTotals group when a value
-        // column is re-added) should follow its neighbour in the freshly generated order,
-        // not be banished to the tail of the grid.
+        /* In pivot mode, new cols with no preserved-order sibling follow their neighbour
+           in the fresh list rather than being pushed to the tail. */
         const newListIndex = this.showingPivotResult ? new Map<AgColumn, number>() : null;
         if (newListIndex) {
             for (let i = 0; i < cols.list.length; i++) {

--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -453,6 +453,20 @@ export class ColumnModel extends BeanStub implements NamedBean {
             return highestSibling;
         };
 
+        // In pivot mode the cols are regenerated each refresh, so an added col with no sibling
+        // in the preserved order (e.g. a freshly-created pivotRowTotals group when a value
+        // column is re-added) should follow its neighbour in the freshly generated order,
+        // not be banished to the tail of the grid.
+        const newListIndex = this.showingPivotResult ? new Map<AgColumn, number>() : null;
+        if (newListIndex) {
+            for (let i = 0; i < cols.list.length; i++) {
+                newListIndex.set(cols.list[i], i);
+            }
+        }
+
+        // pivot-mode bucket: new cols that sit before every preserved col in the new list.
+        const leadingOrphans: AgColumn[] = [];
+
         // array of cols that have no siblings in the last order, to be added at the tail of the results
         const noSiblingsAvailable: AgColumn[] = [];
 
@@ -462,20 +476,33 @@ export class ColumnModel extends BeanStub implements NamedBean {
 
         // for each new col, find the col it needs inserted after and store for when array is constructed
         for (const col of additionalCols) {
-            const prevSiblingIdx = getPreviousSibling(col, null);
-            if (prevSiblingIdx == null) {
+            let anchor = getPreviousSibling(col, null);
+            if (anchor == null && newListIndex) {
+                const idx = newListIndex.get(col)!;
+                for (let j = idx - 1; j >= 0; j--) {
+                    const candidate = cols.list[j];
+                    if (colPositionMap.has(candidate)) {
+                        anchor = candidate;
+                        break;
+                    }
+                }
+                if (anchor == null) {
+                    leadingOrphans.push(col);
+                    continue;
+                }
+            } else if (anchor == null) {
                 noSiblingsAvailable.push(col);
                 continue;
             }
 
-            const prev = previousSiblingPosMap.get(prevSiblingIdx);
+            const prev = previousSiblingPosMap.get(anchor);
             if (prev === undefined) {
-                previousSiblingPosMap.set(prevSiblingIdx, col);
+                previousSiblingPosMap.set(anchor, col);
             } else if (Array.isArray(prev)) {
                 prev.push(col);
             } else {
                 // if we have a single col, then we need to add the new col to the array
-                previousSiblingPosMap.set(prevSiblingIdx, [prev, col]);
+                previousSiblingPosMap.set(anchor, [prev, col]);
             }
         }
 
@@ -483,6 +510,7 @@ export class ColumnModel extends BeanStub implements NamedBean {
         // first it applies all of the cols with no siblings (so no location in last order)
         // then it works backwards through the preserved order - when a col has siblings, it adds
         // them to the array and then adds the col itself.
+        // finally, any leadingOrphans (pivot-only) are written at the head of the array.
 
         const result = new Array(cols.list.length);
         let resultPointer = result.length - 1;
@@ -506,6 +534,10 @@ export class ColumnModel extends BeanStub implements NamedBean {
                 }
             }
             result[resultPointer--] = nextCol;
+        }
+
+        for (let i = leadingOrphans.length - 1; i >= 0; i--) {
+            result[resultPointer--] = leadingOrphans[i];
         }
         cols.list = result;
     }

--- a/packages/ag-grid-community/src/interfaces/iPivotColDefService.ts
+++ b/packages/ag-grid-community/src/interfaces/iPivotColDefService.ts
@@ -4,4 +4,5 @@ import type { ColDef, ColGroupDef } from '../entities/colDef';
 export interface IPivotColDefService {
     createColDefsFromFields: (fields: string[]) => (ColDef | ColGroupDef)[];
     recreateColDef(colDef: ColDef): ColDef;
+    isPivotRowTotalColumn(colDef: ColDef): boolean;
 }

--- a/packages/ag-grid-community/src/interfaces/iPivotResultColsService.ts
+++ b/packages/ag-grid-community/src/interfaces/iPivotResultColsService.ts
@@ -13,7 +13,11 @@ export interface IPivotResultColsService {
 
     getPivotResultCol(key: ColKey): AgColumn | null;
 
-    setPivotResultCols(colDefs: (ColDef | ColGroupDef)[] | null, source: ColumnEventType): void;
+    setPivotResultCols(
+        colDefs: (ColDef | ColGroupDef)[] | null,
+        source: ColumnEventType,
+        useGeneratedOrder?: boolean
+    ): void;
 
     /** Returns pivot result columns ordered for aggregation: regular columns first, total columns after.
      * Cached — only recomputed when pivot result columns change. */

--- a/packages/ag-grid-enterprise/src/pivot/pivotColDefService.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotColDefService.ts
@@ -480,6 +480,10 @@ export class PivotColDefService extends BeanStub implements NamedBean, IPivotCol
         return `pivot_${pivotCols.join('-')}_${pivotKeys.join('-')}_${measureColumnId}`;
     }
 
+    public isPivotRowTotalColumn(colDef: ColDef): boolean {
+        return colDef.colId?.startsWith(PIVOT_ROW_TOTAL_PREFIX) ?? false;
+    }
+
     /**
      * Used by the SSRM to create secondary columns from provided fields
      * @param fields

--- a/packages/ag-grid-enterprise/src/pivot/pivotResultColsService.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotResultColsService.ts
@@ -129,7 +129,11 @@ export class PivotResultColsService extends BeanStub implements NamedBean, IPivo
         return result;
     }
 
-    public setPivotResultCols(colDefs: (ColDef | ColGroupDef)[] | null, source: ColumnEventType): void {
+    public setPivotResultCols(
+        colDefs: (ColDef | ColGroupDef)[] | null,
+        source: ColumnEventType,
+        useGeneratedOrder: boolean = false
+    ): void {
         this.aggOrderedList = undefined; // Invalidate cached aggregation order
         if (!this.colModel.ready) {
             return;
@@ -164,7 +168,7 @@ export class PivotResultColsService extends BeanStub implements NamedBean, IPivo
             }
             const hasPreviousCols = !!this.previousPivotResultCols;
             this.previousPivotResultCols = null;
-            this.colModel.refreshCols(!hasPreviousCols, source);
+            this.colModel.refreshCols(!hasPreviousCols, source, useGeneratedOrder);
         } else {
             this.previousPivotResultCols = this.pivotResultCols ? this.pivotResultCols.tree : null;
             this.pivotResultCols = null;

--- a/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
@@ -44,6 +44,7 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
     private uniqueValues: Map<string, any> = new Map();
 
     private aggregationColumnsHashLastTime: string | null;
+    private aggregationColumnIdsLastTime: string[] | null;
     private aggregationFuncsHashLastTime: string;
     private pivotOrderLastTime: string[] = [];
 
@@ -64,6 +65,7 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
 
     private executePivotOff(): boolean {
         this.aggregationColumnsHashLastTime = null;
+        this.aggregationColumnIdsLastTime = null;
         this.pivotOrderLastTime = [];
         this.uniqueValues = new Map();
         if (this.pivotResultCols.isPivotResultColsPresent()) {
@@ -105,14 +107,21 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
         const uniqueValuesChanged = this.setUniqueValues(uniqueValues);
 
         const aggregationColumns = valueColsSvc?.columns ?? [];
+        const aggregationColumnIds = aggregationColumns.map((column) => column.getId());
         const aggregationColumnsHash = aggregationColumns
             .map((column) => `${column.getId()}-${column.colDef.headerName}`)
             .join('#');
         const aggregationFuncsHash = aggregationColumns.map((column) => column.getAggFunc()!.toString()).join('#');
 
         const aggregationColumnsChanged = this.aggregationColumnsHashLastTime !== aggregationColumnsHash;
+        const aggregationColumnsReordered =
+            this.aggregationColumnIdsLastTime != null &&
+            !_areEqual(this.aggregationColumnIdsLastTime, aggregationColumnIds) &&
+            this.aggregationColumnIdsLastTime.length === aggregationColumnIds.length &&
+            this.aggregationColumnIdsLastTime.every((id) => aggregationColumnIds.includes(id));
         const aggregationFuncsChanged = this.aggregationFuncsHashLastTime !== aggregationFuncsHash;
         this.aggregationColumnsHashLastTime = aggregationColumnsHash;
+        this.aggregationColumnIdsLastTime = aggregationColumnIds;
         this.aggregationFuncsHashLastTime = aggregationFuncsHash;
 
         const groupColumnsHash = (rowGroupColsSvc?.columns ?? []).map((column) => column.getId()).join('#');
@@ -138,7 +147,7 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
             anyGridOptionsChanged
         ) {
             const pivotColumnGroupDefs = this.pivotColDefSvc.createPivotColumnDefs(this.uniqueValues);
-            this.pivotResultCols.setPivotResultCols(pivotColumnGroupDefs, 'rowModelUpdated');
+            this.pivotResultCols.setPivotResultCols(pivotColumnGroupDefs, 'rowModelUpdated', aggregationColumnsReordered);
             // Because the secondary columns have changed, the aggregation needs to visit the whole
             // tree again, so signal the caller to deactivate the changedPath.
             this.lastTimeFailed = false;

--- a/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
@@ -147,7 +147,11 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
             anyGridOptionsChanged
         ) {
             const pivotColumnGroupDefs = this.pivotColDefSvc.createPivotColumnDefs(this.uniqueValues);
-            this.pivotResultCols.setPivotResultCols(pivotColumnGroupDefs, 'rowModelUpdated', aggregationColumnsReordered);
+            this.pivotResultCols.setPivotResultCols(
+                pivotColumnGroupDefs,
+                'rowModelUpdated',
+                aggregationColumnsReordered
+            );
             // Because the secondary columns have changed, the aggregation needs to visit the whole
             // tree again, so signal the caller to deactivate the changedPath.
             this.lastTimeFailed = false;

--- a/testing/behavioural/src/columns/order/pivot-row-totals-value-toggle.test.ts
+++ b/testing/behavioural/src/columns/order/pivot-row-totals-value-toggle.test.ts
@@ -67,11 +67,16 @@ describe('pivotRowTotals + value column toggling', () => {
         expect(rowTotalsArePositionedBeforePivotCols(gridApi)).toBe(true);
 
         gridApi.addValueColumns(['silver']);
-        expect(rowTotalIds(gridApi)).toEqual(['PivotRowTotal_pivot_year__gold', 'PivotRowTotal_pivot_year__silver']);
+        const rowTotalIdsAfterReAddingSilver = rowTotalIds(gridApi);
+        expect(rowTotalIdsAfterReAddingSilver).toEqual([
+            'PivotRowTotal_pivot_year__gold',
+            'PivotRowTotal_pivot_year__silver',
+        ]);
         expect(rowTotalsArePositionedBeforePivotCols(gridApi)).toBe(true);
 
         gridApi.addValueColumns(['bronze']);
-        expect(rowTotalIds(gridApi)).toEqual([
+        const rowTotalIdsAfterReAddingBronze = rowTotalIds(gridApi);
+        expect(rowTotalIdsAfterReAddingBronze).toEqual([
             'PivotRowTotal_pivot_year__gold',
             'PivotRowTotal_pivot_year__silver',
             'PivotRowTotal_pivot_year__bronze',
@@ -101,11 +106,16 @@ describe('pivotRowTotals + value column toggling', () => {
         expect(rowTotalsArePositionedAfterPivotCols()).toBe(true);
 
         gridApi.addValueColumns(['silver']);
-        expect(rowTotalIds(gridApi)).toEqual(['PivotRowTotal_pivot_year__gold', 'PivotRowTotal_pivot_year__silver']);
+        const rowTotalIdsAfterReAddingSilver = rowTotalIds(gridApi);
+        expect(rowTotalIdsAfterReAddingSilver).toEqual([
+            'PivotRowTotal_pivot_year__gold',
+            'PivotRowTotal_pivot_year__silver',
+        ]);
         expect(rowTotalsArePositionedAfterPivotCols()).toBe(true);
 
         gridApi.addValueColumns(['bronze']);
-        expect(rowTotalIds(gridApi)).toEqual([
+        const rowTotalIdsAfterReAddingBronze = rowTotalIds(gridApi);
+        expect(rowTotalIdsAfterReAddingBronze).toEqual([
             'PivotRowTotal_pivot_year__gold',
             'PivotRowTotal_pivot_year__silver',
             'PivotRowTotal_pivot_year__bronze',
@@ -129,12 +139,17 @@ describe('pivotRowTotals + value column toggling', () => {
 
         // Drag silver back in
         gridApi.setValueColumns(['gold', 'silver']);
-        expect(rowTotalIds(gridApi)).toEqual(['PivotRowTotal_pivot_year__gold', 'PivotRowTotal_pivot_year__silver']);
+        const rowTotalIdsAfterReAddingSilver = rowTotalIds(gridApi);
+        expect(rowTotalIdsAfterReAddingSilver).toEqual([
+            'PivotRowTotal_pivot_year__gold',
+            'PivotRowTotal_pivot_year__silver',
+        ]);
         expect(rowTotalsArePositionedBeforePivotCols(gridApi)).toBe(true);
 
         // Drag bronze back in
         gridApi.setValueColumns(['gold', 'silver', 'bronze']);
-        expect(rowTotalIds(gridApi)).toEqual([
+        const rowTotalIdsAfterReAddingBronze = rowTotalIds(gridApi);
+        expect(rowTotalIdsAfterReAddingBronze).toEqual([
             'PivotRowTotal_pivot_year__gold',
             'PivotRowTotal_pivot_year__silver',
             'PivotRowTotal_pivot_year__bronze',

--- a/testing/behavioural/src/columns/order/pivot-row-totals-value-toggle.test.ts
+++ b/testing/behavioural/src/columns/order/pivot-row-totals-value-toggle.test.ts
@@ -141,4 +141,20 @@ describe('pivotRowTotals + value column toggling', () => {
         ]);
         expect(rowTotalsArePositionedBeforePivotCols(gridApi)).toBe(true);
     });
+
+    test('setValueColumns reorder updates generated pivot column order', () => {
+        const gridApi = gridsManager.createGrid('myGrid', {
+            columnDefs,
+            rowData,
+            pivotMode: true,
+        });
+
+        gridApi.setValueColumns(['bronze', 'gold', 'silver']);
+
+        expect(getColumnOrder(gridApi, 'center').filter((id) => id.startsWith('pivot_year_2000_'))).toEqual([
+            'pivot_year_2000_bronze',
+            'pivot_year_2000_gold',
+            'pivot_year_2000_silver',
+        ]);
+    });
 });

--- a/testing/behavioural/src/columns/order/pivot-row-totals-value-toggle.test.ts
+++ b/testing/behavioural/src/columns/order/pivot-row-totals-value-toggle.test.ts
@@ -42,10 +42,7 @@ describe('pivotRowTotals + value column toggling', () => {
     const rowTotalsArePositionedBeforePivotCols = (gridApi: ReturnType<typeof gridsManager.createGrid>) => {
         const order = getColumnOrder(gridApi, 'center');
         // Find last row-total and first non-row-total pivot column.
-        const lastRowTotalIdx = order.reduce(
-            (acc, id, idx) => (id.startsWith('PivotRowTotal_') ? idx : acc),
-            -1
-        );
+        const lastRowTotalIdx = order.reduce((acc, id, idx) => (id.startsWith('PivotRowTotal_') ? idx : acc), -1);
         const firstPivotIdx = order.findIndex((id) => id.startsWith('pivot_'));
         return lastRowTotalIdx < firstPivotIdx;
     };
@@ -70,10 +67,7 @@ describe('pivotRowTotals + value column toggling', () => {
         expect(rowTotalsArePositionedBeforePivotCols(gridApi)).toBe(true);
 
         gridApi.addValueColumns(['silver']);
-        expect(rowTotalIds(gridApi)).toEqual([
-            'PivotRowTotal_pivot_year__gold',
-            'PivotRowTotal_pivot_year__silver',
-        ]);
+        expect(rowTotalIds(gridApi)).toEqual(['PivotRowTotal_pivot_year__gold', 'PivotRowTotal_pivot_year__silver']);
         expect(rowTotalsArePositionedBeforePivotCols(gridApi)).toBe(true);
 
         gridApi.addValueColumns(['bronze']);
@@ -96,10 +90,7 @@ describe('pivotRowTotals + value column toggling', () => {
         const rowTotalsArePositionedAfterPivotCols = () => {
             const order = getColumnOrder(gridApi, 'center');
             const firstRowTotalIdx = order.findIndex((id) => id.startsWith('PivotRowTotal_'));
-            const lastPivotIdx = order.reduce(
-                (acc, id, idx) => (id.startsWith('pivot_') ? idx : acc),
-                -1
-            );
+            const lastPivotIdx = order.reduce((acc, id, idx) => (id.startsWith('pivot_') ? idx : acc), -1);
             return lastPivotIdx < firstRowTotalIdx;
         };
 
@@ -110,10 +101,7 @@ describe('pivotRowTotals + value column toggling', () => {
         expect(rowTotalsArePositionedAfterPivotCols()).toBe(true);
 
         gridApi.addValueColumns(['silver']);
-        expect(rowTotalIds(gridApi)).toEqual([
-            'PivotRowTotal_pivot_year__gold',
-            'PivotRowTotal_pivot_year__silver',
-        ]);
+        expect(rowTotalIds(gridApi)).toEqual(['PivotRowTotal_pivot_year__gold', 'PivotRowTotal_pivot_year__silver']);
         expect(rowTotalsArePositionedAfterPivotCols()).toBe(true);
 
         gridApi.addValueColumns(['bronze']);
@@ -141,10 +129,7 @@ describe('pivotRowTotals + value column toggling', () => {
 
         // Drag silver back in
         gridApi.setValueColumns(['gold', 'silver']);
-        expect(rowTotalIds(gridApi)).toEqual([
-            'PivotRowTotal_pivot_year__gold',
-            'PivotRowTotal_pivot_year__silver',
-        ]);
+        expect(rowTotalIds(gridApi)).toEqual(['PivotRowTotal_pivot_year__gold', 'PivotRowTotal_pivot_year__silver']);
         expect(rowTotalsArePositionedBeforePivotCols(gridApi)).toBe(true);
 
         // Drag bronze back in

--- a/testing/behavioural/src/columns/order/pivot-row-totals-value-toggle.test.ts
+++ b/testing/behavioural/src/columns/order/pivot-row-totals-value-toggle.test.ts
@@ -70,17 +70,17 @@ describe('pivotRowTotals + value column toggling', () => {
         expect(rowTotalsArePositionedBeforePivotCols(gridApi)).toBe(true);
 
         gridApi.addValueColumns(['silver']);
-        expect(rowTotalIds(gridApi).sort()).toEqual([
+        expect(rowTotalIds(gridApi)).toEqual([
             'PivotRowTotal_pivot_year__gold',
             'PivotRowTotal_pivot_year__silver',
         ]);
         expect(rowTotalsArePositionedBeforePivotCols(gridApi)).toBe(true);
 
         gridApi.addValueColumns(['bronze']);
-        expect(rowTotalIds(gridApi).sort()).toEqual([
-            'PivotRowTotal_pivot_year__bronze',
+        expect(rowTotalIds(gridApi)).toEqual([
             'PivotRowTotal_pivot_year__gold',
             'PivotRowTotal_pivot_year__silver',
+            'PivotRowTotal_pivot_year__bronze',
         ]);
         expect(rowTotalsArePositionedBeforePivotCols(gridApi)).toBe(true);
     });
@@ -110,17 +110,17 @@ describe('pivotRowTotals + value column toggling', () => {
         expect(rowTotalsArePositionedAfterPivotCols()).toBe(true);
 
         gridApi.addValueColumns(['silver']);
-        expect(rowTotalIds(gridApi).sort()).toEqual([
+        expect(rowTotalIds(gridApi)).toEqual([
             'PivotRowTotal_pivot_year__gold',
             'PivotRowTotal_pivot_year__silver',
         ]);
         expect(rowTotalsArePositionedAfterPivotCols()).toBe(true);
 
         gridApi.addValueColumns(['bronze']);
-        expect(rowTotalIds(gridApi).sort()).toEqual([
-            'PivotRowTotal_pivot_year__bronze',
+        expect(rowTotalIds(gridApi)).toEqual([
             'PivotRowTotal_pivot_year__gold',
             'PivotRowTotal_pivot_year__silver',
+            'PivotRowTotal_pivot_year__bronze',
         ]);
         expect(rowTotalsArePositionedAfterPivotCols()).toBe(true);
     });
@@ -141,7 +141,7 @@ describe('pivotRowTotals + value column toggling', () => {
 
         // Drag silver back in
         gridApi.setValueColumns(['gold', 'silver']);
-        expect(rowTotalIds(gridApi).sort()).toEqual([
+        expect(rowTotalIds(gridApi)).toEqual([
             'PivotRowTotal_pivot_year__gold',
             'PivotRowTotal_pivot_year__silver',
         ]);
@@ -149,10 +149,10 @@ describe('pivotRowTotals + value column toggling', () => {
 
         // Drag bronze back in
         gridApi.setValueColumns(['gold', 'silver', 'bronze']);
-        expect(rowTotalIds(gridApi).sort()).toEqual([
-            'PivotRowTotal_pivot_year__bronze',
+        expect(rowTotalIds(gridApi)).toEqual([
             'PivotRowTotal_pivot_year__gold',
             'PivotRowTotal_pivot_year__silver',
+            'PivotRowTotal_pivot_year__bronze',
         ]);
         expect(rowTotalsArePositionedBeforePivotCols(gridApi)).toBe(true);
     });

--- a/testing/behavioural/src/columns/order/pivot-row-totals-value-toggle.test.ts
+++ b/testing/behavioural/src/columns/order/pivot-row-totals-value-toggle.test.ts
@@ -1,0 +1,159 @@
+import type { ColDef, ColGroupDef } from 'ag-grid-community';
+import { ClientSideRowModelModule } from 'ag-grid-community';
+import { PivotModule, RowGroupingModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager } from '../../test-utils';
+import { getColumnOrder } from '../column-test-utils';
+
+// Regression coverage for AG-16677:
+// When value columns in pivot mode are removed and then re-added, every
+// re-added value column should produce a pivotRowTotals column group that
+// sits next to the existing row total groups — not pushed to the end of
+// the grid.
+describe('pivotRowTotals + value column toggling', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule, PivotModule],
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    const rowData = [
+        { country: 'Ireland', year: 2000, gold: 1, silver: 2, bronze: 3 },
+        { country: 'Ireland', year: 2004, gold: 4, silver: 5, bronze: 6 },
+        { country: 'Italy', year: 2000, gold: 7, silver: 8, bronze: 9 },
+    ];
+
+    const columnDefs: (ColDef | ColGroupDef)[] = [
+        { field: 'country', rowGroup: true },
+        { field: 'year', pivot: true },
+        { field: 'gold', aggFunc: 'sum' },
+        { field: 'silver', aggFunc: 'sum' },
+        { field: 'bronze', aggFunc: 'sum' },
+    ];
+
+    const rowTotalIds = (gridApi: ReturnType<typeof gridsManager.createGrid>) =>
+        getColumnOrder(gridApi, 'center').filter((id) => id.startsWith('PivotRowTotal_'));
+
+    // Checks the order of the row-total columns relative to the rest of the
+    // pivot columns. The row-total groups must all sit together at the start
+    // of the grid (for pivotRowTotals: 'before').
+    const rowTotalsArePositionedBeforePivotCols = (gridApi: ReturnType<typeof gridsManager.createGrid>) => {
+        const order = getColumnOrder(gridApi, 'center');
+        // Find last row-total and first non-row-total pivot column.
+        const lastRowTotalIdx = order.reduce(
+            (acc, id, idx) => (id.startsWith('PivotRowTotal_') ? idx : acc),
+            -1
+        );
+        const firstPivotIdx = order.findIndex((id) => id.startsWith('pivot_'));
+        return lastRowTotalIdx < firstPivotIdx;
+    };
+
+    test('remove then re-add value columns => all row totals stay grouped at the start', () => {
+        const gridApi = gridsManager.createGrid('myGrid', {
+            columnDefs,
+            rowData,
+            pivotMode: true,
+            pivotRowTotals: 'before',
+        });
+
+        expect(rowTotalIds(gridApi)).toEqual([
+            'PivotRowTotal_pivot_year__gold',
+            'PivotRowTotal_pivot_year__silver',
+            'PivotRowTotal_pivot_year__bronze',
+        ]);
+        expect(rowTotalsArePositionedBeforePivotCols(gridApi)).toBe(true);
+
+        gridApi.removeValueColumns(['silver', 'bronze']);
+        expect(rowTotalIds(gridApi)).toEqual(['PivotRowTotal_pivot_year__gold']);
+        expect(rowTotalsArePositionedBeforePivotCols(gridApi)).toBe(true);
+
+        gridApi.addValueColumns(['silver']);
+        expect(rowTotalIds(gridApi).sort()).toEqual([
+            'PivotRowTotal_pivot_year__gold',
+            'PivotRowTotal_pivot_year__silver',
+        ]);
+        expect(rowTotalsArePositionedBeforePivotCols(gridApi)).toBe(true);
+
+        gridApi.addValueColumns(['bronze']);
+        expect(rowTotalIds(gridApi).sort()).toEqual([
+            'PivotRowTotal_pivot_year__bronze',
+            'PivotRowTotal_pivot_year__gold',
+            'PivotRowTotal_pivot_year__silver',
+        ]);
+        expect(rowTotalsArePositionedBeforePivotCols(gridApi)).toBe(true);
+    });
+
+    test('pivotRowTotals=after: re-added row totals stay grouped at the end', () => {
+        const gridApi = gridsManager.createGrid('myGrid', {
+            columnDefs,
+            rowData,
+            pivotMode: true,
+            pivotRowTotals: 'after',
+        });
+
+        const rowTotalsArePositionedAfterPivotCols = () => {
+            const order = getColumnOrder(gridApi, 'center');
+            const firstRowTotalIdx = order.findIndex((id) => id.startsWith('PivotRowTotal_'));
+            const lastPivotIdx = order.reduce(
+                (acc, id, idx) => (id.startsWith('pivot_') ? idx : acc),
+                -1
+            );
+            return lastPivotIdx < firstRowTotalIdx;
+        };
+
+        expect(rowTotalsArePositionedAfterPivotCols()).toBe(true);
+
+        gridApi.removeValueColumns(['silver', 'bronze']);
+        expect(rowTotalIds(gridApi)).toEqual(['PivotRowTotal_pivot_year__gold']);
+        expect(rowTotalsArePositionedAfterPivotCols()).toBe(true);
+
+        gridApi.addValueColumns(['silver']);
+        expect(rowTotalIds(gridApi).sort()).toEqual([
+            'PivotRowTotal_pivot_year__gold',
+            'PivotRowTotal_pivot_year__silver',
+        ]);
+        expect(rowTotalsArePositionedAfterPivotCols()).toBe(true);
+
+        gridApi.addValueColumns(['bronze']);
+        expect(rowTotalIds(gridApi).sort()).toEqual([
+            'PivotRowTotal_pivot_year__bronze',
+            'PivotRowTotal_pivot_year__gold',
+            'PivotRowTotal_pivot_year__silver',
+        ]);
+        expect(rowTotalsArePositionedAfterPivotCols()).toBe(true);
+    });
+
+    // Matches how the tool panel Values drop zone toggles: it always calls setValueColumns
+    // with the full desired list, never add/remove deltas.
+    test('tool-panel-style setValueColumns toggle: row totals stay grouped at the start', () => {
+        const gridApi = gridsManager.createGrid('myGrid', {
+            columnDefs,
+            rowData,
+            pivotMode: true,
+            pivotRowTotals: 'before',
+        });
+
+        // Drop silver+bronze from the Values section
+        gridApi.setValueColumns(['gold']);
+        expect(rowTotalIds(gridApi)).toEqual(['PivotRowTotal_pivot_year__gold']);
+
+        // Drag silver back in
+        gridApi.setValueColumns(['gold', 'silver']);
+        expect(rowTotalIds(gridApi).sort()).toEqual([
+            'PivotRowTotal_pivot_year__gold',
+            'PivotRowTotal_pivot_year__silver',
+        ]);
+        expect(rowTotalsArePositionedBeforePivotCols(gridApi)).toBe(true);
+
+        // Drag bronze back in
+        gridApi.setValueColumns(['gold', 'silver', 'bronze']);
+        expect(rowTotalIds(gridApi).sort()).toEqual([
+            'PivotRowTotal_pivot_year__bronze',
+            'PivotRowTotal_pivot_year__gold',
+            'PivotRowTotal_pivot_year__silver',
+        ]);
+        expect(rowTotalsArePositionedBeforePivotCols(gridApi)).toBe(true);
+    });
+});


### PR DESCRIPTION
Fix bug with pivot totals column positioning during grid modifications

  - Added isPivotRowTotalColumn() to IPivotColDefService.
  - Implemented it in PivotColDefService using the PivotRowTotal_ colId prefix.
  - Updated restoreColOrder() so new pivot row total columns do not use generic sibling matching.
  - Instead, they anchor after the previous preserved column in the fresh generated list, so they stay after group/service columns and before/after pivot value columns as generated.

  Also fixed a sorting bug: 

  - PivotStage now detects pure value column reorder: same value columns, different order.
  - That signal is passed through pivotResultCols.setPivotResultCols(...).
  - ColumnModel.refreshCols(...) skips restoreColOrder() for that refresh, so the freshly generated pivot order is shown instead of restoring the stale order.
  - Added behavioural coverage for setValueColumns(['bronze', 'gold', 'silver']).

Fix [AG-16677](https://ag-grid.atlassian.net/browse/AG-16677)

Local repro https://plnkr.co/edit/CIAKpYngoZwWnVha?open=main.js  