### PR TITLE
AG-3390 - Fix link checker readable state loss

### DIFF
--- a/external/ag-website-shared/plugins/agLinkChecker.ts
+++ b/external/ag-website-shared/plugins/agLinkChecker.ts
@@ -18,7 +18,6 @@ const HREF_PATTERNS_TO_IGNORE = [
     '#reference-', // API references, as it is rendered client side
     '#example-', // Example references, as they aren't headings
     '#contact-section', // Contact form on about page
-    '#client-side', // TODO: Remove this once CI failure is resolved
 ];
 
 const isCI =

--- a/external/ag-website-shared/plugins/agLinkChecker.ts
+++ b/external/ag-website-shared/plugins/agLinkChecker.ts
@@ -92,46 +92,39 @@ const checkLinks = async (dir: string, files: string[], options: Options) => {
         const anchorTags: string[] = [];
 
         // uses a stream as ingesting the entire file was causing memory crashes.
-        const fileStream = fs.createReadStream(join(dir, filePath));
-        await new Promise<void>((resolve) => {
-            fileStream.on('readable', function () {
-                let prev;
-                let active = false;
-                let str = '';
-                let chunk;
-                while (null !== (chunk = fileStream.read(16384))) {
-                    const strChunk = chunk.toString();
-                    for (let i = 0; i < strChunk.length; i++) {
-                        const chr = strChunk[i];
-                        if (!prev || prev === '<') {
-                            if (chr === 'a') {
-                                active = true;
-                            }
-                        } else if (active && chr === '>') {
-                            active = false;
-                            anchorTags.push(str);
-                            str = '';
-                        }
+        // State is held in the closure here (not inside an event handler) so it
+        // survives across stream chunks — otherwise tags that straddle a chunk
+        // boundary are silently dropped.
+        const fileStream = fs.createReadStream(join(dir, filePath), { encoding: 'utf8' });
+        let prev: string | undefined;
+        let active = false;
+        let str = '';
+        for await (const chunk of fileStream) {
+            const strChunk = chunk as string;
+            for (let i = 0; i < strChunk.length; i++) {
+                const chr = strChunk[i];
+                if (!prev || prev === '<') {
+                    if (chr === 'a') {
+                        active = true;
+                    }
+                } else if (active && chr === '>') {
+                    active = false;
+                    anchorTags.push(str);
+                    str = '';
+                }
 
-                        if (active) {
-                            str += chr;
+                if (active) {
+                    str += chr;
 
-                            if (str.length >= 2 && !str.startsWith('a ')) {
-                                active = false;
-                                str = '';
-                            }
-                        }
-
-                        prev = chr;
+                    if (str.length >= 2 && !str.startsWith('a ')) {
+                        active = false;
+                        str = '';
                     }
                 }
-            });
 
-            fileStream.on('end', () => {
-                resolve();
-            });
-        });
-        fileStream.close();
+                prev = chr;
+            }
+        }
 
         anchorTags.forEach((tag) => {
             const regex = /.*href="(.*?)".*/g;


### PR DESCRIPTION
The HTML anchor parser declared its state (prev/active/str) inside the
'readable' event handler, so the state reset every time the event fired.
For files larger than the stream's high-water mark, readable fires more
than once and any <a> tag straddling a buffer boundary was silently
dropped — producing false-positive "could not be resolved" errors for
links whose target anchor exists on the page.

Hoist the state into the surrounding closure and consume the stream via
`for await…of` so it persists across all chunks.