### PR TITLE
[AG-17295] Fix(styles): drop zone pill font weight

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_column-drop.scss
+++ b/community-modules/styles/src/internal/base/parts/_column-drop.scss
@@ -7,6 +7,7 @@
         height: calc(var(--ag-grid-size) * 4);
         padding: 0 calc(var(--ag-grid-size) * 0.5);
         border: 1px solid var(--ag-chip-border-color);
+        font-weight: normal;
     }
 
     @include ag.keyboard-focus((ag-column-drop-cell), 2px);

--- a/documentation/ag-grid-docs/src/content/docs/row-models/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/row-models/index.mdoc
@@ -15,7 +15,7 @@ The grid comes with four row models:
 
 The Client-Side Row Model deals with client-side data. The Server-Side, Infinite and Viewport Row Models deal with server-side data. The following is a summary of each:
 
-- ## Client-Side
+- ## Client-Side {% #client-side %}
 
     This is the default. The grid will load all of the data into the grid in one go. The grid can then perform filtering, sorting, grouping, pivoting and aggregation all in browser memory.
 

--- a/packages/ag-grid-enterprise/src/widgets/pillDropZonePanel.css
+++ b/packages/ag-grid-enterprise/src/widgets/pillDropZonePanel.css
@@ -17,6 +17,7 @@
     align-items: center;
     background-color: var(--ag-column-drop-cell-background-color);
     color: var(--ag-column-drop-cell-text-color);
+    font-weight: normal;
     border-radius: 500px;
     padding: calc(var(--ag-spacing) * 0.25);
     padding-left: calc(var(--ag-spacing) * 0.75);


### PR DESCRIPTION
- Add `font-weight: normal` to `.ag-column-drop-cell` in theming API (`pillDropZonePanel.css`)
- Add `font-weight: normal` to `.ag-column-drop-cell` in legacy themes (`_column-drop.scss`)

Fixes group and pivot drop zone pills inheriting bold font-weight from `.ag-toolbar`.

Fix [AG-17293](https://ag-grid.atlassian.net/browse/AG-17293)