### PR TITLE
[AG-16296] Maintenance(column): filters return date only values in filter model for celldatatype date

### DIFF
--- a/packages/ag-grid-community/src/filter/provided/date/dateFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/dateFilter.ts
@@ -289,7 +289,8 @@ export class DateFilter extends SimpleFilter<DateFilterModel, Date, DateCompWrap
         const { params, filterType, beans } = this;
         const dataTypeSvc = beans.dataTypeSvc;
         const values = this.getValues(position);
-        const includeDateTime = dataTypeSvc?.getDateIncludesTimeFlag(params.colDef.cellDataType) ?? true;
+        const includeDateTime =
+            params.includeTime ?? dataTypeSvc?.getDateIncludesTimeFlag(params.colDef.cellDataType) ?? true;
 
         const separator = params.useIsoSeparator ? 'T' : ' ';
         if (values.length > 0) {

--- a/packages/ag-grid-community/src/filter/provided/date/dateFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/dateFilter.ts
@@ -286,15 +286,17 @@ export class DateFilter extends SimpleFilter<DateFilterModel, Date, DateCompWrap
     protected createCondition(position: number): DateFilterModel {
         const type = this.getConditionType(position);
         const model: Partial<DateFilterModel> = {};
-        const { params, filterType } = this;
+        const { params, filterType, beans } = this;
+        const dataTypeSvc = beans.dataTypeSvc;
         const values = this.getValues(position);
+        const includeDateTime = dataTypeSvc?.getDateIncludesTimeFlag(params.colDef.cellDataType) ?? true;
 
         const separator = params.useIsoSeparator ? 'T' : ' ';
         if (values.length > 0) {
-            model.dateFrom = _serialiseDate(values[0], true, separator);
+            model.dateFrom = _serialiseDate(values[0], includeDateTime, separator);
         }
         if (values.length > 1) {
-            model.dateTo = _serialiseDate(values[1], true, separator);
+            model.dateTo = _serialiseDate(values[1], includeDateTime, separator);
         }
 
         return {

--- a/packages/ag-grid-community/src/filter/provided/date/iDateFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/iDateFilter.ts
@@ -12,6 +12,7 @@ export interface DateFilterModel extends ISimpleFilterModel {
      * The date value(s) associated with the filter.
      * The type is `string` and the format is `YYYY-MM-DD hh:mm:ss`, e.g. 2019-05-24 00:00:00.
      * If `useIsoSeparator = true`, the format is instead `YYYY-MM-DDThh:mm:ss`.
+     * If `includeTime = false`, or `cellDataType = 'date'` (and `includeTime` is not set), the time part is omitted and the format is `YYYY-MM-DD`, e.g. 2019-05-24.
      * Custom filters can have no values (hence both are optional). Range filter has two values (from and to).
      */
     dateFrom: string | null | undefined;


### PR DESCRIPTION
Use `params.colDef.cellDataType` with `getDateIncludesTimeFlag` to determine whether to include the time component when serialising `dateFrom`/`dateTo` in the date filter model. Previously the time was always included, causing date-only values to carry a time suffix for `cellDataType: 'date'` columns.

Fix [AG-16296](https://ag-grid.atlassian.net/browse/AG-16296)