### PR TITLE
AG-17197-cell-flicker-fix

### DIFF
--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideNodeManager.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideNodeManager.ts
@@ -74,7 +74,7 @@ export class ClientSideNodeManager<TData = any> extends BeanStub {
         const existingLeafs = this.rootNode._leafs;
         if (existingLeafs) {
             for (let i = 0, len = existingLeafs.length; i < len; ++i) {
-                existingLeafs[i]._destroy(false);
+                existingLeafs[i]._destroy(null);
             }
         }
 

--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideNodeManager.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideNodeManager.ts
@@ -69,7 +69,7 @@ export class ClientSideNodeManager<TData = any> extends BeanStub {
             pinnedRowModel.reset(); // only clear pinned rows if using manual pinning
         }
 
-        groupStage?.clearNonLeafs();
+        groupStage?.clearNonLeafs(null); // wholesale — silent destroy, no position events
 
         const existingLeafs = this.rootNode._leafs;
         if (existingLeafs) {

--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideNodeManager.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideNodeManager.ts
@@ -69,7 +69,7 @@ export class ClientSideNodeManager<TData = any> extends BeanStub {
             pinnedRowModel.reset(); // only clear pinned rows if using manual pinning
         }
 
-        groupStage?.clearNonLeafs(null); // wholesale — silent destroy, no position events
+        groupStage?.clearNonLeafs();
 
         const existingLeafs = this.rootNode._leafs;
         if (existingLeafs) {

--- a/packages/ag-grid-community/src/entities/rowNode.ts
+++ b/packages/ag-grid-community/src/entities/rowNode.ts
@@ -943,12 +943,11 @@ export class RowNode<TData = any>
     /**
      * Called internally to destroy this node.
      * @param fadeOut
-     *   - `true`: fade-out animation (clearRowTopAndRowIndex; preserves slide-in via oldRowTop)
-     *   - `false`: instant removal; setRowTop(null) and setRowIndex(null) fire events
-     *   - `null`: silent removal; no position events. Use when the entire row tree is being
-     *     replaced wholesale (setNewRowData, clearNonLeafs) — the rowRenderer is about to tear
-     *     down every RowCtrl anyway, so dying-row events only trigger wasted work in
-     *     cellCtrl.onRowIndexChanged() on rows that are about to vanish.
+     *   - `true`: fade-out animation; preserves slide-in via `oldRowTop`.
+     *   - `false`: instant removal; dispatches position events.
+     *   - `null`: silent. Wholesale tree replacement only — the rowRenderer is about to
+     *     tear down every RowCtrl, so position events would just trigger wasted work in
+     *     `cellCtrl.onRowIndexChanged()` on rows that are about to vanish.
      */
     public _destroy(fadeOut: boolean | null): boolean {
         if (this.destroyed) {
@@ -956,9 +955,8 @@ export class RowNode<TData = any>
         }
         this.destroyed = true;
 
-        // Unpin the pinned sibling when this source row is destroyed.
         // Check pinnedSibling.rowPinned to ensure we're the source row (not a pinned clone being destroyed).
-        // This also prevents re-entrance when _destroyRowNodeSibling clears rowPinned before calling _destroy.
+        // Also prevents re-entrance when _destroyRowNodeSibling clears rowPinned before calling _destroy.
         const pinnedSibling = this.pinnedSibling;
         if (pinnedSibling?.rowPinned && !this.rowPinned) {
             this.beans.pinnedRowModel?.pinRow(pinnedSibling, null);
@@ -970,7 +968,6 @@ export class RowNode<TData = any>
             this.setRowTop(null);
             this.setRowIndex(null);
         } else {
-            // silent: clear position state without dispatching events
             this.oldRowTop = null;
             this.rowTop = null;
             this.rowIndex = null;

--- a/packages/ag-grid-community/src/entities/rowNode.ts
+++ b/packages/ag-grid-community/src/entities/rowNode.ts
@@ -940,8 +940,17 @@ export class RowNode<TData = any>
         return this.childrenAfterSort?.[0] ?? null;
     }
 
-    /** Called internally to destroy this node */
-    public _destroy(fadeOut: boolean): boolean {
+    /**
+     * Called internally to destroy this node.
+     * @param fadeOut
+     *   - `true`: fade-out animation (clearRowTopAndRowIndex; preserves slide-in via oldRowTop)
+     *   - `false`: instant removal; setRowTop(null) and setRowIndex(null) fire events
+     *   - `null`: silent removal; no position events. Use when the entire row tree is being
+     *     replaced wholesale (setNewRowData, clearNonLeafs) — the rowRenderer is about to tear
+     *     down every RowCtrl anyway, so dying-row events only trigger wasted work in
+     *     cellCtrl.onRowIndexChanged() on rows that are about to vanish.
+     */
+    public _destroy(fadeOut: boolean | null): boolean {
         if (this.destroyed) {
             return false;
         }
@@ -955,9 +964,9 @@ export class RowNode<TData = any>
             this.beans.pinnedRowModel?.pinRow(pinnedSibling, null);
         }
 
-        if (fadeOut) {
+        if (fadeOut === true) {
             this.clearRowTopAndRowIndex(); // so row renderer knows to fade row out (and not reposition it)
-        } else {
+        } else if (fadeOut === false) {
             this.setRowTop(null);
             this.setRowIndex(null);
         }

--- a/packages/ag-grid-community/src/entities/rowNode.ts
+++ b/packages/ag-grid-community/src/entities/rowNode.ts
@@ -969,6 +969,12 @@ export class RowNode<TData = any>
         } else if (fadeOut === false) {
             this.setRowTop(null);
             this.setRowIndex(null);
+        } else {
+            // silent: clear position state without dispatching events
+            this.oldRowTop = null;
+            this.rowTop = null;
+            this.rowIndex = null;
+            this.displayed = false;
         }
 
         if (!this.footer) {

--- a/packages/ag-grid-community/src/interfaces/iRowNodeStage.ts
+++ b/packages/ag-grid-community/src/interfaces/iRowNodeStage.ts
@@ -61,10 +61,8 @@ export interface IRowNodeGroupStage<TData = any> extends IRowNodeStage<TData> {
     /** Used to lazily compute and store groupData for a row node - not for siblings */
     loadGroupData(node: RowNode<TData>): Record<string, any> | null;
 
-    /** Clears all stored group rows / tree data fillers.
-     * @param fadeOut forwarded to RowNode._destroy on each dying node — `null` is silent
-     * (use only when the entire row tree is being torn down wholesale). */
-    clearNonLeafs(fadeOut: boolean | null): void;
+    /** Clears all stored group rows / tree data fillers without dispatching position events. */
+    clearNonLeafs(): void;
 
     /** Called when row group columns might have changed */
     invalidateGroupCols(): void;

--- a/packages/ag-grid-community/src/interfaces/iRowNodeStage.ts
+++ b/packages/ag-grid-community/src/interfaces/iRowNodeStage.ts
@@ -61,8 +61,10 @@ export interface IRowNodeGroupStage<TData = any> extends IRowNodeStage<TData> {
     /** Used to lazily compute and store groupData for a row node - not for siblings */
     loadGroupData(node: RowNode<TData>): Record<string, any> | null;
 
-    /** Clears all stored group rows / tree data fillers */
-    clearNonLeafs(): void;
+    /** Clears all stored group rows / tree data fillers.
+     * @param fadeOut forwarded to RowNode._destroy on each dying node — `null` is silent
+     * (use only when the entire row tree is being torn down wholesale). */
+    clearNonLeafs(fadeOut: boolean | null): void;
 
     /** Called when row group columns might have changed */
     invalidateGroupCols(): void;

--- a/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/groupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/groupStrategy.ts
@@ -40,7 +40,7 @@ export class GroupStrategy extends BeanStub implements IRowGroupingStrategy {
     public clearNonLeafs(): void {
         const nonLeafsById = this.nonLeafsById;
         for (const node of nonLeafsById.values()) {
-            node._destroy(false);
+            node._destroy(null);
         }
         nonLeafsById.clear();
     }

--- a/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/groupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/groupStrategy.ts
@@ -37,10 +37,10 @@ export class GroupStrategy extends BeanStub implements IRowGroupingStrategy {
         this.nonLeafsById.clear();
     }
 
-    public clearNonLeafs(): void {
+    public clearNonLeafs(fadeOut: boolean | null): void {
         const nonLeafsById = this.nonLeafsById;
         for (const node of nonLeafsById.values()) {
-            node._destroy(null);
+            node._destroy(fadeOut);
         }
         nonLeafsById.clear();
     }

--- a/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/groupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/groupStrategy/groupStrategy.ts
@@ -37,10 +37,10 @@ export class GroupStrategy extends BeanStub implements IRowGroupingStrategy {
         this.nonLeafsById.clear();
     }
 
-    public clearNonLeafs(fadeOut: boolean | null): void {
+    public clearNonLeafs(): void {
         const nonLeafsById = this.nonLeafsById;
         for (const node of nonLeafsById.values()) {
-            node._destroy(fadeOut);
+            node._destroy(null);
         }
         nonLeafsById.clear();
     }

--- a/packages/ag-grid-enterprise/src/rowHierarchy/groupStage.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/groupStage.ts
@@ -151,8 +151,8 @@ export class GroupStage<TData> extends BeanStub implements NamedBean, _IRowNodeG
         return null;
     }
 
-    public clearNonLeafs(): void {
-        this.strategy?.clearNonLeafs();
+    public clearNonLeafs(fadeOut: boolean | null): void {
+        this.strategy?.clearNonLeafs(fadeOut);
     }
 
     private getWantedStrategyType(): GroupStrategyType {

--- a/packages/ag-grid-enterprise/src/rowHierarchy/groupStage.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/groupStage.ts
@@ -151,8 +151,8 @@ export class GroupStage<TData> extends BeanStub implements NamedBean, _IRowNodeG
         return null;
     }
 
-    public clearNonLeafs(fadeOut: boolean | null): void {
-        this.strategy?.clearNonLeafs(fadeOut);
+    public clearNonLeafs(): void {
+        this.strategy?.clearNonLeafs();
     }
 
     private getWantedStrategyType(): GroupStrategyType {

--- a/packages/ag-grid-enterprise/src/rowHierarchy/rowHierarchyUtils.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/rowHierarchyUtils.ts
@@ -23,9 +23,8 @@ export interface IRowGroupingStrategy<TData = any> extends Bean {
     /** Used to lazily compute and store groupData for a row node */
     loadGroupData(node: RowNode<TData>): Record<string, any> | null;
 
-    /** Clears any cached group/filler nodes maintained by the strategy.
-     * @param fadeOut forwarded to RowNode._destroy on each dying node. */
-    clearNonLeafs(fadeOut: boolean | null): void;
+    /** Clears any cached group/filler nodes maintained by the strategy without dispatching position events. */
+    clearNonLeafs(): void;
 
     /** Called when row group columns changes */
     invalidateGroupCols?(): void;

--- a/packages/ag-grid-enterprise/src/rowHierarchy/rowHierarchyUtils.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/rowHierarchyUtils.ts
@@ -23,8 +23,9 @@ export interface IRowGroupingStrategy<TData = any> extends Bean {
     /** Used to lazily compute and store groupData for a row node */
     loadGroupData(node: RowNode<TData>): Record<string, any> | null;
 
-    /** Clears any cached group/filler nodes maintained by the strategy. */
-    clearNonLeafs(): void;
+    /** Clears any cached group/filler nodes maintained by the strategy.
+     * @param fadeOut forwarded to RowNode._destroy on each dying node. */
+    clearNonLeafs(fadeOut: boolean | null): void;
 
     /** Called when row group columns changes */
     invalidateGroupCols?(): void;

--- a/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
@@ -89,7 +89,7 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
         const fillers = this.nonLeafsById;
         if (fillers) {
             for (const node of fillers.values()) {
-                node._destroy(false);
+                node._destroy(null);
             }
             fillers.clear();
             this.nonLeafsById = null;

--- a/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
@@ -75,21 +75,21 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
 
     public override destroy(): void {
         this.nodesToUnselect = null;
-        this.reset();
+        this.reset(false);
         super.destroy();
     }
 
-    public reset(): void {
-        this.clearNonLeafs();
+    public reset(fadeOut: boolean | null): void {
+        this.clearNonLeafs(fadeOut);
         this.deselectHiddenNodes(false);
         this.fullReload = true;
     }
 
-    public clearNonLeafs(): void {
+    public clearNonLeafs(fadeOut: boolean | null): void {
         const fillers = this.nonLeafsById;
         if (fillers) {
             for (const node of fillers.values()) {
-                node._destroy(null);
+                node._destroy(fadeOut);
             }
             fillers.clear();
             this.nonLeafsById = null;
@@ -119,7 +119,7 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
 
     public execute(rootNode: RowNode<TData>, params: RefreshModelParams<TData>): boolean {
         if (this.fullReload) {
-            this.reset();
+            this.reset(false); // incremental refresh — let the renderer hear the events
         }
 
         const { changedRowNodes, changedPath } = params;

--- a/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
+++ b/packages/ag-grid-enterprise/src/treeData/treeGroupStrategy.ts
@@ -75,21 +75,21 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
 
     public override destroy(): void {
         this.nodesToUnselect = null;
-        this.reset(false);
+        this.reset();
         super.destroy();
     }
 
-    public reset(fadeOut: boolean | null): void {
-        this.clearNonLeafs(fadeOut);
+    public reset(): void {
+        this.clearNonLeafs();
         this.deselectHiddenNodes(false);
         this.fullReload = true;
     }
 
-    public clearNonLeafs(fadeOut: boolean | null): void {
+    public clearNonLeafs(): void {
         const fillers = this.nonLeafsById;
         if (fillers) {
             for (const node of fillers.values()) {
-                node._destroy(fadeOut);
+                node._destroy(null);
             }
             fillers.clear();
             this.nonLeafsById = null;
@@ -119,7 +119,7 @@ export class TreeGroupStrategy<TData = any> extends BeanStub implements IRowGrou
 
     public execute(rootNode: RowNode<TData>, params: RefreshModelParams<TData>): boolean {
         if (this.fullReload) {
-            this.reset(false); // incremental refresh — let the renderer hear the events
+            this.reset();
         }
 
         const { changedRowNodes, changedPath } = params;

--- a/testing/behavioural/src/grouping-data/grouping-simple-data.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-simple-data.test.ts
@@ -907,12 +907,16 @@ describe('ag-grid grouping simple data', () => {
 
         let topChangedCount = 0;
         let rowIndexChangedCount = 0;
+        let displayedChangedCount = 0;
         for (const f of fillers) {
             f.addEventListener('topChanged', () => {
                 ++topChangedCount;
             });
             f.addEventListener('rowIndexChanged', () => {
                 ++rowIndexChangedCount;
+            });
+            f.addEventListener('displayedChanged', () => {
+                ++displayedChangedCount;
             });
         }
 
@@ -930,6 +934,7 @@ describe('ag-grid grouping simple data', () => {
         }
         expect(topChangedCount).toBe(0);
         expect(rowIndexChangedCount).toBe(0);
+        expect(displayedChangedCount).toBe(0);
     });
 
     test('removing all rows in a group fires position events on the dying filler', async () => {

--- a/testing/behavioural/src/grouping-data/grouping-simple-data.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-simple-data.test.ts
@@ -931,4 +931,40 @@ describe('ag-grid grouping simple data', () => {
         expect(topChangedCount).toBe(0);
         expect(rowIndexChangedCount).toBe(0);
     });
+
+    test('removing all rows in a group fires position events on the dying filler', async () => {
+        // Contract: incremental group teardown (e.g. transaction removes all rows in a group)
+        // must still fire position events on the dying filler so the renderer can detach its RowCtrl.
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'name' }, { field: 'country', rowGroup: true, hide: true }],
+            groupDefaultExpanded: -1,
+            rowData: [
+                { name: 'Alice', country: 'IE' },
+                { name: 'Bob', country: 'IT' },
+            ],
+            getRowId: ({ data }) => data.name,
+            animateRows: false,
+        };
+        const api = gridsManager.createGrid('myGrid', gridOptions);
+        await asyncSetTimeout(1);
+
+        const itFiller = api.getRowNode('row-group-country-IT');
+        expect(itFiller).toBeTruthy();
+
+        let topChangedCount = 0;
+        let rowIndexChangedCount = 0;
+        itFiller!.addEventListener('topChanged', () => {
+            ++topChangedCount;
+        });
+        itFiller!.addEventListener('rowIndexChanged', () => {
+            ++rowIndexChangedCount;
+        });
+
+        api.applyTransaction({ remove: [{ name: 'Bob' }] });
+        await asyncSetTimeout(1);
+
+        expect(itFiller!.destroyed).toBe(true);
+        expect(topChangedCount).toBeGreaterThan(0);
+        expect(rowIndexChangedCount).toBeGreaterThan(0);
+    });
 });

--- a/testing/behavioural/src/grouping-data/grouping-simple-data.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-simple-data.test.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridOptions } from 'ag-grid-community';
+import type { ColDef, GridOptions, IRowNode } from 'ag-grid-community';
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { RowGroupingModule } from 'ag-grid-enterprise';
 
@@ -882,5 +882,53 @@ describe('ag-grid grouping simple data', () => {
             · · · · └─┬ LEAF_GROUP id:row-group-l1-B-l2-B1-l3-B1a-l4-B1a1-l5-B1a1i ag-Grid-AutoColumn:"B1a1i"
             · · · · · └── LEAF id:4 l1:"B" l2:"B1" l3:"B1a" l4:"B1a1" l5:"B1a1i" name:"Deep Item 4"
         `);
+    });
+
+    test('setRowData without getRowId destroys group filler nodes silently', async () => {
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'name' }, { field: 'country', rowGroup: true, hide: true }],
+            groupDefaultExpanded: -1,
+            rowData: [
+                { name: 'Alice', country: 'IE' },
+                { name: 'Bob', country: 'IT' },
+            ],
+            animateRows: false,
+        };
+        const api = gridsManager.createGrid('myGrid', gridOptions);
+        await asyncSetTimeout(1);
+
+        const fillers: IRowNode[] = [];
+        api.forEachNode((n) => {
+            if (n.group) {
+                fillers.push(n);
+            }
+        });
+        expect(fillers.length).toBeGreaterThan(0);
+
+        let topChangedCount = 0;
+        let rowIndexChangedCount = 0;
+        for (const f of fillers) {
+            f.addEventListener('topChanged', () => {
+                ++topChangedCount;
+            });
+            f.addEventListener('rowIndexChanged', () => {
+                ++rowIndexChangedCount;
+            });
+        }
+
+        setRowDataChecked(api, [
+            { name: 'Alice', country: 'IE' },
+            { name: 'Bob', country: 'IT' },
+        ]);
+        await asyncSetTimeout(1);
+
+        for (const f of fillers) {
+            expect(f.destroyed).toBe(true);
+            expect(f.rowTop).toBeNull();
+            expect(f.rowIndex).toBeNull();
+            expect(f.displayed).toBe(false);
+        }
+        expect(topChangedCount).toBe(0);
+        expect(rowIndexChangedCount).toBe(0);
     });
 });

--- a/testing/behavioural/src/row-data/row-data.test.ts
+++ b/testing/behavioural/src/row-data/row-data.test.ts
@@ -1,7 +1,7 @@
 import type { MockInstance } from 'vitest';
 
 import { ClientSideRowModelModule, NumberFilterModule, RowApiModule, TextFilterModule } from 'ag-grid-community';
-import type { GridOptions, ModelUpdatedEvent } from 'ag-grid-community';
+import type { GridOptions, IRowNode, ModelUpdatedEvent } from 'ag-grid-community';
 
 import {
     GridRows,
@@ -389,6 +389,62 @@ describe('ag-grid row data', () => {
         // Passing a number should not throw, and should still find the row via property key coercion
         expect(api.getRowNode(1 as any)).toBeTruthy();
         expect(api.getRowNode(999 as any)).toBeUndefined();
+    });
+
+    test('setRowData without getRowId destroys old nodes silently (no topChanged events)', async () => {
+        const row1 = { value: 1 };
+        const row2 = { value: 2 };
+        const row3 = { value: 3 };
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'value' }],
+            rowData: [row1, row2, row3],
+            animateRows: false,
+        };
+        const api = gridsManager.createGrid('myGrid', gridOptions);
+        await asyncSetTimeout(1);
+
+        const initialNodes: IRowNode[] = [];
+        api.forEachNode((n) => initialNodes.push(n));
+        expect(initialNodes).toHaveLength(3);
+
+        await new GridRows(api, 'before').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 value:1
+            ├── LEAF id:1 value:2
+            └── LEAF id:2 value:3
+        `);
+
+        let topChangedCount = 0;
+        let rowIndexChangedCount = 0;
+        for (const node of initialNodes) {
+            node.addEventListener('topChanged', () => {
+                ++topChangedCount;
+            });
+            node.addEventListener('rowIndexChanged', () => {
+                ++rowIndexChangedCount;
+            });
+        }
+
+        setRowDataChecked(api, [{ value: 10 }, row2, row3]);
+        await asyncSetTimeout(1);
+
+        const newNodes: IRowNode[] = [];
+        api.forEachNode((n) => newNodes.push(n));
+        expect(newNodes).toHaveLength(3);
+
+        for (const node of initialNodes) {
+            expect(node.destroyed).toBe(true);
+        }
+        await new GridRows(api, 'after').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 value:10
+            ├── LEAF id:1 value:2
+            └── LEAF id:2 value:3
+        `);
+
+        expect(topChangedCount).toBe(0);
+        expect(rowIndexChangedCount).toBe(0);
     });
 
     describe('onModelUpdated event flags', () => {

--- a/testing/behavioural/src/row-data/row-data.test.ts
+++ b/testing/behavioural/src/row-data/row-data.test.ts
@@ -391,7 +391,7 @@ describe('ag-grid row data', () => {
         expect(api.getRowNode(999 as any)).toBeUndefined();
     });
 
-    test('setRowData without getRowId destroys old nodes silently (no topChanged events)', async () => {
+    test('setRowData without getRowId destroys old nodes silently (no position events)', async () => {
         const row1 = { value: 1 };
         const row2 = { value: 2 };
         const row3 = { value: 3 };
@@ -417,12 +417,16 @@ describe('ag-grid row data', () => {
 
         let topChangedCount = 0;
         let rowIndexChangedCount = 0;
+        let displayedChangedCount = 0;
         for (const node of initialNodes) {
             node.addEventListener('topChanged', () => {
                 ++topChangedCount;
             });
             node.addEventListener('rowIndexChanged', () => {
                 ++rowIndexChangedCount;
+            });
+            node.addEventListener('displayedChanged', () => {
+                ++displayedChangedCount;
             });
         }
 
@@ -448,6 +452,7 @@ describe('ag-grid row data', () => {
 
         expect(topChangedCount).toBe(0);
         expect(rowIndexChangedCount).toBe(0);
+        expect(displayedChangedCount).toBe(0);
     });
 
     describe('onModelUpdated event flags', () => {

--- a/testing/behavioural/src/row-data/row-data.test.ts
+++ b/testing/behavioural/src/row-data/row-data.test.ts
@@ -435,6 +435,9 @@ describe('ag-grid row data', () => {
 
         for (const node of initialNodes) {
             expect(node.destroyed).toBe(true);
+            expect(node.rowTop).toBeNull();
+            expect(node.rowIndex).toBeNull();
+            expect(node.displayed).toBe(false);
         }
         await new GridRows(api, 'after').check(`
             ROOT id:ROOT_NODE_ID

--- a/testing/behavioural/src/selection/master-detail-row-selection.test.ts
+++ b/testing/behavioural/src/selection/master-detail-row-selection.test.ts
@@ -7,6 +7,13 @@ import { MasterDetailModule } from 'ag-grid-enterprise';
 import { TestGridsManager, assertSelectedRowsByIndex, asyncSetTimeout, waitForEvent } from '../test-utils';
 import { GridActions } from './utils';
 
+async function waitForSelection(api: GridApi, expected: number, timeoutMs = 200): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (api.getSelectedNodes().length !== expected && Date.now() < deadline) {
+        await asyncSetTimeout(5);
+    }
+}
+
 describe('Row Selection Grid Options', () => {
     const columnDefs = [{ field: 'sport', cellRenderer: 'agGroupCellRenderer' }];
     const rowData = [
@@ -263,10 +270,12 @@ describe('Row Selection Grid Options', () => {
         // Collapse and re-expand master row to hide/show detail grid
         await actions.collapseGroupRowByIndex(1, { count: 1 });
         await actions.expandGroupRowByIndex(1, { count: 1 });
-        await asyncSetTimeout(12);
 
         info = api.getDetailGridInfo('detail_1')!;
-        await waitForEvent('firstDataRendered', info.api!);
+        // Poll for selection-state restoration on the recreated detail grid: firstDataRendered
+        // is one-shot and may already have fired by the time we attach a listener, so we wait
+        // on the deterministic post-condition instead.
+        await waitForSelection(info.api!, 2);
         detailActions = new GridActions(info.api!, '[row-id="detail_1"]');
 
         // Detail grid should have same rows selected
@@ -286,10 +295,9 @@ describe('Row Selection Grid Options', () => {
         // Collapse and re-expand master row again
         await actions.collapseGroupRowByIndex(1, { count: 1 });
         await actions.expandGroupRowByIndex(1, { count: 1 });
-        await asyncSetTimeout(12);
 
         info = api.getDetailGridInfo('detail_1')!;
-        await waitForEvent('firstDataRendered', info.api!);
+        await waitForSelection(info.api!, 1);
         detailActions = new GridActions(info.api!, '[row-id="detail_1"]');
 
         // Detail grid should have same rows selected

--- a/testing/behavioural/src/selection/master-detail-row-selection.test.ts
+++ b/testing/behavioural/src/selection/master-detail-row-selection.test.ts
@@ -263,9 +263,10 @@ describe('Row Selection Grid Options', () => {
         // Collapse and re-expand master row to hide/show detail grid
         await actions.collapseGroupRowByIndex(1, { count: 1 });
         await actions.expandGroupRowByIndex(1, { count: 1 });
-        await asyncSetTimeout(10);
+        await asyncSetTimeout(12);
 
         info = api.getDetailGridInfo('detail_1')!;
+        await waitForEvent('firstDataRendered', info.api!);
         detailActions = new GridActions(info.api!, '[row-id="detail_1"]');
 
         // Detail grid should have same rows selected
@@ -285,9 +286,10 @@ describe('Row Selection Grid Options', () => {
         // Collapse and re-expand master row again
         await actions.collapseGroupRowByIndex(1, { count: 1 });
         await actions.expandGroupRowByIndex(1, { count: 1 });
-        await asyncSetTimeout(20);
+        await asyncSetTimeout(12);
 
         info = api.getDetailGridInfo('detail_1')!;
+        await waitForEvent('firstDataRendered', info.api!);
         detailActions = new GridActions(info.api!, '[row-id="detail_1"]');
 
         // Detail grid should have same rows selected

--- a/testing/behavioural/src/selection/master-detail-row-selection.test.ts
+++ b/testing/behavioural/src/selection/master-detail-row-selection.test.ts
@@ -4,14 +4,24 @@ import type { DetailGridInfo, GetDetailRowDataParams, GridApi, GridOptions } fro
 import { ClientSideRowModelModule, RowSelectionModule } from 'ag-grid-community';
 import { MasterDetailModule } from 'ag-grid-enterprise';
 
-import { TestGridsManager, assertSelectedRowsByIndex, asyncSetTimeout, waitForEvent } from '../test-utils';
+import { TestGridsManager, assertSelectedRowsByIndex, waitForEvent } from '../test-utils';
 import { GridActions } from './utils';
 
-async function waitForSelection(api: GridApi, expected: number, timeoutMs = 200): Promise<void> {
-    const deadline = Date.now() + timeoutMs;
-    while (api.getSelectedNodes().length !== expected && Date.now() < deadline) {
-        await asyncSetTimeout(5);
-    }
+/**
+ * Latch hooked into `detailGridOptions.onFirstDataRendered`. Call `next()` before
+ * triggering the detail grid (collapse + expand) and await the returned promise —
+ * the latch is set up at grid-creation time so the one-shot event can never fire
+ * before the resolver is registered.
+ */
+function createDetailRenderedLatch(): {
+    onFirstDataRendered: () => void;
+    next: () => Promise<void>;
+} {
+    const pending: Array<() => void> = [];
+    return {
+        onFirstDataRendered: () => pending.shift()?.(),
+        next: () => new Promise<void>((resolve) => pending.push(resolve)),
+    };
 }
 
 describe('Row Selection Grid Options', () => {
@@ -217,6 +227,8 @@ describe('Row Selection Grid Options', () => {
     });
 
     test('detail state properly tracked and restored when collapsing and re-expanding detail grid', async () => {
+        const detailRendered = createDetailRenderedLatch();
+
         const [api, actions] = await createGridAndWait({
             columnDefs,
             rowData,
@@ -226,6 +238,7 @@ describe('Row Selection Grid Options', () => {
                 detailGridOptions: {
                     columnDefs: detailColumnDefs,
                     rowSelection: { mode: 'multiRow' },
+                    onFirstDataRendered: detailRendered.onFirstDataRendered,
                 },
                 getDetailRowData(params: GetDetailRowDataParams) {
                     params.successCallback(params.data.detail);
@@ -241,12 +254,12 @@ describe('Row Selection Grid Options', () => {
         // Round 1
         //////////
 
+        const round1Rendered = detailRendered.next();
         await actions.expandGroupRowByIndex(1, { count: 1 });
+        await round1Rendered;
 
         info = api.getDetailGridInfo('detail_1')!;
         expect(info).not.toBeUndefined();
-
-        await waitForEvent('firstDataRendered', info.api!);
 
         detailActions = new GridActions(info.api!, '[row-id="detail_1"]');
 
@@ -269,13 +282,11 @@ describe('Row Selection Grid Options', () => {
 
         // Collapse and re-expand master row to hide/show detail grid
         await actions.collapseGroupRowByIndex(1, { count: 1 });
+        const round2Rendered = detailRendered.next();
         await actions.expandGroupRowByIndex(1, { count: 1 });
+        await round2Rendered;
 
         info = api.getDetailGridInfo('detail_1')!;
-        // Poll for selection-state restoration on the recreated detail grid: firstDataRendered
-        // is one-shot and may already have fired by the time we attach a listener, so we wait
-        // on the deterministic post-condition instead.
-        await waitForSelection(info.api!, 2);
         detailActions = new GridActions(info.api!, '[row-id="detail_1"]');
 
         // Detail grid should have same rows selected
@@ -294,10 +305,11 @@ describe('Row Selection Grid Options', () => {
 
         // Collapse and re-expand master row again
         await actions.collapseGroupRowByIndex(1, { count: 1 });
+        const round3Rendered = detailRendered.next();
         await actions.expandGroupRowByIndex(1, { count: 1 });
+        await round3Rendered;
 
         info = api.getDetailGridInfo('detail_1')!;
-        await waitForSelection(info.api!, 1);
         detailActions = new GridActions(info.api!, '[row-id="detail_1"]');
 
         // Detail grid should have same rows selected

--- a/testing/behavioural/src/toolbar/toolbar-react.test.tsx
+++ b/testing/behavioural/src/toolbar/toolbar-react.test.tsx
@@ -5,9 +5,12 @@ import { ClientSideRowModelModule, ModuleRegistry, RowSelectionModule, Validatio
 import { ToolbarModule } from 'ag-grid-enterprise';
 import { AgGridReact } from 'ag-grid-react';
 
+import { ignoreConsoleLicenseKeyError } from '../test-utils';
+
 describe('Toolbar (React)', () => {
     beforeAll(() => {
         ModuleRegistry.registerModules([ClientSideRowModelModule, RowSelectionModule, ToolbarModule, ValidationModule]);
+        ignoreConsoleLicenseKeyError();
     });
 
     afterEach(() => {

--- a/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-reset.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-reset.test.ts
@@ -2,6 +2,7 @@ import { setTimeout as asyncSetTimeout } from 'timers/promises';
 import type { MockInstance } from 'vitest';
 
 import { ClientSideRowModelModule, RowSelectionModule } from 'ag-grid-community';
+import type { IRowNode } from 'ag-grid-community';
 import { TreeDataModule } from 'ag-grid-enterprise';
 
 import { GridColumns, GridRows, TestGridsManager, cachedJSONObjects, setRowDataChecked } from '../../test-utils';
@@ -603,5 +604,55 @@ describe('ag-grid hierarchical tree data reset', () => {
         setRowDataChecked(api, []);
 
         await new GridRows(api, 'cleared').check('empty');
+    });
+
+    test('setRowData without getRowId destroys filler nodes silently', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [],
+            autoGroupColumnDef: { headerName: 'Hierarchy' },
+            treeData: true,
+            treeDataChildrenField: 'children',
+            animateRows: false,
+            groupDefaultExpanded: -1,
+            rowData: [
+                { name: 'A', children: [{ name: 'A.1' }] },
+                { name: 'B', children: [{ name: 'B.1' }] },
+            ],
+        });
+        await asyncSetTimeout(1);
+
+        const fillers: IRowNode[] = [];
+        api.forEachNode((n) => {
+            if (n.group) {
+                fillers.push(n);
+            }
+        });
+        expect(fillers.length).toBeGreaterThan(0);
+
+        let topChangedCount = 0;
+        let rowIndexChangedCount = 0;
+        for (const f of fillers) {
+            f.addEventListener('topChanged', () => {
+                ++topChangedCount;
+            });
+            f.addEventListener('rowIndexChanged', () => {
+                ++rowIndexChangedCount;
+            });
+        }
+
+        setRowDataChecked(api, [
+            { name: 'A', children: [{ name: 'A.1' }] },
+            { name: 'B', children: [{ name: 'B.1' }] },
+        ]);
+        await asyncSetTimeout(1);
+
+        for (const f of fillers) {
+            expect(f.destroyed).toBe(true);
+            expect(f.rowTop).toBeNull();
+            expect(f.rowIndex).toBeNull();
+            expect(f.displayed).toBe(false);
+        }
+        expect(topChangedCount).toBe(0);
+        expect(rowIndexChangedCount).toBe(0);
     });
 });

--- a/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-reset.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/hierarchical-tree-data-reset.test.ts
@@ -631,12 +631,16 @@ describe('ag-grid hierarchical tree data reset', () => {
 
         let topChangedCount = 0;
         let rowIndexChangedCount = 0;
+        let displayedChangedCount = 0;
         for (const f of fillers) {
             f.addEventListener('topChanged', () => {
                 ++topChangedCount;
             });
             f.addEventListener('rowIndexChanged', () => {
                 ++rowIndexChangedCount;
+            });
+            f.addEventListener('displayedChanged', () => {
+                ++displayedChangedCount;
             });
         }
 
@@ -654,5 +658,6 @@ describe('ag-grid hierarchical tree data reset', () => {
         }
         expect(topChangedCount).toBe(0);
         expect(rowIndexChangedCount).toBe(0);
+        expect(displayedChangedCount).toBe(0);
     });
 });


### PR DESCRIPTION
The problem was that the original 34 code did not raise the row index changed events when we destroy and recreate all the rows, but version 35 does.
The solution is to add a third value to the fadeOut option of RowNode._destroy in such a way we skip raising those events, consumed by row renderer, when we know we are destroying and recreating all rows

also, fixes master-detail-row-selection.test being flaky sometimes and toolbar-react.test printing license error during tests

FIX AG-17197