### PR TITLE
AG-17384 duplicate grand total row bug (latest)

### DIFF
--- a/packages/ag-grid-community/src/entities/rowNode.ts
+++ b/packages/ag-grid-community/src/entities/rowNode.ts
@@ -126,6 +126,9 @@ export class RowNode<TData = any>
 
     /**
      * Either 'top' or 'bottom' if row pinned, otherwise `undefined` or `null`.
+     * Invariant: only the pinned clone has this set; the source row keeps it null
+     * even while its `pinnedSibling` clone is in a container. Several pin/destroy
+     * code paths rely on this asymmetry to disambiguate clone vs source.
      * If re-naming this property, you must also update `IGNORED_SIBLING_PROPERTIES`
      */
     public rowPinned: RowPinnedType;
@@ -134,6 +137,7 @@ export class RowNode<TData = any>
      * If using manual row pinning, a reference to the sibling node.
      * If this node is in the pinned section, `pinnedSibling` is the source row.
      * If this node is in the main viewport, `pinnedSibling` is the pinned row.
+     * If re-naming this property, you must also update `IGNORED_SIBLING_PROPERTIES`
      */
     public pinnedSibling?: RowNode<TData>;
 
@@ -955,10 +959,10 @@ export class RowNode<TData = any>
         }
         this.destroyed = true;
 
-        // Check pinnedSibling.rowPinned to ensure we're the source row (not a pinned clone being destroyed).
-        // Also prevents re-entrance when _destroyRowNodeSibling clears rowPinned before calling _destroy.
+        // Unpin my clone if I'm the source. Only clones have rowPinned (see _createPinnedSibling),
+        // so this naturally no-ops when the recursive destroy hits the clone.
         const pinnedSibling = this.pinnedSibling;
-        if (pinnedSibling?.rowPinned && !this.rowPinned) {
+        if (pinnedSibling?.rowPinned) {
             this.beans.pinnedRowModel?.pinRow(pinnedSibling, null);
         }
 

--- a/packages/ag-grid-community/src/entities/rowNodeUtils.ts
+++ b/packages/ag-grid-community/src/entities/rowNodeUtils.ts
@@ -40,6 +40,7 @@ const IGNORED_SIBLING_PROPERTIES = new Set<
     '_groupData',
     '_leafs',
     'childStore',
+    'destroyed',
     'groupValue',
     'oldRowTop',
     'sticky',

--- a/packages/ag-grid-community/src/entities/rowNodeUtils.ts
+++ b/packages/ag-grid-community/src/entities/rowNodeUtils.ts
@@ -43,6 +43,8 @@ const IGNORED_SIBLING_PROPERTIES = new Set<
     'destroyed',
     'groupValue',
     'oldRowTop',
+    'pinnedSibling',
+    'rowPinned',
     'sticky',
     'treeNodeFlags',
     'treeParent',

--- a/packages/ag-grid-community/src/pinnedRowModel/manualPinnedRowModel.ts
+++ b/packages/ag-grid-community/src/pinnedRowModel/manualPinnedRowModel.ts
@@ -127,7 +127,10 @@ export class ManualPinnedRowModel extends BeanStub implements IPinnedRowModel {
             // 3. We then react to the `modelUpdated` event (above) to actually add the footer to the pinned row model.
             // Otherwise we would run into either an infinite recursion of `modelUpdated` events, or be missing the `sibling`
             // on the root node.
-            if (level === -1) {
+            // Skip this path when unpinning an existing clone (called from RowNode._destroy):
+            // the standard unpin path below cleans the DOM without mutating _grandTotalPinned.
+            const unpinningExistingClone = float == null && rowNode.rowPinned != null;
+            if (level === -1 && !unpinningExistingClone) {
                 this._grandTotalPinned = float;
                 // CSRM goes through reMapRows so the modelUpdated listener picks up the
                 // change; SSRM has no model-update path so we apply it directly.

--- a/testing/behavioural/src/grouping-data/grouped-pinned-sibling-aggregation.test.ts
+++ b/testing/behavioural/src/grouping-data/grouped-pinned-sibling-aggregation.test.ts
@@ -467,6 +467,60 @@ describe('ag-grid grouping pinned sibling aggregation', () => {
                 PINNED_BOTTOM id:b-bottom-rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " amount:1400
             `);
         });
+
+        test('CSRM pinned grand total stays as a single row after filter change', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs: [
+                    { field: 'country', rowGroup: true, hide: true },
+                    { field: 'amount', aggFunc: 'sum', filter: 'agNumberColumnFilter' },
+                ],
+                rowData: createRowData(),
+                getRowId: (params) => params.data.id,
+                grandTotalRow: 'pinnedBottom',
+                groupDefaultExpanded: -1,
+            });
+
+            expect(api.getPinnedBottomRowCount()).toBe(1);
+            expect(api.getPinnedBottomRow(0)?.aggData?.amount).toBe(1000);
+
+            await api.setColumnFilterModel('amount', { filterType: 'number', type: 'greaterThanOrEqual', filter: 200 });
+            api.onFilterChanged();
+
+            expect(api.getPinnedBottomRowCount()).toBe(1);
+            expect(api.getPinnedTopRowCount()).toBe(0);
+            expect(api.getPinnedBottomRow(0)?.aggData?.amount).toBe(750); // lyon 200 + hamburg 250 + rome 300
+        });
+
+        test('CSRM pinned grand total stays as a single row after cycling position', async () => {
+            const api = await gridsManager.createGridAndWait('myGrid', {
+                columnDefs: [
+                    { field: 'country', rowGroup: true, hide: true },
+                    { field: 'amount', aggFunc: 'sum' },
+                ],
+                rowData: createRowData(),
+                getRowId: (params) => params.data.id,
+                grandTotalRow: 'pinnedBottom',
+                groupDefaultExpanded: -1,
+            });
+
+            expect(api.getPinnedBottomRowCount()).toBe(1);
+            const firstPinned = api.getPinnedBottomRow(0)!;
+
+            api.setGridOption('grandTotalRow', 'pinnedTop');
+            expect(api.getPinnedBottomRowCount()).toBe(0);
+            expect(api.getPinnedTopRowCount()).toBe(1);
+            expect(firstPinned.destroyed).toBe(true);
+            const topPinned = api.getPinnedTopRow(0)!;
+
+            api.setGridOption('grandTotalRow', undefined);
+            expect(api.getPinnedBottomRowCount()).toBe(0);
+            expect(api.getPinnedTopRowCount()).toBe(0);
+            expect(topPinned.destroyed).toBe(true);
+
+            api.setGridOption('grandTotalRow', 'pinnedBottom');
+            expect(api.getPinnedBottomRowCount()).toBe(1);
+            expect(api.getPinnedBottomRow(0)?.destroyed).toBe(false);
+        });
     });
 
     describe('getAggregatedChildren on pinned siblings', () => {

--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-grand-total.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-grand-total.test.ts
@@ -1498,6 +1498,300 @@ describe('SSRM grand total row', () => {
         expect(api.getRowNode(GRAND_TOTAL_ID)?.data?.value).toBe(expectedTotal);
     });
 
+    test('pinnedBottom grand total is replaced (not duplicated) after filter change', async () => {
+        const api: GridApi<RowData> = gridManager.createGrid(null, {
+            columnDefs: [{ field: 'id' }, { field: 'value', filter: 'agNumberColumnFilter' }],
+            rowModelType: 'serverSide',
+            getRowId: (params: GetRowIdParams<RowData>) => params.data.id,
+            grandTotalRow: 'pinnedBottom',
+            serverSideDatasource: {
+                getRows(params: IServerSideGetRowsParams) {
+                    const filter = params.request.filterModel as { value?: { filter?: number } } | null;
+                    const threshold = filter?.value?.filter;
+                    const filtered = threshold != null ? flatRows.filter((r) => r.value > threshold) : flatRows;
+                    const rowData: any[] = [...filtered];
+                    if (params.needsGrandTotal) {
+                        const total = filtered.reduce((s, r) => s + r.value, 0);
+                        rowData.push({ id: GRAND_TOTAL_ID, value: total });
+                    }
+                    setTimeout(() => params.success({ rowData, rowCount: filtered.length }), 0);
+                },
+            },
+        });
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        expect(api.getPinnedBottomRowCount()).toBe(1);
+        expect(api.getPinnedBottomRow(0)?.data?.value).toBe(60);
+
+        await new GridRows(api, 'pinnedBottom initial').check(unindentText`
+            ROOT id:<no-id>
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            └── LEAF id:3 id:"3" value:30
+            PINNED_BOTTOM id:b-bottom-rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:60
+        `);
+
+        api.setFilterModel({ value: { type: 'greaterThan', filter: 15 } });
+        await waitForNoLoadingRows(api);
+        await asyncSetTimeout(50);
+
+        expect(api.getPinnedBottomRowCount()).toBe(1);
+        expect(api.getPinnedBottomRow(0)?.data?.value).toBe(50);
+
+        await new GridRows(api, 'pinnedBottom after filter').check(unindentText`
+            ROOT id:<no-id>
+            ├── LEAF id:2 id:"2" value:20
+            └── LEAF id:3 id:"3" value:30
+            PINNED_BOTTOM id:b-bottom-rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:50
+        `);
+    });
+
+    test('pinnedTop grand total is replaced (not duplicated) after filter change', async () => {
+        const api: GridApi<RowData> = gridManager.createGrid(null, {
+            columnDefs: [{ field: 'id' }, { field: 'value', filter: 'agNumberColumnFilter' }],
+            rowModelType: 'serverSide',
+            getRowId: (params: GetRowIdParams<RowData>) => params.data.id,
+            grandTotalRow: 'pinnedTop',
+            serverSideDatasource: {
+                getRows(params: IServerSideGetRowsParams) {
+                    const filter = params.request.filterModel as { value?: { filter?: number } } | null;
+                    const threshold = filter?.value?.filter;
+                    const filtered = threshold != null ? flatRows.filter((r) => r.value > threshold) : flatRows;
+                    const rowData: any[] = [...filtered];
+                    if (params.needsGrandTotal) {
+                        const total = filtered.reduce((s, r) => s + r.value, 0);
+                        rowData.push({ id: GRAND_TOTAL_ID, value: total });
+                    }
+                    setTimeout(() => params.success({ rowData, rowCount: filtered.length }), 0);
+                },
+            },
+        });
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        expect(api.getPinnedTopRowCount()).toBe(1);
+        expect(api.getPinnedTopRow(0)?.data?.value).toBe(60);
+
+        api.setFilterModel({ value: { type: 'greaterThan', filter: 15 } });
+        await waitForNoLoadingRows(api);
+        await asyncSetTimeout(20);
+
+        expect(api.getPinnedTopRowCount()).toBe(1);
+        expect(api.getPinnedBottomRowCount()).toBe(0);
+        expect(api.getPinnedTopRow(0)?.data?.value).toBe(50);
+    });
+
+    test('pinnedBottom grand total survives repeated filter changes', async () => {
+        const api: GridApi<RowData> = gridManager.createGrid(null, {
+            columnDefs: [{ field: 'id' }, { field: 'value', filter: 'agNumberColumnFilter' }],
+            rowModelType: 'serverSide',
+            getRowId: (params: GetRowIdParams<RowData>) => params.data.id,
+            grandTotalRow: 'pinnedBottom',
+            serverSideDatasource: {
+                getRows(params: IServerSideGetRowsParams) {
+                    const filter = params.request.filterModel as { value?: { filter?: number } } | null;
+                    const threshold = filter?.value?.filter;
+                    const filtered = threshold != null ? flatRows.filter((r) => r.value > threshold) : flatRows;
+                    const rowData: any[] = [...filtered];
+                    if (params.needsGrandTotal) {
+                        const total = filtered.reduce((s, r) => s + r.value, 0);
+                        rowData.push({ id: GRAND_TOTAL_ID, value: total });
+                    }
+                    setTimeout(() => params.success({ rowData, rowCount: filtered.length }), 0);
+                },
+            },
+        });
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        const thresholds = [15, 25, undefined, 9, 15];
+        const expectedValues = [50, 30, 60, 60, 50];
+        for (let i = 0; i < thresholds.length; i++) {
+            const t = thresholds[i];
+            api.setFilterModel(t === undefined ? null : { value: { type: 'greaterThan', filter: t } });
+            await waitForNoLoadingRows(api);
+            await asyncSetTimeout(10);
+
+            expect(api.getPinnedBottomRowCount()).toBe(1);
+            expect(api.getPinnedBottomRow(0)?.data?.value).toBe(expectedValues[i]);
+        }
+    });
+
+    test('pinnedBottom grand total is replaced after aggregation change', async () => {
+        // Aggregation change resets the store entirely — exercises the pinned cleanup path.
+        const api: GridApi<RowData> = gridManager.createGrid(null, {
+            columnDefs: [{ field: 'id' }, { field: 'value', aggFunc: 'sum' }],
+            rowModelType: 'serverSide',
+            getRowId: (params: GetRowIdParams<RowData>) => params.data.id,
+            grandTotalRow: 'pinnedBottom',
+            serverSideDatasource: createFlatDatasource(),
+        });
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+        expect(api.getPinnedBottomRowCount()).toBe(1);
+
+        api.setColumnAggFunc('value', 'avg');
+        await waitForNoLoadingRows(api);
+        await asyncSetTimeout(20);
+
+        expect(api.getPinnedBottomRowCount()).toBe(1);
+    });
+
+    test('pinnedBottom grand total is replaced after refreshServerSide({ purge: true })', async () => {
+        let total = 60;
+        const api: GridApi<RowData> = gridManager.createGrid(null, {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            getRowId: (params: GetRowIdParams<RowData>) => params.data.id,
+            grandTotalRow: 'pinnedBottom',
+            serverSideDatasource: {
+                getRows(params: IServerSideGetRowsParams) {
+                    const rowData: any[] = [...flatRows];
+                    if (params.needsGrandTotal) {
+                        rowData.push({ id: GRAND_TOTAL_ID, value: total });
+                    }
+                    setTimeout(() => params.success({ rowData, rowCount: flatRows.length }), 0);
+                },
+            },
+        });
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+        expect(api.getPinnedBottomRowCount()).toBe(1);
+        expect(api.getPinnedBottomRow(0)?.data?.value).toBe(60);
+
+        total = 123;
+        api.refreshServerSide({ purge: true });
+        await waitForNoLoadingRows(api);
+        await asyncSetTimeout(20);
+
+        expect(api.getPinnedBottomRowCount()).toBe(1);
+        expect(api.getPinnedBottomRow(0)?.data?.value).toBe(123);
+    });
+
+    test('pinnedBottom grand total with grouped grid survives filter change', async () => {
+        interface GroupedRow {
+            id: string;
+            category: string;
+            value: number;
+        }
+
+        const serverRows: GroupedRow[] = [
+            { id: 'a1', category: 'A', value: 10 },
+            { id: 'a2', category: 'A', value: 20 },
+            { id: 'b1', category: 'B', value: 30 },
+        ];
+
+        const api = gridManager.createGrid(null, {
+            columnDefs: [
+                { field: 'category', rowGroup: true, hide: true },
+                { field: 'value', aggFunc: 'sum', filter: 'agNumberColumnFilter' },
+            ],
+            autoGroupColumnDef: { headerName: 'Category' },
+            rowModelType: 'serverSide',
+            getRowId: (params: GetRowIdParams<GroupedRow>) => params.data.id,
+            grandTotalRow: 'pinnedBottom',
+            serverSideDatasource: {
+                getRows(params: IServerSideGetRowsParams) {
+                    const { request } = params;
+                    const filter = request.filterModel as { value?: { filter?: number } } | null;
+                    const threshold = filter?.value?.filter;
+                    const filtered = threshold != null ? serverRows.filter((r) => r.value > threshold) : serverRows;
+                    let rowData: any[];
+
+                    if (request.groupKeys.length === 0) {
+                        const groups = new Map<string, number>();
+                        for (const row of filtered) {
+                            groups.set(row.category, (groups.get(row.category) ?? 0) + row.value);
+                        }
+                        rowData = [...groups.entries()].map(([category, value]) => ({
+                            id: `category:${category}`,
+                            category,
+                            value,
+                            group: true,
+                            leafGroup: true,
+                            key: category,
+                        }));
+                        if (params.needsGrandTotal) {
+                            const total = filtered.reduce((s, r) => s + r.value, 0);
+                            rowData.push({ id: GRAND_TOTAL_ID, value: total });
+                        }
+                    } else {
+                        const groupKey = request.groupKeys[0];
+                        rowData = filtered.filter((r) => r.category === groupKey).map((r) => ({ ...r }));
+                    }
+
+                    const dataRowCount =
+                        request.groupKeys.length === 0
+                            ? rowData.filter((r: any) => r.id !== GRAND_TOTAL_ID).length
+                            : rowData.length;
+                    setTimeout(() => params.success({ rowData, rowCount: dataRowCount }), 0);
+                },
+            },
+        });
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+        expect(api.getPinnedBottomRowCount()).toBe(1);
+        expect(api.getPinnedBottomRow(0)?.data?.value).toBe(60);
+
+        // Filter out category A entirely
+        api.setFilterModel({ value: { type: 'greaterThan', filter: 25 } });
+        await waitForNoLoadingRows(api);
+        await asyncSetTimeout(20);
+
+        expect(api.getPinnedBottomRowCount()).toBe(1);
+        expect(api.getPinnedBottomRow(0)?.data?.value).toBe(30);
+    });
+
+    test('switching from pinnedBottom to bottom after filter change leaves no orphan pinned row', async () => {
+        const api: GridApi<RowData> = gridManager.createGrid(null, {
+            columnDefs: [{ field: 'id' }, { field: 'value', filter: 'agNumberColumnFilter' }],
+            rowModelType: 'serverSide',
+            getRowId: (params: GetRowIdParams<RowData>) => params.data.id,
+            grandTotalRow: 'pinnedBottom',
+            serverSideDatasource: {
+                getRows(params: IServerSideGetRowsParams) {
+                    const filter = params.request.filterModel as { value?: { filter?: number } } | null;
+                    const threshold = filter?.value?.filter;
+                    const filtered = threshold != null ? flatRows.filter((r) => r.value > threshold) : flatRows;
+                    const rowData: any[] = [...filtered];
+                    if (params.needsGrandTotal) {
+                        const total = filtered.reduce((s, r) => s + r.value, 0);
+                        rowData.push({ id: GRAND_TOTAL_ID, value: total });
+                    }
+                    setTimeout(() => params.success({ rowData, rowCount: filtered.length }), 0);
+                },
+            },
+        });
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        api.setFilterModel({ value: { type: 'greaterThan', filter: 15 } });
+        await waitForNoLoadingRows(api);
+        await asyncSetTimeout(20);
+        expect(api.getPinnedBottomRowCount()).toBe(1);
+
+        api.setGridOption('grandTotalRow', 'bottom');
+        await asyncSetTimeout(20);
+
+        expect(api.getPinnedBottomRowCount()).toBe(0);
+        expect(api.getPinnedTopRowCount()).toBe(0);
+
+        await new GridRows(api, 'after switch to inline bottom').check(unindentText`
+            ROOT id:<no-id>
+            ├── LEAF id:2 id:"2" value:20
+            ├── LEAF id:3 id:"3" value:30
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:50
+        `);
+    });
+
     test('async grand total via transaction: filter change hides then restores grand total', async () => {
         const computeTotal = (threshold?: number) =>
             flatRows.filter((r) => threshold === undefined || r.value > threshold).reduce((s, r) => s + r.value, 0);

--- a/testing/behavioural/src/rows/manual-pinned-rows.test.ts
+++ b/testing/behavioural/src/rows/manual-pinned-rows.test.ts
@@ -581,8 +581,12 @@ describe('Manual pinned rows', () => {
             enableRowPinning: true,
             // Pin both a group row and a leaf row.
             isRowPinned: (node) => {
-                if (node.group && node.key === 'A') return 'top';
-                if (!node.group && node.data?.sport === 'rugby') return 'top';
+                if (node.group && node.key === 'A') {
+                    return 'top';
+                }
+                if (!node.group && node.data?.sport === 'rugby') {
+                    return 'top';
+                }
                 return null;
             },
             getRowId(params) {

--- a/testing/behavioural/src/rows/manual-pinned-rows.test.ts
+++ b/testing/behavioural/src/rows/manual-pinned-rows.test.ts
@@ -1,6 +1,6 @@
 import { ClientSideRowModelModule, PaginationModule, PinnedRowModule } from 'ag-grid-community';
 import type { GridApi, RowNode, RowPinnedType } from 'ag-grid-community';
-import { RowGroupingModule } from 'ag-grid-enterprise';
+import { PivotModule, RowGroupingModule } from 'ag-grid-enterprise';
 
 import { GridColumns, GridRows, TestGridsManager, asyncSetTimeout } from '../test-utils';
 
@@ -24,7 +24,7 @@ function getPinnedRows(api: GridApi, floating: NonNullable<RowPinnedType>): RowN
 
 describe('Manual pinned rows', () => {
     const gridsManager = new TestGridsManager({
-        modules: [PinnedRowModule, ClientSideRowModelModule, RowGroupingModule, PaginationModule],
+        modules: [PinnedRowModule, ClientSideRowModelModule, RowGroupingModule, PaginationModule, PivotModule],
     });
 
     const columnDefs = [{ field: 'sport' }];
@@ -495,6 +495,129 @@ describe('Manual pinned rows', () => {
 
         // The row should now be pinned to bottom (after isRowPinned is re-evaluated)
         // Note: isRowPinned is only called on firstDataRendered, so we need to test via setGridOption
+    });
+
+    test('isRowPinnable callback unpins a row when it stops being pinnable', async () => {
+        // Track which sports are pinnable. We start with rugby pinnable, then make it
+        // non-pinnable. The model listens to `rowNodeDataChanged` and re-evaluates pinnability;
+        // when a previously-pinned row becomes non-pinnable, it must be unpinned.
+        let pinnable = new Set(['rugby']);
+
+        const api = await gridsManager.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            enableRowPinning: true,
+            isRowPinned: (node) => (node.data?.sport === 'rugby' ? 'top' : null),
+            isRowPinnable: (node) => pinnable.has(node.data?.sport ?? ''),
+            getRowId(params) {
+                return `${params.level}-${params.data?.sport}`;
+            },
+        });
+
+        assertPinnedRows(api, 'top', ['t-top-0-rugby']);
+        const pinnedRugby = getPinnedRows(api, 'top')[0];
+        const sourceRugby = pinnedRugby.pinnedSibling!;
+
+        // Make rugby no longer pinnable, then trigger rowNodeDataChanged via update.
+        pinnable = new Set();
+        api.applyTransaction({ update: [{ sport: 'rugby' }] });
+        await asyncSetTimeout(10);
+
+        // The previously-pinned row should be unpinned (rowNodeDataChanged listener handles it).
+        assertPinnedRows(api, 'top', []);
+        expect(sourceRugby.destroyed).toBe(false); // source row stays alive
+        expect(sourceRugby.pinnedSibling).toBeUndefined();
+        expect(pinnedRugby.destroyed).toBe(true);
+    });
+
+    test('sort change re-sorts pinned containers', async () => {
+        const api = await gridsManager.createGridAndWait('myGrid', {
+            columnDefs: [{ field: 'sport', sortable: true }],
+            rowData,
+            enableRowPinning: true,
+            isRowPinned: (node) => {
+                const s = node.data?.sport;
+                return s === 'tennis' || s === 'football' || s === 'cricket' ? 'top' : null;
+            },
+            getRowId(params) {
+                return `${params.level}-${params.data?.sport}`;
+            },
+        });
+
+        // Initial order matches source row order: football, tennis, cricket
+        assertPinnedRows(api, 'top', ['t-top-0-football', 't-top-0-tennis', 't-top-0-cricket']);
+
+        // Sort ascending by sport — pinned area must re-sort
+        api.applyColumnState({ state: [{ colId: 'sport', sort: 'asc' }] });
+        await asyncSetTimeout(10);
+        assertPinnedRows(api, 'top', ['t-top-0-cricket', 't-top-0-football', 't-top-0-tennis']);
+
+        // Sort descending
+        api.applyColumnState({ state: [{ colId: 'sport', sort: 'desc' }] });
+        await asyncSetTimeout(10);
+        assertPinnedRows(api, 'top', ['t-top-0-tennis', 't-top-0-football', 't-top-0-cricket']);
+
+        // Clear sort — falls back to source row order
+        api.applyColumnState({ state: [{ colId: 'sport', sort: null }] });
+        await asyncSetTimeout(10);
+        assertPinnedRows(api, 'top', ['t-top-0-football', 't-top-0-tennis', 't-top-0-cricket']);
+    });
+
+    test('pivotMode toggle hides pinned leaf clones and shows them again on toggle off', async () => {
+        // In pivot mode, _shouldHidePinnedRows returns !node.group, hiding leaf clones.
+        // Toggling pivotMode off should bring them back.
+        const api = await gridsManager.createGridAndWait('myGrid', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', pivot: true, hide: true },
+                { field: 'sport' },
+                { field: 'value', aggFunc: 'sum' },
+            ],
+            rowData: [
+                { country: 'A', year: 2024, sport: 'rugby', value: 1 },
+                { country: 'A', year: 2024, sport: 'tennis', value: 2 },
+                { country: 'B', year: 2024, sport: 'rugby', value: 3 },
+            ],
+            enableRowPinning: true,
+            // Pin both a group row and a leaf row.
+            isRowPinned: (node) => {
+                if (node.group && node.key === 'A') return 'top';
+                if (!node.group && node.data?.sport === 'rugby') return 'top';
+                return null;
+            },
+            getRowId(params) {
+                return params.data?.sport ? `leaf-${params.data.country}-${params.data.sport}` : '';
+            },
+            groupDefaultExpanded: -1,
+        });
+
+        // Initially (pivotMode off): both the group AND the leaf clones are visible.
+        const initialPinned = getPinnedRows(api, 'top');
+        const groupClone = initialPinned.find((n) => n.group);
+        const leafClones = initialPinned.filter((n) => !n.group);
+        expect(groupClone).toBeDefined();
+        expect(leafClones.length).toBeGreaterThan(0);
+        const initialCount = initialPinned.length;
+
+        // Turn pivot mode on — leaf clones should be hidden, group clones remain.
+        api.setGridOption('pivotMode', true);
+        await asyncSetTimeout(10);
+
+        const afterPivot = getPinnedRows(api, 'top');
+        expect(afterPivot.every((n) => n.group)).toBe(true); // only groups visible
+        expect(afterPivot.length).toBeLessThan(initialCount);
+
+        // Source nodes for hidden leaves should NOT be destroyed — they're still pinned, just hidden.
+        for (const leaf of leafClones) {
+            expect(leaf.destroyed).toBe(false);
+        }
+
+        // Toggle pivot mode off — leaf clones should come back.
+        api.setGridOption('pivotMode', false);
+        await asyncSetTimeout(10);
+
+        const afterToggleOff = getPinnedRows(api, 'top');
+        expect(afterToggleOff.length).toBe(initialCount);
     });
 
     test('pinned rows survive data updates to other rows', async () => {


### PR DESCRIPTION
Fixes the manual pinned row model not properly handling creation and destroying of pinned rows in SSRM.

This is the same fix as #13797, but targeting `latest` instead of `b35.3.0`.

- for safety and correctness, added more properties to ignore to the sibling, destroyed should not be copied, same for pinned rows when creating a sibling
- fixed pinRow in pinned row model that was executing on _destroy also for the clone node that was causing the issue
- fixes row node destruction handling correctly unpinning
- add tests to increase coverage and this specific case

