### PR TITLE
AG-16517 fix pivot coldef gen

### DIFF
--- a/packages/ag-grid-enterprise/src/pivot/pivotColDefService.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotColDefService.ts
@@ -389,6 +389,7 @@ export class PivotColDefService extends BeanStub implements NamedBean, IPivotCol
             pivotTotalColumnIds,
             columnGroupShow,
             colId,
+            field,
             valueGetter,
             aggFunc,
         } = colDef;
@@ -400,9 +401,13 @@ export class PivotColDefService extends BeanStub implements NamedBean, IPivotCol
 
         const newColDef = this.createColDef(pivotValueColumn as AgColumn, headerName, pivotKeys, !!pivotTotalColumnIds);
 
-        // don't overwrite these
+        // preserve pivot-result identity from the old colDef. `field` must mirror
+        // `colId` (the default valueGetter reads `data[field]`); `createColDef`
+        // regenerates `field` from a fresh id that can diverge from the original
+        // when `totalColumn` differs.
         newColDef.columnGroupShow = columnGroupShow;
         newColDef.colId = colId;
+        newColDef.field = field;
         newColDef.valueGetter = valueGetter;
         newColDef.aggFunc = aggFunc;
         newColDef.pivotTotalColumnIds = pivotTotalColumnIds;

--- a/packages/ag-grid-enterprise/src/pivot/pivotColDefService.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotColDefService.ts
@@ -401,10 +401,7 @@ export class PivotColDefService extends BeanStub implements NamedBean, IPivotCol
 
         const newColDef = this.createColDef(pivotValueColumn as AgColumn, headerName, pivotKeys, !!pivotTotalColumnIds);
 
-        // preserve pivot-result identity from the old colDef. `field` must mirror
-        // `colId` (the default valueGetter reads `data[field]`); `createColDef`
-        // regenerates `field` from a fresh id that can diverge from the original
-        // when `totalColumn` differs.
+        // preserve pivot-result identity from the old colDef.
         newColDef.columnGroupShow = columnGroupShow;
         newColDef.colId = colId;
         newColDef.field = field;

--- a/testing/behavioural/src/grouping-data/pivot-column-defs-update.test.ts
+++ b/testing/behavioural/src/grouping-data/pivot-column-defs-update.test.ts
@@ -1,8 +1,7 @@
-import type { ColDef, Column, GridOptions } from 'ag-grid-community';
+import type { ColDef, Column } from 'ag-grid-community';
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { PivotModule, RowGroupingModule } from 'ag-grid-enterprise';
 
-import type { GridRowsOptions } from '../test-utils';
 import { GridColumns, GridRows, TestGridsManager, applyTransactionChecked } from '../test-utils';
 
 describe('pivot column identity across columnDefs updates', () => {
@@ -41,49 +40,50 @@ describe('pivot column identity across columnDefs updates', () => {
             field: col.getColDef().field,
         }));
 
-    const gridRowsOptions: GridRowsOptions = {
-        forcedColumns: [
-            'ag-Grid-AutoColumn',
-            'pivot_sport-year_Gymnastics-2008_gold',
-            'pivot_sport-year_Gymnastics-2012_gold',
-            'pivot_sport-year_Gymnastics_gold',
-            'pivot_sport-year_Swimming-2008_gold',
-            'pivot_sport-year_Swimming-2012_gold',
-            'pivot_sport-year_Swimming_gold',
-        ],
-        printHiddenRows: false,
-    };
-
-    test('setGridOption(columnDefs) preserves pivot result colIds and field/colId consistency', async () => {
-        const gridOptions: GridOptions = {
-            columnDefs: baseColumnDefs,
-            pivotMode: true,
-        };
-
-        const api = gridsManager.createGrid('myGrid', gridOptions);
-        applyTransactionChecked(api, { add: olympicLikeRows });
-
-        await new GridRows(api, 'rows before round-trip', gridRowsOptions).check(`
+    // Baseline pivot grid output for `baseColumnDefs` + `olympicLikeRows`. Reused
+    // across tests since the round-trip / context update / direct mutation never
+    // changes the rendered tree — only the colDef contents.
+    const checkDefaultRows = (api: ReturnType<typeof gridsManager.createGrid>, label: string) =>
+        new GridRows(api, label).check(`
             ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
-            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+            ├─┬ LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
+            │ ├── LEAF hidden id:0 pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:3 pivot_sport-year_Gymnastics_gold:3 pivot_sport-year_Swimming-2008_gold:3 pivot_sport-year_Swimming-2012_gold:3 pivot_sport-year_Swimming_gold:3
+            │ └── LEAF hidden id:1 pivot_sport-year_Gymnastics-2008_gold:1 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:1 pivot_sport-year_Swimming-2008_gold:1 pivot_sport-year_Swimming-2012_gold:1 pivot_sport-year_Swimming_gold:1
+            └─┬ LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+            · ├── LEAF hidden id:2 pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:4 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:4 pivot_sport-year_Swimming-2012_gold:4 pivot_sport-year_Swimming_gold:4
+            · ├── LEAF hidden id:3 pivot_sport-year_Gymnastics-2008_gold:2 pivot_sport-year_Gymnastics-2012_gold:2 pivot_sport-year_Gymnastics_gold:2 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:2 pivot_sport-year_Swimming_gold:2
+            · └── LEAF hidden id:4 pivot_sport-year_Gymnastics-2008_gold:5 pivot_sport-year_Gymnastics-2012_gold:5 pivot_sport-year_Gymnastics_gold:5 pivot_sport-year_Swimming-2008_gold:5 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:5
         `);
-        await new GridColumns(api, 'cols before round-trip').checkColumns(`
+
+    const checkDefaultCols = (api: ReturnType<typeof gridsManager.createGrid>, label: string) =>
+        new GridColumns(api, label).checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
-            ├─┬ "Gymnastics" GROUP closed
-            │ ├─┬ "2008" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
-            │ ├─┬ "2012" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
-            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
-            └─┬ "Swimming" GROUP closed
-              ├─┬ "2008" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
-              ├─┬ "2012" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
-              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
+            ├─┬ "Gymnastics" GROUP open
+            │ ├─┬ "2008" GROUP
+            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open
+            │ ├─┬ "2012" GROUP
+            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open
+            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed hidden
+            └─┬ "Swimming" GROUP open
+              ├─┬ "2008" GROUP
+              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open
+              ├─┬ "2012" GROUP
+              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open
+              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed hidden
         `);
+
+    test('setGridOption(columnDefs) preserves pivot result colIds and field/colId consistency', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: baseColumnDefs,
+            pivotMode: true,
+            groupDefaultExpanded: -1,
+            pivotDefaultExpanded: -1,
+        });
+        applyTransactionChecked(api, { add: olympicLikeRows });
+
+        await checkDefaultRows(api, 'rows before round-trip');
+        await checkDefaultCols(api, 'cols before round-trip');
 
         const beforeIds = snapshotCols(api.getPivotResultColumns());
         expect(beforeIds.length).toBeGreaterThan(0);
@@ -106,62 +106,24 @@ describe('pivot column identity across columnDefs updates', () => {
             expect(field).toBe(colId);
         }
 
-        await new GridRows(api, 'rows after round-trip', gridRowsOptions).check(`
-            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
-            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-        `);
-        await new GridColumns(api, 'cols after round-trip').checkColumns(`
-            CENTER
-            ├── ag-Grid-AutoColumn "Group" width:200
-            ├─┬ "Gymnastics" GROUP closed
-            │ ├─┬ "2008" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
-            │ ├─┬ "2012" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
-            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
-            └─┬ "Swimming" GROUP closed
-              ├─┬ "2008" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
-              ├─┬ "2012" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
-              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
-        `);
+        await checkDefaultRows(api, 'rows after round-trip');
+        await checkDefaultCols(api, 'cols after round-trip');
     });
 
     test('setGridOption(columnDefs) preserves pivot total result colIds and field/colId consistency', async () => {
         // addExpandablePivotGroups creates "Total" cols with pivotTotalColumnIds set
         // but totalColumn=false. recreateColDef previously used !!pivotTotalColumnIds
         // to flip totalColumn=true on regeneration, breaking field consistency.
-        const gridOptions: GridOptions = {
+        const api = gridsManager.createGrid('myGrid', {
             columnDefs: baseColumnDefs,
             pivotMode: true,
-        };
-
-        const api = gridsManager.createGrid('myGrid', gridOptions);
+            groupDefaultExpanded: -1,
+            pivotDefaultExpanded: -1,
+        });
         applyTransactionChecked(api, { add: olympicLikeRows });
 
-        await new GridRows(api, 'rows before round-trip (totals)', gridRowsOptions).check(`
-            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
-            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-        `);
-        await new GridColumns(api, 'cols before round-trip (totals)').checkColumns(`
-            CENTER
-            ├── ag-Grid-AutoColumn "Group" width:200
-            ├─┬ "Gymnastics" GROUP closed
-            │ ├─┬ "2008" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
-            │ ├─┬ "2012" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
-            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
-            └─┬ "Swimming" GROUP closed
-              ├─┬ "2008" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
-              ├─┬ "2012" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
-              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
-        `);
+        await checkDefaultRows(api, 'rows before round-trip (totals)');
+        await checkDefaultCols(api, 'cols before round-trip (totals)');
 
         const beforeAll = api.getPivotResultColumns() ?? [];
         const totalColsBefore = beforeAll.filter((col) => col.getColDef().pivotTotalColumnIds !== undefined);
@@ -189,59 +151,21 @@ describe('pivot column identity across columnDefs updates', () => {
             expect(def.colId).toBe(col.getColId());
         }
 
-        await new GridRows(api, 'rows after round-trip (totals)', gridRowsOptions).check(`
-            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
-            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-        `);
-        await new GridColumns(api, 'cols after round-trip (totals)').checkColumns(`
-            CENTER
-            ├── ag-Grid-AutoColumn "Group" width:200
-            ├─┬ "Gymnastics" GROUP closed
-            │ ├─┬ "2008" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
-            │ ├─┬ "2012" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
-            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
-            └─┬ "Swimming" GROUP closed
-              ├─┬ "2008" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
-              ├─┬ "2012" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
-              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
-        `);
+        await checkDefaultRows(api, 'rows after round-trip (totals)');
+        await checkDefaultCols(api, 'cols after round-trip (totals)');
     });
 
     test('setGridOption(columnDefs) preserves the pivot result Column instances', async () => {
-        const gridOptions: GridOptions = {
+        const api = gridsManager.createGrid('myGrid', {
             columnDefs: baseColumnDefs,
             pivotMode: true,
-        };
-
-        const api = gridsManager.createGrid('myGrid', gridOptions);
+            groupDefaultExpanded: -1,
+            pivotDefaultExpanded: -1,
+        });
         applyTransactionChecked(api, { add: olympicLikeRows });
 
-        await new GridRows(api, 'rows before instance check', gridRowsOptions).check(`
-            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
-            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-        `);
-        await new GridColumns(api, 'cols before instance check').checkColumns(`
-            CENTER
-            ├── ag-Grid-AutoColumn "Group" width:200
-            ├─┬ "Gymnastics" GROUP closed
-            │ ├─┬ "2008" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
-            │ ├─┬ "2012" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
-            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
-            └─┬ "Swimming" GROUP closed
-              ├─┬ "2008" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
-              ├─┬ "2012" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
-              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
-        `);
+        await checkDefaultRows(api, 'rows before instance check');
+        await checkDefaultCols(api, 'cols before instance check');
 
         const beforeCols = api.getPivotResultColumns() ?? [];
         expect(beforeCols.length).toBeGreaterThan(0);
@@ -256,27 +180,8 @@ describe('pivot column identity across columnDefs updates', () => {
             expect(beforeById.get(col.getColId())).toBe(col);
         }
 
-        await new GridRows(api, 'rows after instance check', gridRowsOptions).check(`
-            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
-            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-        `);
-        await new GridColumns(api, 'cols after instance check').checkColumns(`
-            CENTER
-            ├── ag-Grid-AutoColumn "Group" width:200
-            ├─┬ "Gymnastics" GROUP closed
-            │ ├─┬ "2008" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
-            │ ├─┬ "2012" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
-            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
-            └─┬ "Swimming" GROUP closed
-              ├─┬ "2008" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
-              ├─┬ "2012" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
-              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
-        `);
+        await checkDefaultRows(api, 'rows after instance check');
+        await checkDefaultCols(api, 'cols after instance check');
     });
 
     test('updated context on the value column propagates to pivot result colDefs', async () => {
@@ -293,30 +198,13 @@ describe('pivot column identity across columnDefs updates', () => {
         const api = gridsManager.createGrid('myGrid', {
             columnDefs: initialDefs,
             pivotMode: true,
+            groupDefaultExpanded: -1,
+            pivotDefaultExpanded: -1,
         });
         applyTransactionChecked(api, { add: olympicLikeRows });
 
-        await new GridRows(api, 'rows before context update', gridRowsOptions).check(`
-            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
-            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-        `);
-        await new GridColumns(api, 'cols before context update').checkColumns(`
-            CENTER
-            ├── ag-Grid-AutoColumn "Group" width:200
-            ├─┬ "Gymnastics" GROUP closed
-            │ ├─┬ "2008" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
-            │ ├─┬ "2012" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
-            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
-            └─┬ "Swimming" GROUP closed
-              ├─┬ "2008" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
-              ├─┬ "2012" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
-              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
-        `);
+        await checkDefaultRows(api, 'rows before context update');
+        await checkDefaultCols(api, 'cols before context update');
 
         for (const col of api.getPivotResultColumns() ?? []) {
             expect(col.getColDef().context).toEqual({ version: 1 });
@@ -333,27 +221,8 @@ describe('pivot column identity across columnDefs updates', () => {
             expect(col.getColDef().context).toEqual({ version: 2 });
         }
 
-        await new GridRows(api, 'rows after context update', gridRowsOptions).check(`
-            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
-            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-        `);
-        await new GridColumns(api, 'cols after context update').checkColumns(`
-            CENTER
-            ├── ag-Grid-AutoColumn "Group" width:200
-            ├─┬ "Gymnastics" GROUP closed
-            │ ├─┬ "2008" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
-            │ ├─┬ "2012" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
-            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
-            └─┬ "Swimming" GROUP closed
-              ├─┬ "2008" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
-              ├─┬ "2012" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
-              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
-        `);
+        await checkDefaultRows(api, 'rows after context update');
+        await checkDefaultCols(api, 'cols after context update');
     });
 
     test('processPivotResultColDef can attach pivot-col-specific context on every recreate', async () => {
@@ -367,31 +236,14 @@ describe('pivot column identity across columnDefs updates', () => {
         const api = gridsManager.createGrid('myGrid', {
             columnDefs: baseColumnDefs,
             pivotMode: true,
+            groupDefaultExpanded: -1,
+            pivotDefaultExpanded: -1,
             processPivotResultColDef: stamp,
         });
         applyTransactionChecked(api, { add: olympicLikeRows });
 
-        await new GridRows(api, 'rows before callback recheck', gridRowsOptions).check(`
-            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
-            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-        `);
-        await new GridColumns(api, 'cols before callback recheck').checkColumns(`
-            CENTER
-            ├── ag-Grid-AutoColumn "Group" width:200
-            ├─┬ "Gymnastics" GROUP closed
-            │ ├─┬ "2008" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
-            │ ├─┬ "2012" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
-            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
-            └─┬ "Swimming" GROUP closed
-              ├─┬ "2008" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
-              ├─┬ "2012" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
-              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
-        `);
+        await checkDefaultRows(api, 'rows before callback recheck');
+        await checkDefaultCols(api, 'cols before callback recheck');
 
         const beforeCols = api.getPivotResultColumns() ?? [];
         expect(beforeCols.length).toBeGreaterThan(0);
@@ -405,27 +257,8 @@ describe('pivot column identity across columnDefs updates', () => {
             expect(col.getColDef().context).toEqual({ byColId: col.getColId() });
         }
 
-        await new GridRows(api, 'rows after callback recheck', gridRowsOptions).check(`
-            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
-            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-        `);
-        await new GridColumns(api, 'cols after callback recheck').checkColumns(`
-            CENTER
-            ├── ag-Grid-AutoColumn "Group" width:200
-            ├─┬ "Gymnastics" GROUP closed
-            │ ├─┬ "2008" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
-            │ ├─┬ "2012" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
-            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
-            └─┬ "Swimming" GROUP closed
-              ├─┬ "2008" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
-              ├─┬ "2012" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
-              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
-        `);
+        await checkDefaultRows(api, 'rows after callback recheck');
+        await checkDefaultCols(api, 'cols after callback recheck');
     });
 
     test('custom properties attached directly to a pivot result colDef are NOT preserved across recreate', async () => {
@@ -435,66 +268,30 @@ describe('pivot column identity across columnDefs updates', () => {
         // properties added by directly mutating the pivot result colDef are lost.
         // To attach persistent metadata, attach it to the value col's colDef
         // (Object.assign carries it through) or use processPivotResultColDef.
+        type ColDefWithCustom = ColDef & { myCustomProp?: string };
+
         const api = gridsManager.createGrid('myGrid', {
             columnDefs: baseColumnDefs,
             pivotMode: true,
+            groupDefaultExpanded: -1,
+            pivotDefaultExpanded: -1,
         });
         applyTransactionChecked(api, { add: olympicLikeRows });
 
-        await new GridRows(api, 'rows before mutation', gridRowsOptions).check(`
-            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
-            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-        `);
-        await new GridColumns(api, 'cols before mutation').checkColumns(`
-            CENTER
-            ├── ag-Grid-AutoColumn "Group" width:200
-            ├─┬ "Gymnastics" GROUP closed
-            │ ├─┬ "2008" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
-            │ ├─┬ "2012" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
-            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
-            └─┬ "Swimming" GROUP closed
-              ├─┬ "2008" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
-              ├─┬ "2012" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
-              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
-        `);
+        await checkDefaultRows(api, 'rows before mutation');
+        await checkDefaultCols(api, 'cols before mutation');
 
-        const targetCol = api.getPivotResultColumns()?.[0];
-        expect(targetCol).toBeDefined();
-        const targetColId = targetCol!.getColId();
-
-        (targetCol!.getColDef() as ColDef & { myCustomProp?: string }).myCustomProp = 'foo';
+        const targetCol = api.getPivotResultColumns()![0];
+        const targetColId = targetCol.getColId();
+        (targetCol.getColDef() as ColDefWithCustom).myCustomProp = 'foo';
 
         api.setGridOption('columnDefs', baseColumnDefs);
 
         const afterCol = api.getPivotResultColumns()!.find((col) => col.getColId() === targetColId);
         expect(afterCol).toBeDefined();
-        expect((afterCol!.getColDef() as ColDef & { myCustomProp?: string }).myCustomProp).toBeUndefined();
+        expect((afterCol!.getColDef() as ColDefWithCustom).myCustomProp).toBeUndefined();
 
-        await new GridRows(api, 'rows after mutation', gridRowsOptions).check(`
-            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
-            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
-        `);
-        await new GridColumns(api, 'cols after mutation').checkColumns(`
-            CENTER
-            ├── ag-Grid-AutoColumn "Group" width:200
-            ├─┬ "Gymnastics" GROUP closed
-            │ ├─┬ "2008" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
-            │ ├─┬ "2012" GROUP hidden
-            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
-            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
-            └─┬ "Swimming" GROUP closed
-              ├─┬ "2008" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
-              ├─┬ "2012" GROUP hidden
-              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
-              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
-        `);
+        await checkDefaultRows(api, 'rows after mutation');
+        await checkDefaultCols(api, 'cols after mutation');
     });
 });

--- a/testing/behavioural/src/grouping-data/pivot-column-defs-update.test.ts
+++ b/testing/behavioural/src/grouping-data/pivot-column-defs-update.test.ts
@@ -1,0 +1,272 @@
+import type { ColDef, Column, GridOptions } from 'ag-grid-community';
+import { ClientSideRowModelModule } from 'ag-grid-community';
+import { PivotModule, RowGroupingModule } from 'ag-grid-enterprise';
+
+import type { GridRowsOptions } from '../test-utils';
+import { GridColumns, GridRows, TestGridsManager, applyTransactionChecked } from '../test-utils';
+
+describe('pivot column identity across columnDefs updates', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule, PivotModule],
+    });
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    const olympicLikeRows = [
+        { id: 1, country: 'Russia', sport: 'Gymnastics', year: 2008, gold: 3 },
+        { id: 2, country: 'Russia', sport: 'Gymnastics', year: 2012, gold: 1 },
+        { id: 3, country: 'USA', sport: 'Gymnastics', year: 2008, gold: 4 },
+        { id: 4, country: 'USA', sport: 'Swimming', year: 2008, gold: 2 },
+        { id: 5, country: 'USA', sport: 'Swimming', year: 2012, gold: 5 },
+    ];
+
+    const baseColumnDefs: ColDef[] = [
+        { field: 'country', rowGroup: true },
+        { field: 'sport', pivot: true },
+        { field: 'year', pivot: true },
+        { field: 'gold', aggFunc: 'sum' },
+    ];
+
+    type ColSnapshot = { colId: string; field: string | undefined };
+
+    const snapshotCols = (cols: Column[] | null): ColSnapshot[] =>
+        (cols ?? []).map((col) => ({
+            colId: col.getColId(),
+            field: col.getColDef().field,
+        }));
+
+    const gridRowsOptions: GridRowsOptions = {
+        forcedColumns: [
+            'ag-Grid-AutoColumn',
+            'pivot_sport-year_Gymnastics-2008_gold',
+            'pivot_sport-year_Gymnastics-2012_gold',
+            'pivot_sport-year_Gymnastics_gold',
+            'pivot_sport-year_Swimming-2008_gold',
+            'pivot_sport-year_Swimming-2012_gold',
+            'pivot_sport-year_Swimming_gold',
+        ],
+        printHiddenRows: false,
+    };
+
+    test('setGridOption(columnDefs) preserves pivot result colIds and field/colId consistency', async () => {
+        const gridOptions: GridOptions = {
+            columnDefs: baseColumnDefs,
+            pivotMode: true,
+        };
+
+        const api = gridsManager.createGrid('myGrid', gridOptions);
+        applyTransactionChecked(api, { add: olympicLikeRows });
+
+        await new GridRows(api, 'rows before round-trip', gridRowsOptions).check(``);
+        await new GridColumns(api, 'cols before round-trip').checkColumns(``);
+
+        const beforeIds = snapshotCols(api.getPivotResultColumns());
+        expect(beforeIds.length).toBeGreaterThan(0);
+
+        // Sanity: every pivot result colDef.field must equal its colId so that the
+        // default valueGetter (which reads `params.data[params.colDef.field]`) finds
+        // values keyed by colId.
+        for (const { colId, field } of beforeIds) {
+            expect(field).toBe(colId);
+        }
+
+        // Round-trip the same columnDefs reference. This re-fires colDefChanged on
+        // primary cols, which triggers recreateColDef on every pivot result col.
+        api.setGridOption('columnDefs', baseColumnDefs);
+
+        const afterIds = snapshotCols(api.getPivotResultColumns());
+        expect(afterIds).toEqual(beforeIds);
+
+        for (const { colId, field } of afterIds) {
+            expect(field).toBe(colId);
+        }
+
+        await new GridRows(api, 'rows after round-trip', gridRowsOptions).check(``);
+        await new GridColumns(api, 'cols after round-trip').checkColumns(``);
+    });
+
+    test('setGridOption(columnDefs) preserves pivot total result colIds and field/colId consistency', async () => {
+        // addExpandablePivotGroups creates "Total" cols with pivotTotalColumnIds set
+        // but totalColumn=false. recreateColDef previously used !!pivotTotalColumnIds
+        // to flip totalColumn=true on regeneration, breaking field consistency.
+        const gridOptions: GridOptions = {
+            columnDefs: baseColumnDefs,
+            pivotMode: true,
+        };
+
+        const api = gridsManager.createGrid('myGrid', gridOptions);
+        applyTransactionChecked(api, { add: olympicLikeRows });
+
+        await new GridRows(api, 'rows before round-trip (totals)', gridRowsOptions).check(``);
+        await new GridColumns(api, 'cols before round-trip (totals)').checkColumns(``);
+
+        const beforeAll = api.getPivotResultColumns() ?? [];
+        const totalColsBefore = beforeAll.filter((col) => col.getColDef().pivotTotalColumnIds !== undefined);
+        expect(totalColsBefore.length).toBeGreaterThan(0);
+
+        for (const col of totalColsBefore) {
+            const def = col.getColDef();
+            expect(def.field).toBe(col.getColId());
+            expect(def.colId).toBe(col.getColId());
+        }
+
+        const beforeSnapshot = snapshotCols(beforeAll);
+
+        api.setGridOption('columnDefs', baseColumnDefs);
+
+        const afterAll = api.getPivotResultColumns() ?? [];
+        expect(snapshotCols(afterAll)).toEqual(beforeSnapshot);
+
+        const totalColsAfter = afterAll.filter((col) => col.getColDef().pivotTotalColumnIds !== undefined);
+        expect(totalColsAfter.length).toBe(totalColsBefore.length);
+
+        for (const col of totalColsAfter) {
+            const def = col.getColDef();
+            expect(def.field).toBe(col.getColId());
+            expect(def.colId).toBe(col.getColId());
+        }
+
+        await new GridRows(api, 'rows after round-trip (totals)', gridRowsOptions).check(``);
+        await new GridColumns(api, 'cols after round-trip (totals)').checkColumns(``);
+    });
+
+    test('setGridOption(columnDefs) preserves the pivot result Column instances', async () => {
+        const gridOptions: GridOptions = {
+            columnDefs: baseColumnDefs,
+            pivotMode: true,
+        };
+
+        const api = gridsManager.createGrid('myGrid', gridOptions);
+        applyTransactionChecked(api, { add: olympicLikeRows });
+
+        await new GridRows(api, 'rows before instance check', gridRowsOptions).check(``);
+        await new GridColumns(api, 'cols before instance check').checkColumns(``);
+
+        const beforeCols = api.getPivotResultColumns() ?? [];
+        expect(beforeCols.length).toBeGreaterThan(0);
+        const beforeById = new Map(beforeCols.map((col) => [col.getColId(), col]));
+
+        api.setGridOption('columnDefs', baseColumnDefs);
+
+        const afterCols = api.getPivotResultColumns() ?? [];
+        expect(afterCols.length).toBe(beforeCols.length);
+
+        for (const col of afterCols) {
+            expect(beforeById.get(col.getColId())).toBe(col);
+        }
+
+        await new GridRows(api, 'rows after instance check', gridRowsOptions).check(``);
+        await new GridColumns(api, 'cols after instance check').checkColumns(``);
+    });
+
+    test('updated context on the value column propagates to pivot result colDefs', async () => {
+        // Per-pivot-col customization should be applied via processPivotResultColDef
+        // (which runs on every recreate). When set on the value column's colDef,
+        // context flows through to all derived pivot result colDefs.
+        const initialDefs: ColDef[] = [
+            { field: 'country', rowGroup: true },
+            { field: 'sport', pivot: true },
+            { field: 'year', pivot: true },
+            { field: 'gold', aggFunc: 'sum', context: { version: 1 } },
+        ];
+
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: initialDefs,
+            pivotMode: true,
+        });
+        applyTransactionChecked(api, { add: olympicLikeRows });
+
+        await new GridRows(api, 'rows before context update', gridRowsOptions).check(``);
+        await new GridColumns(api, 'cols before context update').checkColumns(``);
+
+        for (const col of api.getPivotResultColumns() ?? []) {
+            expect(col.getColDef().context).toEqual({ version: 1 });
+        }
+
+        api.setGridOption('columnDefs', [
+            { field: 'country', rowGroup: true },
+            { field: 'sport', pivot: true },
+            { field: 'year', pivot: true },
+            { field: 'gold', aggFunc: 'sum', context: { version: 2 } },
+        ]);
+
+        for (const col of api.getPivotResultColumns() ?? []) {
+            expect(col.getColDef().context).toEqual({ version: 2 });
+        }
+
+        await new GridRows(api, 'rows after context update', gridRowsOptions).check(``);
+        await new GridColumns(api, 'cols after context update').checkColumns(``);
+    });
+
+    test('processPivotResultColDef can attach pivot-col-specific context on every recreate', async () => {
+        // The supported way to attach context per pivot result col is via
+        // `processPivotResultColDef`, which runs on initial creation and every
+        // recreate — so context is reapplied across columnDefs updates.
+        const stamp = (colDef: ColDef): void => {
+            colDef.context = { byColId: colDef.colId };
+        };
+
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: baseColumnDefs,
+            pivotMode: true,
+            processPivotResultColDef: stamp,
+        });
+        applyTransactionChecked(api, { add: olympicLikeRows });
+
+        await new GridRows(api, 'rows before callback recheck', gridRowsOptions).check(``);
+        await new GridColumns(api, 'cols before callback recheck').checkColumns(``);
+
+        const beforeCols = api.getPivotResultColumns() ?? [];
+        expect(beforeCols.length).toBeGreaterThan(0);
+        for (const col of beforeCols) {
+            expect(col.getColDef().context).toEqual({ byColId: col.getColId() });
+        }
+
+        api.setGridOption('columnDefs', baseColumnDefs);
+
+        for (const col of api.getPivotResultColumns() ?? []) {
+            expect(col.getColDef().context).toEqual({ byColId: col.getColId() });
+        }
+
+        await new GridRows(api, 'rows after callback recheck', gridRowsOptions).check(``);
+        await new GridColumns(api, 'cols after callback recheck').checkColumns(``);
+    });
+
+    test('custom properties attached directly to a pivot result colDef are NOT preserved across recreate', async () => {
+        // recreateColDef rebuilds the pivot result colDef from the value column's
+        // colDef and only carries over a fixed set of fields (colId, field,
+        // valueGetter, aggFunc, pivotTotalColumnIds, columnGroupShow). Custom
+        // properties added by directly mutating the pivot result colDef are lost.
+        // To attach persistent metadata, attach it to the value col's colDef
+        // (Object.assign carries it through) or use processPivotResultColDef.
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: baseColumnDefs,
+            pivotMode: true,
+        });
+        applyTransactionChecked(api, { add: olympicLikeRows });
+
+        await new GridRows(api, 'rows before mutation', gridRowsOptions).check(``);
+        await new GridColumns(api, 'cols before mutation').checkColumns(``);
+
+        const targetCol = api.getPivotResultColumns()?.[0];
+        expect(targetCol).toBeDefined();
+        const targetColId = targetCol!.getColId();
+
+        (targetCol!.getColDef() as ColDef & { myCustomProp?: string }).myCustomProp = 'foo';
+
+        api.setGridOption('columnDefs', baseColumnDefs);
+
+        const afterCol = api.getPivotResultColumns()!.find((col) => col.getColId() === targetColId);
+        expect(afterCol).toBeDefined();
+        expect((afterCol!.getColDef() as ColDef & { myCustomProp?: string }).myCustomProp).toBeUndefined();
+
+        await new GridRows(api, 'rows after mutation', gridRowsOptions).check(``);
+        await new GridColumns(api, 'cols after mutation').checkColumns(``);
+    });
+});

--- a/testing/behavioural/src/grouping-data/pivot-column-defs-update.test.ts
+++ b/testing/behavioural/src/grouping-data/pivot-column-defs-update.test.ts
@@ -40,9 +40,6 @@ describe('pivot column identity across columnDefs updates', () => {
             field: col.getColDef().field,
         }));
 
-    // Baseline pivot grid output for `baseColumnDefs` + `olympicLikeRows`. Reused
-    // across tests since the round-trip / context update / direct mutation never
-    // changes the rendered tree — only the colDef contents.
     const checkDefaultRows = (api: ReturnType<typeof gridsManager.createGrid>, label: string) =>
         new GridRows(api, label).check(`
             ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
@@ -88,15 +85,10 @@ describe('pivot column identity across columnDefs updates', () => {
         const beforeIds = snapshotCols(api.getPivotResultColumns());
         expect(beforeIds.length).toBeGreaterThan(0);
 
-        // Sanity: every pivot result colDef.field must equal its colId so that the
-        // default valueGetter (which reads `params.data[params.colDef.field]`) finds
-        // values keyed by colId.
         for (const { colId, field } of beforeIds) {
             expect(field).toBe(colId);
         }
 
-        // Round-trip the same columnDefs reference. This re-fires colDefChanged on
-        // primary cols, which triggers recreateColDef on every pivot result col.
         api.setGridOption('columnDefs', baseColumnDefs);
 
         const afterIds = snapshotCols(api.getPivotResultColumns());
@@ -111,9 +103,6 @@ describe('pivot column identity across columnDefs updates', () => {
     });
 
     test('setGridOption(columnDefs) preserves pivot total result colIds and field/colId consistency', async () => {
-        // addExpandablePivotGroups creates "Total" cols with pivotTotalColumnIds set
-        // but totalColumn=false. recreateColDef previously used !!pivotTotalColumnIds
-        // to flip totalColumn=true on regeneration, breaking field consistency.
         const api = gridsManager.createGrid('myGrid', {
             columnDefs: baseColumnDefs,
             pivotMode: true,
@@ -262,12 +251,6 @@ describe('pivot column identity across columnDefs updates', () => {
     });
 
     test('custom properties attached directly to a pivot result colDef are NOT preserved across recreate', async () => {
-        // recreateColDef rebuilds the pivot result colDef from the value column's
-        // colDef and only carries over a fixed set of fields (colId, field,
-        // valueGetter, aggFunc, pivotTotalColumnIds, columnGroupShow). Custom
-        // properties added by directly mutating the pivot result colDef are lost.
-        // To attach persistent metadata, attach it to the value col's colDef
-        // (Object.assign carries it through) or use processPivotResultColDef.
         type ColDefWithCustom = ColDef & { myCustomProp?: string };
 
         const api = gridsManager.createGrid('myGrid', {
@@ -293,5 +276,33 @@ describe('pivot column identity across columnDefs updates', () => {
 
         await checkDefaultRows(api, 'rows after mutation');
         await checkDefaultCols(api, 'cols after mutation');
+    });
+
+    test('in-place mutation of a value column colDef propagates to pivot result colDefs', async () => {
+        const liveDefs: ColDef[] = [
+            { field: 'country', rowGroup: true },
+            { field: 'sport', pivot: true },
+            { field: 'year', pivot: true },
+            { field: 'gold', aggFunc: 'sum', headerName: 'Gold' },
+        ];
+
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: liveDefs,
+            pivotMode: true,
+            groupDefaultExpanded: -1,
+            pivotDefaultExpanded: -1,
+        });
+        applyTransactionChecked(api, { add: olympicLikeRows });
+
+        for (const col of api.getPivotResultColumns() ?? []) {
+            expect(col.getColDef().headerName).toBe('Gold');
+        }
+
+        liveDefs[3].headerName = 'Gold Medals';
+        api.setGridOption('columnDefs', liveDefs);
+
+        for (const col of api.getPivotResultColumns() ?? []) {
+            expect(col.getColDef().headerName).toBe('Gold Medals');
+        }
     });
 });

--- a/testing/behavioural/src/grouping-data/pivot-column-defs-update.test.ts
+++ b/testing/behavioural/src/grouping-data/pivot-column-defs-update.test.ts
@@ -63,8 +63,27 @@ describe('pivot column identity across columnDefs updates', () => {
         const api = gridsManager.createGrid('myGrid', gridOptions);
         applyTransactionChecked(api, { add: olympicLikeRows });
 
-        await new GridRows(api, 'rows before round-trip', gridRowsOptions).check(``);
-        await new GridColumns(api, 'cols before round-trip').checkColumns(``);
+        await new GridRows(api, 'rows before round-trip', gridRowsOptions).check(`
+            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
+            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+        `);
+        await new GridColumns(api, 'cols before round-trip').checkColumns(`
+            CENTER
+            ├── ag-Grid-AutoColumn "Group" width:200
+            ├─┬ "Gymnastics" GROUP closed
+            │ ├─┬ "2008" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
+            │ ├─┬ "2012" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
+            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
+            └─┬ "Swimming" GROUP closed
+              ├─┬ "2008" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
+              ├─┬ "2012" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
+              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
+        `);
 
         const beforeIds = snapshotCols(api.getPivotResultColumns());
         expect(beforeIds.length).toBeGreaterThan(0);
@@ -87,8 +106,27 @@ describe('pivot column identity across columnDefs updates', () => {
             expect(field).toBe(colId);
         }
 
-        await new GridRows(api, 'rows after round-trip', gridRowsOptions).check(``);
-        await new GridColumns(api, 'cols after round-trip').checkColumns(``);
+        await new GridRows(api, 'rows after round-trip', gridRowsOptions).check(`
+            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
+            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+        `);
+        await new GridColumns(api, 'cols after round-trip').checkColumns(`
+            CENTER
+            ├── ag-Grid-AutoColumn "Group" width:200
+            ├─┬ "Gymnastics" GROUP closed
+            │ ├─┬ "2008" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
+            │ ├─┬ "2012" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
+            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
+            └─┬ "Swimming" GROUP closed
+              ├─┬ "2008" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
+              ├─┬ "2012" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
+              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
+        `);
     });
 
     test('setGridOption(columnDefs) preserves pivot total result colIds and field/colId consistency', async () => {
@@ -103,8 +141,27 @@ describe('pivot column identity across columnDefs updates', () => {
         const api = gridsManager.createGrid('myGrid', gridOptions);
         applyTransactionChecked(api, { add: olympicLikeRows });
 
-        await new GridRows(api, 'rows before round-trip (totals)', gridRowsOptions).check(``);
-        await new GridColumns(api, 'cols before round-trip (totals)').checkColumns(``);
+        await new GridRows(api, 'rows before round-trip (totals)', gridRowsOptions).check(`
+            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
+            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+        `);
+        await new GridColumns(api, 'cols before round-trip (totals)').checkColumns(`
+            CENTER
+            ├── ag-Grid-AutoColumn "Group" width:200
+            ├─┬ "Gymnastics" GROUP closed
+            │ ├─┬ "2008" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
+            │ ├─┬ "2012" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
+            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
+            └─┬ "Swimming" GROUP closed
+              ├─┬ "2008" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
+              ├─┬ "2012" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
+              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
+        `);
 
         const beforeAll = api.getPivotResultColumns() ?? [];
         const totalColsBefore = beforeAll.filter((col) => col.getColDef().pivotTotalColumnIds !== undefined);
@@ -132,8 +189,27 @@ describe('pivot column identity across columnDefs updates', () => {
             expect(def.colId).toBe(col.getColId());
         }
 
-        await new GridRows(api, 'rows after round-trip (totals)', gridRowsOptions).check(``);
-        await new GridColumns(api, 'cols after round-trip (totals)').checkColumns(``);
+        await new GridRows(api, 'rows after round-trip (totals)', gridRowsOptions).check(`
+            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
+            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+        `);
+        await new GridColumns(api, 'cols after round-trip (totals)').checkColumns(`
+            CENTER
+            ├── ag-Grid-AutoColumn "Group" width:200
+            ├─┬ "Gymnastics" GROUP closed
+            │ ├─┬ "2008" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
+            │ ├─┬ "2012" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
+            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
+            └─┬ "Swimming" GROUP closed
+              ├─┬ "2008" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
+              ├─┬ "2012" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
+              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
+        `);
     });
 
     test('setGridOption(columnDefs) preserves the pivot result Column instances', async () => {
@@ -145,8 +221,27 @@ describe('pivot column identity across columnDefs updates', () => {
         const api = gridsManager.createGrid('myGrid', gridOptions);
         applyTransactionChecked(api, { add: olympicLikeRows });
 
-        await new GridRows(api, 'rows before instance check', gridRowsOptions).check(``);
-        await new GridColumns(api, 'cols before instance check').checkColumns(``);
+        await new GridRows(api, 'rows before instance check', gridRowsOptions).check(`
+            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
+            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+        `);
+        await new GridColumns(api, 'cols before instance check').checkColumns(`
+            CENTER
+            ├── ag-Grid-AutoColumn "Group" width:200
+            ├─┬ "Gymnastics" GROUP closed
+            │ ├─┬ "2008" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
+            │ ├─┬ "2012" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
+            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
+            └─┬ "Swimming" GROUP closed
+              ├─┬ "2008" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
+              ├─┬ "2012" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
+              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
+        `);
 
         const beforeCols = api.getPivotResultColumns() ?? [];
         expect(beforeCols.length).toBeGreaterThan(0);
@@ -161,8 +256,27 @@ describe('pivot column identity across columnDefs updates', () => {
             expect(beforeById.get(col.getColId())).toBe(col);
         }
 
-        await new GridRows(api, 'rows after instance check', gridRowsOptions).check(``);
-        await new GridColumns(api, 'cols after instance check').checkColumns(``);
+        await new GridRows(api, 'rows after instance check', gridRowsOptions).check(`
+            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
+            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+        `);
+        await new GridColumns(api, 'cols after instance check').checkColumns(`
+            CENTER
+            ├── ag-Grid-AutoColumn "Group" width:200
+            ├─┬ "Gymnastics" GROUP closed
+            │ ├─┬ "2008" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
+            │ ├─┬ "2012" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
+            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
+            └─┬ "Swimming" GROUP closed
+              ├─┬ "2008" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
+              ├─┬ "2012" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
+              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
+        `);
     });
 
     test('updated context on the value column propagates to pivot result colDefs', async () => {
@@ -182,8 +296,27 @@ describe('pivot column identity across columnDefs updates', () => {
         });
         applyTransactionChecked(api, { add: olympicLikeRows });
 
-        await new GridRows(api, 'rows before context update', gridRowsOptions).check(``);
-        await new GridColumns(api, 'cols before context update').checkColumns(``);
+        await new GridRows(api, 'rows before context update', gridRowsOptions).check(`
+            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
+            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+        `);
+        await new GridColumns(api, 'cols before context update').checkColumns(`
+            CENTER
+            ├── ag-Grid-AutoColumn "Group" width:200
+            ├─┬ "Gymnastics" GROUP closed
+            │ ├─┬ "2008" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
+            │ ├─┬ "2012" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
+            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
+            └─┬ "Swimming" GROUP closed
+              ├─┬ "2008" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
+              ├─┬ "2012" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
+              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
+        `);
 
         for (const col of api.getPivotResultColumns() ?? []) {
             expect(col.getColDef().context).toEqual({ version: 1 });
@@ -200,8 +333,27 @@ describe('pivot column identity across columnDefs updates', () => {
             expect(col.getColDef().context).toEqual({ version: 2 });
         }
 
-        await new GridRows(api, 'rows after context update', gridRowsOptions).check(``);
-        await new GridColumns(api, 'cols after context update').checkColumns(``);
+        await new GridRows(api, 'rows after context update', gridRowsOptions).check(`
+            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
+            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+        `);
+        await new GridColumns(api, 'cols after context update').checkColumns(`
+            CENTER
+            ├── ag-Grid-AutoColumn "Group" width:200
+            ├─┬ "Gymnastics" GROUP closed
+            │ ├─┬ "2008" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
+            │ ├─┬ "2012" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
+            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
+            └─┬ "Swimming" GROUP closed
+              ├─┬ "2008" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
+              ├─┬ "2012" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
+              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
+        `);
     });
 
     test('processPivotResultColDef can attach pivot-col-specific context on every recreate', async () => {
@@ -219,8 +371,27 @@ describe('pivot column identity across columnDefs updates', () => {
         });
         applyTransactionChecked(api, { add: olympicLikeRows });
 
-        await new GridRows(api, 'rows before callback recheck', gridRowsOptions).check(``);
-        await new GridColumns(api, 'cols before callback recheck').checkColumns(``);
+        await new GridRows(api, 'rows before callback recheck', gridRowsOptions).check(`
+            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
+            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+        `);
+        await new GridColumns(api, 'cols before callback recheck').checkColumns(`
+            CENTER
+            ├── ag-Grid-AutoColumn "Group" width:200
+            ├─┬ "Gymnastics" GROUP closed
+            │ ├─┬ "2008" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
+            │ ├─┬ "2012" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
+            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
+            └─┬ "Swimming" GROUP closed
+              ├─┬ "2008" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
+              ├─┬ "2012" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
+              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
+        `);
 
         const beforeCols = api.getPivotResultColumns() ?? [];
         expect(beforeCols.length).toBeGreaterThan(0);
@@ -234,8 +405,27 @@ describe('pivot column identity across columnDefs updates', () => {
             expect(col.getColDef().context).toEqual({ byColId: col.getColId() });
         }
 
-        await new GridRows(api, 'rows after callback recheck', gridRowsOptions).check(``);
-        await new GridColumns(api, 'cols after callback recheck').checkColumns(``);
+        await new GridRows(api, 'rows after callback recheck', gridRowsOptions).check(`
+            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
+            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+        `);
+        await new GridColumns(api, 'cols after callback recheck').checkColumns(`
+            CENTER
+            ├── ag-Grid-AutoColumn "Group" width:200
+            ├─┬ "Gymnastics" GROUP closed
+            │ ├─┬ "2008" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
+            │ ├─┬ "2012" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
+            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
+            └─┬ "Swimming" GROUP closed
+              ├─┬ "2008" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
+              ├─┬ "2012" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
+              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
+        `);
     });
 
     test('custom properties attached directly to a pivot result colDef are NOT preserved across recreate', async () => {
@@ -251,8 +441,27 @@ describe('pivot column identity across columnDefs updates', () => {
         });
         applyTransactionChecked(api, { add: olympicLikeRows });
 
-        await new GridRows(api, 'rows before mutation', gridRowsOptions).check(``);
-        await new GridColumns(api, 'cols before mutation').checkColumns(``);
+        await new GridRows(api, 'rows before mutation', gridRowsOptions).check(`
+            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
+            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+        `);
+        await new GridColumns(api, 'cols before mutation').checkColumns(`
+            CENTER
+            ├── ag-Grid-AutoColumn "Group" width:200
+            ├─┬ "Gymnastics" GROUP closed
+            │ ├─┬ "2008" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
+            │ ├─┬ "2012" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
+            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
+            └─┬ "Swimming" GROUP closed
+              ├─┬ "2008" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
+              ├─┬ "2012" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
+              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
+        `);
 
         const targetCol = api.getPivotResultColumns()?.[0];
         expect(targetCol).toBeDefined();
@@ -266,7 +475,26 @@ describe('pivot column identity across columnDefs updates', () => {
         expect(afterCol).toBeDefined();
         expect((afterCol!.getColDef() as ColDef & { myCustomProp?: string }).myCustomProp).toBeUndefined();
 
-        await new GridRows(api, 'rows after mutation', gridRowsOptions).check(``);
-        await new GridColumns(api, 'cols after mutation').checkColumns(``);
+        await new GridRows(api, 'rows after mutation', gridRowsOptions).check(`
+            ROOT id:ROOT_NODE_ID pivot_sport-year_Gymnastics-2008_gold:7 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:8 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+            ├── LEAF_GROUP collapsed id:row-group-country-Russia ag-Grid-AutoColumn:"Russia" pivot_sport-year_Gymnastics-2008_gold:3 pivot_sport-year_Gymnastics-2012_gold:1 pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:null pivot_sport-year_Swimming-2012_gold:null pivot_sport-year_Swimming_gold:null
+            └── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA" pivot_sport-year_Gymnastics-2008_gold:4 pivot_sport-year_Gymnastics-2012_gold:null pivot_sport-year_Gymnastics_gold:4 pivot_sport-year_Swimming-2008_gold:2 pivot_sport-year_Swimming-2012_gold:5 pivot_sport-year_Swimming_gold:7
+        `);
+        await new GridColumns(api, 'cols after mutation').checkColumns(`
+            CENTER
+            ├── ag-Grid-AutoColumn "Group" width:200
+            ├─┬ "Gymnastics" GROUP closed
+            │ ├─┬ "2008" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2008_gold "Gold" width:200 columnGroupShow:open hidden
+            │ ├─┬ "2012" GROUP hidden
+            │ │ └── pivot_sport-year_Gymnastics-2012_gold "Gold" width:200 columnGroupShow:open hidden
+            │ └── pivot_sport-year_Gymnastics_gold "Gold" width:200 columnGroupShow:closed
+            └─┬ "Swimming" GROUP closed
+              ├─┬ "2008" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2008_gold "Gold" width:200 columnGroupShow:open hidden
+              ├─┬ "2012" GROUP hidden
+              │ └── pivot_sport-year_Swimming-2012_gold "Gold" width:200 columnGroupShow:open hidden
+              └── pivot_sport-year_Swimming_gold "Gold" width:200 columnGroupShow:closed
+        `);
     });
 });


### PR DESCRIPTION
- when recreating a colDef for pivot, we need to be sure the field is copied as well or else the id generator will generate a column id without it

Add tests to ensure that context is maintained, and id works correctly now

FIX AG-16517