### PR TITLE
[Docs] Pin Filter type to Text Filter

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/action-buttons/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/action-buttons/main.ts
@@ -30,7 +30,7 @@ let gridApi: GridApi<IOlympicData>;
 const gridOptions: GridOptions<IOlympicData> = {
     columnDefs: [
         { field: 'athlete' },
-        { field: 'country' },
+        { field: 'country', filter: 'agTextColumnFilter' },
         { field: 'gold' },
         { field: 'silver' },
         { field: 'bronze' },


### PR DESCRIPTION
When the example is run in Javascript all modules are present including the SetFilter. So the Country filter switches from text to Set filter which then means the filter model is not valid.
