### PR TITLE
AG-16818 fix preserve group order

### DIFF
--- a/.rulesync/rules/testing.md
+++ b/.rulesync/rules/testing.md
@@ -180,7 +180,7 @@ for (const [name, example] of Object.entries(EXAMPLES)) {
 1. **Test behaviour, not implementation** - Focus on what the code does, not how
 2. **Keep tests independent** - Each test should be able to run in isolation
 3. **Use descriptive names** - Test names should describe the expected behaviour
-4. **Avoid test helpers that hide behaviour** - Tests should be readable without jumping to helpers
+4. **Avoid test helpers that hide behaviour** - Repetition is fine in tests; prefer inline setup over a shared factory so each test reads top-to-bottom. Do not flag setup duplication in code review, flag duplicated tests also cross file.
 5. **Clean up after tests** - Reset mocks and state in `afterEach`
 6. **Review similar tests** - When adding tests, check related tests for consistency
 

--- a/documentation/ag-grid-docs/src/content/docs/grouping-sorting/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/grouping-sorting/index.mdoc
@@ -61,6 +61,31 @@ const gridOptions = {
 }
 ```
 
+## Maintain Group Order
+
+By default, sorting on a non-group column reorders groups based on the sort. To keep groups in their structural order while only
+sorting the rows within each group, enable `groupMaintainOrder`:
+
+```{% frameworkTransform=true %}
+const gridOptions = {
+    columnDefs: [
+        { field: 'country', rowGroup: true, hide: true },
+        { field: 'athlete' },
+    ],
+    groupMaintainOrder: true,
+};
+```
+
+With `groupMaintainOrder=true`:
+
+- Sorting a leaf column sorts the rows inside each group; groups stay in structural order.
+- Filter changes preserve group order.
+- Transactions add new groups at their structural position — at the end of the data-insertion order, or at the position produced by `initialGroupOrderComparator` if one is configured.
+
+The structural order is the data-insertion order by default, or the order produced by
+[`initialGroupOrderComparator`](#unsorted-group-order) if one is configured. If a group column had a sort applied and the user later
+explicitly clears that sort, the structural order is restored.
+
 ## Unsorted Group Order
 
 When no sorting is applied, the groups are ordered by the order in which they appear in the data. This order can be overwritten with

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
@@ -1390,8 +1390,11 @@ export class AgGridAngular<TData = any, TColDef extends ColDef<TData> = ColDef<a
      * @agModule `RowGroupingModule` / `TreeDataModule`
      */
     @Input() public autoGroupColumnDef: AutoGroupColumnDef<TData> | undefined = undefined;
-    /** When `true`, preserves the current group order when sorting on non-group columns.
-     * If a user explicitly resets the current group sort direction, then the current group column order is not preserved.
+    /** When `true`, sorting on non-group columns does not reorder groups; only the rows within
+     * each group are sorted. Group order remains the structural order set at grouping time
+     * (data-insertion order, or `initialGroupOrderComparator` if configured) and is preserved
+     * across filter changes and transactions. If a group column was sorted via `colDef.sort`
+     * and the user later explicitly clears that sort, the structural order is restored.
      * @default false
      * @agModule `RowGroupingModule`
      */

--- a/packages/ag-grid-community/src/agStack/utils/array.ts
+++ b/packages/ag-grid-community/src/agStack/utils/array.ts
@@ -35,6 +35,20 @@ export function _areEqual<T>(
 }
 
 /**
+ * Returns `prev` (same reference, shared with caller) when it has the same elements as `current`,
+ * otherwise a fresh slice of `current` (or `[]` if `current` is null/undefined). Lets pipelines
+ * keep a stable reference when nothing changed; mutations to the returned array on the reuse
+ * branch also mutate `prev`.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export function _reuseArrayIfEqual<T>(prev: T[] | null | undefined, current: readonly T[] | null | undefined): T[] {
+    if (prev && _areEqual(prev, current)) {
+        return prev;
+    }
+    return current ? current.slice() : [];
+}
+
+/**
  * Utility that uses the fastest looping approach to apply a callback to each element of the array
  * https://jsperf.app/for-for-of-for-in-foreach-comparison
  * If callback returns true, exit early.

--- a/packages/ag-grid-community/src/clientSideRowModel/sortStage.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/sortStage.ts
@@ -1,3 +1,4 @@
+import { _reuseArrayIfEqual } from '../agStack/utils/array';
 import type { NamedBean } from '../context/bean';
 import { BeanStub } from '../context/beanStub';
 import type { GridOptions } from '../entities/gridOptions';
@@ -51,7 +52,8 @@ export class SortStage extends BeanStub implements NamedBean, IRowNodeSortStage 
 
         const useDeltaSort = sortOptions.length > 0 && !!changedRowNodes && this.gos.get('deltaSort');
 
-        let newChildrenAfterSort: RowNode[] | null = null;
+        const prevSort = rootNode.childrenAfterSort;
+        let newChildrenAfterSort: RowNode[];
         if (sortOptions.length > 0) {
             if (useDeltaSort && changedRowNodes) {
                 newChildrenAfterSort = doDeltaSort(
@@ -67,9 +69,10 @@ export class SortStage extends BeanStub implements NamedBean, IRowNodeSortStage 
                     sortOptions
                 );
             }
+        } else {
+            newChildrenAfterSort = _reuseArrayIfEqual(prevSort, rootNode.childrenAfterAggFilter);
         }
 
-        newChildrenAfterSort ||= rootNode.childrenAfterAggFilter?.slice() ?? [];
         rootNode.childrenAfterSort = newChildrenAfterSort;
         updateRowNodeAfterSort(rootNode);
 

--- a/packages/ag-grid-community/src/clientSideRowModel/sortStage.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/sortStage.ts
@@ -74,8 +74,8 @@ export class SortStage extends BeanStub implements NamedBean, IRowNodeSortStage 
         }
 
         rootNode.childrenAfterSort = newChildrenAfterSort;
-        updateRowNodeAfterSort(rootNode);
-
+        // updateRowNodeAfterSort runs before postSortRows — same ordering as AG-309 (Feb 2018,
+        // when postSortRows was introduced). Callbacks see flags consistent with params.nodes.
         const postSortFunc = this.gos.getCallback('postSortRows');
         if (postSortFunc) {
             const params: WithoutGridCommon<PostSortRowsParams> = { nodes: newChildrenAfterSort };

--- a/packages/ag-grid-community/src/clientSideRowModel/sortStage.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/sortStage.ts
@@ -75,7 +75,9 @@ export class SortStage extends BeanStub implements NamedBean, IRowNodeSortStage 
 
         rootNode.childrenAfterSort = newChildrenAfterSort;
 
-        // postSortRows may mutate the array, so refresh child position metadata afterwards.
+        // postSortRows runs first so the array reflects the user's customisation; only then do
+        // we sync child position metadata + fire firstChild/lastChild/childIndex events, ensuring
+        // those flags and events always describe the actually-displayed order.
         const postSortFunc = this.gos.getCallback('postSortRows');
         if (postSortFunc) {
             const params: WithoutGridCommon<PostSortRowsParams> = { nodes: newChildrenAfterSort };

--- a/packages/ag-grid-community/src/clientSideRowModel/sortStage.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/sortStage.ts
@@ -74,12 +74,13 @@ export class SortStage extends BeanStub implements NamedBean, IRowNodeSortStage 
         }
 
         rootNode.childrenAfterSort = newChildrenAfterSort;
-        updateRowNodeAfterSort(rootNode);
 
+        // postSortRows may mutate the array, so refresh child position metadata afterwards.
         const postSortFunc = this.gos.getCallback('postSortRows');
         if (postSortFunc) {
-            const params: WithoutGridCommon<PostSortRowsParams> = { nodes: rootNode.childrenAfterSort };
+            const params: WithoutGridCommon<PostSortRowsParams> = { nodes: newChildrenAfterSort };
             postSortFunc(params);
         }
+        updateRowNodeAfterSort(rootNode);
     }
 }

--- a/packages/ag-grid-community/src/clientSideRowModel/sortStage.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/sortStage.ts
@@ -74,15 +74,12 @@ export class SortStage extends BeanStub implements NamedBean, IRowNodeSortStage 
         }
 
         rootNode.childrenAfterSort = newChildrenAfterSort;
+        updateRowNodeAfterSort(rootNode);
 
-        // postSortRows runs first so the array reflects the user's customisation; only then do
-        // we sync child position metadata + fire firstChild/lastChild/childIndex events, ensuring
-        // those flags and events always describe the actually-displayed order.
         const postSortFunc = this.gos.getCallback('postSortRows');
         if (postSortFunc) {
             const params: WithoutGridCommon<PostSortRowsParams> = { nodes: newChildrenAfterSort };
             postSortFunc(params);
         }
-        updateRowNodeAfterSort(rootNode);
     }
 }

--- a/packages/ag-grid-community/src/entities/gridOptions.ts
+++ b/packages/ag-grid-community/src/entities/gridOptions.ts
@@ -1449,8 +1449,11 @@ export interface GridOptions<TData = any> {
      */
     autoGroupColumnDef?: AutoGroupColumnDef<TData>;
     /**
-     * When `true`, preserves the current group order when sorting on non-group columns.
-     * If a user explicitly resets the current group sort direction, then the current group column order is not preserved.
+     * When `true`, sorting on non-group columns does not reorder groups; only the rows within
+     * each group are sorted. Group order remains the structural order set at grouping time
+     * (data-insertion order, or `initialGroupOrderComparator` if configured) and is preserved
+     * across filter changes and transactions. If a group column was sorted via `colDef.sort`
+     * and the user later explicitly clears that sort, the structural order is restored.
      * @default false
      * @agModule `RowGroupingModule`
      */

--- a/packages/ag-grid-community/src/main-internal.ts
+++ b/packages/ag-grid-community/src/main-internal.ts
@@ -131,7 +131,14 @@ export {
     _setAriaSort,
 } from './agStack/utils/aria';
 export type { AriaSortState } from './agStack/utils/aria';
-export { _areEqual, _flatten, _last, _removeAllFromArray, _removeFromArray } from './agStack/utils/array';
+export {
+    _areEqual,
+    _flatten,
+    _last,
+    _removeAllFromArray,
+    _removeFromArray,
+    _reuseArrayIfEqual,
+} from './agStack/utils/array';
 export { _parseBigIntOrNull } from './agStack/utils/bigInt';
 export { _isBrowserFirefox, _isBrowserSafari, _isIOSUserAgent } from './agStack/utils/browser';
 export { _getDateParts, MONTHS as _MONTHS, _parseDateTimeFromString, _serialiseDate } from './agStack/utils/date';

--- a/packages/ag-grid-community/src/sort/rowNodeSorter.ts
+++ b/packages/ag-grid-community/src/sort/rowNodeSorter.ts
@@ -64,8 +64,9 @@ export class RowNodeSorter extends BeanStub implements NamedBean {
             const sortOption = sortOptions[i];
             const isDescending = sortOption.sort === 'desc';
 
-            let valueA = this.getValue(nodeA, sortOption.column as AgColumn);
-            let valueB = this.getValue(nodeB, sortOption.column as AgColumn);
+            const column = sortOption.column as AgColumn;
+            let valueA = this.getValue(nodeA, column);
+            let valueB = this.getValue(nodeB, column);
 
             let comparatorResult: number;
             const providedComparator = this.getComparator(sortOption, nodeA);

--- a/packages/ag-grid-enterprise/src/rowHierarchy/groupSortStage.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/groupSortStage.ts
@@ -90,11 +90,9 @@ export class GroupSortStage extends BeanStub implements NamedBean, _IRowNodeSort
 
             rowNode.childrenAfterSort = newChildrenAfterSort;
 
-            // postSortRows runs first so the array reflects the user's customisation; only then
-            // do we sync child position metadata + fire firstChild/lastChild/childIndex events,
-            // ensuring those flags and events always describe the actually-displayed order.
-            postSortFunc?.({ nodes: newChildrenAfterSort });
             _updateRowNodeAfterSort(rowNode);
+
+            postSortFunc?.({ nodes: newChildrenAfterSort });
 
             hasAnyFirstChildChanged ||= prevFirstChild !== newChildrenAfterSort[0];
         };

--- a/packages/ag-grid-enterprise/src/rowHierarchy/groupSortStage.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/groupSortStage.ts
@@ -1,7 +1,9 @@
 import type {
+    AgColumn,
     ChangedPath,
     ClientSideRowModelStage,
     GridOptions,
+    GridOptionsService,
     NamedBean,
     RowNode,
     SortOption,
@@ -13,6 +15,7 @@ import {
     _doDeltaSort,
     _forEachChangedGroupDepthFirst,
     _isColumnsSortingCoupledToGroup,
+    _reuseArrayIfEqual,
     _updateRowNodeAfterSort,
 } from 'ag-grid-community';
 
@@ -37,63 +40,56 @@ export class GroupSortStage extends BeanStub implements NamedBean, _IRowNodeSort
             // rolling out to everyone.
             gos.get('deltaSort');
 
-        const groupMaintainOrder = gos.get('groupMaintainOrder');
-        const groupColumnsPresent = colModel.getCols().some((c) => c.isRowGroupActive());
-        const groupCols = rowGroupColsSvc?.columns;
+        const shouldMaintainGroupOrder =
+            gos.get('groupMaintainOrder') &&
+            !!rowGroupColsSvc?.columns.length &&
+            !shouldSortContainsGroupCols(gos, sortOptions);
 
         const isPivotMode = colModel.pivotMode;
         const postSortFunc = gos.getCallback('postSortRows');
 
         let hasAnyFirstChildChanged = false;
-        let sortContainsGroupColumns: boolean | undefined;
 
         const callback = (rowNode: RowNode) => {
-            // It's pointless to sort rows which aren't being displayed. in pivot mode we don't need to sort the leaf group children.
-            const skipSortingPivotLeafs = isPivotMode && rowNode.leafGroup;
+            const leafGroup = rowNode.leafGroup;
+            // It's pointless to sort rows which aren't being displayed. In pivot mode we don't sort leaf group children.
+            const skipSortingPivotLeafs = isPivotMode && leafGroup;
+            const skipSortingGroups = shouldMaintainGroupOrder && !leafGroup;
 
-            let skipSortingGroups = groupMaintainOrder && groupColumnsPresent && !rowNode.leafGroup;
-            if (skipSortingGroups) {
-                sortContainsGroupColumns ??= this.shouldSortContainsGroupCols(sortOptions);
-                skipSortingGroups &&= !sortContainsGroupColumns;
-            }
-
-            let newChildrenAfterSort: RowNode[] | null = null;
-            if (skipSortingGroups) {
-                // Maintain previous visual order in O(n).
-
-                let wasSortExplicitlyRemoved = false;
-                if (groupCols) {
-                    const nextGroupIndex = rowNode.level + 1;
-                    if (nextGroupIndex < groupCols.length) {
-                        wasSortExplicitlyRemoved = groupCols[nextGroupIndex].wasSortExplicitlyRemoved;
-                    }
+            const prevSort = rowNode.childrenAfterSort;
+            let newChildrenAfterSort: RowNode[];
+            if (!skipSortingGroups && sortOptions?.length && !skipSortingPivotLeafs) {
+                if (useDeltaSort && changedRowNodes) {
+                    newChildrenAfterSort = _doDeltaSort(
+                        rowNodeSorter!,
+                        rowNode,
+                        changedRowNodes,
+                        changedPath,
+                        sortOptions
+                    );
+                } else {
+                    newChildrenAfterSort = rowNodeSorter!.doFullSortInPlace(
+                        rowNode.childrenAfterAggFilter!.slice(),
+                        sortOptions
+                    );
                 }
-
-                if (!wasSortExplicitlyRemoved) {
-                    newChildrenAfterSort = preserveGroupOrder(rowNode);
-                }
-            } else if (!sortOptions?.length || skipSortingPivotLeafs) {
-                // if there's no sort to make, skip this step
-            } else if (useDeltaSort && changedRowNodes) {
-                newChildrenAfterSort = _doDeltaSort(rowNodeSorter!, rowNode, changedRowNodes, changedPath, sortOptions);
             } else {
-                newChildrenAfterSort = rowNodeSorter!.doFullSortInPlace(
-                    rowNode.childrenAfterAggFilter!.slice(),
-                    sortOptions
-                );
+                // No sort to apply (groupMaintainOrder, no sort options, or pivot leaf): use the
+                // filter result. `childrenAfterAggFilter` is in `childrenAfterGroup` order, which
+                // the grouping stage keeps stable across transactions and filter cycles — so no
+                // separate "previous visual order" tracking is needed to honour `groupMaintainOrder`.
+                // `postSortRows` (if configured) runs below on every refresh and reapplies the
+                // user's customisation on top of this baseline.
+                newChildrenAfterSort = _reuseArrayIfEqual(prevSort, rowNode.childrenAfterAggFilter);
             }
 
-            newChildrenAfterSort ||= rowNode.childrenAfterAggFilter?.slice() ?? [];
-
-            hasAnyFirstChildChanged ||= rowNode.childrenAfterSort?.[0] !== newChildrenAfterSort[0];
+            hasAnyFirstChildChanged ||= prevSort?.[0] !== newChildrenAfterSort[0];
 
             rowNode.childrenAfterSort = newChildrenAfterSort;
 
             _updateRowNodeAfterSort(rowNode);
 
-            if (postSortFunc) {
-                postSortFunc({ nodes: rowNode.childrenAfterSort });
-            }
+            postSortFunc?.({ nodes: rowNode.childrenAfterSort });
         };
 
         _forEachChangedGroupDepthFirst(rowModel.rootNode, true, changedPath, callback);
@@ -108,72 +104,29 @@ export class GroupSortStage extends BeanStub implements NamedBean, _IRowNodeSort
             }
         }
     }
+}
 
-    private shouldSortContainsGroupCols(sortOptions: SortOption[] | undefined): boolean {
-        const sortOptionsLen = sortOptions?.length;
-        if (!sortOptionsLen) {
-            return false;
-        }
+const shouldSortContainsGroupCols = (gos: GridOptionsService, sortOptions: SortOption[] | undefined): boolean => {
+    const sortOptionsLen = sortOptions?.length;
+    if (!sortOptionsLen) {
+        return false;
+    }
 
-        if (_isColumnsSortingCoupledToGroup(this.gos)) {
-            for (let i = 0; i < sortOptionsLen; ++i) {
-                const column = sortOptions[i].column;
-                if (column.isPrimary() && column.isRowGroupActive()) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
+    if (_isColumnsSortingCoupledToGroup(gos)) {
         for (let i = 0; i < sortOptionsLen; ++i) {
-            if (sortOptions[i].column.getColDef().showRowGroup) {
+            const column = sortOptions[i].column as AgColumn;
+            if (column.primary && column.rowGroupActive) {
                 return true;
             }
         }
         return false;
     }
-}
 
-/**
- * O(n) merge preserving previous visual order and appending new items in current order.
- */
-const preserveGroupOrder = (node: RowNode): RowNode[] | null => {
-    const childrenAfterSort = node.childrenAfterSort;
-    const childrenAfterAggFilter = node.childrenAfterAggFilter;
-
-    const childrenAfterSortLen = childrenAfterSort?.length;
-    const childrenAfterAggFilterLen = childrenAfterAggFilter?.length;
-
-    if (!childrenAfterSortLen || !childrenAfterAggFilterLen) {
-        return null;
-    }
-
-    const result = new Array<RowNode>(childrenAfterAggFilterLen);
-
-    // Track all present nodes.
-    const processed = new Set<RowNode>();
-    for (let i = 0; i < childrenAfterAggFilterLen; ++i) {
-        processed.add(childrenAfterAggFilter[i]);
-    }
-
-    // Keep nodes that are still present, in previous visual order.
-    let writeIdx = 0;
-    for (let i = 0; i < childrenAfterSortLen; ++i) {
-        const node = childrenAfterSort[i];
-        if (processed.delete(node)) {
-            result[writeIdx++] = node;
+    for (let i = 0; i < sortOptionsLen; ++i) {
+        const column = sortOptions[i].column as AgColumn;
+        if (column.colDef.showRowGroup) {
+            return true;
         }
     }
-
-    if (processed.size === 0 && writeIdx === childrenAfterSortLen) {
-        return childrenAfterSort; // No change, return the previous array
-    }
-
-    // Add new nodes
-    for (const newNode of processed) {
-        result[writeIdx++] = newNode;
-    }
-
-    result.length = writeIdx;
-    return result;
+    return false;
 };

--- a/packages/ag-grid-enterprise/src/rowHierarchy/groupSortStage.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/groupSortStage.ts
@@ -83,13 +83,14 @@ export class GroupSortStage extends BeanStub implements NamedBean, _IRowNodeSort
                 newChildrenAfterSort = _reuseArrayIfEqual(prevSort, rowNode.childrenAfterAggFilter);
             }
 
-            hasAnyFirstChildChanged ||= prevSort?.[0] !== newChildrenAfterSort[0];
-
             rowNode.childrenAfterSort = newChildrenAfterSort;
 
+            // postSortRows may mutate the array, so capture the final first child and refresh
+            // child position metadata afterwards.
+            postSortFunc?.({ nodes: newChildrenAfterSort });
             _updateRowNodeAfterSort(rowNode);
 
-            postSortFunc?.({ nodes: rowNode.childrenAfterSort });
+            hasAnyFirstChildChanged ||= prevSort?.[0] !== newChildrenAfterSort[0];
         };
 
         _forEachChangedGroupDepthFirst(rowModel.rootNode, true, changedPath, callback);

--- a/packages/ag-grid-enterprise/src/rowHierarchy/groupSortStage.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/groupSortStage.ts
@@ -83,14 +83,20 @@ export class GroupSortStage extends BeanStub implements NamedBean, _IRowNodeSort
                 newChildrenAfterSort = _reuseArrayIfEqual(prevSort, rowNode.childrenAfterAggFilter);
             }
 
+            // Capture the previous first child by value: when _reuseArrayIfEqual returns prevSort,
+            // newChildrenAfterSort and prevSort point to the same array, so a postSortRows in-place
+            // reorder below would otherwise hide the change.
+            const prevFirstChild = prevSort?.[0];
+
             rowNode.childrenAfterSort = newChildrenAfterSort;
 
-            // postSortRows may mutate the array, so capture the final first child and refresh
-            // child position metadata afterwards.
+            // postSortRows runs first so the array reflects the user's customisation; only then
+            // do we sync child position metadata + fire firstChild/lastChild/childIndex events,
+            // ensuring those flags and events always describe the actually-displayed order.
             postSortFunc?.({ nodes: newChildrenAfterSort });
             _updateRowNodeAfterSort(rowNode);
 
-            hasAnyFirstChildChanged ||= prevSort?.[0] !== newChildrenAfterSort[0];
+            hasAnyFirstChildChanged ||= prevFirstChild !== newChildrenAfterSort[0];
         };
 
         _forEachChangedGroupDepthFirst(rowModel.rootNode, true, changedPath, callback);

--- a/packages/ag-grid-enterprise/src/rowHierarchy/groupSortStage.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/groupSortStage.ts
@@ -90,6 +90,9 @@ export class GroupSortStage extends BeanStub implements NamedBean, _IRowNodeSort
 
             rowNode.childrenAfterSort = newChildrenAfterSort;
 
+            // _updateRowNodeAfterSort runs before postSortRows — same ordering as AG-309
+            // (Feb 2018, when postSortRows was introduced). Callbacks see flags consistent
+            // with params.nodes.
             _updateRowNodeAfterSort(rowNode);
 
             postSortFunc?.({ nodes: newChildrenAfterSort });

--- a/packages/ag-grid-vue3/src/components/utils.ts
+++ b/packages/ag-grid-vue3/src/components/utils.ts
@@ -1213,8 +1213,11 @@ export interface Props<TData> {
          * @agModule `RowGroupingModule` / `TreeDataModule`
          */
     autoGroupColumnDef?: AutoGroupColumnDef<TData>,
-    /** When `true`, preserves the current group order when sorting on non-group columns.
-         * If a user explicitly resets the current group sort direction, then the current group column order is not preserved.
+    /** When `true`, sorting on non-group columns does not reorder groups; only the rows within
+         * each group are sorted. Group order remains the structural order set at grouping time
+         * (data-insertion order, or `initialGroupOrderComparator` if configured) and is preserved
+         * across filter changes and transactions. If a group column was sorted via `colDef.sort`
+         * and the user later explicitly clears that sort, the structural order is restored.
          * @default false
          * @agModule `RowGroupingModule`
          */

--- a/testing/behavioural/src/filters/multi-filter-set-filter-refresh.test.ts
+++ b/testing/behavioural/src/filters/multi-filter-set-filter-refresh.test.ts
@@ -59,7 +59,7 @@ describe('Multi Filter + Set Filter list refresh on floating filter change', () 
         input.value = text;
         input.dispatchEvent(new Event('input', { bubbles: true }));
         input.dispatchEvent(new Event('change', { bubbles: true }));
-        await asyncSetTimeout(5);
+        await asyncSetTimeout(12);
     }
 
     /**
@@ -69,7 +69,7 @@ describe('Multi Filter + Set Filter list refresh on floating filter change', () 
      */
     async function openPopupAndGetDisplayedSetFilterKeys(api: GridApi<Row>): Promise<string[]> {
         api.showColumnFilter('name');
-        await asyncSetTimeout(5);
+        await asyncSetTimeout(12);
         const multiFilter = (await api.getColumnFilterInstance('name')) as MultiFilter | null | undefined;
         const setFilter = multiFilter?.getChildFilterInstance<SetFilter>(1);
         if (!setFilter) {
@@ -82,7 +82,7 @@ describe('Multi Filter + Set Filter list refresh on floating filter change', () 
     test('Scenario A: no popup opened — reopening popup shows filtered Set Filter list', async () => {
         const api = await createGrid();
         // Allow the floating-filter cell to mount its inner text input before we query for it.
-        await asyncSetTimeout(5);
+        await asyncSetTimeout(12);
 
         await typeInFloatingFilter(api, 'michael');
 
@@ -97,12 +97,12 @@ describe('Multi Filter + Set Filter list refresh on floating filter change', () 
 
     test('Scenario B: popup opened+closed before floating filter — reopening popup shows filtered Set Filter list', async () => {
         const api = await createGrid();
-        await asyncSetTimeout(5);
+        await asyncSetTimeout(12);
 
         api.showColumnFilter('name');
-        await asyncSetTimeout(10);
+        await asyncSetTimeout(12);
         api.hideColumnFilter();
-        await asyncSetTimeout(10);
+        await asyncSetTimeout(12);
 
         await typeInFloatingFilter(api, 'michael');
 

--- a/testing/behavioural/src/grouping-data/group-order-maintenance.test.ts
+++ b/testing/behavioural/src/grouping-data/group-order-maintenance.test.ts
@@ -110,11 +110,8 @@ describe('group order maintenance', () => {
     });
 
     test('group order is stable across rowData reorder (immutable mode, getRowId)', async () => {
-        // Reviewer concern: with groupMaintainOrder=true, returning childrenAfterAggFilter as-is
-        // could "silently reshuffle groups" if upstream regrouping reorders cAG. Verifies that
-        // group-level cAG is in fact stable across a setRowData reorder — sortGroupChildren in
-        // the grouping stage sorts filler nodes by __objectId (creation order), so existing groups
-        // keep their relative order even when the new rowData is in a different sequence.
+        // Existing groups keep their creation-order positions when rowData is reapplied in a
+        // different sequence; only new keys would land at the end.
         let rowData = [
             { id: '1', country: 'Audi', athlete: 'A' },
             { id: '2', country: 'BMW', athlete: 'B' },
@@ -149,7 +146,6 @@ describe('group order maintenance', () => {
         ];
         api.setGridOption('rowData', rowData);
 
-        // Group order remains [Audi, BMW, Tesla] (creation order via __objectId), not [Tesla, BMW, Audi].
         await new GridRows(api, 'reorder: groups stay in creation order').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ LEAF_GROUP id:row-group-country-Audi ag-Grid-AutoColumn:"Audi"
@@ -162,10 +158,8 @@ describe('group order maintenance', () => {
     });
 
     test('postSortRows + groupMaintainOrder: customisation reapplies through filter cycles', async () => {
-        // Reviewer concern: returning childrenAfterAggFilter as the input to postSortRows could
-        // erase a previous customisation applied via postSortRows. In practice it doesn't, because
-        // postSortRows runs on every refresh and reapplies its logic to the new input. This test
-        // locks that in: a callback that "moves Tesla to top" survives a filter cycle.
+        // A postSortRows callback that pins one group to the top must keep doing so after any
+        // filter cycle.
         const rowData = [
             { id: '1', country: 'Audi', athlete: 'A' },
             { id: '2', country: 'BMW', athlete: 'B' },
@@ -218,11 +212,53 @@ describe('group order maintenance', () => {
         `);
     });
 
+    test('postSortRows reorder updates firstChild / lastChild / childIndex on each row', async () => {
+        // Child position metadata must reflect the order produced by postSortRows, not the order
+        // of the array as it was passed in. If _updateRowNodeAfterSort runs before postSortRows,
+        // these flags go stale and downstream paths (e.g. groupHideOpenParents refresh) read
+        // the wrong node as the first/last child.
+        const rowData = [
+            { id: '1', country: 'Audi', athlete: 'A' },
+            { id: '2', country: 'BMW', athlete: 'B' },
+            { id: '3', country: 'Tesla', athlete: 'T' },
+        ];
+
+        const api = gridsManager.createGrid('grid-postsort-flags', {
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
+            autoGroupColumnDef: { headerName: 'Country' },
+            animateRows: false,
+            groupDefaultExpanded: -1,
+            groupMaintainOrder: true,
+            rowData,
+            getRowId: (p) => p.data.id,
+            postSortRows: (params) => {
+                // Reverse the array — every node's first/last/index changes.
+                params.nodes.reverse();
+            },
+        });
+
+        const groupKeys = ['Tesla', 'BMW', 'Audi'];
+        const groupNodes = groupKeys.map((key) => api.getRowNode(`row-group-country-${key}`)!);
+
+        groupNodes.forEach((node, idx) => {
+            expect(node.childIndex).toBe(idx);
+            expect(node.firstChild).toBe(idx === 0);
+            expect(node.lastChild).toBe(idx === groupNodes.length - 1);
+        });
+
+        await new GridRows(api, 'postSort: reversed order').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Tesla ag-Grid-AutoColumn:"Tesla"
+            │ └── LEAF id:3 country:"Tesla" athlete:"T"
+            ├─┬ LEAF_GROUP id:row-group-country-BMW ag-Grid-AutoColumn:"BMW"
+            │ └── LEAF id:2 country:"BMW" athlete:"B"
+            └─┬ LEAF_GROUP id:row-group-country-Audi ag-Grid-AutoColumn:"Audi"
+            · └── LEAF id:1 country:"Audi" athlete:"A"
+        `);
+    });
+
     test('pivot mode + groupMaintainOrder: filter cycle preserves group order', async () => {
-        // Reviewer concern: pivot mode may interact differently with the new no-sort fallback.
-        // It does not. In pivot mode, country groups are leaf groups, so the dispatcher routes
-        // them via skipSortingPivotLeafs (which already used aggFilter as the input pre-PR);
-        // _keepOrSlice returns the same content, just with the zero-allocation fast path added.
+        // Group order survives a filter cycle when pivot mode is on.
         const rowData = [
             { id: '1', country: 'Audi', year: 2020, sales: 10 },
             { id: '2', country: 'BMW', year: 2020, sales: 20 },
@@ -461,8 +497,8 @@ describe('group order maintenance', () => {
     });
 
     test('clearing a filter restores the original group order', async () => {
-        // Regression: with a non-first group surviving a filter, clearing the filter used to
-        // leave that group at the end instead of in its original slot.
+        // After a filter narrows the data to a single non-first group, clearing the filter must
+        // restore every group to its original slot, not move the surviving group to the end.
         const rowData = [
             { id: '1', country: 'Ireland', athlete: 'I1' },
             { id: '2', country: 'Italy', athlete: 'T1' },
@@ -621,8 +657,7 @@ describe('group order maintenance', () => {
             · └── LEAF id:1 country:"Tesla" athlete:"Tim"
         `);
 
-        // The grouping stage re-runs the comparator on each transaction, so Acura lands at the
-        // alphabetical start, not at the end of insertion order.
+        // A transaction-added group is placed at its comparator position, not appended at the end.
         applyTransactionChecked(api, { add: [{ id: '4', country: 'Acura', athlete: 'Alex' }] });
         await new GridRows(api, 'comparator: add Acura via transaction — sorted alphabetically').check(`
             ROOT id:ROOT_NODE_ID

--- a/testing/behavioural/src/grouping-data/group-order-maintenance.test.ts
+++ b/testing/behavioural/src/grouping-data/group-order-maintenance.test.ts
@@ -1,11 +1,11 @@
 import { ClientSideRowModelModule, QuickFilterModule } from 'ag-grid-community';
-import { RowGroupingModule } from 'ag-grid-enterprise';
+import { PivotModule, RowGroupingModule } from 'ag-grid-enterprise';
 
 import { GridColumns, GridRows, TestGridsManager, applyTransactionChecked } from '../test-utils';
 
 describe('group order maintenance', () => {
     const gridsManager = new TestGridsManager({
-        modules: [QuickFilterModule, ClientSideRowModelModule, RowGroupingModule],
+        modules: [QuickFilterModule, ClientSideRowModelModule, RowGroupingModule, PivotModule],
     });
 
     afterEach(() => gridsManager.reset());
@@ -107,6 +107,157 @@ describe('group order maintenance', () => {
             ├── ag-Grid-AutoColumn "Country" width:200
             └── athlete "Athlete" width:200
         `);
+    });
+
+    test('group order is stable across rowData reorder (immutable mode, getRowId)', async () => {
+        // Reviewer concern: with groupMaintainOrder=true, returning childrenAfterAggFilter as-is
+        // could "silently reshuffle groups" if upstream regrouping reorders cAG. Verifies that
+        // group-level cAG is in fact stable across a setRowData reorder — sortGroupChildren in
+        // the grouping stage sorts filler nodes by __objectId (creation order), so existing groups
+        // keep their relative order even when the new rowData is in a different sequence.
+        let rowData = [
+            { id: '1', country: 'Audi', athlete: 'A' },
+            { id: '2', country: 'BMW', athlete: 'B' },
+            { id: '3', country: 'Tesla', athlete: 'T' },
+        ];
+
+        const api = gridsManager.createGrid('grid-reorder', {
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
+            autoGroupColumnDef: { headerName: 'Country' },
+            animateRows: false,
+            groupDefaultExpanded: -1,
+            groupMaintainOrder: true,
+            rowData,
+            getRowId: (p) => p.data.id,
+        });
+
+        await new GridRows(api, 'reorder: initial').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Audi ag-Grid-AutoColumn:"Audi"
+            │ └── LEAF id:1 country:"Audi" athlete:"A"
+            ├─┬ LEAF_GROUP id:row-group-country-BMW ag-Grid-AutoColumn:"BMW"
+            │ └── LEAF id:2 country:"BMW" athlete:"B"
+            └─┬ LEAF_GROUP id:row-group-country-Tesla ag-Grid-AutoColumn:"Tesla"
+            · └── LEAF id:3 country:"Tesla" athlete:"T"
+        `);
+
+        // Reorder rowData: Tesla, BMW, Audi.
+        rowData = [
+            { id: '3', country: 'Tesla', athlete: 'T' },
+            { id: '2', country: 'BMW', athlete: 'B' },
+            { id: '1', country: 'Audi', athlete: 'A' },
+        ];
+        api.setGridOption('rowData', rowData);
+
+        // Group order remains [Audi, BMW, Tesla] (creation order via __objectId), not [Tesla, BMW, Audi].
+        await new GridRows(api, 'reorder: groups stay in creation order').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Audi ag-Grid-AutoColumn:"Audi"
+            │ └── LEAF id:1 country:"Audi" athlete:"A"
+            ├─┬ LEAF_GROUP id:row-group-country-BMW ag-Grid-AutoColumn:"BMW"
+            │ └── LEAF id:2 country:"BMW" athlete:"B"
+            └─┬ LEAF_GROUP id:row-group-country-Tesla ag-Grid-AutoColumn:"Tesla"
+            · └── LEAF id:3 country:"Tesla" athlete:"T"
+        `);
+    });
+
+    test('postSortRows + groupMaintainOrder: customisation reapplies through filter cycles', async () => {
+        // Reviewer concern: returning childrenAfterAggFilter as the input to postSortRows could
+        // erase a previous customisation applied via postSortRows. In practice it doesn't, because
+        // postSortRows runs on every refresh and reapplies its logic to the new input. This test
+        // locks that in: a callback that "moves Tesla to top" survives a filter cycle.
+        const rowData = [
+            { id: '1', country: 'Audi', athlete: 'A' },
+            { id: '2', country: 'BMW', athlete: 'B' },
+            { id: '3', country: 'Tesla', athlete: 'T' },
+        ];
+
+        const api = gridsManager.createGrid('grid-postsort', {
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
+            autoGroupColumnDef: { headerName: 'Country' },
+            animateRows: false,
+            groupDefaultExpanded: -1,
+            groupMaintainOrder: true,
+            rowData,
+            getRowId: (p) => p.data.id,
+            postSortRows: (params) => {
+                const teslaIdx = params.nodes.findIndex((n) => n.key === 'Tesla');
+                if (teslaIdx > 0) {
+                    const [tesla] = params.nodes.splice(teslaIdx, 1);
+                    params.nodes.unshift(tesla);
+                }
+            },
+        });
+
+        await new GridRows(api, 'postSort: initial — Tesla pinned to top').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Tesla ag-Grid-AutoColumn:"Tesla"
+            │ └── LEAF id:3 country:"Tesla" athlete:"T"
+            ├─┬ LEAF_GROUP id:row-group-country-Audi ag-Grid-AutoColumn:"Audi"
+            │ └── LEAF id:1 country:"Audi" athlete:"A"
+            └─┬ LEAF_GROUP id:row-group-country-BMW ag-Grid-AutoColumn:"BMW"
+            · └── LEAF id:2 country:"BMW" athlete:"B"
+        `);
+
+        api.setGridOption('quickFilterText', 'BMW');
+        await new GridRows(api, 'postSort: filtered to BMW only').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ LEAF_GROUP id:row-group-country-BMW ag-Grid-AutoColumn:"BMW"
+            · └── LEAF id:2 country:"BMW" athlete:"B"
+        `);
+
+        api.setGridOption('quickFilterText', undefined);
+        await new GridRows(api, 'postSort: clear filter — Tesla pinned again').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Tesla ag-Grid-AutoColumn:"Tesla"
+            │ └── LEAF id:3 country:"Tesla" athlete:"T"
+            ├─┬ LEAF_GROUP id:row-group-country-Audi ag-Grid-AutoColumn:"Audi"
+            │ └── LEAF id:1 country:"Audi" athlete:"A"
+            └─┬ LEAF_GROUP id:row-group-country-BMW ag-Grid-AutoColumn:"BMW"
+            · └── LEAF id:2 country:"BMW" athlete:"B"
+        `);
+    });
+
+    test('pivot mode + groupMaintainOrder: filter cycle preserves group order', async () => {
+        // Reviewer concern: pivot mode may interact differently with the new no-sort fallback.
+        // It does not. In pivot mode, country groups are leaf groups, so the dispatcher routes
+        // them via skipSortingPivotLeafs (which already used aggFilter as the input pre-PR);
+        // _keepOrSlice returns the same content, just with the zero-allocation fast path added.
+        const rowData = [
+            { id: '1', country: 'Audi', year: 2020, sales: 10 },
+            { id: '2', country: 'BMW', year: 2020, sales: 20 },
+            { id: '3', country: 'Tesla', year: 2021, sales: 30 },
+        ];
+
+        const api = gridsManager.createGrid('grid-pivot', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', pivot: true, hide: true },
+                { field: 'sales', aggFunc: 'sum' },
+            ],
+            autoGroupColumnDef: { headerName: 'Country' },
+            animateRows: false,
+            groupDefaultExpanded: -1,
+            groupMaintainOrder: true,
+            pivotMode: true,
+            rowData,
+            getRowId: (p) => p.data.id,
+        });
+
+        const initialOrder = ['Audi', 'BMW', 'Tesla'];
+        const renderedKeys = () =>
+            api
+                .getRenderedNodes()
+                .filter((n) => n.level === 0 && n.group)
+                .map((n) => n.key);
+
+        expect(renderedKeys()).toEqual(initialOrder);
+
+        api.setGridOption('quickFilterText', 'BMW');
+        expect(renderedKeys()).toEqual(['BMW']);
+
+        api.setGridOption('quickFilterText', undefined);
+        expect(renderedKeys()).toEqual(initialOrder);
     });
 
     test('updating a row without changing group does not change group order (groupMaintainOrder=false)', async () => {
@@ -308,6 +459,184 @@ describe('group order maintenance', () => {
             · └── LEAF id:3 country:"France" athlete:"M"
         `);
     });
+
+    test('clearing a filter restores the original group order', async () => {
+        // Regression: with a non-first group surviving a filter, clearing the filter used to
+        // leave that group at the end instead of in its original slot.
+        const rowData = [
+            { id: '1', country: 'Ireland', athlete: 'I1' },
+            { id: '2', country: 'Italy', athlete: 'T1' },
+            { id: '3', country: 'France', athlete: 'F1' },
+            { id: '4', country: 'Spain', athlete: 'S1' },
+        ];
+
+        const api = gridsManager.createGrid('grid-filter-reset', {
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
+            autoGroupColumnDef: { headerName: 'Country' },
+            animateRows: false,
+            groupDefaultExpanded: -1,
+            groupMaintainOrder: true,
+            rowData,
+            getRowId: (p) => p.data.id,
+        });
+
+        api.setGridOption('quickFilterText', 'T1');
+        await new GridRows(api, 'after filter to Italy only').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · └── LEAF id:2 country:"Italy" athlete:"T1"
+        `);
+
+        api.setGridOption('quickFilterText', undefined);
+        await new GridRows(api, 'after clearing filter — original order').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ └── LEAF id:1 country:"Ireland" athlete:"I1"
+            ├─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            │ └── LEAF id:2 country:"Italy" athlete:"T1"
+            ├─┬ LEAF_GROUP id:row-group-country-France ag-Grid-AutoColumn:"France"
+            │ └── LEAF id:3 country:"France" athlete:"F1"
+            └─┬ LEAF_GROUP id:row-group-country-Spain ag-Grid-AutoColumn:"Spain"
+            · └── LEAF id:4 country:"Spain" athlete:"S1"
+        `);
+    });
+
+    test('filter cycle interleaved with add / update / remove transactions', async () => {
+        const rowData = [
+            { id: '1', country: 'Audi', athlete: 'Anna' },
+            { id: '2', country: 'BMW', athlete: 'Bert' },
+            { id: '3', country: 'Tesla', athlete: 'Tim' },
+        ];
+
+        const api = gridsManager.createGrid('grid-stress', {
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
+            autoGroupColumnDef: { headerName: 'Country' },
+            animateRows: false,
+            groupDefaultExpanded: -1,
+            groupMaintainOrder: true,
+            rowData,
+            getRowId: (p) => p.data.id,
+        });
+
+        await new GridRows(api, 'stress: initial').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Audi ag-Grid-AutoColumn:"Audi"
+            │ └── LEAF id:1 country:"Audi" athlete:"Anna"
+            ├─┬ LEAF_GROUP id:row-group-country-BMW ag-Grid-AutoColumn:"BMW"
+            │ └── LEAF id:2 country:"BMW" athlete:"Bert"
+            └─┬ LEAF_GROUP id:row-group-country-Tesla ag-Grid-AutoColumn:"Tesla"
+            · └── LEAF id:3 country:"Tesla" athlete:"Tim"
+        `);
+
+        api.setGridOption('quickFilterText', 'Tim');
+        await new GridRows(api, 'stress: filter Tesla').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ LEAF_GROUP id:row-group-country-Tesla ag-Grid-AutoColumn:"Tesla"
+            · └── LEAF id:3 country:"Tesla" athlete:"Tim"
+        `);
+
+        applyTransactionChecked(api, { add: [{ id: '4', country: 'Volvo', athlete: 'Timmy' }] });
+        await new GridRows(api, 'stress: add Volvo (visible) while filtered').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Tesla ag-Grid-AutoColumn:"Tesla"
+            │ └── LEAF id:3 country:"Tesla" athlete:"Tim"
+            └─┬ LEAF_GROUP id:row-group-country-Volvo ag-Grid-AutoColumn:"Volvo"
+            · └── LEAF id:4 country:"Volvo" athlete:"Timmy"
+        `);
+
+        applyTransactionChecked(api, { update: [{ id: '1', country: 'Audi', athlete: 'Anna-upd' }] });
+        await new GridRows(api, 'stress: update hidden Audi while filtered').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Tesla ag-Grid-AutoColumn:"Tesla"
+            │ └── LEAF id:3 country:"Tesla" athlete:"Tim"
+            └─┬ LEAF_GROUP id:row-group-country-Volvo ag-Grid-AutoColumn:"Volvo"
+            · └── LEAF id:4 country:"Volvo" athlete:"Timmy"
+        `);
+
+        applyTransactionChecked(api, { remove: [{ id: '2', country: 'BMW', athlete: 'Bert' }] });
+        await new GridRows(api, 'stress: remove hidden BMW while filtered').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Tesla ag-Grid-AutoColumn:"Tesla"
+            │ └── LEAF id:3 country:"Tesla" athlete:"Tim"
+            └─┬ LEAF_GROUP id:row-group-country-Volvo ag-Grid-AutoColumn:"Volvo"
+            · └── LEAF id:4 country:"Volvo" athlete:"Timmy"
+        `);
+
+        api.setGridOption('quickFilterText', undefined);
+        await new GridRows(api, 'stress: clear filter — original positions restored').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Audi ag-Grid-AutoColumn:"Audi"
+            │ └── LEAF id:1 country:"Audi" athlete:"Anna-upd"
+            ├─┬ LEAF_GROUP id:row-group-country-Tesla ag-Grid-AutoColumn:"Tesla"
+            │ └── LEAF id:3 country:"Tesla" athlete:"Tim"
+            └─┬ LEAF_GROUP id:row-group-country-Volvo ag-Grid-AutoColumn:"Volvo"
+            · └── LEAF id:4 country:"Volvo" athlete:"Timmy"
+        `);
+    });
+
+    test('initialGroupOrderComparator + groupMaintainOrder + filter cycle', async () => {
+        // Data order is Tesla, BMW, Audi — the comparator should override it to alphabetical.
+        const rowData = [
+            { id: '1', country: 'Tesla', athlete: 'Tim' },
+            { id: '2', country: 'BMW', athlete: 'Bert' },
+            { id: '3', country: 'Audi', athlete: 'Anna' },
+        ];
+
+        const api = gridsManager.createGrid('grid-comparator', {
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
+            autoGroupColumnDef: { headerName: 'Country' },
+            animateRows: false,
+            groupDefaultExpanded: -1,
+            groupMaintainOrder: true,
+            initialGroupOrderComparator: ({ nodeA, nodeB }) => (nodeA.key! < nodeB.key! ? -1 : 1),
+            rowData,
+            getRowId: (p) => p.data.id,
+        });
+
+        await new GridRows(api, 'comparator: initial alphabetical order').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Audi ag-Grid-AutoColumn:"Audi"
+            │ └── LEAF id:3 country:"Audi" athlete:"Anna"
+            ├─┬ LEAF_GROUP id:row-group-country-BMW ag-Grid-AutoColumn:"BMW"
+            │ └── LEAF id:2 country:"BMW" athlete:"Bert"
+            └─┬ LEAF_GROUP id:row-group-country-Tesla ag-Grid-AutoColumn:"Tesla"
+            · └── LEAF id:1 country:"Tesla" athlete:"Tim"
+        `);
+
+        api.setGridOption('quickFilterText', 'Tim');
+        await new GridRows(api, 'comparator: filter Tesla only').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ LEAF_GROUP id:row-group-country-Tesla ag-Grid-AutoColumn:"Tesla"
+            · └── LEAF id:1 country:"Tesla" athlete:"Tim"
+        `);
+
+        api.setGridOption('quickFilterText', undefined);
+        await new GridRows(api, 'comparator: clear filter — alphabetical order restored').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Audi ag-Grid-AutoColumn:"Audi"
+            │ └── LEAF id:3 country:"Audi" athlete:"Anna"
+            ├─┬ LEAF_GROUP id:row-group-country-BMW ag-Grid-AutoColumn:"BMW"
+            │ └── LEAF id:2 country:"BMW" athlete:"Bert"
+            └─┬ LEAF_GROUP id:row-group-country-Tesla ag-Grid-AutoColumn:"Tesla"
+            · └── LEAF id:1 country:"Tesla" athlete:"Tim"
+        `);
+
+        // The grouping stage re-runs the comparator on each transaction, so Acura lands at the
+        // alphabetical start, not at the end of insertion order.
+        applyTransactionChecked(api, { add: [{ id: '4', country: 'Acura', athlete: 'Alex' }] });
+        await new GridRows(api, 'comparator: add Acura via transaction — sorted alphabetically').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-Acura ag-Grid-AutoColumn:"Acura"
+            │ └── LEAF id:4 country:"Acura" athlete:"Alex"
+            ├─┬ LEAF_GROUP id:row-group-country-Audi ag-Grid-AutoColumn:"Audi"
+            │ └── LEAF id:3 country:"Audi" athlete:"Anna"
+            ├─┬ LEAF_GROUP id:row-group-country-BMW ag-Grid-AutoColumn:"BMW"
+            │ └── LEAF id:2 country:"BMW" athlete:"Bert"
+            └─┬ LEAF_GROUP id:row-group-country-Tesla ag-Grid-AutoColumn:"Tesla"
+            · └── LEAF id:1 country:"Tesla" athlete:"Tim"
+        `);
+    });
+
     test('after filtering removes a group, adding a new group appends at end', async () => {
         const rowData = [
             { id: '1', country: 'Ireland', athlete: 'I1' },

--- a/testing/behavioural/src/grouping-data/group-order-maintenance.test.ts
+++ b/testing/behavioural/src/grouping-data/group-order-maintenance.test.ts
@@ -212,11 +212,11 @@ describe('group order maintenance', () => {
         `);
     });
 
-    test('postSortRows reorder updates firstChild / lastChild / childIndex on each row', async () => {
-        // Child position metadata must reflect the order produced by postSortRows, not the order
-        // of the array as it was passed in. If _updateRowNodeAfterSort runs before postSortRows,
-        // these flags go stale and downstream paths (e.g. groupHideOpenParents refresh) read
-        // the wrong node as the first/last child.
+    test('firstChild / lastChild / childIndex flags reflect the order produced by postSortRows', async () => {
+        // The deprecated firstChild/lastChild/childIndex flags must describe the actually-displayed
+        // order. _updateRowNodeAfterSort therefore has to run AFTER postSortRows, otherwise it
+        // syncs flags + fires firstChildChanged/lastChildChanged/childIndexChanged events for the
+        // pre-mutation order and then the array is silently reordered, leaving the flags stale.
         const rowData = [
             { id: '1', country: 'Audi', athlete: 'A' },
             { id: '2', country: 'BMW', athlete: 'B' },
@@ -245,16 +245,57 @@ describe('group order maintenance', () => {
             expect(node.firstChild).toBe(idx === 0);
             expect(node.lastChild).toBe(idx === groupNodes.length - 1);
         });
+    });
 
-        await new GridRows(api, 'postSort: reversed order').check(`
-            ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-country-Tesla ag-Grid-AutoColumn:"Tesla"
-            │ └── LEAF id:3 country:"Tesla" athlete:"T"
-            ├─┬ LEAF_GROUP id:row-group-country-BMW ag-Grid-AutoColumn:"BMW"
-            │ └── LEAF id:2 country:"BMW" athlete:"B"
-            └─┬ LEAF_GROUP id:row-group-country-Audi ag-Grid-AutoColumn:"Audi"
-            · └── LEAF id:1 country:"Audi" athlete:"A"
-        `);
+    test('postSortRows reorder survives a sort refresh on the reused-array path', async () => {
+        const rowData = [
+            { id: '1', country: 'Audi', athlete: 'A' },
+            { id: '2', country: 'BMW', athlete: 'B' },
+            { id: '3', country: 'Tesla', athlete: 'T' },
+        ];
+
+        let promoteKey: string | null = null;
+        const api = gridsManager.createGrid('grid-postsort-reuse', {
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
+            autoGroupColumnDef: { headerName: 'Country' },
+            animateRows: false,
+            groupDefaultExpanded: -1,
+            groupMaintainOrder: true,
+            rowData,
+            getRowId: (p) => p.data.id,
+            postSortRows: (params) => {
+                if (!promoteKey) return;
+                const idx = params.nodes.findIndex((n) => n.key === promoteKey);
+                if (idx > 0) {
+                    const [promoted] = params.nodes.splice(idx, 1);
+                    params.nodes.unshift(promoted);
+                }
+            },
+        });
+
+        const topLevelKeys = () => {
+            const root = api.getRowNode('ROOT_NODE_ID');
+            return (root?.childrenAfterSort ?? []).map((n) => n.key);
+        };
+
+        expect(topLevelKeys()).toEqual(['Audi', 'BMW', 'Tesla']);
+
+        // Force the sort stage to re-run with structurally identical childrenAfterAggFilter so
+        // _reuseArrayIfEqual returns the previous reference. postSortRows then mutates that array.
+        promoteKey = 'Tesla';
+        api.refreshClientSideRowModel('sort');
+
+        expect(topLevelKeys()).toEqual(['Tesla', 'Audi', 'BMW']);
+
+        // Run another refresh on the now-reordered array — postSortRows still applies on top.
+        api.refreshClientSideRowModel('sort');
+        expect(topLevelKeys()).toEqual(['Tesla', 'Audi', 'BMW']);
+
+        // Switching the promoted key takes effect on the next refresh — the new ordering is
+        // produced from the structural baseline ([Audi, BMW, Tesla]) and then BMW is unshifted.
+        promoteKey = 'BMW';
+        api.refreshClientSideRowModel('sort');
+        expect(topLevelKeys()).toEqual(['BMW', 'Audi', 'Tesla']);
     });
 
     test('pivot mode + groupMaintainOrder: filter cycle preserves group order', async () => {

--- a/testing/behavioural/src/grouping-data/group-order-maintenance.test.ts
+++ b/testing/behavioural/src/grouping-data/group-order-maintenance.test.ts
@@ -212,42 +212,11 @@ describe('group order maintenance', () => {
         `);
     });
 
-    test('firstChild / lastChild / childIndex flags reflect the order produced by postSortRows', async () => {
-        // The deprecated firstChild/lastChild/childIndex flags must describe the actually-displayed
-        // order. _updateRowNodeAfterSort therefore has to run AFTER postSortRows, otherwise it
-        // syncs flags + fires firstChildChanged/lastChildChanged/childIndexChanged events for the
-        // pre-mutation order and then the array is silently reordered, leaving the flags stale.
-        const rowData = [
-            { id: '1', country: 'Audi', athlete: 'A' },
-            { id: '2', country: 'BMW', athlete: 'B' },
-            { id: '3', country: 'Tesla', athlete: 'T' },
-        ];
-
-        const api = gridsManager.createGrid('grid-postsort-flags', {
-            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
-            autoGroupColumnDef: { headerName: 'Country' },
-            animateRows: false,
-            groupDefaultExpanded: -1,
-            groupMaintainOrder: true,
-            rowData,
-            getRowId: (p) => p.data.id,
-            postSortRows: (params) => {
-                // Reverse the array — every node's first/last/index changes.
-                params.nodes.reverse();
-            },
-        });
-
-        const groupKeys = ['Tesla', 'BMW', 'Audi'];
-        const groupNodes = groupKeys.map((key) => api.getRowNode(`row-group-country-${key}`)!);
-
-        groupNodes.forEach((node, idx) => {
-            expect(node.childIndex).toBe(idx);
-            expect(node.firstChild).toBe(idx === 0);
-            expect(node.lastChild).toBe(idx === groupNodes.length - 1);
-        });
-    });
-
     test('postSortRows reorder survives a sort refresh on the reused-array path', async () => {
+        // Exercises the path where _reuseArrayIfEqual returns the previous childrenAfterSort by
+        // reference and postSortRows then mutates the same array in place. hasAnyFirstChildChanged
+        // must capture the previous first child by value before postSortRows runs, otherwise the
+        // before/after comparison reads from one shared array and silently misses the change.
         const rowData = [
             { id: '1', country: 'Audi', athlete: 'A' },
             { id: '2', country: 'BMW', athlete: 'B' },
@@ -264,7 +233,9 @@ describe('group order maintenance', () => {
             rowData,
             getRowId: (p) => p.data.id,
             postSortRows: (params) => {
-                if (!promoteKey) return;
+                if (!promoteKey) {
+                    return;
+                }
                 const idx = params.nodes.findIndex((n) => n.key === promoteKey);
                 if (idx > 0) {
                     const [promoted] = params.nodes.splice(idx, 1);


### PR DESCRIPTION
groupMaintainOrder was not behaving correctly after filter, as we lost the order of filtered rows.

The original implementation of groupMaintainOrder was much more complex than it should be, after analysing the whole csrm pipeline again, the correct solution is using the structular order coming from the group stage directly when groupMaintainOrder is true and we have no sorting from group columns, as this is the correct behaviour the user expect and the option implies.

The hard part was to understand that there is actually no visual order to maintain but just the structural order to be reapplied (that is, groups creation date or initial group order comparator) when sort on a group is removed.

- fixed and improved and simplified groupSortStage
- minor optimizations to avoid recreating sorted arrays for flat and grouped when nothing changes
- updated jsdoc to make what the grid option actually do

FIX AG-16818