### PR TITLE
RTI-3337 Theming docs accuracy and clarity updates

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/theming-borders/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-borders/index.mdoc
@@ -4,7 +4,7 @@ title: "Theming API: Customising Borders"
 
 Control the borders around rows, cells and UI elements.
 
-Borders are controlled using theme parameters ending `Border`. There are many such parameters, you can find a full list by searching for "border" in the [Theme Builder](/theme-builder/) "All Parameters" section.
+Borders are controlled using theme parameters ending `Border`. See the [Borders section](./theming-api/#reference-borders) of the parameters reference for the core border parameters, or search "border" in the "All Parameters" section of the [Theme Builder](/theme-builder/) for a full list of border parameters.
 
 The most important parameters relating to borders are:
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-colors/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-colors/index.mdoc
@@ -27,7 +27,9 @@ Some commonly overridden colour parameters are:
 - `dataBackgroundColor` - the background colour of the grid data area
 - `headerBackgroundColor` - the background colour of the header rows
 - `chromeBackgroundColor` - the background colour of the grid's chrome (header, tool panel, etc)
-- `textColor`, `headerTextColor`, `cellTextColor` - override text colours for UI, for headers and cells respectively
+- `textColor` - the color for all text unless overridden by a more specific parameter
+- `headerTextColor` - the color of text in the header
+- `cellTextColor` - the color of text in data cells
 
 Many more colour parameters are available. See the [Colours section](./theming-api/#reference-colours) of the parameters reference for the core colour parameters, or search "color" in the "All Parameters" section of the [Theme Builder](/theme-builder/) for a full list of colour parameters.
 
@@ -54,8 +56,8 @@ All theme parameters with the suffix `Color` are colour values, and can accept t
 | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `string`                                                     | A [CSS colour value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value), such as `'red'`, `'rgb(255, 0, 0)'`, or variable expression `'var(--myColorVar)'`. |
 | `{ ref: 'accentColor' }`                                     | Use the same value as the `accentColor` parameter                                                                                                                      |
-| `{ ref: 'accentColor', mix: 0.25 }`                          | A mix of 25%, `accentColor` 75% transparent                                                                                                                            |
-| `{ ref: 'accentColor', mix: 0.25, onto: 'backgroundColor' }` | A mix of 25%, `accentColor` 75% `backgroundColor`                                                                                                                      |
+| `{ ref: 'accentColor', mix: 0.25 }`                          | A mix of 25% `accentColor`, 75% transparent                                                                                                                            |
+| `{ ref: 'accentColor', mix: 0.25, onto: 'backgroundColor' }` | A mix of 25% `accentColor`, 75% `backgroundColor`                                                                                                                      |
 
 ## Colour Schemes
 
@@ -104,7 +106,7 @@ For this use case we provide theme modes. When a theme uses the `colorSchemeVari
 - `dark`
 - `dark-blue`
 
-It is also possible to define your own colour modes, by passing the mode name to the second parameter of `withParams`. This example defines custom colour schemes for light and dark mode and switches between them by setting the `data-ag-theme-mode` attribute on the `body` element:
+You can also define custom colour modes by passing the mode name as the second argument to `withParams`. This example defines custom colour schemes for light and dark mode and switches between them by setting the `data-ag-theme-mode` attribute on the `body` element:
 
 ```js
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-colors/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-colors/index.mdoc
@@ -29,7 +29,7 @@ Some commonly overridden colour parameters are:
 - `chromeBackgroundColor` - the background colour of the grid's chrome (header, tool panel, etc)
 - `textColor`, `headerTextColor`, `cellTextColor` - override text colours for UI, for headers and cells respectively
 
-Many more parameters are available, search the "All Parameters" section of the [theme builder](/theme-builder/) for a full list.
+Many more colour parameters are available. See the [Colours section](./theming-api/#reference-colours) of the parameters reference for the core colour parameters, or search "color" in the "All Parameters" section of the [Theme Builder](/theme-builder/) for a full list of colour parameters.
 
 For example:
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-compactness/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-compactness/index.mdoc
@@ -26,7 +26,7 @@ To customise the height of grid data rows:
 
 ## More Compactness Parameters
 
-To find compactness parameters relating to a feature, search for the feature name in the "All Parameters" section of the [Theme Builder](/theme-builder/).
+Compactness parameters for each feature are listed in that feature's section of the [parameters reference](./theming-api/) (e.g. [Headers](./theming-api/#reference-headers), [Rows](./theming-api/#reference-rows)). See [Spacing & Sizing](./theming-api/#reference-spacingAndSizing) for parameters that affect the whole grid.
 
 ## Extended Syntax For Length Parameters
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-distribution/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-distribution/index.mdoc
@@ -11,7 +11,7 @@ Most applications create themes by starting with a built-in theme like `themeQua
 The `createTheme` function creates a new theme containing core styles but no parts. If you're going to change most of the parts anyway, starting from a new theme will reduce the bundle size compared to starting with a built-in theme.
 
 ```js
-import { createTheme, iconSetMaterial } from 'ag-grid-community';
+import { createTheme, iconSetMaterial, colorSchemeVariable } from 'ag-grid-community';
 
 const myCustomTheme = createTheme()
     // add just the parts you want
@@ -34,7 +34,7 @@ For organisations that create a library of reusable styles and share them among 
 
 The benefit of using parts rather than adding CSS in your application stylesheets is that the CSS is scoped: the CSS you provide will only apply to grids with your theme applied, whereas by default CSS in your application stylesheets will apply to all grids unless you add rules to prevent it.
 
-The `createPart` function creates an empty part and takes the following arguments:
+The `createPart` function creates a new part. It takes an options object with the following properties:
 
 ```js
 import { createPart } from 'ag-grid-community';
@@ -75,7 +75,7 @@ You have three options for `feature`:
 
 - `undefined`, or omit the feature property. In this case once added to a theme the part can not be removed. Many applications choose to bundle all the CSS for a custom theme in one part with no feature set. This is the simplest way of getting the CSS scoping benefits of using parts.
 - One of the built-in part features, like `checkboxStyle` or `iconSet`. See the [Parts](./theming-parts/) page for a full list. Adding the part to any theme will replace the built-in part with the same feature.
-- A string of your choice, in order to use the same part replacement semantics in your own design system. We recommend prefixing the part name with your organisation to prevent name clashes in future grid versions. For example, Acme Corp might have several typography styles, represented as parts with the feature `acmeCorpTypographyStyle`. Your custom theme can bundle a default typography style, and applications can replace it with a different one if they wish.
+- A string of your choice, to use the same part replacement semantics in your own design system. We recommend prefixing the part name with your organisation to prevent name clashes in future grid versions. For example, Acme Corp might have several typography styles, represented as parts with the feature `acmeCorpTypographyStyle`. Your custom theme can bundle a default typography style, and applications can replace it with a different one if they wish.
 
 #### Naming Of Parameters In Custom Parts
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-fonts/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-fonts/index.mdoc
@@ -2,7 +2,7 @@
 title: "Theming: Customising Fonts"
 ---
 
-Altering typography within the grid
+Alter typography within the grid.
 
 ## Font Family Parameters
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-headers/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-headers/index.mdoc
@@ -62,7 +62,7 @@ The example below adds some styling to `ag-header-cell-filtered`, so when you fi
 
 ## Styling the First and Last Columns
 
-It's possible to style the all first and last column header (Grouped, Non-Grouped and Floating Filters) using CSS by targeting the `.ag-column-first` and `.ag-column-last` selectors as follows:
+You can style all first and last column headers (Grouped, Non-Grouped and Floating Filters) using CSS by targeting the `.ag-column-first` and `.ag-column-last` selectors as follows:
 
 ```css
 .ag-header-group-cell.ag-column-first {

--- a/documentation/ag-grid-docs/src/content/docs/theming-headers/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-headers/index.mdoc
@@ -16,7 +16,7 @@ const myTheme = themeQuartz.withParams({
 });
 ```
 
-For a full list of relevant parameters, search "header" in the "All Parameters" section of the [Theme Builder](/theme-builder/) or use typescript autocompletion in your IDE.
+For the full list, see the [Headers section](./theming-api/#reference-headers) of the parameters reference.
 
 When the theme parameters are not enough you can use CSS classes, in particular `ag-header`, `ag-header-cell`, and `ag-header-group-cell`:
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-master-detail/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-master-detail/index.mdoc
@@ -42,9 +42,9 @@ See [Customising the grid with CSS](./theming-css/) for more details on CSS use.
 
 You can set CSS variables on detail grids, but be aware of a difference in how they work compared to setting them on a master grid.
 
-Some high-level variables control the behaviour of many lower-level variables by providing default values. This is the case for general colors like --ag-background-color and for --ag-spacing.
+Some high-level variables control the behaviour of many lower-level variables by providing default values. This is the case for general colours like --ag-background-color and for --ag-spacing.
 
-In this example we set the background color on the master grid to red. Setting `--ag-background-color` to red sets _default_ values for `--ag-data-background-color`, `--ag-odd-row-background-color` and `--ag-header-background-color`, so because these variables have no values defined, they are set to red. We attempt to set the detail grid to green using the same technique, but now these three variables already have values defined - the red color inherited from the master grid, so the default value provided by `--ag-background-color` has no effect.
+In this example we set the background colour on the master grid to red. Setting `--ag-background-color` to red sets _default_ values for `--ag-data-background-color`, `--ag-odd-row-background-color` and `--ag-header-background-color`, so because these variables have no values defined, they are set to red. We attempt to set the detail grid to green using the same technique, but now these three variables already have values defined - the red colour inherited from the master grid, so the default value provided by `--ag-background-color` has no effect.
 
 ```css
 body {
@@ -57,7 +57,7 @@ body {
 
 {% gridExampleRunner title="Custom Properties and Detail Grids" name="custom-properties" /%}
 
-In order to avoid this, you need to set all the lower-level variable explicitly:
+In order to avoid this, you need to set all the lower-level variables explicitly:
 
 ```css
 body {

--- a/documentation/ag-grid-docs/src/content/docs/theming-master-detail/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-master-detail/index.mdoc
@@ -42,7 +42,7 @@ See [Customising the grid with CSS](./theming-css/) for more details on CSS use.
 
 You can set CSS variables on detail grids, but be aware of a difference in how they work compared to setting them on a master grid.
 
-Some high-level variables control the behaviour of many lower-level variables by providing default values. This is the case for general colours like --ag-background-color and for --ag-spacing.
+High-level variables like `--ag-background-color` and `--ag-spacing` define default values for multiple lower-level variables.
 
 In this example we set the background colour on the master grid to red. Setting `--ag-background-color` to red sets _default_ values for `--ag-data-background-color`, `--ag-odd-row-background-color` and `--ag-header-background-color`, so because these variables have no values defined, they are set to red. We attempt to set the detail grid to green using the same technique, but now these three variables already have values defined - the red colour inherited from the master grid, so the default value provided by `--ag-background-color` has no effect.
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-migration/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-migration/index.mdoc
@@ -105,7 +105,7 @@ public theme = myTheme;
 
 ### 3. Convert any css custom properties you are using to the new names
 
-In legacy themes, custom properties had to be set in CSS. When migrating custom properties to the Theming API you may choose whether to specify them in JavaScript in order to get Typescript validation of property names and values, or to continue to set them in CSS. The list below provides the JS API names, to convert them to CSS use kebab-case and add the `--ag-` prefix (`tooltipTextColor` -> `--ag-tooltip-text-color`).
+In legacy themes, custom properties had to be set in CSS. When migrating custom properties to the Theming API you may choose whether to specify them in JavaScript in order to get TypeScript validation of property names and values, or to continue to set them in CSS. The list below provides the JS API names, to convert them to CSS use kebab-case and add the `--ag-` prefix (`tooltipTextColor` -> `--ag-tooltip-text-color`).
 
 #### Key changes
 
@@ -213,7 +213,7 @@ body {
 }
 ```
 
-### 4. [Sass users only] Remove use of the Sass API
+### 5. [Sass users only] Remove use of the Sass API
 
 The Theming API achieves in JavaScript what the old Sass API did in Sass.
 
@@ -271,7 +271,7 @@ For Angular, consider using [ViewEncapsulation.ShadowDom](https://angular.dev/gu
 
 If you are familiar with the method of theming applications used in v32 and earlier, the following technical context will help you understand what is changing and what remains the same.
 
-The grid is styled using CSS. A running grid instance contains thousands of DOM elements, and each of them has class names like `ag-header` and `ag-row` that can be used in CSS rules that change the style of that element. The grid package from NPM contains CSS that set up a default grid style and expose CSS custom properties (variables) that allow configuration of colors, borders, padding, fonts etc. When you want to go beyond what is possible with the custom properties, you write your own CSS rules targeting the grid's class names.
+The grid is styled using CSS. A running grid instance contains thousands of DOM elements, and each of them has class names like `ag-header` and `ag-row` that can be used in CSS rules that change the style of that element. The grid package from NPM contains CSS that set up a default grid style and expose CSS custom properties (variables) that allow configuration of colours, borders, padding, fonts etc. When you want to go beyond what is possible with the custom properties, you write your own CSS rules targeting the grid's class names.
 
 None of this is changing - the grid is still styled with CSS and CSS custom properties, and you can still extend it with your own CSS rules. What the Theming API changes is the following:
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-migration/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-migration/index.mdoc
@@ -2,7 +2,7 @@
 title: "Migrating to the Theming API"
 ---
 
-Migrating to the Theming API
+Update your app to use the new theming system available in v33
 
 Before v33, themes were imported as CSS files in our NPM modules, and applied by setting a class name on the grid's container element, e.g. `class="ag-theme-quartz"`. In v33, the default method of styling the grid is the Theming API, in which themes are imported as JavaScript objects and passed to the grid as a grid option. The old method of styling (now called legacy themes) is still supported, but is deprecated and will be removed in a future major version.
 
@@ -109,7 +109,7 @@ In legacy themes, custom properties had to be set in CSS. When migrating custom 
 
 #### Key changes
 
-- `--ag-grid-size` -> `spacing` spacing works a little bit differently from the old "grid size". It controls the padding around elements, whereas grid size controlled their size. So setting spacing to `0` will result in a grid with no padding, whereas setting grid size to `0` would have resulted in zero-height rows.
+- `--ag-grid-size` -> `spacing`. Spacing works a little differently from the old grid size: it controls the padding around elements, whereas grid size controlled their size. Setting `spacing` to `0` produces a grid with no padding, whereas setting grid size to `0` produced zero-height rows.
 - `--ag-active-color`, `--ag-alpine-active-color`, `--ag-balham-active-color`, `--ag-material-accent-color` -> use `accentColor`
 - `--ag-borders*` -> there has been a reworking of border parameters, see [Customising Borders](./theming-borders/) for the new list of border parameters.
 - `--ag-row-border-color`, `--ag-row-border-style`, `--ag-row-border-width` -> replaced with `rowBorder`
@@ -121,7 +121,6 @@ While developing the Theming API we took the opportunity to rename many of our p
 
 Note: the replacement parameter is given as name for use in the TypeScript Theming API, e.g. `chromeBackgroundColor`. To use this in CSS, convert it to kebab-case and add the `--ag-` prefix, e.g. `--ag-chrome-background-color`.
 
-- `--ag-secondary-foreground-color` -> `chromeBackgroundColor`
 - `--ag-selected-tab-underline-color` -> `tabSelectedUnderlineColor`
 - `--ag-selected-tab-underline-transition-speed` -> `tabSelectedUnderlineTransitionDuration`
 - `--ag-selected-tab-underline-width` -> `tabSelectedUnderlineWidth`
@@ -149,7 +148,7 @@ Note: the replacement parameter is given as name for use in the TypeScript Themi
 - `--ag-menu-border-color` -> `menuBorderColor`
 - `--ag-panel-border-color` -> `dialogBorder`
 - `--ag-quartz-icon-active-color` -> this was used to apply an outline to focussed icons, now all focussed elements throughout the grid use `focusShadow`
-- `--ag-quartz-icon-hover-color` -> `iconButtonHoverColor`
+- `--ag-quartz-icon-hover-color` -> `iconButtonHoverBackgroundColor`
 
 #### Components with significantly different theming parameters
 
@@ -162,6 +161,7 @@ Note: the replacement parameter is given as name for use in the TypeScript Themi
 These properties were either outdated, confusing to use, or provided no benefit over using CSS rules.
 
 - `--ag-secondary-border-color` -> there is no longer a concept of "secondary" borders use `borderColor` or CSS rules to target specific borders
+- `--ag-secondary-foreground-color` -> there is no longer a concept of "secondary" text color use parameters like `headerTextColor` or CSS rules to target specific components
 - `--ag-borders-side-button`
 - `--ag-tab-min-width`
 - `--ag-menu-min-width`
@@ -279,7 +279,7 @@ None of this is changing - the grid is still styled with CSS and CSS custom prop
 2. There is a TypeScript API for setting CSS custom properties (`theme.withParams(...)`). This provides autocompletion and inline documentation making it easier to find the property you're looking for. You can still set custom properties in CSS if you prefer.
 3. It is now possible to mix and match elements of different themes. Previously, if you wanted the text inputs from Material and the buttons from Quartz, you would have to write your own styles. Now you can compose your own themes using parts from different built in themes (`theme.withPart(...)`).
 4. It is a significant rewrite of the CSS we provide to style the grid, containing many improvements and resolving long-standing issues. It contains all the learnings from 10 years of maintaining the old CSS themes. Some examples of changes we've made:
-    - Compactness and spacing has been completely overhauled. In legacy themes the size of many elements was set as a multiple of `--ag-grid-size`, so lower values produced a more compact grid. However in practice after changing the value, many further tweaks were required to get things looking right. In the Theming API this is replaced by `--ag-spacing` which is designed to "just work" at any value.
+    - Compactness and spacing have been overhauled. In legacy themes the size of many elements was set as a multiple of `--ag-grid-size`, so lower values produced a more compact grid. However in practice after changing the value, many further tweaks were required to get things looking right. In the Theming API this is replaced by `--ag-spacing` which is designed to "just work" at any value.
     - Focus styles look and work better, with focus styles on elements like header cells looking more like the focus styles on form inputs.
     - CSS custom properties now inherit as expected - if you set `--ag-foreground-color` on the `body` element, it will be inherited by all grids on the page. In legacy themes, the custom property had to be set on the same element as the theme class.
     - [Selector specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity) has been reduced across the board, making it easier to override in your own style sheets. For example, in legacy themes if you added the following code to your application's style sheet - `.ag-cell-inline-editing { box-shadow: none; }` - it would not have the intended effect of removing the shadow from cells being edited. This was because our CSS that added the shadow had a more specific selector. In the Theming API this code works as expected.

--- a/documentation/ag-grid-docs/src/content/docs/theming-parameters/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-parameters/index.mdoc
@@ -31,7 +31,7 @@ There are many parameters available, and several ways of finding the right one t
 
 ## Parameter Types
 
-The type of a parameter is determined by the suffix of it name, for example `Color`, `Border` or `Shadow`.
+The type of a parameter is determined by the suffix of its name, for example `Color`, `Border` or `Shadow`.
 
 Every type can accept a string, which is passed to CSS without processing so must be valid CSS syntax for the type of parameter, e.g. `red` is a valid CSS color.
 
@@ -49,7 +49,7 @@ Parameters that refer to on-screen measurements are length values. These will ha
 
 ### Color Values
 
-All parameters ending "Color" are color values. These can accept any [valid CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value), including named colors (`red`), hex values (`#FF0000`) CSS functions (`rgb(255, 0, 0)`) and variable expressions (`var(--myColorVar)`). In addition, the following syntax is supported:
+All parameters ending "Color" are color values. These can accept any [valid CSS color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value), including named colors (`red`), hex values (`#FF0000`), CSS functions (`rgb(255, 0, 0)`) and variable expressions (`var(--myColorVar)`). In addition, the following syntax is supported:
 
 | Syntax                                                       | Description                                       |
 | ------------------------------------------------------------ | ------------------------------------------------- |
@@ -107,7 +107,7 @@ All parameters ending "Image" are image values. These can accept any [valid CSS 
 
 ### Color Scheme Values
 
-All parameters ending "ColorScheme" (and there is only one: `browserColorScheme`) are color scheme values. These can accept any [valid CSS color-scheme value](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme), including`dark`, `light`, `normal`, `inherit` and variable expressions (`var(--myColorScheme)`).
+All parameters ending "ColorScheme" (and there is only one: `browserColorScheme`) are color scheme values. These can accept any [valid CSS color-scheme value](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme), including `dark`, `light`, `normal`, `inherit` and variable expressions (`var(--myColorScheme)`).
 
 ### Duration Values
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-parameters/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-parameters/index.mdoc
@@ -55,8 +55,8 @@ All parameters ending "Color" are color values. These can accept any [valid CSS 
 | Syntax                                                       | Description                                       |
 | ------------------------------------------------------------ | ------------------------------------------------- |
 | `{ ref: 'accentColor' }`                                     | Use the same value as the `accentColor` parameter |
-| `{ ref: 'accentColor', mix: 0.25 }`                          | A mix of 25%, `accentColor` 75% transparent       |
-| `{ ref: 'accentColor', mix: 0.25, onto: 'backgroundColor' }` | A mix of 25%, `accentColor` 75% `backgroundColor` |
+| `{ ref: 'accentColor', mix: 0.25 }`                          | A mix of 25% `accentColor`, 75% transparent       |
+| `{ ref: 'accentColor', mix: 0.25, onto: 'backgroundColor' }` | A mix of 25% `accentColor`, 75% `backgroundColor` |
 
 ### Border Values
 
@@ -65,8 +65,8 @@ All parameters ending "Border" are border values. These can accept any [valid CS
 | Syntax                                         | Description                                                                                                                                                                                                                                                                                                                            |
 | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `{ width: 2, style: 'dashed', color: 'blue' }` | An object with 3 optional properties. `width` can take any [length value](#length-values) and defaults to 1. `style` takes a [CSS border-style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) string and defaults to "solid". `color` takes any [color value](#color-values) and defaults to `{ ref: 'borderColor' }` |
-| `true`                                         | The default border: `{width: 1, style: 'solid' { ref: 'borderColor' }`                                                                                                                                                                                                                                                                 |
-| `false`                                        | A shorthand for `0`                                                                                                                                                                                                                                                                                                                    |
+| `true`                                         | The default border: `{ width: 1, style: 'solid', color: { ref: 'borderColor' } }`                                                                                                                                                                                                                                                      |
+| `false`                                        | A shorthand for `'none'` (no border)                                                                                                                                                                                                                                                                                                   |
 
 ### Border Style Values
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-parameters/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-parameters/index.mdoc
@@ -25,9 +25,10 @@ Under the hood, theme parameters are implemented using CSS custom properties (va
 
 There are many parameters available, and several ways of finding the right one to use:
 
-1. **[Theme Builder](/theme-builder/)** - In the "All Parameters" section of the Theme Builder you can search for parameters and view documentation.
-2. **TypeScript auto-complete** - When using an editor with TypeScript language support, you can see all available parameters with inline documentation.
-3. **Dev tools** - When inspecting an element in the grid, the styles panel shows the CSS custom properties that are being used. A custom property `var(--ag-column-border)` corresponds to the theme parameter `columnBorder`.
+1. **[Theme Parameters Reference](./theming-api/)** - a list of all parameters organised by feature
+2. **[Theme Builder](/theme-builder/)** - In the "All Parameters" section of the Theme Builder you can search for parameters and see their effect on a live grid
+3. **TypeScript auto-complete** - When using an editor with TypeScript language support, you can see all available parameters with inline documentation
+4. **Dev tools** - When inspecting an element in the grid, the styles panel shows the CSS custom properties that are being used. A custom property `var(--ag-column-border)` corresponds to the theme parameter `columnBorder`
 
 ## Parameter Types
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-parts/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-parts/index.mdoc
@@ -30,11 +30,10 @@ The following parts are available:
 - `colorScheme` feature:
     - `colorSchemeVariable` - the default colour scheme for all our [built-in themes](./themes/#built-in-themes). By default it appears light, but can be adjusted using [theme modes](./theming-colors/#theme-modes).
     - `colorSchemeLight` - neutral light scheme
-    - `colorSchemeLightCold` - light scheme with subtle cold tint used by Balham theme
+    - `colorSchemeLightCold` - light scheme with subtle cold tint
     - `colorSchemeLightWarm` - light scheme with subtle warm tint
     - `colorSchemeDark` - neutral dark scheme
     - `colorSchemeDarkBlue` - our preferred dark scheme used on this website
-    - `colorSchemeDarkWarm` - dark scheme with subtle warm tint
     - `colorSchemeDarkWarm` - dark scheme with subtle warm tint
 - `iconSet` feature:
     - `iconSetQuartz` - our default icon set

--- a/documentation/ag-grid-docs/src/content/docs/theming-parts/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-parts/index.mdoc
@@ -8,7 +8,7 @@ Using parts you can, for example, select a text input style that matches you app
 
 ## Configuring Theme Parts
 
-To add a part to a theme, call the `theme.withPart(...)` method which returns a new theme using that part. A theme can only have one part for a given feature, so for example because all color scheme parts have `feature: "colorScheme"`, adding a new color scheme to a theme will remove any existing part.
+To add a part to a theme, call the `theme.withPart(...)` method which returns a new theme using that part. A theme can only have one part for a given feature, so for example because all colour scheme parts have `feature: "colorScheme"`, adding a new colour scheme to a theme will remove any existing part.
 
 ```js
 import { themeQuartz, colorSchemeDark, iconSetMaterial } from 'ag-grid-community';
@@ -19,7 +19,7 @@ const myTheme = themeQuartz
     .withPart(colorSchemeDark);
 ```
 
-This example demonstrates mixing and matching any built-in theme, icon set, and color scheme:
+This example demonstrates mixing and matching any built-in theme, icon set, and colour scheme:
 
 {% gridExampleRunner title="Configuring Theme Parts" name="configuring-theme-parts" /%}
 
@@ -28,7 +28,7 @@ This example demonstrates mixing and matching any built-in theme, icon set, and 
 The following parts are available:
 
 - `colorScheme` feature:
-    - `colorSchemeVariable` - the default color scheme for all our [built-in themes](./themes/#built-in-themes). By default it appears light, but can be adjusted using [theme modes](./theming-colors/#theme-modes).
+    - `colorSchemeVariable` - the default colour scheme for all our [built-in themes](./themes/#built-in-themes). By default it appears light, but can be adjusted using [theme modes](./theming-colors/#theme-modes).
     - `colorSchemeLight` - neutral light scheme
     - `colorSchemeLightCold` - light scheme with subtle cold tint used by Balham theme
     - `colorSchemeLightWarm` - light scheme with subtle warm tint
@@ -64,7 +64,7 @@ The following parts are available:
     - `tabStyleAlpine` - tabs styled as per the Alpine theme
     - `tabStyleRolodex` - tabs designed to imitate paper cards, as used by the Balham theme
 - `styleMaterial` feature (used by the Material theme):
-    - `styleMaterial` - Adds the `primaryColor` parameter defined by [Material Design v2](https://m2.material.io/) and uses this color instead of the `accentColor` for most colored elements. `accentColor` is still used for checked checkboxes and to highlight active filters. This part also applies some adjustments to appearance of elements to match the Material Design specification, e.g. making all button text uppercase.
+    - `styleMaterial` - Adds the `primaryColor` parameter defined by [Material Design v2](https://m2.material.io/) and uses this colour instead of the `accentColor` for most coloured elements. `accentColor` is still used for checked checkboxes and to highlight active filters. This part also applies some adjustments to appearance of elements to match the Material Design specification, e.g. making all button text uppercase.
 
 ## Removing a Part
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-popups/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-popups/index.mdoc
@@ -23,7 +23,7 @@ And you can override shadows for individual elements using more specific paramet
 - `dialogShadow` - Shadow for popup dialogs such as integrated charts and the advanced filter builder
 - `cellEditingShadow` - Shadow for cells being edited
 - `dragAndDropImageShadow` - Shadow for the drag and drop image component element when dragging columns
-- and more - search "shadow" in the "All Parameters" section of the [Theme Builder](/theme-builder/) or use typescript autocompletion in your IDE.
+- and more - see the [Menus & Popups section](./theming-api/#reference-menusAndPopups) of the parameters reference for popup-related parameters, or search "shadow" in the "All Parameters" section of the [Theme Builder](/theme-builder/) for a full list of shadow parameters.
 
 Shadows can use the [extended syntax for shadow values](./theming-parameters/#shadow-values):
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-selections/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-selections/index.mdoc
@@ -13,8 +13,8 @@ const myTheme = themeQuartz.withParams({
     // bright green, 10% opacity
     selectedRowBackgroundColor: 'rgba(0, 255, 0, 0.1)',
 
-    // alternating row colors will be visible through the semi-transparent
-    // selection background color
+    // alternating row colours will be visible through the semi-transparent
+    // selection background colour
     oddRowBackgroundColor: '#8881',
 });
 ```
@@ -27,17 +27,17 @@ const myTheme = themeQuartz.withParams({
 
 ```js
 const myTheme = themeQuartz.withParams({
-    // color and style of border around selection
+    // colour and style of border around selection
     rangeSelectionBorderColor: 'rgb(193, 0, 97)',
     rangeSelectionBorderStyle: 'dashed',
-    // background color of selection - you can use a semi-transparent color
+    // background colour of selection - you can use a semi-transparent colour
     // and it wil overlay on top of the existing cells
     rangeSelectionBackgroundColor: 'rgb(255, 0, 128, 0.1)',
-    // color used to indicate that data has been copied from the cell range
+    // colour used to indicate that data has been copied from the cell range
     rangeSelectionHighlightColor: 'rgb(60, 188, 0, 0.3)',
 
-    // alternating row colors will be visible through the semi-transparent
-    // selection background color
+    // alternating row colours will be visible through the semi-transparent
+    // selection background colour
     oddRowBackgroundColor: '#8881',
 });
 ```

--- a/documentation/ag-grid-docs/src/content/docs/theming-selections/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-selections/index.mdoc
@@ -33,7 +33,7 @@ const myTheme = themeQuartz.withParams({
     // background color of selection - you can use a semi-transparent color
     // and it wil overlay on top of the existing cells
     rangeSelectionBackgroundColor: 'rgb(255, 0, 128, 0.1)',
-    // color used to indicate that data has been copied form the cell range
+    // color used to indicate that data has been copied from the cell range
     rangeSelectionHighlightColor: 'rgb(60, 188, 0, 0.3)',
 
     // alternating row colors will be visible through the semi-transparent

--- a/documentation/ag-grid-docs/src/content/docs/theming-theme-builder/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-theme-builder/index.mdoc
@@ -28,7 +28,7 @@ export const myTheme = themeQuartz
     });
 ```
 
-To use the exported theme, pass the theme object to the `theme` grid option, see [Built-in Themes](./themes/) examples in your framework.
+To use the exported theme, pass the theme object to the `theme` grid option. See [Built-in Themes](./themes/) for framework-specific examples.
 
 ## Importing Themes
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-tool-panels/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-tool-panels/index.mdoc
@@ -6,7 +6,7 @@ Style the Filters [Tool Panel](./component-tool-panel/) and [Columns Tool Panel]
 
 ## Styling the Sidebar Area
 
-The sidebar is a tabbed container for opening and switching between tool panels. The grid exposes many theme parameters for customising the sidebar and tabbed buttons. Search "side" in the "All Parameters" section of the [Theme Builder](/theme-builder/) or use typescript autocompletion in your IDE.
+The sidebar is a tabbed container for opening and switching between tool panels. The grid exposes many theme parameters for customising the sidebar and tabbed buttons. For the full list, see the [Sidebar section](./theming-api/#reference-sidebar) of the parameters reference.
 
 ```js
 const myTheme = themeQuartz.withParams({

--- a/documentation/ag-grid-docs/src/content/docs/theming-widgets/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-widgets/index.mdoc
@@ -84,9 +84,9 @@ If there is no parameter for the effect that you want to achieve, you can use CS
 
 ### Changing Checkbox Icons
 
-The example above uses `checkboxCheckedShapeImage` to replace the default check mark with a X symbol. By default, `checkboxCheckedShapeImage` provides only the shape of the check mark, and the color is replaced using the `checkboxCheckedShapeColor` parameter.
+The example above uses `checkboxCheckedShapeImage` to replace the default check mark with a X symbol. By default, `checkboxCheckedShapeImage` provides only the shape of the check mark, and the colour is replaced using the `checkboxCheckedShapeColor` parameter.
 
-If you have SVG images containing their own color, this example demonstrates how to create a checkbox style with coloured SVG images. It removes the existing checkbox styles using `theme.removePart()` and adds new styles with CSS:
+If you have SVG images containing their own colour, this example demonstrates how to create a checkbox style with coloured SVG images. It removes the existing checkbox styles using `theme.removePart()` and adds new styles with CSS:
 
 {% gridExampleRunner title="Checkbox Styling" name="checkboxes-custom-svg" exampleHeight=450 /%}
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-widgets/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-widgets/index.mdoc
@@ -34,7 +34,7 @@ If there is no parameter for the effect that you want to achieve, you can use CS
 
 ### Underlined Text Inputs
 
-The default text input style is `inputStyleBordered`. The other provided input style is `inputStyleUnderlined` which produces a Material Design style underlined input. These are [theme parts](./theming-parts/) so you can swap them using `theme.usePart()` or create your own:
+The default text input style is `inputStyleBordered`. The other provided input style is `inputStyleUnderlined` which produces a Material Design style underlined input. These are [theme parts](./theming-parts/) so you can swap them using `theme.withPart()` or create your own:
 
 ```js
 const myTheme = themeQuartz.withPart(inputStyleUnderlined);
@@ -86,7 +86,7 @@ If there is no parameter for the effect that you want to achieve, you can use CS
 
 The example above uses `checkboxCheckedShapeImage` to replace the default check mark with a X symbol. By default, `checkboxCheckedShapeImage` provides only the shape of the check mark, and the colour is replaced using the `checkboxCheckedShapeColor` parameter.
 
-If you have SVG images containing their own colour, this example demonstrates how to create a checkbox style with coloured SVG images. It removes the existing checkbox styles using `theme.removePart()` and adds new styles with CSS:
+If you have SVG images containing their own colour, this example demonstrates how to create a checkbox style with coloured SVG images. It removes the existing checkbox styles using `theme.withoutPart()` and adds new styles with CSS:
 
 {% gridExampleRunner title="Checkbox Styling" name="checkboxes-custom-svg" exampleHeight=450 /%}
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-widgets/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-widgets/index.mdoc
@@ -6,7 +6,7 @@ Style text inputs, checkboxes, toggle buttons and range sliders.
 
 ## Styling Text Inputs
 
-The grid exposes many theme parameters beginning `input*` for customising text input appearance. Search "input" in the "All Parameters" section of the [Theme Builder](/theme-builder/) or use typescript autocompletion in your IDE.
+The grid exposes many theme parameters beginning `input*` for customising text input appearance. For the full list, see the [Inputs section](./theming-api/#reference-inputs) of the parameters reference.
 
 ```js
 const myTheme = themeQuartz.withParams({
@@ -50,7 +50,7 @@ If you'd like to create your own input styles from scratch you can remove the ex
 
 ## Styling Checkboxes
 
-The grid exposes many theme parameters beginning `checkbox*` for customising checkbox appearance. Search "checkbox" in the "All Parameters" section of the [Theme Builder](/theme-builder/) or use typescript autocompletion in your IDE.
+The grid exposes many theme parameters beginning `checkbox*` for customising checkbox appearance. For the full list, see the [Checkboxes & Radio Buttons section](./theming-api/#reference-checkboxes) of the parameters reference.
 
 ```js
 const myTheme = themeQuartz.withParams({

--- a/documentation/ag-grid-docs/src/content/docs/theming/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming/index.mdoc
@@ -29,7 +29,7 @@ The [themeStyleContainer grid option](./grid-options/#reference-theme-themeStyle
 - a container element such as the head, body or a div - the styles will be added to the start
 - a `<style>` element - the styles will be added as siblings directly afterwards
 - a function returning a container or style element - the function will be called at grid initialisation time to resolve an element
-- undefined - the document head will be used, except for Shadow DOM see below
+- undefined - the document head will be used, except for Shadow DOM (see below)
 
 ### Themed grids in Shadow DOM / Web Components
 

--- a/documentation/ag-grid-docs/src/content/docs/theming/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming/index.mdoc
@@ -2,7 +2,7 @@
 title: "Theming"
 ---
 
-Theming refers to the process of adjusting design elements such as colours, borders and spacing to match your applications' design.
+Theming refers to the process of adjusting design elements such as colours, borders and spacing to match your application's design.
 
 We provide a range of methods for customising the appearance of the grid so that you can create any look that your designer can imagine. From the quick and easy to the most advanced, they are:
 
@@ -50,7 +50,7 @@ In an application using CSS layers, you typically want the order of layers to be
 2. Set the `themeCssLayer` grid option to `"grid"`. This wraps the grid styles in `@layer grid { ... }`.
 3. Set the `themeStyleContainer` grid option to `document.body` to ensure that the grid styles load after your application styles
 
-Why insert styles into the document body? By default the grid inserts the styles at the _start_ of the head. When using `themeCssLayer: "grid"`, this positioning would cause the grid layer to be the first layer in the document. By the time your application stylesheets are loaded, it's too late to change the layer order: the grid layer is already first, so `@layer resets, grid, application;` has no effect. Setting `themeStyleContainer: document.body` causes the styles to be inserted at the beginning of the body. The effect is very similar to inserting them at the end of the head, except that they are guaranteed to appear after your application stylesheet.
+Why insert styles into the document body? By default the grid inserts the styles at the _start_ of the head. When using `themeCssLayer: "grid"`, this positioning would cause the grid layer to be the first layer in the document. By the time your application stylesheets are loaded, it's too late to change the layer order: the grid layer is already first, so `@layer resets, grid, application;` has no effect. Setting `themeStyleContainer: document.body` causes the styles to be inserted at the beginning of the body.
 
 ## Legacy Themes
 


### PR DESCRIPTION
Fix [RTI-3337](https://ag-grid.atlassian.net/browse/RTI-3337)

Review of all `index.mdoc` files under `documentation/ag-grid-docs/src/content/docs/theming*/` (excluding `theming-v32*`). Each tier below describes the review effort needed.

## Tier 1 — Accuracy fixes

Each replaces a wrong claim, broken snippet, or non-existent API reference.

- **`theming-widgets:37`** — `theme.usePart()` → `theme.withPart()` (no `usePart` method exists). https://www.ag-grid.com/archive/35.3.0/react-data-grid/theming-widgets/#underlined-text-inputs
- **`theming-widgets:89`** — `theme.removePart()` → `theme.withoutPart()` (no `removePart` method exists). https://www.ag-grid.com/archive/35.3.0/react-data-grid/theming-widgets/#changing-checkbox-icons
- **`theming-migration:151`** — `--ag-quartz-icon-hover-color` mapping fixed: was `iconButtonHoverColor` (icon foreground); legacy var was a background; now `iconButtonHoverBackgroundColor`. https://www.ag-grid.com/archive/35.3.0/react-data-grid/theming-migration/#properties-with-a-direct-replacement
- **`theming-migration` (line ~124)** — `--ag-secondary-foreground-color → chromeBackgroundColor` mapping removed (was a fg→bg semantics mismatch; entry deleted entirely). https://www.ag-grid.com/archive/35.3.0/react-data-grid/theming-migration/#properties-with-a-direct-replacement
- **`theming-parameters:67`** — Border `true` default literal repaired (was malformed: missing `color:` key and closing brace). https://www.ag-grid.com/archive/35.3.0/react-data-grid/theming-parameters/#border-values
- **`theming-parameters:68`** — Border `false` shorthand corrected (was "shorthand for `0`"; actually resolves to `'none'`). https://www.ag-grid.com/archive/35.3.0/react-data-grid/theming-parameters/#border-values
- **`theming-parts:33`** — `colorSchemeLightCold` no longer claimed to be used by Balham (Balham uses `colorSchemeVariable`). https://www.ag-grid.com/archive/35.3.0/react-data-grid/theming-parts/#parts-reference
- **`theming-parts:38`** — duplicate `colorSchemeDarkWarm` bullet removed. https://www.ag-grid.com/archive/35.3.0/react-data-grid/theming-parts/#parts-reference
- **`theming-distribution:14`** — `colorSchemeVariable` added to snippet's import (was used on line 19 but not imported). https://www.ag-grid.com/archive/35.3.0/react-data-grid/theming-distribution/#creating-themes-from-scratch

## Tier 2 — Content changes

Substantive wording changes

- **Canonical "Finding Theme Parameters" list now puts the new API reference page first** (Theme Builder demoted to "interactive exploration"; TS autocomplete and Dev tools kept). https://www.ag-grid.com/archive/35.3.0/react-data-grid/theming-parameters/#finding-theme-parameters
- **Eight feature pages now point at the appropriate section of the API reference** instead of "search the Theme Builder". Where the params are scattered across reference sections (Borders, Colours, Shadows), the Theme Builder search is preserved alongside the reference link:
  - https://www.ag-grid.com/archive/35.3.0/react-data-grid/theming-borders/
  - https://www.ag-grid.com/archive/35.3.0/react-data-grid/theming-colors/#colour-parameters
  - https://www.ag-grid.com/archive/35.3.0/react-data-grid/theming-compactness/#more-compactness-parameters
  - https://www.ag-grid.com/archive/35.3.0/react-data-grid/theming-headers/
  - https://www.ag-grid.com/archive/35.3.0/react-data-grid/theming-popups/#drop-shadows
  - https://www.ag-grid.com/archive/35.3.0/react-data-grid/theming-tool-panels/#styling-the-sidebar-area
  - https://www.ag-grid.com/archive/35.3.0/react-data-grid/theming-widgets/#styling-text-inputs
  - https://www.ag-grid.com/archive/35.3.0/react-data-grid/theming-widgets/#styling-checkboxes
- **`theming-distribution:37`** — `createPart` description now correctly describes the API surface (was "takes the following arguments", implying positional args; actually takes one options object). https://www.ag-grid.com/archive/35.3.0/react-data-grid/theming-distribution/#creating-your-own-parts

## Tier 3 — Minor fixes (summary)

See the diff for the full list.

- **UK English in prose** — ~9 instances of `color`/`colors`/`colored` → `colour`/`colours`/`coloured` across `theming-master-detail`, `theming-migration`, `theming-parts`, `theming-selections`, `theming-widgets`. API parameter names inside backticks intentionally stay US English.
- **Typos** — `Typescript` → `TypeScript`; `it name` → `its name`; `form` → `from`; `variable` → `variables` (plural agreement); `applications'` → `application's` (singular possessive).
- **Punctuation** — missing comma in a list (`theming-parameters:52`); missing space before inline code (`theming-parameters:110`); parens added around "see below" (`theming/index:32`).
- **Padding-word removals** — "It is also possible to" → "You can also" (`theming-colors:109`); "in order to" dropped (`theming-distribution:78`).
- **Grammar / sentence-structure fixes** — sentence fragment → imperative (`theming-fonts:5`); ungrammatical "style the all … header" rewritten (`theming-headers:65`); run-on `--ag-grid-size` entry split (`theming-migration:112`); subject-verb agreement "has" → "have" (`theming-migration:282`); comma splice (`theming-theme-builder:31`).
- **Tone / flow polish** — text colour bullets split into three discrete bullets (`theming-colors:30`); overpacked opener compressed (`theming-master-detail:45`); 5-sentence implementation narration compressed to 2 (`theming/index:53`).
- **Structure** — duplicate `### 4.` heading in `theming-migration` renumbered to `### 5.`.