### PR TITLE
AG-17419 Add JSON-LD structured data for AI and SEO

### DIFF
--- a/documentation/ag-grid-docs/src/layouts/Layout.astro
+++ b/documentation/ag-grid-docs/src/layouts/Layout.astro
@@ -11,10 +11,17 @@ import Plausible from '@components/Plausible.astro';
 import { Footer } from '@ag-website-shared/components/footer/Footer';
 import styles from '@layouts/Layout.module.scss';
 import { getApiPaths } from '@utils/apiMenuPath';
-import { SITE_BASE_URL, PUBLIC_GTM_ID, PUBLIC_GTM_AUTH, PUBLIC_GTM_PREVIEW } from '@constants';
+import { SITE_BASE_URL, PUBLIC_GTM_ID, PUBLIC_GTM_AUTH, PUBLIC_GTM_PREVIEW, agGridVersion } from '@constants';
 import GoogleTagManager from '@ag-website-shared/components/google-tag-manager/GoogleTagManager.astro';
 import GoogleTagManagerBody from '@ag-website-shared/components/google-tag-manager/GoogleTagManagerBody.astro';
 import AnnouncementBanner from '@components/announcement-banner/AnnouncementBanner.astro';
+import JsonLd from '@ag-website-shared/components/structured-data/JsonLd.astro';
+import {
+    buildOrganization,
+    buildSoftwareApplication,
+    buildWebSite,
+    type JsonLdObject,
+} from '@ag-website-shared/utils/structuredData';
 
 interface Props {
     title: string;
@@ -27,6 +34,7 @@ interface Props {
     showMicrosoftMessage?: boolean;
     showAnnouncementBanner?: boolean;
     overrideSocialImage?: string;
+    pageStructuredData?: JsonLdObject[];
 }
 
 const { data: metadata } = (await getEntry('metadata', 'metadata')) as CollectionEntry<'metadata'>;
@@ -52,6 +60,7 @@ const {
     showMicrosoftMessage,
     showAnnouncementBanner = false,
     overrideSocialImage,
+    pageStructuredData,
 } = Astro.props;
 
 const path = Astro.url.pathname;
@@ -61,6 +70,54 @@ const lightModeCSSUrl = `url("${urlWithBaseUrl('/images/sun.svg')}")`;
 const darkModeCSSUrl = `url("${urlWithBaseUrl('/images/moon.svg')}")`;
 
 const isHomepage = Astro.url.pathname.replaceAll('/', '') === SITE_BASE_URL.replaceAll('/', '');
+
+const includeStructuredData = !hidePageFromSearchEngines && !isArchive;
+const sameAsUrls = includeStructuredData
+    ? footerItems.flatMap((group) => group.links.filter((link) => link.iconName).map((link) => link.url))
+    : [];
+const organizationLogoUrl = new URL(
+    '/images/ag-logos/png-logos/AG-Grid-Logo_Light-Theme_476_140.png',
+    metadata.canonicalUrlBase
+).toString();
+const structuredData: JsonLdObject[] = includeStructuredData
+    ? [
+          buildOrganization({
+              canonicalUrlBase: metadata.canonicalUrlBase,
+              name: 'AG Grid',
+              logoUrl: organizationLogoUrl,
+              sameAs: sameAsUrls,
+          }),
+          buildWebSite({
+              canonicalUrlBase: metadata.canonicalUrlBase,
+              name: metadata.title,
+              description: metadata.description,
+          }),
+          ...(isHomepage
+              ? [
+                    buildSoftwareApplication({
+                        canonicalUrlBase: metadata.canonicalUrlBase,
+                        name: 'AG Grid',
+                        version: agGridVersion.split('-')[0],
+                        offers: [
+                            {
+                                '@type': 'Offer',
+                                name: 'AG Grid Community',
+                                price: '0',
+                                priceCurrency: 'USD',
+                                url: `${metadata.canonicalUrlBase}/license-pricing/`,
+                            },
+                            {
+                                '@type': 'Offer',
+                                name: 'AG Grid Enterprise',
+                                url: `${metadata.canonicalUrlBase}/license-pricing/`,
+                            },
+                        ],
+                    }),
+                ]
+              : []),
+          ...(pageStructuredData ?? []),
+      ]
+    : [];
 
 const announcementBannerProps = {
     href: urlWithBaseUrl('/campaigns/beyond-the-prompt/'),
@@ -121,6 +178,8 @@ const announcementBannerProps = {
         <meta name="twitter:title" content={title} />
         <meta name="twitter:description" content={description} />
         <meta name="twitter:image" content={socialImage} />
+
+        {structuredData.length > 0 && <JsonLd data={structuredData} />}
 
         {
             !isDev && (

--- a/documentation/ag-grid-docs/src/layouts/Layout.astro
+++ b/documentation/ag-grid-docs/src/layouts/Layout.astro
@@ -20,6 +20,7 @@ import {
     buildOrganization,
     buildSoftwareApplication,
     buildWebSite,
+    siteRootUrl,
     type JsonLdObject,
 } from '@ag-website-shared/utils/structuredData';
 
@@ -75,11 +76,9 @@ const includeStructuredData = !hidePageFromSearchEngines && !isArchive;
 const sameAsUrls = includeStructuredData
     ? footerItems.flatMap((group) => group.links.filter((link) => link.iconName).map((link) => link.url))
     : [];
-const organizationLogoUrl = new URL(
-    '/images/ag-logos/png-logos/AG-Grid-Logo_Light-Theme_476_140.png',
-    metadata.canonicalUrlBase
-).toString();
-const licensePricingUrl = new URL('/license-pricing/', metadata.canonicalUrlBase).toString();
+const siteRoot = siteRootUrl(metadata.canonicalUrlBase);
+const organizationLogoUrl = `${siteRoot}images/ag-logos/png-logos/AG-Grid-Logo_Light-Theme_476_140.png`;
+const licensePricingUrl = `${siteRoot}license-pricing/`;
 const structuredData: JsonLdObject[] = includeStructuredData
     ? [
           buildOrganization({

--- a/documentation/ag-grid-docs/src/layouts/Layout.astro
+++ b/documentation/ag-grid-docs/src/layouts/Layout.astro
@@ -79,6 +79,7 @@ const organizationLogoUrl = new URL(
     '/images/ag-logos/png-logos/AG-Grid-Logo_Light-Theme_476_140.png',
     metadata.canonicalUrlBase
 ).toString();
+const licensePricingUrl = new URL('/license-pricing/', metadata.canonicalUrlBase).toString();
 const structuredData: JsonLdObject[] = includeStructuredData
     ? [
           buildOrganization({
@@ -92,29 +93,25 @@ const structuredData: JsonLdObject[] = includeStructuredData
               name: metadata.title,
               description: metadata.description,
           }),
-          ...(isHomepage
-              ? [
-                    buildSoftwareApplication({
-                        canonicalUrlBase: metadata.canonicalUrlBase,
-                        name: 'AG Grid',
-                        version: agGridVersion.split('-')[0],
-                        offers: [
-                            {
-                                '@type': 'Offer',
-                                name: 'AG Grid Community',
-                                price: '0',
-                                priceCurrency: 'USD',
-                                url: `${metadata.canonicalUrlBase}/license-pricing/`,
-                            },
-                            {
-                                '@type': 'Offer',
-                                name: 'AG Grid Enterprise',
-                                url: `${metadata.canonicalUrlBase}/license-pricing/`,
-                            },
-                        ],
-                    }),
-                ]
-              : []),
+          buildSoftwareApplication({
+              canonicalUrlBase: metadata.canonicalUrlBase,
+              name: 'AG Grid',
+              version: agGridVersion.split('-')[0],
+              offers: [
+                  {
+                      '@type': 'Offer',
+                      name: 'AG Grid Community',
+                      price: '0',
+                      priceCurrency: 'USD',
+                      url: licensePricingUrl,
+                  },
+                  {
+                      '@type': 'Offer',
+                      name: 'AG Grid Enterprise',
+                      url: licensePricingUrl,
+                  },
+              ],
+          }),
           ...(pageStructuredData ?? []),
       ]
     : [];

--- a/documentation/ag-grid-docs/src/pages/[framework]-data-grid/[pageName].astro
+++ b/documentation/ag-grid-docs/src/pages/[framework]-data-grid/[pageName].astro
@@ -15,12 +15,6 @@ import { DocsNav } from '@ag-website-shared/components/docs-navigation/DocsNav';
 import styles from '@ag-website-shared/components/page-styles/docs.module.scss';
 import { parseVersion } from '@ag-website-shared/utils/parseVersion';
 import { agLibraryVersion } from '@constants';
-import {
-    buildBreadcrumbList,
-    buildTechArticle,
-    getSoftwareApplicationId,
-    type JsonLdObject,
-} from '@ag-website-shared/utils/structuredData';
 
 export async function getStaticPaths() {
     const pages = await getCollection('docs');
@@ -46,32 +40,9 @@ const descriptionWithSeoTagline = `${description ? `${description} ` : ''}${seoT
 
 const { data: docsNavData } = (await getEntry('docsNav', 'nav')) as CollectionEntry<'docsNav'>;
 const { data: apiNavData } = (await getEntry('apiNav', 'nav')) as CollectionEntry<'apiNav'>;
-const { data: metadata } = (await getEntry('metadata', 'metadata')) as CollectionEntry<'metadata'>;
 
 const isApiPage = isApiMenuPath({ pageName, menuData: apiNavData });
 const menuData = isApiPage ? apiNavData : docsNavData;
-
-const pageUrl = new URL(path, metadata.canonicalUrlBase).toString();
-const pageStructuredData: JsonLdObject[] = [
-    buildTechArticle({
-        canonicalUrlBase: metadata.canonicalUrlBase,
-        pageUrl,
-        title,
-        description: descriptionWithSeoTagline,
-        aboutEntityId: getSoftwareApplicationId(metadata.canonicalUrlBase),
-    }),
-    buildBreadcrumbList({
-        pageUrl,
-        items: [
-            { name: 'Home', url: `${metadata.canonicalUrlBase}/` },
-            {
-                name: `${frameworkDisplayText} Data Grid`,
-                url: new URL(`/${currentFramework}-data-grid/`, metadata.canonicalUrlBase).toString(),
-            },
-            { name: title, url: pageUrl },
-        ],
-    }),
-];
 
 const { Content } = await render(page);
 
@@ -102,7 +73,6 @@ const headings = await getHeadings({
     description={descriptionWithSeoTagline}
     showSearchBar={true}
     showDocsNav={true}
-    pageStructuredData={pageStructuredData}
 >
     <div class:list={[hidePageMenu && styles.noLeftMenu, styles.contentViewport, 'layout-grid']}>
         {

--- a/documentation/ag-grid-docs/src/pages/[framework]-data-grid/[pageName].astro
+++ b/documentation/ag-grid-docs/src/pages/[framework]-data-grid/[pageName].astro
@@ -15,6 +15,12 @@ import { DocsNav } from '@ag-website-shared/components/docs-navigation/DocsNav';
 import styles from '@ag-website-shared/components/page-styles/docs.module.scss';
 import { parseVersion } from '@ag-website-shared/utils/parseVersion';
 import { agLibraryVersion } from '@constants';
+import {
+    buildBreadcrumbList,
+    buildTechArticle,
+    getSoftwareApplicationId,
+    type JsonLdObject,
+} from '@ag-website-shared/utils/structuredData';
 
 export async function getStaticPaths() {
     const pages = await getCollection('docs');
@@ -40,9 +46,32 @@ const descriptionWithSeoTagline = `${description ? `${description} ` : ''}${seoT
 
 const { data: docsNavData } = (await getEntry('docsNav', 'nav')) as CollectionEntry<'docsNav'>;
 const { data: apiNavData } = (await getEntry('apiNav', 'nav')) as CollectionEntry<'apiNav'>;
+const { data: metadata } = (await getEntry('metadata', 'metadata')) as CollectionEntry<'metadata'>;
 
 const isApiPage = isApiMenuPath({ pageName, menuData: apiNavData });
 const menuData = isApiPage ? apiNavData : docsNavData;
+
+const pageUrl = new URL(path, metadata.canonicalUrlBase).toString();
+const pageStructuredData: JsonLdObject[] = [
+    buildTechArticle({
+        canonicalUrlBase: metadata.canonicalUrlBase,
+        pageUrl,
+        title,
+        description: descriptionWithSeoTagline,
+        aboutEntityId: getSoftwareApplicationId(metadata.canonicalUrlBase),
+    }),
+    buildBreadcrumbList({
+        pageUrl,
+        items: [
+            { name: 'Home', url: `${metadata.canonicalUrlBase}/` },
+            {
+                name: `${frameworkDisplayText} Data Grid`,
+                url: new URL(`/${currentFramework}-data-grid/`, metadata.canonicalUrlBase).toString(),
+            },
+            { name: title, url: pageUrl },
+        ],
+    }),
+];
 
 const { Content } = await render(page);
 
@@ -73,6 +102,7 @@ const headings = await getHeadings({
     description={descriptionWithSeoTagline}
     showSearchBar={true}
     showDocsNav={true}
+    pageStructuredData={pageStructuredData}
 >
     <div class:list={[hidePageMenu && styles.noLeftMenu, styles.contentViewport, 'layout-grid']}>
         {

--- a/external/ag-website-shared/src/components/structured-data/JsonLd.astro
+++ b/external/ag-website-shared/src/components/structured-data/JsonLd.astro
@@ -1,0 +1,13 @@
+---
+import { buildJsonLdDocument, serializeJsonLd, type JsonLdObject } from '@ag-website-shared/utils/structuredData';
+
+interface Props {
+    data: JsonLdObject | JsonLdObject[];
+}
+
+const { data } = Astro.props;
+const nodes = Array.isArray(data) ? data : [data];
+const document = buildJsonLdDocument(nodes);
+---
+
+{nodes.length > 0 && <script type="application/ld+json" set:html={serializeJsonLd(document)} />}

--- a/external/ag-website-shared/src/utils/structuredData.test.ts
+++ b/external/ag-website-shared/src/utils/structuredData.test.ts
@@ -66,6 +66,20 @@ describe('canonicalUrlBase normalisation', () => {
         expect(withSlash['@id']).toBe(`${CANONICAL_URL_BASE}/#organization`);
         expect(withSlash.url).toBe(`${CANONICAL_URL_BASE}/`);
     });
+
+    test('subpath canonical bases (AG Charts / AG Studio) retain the subpath in IDs and URLs', () => {
+        const chartsBase = 'https://www.ag-grid.com/charts';
+
+        const org = buildOrganization({
+            canonicalUrlBase: chartsBase,
+            name: 'AG Charts',
+            logoUrl: `${chartsBase}/images/logo.png`,
+            sameAs: [],
+        });
+
+        expect(org['@id']).toBe('https://www.ag-grid.com/charts/#organization');
+        expect(org.url).toBe('https://www.ag-grid.com/charts/');
+    });
 });
 
 describe('buildSoftwareApplication', () => {

--- a/external/ag-website-shared/src/utils/structuredData.test.ts
+++ b/external/ag-website-shared/src/utils/structuredData.test.ts
@@ -1,0 +1,191 @@
+import {
+    buildBreadcrumbList,
+    buildJsonLdDocument,
+    buildOrganization,
+    buildSoftwareApplication,
+    buildTechArticle,
+    buildWebSite,
+    getSoftwareApplicationId,
+    serializeJsonLd,
+} from './structuredData';
+
+const CANONICAL_URL_BASE = 'https://www.ag-grid.com';
+
+describe('buildOrganization', () => {
+    test('takes name, url, logo and sameAs from inputs (no @context — supplied by document wrapper)', () => {
+        const result = buildOrganization({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            name: 'AG Grid',
+            logoUrl: `${CANONICAL_URL_BASE}/images/logo.png`,
+            sameAs: ['https://github.com/ag-grid/ag-grid', 'https://twitter.com/ag_grid'],
+        });
+
+        expect(result).toEqual({
+            '@type': 'Organization',
+            '@id': `${CANONICAL_URL_BASE}/#organization`,
+            name: 'AG Grid',
+            url: `${CANONICAL_URL_BASE}/`,
+            logo: `${CANONICAL_URL_BASE}/images/logo.png`,
+            sameAs: ['https://github.com/ag-grid/ag-grid', 'https://twitter.com/ag_grid'],
+        });
+        expect(result['@context']).toBeUndefined();
+    });
+});
+
+describe('buildWebSite', () => {
+    test('references the Organization by @id', () => {
+        const result = buildWebSite({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            name: 'AG Grid',
+            description: 'A feature-rich data grid.',
+        });
+
+        expect(result['@type']).toBe('WebSite');
+        expect(result['@id']).toBe(`${CANONICAL_URL_BASE}/#website`);
+        expect(result.publisher).toEqual({ '@id': `${CANONICAL_URL_BASE}/#organization` });
+        expect(result.inLanguage).toBe('en');
+    });
+});
+
+describe('buildSoftwareApplication', () => {
+    test('uses default applicationCategory and operatingSystem when not provided, and omits offers when empty', () => {
+        const result = buildSoftwareApplication({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            name: 'AG Grid',
+            version: '34.0.0',
+        });
+
+        expect(result['@type']).toBe('SoftwareApplication');
+        expect(result.applicationCategory).toBe('DeveloperApplication');
+        expect(result.operatingSystem).toBe('Web Browser');
+        expect(result.softwareVersion).toBe('34.0.0');
+        expect(result.publisher).toEqual({ '@id': `${CANONICAL_URL_BASE}/#organization` });
+        expect(result.offers).toBeUndefined();
+    });
+
+    test('honours caller-supplied applicationCategory, operatingSystem and offers', () => {
+        const result = buildSoftwareApplication({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            name: 'AG Grid',
+            version: '34.0.0',
+            applicationCategory: 'BusinessApplication',
+            operatingSystem: 'iOS',
+            offers: [{ '@type': 'Offer', price: '0', priceCurrency: 'USD' }],
+        });
+
+        expect(result.applicationCategory).toBe('BusinessApplication');
+        expect(result.operatingSystem).toBe('iOS');
+        expect(result.offers).toEqual([{ '@type': 'Offer', price: '0', priceCurrency: 'USD' }]);
+    });
+});
+
+describe('buildTechArticle', () => {
+    test('always links isPartOf to WebSite and publisher to Organization', () => {
+        const pageUrl = `${CANONICAL_URL_BASE}/react-data-grid/getting-started/`;
+        const result = buildTechArticle({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            pageUrl,
+            title: 'Getting Started',
+            description: 'Get started with AG Grid for React.',
+        });
+
+        expect(result['@type']).toBe('TechArticle');
+        expect(result['@id']).toBe(`${pageUrl}#article`);
+        expect(result.headline).toBe('Getting Started');
+        expect(result.url).toBe(pageUrl);
+        expect(result.mainEntityOfPage).toEqual({ '@type': 'WebPage', '@id': pageUrl });
+        expect(result.isPartOf).toEqual({ '@id': `${CANONICAL_URL_BASE}/#website` });
+        expect(result.publisher).toEqual({ '@id': `${CANONICAL_URL_BASE}/#organization` });
+        expect(result.about).toBeUndefined();
+    });
+
+    test('emits an about reference when aboutEntityId is provided', () => {
+        const pageUrl = `${CANONICAL_URL_BASE}/react-data-grid/getting-started/`;
+        const result = buildTechArticle({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            pageUrl,
+            title: 'Getting Started',
+            description: 'Get started with AG Grid for React.',
+            aboutEntityId: getSoftwareApplicationId(CANONICAL_URL_BASE),
+        });
+
+        expect(result.about).toEqual({ '@id': `${CANONICAL_URL_BASE}/#software-application` });
+    });
+});
+
+describe('buildBreadcrumbList', () => {
+    test('numbers ListItem positions starting from 1', () => {
+        const pageUrl = `${CANONICAL_URL_BASE}/react-data-grid/getting-started/`;
+        const result = buildBreadcrumbList({
+            pageUrl,
+            items: [
+                { name: 'Home', url: `${CANONICAL_URL_BASE}/` },
+                { name: 'React Data Grid', url: `${CANONICAL_URL_BASE}/react-data-grid/` },
+                { name: 'Getting Started', url: pageUrl },
+            ],
+        });
+
+        expect(result['@type']).toBe('BreadcrumbList');
+        expect(result['@id']).toBe(`${pageUrl}#breadcrumb`);
+        expect(result.itemListElement).toEqual([
+            { '@type': 'ListItem', position: 1, name: 'Home', item: `${CANONICAL_URL_BASE}/` },
+            {
+                '@type': 'ListItem',
+                position: 2,
+                name: 'React Data Grid',
+                item: `${CANONICAL_URL_BASE}/react-data-grid/`,
+            },
+            { '@type': 'ListItem', position: 3, name: 'Getting Started', item: pageUrl },
+        ]);
+    });
+});
+
+describe('buildJsonLdDocument', () => {
+    test('inlines a single node under @context (no @graph wrapper)', () => {
+        const node = { '@type': 'Thing', name: 'AG Grid' };
+
+        const result = buildJsonLdDocument([node]);
+
+        expect(result).toEqual({
+            '@context': 'https://schema.org',
+            '@type': 'Thing',
+            name: 'AG Grid',
+        });
+        expect(result['@graph']).toBeUndefined();
+    });
+
+    test('wraps multiple nodes in a single @graph with a shared @context', () => {
+        const org = { '@type': 'Organization', name: 'AG Grid' };
+        const site = { '@type': 'WebSite', name: 'ag-grid.com' };
+
+        const result = buildJsonLdDocument([org, site]);
+
+        expect(result).toEqual({
+            '@context': 'https://schema.org',
+            '@graph': [org, site],
+        });
+    });
+});
+
+describe('serializeJsonLd', () => {
+    test('produces valid JSON', () => {
+        const data = { '@type': 'Thing', name: 'AG Grid' };
+
+        const serialised = serializeJsonLd(data);
+
+        expect(JSON.parse(serialised)).toEqual(data);
+    });
+
+    test('escapes </script> sequences to prevent script tag injection', () => {
+        const data = {
+            '@type': 'Thing',
+            description: 'Some text </script><script>alert(1)</script>',
+        };
+
+        const serialised = serializeJsonLd(data);
+
+        expect(serialised).not.toContain('</script>');
+        expect(serialised).toContain('<\\/script>');
+        expect(JSON.parse(serialised)).toEqual(data);
+    });
+});

--- a/external/ag-website-shared/src/utils/structuredData.test.ts
+++ b/external/ag-website-shared/src/utils/structuredData.test.ts
@@ -47,6 +47,27 @@ describe('buildWebSite', () => {
     });
 });
 
+describe('canonicalUrlBase normalisation', () => {
+    test('a trailing slash on canonicalUrlBase does not duplicate in IDs or URLs', () => {
+        const withSlash = buildOrganization({
+            canonicalUrlBase: `${CANONICAL_URL_BASE}/`,
+            name: 'AG Grid',
+            logoUrl: `${CANONICAL_URL_BASE}/images/logo.png`,
+            sameAs: [],
+        });
+        const withoutSlash = buildOrganization({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            name: 'AG Grid',
+            logoUrl: `${CANONICAL_URL_BASE}/images/logo.png`,
+            sameAs: [],
+        });
+
+        expect(withSlash).toEqual(withoutSlash);
+        expect(withSlash['@id']).toBe(`${CANONICAL_URL_BASE}/#organization`);
+        expect(withSlash.url).toBe(`${CANONICAL_URL_BASE}/`);
+    });
+});
+
 describe('buildSoftwareApplication', () => {
     test('uses default applicationCategory and operatingSystem when not provided, and omits offers when empty', () => {
         const result = buildSoftwareApplication({

--- a/external/ag-website-shared/src/utils/structuredData.ts
+++ b/external/ag-website-shared/src/utils/structuredData.ts
@@ -1,0 +1,177 @@
+/**
+ * Builders for schema.org JSON-LD structured data emitted in the page <head>.
+ *
+ * Builders return graph-node objects without `@context` — the surrounding
+ * `<JsonLd>` component supplies a single `@context` at the top of the emitted
+ * `@graph`. Stable `@id` URIs (derived from `canonicalUrlBase`) let nodes
+ * reference each other (Organization, WebSite, SoftwareApplication).
+ *
+ * Shared across AG Grid, AG Charts, and AG Studio. Brand-specific values
+ * (organisation name, product name, offers, etc.) are passed in by the caller.
+ */
+
+export type JsonLdObject = Record<string, unknown>;
+
+interface OrgInput {
+    canonicalUrlBase: string;
+    name: string;
+    logoUrl: string;
+    sameAs: string[];
+}
+
+interface WebSiteInput {
+    canonicalUrlBase: string;
+    name: string;
+    description: string;
+}
+
+interface SoftwareApplicationInput {
+    canonicalUrlBase: string;
+    name: string;
+    version: string;
+    applicationCategory?: string;
+    operatingSystem?: string;
+    offers?: JsonLdObject[];
+}
+
+interface TechArticleInput {
+    canonicalUrlBase: string;
+    pageUrl: string;
+    title: string;
+    description: string;
+    /**
+     * Optional `@id` of the entity this article is about (e.g. a
+     * SoftwareApplication emitted elsewhere on the site). When omitted,
+     * `about` is not set.
+     */
+    aboutEntityId?: string;
+}
+
+export interface BreadcrumbItem {
+    name: string;
+    url: string;
+}
+
+interface BreadcrumbListInput {
+    pageUrl: string;
+    items: BreadcrumbItem[];
+}
+
+const ORGANIZATION_ID_FRAGMENT = '#organization';
+const WEBSITE_ID_FRAGMENT = '#website';
+const SOFTWARE_APPLICATION_ID_FRAGMENT = '#software-application';
+const ARTICLE_ID_FRAGMENT = '#article';
+const BREADCRUMB_ID_FRAGMENT = '#breadcrumb';
+
+export const getOrganizationId = (canonicalUrlBase: string): string =>
+    `${canonicalUrlBase}/${ORGANIZATION_ID_FRAGMENT}`;
+export const getWebSiteId = (canonicalUrlBase: string): string => `${canonicalUrlBase}/${WEBSITE_ID_FRAGMENT}`;
+export const getSoftwareApplicationId = (canonicalUrlBase: string): string =>
+    `${canonicalUrlBase}/${SOFTWARE_APPLICATION_ID_FRAGMENT}`;
+
+export function buildOrganization({ canonicalUrlBase, name, logoUrl, sameAs }: OrgInput): JsonLdObject {
+    return {
+        '@type': 'Organization',
+        '@id': getOrganizationId(canonicalUrlBase),
+        name,
+        url: `${canonicalUrlBase}/`,
+        logo: logoUrl,
+        sameAs,
+    };
+}
+
+export function buildWebSite({ canonicalUrlBase, name, description }: WebSiteInput): JsonLdObject {
+    return {
+        '@type': 'WebSite',
+        '@id': getWebSiteId(canonicalUrlBase),
+        url: `${canonicalUrlBase}/`,
+        name,
+        description,
+        inLanguage: 'en',
+        publisher: { '@id': getOrganizationId(canonicalUrlBase) },
+    };
+}
+
+export function buildSoftwareApplication({
+    canonicalUrlBase,
+    name,
+    version,
+    applicationCategory = 'DeveloperApplication',
+    operatingSystem = 'Web Browser',
+    offers,
+}: SoftwareApplicationInput): JsonLdObject {
+    const result: JsonLdObject = {
+        '@type': 'SoftwareApplication',
+        '@id': getSoftwareApplicationId(canonicalUrlBase),
+        name,
+        applicationCategory,
+        operatingSystem,
+        softwareVersion: version,
+        url: `${canonicalUrlBase}/`,
+        publisher: { '@id': getOrganizationId(canonicalUrlBase) },
+    };
+    if (offers && offers.length > 0) {
+        result.offers = offers;
+    }
+    return result;
+}
+
+export function buildTechArticle({
+    canonicalUrlBase,
+    pageUrl,
+    title,
+    description,
+    aboutEntityId,
+}: TechArticleInput): JsonLdObject {
+    const result: JsonLdObject = {
+        '@type': 'TechArticle',
+        '@id': `${pageUrl}${ARTICLE_ID_FRAGMENT}`,
+        headline: title,
+        description,
+        inLanguage: 'en',
+        url: pageUrl,
+        mainEntityOfPage: { '@type': 'WebPage', '@id': pageUrl },
+        isPartOf: { '@id': getWebSiteId(canonicalUrlBase) },
+        publisher: { '@id': getOrganizationId(canonicalUrlBase) },
+    };
+    if (aboutEntityId) {
+        result.about = { '@id': aboutEntityId };
+    }
+    return result;
+}
+
+export function buildBreadcrumbList({ pageUrl, items }: BreadcrumbListInput): JsonLdObject {
+    return {
+        '@type': 'BreadcrumbList',
+        '@id': `${pageUrl}${BREADCRUMB_ID_FRAGMENT}`,
+        itemListElement: items.map((item, index) => ({
+            '@type': 'ListItem',
+            position: index + 1,
+            name: item.name,
+            item: item.url,
+        })),
+    };
+}
+
+/**
+ * Wrap one or more graph-node objects into a single JSON-LD document with a
+ * shared `@context`. Multiple nodes are combined under `@graph`; a single node
+ * is inlined alongside `@context`.
+ */
+export function buildJsonLdDocument(nodes: JsonLdObject[]): JsonLdObject {
+    if (nodes.length === 1) {
+        return { '@context': 'https://schema.org', ...nodes[0] };
+    }
+    return { '@context': 'https://schema.org', '@graph': nodes };
+}
+
+/**
+ * Serialise a JSON-LD object for embedding inside <script type="application/ld+json">.
+ *
+ * Escapes `</` to `<\/` so a stray `</script>` inside any string field cannot
+ * close the script tag prematurely. `set:html` does not escape inside script
+ * bodies, so the caller must.
+ */
+export function serializeJsonLd(data: JsonLdObject): string {
+    return JSON.stringify(data).replace(/<\//g, '<\\/');
+}

--- a/external/ag-website-shared/src/utils/structuredData.ts
+++ b/external/ag-website-shared/src/utils/structuredData.ts
@@ -58,20 +58,23 @@ interface BreadcrumbListInput {
 }
 
 /**
- * Build an absolute URL by resolving `pathWithFragment` against
- * `canonicalUrlBase`. Robust to a base that does or does not end in `/` —
- * `https://example.com` and `https://example.com/` both produce the same
- * absolute output, which is essential for stable `@id` references and for
- * intra-graph cross-links to resolve.
+ * Return `canonicalUrlBase` with a trailing slash, so callers can append a
+ * site-root-relative path or fragment without worrying about the input form
+ * or doubled slashes. Works for both host-level bases (`https://example.com`)
+ * and subpath bases (`https://example.com/charts`) — both produce the same
+ * output as their trailing-slash equivalents.
+ *
+ * `new URL('/x', base)` is NOT a safe substitute for subpath bases — the
+ * absolute path resolves against the host and discards the subpath segment.
  */
-function resolveUrl(canonicalUrlBase: string, pathWithFragment: string): string {
-    return new URL(pathWithFragment, canonicalUrlBase).toString();
+export function siteRootUrl(canonicalUrlBase: string): string {
+    return canonicalUrlBase.endsWith('/') ? canonicalUrlBase : `${canonicalUrlBase}/`;
 }
 
-export const getOrganizationId = (canonicalUrlBase: string): string => resolveUrl(canonicalUrlBase, '/#organization');
-export const getWebSiteId = (canonicalUrlBase: string): string => resolveUrl(canonicalUrlBase, '/#website');
+export const getOrganizationId = (canonicalUrlBase: string): string => `${siteRootUrl(canonicalUrlBase)}#organization`;
+export const getWebSiteId = (canonicalUrlBase: string): string => `${siteRootUrl(canonicalUrlBase)}#website`;
 export const getSoftwareApplicationId = (canonicalUrlBase: string): string =>
-    resolveUrl(canonicalUrlBase, '/#software-application');
+    `${siteRootUrl(canonicalUrlBase)}#software-application`;
 
 const ARTICLE_ID_FRAGMENT = '#article';
 const BREADCRUMB_ID_FRAGMENT = '#breadcrumb';
@@ -81,7 +84,7 @@ export function buildOrganization({ canonicalUrlBase, name, logoUrl, sameAs }: O
         '@type': 'Organization',
         '@id': getOrganizationId(canonicalUrlBase),
         name,
-        url: resolveUrl(canonicalUrlBase, '/'),
+        url: siteRootUrl(canonicalUrlBase),
         logo: logoUrl,
         sameAs,
     };
@@ -91,7 +94,7 @@ export function buildWebSite({ canonicalUrlBase, name, description }: WebSiteInp
     return {
         '@type': 'WebSite',
         '@id': getWebSiteId(canonicalUrlBase),
-        url: resolveUrl(canonicalUrlBase, '/'),
+        url: siteRootUrl(canonicalUrlBase),
         name,
         description,
         inLanguage: 'en',
@@ -114,7 +117,7 @@ export function buildSoftwareApplication({
         applicationCategory,
         operatingSystem,
         softwareVersion: version,
-        url: resolveUrl(canonicalUrlBase, '/'),
+        url: siteRootUrl(canonicalUrlBase),
         publisher: { '@id': getOrganizationId(canonicalUrlBase) },
     };
     if (offers && offers.length > 0) {

--- a/external/ag-website-shared/src/utils/structuredData.ts
+++ b/external/ag-website-shared/src/utils/structuredData.ts
@@ -57,24 +57,31 @@ interface BreadcrumbListInput {
     items: BreadcrumbItem[];
 }
 
-const ORGANIZATION_ID_FRAGMENT = '#organization';
-const WEBSITE_ID_FRAGMENT = '#website';
-const SOFTWARE_APPLICATION_ID_FRAGMENT = '#software-application';
+/**
+ * Build an absolute URL by resolving `pathWithFragment` against
+ * `canonicalUrlBase`. Robust to a base that does or does not end in `/` —
+ * `https://example.com` and `https://example.com/` both produce the same
+ * absolute output, which is essential for stable `@id` references and for
+ * intra-graph cross-links to resolve.
+ */
+function resolveUrl(canonicalUrlBase: string, pathWithFragment: string): string {
+    return new URL(pathWithFragment, canonicalUrlBase).toString();
+}
+
+export const getOrganizationId = (canonicalUrlBase: string): string => resolveUrl(canonicalUrlBase, '/#organization');
+export const getWebSiteId = (canonicalUrlBase: string): string => resolveUrl(canonicalUrlBase, '/#website');
+export const getSoftwareApplicationId = (canonicalUrlBase: string): string =>
+    resolveUrl(canonicalUrlBase, '/#software-application');
+
 const ARTICLE_ID_FRAGMENT = '#article';
 const BREADCRUMB_ID_FRAGMENT = '#breadcrumb';
-
-export const getOrganizationId = (canonicalUrlBase: string): string =>
-    `${canonicalUrlBase}/${ORGANIZATION_ID_FRAGMENT}`;
-export const getWebSiteId = (canonicalUrlBase: string): string => `${canonicalUrlBase}/${WEBSITE_ID_FRAGMENT}`;
-export const getSoftwareApplicationId = (canonicalUrlBase: string): string =>
-    `${canonicalUrlBase}/${SOFTWARE_APPLICATION_ID_FRAGMENT}`;
 
 export function buildOrganization({ canonicalUrlBase, name, logoUrl, sameAs }: OrgInput): JsonLdObject {
     return {
         '@type': 'Organization',
         '@id': getOrganizationId(canonicalUrlBase),
         name,
-        url: `${canonicalUrlBase}/`,
+        url: resolveUrl(canonicalUrlBase, '/'),
         logo: logoUrl,
         sameAs,
     };
@@ -84,7 +91,7 @@ export function buildWebSite({ canonicalUrlBase, name, description }: WebSiteInp
     return {
         '@type': 'WebSite',
         '@id': getWebSiteId(canonicalUrlBase),
-        url: `${canonicalUrlBase}/`,
+        url: resolveUrl(canonicalUrlBase, '/'),
         name,
         description,
         inLanguage: 'en',
@@ -107,7 +114,7 @@ export function buildSoftwareApplication({
         applicationCategory,
         operatingSystem,
         softwareVersion: version,
-        url: `${canonicalUrlBase}/`,
+        url: resolveUrl(canonicalUrlBase, '/'),
         publisher: { '@id': getOrganizationId(canonicalUrlBase) },
     };
     if (offers && offers.length > 0) {


### PR DESCRIPTION
## Summary

JIRA: [AG-17419](https://ag-grid.atlassian.net/browse/AG-17419) — *Structured Data — no Schema Present. Adding JSON-LD would improve how AI systems understand and represent AG Grid.*

Emits a schema.org `@graph` in the `<head>` of every indexable AG Grid documentation page so AI crawlers (Google AI Overviews, ChatGPT browsing, Perplexity) and SEO consumers (Google rich results, link unfurlers, voice assistants) have a machine-readable description of the organisation, the product, and each docs page.

- **All indexable pages** — `Organization` (logo, `sameAs` derived from the existing footer social links) + `WebSite` (publisher → Organization).
- **Homepage** — additionally `SoftwareApplication` with `applicationCategory: DeveloperApplication`, the released `softwareVersion` (pre-release suffix stripped, eg `35.3.0-beta.20260524.2053` → `35.3.0`), and Community/Enterprise `Offer`s pointing at `/license-pricing/`.
- **Docs pages** (`/[framework]-data-grid/[pageName]/`) — additionally `TechArticle` (`isPartOf` WebSite, `publisher` Organization, `about` SoftwareApplication via `@id`) + `BreadcrumbList` (Home → `{Framework} Data Grid` → page title).
- **All blocks are combined under a single `@graph`** with one shared `@context`.
- **Gated** off for `hidePageFromSearchEngines` and `isArchive` — same condition that currently sets `<meta name="robots" content="noindex">`. Dates are intentionally omitted (no date frontmatter on `.mdoc` files; stamping with build time would be misleading).

The builders, the `JsonLd` component and the `buildJsonLdDocument` graph wrapper live in `external/ag-website-shared` so AG Charts and AG Studio can adopt the same primitives — brand-specific values (organisation name, product name, version, offers, logo) are caller-supplied.

## Test plan

- [x] `yarn nx test ag-website-shared` — 11 builder tests pass (incl. `</script>` escape, `@graph` wrap, default vs caller-supplied SoftwareApplication fields).
- [x] `yarn nx lint ag-grid-docs` clean.
- [x] `yarn nx lint ag-website-shared` clean (pre-existing `NodeJS` warnings only).
- [x] `yarn nx format --sort-root-tsconfig-paths=false`.
- [x] Live dev server — `view-source` of `/` shows one `<script type="application/ld+json">` containing `@graph` with Organization + WebSite + SoftwareApplication (offers link to pricing, version `35.3.0`).
- [x] Live dev server — `view-source` of `/react-data-grid/getting-started/` shows one `<script>` with `@graph` containing Organization + WebSite + TechArticle + BreadcrumbList (no SoftwareApplication off-homepage).
- [x] Live dev server — `view-source` of `/community/lets-cook/` (noindex page) emits zero JSON-LD blocks.
- [ ] Validate against [Schema.org validator](https://validator.schema.org/) and [Google Rich Results Test](https://search.google.com/test/rich-results) once a preview deploy is up.