### PR TITLE
AG-17486 Update theme builder for single-container refactor

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -282,7 +282,7 @@
     .ag-full-width-anchor {
         position: sticky;
         left: 0;
-        width: var(--ag-fw-anchor-width, 100%);
+        width: var(--ag-internal-fw-anchor-width, 100%);
         height: 100%;
     }
 
@@ -800,11 +800,11 @@
     }
 
     .ag-grid-pinned-left-cells {
-        left: var(--ag-pinned-left-sticky-offset, 0px);
+        left: var(--ag-internal-pinned-left-sticky-offset, 0px);
     }
 
     .ag-grid-pinned-right-cells {
-        right: var(--ag-pinned-right-sticky-offset, 0px);
+        right: var(--ag-internal-pinned-right-sticky-offset, 0px);
     }
 
     // place pinned-right after the ::after spacer so the spacer fills the gap between
@@ -829,7 +829,7 @@
 
     .ag-rtl .ag-body-horizontal-scroll .ag-grid-scrolling-cells {
         // when scrollable, offset for the vertical scrollbar on the left in rtl.
-        margin-left: var(--ag-pinned-left-sticky-offset, 0px);
+        margin-left: var(--ag-internal-pinned-left-sticky-offset, 0px);
     }
 
     .ag-row-position-absolute {

--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -827,7 +827,7 @@
         }
     }
 
-    .ag-rtl .ag-body-horizontal-scroll .ag-grid-scrolling-cells {
+    .ag-rtl .ag-grid-scrolling-cells {
         // when scrollable, offset for the vertical scrollbar on the left in rtl.
         margin-left: var(--ag-internal-pinned-left-sticky-offset, 0px);
     }

--- a/documentation/ag-grid-docs/src/components/theme-builder/components/presets/PresetRender.tsx
+++ b/documentation/ag-grid-docs/src/components/theme-builder/components/presets/PresetRender.tsx
@@ -49,7 +49,7 @@ const previewHTML = `
 	<div class="ag-root-wrapper ag-ltr ag-layout-normal" role="presentation" grid-id="2">
 		<div class="ag-root-wrapper-body ag-focus-managed ag-layout-normal" role="presentation">
 			<div class="ag-root ag-unselectable ag-layout-normal ag-body-horizontal-content-no-gap ag-has-left-pinned-cols ag-body-vertical-content-no-gap" role="presentation" style="--ag-internal-pinned-left-sticky-offset: 0px; --ag-internal-pinned-right-sticky-offset: 15px;">
-				<div class="ag-grid-viewport ag-layout-normal" role="grid" aria-colcount="7" aria-multiselectable="true" aria-rowcount="501" style="--ag-fw-anchor-width: 1320px;">
+				<div class="ag-grid-viewport ag-layout-normal" role="grid" aria-colcount="7" aria-multiselectable="true" aria-rowcount="501">
 					<div class="ag-grid-scrollable-area" role="rowgroup" style="width: 1335px;">
 						<div class="ag-grid-pinned-top-rows" role="presentation" style="--ag-top-rows-height: 0px; min-height: calc(var(--ag-header-rows-height, 0px) + 0px); height: calc(var(--ag-header-rows-height, 0px) + 0px); --ag-header-rows-height: 49px;">
 							<div role="presentation" class="ag-header ag-pivot-off ag-header-allow-overflow" style="height: 49px;">

--- a/documentation/ag-grid-docs/src/components/theme-builder/components/presets/PresetRender.tsx
+++ b/documentation/ag-grid-docs/src/components/theme-builder/components/presets/PresetRender.tsx
@@ -48,7 +48,7 @@ const previewHTML = `
 <div class="ag-theme-buttonStyle-1 ag-theme-checkboxStyle-2 ag-theme-iconSet-3 ag-theme-tabStyle-4 ag-theme-inputStyle-5 ag-theme-columnDropStyle-6 ag-theme-params-10" style="height: 100%; --ag-internal-row-border-width: 1px;">
 	<div class="ag-root-wrapper ag-ltr ag-layout-normal" role="presentation" grid-id="2">
 		<div class="ag-root-wrapper-body ag-focus-managed ag-layout-normal" role="presentation">
-			<div class="ag-root ag-unselectable ag-layout-normal ag-body-horizontal-content-no-gap ag-has-left-pinned-cols ag-body-vertical-content-no-gap" role="presentation" style="--ag-pinned-left-sticky-offset: 0px; --ag-pinned-right-sticky-offset: 15px;">
+			<div class="ag-root ag-unselectable ag-layout-normal ag-body-horizontal-content-no-gap ag-has-left-pinned-cols ag-body-vertical-content-no-gap" role="presentation" style="--ag-internal-pinned-left-sticky-offset: 0px; --ag-internal-pinned-right-sticky-offset: 15px;">
 				<div class="ag-grid-viewport ag-layout-normal" role="grid" aria-colcount="7" aria-multiselectable="true" aria-rowcount="501" style="--ag-fw-anchor-width: 1320px;">
 					<div class="ag-grid-scrollable-area" role="rowgroup" style="width: 1335px;">
 						<div class="ag-grid-pinned-top-rows" role="presentation" style="--ag-top-rows-height: 0px; min-height: calc(var(--ag-header-rows-height, 0px) + 0px); height: calc(var(--ag-header-rows-height, 0px) + 0px); --ag-header-rows-height: 49px;">

--- a/documentation/ag-grid-docs/src/components/theme-builder/components/presets/PresetRender.tsx
+++ b/documentation/ag-grid-docs/src/components/theme-builder/components/presets/PresetRender.tsx
@@ -45,75 +45,170 @@ const GridContainer = styled('div')`
 `;
 
 const previewHTML = `
-<div class="ag-root-wrapper ag-ltr ag-layout-normal" role="presentation" grid-id="4">
-    <div class="ag-root-wrapper-body ag-focus-managed ag-layout-normal" role="presentation">
-        <div class="ag-root ag-unselectable ag-layout-normal" role="treegrid" aria-colcount="4" aria-rowcount="8">
-            <div class="ag-grid-viewport ag-layout-normal" role="presentation">
-                <div class="ag-grid-scrollable-area" role="presentation" style="width: 920px;">
-                    <div class="ag-grid-pinned-top-rows" role="presentation" style="--ag-header-rows-height: 44px; --ag-top-rows-height: 0px; min-height: 44px; height: 44px;">
-                        <div class="ag-grid-pinned-top-rows-container ag-focus-managed ag-pivot-off ag-header-allow-overflow" role="rowgroup" style="width: 920px;">
-                            <div class="ag-row ag-header-row ag-header-row-column" role="row" aria-rowindex="1" style="top: 0px; height: 44px; width: 920px;">
-                                <div class="ag-grid-pinned-left-cells" role="presentation" style="width: 56px;">
-                                    <div class="ag-header-cell ag-row-number-header ag-column-first" role="columnheader" aria-colindex="1" style="top: 0px; height: 44px; width: 56px; left: 0px;"></div>
-                                </div>
-                                <div class="ag-grid-scrolling-cells" role="presentation">
-                                    <div class="ag-header-cell ag-column-first" role="columnheader" aria-colindex="2" style="top: 0px; height: 44px; width: 220px; left: 0px;"><div class="ag-header-cell-comp-wrapper"><div class="ag-header-cell-label"><span class="ag-header-cell-text">Country</span></div></div></div>
-                                    <div class="ag-header-cell" role="columnheader" aria-colindex="3" style="top: 0px; height: 44px; width: 220px; left: 220px;"><div class="ag-header-cell-comp-wrapper"><div class="ag-header-cell-label"><span class="ag-header-cell-text">Sport</span></div></div></div>
-                                    <div class="ag-header-cell" role="columnheader" aria-colindex="4" style="top: 0px; height: 44px; width: 220px; left: 440px;"><div class="ag-header-cell-comp-wrapper"><div class="ag-header-cell-label"><span class="ag-header-cell-text">Name</span></div></div></div>
-                                </div>
-                                <div class="ag-grid-pinned-right-cells" role="presentation" style="width: 0px; display: none;"></div>
-                            </div>
-                        </div>
-                        <div class="ag-grid-pinned-top-rows-full-width-container" role="rowgroup"></div>
-                    </div>
-                    <div class="ag-grid-scrolling-rows" role="presentation">
-                        <div class="ag-grid-scrolling-container" role="rowgroup" style="width: 920px; height: 1400px;">
-                            <div class="ag-row ag-row-position-absolute ag-row-even" role="row" aria-rowindex="2" style="top: 0px; height: 42px; width: 920px;">
-                                <div class="ag-grid-pinned-left-cells" role="presentation" style="width: 56px;"><div class="ag-cell ag-column-first" role="gridcell" aria-colindex="1" style="top: 0px; height: 42px; width: 56px; left: 0px;"><span class="ag-cell-value">1</span></div></div>
-                                <div class="ag-grid-scrolling-cells" role="presentation">
-                                    <div class="ag-cell ag-column-first" role="gridcell" aria-colindex="2" style="top: 0px; height: 42px; width: 220px; left: 0px;"><span class="ag-cell-value">Italy</span></div>
-                                    <div class="ag-cell" role="gridcell" aria-colindex="3" style="top: 0px; height: 42px; width: 220px; left: 220px;"><span class="ag-cell-value">Horse Racing</span></div>
-                                    <div class="ag-cell" role="gridcell" aria-colindex="4" style="top: 0px; height: 42px; width: 220px; left: 440px;"><span class="ag-cell-value">Dimple Flanagan</span></div>
-                                </div>
-                                <div class="ag-grid-pinned-right-cells" role="presentation" style="width: 0px; display: none;"></div>
-                            </div>
-                            <div class="ag-row ag-row-position-absolute ag-row-odd ag-row-selected" role="row" aria-rowindex="3" style="top: 42px; height: 42px; width: 920px;">
-                                <div class="ag-grid-pinned-left-cells" role="presentation" style="width: 56px;"><div class="ag-cell ag-column-first" role="gridcell" aria-colindex="1" style="top: 0px; height: 42px; width: 56px; left: 0px;"><span class="ag-cell-value">2</span></div></div>
-                                <div class="ag-grid-scrolling-cells" role="presentation">
-                                    <div class="ag-cell ag-column-first" role="gridcell" aria-colindex="2" style="top: 0px; height: 42px; width: 220px; left: 0px;"><span class="ag-cell-value">Argentina</span></div>
-                                    <div class="ag-cell" role="gridcell" aria-colindex="3" style="top: 0px; height: 42px; width: 220px; left: 220px;"><span class="ag-cell-value">Bowling</span></div>
-                                    <div class="ag-cell" role="gridcell" aria-colindex="4" style="top: 0px; height: 42px; width: 220px; left: 440px;"><span class="ag-cell-value">Olivia Brock</span></div>
-                                </div>
-                                <div class="ag-grid-pinned-right-cells" role="presentation" style="width: 0px; display: none;"></div>
-                            </div>
-                            <div class="ag-row ag-row-position-absolute ag-row-even" role="row" aria-rowindex="4" style="top: 84px; height: 42px; width: 920px;">
-                                <div class="ag-grid-pinned-left-cells" role="presentation" style="width: 56px;"><div class="ag-cell ag-column-first" role="gridcell" aria-colindex="1" style="top: 0px; height: 42px; width: 56px; left: 0px;"><span class="ag-cell-value">3</span></div></div>
-                                <div class="ag-grid-scrolling-cells" role="presentation">
-                                    <div class="ag-cell ag-column-first" role="gridcell" aria-colindex="2" style="top: 0px; height: 42px; width: 220px; left: 0px;"><span class="ag-cell-value">United Kingdom</span></div>
-                                    <div class="ag-cell" role="gridcell" aria-colindex="3" style="top: 0px; height: 42px; width: 220px; left: 220px;"><span class="ag-cell-value">Bobsleigh</span></div>
-                                    <div class="ag-cell" role="gridcell" aria-colindex="4" style="top: 0px; height: 42px; width: 220px; left: 440px;"><span class="ag-cell-value">Ruby Connell</span></div>
-                                </div>
-                                <div class="ag-grid-pinned-right-cells" role="presentation" style="width: 0px; display: none;"></div>
-                            </div>
-                        </div>
-                        <div class="ag-full-width-container" role="rowgroup" style="height: 1400px;"></div>
-                    </div>
-                    <div class="ag-grid-pinned-bottom-rows ag-no-bottom-rows" role="presentation" style="min-height: 0px; height: 0px;">
-                        <div class="ag-grid-pinned-bottom-rows-container" role="rowgroup" style="width: 920px;"></div>
-                        <div class="ag-grid-pinned-bottom-rows-full-width-container" role="rowgroup"></div>
-                    </div>
-                </div>
-            </div>
-            <div class="ag-body-horizontal-scroll ag-apple-scrollbar" aria-hidden="true" style="height: 15px; max-height: 15px; min-height: 15px;">
-                <div class="ag-body-horizontal-scroll-viewport" style="height: 15px; max-height: 15px; min-height: 15px; width: calc(100% - 15px);">
-                    <div class="ag-body-horizontal-scroll-container" style="width: 920px; height: 15px; max-height: 15px; min-height: 15px;"></div>
-                </div>
-                <div class="ag-body-horizontal-scroll-end-spacer" style="width: 15px; max-width: 15px; min-width: 15px; height: 15px;"></div>
-            </div>
-            <div class="ag-body-vertical-scroll ag-apple-scrollbar" aria-hidden="true" style="width: 15px; max-width: 15px; min-width: 15px; top: 44px; bottom: 15px; right: 0px; position: absolute; z-index: 3;">
-                <div class="ag-body-vertical-scroll-viewport" style="width: 15px; max-width: 15px; min-width: 15px;"><div class="ag-body-vertical-scroll-container" style="width: 15px; max-width: 15px; min-width: 15px; height: 1400px;"></div></div>
-            </div>
-        </div>
-    </div>
+<div class="ag-theme-buttonStyle-1 ag-theme-checkboxStyle-2 ag-theme-iconSet-3 ag-theme-tabStyle-4 ag-theme-inputStyle-5 ag-theme-columnDropStyle-6 ag-theme-params-10" style="height: 100%; --ag-internal-row-border-width: 1px;">
+	<div class="ag-root-wrapper ag-ltr ag-layout-normal" role="presentation" grid-id="2">
+		<div class="ag-root-wrapper-body ag-focus-managed ag-layout-normal" role="presentation">
+			<div class="ag-root ag-unselectable ag-layout-normal ag-body-horizontal-content-no-gap ag-has-left-pinned-cols ag-body-vertical-content-no-gap" role="presentation" style="--ag-pinned-left-sticky-offset: 0px; --ag-pinned-right-sticky-offset: 15px;">
+				<div class="ag-grid-viewport ag-layout-normal" role="grid" aria-colcount="7" aria-multiselectable="true" aria-rowcount="501" style="--ag-fw-anchor-width: 1320px;">
+					<div class="ag-grid-scrollable-area" role="rowgroup" style="width: 1335px;">
+						<div class="ag-grid-pinned-top-rows" role="presentation" style="--ag-top-rows-height: 0px; min-height: calc(var(--ag-header-rows-height, 0px) + 0px); height: calc(var(--ag-header-rows-height, 0px) + 0px); --ag-header-rows-height: 49px;">
+							<div role="presentation" class="ag-header ag-pivot-off ag-header-allow-overflow" style="height: 49px;">
+								<div class="ag-header-row ag-header-row-column ag-focus-managed" role="row" tabindex="0" aria-rowindex="1" style="top: 0px; height: 48px; width: 1335px;">
+									<div class="ag-grid-pinned-left-cells" role="presentation" style="width: 60px;">
+										<div class="ag-header-cell ag-column-first ag-header-parent-hidden ag-row-number-header ag-row-number-selection-enabled ag-focus-managed" role="columnheader" col-id="ag-Grid-RowNumbersColumn" aria-colindex="1" tabindex="-1" aria-label="Row Number" style="top: 0px; height: 48px; width: 60px; left: 0px;">
+											<div class="ag-header-cell-resize ag-hidden" role="presentation" aria-hidden="true">
+											</div>
+											<div class="ag-header-cell-comp-wrapper" role="presentation">
+												<div class="ag-cell-label-container" role="presentation">
+													<div class="ag-header-cell-label" data-ref="eLabel" role="presentation">
+														<span class="ag-header-cell-text" data-ref="eText"></span> <span class="ag-header-icon ag-header-label-icon ag-filter-icon ag-hidden" data-ref="eFilter" aria-hidden="true"><span class="ag-icon ag-icon-filter" role="presentation" unselectable="on"></span></span> 
+														<span class="ag-sort-indicator-container" data-ref="eSortIndicator"> <span class="ag-sort-indicator-icon ag-sort-order ag-hidden" data-ref="eSortOrder" aria-hidden="true"></span> <span class="ag-sort-indicator-icon ag-sort-ascending-icon ag-hidden" data-ref="eSortAsc" aria-hidden="true"></span> <span class="ag-sort-indicator-icon ag-sort-descending-icon ag-hidden" data-ref="eSortDesc" aria-hidden="true"></span> <span class="ag-sort-indicator-icon ag-sort-mixed-icon ag-hidden" data-ref="eSortMixed" aria-hidden="true"><span class="ag-icon ag-icon-none" role="presentation" unselectable="on"></span></span> <span class="ag-sort-indicator-icon ag-sort-absolute-ascending-icon ag-hidden" data-ref="eSortAbsoluteAsc" aria-hidden="true"></span> <span class="ag-sort-indicator-icon ag-sort-absolute-descending-icon ag-hidden" data-ref="eSortAbsoluteDesc" aria-hidden="true"></span> <span class="ag-sort-indicator-icon ag-sort-none-icon ag-hidden" data-ref="eSortNone" aria-hidden="true"></span> </span> 
+													</div>
+												</div>
+											</div>
+										</div>
+									</div>
+									<div class="ag-grid-scrolling-cells" role="presentation" style="width: 1260px;">
+										<div class="ag-header-cell ag-header-parent-hidden ag-header-cell-sortable ag-focus-managed" role="columnheader" col-id="country" aria-colindex="2" tabindex="-1" aria-sort="none" style="top: 0px; height: 48px; width: 210px; left: 0px; touch-action: none;">
+											<div class="ag-header-cell-resize ag-hidden" role="presentation" aria-hidden="true">
+											</div>
+											<div class="ag-header-cell-comp-wrapper" role="presentation">
+												<div class="ag-cell-label-container" role="presentation">
+													<span class="ag-header-icon ag-header-cell-menu-button ag-header-menu-icon ag-header-menu-always-show" data-ref="eMenu" aria-hidden="true"><span class="ag-icon ag-icon-menu-alt" role="presentation" unselectable="on"></span></span> <span class="ag-header-icon ag-header-cell-filter-button" data-ref="eFilterButton" aria-hidden="true"><span class="ag-icon ag-icon-filter" role="presentation" unselectable="on"></span></span> 
+													<div class="ag-header-cell-label" data-ref="eLabel" role="presentation">
+														<span class="ag-header-cell-text" data-ref="eText">Country</span> 
+														<span class="ag-sort-indicator-container" data-ref="eSortIndicator"> <span class="ag-sort-indicator-icon ag-sort-order ag-hidden" data-ref="eSortOrder" aria-hidden="true"></span> <span class="ag-sort-indicator-icon ag-sort-ascending-icon ag-hidden" data-ref="eSortAsc" aria-hidden="true"><span class="ag-icon ag-icon-asc" role="presentation" unselectable="on"></span></span> <span class="ag-sort-indicator-icon ag-sort-descending-icon ag-hidden" data-ref="eSortDesc" aria-hidden="true"><span class="ag-icon ag-icon-desc" role="presentation" unselectable="on"></span></span> <span class="ag-sort-indicator-icon ag-sort-mixed-icon ag-hidden" data-ref="eSortMixed" aria-hidden="true"><span class="ag-icon ag-icon-none" role="presentation" unselectable="on"></span></span> <span class="ag-sort-indicator-icon ag-sort-absolute-ascending-icon ag-hidden" data-ref="eSortAbsoluteAsc" aria-hidden="true"><span class="ag-icon ag-icon-aasc" role="presentation" unselectable="on"></span></span> <span class="ag-sort-indicator-icon ag-sort-absolute-descending-icon ag-hidden" data-ref="eSortAbsoluteDesc" aria-hidden="true"><span class="ag-icon ag-icon-adesc" role="presentation" unselectable="on"></span></span> <span class="ag-sort-indicator-icon ag-sort-none-icon ag-hidden" data-ref="eSortNone" aria-hidden="true"><span class="ag-icon ag-icon-none" role="presentation" unselectable="on"></span></span> </span> 
+													</div>
+												</div>
+											</div>
+										</div>
+										<div class="ag-header-cell ag-header-parent-hidden ag-header-cell-sortable ag-focus-managed" role="columnheader" col-id="sport" aria-colindex="3" tabindex="-1" aria-sort="none" style="top: 0px; height: 48px; width: 210px; left: 210px; touch-action: none;">
+											<div class="ag-header-cell-resize ag-hidden" role="presentation" aria-hidden="true">
+											</div>
+											<div class="ag-header-cell-comp-wrapper" role="presentation">
+												<div class="ag-cell-label-container" role="presentation">
+													<span class="ag-header-icon ag-header-cell-menu-button ag-header-menu-icon ag-header-menu-always-show" data-ref="eMenu" aria-hidden="true"><span class="ag-icon ag-icon-menu-alt" role="presentation" unselectable="on"></span></span> <span class="ag-header-icon ag-header-cell-filter-button" data-ref="eFilterButton" aria-hidden="true"><span class="ag-icon ag-icon-filter" role="presentation" unselectable="on"></span></span> 
+													<div class="ag-header-cell-label" data-ref="eLabel" role="presentation">
+														<span class="ag-header-cell-text" data-ref="eText">Sport</span> 
+														<span class="ag-sort-indicator-container" data-ref="eSortIndicator"> <span class="ag-sort-indicator-icon ag-sort-order ag-hidden" data-ref="eSortOrder" aria-hidden="true"></span> <span class="ag-sort-indicator-icon ag-sort-ascending-icon ag-hidden" data-ref="eSortAsc" aria-hidden="true"><span class="ag-icon ag-icon-asc" role="presentation" unselectable="on"></span></span> <span class="ag-sort-indicator-icon ag-sort-descending-icon ag-hidden" data-ref="eSortDesc" aria-hidden="true"><span class="ag-icon ag-icon-desc" role="presentation" unselectable="on"></span></span> <span class="ag-sort-indicator-icon ag-sort-mixed-icon ag-hidden" data-ref="eSortMixed" aria-hidden="true"><span class="ag-icon ag-icon-none" role="presentation" unselectable="on"></span></span> <span class="ag-sort-indicator-icon ag-sort-absolute-ascending-icon ag-hidden" data-ref="eSortAbsoluteAsc" aria-hidden="true"><span class="ag-icon ag-icon-aasc" role="presentation" unselectable="on"></span></span> <span class="ag-sort-indicator-icon ag-sort-absolute-descending-icon ag-hidden" data-ref="eSortAbsoluteDesc" aria-hidden="true"><span class="ag-icon ag-icon-adesc" role="presentation" unselectable="on"></span></span> <span class="ag-sort-indicator-icon ag-sort-none-icon ag-hidden" data-ref="eSortNone" aria-hidden="true"><span class="ag-icon ag-icon-none" role="presentation" unselectable="on"></span></span> </span> 
+													</div>
+												</div>
+											</div>
+										</div>
+										<div class="ag-header-cell ag-header-parent-hidden ag-header-cell-sortable ag-focus-managed" role="columnheader" col-id="name" aria-colindex="4" tabindex="-1" aria-sort="none" style="top: 0px; height: 48px; width: 210px; left: 420px; touch-action: none;">
+											<div class="ag-header-cell-resize ag-hidden" role="presentation" aria-hidden="true">
+											</div>
+											<div class="ag-header-cell-comp-wrapper" role="presentation">
+												<div class="ag-cell-label-container" role="presentation">
+													<span class="ag-header-icon ag-header-cell-menu-button ag-header-menu-icon ag-header-menu-always-show" data-ref="eMenu" aria-hidden="true"><span class="ag-icon ag-icon-menu-alt" role="presentation" unselectable="on"></span></span> <span class="ag-header-icon ag-header-cell-filter-button" data-ref="eFilterButton" aria-hidden="true"><span class="ag-icon ag-icon-filter" role="presentation" unselectable="on"></span></span> 
+													<div class="ag-header-cell-label" data-ref="eLabel" role="presentation">
+														<span class="ag-header-cell-text" data-ref="eText">Name</span> 
+														<span class="ag-sort-indicator-container" data-ref="eSortIndicator"> <span class="ag-sort-indicator-icon ag-sort-order ag-hidden" data-ref="eSortOrder" aria-hidden="true"></span> <span class="ag-sort-indicator-icon ag-sort-ascending-icon ag-hidden" data-ref="eSortAsc" aria-hidden="true"><span class="ag-icon ag-icon-asc" role="presentation" unselectable="on"></span></span> <span class="ag-sort-indicator-icon ag-sort-descending-icon ag-hidden" data-ref="eSortDesc" aria-hidden="true"><span class="ag-icon ag-icon-desc" role="presentation" unselectable="on"></span></span> <span class="ag-sort-indicator-icon ag-sort-mixed-icon ag-hidden" data-ref="eSortMixed" aria-hidden="true"><span class="ag-icon ag-icon-none" role="presentation" unselectable="on"></span></span> <span class="ag-sort-indicator-icon ag-sort-absolute-ascending-icon ag-hidden" data-ref="eSortAbsoluteAsc" aria-hidden="true"><span class="ag-icon ag-icon-aasc" role="presentation" unselectable="on"></span></span> <span class="ag-sort-indicator-icon ag-sort-absolute-descending-icon ag-hidden" data-ref="eSortAbsoluteDesc" aria-hidden="true"><span class="ag-icon ag-icon-adesc" role="presentation" unselectable="on"></span></span> <span class="ag-sort-indicator-icon ag-sort-none-icon ag-hidden" data-ref="eSortNone" aria-hidden="true"><span class="ag-icon ag-icon-none" role="presentation" unselectable="on"></span></span> </span> 
+													</div>
+												</div>
+											</div>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+						<div class="ag-grid-scrolling-rows ag-layout-normal" role="presentation">
+							<div class="ag-grid-scrolling-container ag-row-no-animation" role="presentation" style="width: 1335px; --ag-pinned-row-border-width: 1px; height: 21000px;">
+								<div role="row" row-index="0" row-id="0" tabindex="0" class="ag-row-even ag-row-no-focus ag-row ag-row-level-0 ag-row-first" aria-rowindex="2">
+									<div class="ag-grid-pinned-left-cells" role="presentation" style="width: 60px;">
+										<div class="ag-grid-container-wrapper" role="presentation" style="width: 60px;">
+											<div role="rowheader" col-id="ag-Grid-RowNumbersColumn" tabindex="-1" class="ag-cell ag-cell-not-inline-editing ag-cell-normal-height ag-cell-last-left-pinned ag-column-first ag-row-number-cell ag-row-number-selection-enabled ag-cell-value" aria-colindex="1" style="left: 0px; width: 60px;">
+												1
+											</div>
+										</div>
+									</div>
+									<div class="ag-grid-scrolling-cells" role="presentation">
+										<div class="ag-grid-container-wrapper" role="presentation" style="width: 1260px;">
+											<div role="gridcell" col-id="country" tabindex="-1" class="ag-cell ag-cell-not-inline-editing ag-cell-normal-height ag-cell-value" aria-colindex="2" style="left: 0px; width: 210px;">
+												Iceland
+											</div>
+											<div role="gridcell" col-id="sport" tabindex="-1" class="ag-cell ag-cell-not-inline-editing ag-cell-normal-height ag-cell-value" aria-colindex="3" style="left: 210px; width: 210px;">
+												🏑 Field Hockey
+											</div>
+											<div role="gridcell" col-id="name" tabindex="-1" class="ag-cell ag-cell-not-inline-editing ag-cell-normal-height ag-cell-value" aria-colindex="4" style="left: 420px; width: 210px;">
+												Dimple Kade
+											</div>
+										</div>
+									</div>
+								</div>
+								<div role="row" row-index="1" row-id="1" tabindex="0" class="ag-row-odd ag-row-no-focus ag-row ag-row-level-0" aria-rowindex="3">
+									<div class="ag-grid-pinned-left-cells" role="presentation" style="width: 60px;">
+										<div class="ag-grid-container-wrapper" role="presentation" style="width: 60px;">
+											<div role="rowheader" col-id="ag-Grid-RowNumbersColumn" tabindex="-1" class="ag-cell ag-cell-not-inline-editing ag-cell-normal-height ag-cell-last-left-pinned ag-column-first ag-row-number-cell ag-row-number-selection-enabled ag-cell-value" aria-colindex="1" style="left: 0px; width: 60px;">
+												2
+											</div>
+										</div>
+									</div>
+									<div class="ag-grid-scrolling-cells" role="presentation">
+										<div class="ag-grid-container-wrapper" role="presentation" style="width: 1260px;">
+											<div role="gridcell" col-id="country" tabindex="-1" class="ag-cell ag-cell-not-inline-editing ag-cell-normal-height ag-cell-value" aria-colindex="2" style="left: 0px; width: 210px;">
+												Venezuela
+											</div>
+											<div role="gridcell" col-id="sport" tabindex="-1" class="ag-cell ag-cell-not-inline-editing ag-cell-normal-height ag-cell-value" aria-colindex="3" style="left: 210px; width: 210px;">
+												🏒 Ice Hockey
+											</div>
+											<div role="gridcell" col-id="name" tabindex="-1" class="ag-cell ag-cell-not-inline-editing ag-cell-normal-height ag-cell-value" aria-colindex="4" style="left: 420px; width: 210px;">
+												Isabella Jacoby
+											</div>
+										</div>
+									</div>
+								</div>
+								<div role="row" row-index="2" row-id="2" tabindex="0" class="ag-row-even ag-row-no-focus ag-row ag-row-level-0" aria-rowindex="4">
+									<div class="ag-grid-pinned-left-cells" role="presentation" style="width: 60px;">
+										<div class="ag-grid-container-wrapper" role="presentation" style="width: 60px;">
+											<div role="rowheader" col-id="ag-Grid-RowNumbersColumn" tabindex="-1" class="ag-cell ag-cell-not-inline-editing ag-cell-normal-height ag-cell-last-left-pinned ag-column-first ag-row-number-cell ag-row-number-selection-enabled ag-cell-value" aria-colindex="1" style="left: 0px; width: 60px;">
+												3
+											</div>
+										</div>
+									</div>
+									<div class="ag-grid-scrolling-cells" role="presentation">
+										<div class="ag-grid-container-wrapper" role="presentation" style="width: 1260px;">
+											<div role="gridcell" col-id="country" tabindex="-1" class="ag-cell ag-cell-not-inline-editing ag-cell-normal-height ag-cell-value" aria-colindex="2" style="left: 0px; width: 210px;">
+												Belgium
+											</div>
+											<div role="gridcell" col-id="sport" tabindex="-1" class="ag-cell ag-cell-not-inline-editing ag-cell-normal-height ag-cell-value" aria-colindex="3" style="left: 210px; width: 210px;">
+												🏹 Archery
+											</div>
+											<div role="gridcell" col-id="name" tabindex="-1" class="ag-cell ag-cell-not-inline-editing ag-cell-normal-height ag-cell-value" aria-colindex="4" style="left: 420px; width: 210px;">
+												Daisy Kingston
+											</div>
+										</div>
+									</div>
+								</div>
+								<div role="row" row-index="3" row-id="3" tabindex="0" class="ag-row-odd ag-row-no-focus ag-row ag-row-level-0" aria-rowindex="5">
+									<div class="ag-grid-pinned-left-cells" role="presentation" style="width: 60px;">
+										<div class="ag-grid-container-wrapper" role="presentation" style="width: 60px;">
+											<div role="rowheader" col-id="ag-Grid-RowNumbersColumn" tabindex="-1" class="ag-cell ag-cell-not-inline-editing ag-cell-normal-height ag-cell-last-left-pinned ag-column-first ag-row-number-cell ag-row-number-selection-enabled ag-cell-value" aria-colindex="1" style="left: 0px; width: 60px;">
+												4
+											</div>
+										</div>
+									</div>
+									<div class="ag-grid-scrolling-cells" role="presentation">
+										<div class="ag-grid-container-wrapper" role="presentation" style="width: 1260px;">
+											<div role="gridcell" col-id="country" tabindex="-1" class="ag-cell ag-cell-not-inline-editing ag-cell-normal-height ag-cell-value" aria-colindex="2" style="left: 0px; width: 210px;">
+												Norway
+											</div>
+											<div role="gridcell" col-id="sport" tabindex="-1" class="ag-cell ag-cell-not-inline-editing ag-cell-normal-height ag-cell-value" aria-colindex="3" style="left: 210px; width: 210px;">
+												🏏 Cricket
+											</div>
+											<div role="gridcell" col-id="name" tabindex="-1" class="ag-cell ag-cell-not-inline-editing ag-cell-normal-height ag-cell-value" aria-colindex="4" style="left: 420px; width: 210px;">
+												Grace Jett
+											</div>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
 </div>
+
 `;

--- a/packages/ag-grid-community/src/gridBodyComp/gridBodyCtrl.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/gridBodyCtrl.ts
@@ -242,7 +242,7 @@ export class GridBodyCtrl extends BeanStub {
 
     private updateAnchorWidth(): void {
         const anchorWidth = this.getViewportWidthWithoutScrollbar();
-        this.eGridViewport.style.setProperty('--ag-fw-anchor-width', `${anchorWidth}px`);
+        this.eGridViewport.style.setProperty('--ag-internal-fw-anchor-width', `${anchorWidth}px`);
     }
 
     private setGridRole(): void {
@@ -325,8 +325,8 @@ export class GridBodyCtrl extends BeanStub {
         const leftOffset = isRtl ? scrollbarWidth : 0;
         const rightOffset = isRtl ? 0 : scrollbarWidth;
 
-        eGridBody.style.setProperty('--ag-pinned-left-sticky-offset', `${leftOffset}px`);
-        eGridBody.style.setProperty('--ag-pinned-right-sticky-offset', `${rightOffset}px`);
+        eGridBody.style.setProperty('--ag-internal-pinned-left-sticky-offset', `${leftOffset}px`);
+        eGridBody.style.setProperty('--ag-internal-pinned-right-sticky-offset', `${rightOffset}px`);
     }
 
     // if we do not do this, then the user can select a pic in the grid (eg an image in a custom cell renderer)

--- a/packages/ag-grid-community/src/theming/core/css/_general.css
+++ b/packages/ag-grid-community/src/theming/core/css/_general.css
@@ -341,7 +341,7 @@
         }
     }
 
-    :where(.ag-body-horizontal-scroll .ag-grid-scrolling-cells) {
+    :where(.ag-grid-scrolling-cells) {
         /* when scrollable, offset for the vertical scrollbar on the left in rtl. */
         margin-left: var(--ag-internal-pinned-left-sticky-offset, 0);
     }

--- a/packages/ag-grid-community/src/theming/core/css/_general.css
+++ b/packages/ag-grid-community/src/theming/core/css/_general.css
@@ -125,7 +125,7 @@
 .ag-full-width-anchor {
     position: sticky;
     left: 0;
-    width: var(--ag-fw-anchor-width, 100%);
+    width: var(--ag-internal-fw-anchor-width, 100%);
     height: 100%;
 }
 
@@ -310,13 +310,13 @@
 .ag-grid-pinned-left-cells {
     /* offset pinned-left cells when the vertical scrollbar is rendered on the left (RTL). */
     /* rtl:ignore */
-    left: var(--ag-pinned-left-sticky-offset, 0);
+    left: var(--ag-internal-pinned-left-sticky-offset, 0);
 }
 
 .ag-grid-pinned-right-cells {
     /* offset pinned-right cells when the vertical scrollbar is rendered on the right (LTR). */
     /* rtl:ignore */
-    right: var(--ag-pinned-right-sticky-offset, 0);
+    right: var(--ag-internal-pinned-right-sticky-offset, 0);
 }
 
 /* place pinned-right after the ::after spacer so the spacer fills the gap between
@@ -343,7 +343,7 @@
 
     :where(.ag-body-horizontal-scroll .ag-grid-scrolling-cells) {
         /* when scrollable, offset for the vertical scrollbar on the left in rtl. */
-        margin-left: var(--ag-pinned-left-sticky-offset, 0);
+        margin-left: var(--ag-internal-pinned-left-sticky-offset, 0);
     }
 }
 


### PR DESCRIPTION
Fix [AG-17486](https://ag-grid.atlassian.net/browse/AG-17486)

Two follow-up fixes for the theme builder after the AG-16834 single-container row rendering refactor.

**Prefix internal vars to prevent missing property validation errors**

AG-16834 added three CSS variables that the grid's JS sets on DOM elements and reads back in CSS, but without the `--ag-internal-` prefix. The theme builder's unused-param validation only exempts `--ag-(internal|inherited)-*`, so it logged console errors of the form `CSS contains var(--ag-fw-anchor-width) which does not match a theme param`. All three are internal JS→CSS channels, not public theme params, so they are renamed:

- `--ag-fw-anchor-width` → `--ag-internal-fw-anchor-width` (full-width row anchor width)
- `--ag-pinned-left-sticky-offset` → `--ag-internal-pinned-left-sticky-offset`
- `--ag-pinned-right-sticky-offset` → `--ag-internal-pinned-right-sticky-offset`

**Fix theme builder preset preview appearance**

Updated the static preset preview snapshot (`PresetRender.tsx`) so its DOM structure matches the current single-container grid, removing the visual artifacts in the preview thumbnails.

**Fix RTL scroll offset styles**

A bug fix in Theming code, not Theme Builder per se, done in this PR because it interacts with the `--ag-internal-pinned-left-sticky-offset` change