### PR TITLE
RTI-3339-ssrm-grand-total-row-async-react-example-fix

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/grand-total-transactions/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/grand-total-transactions/main.ts
@@ -3,7 +3,7 @@ import type {
     GridApi,
     GridOptions,
     IServerSideDatasource,
-    IServerSideGetRowsRequest,
+    IServerSideGetRowsParams,
 } from 'ag-grid-community';
 import {
     GRAND_TOTAL_ROW_ID,
@@ -63,7 +63,6 @@ function getServerSideDatasource(server: ReturnType<typeof FakeServer>): IServer
             console.log('[Datasource] - rows requested:', params.request);
 
             const response = server.getData(params.request, false);
-            const { needsGrandTotal, request } = params;
 
             setTimeout(() => {
                 if (!response.success) {
@@ -81,20 +80,21 @@ function getServerSideDatasource(server: ReturnType<typeof FakeServer>): IServer
                 // store.grandTotalData = null. The grid treats null as "explicitly cleared" so
                 // `needsGrandTotal` stays false for subsequent block requests in the same store
                 // — this branch fires exactly once per logical query.
-                if (needsGrandTotal) {
-                    void refreshGrandTotalAsync(request);
+                if (params.needsGrandTotal) {
+                    void refreshGrandTotalAsync(params);
                 }
             }, 800);
         },
     };
 }
 
-async function refreshGrandTotalAsync(request: IServerSideGetRowsRequest) {
+async function refreshGrandTotalAsync(params: IServerSideGetRowsParams<OlympicRow>) {
+    const { api, request } = params;
     const thisRequestId = ++latestGrandTotalRequestId;
     console.log(`[GrandTotal] - request ${thisRequestId} started`);
 
     // Clear the stale total immediately; we'll add the fresh one back when the fetch resolves.
-    gridApi.applyServerSideTransaction({
+    api.applyServerSideTransaction({
         remove: [{ id: GRAND_TOTAL_ROW_ID } as any],
     });
 
@@ -110,7 +110,7 @@ async function refreshGrandTotalAsync(request: IServerSideGetRowsRequest) {
         return;
     }
 
-    gridApi.applyServerSideTransaction({ add: [grandTotalData] });
+    api.applyServerSideTransaction({ add: [grandTotalData] });
     console.log(`[GrandTotal] - request ${thisRequestId} applied`);
 }
 

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/grand-total-transactions/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/grand-total-transactions/main.ts
@@ -84,7 +84,7 @@ function getServerSideDatasource(server: ReturnType<typeof FakeServer>): IServer
                 if (needsGrandTotal) {
                     void refreshGrandTotalAsync(params);
                 }
-            }, 800);
+            }, 500);
         },
     };
 }

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/grand-total-transactions/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/grand-total-transactions/main.ts
@@ -84,7 +84,7 @@ function getServerSideDatasource(server: ReturnType<typeof FakeServer>): IServer
                 if (needsGrandTotal) {
                     void refreshGrandTotalAsync(params);
                 }
-            }, 500);
+            }, 800);
         },
     };
 }
@@ -103,7 +103,7 @@ async function refreshGrandTotalAsync(params: IServerSideGetRowsParams<OlympicRo
     const grandTotalData = await new Promise<OlympicRow>((resolve) => {
         setTimeout(() => {
             resolve(fakeServer.getData(request, true).grandTotalData);
-        }, 1500);
+        }, 1300);
     });
 
     if (thisRequestId !== latestGrandTotalRequestId) {

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/grand-total-transactions/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/grand-total-transactions/main.ts
@@ -63,6 +63,7 @@ function getServerSideDatasource(server: ReturnType<typeof FakeServer>): IServer
             console.log('[Datasource] - rows requested:', params.request);
 
             const response = server.getData(params.request, false);
+            const needsGrandTotal = params.needsGrandTotal;
 
             setTimeout(() => {
                 if (!response.success) {
@@ -80,7 +81,7 @@ function getServerSideDatasource(server: ReturnType<typeof FakeServer>): IServer
                 // store.grandTotalData = null. The grid treats null as "explicitly cleared" so
                 // `needsGrandTotal` stays false for subsequent block requests in the same store
                 // — this branch fires exactly once per logical query.
-                if (params.needsGrandTotal) {
+                if (needsGrandTotal) {
                     void refreshGrandTotalAsync(params);
                 }
             }, 800);


### PR DESCRIPTION
In react gridApi was not available in the example, but we can just use params.api to do the same

FIX RTI-3339