### PR TITLE
AG-17225 add sans-serif fallback to theme font stacks

### DIFF
--- a/packages/ag-grid-community/src/agStack/theming/shared/shared-css.ts
+++ b/packages/ag-grid-community/src/agStack/theming/shared/shared-css.ts
@@ -363,23 +363,25 @@ export const defaultLightColorSchemeParams = {
     browserColorScheme: 'light',
 } as const;
 
+export const defaultFontFamily = [
+    '-apple-system',
+    'BlinkMacSystemFont',
+    'Segoe UI',
+    'Roboto',
+    'Oxygen-Sans',
+    'Ubuntu',
+    'Cantarell',
+    'Helvetica Neue',
+    'sans-serif',
+];
+
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const sharedDefaults: Readonly<SharedThemeParams> = {
     ...defaultLightColorSchemeParams,
     textColor: foregroundColor,
     accentColor: '#2196f3',
     invalidColor: '#e02525',
-    fontFamily: [
-        '-apple-system',
-        'BlinkMacSystemFont',
-        'Segoe UI',
-        'Roboto',
-        'Oxygen-Sans',
-        'Ubuntu',
-        'Cantarell',
-        'Helvetica Neue',
-        'sans-serif',
-    ],
+    fontFamily: defaultFontFamily,
     subtleTextColor: {
         ref: 'textColor',
         mix: 0.5,

--- a/packages/ag-grid-community/src/agStack/theming/shared/shared-css.ts
+++ b/packages/ag-grid-community/src/agStack/theming/shared/shared-css.ts
@@ -363,7 +363,7 @@ export const defaultLightColorSchemeParams = {
     browserColorScheme: 'light',
 } as const;
 
-export const defaultFontFamily = [
+export const defaultFontFamily = () => [
     '-apple-system',
     'BlinkMacSystemFont',
     'Segoe UI',
@@ -381,7 +381,7 @@ export const sharedDefaults: Readonly<SharedThemeParams> = {
     textColor: foregroundColor,
     accentColor: '#2196f3',
     invalidColor: '#e02525',
-    fontFamily: defaultFontFamily,
+    fontFamily: defaultFontFamily(),
     subtleTextColor: {
         ref: 'textColor',
         mix: 0.5,

--- a/packages/ag-grid-community/src/theming/parts/theme/themes.ts
+++ b/packages/ag-grid-community/src/theming/parts/theme/themes.ts
@@ -48,7 +48,7 @@ export type AllThemeParamsForAPIDocumentation = ThemeDefaultParams;
 
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const themeQuartzParams = () => ({
-    fontFamily: [{ googleFont: 'IBM Plex Sans' }, ...defaultFontFamily],
+    fontFamily: [{ googleFont: 'IBM Plex Sans' }, ...defaultFontFamily()],
 });
 
 const makeThemeQuartzTreeShakeable = () =>
@@ -337,7 +337,7 @@ export const themeMaterialParams = () => ({
         spread: 4,
         color: foregroundMix(0.16),
     },
-    fontFamily: [{ googleFont: 'Roboto' }, ...defaultFontFamily],
+    fontFamily: [{ googleFont: 'Roboto' }, ...defaultFontFamily()],
     inputHeight: {
         calc: 'max(iconSize, fontSize) + spacing * 3',
     },

--- a/packages/ag-grid-community/src/theming/parts/theme/themes.ts
+++ b/packages/ag-grid-community/src/theming/parts/theme/themes.ts
@@ -1,4 +1,5 @@
 import { createPart } from '../../../agStack/theming/partImpl';
+import { defaultFontFamily } from '../../../agStack/theming/shared/shared-css';
 import type { Theme } from '../../../agStack/theming/theme';
 import type { ColorValue } from '../../../agStack/theming/themeTypes';
 import {
@@ -47,15 +48,7 @@ export type AllThemeParamsForAPIDocumentation = ThemeDefaultParams;
 
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export const themeQuartzParams = () => ({
-    fontFamily: [
-        { googleFont: 'IBM Plex Sans' },
-        '-apple-system',
-        'BlinkMacSystemFont',
-        'Segoe UI',
-        'Roboto',
-        'Oxygen-Sans',
-        'Ubuntu',
-    ],
+    fontFamily: [{ googleFont: 'IBM Plex Sans' }, ...defaultFontFamily],
 });
 
 const makeThemeQuartzTreeShakeable = () =>
@@ -344,17 +337,7 @@ export const themeMaterialParams = () => ({
         spread: 4,
         color: foregroundMix(0.16),
     },
-    fontFamily: [
-        { googleFont: 'Roboto' },
-        '-apple-system',
-        'BlinkMacSystemFont',
-        'Segoe UI',
-        'Oxygen-Sans',
-        'Ubuntu',
-        'Cantarell',
-        'Helvetica Neue',
-        'sans-serif',
-    ],
+    fontFamily: [{ googleFont: 'Roboto' }, ...defaultFontFamily],
     inputHeight: {
         calc: 'max(iconSize, fontSize) + spacing * 3',
     },


### PR DESCRIPTION
Fix [AG-17225](https://ag-grid.atlassian.net/browse/AG-17225)

- Extract the shared default font stack into a `defaultFontFamily` constant in `shared-css.ts`.
- Reuse it in Quartz and Material theme `fontFamily` values so every theme ends with a generic `sans-serif` fallback after the theme-specific lead font.
- Fixes inconsistent in fallback fonts between themes