### PR TITLE
Rename e2e.sh to docs-e2e.sh

### DIFF
--- a/.rulesync/rules/ag-grid.md
+++ b/.rulesync/rules/ag-grid.md
@@ -113,7 +113,13 @@ For detailed information about preferred technologies and architectural constrai
 - `yarn nx test <package>` – execute Jest unit tests for the affected package.
 - `yarn nx test <package> --testPathPattern="<file-name>"` - test specific test file
 - `yarn nx test <package> --testPathPattern="<file-name>" --testNamePattern="<test-name>"` - test specific test name in a specific test file
-- `yarn nx e2e <package>` – run Playwright flows when altering website behaviour.
+- `./docs-e2e.sh` – run docs Playwright E2E tests directly, bypassing Nx (chromium by default).
+- `./docs-e2e.sh "<file-pattern>"` – run E2E tests matching a file pattern.
+- `./docs-e2e.sh "<file-pattern>" --grep "<test-name>"` – run a specific E2E test by name.
+- `./docs-e2e.sh --all-browsers` – run E2E tests across chromium, firefox, and webkit.
+- `./docs-e2e.sh --framework <name>` – run E2E tests with a specific framework (e.g. react, angular, vue).
+- `./docs-e2e.sh --ui` – open Playwright UI mode.
+- `yarn nx e2e <package>` – run Playwright flows via Nx when altering website behaviour.
 - `yarn nx lint <package>` – apply ESLint and custom rules before final review.
 
 ### Slash Commands

--- a/.rulesync/rules/docs-pages.md
+++ b/.rulesync/rules/docs-pages.md
@@ -63,5 +63,5 @@ Test documentation changes:
 yarn nx dev
 
 # Run E2E tests (chromium only, bypasses Nx)
-./docs-e2e.sh feature-catagory
+./docs-e2e.sh feature-category
 ```

--- a/.rulesync/rules/docs-pages.md
+++ b/.rulesync/rules/docs-pages.md
@@ -62,6 +62,6 @@ Test documentation changes:
 # Start dev server
 yarn nx dev
 
-# Run E2E tests
-yarn nx e2e ag-grid-docs
+# Run E2E tests (chromium only, bypasses Nx)
+./docs-e2e.sh feature-catagory
 ```

--- a/.rulesync/rules/testing.md
+++ b/.rulesync/rules/testing.md
@@ -88,10 +88,33 @@ yarn nx test ag-grid-community --testPathPattern="featureName"
 yarn nx test ag-grid-community --testPathPattern="featureName" --testNamePattern="should handle"
 ```
 
-### E2E Tests
+### E2E Tests (Playwright)
+
+E2E tests run via Playwright against the docs site. `./docs-e2e.sh` runs them directly from the repo root, bypassing Nx, and defaults to chromium only:
 
 ```bash
-# Run documentation E2E tests
+# Run all E2E tests (chromium)
+./docs-e2e.sh
+
+# Run tests matching a file pattern
+./docs-e2e.sh "toolbar"
+
+# Run a specific test by name
+./docs-e2e.sh "toolbar" --grep "Quick filter"
+
+# Run against all browsers
+./docs-e2e.sh --all-browsers
+
+# Run with a specific framework
+./docs-e2e.sh --framework react
+
+# Open Playwright UI mode
+./docs-e2e.sh --ui
+```
+
+The full Nx target is still available when needed:
+
+```bash
 yarn nx e2e ag-grid-docs
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,13 @@ For detailed information about preferred technologies and architectural constrai
 -   `yarn nx test <package>` – execute Jest unit tests for the affected package.
 -   `yarn nx test <package> --testPathPattern="<file-name>"` - test specific test file
 -   `yarn nx test <package> --testPathPattern="<file-name>" --testNamePattern="<test-name>"` - test specific test name in a specific test file
--   `yarn nx e2e <package>` – run Playwright flows when altering website behaviour.
+-   `./docs-e2e.sh` – run docs Playwright E2E tests directly, bypassing Nx (chromium by default).
+-   `./docs-e2e.sh "<file-pattern>"` – run E2E tests matching a file pattern.
+-   `./docs-e2e.sh "<file-pattern>" --grep "<test-name>"` – run a specific E2E test by name.
+-   `./docs-e2e.sh --all-browsers` – run E2E tests across chromium, firefox, and webkit.
+-   `./docs-e2e.sh --framework <name>` – run E2E tests with a specific framework (e.g. react, angular, vue).
+-   `./docs-e2e.sh --ui` – open Playwright UI mode.
+-   `yarn nx e2e <package>` – run Playwright flows via Nx when altering website behaviour.
 -   `yarn nx lint <package>` – apply ESLint and custom rules before final review.
 
 ### Slash Commands
@@ -183,13 +189,11 @@ While this transition is in progress, changes made to Theming API should be appl
 #### Quick Playbooks
 
 -   **Bug fix or feature work (community/enterprise)**
-
     1. Update the affected implementation (typically under `packages/ag-grid-*/src/`).
     2. Sync any dependent docs/examples.
     3. Run `yarn nx test ag-grid-community`, `yarn nx test ag-grid-enterprise`.
 
 -   **Documentation/content update**
-
     1. Consult the [Documentation Pages Guide](.rulesync/rules/docs-pages.md) for structure and patterns.
     2. Modify the relevant content under `documentation/ag-grid-docs/`.
     3. Create or update examples in `_examples/` folder following the [Examples Guide](.rulesync/rules/examples.md).

--- a/docs-e2e.sh
+++ b/docs-e2e.sh
@@ -3,15 +3,15 @@
 # All arguments are forwarded to playwright. Defaults to chromium only.
 #
 # Usage:
-#   ./e2e.sh                                   # Run all tests (chromium)
-#   ./e2e.sh "file-pattern"                    # Run tests matching pattern
-#   ./e2e.sh "file-pattern" --grep "name"      # Run specific test by name
-#   ./e2e.sh --all-browsers                    # Run all browsers
-#   ./e2e.sh --framework react                 # Run with specific framework
-#   ./e2e.sh --url https://localhost:4610      # Run against specific URL
-#   ./e2e.sh --headed                          # Run in headed mode
-#   ./e2e.sh --ui                              # Open Playwright UI mode
-#   ./e2e.sh --debug                           # Debug mode
+#   ./docs-e2e.sh                                   # Run all tests (chromium)
+#   ./docs-e2e.sh "file-pattern"                    # Run tests matching pattern
+#   ./docs-e2e.sh "file-pattern" --grep "name"      # Run specific test by name
+#   ./docs-e2e.sh --all-browsers                    # Run all browsers
+#   ./docs-e2e.sh --framework react                 # Run with specific framework
+#   ./docs-e2e.sh --url https://localhost:4610      # Run against specific URL
+#   ./docs-e2e.sh --headed                          # Run in headed mode
+#   ./docs-e2e.sh --ui                              # Open Playwright UI mode
+#   ./docs-e2e.sh --debug                           # Debug mode
 
 set -euo pipefail
 
@@ -19,7 +19,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
     cat <<'EOF'
-Usage: ./e2e.sh [options] [playwright-args]
+Usage: ./docs-e2e.sh [options] [playwright-args]
 
 Runs docs Playwright e2e tests directly, bypassing Nx. Defaults to chromium only.
 Any unrecognised arguments are forwarded directly to playwright test.
@@ -39,14 +39,14 @@ Playwright options (forwarded as-is):
   --debug                 Debug mode
 
 Examples:
-  ./e2e.sh
-  ./e2e.sh "toolbar"
-  ./e2e.sh "toolbar" --grep "Quick filter"
-  ./e2e.sh --all-browsers
-  ./e2e.sh --framework react
-  ./e2e.sh --url https://localhost:4610
-  ./e2e.sh --headed
-  ./e2e.sh --ui
+  ./docs-e2e.sh
+  ./docs-e2e.sh "toolbar"
+  ./docs-e2e.sh "toolbar" --grep "Quick filter"
+  ./docs-e2e.sh --all-browsers
+  ./docs-e2e.sh --framework react
+  ./docs-e2e.sh --url https://localhost:4610
+  ./docs-e2e.sh --headed
+  ./docs-e2e.sh --ui
 EOF
 }
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "bootstrap": "SHARP_IGNORE_GLOBAL_LIBVIPS=true YARN_REGISTRY=\"https://registry.ag-grid.com\" yarn",
     "git-clean": "git clean -fdx && git reset --hard HEAD",
     "git-purge-local-only": "git fetch -p && for branch in $(git for-each-ref --format '%(refname) %(upstream:track)' refs/heads | awk '$2 == \"[gone]\" {sub(\"refs/heads/\", \"\", $1); print $1}'); do git branch -D $branch; done",
-    "behave": "./behave.sh"
+    "behave": "./behave.sh",
+    "docs-e2e": "./docs-e2e.sh"
   },
   "private": true,
   "engines": {


### PR DESCRIPTION
## Summary

- Renames `e2e.sh` → `docs-e2e.sh` to better describe its purpose (docs-specific Playwright E2E tests)
- Documents the new script commands in `AGENTS.md` and the `.rulesync/` rules
- Adds `docs-e2e` npm script to `package.json`

## Test plan

- [ ] Verify `./docs-e2e.sh` runs correctly (smoke test with a single test file pattern)