### PR TITLE
AG-17400 Guard against null children in columnToolPanel resetChildrenHeight()

### DIFF
--- a/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/columnToolPanel.ts
@@ -432,9 +432,9 @@ export class ColumnToolPanel extends Component implements IColumnToolPanel, IToo
         const children = eGui.children;
 
         for (let i = 0; i < children.length; i++) {
-            const { style } = children[i] as HTMLElement;
-            style.removeProperty('height');
-            style.removeProperty('flex');
+            const style = (children[i] as HTMLElement | undefined)?.style;
+            style?.removeProperty('height');
+            style?.removeProperty('flex');
         }
     }
 


### PR DESCRIPTION
## Summary

- Fixes a flaky webkit E2E test (`master-detail-grids/detail-grid-api › reactFunctionalTs`) caused by a race condition in `ColumnToolPanel.resetChildrenHeight()`
- `eGui.children` is a live `HTMLCollection` that can shrink mid-iteration when React StrictMode unmounts/remounts detail grid components, making `children[i]` undefined
- Added optional chaining to guard against null/undefined children during iteration

## Context

- **JIRA:** [AG-17400](https://ag-grid.atlassian.net/browse/AG-17400)
- **CI failure:** https://github.com/ag-grid/ag-grid/actions/runs/26140052947/job/76883517733

## Test plan

- [ ] Verify existing behavioural tests pass (`yarn nx test ag-grid-enterprise`)
- [ ] Confirm the webkit E2E test (`master-detail-grids/detail-grid-api`) no longer flakes