### PR TITLE
AG-17039 Reorder aggregation function list by usage frequency

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/aggregation-columns/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-columns/index.mdoc
@@ -59,7 +59,7 @@ const gridOptions = {
 ### Allowed Functions
 
 To restrict the aggregation functions that can be applied to a column, set the `allowedAggFuncs` column
-definition property to an array of allowed aggregation function names.
+definition property to an array of allowed aggregation function names. The functions appear in the order specified in the array.
 
 {% gridExampleRunner title="Allowed Aggregations" name="user-configured-allowed-aggregations" /%}
 

--- a/packages/ag-grid-enterprise/src/aggregation/aggFuncService.test.ts
+++ b/packages/ag-grid-enterprise/src/aggregation/aggFuncService.test.ts
@@ -1,4 +1,4 @@
-import type { GridOptionsService, IAggFuncParams } from 'ag-grid-community';
+import type { AgColumn, GridOptionsService, IAggFuncParams } from 'ag-grid-community';
 
 import { mock } from '../test-utils/mock';
 import { AggFuncService } from './aggFuncService';
@@ -13,11 +13,44 @@ function createService(): AggFuncService {
     return service;
 }
 
+function createColumn(allowedAggFuncs?: string[]): AgColumn {
+    return { colDef: { allowedAggFuncs } } as AgColumn;
+}
+
 function createParams(values: any[]): IAggFuncParams {
     return {
         values: values,
     } as IAggFuncParams;
 }
+
+describe('getFuncNames', () => {
+    it('returns built-in functions in priority order', () => {
+        const service = createService();
+        service.getAggFunc('sum');
+        const result = service.getFuncNames(createColumn());
+
+        expect(result).toEqual(['sum', 'avg', 'max', 'min', 'count', 'first', 'last']);
+    });
+
+    it('appends custom functions after built-ins in alphabetical order', () => {
+        const service = createService();
+        service.addAggFuncs({
+            median: () => 0,
+            absolute: () => 0,
+            zScore: () => 0,
+        });
+        const result = service.getFuncNames(createColumn());
+
+        expect(result).toEqual(['sum', 'avg', 'max', 'min', 'count', 'first', 'last', 'absolute', 'median', 'zScore']);
+    });
+
+    it('returns allowedAggFuncs as-is when specified on the column', () => {
+        const service = createService();
+        const result = service.getFuncNames(createColumn(['count', 'sum']));
+
+        expect(result).toEqual(['count', 'sum']);
+    });
+});
 
 describe('aggSum', () => {
     const sum = createService().getAggFunc('sum');

--- a/packages/ag-grid-enterprise/src/aggregation/aggFuncService.ts
+++ b/packages/ag-grid-enterprise/src/aggregation/aggFuncService.ts
@@ -17,7 +17,7 @@ type DefaultAggFuncName = keyof typeof defaultAggFuncNames;
 export class AggFuncService extends BeanStub implements NamedBean, IAggFuncService {
     beanName = 'aggFuncSvc' as const;
 
-    private aggFuncsMap = new Map<string, IAggFunc>();
+    private readonly aggFuncsMap = new Map<string, IAggFunc>();
     private orderedFuncNames: string[] = [];
     private initialised = false;
 

--- a/packages/ag-grid-enterprise/src/aggregation/aggFuncService.ts
+++ b/packages/ag-grid-enterprise/src/aggregation/aggFuncService.ts
@@ -88,7 +88,7 @@ export class AggFuncService extends BeanStub implements NamedBean, IAggFuncServi
     }
 
     public getFuncNames(column: AgColumn): string[] {
-        return column.colDef.allowedAggFuncs ?? this.orderedFuncNames;
+        return column.colDef.allowedAggFuncs ?? this.orderedFuncNames.slice();
     }
 
     private updateOrderedFuncNames(): void {

--- a/packages/ag-grid-enterprise/src/aggregation/aggFuncService.ts
+++ b/packages/ag-grid-enterprise/src/aggregation/aggFuncService.ts
@@ -10,12 +10,15 @@ const defaultAggFuncNames = {
     count: 'Count',
     avg: 'Average',
 } as const;
+
+const DEFAULT_AGG_FUNC_ORDER: DefaultAggFuncName[] = ['sum', 'avg', 'max', 'min', 'count', 'first', 'last'];
 type DefaultAggFuncName = keyof typeof defaultAggFuncNames;
 
 export class AggFuncService extends BeanStub implements NamedBean, IAggFuncService {
     beanName = 'aggFuncSvc' as const;
 
-    private aggFuncsMap: { [key in string]: IAggFunc } = {};
+    private aggFuncsMap = new Map<string, IAggFunc>();
+    private orderedFuncNames: string[] = [];
     private initialised = false;
 
     public postConstruct(): void {
@@ -32,22 +35,16 @@ export class AggFuncService extends BeanStub implements NamedBean, IAggFuncServi
     }
 
     private initialiseWithDefaultAggregations(): void {
-        const aggMap = this.aggFuncsMap as { [key in DefaultAggFuncName]: IAggFunc };
-        aggMap['sum'] = aggSum;
-        aggMap['first'] = aggFirst;
-        aggMap['last'] = aggLast;
-        aggMap['min'] = aggMin;
-        aggMap['max'] = aggMax;
-        aggMap['count'] = aggCount;
-        aggMap['avg'] = aggAvg;
+        const funcMap = this.aggFuncsMap;
+        funcMap.set('sum', aggSum);
+        funcMap.set('first', aggFirst);
+        funcMap.set('last', aggLast);
+        funcMap.set('min', aggMin);
+        funcMap.set('max', aggMax);
+        funcMap.set('count', aggCount);
+        funcMap.set('avg', aggAvg);
         this.initialised = true;
-    }
-
-    private isAggFuncPossible(column: AgColumn, func: string): boolean {
-        const allKeys = this.getFuncNames(column);
-        const allowed = allKeys.includes(func);
-        const funcExists = _exists(this.aggFuncsMap[func]);
-        return allowed && funcExists;
+        this.updateOrderedFuncNames();
     }
 
     public getDefaultFuncLabel(fctName: DefaultAggFuncName): string {
@@ -57,11 +54,14 @@ export class AggFuncService extends BeanStub implements NamedBean, IAggFuncServi
     public getDefaultAggFunc(column: AgColumn): string | null {
         const defaultAgg = column.colDef.defaultAggFunc;
 
-        if (_exists(defaultAgg) && this.isAggFuncPossible(column, defaultAgg)) {
+        const isAggFuncPossible = (func: string) =>
+            _exists(this.aggFuncsMap.get(func)) && this.getFuncNames(column).includes(func);
+
+        if (_exists(defaultAgg) && isAggFuncPossible(defaultAgg)) {
             return defaultAgg;
         }
 
-        if (this.isAggFuncPossible(column, 'sum')) {
+        if (isAggFuncPossible('sum')) {
             return 'sum';
         }
 
@@ -76,24 +76,39 @@ export class AggFuncService extends BeanStub implements NamedBean, IAggFuncServi
         }
         for (const key of Object.keys(aggFuncs)) {
             if (aggFuncs[key]) {
-                this.aggFuncsMap[key] = aggFuncs[key];
+                this.aggFuncsMap.set(key, aggFuncs[key]);
             }
         }
+        this.updateOrderedFuncNames();
     }
 
     public getAggFunc(name: string): IAggFunc {
         this.init();
-        return this.aggFuncsMap[name];
+        return this.aggFuncsMap.get(name)!;
     }
 
     public getFuncNames(column: AgColumn): string[] {
-        const userAllowedFuncs = column.colDef.allowedAggFuncs;
+        return column.colDef.allowedAggFuncs ?? this.orderedFuncNames;
+    }
 
-        return userAllowedFuncs == null ? Object.keys(this.aggFuncsMap).sort() : userAllowedFuncs;
+    private updateOrderedFuncNames(): void {
+        const result: string[] = [];
+        for (const key of DEFAULT_AGG_FUNC_ORDER) {
+            if (this.aggFuncsMap.has(key)) {
+                result.push(key);
+            }
+        }
+        for (const key of [...this.aggFuncsMap.keys()].sort()) {
+            if (!(key in defaultAggFuncNames)) {
+                result.push(key);
+            }
+        }
+        this.orderedFuncNames = result;
     }
 
     public clear(): void {
-        this.aggFuncsMap = {};
+        this.aggFuncsMap.clear();
+        this.orderedFuncNames = [];
     }
 }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17039

Reorder the built-in aggregation function list from alphabetical to a
usage-frequency order: sum, avg, max, min, count, first, last. Custom
agg funcs now appear after built-ins, sorted alphabetically.

Also switches `aggFuncsMap` from a plain object to a `Map` and caches
the ordered func name list so `getFuncNames` is a simple return.

Documents that `allowedAggFuncs` preserves the array order.

Fix [AG-17039](https://ag-grid.atlassian.net/browse/AG-17039)