### PR TITLE
perf(pivot): pre-compute row-total anchors, defer reorder detection

### DIFF
--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -460,25 +460,21 @@ export class ColumnModel extends BeanStub implements NamedBean {
         // in results array
         const previousSiblingPosMap: Map<AgColumn, AgColumn | AgColumn[]> = new Map();
 
+        // Single forward pass over cols.list pre-computes each pivot row-total's
+        // anchor (the most-recent preserved col seen). null value = row total with
+        // no preceding preserved col — falls through to noSiblingsAvailable below.
         const { pivotColDefSvc } = this.beans;
-        let freshListIndex: Map<AgColumn, number> | null = null;
-
-        const getPreviousColInFreshList = (col: AgColumn): AgColumn | null => {
-            if (freshListIndex == null) {
-                freshListIndex = new Map<AgColumn, number>();
-                for (let i = 0; i < cols.list.length; i++) {
-                    freshListIndex.set(cols.list[i], i);
+        let rowTotalAnchors: Map<AgColumn, AgColumn | null> | null = null;
+        if (pivotColDefSvc != null) {
+            let lastPositioned: AgColumn | null = null;
+            for (const col of cols.list) {
+                if (colPositionMap.has(col)) {
+                    lastPositioned = col;
+                } else if (pivotColDefSvc.isPivotRowTotalColumn(col.colDef)) {
+                    (rowTotalAnchors ??= new Map()).set(col, lastPositioned);
                 }
             }
-            const idx = freshListIndex.get(col)!;
-            for (let i = idx - 1; i >= 0; i--) {
-                const candidate = cols.list[i];
-                if (colPositionMap.has(candidate)) {
-                    return candidate;
-                }
-            }
-            return null;
-        };
+        }
 
         const addColAfter = (anchor: AgColumn, col: AgColumn): void => {
             const prev = previousSiblingPosMap.get(anchor);
@@ -494,12 +490,12 @@ export class ColumnModel extends BeanStub implements NamedBean {
 
         // for each new col, find the col it needs inserted after and store for when array is constructed
         for (const col of additionalCols) {
-            if (pivotColDefSvc?.isPivotRowTotalColumn(col.colDef)) {
-                const anchor = getPreviousColInFreshList(col);
-                if (anchor == null) {
-                    noSiblingsAvailable.push(col);
+            const rowTotalAnchor = rowTotalAnchors?.get(col);
+            if (rowTotalAnchor !== undefined) {
+                if (rowTotalAnchor !== null) {
+                    addColAfter(rowTotalAnchor, col);
                 } else {
-                    addColAfter(anchor, col);
+                    noSiblingsAvailable.push(col);
                 }
                 continue;
             }

--- a/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
@@ -107,21 +107,14 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
         const uniqueValuesChanged = this.setUniqueValues(uniqueValues);
 
         const aggregationColumns = valueColsSvc?.columns ?? [];
-        const aggregationColumnIds = aggregationColumns.map((column) => column.getId());
         const aggregationColumnsHash = aggregationColumns
             .map((column) => `${column.getId()}-${column.colDef.headerName}`)
             .join('#');
         const aggregationFuncsHash = aggregationColumns.map((column) => column.getAggFunc()!.toString()).join('#');
 
         const aggregationColumnsChanged = this.aggregationColumnsHashLastTime !== aggregationColumnsHash;
-        const aggregationColumnsReordered =
-            this.aggregationColumnIdsLastTime != null &&
-            !_areEqual(this.aggregationColumnIdsLastTime, aggregationColumnIds) &&
-            this.aggregationColumnIdsLastTime.length === aggregationColumnIds.length &&
-            this.aggregationColumnIdsLastTime.every((id) => aggregationColumnIds.includes(id));
         const aggregationFuncsChanged = this.aggregationFuncsHashLastTime !== aggregationFuncsHash;
         this.aggregationColumnsHashLastTime = aggregationColumnsHash;
-        this.aggregationColumnIdsLastTime = aggregationColumnIds;
         this.aggregationFuncsHashLastTime = aggregationFuncsHash;
 
         const groupColumnsHash = (rowGroupColsSvc?.columns ?? []).map((column) => column.getId()).join('#');
@@ -146,6 +139,17 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
             pivotOrderChanged ||
             anyGridOptionsChanged
         ) {
+            // Reorder detection only matters on the rebuild path. Computing the id
+            // list (and the includes-scan against last time) on every transaction
+            // would burn allocations on the no-op hot path.
+            const aggregationColumnIds = aggregationColumns.map((column) => column.getId());
+            const aggregationColumnsReordered =
+                this.aggregationColumnIdsLastTime != null &&
+                this.aggregationColumnIdsLastTime.length === aggregationColumnIds.length &&
+                !_areEqual(this.aggregationColumnIdsLastTime, aggregationColumnIds) &&
+                this.aggregationColumnIdsLastTime.every((id) => aggregationColumnIds.includes(id));
+            this.aggregationColumnIdsLastTime = aggregationColumnIds;
+
             const pivotColumnGroupDefs = this.pivotColDefSvc.createPivotColumnDefs(this.uniqueValues);
             this.pivotResultCols.setPivotResultCols(
                 pivotColumnGroupDefs,


### PR DESCRIPTION
Follow-up to #13620. Two clean-ups on paths it touched:

**`ColumnModel.restoreColOrder`** — replace the lazy fresh-list index Map + backwards-scan closure with a single forward pass that records each pivot row-total column's anchor (or `null` when none precedes it). Main loop now reads from the pre-computed Map.

**`PivotStage.execute`** — move the `aggregationColumnIds` allocation and the includes-scan reorder check inside the rebuild branch. Both are only consumed when rebuilding pivot result cols, so the no-op transaction hot path no longer pays for them.

Net diff: +28 / -28 (cleaner shape, not bigger).

109 column-order behavioural tests still pass, including the AG-16677 regression added by #13620.