### PR TITLE
AG-16791 ratio aggregation examples

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/_examples/multi-group-levels/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/_examples/multi-group-levels/main.ts
@@ -1,4 +1,4 @@
-import type { GridApi, GridOptions } from 'ag-grid-community';
+import type { GridApi, GridOptions, IAggFuncParams, IAggFuncResult } from 'ag-grid-community';
 import { ClientSideRowModelModule, ModuleRegistry, ValidationModule, createGrid } from 'ag-grid-community';
 import {
     ColumnMenuModule,
@@ -18,55 +18,64 @@ ModuleRegistry.registerModules([
     ...(process.env.NODE_ENV !== 'production' ? [ValidationModule] : []),
 ]);
 
+/** Carries `min`/`max` alongside the scalar `value` so the parent recomputes in `O(N)`. */
+class RangeResult implements IAggFuncResult<number> {
+    constructor(
+        readonly value: number,
+        readonly min: number,
+        readonly max: number
+    ) {}
+
+    toNumber() {
+        return this.value;
+    }
+
+    toString() {
+        return this.value.toFixed(2);
+    }
+}
+
 let gridApi: GridApi<IOlympicData>;
 
 const gridOptions: GridOptions<IOlympicData> = {
     columnDefs: [
         { field: 'country', rowGroup: true, hide: true },
         { field: 'year', rowGroup: true, hide: true },
-        { field: 'total', aggFunc: 'simpleRange' },
-        { field: 'total', aggFunc: 'range' },
+        { headerName: 'Range', field: 'total', aggFunc: 'range' },
     ],
     defaultColDef: {
         flex: 1,
         minWidth: 150,
     },
     autoGroupColumnDef: {
+        field: 'athlete',
         minWidth: 220,
     },
     aggFuncs: {
-        simpleRange: (params) => {
-            const values = params.values;
-            const max = Math.max(...values);
-            const min = Math.min(...values);
-            return max - min;
-        },
-        range: (params) => {
-            const values = params.values;
-            if (params.rowNode.leafGroup) {
-                const max = Math.max(...values);
-                const min = Math.min(...values);
-                return {
-                    max: max,
-                    min: min,
-                    value: max - min,
-                };
-            }
-
-            let max = values[0].max;
-            let min = values[0].min;
-            values.forEach((value) => {
-                max = Math.max(max, value.max);
-                min = Math.min(min, value.min);
-            });
-            return {
-                max: max,
-                min: min,
-                value: max - min,
-            };
-        },
+        range: rangeAggFunc,
     },
 };
+
+function rangeAggFunc(params: IAggFuncParams<IOlympicData>): RangeResult | null {
+    // Read each immediate child via `getDataValue(col, 'data')`:
+    //  - leaf children return the raw `total` number
+    //  - sub-group children return the RangeResult this function produced one
+    //    level down — its `min`/`max` let the parent recompute the range
+    //    without re-walking descendant leaves.
+    let min = Infinity;
+    let max = -Infinity;
+    for (const child of params.aggregatedChildren) {
+        const childValue = child.getDataValue(params.column, 'data');
+        if (typeof childValue === 'number') {
+            min = Math.min(min, childValue);
+            max = Math.max(max, childValue);
+        } else if (childValue instanceof RangeResult) {
+            min = Math.min(min, childValue.min);
+            max = Math.max(max, childValue.max);
+        }
+    }
+    return Number.isFinite(min) ? new RangeResult(max - min, min, max) : null;
+}
 
 // setup the grid after the page has finished loading
 document.addEventListener('DOMContentLoaded', () => {

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/_examples/multi-level-ratio/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/_examples/multi-level-ratio/example.spec.ts
@@ -1,0 +1,11 @@
+import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+
+test.agExample(import.meta, () => {
+    test.eachFramework('Example', async ({ page }) => {
+        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+        await clickAllButtons(page);
+        // END PLACEHOLDER
+    });
+});

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/_examples/multi-level-ratio/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/_examples/multi-level-ratio/index.html
@@ -1,0 +1,1 @@
+<div id="myGrid" style="height: 100%"></div>

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/_examples/multi-level-ratio/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/_examples/multi-level-ratio/main.ts
@@ -1,0 +1,100 @@
+import type { GridApi, GridOptions, IAggFuncParams, IAggFuncResult, ValueGetterParams } from 'ag-grid-community';
+import { ClientSideRowModelModule, ModuleRegistry, ValidationModule, createGrid } from 'ag-grid-community';
+import {
+    ColumnMenuModule,
+    ColumnsToolPanelModule,
+    ContextMenuModule,
+    RowGroupingModule,
+    SetFilterModule,
+} from 'ag-grid-enterprise';
+
+ModuleRegistry.registerModules([
+    ClientSideRowModelModule,
+    ColumnsToolPanelModule,
+    ColumnMenuModule,
+    ContextMenuModule,
+    RowGroupingModule,
+    SetFilterModule,
+    ...(process.env.NODE_ENV !== 'production' ? [ValidationModule] : []),
+]);
+
+/** Carries `gold`/`silver` totals alongside the scalar ratio so the parent recomputes in `O(N)`. */
+class RatioResult implements IAggFuncResult<number> {
+    constructor(
+        readonly value: number,
+        readonly gold: number,
+        readonly silver: number
+    ) {}
+
+    toNumber() {
+        return this.value;
+    }
+
+    toString() {
+        return Number.isFinite(this.value) ? this.value.toFixed(2) : '';
+    }
+}
+
+let gridApi: GridApi<IOlympicData>;
+
+const gridOptions: GridOptions<IOlympicData> = {
+    columnDefs: [
+        { field: 'country', rowGroup: true, hide: true },
+        { field: 'year', rowGroup: true, hide: true },
+        { field: 'total', aggFunc: 'sum' },
+        {
+            headerName: 'Gold to Silver',
+            colId: 'goldSilverRatio',
+            aggFunc: 'ratio',
+            valueGetter: leafRatioValueGetter,
+        },
+    ],
+    aggFuncs: {
+        ratio: ratioAggFunc,
+    },
+    defaultColDef: {
+        flex: 1,
+        minWidth: 150,
+    },
+    autoGroupColumnDef: {
+        field: 'athlete',
+        minWidth: 220,
+    },
+};
+
+// Leaf rows always expose a `RatioResult` so the aggFunc reads every child uniformly.
+// Rows with no silvers produce a non-finite ratio value — `toString` blanks the cell out,
+// while `gold`/`silver` are still preserved for the parent group's running totals.
+// Footer/filler rows have no `data`; return undefined so the cell is left empty.
+function leafRatioValueGetter(params: ValueGetterParams<IOlympicData>): RatioResult | undefined {
+    if (!params.data) {
+        return undefined;
+    }
+    const { gold, silver } = params.data;
+    return new RatioResult(gold / silver, gold, silver);
+}
+
+function ratioAggFunc(params: IAggFuncParams<IOlympicData>): RatioResult | null {
+    let gold = 0;
+    let silver = 0;
+    for (const child of params.aggregatedChildren) {
+        // Every child — leaf or sub-group — exposes a `RatioResult` here. `'data'` mode returns
+        // it as-is; `'value'` would unwrap via `toNumber()` and lose the `gold`/`silver` totals.
+        const ratio = child.getDataValue(params.column, 'data');
+        if (ratio instanceof RatioResult) {
+            gold += ratio.gold;
+            silver += ratio.silver;
+        }
+    }
+    return silver ? new RatioResult(gold / silver, gold, silver) : null;
+}
+
+// setup the grid after the page has finished loading
+document.addEventListener('DOMContentLoaded', () => {
+    const gridDiv = document.querySelector<HTMLElement>('#myGrid')!;
+    gridApi = createGrid(gridDiv, gridOptions);
+
+    fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
+        .then((response) => response.json())
+        .then((data: IOlympicData[]) => gridApi!.setGridOption('rowData', data));
+});

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/_examples/multi-level-ratio/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/_examples/multi-level-ratio/main.ts
@@ -18,20 +18,19 @@ ModuleRegistry.registerModules([
     ...(process.env.NODE_ENV !== 'production' ? [ValidationModule] : []),
 ]);
 
-/** Carries `gold`/`silver` totals alongside the scalar ratio so the parent recomputes in `O(N)`. */
+/** Carries `gold`/`silver` running totals; the ratio is derived so the wrapper can't go inconsistent. */
 class RatioResult implements IAggFuncResult<number> {
     constructor(
-        readonly value: number,
         readonly gold: number,
         readonly silver: number
     ) {}
 
     toNumber() {
-        return this.value;
+        return this.gold / this.silver;
     }
 
     toString() {
-        return Number.isFinite(this.value) ? this.value.toFixed(2) : '';
+        return this.silver ? this.toNumber().toFixed(2) : '';
     }
 }
 
@@ -63,18 +62,18 @@ const gridOptions: GridOptions<IOlympicData> = {
 };
 
 // Leaf rows always expose a `RatioResult` so the aggFunc reads every child uniformly.
-// Rows with no silvers produce a non-finite ratio value — `toString` blanks the cell out,
-// while `gold`/`silver` are still preserved for the parent group's running totals.
+// Rows with no silvers carry `silver: 0` — `toString` blanks the cell, while `gold`/`silver`
+// stay available for the parent group's running totals.
 // Footer/filler rows have no `data`; return undefined so the cell is left empty.
 function leafRatioValueGetter(params: ValueGetterParams<IOlympicData>): RatioResult | undefined {
     if (!params.data) {
         return undefined;
     }
     const { gold, silver } = params.data;
-    return new RatioResult(gold / silver, gold, silver);
+    return new RatioResult(gold, silver);
 }
 
-function ratioAggFunc(params: IAggFuncParams<IOlympicData>): RatioResult | null {
+function ratioAggFunc(params: IAggFuncParams<IOlympicData>): RatioResult {
     let gold = 0;
     let silver = 0;
     for (const child of params.aggregatedChildren) {
@@ -86,7 +85,7 @@ function ratioAggFunc(params: IAggFuncParams<IOlympicData>): RatioResult | null 
             silver += ratio.silver;
         }
     }
-    return silver ? new RatioResult(gold / silver, gold, silver) : null;
+    return new RatioResult(gold, silver);
 }
 
 // setup the grid after the page has finished loading

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/_examples/multi-level-ratio/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/_examples/multi-level-ratio/main.ts
@@ -19,18 +19,23 @@ ModuleRegistry.registerModules([
 ]);
 
 /** Carries `gold`/`silver` running totals; the ratio is derived so the wrapper can't go inconsistent. */
-class RatioResult implements IAggFuncResult<number> {
+class RatioResult implements IAggFuncResult<number | null> {
+    readonly value: number | null;
+
     constructor(
         readonly gold: number,
         readonly silver: number
-    ) {}
+    ) {
+        this.value = silver ? gold / silver : null;
+    }
 
-    toNumber() {
-        return this.gold / this.silver;
+    toNumber(): number | null {
+        return this.value;
     }
 
     toString() {
-        return this.silver ? this.toNumber().toFixed(2) : '';
+        const value = this.value;
+        return value === null ? '' : value.toFixed(2);
     }
 }
 
@@ -64,7 +69,6 @@ const gridOptions: GridOptions<IOlympicData> = {
 // Leaf rows always expose a `RatioResult` so the aggFunc reads every child uniformly.
 // Rows with no silvers carry `silver: 0` — `toString` blanks the cell, while `gold`/`silver`
 // stay available for the parent group's running totals.
-// Footer/filler rows have no `data`; return undefined so the cell is left empty.
 function leafRatioValueGetter(params: ValueGetterParams<IOlympicData>): RatioResult | undefined {
     if (!params.data) {
         return undefined;

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/_examples/registering-functions/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/_examples/registering-functions/main.ts
@@ -1,4 +1,4 @@
-import type { GridApi, GridOptions, IAggFuncParams, ValueFormatterParams, ValueGetterParams } from 'ag-grid-community';
+import type { GridApi, GridOptions, IAggFuncParams } from 'ag-grid-community';
 import { ClientSideRowModelModule, ModuleRegistry, ValidationModule, createGrid } from 'ag-grid-community';
 import {
     ColumnMenuModule,
@@ -26,20 +26,12 @@ const gridOptions: GridOptions<IOlympicData> = {
     columnDefs: [
         { field: 'country', rowGroup: true, hide: true },
         { field: 'total', aggFunc: 'range' },
-        {
-            headerName: 'Gold to Silver',
-            colId: 'goldSilverRatio',
-            aggFunc: 'ratio',
-            valueGetter: ratioValueGetter,
-            valueFormatter: ratioFormatter,
-        },
     ],
     aggFuncs: {
-        range: (params) => {
+        range: (params: IAggFuncParams<IOlympicData>) => {
             const values = params.values;
             return values.length > 0 ? Math.max(...values) - Math.min(...values) : null;
         },
-        ratio: ratioAggFunc,
     },
     defaultColDef: {
         flex: 1,
@@ -49,40 +41,6 @@ const gridOptions: GridOptions<IOlympicData> = {
         minWidth: 220,
     },
 };
-
-function ratioValueGetter(params: ValueGetterParams<IOlympicData>) {
-    if (!(params.node && params.node.group)) {
-        // no need to handle group levels - calculated in the 'ratioAggFunc'
-        return createValueObject(params.data!.gold, params.data!.silver);
-    }
-}
-
-function ratioAggFunc(params: IAggFuncParams) {
-    let goldSum = 0;
-    let silverSum = 0;
-    params.values.forEach((value) => {
-        if (value && value.gold) {
-            goldSum += value.gold;
-        }
-        if (value && value.silver) {
-            silverSum += value.silver;
-        }
-    });
-    return createValueObject(goldSum, silverSum);
-}
-
-function createValueObject(gold: number, silver: number) {
-    return {
-        gold: gold,
-        silver: silver,
-        toString: () => `${gold && silver ? gold / silver : 0}`,
-    };
-}
-
-function ratioFormatter(params: ValueFormatterParams) {
-    if (!params.value || params.value === 0) return '';
-    return '' + Math.round(params.value * 100) / 100;
-}
 
 // setup the grid after the page has finished loading
 document.addEventListener('DOMContentLoaded', () => {

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/index.mdoc
@@ -120,14 +120,18 @@ also gives the leaf cells something to display, and reduces the aggFunc to a sin
 {% gridExampleRunner title="Ratio Across Levels" name="multi-level-ratio" /%}
 
 ```ts
-class RatioResult implements IAggFuncResult<number> {
+class RatioResult implements IAggFuncResult<number | null> {
+    readonly value: number | null;
+
     constructor(
         readonly gold: number,
         readonly silver: number,
-    ) {}
+    ) {
+        this.value = silver ? gold / silver : null;
+    }
 
-    toNumber() { return this.gold / this.silver; }
-    toString() { return this.silver ? this.toNumber().toFixed(2) : ''; }
+    toNumber() { return this.value; }
+    toString() { const v = this.value; return v === null ? '' : v.toFixed(2); }
 }
 
 // Every leaf returns a `RatioResult` so the aggFunc reads each child the same way. Rows with no

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/index.mdoc
@@ -68,12 +68,10 @@ above the leaves.
 
 The fix is to return an [`IAggFuncResult`](./row-object/#reference-data-getDataValue) that carries
 any auxiliary fields the parent needs to recompute. Sub-group children expose the wrapper to the
-parent via `getDataValue(colKey, 'data')`; leaf children expose their raw value via the same call.
+parent via `getDataValue(colKey, 'data')`; leaf children expose their value via the same call — a primitive when the column reads from a `field`, or a wrapper when a `valueGetter` returns one.
 Every child reads the same way at every level.
 
-A class is a natural fit: `toNumber` and `toString` live on the prototype, and `instanceof` (or a
-`typeof` check for leaves) makes it trivial to tell a sub-group's wrapper apart from a leaf's raw
-number.
+A class is a natural fit: `toNumber` and `toString` live on the prototype, and `instanceof` (paired with a `typeof` check when leaves expose a primitive) makes it trivial to identify a wrapper.
 
 {% gridExampleRunner title="Multiple Group Levels" name="multi-group-levels" /%}
 
@@ -124,25 +122,24 @@ also gives the leaf cells something to display, and reduces the aggFunc to a sin
 ```ts
 class RatioResult implements IAggFuncResult<number> {
     constructor(
-        readonly value: number,
         readonly gold: number,
         readonly silver: number,
     ) {}
 
-    toNumber() { return this.value; }
-    toString() { return Number.isFinite(this.value) ? this.value.toFixed(2) : ''; }
+    toNumber() { return this.gold / this.silver; }
+    toString() { return this.silver ? this.toNumber().toFixed(2) : ''; }
 }
 
 // Every leaf returns a `RatioResult` so the aggFunc reads each child the same way. Rows with no
-// silvers produce a non-finite ratio that `toString` blanks out, while `gold`/`silver` are still
-// preserved for the parent group's running totals. Footer/filler rows have no `data`; return
-// undefined so the cell is left empty.
+// silvers carry `silver: 0` — `toString` blanks the cell, while `gold`/`silver` stay available
+// for the parent group's running totals. Footer/filler rows have no `data`; return undefined
+// so the cell is left empty.
 function leafRatioValueGetter(params) {
     if (!params.data) {
         return undefined;
     }
     const { gold, silver } = params.data;
-    return new RatioResult(gold / silver, gold, silver);
+    return new RatioResult(gold, silver);
 }
 
 function ratioAggFunc(params) {
@@ -155,7 +152,7 @@ function ratioAggFunc(params) {
             silver += ratio.silver;
         }
     }
-    return silver ? new RatioResult(gold / silver, gold, silver) : null;
+    return new RatioResult(gold, silver);
 }
 ```
 

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/index.mdoc
@@ -167,8 +167,11 @@ This pattern works whenever each child can be summarised by a few numbers that t
 - **Standard deviation** — carry `sum`, `sum-of-squares`, and `count`; the parent adds all three.
 - **Ratio of sums** — carry the two running sums; the parent adds and divides.
 
-Aggregations that need every leaf value — distinct count, median, percentile — cannot use this
-pattern. For those, walk every descendant leaf with `rowNode.getAggregatedChildren(colKey, true)`.
+The pattern requires that the child summaries can be combined into the parent summary without
+revisiting the leaves — the auxiliary fields must be enough on their own. Aggregations like median
+or percentile do not have that property: a parent's median is not derivable from its children's
+medians. For those, walk every descendant leaf directly via
+`params.rowNode.getAggregatedChildren(params.column, true)`.
 
 {% note %}
 Custom aggregation functions can also be used with [Editing Group Rows](./grouping-edit/).

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/index.mdoc
@@ -61,56 +61,116 @@ const gridOptions = {
 
 ## Multiple Group Levels
 
-When aggregations are applied across multiple levels of grouping, the aggregation function is called recursively.
-This has the effect where some groups aggregate the results of other aggregations, causing incorrect results.
+With multiple levels of grouping, an aggregation function runs once per group at every level. Above
+the leaf groups, `params.values` holds the already-aggregated results from the level below — not
+the raw leaf values — so a function written only against `params.values` produces wrong results
+above the leaves.
 
-To handle this, the aggregation function should return an object containing relevant meta data for the next level of aggregation,
-and a `"value"` field representing the result for this level.
+The fix is to return an [`IAggFuncResult`](./row-object/#reference-data-getDataValue) that carries
+any auxiliary fields the parent needs to recompute. Sub-group children expose the wrapper to the
+parent via `getDataValue(colKey, 'data')`; leaf children expose their raw value via the same call.
+Every child reads the same way at every level.
+
+A class is a natural fit: `toNumber` and `toString` live on the prototype, and `instanceof` (or a
+`typeof` check for leaves) makes it trivial to tell a sub-group's wrapper apart from a leaf's raw
+number.
 
 {% gridExampleRunner title="Multiple Group Levels" name="multi-group-levels" /%}
+
+```ts
+/** Carries `min`/`max` alongside the scalar `value` so the parent recomputes in O(N). */
+class RangeResult implements IAggFuncResult<number> {
+    constructor(
+        readonly value: number,
+        readonly min: number,
+        readonly max: number,
+    ) {}
+
+    toNumber() { return this.value; }
+    toString() { return this.value.toFixed(2); }
+}
+
+function rangeAggFunc(params) {
+    // Read each immediate child via `getDataValue(col, 'data')`:
+    //  - leaf children return the raw `total` number
+    //  - sub-group children return the RangeResult this function produced one
+    //    level down — its `min`/`max` let the parent recompute the range
+    //    without re-walking descendant leaves.
+    let min = Infinity;
+    let max = -Infinity;
+    for (const child of params.aggregatedChildren) {
+        const childValue = child.getDataValue(params.column, 'data');
+        if (typeof childValue === 'number') {
+            min = Math.min(min, childValue);
+            max = Math.max(max, childValue);
+        } else if (childValue instanceof RangeResult) {
+            min = Math.min(min, childValue.min);
+            max = Math.max(max, childValue.max);
+        }
+    }
+    return Number.isFinite(min) ? new RangeResult(max - min, min, max) : null;
+}
+```
+
+`'data'` mode returns the stored wrapper as-is. `'value'` would unwrap it via `toNumber()` to its
+scalar.
+
+A ratio uses the same wrapper pattern — carry the two running sums (`gold` and `silver`) so the
+parent divides at every level. Giving leaf rows the same `RatioResult` shape via a `valueGetter`
+also gives the leaf cells something to display, and reduces the aggFunc to a single branch:
+
+{% gridExampleRunner title="Ratio Across Levels" name="multi-level-ratio" /%}
+
+```ts
+class RatioResult implements IAggFuncResult<number> {
+    constructor(
+        readonly value: number,
+        readonly gold: number,
+        readonly silver: number,
+    ) {}
+
+    toNumber() { return this.value; }
+    toString() { return Number.isFinite(this.value) ? this.value.toFixed(2) : ''; }
+}
+
+// Every leaf returns a `RatioResult` so the aggFunc reads each child the same way. Rows with no
+// silvers produce a non-finite ratio that `toString` blanks out, while `gold`/`silver` are still
+// preserved for the parent group's running totals. Footer/filler rows have no `data`; return
+// undefined so the cell is left empty.
+function leafRatioValueGetter(params) {
+    if (!params.data) {
+        return undefined;
+    }
+    const { gold, silver } = params.data;
+    return new RatioResult(gold / silver, gold, silver);
+}
+
+function ratioAggFunc(params) {
+    let gold = 0;
+    let silver = 0;
+    for (const child of params.aggregatedChildren) {
+        const ratio = child.getDataValue(params.column, 'data');
+        if (ratio instanceof RatioResult) {
+            gold += ratio.gold;
+            silver += ratio.silver;
+        }
+    }
+    return silver ? new RatioResult(gold / silver, gold, silver) : null;
+}
+```
+
+This pattern works whenever each child can be summarised by a few numbers that the parent combines:
+
+- **Range** — carry `min` and `max`; the parent takes the lowest `min` and highest `max`.
+- **Weighted average** — carry `sum` and `count`; the parent adds them up, then divides.
+- **Standard deviation** — carry `sum`, `sum-of-squares`, and `count`; the parent adds all three.
+- **Ratio of sums** — carry the two running sums; the parent adds and divides.
+
+Aggregations that need every leaf value — distinct count, median, percentile — cannot use this
+pattern. For those, walk every descendant leaf with `rowNode.getAggregatedChildren(colKey, true)`.
 
 {% note %}
 Custom aggregation functions can also be used with [Editing Group Rows](./grouping-edit/).
 When a group row is edited, the built-in distribution automatically handles `sum`, `avg`, `min`, `max`, `first`, and `last`.
 For custom aggregation functions, define a per-aggregation distribution strategy or provide a custom `groupRowValueSetter` callback.
 {% /note %}
-
-The above example demonstrates the following configuration to apply a custom `"range"` function which works with multiple
-levels of row grouping:
-
-```{% frameworkTransform=true %}
-const gridOptions = {
-    columnDefs: [
-      { field: 'total', aggFunc: 'range' },
-      // ... other column definitions
-    ],
-    aggFuncs: {
-      range: params => {
-        const values = params.values;
-        // aggregate leaf rows
-        if (params.rowNode.leafGroup) {
-            const max = Math.max(...values);
-            const min = Math.min(...values);
-            return {
-                max: max,
-                min: min,
-                value: max - min,
-            }
-        }
-
-        // aggregate group rows
-        let max = values[0].max;
-        let min = values[0].min;
-        values.forEach(groupResult => {
-            max = Math.max(max, groupResult.max);
-            min = Math.min(min, groupResult.min);
-        });
-        return {
-            max: max,
-            min: min,
-            value: max - min,
-        };
-      }
-    },
-}
-```

--- a/testing/behavioural/src/grouping-data/grouping-aggregation-ratio.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-aggregation-ratio.test.ts
@@ -9,18 +9,23 @@ import { TestGridsManager } from '../test-utils';
  * produce a `RatioResult` for both leaves and groups, so the aggFunc reads each child the
  * same way at every level.
  */
-class RatioResult implements IAggFuncResult<number> {
+class RatioResult implements IAggFuncResult<number | null> {
+    readonly value: number | null;
+
     constructor(
         readonly gold: number,
         readonly silver: number
-    ) {}
+    ) {
+        this.value = silver ? gold / silver : null;
+    }
 
-    toNumber() {
-        return this.gold / this.silver;
+    toNumber(): number | null {
+        return this.value;
     }
 
     toString() {
-        return this.silver ? this.toNumber().toFixed(2) : '';
+        const value = this.value;
+        return value === null ? '' : value.toFixed(2);
     }
 }
 
@@ -33,7 +38,9 @@ interface MedalRow {
 }
 
 function leafRatioValueGetter(params: ValueGetterParams<MedalRow>): RatioResult | undefined {
-    if (!params.data) return undefined;
+    if (!params.data) {
+        return undefined;
+    }
     const { gold, silver } = params.data;
     return new RatioResult(gold, silver);
 }
@@ -54,9 +61,13 @@ function ratioAggFunc(params: IAggFuncParams<MedalRow>): RatioResult {
 function findGroupRow(api: GridApi, key: string): IRowNode {
     let found: IRowNode | undefined;
     api.forEachNode((node) => {
-        if (node.group && node.key === key && !found) found = node;
+        if (node.group && node.key === key && !found) {
+            found = node;
+        }
     });
-    if (!found) throw new Error(`Group row '${key}' not found`);
+    if (!found) {
+        throw new Error(`Group row '${key}' not found`);
+    }
     return found;
 }
 
@@ -138,7 +149,9 @@ describe('ratio-of-sums aggregation via IAggFuncResult wrapper', () => {
         expect(year2000).toBeInstanceOf(RatioResult);
         expect(year2000.gold).toBe(7);
         expect(year2000.silver).toBe(0);
-        expect(Number.isFinite(year2000.toNumber())).toBe(false);
+        // No denominator — wrapper exposes `null` to sort/filter/chart paths, blank to display.
+        expect(year2000.value).toBeNull();
+        expect(year2000.toNumber()).toBeNull();
         expect(year2000.toString()).toBe('');
 
         const year2004 = findGroupRow(api, '2004').aggData?.goldSilverRatio;

--- a/testing/behavioural/src/grouping-data/grouping-aggregation-ratio.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-aggregation-ratio.test.ts
@@ -11,17 +11,16 @@ import { TestGridsManager } from '../test-utils';
  */
 class RatioResult implements IAggFuncResult<number> {
     constructor(
-        readonly value: number,
         readonly gold: number,
         readonly silver: number
     ) {}
 
     toNumber() {
-        return this.value;
+        return this.gold / this.silver;
     }
 
     toString() {
-        return Number.isFinite(this.value) ? this.value.toFixed(2) : '';
+        return this.silver ? this.toNumber().toFixed(2) : '';
     }
 }
 
@@ -36,10 +35,10 @@ interface MedalRow {
 function leafRatioValueGetter(params: ValueGetterParams<MedalRow>): RatioResult | undefined {
     if (!params.data) return undefined;
     const { gold, silver } = params.data;
-    return new RatioResult(gold / silver, gold, silver);
+    return new RatioResult(gold, silver);
 }
 
-function ratioAggFunc(params: IAggFuncParams<MedalRow>): RatioResult | null {
+function ratioAggFunc(params: IAggFuncParams<MedalRow>): RatioResult {
     let gold = 0;
     let silver = 0;
     for (const child of params.aggregatedChildren) {
@@ -49,7 +48,7 @@ function ratioAggFunc(params: IAggFuncParams<MedalRow>): RatioResult | null {
             silver += ratio.silver;
         }
     }
-    return silver ? new RatioResult(gold / silver, gold, silver) : null;
+    return new RatioResult(gold, silver);
 }
 
 function findGroupRow(api: GridApi, key: string): IRowNode {
@@ -98,17 +97,61 @@ describe('ratio-of-sums aggregation via IAggFuncResult wrapper', () => {
         expect(year2000).toBeInstanceOf(RatioResult);
         expect(year2000.gold).toBe(4);
         expect(year2000.silver).toBe(2);
-        expect(year2000.value).toBe(2);
+        expect(year2000.toNumber()).toBe(2);
         expect(year2004.gold).toBe(6);
         expect(year2004.silver).toBe(2);
-        expect(year2004.value).toBe(3);
+        expect(year2004.toNumber()).toBe(3);
 
         // Country-level sums the year wrappers (not the year ratios).
         const ireland = findGroupRow(api, 'Ireland').aggData?.goldSilverRatio;
         expect(ireland.gold).toBe(10);
         expect(ireland.silver).toBe(4);
-        expect(ireland.value).toBe(2.5);
         expect(ireland.toNumber()).toBe(2.5);
         expect(ireland.toString()).toBe('2.50');
+    });
+
+    test('child group with zero silver still contributes its gold to the parent total', () => {
+        const api = gridsManager.createGrid('ratio-zero-silver-child', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', rowGroup: true, hide: true },
+                {
+                    headerName: 'Gold to Silver',
+                    colId: 'goldSilverRatio',
+                    aggFunc: 'ratio',
+                    valueGetter: leafRatioValueGetter,
+                },
+            ],
+            aggFuncs: { ratio: ratioAggFunc },
+            groupDefaultExpanded: -1,
+            getRowId: ({ data }) => data.id,
+            rowData: [
+                // 2000: gold-only — every child's silver is 0.
+                { id: '1', country: 'Ireland', year: 2000, gold: 5, silver: 0 },
+                { id: '2', country: 'Ireland', year: 2000, gold: 2, silver: 0 },
+                // 2004: has silver. Country-level rollup must combine both years.
+                { id: '3', country: 'Ireland', year: 2004, gold: 0, silver: 5 },
+            ] satisfies MedalRow[],
+        });
+
+        const year2000 = findGroupRow(api, '2000').aggData?.goldSilverRatio;
+        expect(year2000).toBeInstanceOf(RatioResult);
+        expect(year2000.gold).toBe(7);
+        expect(year2000.silver).toBe(0);
+        expect(Number.isFinite(year2000.toNumber())).toBe(false);
+        expect(year2000.toString()).toBe('');
+
+        const year2004 = findGroupRow(api, '2004').aggData?.goldSilverRatio;
+        expect(year2004.gold).toBe(0);
+        expect(year2004.silver).toBe(5);
+        expect(year2004.toNumber()).toBe(0);
+
+        // Parent sums both years' gold and silver — would have been 0/5 if the zero-silver
+        // year had returned null instead of a RatioResult.
+        const ireland = findGroupRow(api, 'Ireland').aggData?.goldSilverRatio;
+        expect(ireland).toBeInstanceOf(RatioResult);
+        expect(ireland.gold).toBe(7);
+        expect(ireland.silver).toBe(5);
+        expect(ireland.toNumber()).toBe(7 / 5);
     });
 });

--- a/testing/behavioural/src/grouping-data/grouping-aggregation-ratio.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-aggregation-ratio.test.ts
@@ -1,0 +1,114 @@
+import type { GridApi, IAggFuncParams, IAggFuncResult, IRowNode, ValueGetterParams } from 'ag-grid-community';
+import { ClientSideRowModelModule } from 'ag-grid-community';
+import { RowGroupingModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager } from '../test-utils';
+
+/**
+ * Mirrors the `multi-level-ratio` documentation example. The aggFunc + value getter pair
+ * produce a `RatioResult` for both leaves and groups, so the aggFunc reads each child the
+ * same way at every level.
+ */
+class RatioResult implements IAggFuncResult<number> {
+    constructor(
+        readonly value: number,
+        readonly gold: number,
+        readonly silver: number
+    ) {}
+
+    toNumber() {
+        return this.value;
+    }
+
+    toString() {
+        return Number.isFinite(this.value) ? this.value.toFixed(2) : '';
+    }
+}
+
+interface MedalRow {
+    id: string;
+    country: string;
+    year: number;
+    gold: number;
+    silver: number;
+}
+
+function leafRatioValueGetter(params: ValueGetterParams<MedalRow>): RatioResult | undefined {
+    if (!params.data) return undefined;
+    const { gold, silver } = params.data;
+    return new RatioResult(gold / silver, gold, silver);
+}
+
+function ratioAggFunc(params: IAggFuncParams<MedalRow>): RatioResult | null {
+    let gold = 0;
+    let silver = 0;
+    for (const child of params.aggregatedChildren) {
+        const ratio = child.getDataValue(params.column, 'data');
+        if (ratio instanceof RatioResult) {
+            gold += ratio.gold;
+            silver += ratio.silver;
+        }
+    }
+    return silver ? new RatioResult(gold / silver, gold, silver) : null;
+}
+
+function findGroupRow(api: GridApi, key: string): IRowNode {
+    let found: IRowNode | undefined;
+    api.forEachNode((node) => {
+        if (node.group && node.key === key && !found) found = node;
+    });
+    if (!found) throw new Error(`Group row '${key}' not found`);
+    return found;
+}
+
+describe('ratio-of-sums aggregation via IAggFuncResult wrapper', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule],
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    test('rolls up gold/silver totals correctly across multiple grouping levels', () => {
+        const api = gridsManager.createGrid('ratio-multi-level', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', rowGroup: true, hide: true },
+                {
+                    headerName: 'Gold to Silver',
+                    colId: 'goldSilverRatio',
+                    aggFunc: 'ratio',
+                    valueGetter: leafRatioValueGetter,
+                },
+            ],
+            aggFuncs: { ratio: ratioAggFunc },
+            groupDefaultExpanded: -1,
+            getRowId: ({ data }) => data.id,
+            rowData: [
+                { id: '1', country: 'Ireland', year: 2000, gold: 3, silver: 1 },
+                { id: '2', country: 'Ireland', year: 2000, gold: 1, silver: 1 },
+                { id: '3', country: 'Ireland', year: 2004, gold: 6, silver: 2 },
+            ] satisfies MedalRow[],
+        });
+
+        // Year-level sums
+        const year2000 = findGroupRow(api, '2000').aggData?.goldSilverRatio;
+        const year2004 = findGroupRow(api, '2004').aggData?.goldSilverRatio;
+        expect(year2000).toBeInstanceOf(RatioResult);
+        expect(year2000.gold).toBe(4);
+        expect(year2000.silver).toBe(2);
+        expect(year2000.value).toBe(2);
+        expect(year2004.gold).toBe(6);
+        expect(year2004.silver).toBe(2);
+        expect(year2004.value).toBe(3);
+
+        // Country-level sums the year wrappers (not the year ratios).
+        const ireland = findGroupRow(api, 'Ireland').aggData?.goldSilverRatio;
+        expect(ireland.gold).toBe(10);
+        expect(ireland.silver).toBe(4);
+        expect(ireland.value).toBe(2.5);
+        expect(ireland.toNumber()).toBe(2.5);
+        expect(ireland.toString()).toBe('2.50');
+    });
+});


### PR DESCRIPTION
Ratio aggregations examples were extremely complex as they were written before we introduced in the latest version(s) the new features getAggregatedChildren, aggregatedChildren in agg callback, and rowNode.getDataValue

Simpify the examples, improve the documentation

FIX AG-16791