### PR TITLE
[RTI-3343] Fix(toolbar): row group panel and pivot panel show scrollbar when empty

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_toolbar.scss
+++ b/community-modules/styles/src/internal/base/parts/_toolbar.scss
@@ -88,7 +88,7 @@
     .ag-toolbar-panel {
         display: inline-flex;
         flex: 1;
-        min-width: 235px;
+        min-width: 260px;
     }
 
     .ag-toolbar-input {

--- a/packages/ag-grid-enterprise/src/toolbar/agToolbar.css
+++ b/packages/ag-grid-enterprise/src/toolbar/agToolbar.css
@@ -87,7 +87,7 @@
 .ag-toolbar-panel {
     display: inline-flex;
     flex: 1;
-    min-width: 235px;
+    min-width: 260px;
     padding: 0 calc(var(--ag-spacing) * 2);
 }
 


### PR DESCRIPTION
Fix toolbar panel min-width to prevent scrollbar when row group and pivot panels are empty

- Increase `ag-toolbar-panel` min-width from 235px to 260px in legacy theme and Theming API CSS

Fix [RTI-3343](https://ag-grid.atlassian.net/browse/RTI-3343)