### PR TITLE
RTI-3346 Fix SSRM documentation inaccuracies

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-changing-columns/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-changing-columns/index.mdoc
@@ -3,7 +3,7 @@ title: "SSRM Changing Columns"
 enterprise: true
 ---
 
-It is possible to add and remove columns to the Server-Side Row Model without having the row model reset.
+Columns can be added and removed from the Server-Side Row Model without resetting the row model.
 
 [Changing columns](./column-updating-definitions/) allows you to specify new column definitions to the grid and
 the grid will work out which columns are new and which are old, keeping the state of the old columns.

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-configuration/_examples/cache-block-state/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-configuration/_examples/cache-block-state/main.ts
@@ -38,7 +38,7 @@ const gridOptions: GridOptions<IOlympicDataWithId> = {
     // use the server-side row model
     rowModelType: 'serverSide',
 
-    // only keep 4 blocks of rows (default is keep all rows)
+    // only keep 2 blocks of rows (default is keep all rows)
     maxBlocksInCache: 2,
     debug: true,
 };

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-datasource/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-datasource/index.mdoc
@@ -61,7 +61,7 @@ Notice that the datasource contains a single method `getRows(params)` which is c
 required. A request is supplied in the `params` object which contains all the information required by the server to
 fetch data from the server.
 
-Rows fetched from the server are supplied to the grid via `params.success(data)`.
+Rows fetched from the server are supplied to the grid via `params.success({ rowData: rows })`.
 
 ## Registering the Datasource
 

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/_examples/advanced-filter/fakeServer.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/_examples/advanced-filter/fakeServer.ts
@@ -47,7 +47,7 @@ export function FakeServer(allData) {
             } else if (model.filterType === 'number') {
                 return numberFilterMapper(model.colId, model);
             } else {
-                console.log('filter type not implemented: ' + item.filterType);
+                console.log('filter type not implemented: ' + model.filterType);
                 return ' 1 = 1 ';
             }
         }

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/index.mdoc
@@ -152,9 +152,9 @@ The example below demonstrates Server-side Filtering using the Set Filter. Note 
 
 The [New Filters Tool Panel](./tool-panel-filters-new/) allows for filter changes to be batched together before a new `getRows` request is sent to the datasource.
 
-This is possible by configuring the Filters Tool Panel to [Use Buttons](./tool-panel-filters-new/#using-buttons). Each filter can then be edited in the tool panel, and one request will be sent when the global apply button is clicked.
+This is possible by configuring the New Filters Tool Panel to [Use Buttons](./tool-panel-filters-new/#using-buttons). Each filter can then be edited in the tool panel, and one request will be sent when the global apply button is clicked.
 
-{% gridExampleRunner title="Set Filter Server-Side Filtering" name="global-apply" /%}
+{% gridExampleRunner title="Batching Filter Requests" name="global-apply" /%}
 
 ## Advanced Filter
 

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/group-footer-multiple-cols/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/group-footer-multiple-cols/main.ts
@@ -6,13 +6,7 @@ import type {
     IServerSideGetRowsParams,
     IsServerSideGroupOpenByDefaultParams,
 } from 'ag-grid-community';
-import {
-    GetServerSideGroupLevelParamsParams,
-    ModuleRegistry,
-    ServerSideGroupLevelParams,
-    ValidationModule,
-    createGrid,
-} from 'ag-grid-community';
+import { ModuleRegistry, ValidationModule, createGrid } from 'ag-grid-community';
 import { RowGroupingModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
 
 import { FakeServer } from './fakeServer';

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/group-footer/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/group-footer/main.ts
@@ -6,13 +6,7 @@ import type {
     IServerSideGetRowsParams,
     IsServerSideGroupOpenByDefaultParams,
 } from 'ag-grid-community';
-import {
-    GetServerSideGroupLevelParamsParams,
-    ModuleRegistry,
-    ServerSideGroupLevelParams,
-    ValidationModule,
-    createGrid,
-} from 'ag-grid-community';
+import { ModuleRegistry, ValidationModule, createGrid } from 'ag-grid-community';
 import { RowGroupingModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
 
 import { FakeServer } from './fakeServer';

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/open-by-default/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/open-by-default/main.ts
@@ -6,13 +6,7 @@ import type {
     IServerSideGetRowsParams,
     IsServerSideGroupOpenByDefaultParams,
 } from 'ag-grid-community';
-import {
-    GetServerSideGroupLevelParamsParams,
-    ModuleRegistry,
-    ServerSideGroupLevelParams,
-    ValidationModule,
-    createGrid,
-} from 'ag-grid-community';
+import { ModuleRegistry, ValidationModule, createGrid } from 'ag-grid-community';
 import { RowGroupingModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
 
 import { FakeServer } from './fakeServer';

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/index.mdoc
@@ -263,7 +263,7 @@ In the example below, note the following:
 
 {% gridExampleRunner title="Filtering" name="filtering"  exampleHeight=590 /%}
 
-## Batching Data Requests
+## Deferred Column Configuration
 
 You can configure the Columns Tool Panel to stage changes and require an explicit **Apply** action before they are committed. This allows multiple configuration changes to be made and applied in a single update, avoiding unnecessary intermediate recomputations or requests.
 

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-master-detail/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-master-detail/index.mdoc
@@ -185,7 +185,7 @@ const gridOptions = {
     getRowHeight: params => {
         const isDetailRow = params.node.detail;
 
-        // not that this callback gets called for all rows, not just the detail row
+        // note that this callback gets called for all rows, not just the detail row
         if (isDetailRow) {
             // dynamically calculate detail row height
             return params.data.children.length * 50;
@@ -200,9 +200,7 @@ Option 3 - use autoHeight
 
 ```{% frameworkTransform=true %}
 const gridOptions = {
-    detailCellRendererParams: {
-        autoHeight: true,
-    }
+    detailRowAutoHeight: true,
 }
 ```
 

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-pagination/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-pagination/index.mdoc
@@ -53,7 +53,7 @@ in the response to the grid. See [Server-Side Datasource](./server-side-model-da
 The example below demonstrates server-side Pagination. Note the following:
 
 - Pagination is enabled using the grid option `pagination=true`.
-- A pagination page size of 10 (default is 100) is set using the grid option `paginationPageSize=10`.
+- A pagination page size of 20 (default is 100) is set using the grid option `paginationPageSize=20`.
 - The number of rows returned per request is set to 10 (default is 100) using `cacheBlockSize=10`.
 - Use the arrows in the pagination panel to traverse the data. Note the last page arrow is greyed
   out as the last row index is only supplied to the grid when the last row has been reached.

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/index.mdoc
@@ -164,7 +164,7 @@ function addPivotResultCols(response, api) {
 }
 ```
 
-In the code above, `addPivotColDefs` does not create column groups for simplicity. However, the example below shows a
+In the code above, `addPivotResultCols` does not create column groups for simplicity. However, the example below shows a
 more complex implementation that creates column groups. Note the following:
 
 - Column definitions are created from the `pivotFields` are returned from the server.

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-retry/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-retry/index.mdoc
@@ -3,7 +3,7 @@ title: "Load Retry"
 enterprise: true
 ---
 
-When a datasource load fails, it is possible to retry loading the rows again at a later time.
+When a datasource load fails, call `retryServerSideLoads()` to reload the failed rows at a later time.
 
 When loading fails, the datasource informs the grid of such using the `fail()` callback instead of using the `success()` callback. Calling `fail()` puts the loading rows into a Loading Failed state which hides the loading spinner. No data is shown in these rows as they are not loaded.
 

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/resetting-row-height/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/resetting-row-height/main.ts
@@ -1,27 +1,15 @@
 import type { GridApi, GridOptions } from 'ag-grid-community';
 import {
-    ColumnsToolPanelModule,
-    FiltersToolPanelModule,
     ModuleRegistry,
-    NumberFilterModule,
-    PivotModule,
     ServerSideRowModelApiModule,
     ServerSideRowModelModule,
-    SetFilterModule,
-    TextFilterModule,
     ValidationModule,
     createGrid,
 } from 'ag-grid-enterprise';
 
 ModuleRegistry.registerModules([
-    NumberFilterModule,
     ServerSideRowModelModule,
     ServerSideRowModelApiModule,
-    ColumnsToolPanelModule,
-    FiltersToolPanelModule,
-    SetFilterModule,
-    PivotModule,
-    TextFilterModule,
     ...(process.env.NODE_ENV !== 'production' ? [ValidationModule] : []),
 ]);
 
@@ -39,7 +27,6 @@ const gridOptions: GridOptions<IOlympicDataWithId> = {
         { field: 'bronze' },
         { field: 'total' },
     ],
-    // theme: 'legacy',
     defaultColDef: {
         flex: 1,
         minWidth: 100,

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-selection/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-selection/index.mdoc
@@ -81,7 +81,7 @@ In the example below, note the following;
 The below snippet demonstrates how to set all nodes as selected, except in the case of the "United States" group, whose only selected child is the row with the ID `group-country-year-United States2004`.
 
 ```{% frameworkTransform=true spaceBetweenProperties=true %}
-params.api.setServerSideSelectionState({
+api.setServerSideSelectionState({
     // this root level config can be used to determine a global select-all
     selectAllChildren: true,
     // all of the top level group nodes which do not conform with the select all value will have an entry here

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-tree-data/_examples/purging-tree-data/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-tree-data/_examples/purging-tree-data/main.ts
@@ -7,7 +7,7 @@ import type {
     IServerSideGetRowsRequest,
     IsServerSideGroupOpenByDefaultParams,
 } from 'ag-grid-community';
-import { IsServerSideGroup, ModuleRegistry, ValidationModule, createGrid } from 'ag-grid-community';
+import { ModuleRegistry, ValidationModule, createGrid } from 'ag-grid-community';
 import {
     ColumnMenuModule,
     ColumnsToolPanelModule,

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-refresh/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-refresh/index.mdoc
@@ -21,7 +21,7 @@ To ensure your grid reflects the latest data on your server, you can periodicall
 
 The following example provides a simple demonstration of the different behaviours of the refresh API, note the following:
 
-- Using the **Refresh** button, you can request that all the rows are requested from the server again, bringing them up to date with the server version.
+- Using the **Refresh Rows** button, you can request that all the rows are requested from the server again, bringing them up to date with the server version.
 - Because [Row IDs](./server-side-model-configuration/#providing-row-ids) have been implemented, the grid is able to detect which rows have been updated, and flash cells when using `enableCellChangeFlash`.
 - The `Purge` checkbox enables the purge option in the API call, this causes all rows (and all row state except row selection state) to be reset when the refresh call is made, and replaced with loading rows.
 - When a refresh is finished, note the `storeRefreshed` event is fired, and logged in the console. This is not fired when the purge option is enabled as the rows are reset not refreshed.
@@ -35,8 +35,8 @@ When using row grouping with refreshing you are required to provide a route para
 The following example demonstrates how to refresh specified groups on the server, note the following:
 
 - Using the **Refresh Root Level** button, you can force all the rows in the root level group to refresh, this is equivalent to omitting a route parameter from the `refreshServerSide` API call.
-- The **Refresh \['Canada']** button only refreshes the direct children of the `Canada` row group.
-- The **Refresh \['Canada', '2002']** button only refreshes the direct children of the `2002` row group that belongs to the `Canada` row group.
+- The **Refresh \['Canada'] Group** button only refreshes the direct children of the `Canada` row group.
+- The **Refresh \['Canada', '2002'] Group** button only refreshes the direct children of the `2002` row group that belongs to the `Canada` row group.
 - Because [Row IDs](./server-side-model-configuration/#providing-row-ids) have been implemented, the grid is able to retain the state for reloaded rows, such as whether a group row was expanded.
 - When a refresh is finished, note the `storeRefreshed` event is fired, and logged in the console.
 

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-single-row/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-single-row/index.mdoc
@@ -52,6 +52,6 @@ The example below demonstrates this snippet in action;
 The example below demonstrates how to update all of the rows which the user has selected, note the following:
 
 - The **Update Selected Rows** button will update the row version directly on the selected row nodes.
-- The selected nodes are obtained using the `api.getSelectedNodes()` api, and are then individually updated.
+- The selected nodes are obtained using `api.getSelectedNodes()`, and are then individually updated.
 
 {% gridExampleRunner title="Updating Selected Rows" name="updating-selected-row"  exampleHeight=615 /%}

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/index.mdoc
@@ -3,7 +3,7 @@ title: "SSRM Transactions"
 enterprise: true
 ---
 
-This section show how rows can be added, removed and updated using the Server-Side Transaction API.
+This section shows how rows can be added, removed and updated using the Server-Side Transaction API.
 
 {% note %}
 Server-Side Transactions require [Row IDs](./server-side-model-configuration/#providing-row-ids) to be supplied to grid.
@@ -39,7 +39,7 @@ The following example demonstrates add / update and remove operations via the Se
 
 - When clicking any of the buttons, the console logs each transaction as it is applied to the grid.
 - **Add Above Selected** - adds a row above the selected row using the `addIndex` property as rows are added at the end by default.
-- **Updated Selected** - updates the 'current' value on the selected row.
+- **Update Selected** - updates the 'current' value on the selected row.
 - **Removed Selected** - removes the selected row.
 
 {% gridExampleRunner title="Server-Side Transaction API" name="transactions-simple"  exampleHeight=615 /%}
@@ -100,7 +100,7 @@ api.applyServerSideTransactionAsync({
 
 In the example below, note the following:
 
-- After starting the updates, 1 row is created, 10 rows are updated, and 1 rows is deleted every 10 milliseconds.
+- After starting the updates, 1 row is created, 10 rows are updated, and 1 row is deleted every 10 milliseconds.
 - The transactions are batched, and only executed once every second.
 
 {% gridExampleRunner title="Asynchronous Example" name="transactions-async"  exampleHeight=615 /%}

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-updating/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-updating/index.mdoc
@@ -17,4 +17,4 @@ The different options for keeping the grid updated are as follows:
     - If yes, do you need to handle creating and removing rows?
         - If yes, then use [Transactions](./server-side-model-updating-transactions/)
         - If not, try [Single Row Updates](./server-side-model-updating-single-row/)
-    - If not, then [Refresh The Grid](./server-side-model-updating-refresh/)
+    - If not, then [Refresh](./server-side-model-updating-refresh/)


### PR DESCRIPTION
Fix technical inaccuracies across 20 SSRM documentation pages found during a systematic review.

## Changes

- Fix `ReferenceError` in advanced-filter example (`item` → `model`)
- Fix master-detail Option 3 snippet using non-existent `detailCellRendererParams.autoHeight` — correct property is top-level `detailRowAutoHeight`
- Fix `paginationPageSize` claim in pagination docs (10 → 20) to match example
- Fix misleading `params.success(data)` prose in datasource page — correct form is `params.success({ rowData: rows })`
- Fix stale function name `addPivotColDefs` → `addPivotResultCols` in pivoting docs
- Fix button label mismatches in updating-refresh and updating-transactions docs
- Fix grammar errors and padding phrases across retry, changing-columns, updating-transactions pages
- Fix duplicate example title and inconsistent term in filtering page
- Rename misleading "Batching Data Requests" section in grouping to "Deferred Column Configuration"
- Remove unused module imports from grouping, tree-data, and row-height examples
- Remove stale `// theme: 'legacy'` comment and fix stale block-count comment in examples
- Normalise `params.api` → `api` in selection snippet

Fix [RTI-3346](https://ag-grid.atlassian.net/browse/RTI-3346)