### PR TITLE
AG-12557 Toolbar docs polish and QA fixes

### DIFF
--- a/documentation/ag-grid-docs/package.json
+++ b/documentation/ag-grid-docs/package.json
@@ -96,10 +96,10 @@
     "vue": "^3.5.13"
   },
   "devDependencies": {
-    "@playwright/test": "^1.56.0",
+    "@playwright/test": "^1.59.1",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@types/he": "^1.2.3",
-    "playwright": "^1.56.0",
+    "playwright": "^1.59.1",
     "playwright-ctrf-json-reporter": "0.0.29",
     "prettier-plugin-astro": "^0.14.1",
     "vite-plugin-mkcert": "^1.17.8",

--- a/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/built-in-items/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/built-in-items/example.spec.ts
@@ -8,6 +8,20 @@ test.agExample(import.meta, () => {
         await expect(toolbar).toBeVisible();
 
         await expect(toolbar.locator(':scope > .ag-toolbar-input')).toHaveCount(1);
-        await expect(toolbar.locator(':scope > .ag-toolbar-button')).toHaveCount(1);
+        await expect(toolbar.locator(':scope > .ag-toolbar-button')).toHaveCount(2);
+    });
+
+    test.eachFramework('Typing into quick filter reduces displayed rows', async ({ agIdFor, page }) => {
+        await waitForGridContent(page);
+
+        await page.locator('.ag-toolbar-input-field').fill('Michael Phelps');
+
+        // The first 3 rows in the dataset are all Michael Phelps entries
+        await expect(agIdFor.cell('0', 'athlete')).toContainText('Michael Phelps');
+        await expect(agIdFor.cell('1', 'athlete')).toContainText('Michael Phelps');
+        await expect(agIdFor.cell('2', 'athlete')).toContainText('Michael Phelps');
+
+        // No other rows should be visible
+        await expect(agIdFor.rowNode('3')).not.toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/built-in-items/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/built-in-items/main.ts
@@ -38,12 +38,22 @@ const gridOptions: GridOptions<IOlympicData> = {
         filter: true,
     },
     toolbar: {
-        alignment: 'right',
         items: [
-            { toolbarItem: 'agQuickFilterToolbarItem', alignment: 'left' },
+            // Built in Quick Filter
+            'agQuickFilterToolbarItem',
+            // Action Button to re-size the columns
+            {
+                label: 'Fit Columns To Grid',
+                icon: 'maximize',
+                alignment: 'right',
+                action: (params) => params.api.sizeColumnsToFit(),
+            },
+            // Menu Item for exporting to CSV / Excel
             {
                 toolbarItem: 'agMenuToolbarItem',
                 icon: 'save',
+                alignment: 'right',
+                tooltip: 'Export to Csv / Excel',
                 toolbarItemParams: {
                     menuItems: ['csvExport', 'excelExport'],
                 },

--- a/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/toolbar-custom/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/toolbar-custom/example.spec.ts
@@ -16,10 +16,10 @@ test.agExample(import.meta, () => {
         await expect(page.locator('.ag-header-cell[col-id="gold"] .ag-filter-active')).toBeVisible();
 
         await toolbar.getByLabel('Columns').check();
-        await expect(page.locator('.ag-column-tool-panel')).toBeVisible();
+        await expect(page.locator('.ag-column-panel')).toBeVisible();
 
         // Closing the panel via the side bar tab keeps the radio in sync via getToolbarItemInstance
-        await page.locator('.ag-side-button[aria-label*="Columns"]').click();
+        await page.getByRole('tab', { name: 'Columns' }).click();
         await expect(toolbar.getByLabel('None')).toBeChecked();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/toolbar/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/index.mdoc
@@ -129,10 +129,17 @@ The example below defines two custom items: checkbox toggles that apply column f
 
 When defining a custom component, provide the `toolbarItem` with:
 
-{% if isFramework("javascript","angular", "react") %}
+{% if isFramework("javascript") %}
 
 1. `String`: the name of a registered Toolbar Item Component. See [Registering Custom Components](./components/#registering-custom-components).
 2. `Class`: a direct reference to a Toolbar Item Component.
+
+{% /if %}
+
+{% if isFramework("react", "angular") %}
+
+1. `String`: the name of a registered Toolbar Item Component. See [Registering Custom Components](./components/#registering-custom-components).
+2. `Component`: a direct reference to a Toolbar Item Component.
 
 {% /if %}
 

--- a/documentation/ag-grid-docs/src/content/docs/toolbar/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/index.mdoc
@@ -3,9 +3,9 @@ title: "Quick Access Toolbar"
 enterprise: true
 ---
 
-The Toolbar appears above the grid and provides quick access to common grid actions. It supports built-in items such as quick filter and find inputs, dropdown menus, and embedded panels, and can be extended with [Action Buttons](#action-buttons) or [Custom Components](#custom-components).
+The Toolbar appears above the grid and provides quick access to common grid actions. It supports built-in items such as quick filter and find, dropdown menus, and can be extended with [Action Buttons](#action-buttons) or [Custom Components](#custom-components).
 
-{% gridExampleRunner title="Built-in Items" name="built-in-items" exampleHeight=590 /%}
+{% gridExampleRunner title="Built-in Items" name="built-in-items" exampleHeight=300 /%}
 
 ## Configuring the Toolbar
 
@@ -14,7 +14,27 @@ Set the `toolbar` grid option to a [Toolbar](#reference-Toolbar) object. The `it
 ```{% frameworkTransform=true %}
 const gridOptions = {
     toolbar: {
-        items: ['agQuickFilterToolbarItem'],
+        items: [
+            // Built in Quick Filter
+            'agQuickFilterToolbarItem',
+            // Action Button to re-size the columns
+            {
+                label: 'Fit Columns To Grid',
+                icon: 'maximize',
+                alignment: 'right',
+                action: (params) => params.api.sizeColumnsToFit(),
+            },
+            // Menu Item for exporting to CSV / Excel
+            {
+                toolbarItem: 'agMenuToolbarItem',
+                icon: 'save',
+                alignment: 'right',
+                tooltip: 'Export to Csv / Excel',
+                toolbarItemParams: {
+                    menuItems: ['csvExport', 'excelExport'],
+                },
+            },
+        ],
     },
 
     // other grid options ...
@@ -23,7 +43,7 @@ const gridOptions = {
 
 ### Alignment
 
-Each item can be left&#8209; or right-aligned. The default is left, set on the toolbar via `alignment` and overridden per item with the item's own `alignment`.
+Toolbar items are aligned to the left by default. Set the `alignment` property on the toolbar to change the default alignment for all items, or set it individually per item.
 
 ```{% frameworkTransform=true %}
 const gridOptions = {
@@ -39,7 +59,7 @@ const gridOptions = {
 
 ## Built-in Items
 
-Built-in items require their corresponding modules to be registered. If a required module is not registered, the item is hidden and a console warning is logged.
+A number of built-in toolbar items are provided for common use cases that integrate with existing grid features. Be sure to include the required feature module, otherwise the toolbar item will be excluded.
 
 | Item                                   | Description                                                                                             | Required Modules                          |
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
@@ -52,7 +72,12 @@ Built-in items require their corresponding modules to be registered. If a requir
 
 ### Dropdown Menus
 
-`agMenuToolbarItem` renders a button that opens a dropdown of [Menu Items](./component-menu-item/). Set `label`, `tooltip`, and `icon` on the item and supply `menuItems` via `toolbarItemParams`. The `icon` accepts any [provided icon](./custom-icons/#provided-icons) name. Each entry is either a [`MenuItemDef`](#reference-MenuItemDef) object or one of the built-in string names accepted by the [Context Menu](./context-menu/#built-in-menu-items).
+Use the `agMenuToolbarItem` to render a dropdown of [Menu Items](./component-menu-item/). Configure the button and menu contents using the following properties:
+
+- `label`: Visible text rendered next to the icon. Omit to render an icon-only button.
+- `icon`: Icon displayed on the button. Accepts any [provided icon](./custom-icons/#provided-icons).
+- `tooltip`: Hover tooltip and `aria-label`. Falls back to `label` when omitted.
+- `toolbarItemParams.menuItems`: Items to include in the dropdown. Each entry is either a `MenuItemDef` or one of the [built-in](./context-menu/#built-in-menu-items) menu item names as used by the Context Menu.
 
 ```{% frameworkTransform=true %}
 const gridOptions = {
@@ -72,7 +97,12 @@ const gridOptions = {
 
 ## Action Buttons
 
-Set `label`, `tooltip`, `icon` and `action` on an item to render a button without writing a component. The `action` callback fires on click and receives the grid `api`, `context`, and the item `key`.
+Action buttons provide a convenient way to trigger custom behaviour on click of a toolbar item. Configure an action button using the following properties:
+
+- `label`: Visible text rendered next to the icon. Omit to render an icon-only button.
+- `icon`: Icon displayed on the button. Accepts any [provided icon](./custom-icons/#provided-icons).
+- `tooltip`: Hover tooltip and `aria-label`. Falls back to `label` when omitted.
+- `action`: Callback fired on click. Receives the grid `api`, `context`, and the item `key`.
 
 ```{% frameworkTransform=true %}
 const gridOptions = {
@@ -89,26 +119,17 @@ const gridOptions = {
 }
 ```
 
-`label` is the visible text rendered next to the icon; omit it to render an icon-only button. `icon` accepts any [provided icon](./custom-icons/#provided-icons) name. `tooltip` sets the hover tooltip and `aria-label`, and falls back to `label` when omitted.
-
 ## Custom Components
 
-For controls beyond a button, such as toggles, inputs, or any stateful UI, set `toolbarItem` to a component reference. Custom components can render arbitrary HTML and call any grid API, so they suit cases that the [Action Button](#action-buttons) shorthand cannot express.
+For controls beyond a button, such as toggles, inputs, or any stateful UI, set `toolbarItem` to a custom component. Custom components can render arbitrary HTML and call any grid API, so they suit cases that the [Action Button](#action-buttons) shorthand cannot express.
 
 The example below defines two custom items: checkbox toggles that apply column filters on the left, and a radio group that opens [Side Bar](./tool-panel/) tool panels on the right. The radio group exposes a `setSelected` method, called from the grid's `onToolPanelVisibleChanged` callback via [`getToolbarItemInstance`](#reference-getToolbarItemInstance) to keep its state in sync when a panel is opened or closed elsewhere, for example by clicking a side bar tab.
 
 {% gridExampleRunner title="Custom Toolbar Item" name="toolbar-custom" /%}
 
-The `toolbarItem` property accepts the following values:
+When defining a custom component, provide the `toolbarItem` with:
 
-{% if isFramework("javascript") %}
-
-1. `String`: the name of a registered Toolbar Item Component. See [Registering Custom Components](./components/#registering-custom-components).
-2. `Class`: a direct reference to a Toolbar Item Component.
-
-{% /if %}
-
-{% if isFramework("angular") %}
+{% if isFramework("javascript","angular", "react") %}
 
 1. `String`: the name of a registered Toolbar Item Component. See [Registering Custom Components](./components/#registering-custom-components).
 2. `Class`: a direct reference to a Toolbar Item Component.
@@ -118,13 +139,6 @@ The `toolbarItem` property accepts the following values:
 {% if isFramework("vue") %}
 
 1. `String`: the name of a registered Toolbar Item Component. See [Registering Custom Components](./components/#registering-custom-components).
-
-{% /if %}
-
-{% if isFramework("react") %}
-
-1. `String`: the name of a registered Toolbar Item Component. See [Registering Custom Components](./components/#registering-custom-components).
-2. `Component`: a direct reference to a Toolbar Item Component.
 
 {% /if %}
 
@@ -148,12 +162,18 @@ The toolbar exposes the following [Theme Parameters](./theming-parameters/):
 | `toolbarTextColor`       | Text colour in the toolbar. Defaults to the header text colour.             |
 | `toolbarSeparatorBorder` | Border style for the vertical separator between toolbar items.              |
 
+## Accessing Toolbar Items
+
+To access a toolbar item instance use the grid api method `getToolbarItemInstance(key)`. This is demonstrated in the [Custom Components](#custom-components) example above, where it's used to keep a toolbar radio in sync with side bar tool panel changes.
+
+{% apiDocumentation source="grid-api/api.json" section="accessories" names=["getToolbarItemInstance"] /%}
+
 ## API Reference
+
+### Toolbar
 
 {% apiDocumentation source="grid-options/properties.json" section="accessories" names=["toolbar"] /%}
 
+### IToolbarItemParams
+
 {% interfaceDocumentation interfaceName="IToolbarItemParams" /%}
-
-`getToolbarItemInstance` is demonstrated in the [Custom Components](#custom-components) example, where it's used to keep a toolbar radio in sync with side bar tool panel changes.
-
-{% apiDocumentation source="grid-api/api.json" section="accessories" names=["getToolbarItemInstance"] /%}

--- a/packages/ag-grid-community/src/interfaces/iToolbar.ts
+++ b/packages/ag-grid-community/src/interfaces/iToolbar.ts
@@ -4,8 +4,13 @@ import type { IconName } from '../utils/icon';
 import type { AgGridCommon } from './iCommon';
 import type { DefaultMenuItem, MenuItemDef } from './menuItem';
 
+/**
+ * Configure the [Quick Access Toolbar](https://ag-grid.com/javascript-data-grid/toolbar/)
+ */
 export type Toolbar = {
+    /** Default alignment for items in the toolbar. Defaults to `'left'`. Item-level `alignment` takes precedence. */
     alignment?: 'left' | 'right';
+    /** Items to render in the toolbar. Each entry is either a shorthand string identifier or a full item definition object. */
     items: (ToolbarItemDef | ToolbarItemShorthand)[];
 };
 
@@ -26,6 +31,7 @@ export type ToolbarItemShorthand =
  */
 export type ToolbarItemComponent<T> = ToolbarItemShorthand | T;
 
+/** Params passed to a toolbar item's `action` callback when the item is activated. */
 export interface ToolbarItemActionParams<TData = any, TContext = any> extends AgGridCommon<TData, TContext> {
     /** The toolbar item `key` identifying which item triggered the action. */
     key: string;
@@ -153,6 +159,10 @@ export interface IToolbarItemParams<TData = any, TContext = any, TParams = any> 
     action?: (params: ToolbarItemActionParams<TData, TContext>) => void;
 }
 
+/**
+ * Interface that custom toolbar item components may implement to receive lifecycle callbacks from the grid.
+ * Implement `refresh` to update in-place when the `toolbar` option changes, avoiding a full destroy/recreate cycle.
+ */
 export interface IToolbarItem<TData = any, TContext = any> {
     /**
      * Called when the `toolbar` grid option updates.
@@ -162,6 +172,11 @@ export interface IToolbarItem<TData = any, TContext = any> {
     refresh?(params: IToolbarItemParams<TData, TContext>): boolean;
 }
 
+/**
+ * Full interface for toolbar item components: combines `IToolbarItem` (optional `refresh` callback)
+ * with the standard AG Grid component lifecycle (`IComponent`).
+ * Custom toolbar components that are class-based should implement this interface.
+ */
 export interface IToolbarItemComp<TData = any, TContext = any>
     extends IToolbarItem<TData, TContext>, IComponent<IToolbarItemParams<TData, TContext>> {}
 

--- a/packages/ag-grid-enterprise/src/toolbar/agToolbar.ts
+++ b/packages/ag-grid-enterprise/src/toolbar/agToolbar.ts
@@ -25,7 +25,7 @@ import {
     _findFocusableElements,
     _getActiveDomElement,
     _removeFromParent,
-    _warn,
+    _error,
 } from 'ag-grid-community';
 
 import agToolbarCSS from './agToolbar.css';
@@ -295,7 +295,7 @@ class AgToolbar extends Component implements FocusableContainer, IToolbarComp {
             const { key } = itemConfig;
 
             if (itemConfig.toolbarItem == null) {
-                _warn(301, { key });
+                _error(301, { key });
                 continue;
             }
 

--- a/packages/ag-grid-enterprise/src/toolbar/agToolbar.ts
+++ b/packages/ag-grid-enterprise/src/toolbar/agToolbar.ts
@@ -22,10 +22,10 @@ import {
     _addGridCommonParams,
     _clearElement,
     _createElement,
+    _error,
     _findFocusableElements,
     _getActiveDomElement,
     _removeFromParent,
-    _error,
 } from 'ag-grid-community';
 
 import agToolbarCSS from './agToolbar.css';

--- a/packages/ag-grid-enterprise/src/toolbar/providedItems/findToolbarItem.ts
+++ b/packages/ag-grid-enterprise/src/toolbar/providedItems/findToolbarItem.ts
@@ -1,5 +1,5 @@
 import type { FindChangedEvent, IToolbarItemComp, IToolbarItemParams } from 'ag-grid-community';
-import { Component, _createElement, _debounce, _setDisabled, _warn } from 'ag-grid-community';
+import { Component, _createElement, _debounce, _error, _setDisabled } from 'ag-grid-community';
 
 import { createToolbarIconButton, createToolbarInput } from './toolbarItemUtils';
 
@@ -27,7 +27,7 @@ export class FindToolbarItem extends Component implements IToolbarItemComp {
 
     public init(_params: IToolbarItemParams): void {
         if (!this.gos.isModuleRegistered('Find')) {
-            _warn(302, { itemName: 'agFindToolbarItem', moduleName: 'Find', ...this.gos.getModuleErrorParams() });
+            _error(302, { itemName: 'agFindToolbarItem', moduleName: 'Find', ...this.gos.getModuleErrorParams() });
             this.setDisplayed(false);
             return;
         }

--- a/packages/ag-grid-enterprise/src/toolbar/providedItems/pivotPanelToolbarItem.ts
+++ b/packages/ag-grid-enterprise/src/toolbar/providedItems/pivotPanelToolbarItem.ts
@@ -1,5 +1,7 @@
 import type { IToolbarItemComp, IToolbarItemParams } from 'ag-grid-community';
-import { Component, _warn } from 'ag-grid-community';
+import { Component, _error } from 'ag-grid-community';
+
+import { getRowGroupPanelBuilder } from './toolbarItemUtils';
 
 export class PivotPanelToolbarItem extends Component implements IToolbarItemComp {
     constructor() {
@@ -8,7 +10,7 @@ export class PivotPanelToolbarItem extends Component implements IToolbarItemComp
 
     public init(_params: IToolbarItemParams): void {
         if (!this.gos.isModuleRegistered('Pivot')) {
-            _warn(302, {
+            _error(302, {
                 itemName: 'agPivotPanelToolbarItem',
                 moduleName: 'Pivot',
                 ...this.gos.getModuleErrorParams(),
@@ -17,13 +19,8 @@ export class PivotPanelToolbarItem extends Component implements IToolbarItemComp
             return;
         }
 
-        const builder = this.beans.rowGroupPanelBuilder;
+        const builder = getRowGroupPanelBuilder(this.beans, 'agPivotPanelToolbarItem');
         if (!builder) {
-            _warn(302, {
-                itemName: 'agPivotPanelToolbarItem',
-                moduleName: 'RowGroupingPanel',
-                ...this.gos.getModuleErrorParams(),
-            });
             this.setDisplayed(false);
             return;
         }

--- a/packages/ag-grid-enterprise/src/toolbar/providedItems/quickFilterToolbarItem.ts
+++ b/packages/ag-grid-enterprise/src/toolbar/providedItems/quickFilterToolbarItem.ts
@@ -1,5 +1,5 @@
 import type { IToolbarItemComp, IToolbarItemParams } from 'ag-grid-community';
-import { Component, _debounce, _warn } from 'ag-grid-community';
+import { Component, _debounce, _error } from 'ag-grid-community';
 
 import { createToolbarInput } from './toolbarItemUtils';
 
@@ -14,7 +14,7 @@ export class QuickFilterToolbarItem extends Component implements IToolbarItemCom
 
     public init(_params: IToolbarItemParams): void {
         if (!this.gos.isModuleRegistered('QuickFilter')) {
-            _warn(302, {
+            _error(302, {
                 itemName: 'agQuickFilterToolbarItem',
                 moduleName: 'QuickFilter',
                 ...this.gos.getModuleErrorParams(),

--- a/packages/ag-grid-enterprise/src/toolbar/providedItems/rowGroupPanelToolbarItem.ts
+++ b/packages/ag-grid-enterprise/src/toolbar/providedItems/rowGroupPanelToolbarItem.ts
@@ -1,5 +1,7 @@
 import type { IToolbarItemComp, IToolbarItemParams } from 'ag-grid-community';
-import { Component, _warn } from 'ag-grid-community';
+import { Component } from 'ag-grid-community';
+
+import { getRowGroupPanelBuilder } from './toolbarItemUtils';
 
 export class RowGroupPanelToolbarItem extends Component implements IToolbarItemComp {
     constructor() {
@@ -7,13 +9,8 @@ export class RowGroupPanelToolbarItem extends Component implements IToolbarItemC
     }
 
     public init(_params: IToolbarItemParams): void {
-        const builder = this.beans.rowGroupPanelBuilder;
+        const builder = getRowGroupPanelBuilder(this.beans, 'agRowGroupPanelToolbarItem');
         if (!builder) {
-            _warn(302, {
-                itemName: 'agRowGroupPanelToolbarItem',
-                moduleName: 'RowGroupingPanel',
-                ...this.gos.getModuleErrorParams(),
-            });
             this.setDisplayed(false);
             return;
         }

--- a/packages/ag-grid-enterprise/src/toolbar/providedItems/toolbarItemUtils.ts
+++ b/packages/ag-grid-enterprise/src/toolbar/providedItems/toolbarItemUtils.ts
@@ -4,6 +4,7 @@ import {
     _clearElement,
     _createElement,
     _createIconNoSpan,
+    _error,
     _setAriaLabel,
     _setDisabled,
     _setDisplayed,
@@ -105,4 +106,12 @@ export function renderToolbarButtonContents(
 
     _setAriaLabel(eGui, hoverText);
     _addOrRemoveAttribute(eGui, 'title', hoverText);
+}
+
+export function getRowGroupPanelBuilder(beans: BeanCollection, itemName: string) {
+    const builder = beans.rowGroupPanelBuilder;
+    if (!builder) {
+        _error(302, { itemName, moduleName: 'RowGroupingPanel', ...beans.gos.getModuleErrorParams() });
+    }
+    return builder;
 }

--- a/testing/behavioural/src/toolbar/toolbar-find.test.ts
+++ b/testing/behavioural/src/toolbar/toolbar-find.test.ts
@@ -81,8 +81,8 @@ describe('Toolbar find item', () => {
             minimalGridMgr.reset();
         });
 
-        test('hides find and logs warning when FindModule is not registered', async () => {
-            const warnSpy = vitest.spyOn(console, 'warn').mockImplementation(() => {});
+        test('hides find and logs error when FindModule is not registered', async () => {
+            const errorSpy = vitest.spyOn(console, 'error').mockImplementation(() => {});
 
             const api = minimalGridMgr.createGrid('find-no-module', {
                 columnDefs: [{ field: 'name' }],
@@ -97,13 +97,13 @@ describe('Toolbar find item', () => {
             expect(item).not.toBeNull();
             expect(item!.classList.contains('ag-hidden')).toBe(true);
 
-            expect(warnSpy).toHaveBeenCalledWith(
-                expect.stringContaining('warning #302'),
+            expect(errorSpy).toHaveBeenCalledWith(
+                expect.stringContaining('error #302'),
                 expect.stringContaining('agFindToolbarItem'),
                 expect.anything()
             );
 
-            warnSpy.mockRestore();
+            errorSpy.mockRestore();
         });
     });
 });

--- a/testing/behavioural/src/toolbar/toolbar-panel-items.test.ts
+++ b/testing/behavioural/src/toolbar/toolbar-panel-items.test.ts
@@ -226,7 +226,7 @@ describe('Toolbar panel items (rowGroupPanel and pivotPanel)', () => {
         });
     });
 
-    describe('console warnings for missing feature modules', () => {
+    describe('console error for missing feature modules', () => {
         const minimalGridMgr = new TestGridsManager({
             modules: [ClientSideRowModelModule, ToolbarModule],
         });
@@ -235,8 +235,8 @@ describe('Toolbar panel items (rowGroupPanel and pivotPanel)', () => {
             minimalGridMgr.reset();
         });
 
-        test('hides rowGroupPanel and logs warning when RowGroupingModule is not registered', async () => {
-            const warnSpy = vitest.spyOn(console, 'warn').mockImplementation(() => {});
+        test('hides rowGroupPanel and logs error when RowGroupingModule is not registered', async () => {
+            const errorSpy = vitest.spyOn(console, 'error').mockImplementation(() => {});
 
             const api = minimalGridMgr.createGrid('row-group-panel-no-module', {
                 columnDefs: [{ field: 'name' }],
@@ -251,17 +251,17 @@ describe('Toolbar panel items (rowGroupPanel and pivotPanel)', () => {
             expect(item).not.toBeNull();
             expect(item!.classList.contains('ag-hidden')).toBe(true);
 
-            expect(warnSpy).toHaveBeenCalledWith(
-                expect.stringContaining('warning #302'),
+            expect(errorSpy).toHaveBeenCalledWith(
+                expect.stringContaining('error #302'),
                 expect.stringContaining('agRowGroupPanelToolbarItem'),
                 expect.anything()
             );
 
-            warnSpy.mockRestore();
+            errorSpy.mockRestore();
         });
 
-        test('hides pivotPanel and logs warning when PivotModule is not registered', async () => {
-            const warnSpy = vitest.spyOn(console, 'warn').mockImplementation(() => {});
+        test('hides pivotPanel and logs error when PivotModule is not registered', async () => {
+            const errorSpy = vitest.spyOn(console, 'error').mockImplementation(() => {});
 
             const api = minimalGridMgr.createGrid('pivot-panel-no-module', {
                 columnDefs: [{ field: 'name' }],
@@ -276,13 +276,13 @@ describe('Toolbar panel items (rowGroupPanel and pivotPanel)', () => {
             expect(item).not.toBeNull();
             expect(item!.classList.contains('ag-hidden')).toBe(true);
 
-            expect(warnSpy).toHaveBeenCalledWith(
-                expect.stringContaining('warning #302'),
+            expect(errorSpy).toHaveBeenCalledWith(
+                expect.stringContaining('error #302'),
                 expect.stringContaining('agPivotPanelToolbarItem'),
                 expect.anything()
             );
 
-            warnSpy.mockRestore();
+            errorSpy.mockRestore();
         });
     });
 });

--- a/testing/behavioural/src/toolbar/toolbar-quick-filter.test.ts
+++ b/testing/behavioural/src/toolbar/toolbar-quick-filter.test.ts
@@ -61,8 +61,8 @@ describe('Toolbar quickFilter item', () => {
             minimalGridMgr.reset();
         });
 
-        test('hides quickFilter and logs warning when QuickFilterModule is not registered', async () => {
-            const warnSpy = vitest.spyOn(console, 'warn').mockImplementation(() => {});
+        test('hides quickFilter and logs error when QuickFilterModule is not registered', async () => {
+            const errorSpy = vitest.spyOn(console, 'error').mockImplementation(() => {});
 
             const api = minimalGridMgr.createGrid('quick-filter-no-module', {
                 columnDefs: [{ field: 'name' }],
@@ -77,13 +77,13 @@ describe('Toolbar quickFilter item', () => {
             expect(item).not.toBeNull();
             expect(item!.classList.contains('ag-hidden')).toBe(true);
 
-            expect(warnSpy).toHaveBeenCalledWith(
-                expect.stringContaining('warning #302'),
+            expect(errorSpy).toHaveBeenCalledWith(
+                expect.stringContaining('error #302'),
                 expect.stringContaining('agQuickFilterToolbarItem'),
                 expect.anything()
             );
 
-            warnSpy.mockRestore();
+            errorSpy.mockRestore();
         });
     });
 });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,7 +12,11 @@
     "target": "ES2020",
     "useDefineForClassFields": false,
     "module": "commonjs",
-    "lib": ["ES2022", "DOM", "dom.iterable"],
+    "lib": [
+      "ES2022",
+      "DOM",
+      "dom.iterable"
+    ],
     "skipLibCheck": true,
     "isolatedModules": true,
     "strictBindCallApply": true,
@@ -25,9 +29,16 @@
     "noUnusedLocals": false,
     "noImplicitOverride": true,
     "paths": {
-      "ag-grid-community": ["packages/ag-grid-community/src/main.ts"],
-      "ag-grid-enterprise": ["packages/ag-grid-enterprise/src/main.ts"]
+      "ag-grid-community": [
+        "packages/ag-grid-community/src/main.ts"
+      ],
+      "ag-grid-enterprise": [
+        "packages/ag-grid-enterprise/src/main.ts"
+      ]
     }
   },
-  "exclude": ["node_modules", "tmp"]
+  "exclude": [
+    "node_modules",
+    "tmp"
+  ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,11 +12,7 @@
     "target": "ES2020",
     "useDefineForClassFields": false,
     "module": "commonjs",
-    "lib": [
-      "ES2022",
-      "DOM",
-      "dom.iterable"
-    ],
+    "lib": ["ES2022", "DOM", "dom.iterable"],
     "skipLibCheck": true,
     "isolatedModules": true,
     "strictBindCallApply": true,
@@ -29,16 +25,9 @@
     "noUnusedLocals": false,
     "noImplicitOverride": true,
     "paths": {
-      "ag-grid-community": [
-        "packages/ag-grid-community/src/main.ts"
-      ],
-      "ag-grid-enterprise": [
-        "packages/ag-grid-enterprise/src/main.ts"
-      ]
+      "ag-grid-community": ["packages/ag-grid-community/src/main.ts"],
+      "ag-grid-enterprise": ["packages/ag-grid-enterprise/src/main.ts"]
     }
   },
-  "exclude": [
-    "node_modules",
-    "tmp"
-  ]
+  "exclude": ["node_modules", "tmp"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6310,13 +6310,6 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@playwright/test@^1.56.0":
-  version "1.56.1"
-  resolved "http://52.50.158.57:4873/@playwright/test/-/test-1.56.1.tgz#6e3bf3d0c90c5cf94bf64bdb56fd15a805c8bd3f"
-  integrity sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==
-  dependencies:
-    playwright "1.56.1"
-
 "@playwright/test@^1.59.1":
   version "1.59.1"
   resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.59.1.tgz#5c4d38eac84a61527af466602ae20277685a02d6"
@@ -20421,11 +20414,6 @@ pkg-types@^2.3.0:
     exsolve "^1.0.7"
     pathe "^2.0.3"
 
-playwright-core@1.56.1:
-  version "1.56.1"
-  resolved "http://52.50.158.57:4873/playwright-core/-/playwright-core-1.56.1.tgz#24a66481e5cd33a045632230aa2c4f0cb6b1db3d"
-  integrity sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==
-
 playwright-core@1.59.1:
   version "1.59.1"
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.59.1.tgz#d8a2b28bcb8f2bd08ef3df93b02ae83c813244b2"
@@ -20445,15 +20433,6 @@ playwright-network-cache@0.2.2:
   dependencies:
     debug "^4.4.0"
     mime-types "2.1.35"
-
-playwright@1.56.1, playwright@^1.56.0:
-  version "1.56.1"
-  resolved "http://52.50.158.57:4873/playwright/-/playwright-1.56.1.tgz#62e3b99ddebed0d475e5936a152c88e68be55fbf"
-  integrity sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==
-  dependencies:
-    playwright-core "1.56.1"
-  optionalDependencies:
-    fsevents "2.3.2"
 
 playwright@1.59.1, playwright@^1.59.1:
   version "1.59.1"
@@ -23551,16 +23530,7 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "http://52.50.158.57:4873/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "http://52.50.158.57:4873/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -23673,7 +23643,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "http://52.50.158.57:4873/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -23686,13 +23656,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "http://52.50.158.57:4873/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.2"
@@ -26232,7 +26195,7 @@ wordwrap@^1.0.0:
   resolved "http://52.50.158.57:4873/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "http://52.50.158.57:4873/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -26254,15 +26217,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "http://52.50.158.57:4873/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "http://52.50.158.57:4873/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-12557

Follow-up QA fixes and documentation polish for the Quick Access Toolbar:

- **Playwright**: upgrade `@playwright/test` and `playwright` from `1.56` to `1.59.1`; fix broken E2E selectors in `toolbar-custom` spec (`.ag-column-panel`, role-based tab locator)
- **Docs**: rewrite `toolbar/index.mdoc` prose — convert Dropdown Menu and Action Button descriptions to bullet-list property tables, restructure API Reference with subheadings, move `getToolbarItemInstance` into a dedicated section, fix React framework block (`Component` not `Class`)
- **JsDocs**: add missing JsDoc comments to `Toolbar`, `ToolbarItemActionParams`, `IToolbarItem`, and `IToolbarItemComp` in `iToolbar.ts`
- **Module guards**: escalate `_warn(302)` to `_error(302)` for missing modules across `findToolbarItem`, `quickFilterToolbarItem`, `rowGroupPanelToolbarItem`, and `pivotPanelToolbarItem`
- **Refactor**: extract shared `getRowGroupPanelBuilder` helper in `toolbarItemUtils.ts` to deduplicate the builder null-check + error pattern in `rowGroupPanelToolbarItem` and `pivotPanelToolbarItem`
- **Tests**: extend `built-in-items` spec with a quick-filter interaction test; correct button count assertion from 1 to 2
