### PR TITLE
AG-6377 Fix pagination test IDs after page input refactor

### DIFF
--- a/packages/ag-grid-community/src/testing/testIdService.ts
+++ b/packages/ag-grid-community/src/testing/testIdService.ts
@@ -356,12 +356,18 @@ export class TestIdService extends BeanStub implements NamedBean, ITestIdService
             pagingPanel.querySelectorAll('.ag-paging-page-summary-panel .ag-paging-number').forEach((pagingNumber) => {
                 const dataRef = pagingNumber.getAttribute('data-ref');
                 switch (dataRef) {
-                    case 'lbCurrent':
+                    case 'lbCurrentStatic':
                         setTestId(
                             pagingNumber,
                             agTestIdFor.paginationSummaryPanelCurrentPage(pagingNumber.textContent)
                         );
                         break;
+                    case 'lbCurrentInput': {
+                        const inputValue =
+                            pagingNumber.querySelector<HTMLInputElement>('input')?.value ?? pagingNumber.textContent;
+                        setTestId(pagingNumber, agTestIdFor.paginationSummaryPanelCurrentPage(inputValue));
+                        break;
+                    }
                     case 'lbTotal':
                         setTestId(pagingNumber, agTestIdFor.paginationSummaryPanelTotalPage(pagingNumber.textContent));
                         break;


### PR DESCRIPTION
## Summary

- The AG-6377 commit (`56e55b90eed`) replaced the single `lbCurrent` ref in `pageSummaryComp` with `lbCurrentInput` (number input) and `lbCurrentStatic` (plain text), but `testIdService` still matched only `data-ref="lbCurrent"`
- This meant the `paginationSummaryPanelCurrentPage` test ID was never applied to any DOM element, causing all pagination e2e tests to fail across every framework and browser
- Updated the switch in `testIdService.ts` to handle both new ref names, reading the input value from the inner `<input>` element for the `lbCurrentInput` case

Fixes 10 pagination test failures across all framework jobs in CI: https://github.com/ag-grid/ag-grid/actions/runs/26431112154

## Test plan

- [ ] Pagination e2e tests pass across all frameworks (`row-pagination/auto-page-size`, `client-paging`, `custom-paging`, `grouping-normal`, `grouping-paginate-child-rows`)
- [ ] `custom-paging` example (which uses `suppressPageInput: true`) still correctly applies test IDs via the `lbCurrentStatic` path