### PR TITLE
AG-13924 Preserve integrated chart series order on grid state changes

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-api-save-restore-charts/_examples/saving-and-restoring-charts/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-api-save-restore-charts/_examples/saving-and-restoring-charts/example.spec.ts
@@ -1,11 +1,167 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import type { Page } from '@playwright/test';
+import { dragOverTo, ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
+
+// Opens the chart toolbar popup menu and navigates to the "Set Up" (data) tab,
+// making the series pill list visible.
+async function openChartDataPanel(page: Page): Promise<void> {
+    await page.locator('.ag-chart-menu-toolbar-button').first().click();
+    await page.locator('.ag-menu-option-text', { hasText: 'Edit Chart' }).click();
+    await page.locator('.ag-tab', { hasText: 'Set Up' }).click();
+    await page.locator('.ag-pill-select').first().waitFor({ state: 'visible' });
+}
+
+async function getSeriesOrder(page: Page): Promise<string[]> {
+    return page.locator('.ag-pill-select .ag-column-drop-cell-text').allTextContents();
+}
+
+// Drags the series pill drag handle at `fromIndex` over the pill at `toIndex`.
+async function reorderSeriesPill(page: Page, fromIndex: number, toIndex: number): Promise<void> {
+    const handles = page.locator('.ag-pill-select .ag-drag-handle');
+    const targets = page.locator('.ag-pill-select .ag-column-drop-cell');
+    await dragOverTo(handles.nth(fromIndex), targets.nth(toIndex));
+}
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Example loads', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
     });
+
+    // AG-13924: TC1 — sorting a grid column must not reset the user-defined series order.
+    test.vanilla('TC1 - sort preserves series order', async ({ page, remoteGrid }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        await openChartDataPanel(page);
+
+        const initialOrder = await getSeriesOrder(page);
+        expect(initialOrder[0]).toBe('Sugar');
+        expect(initialOrder[1]).toBe('Fat');
+
+        // Move 'Fat' (index 1) above 'Sugar' (index 0).
+        await reorderSeriesPill(page, 1, 0);
+        const orderAfterDrag = await getSeriesOrder(page);
+        expect(orderAfterDrag[0]).toBe('Fat');
+        expect(orderAfterDrag[1]).toBe('Sugar');
+
+        // Apply a column sort — fires modelUpdated on the grid.
+        const remoteApi = remoteGrid(page);
+        await remoteApi.applyColumnState({ state: [{ colId: 'country', sort: 'asc' }] });
+
+        const orderAfterSort = await getSeriesOrder(page);
+        expect(orderAfterSort[0]).toBe('Fat');
+        expect(orderAfterSort[1]).toBe('Sugar');
+        expect(orderAfterSort[2]).toBe('Weight');
+    });
+
+    // AG-13924: TC2 — toggling row group expansion must not reset the user-defined series order.
+    test.vanilla('TC2 - row group expansion toggle preserves series order', async ({ page, remoteGrid }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        // Add a row group so we can expand/collapse rows.
+        const remoteApi = remoteGrid(page);
+        await remoteApi.applyColumnState({
+            state: [{ colId: 'country', rowGroup: true, hide: true }],
+        });
+        await waitForGridContent(page);
+
+        await openChartDataPanel(page);
+
+        // Move 'Fat' (index 1) above 'Sugar' (index 0).
+        await reorderSeriesPill(page, 1, 0);
+        const orderAfterDrag = await getSeriesOrder(page);
+        expect(orderAfterDrag[0]).toBe('Fat');
+
+        // Collapse all row groups — fires modelUpdated.
+        await remoteApi.collapseAll();
+
+        const orderAfterCollapse = await getSeriesOrder(page);
+        expect(orderAfterCollapse[0]).toBe('Fat');
+        expect(orderAfterCollapse[1]).toBe('Sugar');
+        expect(orderAfterCollapse[2]).toBe('Weight');
+    });
+
+    // AG-13924: TC3 — filtering a grid column must not reset the user-defined series order.
+    test.vanilla('TC3 - filtering preserves series order', async ({ page, remoteGrid }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        await openChartDataPanel(page);
+
+        // Move 'Fat' (index 1) above 'Sugar' (index 0).
+        await reorderSeriesPill(page, 1, 0);
+        const orderAfterDrag = await getSeriesOrder(page);
+        expect(orderAfterDrag[0]).toBe('Fat');
+
+        // Apply a quick filter — fires modelUpdated on the grid.
+        const remoteApi = remoteGrid(page);
+        await remoteApi.setGridOption('quickFilterText', 'Ireland');
+
+        const orderAfterFilter = await getSeriesOrder(page);
+        expect(orderAfterFilter[0]).toBe('Fat');
+        expect(orderAfterFilter[1]).toBe('Sugar');
+        expect(orderAfterFilter[2]).toBe('Weight');
+    });
+
+    // AG-13924: TC4 — hiding a column must preserve the relative order of the remaining series.
+    test.vanilla('TC4 - column hide preserves order of remaining series', async ({ page, remoteGrid }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        await openChartDataPanel(page);
+
+        // Reorder to [Fat, Sugar, Weight].
+        await reorderSeriesPill(page, 1, 0);
+        const orderAfterDrag = await getSeriesOrder(page);
+        expect(orderAfterDrag).toEqual(['Fat', 'Sugar', 'Weight']);
+
+        // Hide 'weight' — fires columnVisible on the grid.
+        const remoteApi = remoteGrid(page);
+        await remoteApi.applyColumnState({ state: [{ colId: 'weight', hide: true }] });
+
+        // Weight is gone; Fat and Sugar must stay in their user-defined order.
+        const orderAfterHide = await getSeriesOrder(page);
+        expect(orderAfterHide).toEqual(['Fat', 'Sugar']);
+    });
+
+    // AG-13924: TC5 — restoring a saved chart model after hiding a column must preserve the
+    // relative series order of the surviving (visible) columns.
+    //
+    // restoreChart() creates a brand-new ChartDataModel. During initialisation the reference
+    // cell range is derived from the saved model and includes all columns, even hidden ones.
+    // The fix ensures hidden columns are excluded from the "selected" set so the panel only
+    // shows the visible series in their user-defined relative order.
+    test.vanilla(
+        'TC5 - restore chart preserves relative series order after column hide',
+        async ({ page, remoteGrid }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
+
+            await openChartDataPanel(page);
+
+            // Reorder to [Fat, Sugar, Weight].
+            await reorderSeriesPill(page, 1, 0);
+            const orderAfterDrag = await getSeriesOrder(page);
+            expect(orderAfterDrag).toEqual(['Fat', 'Sugar', 'Weight']);
+
+            // Save the chart via the example's Save button, then clear it.
+            await page.getByRole('button', { name: 'Save chart' }).click();
+            await page.getByRole('button', { name: 'Clear chart' }).click();
+
+            // Hide 'fat' so only Sugar and Weight remain visible.
+            const remoteApi = remoteGrid(page);
+            await remoteApi.applyColumnState({ state: [{ colId: 'fat', hide: true }] });
+
+            // Restore from the saved model (which had fat before sugar).
+            await page.getByRole('button', { name: 'Restore chart' }).click();
+
+            await openChartDataPanel(page);
+
+            // Fat is hidden — it must not appear as selected. Sugar and Weight should
+            // retain their relative order from the original user-defined sequence.
+            const orderAfterRestore = await getSeriesOrder(page);
+            expect(orderAfterRestore).toEqual(['Sugar', 'Weight']);
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-api-save-restore-charts/_examples/saving-and-restoring-charts/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-api-save-restore-charts/_examples/saving-and-restoring-charts/example.spec.ts
@@ -140,28 +140,32 @@ test.agExample(import.meta, () => {
 
             await openChartDataPanel(page);
 
-            // Reorder to [Fat, Sugar, Weight].
-            await reorderSeriesPill(page, 1, 0);
+            // Reorder to [Weight, Sugar, Fat] — Weight moved before Sugar and Fat.
+            // Grid column order is [Sugar, Fat, Weight], so after removing Sugar the grid
+            // order would give [Fat, Weight], but the saved user order should give [Weight, Fat].
+            // The two differ, which lets this test catch an ordering regression.
+            await reorderSeriesPill(page, 2, 0);
             const orderAfterDrag = await getSeriesOrder(page);
-            expect(orderAfterDrag).toEqual(['Fat', 'Sugar', 'Weight']);
+            expect(orderAfterDrag).toEqual(['Weight', 'Sugar', 'Fat']);
 
             // Save the chart via the example's Save button, then clear it.
             await page.getByRole('button', { name: 'Save chart' }).click();
             await page.getByRole('button', { name: 'Clear chart' }).click();
 
-            // Hide 'fat' so only Sugar and Weight remain visible.
+            // Hide 'sugar' so only Weight and Fat remain visible.
             const remoteApi = remoteGrid(page);
-            await remoteApi.applyColumnState({ state: [{ colId: 'fat', hide: true }] });
+            await remoteApi.applyColumnState({ state: [{ colId: 'sugar', hide: true }] });
 
-            // Restore from the saved model (which had fat before sugar).
+            // Restore from the saved model (which had weight before fat).
             await page.getByRole('button', { name: 'Restore chart' }).click();
 
             await openChartDataPanel(page);
 
-            // Fat is hidden — it must not appear as selected. Sugar and Weight should
-            // retain their relative order from the original user-defined sequence.
+            // Sugar is hidden — it must not appear as selected. Weight and Fat must retain
+            // their user-defined relative order [Weight, Fat], not the grid column order
+            // [Fat, Weight] that would result if restore ignored the saved series ordering.
             const orderAfterRestore = await getSeriesOrder(page);
-            expect(orderAfterRestore).toEqual(['Sugar', 'Weight']);
+            expect(orderAfterRestore).toEqual(['Weight', 'Fat']);
         }
     );
 });

--- a/packages/ag-grid-enterprise/src/charts/chartComp/model/chartDataModel.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/model/chartDataModel.ts
@@ -437,7 +437,7 @@ export class ChartDataModel extends BeanStub {
                 column,
                 colId: column.colId,
                 displayName: this.getColDisplayName(column),
-                selected: allCols.has(column),
+                selected: allCols.has(column) && column.isVisible(),
                 order: order++,
             });
         });

--- a/packages/ag-grid-enterprise/src/charts/chartComp/model/chartDataModel.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/model/chartDataModel.ts
@@ -399,7 +399,9 @@ export class ChartDataModel extends BeanStub {
                 this.crossFiltering && this.aggFunc
                     ? aggFuncDimension.getColId() === column.colId
                     : (this.useGroupColumnAsCategory && groupingActive && autoGroup) ||
-                      ((!hasSelectedDimension || supportsMultipleDimensions) && allCols.has(column));
+                      ((!hasSelectedDimension || supportsMultipleDimensions) &&
+                          allCols.has(column) &&
+                          column.isVisible());
 
             this.dimensionColState.push({
                 column,

--- a/packages/ag-grid-enterprise/src/charts/chartComp/model/chartDataModel.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/model/chartDataModel.ts
@@ -374,6 +374,10 @@ export class ChartDataModel extends BeanStub {
         const allCols = this.getAllColumnsFromRanges();
         const isInitialising = this.valueColState.length < 1;
 
+        const savedValueOrder = isInitialising
+            ? undefined
+            : new Map(this.valueColState.map((cs) => [cs.colId, cs.order]));
+
         this.dimensionColState = [];
         this.valueColState = [];
 
@@ -437,6 +441,14 @@ export class ChartDataModel extends BeanStub {
                 order: order++,
             });
         });
+
+        if (savedValueOrder) {
+            let nextOrder = Math.max(...savedValueOrder.values()) + 1;
+            this.valueColState.forEach((cs) => {
+                cs.order = savedValueOrder.has(cs.colId) ? savedValueOrder.get(cs.colId)! : nextOrder++;
+            });
+            this.valueColState.sort((a, b) => a.order - b.order);
+        }
     }
 
     private updateColumnState(updatedCol: ColState, resetOrder?: boolean): void {


### PR DESCRIPTION
## Summary

- **Root cause**: `ChartDataModel.resetColumnState()` unconditionally rebuilt `valueColState` without preserving the user-defined series order, so every grid event (sort, filter, row group, column visibility) reset series to grid-column order.
- **Fix 1** (`resetColumnState` — non-initialising path): snapshot the existing `colId → order` map before clearing `valueColState`, then restore it after rebuilding. New columns appended at the end. Covers TC1–TC4.
- **Fix 2** (`resetColumnState` — initialising/restore path): added `&& column.isVisible()` to the `selected` determination. When restoring a chart via `restoreChart()` after a column has been hidden, the saved reference cell range includes the hidden column; without the check it would be re-selected incorrectly. Covers TC5.

## Test plan

- [x] TC1 — sorting a grid column does not reset user-defined series order
- [x] TC2 — toggling row group expansion does not reset user-defined series order
- [x] TC3 — applying a quick filter does not reset user-defined series order
- [x] TC4 — hiding a column preserves the relative order of the remaining series
- [x] TC5 — restoring a saved chart after hiding a column keeps the surviving series in their user-defined relative order (hidden column excluded)

All 11 Playwright tests pass (`./docs-e2e.sh "saving-and-restoring"`).