### PR TITLE
AG-3390 - Port docs examples fixes from studio

### DIFF
--- a/documentation/ag-grid-docs/src/components/docs/utils/pageData.ts
+++ b/documentation/ag-grid-docs/src/components/docs/utils/pageData.ts
@@ -12,6 +12,7 @@ interface Example {
     internalFramework: InternalFramework;
     pageName: string;
     exampleName: string;
+    supportedFrameworks?: InternalFramework[];
 }
 
 type DocExamplePages = Awaited<ReturnType<typeof getDocsExamplePages>>;
@@ -23,6 +24,7 @@ type DocExamplePage = DocExamplePages[number]['params'] & {
     hasSimpleHtml?: boolean;
     scriptNonce?: string;
     sourceFileList?: string[];
+    supportedFrameworks?: InternalFramework[];
 };
 type DocFrameworkExamples = Record<InternalFramework, DocExamplePage>;
 
@@ -84,19 +86,17 @@ async function getDocsExampleNameParts({ pages }: { pages: DocsPage[] }): Promis
         : internalFrameworkExamples;
 
     return filteredInternalFrameworkExamples
-        .flatMap((example) => {
-            const frameworkSupported =
-                example.supportedFrameworks === undefined || example.supportedFrameworks.has(example.internalFramework);
-
-            if (!frameworkSupported) {
-                return undefined;
-            }
-
-            return {
-                ...example,
-            };
+        .filter((example) => {
+            return (
+                example.supportedFrameworks === undefined || example.supportedFrameworks.has(example.internalFramework)
+            );
         })
-        .filter((e) => e !== undefined) as Example[];
+        .map(({ internalFramework, pageName, exampleName, supportedFrameworks }) => ({
+            internalFramework,
+            pageName,
+            exampleName,
+            supportedFrameworks: supportedFrameworks ? Array.from(supportedFrameworks) : undefined,
+        }));
 }
 
 export async function getDocsExamplePages({ pages }: { pages: DocsPage[] }) {
@@ -122,7 +122,7 @@ function allPropertiesAreTruthy(entries: [string, DocExamplePage][], property: k
 function flattenDocsExampleContents(data: Record<string, DocFrameworkExamples>) {
     return Object.values(data).map((frameworkExamples) => {
         const frameworkEntries = Object.entries(frameworkExamples);
-        const [_, { pageName, exampleName, sourceFileList, scriptNonce }] = frameworkEntries[0];
+        const [_, { pageName, exampleName, sourceFileList, scriptNonce, supportedFrameworks }] = frameworkEntries[0];
         const isEnterprise = allPropertiesAreTruthy(frameworkEntries, 'isEnterprise');
         const isIntegratedCharts = allPropertiesAreTruthy(frameworkEntries, 'isIntegratedCharts');
         const isLocale = allPropertiesAreTruthy(frameworkEntries, 'isLocale');
@@ -140,19 +140,18 @@ function flattenDocsExampleContents(data: Record<string, DocFrameworkExamples>) 
             hasExampleConsoleLog,
             hasSimpleHtml,
             scriptNonce,
+            supportedFrameworks,
             frameworkExamples,
         };
     });
 }
 
 export async function getDocsExampleContents({ pages }: { pages: DocsPage[] }) {
-    const examples = await getDocsExamplePages({
-        pages,
-    });
+    const examples = await getDocsExampleNameParts({ pages });
 
     const exampleContents: Record<string, DocFrameworkExamples> = {};
     const examplePromises = examples.map(async (example) => {
-        const { internalFramework, pageName, exampleName } = example.params;
+        const { internalFramework, pageName, exampleName, supportedFrameworks } = example;
         const key = `${pageName}-${exampleName}`;
         if (!exampleContents[key]) {
             exampleContents[key] = {} as DocFrameworkExamples;
@@ -173,7 +172,10 @@ export async function getDocsExampleContents({ pages }: { pages: DocsPage[] }) {
             hasSimpleHtml: contents?.hasSimpleHtml,
             sourceFileList: contents?.sourceFileList,
             scriptNonce: contents?.scriptNonce,
-            ...example.params,
+            internalFramework,
+            pageName,
+            exampleName,
+            supportedFrameworks,
         };
     });
     await Promise.all(examplePromises);

--- a/documentation/ag-grid-docs/src/pages/debug/docs-examples.astro
+++ b/documentation/ag-grid-docs/src/pages/debug/docs-examples.astro
@@ -3,26 +3,26 @@ import { getCollection } from 'astro:content';
 import DebugLayout from '@layouts/DebugLayout.astro';
 import { getDocsExampleContents } from '@components/docs/utils/pageData';
 
-import { DocsExamples } from '@ag-website-shared/components/docs-examples/components/DocsExamples';
+import {
+    DocsExamples,
+    type ExampleProperty,
+} from '@ag-website-shared/components/docs-examples/components/DocsExamples';
 
 const pages = await getCollection('docs');
 const exampleContents = await getDocsExampleContents({ pages });
+const properties: ExampleProperty[] = [
+    'sourceFileList',
+    'isEnterprise',
+    'isIntegratedCharts',
+    'isLocale',
+    'hasExampleConsoleLog',
+    'hasSimpleHtml',
+    'scriptNonce',
+    'supportedFrameworks',
+];
 ---
 
 <DebugLayout title={`Debug: Docs Example Pages`}>
     <h1>Docs Example Pages</h1>
-    <DocsExamples
-        library="grid"
-        client:load
-        exampleContents={exampleContents}
-        properties={[
-            'sourceFileList',
-            'isEnterprise',
-            'isIntegratedCharts',
-            'isLocale',
-            'hasExampleConsoleLog',
-            'hasSimpleHtml',
-            'scriptNonce',
-        ]}
-    />
+    <DocsExamples library="grid" client:load exampleContents={exampleContents} properties={properties} />
 </DebugLayout>

--- a/documentation/ag-grid-docs/src/types/ag-grid.d.ts
+++ b/documentation/ag-grid-docs/src/types/ag-grid.d.ts
@@ -5,7 +5,7 @@ export type Framework = 'javascript' | 'react' | 'angular' | 'vue';
 
 export type InternalFramework = 'vanilla' | 'typescript' | 'reactFunctional' | 'reactFunctionalTs' | 'angular' | 'vue3';
 
-export type Library = 'charts' | 'grid' | 'dash';
+export type Library = 'charts' | 'grid' | 'studio';
 
 export interface MenuSection {
     title?: string;

--- a/external/ag-website-shared/src/components/docs-examples/components/DocsExamples.tsx
+++ b/external/ag-website-shared/src/components/docs-examples/components/DocsExamples.tsx
@@ -35,7 +35,8 @@ export type ExampleProperty =
     | 'hasExampleConsoleLog'
     | 'hasExampleControls'
     | 'hasSimpleHtml'
-    | 'scriptNonce';
+    | 'scriptNonce'
+    | 'supportedFrameworks';
 
 export interface Props {
     library: Library;
@@ -66,6 +67,14 @@ const URL_MAPPING: Record<
             `https://charts-staging.ag-grid.com/javascript/${pageName}/#example-${exampleName}`,
         production: ({ pageName, exampleName }) =>
             `https://www.ag-grid.com/charts/javascript/${pageName}/#example-${exampleName}`,
+    },
+    studio: {
+        local: ({ pageName, exampleName }) =>
+            `https://localhost:4620/studio/javascript/${pageName}/#example-${exampleName}`,
+        staging: ({ pageName, exampleName }) =>
+            `https://studio-staging.ag-grid.com/javascript/${pageName}/#example-${exampleName}`,
+        production: ({ pageName, exampleName }) =>
+            `https://www.ag-grid.com/studio/javascript/${pageName}/#example-${exampleName}`,
     },
 };
 
@@ -133,6 +142,23 @@ const ALL_PROPERTIES: (ColDef & {
         headerName: 'Nonce',
         enableRowGroup: true,
         minWidth: 115,
+    },
+    {
+        field: 'supportedFrameworks',
+        headerName: 'Supported Frameworks',
+        enableRowGroup: true,
+        filter: 'agSetColumnFilter',
+        minWidth: 200,
+        valueFormatter: ({ value, node }) => {
+            if (node?.group) {
+                return '';
+            }
+            if (!value) {
+                return 'all';
+            }
+
+            return Array.isArray(value) ? value.join(', ') : value;
+        },
     },
 ];
 

--- a/external/ag-website-shared/src/components/docs-examples/components/cell-renderers/LinkCellRenderer.tsx
+++ b/external/ag-website-shared/src/components/docs-examples/components/cell-renderers/LinkCellRenderer.tsx
@@ -10,7 +10,10 @@ export function LinkCellRenderer({ colDef, data }) {
         return;
     }
     const internalFramework = colDef.colId;
-    const { pageName, exampleName } = data;
+    const { pageName, exampleName, supportedFrameworks } = data;
+    if (supportedFrameworks && !supportedFrameworks.includes(internalFramework)) {
+        return null;
+    }
     const titlePrefix = `${pageName} > ${exampleName} > ${internalFramework}`;
 
     return (


### PR DESCRIPTION
Add supportedFrameworks to ExampleProperty and ALL_PROPERTIES, add studio URL mapping, and filter LinkCellRenderer links by supportedFrameworks.

Based off https://github.com/ag-grid/ag-studio/pull/1479