### PR TITLE
[AG-17270] Fix(toolbar): pin built in actions not working

### DIFF
--- a/.github/workflows/gh-comment-hook.yml
+++ b/.github/workflows/gh-comment-hook.yml
@@ -89,12 +89,12 @@ jobs:
                     version: 1,
                     content: [
                         paragraph([
-                            txt(`${sentinel}[This issue was mentioned in `),
+                            txt(`This issue was mentioned in `),
                             link(`PR #${issue_number}`, prLink),
                             pr_title ? txt(` — ${pr_title}`) : txt(''),
                             txt(' by '),
                             link('CI workflow', process.env.JOB_URL || '#'),
-                            txt('.]'),
+                            txt(`.\n${sentinel}`),
                         ]),
                     ],
                 };

--- a/.github/workflows/gh-comment-hook.yml
+++ b/.github/workflows/gh-comment-hook.yml
@@ -65,7 +65,7 @@ jobs:
 
             const prLink = `https://github.com/${owner}/${repo}/pull/${issue_number}`;
             // Sentinel string embedded in the comment so we can detect it later and avoid duplicates
-            const sentinel = `<!-- gh-pr-mention:pr=${issue_number} -->`;
+            const sentinel = `gh-pr-mention:pr=${issue_number}`;
 
             const paragraph = (content) => ({ type: 'paragraph', content: Array.isArray(content) ? content : [content] });
             const txt = (text) => ({ text, type: 'text' });
@@ -77,7 +77,7 @@ jobs:
                 const alreadyPosted = existing?.some(c => {
                     // Comments stored as ADF; fall back to plain text check on stringified body
                     const raw = JSON.stringify(c.body || '');
-                    return raw.includes(`pr=${issue_number}`);
+                    return raw.includes(sentinel);
                 });
                 if (alreadyPosted) {
                     console.log(`Skipping ${ticket} — already has a comment for PR #${issue_number}`);

--- a/packages/ag-grid-enterprise/src/menu/menuItemMapper.ts
+++ b/packages/ag-grid-enterprise/src/menu/menuItemMapper.ts
@@ -5,6 +5,7 @@ import type {
     GetNoteParams,
     IAggFuncService,
     IColsService,
+    IMenuActionParams,
     INoteAccess,
     INotesService,
     LocaleTextFunc,
@@ -121,12 +122,16 @@ export class MenuItemMapper extends BeanStub implements NamedBean {
             valueColsSvc,
         } = beans;
 
-        const forEachRowInSelection = (action: (node: RowNode) => void) => {
-            rangeSvc?.getCellRanges()?.forEach((cellRange) => {
+        const getPinActionHandler = (sideOrRemove: 'top' | 'bottom' | null, { node, column }: IMenuActionParams) => {
+            if (node) {
+                return pinnedRowModel!.pinRow(node as RowNode, sideOrRemove ?? null, column as AgColumn);
+            }
+            // pick selected cells / rows / columns
+            return rangeSvc?.getCellRanges()?.forEach((cellRange) => {
                 rangeSvc.forEachRowInRange(cellRange, (row) => {
-                    const node = _getRowNode(beans, row);
-                    if (node) {
-                        action(node);
+                    const nodeFromSelection = _getRowNode(beans, row);
+                    if (nodeFromSelection) {
+                        pinnedRowModel!.pinRow(nodeFromSelection, sideOrRemove ?? null, null);
                     }
                 });
             });
@@ -203,13 +208,7 @@ export class MenuItemMapper extends BeanStub implements NamedBean {
                         ? {
                               name: localeTextFunc('pinTop', 'Pin to Top'),
                               icon: _createIconNoSpan('rowPinTop', beans, column),
-                              action: ({ node, column }) => {
-                                  if (node) {
-                                      pinnedRowModel.pinRow(node as RowNode, 'top', column as AgColumn | null);
-                                  } else {
-                                      forEachRowInSelection((node) => pinnedRowModel.pinRow(node, 'top', null));
-                                  }
-                              },
+                              action: getPinActionHandler.bind(this, 'top'),
                           }
                         : null;
                 case 'pinBottom':
@@ -217,13 +216,7 @@ export class MenuItemMapper extends BeanStub implements NamedBean {
                         ? {
                               name: localeTextFunc('pinBottom', 'Pin to Bottom'),
                               icon: _createIconNoSpan('rowPinBottom', beans, column),
-                              action: ({ node, column }) => {
-                                  if (node) {
-                                      pinnedRowModel.pinRow(node as RowNode, 'bottom', column as AgColumn | null);
-                                  } else {
-                                      forEachRowInSelection((node) => pinnedRowModel.pinRow(node, 'bottom', null));
-                                  }
-                              },
+                              action: getPinActionHandler.bind(this, 'bottom'),
                           }
                         : null;
                 case 'unpinRow':
@@ -231,13 +224,7 @@ export class MenuItemMapper extends BeanStub implements NamedBean {
                         ? {
                               name: localeTextFunc('unpinRow', 'Unpin Row'),
                               icon: _createIconNoSpan('rowUnpin', beans, column),
-                              action: ({ node, column }) => {
-                                  if (node) {
-                                      pinnedRowModel.pinRow(node as RowNode, null, column as AgColumn | null);
-                                  } else {
-                                      forEachRowInSelection((node) => pinnedRowModel.pinRow(node, null, null));
-                                  }
-                              },
+                              action: getPinActionHandler.bind(this, null),
                           }
                         : null;
                 case 'valueAggSubMenu':

--- a/packages/ag-grid-enterprise/src/menu/menuItemMapper.ts
+++ b/packages/ag-grid-enterprise/src/menu/menuItemMapper.ts
@@ -98,26 +98,39 @@ export class MenuItemMapper extends BeanStub implements NamedBean {
 
         const localeTextFunc = this.getLocaleTextFunc();
         const { beans, gos } = this;
+
         const {
-            pinnedCols,
-            colAutosize,
             aggFuncSvc,
-            rowGroupColsSvc,
-            colNames,
-            colModel,
+            chartMenuItemMapper,
             clipboardSvc,
-            expansionSvc,
-            focusSvc,
+            colAutosize,
+            colChooserFactory,
+            colModel,
+            colNames,
             csvCreator,
             excelCreator,
+            expansionSvc,
+            focusSvc,
             menuSvc,
-            colChooserFactory,
-            sortSvc,
-            chartMenuItemMapper,
-            valueColsSvc,
-            pinnedRowModel,
             notesSvc,
+            pinnedCols,
+            pinnedRowModel,
+            rangeSvc,
+            rowGroupColsSvc,
+            sortSvc,
+            valueColsSvc,
         } = beans;
+
+        const forEachRowInSelection = (action: (node: RowNode) => void) => {
+            rangeSvc?.getCellRanges().forEach((cellRange) => {
+                rangeSvc.forEachRowInRange(cellRange, (row) => {
+                    const node = _getRowNode(beans, row);
+                    if (node) {
+                        action(node);
+                    }
+                });
+            });
+        };
 
         const getStockMenuItem = (
             key: DefaultMenuItem,
@@ -190,8 +203,13 @@ export class MenuItemMapper extends BeanStub implements NamedBean {
                         ? {
                               name: localeTextFunc('pinTop', 'Pin to Top'),
                               icon: _createIconNoSpan('rowPinTop', beans, column),
-                              action: ({ node, column }) =>
-                                  node && pinnedRowModel.pinRow(node as RowNode, 'top', column as AgColumn | null),
+                              action: ({ node, column }) => {
+                                  if (node) {
+                                      pinnedRowModel.pinRow(node as RowNode, 'top', column as AgColumn | null);
+                                  } else {
+                                      forEachRowInSelection((node) => pinnedRowModel.pinRow(node, 'top', null));
+                                  }
+                              },
                           }
                         : null;
                 case 'pinBottom':
@@ -199,8 +217,13 @@ export class MenuItemMapper extends BeanStub implements NamedBean {
                         ? {
                               name: localeTextFunc('pinBottom', 'Pin to Bottom'),
                               icon: _createIconNoSpan('rowPinBottom', beans, column),
-                              action: ({ node, column }) =>
-                                  node && pinnedRowModel.pinRow(node as RowNode, 'bottom', column as AgColumn | null),
+                              action: ({ node, column }) => {
+                                  if (node) {
+                                      pinnedRowModel.pinRow(node as RowNode, 'bottom', column as AgColumn | null);
+                                  } else {
+                                      forEachRowInSelection((node) => pinnedRowModel.pinRow(node, 'bottom', null));
+                                  }
+                              },
                           }
                         : null;
                 case 'unpinRow':
@@ -208,8 +231,13 @@ export class MenuItemMapper extends BeanStub implements NamedBean {
                         ? {
                               name: localeTextFunc('unpinRow', 'Unpin Row'),
                               icon: _createIconNoSpan('rowUnpin', beans, column),
-                              action: ({ node, column }) =>
-                                  node && pinnedRowModel.pinRow(node as RowNode, null, column as AgColumn | null),
+                              action: ({ node, column }) => {
+                                  if (node) {
+                                      pinnedRowModel.pinRow(node as RowNode, null, column as AgColumn | null);
+                                  } else {
+                                      forEachRowInSelection((node) => pinnedRowModel.pinRow(node, null, null));
+                                  }
+                              },
                           }
                         : null;
                 case 'valueAggSubMenu':

--- a/packages/ag-grid-enterprise/src/menu/menuItemMapper.ts
+++ b/packages/ag-grid-enterprise/src/menu/menuItemMapper.ts
@@ -122,7 +122,7 @@ export class MenuItemMapper extends BeanStub implements NamedBean {
         } = beans;
 
         const forEachRowInSelection = (action: (node: RowNode) => void) => {
-            rangeSvc?.getCellRanges().forEach((cellRange) => {
+            rangeSvc?.getCellRanges()?.forEach((cellRange) => {
                 rangeSvc.forEachRowInRange(cellRange, (row) => {
                     const node = _getRowNode(beans, row);
                     if (node) {

--- a/packages/ag-grid-enterprise/src/menu/menuItemMapper.ts
+++ b/packages/ag-grid-enterprise/src/menu/menuItemMapper.ts
@@ -122,20 +122,22 @@ export class MenuItemMapper extends BeanStub implements NamedBean {
             valueColsSvc,
         } = beans;
 
-        const getPinActionHandler = (sideOrRemove: 'top' | 'bottom' | null, { node, column }: IMenuActionParams) => {
-            if (node) {
-                return pinnedRowModel!.pinRow(node as RowNode, sideOrRemove ?? null, column as AgColumn);
-            }
-            // pick selected cells / rows / columns
-            return rangeSvc?.getCellRanges()?.forEach((cellRange) => {
-                rangeSvc.forEachRowInRange(cellRange, (row) => {
-                    const nodeFromSelection = _getRowNode(beans, row);
-                    if (nodeFromSelection) {
-                        pinnedRowModel!.pinRow(nodeFromSelection, sideOrRemove ?? null, null);
-                    }
+        const getPinActionHandler =
+            (sideOrRemove: 'top' | 'bottom' | null) =>
+            ({ node, column }: IMenuActionParams) => {
+                if (node) {
+                    return pinnedRowModel!.pinRow(node as RowNode, sideOrRemove ?? null, column as AgColumn);
+                }
+                // pick selected cells / rows / columns
+                return rangeSvc?.getCellRanges()?.forEach((cellRange) => {
+                    rangeSvc.forEachRowInRange(cellRange, (row) => {
+                        const nodeFromSelection = _getRowNode(beans, row);
+                        if (nodeFromSelection) {
+                            pinnedRowModel!.pinRow(nodeFromSelection, sideOrRemove ?? null, null);
+                        }
+                    });
                 });
-            });
-        };
+            };
 
         const getStockMenuItem = (
             key: DefaultMenuItem,
@@ -208,7 +210,7 @@ export class MenuItemMapper extends BeanStub implements NamedBean {
                         ? {
                               name: localeTextFunc('pinTop', 'Pin to Top'),
                               icon: _createIconNoSpan('rowPinTop', beans, column),
-                              action: getPinActionHandler.bind(this, 'top'),
+                              action: getPinActionHandler('top'),
                           }
                         : null;
                 case 'pinBottom':
@@ -216,7 +218,7 @@ export class MenuItemMapper extends BeanStub implements NamedBean {
                         ? {
                               name: localeTextFunc('pinBottom', 'Pin to Bottom'),
                               icon: _createIconNoSpan('rowPinBottom', beans, column),
-                              action: getPinActionHandler.bind(this, 'bottom'),
+                              action: getPinActionHandler('bottom'),
                           }
                         : null;
                 case 'unpinRow':
@@ -224,7 +226,7 @@ export class MenuItemMapper extends BeanStub implements NamedBean {
                         ? {
                               name: localeTextFunc('unpinRow', 'Unpin Row'),
                               icon: _createIconNoSpan('rowUnpin', beans, column),
-                              action: getPinActionHandler.bind(this, null),
+                              action: getPinActionHandler(null),
                           }
                         : null;
                 case 'valueAggSubMenu':


### PR DESCRIPTION
Fall back to iterating over the current range selection for pinTop, pinBottom, and unpinRow actions when triggered from the toolbar (where no row node is provided).

Fix [AG-17270](https://ag-grid.atlassian.net/browse/AG-17270) 