### PR TITLE
AG-13924 Preserve integrated chart series order when restoring with rebuilt cellRange

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-api-save-restore-charts/_examples/saving-and-restoring-charts/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-api-save-restore-charts/_examples/saving-and-restoring-charts/example.spec.ts
@@ -125,45 +125,55 @@ test.agExample(import.meta, () => {
         expect(orderAfterHide).toEqual(['Fat', 'Sugar']);
     });
 
-    // AG-13924: TC5 — restoring a saved chart model after hiding a column must preserve the
-    // relative series order of the surviving (visible) columns.
+    // AG-13924: TC5 — the customer pattern is to rebuild cellRange.columns from the current
+    // visible grid columns (in grid order) before calling restoreChart(), so that removed
+    // columns are dropped. The saved relative series order must survive that rebuild.
     //
-    // restoreChart() creates a brand-new ChartDataModel. During initialisation the reference
-    // cell range is derived from the saved model and includes all columns, even hidden ones.
-    // The fix ensures hidden columns are excluded from the "selected" set so the panel only
-    // shows the visible series in their user-defined relative order.
+    // getChartModels() now includes seriesColOrder, which carries the user-defined ordering
+    // independently of cellRange.columns. restoreChart() uses it during initialisation to
+    // sort valueColState, so the surviving series come out in the saved relative order even
+    // when cellRange.columns has been rebuilt in grid column order.
     test.vanilla(
-        'TC5 - restore chart preserves relative series order after column hide',
+        'TC5 - restore chart preserves relative series order when cellRange is rebuilt from grid columns',
         async ({ page, remoteGrid }) => {
             await ensureGridReady(page);
             await waitForGridContent(page);
 
             await openChartDataPanel(page);
 
-            // Reorder to [Weight, Sugar, Fat] — Weight moved before Sugar and Fat.
-            // Grid column order is [Sugar, Fat, Weight], so after removing Sugar the grid
-            // order would give [Fat, Weight], but the saved user order should give [Weight, Fat].
+            // Reorder to [Weight, Sugar, Fat].
+            // Grid column order is [Sugar, Fat, Weight], so rebuilding from grid order after
+            // removing Sugar would give [Fat, Weight]. The saved user order gives [Weight, Fat].
             // The two differ, which lets this test catch an ordering regression.
             await reorderSeriesPill(page, 2, 0);
             const orderAfterDrag = await getSeriesOrder(page);
             expect(orderAfterDrag).toEqual(['Weight', 'Sugar', 'Fat']);
 
-            // Save the chart via the example's Save button, then clear it.
-            await page.getByRole('button', { name: 'Save chart' }).click();
-            await page.getByRole('button', { name: 'Clear chart' }).click();
-
-            // Hide 'sugar' so only Weight and Fat remain visible.
+            // Snapshot the current chart model (includes seriesColOrder = [weight, sugar, fat]).
             const remoteApi = remoteGrid(page);
+            const models = await remoteApi.getChartModels();
+            const savedModel = models![0];
+
+            // Clear the chart, then hide 'sugar' so only Fat and Weight remain visible.
+            await page.getByRole('button', { name: 'Clear chart' }).click();
             await remoteApi.applyColumnState({ state: [{ colId: 'sugar', hide: true }] });
 
-            // Restore from the saved model (which had weight before fat).
-            await page.getByRole('button', { name: 'Restore chart' }).click();
+            // Simulate the customer pattern: rebuild cellRange.columns from current visible
+            // columns in grid order (Fat before Weight), dropping Sugar.
+            const modifiedModel = {
+                ...savedModel,
+                cellRange: {
+                    ...savedModel.cellRange,
+                    columns: ['country', 'fat', 'weight'],
+                },
+            };
+
+            // Restore — seriesColOrder in the model must override the rebuilt column order.
+            await remoteApi.restoreChart(modifiedModel as any);
 
             await openChartDataPanel(page);
 
-            // Sugar is hidden — it must not appear as selected. Weight and Fat must retain
-            // their user-defined relative order [Weight, Fat], not the grid column order
-            // [Fat, Weight] that would result if restore ignored the saved series ordering.
+            // Weight must appear before Fat (saved user order), not after (grid column order).
             const orderAfterRestore = await getSeriesOrder(page);
             expect(orderAfterRestore).toEqual(['Weight', 'Fat']);
         }

--- a/packages/ag-grid-community/src/interfaces/IChartService.ts
+++ b/packages/ag-grid-community/src/interfaces/IChartService.ts
@@ -77,6 +77,8 @@ export interface ChartModel {
     seriesChartTypes?: SeriesChartType[];
     seriesGroupType?: SeriesGroupType;
     useGroupColumnAsCategory?: boolean;
+    /** Ordered list of value column IDs reflecting the user-defined series order at the time the model was saved. */
+    seriesColOrder?: string[];
 }
 
 export interface IChartService {

--- a/packages/ag-grid-enterprise/src/charts/chartComp/chartController.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/chartController.ts
@@ -278,6 +278,7 @@ export class ChartController extends BeanStub<ChartControllerEvent> {
             seriesChartTypes,
             seriesGroupType: this.model.seriesGroupType,
             useGroupColumnAsCategory: this.model.useGroupColumnAsCategory,
+            seriesColOrder: this.model.valueColState.map((cs) => cs.colId),
         };
     }
 

--- a/packages/ag-grid-enterprise/src/charts/chartComp/gridChartComp.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/gridChartComp.ts
@@ -80,6 +80,7 @@ export interface GridChartParams {
     seriesChartTypes?: SeriesChartType[];
     crossFilteringResetCallback?: () => void;
     useGroupColumnAsCategory?: boolean;
+    seriesColOrder?: string[];
 }
 
 export class GridChartComp extends Component {

--- a/packages/ag-grid-enterprise/src/charts/chartComp/model/chartDataModel.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/model/chartDataModel.ts
@@ -46,6 +46,7 @@ export interface ChartModelParams {
     seriesChartTypes?: SeriesChartType[];
     seriesGroupType?: SeriesGroupType;
     useGroupColumnAsCategory?: boolean;
+    seriesColOrder?: string[];
 }
 
 export const DEFAULT_CHART_CATEGORY = 'AG-GRID-DEFAULT-CATEGORY';
@@ -450,6 +451,17 @@ export class ChartDataModel extends BeanStub {
                 cs.order = savedValueOrder.has(cs.colId) ? savedValueOrder.get(cs.colId)! : nextOrder++;
             });
             this.valueColState.sort((a, b) => a.order - b.order);
+        } else if (isInitialising && this.params.seriesColOrder) {
+            // When restoring a saved model the caller may have rebuilt cellRange.columns in
+            // grid column order, overwriting the user-defined series order. seriesColOrder
+            // carries the original ordering so we re-sort here to honour it.
+            const orderMap = new Map(this.params.seriesColOrder.map((id, i) => [id, i]));
+            const sentinel = this.params.seriesColOrder.length;
+            this.valueColState.sort((a, b) => {
+                const ia = orderMap.has(a.colId) ? orderMap.get(a.colId)! : sentinel;
+                const ib = orderMap.has(b.colId) ? orderMap.get(b.colId)! : sentinel;
+                return ia - ib;
+            });
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds `seriesColOrder?: string[]` to the `ChartModel` interface. `getChartModels()` now populates it with the current user-defined value column order.
- During `restoreChart()`, if `seriesColOrder` is present, it is used to sort `valueColState` during initialisation — independently of `cellRange.columns`, which callers typically rebuild from current grid columns in grid order.
- Updates TC5 to exercise the real customer pattern: snapshot the model, clear the chart, hide a column, rebuild `cellRange.columns` in grid order, then restore and verify the saved relative series order is preserved.

## Motivation

Customers save chart models with `getChartModels()` and later restore them after the available column set has changed. The established pattern is to rebuild `cellRange.columns` from the current visible grid columns before calling `restoreChart()`. Because this rebuild uses grid column order, the saved user-defined series order was lost — causing legend colours and series positions to shift on restore.

`seriesColOrder` is a new optional field the caller does not know to overwrite, so it survives the `cellRange.columns` rebuild and lets the grid recover the original ordering.

## Test plan

- TC1–TC5 all pass (`./docs-e2e.sh "saving-and-restoring"`)
- TC5 now directly tests the customer rebuild pattern (previously tested passive restore only)
- `yarn nx build:types ag-grid-enterprise` passes clean

Fix [AG-13924](https://ag-grid.atlassian.net/browse/AG-13924)