### PR TITLE
AG-17506 Align full width row content to vertical centre

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -284,6 +284,8 @@
         left: 0;
         width: var(--ag-fw-anchor-width, 100%);
         height: 100%;
+        display: flex;
+        align-items: center;
     }
 
     .ag-virtual-list-container {

--- a/packages/ag-grid-community/src/theming/core/css/_general.css
+++ b/packages/ag-grid-community/src/theming/core/css/_general.css
@@ -127,6 +127,8 @@
     left: 0;
     width: var(--ag-fw-anchor-width, 100%);
     height: 100%;
+    display: flex;
+    align-items: center;
 }
 
 /**


### PR DESCRIPTION
Fix [AG-17506](https://ag-grid.atlassian.net/browse/AG-17506)

`ag-row` divs are `display: flex; / align-items: center`. Previously, full width row components were direct children of the row. The single container refactor introduced a new div with display block, with the effect that children are misaligned. This PR restores display:flex on the wrapper, ensuring that full width row components are still in a flex container.