### PR TITLE
Sync ag-shared from AG-3390-snyk-issues-axios

### DIFF
--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = d9a9d4ab7ab6b5313c13eb85b40335f8fea13719
-	parent = 05324011af73d220814034bb1d5c1a05fe044a8d
+	commit = e28574f98fdffd9a3e1b9f03a63ec844a6d848e8
+	parent = d1d5936813bd20150cc1ff101bebd06503ab2a1f
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/scripts/snyk-viewer/index.mjs
+++ b/external/ag-shared/scripts/snyk-viewer/index.mjs
@@ -206,6 +206,11 @@ function addSnykIgnoreEntry(snykFile, vulnId, depPath, reason, expires) {
         content = '# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\n\nignore:\npatch: {}\n';
     }
 
+    // Snyk CLI / snykClean.mjs writes `ignore: {}` when the section is empty.
+    // YAML rejects mixing the inline empty mapping with block-style children,
+    // so collapse it to `ignore:` before inserting any vuln block beneath it.
+    content = content.replace(/^ignore:[ \t]*\{[ \t]*\}[ \t]*$/m, 'ignore:');
+
     // Use js-yaml to get a correctly-quoted key for the dep path.
     // Dump as a single-key mapping, strip the ": null" value, then append ":".
     // e.g. "@nx/foo@1 > bar@2"  →  "'@nx/foo@1 > bar@2':"
@@ -687,7 +692,7 @@ const server = createServer((req, res) => {
 
 server.listen(args.port, '127.0.0.1', () => {
     const url = `http://localhost:${args.port}`;
-    console.log(`\nSnyk Viewer running at ${url}`);
+    console.log(`\nSnyk Viewer running at \x1b[36m\x1b[4m${url}\x1b[0m`);
     console.log(`Loaded ${snykData.length} project(s) from ${args.file}`);
     console.log('Press Ctrl+C to stop.\n');
     if (args.open) openBrowser(url);

--- a/external/ag-shared/scripts/snyk/snykClean.mjs
+++ b/external/ag-shared/scripts/snyk/snykClean.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readFileSync, writeFileSync, readdirSync } from 'fs';
+import { readFileSync, writeFileSync, readdirSync, unlinkSync } from 'fs';
 import { resolve, relative } from 'path';
 
 // ---------------------------------------------------------------------------
@@ -326,6 +326,12 @@ function removeStaleEntries(content, stalePaths) {
     return result;
 }
 
+// Both top-level sections are the empty inline mapping → nothing left to keep.
+function isSnykFileEmpty(content) {
+    return /^ignore:\s*\{\s*\}\s*$/m.test(content)
+        && /^patch:\s*\{\s*\}\s*$/m.test(content);
+}
+
 // ---------------------------------------------------------------------------
 // Check which entries are stale
 // ---------------------------------------------------------------------------
@@ -385,8 +391,17 @@ function main() {
         totalRemoved += staleEntries.length;
         filesModified++;
 
-        if (!args.dryRun) {
-            const cleaned = removeStaleEntries(content, staleEntries);
+        const cleaned = removeStaleEntries(content, staleEntries);
+        const fileNowEmpty = isSnykFileEmpty(cleaned);
+
+        if (args.dryRun) {
+            if (fileNowEmpty) {
+                console.log(`  → would delete ${relPath} (no remaining ignores or patches)`);
+            }
+        } else if (fileNowEmpty) {
+            unlinkSync(filePath);
+            console.log(`  → deleted ${relPath} (no remaining ignores or patches)`);
+        } else {
             writeFileSync(filePath, cleaned, 'utf8');
         }
     }


### PR DESCRIPTION
## Summary
Sync ag-shared subrepo from ag-charts@AG-3390-snyk-issues-axios.

### ag-shared changes pulled
- `scripts/snyk-viewer/index.mjs` — fix YAML parse error when inserting block-style ignore entries beneath an inline `ignore: {}` mapping; highlight the URL with ANSI cyan/underline so it's clickable in terminals.
- `scripts/snyk/snykClean.mjs` — delete `.snyk` files when both `ignore` and `patch` sections become empty after pruning stale entries (with `--dry-run` reporting).

No companion changes required in this repo.

## Cross-repo PRs
- Source: https://github.com/ag-grid/ag-charts/pull/6703

## Test plan
- [x] Verify `external/ag-shared/` content matches source ag-charts
- [ ] `./external/ag-shared/scripts/setup-prompts/verify-rulesync.sh` passes
- [ ] No unrelated drift in diff vs `origin/latest`