### PR TITLE
improve-col-model-tests-and-fix-ide-and-agents-rules

### DIFF
--- a/.rulesync/rules/ag-grid.md
+++ b/.rulesync/rules/ag-grid.md
@@ -177,13 +177,29 @@ For comprehensive testing information, see [Testing Guide](.rulesync/rules/testi
 
 #### Code Quality
 
-For code quality guidelines, see [Code Quality Guide](.rulesync/rules/code-quality.md).
+For shared code quality guidelines, see [Code Quality Guide](.rulesync/rules/code-quality.md).
 
 Essential practices:
 
 - Run `yarn nx format --sort-root-tsconfig-paths=false` before committing
 - Self-review your changes before proposing commits
 - Ensure tests exercise real implementations, not test helpers
+
+#### AG Grid Coding Style
+
+Layered on the shared code-quality guide; enforced by ESLint plus team preferences.
+
+- Always use braces for `if/else/for/while/do`.
+- Cache repeated field access in a local — performance requirement.
+- Canonical array loop: `for (let i = 0, len = a.length; i < len; ++i)`. No `Array.forEach`. `Map.forEach` is fine.
+- No lonely `if` — use guard returns, `if/else if`, or ternaries. Applies to loops too.
+- No nested ternaries — extract to a named variable.
+- No short-circuit side effects (`cond && fn()`). No assignments in expressions.
+- No `for...in`. Use `Object.keys()` + index loops; prefer `Object.keys()` over `Object.entries()` when values aren't needed.
+- No static class properties — use module-level constants.
+- Explicit access modifiers on every class member; `readonly` when not reassigned.
+- Destructure only for 2+ fields; single field uses dot access.
+- `import type` for compile-time-only imports; separate `import type { Foo }` statements, no inline `{ type Foo, Bar }`.
 
 #### Styling
 

--- a/.rulesync/rules/testing.md
+++ b/.rulesync/rules/testing.md
@@ -208,6 +208,42 @@ for (const [name, example] of Object.entries(EXAMPLES)) {
 6. **Clean up after tests** - Reset mocks and state in `afterEach`
 7. **Review similar tests** - When adding tests, check related tests for consistency
 
+
+## GridRows and GridColumns Snapshots
+
+For behavioural tests, prefer `GridRows` and `GridColumns` snapshots over raw API assertions where practical. They produce inline snapshots that make the grid state visually readable and update automatically.
+
+```typescript
+import { GridColumns, GridRows } from '../test-utils';
+
+// Snapshot grid rows (rendered cell values, grouping, selection state, etc.)
+await new GridRows(api, 'description').check();
+
+// Snapshot column state (visibility, order, pinning, pivoting, etc.)
+await new GridColumns(api, 'description').checkColumns();
+```
+
+When behaviour cannot be captured by a snapshot — for example verifying a specific return value, event payload, or count — combine snapshots with targeted API checks:
+
+```typescript
+await new GridRows(api, 'after sort').check();
+expect(api.getDisplayedRowCount()).toBe(3);
+```
+
+Update snapshots after intentional grid state changes:
+
+```bash
+./behave.sh --update-grid-rows # update all
+./behave.sh --update-grid-rows "column-lookup"    # update matching files only
+```
+
+Since our test framrwork and mockGridLayout.ts are written as we go,
+if they do not cover a scenario that arise in a new test, they must be updated and fixed.
+
+## Style in Tests
+
+Tests must respect ESLint rules, but the non-lint-enforced coding-style preferences.
+
 ## Coverage
 
 - Aim for meaningful coverage, not 100%

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,9 +24,10 @@
     "**/node_modules": true,
     "**/typings": true
   },
-  "typescript.preferences.autoImportFileExcludePatterns": ["**/main", "**/main-umd*"],
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "eslint.experimental.useFlatConfig": true,
+  "js/ts.preferences.autoImportFileExcludePatterns": ["**/main", "**/main-umd*"],
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "eslint.useFlatConfig": true,
+  "eslint.workingDirectories": [{ "mode": "auto" }],
   "[typescript]": {
     "editor.autoClosingBrackets": "always"
   },
@@ -109,7 +110,7 @@
   ],
   "git.autoRepositoryDetection": "subFolders",
   "git.repositoryScanIgnoredFolders": ["node_modules", "dist", "typings"],
-  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "angular.enable-strict-mode-prompt": false,
   "json.schemas": [
     {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,13 +170,30 @@ For comprehensive testing information, see [Testing Guide](.rulesync/rules/testi
 
 #### Code Quality
 
-For code quality guidelines, see [Code Quality Guide](.rulesync/rules/code-quality.md).
+For shared code quality guidelines, see [Code Quality Guide](.rulesync/rules/code-quality.md).
 
 Essential practices:
 
 - Run `yarn nx format --sort-root-tsconfig-paths=false` before committing
 - Self-review your changes before proposing commits
 - Ensure tests exercise real implementations, not test helpers
+
+#### AG Grid Coding Style
+
+Layered on the shared code-quality guide; enforced by ESLint plus team preferences.
+
+- Always use braces for `if/else/for/while/do`.
+- Cache repeated field access in a local — performance requirement.
+- Performance over bundle size.
+- Canonical array loop: `for (let i = 0, len = a.length; i < len; ++i)`. No `Array.forEach`. `Map.forEach` is fine.
+- No lonely `if` — use guard returns, `if/else if`, or ternaries. Applies to loops too.
+- No nested ternaries — extract to a named variable.
+- No short-circuit side effects (`cond && fn()`). No assignments in expressions.
+- No `for...in`. Use `Object.keys()` + index loops; prefer `Object.keys()` over `Object.entries()` when values aren't needed.
+- No static class properties — use module-level constants.
+- Explicit access modifiers on every class member; `readonly` when not reassigned.
+- Destructure only for 2+ fields; single field uses dot access.
+- `import type` for compile-time-only imports; separate `import type { Foo }` statements, no inline `{ type Foo, Bar }`.
 
 #### Styling
 

--- a/packages/ag-grid-enterprise/tsconfig.lib.json
+++ b/packages/ag-grid-enterprise/tsconfig.lib.json
@@ -4,7 +4,15 @@
     "types": ["vite/client"],
     "baseUrl": "src",
     "module": "preserve",
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    // Re-establish source path mappings under the overridden `baseUrl: "src"`. Without this the
+    // inherited mappings in tsconfig.base.json resolve to wrong filesystem paths and TS falls
+    // back to `node_modules` (dist .d.ts), breaking IDE go-to-definition / find-references.
+    // `paths` only affects resolution during type-checking — emitted .d.ts files still use the
+    // bare `'ag-grid-community'` module name.
+    "paths": {
+      "ag-grid-community": ["../../ag-grid-community/src/main.ts"]
+    }
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts", "src/**/test/**", "src/**/test-utils/**"]

--- a/testing/behavioural/src/columns/column-destruction.test.ts
+++ b/testing/behavioural/src/columns/column-destruction.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Tests that column beans are destroyed exactly once when the grid is torn down,
+ * and that intermediate rebuilds (pivot toggles, columnDefs replacement) don't leak.
+ *
+ * Design B ownership: ColumnModel.destroy() is the single owner of all column beans
+ * at teardown — it walks colsTree once and destroys everything (leaves, source-tree
+ * groups, and balanceTreeForAutoCols wrappers). Leaf services (auto/sel/rn/pivot)
+ * still own mid-life destruction in their createColumns paths, but defer teardown
+ * destruction to ColumnModel to prevent double-destroy.
+ */
+import type { Column, GridApi } from 'ag-grid-community';
+import { ClientSideRowModelModule, RowSelectionModule } from 'ag-grid-community';
+import { PivotModule, RowGroupingModule, RowNumbersModule, TreeDataModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+
+interface DestroyTracker {
+    destroyCount: Map<string, number>;
+    track: (col: Column) => void;
+}
+
+/** Patches a column's destroy() to count invocations. Returns a tracker. */
+const createDestroyTracker = (): DestroyTracker => {
+    const destroyCount = new Map<string, number>();
+    return {
+        destroyCount,
+        track: (col: Column) => {
+            const id = col.getColId();
+            const original = (col as any).destroy.bind(col);
+            (col as any).destroy = () => {
+                destroyCount.set(id, (destroyCount.get(id) ?? 0) + 1);
+                original();
+            };
+        },
+    };
+};
+
+/** Collects every AgColumn reachable from the grid: primary, auto, selection, row-numbers, pivot result, hierarchy. */
+const collectAllColumns = (api: GridApi): Column[] => {
+    const seen = new Set<Column>();
+    const result: Column[] = [];
+    const add = (col: Column | null | undefined) => {
+        if (col && !seen.has(col)) {
+            seen.add(col);
+            result.push(col);
+        }
+    };
+    api.getColumns()?.forEach(add);
+    api.getAllGridColumns()?.forEach(add);
+    api.getPivotResultColumns()?.forEach(add);
+    return result;
+};
+
+describe('Column destruction', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [
+            ClientSideRowModelModule,
+            RowGroupingModule,
+            PivotModule,
+            RowNumbersModule,
+            RowSelectionModule,
+            TreeDataModule,
+        ],
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    test('destroys every column exactly once on grid teardown — primary + auto + selection + rowNumbers', () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { colId: 'country', rowGroup: true },
+                { colId: 'sport', rowGroup: true },
+                { colId: 'gold' },
+                { colId: 'silver' },
+            ],
+            rowData: [{ country: 'USA', sport: 'Swimming', gold: 3, silver: 1 }],
+            rowSelection: { mode: 'multiRow', checkboxes: true },
+            rowNumbers: true,
+            groupDefaultExpanded: 1,
+        });
+
+        const tracker = createDestroyTracker();
+        const columnsBeforeDestroy = collectAllColumns(api);
+        expect(columnsBeforeDestroy.length).toBeGreaterThan(0);
+        for (const col of columnsBeforeDestroy) {
+            tracker.track(col);
+            expect((col as any).isAlive()).toBe(true);
+        }
+
+        api.destroy();
+
+        for (const col of columnsBeforeDestroy) {
+            const id = col.getColId();
+            expect({ id, count: tracker.destroyCount.get(id) ?? 0 }).toEqual({ id, count: 1 });
+            expect((col as any).isAlive()).toBe(false);
+        }
+    });
+
+    test('destroys every column exactly once on grid teardown — with column groups', () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                {
+                    headerName: 'Athlete Info',
+                    children: [{ colId: 'athlete' }, { colId: 'country', rowGroup: true }],
+                },
+                {
+                    headerName: 'Medals',
+                    children: [{ colId: 'gold' }, { colId: 'silver' }, { colId: 'bronze' }],
+                },
+            ],
+            rowData: [{ athlete: 'A', country: 'USA', gold: 1, silver: 0, bronze: 2 }],
+            rowSelection: { mode: 'multiRow', checkboxes: true },
+            rowNumbers: true,
+            groupDefaultExpanded: 1,
+        });
+
+        const tracker = createDestroyTracker();
+        const columnsBeforeDestroy = collectAllColumns(api);
+        for (const col of columnsBeforeDestroy) {
+            tracker.track(col);
+        }
+
+        api.destroy();
+
+        for (const col of columnsBeforeDestroy) {
+            const id = col.getColId();
+            expect({ id, count: tracker.destroyCount.get(id) ?? 0 }).toEqual({ id, count: 1 });
+            expect((col as any).isAlive()).toBe(false);
+        }
+    });
+
+    test('destroys every column exactly once on grid teardown — pivot mode', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { colId: 'country', rowGroup: true },
+                { colId: 'year', pivot: true },
+                { colId: 'sport' },
+                { colId: 'gold', aggFunc: 'sum' },
+            ],
+            rowData: [
+                { country: 'USA', year: 2020, sport: 'Swimming', gold: 3 },
+                { country: 'USA', year: 2024, sport: 'Swimming', gold: 5 },
+                { country: 'UK', year: 2020, sport: 'Running', gold: 1 },
+            ],
+            pivotMode: true,
+            rowSelection: { mode: 'multiRow', checkboxes: true },
+            rowNumbers: true,
+        });
+        await asyncSetTimeout(0);
+
+        const tracker = createDestroyTracker();
+        const columnsBeforeDestroy = collectAllColumns(api);
+        // sanity: pivot result columns must be present
+        const pivotResult = api.getPivotResultColumns() ?? [];
+        expect(pivotResult.length).toBeGreaterThan(0);
+        for (const col of columnsBeforeDestroy) {
+            tracker.track(col);
+        }
+
+        api.destroy();
+
+        for (const col of columnsBeforeDestroy) {
+            const id = col.getColId();
+            expect({ id, count: tracker.destroyCount.get(id) ?? 0 }).toEqual({ id, count: 1 });
+            expect((col as any).isAlive()).toBe(false);
+        }
+    });
+
+    test('toggling pivot mode multiple times then destroying still destroys each surviving column once', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { colId: 'country', rowGroup: true },
+                { colId: 'year', pivot: true },
+                { colId: 'gold', aggFunc: 'sum' },
+            ],
+            rowData: [
+                { country: 'USA', year: 2020, gold: 3 },
+                { country: 'UK', year: 2024, gold: 1 },
+            ],
+            pivotMode: false,
+            rowSelection: { mode: 'multiRow', checkboxes: true },
+            rowNumbers: true,
+        });
+
+        api.setGridOption('pivotMode', true);
+        await asyncSetTimeout(0);
+        api.setGridOption('pivotMode', false);
+        await asyncSetTimeout(0);
+        api.setGridOption('pivotMode', true);
+        await asyncSetTimeout(0);
+
+        const tracker = createDestroyTracker();
+        const columnsBeforeDestroy = collectAllColumns(api);
+        for (const col of columnsBeforeDestroy) {
+            tracker.track(col);
+        }
+
+        api.destroy();
+
+        for (const col of columnsBeforeDestroy) {
+            const id = col.getColId();
+            expect({ id, count: tracker.destroyCount.get(id) ?? 0 }).toEqual({ id, count: 1 });
+            expect((col as any).isAlive()).toBe(false);
+        }
+    });
+
+    test('replacing columnDefs then destroying does not leak old beans and destroys new beans once', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ colId: 'a' }, { colId: 'b', rowGroup: true }],
+            rowData: [{ a: 1, b: 'x' }],
+            rowSelection: { mode: 'multiRow', checkboxes: true },
+        });
+
+        const oldColumns = collectAllColumns(api);
+        const oldTracker = createDestroyTracker();
+        for (const col of oldColumns) {
+            oldTracker.track(col);
+        }
+
+        // Full replacement of primary defs. Selection col / auto-group col instances may be
+        // reused if their config didn't change — we only assert that displaced beans are
+        // destroyed exactly once, not that EVERY old bean is destroyed.
+        api.setGridOption('columnDefs', [{ colId: 'x' }, { colId: 'y', rowGroup: true }, { colId: 'z' }]);
+        await asyncSetTimeout(0);
+
+        const survivingIds = new Set(collectAllColumns(api).map((c) => c.getColId()));
+        for (const col of oldColumns) {
+            const id = col.getColId();
+            const expected = survivingIds.has(id) && (col as any).isAlive() ? 0 : 1;
+            expect({ id, count: oldTracker.destroyCount.get(id) ?? 0 }).toEqual({ id, count: expected });
+        }
+
+        const newColumns = collectAllColumns(api);
+        const newTracker = createDestroyTracker();
+        for (const col of newColumns) {
+            newTracker.track(col);
+            expect((col as any).isAlive()).toBe(true);
+        }
+
+        api.destroy();
+
+        for (const col of newColumns) {
+            const id = col.getColId();
+            expect({ id, count: newTracker.destroyCount.get(id) ?? 0 }).toEqual({ id, count: 1 });
+            expect((col as any).isAlive()).toBe(false);
+        }
+    });
+
+    test('tree data with auto group column destroys cleanly', () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'jobTitle' }, { field: 'employmentType' }],
+            rowData: [
+                { orgHierarchy: ['Erica'], jobTitle: 'CEO', employmentType: 'Permanent' },
+                { orgHierarchy: ['Erica', 'Malcolm'], jobTitle: 'VP', employmentType: 'Permanent' },
+            ],
+            treeData: true,
+            getDataPath: (data: any) => data.orgHierarchy,
+            autoGroupColumnDef: { headerName: 'Org Hierarchy', cellRendererParams: { suppressCount: true } },
+            rowSelection: { mode: 'multiRow', checkboxes: true },
+            rowNumbers: true,
+        });
+
+        const tracker = createDestroyTracker();
+        const columnsBeforeDestroy = collectAllColumns(api);
+        for (const col of columnsBeforeDestroy) {
+            tracker.track(col);
+        }
+
+        api.destroy();
+
+        for (const col of columnsBeforeDestroy) {
+            const id = col.getColId();
+            expect({ id, count: tracker.destroyCount.get(id) ?? 0 }).toEqual({ id, count: 1 });
+            expect((col as any).isAlive()).toBe(false);
+        }
+    });
+});

--- a/testing/behavioural/src/columns/column-edge-cases.test.ts
+++ b/testing/behavioural/src/columns/column-edge-cases.test.ts
@@ -336,6 +336,89 @@ describe('Column Edge Cases', () => {
                 └── right width:200
             `);
         });
+
+        test('allDisplayedColumns order: LTR=[left, center, right], RTL=[right, center, left]', async () => {
+            const columnDefs: ColDef[] = [
+                { colId: 'L1', pinned: 'left' },
+                { colId: 'L2', pinned: 'left' },
+                { colId: 'C1' },
+                { colId: 'C2' },
+                { colId: 'R1', pinned: 'right' },
+                { colId: 'R2', pinned: 'right' },
+            ];
+
+            const ltrApi = gridsManager.createGrid('ltrGrid', { columnDefs, enableRtl: false });
+            expect(ltrApi.getAllDisplayedColumns().map((c: Column) => c.getColId())).toEqual([
+                'L1',
+                'L2',
+                'C1',
+                'C2',
+                'R1',
+                'R2',
+            ]);
+
+            const rtlApi = gridsManager.createGrid('rtlGrid', { columnDefs, enableRtl: true });
+            expect(rtlApi.getAllDisplayedColumns().map((c: Column) => c.getColId())).toEqual([
+                'R1',
+                'R2',
+                'C1',
+                'C2',
+                'L1',
+                'L2',
+            ]);
+        });
+
+        test('getDisplayedColAfter / getDisplayedColBefore navigate within allDisplayedColumns order', async () => {
+            const columnDefs: ColDef[] = [
+                { colId: 'L', pinned: 'left' },
+                { colId: 'C1' },
+                { colId: 'C2' },
+                { colId: 'R', pinned: 'right' },
+            ];
+
+            for (const enableRtl of [false, true]) {
+                const api = gridsManager.createGrid(`grid-${enableRtl}`, { columnDefs, enableRtl });
+                const order = api.getAllDisplayedColumns();
+                // Walk the chain via getDisplayedColAfter and assert it traces allDisplayedColumns.
+                const walked = [order[0]];
+                let cur: Column | null = order[0];
+                while ((cur = api.getDisplayedColAfter(cur))) {
+                    walked.push(cur);
+                }
+                expect(walked.map((c) => c.getColId())).toEqual(order.map((c) => c.getColId()));
+
+                // And the reverse via getDisplayedColBefore.
+                const walkedBack = [order[order.length - 1]];
+                cur = order[order.length - 1];
+                while ((cur = api.getDisplayedColBefore(cur))) {
+                    walkedBack.push(cur);
+                }
+                walkedBack.reverse();
+                expect(walkedBack.map((c) => c.getColId())).toEqual(order.map((c) => c.getColId()));
+
+                // Edge cases: first has no before, last has no after.
+                expect(api.getDisplayedColBefore(order[0])).toBeNull();
+                expect(api.getDisplayedColAfter(order[order.length - 1])).toBeNull();
+            }
+        });
+
+        test('isPinningLeft / isPinningRight reflect presence of pinned columns', async () => {
+            for (const enableRtl of [false, true]) {
+                const noPinApi = gridsManager.createGrid(`no-pin-${enableRtl}`, {
+                    columnDefs: [{ colId: 'a' }, { colId: 'b' }],
+                    enableRtl,
+                });
+                expect(noPinApi.isPinningLeft()).toBe(false);
+                expect(noPinApi.isPinningRight()).toBe(false);
+
+                const bothApi = gridsManager.createGrid(`both-${enableRtl}`, {
+                    columnDefs: [{ colId: 'a', pinned: 'left' }, { colId: 'b' }, { colId: 'c', pinned: 'right' }],
+                    enableRtl,
+                });
+                expect(bothApi.isPinningLeft()).toBe(true);
+                expect(bothApi.isPinningRight()).toBe(true);
+            }
+        });
     });
 
     describe('colSpan interactions', () => {

--- a/testing/behavioural/src/columns/column-lookup.test.ts
+++ b/testing/behavioural/src/columns/column-lookup.test.ts
@@ -1,12 +1,15 @@
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
-import type { Column } from 'ag-grid-community';
-import { ClientSideRowModelModule, ColumnApiModule } from 'ag-grid-community';
+import type { ColDef, Column } from 'ag-grid-community';
+import { ClientSideRowModelModule, ColumnApiModule, RowSelectionModule } from 'ag-grid-community';
+import { PivotModule, RowGroupingModule } from 'ag-grid-enterprise';
 
-import { TestGridsManager } from '../test-utils';
+import { GridColumns, GridRows, TestGridsManager, asyncSetTimeout } from '../test-utils';
 
 describe('Column lookup', () => {
-    const gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule, ColumnApiModule] });
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, ColumnApiModule, RowSelectionModule, RowGroupingModule, PivotModule],
+    });
 
     beforeEach(() => {
         gridsManager.reset();
@@ -61,6 +64,83 @@ describe('Column lookup', () => {
             const resolved = api.getColumn(staleRef);
             expect(resolved).not.toBeNull();
             expect(resolved!.getColId()).toBe('alpha');
+        });
+
+        // skipped on `latest` — ColDef-by-reference lookup fixed in AG-17366-column-model-rewrite
+        test.skip('resolves a column by ColDef reference when colDef has no explicit colId (field fast-path)', () => {
+            const nameCol: ColDef = { field: 'name' };
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [nameCol, { field: 'age' }],
+            });
+
+            const col = api.getColumn(nameCol as any);
+            expect(col).not.toBeNull();
+            expect(col!.getColId()).toBe('name');
+        });
+
+        // skipped on `latest` — ColDef-by-reference lookup fixed in AG-17366-column-model-rewrite
+        test.skip('resolves a column by ColDef reference when colDef has no colId or field (reference scan)', () => {
+            const anonCol: ColDef = { headerName: 'Anonymous' };
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [{ field: 'name' }, anonCol],
+            });
+
+            const col = api.getColumn(anonCol as any);
+            expect(col).not.toBeNull();
+            expect(col!.getColDef().headerName).toBe('Anonymous');
+        });
+
+        test('returns null for a ColDef reference not present in the grid', () => {
+            const outsider: ColDef = { field: 'ghost' };
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [{ field: 'name' }],
+            });
+
+            expect(api.getColumn(outsider as any)).toBeNull();
+        });
+
+        // skipped on `latest` — ColDef-by-reference lookup fixed in AG-17366-column-model-rewrite
+        test.skip('resolves correct column when two ColDefs share the same field', () => {
+            const firstCol: ColDef = { field: 'value', headerName: 'First' };
+            const secondCol: ColDef = { field: 'value', headerName: 'Second' };
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [firstCol, secondCol],
+            });
+
+            // ColumnKeyCreator generates 'value' for firstCol and 'value_1' for secondCol
+            const first = api.getColumn(firstCol as any);
+            const second = api.getColumn(secondCol as any);
+            expect(first).not.toBeNull();
+            expect(second).not.toBeNull();
+            expect(first!.getColId()).toBe('value');
+            expect(second!.getColId()).toBe('value_1');
+            expect(first).not.toBe(second);
+        });
+    });
+
+    describe('getColDefCol — ColDef without colId', () => {
+        // skipped on `latest` — ColDef-by-reference lookup fixed in AG-17366-column-model-rewrite
+        test.skip('setColumnsPinned resolves column by ColDef reference when colDef has no colId', () => {
+            const nameCol: ColDef = { field: 'name' };
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [nameCol, { field: 'age' }],
+            });
+
+            // ColDef objects are accepted at runtime even though the TS type is (string | Column)[]
+            api.setColumnsPinned([nameCol as any], 'left');
+
+            expect(api.getColumn(nameCol as any)!.isPinnedLeft()).toBe(true);
+            expect(api.getColumn('age')!.isPinnedLeft()).toBe(false);
+        });
+
+        test('setColumnsPinned silently ignores a ColDef reference not in the grid', () => {
+            const outsider: ColDef = { field: 'ghost' };
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [{ field: 'name' }],
+            });
+
+            expect(() => api.setColumnsPinned([outsider as any], 'left')).not.toThrow();
+            expect(api.getColumn('name')!.isPinnedLeft()).toBe(false);
         });
     });
 
@@ -128,6 +208,60 @@ describe('Column lookup', () => {
         });
     });
 
+    // `getColumnState()` iterates every col known to the grid via the internal `getAllCols()`.
+    // Asserting no duplicate entries catches silent over-inclusion of service / hierarchy cols.
+    describe('getColumnState() — every col appears exactly once', () => {
+        function hasNoDuplicates(ids: string[]): boolean {
+            return new Set(ids).size === ids.length;
+        }
+
+        test('plain cols — no duplicates', () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [{ colId: 'a' }, { colId: 'b' }, { colId: 'c' }],
+            });
+
+            const ids = api.getColumnState().map((s) => s.colId!);
+            expect(hasNoDuplicates(ids)).toBe(true);
+            expect(ids).toEqual(expect.arrayContaining(['a', 'b', 'c']));
+        });
+
+        test('with row grouping — auto-group col appears exactly once', () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [{ colId: 'country', rowGroup: true }, { colId: 'value' }],
+                rowData: [{ country: 'A', value: 1 }],
+            });
+
+            const ids = api.getColumnState().map((s) => s.colId!);
+            expect(hasNoDuplicates(ids)).toBe(true);
+            expect(ids).toEqual(expect.arrayContaining(['country', 'value', 'ag-Grid-AutoColumn']));
+        });
+
+        test('with row selection — selection col appears exactly once', () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [{ colId: 'a' }, { colId: 'b' }],
+                rowSelection: { mode: 'multiRow', checkboxes: true },
+                rowData: [{ a: 1, b: 2 }],
+            });
+
+            const ids = api.getColumnState().map((s) => s.colId!);
+            expect(hasNoDuplicates(ids)).toBe(true);
+            expect(ids).toEqual(expect.arrayContaining(['a', 'b', 'ag-Grid-SelectionColumn']));
+        });
+
+        test('state survives setGridOption(columnDefs) with no duplicates', () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [{ colId: 'a' }, { colId: 'b' }],
+            });
+
+            api.setGridOption('columnDefs', [{ colId: 'x' }, { colId: 'y' }, { colId: 'z' }]);
+
+            const ids = api.getColumnState().map((s) => s.colId!);
+            expect(hasNoDuplicates(ids)).toBe(true);
+            expect(ids).toEqual(expect.arrayContaining(['x', 'y', 'z']));
+            expect(ids).not.toContain('a');
+        });
+    });
+
     describe('getColumnDefs()', () => {
         test('exports column defs with current runtime state', () => {
             const api = gridsManager.createGrid('myGrid', {
@@ -163,6 +297,137 @@ describe('Column lookup', () => {
             expect(params).toEqual({ min: 0, max: 100 });
             // Ensure it's a clone, not the same reference
             expect(params).not.toBe((api.getColumn('x') as any)?.getColDef().cellEditorParams);
+        });
+
+        test('does not pollute Object.prototype when colDef contains __proto__ payload', () => {
+            const pollutionPayload = JSON.parse('{"__proto__":{"polluted":"yes"}}');
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [{ colId: 'x', cellEditorParams: pollutionPayload }],
+            });
+
+            // Exporting the colDefs exercises cloneColDef on the payload.
+            const defs = api.getColumnDefs()!;
+            expect(defs).toBeDefined();
+
+            // The clone must not have polluted Object.prototype or a fresh object's prototype.
+            expect(({} as any).polluted).toBeUndefined();
+            expect((Object.prototype as any).polluted).toBeUndefined();
+        });
+
+        test('round-trip getColumnDefs → setGridOption preserves order / pin / sort / hide / width', () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [
+                    { colId: 'a', width: 110 },
+                    { colId: 'b', width: 120, pinned: 'left' },
+                    { colId: 'c', width: 130, hide: true },
+                    { colId: 'd', width: 140, sort: 'desc' },
+                ],
+            });
+
+            api.moveColumns(['d'], 0);
+            api.setColumnsPinned(['c'], 'right');
+            api.applyColumnState({ state: [{ colId: 'a', sort: 'asc' }] });
+
+            const before = api.getColumnState().map((s) => ({
+                colId: s.colId,
+                width: s.width,
+                pinned: s.pinned ?? null,
+                hide: s.hide ?? false,
+                sort: s.sort ?? null,
+            }));
+
+            const exported = api.getColumnDefs()!;
+            api.setGridOption('columnDefs', exported as any);
+
+            const after = api.getColumnState().map((s) => ({
+                colId: s.colId,
+                width: s.width,
+                pinned: s.pinned ?? null,
+                hide: s.hide ?? false,
+                sort: s.sort ?? null,
+            }));
+
+            expect(after).toEqual(before);
+        });
+    });
+
+    describe('getColDefCol discriminator', () => {
+        test('placeholder measure col created in pivot mode with zero value cols is findable via getColumn', async () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [
+                    { colId: 'country', rowGroup: true },
+                    { colId: 'year', enablePivot: true, pivot: true },
+                    { colId: 'sales' },
+                ],
+                pivotMode: true,
+                rowData: [
+                    { country: 'USA', year: 2020, sales: 10 },
+                    { country: 'USA', year: 2021, sales: 20 },
+                    { country: 'UK', year: 2020, sales: 30 },
+                ],
+            });
+            await asyncSetTimeout(0);
+
+            const pivotResultCols = api.getPivotResultColumns();
+            expect(pivotResultCols).not.toBeNull();
+            expect(pivotResultCols!.length).toBeGreaterThan(0);
+
+            for (const col of pivotResultCols!) {
+                const found = api.getColumn(col.getColId());
+                expect(found).toBe(col);
+            }
+
+            await new GridColumns(api, 'pivot mode no value cols — placeholder measure cols').checkColumns(false);
+            await new GridRows(api, 'pivot mode no value cols — rows').check(false);
+        });
+    });
+
+    describe('getColumnState() — no duplicates with hierarchy cols', () => {
+        function hasNoDuplicates(ids: string[]): boolean {
+            return new Set(ids).size === ids.length;
+        }
+
+        // skipped on `latest` — fix lands with AG-17366-column-model-rewrite
+        test.skip('groupHierarchy virtuals appear exactly once in getColumnState()', async () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [
+                    { field: 'country' },
+                    { field: 'date', rowGroup: true, groupHierarchy: ['year', 'month'] },
+                ],
+                rowData: [
+                    { country: 'USA', date: new Date(2020, 0, 1) },
+                    { country: 'USA', date: new Date(2020, 5, 1) },
+                ],
+            });
+            await asyncSetTimeout(0);
+
+            const ids = api.getColumnState().map((s) => s.colId!);
+            expect(hasNoDuplicates(ids)).toBe(true);
+
+            const hierarchyIds = ids.filter((id) => id.startsWith('ag-Grid-HierarchyColumn-date'));
+            expect(hierarchyIds.length).toBeGreaterThan(0);
+            for (const hid of hierarchyIds) {
+                expect(ids.filter((id) => id === hid).length).toBe(1);
+            }
+
+            await new GridColumns(api, 'hierarchy virtuals visible exactly once').checkColumns(false);
+        });
+
+        // skipped on `latest` — fix lands with AG-17366-column-model-rewrite
+        test.skip('getAllGridColumns includes hierarchy virtuals exactly once', async () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [
+                    { field: 'country' },
+                    { field: 'date', rowGroup: true, groupHierarchy: ['year', 'month'] },
+                ],
+                rowData: [{ country: 'USA', date: new Date(2020, 0, 1) }],
+            });
+            await asyncSetTimeout(0);
+
+            const ids = api.getAllGridColumns().map((c: Column) => c.getColId());
+            expect(hasNoDuplicates(ids)).toBe(true);
+
+            await new GridRows(api, 'rows with hierarchy virtuals').check(false);
         });
     });
 });

--- a/testing/behavioural/src/columns/column-mutations.test.ts
+++ b/testing/behavioural/src/columns/column-mutations.test.ts
@@ -8,14 +8,21 @@
  * - Validators catch no errors after heavy mutations
  */
 import type { ColDef, Column } from 'ag-grid-community';
-import { ClientSideRowModelModule } from 'ag-grid-community';
-import { PivotModule, RowGroupingModule } from 'ag-grid-enterprise';
+import { ClientSideRowModelModule, RowSelectionModule } from 'ag-grid-community';
+import { PivotModule, RowGroupingModule, RowNumbersModule, TreeDataModule } from 'ag-grid-enterprise';
 
-import { GridColumns, TestGridsManager } from '../test-utils';
+import { GridColumns, GridRows, TestGridsManager, asyncSetTimeout } from '../test-utils';
 
 describe('Column Mutations', () => {
     const gridsManager = new TestGridsManager({
-        modules: [ClientSideRowModelModule, RowGroupingModule, PivotModule],
+        modules: [
+            ClientSideRowModelModule,
+            RowGroupingModule,
+            PivotModule,
+            RowSelectionModule,
+            RowNumbersModule,
+            TreeDataModule,
+        ],
     });
 
     afterEach(() => {
@@ -1195,6 +1202,874 @@ describe('Column Mutations', () => {
                 ├── b width:200
                 └── c width:200 lockPosition:right
             `);
+        });
+    });
+
+    /**
+     * Locks in the behaviour of the order tracker (`lastOrder` / `lastPivotOrder`) around
+     * service-col recreation. When a service col (auto-group / selection / row-numbers) is
+     * freshly created, the previous order tracker may hold a stale reference that no longer
+     * exists in `colsById`. The order tracker must rebuild so the fresh service col appears at
+     * the head of the displayed list while the user's reorder is preserved for the remaining
+     * cols.
+     */
+    describe('column order preservation across service-col recreation', () => {
+        test('rowSelection toggled on after user reorder: selection col at head, user order kept', async () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [{ colId: 'a' }, { colId: 'b' }, { colId: 'c' }],
+                maintainColumnOrder: true,
+            });
+
+            api.moveColumns(['c'], 0);
+
+            await new GridColumns(api, 'after user reorder').checkColumns(`
+                CENTER
+                ├── c width:200
+                ├── a width:200
+                └── b width:200
+            `);
+
+            api.setGridOption('rowSelection', { mode: 'multiRow', checkboxes: true });
+
+            await new GridColumns(api, 'after selection enabled').checkColumns(`
+                CENTER
+                ├── ag-Grid-SelectionColumn width:50 !resizable !sortable suppressMovable lockPosition:left
+                ├── c width:200
+                ├── a width:200
+                └── b width:200
+            `);
+        });
+
+        test('rowNumbers toggled on after user reorder: rowNumbers col at head, user order kept', async () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [{ colId: 'a' }, { colId: 'b' }, { colId: 'c' }],
+                maintainColumnOrder: true,
+            });
+
+            api.moveColumns(['c'], 0);
+
+            api.setGridOption('rowNumbers', true);
+
+            await new GridColumns(api, 'after rowNumbers enabled').checkColumns(`
+                LEFT
+                └── ag-Grid-RowNumbersColumn width:60 !resizable !sortable suppressMovable lockPosition:left
+                CENTER
+                ├── c width:200
+                ├── a width:200
+                └── b width:200
+            `);
+        });
+
+        test('auto-group col added after user reorder: auto col at head, user order kept', async () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [{ colId: 'a' }, { colId: 'b' }, { colId: 'c' }],
+                maintainColumnOrder: true,
+            });
+
+            api.moveColumns(['c'], 0);
+
+            api.setGridOption('columnDefs', [{ colId: 'a', rowGroup: true }, { colId: 'b' }, { colId: 'c' }]);
+
+            await new GridColumns(api, 'after row grouping enabled').checkColumns(`
+                CENTER
+                ├── ag-Grid-AutoColumn "Group" width:200
+                ├── c width:200
+                ├── a width:200 rowGroup
+                └── b width:200
+            `);
+        });
+
+        test('toggle rowSelection off then on preserves user reorder', async () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [{ colId: 'a' }, { colId: 'b' }, { colId: 'c' }],
+                rowSelection: { mode: 'multiRow', checkboxes: true },
+                maintainColumnOrder: true,
+            });
+
+            api.moveColumns(['c'], 1);
+
+            await new GridColumns(api, 'after user reorder with selection').checkColumns(`
+                CENTER
+                ├── ag-Grid-SelectionColumn width:50 !resizable !sortable suppressMovable lockPosition:left
+                ├── c width:200
+                ├── a width:200
+                └── b width:200
+            `);
+
+            api.setGridOption('rowSelection', undefined);
+
+            await new GridColumns(api, 'after selection disabled').checkColumns(`
+                CENTER
+                ├── c width:200
+                ├── a width:200
+                └── b width:200
+            `);
+
+            api.setGridOption('rowSelection', { mode: 'multiRow', checkboxes: true });
+
+            await new GridColumns(api, 'after selection re-enabled').checkColumns(`
+                CENTER
+                ├── ag-Grid-SelectionColumn width:50 !resizable !sortable suppressMovable lockPosition:left
+                ├── c width:200
+                ├── a width:200
+                └── b width:200
+            `);
+        });
+
+        test('user-reordered selection col stays at moved position when its config changes', async () => {
+            // With maintainColumnOrder=true and the user having overridden the default
+            // lockPosition so the selection col is movable, a regenerated selection col should
+            // stay at the user's position rather than snapping to the head — per the docs:
+            // "prioritise the order of the columns as they appear in the grid".
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [{ colId: 'a' }, { colId: 'b' }, { colId: 'c' }],
+                rowSelection: { mode: 'multiRow', checkboxes: true },
+                selectionColumnDef: { lockPosition: false, suppressMovable: false },
+                maintainColumnOrder: true,
+            });
+
+            // Move selection col to position 2 (after 'a', 'b').
+            api.moveColumns(['ag-Grid-SelectionColumn'], 2);
+
+            await new GridColumns(api, 'user moved selection col').checkColumns(`
+                CENTER
+                ├── a width:200
+                ├── b width:200
+                ├── ag-Grid-SelectionColumn width:50 !resizable !sortable
+                └── c width:200
+            `);
+
+            // Change selection config — triggers selection col regeneration.
+            api.setGridOption('rowSelection', { mode: 'multiRow', checkboxes: true, headerCheckbox: true });
+
+            // Selection col should remain at the user-chosen position.
+            await new GridColumns(api, 'after selection regenerated').checkColumns(`
+                CENTER
+                ├── a width:200
+                ├── b width:200
+                ├── ag-Grid-SelectionColumn width:50 !resizable !sortable
+                └── c width:200
+            `);
+        });
+
+        test('multiple service cols added simultaneously appear at head in fixed order', async () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [{ colId: 'a' }, { colId: 'b' }, { colId: 'c' }],
+                maintainColumnOrder: true,
+            });
+
+            api.moveColumns(['c'], 0);
+
+            api.setGridOption('columnDefs', [{ colId: 'a', rowGroup: true }, { colId: 'b' }, { colId: 'c' }]);
+            api.setGridOption('rowNumbers', true);
+            api.setGridOption('rowSelection', { mode: 'multiRow', checkboxes: true });
+
+            // Display order at head: rowNumber (left-pinned) → selection (left-pinned in center
+            // bucket) → autoGroup → user-reorder preserved.
+            await new GridColumns(api, 'all service cols enabled').checkColumns(`
+                LEFT
+                └── ag-Grid-RowNumbersColumn width:60 !resizable !sortable suppressMovable lockPosition:left
+                CENTER
+                ├── ag-Grid-SelectionColumn width:50 !resizable !sortable suppressMovable lockPosition:left
+                ├── ag-Grid-AutoColumn "Group" width:200
+                ├── c width:200
+                ├── a width:200 rowGroup
+                └── b width:200
+            `);
+        });
+    });
+
+    describe('service col instance preservation across configuration changes', () => {
+        test('autoGroupColumnDef change keeps auto-col instance, updates the colDef', async () => {
+            const api = gridsManager.createGrid('autoGroup', {
+                columnDefs: [{ field: 'country', rowGroup: true }, { field: 'value' }],
+                rowData: [
+                    { country: 'USA', value: 1 },
+                    { country: 'UK', value: 2 },
+                ],
+                autoGroupColumnDef: { headerName: 'Group A', width: 180 },
+            });
+            await asyncSetTimeout(0);
+
+            const autoColBefore = api.getColumn('ag-Grid-AutoColumn');
+            expect(autoColBefore).not.toBeNull();
+            expect(autoColBefore!.getColDef().headerName).toBe('Group A');
+            expect(autoColBefore!.getActualWidth()).toBe(180);
+
+            api.setGridOption('autoGroupColumnDef', { headerName: 'Group B', width: 220 });
+            await asyncSetTimeout(0);
+
+            const autoColAfter = api.getColumn('ag-Grid-AutoColumn');
+            expect(autoColAfter).toBe(autoColBefore);
+            expect(autoColAfter!.getColDef().headerName).toBe('Group B');
+            expect(autoColAfter!.getActualWidth()).toBe(220);
+
+            await new GridColumns(api, 'autoGroupColumnDef changed; auto col instance preserved').checkColumns(false);
+            await new GridRows(api, 'rows after autoGroupColumnDef change').check(false);
+        });
+
+        test('pivot mode toggle preserves selection col instance', async () => {
+            const api = gridsManager.createGrid('pivotToggle', {
+                columnDefs: [
+                    { field: 'country', rowGroup: true },
+                    { field: 'sport', enablePivot: true },
+                    { field: 'gold', aggFunc: 'sum' },
+                ],
+                rowData: [
+                    { country: 'USA', sport: 'Swimming', gold: 5 },
+                    { country: 'UK', sport: 'Running', gold: 3 },
+                ],
+                rowSelection: { mode: 'multiRow', checkboxes: true },
+            });
+            await asyncSetTimeout(0);
+
+            const selBefore = api.getColumn('ag-Grid-SelectionColumn');
+            expect(selBefore).not.toBeNull();
+
+            api.setGridOption('pivotMode', true);
+            await asyncSetTimeout(0);
+            expect(api.getColumn('ag-Grid-SelectionColumn')).toBe(selBefore);
+
+            api.setGridOption('pivotMode', false);
+            await asyncSetTimeout(0);
+            expect(api.getColumn('ag-Grid-SelectionColumn')).toBe(selBefore);
+            expect((selBefore as any).isAlive()).toBe(true);
+        });
+    });
+
+    describe('lastOrder per pivot mode (maintainColumnOrder)', () => {
+        test('user reorder in primary mode is preserved after pivot toggle round-trip', async () => {
+            const api = gridsManager.createGrid('lastOrder', {
+                columnDefs: [
+                    { colId: 'country', rowGroup: true },
+                    { colId: 'sport', enablePivot: true },
+                    { colId: 'gold', aggFunc: 'sum' },
+                    { colId: 'silver', aggFunc: 'sum' },
+                    { colId: 'bronze', aggFunc: 'sum' },
+                ],
+                rowData: [
+                    { country: 'USA', sport: 'Swim', gold: 1, silver: 2, bronze: 3 },
+                    { country: 'UK', sport: 'Run', gold: 4, silver: 5, bronze: 6 },
+                ],
+                maintainColumnOrder: true,
+            });
+            await asyncSetTimeout(0);
+
+            api.moveColumns(['bronze'], 0);
+            await asyncSetTimeout(0);
+            const primaryOrderBefore = api
+                .getAllDisplayedColumns()
+                .map((c) => c.getColId())
+                .filter((id) => !id.startsWith('ag-Grid'));
+            expect(primaryOrderBefore[0]).toBe('bronze');
+
+            api.setGridOption('pivotMode', true);
+            await asyncSetTimeout(0);
+            api.setGridOption('pivotMode', false);
+            await asyncSetTimeout(0);
+
+            const primaryOrderAfter = api
+                .getAllDisplayedColumns()
+                .map((c) => c.getColId())
+                .filter((id) => !id.startsWith('ag-Grid'));
+
+            expect(primaryOrderAfter).toEqual(primaryOrderBefore);
+        });
+    });
+
+    describe('applyColumnState resilience', () => {
+        test('unknown colIds in state are ignored, valid colIds updated', () => {
+            const api = gridsManager.createGrid('unknownState', {
+                columnDefs: [
+                    { colId: 'a', width: 100 },
+                    { colId: 'b', width: 100 },
+                ],
+            });
+
+            expect(() =>
+                api.applyColumnState({
+                    state: [
+                        { colId: 'a', width: 175 },
+                        { colId: 'does-not-exist', width: 999 },
+                        { colId: 'also-fake', sort: 'asc' },
+                        { colId: 'b', width: 225 },
+                    ],
+                })
+            ).not.toThrow();
+
+            const widths = Object.fromEntries(api.getColumnState().map((s) => [s.colId, s.width]));
+            expect(widths['a']).toBe(175);
+            expect(widths['b']).toBe(225);
+            expect(widths['does-not-exist']).toBeUndefined();
+            expect(widths['also-fake']).toBeUndefined();
+        });
+    });
+
+    describe('setColumnsVisible idempotence', () => {
+        test('setting same visibility twice does not refire columnVisible event', async () => {
+            const api = gridsManager.createGrid('idempotent', {
+                columnDefs: [{ colId: 'a' }, { colId: 'b' }],
+            });
+
+            let eventCount = 0;
+            api.addEventListener('columnVisible', () => {
+                eventCount++;
+            });
+
+            api.setColumnsVisible(['a'], false);
+            await asyncSetTimeout(0);
+            expect(eventCount).toBe(1);
+
+            api.setColumnsVisible(['a'], false);
+            await asyncSetTimeout(0);
+            expect(eventCount).toBe(1);
+
+            api.setColumnsVisible(['a'], true);
+            await asyncSetTimeout(0);
+            expect(eventCount).toBe(2);
+        });
+    });
+
+    describe('locked columns + maintainColumnOrder + new cols', () => {
+        test('lockPosition cols stay locked when new cols added via setGridOption', async () => {
+            const api = gridsManager.createGrid('lockedMaintain', {
+                columnDefs: [
+                    { colId: 'leftLock', lockPosition: 'left' },
+                    { colId: 'a' },
+                    { colId: 'b' },
+                    { colId: 'rightLock', lockPosition: 'right' },
+                ],
+                maintainColumnOrder: true,
+            });
+            await asyncSetTimeout(0);
+
+            api.moveColumns(['b'], 1);
+            await asyncSetTimeout(0);
+
+            const orderBefore = api.getAllDisplayedColumns().map((c) => c.getColId());
+            expect(orderBefore[0]).toBe('leftLock');
+            expect(orderBefore[orderBefore.length - 1]).toBe('rightLock');
+
+            api.setGridOption('columnDefs', [
+                { colId: 'leftLock', lockPosition: 'left' },
+                { colId: 'a' },
+                { colId: 'b' },
+                { colId: 'c' },
+                { colId: 'rightLock', lockPosition: 'right' },
+            ]);
+            await asyncSetTimeout(0);
+
+            const orderAfter = api.getAllDisplayedColumns().map((c) => c.getColId());
+            expect(orderAfter[0]).toBe('leftLock');
+            expect(orderAfter[orderAfter.length - 1]).toBe('rightLock');
+            expect(orderAfter).toContain('c');
+        });
+    });
+
+    describe('getColumnDefs rowGroupIndex / pivotIndex', () => {
+        test('rowGroupIndex reflects row-group ordering in exported defs', async () => {
+            const api = gridsManager.createGrid('rgIndex', {
+                columnDefs: [
+                    { colId: 'a' },
+                    { colId: 'b', rowGroup: true, rowGroupIndex: 1 },
+                    { colId: 'c', rowGroup: true, rowGroupIndex: 0 },
+                ],
+                rowData: [{ a: 1, b: 'x', c: 'y' }],
+            });
+            await asyncSetTimeout(0);
+
+            const defs = api.getColumnDefs()! as ColDef[];
+            const byId = Object.fromEntries(defs.map((d) => [d.colId, d]));
+            expect(byId['b'].rowGroup).toBe(true);
+            expect(byId['c'].rowGroup).toBe(true);
+            expect(byId['b'].rowGroupIndex).toBe(1);
+            expect(byId['c'].rowGroupIndex).toBe(0);
+            expect(byId['a'].rowGroup).toBeFalsy();
+        });
+
+        test('pivotIndex reflects pivot ordering in exported defs', async () => {
+            const api = gridsManager.createGrid('pivIndex', {
+                columnDefs: [
+                    { colId: 'a' },
+                    { colId: 'b', pivot: true, pivotIndex: 1 },
+                    { colId: 'c', pivot: true, pivotIndex: 0 },
+                    { colId: 'val', aggFunc: 'sum' },
+                ],
+                pivotMode: true,
+                rowData: [{ a: 1, b: 'x', c: 'y', val: 5 }],
+            });
+            await asyncSetTimeout(0);
+
+            const defs = api.getColumnDefs()! as ColDef[];
+            const byId = Object.fromEntries(defs.map((d) => [d.colId, d]));
+            expect(byId['b'].pivot).toBe(true);
+            expect(byId['c'].pivot).toBe(true);
+            expect(byId['b'].pivotIndex).toBe(1);
+            expect(byId['c'].pivotIndex).toBe(0);
+        });
+    });
+
+    describe('applyColumnState with applyOrder including auto cols', () => {
+        test('applyOrder repositions the auto-group col among user cols', async () => {
+            const api = gridsManager.createGrid('applyOrderAuto', {
+                columnDefs: [{ colId: 'country', rowGroup: true }, { colId: 'a' }, { colId: 'b' }, { colId: 'c' }],
+                rowData: [{ country: 'USA', a: 1, b: 2, c: 3 }],
+            });
+            await asyncSetTimeout(0);
+
+            api.applyColumnState({
+                state: [
+                    { colId: 'a' },
+                    { colId: 'ag-Grid-AutoColumn' },
+                    { colId: 'b' },
+                    { colId: 'c' },
+                    { colId: 'country' },
+                ],
+                applyOrder: true,
+            });
+            await asyncSetTimeout(0);
+
+            const order = api.getAllDisplayedColumns().map((c) => c.getColId());
+            const autoIdx = order.indexOf('ag-Grid-AutoColumn');
+            const aIdx = order.indexOf('a');
+            const bIdx = order.indexOf('b');
+            expect(autoIdx).toBeGreaterThan(aIdx);
+            expect(autoIdx).toBeLessThan(bIdx);
+        });
+    });
+
+    describe('service col wrapper cache identity', () => {
+        test('selection col instance preserved across multiple rowGroup toggles', async () => {
+            const api = gridsManager.createGrid('selWrapperIdentity', {
+                columnDefs: [{ colId: 'country' }, { colId: 'sport' }, { colId: 'value' }],
+                rowData: [{ country: 'USA', sport: 'Swim', value: 1 }],
+                rowSelection: { mode: 'multiRow', checkboxes: true },
+            });
+            await asyncSetTimeout(0);
+
+            const selCol = api.getColumn('ag-Grid-SelectionColumn');
+            expect(selCol).not.toBeNull();
+
+            api.setRowGroupColumns(['country']);
+            await asyncSetTimeout(0);
+            expect(api.getColumn('ag-Grid-SelectionColumn')).toBe(selCol);
+
+            api.setRowGroupColumns(['country', 'sport']);
+            await asyncSetTimeout(0);
+            expect(api.getColumn('ag-Grid-SelectionColumn')).toBe(selCol);
+
+            api.setRowGroupColumns([]);
+            await asyncSetTimeout(0);
+            expect(api.getColumn('ag-Grid-SelectionColumn')).toBe(selCol);
+            expect((selCol as any).isAlive()).toBe(true);
+        });
+
+        test('rowNumbers col instance preserved across pivot toggles', async () => {
+            const api = gridsManager.createGrid('rnWrapperIdentity', {
+                columnDefs: [
+                    { colId: 'country', rowGroup: true },
+                    { colId: 'sport', enablePivot: true },
+                    { colId: 'value', aggFunc: 'sum' },
+                ],
+                rowData: [{ country: 'USA', sport: 'Swim', value: 1 }],
+                rowNumbers: true,
+            });
+            await asyncSetTimeout(0);
+
+            const rnCol = api.getColumn('ag-Grid-RowNumbersColumn');
+            expect(rnCol).not.toBeNull();
+
+            api.setGridOption('pivotMode', true);
+            await asyncSetTimeout(0);
+            expect(api.getColumn('ag-Grid-RowNumbersColumn')).toBe(rnCol);
+
+            api.setGridOption('pivotMode', false);
+            await asyncSetTimeout(0);
+            expect(api.getColumn('ag-Grid-RowNumbersColumn')).toBe(rnCol);
+            expect((rnCol as any).isAlive()).toBe(true);
+        });
+    });
+
+    describe('deeply nested column group depth', () => {
+        test('tree depth reflects 4-level nested groups', async () => {
+            const api = gridsManager.createGrid('deepGroups', {
+                columnDefs: [
+                    {
+                        headerName: 'L1',
+                        children: [
+                            {
+                                headerName: 'L2',
+                                children: [
+                                    {
+                                        headerName: 'L3',
+                                        children: [{ colId: 'leaf' }],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            });
+            await asyncSetTimeout(0);
+
+            await new GridColumns(api, 'four-level nested groups').checkColumns(false);
+            const leaf = api.getColumn('leaf');
+            expect(leaf).not.toBeNull();
+        });
+    });
+
+    describe('state round-trip with rowGroup + pivot active', () => {
+        test('getColumnState ↔ applyColumnState preserves rowGroupIndex + pivotIndex', async () => {
+            const api = gridsManager.createGrid('stateRoundTrip', {
+                columnDefs: [
+                    { colId: 'country', rowGroup: true, rowGroupIndex: 0 },
+                    { colId: 'year', rowGroup: true, rowGroupIndex: 1 },
+                    { colId: 'sport', pivot: true, pivotIndex: 0 },
+                    { colId: 'gold', aggFunc: 'sum' },
+                ],
+                rowData: [{ country: 'USA', year: 2020, sport: 'Swim', gold: 1 }],
+                pivotMode: true,
+            });
+            await asyncSetTimeout(0);
+
+            const stateBefore = api.getColumnState();
+
+            api.resetColumnState();
+            await asyncSetTimeout(0);
+            api.applyColumnState({ state: stateBefore, applyOrder: true });
+            await asyncSetTimeout(0);
+
+            const stateAfter = api.getColumnState();
+            const pickRelevant = (s: any) => ({
+                colId: s.colId,
+                rowGroup: s.rowGroup ?? false,
+                rowGroupIndex: s.rowGroupIndex ?? null,
+                pivot: s.pivot ?? false,
+                pivotIndex: s.pivotIndex ?? null,
+                aggFunc: s.aggFunc ?? null,
+            });
+            expect(stateAfter.map(pickRelevant)).toEqual(stateBefore.map(pickRelevant));
+        });
+    });
+
+    describe('insertVirtualColumnsForCol splice position', () => {
+        test('hierarchy virtuals precede source col, in declared order', async () => {
+            const api = gridsManager.createGrid('splicePos', {
+                columnDefs: [
+                    { colId: 'a' },
+                    { colId: 'b', rowGroup: true },
+                    { colId: 'date', rowGroup: true, groupHierarchy: ['year', 'month'] },
+                    { colId: 'c' },
+                ],
+                rowData: [{ a: 1, b: 'x', date: new Date(2020, 5, 15), c: 2 }],
+                groupDisplayType: 'multipleColumns',
+            });
+            await asyncSetTimeout(0);
+
+            const rgIds = api.getRowGroupColumns().map((c) => c.getColId());
+            const dateIdx = rgIds.indexOf('date');
+            const yearIdx = rgIds.findIndex((id) => id.includes('-date-year'));
+            const monthIdx = rgIds.findIndex((id) => id.includes('-date-month'));
+
+            expect(dateIdx).toBeGreaterThanOrEqual(0);
+            expect(yearIdx).toBeGreaterThanOrEqual(0);
+            expect(monthIdx).toBeGreaterThanOrEqual(0);
+            expect(yearIdx).toBeLessThan(monthIdx);
+            expect(monthIdx).toBeLessThan(dateIdx);
+            expect(new Set(rgIds).size).toBe(rgIds.length);
+        });
+    });
+
+    describe('balanceColumnTree padding (mixed-depth user trees)', () => {
+        test('flat leaf and grouped leaf coexist at the same render depth', async () => {
+            const api = gridsManager.createGrid('mixDepth', {
+                columnDefs: [
+                    { colId: 'flat' },
+                    {
+                        headerName: 'OuterGroup',
+                        children: [{ colId: 'nested' }],
+                    },
+                ],
+            });
+            await asyncSetTimeout(0);
+
+            await new GridColumns(api, 'flat + nested coexist').checkColumns(false);
+
+            expect(api.getColumn('flat')).not.toBeNull();
+            expect(api.getColumn('nested')).not.toBeNull();
+        });
+
+        test('autoGroupCol wraps to match user tree depth when rowGroup is added', async () => {
+            const api = gridsManager.createGrid('autoColDepth', {
+                columnDefs: [
+                    { colId: 'country', rowGroup: true },
+                    {
+                        headerName: 'Stats',
+                        children: [
+                            {
+                                headerName: 'Medals',
+                                children: [{ colId: 'gold' }, { colId: 'silver' }],
+                            },
+                        ],
+                    },
+                ],
+                rowData: [{ country: 'USA', gold: 1, silver: 2 }],
+            });
+            await asyncSetTimeout(0);
+
+            await new GridColumns(api, 'auto col wrapped to deep tree').checkColumns(false);
+            expect(api.getColumn('ag-Grid-AutoColumn')).not.toBeNull();
+        });
+    });
+
+    describe('service wrapper cache lifecycle', () => {
+        test('disabling rowSelection destroys the cached selection-col wrapper', async () => {
+            const api = gridsManager.createGrid('selWrapperDestroy', {
+                columnDefs: [{ colId: 'a' }, { colId: 'b' }],
+                rowData: [{ a: 1, b: 2 }],
+                rowSelection: { mode: 'multiRow', checkboxes: true },
+            });
+            await asyncSetTimeout(0);
+
+            const sel = api.getColumn('ag-Grid-SelectionColumn');
+            expect(sel).not.toBeNull();
+
+            api.setGridOption('rowSelection', undefined);
+            await asyncSetTimeout(0);
+
+            expect(api.getColumn('ag-Grid-SelectionColumn')).toBeNull();
+            expect((sel as any).isAlive()).toBe(false);
+
+            await new GridColumns(api, 'after disabling rowSelection').checkColumns(false);
+        });
+    });
+
+    describe('applyPrevOrder edge cases (maintainColumnOrder)', () => {
+        test('all cols replaced (no preserved anchors) keeps freshly-emitted order', async () => {
+            const api = gridsManager.createGrid('allReplaced', {
+                columnDefs: [{ colId: 'a' }, { colId: 'b' }, { colId: 'c' }],
+                maintainColumnOrder: true,
+            });
+            await asyncSetTimeout(0);
+
+            api.moveColumns(['c'], 0);
+            await asyncSetTimeout(0);
+
+            api.setGridOption('columnDefs', [{ colId: 'x' }, { colId: 'y' }, { colId: 'z' }]);
+            await asyncSetTimeout(0);
+
+            const order = api.getAllDisplayedColumns().map((c) => c.getColId());
+            expect(order).toEqual(['x', 'y', 'z']);
+
+            await new GridColumns(api, 'all replaced — fresh order kept').checkColumns(false);
+        });
+
+        test('new sibling col joins the group via the multi-level ancestor walk', async () => {
+            const api = gridsManager.createGrid('multiLevelAnchor', {
+                columnDefs: [
+                    {
+                        headerName: 'Outer',
+                        children: [{ headerName: 'Inner', children: [{ colId: 'a' }, { colId: 'b' }] }, { colId: 'c' }],
+                    },
+                    { colId: 'd' },
+                ],
+                maintainColumnOrder: true,
+            });
+            await asyncSetTimeout(0);
+
+            api.moveColumns(['d'], 0);
+            await asyncSetTimeout(0);
+
+            api.setGridOption('columnDefs', [
+                {
+                    headerName: 'Outer',
+                    children: [
+                        { headerName: 'Inner', children: [{ colId: 'a' }, { colId: 'b' }, { colId: 'b2' }] },
+                        { colId: 'c' },
+                    ],
+                },
+                { colId: 'd' },
+            ]);
+            await asyncSetTimeout(0);
+
+            const order = api.getAllDisplayedColumns().map((c) => c.getColId());
+            const b = order.indexOf('b');
+            const b2 = order.indexOf('b2');
+            const c = order.indexOf('c');
+            expect(b).toBeGreaterThanOrEqual(0);
+            expect(b2).toBeGreaterThanOrEqual(0);
+            expect(c).toBeGreaterThanOrEqual(0);
+            expect(b2).toBeGreaterThan(b);
+            expect(b2).toBeLessThan(c);
+
+            await new GridColumns(api, 'new sibling placed via ancestor walk').checkColumns(false);
+        });
+    });
+
+    describe('group reuse by groupId across colDef changes', () => {
+        test('AgProvidedColumnGroup with same groupId is reused after setColumnDefs', async () => {
+            const api = gridsManager.createGrid('groupReuse', {
+                columnDefs: [
+                    {
+                        headerName: 'G1',
+                        groupId: 'g1',
+                        children: [{ colId: 'a' }, { colId: 'b' }],
+                    },
+                ],
+            });
+            await asyncSetTimeout(0);
+
+            const beforeCount = api.getAllGridColumns().length;
+            api.setGridOption('columnDefs', [
+                {
+                    headerName: 'G1 Renamed',
+                    groupId: 'g1',
+                    children: [{ colId: 'a' }, { colId: 'b' }, { colId: 'c' }],
+                },
+            ]);
+            await asyncSetTimeout(0);
+
+            const afterCount = api.getAllGridColumns().length;
+            expect(afterCount).toBe(beforeCount + 1);
+            expect(api.getColumn('c')).not.toBeNull();
+
+            await new GridColumns(api, 'group reused with new child').checkColumns(false);
+        });
+    });
+
+    describe('getColDefColOrCol vs getCol semantics', () => {
+        test('getColumn resolves both user cols and service cols by id', async () => {
+            const api = gridsManager.createGrid('getColSurface', {
+                columnDefs: [{ field: 'country', rowGroup: true }, { field: 'value' }],
+                rowData: [{ country: 'USA', value: 1 }],
+                rowSelection: { mode: 'multiRow', checkboxes: true },
+                rowNumbers: true,
+            });
+            await asyncSetTimeout(0);
+
+            expect(api.getColumn('value')).not.toBeNull();
+            expect(api.getColumn('country')).not.toBeNull();
+            expect(api.getColumn('ag-Grid-AutoColumn')).not.toBeNull();
+            expect(api.getColumn('ag-Grid-SelectionColumn')).not.toBeNull();
+            expect(api.getColumn('ag-Grid-RowNumbersColumn')).not.toBeNull();
+            expect(api.getColumn('does-not-exist')).toBeNull();
+        });
+    });
+
+    describe('rowGroupIndex null clears the prior flag', () => {
+        test('setting rowGroupIndex: null via applyColumnState removes the col from rowGroup set', async () => {
+            const api = gridsManager.createGrid('clearRG', {
+                columnDefs: [{ colId: 'country', rowGroup: true, rowGroupIndex: 0 }, { colId: 'value' }],
+                rowData: [{ country: 'USA', value: 1 }],
+            });
+            await asyncSetTimeout(0);
+
+            expect(api.getRowGroupColumns().map((c) => c.getColId())).toEqual(['country']);
+
+            api.applyColumnState({ state: [{ colId: 'country', rowGroupIndex: null }] });
+            await asyncSetTimeout(0);
+
+            expect(api.getRowGroupColumns()).toHaveLength(0);
+
+            await new GridColumns(api, 'rowGroupIndex null clears flag').checkColumns(false);
+            await new GridRows(api, 'rows after clearing rowGroup').check(false);
+        });
+    });
+
+    describe('applyColumnState second pass for pivot result cols', () => {
+        test('applyColumnState applies sort to pivot result col by colId', async () => {
+            const api = gridsManager.createGrid('applyPivotState', {
+                columnDefs: [
+                    { colId: 'country', rowGroup: true },
+                    { colId: 'sport', pivot: true },
+                    { colId: 'gold', aggFunc: 'sum' },
+                ],
+                pivotMode: true,
+                rowData: [
+                    { country: 'USA', sport: 'Swim', gold: 5 },
+                    { country: 'USA', sport: 'Run', gold: 3 },
+                    { country: 'UK', sport: 'Swim', gold: 2 },
+                ],
+            });
+            await asyncSetTimeout(0);
+
+            const pivotCols = api.getPivotResultColumns();
+            expect(pivotCols).not.toBeNull();
+            expect(pivotCols!.length).toBeGreaterThan(0);
+
+            const targetColId = pivotCols![0].getColId();
+
+            api.applyColumnState({ state: [{ colId: targetColId, sort: 'desc' }] });
+            await asyncSetTimeout(0);
+
+            const target = api.getColumn(targetColId);
+            expect(target).not.toBeNull();
+            expect(target!.getSort()).toBe('desc');
+
+            await new GridRows(api, 'rows sorted by pivot result col').check(false);
+        });
+    });
+
+    describe('autoColService groupDisplayType=custom suppresses auto col', () => {
+        test('with groupDisplayType=custom, no auto-group col is created', async () => {
+            const api = gridsManager.createGrid('customGroupDisplay', {
+                columnDefs: [{ colId: 'country', rowGroup: true }, { colId: 'value' }],
+                rowData: [
+                    { country: 'USA', value: 1 },
+                    { country: 'UK', value: 2 },
+                ],
+                groupDisplayType: 'custom',
+            });
+            await asyncSetTimeout(0);
+
+            expect(api.getColumn('ag-Grid-AutoColumn')).toBeNull();
+            expect(api.getRowGroupColumns().map((c) => c.getColId())).toEqual(['country']);
+
+            await new GridColumns(api, 'groupDisplayType=custom — no auto col').checkColumns(false);
+        });
+    });
+
+    describe('isPivotActive transitions', () => {
+        test('pivotMode reflects toggles via setGridOption', async () => {
+            const api = gridsManager.createGrid('pivotActive', {
+                columnDefs: [
+                    { colId: 'country', rowGroup: true },
+                    { colId: 'sport', pivot: true },
+                    { colId: 'gold', aggFunc: 'sum' },
+                ],
+                rowData: [{ country: 'USA', sport: 'Swim', gold: 1 }],
+            });
+            await asyncSetTimeout(0);
+
+            expect(api.isPivotMode()).toBe(false);
+
+            api.setGridOption('pivotMode', true);
+            await asyncSetTimeout(0);
+            expect(api.isPivotMode()).toBe(true);
+
+            api.setGridOption('pivotMode', false);
+            await asyncSetTimeout(0);
+            expect(api.isPivotMode()).toBe(false);
+        });
+    });
+
+    describe('treeData auto-col lifecycle', () => {
+        test('treeData=true creates auto-group col without rowGroup colDef', async () => {
+            const api = gridsManager.createGrid('treeDataAuto', {
+                columnDefs: [{ field: 'jobTitle' }, { field: 'employmentType' }],
+                rowData: [
+                    { orgHierarchy: ['Erica'], jobTitle: 'CEO', employmentType: 'Permanent' },
+                    { orgHierarchy: ['Erica', 'Malcolm'], jobTitle: 'VP', employmentType: 'Permanent' },
+                ],
+                treeData: true,
+                getDataPath: (data: any) => data.orgHierarchy,
+                groupDefaultExpanded: -1,
+            });
+            await asyncSetTimeout(0);
+
+            expect(api.getColumn('ag-Grid-AutoColumn')).not.toBeNull();
+
+            await new GridColumns(api, 'treeData auto col').checkColumns(false);
         });
     });
 });

--- a/testing/behavioural/src/grouping-data/pivot-column-defs-update.test.ts
+++ b/testing/behavioural/src/grouping-data/pivot-column-defs-update.test.ts
@@ -2,7 +2,7 @@ import type { ColDef, Column } from 'ag-grid-community';
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { PivotModule, RowGroupingModule } from 'ag-grid-enterprise';
 
-import { GridColumns, GridRows, TestGridsManager, applyTransactionChecked } from '../test-utils';
+import { GridColumns, GridRows, TestGridsManager, applyTransactionChecked, asyncSetTimeout } from '../test-utils';
 
 describe('pivot column identity across columnDefs updates', () => {
     const gridsManager = new TestGridsManager({
@@ -303,6 +303,36 @@ describe('pivot column identity across columnDefs updates', () => {
 
         for (const col of api.getPivotResultColumns() ?? []) {
             expect(col.getColDef().headerName).toBe('Gold Medals');
+        }
+    });
+
+    // skipped on `latest` — bean leak fix lands with AG-17366-column-model-rewrite
+    test.skip('pivot result cols dropped across a clear/restore window are destroyed (no bean leak)', async () => {
+        const api = gridsManager.createGrid('clearRestoreLeak', {
+            columnDefs: baseColumnDefs,
+            pivotMode: true,
+            groupDefaultExpanded: -1,
+            pivotDefaultExpanded: -1,
+        });
+        applyTransactionChecked(api, { add: olympicLikeRows });
+        await asyncSetTimeout(0);
+
+        const oldPivotCols = api.getPivotResultColumns() ?? [];
+        expect(oldPivotCols.length).toBeGreaterThan(0);
+
+        api.setPivotColumns([]);
+        await asyncSetTimeout(0);
+
+        api.setPivotColumns(['sport']);
+        await asyncSetTimeout(0);
+
+        const newPivotCols = api.getPivotResultColumns() ?? [];
+        const newSet = new Set(newPivotCols);
+
+        for (const oldCol of oldPivotCols) {
+            if (!newSet.has(oldCol)) {
+                expect((oldCol as any).isAlive()).toBe(false);
+            }
         }
     });
 });

--- a/testing/behavioural/src/grouping-data/pivot-group-hierarchy.test.ts
+++ b/testing/behavioural/src/grouping-data/pivot-group-hierarchy.test.ts
@@ -297,4 +297,289 @@ describe('pivot with groupHierarchy (date-time)', () => {
             └── LEAF_GROUP collapsed id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
         `);
     });
+
+    // skipped on `latest` — fix lands with AG-17366-column-model-rewrite
+    test.skip('re-setting identical columnDefs does not leave destroyed hierarchy columns', async () => {
+        const api = createPivotDateTimeGrid();
+        api.setPivotColumns(['date']);
+        await asyncSetTimeout(0);
+
+        const firstRun = api.getPivotResultColumns();
+        expect(firstRun).not.toBeNull();
+        expect(firstRun!.length).toBeGreaterThan(0);
+
+        // Capture hierarchy column instances before the rebuild. These are the beans at risk
+        // of being destroyed and re-exposed via the ID-equal early-return.
+        const hierarchyColsBefore = api
+            .getColumns()!
+            .filter((c) => c.getColId().startsWith('ag-Grid-HierarchyColumn-date'));
+        expect(hierarchyColsBefore.length).toBeGreaterThan(0);
+
+        // Re-apply the same columnDefs. This rebuilds the colDefTree, which on the buggy
+        // path destroyed the hierarchy beans before keeping them via the ID-equal early-return.
+        api.setGridOption('columnDefs', [
+            { field: 'athlete' },
+            { field: 'country', rowGroup: true },
+            { field: 'sport' },
+            {
+                field: 'date',
+                enablePivot: true,
+                groupHierarchy: ['year', 'month'],
+            },
+            { field: 'total', aggFunc: 'sum' },
+        ]);
+        await asyncSetTimeout(0);
+
+        const hierarchyColsAfter = api
+            .getColumns()!
+            .filter((c) => c.getColId().startsWith('ag-Grid-HierarchyColumn-date'));
+        expect(hierarchyColsAfter.length).toBeGreaterThan(0);
+        for (const col of hierarchyColsAfter) {
+            expect((col as any).isAlive()).toBe(true);
+        }
+
+        await new GridRows(api, 'hierarchy columns after re-setting identical defs', getGridRowsOptions()).check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF_GROUP collapsed id:row-group-country-USA ag-Grid-AutoColumn:"USA"
+            └── LEAF_GROUP collapsed id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+        `);
+    });
+
+    /**
+     * Locks in the sort behaviour of `GroupHierarchyColService.compareVirtualColumns` when both
+     * a source col and one of its virtual cols are simultaneously row-grouped. The virtual cols
+     * must sort BEFORE the source col, and virtual cols from the same source must keep their
+     * insertion-order within that source's bucket.
+     */
+    test('virtual cols sort before their source col when both are row-grouped', async () => {
+        // A date col with `groupHierarchy: ['year', 'month']` AND `rowGroup: true` makes the
+        // source col plus both virtual cols (year, month) eligible to be row-group cols. The
+        // sort comparator in BaseColsService.sortColumns delegates to
+        // GroupHierarchyColService.compareVirtualColumns for these pairs.
+        const api = gridsManager.createGrid('hierarchyRowGroup', {
+            columnDefs: [{ field: 'country' }, { field: 'date', rowGroup: true, groupHierarchy: ['year', 'month'] }],
+            rowData: [
+                { country: 'USA', date: new Date(2020, 0, 1) },
+                { country: 'UK', date: new Date(2021, 5, 15) },
+            ],
+            groupDisplayType: 'multipleColumns',
+        });
+        await asyncSetTimeout(0);
+
+        // Expected order in row-group cols list: [year-virtual, month-virtual, date-source].
+        // The compareVirtualColumns:
+        //   - returns -1 for (year, date) since year is virtual-of date  →  year before date
+        //   - returns -1 for (month, date) since month is virtual-of date  →  month before date
+        //   - returns insertion-order for (year, month) within date's bucket  →  year before month
+        const rowGroupCols = api.getRowGroupColumns().map((c) => c.getColId());
+        const yearIdx = rowGroupCols.findIndex((id) => id.includes('-date-year'));
+        const monthIdx = rowGroupCols.findIndex((id) => id.includes('-date-month'));
+        const dateIdx = rowGroupCols.findIndex((id) => id === 'date');
+        expect(yearIdx).toBeGreaterThanOrEqual(0);
+        expect(monthIdx).toBeGreaterThanOrEqual(0);
+        expect(dateIdx).toBeGreaterThanOrEqual(0);
+        expect(yearIdx).toBeLessThan(monthIdx);
+        expect(monthIdx).toBeLessThan(dateIdx);
+
+        // Sanity: GridColumns snapshot of the displayed structure.
+        await new GridColumns(api, 'date hierarchy as row groups').checkColumns(false);
+    });
+
+    test('adding groupHierarchy at runtime creates virtual columns', async () => {
+        const api = gridsManager.createGrid('addHierarchy', {
+            columnDefs: [{ field: 'country' }, { field: 'date', rowGroup: true }],
+            rowData: [{ country: 'USA', date: new Date(2020, 5, 15) }],
+            groupDefaultExpanded: -1,
+        });
+        await asyncSetTimeout(0);
+
+        const beforeIds = api.getAllGridColumns().map((c) => c.getColId());
+        expect(beforeIds.filter((id) => id.startsWith('ag-Grid-HierarchyColumn-date'))).toHaveLength(0);
+
+        api.setGridOption('columnDefs', [
+            { field: 'country' },
+            { field: 'date', rowGroup: true, groupHierarchy: ['year', 'month'] },
+        ]);
+        await asyncSetTimeout(0);
+
+        const afterIds = api.getAllGridColumns().map((c) => c.getColId());
+        const hierarchyIds = afterIds.filter((id) => id.startsWith('ag-Grid-HierarchyColumn-date'));
+        expect(hierarchyIds.length).toBeGreaterThan(0);
+        expect(new Set(hierarchyIds).size).toBe(hierarchyIds.length);
+
+        await new GridColumns(api, 'hierarchy added at runtime').checkColumns(false);
+        await new GridRows(api, 'rows after hierarchy added').check(false);
+    });
+
+    test('removing groupHierarchy at runtime destroys virtual columns', async () => {
+        const api = gridsManager.createGrid('removeHierarchy', {
+            columnDefs: [{ field: 'country' }, { field: 'date', rowGroup: true, groupHierarchy: ['year', 'month'] }],
+            rowData: [{ country: 'USA', date: new Date(2020, 5, 15) }],
+            groupDefaultExpanded: -1,
+        });
+        await asyncSetTimeout(0);
+
+        const virtualColsBefore = api
+            .getAllGridColumns()
+            .filter((c) => c.getColId().startsWith('ag-Grid-HierarchyColumn-date'));
+        expect(virtualColsBefore.length).toBeGreaterThan(0);
+
+        api.setGridOption('columnDefs', [{ field: 'country' }, { field: 'date', rowGroup: true }]);
+        await asyncSetTimeout(0);
+
+        const virtualColsAfter = api
+            .getAllGridColumns()
+            .filter((c) => c.getColId().startsWith('ag-Grid-HierarchyColumn-date'));
+        expect(virtualColsAfter).toHaveLength(0);
+
+        for (const col of virtualColsBefore) {
+            expect((col as any).isAlive()).toBe(false);
+        }
+
+        await new GridColumns(api, 'hierarchy removed at runtime').checkColumns(false);
+        await new GridRows(api, 'rows after hierarchy removed').check(false);
+    });
+
+    test('changing groupHierarchy array contents regenerates virtuals', async () => {
+        const api = gridsManager.createGrid('changeHierarchy', {
+            columnDefs: [{ field: 'country' }, { field: 'date', rowGroup: true, groupHierarchy: ['year'] }],
+            rowData: [{ country: 'USA', date: new Date(2020, 5, 15) }],
+        });
+        await asyncSetTimeout(0);
+
+        const yearVirtualsBefore = api.getAllGridColumns().filter((c) => c.getColId().includes('-date-year'));
+        const monthVirtualsBefore = api.getAllGridColumns().filter((c) => c.getColId().includes('-date-month'));
+        expect(yearVirtualsBefore.length).toBeGreaterThan(0);
+        expect(monthVirtualsBefore).toHaveLength(0);
+
+        api.setGridOption('columnDefs', [
+            { field: 'country' },
+            { field: 'date', rowGroup: true, groupHierarchy: ['year', 'month'] },
+        ]);
+        await asyncSetTimeout(0);
+
+        const yearVirtualsAfter = api.getAllGridColumns().filter((c) => c.getColId().includes('-date-year'));
+        const monthVirtualsAfter = api.getAllGridColumns().filter((c) => c.getColId().includes('-date-month'));
+        expect(yearVirtualsAfter.length).toBeGreaterThan(0);
+        expect(monthVirtualsAfter.length).toBeGreaterThan(0);
+
+        const allIds = api.getAllGridColumns().map((c) => c.getColId());
+        expect(new Set(allIds).size).toBe(allIds.length);
+
+        await new GridColumns(api, 'hierarchy expanded year → year+month').checkColumns(false);
+        await new GridRows(api, 'rows after hierarchy expanded').check(false);
+    });
+
+    test('getPivotResultColumns() returns null when pivot mode is off', async () => {
+        const api = gridsManager.createGrid('pivotOff', {
+            columnDefs: [{ field: 'country', rowGroup: true }, { field: 'sport' }, { field: 'gold', aggFunc: 'sum' }],
+            rowData: [{ country: 'USA', sport: 'Swim', gold: 5 }],
+        });
+        await asyncSetTimeout(0);
+
+        const cols = api.getPivotResultColumns();
+        expect(cols == null || cols.length === 0).toBe(true);
+    });
+
+    test('toggling pivot mode off after on clears pivot result cols', async () => {
+        const api = createPivotDateTimeGrid();
+        api.setPivotColumns(['date']);
+        await asyncSetTimeout(0);
+
+        expect(api.getPivotResultColumns()).not.toBeNull();
+        expect(api.getPivotResultColumns()!.length).toBeGreaterThan(0);
+
+        api.setGridOption('pivotMode', false);
+        await asyncSetTimeout(0);
+
+        const cols = api.getPivotResultColumns();
+        expect(cols == null || cols.length === 0).toBe(true);
+    });
+
+    test('row-grouping the same hierarchy col twice does not duplicate virtuals', async () => {
+        const api = gridsManager.createGrid('dedup', {
+            columnDefs: [{ field: 'country' }, { field: 'date', rowGroup: true, groupHierarchy: ['year', 'month'] }],
+            rowData: [{ country: 'USA', date: new Date(2020, 5, 15) }],
+        });
+        await asyncSetTimeout(0);
+
+        const beforeCount = api.getRowGroupColumns().length;
+        expect(beforeCount).toBeGreaterThan(0);
+
+        api.addRowGroupColumns(['date']);
+        await asyncSetTimeout(0);
+
+        const afterCount = api.getRowGroupColumns().length;
+        expect(afterCount).toBe(beforeCount);
+
+        const ids = api.getRowGroupColumns().map((c) => c.getColId());
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    test('virtual siblings preserve insertion order in multi-sort row-group output', async () => {
+        const api = gridsManager.createGrid('multiSortVirtual', {
+            columnDefs: [
+                { field: 'country' },
+                { field: 'date', rowGroup: true, groupHierarchy: ['year', 'quarter', 'month'] },
+            ],
+            rowData: [{ country: 'USA', date: new Date(2020, 5, 15) }],
+            groupDisplayType: 'multipleColumns',
+        });
+        await asyncSetTimeout(0);
+
+        const rgIds = api.getRowGroupColumns().map((c) => c.getColId());
+        const yearIdx = rgIds.findIndex((id) => id.includes('-date-year'));
+        const quarterIdx = rgIds.findIndex((id) => id.includes('-date-quarter'));
+        const monthIdx = rgIds.findIndex((id) => id.includes('-date-month'));
+        const dateIdx = rgIds.findIndex((id) => id === 'date');
+
+        expect(yearIdx).toBeGreaterThanOrEqual(0);
+        expect(quarterIdx).toBeGreaterThanOrEqual(0);
+        expect(monthIdx).toBeGreaterThanOrEqual(0);
+        expect(dateIdx).toBeGreaterThanOrEqual(0);
+        expect(yearIdx).toBeLessThan(quarterIdx);
+        expect(quarterIdx).toBeLessThan(monthIdx);
+        expect(monthIdx).toBeLessThan(dateIdx);
+    });
+
+    test('clearing pivot then re-applying same pivot reuses saved pivot result cols', async () => {
+        const api = createPivotDateTimeGrid();
+        api.setPivotColumns(['date']);
+        await asyncSetTimeout(0);
+
+        const before = api.getPivotResultColumns();
+        expect(before).not.toBeNull();
+        const colIdsBefore = before!.map((c) => c.getColId());
+
+        api.setPivotColumns([]);
+        await asyncSetTimeout(0);
+
+        api.setPivotColumns(['date']);
+        await asyncSetTimeout(0);
+
+        const after = api.getPivotResultColumns();
+        expect(after).not.toBeNull();
+        expect(after!.map((c) => c.getColId())).toEqual(colIdsBefore);
+    });
+
+    test('hierarchy virtual visibility unchanged by ungrouping then re-grouping its source', async () => {
+        const api = gridsManager.createGrid('hierVirtualVisible', {
+            columnDefs: [{ field: 'country' }, { field: 'date', rowGroup: true, groupHierarchy: ['year', 'month'] }],
+            rowData: [{ country: 'USA', date: new Date(2020, 5, 15) }],
+        });
+        await asyncSetTimeout(0);
+
+        const yearVirtualBefore = api.getAllGridColumns().find((c) => c.getColId().includes('-date-year'));
+        expect(yearVirtualBefore).toBeDefined();
+        const wasVisible = yearVirtualBefore!.isVisible();
+
+        api.removeRowGroupColumns(['date']);
+        await asyncSetTimeout(0);
+        api.addRowGroupColumns(['date']);
+        await asyncSetTimeout(0);
+
+        const yearVirtualAfter = api.getAllGridColumns().find((c) => c.getColId().includes('-date-year'));
+        expect(yearVirtualAfter).toBeDefined();
+        expect(yearVirtualAfter!.isVisible()).toBe(wasVisible);
+    });
 });

--- a/testing/behavioural/src/sorting/sort-service.test.ts
+++ b/testing/behavioural/src/sorting/sort-service.test.ts
@@ -331,6 +331,42 @@ describe('SortService', () => {
                 └── LEAF id:1 a:"z" b:"m"
             `);
         });
+
+        test('sort cache is invalidated after reapplying identical columnDefs', async () => {
+            // Regression guard: SortService caches sortedCols (an AgColumn[]). If setGridOption
+            // produces a display tree that compares equal to the previous one, gridColumnsChanged
+            // may not fire even though service-managed columns can be rebuilt. The service must
+            // listen to newColumnsLoaded as a defensive net so the cache is rebuilt against
+            // live column instances every time columnDefs flow through the grid.
+            const api = gridMgr.createGrid('g', {
+                columnDefs: [
+                    { colId: 'a', field: 'a' },
+                    { colId: 'b', field: 'b' },
+                ],
+                rowData,
+                getRowId: (p) => p.data.id,
+            });
+
+            api.applyColumnState({ state: [{ colId: 'a', sort: 'asc' }] });
+            // Warm the cache by reading getSortModel (builds sortCache.sortedCols).
+            expect(getSortModel(api)).toEqual([{ colId: 'a', sort: 'asc' }]);
+
+            // Re-apply the same columnDefs structure. The tree is identical by content, so
+            // gridColumnsChanged may short-circuit; newColumnsLoaded should still fire.
+            api.setGridOption('columnDefs', [
+                { colId: 'a', field: 'a' },
+                { colId: 'b', field: 'b' },
+            ]);
+
+            // Sort state and row order must still be correct after the reapply.
+            expect(getSortModel(api)).toEqual([{ colId: 'a', sort: 'asc' }]);
+            await new GridRows(api, 'sort survives identical columnDefs reapply').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:2 a:"a" b:"x"
+                ├── LEAF id:3 a:"m" b:"a"
+                └── LEAF id:1 a:"z" b:"m"
+            `);
+        });
     });
 
     describe('sort with visibility changes', () => {
@@ -475,6 +511,52 @@ describe('SortService', () => {
             const state = api.getColumnState();
             const aState = state.find((s) => s.colId === 'a');
             expect(aState?.sort).toBe('asc');
+        });
+
+        test('multi-sort display ordinals are sequential in coupled mode (regression)', async () => {
+            // Two row-group cols with sort, each reflected through its own auto-group display col.
+            // The sort indicator UI must show ordinals "1" and "2" (sequential display indices),
+            // not "1" and "3" — which would happen if the index map used raw array positions
+            // from the interleaved sortedCols list instead of counting display cols only.
+            const api = gridMgr.createGrid('g', {
+                columnDefs: [
+                    { colId: 'a', field: 'a', rowGroup: true, sort: 'asc', sortIndex: 0 },
+                    { colId: 'b', field: 'b', rowGroup: true, sort: 'asc', sortIndex: 1 },
+                    { colId: 'c', field: 'c' },
+                ],
+                rowData: [
+                    { id: '1', a: 'x', b: 'p', c: 1 },
+                    { id: '2', a: 'y', b: 'q', c: 2 },
+                ],
+                groupDisplayType: 'multipleColumns',
+                getRowId: (p) => p.data.id,
+            });
+
+            // Read the sort-order indicator text from the rendered headers. `_setDisplayed` toggles
+            // the ag-hidden class when showing/hiding; visible order elements hold the 1-based text.
+            const headerRoot = TestGridsManager.getHTMLElement(api);
+            const orderEls = Array.from(
+                headerRoot?.querySelectorAll('.ag-header-cell .ag-sort-order') ?? []
+            ) as HTMLElement[];
+            const visibleOrders = orderEls
+                .filter((el) => !el.classList.contains('ag-hidden'))
+                .map((el) => el.textContent ?? '');
+
+            // Two display cols (a, b) each linked to their source row-group col. Each pair shares
+            // an ordinal: display-a + source-a = "1", display-b + source-b = "2". Pre-fix bug
+            // would have produced "1" and "3" (array positions in the interleaved sortedCols list)
+            // instead of "1" and "2".
+            expect(visibleOrders.sort()).toEqual(['1', '1', '2', '2']);
+
+            // Also exercise the DOM validator so its aria-sort check runs against coupled-mode display cols.
+            await new GridColumns(api, 'multi-sort coupled').checkColumns(`
+                CENTER
+                ├── ag-Grid-AutoColumn-a "A" width:200
+                ├── ag-Grid-AutoColumn-b "B" width:200
+                ├── a "A" width:200 sort:asc sortIndex:0 rowGroup
+                ├── b "B" width:200 sort:asc sortIndex:1 rowGroup
+                └── c "C" width:200
+            `);
         });
     });
 


### PR DESCRIPTION
Before raising the next column model rewrite pull request, we need to increase test coverage, so this add more test code.
Add ".skip" in the edge cases / bugs i found in latest and will be fixed by my next PR.

Since new versions of vscode plugins were released and ts version, we are missing some functionality in the ide:
    - update .vscode/settings.json to remove the deprecated or removed settings that were not picked up, this resulted in eslint rules not showing up correctly in the ide like lonely if or no ternary
    - update enterprise tsconfig to resolve to source files, or else it tries to resolve .d.ts in dist, so "find all references" and "got to definition" do not work and go to the built .d.ts files

See https://raw.githubusercontent.com/microsoft/vscode/main/extensions/typescript-language-features/package.json for the list of keys supported in settings.json
 
This also updates agents instructions to follow our code style and testing style, this covers most of the mistakes I usually see in the agents writing code, this should reduce wasted refactoring loops and wasted lint rules misses.
