### PR TITLE
AG-14740 Horizontal scroll overflow for pagination panel and status bar

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -1578,8 +1578,14 @@
     //  ****************************
     // */
     .ag-paging-panel {
-        align-items: center;
         display: flex;
+    }
+
+    .ag-paging-panel-content {
+        display: flex;
+        flex: 0 0 auto;
+        min-width: 100%;
+        align-items: center;
         justify-content: flex-end;
     }
 

--- a/community-modules/styles/src/internal/base/parts/_footer.scss
+++ b/community-modules/styles/src/internal/base/parts/_footer.scss
@@ -6,7 +6,11 @@
         border-top-color: var(--ag-border-color);
         color: var(--ag-secondary-foreground-color);
         height: var(--ag-pagination-panel-height);
+        overflow: auto hidden;
+        scrollbar-width: thin;
+    }
 
+    .ag-paging-panel-content {
         > * {
             margin: 0 var(--ag-cell-horizontal-padding);
         }
@@ -40,6 +44,8 @@
         padding-right: calc(var(--ag-grid-size) * 4);
         padding-left: calc(var(--ag-grid-size) * 4);
         line-height: 1.5;
+        overflow: auto hidden;
+        scrollbar-width: thin;
     }
 
     .ag-status-name-value-value {

--- a/packages/ag-grid-community/src/pagination/paginationComp.css
+++ b/packages/ag-grid-community/src/pagination/paginationComp.css
@@ -1,26 +1,23 @@
 .ag-paging-panel {
-    align-items: center;
     display: flex;
+    height: var(--ag-pagination-panel-height);
+    border-top: var(--ag-footer-row-border);
+    overflow: auto hidden;
+    scrollbar-width: thin;
+}
+
+.ag-paging-panel-content {
+    display: flex;
+    flex: 0 0 auto;
+    min-width: 100%;
+    align-items: center;
     justify-content: flex-end;
     gap: calc(var(--ag-spacing) * 4);
-    padding: calc(var(--ag-spacing) * 0.5) var(--ag-cell-horizontal-padding);
-    min-height: var(--ag-pagination-panel-height);
-    border-top: var(--ag-footer-row-border);
-    flex-wrap: wrap-reverse;
-    row-gap: calc(var(--ag-spacing) * 0.5);
-
-    @container (width < 600px) {
-        justify-content: center;
-    }
+    padding: 0 var(--ag-cell-horizontal-padding);
 }
 
 :where(.ag-paging-page-size) .ag-wrapper {
     min-width: 50px;
-}
-
-.ag-paging-row-summary-panel,
-.ag-paging-page-summary-panel {
-    margin: calc(var(--ag-spacing) * 0.5);
 }
 
 .ag-paging-page-summary-panel {

--- a/packages/ag-grid-community/src/pagination/paginationComp.ts
+++ b/packages/ag-grid-community/src/pagination/paginationComp.ts
@@ -1,3 +1,4 @@
+import { RefPlaceholder } from '../agStack/interfaces/agComponent';
 import { _removeFromParent } from '../agStack/utils/dom';
 import type { PaginationPanel } from '../entities/gridOptions';
 import type { FocusableContainer } from '../interfaces/iFocusableContainer';
@@ -14,6 +15,8 @@ const DEFAULT_PANELS: readonly PaginationPanel[] = ['pageSize', 'rowSummary', 'p
 type AriaAnnounceKey = 'paginationRow' | 'paginationPage';
 
 class PaginationComp extends TabGuardComp implements FocusableContainer {
+    private readonly eContent: HTMLElement = RefPlaceholder;
+
     private pageSizeComp: PageSizeSelectorComp | undefined;
     private rowSummaryComp: RowSummaryComp | undefined;
     private pageSummaryComp: PageSummaryComp | undefined;
@@ -38,6 +41,7 @@ class PaginationComp extends TabGuardComp implements FocusableContainer {
             tag: 'div',
             cls: 'ag-paging-panel ag-unselectable',
             attrs: { id: idPrefix },
+            children: [{ tag: 'div', cls: 'ag-paging-panel-content', ref: 'eContent' }],
         });
 
         this.initialiseTabGuard({
@@ -88,14 +92,14 @@ class PaginationComp extends TabGuardComp implements FocusableContainer {
             if (panelName === 'pageSize') {
                 this.pageSizeComp = this.createManagedBean(new PageSizeSelectorComp());
                 this.pageSizeComp.updateVisibility();
-                this.appendChild(this.pageSizeComp);
+                this.eContent.appendChild(this.pageSizeComp.getGui());
             } else if (panelName === 'rowSummary') {
                 this.rowSummaryComp = this.createManagedBean(new RowSummaryComp(idPrefix));
-                this.appendChild(this.rowSummaryComp);
+                this.eContent.appendChild(this.rowSummaryComp.getGui());
             } else if (panelName === 'pageSummary') {
                 const suppressPageInput = typeof panel === 'object' ? panel.suppressPageInput : undefined;
                 this.pageSummaryComp = this.createManagedBean(new PageSummaryComp(idPrefix, suppressPageInput));
-                this.appendChild(this.pageSummaryComp);
+                this.eContent.appendChild(this.pageSummaryComp.getGui());
             }
         }
         this.updateHasVisiblePanel();

--- a/packages/ag-grid-enterprise/src/statusBar/agStatusBar.css
+++ b/packages/ag-grid-enterprise/src/statusBar/agStatusBar.css
@@ -1,7 +1,8 @@
 .ag-status-bar {
     display: flex;
     justify-content: space-between;
-    overflow: hidden;
+    overflow: auto hidden;
+    scrollbar-width: thin;
     border-top: var(--ag-footer-row-border);
     padding-right: calc(var(--ag-spacing) * 4);
     padding-left: calc(var(--ag-spacing) * 4);


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-14740

When the grid is narrow, the pagination panel and status bar now scroll horizontally with a thin scrollbar instead of wrapping or clipping — a consistent overflow model matching the row group / pivot drop zones.

- **Pagination panel** is split into a scroll viewport (`.ag-paging-panel`) and an inner content row (`.ag-paging-panel-content`). The content row stays right-aligned when there's room (`min-width: 100%` + `justify-content: flex-end`) and grows past the viewport when controls overflow, so the viewport scrolls and every control stays reachable. (`justify-content: flex-end` alone pushes overflow off the unreachable start edge, so the inner-row split is required.)
- **Status bar** uses `overflow: auto hidden` + thin scrollbar.
- Backs out the v35.1.0 wrap rules from AG-13743 (`flex-wrap`, `row-gap`, the `@container` width query, `min-height`, per-item margins).
- Applied to both the Theming API and Legacy themes.

Verified live (Theming API): right-aligned when wide, scrollable and fully reachable when narrow, vertically centred. Legacy-theme rendering and print output were not verified live (manual test uses the Theming API) — worth a spot-check before merge.

Fix [AG-14740](https://ag-grid.atlassian.net/browse/AG-14740)