### PR TITLE
AG-17491 fix module-size CI cache and post-checkout issues

### DIFF
--- a/.github/actions/module-size-test/action.yml
+++ b/.github/actions/module-size-test/action.yml
@@ -25,10 +25,6 @@ inputs:
     description: 'Git ref to get .github/actions from (for testing older refs that lack these actions)'
     required: false
     default: ''
-  source-ref:
-    description: 'Git ref to get source code from (swaps src folders for ag-grid-community, ag-grid-enterprise, ag-grid-react). When set, uses ref for tooling but source-ref for actual source code.'
-    required: false
-    default: ''
 
 runs:
   using: composite
@@ -54,54 +50,6 @@ runs:
         rm -rf .github/actions
         cp -r .actions-temp/.github/actions .github/actions
         rm -rf .actions-temp
-
-    - name: Checkout source from source-ref
-      if: inputs.source-ref != '' && inputs.source-ref != inputs.ref
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ inputs.source-ref }}
-        sparse-checkout: |
-          packages/ag-grid-community/src
-          packages/ag-grid-enterprise/src
-          packages/ag-grid-react/src
-        path: .source-temp
-
-    - name: Swap src folders from source-ref
-      if: inputs.source-ref != '' && inputs.source-ref != inputs.ref
-      shell: bash
-      run: |
-        echo "Swapping src folders from ${{ inputs.source-ref }} into ${{ inputs.ref }} tooling..."
-
-        # Swap ag-grid-community/src
-        if [ -d ".source-temp/packages/ag-grid-community/src" ]; then
-          rm -rf packages/ag-grid-community/src
-          cp -r .source-temp/packages/ag-grid-community/src packages/ag-grid-community/src
-          echo "✓ Swapped ag-grid-community/src"
-        else
-          echo "⚠ Warning: ag-grid-community/src not found in source-ref"
-        fi
-
-        # Swap ag-grid-enterprise/src
-        if [ -d ".source-temp/packages/ag-grid-enterprise/src" ]; then
-          rm -rf packages/ag-grid-enterprise/src
-          cp -r .source-temp/packages/ag-grid-enterprise/src packages/ag-grid-enterprise/src
-          echo "✓ Swapped ag-grid-enterprise/src"
-        else
-          echo "⚠ Warning: ag-grid-enterprise/src not found in source-ref"
-        fi
-
-        # Swap ag-grid-react/src
-        if [ -d ".source-temp/packages/ag-grid-react/src" ]; then
-          rm -rf packages/ag-grid-react/src
-          cp -r .source-temp/packages/ag-grid-react/src packages/ag-grid-react/src
-          echo "✓ Swapped ag-grid-react/src"
-        else
-          echo "⚠ Warning: ag-grid-react/src not found in source-ref"
-        fi
-
-        # Clean up
-        rm -rf .source-temp
-        echo "Source swap complete."
 
     - name: Setup
       uses: ./.github/actions/setup-nx

--- a/.github/actions/module-size-test/action.yml
+++ b/.github/actions/module-size-test/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'Git ref to get .github/actions from (for testing older refs that lack these actions)'
     required: false
     default: ''
+  cache-mode:
+    description: 'Cache mode for setup-nx (rw, ro, off). Use off for release tags to avoid cross-version cache hits.'
+    required: false
+    default: 'ro'
 
 runs:
   using: composite
@@ -54,8 +58,13 @@ runs:
     - name: Setup
       uses: ./.github/actions/setup-nx
       with:
-        cache_mode: ro
+        cache_mode: ${{ inputs.cache-mode }}
         base_ref: ${{ inputs.base-ref || inputs.ref }}
+
+    - name: yarn install (no cache)
+      if: inputs.cache-mode == 'off'
+      shell: bash
+      run: yarn install --ci
 
     - name: Build dependencies
       shell: bash

--- a/.github/workflows/module-size-comparison.yml
+++ b/.github/workflows/module-size-comparison.yml
@@ -177,6 +177,7 @@ jobs:
           artifact-prefix: module-size-base
           artifact-suffix: ${{ needs.prepare.outputs.pr-number }}
           base-ref: ${{ needs.prepare.outputs.base-ref }}
+          actions-ref: ${{ needs.prepare.outputs.head-sha }}
 
   # Merge base shards and save to cache (only when we had to build)
   cache-base-results:

--- a/.github/workflows/module-size-vs-release.yml
+++ b/.github/workflows/module-size-vs-release.yml
@@ -153,6 +153,7 @@ jobs:
           shard: ${{ matrix.shard }}
           total-shards: ${{ strategy.job-total }}
           artifact-prefix: module-size-release
+          cache-mode: 'off'
 
   # Cache release results (only when we had to build)
   cache-release-results:

--- a/.github/workflows/module-size-vs-release.yml
+++ b/.github/workflows/module-size-vs-release.yml
@@ -130,7 +130,6 @@ jobs:
           base-ref: ${{ env.TEST_BRANCH }}
 
   # Build and run module size tests on release tag (sharded) - only if cache miss
-  # Uses test branch tooling with source code from the release tag
   module-size-release:
     name: Module Size Release (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
@@ -140,24 +139,20 @@ jobs:
       matrix:
         shard: ${{ fromJSON(needs.prepare.outputs.shard-matrix) }}
       fail-fast: false
-    env:
-      TEST_BRANCH: ${{ needs.prepare.outputs.test-branch }}
     steps:
       - name: Checkout for actions
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.TEST_BRANCH }}
+          ref: ${{ needs.prepare.outputs.release-tag }}
           fetch-depth: 1
 
       - name: Run module size tests
         uses: ./.github/actions/module-size-test
         with:
-          ref: ${{ env.TEST_BRANCH }}
+          ref: ${{ needs.prepare.outputs.release-tag }}
           shard: ${{ matrix.shard }}
           total-shards: ${{ strategy.job-total }}
           artifact-prefix: module-size-release
-          base-ref: ${{ env.TEST_BRANCH }}
-          source-ref: ${{ needs.prepare.outputs.release-tag }}
 
   # Cache release results (only when we had to build)
   cache-release-results:


### PR DESCRIPTION
## Summary

Follow-up to #13921 — fixes two CI issues with the simplified module-size-vs-release workflow:

- **Post-checkout index error**: The `module-size-base` job in `module-size-comparison.yml` checks out the PR head for the action, then the composite action checks out the merge-base. Pass `actions-ref` so the action restores the correct `.github/actions/` after checkout, avoiding runner Post-step index mismatch.
- **TS build failure on release tag**: The `setup-nx` cache `restore-keys` fallback matches `latest`'s `node_modules` cache, pulling in a newer TypeScript that rejects the release code. Add `cache-mode` input to the composite action and pass `off` for release builds so they do a clean `yarn install` from their own `yarn.lock`.

## Test plan

- [ ] `module-size-comparison` CI passes on this PR (validates the `actions-ref` fix)
- [ ] Manually trigger `module-size-vs-release` after merge to validate the `cache-mode: off` fix