### PR TITLE
Feature: Suppress Expansion flag on GroupCellRenderer

### DIFF
--- a/packages/ag-grid-community/src/interfaces/groupCellRenderer.ts
+++ b/packages/ag-grid-community/src/interfaces/groupCellRenderer.ts
@@ -27,6 +27,8 @@ export interface IGroupCellRendererParams<TData = any, TValue = any> {
     totalValueGetter?: string | TotalValueGetterFunc;
     /** If `true`, count is not displayed beside the name. */
     suppressCount?: boolean;
+    /** If `true`, expansion is not permitted, even if it normally would be. */
+    suppressExpansion?: boolean;
     /**
      * Set to `true`, or a function that returns `true`, if a checkbox should be included.
      *

--- a/packages/ag-grid-enterprise/src/rowHierarchy/rendering/groupCellRendererCtrl.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/rendering/groupCellRendererCtrl.ts
@@ -393,7 +393,11 @@ export class GroupCellRendererCtrl extends BeanStub implements IGroupCellRendere
      * @returns whether this cell is expandable
      */
     private isExpandable(): boolean {
-        const { node, column, colDef } = this.params;
+        const { node, column, colDef, suppressExpansion } = this.params;
+
+        if (suppressExpansion) {
+            return false;
+        }
 
         // checking the node expandable checks pivot leafGroup, footer etc.
         if (!this.displayedNode.isExpandable()) {


### PR DESCRIPTION
We have a requirement to prevent expansion of certain grouped rows.

This requirement is not unique to our business nor our clients - there are many examples of users of AG-Grid looking for this feature across various forums etc.

A common solution to this is to use the `cellRendererSelector` to return `null` when expansion should be suppressed. However, this also eliminates the indentation that would normally be applied, so can look a bit messy.

This PR adds a new optional boolean parameter - `suppressExpansion` to `IGroupCellRendererParams`. If this is set to `true`, then `GroupCellRendererCtrl.isExpandable()` will return `false`, preventing display of the expansion chevron, and ensuring that expansion is not possible via any mechanism in the UI.