### PR TITLE
Improve doc E2E test stability on WebKit

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/toolbar-custom/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/toolbar-custom/example.spec.ts
@@ -12,18 +12,19 @@ test.agExample(import.meta, () => {
         await expect(checkboxes).toHaveCount(2);
         await expect(radios).toHaveCount(3);
 
-        await checkboxes.nth(0).check();
+        await checkboxes.nth(0).click();
         await expect(page.locator('.ag-header-cell[col-id="gold"] .ag-filter-active')).toBeVisible();
 
         // Reset to a known starting point — Columns is selected by default in this example
-        await toolbar.getByLabel('None').check();
+        await toolbar.getByLabel('None').click();
         await expect(page.locator('.ag-column-panel')).toBeHidden();
 
-        await toolbar.getByLabel('Columns').check();
+        await toolbar.getByLabel('Columns').click();
         await expect(page.locator('.ag-column-panel')).toBeVisible();
 
         // Closing the panel via the side bar tab keeps the radio in sync via getToolbarItemInstance
         await page.getByRole('tab', { name: 'Columns' }).click();
+        await expect(page.locator('.ag-column-panel')).toBeHidden();
         await expect(toolbar.getByLabel('None')).toBeChecked();
     });
 });

--- a/documentation/ag-grid-docs/src/utils/grid/test/scrollGridRelative.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test/scrollGridRelative.ts
@@ -93,10 +93,11 @@ export async function scrollGridRelative(
     }
 
     await test.step(`Scroll grid ${directionWord.join('-')}`, async () => {
+        const browserName = page.context().browser()?.browserType().name();
         if (
             method === 'element' ||
-            // On Firefox the wheel event doesn't scroll the element as expected under testing
-            (method === 'wheel' && page.context().browser()?.browserType().name() === 'firefox')
+            // On Firefox and WebKit the wheel event doesn't scroll the element reliably under testing
+            (method === 'wheel' && (browserName === 'firefox' || browserName === 'webkit'))
         ) {
             await scrollElement();
         } else if (method === 'wheel') {


### PR DESCRIPTION
## Summary

Fixes two flaky/failing E2E tests on WebKit in CI:

- **`scrollGridRelative` WebKit fallback** — `mouse.wheel()` doesn't reliably scroll large distances on WebKit (single `wheel(0, 20500)` may not travel the full distance). Extended the existing Firefox fallback to also use direct `el.scrollTop`/`el.scrollLeft` manipulation for WebKit.

- **toolbar-custom `check()` → `click()`** — React controlled inputs (`checked={state}`) cause the DOM `checked` property to bounce during async state updates. Playwright's `check()` verifies the state change synchronously and fails with "Clicking the checkbox did not change its state". Switched to `click()` since the test already has proper assertions for the expected outcomes.

- **Intermediate panel assertion** — Added assertion that the column panel actually closes before checking radio sync state, preventing a race between sidebar close and event handler propagation.

## Test plan

- [x] `toolbar-custom` test passes 60/60 on WebKit locally (was ~1-2/60 flaky before)
- [x] `full-row-editing-test` scroll test passes 30/30 on WebKit locally (was flaky before)
- [x] All `full-row-editing-test` tests pass across chromium, firefox, and webkit (90/90)
- [x] All `toolbar-custom` tests pass across all browsers (18/18)