### PR TITLE
AG-17289 Fix release date for 35.3.0 (13th -> 12th May 2026)

### DIFF
--- a/documentation/ag-grid-docs/public/changelog/releases/35_3_0.md
+++ b/documentation/ag-grid-docs/public/changelog/releases/35_3_0.md
@@ -1,4 +1,4 @@
-#### 13th May 2026 - Grid v35.3.0 (Charts v13.3.0)
+#### 12th May 2026 - Grid v35.3.0 (Charts v13.3.0)
 
 See table below for changes included in this release.
 

--- a/documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json
+++ b/documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json
@@ -1,7 +1,7 @@
 [
     {
         "version": "35.3.0",
-        "date": "13th May 2026",
+        "date": "12th May 2026",
         "landingPageHighlight": "Quick Access Toolbar, Cell Notes, Grand Total Row for server-side row model, Performance Improvements, Quality Improvements",
         "highlights": [
             {


### PR DESCRIPTION
Fixes the 35.3.0 release date in the docs archive from `13th May 2026` to `12th May 2026`.

Files changed:
- `documentation/ag-grid-docs/public/changelog/releases/35_3_0.md`
- `documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json`

Targets the `b35.3.0` release branch. `latest` will pick up the corrected date via the standard release flow.

Fix [AG-17289](https://ag-grid.atlassian.net/browse/AG-17289)