### PR TITLE
Sync ag-shared: SSH fallback + snyk fixes

### DIFF
--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = e28574f98fdffd9a3e1b9f03a63ec844a6d848e8
-	parent = d1d5936813bd20150cc1ff101bebd06503ab2a1f
+	commit = d6f93e4d145bf572ede20199bcaf1094aef3cf2c
+	parent = 4d1c1c36341f1ce9d9b1494b38bc5c89bff0ef94
 	method = rebase
 	cmdver = 0.4.9


### PR DESCRIPTION
## Summary
Sync ag-shared subrepo to all consuming repos.

### Changes
- **rulesync-fetch SSH fallback** — `fetch.sh` now detects when the consumer repo's `origin` remote uses SSH and mirrors that scheme for plugin fetches, avoiding HTTPS auth prompts for SSH-cloned repos
- **snyk-viewer fix** — `addSnykIgnoreEntry()` collapses `ignore: {}` to `ignore:` before inserting vuln blocks (fixes YAML parse errors); coloured URL in server startup message
- **snykClean.mjs** — deletes `.snyk` files that become empty after cleanup (both `ignore` and `patch` sections are `{}`); adds `isSnykFileEmpty()` helper

## Cross-repo PRs
- ag-charts: https://github.com/ag-grid/ag-charts/pull/6839
- ag-studio: https://github.com/ag-grid/ag-studio/pull/1468

## Test plan
- [ ] Verify ag-shared content matches across all repos
- [ ] Verify `fetch.sh` SSH fallback works for SSH-cloned repos
- [ ] Run setup-prompts verification in each repo