### PR TITLE
AG-17134 - Ignore benign report-only CSP console warning in docs e2e

### DIFF
--- a/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
@@ -105,6 +105,11 @@ const excludeErrors = [
     'Layout was forced before the page was fully loaded. If stylesheets are not yet loaded this may cause a flash of unstyled content.',
     'Request to access cookie or storage on “<URL>” was blocked because it came from a tracker and Enhanced Tracking Protection is enabled.',
     'This site appears to use a scroll-linked positioning effect.',
+    // AG-17134: staging serves a Content-Security-Policy-Report-Only header with no report endpoint
+    // (violations are captured via the securitypolicyviolation JS listener, not report-uri/report-to).
+    // Browsers warn that such a policy can't report — benign for our validation window.
+    'has a Report-Only policy without a report-uri directive nor a report-to directive', // Firefox
+    "was delivered in report-only mode, but does not specify a 'report-uri'", // Chromium
     // React warnings from examples that intentionally render read-only controls / raw style props.
     'You provided a `checked` prop to a form field without an `onChange` handler.',
     'Unsupported style property %s. Did you mean %s? white-space whiteSpace',


### PR DESCRIPTION
## What

Adds two entries to the docs e2e `excludeErrors` allowlist (`documentation/ag-grid-docs/src/utils/grid/test-utils.ts`) so the report-only CSP validation on staging doesn't fail Playwright runs.

## Why

Staging now serves a `Content-Security-Policy-Report-Only` header (via the generated `.htaccess`) with **no** `report-uri`/`report-to` directive — by design, since violations are captured through the JS `securitypolicyviolation` listener rather than a network report endpoint. Firefox and Chromium each emit a console warning that a report-only policy without a reporting endpoint can neither block nor report. This fires on *every* staging page (the standalone example pages the e2e suite loads included), tripping `setupConsoleExpectations`.

The warning is benign for our validation window, so it's allowlisted the same way the other browser-specific warnings are. Match strings are host-independent and narrow enough not to swallow real CSP violation reports.

## Notes

- Covers Firefox and Chromium phrasings; WebKit/Safari does not emit this warning.
- These entries become dead once staging flips from report-only to **enforce** (an enforcing `Content-Security-Policy` header needs no report endpoint) — safe to remove at that point.

## Test plan

To be run on TeamCity once merged into `latest` (docs e2e against `grid-staging.ag-grid.com`).