### PR TITLE
AG-17289 Add release content for 35.3.0

### DIFF
--- a/documentation/ag-grid-docs/public/changelog/changelog.json
+++ b/documentation/ag-grid-docs/public/changelog/changelog.json
@@ -1,5 +1,19 @@
 [
     {
+        "key": "AG-17289",
+        "issueType": "Task",
+        "manualEntry": true,
+        "summary": "Placeholder for 35.3.0",
+        "versions": ["35.3.0"],
+        "status": "Done",
+        "resolution": "Done",
+        "features": null,
+        "moreInformation": null,
+        "deprecationNotes": null,
+        "breakingChangesNotes": null,
+        "documentationUrl": null
+    },
+    {
         "key": "AG-17021",
         "issueType": "Bug",
         "manualEntry": true,

--- a/documentation/ag-grid-docs/public/changelog/releaseVersionNotes.json
+++ b/documentation/ag-grid-docs/public/changelog/releaseVersionNotes.json
@@ -1,5 +1,9 @@
 [
     {
+        "release version": "35.3.0",
+        "markdown": "/releases/35_3_0.md"
+    },
+    {
         "release version": "35.2.1",
         "markdown": "/releases/35_2_1.md"
     },

--- a/documentation/ag-grid-docs/public/changelog/releases/35_3_0.md
+++ b/documentation/ag-grid-docs/public/changelog/releases/35_3_0.md
@@ -1,0 +1,5 @@
+#### 13th May 2026 - Grid v35.3.0 (Charts v13.3.0)
+
+See table below for changes included in this release.
+
+For more details see [v35.3 release post](https://blog.ag-grid.com/whats-new-in-ag-grid-35-3/).

--- a/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-35-3/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-35-3/index.mdoc
@@ -1,0 +1,37 @@
+---
+title: "Upgrading to AG Grid 35.3"
+description: "See what's new in AG Grid, view a full list of changes and migrate your $framework Data Grid to version v35.3."
+migrationVersion: "35.3.0"
+---
+
+Quick Access Toolbar, Cell Notes, Grand Total Row for server-side row model, Performance Improvements, Quality Improvements
+
+## What's New
+
+AG Grid {% migrationVersion() %} adds important new features - [Quick Access Toolbar](./toolbar/), [Cell Notes](./notes/), [Grand Total Row for server-side row model](./server-side-model-grouping/#grand-total-row), Performance Improvements, Quality Improvements.
+These improvements involve no breaking changes as listed below.
+
+<!--
+Documentation to the highest patch release of the major/minor
+NOTE: This will not show if the current library version is the same as the migration version
+-->
+
+{% documentationArchiveSection version=migrationVersionPatch() /%}
+
+## Breaking Changes
+
+There are no breaking changes in AG Grid version {% migrationVersion() %}.
+
+## Behaviour Changes
+
+There are no behaviour changes in AG Grid version {% migrationVersion() %}.
+
+## Removal of Deprecated APIs
+
+There are no deprecated API removals in AG Grid version {% migrationVersion() %}.
+
+## Deprecations
+
+There are no deprecations in AG Grid version {% migrationVersion() %}.
+
+{% changelogSection version=$migrationVersion /%}

--- a/documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json
+++ b/documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json
@@ -1,5 +1,32 @@
 [
     {
+        "version": "35.3.0",
+        "date": "13th May 2026",
+        "landingPageHighlight": "Quick Access Toolbar, Cell Notes, Grand Total Row for server-side row model, Performance Improvements, Quality Improvements",
+        "highlights": [
+            {
+                "text": "Quick Access Toolbar",
+                "path": "./toolbar/"
+            },
+            {
+                "text": "Cell Notes",
+                "path": "./notes/"
+            },
+            {
+                "text": "Grand Total Row for server-side row model",
+                "path": "./server-side-model-grouping/#grand-total-row"
+            },
+            {
+                "text": "Performance Improvements"
+            },
+            {
+                "text": "Quality Improvements"
+            }
+        ],
+        "notesPath": "./upgrading-to-ag-grid-35-3",
+        "hideBlogPostLink": false
+    },
+    {
         "version": "35.2.1",
         "date": "7th April 2026"
     },


### PR DESCRIPTION
Fixes AG-17289

Adds changelog entry, release notes file, version archive entry (with What's New tile metadata), and migration guide page for v35.3.0 (Charts v13.3.0).

PR base is `latest` because the `b35.3.0` release branch does not yet exist on origin.