### PR TITLE
RTI-3327 fix-tree-list-aria-warning-on-click

### DIFF
--- a/packages/ag-grid-community/src/agStack/core/baseDragService.ts
+++ b/packages/ag-grid-community/src/agStack/core/baseDragService.ts
@@ -14,9 +14,9 @@ import {
     _areEventsNear,
     _getFirstActiveTouch,
     _isEventFromThisInstance,
+    _preventEventDefault,
     addTempEventHandlers,
     clearTempEventHandlers,
-    preventEventDefault,
 } from '../utils/event';
 import { AgBeanStub } from './agBeanStub';
 
@@ -171,7 +171,7 @@ export class BaseDragService<
 
         addTempEventHandlers(
             drag.handlers,
-            [rootEl, 'contextmenu', preventEventDefault],
+            [rootEl, 'contextmenu', _preventEventDefault],
             [rootEl, 'keydown', keydownEvent],
             [eDocument, 'scroll', onScroll, { capture: true }],
             [eDocument.defaultView || window, 'scroll', onScroll],
@@ -294,7 +294,7 @@ export class BaseDragService<
 
         if (this.isPointer()) {
             if (this.dragging) {
-                preventEventDefault(touchEvent);
+                _preventEventDefault(touchEvent);
             }
             return; // Active pointer drag in progress, ignore legacy touch start
         }
@@ -328,10 +328,10 @@ export class BaseDragService<
         }
     }
 
-    /** preventEventDefault on the event while dragging only and if the event is cancellable */
+    /** _preventEventDefault on the event while dragging only and if the event is cancellable */
     private draggingPreventDefault(e: Event): void {
         if (this.dragging) {
-            preventEventDefault(e);
+            _preventEventDefault(e);
         }
     }
 
@@ -392,7 +392,7 @@ export class BaseDragService<
         }
 
         if (this.shouldPreventMouseEvent(mouseEvent)) {
-            preventEventDefault(mouseEvent);
+            _preventEventDefault(mouseEvent);
         }
 
         this.onMove(mouseEvent);

--- a/packages/ag-grid-community/src/agStack/utils/event.ts
+++ b/packages/ag-grid-community/src/agStack/utils/event.ts
@@ -220,8 +220,8 @@ export const clearTempEventHandlers = (list: TempEventHandler[] | null | undefin
     }
 };
 
-export const preventEventDefault = (event: Event) => {
-    if (event.cancelable) {
+export const _preventEventDefault = (event: Event | null | undefined) => {
+    if (event?.cancelable) {
         event.preventDefault();
     }
 };

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
@@ -1,5 +1,5 @@
 import type { LocaleTextFunc } from '../agStack/interfaces/iLocaleService';
-import { _isEventSupported, preventEventDefault } from '../agStack/utils/event';
+import { _isEventSupported, _preventEventDefault } from '../agStack/utils/event';
 import type { AgColumn } from '../entities/agColumn';
 import type { RowNode } from '../entities/rowNode';
 import type { IRowDragItem } from '../interfaces/iRowDragItem';
@@ -173,8 +173,8 @@ export class RowDragComp extends Component {
             this.removeMouseDownListener();
 
             const listeners: Record<string, (e: MouseEvent | PointerEvent) => void> = _isEventSupported('pointerdown')
-                ? { pointerdown: preventEventDefault }
-                : { mousedown: preventEventDefault };
+                ? { pointerdown: _preventEventDefault }
+                : { mousedown: _preventEventDefault };
 
             this.mouseDownListener = this.addManagedElementListeners(eGui, listeners)[0];
         }

--- a/packages/ag-grid-community/src/main-internal.ts
+++ b/packages/ag-grid-community/src/main-internal.ts
@@ -175,7 +175,7 @@ export {
     _setVisible,
 } from './agStack/utils/dom';
 export type { AgElementParams as _AgElementParams } from './agStack/utils/dom';
-export { _anchorElementToMouseMoveEvent, _isElementInEventPath } from './agStack/utils/event';
+export { _anchorElementToMouseMoveEvent, _isElementInEventPath, _preventEventDefault } from './agStack/utils/event';
 export {
     _findFocusableElements,
     _findNextFocusableElement,

--- a/packages/ag-grid-community/src/widgets/touchListener.ts
+++ b/packages/ag-grid-community/src/widgets/touchListener.ts
@@ -4,9 +4,9 @@ import type { IEventEmitter, IEventListener } from '../agStack/interfaces/iEvent
 import {
     _areEventsNear,
     _getFirstActiveTouch,
+    _preventEventDefault,
     addTempEventHandlers,
     clearTempEventHandlers,
-    preventEventDefault,
 } from '../agStack/utils/event';
 import type { TempEventHandler } from '../agStack/utils/event';
 
@@ -99,7 +99,7 @@ export class TouchListener implements IEventEmitter<TouchListenerEvent> {
                 [doc, 'touchcancel', touchCancel, passiveTrue],
                 // we set passive=false, as we want to prevent default on this event
                 [doc, 'touchend', touchEnd, passiveFalse],
-                [doc, 'contextmenu', preventEventDefault, passiveFalse]
+                [doc, 'contextmenu', _preventEventDefault, passiveFalse]
             );
         }
 
@@ -137,7 +137,7 @@ export class TouchListener implements IEventEmitter<TouchListenerEvent> {
         }
 
         if (this.preventClick) {
-            preventEventDefault(touchEvent); // stops the tap from also been processed as a mouse click
+            _preventEventDefault(touchEvent); // stops the tap from also been processed as a mouse click
         }
 
         this.cancel();

--- a/packages/ag-grid-enterprise/src/setFilter/setFilterListItem.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilterListItem.ts
@@ -23,6 +23,7 @@ import {
     _getCellRendererDetails,
     _getShouldDisplayTooltip,
     _isShowTooltipWhenTruncated,
+    _preventEventDefault,
     _setAriaChecked,
     _setAriaDescribedBy,
     _setAriaExpanded,
@@ -167,12 +168,17 @@ export class SetFilterListItem<V> extends Component<SetFilterListItemEvent> {
 
         this.render();
 
-        this.eCheckbox
+        const eInput = this.eCheckbox
             .setLabelEllipsis(true)
             .setValue(this.isSelected, true)
             .setDisabled(!!this.params.readOnly)
-            .getInputElement()
-            .setAttribute('tabindex', '-1');
+            .getInputElement();
+        eInput.setAttribute('tabindex', '-1');
+        this.addManagedElementListeners(eInput, {
+            // Focus belongs on the outer treeitem wrapper; for aria-hidden tree groups, focusing
+            // the inner input triggers a Chromium aria-hidden warning. The click still toggles.
+            mousedown: _preventEventDefault,
+        });
 
         this.refreshVariableAriaLabels();
 

--- a/testing/behavioural/src/filters/set-filter-tree-list-aria.test.ts
+++ b/testing/behavioural/src/filters/set-filter-tree-list-aria.test.ts
@@ -1,0 +1,145 @@
+import type { GridApi, ISetFilterParams } from 'ag-grid-community';
+import { ClientSideRowModelModule } from 'ag-grid-community';
+import type { SetFilter } from 'ag-grid-enterprise';
+import { SetFilterModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+
+interface Row {
+    category: string;
+}
+
+const ROW_DATA: Row[] = [
+    { category: 'fruits/apple' },
+    { category: 'fruits/banana' },
+    { category: 'veggies/carrot' },
+    { category: 'veggies/lettuce' },
+];
+
+// jsdom has no layout engine, so VirtualList viewports get 20px height from the mock layout
+// and render 0 rows. Patch getBoundingClientRect + offsetHeight at the prototype level so
+// the set filter's virtual list viewport has a usable height and actually renders rows.
+let savedGetBoundingClientRect: typeof Element.prototype.getBoundingClientRect;
+const origOffsetHeightDesc = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
+const origClientHeightDesc = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+
+describe('Set Filter Tree List - Accessibility (aria-hidden + focus)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, SetFilterModule],
+    });
+
+    let host: HTMLElement | null = null;
+
+    beforeAll(() => {
+        savedGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+
+        Object.defineProperty(Element.prototype, 'getBoundingClientRect', {
+            configurable: true,
+            writable: true,
+            value: function (this: Element) {
+                const rect = savedGetBoundingClientRect.call(this);
+                if (this.classList.contains('ag-filter-virtual-list-viewport')) {
+                    return new DOMRect(rect.x, rect.y, rect.width || 200, 400);
+                }
+                return rect;
+            },
+        });
+
+        // mockGridLayout defines offsetHeight on Element.prototype, but jsdom defines it on
+        // HTMLElement.prototype (returning 0), which takes precedence. Override here so
+        // VirtualList's gui.offsetHeight reads the patched getBoundingClientRect().
+        Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+            get(this: HTMLElement) {
+                return this.getBoundingClientRect().height;
+            },
+            configurable: true,
+        });
+        Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+            get(this: HTMLElement) {
+                return this.getBoundingClientRect().height;
+            },
+            configurable: true,
+        });
+    });
+
+    afterAll(() => {
+        if (savedGetBoundingClientRect) {
+            Object.defineProperty(Element.prototype, 'getBoundingClientRect', {
+                configurable: true,
+                writable: true,
+                value: savedGetBoundingClientRect,
+            });
+        }
+        if (origOffsetHeightDesc) {
+            Object.defineProperty(HTMLElement.prototype, 'offsetHeight', origOffsetHeightDesc);
+        }
+        if (origClientHeightDesc) {
+            Object.defineProperty(HTMLElement.prototype, 'clientHeight', origClientHeightDesc);
+        }
+    });
+
+    afterEach(() => {
+        host?.remove();
+        host = null;
+        gridsManager.reset();
+    });
+
+    async function openTreeListFilter(): Promise<{ api: GridApi<Row>; setFilter: SetFilter<string> }> {
+        const api = await gridsManager.createGridAndWait<Row>('grid1', {
+            columnDefs: [
+                {
+                    field: 'category',
+                    filter: 'agSetColumnFilter',
+                    filterParams: {
+                        treeList: true,
+                        treeListPathGetter: (value) => (value ? value.split('/') : null),
+                    } as ISetFilterParams,
+                },
+            ],
+            rowData: ROW_DATA,
+        });
+
+        const setFilter = (await api.getColumnFilterInstance('category')) as SetFilter<string> | null | undefined;
+        if (!setFilter) {
+            throw new Error('Expected SetFilter instance for category column');
+        }
+
+        host = document.createElement('div');
+        host.style.width = '300px';
+        host.style.height = '400px';
+        host.appendChild(setFilter.getGui());
+        document.body.appendChild(host);
+
+        setFilter.afterGuiAttached();
+        await asyncSetTimeout(0);
+
+        // Nudge the viewport so drawVirtualRows() re-evaluates the now-positive height.
+        const viewport = host.querySelector<HTMLElement>('.ag-filter-virtual-list-viewport');
+        if (viewport) {
+            viewport.scrollTop = 1;
+            viewport.scrollTop = 0;
+        }
+        await asyncSetTimeout(0);
+
+        return { api, setFilter };
+    }
+
+    test('tree-list group checkbox suppresses focus on mousedown without breaking click toggle', async () => {
+        await openTreeListFilter();
+
+        const ariaHiddenItem = document.querySelector<HTMLElement>('.ag-set-filter-item[aria-hidden="true"]');
+        expect(ariaHiddenItem).not.toBeNull();
+
+        const input = ariaHiddenItem!.querySelector<HTMLInputElement>('input.ag-input-field-input');
+        expect(input).not.toBeNull();
+        const initiallyChecked = input!.checked;
+
+        const mousedownEvent = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+        input!.dispatchEvent(mousedownEvent);
+        expect(mousedownEvent.defaultPrevented).toBe(true);
+
+        input!.click();
+        await asyncSetTimeout(0);
+        expect(input!.checked).toBe(!initiallyChecked);
+    });
+});


### PR DESCRIPTION
Clicking the set-filter tree-group checkbox focused an input inside an aria-hidden wrapper; fixed by suppressing mousedown focus on that input, which is already tabindex="-1" so click/toggle and keyboard nav are unaffected.

Also, reuse (and export from main-internal) _preventEventDefault 

FIX RTI-3327