### PR TITLE
AG-17491 use latest's actions for release module-size job

### DIFF
--- a/.github/workflows/module-size-vs-release.yml
+++ b/.github/workflows/module-size-vs-release.yml
@@ -139,11 +139,13 @@ jobs:
       matrix:
         shard: ${{ fromJSON(needs.prepare.outputs.shard-matrix) }}
       fail-fast: false
+    env:
+      TEST_BRANCH: ${{ needs.prepare.outputs.test-branch }}
     steps:
       - name: Checkout for actions
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare.outputs.release-tag }}
+          ref: ${{ env.TEST_BRANCH }}
           fetch-depth: 1
 
       - name: Run module size tests
@@ -154,6 +156,7 @@ jobs:
           total-shards: ${{ strategy.job-total }}
           artifact-prefix: module-size-release
           cache-mode: 'off'
+          actions-ref: ${{ env.TEST_BRANCH }}
 
   # Cache release results (only when we had to build)
   cache-release-results:


### PR DESCRIPTION
## Summary

Follow-up to #13924 — the release job in `module-size-vs-release` checks out the release tag to get the composite action, but the release tag's `action.yml` doesn't have the `cache-mode` input (added in #13924). The input is silently ignored, `cache_mode` defaults to `ro`, and the cache fallback restores latest's `node_modules` (TS 5.8.3) which rejects the release code (built with TS 5.4.5).

**Fix:** Checkout `latest` (test branch) for the action, pass the release tag as `ref` so the composite action checks out the release code, and use `actions-ref` to restore latest's `.github/actions/` after checkout.

Replaces #13925 (which had merge conflicts from stale history).

## Test plan

- [ ] Manually trigger `module-size-vs-release` after merge — release shards should build with their own TS version