### PR TITLE
AG-15209 Introduce pickerFieldHeight theme param

### DIFF
--- a/documentation/ag-grid-docs/src/content/api-documentation/theming-api/properties.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/theming-api/properties.json
@@ -263,6 +263,7 @@
         "pickerButtonBorderRadius": {},
         "pickerButtonFocusBackgroundColor": {},
         "pickerButtonFocusBorder": {},
+        "pickerFieldHeight": {},
         "pickerListBackgroundColor": {},
         "pickerListBorder": {},
         "selectCellBackgroundColor": {},

--- a/packages/ag-grid-community/src/agStack/widgets/agPickerField.css
+++ b/packages/ag-grid-community/src/agStack/widgets/agPickerField.css
@@ -20,7 +20,7 @@
     border: var(--ag-picker-button-border);
     border-radius: var(--ag-picker-button-border-radius);
     background-color: var(--ag-picker-button-background-color);
-    min-height: max(var(--ag-list-item-height), calc(var(--ag-spacing) * 4));
+    min-height: var(--ag-picker-field-height);
 
     &:where(.invalid) {
         background-color: var(--ag-input-invalid-background-color);

--- a/packages/ag-grid-community/src/theming/core/core-css.ts
+++ b/packages/ag-grid-community/src/theming/core/core-css.ts
@@ -459,7 +459,12 @@ export interface CoreParams extends SharedThemeParams {
     rowHeight: LengthValue;
 
     /**
-     * Height of the pagination panel at the bottom of the grid. Defaults to the higher of rowHeight or 22px.
+     * Minimum height of picker fields such as select dropdowns and color pickers. Picker fields may be taller than this if they contain larger content.
+     */
+    pickerFieldHeight: LengthValue;
+
+    /**
+     * Height of the pagination panel at the bottom of the grid.
      */
     paginationPanelHeight: LengthValue;
 
@@ -909,9 +914,13 @@ export const coreDefaults: Readonly<Omit<CoreParams, keyof SharedThemeParams>> =
         calc: 'max(iconSize, cellFontSize) + spacing * 3.25 * rowVerticalPaddingScale',
     },
     rowVerticalPaddingScale: 1,
+    // Unlike other picker field params, pickerFieldHeight must be a core param
+    // because the pagination panel height depends on it
+    pickerFieldHeight: {
+        calc: 'max(iconSize, fontSize) + spacing * 2',
+    },
     paginationPanelHeight: {
-        ref: 'rowHeight',
-        calc: 'max(rowHeight, 22px)',
+        calc: 'pickerFieldHeight + spacing * 2',
     },
     dragHandleColor: foregroundMix(0.7),
     headerColumnResizeHandleHeight: '30%',


### PR DESCRIPTION
Fix [AG-15209](https://ag-grid.atlassian.net/browse/AG-15209)

- Adds a `pickerFieldHeight` core theme param — the minimum height of picker fields
- Re-bases the `paginationPanelHeight` default to `pickerFieldHeight + spacing * 2` (was `max(rowHeight, 22px)`), so the pagination panel always leaves room around the page size selector.

Theming API only — legacy SCSS themes are intentionally unchanged.