### PR TITLE
AG-16811 fix header sizing and default fontWeight

### DIFF
--- a/packages/ag-grid-community/src/agStack/theming/shared/shared-css.ts
+++ b/packages/ag-grid-community/src/agStack/theming/shared/shared-css.ts
@@ -390,7 +390,7 @@ export const sharedDefaults: Readonly<SharedThemeParams> = {
     borderRadius: 4,
     spacing: 8,
     fontSize: 14,
-    fontWeight: 'inherit',
+    fontWeight: 400,
     focusShadow: {
         spread: 3,
         color: accentMix(0.5),
@@ -507,7 +507,7 @@ export const sharedDefaults: Readonly<SharedThemeParams> = {
         ref: 'textColor',
     },
     headerHeight: {
-        calc: 'max(iconSize, dataFontSize) + spacing * 4 * headerVerticalPaddingScale',
+        calc: 'max(iconSize, headerFontSize) + spacing * 4 * headerVerticalPaddingScale',
     },
     headerVerticalPaddingScale: 1,
     menuBorder: {

--- a/packages/ag-grid-community/src/theming/parts/theme/themes.ts
+++ b/packages/ag-grid-community/src/theming/parts/theme/themes.ts
@@ -309,7 +309,7 @@ export const themeMaterialParams = () => ({
         calc: 'max(iconSize, cellFontSize) + spacing * 3.75 * rowVerticalPaddingScale',
     },
     headerHeight: {
-        calc: 'max(iconSize, dataFontSize) + spacing * 4.75 * headerVerticalPaddingScale',
+        calc: 'max(iconSize, headerFontSize) + spacing * 4.75 * headerVerticalPaddingScale',
     },
     widgetVerticalSpacing: {
         calc: 'spacing * 1.75',


### PR DESCRIPTION
Fix [AG-16811](https://ag-grid.atlassian.net/browse/AG-16811)

- **`headerHeight` calc now uses `headerFontSize`** (was `dataFontSize`), so changing `headerFontSize` affects both the header text size and the header height — previously height tracked `dataFontSize` while text size tracked `headerFontSize`. Applied to both `sharedDefaults` and `themeMaterialParams`.
- **Default `fontWeight` is now `400`** (was `'inherit'`), so the grid renders at a known weight regardless of the host container's `font-weight`.