### PR TITLE
[AG-17294] Fix(toolbar): legacy Alpine font weight and button hover

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_column-drop.scss
+++ b/community-modules/styles/src/internal/base/parts/_column-drop.scss
@@ -37,6 +37,12 @@
         color: var(--ag-secondary-foreground-color);
         height: var(--ag-header-height);
         border-bottom: var(--ag-borders) var(--ag-border-color);
+
+        @include ag.unthemed-rtl(
+            (
+                padding-left: var(--ag-cell-horizontal-padding),
+            )
+        );
     }
 
     .ag-column-drop-horizontal-half-width:not(:last-child) {

--- a/community-modules/styles/src/internal/base/parts/_toolbar.scss
+++ b/community-modules/styles/src/internal/base/parts/_toolbar.scss
@@ -45,14 +45,14 @@
     }
 
     .ag-toolbar-button-wrapper:hover {
-        background-color: transparent;
-        color: var(--ag-foreground-color);
+        background-color: var(--ag-icon-button-hover-background-color, transparent);
+        color: var(--ag-icon-button-hover-color, var(--ag-foreground-color));
     }
 
     // stylelint-disable-next-line selector-max-specificity
     .ag-toolbar-button-wrapper:hover .ag-toolbar-button,
     .ag-toolbar-button-wrapper:hover .ag-toolbar-button .ag-icon {
-        color: var(--ag-foreground-color);
+        color: var(--ag-icon-button-hover-color, var(--ag-foreground-color));
     }
 
     // stylelint-disable-next-line selector-max-specificity
@@ -160,6 +160,9 @@
         background-color: transparent;
         border-bottom: none;
         padding: 0;
+        font-weight: normal;
+        font-size: var(--ag-font-size);
+        font-family: var(--ag-font-family);
     }
 
     // stylelint-disable-next-line selector-max-specificity

--- a/community-modules/styles/src/internal/base/parts/_toolbar.scss
+++ b/community-modules/styles/src/internal/base/parts/_toolbar.scss
@@ -83,7 +83,6 @@
         display: inline-flex;
         flex: 1;
         min-width: 235px;
-        padding: 0 calc(var(--ag-grid-size) * 2);
     }
 
     .ag-toolbar-input {

--- a/community-modules/styles/src/internal/themes/alpine/_alpine-variables.scss
+++ b/community-modules/styles/src/internal/themes/alpine/_alpine-variables.scss
@@ -97,6 +97,7 @@
         -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue',
         sans-serif;
     --ag-font-size: 13px;
+    --ag-header-font-weight: 700;
     --ag-icon-font-family: agGridAlpine;
 
     // MISC

--- a/community-modules/styles/src/internal/themes/alpine/_alpine-variables.scss
+++ b/community-modules/styles/src/internal/themes/alpine/_alpine-variables.scss
@@ -97,7 +97,6 @@
         -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue',
         sans-serif;
     --ag-font-size: 13px;
-    --ag-header-font-weight: 700;
     --ag-icon-font-family: agGridAlpine;
 
     // MISC

--- a/community-modules/styles/src/internal/themes/alpine/_index.scss
+++ b/community-modules/styles/src/internal/themes/alpine/_index.scss
@@ -17,6 +17,10 @@
         color: var(--ag-header-foreground-color);
     }
 
+    .ag-toolbar {
+        font-weight: 700;
+    }
+
     .ag-row {
         font-size: calc(var(--ag-font-size) + 1px);
     }

--- a/packages/ag-grid-enterprise/src/toolbar/agToolbar.css
+++ b/packages/ag-grid-enterprise/src/toolbar/agToolbar.css
@@ -150,6 +150,9 @@
     background-color: transparent;
     border-bottom: none;
     padding: 0;
+    font-weight: var(--ag-cell-font-weight);
+    font-size: var(--ag-cell-font-size);
+    font-family: var(--ag-cell-font-family);
 }
 
 /* stylelint-disable-next-line selector-max-specificity */


### PR DESCRIPTION
- Fix legacy Alpine toolbar font weight: use direct `font-weight: 700` on `.ag-toolbar` in `_index.scss` (same pattern as `.ag-header-row`) instead of declaring `--ag-header-font-weight` variable
- Restore `--ag-icon-button-hover-color` on toolbar button hover (was hardcoded to `--ag-foreground-color`, losing the blue active-colour hover in Alpine)
- Restore `padding-left: var(--ag-cell-horizontal-padding)` to `.ag-column-drop-horizontal` in legacy themes — removed globally in #13683, breaking the standalone group panel drop zone; inside toolbar `.ag-toolbar-panel .ag-column-drop-horizontal` keeps `padding: 0` (spacing comes from `.ag-toolbar-item` margin instead)
- Remove own horizontal padding from `.ag-toolbar-panel` in legacy themes — double-spacing with the drop zone's own padding and the item margin

Fix [AG-17294](https://ag-grid.atlassian.net/browse/AG-17294)