### PR TITLE
AG-17227 Use chart-level context for sparklines, drop callback wrapping

### DIFF
--- a/packages/ag-grid-enterprise/src/sparkline/sparklineCellRenderer.ts
+++ b/packages/ag-grid-enterprise/src/sparkline/sparklineCellRenderer.ts
@@ -121,13 +121,8 @@ export class SparklineCellRenderer extends Component implements ICellRenderer {
 
             this.sparklineOptions.type ??= 'line';
 
-            // No `tooltip.renderer` is installed when the user didn't supply one — the
-            // chart-side sparkline preset produces a sensible default that includes
-            // the x value when it is user-meaningful. Installing a function here would
-            // poison the chart's structural-options cache key and disable the optimised
-            // creation path for every sparkline cell.
-
-            // create new sparkline
+            // No default `tooltip.renderer` install — the chart-side sparkline preset
+            // supplies one. A function here would poison the structural-options cache.
             this.sparklineInstance = params.createSparkline!(this.sparklineOptions);
             return true;
         } else if (this.sparklineInstance) {

--- a/packages/ag-grid-enterprise/src/sparkline/sparklineCellRenderer.ts
+++ b/packages/ag-grid-enterprise/src/sparkline/sparklineCellRenderer.ts
@@ -1,9 +1,4 @@
-import type {
-    AgChartInstance,
-    AgSparklineOptions,
-    AgSparklineTooltipRendererParams,
-    AgSparklineTooltipRendererResult,
-} from 'ag-charts-types';
+import type { AgChartInstance, AgSparklineOptions } from 'ag-charts-types';
 
 import type { AgColumn, Environment, ICellRenderer, ISparklineCellRendererParams, RowNode } from 'ag-grid-community';
 import {
@@ -21,16 +16,6 @@ import {
     getSparklineSummary,
     interpolateTemplate,
 } from './sparklinesUtils';
-
-function tooltipRendererWithXValue(
-    params: AgSparklineTooltipRendererParams<unknown>
-): AgSparklineTooltipRendererResult {
-    return { content: `${params.xValue} ${params.yValue}` };
-}
-
-function tooltipRenderer(params: AgSparklineTooltipRendererParams<unknown>): AgSparklineTooltipRendererResult {
-    return { content: `${params.yValue}` };
-}
 
 const COMPONENT_PREFIX = 'ag-sparkline';
 
@@ -136,17 +121,11 @@ export class SparklineCellRenderer extends Component implements ICellRenderer {
 
             this.sparklineOptions.type ??= 'line';
 
-            // Only install the Grid's default tooltip renderer when the user didn't
-            // supply one — the chart-side sparkline preset wraps whatever sits at
-            // `tooltip.renderer` and injects `params.context` from the chart-level
-            // `context` field via `callWithContext`, so no per-callback wrapping is
-            // needed for context propagation.
-            if (!this.sparklineOptions.tooltip?.renderer) {
-                this.sparklineOptions.tooltip = {
-                    ...this.sparklineOptions.tooltip,
-                    renderer: this.getDefaultTooltipRenderer(),
-                };
-            }
+            // No `tooltip.renderer` is installed when the user didn't supply one — the
+            // chart-side sparkline preset produces a sensible default that includes
+            // the x value when it is user-meaningful. Installing a function here would
+            // poison the chart's structural-options cache key and disable the optimised
+            // creation path for every sparkline cell.
 
             // create new sparkline
             this.sparklineInstance = params.createSparkline!(this.sparklineOptions);
@@ -199,12 +178,6 @@ export class SparklineCellRenderer extends Component implements ICellRenderer {
             data: this.params?.data,
             cellData: this.params?.value,
         };
-    }
-
-    private getDefaultTooltipRenderer() {
-        const xKeyProvided = this.sparklineOptions.xKey;
-        const tupleData = Array.isArray(this.sparklineOptions.data?.[0]);
-        return xKeyProvided || tupleData ? tooltipRendererWithXValue : tooltipRenderer;
     }
 
     public override destroy() {

--- a/packages/ag-grid-enterprise/src/sparkline/sparklineCellRenderer.ts
+++ b/packages/ag-grid-enterprise/src/sparkline/sparklineCellRenderer.ts
@@ -1,10 +1,8 @@
 import type {
     AgChartInstance,
-    AgChartTheme,
     AgSparklineOptions,
     AgSparklineTooltipRendererParams,
     AgSparklineTooltipRendererResult,
-    AgTooltipRendererResult,
 } from 'ag-charts-types';
 
 import type { AgColumn, Environment, ICellRenderer, ISparklineCellRendererParams, RowNode } from 'ag-grid-community';
@@ -22,7 +20,6 @@ import {
     getSparklineAriaTemplate,
     getSparklineSummary,
     interpolateTemplate,
-    wrapFn,
 } from './sparklinesUtils';
 
 function tooltipRendererWithXValue(
@@ -134,26 +131,21 @@ export class SparklineCellRenderer extends Component implements ICellRenderer {
                 ...params.sparklineOptions,
                 ...(styleNonce ? { styleNonce } : {}),
                 data,
+                context: this.createContext(),
             } as AgSparklineOptions;
 
             this.sparklineOptions.type ??= 'line';
 
-            if (this.sparklineOptions.tooltip?.renderer) {
-                this.wrapTooltipRenderer();
-            } else {
-                const renderer = this.getDefaultTooltipRenderer();
+            // Only install the Grid's default tooltip renderer when the user didn't
+            // supply one — the chart-side sparkline preset wraps whatever sits at
+            // `tooltip.renderer` and injects `params.context` from the chart-level
+            // `context` field via `callWithContext`, so no per-callback wrapping is
+            // needed for context propagation.
+            if (!this.sparklineOptions.tooltip?.renderer) {
                 this.sparklineOptions.tooltip = {
                     ...this.sparklineOptions.tooltip,
-                    renderer,
+                    renderer: this.getDefaultTooltipRenderer(),
                 };
-            }
-
-            // Only bar sparklines have itemStyler
-            const theme = this.sparklineOptions?.theme as AgChartTheme;
-            if (this.sparklineOptions.type === 'bar' && this.sparklineOptions.itemStyler) {
-                this.wrapItemStyler(this.sparklineOptions);
-            } else if (theme?.overrides?.bar?.series?.itemStyler) {
-                this.wrapItemStyler(theme.overrides.bar.series);
             }
 
             // create new sparkline
@@ -165,6 +157,7 @@ export class SparklineCellRenderer extends Component implements ICellRenderer {
                 data,
                 width,
                 height,
+                context: this.createContext(),
                 ...(styleNonce ? { styleNonce } : {}),
             });
 
@@ -208,43 +201,10 @@ export class SparklineCellRenderer extends Component implements ICellRenderer {
         };
     }
 
-    private getDefaultTooltipRenderer(userRendererResult?: AgTooltipRendererResult) {
-        const userTitle = userRendererResult?.title;
+    private getDefaultTooltipRenderer() {
         const xKeyProvided = this.sparklineOptions.xKey;
         const tupleData = Array.isArray(this.sparklineOptions.data?.[0]);
-
-        const showXValue = !userTitle && (xKeyProvided || tupleData);
-
-        return showXValue ? tooltipRendererWithXValue : tooltipRenderer;
-    }
-
-    private wrapItemStyler(container: { itemStyler?: any }) {
-        container.itemStyler = wrapFn(container.itemStyler, (fn, stylerParams: any): any => {
-            return fn({
-                ...stylerParams,
-                context: this.createContext(),
-            });
-        });
-    }
-
-    private wrapTooltipRenderer() {
-        this.sparklineOptions.tooltip = {
-            ...this.sparklineOptions.tooltip,
-            renderer: wrapFn(this.sparklineOptions.tooltip!.renderer!, (fn, tooltipParams: any): any => {
-                const userRendererResult = fn({
-                    ...tooltipParams,
-                    context: this.createContext(),
-                });
-
-                if (typeof userRendererResult === 'string') {
-                    return userRendererResult;
-                }
-                return {
-                    ...this.getDefaultTooltipRenderer(userRendererResult)(tooltipParams),
-                    ...userRendererResult,
-                };
-            }),
-        };
+        return xKeyProvided || tupleData ? tooltipRendererWithXValue : tooltipRenderer;
     }
 
     public override destroy() {

--- a/packages/ag-grid-enterprise/src/sparkline/sparklinesUtils.ts
+++ b/packages/ag-grid-enterprise/src/sparkline/sparklinesUtils.ts
@@ -2,24 +2,8 @@ import type { AgSparklineOptions } from 'ag-charts-types';
 
 import type { LocaleTextFunc } from 'ag-grid-community';
 
-const WrappedFunctionMarker = Symbol('WrappedFunctionMarker');
-
-type FunctionParams = (...args: any[]) => any;
-type WrapperFunctionParams = (fn: FunctionParams, ...args: any[]) => any;
 type SparklineTranslate = (key: string, defaultValue: string, variableValues?: string[]) => string;
 type SparklineNumberFormatter = (value: number) => string;
-
-export const wrapFn = (fn: FunctionParams, wrapperFn: WrapperFunctionParams) => {
-    if ((fn as any)[WrappedFunctionMarker]) {
-        return fn;
-    }
-
-    const wrapped = (...args: any[]) => wrapperFn(fn, ...args);
-
-    wrapped[WrappedFunctionMarker] = WrappedFunctionMarker;
-
-    return wrapped;
-};
 
 // ARIA
 const defaultSparklineAriaDescription =


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17227

Replace per-callback context wrapping with chart-level `context`, so the sparkline cell renderer no longer puts a function into `sparklineOptions` and the chart's structural-options cache can hit on the second cell onward.

- `sparklineCellRenderer.ts` — set `context: { data, cellData }` on the chart options at init and on every `update()`. Drop `wrapTooltipRenderer` / `wrapItemStyler` (user callbacks now receive `params.context` via the chart-side `callWithContext` path). Drop the default `tooltipRenderer` / `tooltipRendererWithXValue` install — the chart-side sparkline preset supplies an equivalent default.
- `sparklinesUtils.ts` — remove the now-unused `wrapFn` helper.

Depends on ag-grid/ag-charts#6931, which adds context to `FAST_PATH_OPTIONS`, fixes the cache-aliasing for `context`/`container`, and adds the xValue-aware default to the preset. Land that first.

Fix [AG-17227](https://ag-grid.atlassian.net/browse/AG-17227)