### PR TITLE
AG-16524 Use col-resize and row-resize cursors for resize handles

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -482,7 +482,7 @@
         width: 8px;
         top: 0;
 
-        cursor: ew-resize;
+        cursor: col-resize;
 
         // unpinned headers get their rezise handle on the right in normal mode and left in RTL mode
         @include ag.unthemed-rtl(
@@ -1795,7 +1795,7 @@
         left: 0;
         height: 4px;
         width: 100%;
-        cursor: ns-resize;
+        cursor: row-resize;
     }
 
     .ag-grid-pinned-bottom-rows .ag-row-numbers-resizer {

--- a/packages/ag-grid-community/src/columnResize/groupResizeFeature.ts
+++ b/packages/ag-grid-community/src/columnResize/groupResizeFeature.ts
@@ -41,6 +41,7 @@ export class GroupResizeFeature extends BeanStub implements IHeaderResizeFeature
 
         const finishedWithResizeFunc = horizontalResizeSvc!.addResizeBar({
             eResizeBar: this.eResize,
+            isColumn: true,
             onResizeStart: this.onResizeStart.bind(this),
             onResizing: this.onResizing.bind(this, false),
             onResizeEnd: this.onResizing.bind(this, true),

--- a/packages/ag-grid-community/src/columnResize/resizeFeature.ts
+++ b/packages/ag-grid-community/src/columnResize/resizeFeature.ts
@@ -35,6 +35,7 @@ export class ResizeFeature extends BeanStub implements IHeaderResizeFeature {
 
             const finishedWithResizeFunc = horizontalResizeSvc!.addResizeBar({
                 eResizeBar: this.eResize,
+                isColumn: true,
                 onResizeStart: this.onResizeStart.bind(this),
                 onResizing: this.onResizing.bind(this, false),
                 onResizeEnd: this.onResizing.bind(this, true),

--- a/packages/ag-grid-community/src/dragAndDrop/horizontalResizeService.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/horizontalResizeService.ts
@@ -6,6 +6,8 @@ import { BeanStub } from '../context/beanStub';
 interface HorizontalResizeParams {
     eResizeBar: HTMLElement;
     dragStartPixels?: number;
+    /** use column cursor when resizing, default false */
+    isColumn?: boolean;
     onResizeStart: (shiftKey: boolean) => void;
     onResizing: (delta: number) => void;
     onResizeEnd: (delta: number) => void;
@@ -44,16 +46,16 @@ export class HorizontalResizeService extends BeanStub implements NamedBean {
     private onDragStart(params: HorizontalResizeParams, mouseEvent: MouseEvent | Touch): void {
         this.dragStartX = mouseEvent.clientX;
 
-        this.setResizeIcons();
+        this.setResizeIcons(!!params.isColumn);
 
         const shiftKey = mouseEvent instanceof MouseEvent && mouseEvent.shiftKey === true;
         params.onResizeStart(shiftKey);
     }
 
-    private setResizeIcons(): void {
+    private setResizeIcons(isColumn: boolean): void {
         const ctrl = this.beans.ctrlsSvc.get('gridCtrl');
         // change the body cursor, so when drag moves out of the drag bar, the cursor is still 'resize' (or 'move'
-        ctrl.setResizeCursor(Direction.Horizontal);
+        ctrl.setResizeCursor(Direction.Horizontal, isColumn);
         // we don't want text selection outside the grid (otherwise it looks weird as text highlights when we move)
         ctrl.disableUserSelect(true);
     }

--- a/packages/ag-grid-community/src/gridComp/gridCtrl.ts
+++ b/packages/ag-grid-community/src/gridComp/gridCtrl.ts
@@ -116,11 +116,13 @@ export class GridCtrl extends BeanStub {
         return this.eGui;
     }
 
-    public setResizeCursor(direction: Direction | false): void {
+    public setResizeCursor(direction: Direction | false, isColumn: boolean = false): void {
         const { view } = this;
 
         if (direction === false) {
             view.setCursor(null);
+        } else if (isColumn) {
+            view.setCursor(direction === Direction.Horizontal ? 'col-resize' : 'row-resize');
         } else {
             view.setCursor(direction === Direction.Horizontal ? 'ew-resize' : 'ns-resize');
         }

--- a/packages/ag-grid-community/src/theming/core/css/_header.css
+++ b/packages/ag-grid-community/src/theming/core/css/_header.css
@@ -292,7 +292,7 @@
     height: 100%;
     width: 8px;
     top: 0;
-    cursor: ew-resize;
+    cursor: col-resize;
 
     /* unpinned headers get their resize handle on the right in normal mode and left in RTL mode */
     right: -3px;

--- a/packages/ag-grid-enterprise/src/rowNumbers/rowNumbers.css
+++ b/packages/ag-grid-enterprise/src/rowNumbers/rowNumbers.css
@@ -18,7 +18,7 @@
     left: 0;
     height: 4px;
     width: 100%;
-    cursor: ns-resize;
+    cursor: row-resize;
 }
 
 /* stylelint-disable-next-line selector-max-specificity */

--- a/packages/ag-grid-enterprise/src/rowNumbers/rowNumbersRowResizer.ts
+++ b/packages/ag-grid-enterprise/src/rowNumbers/rowNumbersRowResizer.ts
@@ -48,7 +48,7 @@ export class AgRowNumbersRowResizer extends Component {
         } = this;
 
         const ctrl = ctrlsSvc.get('gridCtrl');
-        ctrl.setResizeCursor(Direction.Vertical);
+        ctrl.setResizeCursor(Direction.Vertical, true);
 
         this.dragging = true;
         this.initialHeight = this.node.rowHeight as number;


### PR DESCRIPTION
Fix [AG-16524](https://ag-grid.atlassian.net/browse/AG-16524)

Switch the column-header resize handle and row-number row resizer from the directional `ew-resize`/`ns-resize` cursors to the semantic `col-resize`/`row-resize` cursors. Applied in both the legacy SCSS themes and the Theming API CSS.