### PR TITLE
AG-17383 Fix SetFilter crash when grid destroyed before async values resolve

### DIFF
--- a/packages/ag-grid-enterprise/src/setFilter/setFilterHandler.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilterHandler.ts
@@ -325,7 +325,7 @@ export class SetFilterHandler<TValue = string>
             }
             const clearOnAllSelected =
                 !filterParams.defaultToNothingSelected &&
-                (this.valueModel.valuesType === SetFilterModelValuesType.TAKEN_FROM_GRID_VALUES ||
+                (valueModel.valuesType === SetFilterModelValuesType.TAKEN_FROM_GRID_VALUES ||
                     !filterParams.suppressClearModelOnRefreshValues);
             const allSelected = clearOnAllSelected && numNewValues === existingFormattedKeys.size;
 

--- a/packages/ag-grid-enterprise/src/setFilter/setValueModel.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setValueModel.ts
@@ -158,7 +158,11 @@ export class SetValueModel<TValue> extends BeanStub<SetValueModelEvent> {
         this.allKeys = new AgPromise<(string | null)[]>((resolve) => {
             switch (this.valuesType) {
                 case SetFilterModelValuesType.TAKEN_FROM_GRID_VALUES:
-                    this.getValuesFromRowsAsync().then((values) => resolve(this.processAllValues(values)));
+                    this.getValuesFromRowsAsync().then((values) => {
+                        if (this.isAlive()) {
+                            resolve(this.processAllValues(values));
+                        }
+                    });
 
                     break;
                 case SetFilterModelValuesType.PROVIDED_LIST: {
@@ -178,9 +182,11 @@ export class SetValueModel<TValue> extends BeanStub<SetValueModelEvent> {
                     const { column, colDef } = this.params.handlerParams;
                     const params: SetFilterValuesFuncParams<any, TValue> = _addGridCommonParams(this.gos, {
                         success: (values) => {
-                            this.dispatchLocalEvent({ type: 'loadingEnd' });
+                            if (this.isAlive()) {
+                                this.dispatchLocalEvent({ type: 'loadingEnd' });
 
-                            resolve(this.processAllValues(this.uniqueValues(this.validateProvidedValues(values))));
+                                resolve(this.processAllValues(this.uniqueValues(this.validateProvidedValues(values))));
+                            }
                         },
                         colDef,
                         column,

--- a/testing/behavioural/src/filters/set-filter-async-destroy.test.ts
+++ b/testing/behavioural/src/filters/set-filter-async-destroy.test.ts
@@ -1,5 +1,6 @@
 import type { GridApi, GridOptions, ISetFilterParams, SetFilterValuesFuncParams } from 'ag-grid-community';
 import { ClientSideRowModelModule } from 'ag-grid-community';
+import type { SetFilter } from 'ag-grid-enterprise';
 import { SetFilterModule } from 'ag-grid-enterprise';
 
 import { TestGridsManager, asyncSetTimeout } from '../test-utils';
@@ -55,15 +56,55 @@ describe('Set Filter async destroy safety', () => {
         };
     }
 
-    test('destroy before PROVIDED_CALLBACK success() fires does not throw', async () => {
-        const { api, fireSuccess } = createGridWithAsyncValues();
+    test('success() called after destroy does not resolve allKeys', async () => {
+        let capturedSuccess: ((values: string[]) => void) | undefined;
 
-        // Trigger validateModel by applying a filter model before values have loaded
-        await api.setColumnFilterModel('category', { filterType: 'set', values: ['A'] });
+        const api = gridsManager.createGrid('grid2', {
+            columnDefs: [
+                { field: 'name' },
+                {
+                    field: 'category',
+                    filter: 'agSetColumnFilter',
+                    filterParams: {
+                        values: (params: SetFilterValuesFuncParams) => {
+                            capturedSuccess = params.success;
+                        },
+                    } as ISetFilterParams,
+                },
+            ],
+            rowData: ROW_DATA,
+        });
+
+        // getColumnFilterInstance creates the filter and queues the values callback setTimeout
+        // without blocking on allKeys resolution
+        const setFilter = (await api.getColumnFilterInstance('category')) as SetFilter<string>;
+        const valueModel = setFilter.handler.valueModel;
+
+        // Flush the macrotask that fires the values callback so capturedSuccess is populated
+        await asyncSetTimeout(0);
 
         api.destroy();
 
-        // Simulate the delayed async values callback resolving after destroy
+        capturedSuccess?.(['A', 'B', 'C']);
+        await asyncSetTimeout(0);
+
+        // isInitialised() is set inside allKeys.then() — if the guard blocked resolution it stays false
+        expect(valueModel.isInitialised()).toBe(false);
+    });
+
+    test('destroy before PROVIDED_CALLBACK success() fires does not throw', async () => {
+        const { api, fireSuccess } = createGridWithAsyncValues();
+
+        // updateAllValues() invokes the values callback via window.setTimeout, so we must flush
+        // the macrotask queue before capturedSuccess is populated and ready to be called.
+        await asyncSetTimeout(0);
+
+        // Trigger validateModel — don't await, it chains off the still-pending allKeys promise
+        void api.setColumnFilterModel('category', { filterType: 'set', values: ['A'] });
+
+        api.destroy();
+
+        // success() fires after destroy — the isAlive guard should prevent allKeys from resolving
         expect(() => fireSuccess()).not.toThrow();
         await asyncSetTimeout(0);
     });
@@ -74,7 +115,10 @@ describe('Set Filter async destroy safety', () => {
         let filterChangedCount = 0;
         api.addEventListener('filterChanged', () => filterChangedCount++);
 
-        await api.setColumnFilterModel('category', { filterType: 'set', values: ['A'] });
+        // Flush the macrotask that fires the values callback so capturedSuccess is populated
+        await asyncSetTimeout(0);
+
+        void api.setColumnFilterModel('category', { filterType: 'set', values: ['A'] });
 
         api.destroy();
         fireSuccess();
@@ -111,12 +155,14 @@ describe('Set Filter async destroy safety', () => {
             rowData: ROW_DATA,
         });
 
-        // Applying a filter on the name column fires filterChanged → onAnyFilterChanged on the
-        // category set filter, which calls refreshAvailable() and chains off the still-pending
-        // allKeys promise
+        // Flush the macrotask that fires the category values callback so capturedSuccess is populated
+        await asyncSetTimeout(0);
+
+        // Apply a name filter — fires filterChanged → onAnyFilterChanged on the category set filter,
+        // which calls refreshAvailable() and chains off the still-pending allKeys promise
         await api.setColumnFilterModel('name', { filterType: 'set', values: ['Item 1'] });
         api.onFilterChanged();
-        await asyncSetTimeout(0); // let the setTimeout inside onAnyFilterChanged fire
+        await asyncSetTimeout(0); // let the window.setTimeout inside onAnyFilterChanged fire
 
         api.destroy();
 

--- a/testing/behavioural/src/filters/set-filter-async-destroy.test.ts
+++ b/testing/behavioural/src/filters/set-filter-async-destroy.test.ts
@@ -1,0 +1,126 @@
+import type { GridApi, GridOptions, ISetFilterParams, SetFilterValuesFuncParams } from 'ag-grid-community';
+import { ClientSideRowModelModule } from 'ag-grid-community';
+import { SetFilterModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+
+interface Row {
+    name: string;
+    category: string;
+}
+
+const ROW_DATA: Row[] = [
+    { name: 'Item 1', category: 'A' },
+    { name: 'Item 2', category: 'B' },
+    { name: 'Item 3', category: 'C' },
+];
+
+describe('Set Filter async destroy safety', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, SetFilterModule],
+    });
+
+    afterEach(() => gridsManager.reset());
+
+    /**
+     * Creates a grid whose category column uses a PROVIDED_CALLBACK async values function.
+     * Returns the api and a `fireSuccess` function to control when params.success() fires.
+     */
+    function createGridWithAsyncValues(overrides?: Partial<GridOptions<Row>>): {
+        api: GridApi<Row>;
+        fireSuccess: (values?: string[]) => void;
+    } {
+        let capturedSuccess: ((values: string[]) => void) | undefined;
+
+        const api = gridsManager.createGrid('grid1', {
+            columnDefs: [
+                { field: 'name' },
+                {
+                    field: 'category',
+                    filter: 'agSetColumnFilter',
+                    filterParams: {
+                        values: (params: SetFilterValuesFuncParams) => {
+                            capturedSuccess = params.success;
+                        },
+                    } as ISetFilterParams,
+                },
+            ],
+            rowData: ROW_DATA,
+            ...overrides,
+        });
+
+        return {
+            api,
+            fireSuccess: (values = ['A', 'B', 'C']) => capturedSuccess?.(values),
+        };
+    }
+
+    test('destroy before PROVIDED_CALLBACK success() fires does not throw', async () => {
+        const { api, fireSuccess } = createGridWithAsyncValues();
+
+        // Trigger validateModel by applying a filter model before values have loaded
+        await api.setColumnFilterModel('category', { filterType: 'set', values: ['A'] });
+
+        api.destroy();
+
+        // Simulate the delayed async values callback resolving after destroy
+        expect(() => fireSuccess()).not.toThrow();
+        await asyncSetTimeout(0);
+    });
+
+    test('filter model is not applied after destroy when success() fires late', async () => {
+        const { api, fireSuccess } = createGridWithAsyncValues();
+
+        let filterChangedCount = 0;
+        api.addEventListener('filterChanged', () => filterChangedCount++);
+
+        await api.setColumnFilterModel('category', { filterType: 'set', values: ['A'] });
+
+        api.destroy();
+        fireSuccess();
+        await asyncSetTimeout(0);
+
+        expect(filterChangedCount).toBe(0);
+    });
+
+    test('destroy during onAnyFilterChanged (another column filter change while values loading) does not throw', async () => {
+        let capturedSuccess: ((values: string[]) => void) | undefined;
+
+        const api = gridsManager.createGrid('grid2', {
+            columnDefs: [
+                {
+                    // name column uses a synchronous provided list — applying a filter on it
+                    // dispatches filterChanged, which triggers onAnyFilterChanged on the category
+                    // set filter whose allKeys promise is still pending
+                    field: 'name',
+                    filter: 'agSetColumnFilter',
+                    filterParams: {
+                        values: ['Item 1', 'Item 2', 'Item 3'],
+                    } as ISetFilterParams,
+                },
+                {
+                    field: 'category',
+                    filter: 'agSetColumnFilter',
+                    filterParams: {
+                        values: (params: SetFilterValuesFuncParams) => {
+                            capturedSuccess = params.success;
+                        },
+                    } as ISetFilterParams,
+                },
+            ],
+            rowData: ROW_DATA,
+        });
+
+        // Applying a filter on the name column fires filterChanged → onAnyFilterChanged on the
+        // category set filter, which calls refreshAvailable() and chains off the still-pending
+        // allKeys promise
+        await api.setColumnFilterModel('name', { filterType: 'set', values: ['Item 1'] });
+        api.onFilterChanged();
+        await asyncSetTimeout(0); // let the setTimeout inside onAnyFilterChanged fire
+
+        api.destroy();
+
+        expect(() => capturedSuccess?.(['A', 'B', 'C'])).not.toThrow();
+        await asyncSetTimeout(0);
+    });
+});


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17383

When a grid with a `PROVIDED_CALLBACK` SetFilter is destroyed before the async values callback fires (e.g. navigating away from an Angular SPA), the `allKeys` promise could settle after `destroy()` had nulled `this.valueModel`. This caused `TypeError: Cannot read properties of undefined (reading 'valuesType')` in the `validateModel()` `.then()` callback, which used `this.valueModel` instead of the locally-captured `valueModel`.

**Root cause:** `SetValueModel.updateAllValues()` called `resolve()` inside async callbacks with no liveness check, so all downstream `.then()` chains (`validateModel`, `onAnyFilterChanged`, `syncAfterDataChange`, `refreshFilterValues`, `setFilterValues`) could run on a destroyed bean.

**Fix:**
- Guard both async `resolve()` calls in `updateAllValues()` with `isAlive()` — the `PROVIDED_CALLBACK` `success()` handler and the `TAKEN_FROM_GRID_VALUES` `getValuesFromRowsAsync()` callback. Since every downstream chain waits on `allKeys`, blocking its resolution at the source stops all callbacks in one place.
- Fix `validateModel()` using `this.valueModel.valuesType` inside a `.then()` callback instead of the locally-captured `valueModel.valuesType`.

**Tests:** Three new behavioural tests covering destroy-before-success for the main bug path, the `onAnyFilterChanged` code path, and a check that no `filterChanged` event fires after destroy.

Fix [AG-17383](https://ag-grid.atlassian.net/browse/AG-17383)