### PR TITLE
AG-3390 - Harden grid staging deploy script

### DIFF
--- a/scripts/deployments/updateGridStagingRemote.sh
+++ b/scripts/deployments/updateGridStagingRemote.sh
@@ -1,14 +1,35 @@
 #!/usr/bin/env bash
 
-echo "Backing up branch builds"
-cp -R @WWW_ROOT_DIR@/html/branch-builds @WWW_ROOT_DIR@/
+set -euo pipefail
 
-echo "Cleaning current grid staging"
-rm -rf @WWW_ROOT_DIR@/html/*
-mv @FILENAME@ @WWW_ROOT_DIR@/html/
+STAGING_DIR="@WWW_ROOT_DIR@/html"
+ZIP_PATH="@WWW_ROOT_DIR@/@FILENAME@"
+STAGING_NEW="${STAGING_DIR}.new.$$"
+STAGING_OLD="${STAGING_DIR}.old"
+BRANCH_BUILDS_DIR="branch-builds"
 
-echo "Unzipping new grid staging"
-unzip -q @WWW_ROOT_DIR@/html/@FILENAME@ -d @WWW_ROOT_DIR@/html/
+echo "Validating uploaded archive at ${ZIP_PATH}"
+if [ ! -f "${ZIP_PATH}" ]; then
+    echo "ERROR: ${ZIP_PATH} not found"
+    exit 1
+fi
+unzip -tq "${ZIP_PATH}"
 
-echo "Restoring branch builds"
-cp -R @WWW_ROOT_DIR@/branch-builds @WWW_ROOT_DIR@/html/
+echo "Extracting to ${STAGING_NEW}"
+mkdir -p "${STAGING_NEW}"
+unzip -q "${ZIP_PATH}" -d "${STAGING_NEW}"
+
+if [ -d "${STAGING_DIR}/${BRANCH_BUILDS_DIR}" ]; then
+    echo "Preserving ${BRANCH_BUILDS_DIR} into ${STAGING_NEW}"
+    cp -R "${STAGING_DIR}/${BRANCH_BUILDS_DIR}" "${STAGING_NEW}/${BRANCH_BUILDS_DIR}"
+fi
+
+echo "Swapping into ${STAGING_DIR}"
+rm -rf "${STAGING_OLD}"
+if [ -d "${STAGING_DIR}" ]; then
+    mv "${STAGING_DIR}" "${STAGING_OLD}"
+fi
+mv "${STAGING_NEW}" "${STAGING_DIR}"
+
+echo "Cleaning up"
+rm -rf "${STAGING_OLD}" "${ZIP_PATH}"


### PR DESCRIPTION
## Summary

Ports the hardening applied to the charts staging deploy script in [ag-charts PR #6893](https://github.com/ag-grid/ag-charts/pull/6893) over to grid's equivalent `updateGridStagingRemote.sh`.

The changes:

- Add `set -euo pipefail` so a failed `unzip`/`mv` halts the deploy rather than continuing with stale or missing files.
- Validate the uploaded archive (existence + `unzip -tq`) **before** touching the live site, so a corrupt or missing upload can no longer wipe the existing staging deploy.
- Extract into a temp `${STAGING_DIR}.new.$$` directory and swap into place with `mv`, keeping the previous deploy aside as `${STAGING_DIR}.old` until cleanup. The `branch-builds` subtree is preserved into the new dir before the swap, preserving the existing behaviour.

Companion `createAndDeployDocsToTCGH.sh` is intentionally **out of scope** for this PR — it can be hardened separately if desired.

## Test plan

- [ ] Manual review of the diff against [ag-charts PR #6893](https://github.com/ag-grid/ag-charts/pull/6893/files) for parity.
- [ ] Confirm the deploy succeeds end-to-end on a TC pipeline run against the staging host (verify `branch-builds` survives across deploys, archive validation rejects a corrupt upload, and previous `html` content is fully replaced).