### PR TITLE
AG-15213 - add autoHeightMinBodyHeight theme parameter

### DIFF
--- a/community-modules/styles/src/internal/base/_base-variables.scss
+++ b/community-modules/styles/src/internal/base/_base-variables.scss
@@ -197,6 +197,8 @@
 
         --ag-row-height: calc(var(--ag-grid-size) * 6 + 1px);
 
+        --ag-auto-height-min-body-height: 50px;
+
         --ag-header-height: var(--ag-row-height);
 
         --ag-pagination-panel-height: var(--ag-header-height);

--- a/community-modules/styles/src/internal/base/parts/_grid-layout.scss
+++ b/community-modules/styles/src/internal/base/parts/_grid-layout.scss
@@ -352,8 +352,8 @@
 
     .ag-layout-auto-height,
     .ag-layout-print {
-        .ag-grid-scrolling-container {
-            min-height: 50px;
+        .ag-grid-scrolling-rows {
+            min-height: var(--ag-auto-height-min-body-height);
         }
     }
 

--- a/community-modules/styles/src/internal/themes/alpine/_alpine-variables.scss
+++ b/community-modules/styles/src/internal/themes/alpine/_alpine-variables.scss
@@ -77,6 +77,7 @@
     --ag-grid-size: 6px;
     --ag-icon-size: 16px;
     --ag-row-height: calc(var(--ag-grid-size) * 7); // if changed, update environment.ts
+    --ag-auto-height-min-body-height: 150px;
     --ag-header-height: calc(var(--ag-grid-size) * 8); // if changed, update environment.ts
     --ag-list-item-height: calc(var(--ag-grid-size) * 4); // if changed, update environment.ts
     --ag-column-select-indent-size: var(--ag-icon-size);

--- a/community-modules/styles/src/internal/themes/alpine/_index.scss
+++ b/community-modules/styles/src/internal/themes/alpine/_index.scss
@@ -291,13 +291,6 @@
         color: var(--ag-alpine-active-color);
     }
 
-    .ag-layout-auto-height,
-    .ag-layout-print {
-        .ag-grid-scrolling-container {
-            min-height: 150px;
-        }
-    }
-
     .ag-date-time-list-page-entry-is-current {
         background-color: var(--ag-alpine-active-color);
     }

--- a/community-modules/styles/src/internal/themes/material/_index.scss
+++ b/community-modules/styles/src/internal/themes/material/_index.scss
@@ -272,13 +272,6 @@
         );
     }
 
-    .ag-layout-auto-height,
-    .ag-layout-print {
-        .ag-grid-scrolling-container {
-            min-height: 150px;
-        }
-    }
-
     .ag-picker-field-wrapper:focus-within {
         box-shadow: 0 0 0 1px var(--ag-material-primary-color);
     }

--- a/community-modules/styles/src/internal/themes/material/_material-variables.scss
+++ b/community-modules/styles/src/internal/themes/material/_material-variables.scss
@@ -60,6 +60,7 @@
     --ag-icon-size: 18px;
     --ag-header-height: calc(var(--ag-grid-size) * 7);
     --ag-row-height: calc(var(--ag-grid-size) * 6);
+    --ag-auto-height-min-body-height: 150px;
     --ag-cell-horizontal-padding: calc(var(--ag-grid-size) * 3);
     --ag-list-item-height: calc(var(--ag-grid-size) * 4);
     --ag-row-group-indent-size: calc(var(--ag-grid-size) * 3 + var(--ag-icon-size));

--- a/community-modules/styles/src/internal/themes/quartz/_index.scss
+++ b/community-modules/styles/src/internal/themes/quartz/_index.scss
@@ -601,13 +601,6 @@
         margin: 0;
     }
 
-    .ag-layout-auto-height,
-    .ag-layout-print {
-        .ag-grid-scrolling-container {
-            min-height: 150px;
-        }
-    }
-
     .ag-date-time-list-page-entry-is-current {
         background-color: var(--ag-active-color);
     }

--- a/community-modules/styles/src/internal/themes/quartz/_quartz-variables.scss
+++ b/community-modules/styles/src/internal/themes/quartz/_quartz-variables.scss
@@ -79,6 +79,7 @@
     --ag-icon-size: 16px;
     --ag-header-height: calc(var(--ag-font-size) + var(--ag-grid-size) * 4.25); // if changed, update environment.ts
     --ag-row-height: calc(var(--ag-font-size) + var(--ag-grid-size) * 3.5); // if changed, update environment.ts
+    --ag-auto-height-min-body-height: 150px;
     --ag-list-item-height: calc(
         var(--ag-icon-size) + var(--ag-widget-vertical-spacing)
     ); // if changed, update environment.ts

--- a/documentation/ag-grid-docs/src/content/api-documentation/global-style-customisation-variables/variables.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/global-style-customisation-variables/variables.json
@@ -393,6 +393,10 @@
             "description": "Height of grid rows",
             "type": "CSS length (e.g. `0`, `4px` or `50%`)"
         },
+        "--ag-auto-height-min-body-height": {
+            "description": "Minimum height of the grid's rows section when using auto-height or print layout. This prevents an empty grid from collapsing to nothing. Set to `0` to remove the minimum height.",
+            "type": "CSS length (e.g. `0`, `4px` or `50%`)"
+        },
         "--ag-header-height": {
             "description": "Height of header rows",
             "type": "CSS length (e.g. `0`, `4px` or `50%`)"

--- a/documentation/ag-grid-docs/src/content/api-documentation/theming-api/properties.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/theming-api/properties.json
@@ -41,6 +41,7 @@
         },
         "headerHeight": {},
         "rowHeight": {},
+        "autoHeightMinBodyHeight": {},
         "listItemHeight": {},
         "paginationPanelHeight": {},
         "widgetContainerHorizontalPadding": {},

--- a/documentation/ag-grid-docs/src/content/docs/grid-size/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/grid-size/index.mdoc
@@ -133,12 +133,14 @@ When viewed inline below, the scroll bars shown are for the containing iframe, n
 
 ### Min Height with Auto Height
 
-When using Auto Height, there is a minimum of 150px set to the grid rows section. This is to avoid an empty grid which would look weird. To remove this minimum height, add the following CSS:
+When using Auto Height, the grid rows section has a minimum height of 150px. This is to avoid a zero-height grid which looks weird.
 
-```css
-.ag-grid-scrolling-container {
-    min-height: unset !important;
-}
+Use the `autoHeightMinBodyHeight` [theme parameter](./theming-parameters/) to change this minimum:
+
+```js
+const myTheme = themeQuartz.withParams({
+    autoHeightMinBodyHeight: 40,
+});
 ```
 
 It is not possible to specify a max height when using auto-height.

--- a/packages/ag-grid-community/src/theming/core/core-css.ts
+++ b/packages/ag-grid-community/src/theming/core/core-css.ts
@@ -54,6 +54,11 @@ export interface CoreParams extends SharedThemeParams {
     advancedFilterBuilderValuePillColor: ColorValue;
 
     /**
+     * Minimum height of the grid's rows section when using auto-height or print layout. This prevents an empty grid from collapsing to nothing. Set to `0` to remove the minimum height.
+     */
+    autoHeightMinBodyHeight: LengthValue;
+
+    /**
      * Padding at the start and end of grid cells and header cells.
      */
     cellHorizontalPadding: LengthValue;
@@ -893,6 +898,7 @@ export const coreDefaults: Readonly<Omit<CoreParams, keyof SharedThemeParams>> =
         calc: 'spacing * 1.5',
     },
     cellHorizontalPaddingScale: 1,
+    autoHeightMinBodyHeight: 150,
     rowGroupIndentSize: {
         calc: 'cellWidgetSpacing + iconSize',
     },

--- a/packages/ag-grid-community/src/theming/core/css/_grid-layout.css
+++ b/packages/ag-grid-community/src/theming/core/css/_grid-layout.css
@@ -451,8 +451,8 @@
 
 .ag-layout-auto-height,
 .ag-layout-print {
-    .ag-grid-scrolling-container {
-        min-height: 150px;
+    .ag-grid-scrolling-rows {
+        min-height: var(--ag-auto-height-min-body-height);
     }
 }
 


### PR DESCRIPTION
Fix [AG-15213](https://ag-grid.atlassian.net/browse/AG-15213)

Exposes the auto-height/print-layout minimum body height as a customisable theme parameter, so users can change or remove it without writing `!important` CSS overrides (previously the only option, as documented under "Min Height with Auto Height").

- **Theming API:** new `autoHeightMinBodyHeight` param (`LengthValue`, default `150`)
- **Legacy themes:** new `--ag-auto-height-min-body-height` CSS variable.

Default values and rendered behaviour are unchanged — this only makes the existing minimum configurable.