### PR TITLE
AG-17286 react rows flickering with transactions

### DIFF
--- a/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
@@ -195,9 +195,9 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
 
         this.addListeners();
 
-        // Pre-create CellCtrls so framework wrappers can seed their first render with
-        // them; otherwise bulk adds flash empty rows. Scroll-driven creation stays
-        // deferred so scroll throughput isn't blocked by upfront CellCtrl construction.
+        // Pre-create CellCtrls so framework wrappers can seed their first render and
+        // avoid the bulk-add empty-row flash.
+        // The animation-frame path is left to handle deferred creation.
         if (!useAnimationFrameForCreate && !this.isFullWidth()) {
             this.createAllCellCtrls();
         }
@@ -697,10 +697,9 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
     }
 
     /**
-     * Returns the CellCtrls for the given container type if they were eagerly created
-     * in the constructor, or `null` if creation is deferred (scroll-driven path or
-     * full-width row). Lets framework wrappers seed their initial render and avoid an
-     * empty-row flicker when many rows mount in one batch.
+     * CellCtrls for the container if eagerly created in the constructor, or `null`
+     * when creation is deferred (animation-frame path) or skipped (full-width rows).
+     * Used by framework wrappers to seed first render and avoid bulk-add flicker.
      */
     public getInitialCellCtrls(containerType: RowContainerType): CellCtrl[] | null {
         if (this.useAnimationFrameForCreate || this.isFullWidth()) {

--- a/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
@@ -194,6 +194,13 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         this.fullWidthNotesFeature = this.isFullWidth() ? beans.notesSvc?.createFullWidthNotesFeature(this) : undefined;
 
         this.addListeners();
+
+        // Pre-create CellCtrls so framework wrappers can seed their first render with
+        // them; otherwise bulk adds flash empty rows. Scroll-driven creation stays
+        // deferred so scroll throughput isn't blocked by upfront CellCtrl construction.
+        if (!useAnimationFrameForCreate && !this.isFullWidth()) {
+            this.createAllCellCtrls();
+        }
     }
 
     private initRowBusinessKey(): void {
@@ -657,7 +664,7 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         }
     }
 
-    private getCellCtrlsForContainer(containerType: RowContainerType) {
+    private getCellCtrlsForContainer(containerType: RowContainerType): CellCtrl[] {
         switch (containerType) {
             case 'left':
                 return this.leftCellCtrls.list;
@@ -687,6 +694,19 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
             const rightCols = presentedColsService.getRightColsForRow(this.rowNode);
             this.rightCellCtrls = this.createCellCtrls(this.rightCellCtrls, rightCols, 'right');
         }
+    }
+
+    /**
+     * Returns the CellCtrls for the given container type if they were eagerly created
+     * in the constructor, or `null` if creation is deferred (scroll-driven path or
+     * full-width row). Lets framework wrappers seed their initial render and avoid an
+     * empty-row flicker when many rows mount in one batch.
+     */
+    public getInitialCellCtrls(containerType: RowContainerType): CellCtrl[] | null {
+        if (this.useAnimationFrameForCreate || this.isFullWidth()) {
+            return null;
+        }
+        return this.getCellCtrlsForContainer(containerType);
     }
 
     private isCellEligibleToBeRemoved(cellCtrl: CellCtrl, nextContainerPinned: ColumnPinnedType): boolean {

--- a/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
@@ -198,6 +198,7 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         // Pre-create CellCtrls so framework wrappers can seed their first render and
         // avoid the bulk-add empty-row flash.
         // The animation-frame path is left to handle deferred creation.
+        // We are disabling this also during scroll to not cause sluggishness.
         if (!useAnimationFrameForCreate && !this.isFullWidth()) {
             this.createAllCellCtrls();
         }
@@ -699,6 +700,8 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
     /**
      * CellCtrls for the container if eagerly created in the constructor, or `null`
      * when creation is deferred (animation-frame path) or skipped (full-width rows).
+     * We don't want to enable this during scrolling as well, as it can cause sluggishness
+     * during scroll.
      * Used by framework wrappers to seed first render and avoid bulk-add flicker.
      */
     public getInitialCellCtrls(containerType: RowContainerType): CellCtrl[] | null {

--- a/packages/ag-grid-react/src/reactUi/rows/rowComp.tsx
+++ b/packages/ag-grid-react/src/reactUi/rows/rowComp.tsx
@@ -37,8 +37,8 @@ const RowComp = ({ rowCtrl, containerType }: { rowCtrl: RowCtrl; containerType: 
     const [rowBusinessKey, setRowBusinessKey] = useState<string | null>(() => rowCtrl.businessKey);
 
     const [userStyles, setUserStyles] = useState<RowStyle | undefined>(() => rowCtrl.rowStyles);
-    // Seeded so bulk-add doesn't flash empty rows; getInitialCellCtrls self-gates
-    // to no-op for the scroll-driven path and for full-width rows.
+    // Seeded so bulk-add doesn't flash empty rows; getInitialCellCtrls returns
+    // null when creation is deferred or not applicable.
     const [cellCtrlsFlushSync, setCellCtrlsFlushSync] = useState<CellCtrl[] | null>(() =>
         rowCtrl.getInitialCellCtrls(containerType)
     );

--- a/packages/ag-grid-react/src/reactUi/rows/rowComp.tsx
+++ b/packages/ag-grid-react/src/reactUi/rows/rowComp.tsx
@@ -37,8 +37,12 @@ const RowComp = ({ rowCtrl, containerType }: { rowCtrl: RowCtrl; containerType: 
     const [rowBusinessKey, setRowBusinessKey] = useState<string | null>(() => rowCtrl.businessKey);
 
     const [userStyles, setUserStyles] = useState<RowStyle | undefined>(() => rowCtrl.rowStyles);
-    const cellCtrlsRef = useRef<CellCtrl[] | null>(null);
-    const [cellCtrlsFlushSync, setCellCtrlsFlushSync] = useState<CellCtrl[] | null>(() => null);
+    // Seeded so bulk-add doesn't flash empty rows; getInitialCellCtrls self-gates
+    // to no-op for the scroll-driven path and for full-width rows.
+    const [cellCtrlsFlushSync, setCellCtrlsFlushSync] = useState<CellCtrl[] | null>(() =>
+        rowCtrl.getInitialCellCtrls(containerType)
+    );
+    const cellCtrlsRef = useRef<CellCtrl[] | null>(cellCtrlsFlushSync);
     const [fullWidthCompDetails, setFullWidthCompDetails] = useState<UserCompDetails>();
 
     // these styles have initial values, so element is placed into the DOM with them,

--- a/testing/behavioural/src/row-data/bulk-add-cell-flicker-react.test.tsx
+++ b/testing/behavioural/src/row-data/bulk-add-cell-flicker-react.test.tsx
@@ -16,11 +16,10 @@ import { asyncSetTimeout, ignoreConsoleLicenseKeyError } from '../test-utils';
 const ROW_SELECTOR = '[row-id]';
 
 /**
- * Detection strategy: a MutationObserver records every mutation where an
- * element is appended INTO an already-attached row. Pre-fix this fires for
- * every newly-added row (RowComp inserts an empty container, then fills its
- * cells / full-width content on a later commit); post-fix it never does for
- * the eager path.
+ * Detection strategy: a MutationObserver records mutations where an element is
+ * appended INTO an already-attached row. Pre-fix this fires for every newly-added
+ * row (RowComp mounts empty, fills cells on a later commit); post-fix RowCtrl
+ * pre-creates the cells so the row's first commit already contains them.
  */
 describe('Eager row content seed (bulk-add flicker regression)', () => {
     beforeAll(() => {

--- a/testing/behavioural/src/row-data/bulk-add-cell-flicker-react.test.tsx
+++ b/testing/behavioural/src/row-data/bulk-add-cell-flicker-react.test.tsx
@@ -1,0 +1,210 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import type { ColDef, GridApi } from 'ag-grid-community';
+import {
+    ClientSideRowModelApiModule,
+    ClientSideRowModelModule,
+    ColumnApiModule,
+    ModuleRegistry,
+    RowApiModule,
+} from 'ag-grid-community';
+import { AgGridReact } from 'ag-grid-react';
+
+import { asyncSetTimeout, ignoreConsoleLicenseKeyError } from '../test-utils';
+
+const ROW_SELECTOR = '[row-id]';
+
+/**
+ * Detection strategy: a MutationObserver records every mutation where an
+ * element is appended INTO an already-attached row. Pre-fix this fires for
+ * every newly-added row (RowComp inserts an empty container, then fills its
+ * cells / full-width content on a later commit); post-fix it never does for
+ * the eager path.
+ */
+describe('Eager row content seed (bulk-add flicker regression)', () => {
+    beforeAll(() => {
+        ModuleRegistry.registerModules([
+            ClientSideRowModelModule,
+            ClientSideRowModelApiModule,
+            RowApiModule,
+            ColumnApiModule,
+        ]);
+        ignoreConsoleLicenseKeyError();
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    type FlickerRecord = { rowId: string | null; addedElements: number };
+
+    /** Records every mutation where a child element is appended into an already-attached row. */
+    async function recordContentAppendedIntoExistingRows(
+        root: HTMLElement,
+        mutate: () => Promise<void> | void
+    ): Promise<FlickerRecord[]> {
+        const records: FlickerRecord[] = [];
+        const observer = new MutationObserver((mutations) => {
+            for (const mutation of mutations) {
+                if (mutation.type !== 'childList' || mutation.addedNodes.length === 0) {
+                    continue;
+                }
+                const target = mutation.target;
+                if (!(target instanceof HTMLElement) || !target.hasAttribute('row-id')) {
+                    continue;
+                }
+                const addedElements = Array.from(mutation.addedNodes).filter(
+                    (n): n is HTMLElement => n instanceof HTMLElement
+                ).length;
+                if (addedElements > 0) {
+                    records.push({ rowId: target.getAttribute('row-id'), addedElements });
+                }
+            }
+        });
+        observer.observe(root, { childList: true, subtree: true });
+        try {
+            await mutate();
+            await asyncSetTimeout(0); // drain MutationObserver microtask queue
+        } finally {
+            observer.disconnect();
+        }
+        return records;
+    }
+
+    function expectNoFlicker(records: FlickerRecord[]) {
+        if (records.length === 0) {
+            return;
+        }
+        const total = records.reduce((acc, r) => acc + r.addedElements, 0);
+        throw new Error(
+            `Expected new rows to be inserted with content already attached, but ${total} element(s) were ` +
+                `appended into ${records.length} already-attached row(s). First: ${JSON.stringify(records.slice(0, 5))}`
+        );
+    }
+
+    test('center-only columns: bulk add inserts rows with cells attached', async () => {
+        const columnDefs: ColDef[] = [{ field: 'a' }, { field: 'b' }, { field: 'c' }];
+        const initialRowData = Array.from({ length: 5 }, (_, i) => ({ a: `a${i}`, b: `b${i}`, c: `c${i}` }));
+
+        let gridApi: GridApi | undefined;
+        const rendered = render(
+            <div style={{ height: 400, width: 600 }}>
+                <AgGridReact
+                    rowData={initialRowData}
+                    columnDefs={columnDefs}
+                    onGridReady={(p) => {
+                        gridApi = p.api;
+                    }}
+                />
+            </div>
+        );
+
+        await waitFor(() => expect(rendered.container.querySelectorAll(ROW_SELECTOR).length).toBeGreaterThan(0));
+
+        const records = await recordContentAppendedIntoExistingRows(rendered.container, async () => {
+            const additions = Array.from({ length: 20 }, (_, i) => ({ a: `na${i}`, b: `nb${i}`, c: `nc${i}` }));
+            act(() => {
+                gridApi!.applyTransaction({ add: additions });
+            });
+            await waitFor(() =>
+                expect(rendered.container.querySelectorAll(ROW_SELECTOR).length).toBeGreaterThan(initialRowData.length)
+            );
+        });
+
+        expectNoFlicker(records);
+    });
+
+    test('pinned columns: left and right containers also receive pre-created cells', async () => {
+        const columnDefs: ColDef[] = [
+            { field: 'l1', pinned: 'left' },
+            { field: 'l2', pinned: 'left' },
+            { field: 'c1' },
+            { field: 'c2' },
+            { field: 'r1', pinned: 'right' },
+        ];
+        const makeRow = (i: number) => ({
+            l1: `l1-${i}`,
+            l2: `l2-${i}`,
+            c1: `c1-${i}`,
+            c2: `c2-${i}`,
+            r1: `r1-${i}`,
+        });
+        const initialRowData = Array.from({ length: 3 }, (_, i) => makeRow(i));
+
+        let gridApi: GridApi | undefined;
+        const rendered = render(
+            <div style={{ height: 400, width: 800 }}>
+                <AgGridReact
+                    rowData={initialRowData}
+                    columnDefs={columnDefs}
+                    onGridReady={(p) => {
+                        gridApi = p.api;
+                    }}
+                />
+            </div>
+        );
+
+        await waitFor(() => expect(rendered.container.querySelectorAll(ROW_SELECTOR).length).toBeGreaterThan(0));
+
+        // Each row appears 3 times in the DOM (left/center/right containers).
+        const records = await recordContentAppendedIntoExistingRows(rendered.container, async () => {
+            const additions = Array.from({ length: 20 }, (_, i) => makeRow(100 + i));
+            act(() => {
+                gridApi!.applyTransaction({ add: additions });
+            });
+            await waitFor(() =>
+                expect(rendered.container.querySelectorAll(ROW_SELECTOR).length).toBeGreaterThan(
+                    initialRowData.length * 3
+                )
+            );
+        });
+
+        expectNoFlicker(records);
+    });
+
+    test('column visibility toggle after bulk add still produces correct cells', async () => {
+        // Guards against a regression where the constructor pre-creation prevents the
+        // setComp-driven reconciliation from picking up subsequent column changes.
+        const columnDefs: ColDef[] = [{ field: 'a' }, { field: 'b' }, { field: 'c' }];
+        const initialRowData = Array.from({ length: 3 }, (_, i) => ({ a: `a${i}`, b: `b${i}`, c: `c${i}` }));
+
+        let gridApi: GridApi | undefined;
+        const rendered = render(
+            <div style={{ height: 400, width: 600 }}>
+                <AgGridReact
+                    rowData={initialRowData}
+                    columnDefs={columnDefs}
+                    onGridReady={(p) => {
+                        gridApi = p.api;
+                    }}
+                />
+            </div>
+        );
+
+        await waitFor(() => expect(rendered.container.querySelectorAll(ROW_SELECTOR).length).toBeGreaterThan(0));
+
+        act(() => {
+            gridApi!.applyTransaction({
+                add: Array.from({ length: 20 }, (_, i) => ({ a: `na${i}`, b: `nb${i}`, c: `nc${i}` })),
+            });
+        });
+        await waitFor(() =>
+            expect(rendered.container.querySelectorAll(ROW_SELECTOR).length).toBeGreaterThan(initialRowData.length)
+        );
+
+        act(() => {
+            gridApi!.setColumnsVisible(['b'], false);
+        });
+
+        await waitFor(() => {
+            const dataRows = Array.from(rendered.container.querySelectorAll(ROW_SELECTOR)).filter(
+                (r) => r.querySelectorAll('[role="gridcell"]').length > 0
+            );
+            expect(dataRows.length).toBeGreaterThan(0);
+            for (const row of dataRows) {
+                expect(row.querySelectorAll('[role="gridcell"]').length).toBe(2);
+            }
+        });
+    });
+});


### PR DESCRIPTION
# AG-17286 — React rows flashing during bulk transactions

When many rows are added in one React batch (e.g. `applyTransactionAsync` of a large batch), every newly-mounted row briefly paints as an empty `<div role="row"/>` before its cells appear, producing a visible flash on a stationary viewport.

`RowComp` initialised its cell-list state to `null` and only populated it on a subsequent commit after `setComp` fired. `RowCtrl` now creates the cells eagerly in its constructor and exposes them via `getInitialCellCtrls`; `RowComp` seeds its `useState` initializer from it, so the first React commit already contains cells. `setComp`'s subsequent call reconciles by `colInstanceId` and reuses the existing CellCtrls — no duplicate construction.

## Scope

The fix targets non-deferred mounts — initial render, transaction adds, set-row-data — where the viewport is stationary and the empty-row paint is jarring. Rows mounted via the animation-frame path (used during scroll) continue to defer cell creation and still render empty briefly before cells fill in, exactly as before. Eager creation in that path would force `createAllCellCtrls` synchronously inside the React commit on every newly-mounted row, which is what the animation-frame service exists to avoid.

Full-width rows are not addressed. They exhibit an analogous gap but the params shape requires `eGridCell: HTMLElement` which doesn't exist before the row's DOM is attached. Fixing it cleanly needs either a public API change (mark `eGridCell` optional) or a `flushSync` around the existing `setupFullWidth` setState — both deserve their own ticket: [AG-17287](https://ag-grid.atlassian.net/browse/AG-17287).

## Tests

Plunkr example: https://plnkr.co/edit/ZoSHy9xkfsTGWqML?open=index.jsx

Behavioural tests use a `MutationObserver` to detect content being appended into already-attached rows — the regression signature. Coverage: center-only columns, pinned (left/right) containers, and column-visibility toggle after bulk-add to confirm the post-construction reconciliation still works.

FIX AG-17286
