### PR TITLE
AG-16267 reduce value parser calls

### DIFF
--- a/packages/ag-grid-community/src/edit/cellEditors/dateStringCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/dateStringCellEditor.ts
@@ -19,6 +19,10 @@ class DateStringCellEditorInput implements CellEditorInput<string, IDateStringCe
     private eEditor: GridInputDateField;
     private params: IDateStringCellEditorParams;
     private includeTime: boolean | undefined;
+    /** Last raw input passed to `params.parseValue`. Initialised to `this` as an "uncached" sentinel — a DOM raw value can never equal the editor instance, so the first cache check always misses. */
+    private cachedRaw: unknown = this;
+    /** Memoised parse result for `cachedRaw`. Returned by `getValue()` when the raw input is unchanged across repeated validation/sync passes within an edit session. */
+    private cachedParsed: string | null | undefined;
 
     constructor(
         private readonly getDataTypeService: () => DataTypeService | undefined,
@@ -106,11 +110,21 @@ class DateStringCellEditorInput implements CellEditorInput<string, IDateStringCe
 
     public getValue(): string | null | undefined {
         const { params, eEditor } = this;
+        // Key the cache on the formatted date string — the exact input to parseValue —
+        // so the cache cannot diverge from what the parser would actually receive.
         const value = this.formatDate(eEditor.getDate());
-        if (!_exists(value) && !_exists(params.value)) {
-            return params.value;
+        if (Object.is(this.cachedRaw, value)) {
+            return this.cachedParsed;
         }
-        return params.parseValue(value ?? '');
+        let parsed: string | null | undefined;
+        if (!_exists(value) && !_exists(params.value)) {
+            parsed = params.value;
+        } else {
+            parsed = params.parseValue(value ?? '');
+        }
+        this.cachedRaw = value;
+        this.cachedParsed = parsed;
+        return parsed;
     }
 
     public getStartValue(): string | null | undefined {

--- a/packages/ag-grid-community/src/edit/cellEditors/largeTextCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/largeTextCellEditor.ts
@@ -22,6 +22,10 @@ export class LargeTextCellEditor extends AgAbstractCellEditor<ILargeTextEditorPa
     protected readonly eEditor: GridInputTextArea = RefPlaceholder;
     private focusAfterAttached: boolean;
     private highlightAllOnFocus: boolean;
+    /** Last raw input passed to `params.parseValue`. Initialised to `this` as an "uncached" sentinel — a DOM raw value can never equal the editor instance, so the first cache check always misses. */
+    private cachedRaw: unknown = this;
+    /** Memoised parse result for `cachedRaw`. Returned by `getValue()` when the raw input is unchanged across repeated validation/sync passes within an edit session. */
+    private cachedParsed: any;
 
     constructor() {
         super(LargeTextCellElement, [AgInputTextAreaSelector]);
@@ -120,7 +124,13 @@ export class LargeTextCellEditor extends AgAbstractCellEditor<ILargeTextEditorPa
         if (!_exists(editorValue) && !_exists(value)) {
             return value;
         }
-        return params.parseValue(editorValue!);
+        if (Object.is(this.cachedRaw, editorValue)) {
+            return this.cachedParsed;
+        }
+        const parsed = params.parseValue(editorValue!);
+        this.cachedRaw = editorValue;
+        this.cachedParsed = parsed;
+        return parsed;
     }
 
     public getValidationElement(): HTMLElement | HTMLInputElement {

--- a/packages/ag-grid-community/src/edit/cellEditors/numberCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/numberCellEditor.ts
@@ -119,10 +119,10 @@ class NumberCellEditorInput implements CellEditorInput<number, INumberCellEditor
                 result = null;
             } else {
                 const numeric = Number(parsedValue);
-                result = isNaN(numeric) ? null : numeric;
+                result = Number.isNaN(numeric) ? null : numeric;
             }
         } else {
-            result = isNaN(parsedValue) ? null : parsedValue;
+            result = Number.isNaN(parsedValue) ? null : parsedValue;
         }
         this.cachedRaw = value;
         this.cachedParsed = result;

--- a/packages/ag-grid-community/src/edit/cellEditors/numberCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/numberCellEditor.ts
@@ -17,6 +17,10 @@ const NumberCellElement: ElementParams = {
 class NumberCellEditorInput implements CellEditorInput<number, INumberCellEditorParams, GridInputNumberField> {
     private eEditor: GridInputNumberField;
     private params: INumberCellEditorParams;
+    /** Last raw input passed to `params.parseValue`. Initialised to `this` as an "uncached" sentinel — a DOM raw value can never equal the editor instance, so the first cache check always misses. */
+    private cachedRaw: unknown = this;
+    /** Memoised parse result for `cachedRaw`. Returned by `getValue()` when the raw input is unchanged across repeated validation/sync passes within an edit session. */
+    private cachedParsed: number | null | undefined;
 
     constructor(private readonly getLocaleTextFunc: () => LocaleTextFunc) {}
 
@@ -103,17 +107,26 @@ class NumberCellEditorInput implements CellEditorInput<number, INumberCellEditor
         if (!_exists(value) && !_exists(params.value)) {
             return params.value;
         }
-        let parsedValue = params.parseValue(value!);
+        if (Object.is(this.cachedRaw, value)) {
+            return this.cachedParsed;
+        }
+        const parsedValue = params.parseValue(value!);
+        let result: number | null | undefined;
         if (parsedValue == null) {
-            return parsedValue;
-        }
-        if (typeof parsedValue === 'string') {
+            result = parsedValue;
+        } else if (typeof parsedValue === 'string') {
             if (parsedValue === '') {
-                return null;
+                result = null;
+            } else {
+                const numeric = Number(parsedValue);
+                result = isNaN(numeric) ? null : numeric;
             }
-            parsedValue = Number(parsedValue);
+        } else {
+            result = isNaN(parsedValue) ? null : parsedValue;
         }
-        return isNaN(parsedValue) ? null : parsedValue;
+        this.cachedRaw = value;
+        this.cachedParsed = result;
+        return result;
     }
 
     public getStartValue(): string | null | undefined {

--- a/packages/ag-grid-community/src/edit/cellEditors/textCellEditor.ts
+++ b/packages/ag-grid-community/src/edit/cellEditors/textCellEditor.ts
@@ -20,6 +20,10 @@ class TextCellEditorInput<TValue = any> implements CellEditorInput<
 > {
     private eEditor: GridInputTextField;
     private params: ITextCellEditorParams<any, TValue>;
+    /** Last raw input passed to `params.parseValue`. Initialised to `this` as an "uncached" sentinel — a DOM raw value can never equal the editor instance, so the first cache check always misses. */
+    private cachedRaw: unknown = this;
+    /** Memoised parse result for `cachedRaw`. Returned by `getValue()` when the raw input is unchanged across repeated validation/sync passes within an edit session. */
+    private cachedParsed: TValue | null | undefined;
 
     constructor(private readonly getLocaleTextFunc: () => LocaleTextFunc) {}
 
@@ -72,7 +76,13 @@ class TextCellEditorInput<TValue = any> implements CellEditorInput<
         if (!_exists(value) && !_exists(params.value)) {
             return params.value;
         }
-        return params.parseValue(value!);
+        if (Object.is(this.cachedRaw, value)) {
+            return this.cachedParsed;
+        }
+        const parsed = params.parseValue(value!);
+        this.cachedRaw = value;
+        this.cachedParsed = parsed;
+        return parsed;
     }
 
     public getStartValue(): string | null | undefined {

--- a/packages/ag-grid-enterprise/src/formula/editor/formulaCellEditor.ts
+++ b/packages/ag-grid-enterprise/src/formula/editor/formulaCellEditor.ts
@@ -11,6 +11,10 @@ export class FormulaCellEditor<TData = any, TValue = any, TContext = any> extend
 > {
     protected eEditor: AgFormulaInputField = RefPlaceholder;
     private focusAfterAttached = false;
+    /** Last raw input passed to `params.parseValue`. Initialised to `this` as an "uncached" sentinel — a DOM raw value can never equal the editor instance, so the first cache check always misses. */
+    private cachedRaw: unknown = this;
+    /** Memoised parse result for `cachedRaw`. Returned by `getValue()` when the raw input is unchanged across repeated validation/sync passes within an edit session. */
+    private cachedParsed: any;
 
     constructor() {
         super({ tag: 'div', cls: 'ag-cell-edit-wrapper' });
@@ -125,7 +129,13 @@ export class FormulaCellEditor<TData = any, TValue = any, TContext = any> extend
             return value;
         }
 
-        return parseValue(String(rawValue));
+        if (Object.is(this.cachedRaw, rawValue)) {
+            return this.cachedParsed;
+        }
+        const parsed = parseValue(String(rawValue));
+        this.cachedRaw = rawValue;
+        this.cachedParsed = parsed;
+        return parsed;
     }
 
     public getValidationElement(): HTMLElement | HTMLInputElement {

--- a/packages/ag-grid-enterprise/src/richSelect/richSelectCellEditor.ts
+++ b/packages/ag-grid-enterprise/src/richSelect/richSelectCellEditor.ts
@@ -25,6 +25,10 @@ export class RichSelectCellEditor<TData = any, TValue = any, TContext = any> ext
     protected eEditor: AgRichSelect<TValue>;
     private pendingInitialEventKey: string | null = null;
     private initialEventKeyProcessed = false;
+    /** Last raw input passed to `params.parseValue`. Initialised to `this` as an "uncached" sentinel — a DOM raw value can never equal the editor instance, so the first cache check always misses. */
+    private cachedRaw: unknown = this;
+    /** Memoised parse result for `cachedRaw`. Returned by `getValue()` when the raw input is unchanged across repeated validation/sync passes within an edit session. */
+    private cachedParsed: any;
 
     constructor() {
         super({ tag: 'div', cls: 'ag-cell-edit-wrapper' });
@@ -417,10 +421,14 @@ export class RichSelectCellEditor<TData = any, TValue = any, TContext = any> ext
     }
 
     public getValue(): any {
-        const { params } = this;
         const value = this.eEditor.getValue();
-
-        return params.parseValue?.(value) ?? value;
+        if (Object.is(this.cachedRaw, value)) {
+            return this.cachedParsed;
+        }
+        const parsed = this.params.parseValue?.(value) ?? value;
+        this.cachedRaw = value;
+        this.cachedParsed = parsed;
+        return parsed;
     }
 
     public override isPopup(): boolean {

--- a/testing/behavioural/src/cell-editing/cell-editing-value-parser-cache.test.ts
+++ b/testing/behavioural/src/cell-editing/cell-editing-value-parser-cache.test.ts
@@ -1,0 +1,180 @@
+import { getByTestId } from '@testing-library/dom';
+import { userEvent } from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import type { ColDef, ValueParserParams } from 'ag-grid-community';
+import {
+    LargeTextEditorModule,
+    NumberEditorModule,
+    TextEditorModule,
+    agTestIdFor,
+    getGridElement,
+    setupAgTestIds,
+} from 'ag-grid-community';
+import { RichSelectModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout, waitForInput } from '../test-utils';
+
+/**
+ * AG-15846 regression: column `valueParser` should not be called repeatedly with the
+ * same raw input during a single edit session. The fix memoises `getValue()` per editor
+ * instance keyed on raw input — every code path (validation/sync/commit) that calls
+ * `getValue()` shares this cache.
+ *
+ * Invariant tested: across one edit session, `valueParser` never receives the same raw
+ * input twice. Each unique raw value parses at most once.
+ */
+describe('Cell Editing — valueParser cache (AG-15846)', () => {
+    const gridMgr = new TestGridsManager({
+        includeDefaultModules: true,
+        modules: [TextEditorModule, NumberEditorModule, LargeTextEditorModule, RichSelectModule],
+    });
+
+    beforeAll(() => setupAgTestIds());
+    afterEach(() => gridMgr.reset());
+
+    /**
+     * Verifies the parser was never invoked twice with the same raw `newValue`.
+     * Returns the list of raw inputs the parser saw in invocation order, for
+     * stronger per-test assertions.
+     */
+    function expectNoRepeatedRawInputs(parser: ReturnType<typeof vi.fn>): unknown[] {
+        const rawInputs = parser.mock.calls.map((c) => (c[0] as ValueParserParams).newValue);
+        const seen = new Set<unknown>();
+        for (const r of rawInputs) {
+            expect(seen.has(r)).toBe(false);
+            seen.add(r);
+        }
+        return rawInputs;
+    }
+
+    describe('parser is not called with duplicate raw inputs across one edit session', () => {
+        test.each([
+            { name: 'text', editor: 'agTextCellEditor', field: 'a', initial: 'hello', popup: false },
+            { name: 'largeText', editor: 'agLargeTextCellEditor', field: 'a', initial: 'hello', popup: true },
+            { name: 'number', editor: 'agNumberCellEditor', field: 'a', initial: 100, popup: false },
+        ])('$name editor — open + commit unchanged', async ({ editor, field, initial, popup }) => {
+            const valueParser = vi.fn((p: ValueParserParams) => p.newValue);
+
+            const columnDefs: ColDef[] = [{ field, cellEditor: editor, valueParser, editable: true }];
+            const api = await gridMgr.createGridAndWait('myGrid', { columnDefs, rowData: [{ [field]: initial }] });
+
+            const gridDiv = getGridElement(api)! as HTMLElement;
+            await asyncSetTimeout(1);
+
+            const cell = getByTestId(gridDiv, agTestIdFor.cell('0', field));
+            await userEvent.dblClick(cell);
+            await asyncSetTimeout(1);
+
+            await waitForInput(gridDiv, cell, { popup });
+
+            // Commit unchanged: opening + closing the editor should not cause repeated parser calls
+            // for the same raw input across the validation / sync / commit passes.
+            await userEvent.keyboard('{Enter}');
+            await asyncSetTimeout(1);
+
+            expectNoRepeatedRawInputs(valueParser);
+        });
+
+        test('text editor — open, type, commit', async () => {
+            const valueParser = vi.fn((p: ValueParserParams) => p.newValue);
+
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'a', cellEditor: 'agTextCellEditor', valueParser, editable: true }],
+                rowData: [{ a: 'old' }],
+            });
+
+            const gridDiv = getGridElement(api)! as HTMLElement;
+            await asyncSetTimeout(1);
+
+            const cell = getByTestId(gridDiv, agTestIdFor.cell('0', 'a'));
+            await userEvent.dblClick(cell);
+            await asyncSetTimeout(1);
+
+            const input = await waitForInput(gridDiv, cell);
+            await userEvent.clear(input);
+            await userEvent.keyboard('hi');
+            await asyncSetTimeout(1);
+
+            await userEvent.keyboard('{Enter}');
+            await asyncSetTimeout(1);
+
+            const rawInputs = expectNoRepeatedRawInputs(valueParser);
+
+            // The committed value should have been parsed exactly once.
+            expect(rawInputs).toContain('hi');
+            expect(rawInputs.filter((v) => v === 'hi')).toHaveLength(1);
+        });
+
+        test('number editor — bug report scenario (AG-15846)', async () => {
+            // Mirrors the user-reported reproduction: a column with a custom valueParser, click
+            // the cell, type "0", press Enter. Before the fix the parser ran ~15 times; the
+            // invariant we lock in is that no raw input is parsed twice within the session.
+            const valueParser = vi.fn((p: ValueParserParams) => Number(p.newValue));
+
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [{ field: 'numberGood', cellEditor: 'agNumberCellEditor', valueParser, editable: true }],
+                rowData: [{ numberGood: 1234 }],
+            });
+
+            const gridDiv = getGridElement(api)! as HTMLElement;
+            await asyncSetTimeout(1);
+
+            const cell = getByTestId(gridDiv, agTestIdFor.cell('0', 'numberGood'));
+            await userEvent.click(cell);
+            await userEvent.keyboard('{Enter}'); // start edit (Enter on a focused cell)
+            await asyncSetTimeout(1);
+
+            const input = await waitForInput(gridDiv, cell);
+            await userEvent.clear(input);
+            await userEvent.keyboard('0');
+            await asyncSetTimeout(1);
+
+            await userEvent.keyboard('{Enter}'); // commit
+            await asyncSetTimeout(1);
+
+            const rawInputs = expectNoRepeatedRawInputs(valueParser);
+            expect(rawInputs).toContain('0');
+            expect(rawInputs.filter((v) => v === '0')).toHaveLength(1);
+        });
+    });
+
+    describe('cache interacts correctly with validation rules', () => {
+        // When validation rules are present, both `editor.getValidationErrors()` and the sync
+        // path call `editor.getValue()`. The per-editor cache ensures `valueParser` runs at
+        // most once per unique raw input across both call sites.
+        test('text editor with maxLength validation', async () => {
+            const valueParser = vi.fn((p: ValueParserParams) => p.newValue);
+
+            const api = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs: [
+                    {
+                        field: 'a',
+                        cellEditor: 'agTextCellEditor',
+                        cellEditorParams: { maxLength: 100 },
+                        valueParser,
+                        editable: true,
+                    },
+                ],
+                rowData: [{ a: 'short' }],
+            });
+
+            const gridDiv = getGridElement(api)! as HTMLElement;
+            await asyncSetTimeout(1);
+
+            const cell = getByTestId(gridDiv, agTestIdFor.cell('0', 'a'));
+            await userEvent.dblClick(cell);
+            await asyncSetTimeout(1);
+
+            const input = await waitForInput(gridDiv, cell);
+            await userEvent.clear(input);
+            await userEvent.keyboard('typed');
+            await asyncSetTimeout(1);
+
+            await userEvent.keyboard('{Enter}');
+            await asyncSetTimeout(1);
+
+            expectNoRepeatedRawInputs(valueParser);
+        });
+    });
+});


### PR DESCRIPTION
This reduces duplicates calls to parse value in our internal editors by checking if the value parse changed since last time and caching it. This keep still the call at every keystroke, but becomes a single call instead of 3.

It is quite hard to try to reduce the calls further than this and we should not need it as it could cause behavioural changes.

FIX [AG-16267](https://ag-grid.atlassian.net/browse/AG-16267)