### PR TITLE
Use apiDocumentation for ColDef properties

### DIFF
--- a/documentation/ag-grid-docs/src/components/reference-documentation/utils/getInterfaceDocumentationModel.ts
+++ b/documentation/ag-grid-docs/src/components/reference-documentation/utils/getInterfaceDocumentationModel.ts
@@ -212,6 +212,9 @@ function getDocCode({
     };
 }
 
+// These should use apiDocumentation so that @agModule tag is correctly rendered.
+const DISALLOWED_INTERFACE_NAMES = ['ColDef', 'GridOptions'];
+
 export function getInterfaceDocumentationModel({
     framework,
     interfaceName,
@@ -222,6 +225,12 @@ export function getInterfaceDocumentationModel({
     interfaceLookup,
     codeLookup,
 }: Params): InterfaceDocumentationModel {
+    if (DISALLOWED_INTERFACE_NAMES.includes(interfaceName)) {
+        throw new Error(
+            `<interface-documentation>: '${interfaceName}' should not be used with interfaceDocumentation. Use apiDocumentation with the appropriate properties.json source instead.`
+        );
+    }
+
     const codeData = codeLookup[interfaceName];
     const model = config.asCode
         ? getDocCode({

--- a/documentation/ag-grid-docs/src/content/docs/column-headers-styling/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-headers-styling/index.mdoc
@@ -10,7 +10,7 @@ Column Headers can be styled using CSS classes and inline styles. Header row hei
 Used to provide CSS styles directly (not using a class) to the header. Can be either an object
 of CSS styles, or a function returning an object of CSS styles.
 
-{% interfaceDocumentation interfaceName="ColDef" names=["headerStyle" ] /%}
+{% apiDocumentation source="column-properties/properties.json" section="header" names=["headerStyle"] /%}
 
 ```{% frameworkTransform=true spaceBetweenProperties=true %}
 const gridOptions = {
@@ -41,7 +41,7 @@ const gridOptions = {
 Provides a class for the header. Can be a string (a class), array of strings
 (array of classes), or a function (that returns a string or an array of strings).
 
-{% interfaceDocumentation interfaceName="ColDef" names=["headerClass" ] /%}
+{% apiDocumentation source="column-properties/properties.json" section="header" names=["headerClass"] /%}
 
 ```{% frameworkTransform=true spaceBetweenProperties=true %}
 const gridOptions = {

--- a/documentation/ag-grid-docs/src/content/docs/tooltips/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/tooltips/index.mdoc
@@ -8,7 +8,7 @@ Tooltips can be set for Cells and Column Headers.
 
 The following [Column Definition](./column-definitions/) properties set Tooltips:
 
-{% interfaceDocumentation interfaceName="ColDef" names=["tooltipField", "tooltipValueGetter","headerTooltip"] overrideSrc="tooltips/tooltips.json" config={"description":""} /%}
+{% apiDocumentation source="column-properties/properties.json" section="tooltips" names=["tooltipField", "tooltipValueGetter", "headerTooltip"] /%}
 
 ## Tooltips for Truncated Text
 


### PR DESCRIPTION
## Summary

- Switched ColDef property references from `interfaceDocumentation` to `apiDocumentation` on the tooltips and column-headers-styling pages so that `@agModule` tags are correctly enriched and module badges render
- Added a guard in `getInterfaceDocumentationModel` that throws if `interfaceDocumentation` is used with `ColDef` or `GridOptions`, directing authors to use `apiDocumentation` instead
- 
<img width="971" height="160" alt="Screenshot 2026-05-14 at 15 30 09" src="https://github.com/user-attachments/assets/b7a09a4c-a9f9-4e5b-ba7d-8b4465c710dc" />

## Test plan

- [ ] Verify module badges render on https://grid-staging.ag-grid.com/javascript-data-grid/tooltips/#reference-ColDef-tooltipField
- [ ] Confirm no `@agModule` text leaks into visible descriptions