### PR TITLE
Improve examples skill guide with HTML patterns and spec template

### DIFF
--- a/.rulesync/rules/examples.md
+++ b/.rulesync/rules/examples.md
@@ -21,10 +21,11 @@ documentation/ag-grid-docs/src/content/docs/feature-name/
 ├── index.mdoc           # Documentation page
 └── _examples/
     └── example-name/
-        ├── main.ts      # Main example code
-        ├── index.html   # HTML template
-        ├── styles.css   # Optional styles
-        └── data.ts      # Optional data file
+        ├── main.ts          # Main example code
+        ├── index.html       # HTML template
+        ├── example.spec.ts  # Playwright test (required — see below)
+        ├── styles.css       # Optional — required when using a wrapper div
+        └── data.ts          # Optional data file
 ```
 
 ## Framework Compatibility
@@ -52,7 +53,78 @@ yarn nx validate-examples ag-grid-docs
 
 # Generate framework variants
 yarn nx generate-examples ag-grid-docs
+
+# Run Playwright E2E tests for a specific example
+./docs-e2e.sh "example-name"
+
+# Run a specific test by name
+./docs-e2e.sh "example-name" --grep "test name"
+
+# Run against a specific framework
+./docs-e2e.sh "example-name" --framework react
 ```
+
+## HTML Container Patterns
+
+The docs site renders examples in an iframe with a fixed height. The grid must fill the available space or it collapses to zero height.
+
+### Simple grid (no buttons or controls)
+
+Use a single div with `height: 100%`:
+
+```html
+<div id="myGrid" style="height: 100%"></div>
+```
+
+### Grid with buttons or controls
+
+Wrap everything in an `example-wrapper` div and add a `styles.css`:
+
+**index.html:**
+```html
+<div class="example-wrapper">
+    <div style="margin-bottom: 1rem">
+        <button onclick="onDoSomething()">Do Something</button>
+    </div>
+    <div id="myGrid"></div>
+</div>
+```
+
+**styles.css:**
+```css
+.example-wrapper {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+#myGrid {
+    flex: 1 1 0px;
+    width: 100%;
+}
+```
+
+The flexbox layout makes the controls sit at the top and the grid fills the remaining vertical space.
+
+## Example Spec File (Required)
+
+Every example **must** have an `example.spec.ts` file. Without it, the build fails. At minimum, use this placeholder template:
+
+```typescript
+import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+
+test.agExample(import.meta, () => {
+    test.eachFramework('Example', async ({ page }) => {
+        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+        await clickAllButtons(page);
+        // END PLACEHOLDER
+    });
+});
+```
+
+Replace the placeholder with meaningful assertions when the example demonstrates specific interactive behaviour.
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary

- Add HTML container patterns documentation (simple grid vs grid with controls using flexbox wrapper)
- Add E2E test commands (`docs-e2e.sh` usage) to the essential commands section
- Add required `example.spec.ts` template with placeholder test pattern
- Fix alignment in the example directory structure listing

## Test plan

- [ ] Verify the examples guide renders correctly in editors/viewers
- [ ] Confirm the `example.spec.ts` template matches the actual test utility imports