### PR TITLE
Resolve flaky multi-filter test

### DIFF
--- a/packages/ag-grid-enterprise/src/multiFilter/multiFilterUi.ts
+++ b/packages/ag-grid-enterprise/src/multiFilter/multiFilterUi.ts
@@ -61,6 +61,11 @@ export class MultiFilterUi
         // we have to refresh the GUI here to ensure that Angular components are not rendered in odd places
         return new AgPromise<void>((resolve) => {
             AgPromise.all(filterPromises).then((filters) => {
+                if (!this.isAlive()) {
+                    this.destroyFilters();
+                    resolve();
+                    return;
+                }
                 this.filters = filters!;
                 this.refreshGui('columnMenu').then(() => {
                     resolve();
@@ -111,12 +116,16 @@ export class MultiFilterUi
         return this.filters.length;
     }
 
-    public override destroy(): void {
+    private destroyFilters() {
         for (const filter of this.filters) {
             this.destroyBean(filter);
         }
 
         this.filters.length = 0;
+    }
+
+    public override destroy(): void {
+        this.destroyFilters();
 
         super.destroy();
     }

--- a/packages/ag-grid-enterprise/src/multiFilter/multiFilterUi.ts
+++ b/packages/ag-grid-enterprise/src/multiFilter/multiFilterUi.ts
@@ -62,7 +62,7 @@ export class MultiFilterUi
         return new AgPromise<void>((resolve) => {
             AgPromise.all(filterPromises).then((filters) => {
                 if (!this.isAlive()) {
-                    this.destroyFilters();
+                    this.destroyBeans(filters ?? []);
                     resolve();
                     return;
                 }
@@ -116,16 +116,8 @@ export class MultiFilterUi
         return this.filters.length;
     }
 
-    private destroyFilters() {
-        for (const filter of this.filters) {
-            this.destroyBean(filter);
-        }
-
-        this.filters.length = 0;
-    }
-
     public override destroy(): void {
-        this.destroyFilters();
+        this.filters = this.destroyBeans(this.filters);
 
         super.destroy();
     }


### PR DESCRIPTION
Fixes a race condition in MultiFilterUi.init() where opening and immediately closing a multi-filter popup could leave stale async callbacks firing after the component was destroyed. This caused spurious filterChanged events that temporarily reset filtered row counts, producing intermittent test failures on loaded CI.

https://github.com/ag-grid/ag-grid/actions/runs/25206805562/job/73909375445