### PR TITLE
AG-17455 ensure-col-header-clear-dom

### DIFF
--- a/packages/ag-grid-community/src/columns/columnViewportService.ts
+++ b/packages/ag-grid-community/src/columns/columnViewportService.ts
@@ -133,6 +133,9 @@ export class ColumnViewportService extends BeanStub implements NamedBean {
         this.rowsOfHeadersToRenderLeft = {};
         this.rowsOfHeadersToRenderRight = {};
         this.rowsOfHeadersToRenderCenter = {};
+        this.columnsToRenderLeft = [];
+        this.columnsToRenderRight = [];
+        this.columnsToRenderCenter = [];
         this.colsWithinViewportHash = '';
     }
 

--- a/testing/behavioural/src/columns/column-mutations.test.ts
+++ b/testing/behavioural/src/columns/column-mutations.test.ts
@@ -12,6 +12,7 @@ import { ClientSideRowModelModule, RowSelectionModule } from 'ag-grid-community'
 import { PivotModule, RowGroupingModule, RowNumbersModule, TreeDataModule } from 'ag-grid-enterprise';
 
 import { GridColumns, GridRows, TestGridsManager, asyncSetTimeout } from '../test-utils';
+import { getGridHTMLElement } from '../test-utils/gridRows/gridHtmlRows';
 
 describe('Column Mutations', () => {
     const gridsManager = new TestGridsManager({
@@ -1013,6 +1014,64 @@ describe('Column Mutations', () => {
 
             expect(api.getAllGridColumns().length).toBe(0);
             await new GridColumns(api, 'cleared').checkColumns('empty');
+        });
+
+        test('setColumnDefs round-trip empty, populated, empty leaves no stale header DOM', async () => {
+            const columnDefs = [
+                { colId: 'a', field: 'a' },
+                { colId: 'b', field: 'b' },
+            ];
+            const rowData = [
+                { a: 'a1', b: 'b1' },
+                { a: 'a2', b: 'b2' },
+            ];
+            const api = gridsManager.createGrid('myGrid', { columnDefs, rowData });
+
+            const gridElement = getGridHTMLElement(api)!;
+            const headerCellCount = () => gridElement.querySelectorAll('.ag-header-cell[col-id]').length;
+
+            expect(headerCellCount()).toBe(2);
+            await new GridColumns(api, 'initial').checkColumns(`
+                CENTER
+                ├── a "A" width:200
+                └── b "B" width:200
+            `);
+            await new GridRows(api, 'initial').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 a:"a1" b:"b1"
+                └── LEAF id:1 a:"a2" b:"b2"
+            `);
+
+            api.setGridOption('columnDefs', []);
+            expect(headerCellCount()).toBe(0);
+            await new GridColumns(api, 'cleared').checkColumns('empty');
+            await new GridRows(api, 'cleared').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0
+                └── LEAF id:1
+            `);
+
+            api.setGridOption('columnDefs', columnDefs);
+            expect(headerCellCount()).toBe(2);
+            await new GridColumns(api, 're-added').checkColumns(`
+                CENTER
+                ├── a "A" width:200
+                └── b "B" width:200
+            `);
+            await new GridRows(api, 're-added').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 a:"a1" b:"b1"
+                └── LEAF id:1 a:"a2" b:"b2"
+            `);
+
+            api.setGridOption('columnDefs', []);
+            expect(headerCellCount()).toBe(0);
+            await new GridColumns(api, 'cleared again').checkColumns('empty');
+            await new GridRows(api, 'cleared again').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0
+                └── LEAF id:1
+            `);
         });
 
         test('column tree depth is consistent across sections', async () => {

--- a/testing/behavioural/src/test-utils/gridColumns/columns-validation-dom/gridColumnsDomValidator.ts
+++ b/testing/behavioural/src/test-utils/gridColumns/columns-validation-dom/gridColumnsDomValidator.ts
@@ -65,24 +65,22 @@ export class GridColumnsDomValidator {
             }
         }
 
-        if (!gridColumns.hasColumnGroups) {
-            return;
-        }
-
         const expectedGroupIds = new Set<string>();
-        const visitGroups = (items: (Column | ColumnGroup)[]) => {
-            for (const item of items) {
-                if (!item.isColumn) {
-                    const group = item as ColumnGroup;
-                    expectedGroupIds.add(String(group.getUniqueId()));
-                    const children = group.getDisplayedChildren();
-                    if (children) {
-                        visitGroups(children);
+        if (gridColumns.hasColumnGroups) {
+            const visitGroups = (items: (Column | ColumnGroup)[]) => {
+                for (const item of items) {
+                    if (!item.isColumn) {
+                        const group = item as ColumnGroup;
+                        expectedGroupIds.add(String(group.getUniqueId()));
+                        const children = group.getDisplayedChildren();
+                        if (children) {
+                            visitGroups(children);
+                        }
                     }
                 }
-            }
-        };
-        visitGroups([...gridColumns.leftTree, ...gridColumns.centerTree, ...gridColumns.rightTree]);
+            };
+            visitGroups([...gridColumns.leftTree, ...gridColumns.centerTree, ...gridColumns.rightTree]);
+        }
 
         for (const cell of headerRoot.querySelectorAll('.ag-header-group-cell[col-id]')) {
             const colId = cell.getAttribute('col-id');

--- a/testing/behavioural/src/test-utils/gridColumns/columns-validation-dom/gridColumnsDomValidator.ts
+++ b/testing/behavioural/src/test-utils/gridColumns/columns-validation-dom/gridColumnsDomValidator.ts
@@ -36,6 +36,62 @@ export class GridColumnsDomValidator {
         if (gridColumns.hasColumnGroups) {
             this.validateGroupHeaders(gridColumns, headerRoot);
         }
+
+        // ── Stale header cells (cells in DOM that no longer correspond to a column/group)
+        this.validateNoStaleHeaderCells(gridColumns, headerRoot);
+    }
+
+    /**
+     * Verifies the DOM contains no `.ag-header-cell` / `.ag-header-group-cell` whose `col-id` is not
+     * in the set the grid currently expects to render.
+     *
+     * Expected columns: `getAllDisplayedVirtualColumns()` — viewport-aware, so when column
+     * virtualisation drops a column from the DOM it is also dropped from the expected set.
+     * Expected groups: every group in the displayed trees, including padding groups (header rows
+     * are not column-virtualised at the group level in our test env, viewportRight === 0).
+     */
+    private validateNoStaleHeaderCells(gridColumns: GridColumns, headerRoot: HTMLElement): void {
+        const expectedColIds = new Set<string>();
+        for (const col of gridColumns.api.getAllDisplayedVirtualColumns() ?? []) {
+            expectedColIds.add(col.getColId());
+        }
+
+        for (const cell of headerRoot.querySelectorAll('.ag-header-cell[col-id]')) {
+            const colId = cell.getAttribute('col-id');
+            if (colId != null && !expectedColIds.has(colId)) {
+                this.errors.default.add(
+                    `Stale .ag-header-cell[col-id="${colId}"] found in DOM but column is not displayed.`
+                );
+            }
+        }
+
+        if (!gridColumns.hasColumnGroups) {
+            return;
+        }
+
+        const expectedGroupIds = new Set<string>();
+        const visitGroups = (items: (Column | ColumnGroup)[]) => {
+            for (const item of items) {
+                if (!item.isColumn) {
+                    const group = item as ColumnGroup;
+                    expectedGroupIds.add(String(group.getUniqueId()));
+                    const children = group.getDisplayedChildren();
+                    if (children) {
+                        visitGroups(children);
+                    }
+                }
+            }
+        };
+        visitGroups([...gridColumns.leftTree, ...gridColumns.centerTree, ...gridColumns.rightTree]);
+
+        for (const cell of headerRoot.querySelectorAll('.ag-header-group-cell[col-id]')) {
+            const colId = cell.getAttribute('col-id');
+            if (colId != null && !expectedGroupIds.has(colId)) {
+                this.errors.default.add(
+                    `Stale .ag-header-group-cell[col-id="${colId}"] found in DOM but group is not displayed.`
+                );
+            }
+        }
     }
 
     // ── Header root ─────────────────────────────────────────────────────────


### PR DESCRIPTION
when clearing the column viewport service we need to clear also columnsToRender or else they will still be present

FIX AG-17455