### PR TITLE
AG-17161 - Regenerate stale base/search.svg theme icon

### DIFF
--- a/documentation/ag-grid-docs/public/theme-icons/base/search.svg
+++ b/documentation/ag-grid-docs/public/theme-icons/base/search.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2" viewBox="0 0 24 24">
-<path d="M11 2A9 9 0 1 0 11 20A9 9 0 1 0 11 2ZM11 4A7 7 0 1 1 11 18A7 7 0 1 1 11 4ZM21.71 20.29L20.29 21.71L15.94 17.36L17.36 15.94Z"/>
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" style="fill-rule:nonzero;clip-rule:nonzero;stroke-linejoin:round;stroke-miterlimit:2" viewBox="0 0 24 24">
+<path d="M11 2A9 9 0 1 0 11 20A9 9 0 1 0 11 2ZM11 4A7 7 0 1 1 11 18A7 7 0 1 1 11 4ZM21.71 20.29L17.36 15.94L15.94 17.36L20.29 21.71Z"/>
 </svg>


### PR DESCRIPTION
`documentation/ag-grid-docs/public/theme-icons/base/search.svg` is a generated copy of `community-modules/styles/icon-fonts/fonts/agGridClassic/search.svg`, produced by the docs `build:copy-styles` rsync target. The source and its committed copy have been out of sync in `latest`:

This drift was introduced in #13683 (AG-17161), which added the icon sources but committed the generated `public/theme-icons/**` copies with stale content. Anyone running the docs build (or `nx dev`) then sees `search.svg` reappear as a modified file in their diff.