### PR TITLE
AG-8439 fix-pinned-top-btm

### DIFF
--- a/packages/ag-grid-community/src/entities/rowNode.ts
+++ b/packages/ag-grid-community/src/entities/rowNode.ts
@@ -341,7 +341,7 @@ export class RowNode<TData = any>
      * Replaces the data on the `rowNode`. When this method is called, the grid refreshes the entire rendered row if it is displayed.
      */
     public setData(data: TData): void {
-        this.setDataCommon(data, false);
+        this.setDataCommon(data, 'set');
     }
 
     // similar to setRowData, however it is expected that the data is the same data item. this
@@ -354,12 +354,23 @@ export class RowNode<TData = any>
      * Updates the data on the `rowNode`. When this method is called, the grid refreshes the entire rendered row if it is displayed.
      */
     public updateData(data: TData): void {
-        this.setDataCommon(data, true);
+        this.setDataCommon(data, 'update');
     }
 
-    private setDataCommon(data: TData, update: boolean): void {
+    /**
+     * Like {@link updateData}, but does NOT mirror the data onto `this.sibling`. Used for
+     * row nodes whose sibling must not share data — e.g. the SSRM grand total node, whose
+     * sibling is the root.
+     * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+     */
+    public _updateDataNoSibling(data: TData): void {
+        this.setDataCommon(data, 'updateNoSibling');
+    }
+
+    private setDataCommon(data: TData, mode: 'set' | 'update' | 'updateNoSibling'): void {
         const { valueCache, eventSvc } = this.beans;
         const oldData = this.data;
+        const update = mode !== 'set';
 
         this.data = data;
         valueCache?.onDataChanged();
@@ -369,10 +380,13 @@ export class RowNode<TData = any>
         const event: DataChangedEvent<TData> = this.createDataChangedEvent(data, oldData, update);
         this.__localEventService?.dispatchEvent(event);
 
-        if (this.sibling) {
-            this.sibling.data = data;
-            const event: DataChangedEvent<TData> = this.sibling.createDataChangedEvent(data, oldData, update);
-            this.sibling.__localEventService?.dispatchEvent(event);
+        if (mode !== 'updateNoSibling') {
+            const sibling = this.sibling;
+            if (sibling) {
+                sibling.data = data;
+                const event: DataChangedEvent<TData> = sibling.createDataChangedEvent(data, oldData, update);
+                sibling.__localEventService?.dispatchEvent(event);
+            }
         }
 
         eventSvc.dispatchEvent({ type: 'rowNodeDataChanged', node: this });

--- a/packages/ag-grid-community/src/gridOptionsUtils.ts
+++ b/packages/ag-grid-community/src/gridOptionsUtils.ts
@@ -235,6 +235,22 @@ export function _getGrandTotalRow(gos: GridOptionsService): GridOptions['grandTo
     return gos.get('grandTotalRow');
 }
 
+/**
+ * Maps a `grandTotalRow` option to the floating side the grand total should be pinned to,
+ * or `null` when it should render inline (or is disabled).
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export function _getGrandTotalPinnedFloat(grandTotalRow: GridOptions['grandTotalRow']): 'top' | 'bottom' | null {
+    switch (grandTotalRow) {
+        case 'pinnedTop':
+            return 'top';
+        case 'pinnedBottom':
+            return 'bottom';
+        default:
+            return null;
+    }
+}
+
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _getGroupTotalRowCallback(
     gos: GridOptionsService

--- a/packages/ag-grid-community/src/main-internal.ts
+++ b/packages/ag-grid-community/src/main-internal.ts
@@ -367,6 +367,7 @@ export {
     _getCheckboxLocation,
     _getEnableColumnSelection,
     _getFillHandle,
+    _getGrandTotalPinnedFloat,
     _getGrandTotalRow,
     _getGridOption,
     _getGroupAggFiltering,

--- a/packages/ag-grid-community/src/pinnedRowModel/manualPinnedRowModel.ts
+++ b/packages/ag-grid-community/src/pinnedRowModel/manualPinnedRowModel.ts
@@ -6,7 +6,7 @@ import { ROW_ID_PREFIX_BOTTOM_PINNED, ROW_ID_PREFIX_TOP_PINNED } from '../entiti
 import type { RowNode } from '../entities/rowNode';
 import { _createRowNodeSibling } from '../entities/rowNodeUtils';
 import type { StylesChangedEvent } from '../events';
-import { _getRowHeightForNode } from '../gridOptionsUtils';
+import { _getGrandTotalPinnedFloat, _getRowHeightForNode } from '../gridOptionsUtils';
 import type { RowPinningState } from '../interfaces/gridState';
 import type { IClientSideRowModel } from '../interfaces/iClientSideRowModel';
 import type { IPinnedRowModel } from '../interfaces/iPinnedRowModel';
@@ -84,8 +84,7 @@ export class ManualPinnedRowModel extends BeanStub implements IPinnedRowModel {
         });
 
         this.addManagedPropertyListener('grandTotalRow', ({ currentValue }) => {
-            this._grandTotalPinned =
-                currentValue === 'pinnedBottom' ? 'bottom' : currentValue === 'pinnedTop' ? 'top' : null;
+            this._grandTotalPinned = _getGrandTotalPinnedFloat(currentValue);
         });
 
         this.addManagedPropertyListener('isRowPinned', runIsRowPinned);
@@ -130,8 +129,14 @@ export class ManualPinnedRowModel extends BeanStub implements IPinnedRowModel {
             // on the root node.
             if (level === -1) {
                 this._grandTotalPinned = float;
-                // We need to refresh the model, but only if we are not already refreshing.
-                this.csrm?.reMapRows();
+                // CSRM goes through reMapRows so the modelUpdated listener picks up the
+                // change; SSRM has no model-update path so we apply it directly.
+                const csrm = this.csrm;
+                if (csrm) {
+                    csrm.reMapRows();
+                } else if (this.ssrm) {
+                    this.pinGrandTotalRow();
+                }
                 return;
             }
         }

--- a/packages/ag-grid-enterprise/src/rowHierarchy/flattenStage.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/flattenStage.ts
@@ -5,7 +5,7 @@ import type {
     RowNode,
     _IRowNodeFlattenStage,
 } from 'ag-grid-community';
-import { BeanStub } from 'ag-grid-community';
+import { BeanStub, _getGrandTotalPinnedFloat } from 'ag-grid-community';
 
 import { _createRowNodeFooter, _destroyRowNodeFooter } from '../aggregation/footerUtils';
 import type { FlattenDetails } from './flattenUtils';
@@ -63,12 +63,11 @@ export class FlattenStage extends BeanStub implements _IRowNodeFlattenStage, Nam
 
         if (includeGrandTotalRow) {
             const footerNode = _createRowNodeFooter(rootNode, beans);
-            // want to not render the footer row here if pinned via grid options
-            if (grandTotalRow === 'pinnedBottom' || grandTotalRow === 'pinnedTop') {
-                this.beans.pinnedRowModel?.setGrandTotalPinned(grandTotalRow === 'pinnedBottom' ? 'bottom' : 'top');
+            const pinnedFloat = _getGrandTotalPinnedFloat(grandTotalRow);
+            if (pinnedFloat) {
+                this.beans.pinnedRowModel?.setGrandTotalPinned(pinnedFloat);
             } else {
-                const addToTop = grandTotalRow === 'top';
-                this.addRowNodeToRowsToDisplay(details, footerNode, result, 0, addToTop);
+                this.addRowNodeToRowsToDisplay(details, footerNode, result, 0, grandTotalRow === 'top');
             }
         }
 

--- a/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyCache.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyCache.ts
@@ -1075,15 +1075,12 @@ export class LazyCache extends BeanStub {
         });
     }
 
-    /**
-     * Creates or updates the grand total row node from server response data.
-     * Uses _createRowNodeFooter with the same sibling pattern as CSRM.
-     */
-    public createOrUpdateGrandTotalNode(data: any): void {
+    /** Creates the grand total row node, or applies new data to the existing one. */
+    public createOrUpdateGrandTotalNode(data: any): RowNode {
         const existingNode = this.store.getGrandTotalNode();
         if (existingNode) {
-            this.blockUtils.updateDataIntoRowNode(existingNode, data);
-            return;
+            existingNode._updateDataNoSibling(data);
+            return existingNode;
         }
 
         const parentNode = this.store.getParentNode();
@@ -1096,6 +1093,7 @@ export class LazyCache extends BeanStub {
         newNode.setRowHeight(rowHeight.height, rowHeight.estimated);
 
         this.nodeManager.addRowNode(newNode);
+        return newNode;
     }
 
     public getOrderedNodeMap() {
@@ -1144,7 +1142,7 @@ export class LazyCache extends BeanStub {
                 store.grandTotalData = data;
                 const grandTotalNode = store.getGrandTotalNode();
                 if (grandTotalNode) {
-                    blockUtils.updateDataIntoRowNode(grandTotalNode, data);
+                    grandTotalNode._updateDataNoSibling(data);
                     updatedNodes.push(grandTotalNode);
                 }
                 continue;

--- a/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyStore.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyStore.ts
@@ -19,6 +19,7 @@ import type {
 import {
     BeanStub,
     ServerSideTransactionResultStatus,
+    _getGrandTotalPinnedFloat,
     _getGrandTotalRow,
     _getGroupTotalRowCallback,
     _getRowHeightAsNumber,
@@ -327,21 +328,41 @@ export class LazyStore extends BeanStub implements IServerSideStore {
             );
         }
 
-        const grandTotalPosition = this.parentRowNode.level === -1 ? _getGrandTotalRow(this.gos) : undefined;
-        let grandTotalNode = this.getGrandTotalNode();
+        // Reconcile the grand total node and its pinned/inline placement. Root store only.
+        // `inlineGrandTotal` is the node to display inline (top or bottom of root rows);
+        // it stays undefined when the grand total is disabled or pinned.
+        let inlineGrandTotalTop: RowNode | undefined;
+        let inlineGrandTotalBottom: RowNode | undefined;
+        if (this.parentRowNode.level === -1) {
+            const grandTotalRow = _getGrandTotalRow(this.gos);
+            let grandTotalNode = this.getGrandTotalNode();
+            if (grandTotalRow && this.grandTotalData) {
+                if (!grandTotalNode) {
+                    grandTotalNode = this.cache.createOrUpdateGrandTotalNode(this.grandTotalData);
+                }
+            } else if (grandTotalNode) {
+                this.destroyGrandTotalRow();
+                grandTotalNode = undefined;
+            }
 
-        if (grandTotalPosition && !grandTotalNode && this.grandTotalData) {
-            this.cache.createOrUpdateGrandTotalNode(this.grandTotalData);
-            grandTotalNode = this.getGrandTotalNode();
-        }
-        // e.g. when cleared via transaction remove or option toggled off
-        if (grandTotalNode && (!grandTotalPosition || !this.grandTotalData)) {
-            this.destroyGrandTotalRow();
-            grandTotalNode = undefined;
+            const pinnedFloat = _getGrandTotalPinnedFloat(grandTotalRow);
+            this.beans.pinnedRowModel?.setGrandTotalPinned(pinnedFloat);
+
+            if (grandTotalNode) {
+                if (pinnedFloat) {
+                    // Pinned grand totals don't take part in the inline display index;
+                    // clear any stale index left from a previous inline placement.
+                    this.blockUtils.clearDisplayIndex(grandTotalNode);
+                } else if (grandTotalRow === 'top') {
+                    inlineGrandTotalTop = grandTotalNode;
+                } else if (grandTotalRow === 'bottom') {
+                    inlineGrandTotalBottom = grandTotalNode;
+                }
+            }
         }
 
-        if (grandTotalPosition === 'top' && grandTotalNode) {
-            this.blockUtils.setDisplayIndex(grandTotalNode, displayIndexSeq, nextRowTop, uiLevel);
+        if (inlineGrandTotalTop) {
+            this.blockUtils.setDisplayIndex(inlineGrandTotalTop, displayIndexSeq, nextRowTop, uiLevel);
         }
 
         // delegate to the store to set the row display indexes
@@ -356,8 +377,8 @@ export class LazyStore extends BeanStub implements IServerSideStore {
             );
         }
 
-        if (grandTotalPosition === 'bottom' && grandTotalNode) {
-            this.blockUtils.setDisplayIndex(grandTotalNode, displayIndexSeq, nextRowTop, uiLevel);
+        if (inlineGrandTotalBottom) {
+            this.blockUtils.setDisplayIndex(inlineGrandTotalBottom, displayIndexSeq, nextRowTop, uiLevel);
         }
 
         this.displayIndexEnd = displayIndexSeq.value;

--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-grand-total.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-grand-total.test.ts
@@ -5,7 +5,13 @@ import type {
     IServerSideDatasource,
     IServerSideGetRowsParams,
 } from 'ag-grid-community';
-import { GRAND_TOTAL_ROW_ID, NumberFilterModule, PaginationModule, ROOT_NODE_ID } from 'ag-grid-community';
+import {
+    GRAND_TOTAL_ROW_ID,
+    NumberFilterModule,
+    PaginationModule,
+    PinnedRowModule,
+    ROOT_NODE_ID,
+} from 'ag-grid-community';
 import { RowGroupingModule, ServerSideRowModelApiModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
 
 import {
@@ -27,6 +33,7 @@ describe('SSRM grand total row', () => {
             RowGroupingModule,
             PaginationModule,
             NumberFilterModule,
+            PinnedRowModule,
         ],
     });
 
@@ -392,7 +399,7 @@ describe('SSRM grand total row', () => {
 
         const gridRows = new GridRows(api, 'after update');
         await gridRows.check(unindentText`
-            ROOT id:<no-id> id:"rowGroupFooter_ROOT_NODE_ID" value:999
+            ROOT id:<no-id>
             ├── LEAF id:1 id:"1" value:10
             ├── LEAF id:2 id:"2" value:20
             ├── LEAF id:3 id:"3" value:30
@@ -630,7 +637,7 @@ describe('SSRM grand total row', () => {
         expect(api.getDisplayedRowCount()).toBe(4);
     });
 
-    test('pinned grand total row (pinnedBottom)', async () => {
+    test('grand total at pinnedBottom renders in pinned area, not inline', async () => {
         const api = gridManager.createGrid(
             null,
             createFlatGridOptions({
@@ -641,13 +648,23 @@ describe('SSRM grand total row', () => {
         await waitForEvent('firstDataRendered', api);
         await waitForNoLoadingRows(api);
 
-        // The grand total row data should still be stored
-        const grandTotal = api.getRowNode(GRAND_TOTAL_ID);
-        expect(grandTotal).toBeDefined();
-        expect(grandTotal!.data.value).toBe(60);
+        // Grand total is in the pinned bottom area, not inline with data rows
+        await new GridRows(api, 'pinnedBottom').check(unindentText`
+            ROOT id:<no-id>
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            └── LEAF id:3 id:"3" value:30
+            PINNED_BOTTOM id:b-bottom-rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:60
+        `);
+
+        expect(api.getPinnedBottomRowCount()).toBe(1);
+        expect(api.getPinnedTopRowCount()).toBe(0);
+        expect(api.getPinnedBottomRow(0)?.data?.value).toBe(60);
+        // Displayed (non-pinned) row count should not include the pinned grand total
+        expect(api.getDisplayedRowCount()).toBe(3);
     });
 
-    test('pinned grand total row (pinnedTop)', async () => {
+    test('grand total at pinnedTop renders in pinned area, not inline', async () => {
         const api = gridManager.createGrid(
             null,
             createFlatGridOptions({
@@ -658,10 +675,408 @@ describe('SSRM grand total row', () => {
         await waitForEvent('firstDataRendered', api);
         await waitForNoLoadingRows(api);
 
-        // The grand total row data should still be stored
-        const grandTotal = api.getRowNode(GRAND_TOTAL_ID);
-        expect(grandTotal).toBeDefined();
-        expect(grandTotal!.data.value).toBe(60);
+        await new GridRows(api, 'pinnedTop').check(unindentText`
+            PINNED_TOP id:t-top-rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:60
+            ROOT id:<no-id>
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            └── LEAF id:3 id:"3" value:30
+        `);
+
+        expect(api.getPinnedTopRowCount()).toBe(1);
+        expect(api.getPinnedBottomRowCount()).toBe(0);
+        expect(api.getPinnedTopRow(0)?.data?.value).toBe(60);
+        expect(api.getDisplayedRowCount()).toBe(3);
+    });
+
+    test('cycle through grandTotalRow positions including pinned', async () => {
+        const api = gridManager.createGrid(
+            null,
+            createFlatGridOptions({
+                grandTotalRow: 'bottom',
+            })
+        );
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        // bottom (inline)
+        await new GridRows(api, 'bottom').check(unindentText`
+            ROOT id:<no-id>
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            ├── LEAF id:3 id:"3" value:30
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:60
+        `);
+        expect(api.getPinnedBottomRowCount()).toBe(0);
+
+        // bottom → pinnedBottom
+        api.setGridOption('grandTotalRow', 'pinnedBottom');
+        await asyncSetTimeout(10);
+
+        await new GridRows(api, 'pinnedBottom').check(unindentText`
+            ROOT id:<no-id>
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            └── LEAF id:3 id:"3" value:30
+            PINNED_BOTTOM id:b-bottom-rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:60
+        `);
+        expect(api.getPinnedBottomRowCount()).toBe(1);
+        expect(api.getPinnedTopRowCount()).toBe(0);
+        const pinnedBottomNode = api.getPinnedBottomRow(0)!;
+        expect(pinnedBottomNode.destroyed).toBe(false);
+
+        // pinnedBottom → pinnedTop: the previous pinned-bottom sibling must be destroyed,
+        // not orphaned in the bottom container.
+        api.setGridOption('grandTotalRow', 'pinnedTop');
+        await asyncSetTimeout(10);
+
+        await new GridRows(api, 'pinnedTop').check(unindentText`
+            PINNED_TOP id:t-top-rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:60
+            ROOT id:<no-id>
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            └── LEAF id:3 id:"3" value:30
+        `);
+        expect(api.getPinnedTopRowCount()).toBe(1);
+        expect(api.getPinnedBottomRowCount()).toBe(0);
+        expect(pinnedBottomNode.destroyed).toBe(true);
+        const pinnedTopNode = api.getPinnedTopRow(0)!;
+        expect(pinnedTopNode.destroyed).toBe(false);
+
+        // pinnedTop → top (back to inline). The pinned-top sibling must be destroyed.
+        api.setGridOption('grandTotalRow', 'top');
+        await asyncSetTimeout(10);
+        expect(pinnedTopNode.destroyed).toBe(true);
+
+        await new GridRows(api, 'top').check(unindentText`
+            ROOT id:<no-id>
+            ├─ footer id:rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:60
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            └── LEAF id:3 id:"3" value:30
+        `);
+        expect(api.getPinnedTopRowCount()).toBe(0);
+        expect(api.getPinnedBottomRowCount()).toBe(0);
+
+        // top → pinnedBottom
+        api.setGridOption('grandTotalRow', 'pinnedBottom');
+        await asyncSetTimeout(10);
+
+        await new GridRows(api, 'pinnedBottom again').check(unindentText`
+            ROOT id:<no-id>
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            └── LEAF id:3 id:"3" value:30
+            PINNED_BOTTOM id:b-bottom-rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:60
+        `);
+        expect(api.getPinnedBottomRowCount()).toBe(1);
+
+        // pinnedBottom → undefined (grand total removed). The pinned sibling must be destroyed.
+        const lastPinnedBottomNode = api.getPinnedBottomRow(0)!;
+        api.setGridOption('grandTotalRow', undefined);
+        await asyncSetTimeout(10);
+
+        await new GridRows(api, 'disabled').check(unindentText`
+            ROOT id:<no-id>
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            └── LEAF id:3 id:"3" value:30
+        `);
+        expect(api.getPinnedBottomRowCount()).toBe(0);
+        expect(api.getPinnedTopRowCount()).toBe(0);
+        expect(lastPinnedBottomNode.destroyed).toBe(true);
+    });
+
+    test('pinned grand total updates when value changes via transaction', async () => {
+        const api = gridManager.createGrid(
+            null,
+            createFlatGridOptions({
+                grandTotalRow: 'pinnedBottom',
+            })
+        );
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        expect(api.getPinnedBottomRow(0)?.data?.value).toBe(60);
+
+        api.applyServerSideTransaction({
+            update: [{ id: GRAND_TOTAL_ID, value: 999 }],
+        });
+        await asyncSetTimeout(10);
+
+        expect(api.getPinnedBottomRow(0)?.data?.value).toBe(999);
+        await new GridRows(api, 'after pinned grand total update').check(unindentText`
+            ROOT id:<no-id>
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            └── LEAF id:3 id:"3" value:30
+            PINNED_BOTTOM id:b-bottom-rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:999
+        `);
+    });
+
+    test('pinned grand total with grouped grid', async () => {
+        interface GroupedRow {
+            id: string;
+            category: string;
+            value: number;
+        }
+
+        const serverRows: GroupedRow[] = [
+            { id: 'a1', category: 'A', value: 10 },
+            { id: 'a2', category: 'A', value: 20 },
+            { id: 'b1', category: 'B', value: 30 },
+        ];
+
+        const api = gridManager.createGrid(null, {
+            columnDefs: [
+                { field: 'category', rowGroup: true, hide: true },
+                { field: 'value', aggFunc: 'sum' },
+            ],
+            autoGroupColumnDef: { headerName: 'Category' },
+            rowModelType: 'serverSide',
+            getRowId: (params: GetRowIdParams<GroupedRow>) => params.data.id,
+            grandTotalRow: 'pinnedBottom',
+            serverSideDatasource: {
+                getRows(params: IServerSideGetRowsParams) {
+                    const { request } = params;
+                    let rowData: any[];
+
+                    if (request.groupKeys.length === 0) {
+                        const groups = new Map<string, number>();
+                        for (const row of serverRows) {
+                            groups.set(row.category, (groups.get(row.category) ?? 0) + row.value);
+                        }
+                        rowData = [...groups.entries()].map(([category, value]) => ({
+                            id: `category:${category}`,
+                            category,
+                            value,
+                            group: true,
+                            leafGroup: true,
+                            key: category,
+                        }));
+                        if (params.needsGrandTotal) {
+                            const total = serverRows.reduce((s, r) => s + r.value, 0);
+                            rowData.push({ id: GRAND_TOTAL_ID, value: total });
+                        }
+                    } else {
+                        const groupKey = request.groupKeys[0];
+                        rowData = serverRows.filter((r) => r.category === groupKey).map((r) => ({ ...r }));
+                    }
+
+                    const dataRowCount =
+                        request.groupKeys.length === 0
+                            ? rowData.filter((r: any) => r.id !== GRAND_TOTAL_ID).length
+                            : rowData.length;
+                    setTimeout(() => params.success({ rowData, rowCount: dataRowCount }), 0);
+                },
+            },
+        });
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        await new GridRows(api, 'grouped pinnedBottom').check(unindentText`
+            ROOT id:<no-id>
+            ├── GROUP-leafGroup collapsed id:"category:A" ag-Grid-AutoColumn:"A" category:"A" value:30
+            └── GROUP-leafGroup collapsed id:"category:B" ag-Grid-AutoColumn:"B" category:"B" value:30
+            PINNED_BOTTOM id:b-bottom-rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " value:60
+        `);
+
+        expect(api.getPinnedBottomRowCount()).toBe(1);
+        expect(api.getPinnedBottomRow(0)?.data?.value).toBe(60);
+    });
+
+    // --- Updating grand total via getRows / transaction ---
+
+    test('grand total updates when getRows returns a new value via id in rowData', async () => {
+        let total = 60;
+        const api = gridManager.createGrid(null, {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            getRowId: (params: GetRowIdParams<RowData>) => params.data.id,
+            grandTotalRow: 'bottom',
+            serverSideDatasource: {
+                getRows(params: IServerSideGetRowsParams) {
+                    const rowData: any[] = [...flatRows];
+                    if (params.needsGrandTotal) {
+                        rowData.push({ id: GRAND_TOTAL_ID, value: total });
+                    }
+                    setTimeout(() => params.success({ rowData, rowCount: flatRows.length }), 0);
+                },
+            },
+        });
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+        expect(api.getRowNode(GRAND_TOTAL_ID)?.data?.value).toBe(60);
+
+        const originalNodeId = api.getRowNode(GRAND_TOTAL_ID)?.id;
+        total = 999;
+        api.refreshServerSide({ purge: true });
+        await waitForNoLoadingRows(api);
+
+        // The same node is updated in place (compare by id to avoid row-node deep diff on failure)
+        expect(api.getRowNode(GRAND_TOTAL_ID)?.id).toBe(originalNodeId);
+        expect(api.getRowNode(GRAND_TOTAL_ID)?.data?.value).toBe(999);
+
+        await new GridRows(api, 'after getRows id update').check(unindentText`
+            ROOT id:<no-id>
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            ├── LEAF id:3 id:"3" value:30
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:999
+        `);
+    });
+
+    test('pinned grand total updates when value changes via transaction update', async () => {
+        const api = gridManager.createGrid(null, createFlatGridOptions({ grandTotalRow: 'pinnedTop' }));
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+        expect(api.getPinnedTopRow(0)?.data?.value).toBe(60);
+
+        api.applyServerSideTransaction({ update: [{ id: GRAND_TOTAL_ID, value: 321 }] });
+        await asyncSetTimeout(10);
+
+        expect(api.getPinnedTopRow(0)?.data?.value).toBe(321);
+        expect(api.getPinnedTopRowCount()).toBe(1);
+        expect(api.getPinnedBottomRowCount()).toBe(0);
+    });
+
+    test('grand total updates when getRows returns a new value via grandTotalData field', async () => {
+        let total = 60;
+        const api = gridManager.createGrid(null, {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            getRowId: (params: GetRowIdParams<RowData>) => params.data.id,
+            grandTotalRow: 'bottom',
+            serverSideDatasource: {
+                getRows(params: IServerSideGetRowsParams) {
+                    setTimeout(() => {
+                        params.success({
+                            rowData: [...flatRows],
+                            rowCount: flatRows.length,
+                            grandTotalData: { id: GRAND_TOTAL_ID, value: total },
+                        });
+                    }, 0);
+                },
+            },
+        });
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+        expect(api.getRowNode(GRAND_TOTAL_ID)?.data?.value).toBe(60);
+
+        const originalNodeId = api.getRowNode(GRAND_TOTAL_ID)?.id;
+        total = 123;
+        api.refreshServerSide({ purge: true });
+        await waitForNoLoadingRows(api);
+
+        expect(api.getRowNode(GRAND_TOTAL_ID)?.data?.value).toBe(123);
+        expect(api.getRowNode(GRAND_TOTAL_ID)?.id).toBe(originalNodeId);
+    });
+
+    test('grand total is unaffected when getRows is called on a child group', async () => {
+        // Expanding a group calls getRows on the group's store (not the root). The root's
+        // grand total must not be destroyed or duplicated by that load.
+        interface GroupedRow {
+            id: string;
+            category: string;
+            value: number;
+        }
+
+        const serverRows: GroupedRow[] = [
+            { id: 'a1', category: 'A', value: 10 },
+            { id: 'a2', category: 'A', value: 20 },
+            { id: 'b1', category: 'B', value: 30 },
+        ];
+        const groupKeysCalls: string[][] = [];
+
+        const api = gridManager.createGrid(null, {
+            columnDefs: [
+                { field: 'category', rowGroup: true, hide: true },
+                { field: 'value', aggFunc: 'sum' },
+            ],
+            autoGroupColumnDef: { headerName: 'Category' },
+            rowModelType: 'serverSide',
+            getRowId: (params: GetRowIdParams<GroupedRow>) => params.data.id,
+            grandTotalRow: 'bottom',
+            serverSideDatasource: {
+                getRows(params: IServerSideGetRowsParams) {
+                    const { request } = params;
+                    groupKeysCalls.push([...request.groupKeys]);
+                    let rowData: any[];
+
+                    if (request.groupKeys.length === 0) {
+                        const groups = new Map<string, number>();
+                        for (const row of serverRows) {
+                            groups.set(row.category, (groups.get(row.category) ?? 0) + row.value);
+                        }
+                        rowData = [...groups.entries()].map(([category, value]) => ({
+                            id: `category:${category}`,
+                            category,
+                            value,
+                            group: true,
+                            leafGroup: true,
+                            key: category,
+                        }));
+                        if (params.needsGrandTotal) {
+                            const total = serverRows.reduce((s, r) => s + r.value, 0);
+                            rowData.push({ id: GRAND_TOTAL_ID, value: total });
+                        }
+                    } else {
+                        const groupKey = request.groupKeys[0];
+                        rowData = serverRows.filter((r) => r.category === groupKey).map((r) => ({ ...r }));
+                    }
+
+                    const dataRowCount =
+                        request.groupKeys.length === 0
+                            ? rowData.filter((r: any) => r.id !== GRAND_TOTAL_ID).length
+                            : rowData.length;
+                    setTimeout(() => params.success({ rowData, rowCount: dataRowCount }), 0);
+                },
+            },
+        });
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+        const grandTotalNodeId = api.getRowNode(GRAND_TOTAL_ID)?.id;
+        expect(grandTotalNodeId).toBeDefined();
+        expect(api.getRowNode(GRAND_TOTAL_ID)?.data?.value).toBe(60);
+
+        // Expanding group A triggers getRows({groupKeys: ['A']}) on the group store
+        groupKeysCalls.length = 0;
+        api.getRowNode('category:A')?.setExpanded(true);
+        await waitForNoLoadingRows(api);
+        await asyncSetTimeout(10);
+
+        expect(groupKeysCalls).toEqual([['A']]);
+        // The root's grand total is the same instance with the same data
+        expect(api.getRowNode(GRAND_TOTAL_ID)?.id).toBe(grandTotalNodeId);
+        expect(api.getRowNode(GRAND_TOTAL_ID)?.data?.value).toBe(60);
+    });
+
+    test('grand total updates when value changes via transaction (inline)', async () => {
+        const api = gridManager.createGrid(null, createFlatGridOptions({ grandTotalRow: 'bottom' }));
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        const originalNodeId = api.getRowNode(GRAND_TOTAL_ID)?.id;
+        api.applyServerSideTransaction({ update: [{ id: GRAND_TOTAL_ID, value: 999 }] });
+        await asyncSetTimeout(10);
+
+        expect(api.getRowNode(GRAND_TOTAL_ID)?.id).toBe(originalNodeId);
+        expect(api.getRowNode(GRAND_TOTAL_ID)?.data?.value).toBe(999);
+        await new GridRows(api, 'after inline transaction update').check(unindentText`
+            ROOT id:<no-id>
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            ├── LEAF id:3 id:"3" value:30
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:999
+        `);
     });
 
     // --- grandTotalData field tests ---

--- a/testing/behavioural/src/rows/manual-pinned-rows.test.ts
+++ b/testing/behavioural/src/rows/manual-pinned-rows.test.ts
@@ -180,12 +180,54 @@ describe('Manual pinned rows', () => {
 
         assertPinnedRows(api, 'top', ['t-top-0-rugby']);
         assertPinnedRows(api, 'bottom', ['b-bottom-rowGroupFooter_ROOT_NODE_ID']);
+        const oldPinnedBottom = getPinnedRows(api, 'bottom')[0];
+        expect(oldPinnedBottom.destroyed).toBe(false);
 
         api.setGridOption('grandTotalRow', 'pinnedTop');
         await asyncSetTimeout(10);
 
         assertPinnedRows(api, 'top', ['t-top-rowGroupFooter_ROOT_NODE_ID', 't-top-0-rugby']);
         assertPinnedRows(api, 'bottom', []);
+        expect(oldPinnedBottom.destroyed).toBe(true);
+    });
+
+    test('cycle through grandTotalRow positions including pinned', async () => {
+        const api = await gridsManager.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            getRowId(params) {
+                return `${params.level}-${params.data?.sport}`;
+            },
+            grandTotalRow: 'pinnedTop',
+        });
+
+        // pinnedTop
+        assertPinnedRows(api, 'top', ['t-top-rowGroupFooter_ROOT_NODE_ID']);
+        assertPinnedRows(api, 'bottom', []);
+        const topPinnedNode = getPinnedRows(api, 'top')[0];
+        expect(topPinnedNode.destroyed).toBe(false);
+
+        api.setGridOption('grandTotalRow', 'top');
+        await asyncSetTimeout(10);
+        assertPinnedRows(api, 'top', []);
+        assertPinnedRows(api, 'bottom', []);
+        expect(topPinnedNode.destroyed).toBe(true);
+
+        api.setGridOption('grandTotalRow', 'pinnedBottom');
+        await asyncSetTimeout(10);
+        assertPinnedRows(api, 'top', []);
+        assertPinnedRows(api, 'bottom', ['b-bottom-rowGroupFooter_ROOT_NODE_ID']);
+
+        const bottomNode = getPinnedRows(api, 'bottom')[0];
+        expect(bottomNode.rowPinned).toBe('bottom');
+        expect(bottomNode.destroyed).toBe(false);
+        expect(bottomNode).not.toBe(topPinnedNode);
+
+        api.setGridOption('grandTotalRow', undefined);
+        await asyncSetTimeout(10);
+        assertPinnedRows(api, 'top', []);
+        assertPinnedRows(api, 'bottom', []);
+        expect(bottomNode.destroyed).toBe(true);
     });
 
     test('pinned row is unpinned when source row is destroyed via transaction remove', async () => {


### PR DESCRIPTION
1. SSRM: `grandTotalRow: 'pinnedTop' | 'pinnedBottom'` did not work, only top and bottom was working
2. CSRM and SSRM: cycling `grandTotalRow` between pinned and inline positions
   left a destroyed pinned sibling on `rootNode.sibling`. The next pin reused
   the stale state and rendered the grand total in the wrong container, or
   duplicated it.
3. SSRM: switching from inline to pinned left a stale `rowIndex` on the grand
   total node.
4. SSRM: transaction `update` and getRows updates on the grand total leaked
   the grand-total payload onto `rootNode.data` via `RowNode.sibling`. The
   root must not hold row data.

### Changes

- `manualPinnedRowModel.ts`: SSRM grand-total pin requests now apply directly
  via `pinGrandTotalRow`; CSRM keeps its `reMapRows()` round-trip.
- `lazyStore.ts`: at display-index time, the root store reconciles the grand
  total node and its pinned/inline placement against `grandTotalRow` and the
  cached `grandTotalData`; clears the stale display index when transitioning
  to pinned.
- `lazyCache.ts`: `createOrUpdateGrandTotalNode` returns the node; transaction
  and refresh paths apply data via `_updateDataNoSibling`.
- `rowNode.ts`: `setDataCommon` takes a `'set' | 'update' | 'updateNoSibling'`
  union; new `_updateDataNoSibling` skips sibling propagation.
- `gridOptionsUtils.ts`: new `_getGrandTotalPinnedFloat` helper, used by
  `lazyStore`, `manualPinnedRowModel`, and `flattenStage` (replaces three
  duplicated ternaries).

FIX AG-8439