### PR TITLE
AG-17219 Apply borderRadius theme parameter to picker dropdowns

### DIFF
--- a/documentation/ag-grid-docs/src/content/api-documentation/theming-api/properties.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/theming-api/properties.json
@@ -259,6 +259,7 @@
         },
         "pickerButtonBackgroundColor": {},
         "pickerButtonBorder": {},
+        "pickerButtonBorderRadius": {},
         "pickerButtonFocusBackgroundColor": {},
         "pickerButtonFocusBorder": {},
         "pickerListBackgroundColor": {},

--- a/packages/ag-grid-community/src/agStack/widgets/agPickerField.css
+++ b/packages/ag-grid-community/src/agStack/widgets/agPickerField.css
@@ -18,7 +18,7 @@
 .ag-picker-field-wrapper {
     overflow: hidden;
     border: var(--ag-picker-button-border);
-    border-radius: 5px;
+    border-radius: var(--ag-picker-button-border-radius);
     background-color: var(--ag-picker-button-background-color);
     min-height: max(var(--ag-list-item-height), calc(var(--ag-spacing) * 4));
 

--- a/packages/ag-grid-community/src/theming/parts/input-style/input-styles.ts
+++ b/packages/ag-grid-community/src/theming/parts/input-style/input-styles.ts
@@ -108,6 +108,11 @@ export type InputStyleParams = {
     pickerButtonBorder: BorderValue;
 
     /**
+     * Corner radius of buttons with attached dropdown menus (e.g. select fields)
+     */
+    pickerButtonBorderRadius: LengthValue;
+
+    /**
      * Border around buttons with attached dropdown menus (e.g. select fields) when focussed
      */
     pickerButtonFocusBorder: BorderValue;
@@ -205,6 +210,7 @@ const baseParams: InputStyleParams = {
         ref: 'inputTextColor',
     },
     pickerButtonBorder: false,
+    pickerButtonBorderRadius: 0,
     pickerButtonFocusBorder: { ref: 'inputFocusBorder' },
     pickerButtonBackgroundColor: { ref: 'backgroundColor' },
     pickerButtonFocusBackgroundColor: { ref: 'backgroundColor' },
@@ -254,6 +260,9 @@ const makeInputStyleBorderedTreeShakeable = () =>
                 color: { ref: 'invalidColor' },
             },
             pickerButtonBorder: true,
+            pickerButtonBorderRadius: {
+                ref: 'borderRadius',
+            },
             pickerListBorder: true,
         },
         css: () => inputStyleBaseCSS + inputStyleBorderedCSS,


### PR DESCRIPTION
Fix [AG-17219](https://ag-grid.atlassian.net/browse/AG-17219)

**Theming API only change.** Picker fields (select dropdowns) previously hardcoded a `5px` border radius, so they did not respond to the `borderRadius` theme parameter. This was most visible on `themeMaterial` (rectangular cells with rounded picker dropdowns inside them).

The fix introduces a new `pickerButtonBorderRadius` parameter on input styles. In `inputStyleBordered` it references `borderRadius`, matching the pattern already used by text inputs and checkboxes. The unbordered `inputStyleBase` keeps `0` (unchanged effective behaviour — no borders to round).