### PR TITLE
RTI-3324-improve-first-grouping-example

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/grouping/_examples/kitchen-sink/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grouping/_examples/kitchen-sink/main.ts
@@ -13,10 +13,10 @@ let gridApi: GridApi<IOlympicData>;
 
 const gridOptions: GridOptions<IOlympicData> = {
     columnDefs: [
-        { field: 'country', rowGroup: true, hide: true },
-        { field: 'year', rowGroup: true, hide: true },
+        { field: 'country', rowGroup: true, enableRowGroup: true, hide: true },
+        { field: 'year', rowGroup: true, enableRowGroup: true, hide: true },
         { field: 'athlete' },
-        { field: 'sport' },
+        { field: 'sport', enableRowGroup: true },
         { field: 'gold' },
         { field: 'silver' },
         { field: 'bronze' },


### PR DESCRIPTION
Improve the example to enable dragging meaningful columns to the grouping header

FIX RTI-3324
