### PR TITLE
RTI-3337 Follow-up theming docs fixes

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/theming-compactness/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-compactness/index.mdoc
@@ -6,7 +6,7 @@ Add more white space or pack more data into the UI.
 
 `spacing` is the main theme parameter that controls how tightly data and UI elements are packed together. All padding in the grid is defined as a multiple of this value, so increasing it will make most components larger by increasing their internal white space while leaving the size of text and icons unchanged.
 
-In the following example, classes are applied to the grid container that change compactness dynamically:
+The following example changes compactness dynamically by updating the `--ag-spacing` CSS custom property:
 
 {% gridExampleRunner title="Dynamic Height" name="dynamic-height"  exampleHeight=450 /%}
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-headers/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-headers/index.mdoc
@@ -21,14 +21,14 @@ For the full list, see the [Headers section](./theming-api/#reference-headers) o
 When the theme parameters are not enough you can use CSS classes, in particular `ag-header`, `ag-header-cell`, and `ag-header-group-cell`:
 
 ```css
-.ag-theme-quartz .ag-header {
+.ag-header {
     font-family: cursive;
 }
-.ag-theme-quartz .ag-header-group-cell {
+.ag-header-group-cell {
     font-weight: normal;
     font-size: 22px;
 }
-.ag-theme-quartz .ag-header-cell {
+.ag-header-cell {
     font-size: 18px;
 }
 ```

--- a/documentation/ag-grid-docs/src/content/docs/theming-parameters/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-parameters/index.mdoc
@@ -117,7 +117,7 @@ All parameters ending "ColorScheme" (and there is only one: `browserColorScheme`
 
 All parameters ending "Duration" are duration values. These can accept any [valid CSS time value](https://developer.mozilla.org/en-US/docs/Web/CSS/time), such as `'1s'`, `'500ms'` and variable expressions (`'var(--myAnimationDelayTime)'`). In addition, the following syntax is supported:
 
-| Syntax                         | Description                                                                                                          |
-| ------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| `0.4`                          | A plain number is treated as a number of **seconds** (so `0.4` becomes `0.4s`). To use milliseconds, pass `'400ms'`. |
-| `{ ref: 'someOtherDuration' }` | Use the same value as another duration parameter.                                                                    |
+| Syntax                         | Description                                                                |
+| ------------------------------ | -------------------------------------------------------------------------- |
+| `0.4`                          | A plain number is treated as a number of seconds, so `0.4` becomes `0.4s`. |
+| `{ ref: 'someOtherDuration' }` | Use the same value as another duration parameter.                          |

--- a/documentation/ag-grid-docs/src/content/docs/theming-parameters/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-parameters/index.mdoc
@@ -93,9 +93,12 @@ All parameters ending "Scale" are scale values, which are multiplied by other va
 
 All parameters ending "Shadow" are shadow values. These can accept any [valid CSS box-shadow value](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow), such as `2px 2px 4px 2px rgba(0, 0, 0, 0.5)` and variable expressions (`var(--myShadowVar)`). In addition, the following syntax is supported:
 
-| Syntax                                                                          | Description                                                                                                                                                                                                                             |
-| ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `{ offsetX: 2, offsetY: 2, radius: 4, spread: 2, color: 'rgba(0, 0, 0, 0.5)' }` | An object with 5 optional properties. `offsetX`, `offsetY`, `radius` and `spread` take any [length value](#length-values) and default to 0. `color` takes any [color value](#color-values) and defaults to `{ ref: 'foregroundColor' }` |
+| Syntax                                                                                        | Description                                                                                                                                                                                                                                                           |
+| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `{ offsetX: 2, offsetY: 2, radius: 4, spread: 2, color: 'rgba(0, 0, 0, 0.5)', inset: false }` | An object with 6 optional properties. `offsetX`, `offsetY`, `radius` and `spread` take any [length value](#length-values) and default to 0. `color` takes any [color value](#color-values) and defaults to `{ ref: 'foregroundColor' }`. `inset` defaults to `false`. |
+| Array of objects                                                                              | Pass an array of shadow objects to apply multiple stacked shadows, e.g. `[{ offsetY: 1, radius: 2 }, { offsetY: 4, radius: 8 }]`.                                                                                                                                     |
+| `{ ref: 'cardShadow' }`                                                                       | Use the same value as the `cardShadow` parameter.                                                                                                                                                                                                                     |
+| `false`                                                                                       | A shorthand for `'none'` (no shadow).                                                                                                                                                                                                                                 |
 
 ### Image Values
 
@@ -112,4 +115,9 @@ All parameters ending "ColorScheme" (and there is only one: `browserColorScheme`
 
 ### Duration Values
 
-All parameters ending "Duration" are duration values. These can accept any [valid CSS time value](https://developer.mozilla.org/en-US/docs/Web/CSS/time), such as `1s`, `500ms` and variable expressions (`var(--myAnimationDelayTime)`).
+All parameters ending "Duration" are duration values. These can accept any [valid CSS time value](https://developer.mozilla.org/en-US/docs/Web/CSS/time), such as `'1s'`, `'500ms'` and variable expressions (`'var(--myAnimationDelayTime)'`). In addition, the following syntax is supported:
+
+| Syntax                         | Description                                                                                                          |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `0.4`                          | A plain number is treated as a number of **seconds** (so `0.4` becomes `0.4s`). To use milliseconds, pass `'400ms'`. |
+| `{ ref: 'someOtherDuration' }` | Use the same value as another duration parameter.                                                                    |

--- a/documentation/ag-grid-docs/src/content/docs/theming-widgets/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-widgets/index.mdoc
@@ -2,7 +2,7 @@
 title: "Customising Inputs & Widgets"
 ---
 
-Style text inputs, checkboxes, toggle buttons and range sliders.
+Style text inputs, checkboxes and toggle buttons.
 
 ## Styling Text Inputs
 


### PR DESCRIPTION
Fix [RTI-3337](https://ag-grid.atlassian.net/browse/RTI-3337)

Follow-up to [AG-13722](https://ag-grid.atlassian.net/browse/AG-13722). A second review pass on the same set of theming pages surfaced five fixes the first pass did not catch.

## Summary

- `theming-parameters` — Document `DurationValue` plain-number form (treated as **seconds**, not milliseconds — a user passing `300` thinking ms gets 300s). Add `ShadowValue` table rows for `inset`, array form, `{ ref }`, and `false → 'none'`.
- `theming-compactness` — Lead-in described the example as applying classes to the grid container; the example actually updates the `--ag-spacing` CSS custom property via a slider.
- `theming-widgets` — Intro promised coverage of range sliders, but the page has no range-slider section or example. Removed from the intro.
- `theming-headers` — Inline CSS snippet was prefixed with `.ag-theme-quartz`; the prefix is not required with the Theming API and the example's `styles.css` uses bare selectors. Snippet now matches.