### PR TITLE
AG-17134 - Allow AG subdomains to embed examples; drop X-Frame-Options

### DIFF
--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
@@ -134,7 +134,7 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://codesandbox.io', // example-runner "Open in CodeSandbox" form POST
             'https://plnkr.co', // example-runner "Open in Plunker" form POST
         ],
-        'frame-ancestors': [SELF],
+        'frame-ancestors': [SELF, AG_GRID_HOSTS], // allow *.ag-grid.com (e.g. blog) to embed examples
     };
 
     if (env === 'dev') {

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
@@ -169,7 +169,9 @@ ${modExpiresRules}
 ${modDeflateRules}
 ${getModRewriteRules()}
 
-Header always set X-Frame-Options "SAMEORIGIN"
+# X-Frame-Options intentionally omitted: it can't allow-list subdomains, so it blocks
+# blog.ag-grid.com (and other *.ag-grid.com) from embedding examples. Clickjacking
+# protection is handled by the CSP frame-ancestors directive instead (see cspRules.ts).
 Header always set Referrer-Policy "strict-origin-when-cross-origin"
 Header always set Permissions-Policy "geolocation=(), microphone=(), camera=()"
 


### PR DESCRIPTION
## Problem

Examples embedded on `blog.ag-grid.com` (e.g. the AI Toolkit post) stopped rendering. The blog iframes examples from `www.ag-grid.com`, but the `X-Frame-Options: SAMEORIGIN` header (added https://github.com/ag-grid/ag-grid/pull/13838) only allows same-origin framing — `blog.ag-grid.com ≠ www.ag-grid.com`, so the browser refuses the iframe. `X-Frame-Options` has no way to allow-list subdomains (`ALLOW-FROM` is deprecated/ignored).

## Fix

- Remove `X-Frame-Options: SAMEORIGIN` from the production `.htaccess`.
- Widen the CSP `frame-ancestors` directive from `'self'` to `'self' https://*.ag-grid.com`, so AG subdomains (blog, etc.) can embed examples while all other origins are still refused — i.e. clickjacking protection is retained, just moved to the modern mechanism.

## Notes

- Removing `X-Frame-Options` fixes the blog embeds immediately (it's the only *enforced* framing control today). `frame-ancestors` only fully re-enforces once the CSP leaves report-only — accepted, the report-only window is short and clickjacking risk on docs pages is limited.
- `X-Frame-Options` was added by the in-flight AG-3390 SEO work — coordinate if that branch also touches this block.
- Charts (#) and studio (#) get the matching `frame-ancestors` widening; they inherit grid's root `X-Frame-Options` (now removed) as subdirectories of `www.ag-grid.com`.
- Reverts `X-Frame-Options: SAMEORIGIN` header from https://github.com/ag-grid/ag-grid/pull/13838