### PR TITLE
AG-12557 toolbar QA fixes

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_toolbar.scss
+++ b/community-modules/styles/src/internal/base/parts/_toolbar.scss
@@ -143,6 +143,7 @@
         border-radius: var(--ag-border-radius);
         width: 280px;
         max-width: none;
+        min-width: 220px;
     }
 
     .ag-toolbar-find:focus-within {

--- a/community-modules/styles/src/internal/base/parts/_toolbar.scss
+++ b/community-modules/styles/src/internal/base/parts/_toolbar.scss
@@ -111,6 +111,10 @@
         box-shadow: var(--ag-focus-shadow);
     }
 
+    .ag-toolbar-input-field::placeholder {
+        color: var(--ag-input-placeholder-text-color);
+    }
+
     .ag-toolbar-panel .ag-column-drop-horizontal {
         background-color: transparent;
         border-bottom: none;

--- a/documentation/ag-grid-docs/src/content/docs/toolbar/_component-interface-angular.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/_component-interface-angular.mdoc
@@ -14,12 +14,9 @@ interface IToolbarItemAngularComp {
 
     // optional methods
 
-    // Called when the `toolbar` grid option is updated.
-    // If this method returns `true`, the grid assumes that
-    // the toolbar item has updated with the latest params,
-    // and takes no further action. If this method returns `false`,
-    // or is not implemented, the grid will destroy and
-    // recreate the toolbar item.
+    // Called when the `toolbar` grid option updates.
+    // Return `true` if the component updates itself with the new params.
+    // Return `false` (or omit) to have the grid destroy and recreate the component.
     refresh(params: IToolbarItemParams): boolean;
 }
 ```

--- a/documentation/ag-grid-docs/src/content/docs/toolbar/_component-interface-javascript.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/_component-interface-javascript.mdoc
@@ -17,12 +17,9 @@ interface IToolbarItemComp {
     // See below for details on the parameters.
     init(params: IToolbarItemParams): void;
 
-    // Called when the `toolbar` grid option is updated.
-    // If this method returns `true`, the grid assumes that
-    // the toolbar item has updated with the latest params,
-    // and takes no further action. If this method returns `false`,
-    // or is not implemented, the grid will destroy and
-    // recreate the toolbar item.
+    // Called when the `toolbar` grid option updates.
+    // Return `true` if the component updates itself with the new params.
+    // Return `false` (or omit) to have the grid destroy and recreate the component.
     refresh(params: IToolbarItemParams): boolean;
 
     // Gets called when the grid is destroyed.

--- a/documentation/ag-grid-docs/src/content/docs/toolbar/_component-interface-vue.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/_component-interface-vue.mdoc
@@ -6,12 +6,9 @@ Any valid Vue component can be a toolbar item component, however it is also poss
 
 ```ts
 interface IToolbarItem {
-    // Called when the `toolbar` grid option is updated.
-    // If this method returns `true`, the grid assumes that
-    // the toolbar item has updated with the latest params,
-    // and takes no further action. If this method returns `false`,
-    // or is not implemented, the grid will destroy and
-    // recreate the toolbar item.
+    // Called when the `toolbar` grid option updates.
+    // Return `true` if the component updates itself with the new params.
+    // Return `false` (or omit) to have the grid destroy and recreate the component.
     refresh(params: IToolbarItemParams): boolean;
 }
 ```

--- a/packages/ag-grid-enterprise/src/toolbar/agToolbar.css
+++ b/packages/ag-grid-enterprise/src/toolbar/agToolbar.css
@@ -98,6 +98,10 @@
     box-shadow: var(--ag-focus-shadow);
 }
 
+.ag-toolbar-input-field::placeholder {
+    color: var(--ag-input-placeholder-text-color);
+}
+
 /* stylelint-disable-next-line selector-max-specificity */
 .ag-toolbar-panel .ag-column-drop-horizontal {
     background-color: transparent;

--- a/packages/ag-grid-enterprise/src/toolbar/agToolbar.css
+++ b/packages/ag-grid-enterprise/src/toolbar/agToolbar.css
@@ -127,6 +127,7 @@
     border-radius: var(--ag-border-radius);
     width: 280px;
     max-width: none;
+    min-width: 220px;
 }
 
 .ag-toolbar-find:focus-within {


### PR DESCRIPTION
- Style toolbar input placeholder text colour using `--ag-input-placeholder-text-color`
- Align `refresh` jsdoc in toolbar component-interface mdoc files (angular, javascript, vue) with `IToolbarItem.refresh` in `iToolbar.ts`
- Add `min-width: 220px` to toolbar find input