### PR TITLE
AG-17060-get-value-optimization-1

### DIFF
--- a/packages/ag-grid-community/src/agStack/utils/value.ts
+++ b/packages/ag-grid-community/src/agStack/utils/value.ts
@@ -1,23 +1,16 @@
-export function _getValueUsingField(data: any, field: string, fieldContainsDots: boolean): any {
-    if (!field || !data) {
-        return;
-    }
-
-    // if no '.', then it's not a deep value
-    if (!fieldContainsDots) {
-        return data[field];
-    }
-
-    // otherwise it is a deep value, so need to dig for it
+/**
+ * Reads a deep property from `data` using a dotted path. Callers must have already verified
+ * that the field contains dots — for plain field names use `data[field]` directly.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ */
+export function _getValueUsingDotField(data: any, field: string): any {
     const fields = field.split('.');
     let currentObject = data;
-
     for (let i = 0; i < fields.length; i++) {
         if (currentObject == null) {
             return undefined;
         }
         currentObject = currentObject[fields[i]];
     }
-
     return currentObject;
 }

--- a/packages/ag-grid-community/src/columns/dataTypeService.ts
+++ b/packages/ag-grid-community/src/columns/dataTypeService.ts
@@ -3,7 +3,7 @@ import type { IEventListener } from '../agStack/interfaces/iEventEmitter';
 import { _parseBigIntOrNull } from '../agStack/utils/bigInt';
 import { _isValidDate, _isValidDateTime, _parseDateTimeFromString, _serialiseDate } from '../agStack/utils/date';
 import { _toStringOrNull } from '../agStack/utils/generic';
-import { _getValueUsingField } from '../agStack/utils/value';
+import { _getValueUsingDotField } from '../agStack/utils/value';
 import type { NamedBean } from '../context/bean';
 import { BeanStub } from '../context/beanStub';
 import type { BeanCollection } from '../context/context';
@@ -310,7 +310,7 @@ export class DataTypeService extends BeanStub implements NamedBean {
         const initialData = this.getInitialData();
         if (initialData) {
             const fieldContainsDots = field.includes('.') && !this.gos.get('suppressFieldDotNotation');
-            value = _getValueUsingField(initialData, field, fieldContainsDots);
+            value = fieldContainsDots ? _getValueUsingDotField(initialData, field) : initialData[field];
         } else {
             this.initWaitForRowData(colId);
         }

--- a/packages/ag-grid-community/src/edit/editService.ts
+++ b/packages/ag-grid-community/src/edit/editService.ts
@@ -1012,11 +1012,7 @@ export class EditService extends BeanStub implements NamedBean {
      * Gets the pending edit value for a cell (used by ValueService).
      * Returns undefined to fallback to committed data/valueGetter.
      */
-    public getPendingEditValue(rowNode: IRowNode, column: Column, from: CellValueResolveFrom): any {
-        if (from === 'data') {
-            return undefined; // 'data' mode: always use committed data, never edit values
-        }
-
+    public getPendingEditValue(rowNode: IRowNode, column: Column, from: Exclude<CellValueResolveFrom, 'data'>): any {
         if (from === 'batch' && !this.batch) {
             return undefined; // 'batch' mode: only return edit values when batch editing is active
         }

--- a/packages/ag-grid-community/src/entities/agColumn.ts
+++ b/packages/ag-grid-community/src/entities/agColumn.ts
@@ -113,7 +113,7 @@ export class AgColumn<TValue = any>
 
     private readonly colEventSvc: LocalEventService<ColumnEventName> = new LocalEventService();
 
-    private fieldContainsDots: boolean;
+    public fieldContainsDots: boolean;
     private tooltipFieldContainsDots: boolean;
     public tooltipEnabled = false;
 

--- a/packages/ag-grid-community/src/tooltip/tooltipService.ts
+++ b/packages/ag-grid-community/src/tooltip/tooltipService.ts
@@ -1,7 +1,7 @@
 import type { LocaleTextFunc } from '../agStack/interfaces/iLocaleService';
 import { _isElementOverflowingCallback } from '../agStack/utils/dom';
 import { _exists } from '../agStack/utils/generic';
-import { _getValueUsingField } from '../agStack/utils/value';
+import { _getValueUsingDotField } from '../agStack/utils/value';
 import type { NamedBean } from '../context/bean';
 import { BeanStub } from '../context/beanStub';
 import type { BeanCollection } from '../context/context';
@@ -169,8 +169,11 @@ const resolveCellTooltip = ({
 
     // 4) column tooltip field/valueGetter is the final fallback.
     if (colDef.tooltipField && _exists(data)) {
+        const tooltipField = colDef.tooltipField;
         return {
-            value: _getValueUsingField(data, colDef.tooltipField, column.isTooltipFieldContainsDots()),
+            value: column.isTooltipFieldContainsDots()
+                ? _getValueUsingDotField(data, tooltipField)
+                : data[tooltipField],
             location: 'cell',
             shouldDisplay: shouldDisplayColumnTooltip,
         };

--- a/packages/ag-grid-community/src/valueService/valueCache.ts
+++ b/packages/ag-grid-community/src/valueService/valueCache.ts
@@ -7,44 +7,35 @@ export class ValueCache extends BeanStub implements NamedBean {
     beanName = 'valueCache' as const;
 
     private cacheVersion = 0;
-    private active: boolean;
-    private neverExpires: boolean;
+    private neverExpires: boolean = false;
 
     public postConstruct(): void {
-        const gos = this.gos;
-        this.active = gos.get('valueCache');
-        this.neverExpires = gos.get('valueCacheNeverExpires');
+        this.neverExpires = this.gos.get('valueCacheNeverExpires');
     }
 
     public onDataChanged(): void {
-        if (this.neverExpires) {
-            return;
+        if (!this.neverExpires) {
+            this.expire();
         }
-
-        this.expire();
     }
 
     public expire(): void {
         this.cacheVersion++;
     }
 
-    public setValue(rowNode: RowNode, colId: string, value: any): any {
-        if (this.active) {
-            const cacheVersion = this.cacheVersion;
-            if (rowNode.__cacheVersion !== cacheVersion) {
-                rowNode.__cacheVersion = cacheVersion;
-                rowNode.__cacheData = {};
-            }
-
-            rowNode.__cacheData[colId] = value;
+    public setValue(rowNode: RowNode, colId: string, value: any): void {
+        const cacheVersion = this.cacheVersion;
+        if (rowNode.__cacheVersion !== cacheVersion) {
+            rowNode.__cacheVersion = cacheVersion;
+            rowNode.__cacheData = {};
         }
+        rowNode.__cacheData[colId] = value;
     }
 
     public getValue(rowNode: RowNode, colId: string): any {
-        if (!this.active || rowNode.__cacheVersion !== this.cacheVersion) {
+        if (rowNode.__cacheVersion !== this.cacheVersion) {
             return undefined;
         }
-
         return rowNode.__cacheData[colId];
     }
 }

--- a/packages/ag-grid-community/src/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.ts
@@ -1,6 +1,6 @@
 import { _exists, _missing } from '../agStack/utils/generic';
 import { _isExpressionString } from '../agStack/utils/string';
-import { _getValueUsingField } from '../agStack/utils/value';
+import { _getValueUsingDotField } from '../agStack/utils/value';
 import type { ColumnModel } from '../columns/columnModel';
 import type { DataTypeService } from '../columns/dataTypeService';
 import type { NamedBean } from '../context/bean';
@@ -31,13 +31,31 @@ import type { ValueCache } from './valueCache';
 export class ValueService extends BeanStub implements NamedBean {
     beanName = 'valueSvc' as const;
 
-    private expressionSvc?: ExpressionService;
-    private colModel: ColumnModel;
-    private valueCache?: ValueCache;
-    private dataTypeSvc?: DataTypeService;
-    private editSvc?: EditService;
-    private formulaDataSvc?: IFormulaDataService;
-    private rowGroupColsSvc?: IColsService;
+    // Hot-path fields first (read on every getValue call). All declared with primitive
+    // defaults so V8 picks a stable hidden-class shape from the moment the instance is
+    // constructed — `init()` and `postConstruct` overwrite values without reshaping.
+    // Defaults to the no-cache variant so the initial render (driven by rowRenderer's
+    // postConstruct, which runs before valueSvc.postConstruct) bypasses the cache.
+    private executeValueGetter: (
+        valueGetter: string | ((...args: any[]) => any),
+        data: any,
+        column: AgColumn,
+        rowNode: IRowNode
+    ) => any = this.executeValueGetterWithoutValueCache;
+    private isTreeData: boolean = false;
+    private isSsrm: boolean = false;
+    private cellExpressions: boolean = false;
+    private groupSuppressBlankHeader: boolean = false;
+
+    // Bean refs — assigned in wireBeans. Initialised to undefined so the property slot
+    // exists in the same shape from construction time.
+    private editSvc: EditService | undefined = undefined;
+    private valueCache: ValueCache | undefined = undefined;
+    private rowGroupColsSvc: IColsService | undefined = undefined;
+    private colModel!: ColumnModel;
+    private expressionSvc: ExpressionService | undefined = undefined;
+    private dataTypeSvc: DataTypeService | undefined = undefined;
+    private formulaDataSvc: IFormulaDataService | undefined = undefined;
 
     public wireBeans(beans: BeanCollection): void {
         this.expressionSvc = beans.expressionSvc;
@@ -47,39 +65,25 @@ export class ValueService extends BeanStub implements NamedBean {
         this.editSvc = beans.editSvc;
         this.formulaDataSvc = beans.formulaDataSvc;
         this.rowGroupColsSvc = beans.rowGroupColsSvc;
+        this.init();
     }
 
-    private cellExpressions: boolean;
-
-    // Store locally for performance reasons and keep updated via property listener
-    private isTreeData: boolean;
-
-    private initialised = false;
-
-    private isSsrm = false;
-
-    private executeValueGetter: (
-        valueGetter: string | ((...args: any[]) => any),
-        data: any,
-        column: AgColumn,
-        rowNode: IRowNode
-    ) => any;
-
-    public postConstruct(): void {
-        if (!this.initialised) {
-            this.init();
-        }
-    }
-
+    /** Called by both wireBeans and postConstruct */
     private init(): void {
-        const { gos, valueCache } = this;
-        this.executeValueGetter = valueCache
-            ? this.executeValueGetterWithValueCache.bind(this)
-            : this.executeValueGetterWithoutValueCache.bind(this);
+        const gos = this.gos;
         this.isSsrm = _isServerSideRowModel(gos);
         this.cellExpressions = gos.get('enableCellExpressions');
         this.isTreeData = gos.get('treeData');
-        this.initialised = true;
+        this.groupSuppressBlankHeader = gos.get('groupSuppressBlankHeader');
+    }
+
+    public postConstruct(): void {
+        this.init();
+        // Branching on the option (not just bean presence) avoids two no-op method calls per
+        // cell read for full-bundle users who leave the cache off — the common case.
+        if (this.valueCache && this.gos.get('valueCache')) {
+            this.executeValueGetter = this.executeValueGetterWithValueCache;
+        }
 
         // We listen to our own event and use it to call the columnSpecific callback,
         // this way the handler calls are correctly interleaved with other global events
@@ -88,6 +92,10 @@ export class ValueService extends BeanStub implements NamedBean {
         this.addDestroyFunc(() => this.eventSvc.removeListener('cellValueChanged', listener, true));
 
         this.addManagedPropertyListener('treeData', (propChange) => (this.isTreeData = propChange.currentValue));
+        this.addManagedPropertyListener(
+            'groupSuppressBlankHeader',
+            (propChange) => (this.groupSuppressBlankHeader = propChange.currentValue)
+        );
     }
 
     /**
@@ -173,12 +181,6 @@ export class ValueService extends BeanStub implements NamedBean {
         from: CellValueResolveFrom,
         ignoreAggData: boolean = false
     ): any {
-        // hack - the grid is getting refreshed before this bean gets initialised, race condition.
-        // really should have a way so they get initialised in the right order???
-        if (!this.initialised) {
-            this.init();
-        }
-
         if (!rowNode) {
             return;
         }
@@ -194,10 +196,13 @@ export class ValueService extends BeanStub implements NamedBean {
             }
         }
 
-        // Check for edit/pending values if not requesting committed data
-        const pending = this.editSvc?.getPendingEditValue(rowNode, column, from);
-        if (pending !== undefined) {
-            return pending;
+        const editSvc = this.editSvc;
+        if (editSvc) {
+            // Check for edit/pending values if not requesting committed data
+            const pending = editSvc.getPendingEditValue(rowNode, column, from);
+            if (pending !== undefined) {
+                return pending;
+            }
         }
 
         let result = this.resolveValue(column, rowNode, ignoreAggData, isGroup);
@@ -239,9 +244,9 @@ export class ValueService extends BeanStub implements NamedBean {
         if (!node.group || node.footer || node.level === -1) {
             return false;
         }
-        // groupShowsAggData = this.gos.get('groupSuppressBlankHeader') || !node.sibling
+        // groupShowsAggData = this.groupSuppressBlankHeader || !node.sibling
         // We return true only if !groupShowsAggData, i.e., !groupSuppressBlankHeader && node.sibling
-        if (!node.sibling || this.gos.get('groupSuppressBlankHeader')) {
+        if (!node.sibling || this.groupSuppressBlankHeader) {
             return false;
         }
         // When in pivot mode, leafGroups cannot be expanded
@@ -285,7 +290,7 @@ export class ValueService extends BeanStub implements NamedBean {
                 return this.executeValueGetter(valueGetter, data, column, rowNode);
             }
             if (field && data) {
-                return _getValueUsingField(data, field, column.isFieldContainsDots());
+                return column.fieldContainsDots ? _getValueUsingDotField(data, field) : data[field];
             }
         }
 
@@ -314,11 +319,15 @@ export class ValueService extends BeanStub implements NamedBean {
         if (ssrmFooterGroupCol) {
             // this is for group footers in SSRM, as the SSRM row won't have groupData, need to extract
             // the group value from the data using the row field
-            return _getValueUsingField(data, rowNode.field!, column.isFieldContainsDots());
+            const rowField = rowNode.field!;
+            return column.fieldContainsDots ? _getValueUsingDotField(data, rowField) : data[rowField];
         }
 
         if (field && data && !ignoreSsrmAggData) {
-            return allowUserValuesForCell ? _getValueUsingField(data, field, column.isFieldContainsDots()) : undefined;
+            if (!allowUserValuesForCell) {
+                return undefined;
+            }
+            return column.fieldContainsDots ? _getValueUsingDotField(data, field) : data[field];
         }
 
         return undefined;
@@ -660,7 +669,7 @@ export class ValueService extends BeanStub implements NamedBean {
             return this.expressionSvc?.evaluate(valueSetter, setterParams);
         }
 
-        return !!rowData && this.setValueUsingField(rowData, field, newValue, column.isFieldContainsDots());
+        return !!rowData && this.setValueUsingField(rowData, field, newValue, column.fieldContainsDots);
     }
 
     private dispatchCellValueChangedEvent(

--- a/packages/ag-grid-community/src/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.ts
@@ -79,8 +79,8 @@ export class ValueService extends BeanStub implements NamedBean {
 
     public postConstruct(): void {
         this.init();
-        // Branching on the option (not just bean presence) avoids two no-op method calls per
-        // cell read for full-bundle users who leave the cache off — the common case.
+        // Cache variant bound here, not in wireBeans, so the rowRenderer.postConstruct
+        // race-window render uses the safe no-cache default.
         if (this.valueCache && this.gos.get('valueCache')) {
             this.executeValueGetter = this.executeValueGetterWithValueCache;
         }
@@ -317,8 +317,10 @@ export class ValueService extends BeanStub implements NamedBean {
         const ssrmFooterGroupCol =
             isSsrm && rowNode.footer && rowNode.field && (rowGroupColId === true || rowGroupColId === rowNode.field);
         if (ssrmFooterGroupCol) {
-            // this is for group footers in SSRM, as the SSRM row won't have groupData, need to extract
-            // the group value from the data using the row field
+            // SSRM footer rows have no groupData — read the group value from data using the row field.
+            if (!data) {
+                return undefined;
+            }
             const rowField = rowNode.field!;
             return column.fieldContainsDots ? _getValueUsingDotField(data, rowField) : data[rowField];
         }

--- a/packages/ag-grid-community/src/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.ts
@@ -34,8 +34,10 @@ export class ValueService extends BeanStub implements NamedBean {
     // Hot-path fields first (read on every getValue call). All declared with primitive
     // defaults so V8 picks a stable hidden-class shape from the moment the instance is
     // constructed — `init()` and `postConstruct` overwrite values without reshaping.
-    // Defaults to the no-cache variant so the initial render (driven by rowRenderer's
-    // postConstruct, which runs before valueSvc.postConstruct) bypasses the cache.
+    /**
+     * Bound by `init()` to the cache or no-cache variant. Default is no-cache for safety.
+     * Unbound method reference is fine — call sites use `this.executeValueGetter(...)`.
+     */
     private executeValueGetter: (
         valueGetter: string | ((...args: any[]) => any),
         data: any,

--- a/packages/ag-grid-community/src/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.ts
@@ -198,7 +198,7 @@ export class ValueService extends BeanStub implements NamedBean {
         }
 
         const editSvc = this.editSvc;
-        if (editSvc) {
+        if (editSvc && from !== 'data') {
             // Check for edit/pending values if not requesting committed data
             const pending = editSvc.getPendingEditValue(rowNode, column, from);
             if (pending !== undefined) {

--- a/packages/ag-grid-community/src/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.ts
@@ -75,15 +75,14 @@ export class ValueService extends BeanStub implements NamedBean {
         this.cellExpressions = gos.get('enableCellExpressions');
         this.isTreeData = gos.get('treeData');
         this.groupSuppressBlankHeader = gos.get('groupSuppressBlankHeader');
+        this.executeValueGetter =
+            this.valueCache && gos.get('valueCache')
+                ? this.executeValueGetterWithValueCache
+                : this.executeValueGetterWithoutValueCache;
     }
 
     public postConstruct(): void {
         this.init();
-        // Cache variant bound here, not in wireBeans, so the rowRenderer.postConstruct
-        // race-window render uses the safe no-cache default.
-        if (this.valueCache && this.gos.get('valueCache')) {
-            this.executeValueGetter = this.executeValueGetterWithValueCache;
-        }
 
         // We listen to our own event and use it to call the columnSpecific callback,
         // this way the handler calls are correctly interleaved with other global events

--- a/testing/behavioural/src/benchmarks/bench-compare.mjs
+++ b/testing/behavioural/src/benchmarks/bench-compare.mjs
@@ -539,23 +539,32 @@ function round(v, decimals) {
 }
 
 /**
- * Sort worst-first, best-last. Uses the signed conservative delta as the primary key so
- * confidence-interval-aware regressions rank above noisy non-changes, which rank above
- * confidence-interval-aware improvements. Falls back to the signed raw delta, then name.
+ * Sort biggest-change-first. Primary key is the signed raw delta — the same metric the
+ * "Result" column shows ("1.20x faster" etc.) — so the visible ordering matches the displayed
+ * numbers. Conservative delta is used elsewhere (to classify rows as certain vs noisy) but
+ * disagreed with what readers see in the Result column when used as the sort key.
+ *
+ * Within each direction (improvements / regressions), descending by magnitude — so the
+ * biggest improvement is at the top, then smaller improvements, then unchanged, then small
+ * regressions, then the worst regression at the bottom. This is sign-aware: regressions stay
+ * grouped at the bottom rather than sorting purely by absolute magnitude.
+ *
+ * Tie-break on conservative delta (so equally-fast benchmarks with tighter CIs rank higher)
+ * then on name for determinism.
  */
-function bySignedDeltaAsc(a, b) {
-    const diff = a.deltaConservative - b.deltaConservative;
-    if (diff !== 0) {
-        return diff;
-    }
-    const rawDiff = a.delta - b.delta;
+function bySignedDeltaDesc(a, b) {
+    const rawDiff = b.delta - a.delta;
     if (rawDiff !== 0) {
         return rawDiff;
+    }
+    const ciDiff = b.deltaConservative - a.deltaConservative;
+    if (ciDiff !== 0) {
+        return ciDiff;
     }
     return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
 }
 
-comparisons.sort(bySignedDeltaAsc);
+comparisons.sort(bySignedDeltaDesc);
 
 // ── Output ──
 
@@ -649,8 +658,10 @@ md += `rme = max(run-to-run std, mean within-run rme).\n\n`;
 //             delta is large enough to warrant investigation.
 const notableCertain = comparisons
     .filter((c) => !isNoisy(c) && Math.abs(c.deltaConservative) >= CERTAIN_MIN_PCT)
-    .sort(bySignedDeltaAsc);
-const notableNoisy = comparisons.filter((c) => isNoisy(c) && Math.abs(c.delta) >= NOISY_MIN_PCT).sort(bySignedDeltaAsc);
+    .sort(bySignedDeltaDesc);
+const notableNoisy = comparisons
+    .filter((c) => isNoisy(c) && Math.abs(c.delta) >= NOISY_MIN_PCT)
+    .sort(bySignedDeltaDesc);
 const notable = [...notableCertain, ...notableNoisy];
 
 function writeNotableTable(header, rows) {

--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-grouping.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-grouping.test.ts
@@ -184,6 +184,9 @@ describe('csv exports for server-side grouping', () => {
         expect(irelandYear2000Total?.footer).toBe(true);
         expect(irelandYear2000Total?.data?.medals).toBe(5);
 
+        expect(api.getCellValue({ rowNode: irelandGroupTotal!, colKey: 'ag-Grid-AutoColumn-country' })).toBe('Ireland');
+        expect(api.getCellValue({ rowNode: irelandYear2000Total!, colKey: 'ag-Grid-AutoColumn-year' })).toBe('2000');
+
         expect(unindentText(api.getDataAsCsv({ suppressQuotes: true }))).toEqual(unindentText`
             Country,Country,sum(Medals)
             Ireland,,

--- a/testing/behavioural/src/row-data/row-node-get-data-value.test.ts
+++ b/testing/behavioural/src/row-data/row-node-get-data-value.test.ts
@@ -374,6 +374,38 @@ describe('RowNode.getDataValue', () => {
             expect(child1Node.getDataValue('name')).toBe('Child 1');
             expect(child1Node.getDataValue('value')).toBe(20);
         });
+
+        test('getDataValue runs valueGetter on tree-data rows', async () => {
+            const api = await gridsManager.createGridAndWait('tree-valueGetter', {
+                columnDefs: [
+                    { field: 'name' },
+                    { colId: 'shouted', valueGetter: (p) => p.data?.name?.toUpperCase() ?? null },
+                ],
+                treeData: true,
+                treeDataChildrenField: 'children',
+                rowData: [
+                    {
+                        id: '1',
+                        name: 'Parent',
+                        children: [
+                            { id: '1-1', name: 'ChildA' },
+                            { id: '1-2', name: 'ChildB' },
+                        ],
+                    },
+                ],
+                getRowId: (params) => params.data.id,
+                groupDefaultExpanded: -1,
+            });
+
+            await asyncSetTimeout(1);
+
+            // Parent (group row) — valueGetter executes against the row's own data
+            expect(api.getRowNode('1')!.getDataValue('shouted')).toBe('PARENT');
+
+            // Child rows
+            expect(api.getRowNode('1-1')!.getDataValue('shouted')).toBe('CHILDA');
+            expect(api.getRowNode('1-2')!.getDataValue('shouted')).toBe('CHILDB');
+        });
     });
 
     describe('with setDataValue', () => {
@@ -2568,6 +2600,60 @@ describe('RowNode.getDataValue', () => {
 
             // Aggregated gold values still work
             expect(countryGroup.getDataValue('gold')).toBe(10);
+        });
+
+        test('getDataValue ignores valueGetter on a showRowGroup column for group rows (groupData wins; level guard returns null at deeper levels)', async () => {
+            const valueGetterCallCount = { count: 0 };
+            const api = await gridsManager.createGridAndWait('showRowGroup-valueGetter-blocked', {
+                columnDefs: [
+                    {
+                        colId: 'countryGroupCol',
+                        showRowGroup: 'country',
+                        cellRenderer: 'agGroupCellRenderer',
+                        valueGetter: (p) => {
+                            valueGetterCallCount.count++;
+                            return p.data ? `getter:${p.data.country}` : 'getter:no-data';
+                        },
+                    },
+                    {
+                        colId: 'athleteGroupCol',
+                        showRowGroup: 'athlete',
+                        cellRenderer: 'agGroupCellRenderer',
+                        valueGetter: () => {
+                            valueGetterCallCount.count++;
+                            return 'getter:athlete';
+                        },
+                    },
+                    { field: 'country', rowGroup: true, hide: true },
+                    { field: 'athlete', rowGroup: true, hide: true },
+                    { field: 'gold', aggFunc: 'sum' },
+                ],
+                groupDisplayType: 'custom',
+                groupDefaultExpanded: -1,
+                getRowId: ({ data }) => data.id,
+                rowData: [
+                    { id: '1', country: 'USA', athlete: 'Michael', gold: 8 },
+                    { id: '2', country: 'USA', athlete: 'Ryan', gold: 2 },
+                ],
+            });
+            await asyncSetTimeout(1);
+
+            const countryGroup = api.getRowNode('row-group-country-USA')!;
+            const athleteGroup = api.getRowNode('row-group-country-USA-athlete-Michael')!;
+
+            // Only count invocations from the explicit getDataValue calls below.
+            valueGetterCallCount.count = 0;
+
+            // Matching level: groupData wins, getter not invoked.
+            expect(countryGroup.getDataValue('countryGroupCol')).toBe('USA');
+
+            // Deeper level on country col (idx 0 ≯ level 1): undefined, getter blocked.
+            expect(athleteGroup.getDataValue('countryGroupCol')).toBeUndefined();
+
+            // Shallower level on athlete col (idx 1 > level 0): null via the level guard.
+            expect(countryGroup.getDataValue('athleteGroupCol')).toBeNull();
+
+            expect(valueGetterCallCount.count).toBe(0);
         });
 
         test('tree data group rows resolve showRowGroup columns from their own data', async () => {

--- a/testing/behavioural/src/row-data/row-node-get-data-value.test.ts
+++ b/testing/behavioural/src/row-data/row-node-get-data-value.test.ts
@@ -2603,7 +2603,7 @@ describe('RowNode.getDataValue', () => {
         });
 
         test('getDataValue ignores valueGetter on a showRowGroup column for group rows (groupData wins; level guard returns null at deeper levels)', async () => {
-            const valueGetterCallCount = { count: 0 };
+            let valueGetterCalls = 0;
             const api = await gridsManager.createGridAndWait('showRowGroup-valueGetter-blocked', {
                 columnDefs: [
                     {
@@ -2611,7 +2611,7 @@ describe('RowNode.getDataValue', () => {
                         showRowGroup: 'country',
                         cellRenderer: 'agGroupCellRenderer',
                         valueGetter: (p) => {
-                            valueGetterCallCount.count++;
+                            valueGetterCalls++;
                             return p.data ? `getter:${p.data.country}` : 'getter:no-data';
                         },
                     },
@@ -2620,7 +2620,7 @@ describe('RowNode.getDataValue', () => {
                         showRowGroup: 'athlete',
                         cellRenderer: 'agGroupCellRenderer',
                         valueGetter: () => {
-                            valueGetterCallCount.count++;
+                            valueGetterCalls++;
                             return 'getter:athlete';
                         },
                     },
@@ -2642,7 +2642,7 @@ describe('RowNode.getDataValue', () => {
             const athleteGroup = api.getRowNode('row-group-country-USA-athlete-Michael')!;
 
             // Only count invocations from the explicit getDataValue calls below.
-            valueGetterCallCount.count = 0;
+            valueGetterCalls = 0;
 
             // Matching level: groupData wins, getter not invoked.
             expect(countryGroup.getDataValue('countryGroupCol')).toBe('USA');
@@ -2653,7 +2653,7 @@ describe('RowNode.getDataValue', () => {
             // Shallower level on athlete col (idx 1 > level 0): null via the level guard.
             expect(countryGroup.getDataValue('athleteGroupCol')).toBeNull();
 
-            expect(valueGetterCallCount.count).toBe(0);
+            expect(valueGetterCalls).toBe(0);
         });
 
         test('tree data group rows resolve showRowGroup columns from their own data', async () => {

--- a/testing/behavioural/src/services/value-service-init.test.ts
+++ b/testing/behavioural/src/services/value-service-init.test.ts
@@ -1,0 +1,164 @@
+import type { GridApi, ValueGetterParams } from 'ag-grid-community';
+import { ClientSideRowModelModule, ValueCacheModule } from 'ag-grid-community';
+import { TreeDataModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager } from '../test-utils';
+
+interface Person {
+    firstName: string;
+    lastName: string;
+    age: number;
+}
+
+const PEOPLE: Person[] = [
+    { firstName: 'Ada', lastName: 'Lovelace', age: 36 },
+    { firstName: 'Alan', lastName: 'Turing', age: 41 },
+];
+
+describe('ValueService init in wireBeans', () => {
+    // Every grid renders during postConstruct, exercising the rowRenderer → valueSvc.getValue
+    // path that previously required an `if (!initialised) init()` hack inside getValue.
+
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule],
+    });
+
+    afterEach(() => gridsManager.reset());
+
+    test('field path: api.getCellValue works synchronously after createGrid', () => {
+        const api: GridApi<Person> = gridsManager.createGrid('grid-field', {
+            columnDefs: [{ colId: 'firstName', field: 'firstName' }],
+            rowData: PEOPLE,
+        });
+
+        const node = api.getRowNode('0')!;
+        expect(api.getCellValue({ rowNode: node, colKey: 'firstName' })).toBe('Ada');
+    });
+
+    test('valueGetter path: getCellValue runs the function getter immediately after createGrid', () => {
+        const fullName = (params: ValueGetterParams<Person>) => `${params.data!.firstName} ${params.data!.lastName}`;
+
+        const api: GridApi<Person> = gridsManager.createGrid('grid-fn-getter', {
+            columnDefs: [{ colId: 'fullName', valueGetter: fullName }],
+            rowData: PEOPLE,
+        });
+
+        const node = api.getRowNode('0')!;
+        expect(api.getCellValue({ rowNode: node, colKey: 'fullName' })).toBe('Ada Lovelace');
+    });
+
+    test('valueCache path: cache-variant executeValueGetter is bound during wireBeans', () => {
+        let calls = 0;
+        const countingGetter = (params: ValueGetterParams<Person>) => {
+            calls++;
+            return params.data!.firstName.toUpperCase();
+        };
+
+        const api: GridApi<Person> = gridsManager.createGrid(
+            'grid-value-cache',
+            {
+                columnDefs: [{ colId: 'shouted', valueGetter: countingGetter }],
+                rowData: PEOPLE,
+                valueCache: true,
+            },
+            { modules: [ValueCacheModule] }
+        );
+
+        const node = api.getRowNode('0')!;
+
+        const callsBeforeApi = calls;
+        expect(api.getCellValue({ rowNode: node, colKey: 'shouted' })).toBe('ADA');
+        expect(api.getCellValue({ rowNode: node, colKey: 'shouted' })).toBe('ADA');
+        expect(api.getCellValue({ rowNode: node, colKey: 'shouted' })).toBe('ADA');
+        // Cache hit — getter not re-invoked.
+        expect(calls).toBe(callsBeforeApi);
+    });
+
+    test('no-valueCache path: every getCellValue call re-invokes the getter when ValueCacheModule is NOT registered', () => {
+        let calls = 0;
+        const countingGetter = (params: ValueGetterParams<Person>) => {
+            calls++;
+            return params.data!.firstName.toUpperCase();
+        };
+
+        const api: GridApi<Person> = gridsManager.createGrid('grid-no-value-cache', {
+            columnDefs: [{ colId: 'shouted', valueGetter: countingGetter }],
+            rowData: PEOPLE,
+        });
+
+        const node = api.getRowNode('0')!;
+
+        const callsBeforeApi = calls;
+        expect(api.getCellValue({ rowNode: node, colKey: 'shouted' })).toBe('ADA');
+        expect(api.getCellValue({ rowNode: node, colKey: 'shouted' })).toBe('ADA');
+        expect(api.getCellValue({ rowNode: node, colKey: 'shouted' })).toBe('ADA');
+        // No cache — every api call re-invokes the getter.
+        expect(calls).toBe(callsBeforeApi + 3);
+    });
+
+    test('cellExpressions path: string valueGetter is evaluated as an expression', () => {
+        // ExpressionModule is part of the core bundle, so no extra module registration is needed.
+        const api: GridApi<Person> = gridsManager.createGrid('grid-expressions', {
+            columnDefs: [{ colId: 'doubled', valueGetter: 'data.age * 2' }],
+            rowData: PEOPLE,
+            enableCellExpressions: true,
+        });
+
+        const node = api.getRowNode('0')!;
+        expect(api.getCellValue({ rowNode: node, colKey: 'doubled' })).toBe(72);
+    });
+
+    test('treeData option change is picked up by the listener registered in postConstruct', () => {
+        interface TreePerson extends Person {
+            children?: TreePerson[];
+        }
+        const treeData: TreePerson[] = [
+            { firstName: 'Ada', lastName: 'Lovelace', age: 36, children: [] },
+            { firstName: 'Alan', lastName: 'Turing', age: 41 },
+        ];
+
+        const api: GridApi<TreePerson> = gridsManager.createGrid(
+            'grid-tree-data',
+            {
+                columnDefs: [{ colId: 'firstName', field: 'firstName' }],
+                rowData: treeData,
+                treeData: false,
+                treeDataChildrenField: 'children',
+            },
+            { modules: [TreeDataModule] }
+        );
+
+        const node = api.getRowNode('0')!;
+        expect(api.getCellValue({ rowNode: node, colKey: 'firstName' })).toBe('Ada');
+
+        // Flipping treeData after init must still update ValueService's cached isTreeData.
+        api.setGridOption('treeData', true);
+        expect(api.getCellValue({ rowNode: node, colKey: 'firstName' })).toBe('Ada');
+    });
+
+    test('valueGetter.getValue callback resolves cross-column values during the initial render', () => {
+        // params.getValue fires during rowRenderer.postConstruct's initial render — the exact
+        // window that motivated the original race-condition hack.
+        const observed: Array<string | undefined> = [];
+        const compositeGetter = (params: ValueGetterParams<Person>) => {
+            const first = params.getValue('firstName');
+            observed.push(first);
+            return `${first} (${params.data!.age})`;
+        };
+
+        const api: GridApi<Person> = gridsManager.createGrid('grid-cross-col-getter', {
+            columnDefs: [
+                { colId: 'firstName', field: 'firstName' },
+                { colId: 'composite', valueGetter: compositeGetter },
+            ],
+            rowData: PEOPLE,
+        });
+
+        // Cross-column lookups during the initial render must resolve, not return undefined.
+        expect(observed.length).toBeGreaterThan(0);
+        expect(observed.every((v) => typeof v === 'string')).toBe(true);
+
+        const node = api.getRowNode('0')!;
+        expect(api.getCellValue({ rowNode: node, colKey: 'composite' })).toBe('Ada (36)');
+    });
+});

--- a/testing/behavioural/src/services/value-service-init.test.ts
+++ b/testing/behavioural/src/services/value-service-init.test.ts
@@ -47,7 +47,7 @@ describe('ValueService init in wireBeans', () => {
         expect(api.getCellValue({ rowNode: node, colKey: 'fullName' })).toBe('Ada Lovelace');
     });
 
-    test('valueCache path: cache-variant executeValueGetter is bound during wireBeans', () => {
+    test('valueCache path: cache-variant executeValueGetter is bound in postConstruct', () => {
         let calls = 0;
         const countingGetter = (params: ValueGetterParams<Person>) => {
             calls++;
@@ -72,6 +72,37 @@ describe('ValueService init in wireBeans', () => {
         expect(api.getCellValue({ rowNode: node, colKey: 'shouted' })).toBe('ADA');
         // Cache hit — getter not re-invoked.
         expect(calls).toBe(callsBeforeApi);
+    });
+
+    test('valueCache: by the time createGrid returns, the cache is populated and the first API read is a hit', () => {
+        // Locks in the user-visible contract: regardless of which render pass populated the
+        // cache (the rowRenderer.postConstruct race window uses the no-cache variant; any
+        // later render before createGrid returns uses the cache variant), the cache MUST be
+        // ready by the time the api is handed to user code. The first user API call must be
+        // a cache hit, not a populating call — otherwise non-deterministic getters would
+        // produce a different value on first API read vs. subsequent reads.
+        let calls = 0;
+        const countingGetter = (params: ValueGetterParams<Person>) => {
+            calls++;
+            return params.data!.firstName.toUpperCase();
+        };
+
+        const api: GridApi<Person> = gridsManager.createGrid(
+            'grid-value-cache-populated',
+            {
+                columnDefs: [{ colId: 'shouted', valueGetter: countingGetter }],
+                rowData: PEOPLE,
+                valueCache: true,
+            },
+            { modules: [ValueCacheModule] }
+        );
+
+        const node = api.getRowNode('0')!;
+
+        // The cache must be populated for this row before user code runs.
+        const callsAfterCreate = calls;
+        api.getCellValue({ rowNode: node, colKey: 'shouted' });
+        expect(calls).toBe(callsAfterCreate);
     });
 
     test('no-valueCache path: every getCellValue call re-invokes the getter when ValueCacheModule is NOT registered', () => {

--- a/testing/behavioural/src/services/value-service-init.test.ts
+++ b/testing/behavioural/src/services/value-service-init.test.ts
@@ -75,12 +75,8 @@ describe('ValueService init in wireBeans', () => {
     });
 
     test('valueCache: by the time createGrid returns, the cache is populated and the first API read is a hit', () => {
-        // Locks in the user-visible contract: regardless of which render pass populated the
-        // cache (the rowRenderer.postConstruct race window uses the no-cache variant; any
-        // later render before createGrid returns uses the cache variant), the cache MUST be
-        // ready by the time the api is handed to user code. The first user API call must be
-        // a cache hit, not a populating call — otherwise non-deterministic getters would
-        // produce a different value on first API read vs. subsequent reads.
+        // Cache variant is bound in init() (wireBeans), so the very first render writes to
+        // the cache. The first user API read after createGrid must therefore be a cache hit.
         let calls = 0;
         const countingGetter = (params: ValueGetterParams<Person>) => {
             calls++;


### PR DESCRIPTION
## Summary

First pass on `getValue` performance. Removes the long-standing init race-condition hack, tightens `ValueService` / `ValueCache` lifecycle, and inlines the most common `getValue` path. **+6% to +22%** on every cell-read-heavy benchmark, no regressions.

## Init race fix

`ValueService.getValue` had a hot-path guard:

```ts
// hack - the grid is getting refreshed before this bean gets initialised, race condition.
if (!this.initialised) {
    this.init();
}
```

`rowRenderer` (gridBeanComparator index 45) renders during its postConstruct, calling `valueSvc.getValue` before `valueSvc.postConstruct` (index 50) had run.

**Fix:** state needed by `getValue` (`isSsrm`, `cellExpressions`, `isTreeData`, `groupSuppressBlankHeader`) initialised in `wireBeans`. All beans complete `wireBeans` before any `postConstruct` runs, so `getValue` is ready when rowRenderer fires. Listeners stay in `postConstruct`. The per-call guard is gone.

`init()` is called from both `wireBeans` and `postConstruct` — defensive, costs ~4 `gos.get` per grid creation.

## Other changes

- **`ValueCache.active` removed.** With `executeValueGetter` bound to the cache variant only when the option is enabled, the per-call `if (this.active)` guard is dead. `setValue`/`getValue`. The binding is decided in `init()` (called from `wireBeans` and postConstruct defensively), so the cache is active from the very first render.

- **Inline no-dot hot path.** `_getValueUsingField` → `_getValueUsingDotField` (drops the bool param, handles only the dot-path case). Internal callers (`valueService`, `tooltipService`, `dataTypeService`) now branch: `column.fieldContainsDots ? _getValueUsingDotField(data, field) : data[field]`. The hot path is one property read, no function call.

- **Cache `groupSuppressBlankHeader`.** Read once in `init()`, kept in sync via property listener. Saves one `gos.get` per cell display.

- **Direct field access on `AgColumn`.** `fieldContainsDots` made `public` (per the file's own "prefer direct property access on hot paths" comment). All `column.isFieldContainsDots()` calls in `valueService` replaced with `column.fieldContainsDots`. Method kept for the public `Column` interface.

- **V8 hidden-class hygiene.** `ValueService` fields reordered (hot-path reads first), all non-bean fields initialised to primitive defaults at declaration. Constructor-time shape matches post-init shape; no hidden-class transitions.

## Tests

- New `services/value-service-init.test.ts` (7 tests) — covers `getValue` from any postConstruct entry point, every wireBeans-time state branch, runtime `treeData` toggle, and cross-column `params.getValue` from inside a valueGetter.
- `row-node-get-data-value.test.ts` — covers `resolveValue` gaps: treeData + valueGetter; valueGetter blocked on `showRowGroup` group rows + level guard at deeper/shallower levels.
- `ssrm-grouping.test.ts` — SSRM-footer fallback branch.

## Benchmark deltas

Median hz across 2 runs per side. Sorted biggest improvement first.

| File                   | Benchmark                                             | base (ops/s) | test (ops/s) | Result           |
| ---------------------- | ----------------------------------------------------- | -----------: | -----------: | ---------------- |
| getvalue               | getDataValue by string (last of 100 cols)             |       9196.2 |       11,175 | **1.22x faster** |
| delta-sort-transaction | applyTransaction (deltaSort: false) - 1 update        |        8.021 |        9.617 | **1.20x faster** |
| getvalue               | getDataValue by string (first col)                    |       17,300 |       20,302 | **1.17x faster** |
| grouping-aggregation   | transaction (5/50 cols) — CellsPath                   |        92.60 |        108.4 | **1.17x faster** |
| grouping-aggregation   | transaction (all 50 cols) — RowsPath                  |        84.03 |        97.94 | **1.17x faster** |
| grouping-aggregation   | immutable (5/50 cols) — CellsPath                     |        91.05 |        103.5 | **1.14x faster** |
| flat-sorting           | sort 30000 rows                                       |        31.96 |        36.18 | **1.13x faster** |
| pivot-aggregation      | transaction update (500 rows, high-cardinality)       |        281.2 |        313.6 | **1.12x faster** |
| getvalue               | getCellValue by string (last of 100 cols)             |       10,121 |       11,188 | **1.11x faster** |
| getvalue               | getDataValue by Column object (first col)             |       14,691 |       16,107 | **1.10x faster** |
| pivot-aggregation      | transaction update (500 rows, comparator)             |        281.3 |        307.3 | **1.09x faster** |
| grouping-aggregation   | immutable (5/50 cols) — RowsPath                      |        92.58 |        101.3 | **1.09x faster** |
| pivot-aggregation      | immutable update (500 rows, comparator)               |        221.9 |        240.7 | **1.08x faster** |
| flat-pipeline          | filter + sort 30000 rows                              |        19.63 |        21.28 | **1.08x faster** |
| formulas               | swap columns then re-evaluate 6000 formulas           |       1117.0 |       1200.3 | **1.07x faster** |
| pivot-aggregation      | transaction update (500 rows, no-comparator baseline) |        62.01 |        66.34 | **1.07x faster** |
| grouping-aggregation   | transaction (5/50 cols) — RowsPath                    |        96.93 |        102.8 | **1.06x faster** |
| grouping-aggregation   | immutable (all 50 cols) — CellsPath                   |        87.81 |        92.81 | **1.06x faster** |

The `getDataValue by Column object (last of 100 cols)` outlier (~75 hz, ~700x slower than direct access) is `ColumnModel.getColFromCollection` doing an O(N) scan when the key is an `AgColumn` rather than a string. Out of scope here — separate column-model PR.

## Reviewer notes

- **`init()` called from both `wireBeans` and `postConstruct`** is defensive idempotent — every read is stable across both phases.

- **SSRM-footer branch uses `column.fieldContainsDots` to read `rowNode.field`** — this IS a pre-existing latent bug, deliberately preserved here.

- **No `data` null-guard on the other inline branches** (treeData branch and final field branch) because both are inside `if (field && data && …)` outer guards — `data` is provably truthy when the inline runs. Identical to OLD `_getValueUsingField` semantics.

- **`_getValueUsingDotField` has no internal `field` / `data` null-guard.** All three internal call sites (`valueService`, `tooltipService`, `dataTypeService`) check both before calling.

- **`valueCache.setValue`/`getValue` lost their `if (this.active)` guards.** and callers must only invoke when caching is enabled. The only call sites are inside `executeValueGetterWithValueCache`, which is only bound when `valueCache` is registered AND the option is true. Precondition is enforced by the binding, not per-call branching.

- **`AgColumn.isFieldContainsDots()` method retained alongside the now-public field.** Internal callers use `column.fieldContainsDots` directly; the method stays for the public `Column` interface contract — external consumers continue to work.

- **`groupSuppressBlankHeader` now reactive** via `addManagedPropertyListener`. Behaviour identical to before (option was always read fresh). Perf: read happens once per option-change rather than once per cell display.

## Follow-ups

- **`ColumnModel.getColFromCollection` O(N) on object keys** — fix the `map[key]` shortcut to dispatch on `key.colId` when key is an `AgColumn`. Closes the 700x outlier.
- **Pre-existing latent bug: SSRM footer + dotted rowGroup field + auto group column** — see Reviewer notes. The fix is to compute the dot-notation decision from `rowNode.field.includes('.') && !suppressFieldDotNotation` in the SSRM-footer branch. Out of scope here because (a) it changes observable output and (b) needs a dedicated test for the dotted-SSRM-rowGroup combination. Recorded in the ticket https://ag-grid.atlassian.net/browse/AG-17254