### PR TITLE
[RTI-3312] Fix(toolbar): row group panel and pivot panel placeholder text appears bolder than existing rgp and pp panels

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_toolbar.scss
+++ b/community-modules/styles/src/internal/base/parts/_toolbar.scss
@@ -11,7 +11,6 @@
         color: var(--ag-toolbar-text-color);
         font-family: var(--ag-header-font-family);
         font-size: var(--ag-header-font-size);
-        font-weight: var(--ag-header-font-weight);
         white-space: nowrap;
     }
 
@@ -22,6 +21,10 @@
     .ag-toolbar-item {
         display: inline-flex;
         margin: 0 calc(var(--ag-grid-size, 8px) * 2);
+    }
+
+    .ag-toolbar-item:where(:not(.ag-toolbar-panel)) {
+        font-weight: var(--ag-header-font-weight);
     }
 
     .ag-toolbar-button-wrapper {
@@ -164,7 +167,6 @@
         background-color: transparent;
         border-bottom: none;
         padding: 0;
-        font-weight: normal;
         font-size: var(--ag-font-size);
         font-family: var(--ag-font-family);
     }

--- a/community-modules/styles/src/internal/themes/alpine/_index.scss
+++ b/community-modules/styles/src/internal/themes/alpine/_index.scss
@@ -17,7 +17,7 @@
         color: var(--ag-header-foreground-color);
     }
 
-    .ag-toolbar {
+    .ag-toolbar-item:where(:not(.ag-toolbar-panel)) {
         font-weight: 700;
     }
 

--- a/community-modules/styles/src/internal/themes/balham/_index.scss
+++ b/community-modules/styles/src/internal/themes/balham/_index.scss
@@ -85,7 +85,7 @@
         height: var(--ag-header-height);
     }
 
-    .ag-toolbar {
+    .ag-toolbar-item:where(:not(.ag-toolbar-panel)) {
         font-weight: 600;
     }
 

--- a/community-modules/styles/src/internal/themes/material/_index.scss
+++ b/community-modules/styles/src/internal/themes/material/_index.scss
@@ -26,8 +26,11 @@
         background-color: var(--ag-subheader-background-color);
     }
 
-    .ag-toolbar {
+    .ag-toolbar-item:where(:not(.ag-toolbar-panel)) {
         font-weight: 600;
+    }
+
+    .ag-toolbar-item {
         font-size: calc(var(--ag-font-size) - 1px);
     }
 

--- a/community-modules/styles/src/internal/themes/quartz/_index.scss
+++ b/community-modules/styles/src/internal/themes/quartz/_index.scss
@@ -17,7 +17,7 @@
         color: var(--ag-header-foreground-color);
     }
 
-    .ag-toolbar {
+    .ag-toolbar-item:where(:not(.ag-toolbar-panel)) {
         font-weight: 500;
     }
 

--- a/packages/ag-grid-enterprise/src/toolbar/agToolbar.css
+++ b/packages/ag-grid-enterprise/src/toolbar/agToolbar.css
@@ -8,7 +8,6 @@
     color: var(--ag-toolbar-text-color);
     font-family: var(--ag-header-font-family);
     font-size: var(--ag-header-font-size);
-    font-weight: var(--ag-header-font-weight);
     white-space: nowrap;
 }
 
@@ -18,6 +17,10 @@
 
 .ag-toolbar-item {
     display: inline-flex;
+}
+
+.ag-toolbar-item:where(:not(.ag-toolbar-panel)) {
+    font-weight: var(--ag-header-font-weight);
 }
 
 .ag-toolbar-button-wrapper {
@@ -30,13 +33,13 @@
     display: inline-flex;
     align-items: center;
     gap: var(--ag-spacing);
-    padding: calc(var(--ag-spacing));
+    padding: var(--ag-spacing);
     border: 0;
     background: transparent;
-    color: var(--ag-header-foreground-color);
-    font-family: inherit;
+    color: var(--ag-toolbar-text-color);
+    font-family: var(--ag-header-font-family);
     font-size: var(--ag-header-font-size);
-    font-weight: inherit;
+    font-weight: var(--ag-header-font-weight);
     cursor: pointer;
     line-height: 1;
     white-space: nowrap;
@@ -155,7 +158,6 @@
     background-color: transparent;
     border-bottom: none;
     padding: 0;
-    font-weight: var(--ag-cell-font-weight);
     font-size: var(--ag-font-size);
     font-family: var(--ag-cell-font-family);
 }


### PR DESCRIPTION
Fix toolbar panel placeholder text appearing bolder than row group and pivot panels

Scope font-weight to non-panel toolbar items only, so column drop panels inherit normal weight instead of the header font-weight.

Fix [RTI-3312](https://ag-grid.atlassian.net/browse/RTI-3312) 