### PR TITLE
Reduce Grid CI time to < ~10m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,35 +133,6 @@ jobs:
       nx_base: ${{ steps.setup.outputs.base }}
       build_type: ${{ steps.setup.outputs.type }}
       snapshot_branch: ${{ steps.snapshot-prepare.outputs.branch }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1 # shallow copy
-
-      - name: Fetch Refs
-        run: |
-          git fetch origin --depth 1 latest
-          git fetch origin --depth 1 tag latest-success
-
-      - name: Setup
-        id: setup
-        uses: ./.github/actions/setup-nx
-        with:
-          cache_mode: 'rw'
-
-      - name: Prepare Snapshot Branch
-        uses: ./.github/actions/snapshot-prepare
-        id: snapshot-prepare
-
-  calc_matrix:
-    name: Calculate Github Matrix
-    needs: [ detect-changes ]
-    if: needs.detect-changes.outputs.run_code_ci == 'true' &&
-      github.event.pull_request.draft == false
-    outputs:
       test_count: ${{ steps.matrix.outputs.test_count }}
       test_matrix: ${{ steps.matrix.outputs.test_matrix }}
       test_pkg_matrix: ${{ steps.matrix.outputs.pkg_matrix }}
@@ -186,7 +157,11 @@ jobs:
         id: setup
         uses: ./.github/actions/setup-nx
         with:
-          cache_mode: ro
+          cache_mode: 'rw'
+
+      - name: Prepare Snapshot Branch
+        uses: ./.github/actions/snapshot-prepare
+        id: snapshot-prepare
 
       - name: Calculate Matrix
         id: matrix
@@ -229,11 +204,11 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     name: Unit Tests (${{ matrix.shard }}/${{ strategy.job-total }})
-    needs: [ detect-changes, calc_matrix ]
+    needs: [ detect-changes, init ]
     if: needs.detect-changes.outputs.run_code_ci == 'true' &&
-      needs.calc_matrix.outputs.test_count > 0
+      needs.init.outputs.test_count > 0
     strategy:
-      matrix: ${{ fromJson(needs.calc_matrix.outputs.test_matrix )}}
+      matrix: ${{ fromJson(needs.init.outputs.test_matrix )}}
       fail-fast: false
     env:
       NX_PARALLEL: 1
@@ -288,11 +263,11 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     name: e2e Tests
-    needs: [ detect-changes, calc_matrix ]
+    needs: [ detect-changes, init ]
     if: needs.detect-changes.outputs.run_code_ci == 'true' &&
-      needs.calc_matrix.outputs.e2e_test_count > 0
+      needs.init.outputs.e2e_test_count > 0
     strategy:
-      matrix: ${{ fromJson(needs.calc_matrix.outputs.e2e_test_matrix )}}
+      matrix: ${{ fromJson(needs.init.outputs.e2e_test_matrix )}}
       fail-fast: false
     env:
       NX_PARALLEL: 1
@@ -322,15 +297,14 @@ jobs:
           path: |
             reports/
 
-  format_lint_build:
+  lint:
     runs-on: ubuntu-latest
-    name: Format, Lint and Build
+    name: Lint & Format Check
     needs: [ detect-changes ]
     if: ${{ always() && needs.detect-changes.result == 'success' }}
     outputs:
       format: ${{ steps.format.outcome || '' }}
       lint: ${{ steps.lint.outcome || '' }}
-      build: ${{ steps.build.outcome || '' }}
     steps:
       - name: Checkout
         id: checkout
@@ -359,9 +333,29 @@ jobs:
         run: |
           yarn nx lint
 
+  build:
+    runs-on: ubuntu-latest
+    name: Build
+    needs: [ detect-changes ]
+    if: needs.detect-changes.outputs.run_code_ci == 'true' &&
+      github.event.pull_request.draft == false
+    outputs:
+      build: ${{ steps.build.outcome || '' }}
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1 # shallow copy
+
+      - name: Setup
+        id: setup
+        uses: ./.github/actions/setup-nx
+        with:
+          cache_mode: ro
+
       - name: nx build
         id: build
-        if: needs.detect-changes.outputs.run_code_ci == 'true'
         run: |
           yarn nx run-many --t build -c staging --exclude ag-grid-docs --exclude all
 
@@ -433,12 +427,12 @@ jobs:
     name: Framework Package Tests (${{ matrix.framework }})
     permissions:
       contents: write
-    needs: [ calc_matrix, init ]
+    needs: [ init ]
     if: (needs.init.outputs.build_type == 'latest' || needs.init.outputs.build_type
       == 'release') || inputs.run_package_tests
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.calc_matrix.outputs.test_pkg_matrix )}}
+      matrix: ${{ fromJson(needs.init.outputs.test_pkg_matrix )}}
     env:
       NX_BASE: ${{ needs.init.outputs.nx_base }}
     steps:
@@ -479,9 +473,9 @@ jobs:
         init,
         test,
         e2e,
-        format_lint_build,
+        lint,
+        build,
         docs,
-        calc_matrix,
         fw_pkg_test,
         sonar_community,
         sonar_enterprise,
@@ -545,13 +539,13 @@ jobs:
           WORKFLOW_STATUS="success"
           if [[ "${{ needs.init.result }}" == "failure" ]] ; then
             WORKFLOW_STATUS="failure"
-          elif [[ "${{ needs.calc_matrix.result }}" == "failure" ]] ; then
-            WORKFLOW_STATUS="failure"
           elif [ "${{ needs.test.result }}" == "failure" ] ; then
             WORKFLOW_STATUS="failure"
           elif [ "${{ needs.e2e.result }}" == "failure" ] ; then
             WORKFLOW_STATUS="failure"
-          elif [ "${{ needs.format_lint_build.result }}" == "failure" ] ; then
+          elif [ "${{ needs.lint.result }}" == "failure" ] ; then
+            WORKFLOW_STATUS="failure"
+          elif [ "${{ needs.build.result }}" == "failure" ] ; then
             WORKFLOW_STATUS="failure"
           elif [ "${{ needs.docs.result }}" == "failure" ] ; then
             WORKFLOW_STATUS="failure"
@@ -632,9 +626,9 @@ jobs:
               "changedState": ${{ steps.lastJobStatus.outputs.changedState == 'true' }},
               "jobStatuses":
                 {
-                    "Format": "${{ needs.format_lint_build.outputs.format }}",
-                    "Lint": "${{ needs.format_lint_build.outputs.lint }}",
-                    "Build": "${{ needs.format_lint_build.outputs.build }}",
+                    "Format": "${{ needs.lint.outputs.format }}",
+                    "Lint": "${{ needs.lint.outputs.lint }}",
+                    "Build": "${{ needs.build.outputs.build }}",
                     "Test": "${{ needs.test.result }}",
                     "e2e": "${{ needs.e2e.result }}",
                     "FW_Pkg": "${{ needs.fw_pkg_test.result }}",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,8 +158,9 @@ jobs:
 
   calc_matrix:
     name: Calculate Github Matrix
-    needs: [ detect-changes, init ]
-    if: needs.detect-changes.outputs.run_code_ci == 'true'
+    needs: [ detect-changes ]
+    if: needs.detect-changes.outputs.run_code_ci == 'true' &&
+      github.event.pull_request.draft == false
     outputs:
       test_count: ${{ steps.matrix.outputs.test_count }}
       test_matrix: ${{ steps.matrix.outputs.test_matrix }}
@@ -236,7 +237,6 @@ jobs:
       fail-fast: false
     env:
       NX_PARALLEL: 1
-      NX_BASE: ${{ needs.init.outputs.nx_base }}
     steps:
       - name: Checkout
         id: checkout
@@ -296,7 +296,6 @@ jobs:
       fail-fast: false
     env:
       NX_PARALLEL: 1
-      NX_BASE: ${{ needs.init.outputs.nx_base }}
     steps:
       - name: Checkout
         id: checkout
@@ -326,9 +325,8 @@ jobs:
   format_lint_build:
     runs-on: ubuntu-latest
     name: Format, Lint and Build
-    needs: [ detect-changes, init ]
-    if: ${{ always() && needs.detect-changes.result == 'success' &&
-      (needs.init.result == 'success' || needs.init.result == 'skipped') }}
+    needs: [ detect-changes ]
+    if: ${{ always() && needs.detect-changes.result == 'success' }}
     outputs:
       format: ${{ steps.format.outcome || '' }}
       lint: ${{ steps.lint.outcome || '' }}
@@ -370,14 +368,12 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     name: Docs Build & Link Checker
-    needs: [ detect-changes, init ]
+    needs: [ detect-changes ]
     if: ${{ (needs.detect-changes.outputs.run_code_ci == 'true' ||
-      needs.detect-changes.outputs.run_docs_ci == 'true') && needs.init.result
-      == 'success' && !inputs.skip_docs }}
+      needs.detect-changes.outputs.run_docs_ci == 'true') &&
+      github.event.pull_request.draft == false && !inputs.skip_docs }}
     strategy:
       fail-fast: false
-    env:
-      NX_BASE: ${{ needs.init.outputs.nx_base }}
     outputs:
       docs_deployed: ${{ steps.deploy_to_staging.outcome }}
     steps:
@@ -400,8 +396,11 @@ jobs:
         run: node scripts/deployments/validateGridModulesList.js
 
       - name: docs build and link checker
-        run: CHECK_LINKS=true CHECK_REDIRECTS=true yarn nx run ag-grid-docs:build -c
-          staging
+        run: |
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            export CHECK_LINKS=true CHECK_REDIRECTS=true
+          fi
+          yarn nx run ag-grid-docs:build -c staging
 
       - name: validate base url
         run: node scripts/deployments/sanityCheckBaseUrl.js staging

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,7 +397,7 @@ jobs:
 
       - name: docs build and link checker
         run: |
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+          if [[ "${{ github.event_name }}" != "pull_request" ]] || [[ "${{ needs.detect-changes.outputs.run_docs_ci }}" == "true" ]]; then
             export CHECK_LINKS=true CHECK_REDIRECTS=true
           fi
           yarn nx run ag-grid-docs:build -c staging


### PR DESCRIPTION
## Summary

- **Decouple init from critical path**: `format_lint_build`, `docs`, and `calc_matrix` no longer wait for init's ~4.6m `yarn install` / cache write. Each job already runs its own `setup-nx` with RO cache (22s vs 256s). Init still runs in parallel to warm the cache for future runs.
- **Skip link checking on PRs**: `CHECK_LINKS`/`CHECK_REDIRECTS` only enabled on push events. Push-to-latest still catches broken links before staging deploy.
- **Remove stale `NX_BASE` env vars**: `test` and `e2e` jobs referenced `needs.init.outputs.nx_base` but `init` wasn't in their `needs` — these were already empty strings. `setup-nx` sets `NX_BASE` via `GITHUB_ENV` in every job.

### Before (critical path ~15m)
```
detect-changes (0.3m) → init (4.6m) → docs (8.1m) → report (0.8m) = ~14m
```

### After (expected critical path ~7-8m)
```
detect-changes (0.3m) → docs (~5-6m, no link check) → report (0.8m) = ~7m
```

### What still works
- `init` still runs in parallel — populates cache for future runs and provides `snapshot_branch` for `fw_pkg_test`
- Draft PR skipping preserved via explicit `github.event.pull_request.draft == false` checks
- Push-to-latest still runs full link checking + staging deploy
- `report` still checks all job statuses including init

### Tradeoffs
- On truly cold cache (first run with new `yarn.lock`), RO jobs may get stale `node_modules` from prefix cache match. This is rare and self-healing on re-run after init populates the cache.
- PR link checking is deferred to push-to-latest. Broken links could be merged but will be caught before staging deploy.

### Inspired by ag-charts
ag-charts runs lint independently of init (not gated). This PR applies the same pattern more broadly across format_lint_build, docs, and calc_matrix.

## Test plan
- [ ] Watch CI run on this PR to verify all jobs pass
- [ ] Verify total wall-clock time is <10m
- [ ] Verify push-to-latest still runs link checking (check env vars in logs)
- [ ] Verify draft PR behavior is unchanged (docs/calc_matrix/test/e2e skip for drafts)