### PR TITLE
AG-17396 Fix column auto-size when grid is inside a CSS-scaled parent

### DIFF
--- a/packages/ag-grid-community/src/rendering/autoWidthCalculator.ts
+++ b/packages/ag-grid-community/src/rendering/autoWidthCalculator.ts
@@ -69,7 +69,7 @@ export class AutoWidthCalculator extends BeanStub implements NamedBean {
 
         // at this point, all the clones are lined up vertically with natural widths. the dummy
         // container will have a width wide enough just to fit the largest.
-        const dummyContainerWidth = Math.ceil(eDummyContainer.getBoundingClientRect().width);
+        const dummyContainerWidth = eDummyContainer.offsetWidth;
 
         // we are finished with the dummy container, so get rid of it
         eDummyContainer.remove();


### PR DESCRIPTION
Fix [AG-17396](https://ag-grid.atlassian.net/browse/AG-17396)

When an ancestor element has a CSS transform such as `scale()`, cell content measurement is incorrect. Fix this by using `offsetWidth` instead.