### PR TITLE
AG-17363 fix SSRM infinite loading when expanding empty group with groupTotalRow

### DIFF
--- a/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyStore.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyStore.ts
@@ -274,10 +274,11 @@ export class LazyStore extends BeanStub implements IServerSideStore {
      * @returns the virtual size of this store
      */
     getRowCount(): number {
+        const rowCount = this.cache.getRowCount();
         if (this.parentRowNode.sibling) {
-            return this.cache.getRowCount() + 1;
+            return rowCount + 1;
         }
-        return this.cache.getRowCount();
+        return rowCount;
     }
 
     /**

--- a/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyStore.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyStore.ts
@@ -294,7 +294,7 @@ export class LazyStore extends BeanStub implements IServerSideStore {
      * @returns whether or not the row exists within this store
      */
     isDisplayIndexInStore(displayIndex: number): boolean {
-        if (this.cache.getRowCount() === 0) {
+        if (this.getRowCount() === 0) {
             return false;
         }
 

--- a/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-empty-group-footer.test.ts
+++ b/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-empty-group-footer.test.ts
@@ -1,0 +1,198 @@
+import type { GridOptions, IServerSideDatasource, IServerSideGetRowsParams } from 'ag-grid-community';
+import { ServerSideRowModelModule, TreeDataModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../../test-utils';
+import { waitForNoLoadingRows } from '../../test-utils/ssrm-test-utils';
+
+describe('ag-grid SSRM tree data empty group with groupTotalRow', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelModule, TreeDataModule],
+    });
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    function createDatasource() {
+        const tracker = { loadCount: 0 };
+
+        const datasource: IServerSideDatasource = {
+            getRows: (params: IServerSideGetRowsParams) => {
+                tracker.loadCount++;
+                const groupKeys = params.request.groupKeys ?? [];
+
+                if (groupKeys.length === 0) {
+                    setTimeout(() => {
+                        params.success({
+                            rowData: [{ id: 'A', name: 'Node A', group: true }],
+                        });
+                    }, 1);
+                } else {
+                    setTimeout(() => {
+                        params.success({ rowData: [] });
+                    }, 1);
+                }
+            },
+        };
+
+        return { datasource, tracker };
+    }
+
+    async function waitForLoadCount(tracker: { loadCount: number }, target: number, timeoutMs = 500) {
+        for (let elapsed = 0; elapsed < timeoutMs && tracker.loadCount < target; elapsed += 5) {
+            await asyncSetTimeout(5);
+        }
+    }
+
+    test('expanding group with empty children and groupTotalRow bottom does not cause infinite requests', async () => {
+        const { datasource, tracker } = createDatasource();
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id', hide: true }, { field: 'name' }],
+            autoGroupColumnDef: { field: 'name' },
+            treeData: true,
+            rowModelType: 'serverSide',
+            animateRows: false,
+            groupTotalRow: 'bottom',
+            getRowId: ({ data }) => data.id,
+            isServerSideGroup: (data: any) => data.group,
+            getServerSideGroupKey: (data: any) => data.id,
+            serverSideDatasource: datasource,
+        };
+
+        const api = gridsManager.createGrid('ssrmEmptyGroupFooter', gridOptions);
+
+        // Wait for root load (1 request)
+        await waitForLoadCount(tracker, 1);
+        await waitForNoLoadingRows(api);
+        expect(tracker.loadCount).toBe(1);
+
+        // Expand Node A (which has group: true but empty children)
+        api.getRowNode('A')!.setExpanded(true);
+
+        // Wait for children load (2nd request)
+        await waitForLoadCount(tracker, 2);
+        await asyncSetTimeout(20);
+        expect(tracker.loadCount).toBe(2);
+
+        // Wait more — if there's an infinite loop, loadCount will keep growing
+        await asyncSetTimeout(200);
+
+        expect(tracker.loadCount).toBe(2);
+    });
+
+    test('expanding empty group with groupHideOpenParents and groupTotalRow bottom does not cause infinite requests', async () => {
+        const tracker = { loadCount: 0, active: true };
+
+        const datasource: IServerSideDatasource = {
+            getRows: (params: IServerSideGetRowsParams) => {
+                tracker.loadCount++;
+                const groupKeys = params.request.groupKeys ?? [];
+
+                let rowData: any[];
+                if (groupKeys.length === 0) {
+                    rowData = [{ id: 'A', name: 'Node A', group: true }];
+                } else if (groupKeys.length === 1 && groupKeys[0] === 'A') {
+                    rowData = [{ id: 'B', name: 'Node B', group: true }];
+                } else {
+                    rowData = [];
+                }
+
+                setTimeout(() => {
+                    if (tracker.active) {
+                        params.success({ rowData });
+                    }
+                }, 1);
+            },
+        };
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id', hide: true }, { field: 'name' }],
+            autoGroupColumnDef: { field: 'name' },
+            treeData: true,
+            rowModelType: 'serverSide',
+            animateRows: false,
+            groupTotalRow: 'bottom',
+            groupHideOpenParents: true,
+            getRowId: ({ data }) => data.id,
+            isServerSideGroup: (data: any) => data?.group,
+            getServerSideGroupKey: (data: any) => data?.id,
+            serverSideDatasource: datasource,
+        };
+
+        const api = gridsManager.createGrid('ssrmHideOpenParents', gridOptions);
+
+        // Wait for root load
+        await waitForLoadCount(tracker, 1);
+        await waitForNoLoadingRows(api);
+        expect(tracker.loadCount).toBe(1);
+
+        // Expand Node A — its row becomes hidden due to groupHideOpenParents
+        api.getRowNode('A')!.setExpanded(true);
+
+        // Wait for Node A's children to load (Node B)
+        await waitForLoadCount(tracker, 2);
+        await waitForNoLoadingRows(api);
+        expect(tracker.loadCount).toBe(2);
+
+        // Expand Node B — also hidden, its child store loads empty
+        api.getRowNode('B')!.setExpanded(true);
+
+        // Wait for Node B's children to load (empty)
+        await waitForLoadCount(tracker, 3);
+        await asyncSetTimeout(20);
+        expect(tracker.loadCount).toBe(3);
+
+        // The footer for Node B's empty store must be resolved via the
+        // groupHideOpenParents DFS path (lazyCache.ts:180-186), not the
+        // contiguous-previous-node shortcut, because Node B is hidden.
+        // Before the fix, isDisplayIndexInStore returned false for the
+        // footer index, causing the parent cache to create a spurious stub.
+        await asyncSetTimeout(200);
+
+        expect(tracker.loadCount).toBe(3);
+
+        tracker.active = false;
+        await asyncSetTimeout(10);
+    });
+
+    test('expanding group with empty children without groupTotalRow does not cause infinite requests', async () => {
+        const { datasource, tracker } = createDatasource();
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id', hide: true }, { field: 'name' }],
+            autoGroupColumnDef: { field: 'name' },
+            treeData: true,
+            rowModelType: 'serverSide',
+            animateRows: false,
+            getRowId: ({ data }) => data.id,
+            isServerSideGroup: (data: any) => data.group,
+            getServerSideGroupKey: (data: any) => data.id,
+            serverSideDatasource: datasource,
+        };
+
+        const api = gridsManager.createGrid('ssrmEmptyGroupNoFooter', gridOptions);
+
+        // Wait for root load
+        await waitForLoadCount(tracker, 1);
+        await waitForNoLoadingRows(api);
+        expect(tracker.loadCount).toBe(1);
+
+        // Expand Node A
+        api.getRowNode('A')!.setExpanded(true);
+
+        // Wait for children load
+        await waitForLoadCount(tracker, 2);
+        await asyncSetTimeout(20);
+        expect(tracker.loadCount).toBe(2);
+
+        // Wait more
+        await asyncSetTimeout(200);
+
+        expect(tracker.loadCount).toBe(2);
+    });
+});


### PR DESCRIPTION
Fix [AG-17363](https://ag-grid.atlassian.net/browse/AG-17363)

- Fixes infinite server requests when expanding a node marked `group: true` that returns empty children in SSRM Tree Data mode with `groupTotalRow: 'bottom'`
- Root cause: `isDisplayIndexInStore` used `cache.getRowCount()` (data rows only), so a child store with 0 data rows but a footer row would disown its display index — the parent cache then created a spurious stub for that index, triggering a load→empty→footer→stub loop
- Fix: use `getRowCount()` which includes the footer in its count, so the store correctly claims ownership of the footer's display index

## Test plan

- [x] New behavioural test: empty group + `groupTotalRow: 'bottom'` — verifies no infinite requests
- [x] New behavioural test: empty group without `groupTotalRow` — verifies existing behaviour preserved
- [x] New behavioural test: empty group + `groupTotalRow: 'bottom'` + `groupHideOpenParents: true` — covers the DFS lookup path (`lazyCache.ts:181`)
- [x] 749/749 SSRM tests pass
- [x] 272/272 tree-data tests pass
- [x] 2329/2329 grouping tests pass