### PR TITLE
AG-17221 Fix React cell render loop on column drag

### DIFF
--- a/packages/ag-grid-react/src/reactUi/cells/cellComp.tsx
+++ b/packages/ag-grid-react/src/reactUi/cells/cellComp.tsx
@@ -133,12 +133,17 @@ const CellComp = ({
         const newDetails = renderDetails;
         lastRenderDetails.current = renderDetails;
 
-        // if not updating renderDetails, do nothing
+        // Skip the effect unless we have a real renderDetails change. A wrapper-only change (same inner
+        // compDetails ref, new wrapper object) would otherwise drive an infinite update loop:
+        // refresh() → setRenderKey → renderer remount → cellCtrl re-emits compDetails → repeat
+        // (e.g. during column drag-and-drop with agGroupCellRenderer, whose refresh() deliberately
+        // returns false).
         if (
             oldDetails == null ||
             oldDetails.compDetails == null ||
             newDetails == null ||
-            newDetails.compDetails == null
+            newDetails.compDetails == null ||
+            oldDetails.compDetails === newDetails.compDetails
         ) {
             return;
         }
@@ -147,15 +152,6 @@ const CellComp = ({
 
         const oldCompDetails = oldDetails.compDetails;
         const newCompDetails = newDetails.compDetails;
-
-        // if the compDetails reference hasn't changed, there's nothing to refresh. Without this guard,
-        // a wrapper-only renderDetails change (same inner compDetails ref, new wrapper object) would
-        // call refresh() → setRenderKey → renderer remount → cellCtrl re-emits compDetails → repeat,
-        // producing an infinite update loop (e.g. during column drag-and-drop with agGroupCellRenderer,
-        // whose refresh() deliberately returns false).
-        if (oldCompDetails === newCompDetails) {
-            return;
-        }
 
         // if different Cell Renderer, then do nothing, as renderer will be recreated
         if (oldCompDetails.componentClass != newCompDetails.componentClass) {

--- a/packages/ag-grid-react/src/reactUi/cells/cellComp.tsx
+++ b/packages/ag-grid-react/src/reactUi/cells/cellComp.tsx
@@ -138,20 +138,13 @@ const CellComp = ({
         // refresh() → setRenderKey → renderer remount → cellCtrl re-emits compDetails → repeat
         // (e.g. during column drag-and-drop with agGroupCellRenderer, whose refresh() deliberately
         // returns false).
-        if (
-            oldDetails == null ||
-            oldDetails.compDetails == null ||
-            newDetails == null ||
-            newDetails.compDetails == null ||
-            oldDetails.compDetails === newDetails.compDetails
-        ) {
+        const oldCompDetails = oldDetails?.compDetails;
+        const newCompDetails = newDetails?.compDetails;
+        if (oldCompDetails == null || newCompDetails == null || oldCompDetails === newCompDetails) {
             return;
         }
 
         rowDragCompRef.current?.refreshVisibility();
-
-        const oldCompDetails = oldDetails.compDetails;
-        const newCompDetails = newDetails.compDetails;
 
         // if different Cell Renderer, then do nothing, as renderer will be recreated
         if (oldCompDetails.componentClass != newCompDetails.componentClass) {

--- a/packages/ag-grid-react/src/reactUi/cells/cellComp.tsx
+++ b/packages/ag-grid-react/src/reactUi/cells/cellComp.tsx
@@ -148,6 +148,15 @@ const CellComp = ({
         const oldCompDetails = oldDetails.compDetails;
         const newCompDetails = newDetails.compDetails;
 
+        // if the compDetails reference hasn't changed, there's nothing to refresh. Without this guard,
+        // a wrapper-only renderDetails change (same inner compDetails ref, new wrapper object) would
+        // call refresh() → setRenderKey → renderer remount → cellCtrl re-emits compDetails → repeat,
+        // producing an infinite update loop (e.g. during column drag-and-drop with agGroupCellRenderer,
+        // whose refresh() deliberately returns false).
+        if (oldCompDetails === newCompDetails) {
+            return;
+        }
+
         // if different Cell Renderer, then do nothing, as renderer will be recreated
         if (oldCompDetails.componentClass != newCompDetails.componentClass) {
             return;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17221

Fixes an infinite "Maximum update depth exceeded" React error triggered by column drag-and-drop on grids that use an auto group column with `cellRenderer: 'agGroupCellRenderer'` (the default for grouped grids).

### Root cause

In `cellComp.tsx`, the `useLayoutEffect` on `[renderDetails]` fires whenever the *wrapper* `{ compDetails, value, force }` object changes — even when the inner `compDetails` reference is unchanged. The effect calls `cellRendererRef.current.refresh(params)` and, if the result is not `true`, increments `renderKey` to force a remount.

`agGroupCellRenderer.refresh()` deliberately returns `false`, so every wrapper-only renderDetails change bumps `renderKey`, which remounts the renderer, which re-enters `cellCtrl`'s refresh path, which calls `compProxy.setRenderDetails` again — closing an infinite loop.

This surfaces during column drag because `dragAndDropService.handleEnter` → `setColsVisible` → `_applyColumnState` → `columnModel.refreshCols` → `autoColService.createColumns` rebuilds the auto group column and dispatches a `colDef` event on every drag tick, prompting `cellCtrl.refreshCell` to call `setRenderDetails` repeatedly with `compDetails` references that net out to the same end state.

### Fix

Add an early-return in the layout effect when `oldCompDetails === newCompDetails`. When the inner `compDetails` reference hasn't changed, there is nothing for `refresh()` / `setRenderKey` to do. The existing reducer-side check in `compProxy.setRenderDetails` only catches *per-call* redundancy; it cannot detect a sequence of legitimate-individual-but-net-zero updates. The layout-effect guard sees the net result across commits and is the correct level to suppress the no-op.

Fix [AG-17221](https://ag-grid.atlassian.net/browse/AG-17221)