### PR TITLE
AG-17134 - allowlist additional CSP report-only console warnings

### DIFF
--- a/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
@@ -110,6 +110,8 @@ const excludeErrors = [
     // Browsers warn that such a policy can't report — benign for our validation window.
     'has a Report-Only policy without a report-uri directive nor a report-to directive', // Firefox
     "was delivered in report-only mode, but does not specify a 'report-uri'", // Chromium
+    "was delivered in report-only mode, but does not specify a 'report-to'", // Chromium
+    "directive 'frame-ancestors' is ignored when delivered in a report-only policy",
     // React warnings from examples that intentionally render read-only controls / raw style props.
     'You provided a `checked` prop to a form field without an `onChange` handler.',
     'Unsupported style property %s. Did you mean %s? white-space whiteSpace',


### PR DESCRIPTION
## Summary

- Adds two missing CSP report-only warning patterns to the E2E `excludeErrors` allowlist so doc tests stop failing on benign browser console messages
- Covers the Chromium `report-to` variant (existing entry only matched `report-uri`) and the `frame-ancestors` ignored-in-report-only warning

Closes AG-17134

## Test plan

- [ ] Run `./docs-e2e.sh` against an example that was previously failing (e.g. `accessibility/accessibility`) and confirm it passes