### PR TITLE
AG-17362 Fix checkbox test IDs disappearing in column chooser on scroll

### DIFF
--- a/packages/ag-grid-community/src/testing/testIdService.ts
+++ b/packages/ag-grid-community/src/testing/testIdService.ts
@@ -72,7 +72,7 @@ export class TestIdService extends BeanStub implements NamedBean, ITestIdService
         };
         root.addEventListener('scroll', onScroll, { capture: true });
         this.addDestroyFunc(() =>
-            root.removeEventListener('scroll', onScroll, { capture: true } as EventListenerOptions)
+            root.removeEventListener('scroll', onScroll, { capture: true })
         );
     }
 

--- a/packages/ag-grid-community/src/testing/testIdService.ts
+++ b/packages/ag-grid-community/src/testing/testIdService.ts
@@ -71,9 +71,7 @@ export class TestIdService extends BeanStub implements NamedBean, ITestIdService
             }
         };
         root.addEventListener('scroll', onScroll, { capture: true });
-        this.addDestroyFunc(() =>
-            root.removeEventListener('scroll', onScroll, { capture: true })
-        );
+        this.addDestroyFunc(() => root.removeEventListener('scroll', onScroll, { capture: true }));
     }
 
     public setupAllTestIds(): void {

--- a/packages/ag-grid-community/src/testing/testIdService.ts
+++ b/packages/ag-grid-community/src/testing/testIdService.ts
@@ -55,6 +55,25 @@ export class TestIdService extends BeanStub implements NamedBean, ITestIdService
             filterChanged: setup,
             cellSelectionChanged: setup,
         });
+
+        // Virtual lists in column panels/choosers create new DOM elements on scroll,
+        // which lose their test IDs. Capture-phase scroll listener re-applies them.
+        const root = _getRootNode(this.beans);
+        const onVirtualListScroll = _debounce(this, () => this.setupAllTestIds(), 100);
+        const onScroll = (e: Event) => {
+            const target = e.target;
+            if (
+                target instanceof HTMLElement &&
+                target.classList.contains('ag-virtual-list-viewport') &&
+                (target.closest('.ag-column-panel') || target.closest('.ag-panel'))
+            ) {
+                onVirtualListScroll();
+            }
+        };
+        root.addEventListener('scroll', onScroll, { capture: true });
+        this.addDestroyFunc(() =>
+            root.removeEventListener('scroll', onScroll, { capture: true } as EventListenerOptions)
+        );
     }
 
     public setupAllTestIds(): void {

--- a/testing/behavioural/src/columnToolPanel/column-chooser-test-ids.test.ts
+++ b/testing/behavioural/src/columnToolPanel/column-chooser-test-ids.test.ts
@@ -1,0 +1,131 @@
+import type { ColDef, GridApi } from 'ag-grid-community';
+import { agTestIdFor, getGridElement, setupAgTestIds } from 'ag-grid-community';
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+
+describe('column tool panel test IDs with virtualization', () => {
+    const gridMgr = new TestGridsManager({
+        modules: [AllEnterpriseModule],
+    });
+
+    const columnDefs: ColDef[] = Array.from({ length: 30 }, (_, i) => ({
+        field: `col${i}`,
+        headerName: `Column ${i}`,
+    }));
+
+    const rowData = [Object.fromEntries(columnDefs.map((c) => [c.field, `val_${c.field}`]))];
+
+    beforeAll(() => {
+        setupAgTestIds();
+    });
+
+    afterEach(() => {
+        gridMgr.reset();
+    });
+
+    async function createGrid(): Promise<GridApi> {
+        return gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            sideBar: {
+                toolPanels: [
+                    {
+                        id: 'columns',
+                        labelDefault: 'Columns',
+                        labelKey: 'columns',
+                        iconKey: 'columns',
+                        toolPanel: 'agColumnsToolPanel',
+                    },
+                ],
+                defaultToolPanel: 'columns',
+            },
+        });
+    }
+
+    function forceVirtualListRender(gridApi: GridApi): HTMLElement {
+        const gridEl = getGridElement(gridApi)! as HTMLElement;
+        const viewport = gridEl.querySelector('.ag-column-select-virtual-list-viewport') as HTMLElement;
+        // jsdom doesn't have a layout engine so offsetHeight returns 0, which prevents
+        // the virtual list from rendering items. Override it on the instance.
+        Object.defineProperty(viewport, 'offsetHeight', { value: 200, configurable: true });
+        // Trigger virtual list render via scroll event
+        viewport.dispatchEvent(new Event('scroll'));
+        return viewport;
+    }
+
+    function getVisibleCheckboxTestIds(gridApi: GridApi): string[] {
+        const gridEl = getGridElement(gridApi)! as HTMLElement;
+        const items = gridEl.querySelectorAll('.ag-column-select-virtual-list-item');
+        const testIds: string[] = [];
+        items.forEach((item) => {
+            const checkbox = item.querySelector('.ag-column-select-checkbox input[type=checkbox]');
+            const testId = checkbox?.getAttribute('data-testid');
+            if (testId) {
+                testIds.push(testId);
+            }
+        });
+        return testIds;
+    }
+
+    function getVisibleItemLabels(gridApi: GridApi): (string | null)[] {
+        const gridEl = getGridElement(gridApi)! as HTMLElement;
+        const items = gridEl.querySelectorAll('.ag-column-select-virtual-list-item');
+        return Array.from(items, (item) => item.getAttribute('aria-label'));
+    }
+
+    function countCheckboxesWithoutTestId(gridApi: GridApi): string[] {
+        const gridEl = getGridElement(gridApi)! as HTMLElement;
+        const items = gridEl.querySelectorAll('.ag-column-select-virtual-list-item');
+        const missing: string[] = [];
+        items.forEach((item) => {
+            const label = item.getAttribute('aria-label');
+            const checkbox = item.querySelector('.ag-column-select-checkbox input[type=checkbox]');
+            if (checkbox && !checkbox.getAttribute('data-testid')) {
+                missing.push(label ?? 'unknown');
+            }
+        });
+        return missing;
+    }
+
+    it('should maintain checkbox test IDs after scrolling the virtual list', async () => {
+        const api = await createGrid();
+        await asyncSetTimeout(50);
+
+        const viewport = forceVirtualListRender(api);
+        await asyncSetTimeout(200);
+
+        // Initial state: visible items should have test IDs
+        const initialLabels = getVisibleItemLabels(api);
+        expect(initialLabels.length).toBeGreaterThan(0);
+        expect(initialLabels).toContain('Column 0 Column');
+
+        const initialTestIds = getVisibleCheckboxTestIds(api);
+        expect(initialTestIds.length).toBeGreaterThan(0);
+        expect(initialTestIds[0]).toBe(agTestIdFor.columnSelectListItemCheckbox('Column 0 Column'));
+
+        // Scroll down to reveal new items
+        viewport.scrollTop = 500;
+        await asyncSetTimeout(200);
+
+        const scrolledLabels = getVisibleItemLabels(api);
+        expect(scrolledLabels.length).toBeGreaterThan(0);
+        expect(scrolledLabels).not.toContain('Column 0 Column');
+
+        // Every visible checkbox should have a test ID
+        const missingAfterScrollDown = countCheckboxesWithoutTestId(api);
+        expect(missingAfterScrollDown).toEqual([]);
+
+        // Scroll back to top
+        viewport.scrollTop = 0;
+        await asyncSetTimeout(200);
+
+        const scrolledBackLabels = getVisibleItemLabels(api);
+        expect(scrolledBackLabels).toContain('Column 0 Column');
+
+        // Checkboxes should still have test IDs after scrolling back
+        const missingAfterScrollBack = countCheckboxesWithoutTestId(api);
+        expect(missingAfterScrollBack).toEqual([]);
+        expect(getVisibleCheckboxTestIds(api)[0]).toBe(agTestIdFor.columnSelectListItemCheckbox('Column 0 Column'));
+    });
+});


### PR DESCRIPTION
## Summary

- `setupAllTestIds()` was only triggered by grid-level events (`sideBarUpdated`, `columnMenuVisibleChanged`, etc.), so when the column chooser virtual list scrolled and created new DOM elements via virtualization, they never received test IDs.
- Added a capture-phase `scroll` listener on the root node that detects scrolling inside column panels (`.ag-column-panel`) or chooser popups (`.ag-panel`) and re-applies test IDs via a 100ms debounce.
- Added a behavioural test that verifies checkbox test IDs persist after scrolling down and back up in the column tool panel virtual list.

## Test plan

- [x] New behavioural test `column-chooser-test-ids.test.ts` passes with the fix and fails without it
- [ ] Manual verification: open column chooser with many columns, scroll down/up, confirm `data-testid` attributes remain on checkbox elements