### PR TITLE
rulesync-fetch: fall back to SSH when consumer origin is SSH

### DIFF
--- a/external/ag-shared/scripts/rulesync-fetch/fetch.sh
+++ b/external/ag-shared/scripts/rulesync-fetch/fetch.sh
@@ -11,7 +11,12 @@
 #   3. gh CLI                  — if `gh auth token` resolves a token, use it
 #                                the same way as GITHUB_TOKEN. Transparent for
 #                                developers already logged in with `gh`.
-#   4. Fallback                 — https clone with no explicit credentials; git's
+#   4. Consumer origin is SSH  — if the consumer repo's `origin` remote points
+#                                at github.com over SSH, mirror that scheme.
+#                                Cheap and local (single `git config` read),
+#                                and a strong signal that the developer has
+#                                working SSH keys for github.com.
+#   5. Fallback                 — https clone with no explicit credentials; git's
 #                                credential helper (osxkeychain, manager, etc.)
 #                                supplies auth. The dev workstation path.
 #
@@ -51,6 +56,12 @@ elif command -v gh >/dev/null 2>&1 && _gh_token="$(gh auth token 2>/dev/null)" &
         AUTH_MODE="gh"
     fi
     unset _gh_token
+elif _origin_url=$(git config --get remote.origin.url 2>/dev/null) && [[ "$_origin_url" =~ ^(git@github\.com:|ssh://git@github\.com/) ]]; then
+    # No gh / GITHUB_TOKEN, but the consumer repo was cloned over SSH. The
+    # developer almost certainly has working SSH keys for github.com, so mirror
+    # that scheme rather than falling through to an HTTPS prompt.
+    AUTH_MODE="origin-ssh"
+    unset _origin_url
 else
     AUTH_MODE="https"
 fi
@@ -72,9 +83,10 @@ fi
 
 resolve_repo_url() {
     case "$AUTH_MODE" in
-        override) echo "$AG_DEV_PROMPTS_REPO" ;;
-        gh-ssh)   echo "git@github.com:${REPO_SLUG}.git" ;;
-        *)        echo "https://github.com/${REPO_SLUG}.git" ;;
+        override)   echo "$AG_DEV_PROMPTS_REPO" ;;
+        gh-ssh)     echo "git@github.com:${REPO_SLUG}.git" ;;
+        origin-ssh) echo "git@github.com:${REPO_SLUG}.git" ;;
+        *)          echo "https://github.com/${REPO_SLUG}.git" ;;
     esac
 }
 
@@ -163,6 +175,36 @@ SSH clone was attempted from $REPO_URL and failed. Likely causes:
   * Prefer HTTPS? Switch gh's git protocol and re-run:
       gh config set -h github.com git_protocol https
       gh auth setup-git
+      yarn
+
+Verify SSH access directly:
+  ssh -T git@github.com
+EOF
+            ;;
+        origin-ssh)
+            cat >&2 <<EOF
+Auth path: SSH inferred from the consumer repo's origin remote.
+
+No GITHUB_TOKEN and no \`gh\` login were found, but this repo's \`origin\`
+points at github.com over SSH, so we tried the same scheme for
+${REPO_SLUG} and it failed. Likely causes:
+
+  * SSH key not loaded into ssh-agent:
+      ssh-add -l
+      ssh-add ~/.ssh/id_ed25519     # or your key path
+
+  * SSH key registered with GitHub but missing SAML SSO authorization
+    for the ag-grid org:
+      # Authorize: https://github.com/organizations/ag-grid/sso
+
+  * Prefer HTTPS instead? Install gh and authenticate:
+      brew install gh
+      gh auth login --hostname github.com --git-protocol https --web
+      gh auth setup-git
+      yarn
+
+  * Or supply a token directly:
+      export GITHUB_TOKEN=ghp_...
       yarn
 
 Verify SSH access directly:


### PR DESCRIPTION
## Summary

Reported in [Slack](https://ag-grid.slack.com/archives/C0ABU0FQF1R/p1778418058851609): running `yarn` prompted for a GitHub username/password during the ag-dev-prompts fetch on a workstation already authenticated to GitHub via SSH keys.

`external/ag-shared/scripts/rulesync-fetch/fetch.sh` resolves auth in this order:

1. `AG_DEV_PROMPTS_REPO` override
2. `GITHUB_TOKEN`
3. `gh auth token` (matches gh's configured git_protocol)
4. **HTTPS fallback** — relies on git's credential helper, which prompts when no creds are cached

Developers without `gh` installed but with working SSH keys for github.com (i.e. they cloned the consumer repo over SSH) currently land on step 4 and get the prompt. SSH is never attempted.

This PR inserts a new step between 3 and 4: read `git config --get remote.origin.url` (cheap, local, no network) and, if the consumer repo's origin is `git@github.com:…` or `ssh://git@github.com/…`, clone ag-dev-prompts over SSH using the same scheme. Includes a tailored remediation message for the new `origin-ssh` auth mode.

Existing flows (HTTPS clones, gh, GITHUB_TOKEN, AG_DEV_PROMPTS_REPO override) are unchanged.

**Note:** We're in code freeze, so this is not being synced back to `ag-shared` yet — change lives only in this repo for now.

## Test plan

- [ ] On an SSH-cloned checkout with no `gh` and no `GITHUB_TOKEN`: `rm -rf ~/.cache/ag-dev-prompts && yarn` succeeds without an HTTPS prompt
- [ ] On an HTTPS-cloned checkout: behaviour unchanged (still HTTPS fallback)
- [ ] With `gh auth token` available: still uses gh path
- [ ] With `GITHUB_TOKEN` set: still uses token path