### PR TITLE
AG-17161 Remove legacy theme toolbar shims

### DIFF
--- a/community-modules/styles/src/internal/base/_base-variables.scss
+++ b/community-modules/styles/src/internal/base/_base-variables.scss
@@ -25,20 +25,6 @@
         --ag-toolbar-separator-color: var(--ag-border-color);
         --ag-toolbar-separator-width: 1px;
 
-        // Shims mapping new Theming API variable names used by toolbar SCSS to legacy equivalents
-        --ag-spacing: var(--ag-grid-size);
-        --ag-text-color: var(--ag-foreground-color);
-        --ag-header-row-border: var(--ag-borders) var(--ag-border-color);
-        --ag-toolbar-separator-border: solid var(--ag-toolbar-separator-width) var(--ag-toolbar-separator-color);
-        --ag-input-border: var(--ag-borders-input) var(--ag-input-border-color);
-        --ag-input-border-radius: var(--ag-border-radius);
-        --ag-input-background-color: var(--ag-background-color);
-        --ag-input-placeholder-text-color: var(--ag-disabled-foreground-color);
-        --ag-input-focus-border: var(--ag-borders-input) var(--ag-input-focus-border-color);
-        --ag-focus-shadow: var(--ag-input-focus-box-shadow);
-        --ag-icon-button-hover-background-color: transparent;
-        --ag-icon-button-hover-color: var(--ag-foreground-color);
-
         --ag-tooltip-background-color: transparent;
 
         --ag-tooltip-error-background-color: color-mix(
@@ -295,7 +281,7 @@
         --ag-note-popup-background-color: var(--ag-menu-background-color);
         --ag-note-popup-text-color: color-mix(in srgb, transparent, var(--ag-foreground-color) 75%);
         --ag-note-popup-input-text-color: var(--ag-input-text-color);
-        --ag-note-popup-input-background-color: var(--ag-input-background-color);
+        --ag-note-popup-input-background-color: var(--ag-background-color);
         --ag-note-popup-border: var(--ag-dialog-border);
         --ag-note-popup-padding: calc(var(--ag-grid-size) / 2);
     }

--- a/community-modules/styles/src/internal/base/parts/_batch-edit.scss
+++ b/community-modules/styles/src/internal/base/parts/_batch-edit.scss
@@ -11,7 +11,7 @@
         // if the user supplies a semi-transparent background the content of the
         // cell below won't be visible
         background-color: var(--ag-background-color);
-        background-image: linear-gradient(0deg, var(--ag-input-background-color), var(--ag-input-background-color));
+        background-image: linear-gradient(0deg, var(--ag-background-color), var(--ag-background-color));
     }
 
     .ag-row-batch-edit {

--- a/community-modules/styles/src/internal/base/parts/_toolbar.scss
+++ b/community-modules/styles/src/internal/base/parts/_toolbar.scss
@@ -5,7 +5,7 @@
         display: flex;
         align-items: center;
         overflow: hidden;
-        border-bottom: var(--ag-header-row-border);
+        border-bottom: var(--ag-borders) var(--ag-border-color);
         min-height: var(--ag-header-height);
         background-color: var(--ag-toolbar-background-color);
         color: var(--ag-toolbar-text-color);
@@ -21,20 +21,20 @@
 
     .ag-toolbar-item {
         display: inline-flex;
-        margin: 0 calc(var(--ag-spacing, 8px) * 2);
+        margin: 0 calc(var(--ag-grid-size, 8px) * 2);
     }
 
     .ag-toolbar-button-wrapper {
         display: inline-flex;
-        padding: calc(var(--ag-spacing) * 0.25);
+        padding: calc(var(--ag-grid-size) * 0.25);
         height: 100%;
     }
 
     .ag-toolbar-button {
         display: inline-flex;
         align-items: center;
-        gap: var(--ag-spacing);
-        padding: calc(var(--ag-spacing));
+        gap: var(--ag-grid-size);
+        padding: calc(var(--ag-grid-size));
         border: 0;
         background: transparent;
         color: var(--ag-toolbar-text-color);
@@ -45,14 +45,14 @@
     }
 
     .ag-toolbar-button-wrapper:hover {
-        background-color: var(--ag-icon-button-hover-background-color);
-        color: var(--ag-icon-button-hover-color);
+        background-color: transparent;
+        color: var(--ag-foreground-color);
     }
 
     // stylelint-disable-next-line selector-max-specificity
     .ag-toolbar-button-wrapper:hover .ag-toolbar-button,
     .ag-toolbar-button-wrapper:hover .ag-toolbar-button .ag-icon {
-        color: var(--ag-icon-button-hover-color);
+        color: var(--ag-foreground-color);
     }
 
     // stylelint-disable-next-line selector-max-specificity
@@ -66,7 +66,7 @@
     }
 
     .ag-toolbar-button:focus-visible {
-        box-shadow: var(--ag-focus-shadow);
+        box-shadow: var(--ag-input-focus-box-shadow);
     }
 
     .ag-toolbar-button:focus:not(:focus-visible) {
@@ -83,7 +83,7 @@
         display: inline-flex;
         flex: 1;
         min-width: 235px;
-        padding: 0 calc(var(--ag-spacing) * 2);
+        padding: 0 calc(var(--ag-grid-size) * 2);
     }
 
     .ag-toolbar-input {
@@ -92,7 +92,7 @@
         align-items: center;
         min-width: 200px;
         max-width: none;
-        margin: 0 calc(var(--ag-spacing) * 2);
+        margin: 0 calc(var(--ag-grid-size) * 2);
     }
 
     // stylelint-disable-next-line selector-max-specificity
@@ -103,12 +103,12 @@
     // stylelint-disable-next-line selector-max-specificity
     .ag-toolbar > .ag-toolbar-input:first-child,
     .ag-toolbar-right-start + .ag-toolbar-input {
-        margin-inline-start: var(--ag-spacing);
+        margin-inline-start: var(--ag-grid-size);
     }
 
     // stylelint-disable-next-line selector-max-specificity
     .ag-toolbar > .ag-toolbar-input:last-child {
-        margin-inline-end: var(--ag-spacing);
+        margin-inline-end: var(--ag-grid-size);
     }
 
     .ag-toolbar-input-icon {
@@ -118,19 +118,19 @@
         color: var(--ag-toolbar-text-color);
         opacity: 0.5;
         pointer-events: none;
-        inset-inline-start: var(--ag-spacing);
+        inset-inline-start: var(--ag-grid-size);
     }
 
     .ag-toolbar-input-field {
-        color: var(--ag-text-color);
+        color: var(--ag-foreground-color);
         font-size: var(--ag-font-size);
         line-height: 1.5;
         outline: none;
-        border: var(--ag-input-border);
-        border-radius: var(--ag-input-border-radius);
+        border: var(--ag-borders-input) var(--ag-input-border-color);
+        border-radius: var(--ag-border-radius);
         width: 100%;
-        padding-block: calc(var(--ag-spacing) * 0.5);
-        padding-inline: calc(var(--ag-icon-size) + var(--ag-spacing) * 2) var(--ag-spacing);
+        padding-block: calc(var(--ag-grid-size) * 0.5);
+        padding-inline: calc(var(--ag-icon-size) + var(--ag-grid-size) * 2) var(--ag-grid-size);
     }
 
     // High-specificity padding override — beats theme text-input padding-left rules
@@ -140,20 +140,20 @@
         input[class^='ag-'][type='text'].ag-toolbar-input-field {
             @include ag.unthemed-rtl(
                 (
-                    padding-left: calc(var(--ag-icon-size) + var(--ag-spacing) * 2),
-                    padding-right: var(--ag-spacing),
+                    padding-left: calc(var(--ag-icon-size) + var(--ag-grid-size) * 2),
+                    padding-right: var(--ag-grid-size),
                 )
             );
         }
     }
 
     .ag-toolbar-input-field:focus {
-        box-shadow: var(--ag-focus-shadow);
-        border: var(--ag-input-focus-border);
+        box-shadow: var(--ag-input-focus-box-shadow);
+        border: var(--ag-borders-input) var(--ag-input-focus-border-color);
     }
 
     .ag-toolbar-input-field::placeholder {
-        color: var(--ag-input-placeholder-text-color);
+        color: var(--ag-disabled-foreground-color);
     }
 
     .ag-toolbar-panel .ag-column-drop-horizontal {
@@ -175,23 +175,23 @@
     .ag-toolbar-separator {
         align-self: stretch;
         width: 0;
-        margin: calc(var(--ag-spacing) * 1.75) 0;
-        border-inline-start: var(--ag-toolbar-separator-border);
+        margin: calc(var(--ag-grid-size) * 1.75) 0;
+        border-inline-start: solid var(--ag-toolbar-separator-width) var(--ag-toolbar-separator-color);
     }
 
     .ag-toolbar-find {
-        gap: calc(var(--ag-spacing) * 0.5);
+        gap: calc(var(--ag-grid-size) * 0.5);
         width: 280px;
         max-width: none;
         min-width: 220px;
-        border: var(--ag-input-border);
-        border-radius: var(--ag-input-border-radius);
-        background-color: var(--ag-input-background-color);
+        border: var(--ag-borders-input) var(--ag-input-border-color);
+        border-radius: var(--ag-border-radius);
+        background-color: var(--ag-background-color);
     }
 
     .ag-toolbar-find:focus-within {
-        box-shadow: var(--ag-focus-shadow);
-        border: var(--ag-input-focus-border);
+        box-shadow: var(--ag-input-focus-box-shadow);
+        border: var(--ag-borders-input) var(--ag-input-focus-border-color);
     }
 
     .ag-toolbar-find .ag-toolbar-input-field {
@@ -226,6 +226,6 @@
 
     .ag-toolbar-find-button {
         flex-shrink: 0;
-        padding: calc(var(--ag-spacing) * 0.5);
+        padding: calc(var(--ag-grid-size) * 0.5);
     }
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17161

- Remove the shim CSS variables block from `_base-variables.scss` that mapped new Theming API names to legacy equivalents
- Update `_toolbar.scss` to use legacy variables directly: `--ag-grid-size`, `--ag-foreground-color`, `--ag-borders`, `--ag-border-color`, `--ag-borders-input`, `--ag-input-border-color`, `--ag-border-radius`, `--ag-background-color`, `--ag-disabled-foreground-color`, `--ag-input-focus-box-shadow`, `--ag-input-focus-border-color`, `--ag-toolbar-separator-width`, `--ag-toolbar-separator-color`
- Update `_batch-edit.scss` to use `--ag-background-color` directly instead of the removed `--ag-input-background-color` shim
- Update `--ag-note-popup-input-background-color` in `_base-variables.scss` to reference `--ag-background-color` directly

Fix [AG-17161](https://ag-grid.atlassian.net/browse/AG-17161)