### PR TITLE
AG-17467 Add release content for 35.3.1

### DIFF
--- a/documentation/ag-grid-docs/public/changelog/changelog.json
+++ b/documentation/ag-grid-docs/public/changelog/changelog.json
@@ -1,5 +1,19 @@
 [
     {
+        "key": "AG-17467",
+        "issueType": "Task",
+        "manualEntry": true,
+        "summary": "Placeholder for 35.3.1",
+        "versions": ["35.3.1"],
+        "status": "Done",
+        "resolution": "Done",
+        "features": null,
+        "moreInformation": null,
+        "deprecationNotes": null,
+        "breakingChangesNotes": null,
+        "documentationUrl": null
+    },
+    {
         "key": "AG-17289",
         "issueType": "Task",
         "manualEntry": true,

--- a/documentation/ag-grid-docs/public/changelog/releaseVersionNotes.json
+++ b/documentation/ag-grid-docs/public/changelog/releaseVersionNotes.json
@@ -1,5 +1,9 @@
 [
     {
+        "release version": "35.3.1",
+        "markdown": "/releases/35_3_1.md"
+    },
+    {
         "release version": "35.3.0",
         "markdown": "/releases/35_3_0.md"
     },

--- a/documentation/ag-grid-docs/public/changelog/releases/35_3_1.md
+++ b/documentation/ag-grid-docs/public/changelog/releases/35_3_1.md
@@ -1,0 +1,3 @@
+#### 2nd June 2026 - Grid v35.3.1 (Charts v13.3.1)
+
+See table below for changes included in this release.

--- a/documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json
+++ b/documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json
@@ -1,6 +1,7 @@
 [
     {
-        "version": "35.3.1"
+        "version": "35.3.1",
+        "date": "2nd June 2026"
     },
     {
         "version": "35.3.0",


### PR DESCRIPTION
Adds changelog entry, release-notes file, and version archive entry for v35.3.1 (Charts v13.3.1, 2nd June 2026).

This is a patch release, so no migration guide page is created.

## Changes
- `changelog.json` — placeholder entry for 35.3.1
- `releaseVersionNotes.json` — maps 35.3.1 to its release-notes markdown
- `releases/35_3_1.md` — new release-notes file
- `ag-grid-versions.json` — adds the release date to the existing 35.3.1 archive entry

Fix [AG-17467](https://ag-grid.atlassian.net/browse/AG-17467)