### PR TITLE
AG-17220 fix inner header component destroyed on every column def update

### DIFF
--- a/packages/ag-grid-community/src/headerRendering/cells/column/headerComp.ts
+++ b/packages/ag-grid-community/src/headerRendering/cells/column/headerComp.ts
@@ -1,5 +1,5 @@
 import { RefPlaceholder } from '../../../agStack/interfaces/agComponent';
-import { _removeFromParent, _setDisplayed } from '../../../agStack/utils/dom';
+import { _clearElement, _removeFromParent, _setDisplayed } from '../../../agStack/utils/dom';
 import { _toString } from '../../../agStack/utils/string';
 import { _getInnerHeaderCompDetails } from '../../../components/framework/userCompUtils';
 import type { AgColumn } from '../../../entities/agColumn';
@@ -86,6 +86,7 @@ export class HeaderComp extends Component implements IHeaderComp {
     private innerHeaderComponent: IInnerHeaderComponent | undefined;
     private currentInnerHeaderComponent: IHeaderParams['innerHeaderComponent'];
     private isLoadingInnerComponent: boolean = false;
+    private innerComponentGeneration: number = 0;
 
     private mouseListener?: HeaderCellMouseListenerFeature;
 
@@ -186,6 +187,7 @@ export class HeaderComp extends Component implements IHeaderComp {
         }
 
         this.isLoadingInnerComponent = true;
+        const generation = ++this.innerComponentGeneration;
 
         userCompDetails.newAgStackInstance().then((comp) => {
             this.isLoadingInnerComponent = false;
@@ -194,8 +196,9 @@ export class HeaderComp extends Component implements IHeaderComp {
                 return;
             }
 
-            if (this.isAlive()) {
+            if (this.isAlive() && generation === this.innerComponentGeneration) {
                 this.innerHeaderComponent = comp;
+                _clearElement(this.eText);
                 this.eText?.appendChild(comp.getGui());
             } else {
                 this.destroyBean(comp);

--- a/packages/ag-grid-community/src/headerRendering/cells/column/headerComp.ts
+++ b/packages/ag-grid-community/src/headerRendering/cells/column/headerComp.ts
@@ -2,7 +2,6 @@ import { RefPlaceholder } from '../../../agStack/interfaces/agComponent';
 import { _removeFromParent, _setDisplayed } from '../../../agStack/utils/dom';
 import { _toString } from '../../../agStack/utils/string';
 import { _getInnerHeaderCompDetails } from '../../../components/framework/userCompUtils';
-import type { UserComponentFactory } from '../../../components/framework/userComponentFactory';
 import type { AgColumn } from '../../../entities/agColumn';
 import { _isLegacyMenuEnabled } from '../../../gridOptionsUtils';
 import type { IHeaderComp, IHeaderParams, IInnerHeaderComponent } from '../../../interfaces/iHeader';
@@ -79,7 +78,9 @@ export class HeaderComp extends Component implements IHeaderComp {
     public params: IHeaderParams;
 
     private currentDisplayName: string;
-    private currentTemplate: ElementParams | string | null | undefined;
+    private currentTemplateCustom: string | undefined;
+    private currentFormulaActive: boolean;
+    private currentHasSortIndicator: boolean;
     private currentShowMenu: boolean;
     private currentSuppressMenuHide: boolean;
     private currentSort: boolean | undefined;
@@ -91,19 +92,29 @@ export class HeaderComp extends Component implements IHeaderComp {
     private mouseListener?: HeaderCellMouseListenerFeature;
 
     public refresh(params: IHeaderParams): boolean {
-        const oldParams = this.params;
+        const {
+            beans: { formula, sortSvc },
+            currentTemplateCustom,
+            currentFormulaActive,
+            currentShowMenu,
+            currentHasSortIndicator,
+            currentSort,
+            currentSuppressMenuHide,
+            params: oldParams,
+        } = this;
         this.params = params;
 
-        // if template changed, then recreate the whole comp, the code required to manage
-        // a changing template is to difficult for what it's worth.
+        // if template changed, then recreate the whole comp
         if (
-            this.workOutTemplate(params, !!this.beans?.sortSvc) != this.currentTemplate ||
-            this.workOutShowMenu() != this.currentShowMenu ||
-            params.enableSorting != this.currentSort ||
-            (params.column as AgColumn).formulaRef != this.currentRef ||
-            (this.currentSuppressMenuHide != null && this.shouldSuppressMenuHide() != this.currentSuppressMenuHide) ||
+            !!formula?.active !== currentFormulaActive ||
+            !!sortSvc !== currentHasSortIndicator ||
+            params.enableSorting != currentSort ||
             oldParams.enableFilterButton != params.enableFilterButton ||
-            oldParams.enableFilterIcon != params.enableFilterIcon
+            oldParams.enableFilterIcon != params.enableFilterIcon ||
+            (params.column as AgColumn).formulaRef != this.currentRef ||
+            (params.template?.trim?.() ?? params.template) !== currentTemplateCustom ||
+            this.workOutShowMenu() != currentShowMenu ||
+            (currentSuppressMenuHide != null && this.shouldSuppressMenuHide() != currentSuppressMenuHide)
         ) {
             return false;
         }
@@ -112,7 +123,9 @@ export class HeaderComp extends Component implements IHeaderComp {
             // Mimic the merging of params that happens during init of _getInnerHeaderCompDetails(userCompFactory, params, params);
             const mergedParams = { ...params };
             _mergeDeep(mergedParams, params.innerHeaderComponentParams);
-            this.innerHeaderComponent.refresh?.(mergedParams);
+            if (this.innerHeaderComponent.refresh?.(mergedParams) === false) {
+                this.replaceInnerHeaderComponent(params);
+            }
         } else {
             this.setDisplayName(params);
         }
@@ -133,10 +146,13 @@ export class HeaderComp extends Component implements IHeaderComp {
     public init(params: IHeaderParams): void {
         this.params = params;
 
-        const { sortSvc, touchSvc, rowNumbersSvc, userCompFactory } = this.beans;
+        const { sortSvc, touchSvc, rowNumbersSvc, formula } = this.beans;
         const sortComp = sortSvc?.getSortIndicatorSelector();
-        this.currentTemplate = this.workOutTemplate(params, !!sortComp);
-        this.setTemplate(this.currentTemplate, sortComp ? [sortComp] : undefined);
+        const template = this.workOutTemplate(params, !!sortComp);
+        this.currentTemplateCustom = params.template?.trim?.() ?? params.template;
+        this.currentFormulaActive = !!formula?.active;
+        this.currentHasSortIndicator = !!sortComp;
+        this.setTemplate(template, sortComp ? [sortComp] : undefined);
 
         if (this.eLabel) {
             this.mouseListener ??= this.createManagedBean(
@@ -152,11 +168,12 @@ export class HeaderComp extends Component implements IHeaderComp {
         rowNumbersSvc?.setupForHeader(this);
         this.setupFilterIcon();
         this.setupFilterButton();
-        this.workOutInnerHeaderComponent(userCompFactory, params);
+        this.workOutInnerHeaderComponent(params);
         this.setDisplayName(params);
     }
 
-    private workOutInnerHeaderComponent(userCompFactory: UserComponentFactory, params: IHeaderParams): void {
+    private workOutInnerHeaderComponent(params: IHeaderParams): void {
+        const userCompFactory = this.beans.userCompFactory;
         const userCompDetails = _getInnerHeaderCompDetails(userCompFactory, params, params);
 
         if (!userCompDetails) {
@@ -174,13 +191,18 @@ export class HeaderComp extends Component implements IHeaderComp {
 
             if (this.isAlive()) {
                 this.innerHeaderComponent = comp;
-                if (this.eText) {
-                    this.eText.appendChild(comp.getGui());
-                }
+                this.eText?.appendChild(comp.getGui());
             } else {
                 this.destroyBean(comp);
             }
         });
+    }
+
+    private replaceInnerHeaderComponent(params: IHeaderParams): void {
+        const oldGui = this.innerHeaderComponent!.getGui();
+        _removeFromParent(oldGui);
+        this.innerHeaderComponent = this.destroyBean(this.innerHeaderComponent);
+        this.workOutInnerHeaderComponent(params);
     }
 
     private setDisplayName(params: IHeaderParams) {

--- a/packages/ag-grid-community/src/headerRendering/cells/column/headerComp.ts
+++ b/packages/ag-grid-community/src/headerRendering/cells/column/headerComp.ts
@@ -78,12 +78,9 @@ export class HeaderComp extends Component implements IHeaderComp {
     public params: IHeaderParams;
 
     private currentDisplayName: string;
-    private currentTemplateCustom: string | undefined;
-    private currentFormulaActive: boolean;
-    private currentHasSortIndicator: boolean;
+    private currentFormulaActive: boolean | undefined;
     private currentShowMenu: boolean;
     private currentSuppressMenuHide: boolean;
-    private currentSort: boolean | undefined;
     private currentRef: string | null;
 
     private innerHeaderComponent: IInnerHeaderComponent | undefined;
@@ -93,40 +90,21 @@ export class HeaderComp extends Component implements IHeaderComp {
     private mouseListener?: HeaderCellMouseListenerFeature;
 
     public refresh(params: IHeaderParams): boolean {
-        const {
-            beans: { formula, sortSvc },
-            currentTemplateCustom,
-            currentFormulaActive,
-            currentShowMenu,
-            currentHasSortIndicator,
-            currentSort,
-            currentSuppressMenuHide,
-            params: oldParams,
-        } = this;
+        const oldParams = this.params;
         this.params = params;
 
         // if template changed, then recreate the whole comp
-        if (
-            !!formula?.active !== currentFormulaActive ||
-            !!sortSvc?.getSortIndicatorSelector() !== currentHasSortIndicator ||
-            params.enableSorting != currentSort ||
-            oldParams.enableFilterButton != params.enableFilterButton ||
-            oldParams.enableFilterIcon != params.enableFilterIcon ||
-            (params.column as AgColumn).formulaRef != this.currentRef ||
-            (params.template?.trim?.() ?? params.template) !== currentTemplateCustom ||
-            this.workOutShowMenu() != currentShowMenu ||
-            (currentSuppressMenuHide != null && this.shouldSuppressMenuHide() != currentSuppressMenuHide)
-        ) {
+        if (this.anythingChanged(oldParams, params)) {
             return false;
         }
 
-        if (this.innerHeaderComponent) {
+        if (this.innerHeaderComponent || params.innerHeaderComponent) {
             // Mimic the merging of params that happens during init of _getInnerHeaderCompDetails(userCompFactory, params, params);
             const mergedParams = { ...params };
             _mergeDeep(mergedParams, params.innerHeaderComponentParams);
             if (
                 params.innerHeaderComponent !== this.currentInnerHeaderComponent ||
-                !this.innerHeaderComponent.refresh?.(mergedParams)
+                !this.innerHeaderComponent?.refresh?.(mergedParams)
             ) {
                 this.replaceInnerHeaderComponent(params);
             }
@@ -137,14 +115,38 @@ export class HeaderComp extends Component implements IHeaderComp {
         return true;
     }
 
-    private workOutTemplate(params: IHeaderParams, isSorting: boolean): string | ElementParams {
-        const { formula } = this.beans;
+    private anythingChanged(oldParams: IHeaderParams, newParams: IHeaderParams): boolean {
+        const {
+            beans,
+            currentFormulaActive,
+            currentRef: currentFormulaRef,
+            currentShowMenu,
+            currentSuppressMenuHide,
+        } = this;
+
+        return (
+            oldParams.enableSorting != newParams.enableSorting ||
+            oldParams.enableFilterButton != newParams.enableFilterButton ||
+            oldParams.enableFilterIcon != newParams.enableFilterIcon ||
+            oldParams.template != newParams.template ||
+            currentFormulaActive !== beans.formula?.active ||
+            currentFormulaRef != (newParams.column as AgColumn).formulaRef ||
+            currentShowMenu != this.workOutShowMenu() ||
+            (currentSuppressMenuHide != null && this.shouldSuppressMenuHide() != currentSuppressMenuHide)
+        );
+    }
+
+    private workOutTemplate(
+        params: IHeaderParams,
+        isSorting: boolean,
+        isFormulaActive: boolean
+    ): string | ElementParams {
         const paramsTemplate = params.template;
         if (paramsTemplate) {
             // take account of any newlines & whitespace before/after the actual template
             return paramsTemplate?.trim ? paramsTemplate.trim() : paramsTemplate;
         }
-        return getHeaderCompElementParams(!!formula?.active, isSorting);
+        return getHeaderCompElementParams(isFormulaActive, isSorting);
     }
 
     public init(params: IHeaderParams): void {
@@ -152,10 +154,8 @@ export class HeaderComp extends Component implements IHeaderComp {
 
         const { sortSvc, touchSvc, rowNumbersSvc, formula } = this.beans;
         const sortComp = sortSvc?.getSortIndicatorSelector();
-        const template = this.workOutTemplate(params, !!sortComp);
-        this.currentTemplateCustom = params.template?.trim?.() ?? params.template;
-        this.currentFormulaActive = !!formula?.active;
-        this.currentHasSortIndicator = !!sortComp;
+        this.currentFormulaActive = formula?.active;
+        const template = this.workOutTemplate(params, !!sortComp, !!this.currentFormulaActive);
         this.setTemplate(template, sortComp ? [sortComp] : undefined);
 
         if (this.eLabel) {
@@ -204,9 +204,11 @@ export class HeaderComp extends Component implements IHeaderComp {
     }
 
     private replaceInnerHeaderComponent(params: IHeaderParams): void {
-        const oldGui = this.innerHeaderComponent!.getGui();
-        _removeFromParent(oldGui);
-        this.innerHeaderComponent = this.destroyBean(this.innerHeaderComponent);
+        const curr = this.innerHeaderComponent;
+        if (curr) {
+            _removeFromParent(curr.getGui());
+            this.destroyBean(curr);
+        }
         this.workOutInnerHeaderComponent(params);
         if (!this.currentInnerHeaderComponent && this.eText) {
             // innerHeaderComponent removed — restore plain text, bypassing the
@@ -309,7 +311,6 @@ export class HeaderComp extends Component implements IHeaderComp {
             return;
         }
         const { enableSorting, column } = this.params;
-        this.currentSort = enableSorting;
 
         // eSortIndicator will not be present when customers provided custom header
         // templates, in that case, we need to look for provided sort elements and
@@ -341,7 +342,7 @@ export class HeaderComp extends Component implements IHeaderComp {
         // we set up the indicator prior to the check for whether this column is sortable, as it allows the indicator to
         // set up the multi sort indicator which can appear irrelevant of whether this column can itself be sorted.
         // this can occur in the case of a non-sortable group display column.
-        if (!this.currentSort) {
+        if (!enableSorting) {
             return;
         }
 

--- a/packages/ag-grid-community/src/headerRendering/cells/column/headerComp.ts
+++ b/packages/ag-grid-community/src/headerRendering/cells/column/headerComp.ts
@@ -87,7 +87,7 @@ export class HeaderComp extends Component implements IHeaderComp {
     private currentRef: string | null;
 
     private innerHeaderComponent: IInnerHeaderComponent | undefined;
-    private currentInnerHeaderComponent: any;
+    private currentInnerHeaderComponent: IHeaderParams['innerHeaderComponent'];
     private isLoadingInnerComponent: boolean = false;
 
     private mouseListener?: HeaderCellMouseListenerFeature;
@@ -108,7 +108,7 @@ export class HeaderComp extends Component implements IHeaderComp {
         // if template changed, then recreate the whole comp
         if (
             !!formula?.active !== currentFormulaActive ||
-            !!sortSvc !== currentHasSortIndicator ||
+            !!sortSvc?.getSortIndicatorSelector() !== currentHasSortIndicator ||
             params.enableSorting != currentSort ||
             oldParams.enableFilterButton != params.enableFilterButton ||
             oldParams.enableFilterIcon != params.enableFilterIcon ||
@@ -208,6 +208,11 @@ export class HeaderComp extends Component implements IHeaderComp {
         _removeFromParent(oldGui);
         this.innerHeaderComponent = this.destroyBean(this.innerHeaderComponent);
         this.workOutInnerHeaderComponent(params);
+        if (!this.currentInnerHeaderComponent && this.eText) {
+            // innerHeaderComponent removed — restore plain text, bypassing the
+            // oldDisplayName === displayName early-exit in setDisplayName
+            this.eText.textContent = _toString(params.displayName);
+        }
     }
 
     private setDisplayName(params: IHeaderParams) {

--- a/packages/ag-grid-community/src/headerRendering/cells/column/headerComp.ts
+++ b/packages/ag-grid-community/src/headerRendering/cells/column/headerComp.ts
@@ -77,7 +77,7 @@ export class HeaderComp extends Component implements IHeaderComp {
 
     public params: IHeaderParams;
 
-    private currentDisplayName: string;
+    private currentDisplayName: string | undefined;
     private currentFormulaActive: boolean | undefined;
     private currentShowMenu: boolean;
     private currentSuppressMenuHide: boolean;
@@ -99,7 +99,7 @@ export class HeaderComp extends Component implements IHeaderComp {
             return false;
         }
 
-        if (this.innerHeaderComponent || params.innerHeaderComponent) {
+        if (this.innerHeaderComponent || params.innerHeaderComponent || this.isLoadingInnerComponent) {
             // Mimic the merging of params that happens during init of _getInnerHeaderCompDetails(userCompFactory, params, params);
             const mergedParams = { ...params };
             _mergeDeep(mergedParams, params.innerHeaderComponentParams);
@@ -179,15 +179,15 @@ export class HeaderComp extends Component implements IHeaderComp {
 
     private workOutInnerHeaderComponent(params: IHeaderParams): void {
         this.currentInnerHeaderComponent = params.innerHeaderComponent;
-        const userCompFactory = this.beans.userCompFactory;
-        const userCompDetails = _getInnerHeaderCompDetails(userCompFactory, params, params);
+        const generation = ++this.innerComponentGeneration;
+        const userCompDetails = _getInnerHeaderCompDetails(this.beans.userCompFactory, params, params);
 
         if (!userCompDetails) {
+            this.isLoadingInnerComponent = false;
             return;
         }
 
         this.isLoadingInnerComponent = true;
-        const generation = ++this.innerComponentGeneration;
 
         userCompDetails.newAgStackInstance().then((comp) => {
             this.isLoadingInnerComponent = false;
@@ -208,15 +208,17 @@ export class HeaderComp extends Component implements IHeaderComp {
 
     private replaceInnerHeaderComponent(params: IHeaderParams): void {
         const curr = this.innerHeaderComponent;
+        this.innerHeaderComponent = undefined;
         if (curr) {
             _removeFromParent(curr.getGui());
             this.destroyBean(curr);
         }
         this.workOutInnerHeaderComponent(params);
-        if (!this.currentInnerHeaderComponent && this.eText) {
+        if (!this.currentInnerHeaderComponent) {
             // innerHeaderComponent removed — restore plain text, bypassing the
             // oldDisplayName === displayName early-exit in setDisplayName
-            this.eText.textContent = _toString(params.displayName);
+            this.currentDisplayName = undefined;
+            this.setDisplayName(params);
         }
     }
 

--- a/packages/ag-grid-community/src/headerRendering/cells/column/headerComp.ts
+++ b/packages/ag-grid-community/src/headerRendering/cells/column/headerComp.ts
@@ -87,6 +87,7 @@ export class HeaderComp extends Component implements IHeaderComp {
     private currentRef: string | null;
 
     private innerHeaderComponent: IInnerHeaderComponent | undefined;
+    private currentInnerHeaderComponent: any;
     private isLoadingInnerComponent: boolean = false;
 
     private mouseListener?: HeaderCellMouseListenerFeature;
@@ -123,7 +124,10 @@ export class HeaderComp extends Component implements IHeaderComp {
             // Mimic the merging of params that happens during init of _getInnerHeaderCompDetails(userCompFactory, params, params);
             const mergedParams = { ...params };
             _mergeDeep(mergedParams, params.innerHeaderComponentParams);
-            if (this.innerHeaderComponent.refresh?.(mergedParams) === false) {
+            if (
+                params.innerHeaderComponent !== this.currentInnerHeaderComponent ||
+                !this.innerHeaderComponent.refresh?.(mergedParams)
+            ) {
                 this.replaceInnerHeaderComponent(params);
             }
         } else {
@@ -173,6 +177,7 @@ export class HeaderComp extends Component implements IHeaderComp {
     }
 
     private workOutInnerHeaderComponent(params: IHeaderParams): void {
+        this.currentInnerHeaderComponent = params.innerHeaderComponent;
         const userCompFactory = this.beans.userCompFactory;
         const userCompDetails = _getInnerHeaderCompDetails(userCompFactory, params, params);
 

--- a/packages/ag-grid-community/src/interfaces/iHeader.ts
+++ b/packages/ag-grid-community/src/interfaces/iHeader.ts
@@ -85,7 +85,16 @@ export interface IHeaderParams<TData = any, TContext = any> extends AgGridCommon
 }
 
 export interface IHeader {
-    /** Get the header to refresh. Gets called whenever Column Defs are updated. */
+    /**
+     * Called whenever Column Defs are updated. Return `true` to indicate the component handled
+     * the update in-place. Return `false` to signal that the component cannot handle the new
+     * params and must be recreated.
+     *
+     * The scope of recreation depends on where the component is used:
+     * - **`headerComponent`** — returning `false` destroys and recreates the entire header cell.
+     * - **`innerHeaderComponent`** — returning `false` destroys and recreates only the inner
+     *   component; the outer `HeaderComp` wrapper remains alive.
+     */
     refresh(params: IHeaderParams): boolean;
 }
 

--- a/packages/ag-grid-community/src/interfaces/iHeader.ts
+++ b/packages/ag-grid-community/src/interfaces/iHeader.ts
@@ -85,16 +85,7 @@ export interface IHeaderParams<TData = any, TContext = any> extends AgGridCommon
 }
 
 export interface IHeader {
-    /**
-     * Called whenever Column Defs are updated. Return `true` to indicate the component handled
-     * the update in-place. Return `false` to signal that the component cannot handle the new
-     * params and must be recreated.
-     *
-     * The scope of recreation depends on where the component is used:
-     * - **`headerComponent`** — returning `false` destroys and recreates the entire header cell.
-     * - **`innerHeaderComponent`** — returning `false` destroys and recreates only the inner
-     *   component; the outer `HeaderComp` wrapper remains alive.
-     */
+    /** Called whenever Column Defs are updated. Return `false` to signal the component cannot handle the new params and must be recreated. */
     refresh(params: IHeaderParams): boolean;
 }
 

--- a/testing/behavioural/src/columns/headers/columns-header-inner-react.test.tsx
+++ b/testing/behavioural/src/columns/headers/columns-header-inner-react.test.tsx
@@ -5,6 +5,8 @@ import type { ColDef, IHeaderParams } from 'ag-grid-community';
 import { AllCommunityModule } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
 
+// PortalManager batches React renders via setTimeout. Awaiting one event-loop turn
+// ensures all pending portal mounts/unmounts and downstream promise resolutions settle.
 const flushPortalUpdates = () =>
     act(async () => {
         await new Promise<void>((resolve) => setTimeout(resolve));
@@ -149,41 +151,49 @@ describe('React header component lifecycle', () => {
         RejectingInnerHeader.reset();
     });
 
-    it('headerComponent and innerHeaderComponent are both re-rendered rather than remounted when column defs are updated', async () => {
-        render(<GridApp defs={columnDefs} />);
+    it('stale in-flight innerHeaderComponent is destroyed if column defs update before the portal renders', async () => {
+        const { container } = render(<GridApp defs={columnDefs} />);
 
-        // PortalManager mounts via setTimeout batching, so wait for initial mount
+        // Click before the portal renders — the gen-1 creation is in-flight.
+        // Both portals end up rendering in the same batch, but the gen-1 instance must be
+        // destroyed so exactly one component remains alive.
+        fireEvent.click(screen.getByRole('button', { name: 'Update Cols' }));
+        await flushPortalUpdates();
+
+        expect(innerMountCount - innerUnmountCount).toBe(1);
+        expect(container.querySelector('.custom-inner-header')?.textContent).toBe('inner');
+    });
+
+    it('headerComponent and innerHeaderComponent are both re-rendered rather than remounted when column defs are updated', async () => {
+        const { container } = render(<GridApp defs={columnDefs} />);
+
         await waitFor(() => {
             expect(headerMountCount).toBe(1);
             expect(innerMountCount).toBe(1);
         });
         expect(headerUnmountCount).toBe(0);
         expect(innerUnmountCount).toBe(0);
+        expect(container.querySelector('.custom-inner-header')?.textContent).toBe('inner');
 
         fireEvent.click(screen.getByRole('button', { name: 'Update Cols' }));
-
-        // Flush any pending portal updates — PortalManager batches via setTimeout, so a
-        // resolved setTimeout scheduled after the click will run after those callbacks.
         await flushPortalUpdates();
 
         expect(headerMountCount).toBe(1);
         expect(headerUnmountCount).toBe(0);
         expect(innerMountCount).toBe(1);
         expect(innerUnmountCount).toBe(0);
+        expect(container.querySelector('.custom-inner-header')?.textContent).toBe('inner');
     });
 
     it('innerHeaderComponent is remounted when its refresh returns false, outer headerComp stays alive', async () => {
         render(<GridApp defs={rejectingColumnDefs} />);
 
-        // Wait for the React headerComponent portal to mount
         await waitFor(() => expect(headerMountCount).toBe(1));
         expect(RejectingInnerHeader.initCount).toBe(1);
         expect(RejectingInnerHeader.destroyCount).toBe(0);
 
         fireEvent.click(screen.getByRole('button', { name: 'Update Cols' }));
-
-        // RejectingInnerHeader lifecycle is synchronous (vanilla JS, no portal), so counts
-        // are available immediately. Flush setTimeout for the portal-based CustomHeader.
+        // RejectingInnerHeader is vanilla JS (synchronous), but CustomHeader uses a portal.
         await flushPortalUpdates();
 
         // Inner component signalled it cannot handle the update — it should be replaced
@@ -204,10 +214,12 @@ describe('React header component lifecycle', () => {
             { field: 'b', sortable: false, headerComponentParams: { innerHeaderComponent: CustomInnerHeader2 } },
         ];
 
-        render(<SwitchingGridApp defs1={defs1} defs2={defs2} />);
+        const { container } = render(<SwitchingGridApp defs1={defs1} defs2={defs2} />);
 
         await waitFor(() => expect(innerMountCount).toBe(1));
         expect(innerMountCount2).toBe(0);
+        expect(container.querySelector('.custom-inner-header')?.textContent).toBe('inner');
+        expect(container.querySelector('.custom-inner-header-2')).toBeNull();
 
         fireEvent.click(screen.getByRole('button', { name: 'Switch Cols' }));
 
@@ -217,6 +229,8 @@ describe('React header component lifecycle', () => {
         expect(innerUnmountCount).toBe(1);
         expect(innerMountCount2).toBe(1);
         expect(innerUnmountCount2).toBe(0);
+        expect(container.querySelector('.custom-inner-header')).toBeNull();
+        expect(container.querySelector('.custom-inner-header-2')).not.toBeNull();
     });
 
     it('innerHeaderComponent re-renders with updated props when column def changes', async () => {
@@ -237,15 +251,17 @@ describe('React header component lifecycle', () => {
             },
         ];
 
-        render(<SwitchingGridApp defs1={defs1} defs2={defs2} />);
+        const { container } = render(<SwitchingGridApp defs1={defs1} defs2={defs2} />);
 
         await waitFor(() => expect(lastInnerDisplayName).toBe('Before'));
+        expect(container.querySelector('.props-capturing')?.textContent).toBe('Before');
 
         fireEvent.click(screen.getByRole('button', { name: 'Switch Cols' }));
 
         await flushPortalUpdates();
 
         expect(lastInnerDisplayName).toBe('After');
+        expect(container.querySelector('.props-capturing')?.textContent).toBe('After');
     });
 
     it('innerHeaderComponent re-renders with updated innerHeaderComponentParams', async () => {
@@ -270,15 +286,17 @@ describe('React header component lifecycle', () => {
             },
         ];
 
-        render(<SwitchingGridApp defs1={defs1} defs2={defs2} />);
+        const { container } = render(<SwitchingGridApp defs1={defs1} defs2={defs2} />);
 
         await waitFor(() => expect(lastCustomLabel).toBe('Before'));
+        expect(container.querySelector('.custom-label')?.textContent).toBe('Before');
 
         fireEvent.click(screen.getByRole('button', { name: 'Switch Cols' }));
 
         await flushPortalUpdates();
 
         expect(lastCustomLabel).toBe('After');
+        expect(container.querySelector('.custom-label')?.textContent).toBe('After');
     });
 
     it('removing innerHeaderComponent restores display name text in the header cell', async () => {
@@ -295,12 +313,14 @@ describe('React header component lifecycle', () => {
         const { container } = render(<SwitchingGridApp defs1={defs1} defs2={defs2} />);
 
         await waitFor(() => expect(innerMountCount).toBe(1));
+        expect(container.querySelector('.custom-inner-header')?.textContent).toBe('inner');
 
         fireEvent.click(screen.getByRole('button', { name: 'Switch Cols' }));
 
         await flushPortalUpdates();
 
         expect(innerUnmountCount).toBe(1);
+        expect(container.querySelector('.custom-inner-header')).toBeNull();
         expect(container.querySelector('.ag-header-cell-text')?.textContent).toBe('My Header');
     });
 });

--- a/testing/behavioural/src/columns/headers/columns-header-inner-react.test.tsx
+++ b/testing/behavioural/src/columns/headers/columns-header-inner-react.test.tsx
@@ -9,6 +9,10 @@ let headerMountCount = 0;
 let headerUnmountCount = 0;
 let innerMountCount = 0;
 let innerUnmountCount = 0;
+let innerMountCount2 = 0;
+let innerUnmountCount2 = 0;
+let lastInnerDisplayName: string | undefined;
+let lastCustomLabel: string | undefined;
 
 const CustomHeader = () => {
     useEffect(() => {
@@ -28,6 +32,36 @@ const CustomInnerHeader = () => {
         };
     }, []);
     return <span className="custom-inner-header">inner</span>;
+};
+
+const CustomLabelInnerHeader = (params: IHeaderParams & { customLabel: string }) => {
+    lastCustomLabel = params.customLabel;
+    return <span className="custom-label">{params.customLabel}</span>;
+};
+
+const PropsCapturingInnerHeader = ({ displayName }: IHeaderParams) => {
+    lastInnerDisplayName = displayName;
+    return <span className="props-capturing">{displayName}</span>;
+};
+
+const CustomInnerHeader2 = ({ displayName }: IHeaderParams) => {
+    const [count, setCount] = React.useState(0);
+
+    useEffect(() => {
+        innerMountCount2++;
+        const interval = setInterval(() => setCount((prev) => prev + 1), 1000);
+        return () => {
+            innerUnmountCount2++;
+            clearInterval(interval);
+        };
+    }, []);
+
+    return (
+        <div className="custom-inner-header-2">
+            <span>{displayName}</span>
+            <span>{count}</span>
+        </div>
+    );
 };
 
 // Vanilla JS inner header component that signals it cannot handle a refresh.
@@ -86,6 +120,16 @@ const GridApp = ({ defs }: { defs: ColDef[] }) => {
     );
 };
 
+const SwitchingGridApp = ({ defs1, defs2 }: { defs1: ColDef[]; defs2: ColDef[] }) => {
+    const [cols, setCols] = useState<ColDef[]>(defs1);
+    return (
+        <>
+            <button onClick={() => setCols(defs2)}>Switch Cols</button>
+            <AgGridReact rowData={rowData} columnDefs={cols} modules={[AllCommunityModule]} />
+        </>
+    );
+};
+
 describe('React header component lifecycle', () => {
     beforeEach(() => {
         cleanup();
@@ -93,6 +137,10 @@ describe('React header component lifecycle', () => {
         headerUnmountCount = 0;
         innerMountCount = 0;
         innerUnmountCount = 0;
+        innerMountCount2 = 0;
+        innerUnmountCount2 = 0;
+        lastInnerDisplayName = undefined;
+        lastCustomLabel = undefined;
         RejectingInnerHeader.reset();
     });
 
@@ -145,5 +193,96 @@ describe('React header component lifecycle', () => {
         // Outer headerComp (CustomHeader on the adjacent column) must not have been remounted
         expect(headerMountCount).toBe(1);
         expect(headerUnmountCount).toBe(0);
+    });
+
+    it('innerHeaderComponent is replaced when the configured component class changes', async () => {
+        const defs1: ColDef[] = [
+            { field: 'b', sortable: false, headerComponentParams: { innerHeaderComponent: CustomInnerHeader } },
+        ];
+        const defs2: ColDef[] = [
+            { field: 'b', sortable: false, headerComponentParams: { innerHeaderComponent: CustomInnerHeader2 } },
+        ];
+
+        render(<SwitchingGridApp defs1={defs1} defs2={defs2} />);
+
+        await waitFor(() => expect(innerMountCount).toBe(1));
+        expect(innerMountCount2).toBe(0);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Switch Cols' }));
+
+        await act(async () => {
+            await new Promise<void>((resolve) => setTimeout(resolve));
+        });
+
+        // Old component should be unmounted and the new component mounted in its place
+        expect(innerUnmountCount).toBe(1);
+        expect(innerMountCount2).toBe(1);
+        expect(innerUnmountCount2).toBe(0);
+    });
+
+    it('innerHeaderComponent re-renders with updated props when column def changes', async () => {
+        const defs1: ColDef[] = [
+            {
+                field: 'b',
+                headerName: 'Before',
+                sortable: false,
+                headerComponentParams: { innerHeaderComponent: PropsCapturingInnerHeader },
+            },
+        ];
+        const defs2: ColDef[] = [
+            {
+                field: 'b',
+                headerName: 'After',
+                sortable: false,
+                headerComponentParams: { innerHeaderComponent: PropsCapturingInnerHeader },
+            },
+        ];
+
+        render(<SwitchingGridApp defs1={defs1} defs2={defs2} />);
+
+        await waitFor(() => expect(lastInnerDisplayName).toBe('Before'));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Switch Cols' }));
+
+        await act(async () => {
+            await new Promise<void>((resolve) => setTimeout(resolve));
+        });
+
+        expect(lastInnerDisplayName).toBe('After');
+    });
+
+    it('innerHeaderComponent re-renders with updated innerHeaderComponentParams', async () => {
+        const defs1: ColDef[] = [
+            {
+                field: 'b',
+                sortable: false,
+                headerComponentParams: {
+                    innerHeaderComponent: CustomLabelInnerHeader,
+                    innerHeaderComponentParams: { customLabel: 'Before' },
+                },
+            },
+        ];
+        const defs2: ColDef[] = [
+            {
+                field: 'b',
+                sortable: false,
+                headerComponentParams: {
+                    innerHeaderComponent: CustomLabelInnerHeader,
+                    innerHeaderComponentParams: { customLabel: 'After' },
+                },
+            },
+        ];
+
+        render(<SwitchingGridApp defs1={defs1} defs2={defs2} />);
+
+        await waitFor(() => expect(lastCustomLabel).toBe('Before'));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Switch Cols' }));
+
+        await act(async () => {
+            await new Promise<void>((resolve) => setTimeout(resolve));
+        });
+
+        expect(lastCustomLabel).toBe('After');
     });
 });

--- a/testing/behavioural/src/columns/headers/columns-header-inner-react.test.tsx
+++ b/testing/behavioural/src/columns/headers/columns-header-inner-react.test.tsx
@@ -5,6 +5,11 @@ import type { ColDef, IHeaderParams } from 'ag-grid-community';
 import { AllCommunityModule } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
 
+const flushPortalUpdates = () =>
+    act(async () => {
+        await new Promise<void>((resolve) => setTimeout(resolve));
+    });
+
 let headerMountCount = 0;
 let headerUnmountCount = 0;
 let innerMountCount = 0;
@@ -159,9 +164,7 @@ describe('React header component lifecycle', () => {
 
         // Flush any pending portal updates — PortalManager batches via setTimeout, so a
         // resolved setTimeout scheduled after the click will run after those callbacks.
-        await act(async () => {
-            await new Promise<void>((resolve) => setTimeout(resolve));
-        });
+        await flushPortalUpdates();
 
         expect(headerMountCount).toBe(1);
         expect(headerUnmountCount).toBe(0);
@@ -181,9 +184,7 @@ describe('React header component lifecycle', () => {
 
         // RejectingInnerHeader lifecycle is synchronous (vanilla JS, no portal), so counts
         // are available immediately. Flush setTimeout for the portal-based CustomHeader.
-        await act(async () => {
-            await new Promise<void>((resolve) => setTimeout(resolve));
-        });
+        await flushPortalUpdates();
 
         // Inner component signalled it cannot handle the update — it should be replaced
         expect(RejectingInnerHeader.refreshCount).toBe(1);
@@ -210,9 +211,7 @@ describe('React header component lifecycle', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'Switch Cols' }));
 
-        await act(async () => {
-            await new Promise<void>((resolve) => setTimeout(resolve));
-        });
+        await flushPortalUpdates();
 
         // Old component should be unmounted and the new component mounted in its place
         expect(innerUnmountCount).toBe(1);
@@ -244,9 +243,7 @@ describe('React header component lifecycle', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'Switch Cols' }));
 
-        await act(async () => {
-            await new Promise<void>((resolve) => setTimeout(resolve));
-        });
+        await flushPortalUpdates();
 
         expect(lastInnerDisplayName).toBe('After');
     });
@@ -279,10 +276,31 @@ describe('React header component lifecycle', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'Switch Cols' }));
 
-        await act(async () => {
-            await new Promise<void>((resolve) => setTimeout(resolve));
-        });
+        await flushPortalUpdates();
 
         expect(lastCustomLabel).toBe('After');
+    });
+
+    it('removing innerHeaderComponent restores display name text in the header cell', async () => {
+        const defs1: ColDef[] = [
+            {
+                field: 'b',
+                headerName: 'My Header',
+                sortable: false,
+                headerComponentParams: { innerHeaderComponent: CustomInnerHeader },
+            },
+        ];
+        const defs2: ColDef[] = [{ field: 'b', headerName: 'My Header', sortable: false }];
+
+        const { container } = render(<SwitchingGridApp defs1={defs1} defs2={defs2} />);
+
+        await waitFor(() => expect(innerMountCount).toBe(1));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Switch Cols' }));
+
+        await flushPortalUpdates();
+
+        expect(innerUnmountCount).toBe(1);
+        expect(container.querySelector('.ag-header-cell-text')?.textContent).toBe('My Header');
     });
 });

--- a/testing/behavioural/src/columns/headers/columns-header-inner.test.ts
+++ b/testing/behavioural/src/columns/headers/columns-header-inner.test.ts
@@ -30,11 +30,12 @@ function makeTrackedInnerHeader(refreshBehaviour?: 'accept' | 'reject' | 'none')
             TrackedComp.refreshCount = 0;
         }
 
-        protected gui = document.createElement('span');
+        private gui = document.createElement('span');
 
         init(_params: IHeaderParams): void {
             TrackedComp.initCount++;
             this.gui = document.createElement('span');
+            this.gui.textContent = 'Inner';
         }
 
         getGui(): HTMLElement {
@@ -46,20 +47,18 @@ function makeTrackedInnerHeader(refreshBehaviour?: 'accept' | 'reject' | 'none')
         }
     }
 
-    if (refreshBehaviour === 'accept') {
-        (TrackedComp.prototype as any).refresh = function (_params: IHeaderParams): boolean {
-            TrackedComp.refreshCount++;
-            return true;
-        };
-    } else if (refreshBehaviour === 'reject') {
-        (TrackedComp.prototype as any).refresh = function (_params: IHeaderParams): boolean {
-            TrackedComp.refreshCount++;
-            return false;
-        };
+    if (refreshBehaviour === 'none') {
+        return TrackedComp as unknown as TrackedClass;
     }
-    // 'none': no refresh method at all
 
-    return TrackedComp as unknown as TrackedClass;
+    const returns = refreshBehaviour === 'accept';
+    class WithRefresh extends TrackedComp {
+        refresh(_params: IHeaderParams): boolean {
+            TrackedComp.refreshCount++;
+            return returns;
+        }
+    }
+    return WithRefresh as unknown as TrackedClass;
 }
 
 const TrackingHeaderComp = makeTrackedInnerHeader('accept');
@@ -78,6 +77,8 @@ const rejectingColumnDefs: ColDef[] = [
     { field: 'b', sortable: false, headerComponentParams: { innerHeaderComponent: RejectingInnerHeader } },
 ];
 
+const headerText = (el: HTMLElement) => el.querySelector('.ag-header-cell-text')?.textContent;
+
 describe('header component lifecycle', () => {
     beforeEach(() => {
         TrackingHeaderComp.reset();
@@ -95,6 +96,7 @@ describe('header component lifecycle', () => {
         expect(TrackingHeaderComp.destroyCount).toBe(0);
         expect(TrackingInnerHeader.initCount).toBe(1);
         expect(TrackingInnerHeader.destroyCount).toBe(0);
+        expect(headerText(eGridDiv)).toBe('Inner');
 
         // Simulates a React setColumnDefs call with equivalent definitions.
         // Before the fix, HeaderComp.refresh() always returned false due to a broken
@@ -107,6 +109,7 @@ describe('header component lifecycle', () => {
         expect(TrackingInnerHeader.initCount).toBe(1);
         expect(TrackingInnerHeader.destroyCount).toBe(0);
         expect(TrackingInnerHeader.refreshCount).toBe(1);
+        expect(headerText(eGridDiv)).toBe('Inner');
 
         api.destroy();
     });
@@ -122,6 +125,7 @@ describe('header component lifecycle', () => {
         expect(TrackingHeaderComp.initCount).toBe(1);
         expect(RejectingInnerHeader.initCount).toBe(1);
         expect(RejectingInnerHeader.destroyCount).toBe(0);
+        expect(headerText(eGridDiv)).toBe('Inner');
 
         api.setGridOption('columnDefs', [...rejectingColumnDefs]);
 
@@ -133,6 +137,7 @@ describe('header component lifecycle', () => {
         // Outer headerComp on the adjacent column must not have been remounted
         expect(TrackingHeaderComp.initCount).toBe(1);
         expect(TrackingHeaderComp.destroyCount).toBe(0);
+        expect(headerText(eGridDiv)).toBe('Inner');
 
         api.destroy();
     });
@@ -156,6 +161,7 @@ describe('header component lifecycle', () => {
 
         expect(TrackingInnerHeader.initCount).toBe(1);
         expect(AlternativeInnerHeader.initCount).toBe(0);
+        expect(headerText(eGridDiv)).toBe('Inner');
 
         api.setGridOption('columnDefs', [
             { field: 'b', sortable: false, headerComponentParams: { innerHeaderComponent: AlternativeInnerHeader } },
@@ -164,6 +170,7 @@ describe('header component lifecycle', () => {
         // Old component should be destroyed and the new class initialised in its place
         expect(TrackingInnerHeader.destroyCount).toBe(1);
         expect(AlternativeInnerHeader.initCount).toBe(1);
+        expect(headerText(eGridDiv)).toBe('Inner');
 
         api.destroy();
     });
@@ -187,11 +194,12 @@ describe('header component lifecycle', () => {
         );
 
         expect(TrackingInnerHeader.initCount).toBe(1);
+        expect(headerText(eGridDiv)).toBe('Inner');
 
         api.setGridOption('columnDefs', [{ field: 'b', headerName: 'My Header', sortable: false }]);
 
         expect(TrackingInnerHeader.destroyCount).toBe(1);
-        expect(eGridDiv.querySelector('.ag-header-cell-text')?.textContent).toBe('My Header');
+        expect(headerText(eGridDiv)).toBe('My Header');
 
         api.destroy();
     });
@@ -206,13 +214,13 @@ describe('header component lifecycle', () => {
                         field: 'b',
                         headerName: 'My Header',
                         sortable: false,
-                        // headerComponentParams: { innerHeaderComponent: TrackingInnerHeader },
                     },
                 ],
                 rowData,
             },
             { modules: [ClientSideRowModelModule] }
         );
+        expect(headerText(eGridDiv)).toBe('My Header');
 
         api.setGridOption('columnDefs', [
             {
@@ -225,7 +233,7 @@ describe('header component lifecycle', () => {
 
         expect(TrackingInnerHeader.initCount).toBe(1);
         expect(TrackingInnerHeader.destroyCount).toBe(0);
-        expect(eGridDiv.querySelector('.ag-header-cell-text')?.textContent).toBe('My Header');
+        expect(headerText(eGridDiv)).toBe('Inner');
 
         api.destroy();
     });
@@ -242,11 +250,13 @@ describe('header component lifecycle', () => {
         );
 
         expect(NoRefreshInnerHeader.initCount).toBe(1);
+        expect(headerText(eGridDiv)).toBe('Inner');
 
         api.setGridOption('columnDefs', [...noRefreshDefs]);
 
         expect(NoRefreshInnerHeader.destroyCount).toBe(1);
         expect(NoRefreshInnerHeader.initCount).toBe(2);
+        expect(headerText(eGridDiv)).toBe('Inner');
 
         api.destroy();
     });
@@ -256,9 +266,12 @@ describe('header component lifecycle', () => {
 
         class CapturingRefreshInner {
             private readonly gui = document.createElement('span');
-            init(_params: IHeaderParams): void {}
+            init(params: IHeaderParams): void {
+                this.gui.textContent = params.displayName;
+            }
             refresh(params: IHeaderParams): boolean {
                 refreshedDisplayName = params.displayName;
+                this.gui.textContent = params.displayName;
                 return true;
             }
             getGui(): HTMLElement {
@@ -283,6 +296,8 @@ describe('header component lifecycle', () => {
             { modules: [ClientSideRowModelModule] }
         );
 
+        expect(headerText(eGridDiv)).toBe('Before');
+
         api.setGridOption('columnDefs', [
             {
                 field: 'b',
@@ -293,6 +308,7 @@ describe('header component lifecycle', () => {
         ]);
 
         expect(refreshedDisplayName).toBe('After');
+        expect(headerText(eGridDiv)).toBe('After');
 
         api.destroy();
     });
@@ -304,6 +320,7 @@ describe('header component lifecycle', () => {
             private readonly gui = document.createElement('span');
             init(params: IHeaderParams): void {
                 lastInitDisplayName = params.displayName;
+                this.gui.textContent = params.displayName;
             }
             getGui(): HTMLElement {
                 return this.gui;
@@ -328,6 +345,7 @@ describe('header component lifecycle', () => {
         );
 
         expect(lastInitDisplayName).toBe('Before');
+        expect(headerText(eGridDiv)).toBe('Before');
 
         api.setGridOption('columnDefs', [
             {
@@ -339,6 +357,7 @@ describe('header component lifecycle', () => {
         ]);
 
         expect(lastInitDisplayName).toBe('After');
+        expect(headerText(eGridDiv)).toBe('After');
 
         api.destroy();
     });
@@ -351,6 +370,7 @@ describe('header component lifecycle', () => {
             init(params: IHeaderParams): void {
                 lastInitDisplayName = params.displayName;
                 this.gui = document.createElement('span');
+                this.gui.textContent = params.displayName;
             }
             refresh(_params: IHeaderParams): boolean {
                 return false;
@@ -378,6 +398,7 @@ describe('header component lifecycle', () => {
         );
 
         expect(lastInitDisplayName).toBe('Before');
+        expect(headerText(eGridDiv)).toBe('Before');
 
         api.setGridOption('columnDefs', [
             {
@@ -389,6 +410,7 @@ describe('header component lifecycle', () => {
         ]);
 
         expect(lastInitDisplayName).toBe('After');
+        expect(headerText(eGridDiv)).toBe('After');
 
         api.destroy();
     });
@@ -398,9 +420,12 @@ describe('header component lifecycle', () => {
 
         class CapturingRefreshInnerWithLabel {
             private readonly gui = document.createElement('span');
-            init(_params: IHeaderParams): void {}
+            init(params: IHeaderParams): void {
+                this.gui.textContent = (params as any).customLabel;
+            }
             refresh(params: IHeaderParams): boolean {
                 refreshedLabel = (params as any).customLabel;
+                this.gui.textContent = (params as any).customLabel;
                 return true;
             }
             getGui(): HTMLElement {
@@ -427,6 +452,8 @@ describe('header component lifecycle', () => {
             { modules: [ClientSideRowModelModule] }
         );
 
+        expect(headerText(eGridDiv)).toBe('Before');
+
         api.setGridOption('columnDefs', [
             {
                 field: 'b',
@@ -439,6 +466,7 @@ describe('header component lifecycle', () => {
         ]);
 
         expect(refreshedLabel).toBe('After');
+        expect(headerText(eGridDiv)).toBe('After');
 
         api.destroy();
     });
@@ -450,6 +478,7 @@ describe('header component lifecycle', () => {
             private readonly gui = document.createElement('span');
             init(params: IHeaderParams): void {
                 lastInitLabel = (params as any).customLabel;
+                this.gui.textContent = (params as any).customLabel;
             }
             getGui(): HTMLElement {
                 return this.gui;
@@ -476,6 +505,7 @@ describe('header component lifecycle', () => {
         );
 
         expect(lastInitLabel).toBe('Before');
+        expect(headerText(eGridDiv)).toBe('Before');
 
         api.setGridOption('columnDefs', [
             {
@@ -489,6 +519,7 @@ describe('header component lifecycle', () => {
         ]);
 
         expect(lastInitLabel).toBe('After');
+        expect(headerText(eGridDiv)).toBe('After');
 
         api.destroy();
     });
@@ -501,6 +532,7 @@ describe('header component lifecycle', () => {
             init(params: IHeaderParams): void {
                 lastInitLabel = (params as any).customLabel;
                 this.gui = document.createElement('span');
+                this.gui.textContent = (params as any).customLabel;
             }
             refresh(_params: IHeaderParams): boolean {
                 return false;
@@ -530,6 +562,7 @@ describe('header component lifecycle', () => {
         );
 
         expect(lastInitLabel).toBe('Before');
+        expect(headerText(eGridDiv)).toBe('Before');
 
         api.setGridOption('columnDefs', [
             {
@@ -543,6 +576,7 @@ describe('header component lifecycle', () => {
         ]);
 
         expect(lastInitLabel).toBe('After');
+        expect(headerText(eGridDiv)).toBe('After');
 
         api.destroy();
     });

--- a/testing/behavioural/src/columns/headers/columns-header-inner.test.ts
+++ b/testing/behavioural/src/columns/headers/columns-header-inner.test.ts
@@ -65,6 +65,58 @@ class TrackingInnerHeader {
     }
 }
 
+class AlternativeInnerHeader {
+    static initCount = 0;
+    static destroyCount = 0;
+
+    static reset(): void {
+        AlternativeInnerHeader.initCount = 0;
+        AlternativeInnerHeader.destroyCount = 0;
+    }
+
+    private readonly gui = document.createElement('span');
+
+    init(_params: IHeaderParams): void {
+        AlternativeInnerHeader.initCount++;
+    }
+
+    refresh(_params: IHeaderParams): boolean {
+        return true;
+    }
+
+    getGui(): HTMLElement {
+        return this.gui;
+    }
+
+    destroy(): void {
+        AlternativeInnerHeader.destroyCount++;
+    }
+}
+
+class NoRefreshInnerHeader {
+    static initCount = 0;
+    static destroyCount = 0;
+
+    static reset(): void {
+        NoRefreshInnerHeader.initCount = 0;
+        NoRefreshInnerHeader.destroyCount = 0;
+    }
+
+    private readonly gui = document.createElement('span');
+
+    init(_params: IHeaderParams): void {
+        NoRefreshInnerHeader.initCount++;
+    }
+
+    getGui(): HTMLElement {
+        return this.gui;
+    }
+
+    destroy(): void {
+        NoRefreshInnerHeader.destroyCount++;
+    }
+}
+
 class RejectingInnerHeader {
     static initCount = 0;
     static destroyCount = 0;
@@ -111,6 +163,8 @@ describe('header component lifecycle', () => {
     beforeEach(() => {
         TrackingHeaderComp.reset();
         TrackingInnerHeader.reset();
+        AlternativeInnerHeader.reset();
+        NoRefreshInnerHeader.reset();
         RejectingInnerHeader.reset();
     });
 
@@ -160,6 +214,354 @@ describe('header component lifecycle', () => {
         // Outer headerComp on the adjacent column must not have been remounted
         expect(TrackingHeaderComp.initCount).toBe(1);
         expect(TrackingHeaderComp.destroyCount).toBe(0);
+
+        api.destroy();
+    });
+
+    test('innerHeaderComponent is replaced when the configured component class changes', () => {
+        const eGridDiv = document.createElement('div');
+        const api = createGrid(
+            eGridDiv,
+            {
+                columnDefs: [
+                    {
+                        field: 'b',
+                        sortable: false,
+                        headerComponentParams: { innerHeaderComponent: TrackingInnerHeader },
+                    },
+                ],
+                rowData,
+            },
+            { modules: [ClientSideRowModelModule] }
+        );
+
+        expect(TrackingInnerHeader.initCount).toBe(1);
+        expect(AlternativeInnerHeader.initCount).toBe(0);
+
+        api.setGridOption('columnDefs', [
+            { field: 'b', sortable: false, headerComponentParams: { innerHeaderComponent: AlternativeInnerHeader } },
+        ]);
+
+        // Old component should be destroyed and the new class initialised in its place
+        expect(TrackingInnerHeader.destroyCount).toBe(1);
+        expect(AlternativeInnerHeader.initCount).toBe(1);
+
+        api.destroy();
+    });
+
+    test('innerHeaderComponent without refresh is recreated on column def update, consistent with cell renderer behaviour', () => {
+        const eGridDiv = document.createElement('div');
+        const noRefreshDefs: ColDef[] = [
+            { field: 'b', sortable: false, headerComponentParams: { innerHeaderComponent: NoRefreshInnerHeader } },
+        ];
+        const api = createGrid(
+            eGridDiv,
+            { columnDefs: noRefreshDefs, rowData },
+            { modules: [ClientSideRowModelModule] }
+        );
+
+        expect(NoRefreshInnerHeader.initCount).toBe(1);
+
+        api.setGridOption('columnDefs', [...noRefreshDefs]);
+
+        expect(NoRefreshInnerHeader.destroyCount).toBe(1);
+        expect(NoRefreshInnerHeader.initCount).toBe(2);
+
+        api.destroy();
+    });
+
+    test('innerHeaderComponent.refresh() receives updated params when column def changes', () => {
+        let refreshedDisplayName: string | undefined;
+
+        class CapturingRefreshInner {
+            private readonly gui = document.createElement('span');
+            init(_params: IHeaderParams): void {}
+            refresh(params: IHeaderParams): boolean {
+                refreshedDisplayName = params.displayName;
+                return true;
+            }
+            getGui(): HTMLElement {
+                return this.gui;
+            }
+        }
+
+        const eGridDiv = document.createElement('div');
+        const api = createGrid(
+            eGridDiv,
+            {
+                columnDefs: [
+                    {
+                        field: 'b',
+                        headerName: 'Before',
+                        sortable: false,
+                        headerComponentParams: { innerHeaderComponent: CapturingRefreshInner },
+                    },
+                ],
+                rowData,
+            },
+            { modules: [ClientSideRowModelModule] }
+        );
+
+        api.setGridOption('columnDefs', [
+            {
+                field: 'b',
+                headerName: 'After',
+                sortable: false,
+                headerComponentParams: { innerHeaderComponent: CapturingRefreshInner },
+            },
+        ]);
+
+        expect(refreshedDisplayName).toBe('After');
+
+        api.destroy();
+    });
+
+    test('innerHeaderComponent without refresh receives updated params in init() when recreated', () => {
+        let lastInitDisplayName: string | undefined;
+
+        class NoRefreshCapturingInner {
+            private readonly gui = document.createElement('span');
+            init(params: IHeaderParams): void {
+                lastInitDisplayName = params.displayName;
+            }
+            getGui(): HTMLElement {
+                return this.gui;
+            }
+        }
+
+        const eGridDiv = document.createElement('div');
+        const api = createGrid(
+            eGridDiv,
+            {
+                columnDefs: [
+                    {
+                        field: 'b',
+                        headerName: 'Before',
+                        sortable: false,
+                        headerComponentParams: { innerHeaderComponent: NoRefreshCapturingInner },
+                    },
+                ],
+                rowData,
+            },
+            { modules: [ClientSideRowModelModule] }
+        );
+
+        expect(lastInitDisplayName).toBe('Before');
+
+        api.setGridOption('columnDefs', [
+            {
+                field: 'b',
+                headerName: 'After',
+                sortable: false,
+                headerComponentParams: { innerHeaderComponent: NoRefreshCapturingInner },
+            },
+        ]);
+
+        expect(lastInitDisplayName).toBe('After');
+
+        api.destroy();
+    });
+
+    test('innerHeaderComponent receives updated params in init() when recreated after refresh returns false', () => {
+        let lastInitDisplayName: string | undefined;
+
+        class RejectingCapturingInner {
+            private gui = document.createElement('span');
+            init(params: IHeaderParams): void {
+                lastInitDisplayName = params.displayName;
+                this.gui = document.createElement('span');
+            }
+            refresh(_params: IHeaderParams): boolean {
+                return false;
+            }
+            getGui(): HTMLElement {
+                return this.gui;
+            }
+        }
+
+        const eGridDiv = document.createElement('div');
+        const api = createGrid(
+            eGridDiv,
+            {
+                columnDefs: [
+                    {
+                        field: 'b',
+                        headerName: 'Before',
+                        sortable: false,
+                        headerComponentParams: { innerHeaderComponent: RejectingCapturingInner },
+                    },
+                ],
+                rowData,
+            },
+            { modules: [ClientSideRowModelModule] }
+        );
+
+        expect(lastInitDisplayName).toBe('Before');
+
+        api.setGridOption('columnDefs', [
+            {
+                field: 'b',
+                headerName: 'After',
+                sortable: false,
+                headerComponentParams: { innerHeaderComponent: RejectingCapturingInner },
+            },
+        ]);
+
+        expect(lastInitDisplayName).toBe('After');
+
+        api.destroy();
+    });
+
+    test('innerHeaderComponent.refresh() receives updated innerHeaderComponentParams', () => {
+        let refreshedLabel: string | undefined;
+
+        class CapturingRefreshInnerWithLabel {
+            private readonly gui = document.createElement('span');
+            init(_params: IHeaderParams): void {}
+            refresh(params: IHeaderParams): boolean {
+                refreshedLabel = (params as any).customLabel;
+                return true;
+            }
+            getGui(): HTMLElement {
+                return this.gui;
+            }
+        }
+
+        const eGridDiv = document.createElement('div');
+        const api = createGrid(
+            eGridDiv,
+            {
+                columnDefs: [
+                    {
+                        field: 'b',
+                        sortable: false,
+                        headerComponentParams: {
+                            innerHeaderComponent: CapturingRefreshInnerWithLabel,
+                            innerHeaderComponentParams: { customLabel: 'Before' },
+                        },
+                    },
+                ],
+                rowData,
+            },
+            { modules: [ClientSideRowModelModule] }
+        );
+
+        api.setGridOption('columnDefs', [
+            {
+                field: 'b',
+                sortable: false,
+                headerComponentParams: {
+                    innerHeaderComponent: CapturingRefreshInnerWithLabel,
+                    innerHeaderComponentParams: { customLabel: 'After' },
+                },
+            },
+        ]);
+
+        expect(refreshedLabel).toBe('After');
+
+        api.destroy();
+    });
+
+    test('innerHeaderComponent without refresh receives updated innerHeaderComponentParams in init() when recreated', () => {
+        let lastInitLabel: string | undefined;
+
+        class NoRefreshCapturingInnerWithLabel {
+            private readonly gui = document.createElement('span');
+            init(params: IHeaderParams): void {
+                lastInitLabel = (params as any).customLabel;
+            }
+            getGui(): HTMLElement {
+                return this.gui;
+            }
+        }
+
+        const eGridDiv = document.createElement('div');
+        const api = createGrid(
+            eGridDiv,
+            {
+                columnDefs: [
+                    {
+                        field: 'b',
+                        sortable: false,
+                        headerComponentParams: {
+                            innerHeaderComponent: NoRefreshCapturingInnerWithLabel,
+                            innerHeaderComponentParams: { customLabel: 'Before' },
+                        },
+                    },
+                ],
+                rowData,
+            },
+            { modules: [ClientSideRowModelModule] }
+        );
+
+        expect(lastInitLabel).toBe('Before');
+
+        api.setGridOption('columnDefs', [
+            {
+                field: 'b',
+                sortable: false,
+                headerComponentParams: {
+                    innerHeaderComponent: NoRefreshCapturingInnerWithLabel,
+                    innerHeaderComponentParams: { customLabel: 'After' },
+                },
+            },
+        ]);
+
+        expect(lastInitLabel).toBe('After');
+
+        api.destroy();
+    });
+
+    test('innerHeaderComponent receives updated innerHeaderComponentParams in init() when recreated after refresh returns false', () => {
+        let lastInitLabel: string | undefined;
+
+        class RejectingCapturingInnerWithLabel {
+            private gui = document.createElement('span');
+            init(params: IHeaderParams): void {
+                lastInitLabel = (params as any).customLabel;
+                this.gui = document.createElement('span');
+            }
+            refresh(_params: IHeaderParams): boolean {
+                return false;
+            }
+            getGui(): HTMLElement {
+                return this.gui;
+            }
+        }
+
+        const eGridDiv = document.createElement('div');
+        const api = createGrid(
+            eGridDiv,
+            {
+                columnDefs: [
+                    {
+                        field: 'b',
+                        sortable: false,
+                        headerComponentParams: {
+                            innerHeaderComponent: RejectingCapturingInnerWithLabel,
+                            innerHeaderComponentParams: { customLabel: 'Before' },
+                        },
+                    },
+                ],
+                rowData,
+            },
+            { modules: [ClientSideRowModelModule] }
+        );
+
+        expect(lastInitLabel).toBe('Before');
+
+        api.setGridOption('columnDefs', [
+            {
+                field: 'b',
+                sortable: false,
+                headerComponentParams: {
+                    innerHeaderComponent: RejectingCapturingInnerWithLabel,
+                    innerHeaderComponentParams: { customLabel: 'After' },
+                },
+            },
+        ]);
+
+        expect(lastInitLabel).toBe('After');
 
         api.destroy();
     });

--- a/testing/behavioural/src/columns/headers/columns-header-inner.test.ts
+++ b/testing/behavioural/src/columns/headers/columns-header-inner.test.ts
@@ -196,6 +196,40 @@ describe('header component lifecycle', () => {
         api.destroy();
     });
 
+    test('adding innerHeaderComponent when it was not originally present correctly renderers new innerHeaderComponent', () => {
+        const eGridDiv = document.createElement('div');
+        const api = createGrid(
+            eGridDiv,
+            {
+                columnDefs: [
+                    {
+                        field: 'b',
+                        headerName: 'My Header',
+                        sortable: false,
+                        // headerComponentParams: { innerHeaderComponent: TrackingInnerHeader },
+                    },
+                ],
+                rowData,
+            },
+            { modules: [ClientSideRowModelModule] }
+        );
+
+        api.setGridOption('columnDefs', [
+            {
+                field: 'b',
+                headerName: 'My Header',
+                sortable: false,
+                headerComponentParams: { innerHeaderComponent: TrackingInnerHeader },
+            },
+        ]);
+
+        expect(TrackingInnerHeader.initCount).toBe(1);
+        expect(TrackingInnerHeader.destroyCount).toBe(0);
+        expect(eGridDiv.querySelector('.ag-header-cell-text')?.textContent).toBe('My Header');
+
+        api.destroy();
+    });
+
     test('innerHeaderComponent without refresh is recreated on column def update, consistent with cell renderer behaviour', () => {
         const eGridDiv = document.createElement('div');
         const noRefreshDefs: ColDef[] = [

--- a/testing/behavioural/src/columns/headers/columns-header-inner.test.ts
+++ b/testing/behavioural/src/columns/headers/columns-header-inner.test.ts
@@ -3,151 +3,70 @@ import { ClientSideRowModelModule, createGrid } from 'ag-grid-community';
 
 const rowData = [{ a: 1, b: 10 }];
 
-class TrackingHeaderComp {
-    static initCount = 0;
-    static destroyCount = 0;
-    static refreshCount = 0;
-
-    static reset(): void {
-        TrackingHeaderComp.initCount = 0;
-        TrackingHeaderComp.destroyCount = 0;
-        TrackingHeaderComp.refreshCount = 0;
-    }
-
-    private readonly gui = document.createElement('div');
-
-    init(_params: IHeaderParams): void {
-        TrackingHeaderComp.initCount++;
-    }
-
-    refresh(_params: IHeaderParams): boolean {
-        TrackingHeaderComp.refreshCount++;
-        return true;
-    }
-
-    getGui(): HTMLElement {
-        return this.gui;
-    }
-
-    destroy(): void {
-        TrackingHeaderComp.destroyCount++;
-    }
+interface TrackedClass {
+    initCount: number;
+    destroyCount: number;
+    refreshCount: number;
+    reset(): void;
+    new (): TrackedInstance;
 }
 
-class TrackingInnerHeader {
-    static initCount = 0;
-    static destroyCount = 0;
-    static refreshCount = 0;
-
-    static reset(): void {
-        TrackingInnerHeader.initCount = 0;
-        TrackingInnerHeader.destroyCount = 0;
-        TrackingInnerHeader.refreshCount = 0;
-    }
-
-    private readonly gui = document.createElement('span');
-
-    init(_params: IHeaderParams): void {
-        TrackingInnerHeader.initCount++;
-    }
-
-    refresh(_params: IHeaderParams): boolean {
-        TrackingInnerHeader.refreshCount++;
-        return true;
-    }
-
-    getGui(): HTMLElement {
-        return this.gui;
-    }
-
-    destroy(): void {
-        TrackingInnerHeader.destroyCount++;
-    }
+interface TrackedInstance {
+    init(params: IHeaderParams): void;
+    refresh?(params: IHeaderParams): boolean;
+    getGui(): HTMLElement;
+    destroy(): void;
 }
 
-class AlternativeInnerHeader {
-    static initCount = 0;
-    static destroyCount = 0;
+function makeTrackedInnerHeader(refreshBehaviour?: 'accept' | 'reject' | 'none'): TrackedClass {
+    class TrackedComp {
+        static initCount = 0;
+        static destroyCount = 0;
+        static refreshCount = 0;
 
-    static reset(): void {
-        AlternativeInnerHeader.initCount = 0;
-        AlternativeInnerHeader.destroyCount = 0;
+        static reset(): void {
+            TrackedComp.initCount = 0;
+            TrackedComp.destroyCount = 0;
+            TrackedComp.refreshCount = 0;
+        }
+
+        protected gui = document.createElement('span');
+
+        init(_params: IHeaderParams): void {
+            TrackedComp.initCount++;
+            this.gui = document.createElement('span');
+        }
+
+        getGui(): HTMLElement {
+            return this.gui;
+        }
+
+        destroy(): void {
+            TrackedComp.destroyCount++;
+        }
     }
 
-    private readonly gui = document.createElement('span');
-
-    init(_params: IHeaderParams): void {
-        AlternativeInnerHeader.initCount++;
+    if (refreshBehaviour === 'accept') {
+        (TrackedComp.prototype as any).refresh = function (_params: IHeaderParams): boolean {
+            TrackedComp.refreshCount++;
+            return true;
+        };
+    } else if (refreshBehaviour === 'reject') {
+        (TrackedComp.prototype as any).refresh = function (_params: IHeaderParams): boolean {
+            TrackedComp.refreshCount++;
+            return false;
+        };
     }
+    // 'none': no refresh method at all
 
-    refresh(_params: IHeaderParams): boolean {
-        return true;
-    }
-
-    getGui(): HTMLElement {
-        return this.gui;
-    }
-
-    destroy(): void {
-        AlternativeInnerHeader.destroyCount++;
-    }
+    return TrackedComp as unknown as TrackedClass;
 }
 
-class NoRefreshInnerHeader {
-    static initCount = 0;
-    static destroyCount = 0;
-
-    static reset(): void {
-        NoRefreshInnerHeader.initCount = 0;
-        NoRefreshInnerHeader.destroyCount = 0;
-    }
-
-    private readonly gui = document.createElement('span');
-
-    init(_params: IHeaderParams): void {
-        NoRefreshInnerHeader.initCount++;
-    }
-
-    getGui(): HTMLElement {
-        return this.gui;
-    }
-
-    destroy(): void {
-        NoRefreshInnerHeader.destroyCount++;
-    }
-}
-
-class RejectingInnerHeader {
-    static initCount = 0;
-    static destroyCount = 0;
-    static refreshCount = 0;
-
-    static reset(): void {
-        RejectingInnerHeader.initCount = 0;
-        RejectingInnerHeader.destroyCount = 0;
-        RejectingInnerHeader.refreshCount = 0;
-    }
-
-    private gui = document.createElement('span');
-
-    init(_params: IHeaderParams): void {
-        RejectingInnerHeader.initCount++;
-        this.gui = document.createElement('span');
-    }
-
-    refresh(_params: IHeaderParams): boolean {
-        RejectingInnerHeader.refreshCount++;
-        return false;
-    }
-
-    getGui(): HTMLElement {
-        return this.gui;
-    }
-
-    destroy(): void {
-        RejectingInnerHeader.destroyCount++;
-    }
-}
+const TrackingHeaderComp = makeTrackedInnerHeader('accept');
+const TrackingInnerHeader = makeTrackedInnerHeader('accept');
+const AlternativeInnerHeader = makeTrackedInnerHeader('accept');
+const NoRefreshInnerHeader = makeTrackedInnerHeader('none');
+const RejectingInnerHeader = makeTrackedInnerHeader('reject');
 
 const columnDefs: ColDef[] = [
     { field: 'a', headerComponent: TrackingHeaderComp },
@@ -245,6 +164,34 @@ describe('header component lifecycle', () => {
         // Old component should be destroyed and the new class initialised in its place
         expect(TrackingInnerHeader.destroyCount).toBe(1);
         expect(AlternativeInnerHeader.initCount).toBe(1);
+
+        api.destroy();
+    });
+
+    test('removing innerHeaderComponent restores display name text in the header cell', () => {
+        const eGridDiv = document.createElement('div');
+        const api = createGrid(
+            eGridDiv,
+            {
+                columnDefs: [
+                    {
+                        field: 'b',
+                        headerName: 'My Header',
+                        sortable: false,
+                        headerComponentParams: { innerHeaderComponent: TrackingInnerHeader },
+                    },
+                ],
+                rowData,
+            },
+            { modules: [ClientSideRowModelModule] }
+        );
+
+        expect(TrackingInnerHeader.initCount).toBe(1);
+
+        api.setGridOption('columnDefs', [{ field: 'b', headerName: 'My Header', sortable: false }]);
+
+        expect(TrackingInnerHeader.destroyCount).toBe(1);
+        expect(eGridDiv.querySelector('.ag-header-cell-text')?.textContent).toBe('My Header');
 
         api.destroy();
     });

--- a/testing/behavioural/src/columns/headers/columns-header-inner.test.ts
+++ b/testing/behavioural/src/columns/headers/columns-header-inner.test.ts
@@ -18,7 +18,7 @@ interface TrackedInstance {
     destroy(): void;
 }
 
-function makeTrackedInnerHeader(refreshBehaviour?: 'accept' | 'reject' | 'none'): TrackedClass {
+function makeTrackedInnerHeader(refreshBehaviour: 'accept' | 'reject' | 'none'): TrackedClass {
     class TrackedComp {
         static initCount = 0;
         static destroyCount = 0;

--- a/testing/behavioural/src/columns/headers/columns-header-inner.test.ts
+++ b/testing/behavioural/src/columns/headers/columns-header-inner.test.ts
@@ -1,0 +1,166 @@
+import type { ColDef, IHeaderParams } from 'ag-grid-community';
+import { ClientSideRowModelModule, createGrid } from 'ag-grid-community';
+
+const rowData = [{ a: 1, b: 10 }];
+
+class TrackingHeaderComp {
+    static initCount = 0;
+    static destroyCount = 0;
+    static refreshCount = 0;
+
+    static reset(): void {
+        TrackingHeaderComp.initCount = 0;
+        TrackingHeaderComp.destroyCount = 0;
+        TrackingHeaderComp.refreshCount = 0;
+    }
+
+    private readonly gui = document.createElement('div');
+
+    init(_params: IHeaderParams): void {
+        TrackingHeaderComp.initCount++;
+    }
+
+    refresh(_params: IHeaderParams): boolean {
+        TrackingHeaderComp.refreshCount++;
+        return true;
+    }
+
+    getGui(): HTMLElement {
+        return this.gui;
+    }
+
+    destroy(): void {
+        TrackingHeaderComp.destroyCount++;
+    }
+}
+
+class TrackingInnerHeader {
+    static initCount = 0;
+    static destroyCount = 0;
+    static refreshCount = 0;
+
+    static reset(): void {
+        TrackingInnerHeader.initCount = 0;
+        TrackingInnerHeader.destroyCount = 0;
+        TrackingInnerHeader.refreshCount = 0;
+    }
+
+    private readonly gui = document.createElement('span');
+
+    init(_params: IHeaderParams): void {
+        TrackingInnerHeader.initCount++;
+    }
+
+    refresh(_params: IHeaderParams): boolean {
+        TrackingInnerHeader.refreshCount++;
+        return true;
+    }
+
+    getGui(): HTMLElement {
+        return this.gui;
+    }
+
+    destroy(): void {
+        TrackingInnerHeader.destroyCount++;
+    }
+}
+
+class RejectingInnerHeader {
+    static initCount = 0;
+    static destroyCount = 0;
+    static refreshCount = 0;
+
+    static reset(): void {
+        RejectingInnerHeader.initCount = 0;
+        RejectingInnerHeader.destroyCount = 0;
+        RejectingInnerHeader.refreshCount = 0;
+    }
+
+    private gui = document.createElement('span');
+
+    init(_params: IHeaderParams): void {
+        RejectingInnerHeader.initCount++;
+        this.gui = document.createElement('span');
+    }
+
+    refresh(_params: IHeaderParams): boolean {
+        RejectingInnerHeader.refreshCount++;
+        return false;
+    }
+
+    getGui(): HTMLElement {
+        return this.gui;
+    }
+
+    destroy(): void {
+        RejectingInnerHeader.destroyCount++;
+    }
+}
+
+const columnDefs: ColDef[] = [
+    { field: 'a', headerComponent: TrackingHeaderComp },
+    { field: 'b', sortable: false, headerComponentParams: { innerHeaderComponent: TrackingInnerHeader } },
+];
+
+const rejectingColumnDefs: ColDef[] = [
+    { field: 'a', headerComponent: TrackingHeaderComp },
+    { field: 'b', sortable: false, headerComponentParams: { innerHeaderComponent: RejectingInnerHeader } },
+];
+
+describe('header component lifecycle', () => {
+    beforeEach(() => {
+        TrackingHeaderComp.reset();
+        TrackingInnerHeader.reset();
+        RejectingInnerHeader.reset();
+    });
+
+    test('headerComponent and innerHeaderComponent are both refreshed rather than remounted when column defs are updated', () => {
+        const eGridDiv = document.createElement('div');
+        const api = createGrid(eGridDiv, { columnDefs, rowData }, { modules: [ClientSideRowModelModule] });
+
+        expect(TrackingHeaderComp.initCount).toBe(1);
+        expect(TrackingHeaderComp.destroyCount).toBe(0);
+        expect(TrackingInnerHeader.initCount).toBe(1);
+        expect(TrackingInnerHeader.destroyCount).toBe(0);
+
+        // Simulates a React setColumnDefs call with equivalent definitions.
+        // Before the fix, HeaderComp.refresh() always returned false due to a broken
+        // template object reference comparison, causing innerHeaderComponent to be remounted.
+        api.setGridOption('columnDefs', [...columnDefs]);
+
+        expect(TrackingHeaderComp.initCount).toBe(1);
+        expect(TrackingHeaderComp.destroyCount).toBe(0);
+        expect(TrackingHeaderComp.refreshCount).toBe(1);
+        expect(TrackingInnerHeader.initCount).toBe(1);
+        expect(TrackingInnerHeader.destroyCount).toBe(0);
+        expect(TrackingInnerHeader.refreshCount).toBe(1);
+
+        api.destroy();
+    });
+
+    test('innerHeaderComponent is remounted when its refresh returns false, outer headerComp stays alive', () => {
+        const eGridDiv = document.createElement('div');
+        const api = createGrid(
+            eGridDiv,
+            { columnDefs: rejectingColumnDefs, rowData },
+            { modules: [ClientSideRowModelModule] }
+        );
+
+        expect(TrackingHeaderComp.initCount).toBe(1);
+        expect(RejectingInnerHeader.initCount).toBe(1);
+        expect(RejectingInnerHeader.destroyCount).toBe(0);
+
+        api.setGridOption('columnDefs', [...rejectingColumnDefs]);
+
+        // Inner component signalled it cannot handle the update — it should be replaced
+        expect(RejectingInnerHeader.refreshCount).toBe(1);
+        expect(RejectingInnerHeader.destroyCount).toBe(1);
+        expect(RejectingInnerHeader.initCount).toBe(2);
+
+        // Outer headerComp on the adjacent column must not have been remounted
+        expect(TrackingHeaderComp.initCount).toBe(1);
+        expect(TrackingHeaderComp.destroyCount).toBe(0);
+
+        api.destroy();
+    });
+});

--- a/testing/behavioural/src/columns/headers/columns-header-inner.test.tsx
+++ b/testing/behavioural/src/columns/headers/columns-header-inner.test.tsx
@@ -1,0 +1,149 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React, { useEffect, useState } from 'react';
+
+import type { ColDef, IHeaderParams } from 'ag-grid-community';
+import { AllCommunityModule } from 'ag-grid-community';
+import { AgGridReact } from 'ag-grid-react';
+
+let headerMountCount = 0;
+let headerUnmountCount = 0;
+let innerMountCount = 0;
+let innerUnmountCount = 0;
+
+const CustomHeader = () => {
+    useEffect(() => {
+        headerMountCount++;
+        return () => {
+            headerUnmountCount++;
+        };
+    }, []);
+    return <div className="custom-header">header</div>;
+};
+
+const CustomInnerHeader = () => {
+    useEffect(() => {
+        innerMountCount++;
+        return () => {
+            innerUnmountCount++;
+        };
+    }, []);
+    return <span className="custom-inner-header">inner</span>;
+};
+
+// Vanilla JS inner header component that signals it cannot handle a refresh.
+// Used to verify that only the inner component is remounted, not the outer HeaderComp.
+class RejectingInnerHeader {
+    static initCount = 0;
+    static destroyCount = 0;
+    static refreshCount = 0;
+
+    static reset(): void {
+        RejectingInnerHeader.initCount = 0;
+        RejectingInnerHeader.destroyCount = 0;
+        RejectingInnerHeader.refreshCount = 0;
+    }
+
+    private gui = document.createElement('span');
+
+    init(_params: IHeaderParams): void {
+        RejectingInnerHeader.initCount++;
+        this.gui = document.createElement('span');
+    }
+
+    refresh(_params: IHeaderParams): boolean {
+        RejectingInnerHeader.refreshCount++;
+        return false;
+    }
+
+    getGui(): HTMLElement {
+        return this.gui;
+    }
+
+    destroy(): void {
+        RejectingInnerHeader.destroyCount++;
+    }
+}
+
+const columnDefs: ColDef[] = [
+    { field: 'a', headerComponent: CustomHeader },
+    { field: 'b', sortable: false, headerComponentParams: { innerHeaderComponent: CustomInnerHeader } },
+];
+
+const rejectingColumnDefs: ColDef[] = [
+    { field: 'a', headerComponent: CustomHeader },
+    { field: 'b', sortable: false, headerComponentParams: { innerHeaderComponent: RejectingInnerHeader } },
+];
+
+const rowData = [{ a: 1, b: 10 }];
+
+const GridApp = ({ defs }: { defs: ColDef[] }) => {
+    const [cols, setCols] = useState<ColDef[]>(defs);
+    return (
+        <>
+            <button onClick={() => setCols([...defs])}>Update Cols</button>
+            <AgGridReact rowData={rowData} columnDefs={cols} modules={[AllCommunityModule]} />
+        </>
+    );
+};
+
+describe('React header component lifecycle', () => {
+    beforeEach(() => {
+        cleanup();
+        headerMountCount = 0;
+        headerUnmountCount = 0;
+        innerMountCount = 0;
+        innerUnmountCount = 0;
+        RejectingInnerHeader.reset();
+    });
+
+    it('headerComponent and innerHeaderComponent are both re-rendered rather than remounted when column defs are updated', async () => {
+        render(<GridApp defs={columnDefs} />);
+
+        // PortalManager mounts via setTimeout batching, so wait for initial mount
+        await waitFor(() => {
+            expect(headerMountCount).toBe(1);
+            expect(innerMountCount).toBe(1);
+        });
+        expect(headerUnmountCount).toBe(0);
+        expect(innerUnmountCount).toBe(0);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Update Cols' }));
+
+        // Flush any pending portal updates — PortalManager batches via setTimeout, so a
+        // resolved setTimeout scheduled after the click will run after those callbacks.
+        await act(async () => {
+            await new Promise<void>((resolve) => setTimeout(resolve));
+        });
+
+        expect(headerMountCount).toBe(1);
+        expect(headerUnmountCount).toBe(0);
+        expect(innerMountCount).toBe(1);
+        expect(innerUnmountCount).toBe(0);
+    });
+
+    it('innerHeaderComponent is remounted when its refresh returns false, outer headerComp stays alive', async () => {
+        render(<GridApp defs={rejectingColumnDefs} />);
+
+        // Wait for the React headerComponent portal to mount
+        await waitFor(() => expect(headerMountCount).toBe(1));
+        expect(RejectingInnerHeader.initCount).toBe(1);
+        expect(RejectingInnerHeader.destroyCount).toBe(0);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Update Cols' }));
+
+        // RejectingInnerHeader lifecycle is synchronous (vanilla JS, no portal), so counts
+        // are available immediately. Flush setTimeout for the portal-based CustomHeader.
+        await act(async () => {
+            await new Promise<void>((resolve) => setTimeout(resolve));
+        });
+
+        // Inner component signalled it cannot handle the update — it should be replaced
+        expect(RejectingInnerHeader.refreshCount).toBe(1);
+        expect(RejectingInnerHeader.destroyCount).toBe(1);
+        expect(RejectingInnerHeader.initCount).toBe(2);
+
+        // Outer headerComp (CustomHeader on the adjacent column) must not have been remounted
+        expect(headerMountCount).toBe(1);
+        expect(headerUnmountCount).toBe(0);
+    });
+});


### PR DESCRIPTION
## Problem

`HeaderComp.refresh()` compared the current template against the result of `workOutTemplate()`, but that function returns a **new** `ElementParams` object on every call. The reference was never equal, so `refresh()` always returned `false`, triggering a full destroy + remount of the header cell (and its `innerHeaderComponent`) on every `setColumnDefs` call.

A second, related issue: when `innerHeaderComponent.refresh()` returns `false` (signalling it cannot handle the update), the return value was silently ignored — the inner component was left stale. Worse, the outer `HeaderComp` would have been remounted unnecessarily if it returned false because of the template comparison bug above.

## Fix

- Replace the single template-reference comparison with three explicit boolean checks: custom template string, formula-active state, and sort-indicator presence. These are exactly the conditions `workOutTemplate()` inspects, so the equality check is now direct and allocation-free.
- When `innerHeaderComponent.refresh()` returns `false`, only the inner component is replaced (`replaceInnerHeaderComponent`) — the outer `HeaderComp` stays alive.
- Reorder `replaceInnerHeaderComponent` to detach the old GUI from the DOM before calling `destroyBean`, so the element is not briefly orphaned in `eText`.

## Tests

Two new behavioural test files:

- `columns-header-inner.test.ts` — vanilla-JS grid, verifies both scenarios (refresh not remount; inner component remount when refresh returns false, outer header unaffected).
- `columns-header-inner.test.tsx` — React grid, same two scenarios using `useEffect` mount/unmount counters.

Fix [AG-17220](https://ag-grid.atlassian.net/browse/AG-17220)