### PR TITLE
AG-3390 Post Jira comment when PR is opened referencing a ticket

### DIFF
--- a/.github/workflows/gh-comment-hook.yml
+++ b/.github/workflows/gh-comment-hook.yml
@@ -14,6 +14,13 @@ jobs:
       pull-requests: write
       issues: write
     steps:
+      - name: Checkout repository
+        if: github.event.action == 'opened'
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout:
+            'scripts/ci/_utils.mjs'
+
       - name: Replace mention with jira link
         id: notify-start
         uses: actions/github-script@v7
@@ -21,6 +28,11 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_ID: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          EVENT_ACTION: ${{ github.event.action }}
+          JIRA_API_AUTH: ${{ secrets.JIRA_API_AUTH }}
+          JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           result-encoding: string
           script: |
@@ -28,8 +40,69 @@ jobs:
             const repo = context.repo.repo;
             const old_body = process.env.PR_BODY || '';
             const issue_number = process.env.PR_ID;
-            
+            const pr_url = process.env.PR_URL;
+            const pr_title = process.env.PR_TITLE;
+            const eventAction = process.env.EVENT_ACTION;
+
+            // Expand bare JIRA ticket mentions (#AG-XXXX) into markdown links
             const body = old_body.replace(/#((AG|RTI)-\d{3,})/g, `[$1](https://ag-grid.atlassian.net/browse/$1)`);
             if (body !== old_body) {
                 await github.rest.issues.update({ owner, repo, issue_number, body });
             }
+
+            // Post a Jira comment only when the PR is first opened
+            if (eventAction !== 'opened') return;
+            if (!process.env.JIRA_API_AUTH) return;
+
+            const { addJiraComment, getJiraIssue, getJiraIssueComments, getCurrentJiraUser, unwatchJiraIssue } =
+                require('./scripts/ci/_utils.mjs');
+
+            // Collect all JIRA tickets referenced in the PR body (using the possibly-updated body)
+            const ticketRegex = /(AG|RTI)-\d{3,}/gi;
+            const tickets = [...new Set([...(body || old_body).matchAll(ticketRegex)].map(m => m[0].toUpperCase()))];
+            if (!tickets.length) return;
+
+            const prLink = `https://github.com/${owner}/${repo}/pull/${issue_number}`;
+            // Sentinel string embedded in the comment so we can detect it later and avoid duplicates
+            const sentinel = `<!-- gh-pr-mention:pr=${issue_number} -->`;
+
+            const paragraph = (content) => ({ type: 'paragraph', content: Array.isArray(content) ? content : [content] });
+            const txt = (text) => ({ text, type: 'text' });
+            const link = (text, url) => ({ type: 'text', text, marks: [{ type: 'link', attrs: { href: url, title: text } }] });
+
+            await Promise.all(tickets.map(async (ticket) => {
+                // Deduplicate: check whether we already posted a comment for this PR on this ticket
+                const existing = await getJiraIssueComments(ticket);
+                const alreadyPosted = existing?.some(c => {
+                    // Comments stored as ADF; fall back to plain text check on stringified body
+                    const raw = JSON.stringify(c.body || '');
+                    return raw.includes(`pr=${issue_number}`);
+                });
+                if (alreadyPosted) {
+                    console.log(`Skipping ${ticket} — already has a comment for PR #${issue_number}`);
+                    return;
+                }
+
+                const adf = {
+                    type: 'doc',
+                    version: 1,
+                    content: [
+                        paragraph([
+                            txt(`${sentinel}[This issue was mentioned in `),
+                            link(`PR #${issue_number}`, prLink),
+                            pr_title ? txt(` — ${pr_title}`) : txt(''),
+                            txt(' by '),
+                            link('CI workflow', process.env.JOB_URL || '#'),
+                            txt('.]'),
+                        ]),
+                    ],
+                };
+
+                const issue = await getJiraIssue(ticket);
+                const isWatching = issue?.fields?.watches?.isWatching ?? false;
+                await addJiraComment(ticket, adf);
+                if (!isWatching) {
+                    const self = await getCurrentJiraUser();
+                    await unwatchJiraIssue(ticket, self);
+                }
+            }));

--- a/.github/workflows/gh-comment-hook.yml
+++ b/.github/workflows/gh-comment-hook.yml
@@ -54,7 +54,7 @@ jobs:
             if (eventAction !== 'opened') return;
             if (!process.env.JIRA_API_AUTH) return;
 
-            const { addJiraComment, getJiraIssue, getJiraIssueComments, getCurrentJiraUser, unwatchJiraIssue } =
+            const { addJiraComment, getJiraIssueComments } =
                 require('./scripts/ci/_utils.mjs');
 
             // Collect all JIRA tickets referenced in the PR body (using the possibly-updated body)
@@ -98,11 +98,5 @@ jobs:
                     ],
                 };
 
-                const issue = await getJiraIssue(ticket);
-                const isWatching = issue?.fields?.watches?.isWatching ?? false;
                 await addJiraComment(ticket, adf);
-                if (!isWatching) {
-                    const self = await getCurrentJiraUser();
-                    await unwatchJiraIssue(ticket, self);
-                }
             }));

--- a/.github/workflows/gh-comment-hook.yml
+++ b/.github/workflows/gh-comment-hook.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   expand-jira-links:
+    if: github.repository == 'ag-grid/ag-grid'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/scripts/ci/_utils.mjs
+++ b/scripts/ci/_utils.mjs
@@ -190,6 +190,17 @@ export async function unwatchJiraIssue(issueKey, userId) {
     }
 }
 
+export async function getJiraIssueComments(issueKey) {
+    const url = `https://ag-grid.atlassian.net/rest/api/3/issue/${issueKey}/comment?maxResults=100`;
+    try {
+        const data = await commonFetch(url, { method: 'GET' });
+        return data.comments || [];
+    } catch (error) {
+        console.error('Error fetching comments:', error.message);
+        throw error;
+    }
+}
+
 export async function getJiraWatches(issueKey) {
     const url = `https://ag-grid.atlassian.net/rest/api/3/issue/${issueKey}/watchers`;
     try {


### PR DESCRIPTION
- When a PR is opened, post an ADF comment to each referenced Jira ticket linking back to the PR
- Add deduplication via sentinel string to avoid duplicate comments
- Add `getJiraIssueComments` helper to `scripts/ci/_utils.mjs`