### PR TITLE
AG-17509 Fix Tab key TypeError when suppressHeaderFocus is true

### DIFF
--- a/packages/ag-grid-community/src/navigation/headerNavigationService.ts
+++ b/packages/ag-grid-community/src/navigation/headerNavigationService.ts
@@ -183,7 +183,10 @@ export class HeaderNavigationService extends BeanStub implements NamedBean {
         event: KeyboardEvent
     ): boolean {
         const { focusSvc, gos } = this.beans;
-        const focusedHeader = { ...focusSvc.focusedHeader! };
+        if (!focusSvc.focusedHeader) {
+            return false;
+        }
+        const focusedHeader = { ...focusSvc.focusedHeader };
         let nextHeader: HeaderPosition;
         let normalisedDirection: 'Before' | 'After';
 

--- a/testing/behavioural/src/navigation/suppress-header-focus-tab.test.ts
+++ b/testing/behavioural/src/navigation/suppress-header-focus-tab.test.ts
@@ -1,0 +1,79 @@
+import type { ColDef } from 'ag-grid-community';
+import { ClientSideRowModelModule, KeyCode, getGridElement } from 'ag-grid-community';
+
+import { TestGridsManager } from '../test-utils';
+
+interface RowData {
+    make: string;
+    model: string;
+    price: number;
+    electric: boolean;
+}
+
+const columnDefs: ColDef<RowData>[] = [
+    { field: 'make' },
+    { field: 'model' },
+    { field: 'price' },
+    { field: 'electric' },
+];
+
+describe('suppressHeaderFocus tab navigation', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule],
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    function testTabOnHeaderRow(gridOptions: Parameters<typeof gridsManager.createGrid>[1]) {
+        const host = document.createElement('div');
+        const aboveInput = document.createElement('input');
+        const gridDiv = document.createElement('div');
+        const belowInput = document.createElement('input');
+        host.append(aboveInput, gridDiv, belowInput);
+        document.body.appendChild(host);
+
+        const errors: ErrorEvent[] = [];
+        const onError = (e: ErrorEvent) => errors.push(e);
+        window.addEventListener('error', onError);
+
+        try {
+            const api = gridsManager.createGrid(gridDiv, gridOptions);
+
+            const gridElement = getGridElement(api) as HTMLElement;
+            const headerRow = gridElement.querySelector<HTMLElement>('.ag-header-row')!;
+
+            expect(headerRow).toBeTruthy();
+
+            headerRow.focus();
+            headerRow.dispatchEvent(
+                new KeyboardEvent('keydown', { key: KeyCode.TAB, bubbles: true, cancelable: true })
+            );
+
+            expect(errors).toHaveLength(0);
+        } finally {
+            window.removeEventListener('error', onError);
+            host.remove();
+        }
+    }
+
+    test('tabbing on header row with suppressHeaderFocus and empty rowData does not throw', () => {
+        testTabOnHeaderRow({
+            columnDefs,
+            rowData: [],
+            defaultColDef: { flex: 1 },
+            suppressHeaderFocus: true,
+        });
+    });
+
+    test('tabbing on header row with suppressHeaderFocus and suppressCellFocus does not throw', () => {
+        testTabOnHeaderRow({
+            columnDefs,
+            rowData: [{ make: 'test' }],
+            defaultColDef: { flex: 1 },
+            suppressHeaderFocus: true,
+            suppressCellFocus: true,
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Guard against null `focusedHeader` in `navigateHorizontally` to prevent TypeError when Tab is pressed on the header row with `suppressHeaderFocus` enabled.
- The crash occurred because `{ ...focusSvc.focusedHeader! }` spreads null into `{}`, cascading into `getColGroupAtLevel` where `column.parent` is null.

## Test plan

- [x] New behavioural test: `suppressHeaderFocus: true` with empty `rowData`
- [x] New behavioural test: `suppressHeaderFocus: true` + `suppressCellFocus: true` with row data
- [x] All 133 existing navigation tests pass
- [x] All 8 focus-related tests pass
- [x] `build:types ag-grid-community` passes
- [x] `lint ag-grid-community` passes

Fix [AG-17509](https://ag-grid.atlassian.net/browse/AG-17509)