### PR TITLE
AG-17267 Fix rowSelected event showing null browser event with groupSelects: 'descendants'

### DIFF
--- a/packages/ag-grid-community/src/interfaces/iSelectionService.ts
+++ b/packages/ag-grid-community/src/interfaces/iSelectionService.ts
@@ -24,7 +24,11 @@ export interface ISelectionService {
     setNodesSelected(params: ISetNodesSelectedParams): number;
     filterFromSelection?(predicate: (node: RowNode) => boolean): void;
     /** Should only be called if groupSelects = 'descendants' or 'filteredDescendants' in CSRM */
-    updateGroupsFromChildrenSelections?(source: SelectionEventSourceType, changedPath?: ChangedPath): boolean;
+    updateGroupsFromChildrenSelections?(
+        source: SelectionEventSourceType,
+        changedPath?: ChangedPath,
+        event?: Event
+    ): boolean;
     syncInRowNode(rowNode: RowNode, oldNode?: RowNode): void;
     reset(source: SelectionEventSourceType): void;
     getBestCostNodeSelection(): RowNode[] | undefined;

--- a/packages/ag-grid-community/src/selection/baseSelectionService.ts
+++ b/packages/ag-grid-community/src/selection/baseSelectionService.ts
@@ -111,7 +111,11 @@ export abstract class BaseSelectionService extends BeanStub {
         this.beans.ariaAnnounce?.announceValue(label, 'rowSelection');
     }
 
-    public updateGroupsFromChildrenSelections?(source: SelectionEventSourceType, changedPath?: ChangedPath): boolean;
+    public updateGroupsFromChildrenSelections?(
+        source: SelectionEventSourceType,
+        changedPath?: ChangedPath,
+        event?: Event
+    ): boolean;
 
     public abstract setNodesSelected(params: ISetNodesSelectedParams): number;
 

--- a/packages/ag-grid-community/src/selection/selectionService.ts
+++ b/packages/ag-grid-community/src/selection/selectionService.ts
@@ -167,7 +167,7 @@ export class SelectionService extends BaseSelectionService implements NamedBean,
             }
 
             if (this.groupSelectsDescendants && node.childrenAfterGroup?.length) {
-                updatedCount += this.selectChildren(node, newValue, source);
+                updatedCount += this.selectChildren(node, newValue, source, event);
             }
         }
 
@@ -184,7 +184,7 @@ export class SelectionService extends BaseSelectionService implements NamedBean,
 
             // only if we selected something, then update groups and fire events
             if (updatedCount > 0) {
-                this.updateGroupsFromChildrenSelections(source);
+                this.updateGroupsFromChildrenSelections(source, undefined, event);
 
                 // this is the very end of the 'action node', so we finished all the updates,
                 // including any parent / child changes that this method caused
@@ -221,7 +221,7 @@ export class SelectionService extends BaseSelectionService implements NamedBean,
         return updatedCount;
     }
 
-    private selectChildren(node: RowNode, newValue: boolean, source: SelectionEventSourceType): number {
+    private selectChildren(node: RowNode, newValue: boolean, source: SelectionEventSourceType, event?: Event): number {
         const children = this.groupSelectsFiltered ? node.childrenAfterAggFilter : node.childrenAfterGroup;
 
         if (!children) {
@@ -233,6 +233,7 @@ export class SelectionService extends BaseSelectionService implements NamedBean,
             clearSelection: false,
             suppressFinishActions: true,
             source,
+            event,
             nodes: children,
         });
     }
@@ -267,7 +268,8 @@ export class SelectionService extends BaseSelectionService implements NamedBean,
 
     public override updateGroupsFromChildrenSelections(
         source: SelectionEventSourceType,
-        changedPath?: ChangedPath
+        changedPath?: ChangedPath,
+        event?: Event
     ): boolean {
         // we only do this when group selection state depends on selected children
         if (!this.groupSelectsDescendants) {
@@ -290,7 +292,7 @@ export class SelectionService extends BaseSelectionService implements NamedBean,
             if (rowNode !== rootNode) {
                 const selected = this.calculateSelectedFromChildren(rowNode);
                 selectionChanged =
-                    this.selectRowNode(rowNode, selected === null ? false : selected, undefined, source) ||
+                    this.selectRowNode(rowNode, selected === null ? false : selected, event, source) ||
                     selectionChanged;
             }
         };

--- a/testing/behavioural/src/grouping-data/grouping-selection.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-selection.test.ts
@@ -1,7 +1,9 @@
+import type { RowSelectedEvent } from 'ag-grid-community';
 import { ClientSideRowModelModule, RowSelectionModule, TextFilterModule } from 'ag-grid-community';
 import { RowGroupingModule } from 'ag-grid-enterprise';
 
 import { GridColumns, GridRows, TestGridsManager, applyTransactionChecked, cachedJSONObjects } from '../test-utils';
+import { waitForEvent } from '../test-utils/test-utils-events';
 
 describe('ag-grid grouping selection', () => {
     const gridsManager = new TestGridsManager({
@@ -316,6 +318,59 @@ describe('ag-grid grouping selection', () => {
             · │ └── LEAF id:4 country:"Italy" year:2020 athlete:"Mario Rossi" sport:"Soccer"
             · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2021 ag-Grid-AutoColumn:2021
             · · └── LEAF id:5 country:"Italy" year:2021 athlete:"Luigi Verdi" sport:"Football"
+        `);
+    });
+
+    test('AG-17267 rowSelected event includes browser event for group and descendants', async () => {
+        const rowData = cachedJSONObjects.array([
+            { id: '1', country: 'Ireland', athlete: 'Alice' },
+            { id: '2', country: 'Ireland', athlete: 'Bob' },
+            { id: '3', country: 'Italy', athlete: 'Carlo' },
+        ]);
+
+        const events: RowSelectedEvent[] = [];
+
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
+            autoGroupColumnDef: { headerName: 'Country' },
+            animateRows: false,
+            rowSelection: {
+                mode: 'multiRow',
+                groupSelects: 'descendants',
+                enableClickSelection: true,
+            },
+            groupDefaultExpanded: -1,
+            rowData,
+            getRowId: (params) => params.data.id,
+            onRowSelected: (e) => events.push(e),
+        });
+
+        await waitForEvent('firstDataRendered', api);
+
+        const groupNode = api.getRowNode('row-group-country-Ireland')!;
+        const mouseEvent = new MouseEvent('click', { bubbles: true });
+
+        // Access the selection service via the internal bean collection
+        const beans = (groupNode as any).beans;
+        beans.selectionSvc.handleSelectionEvent(mouseEvent, groupNode, 'rowClicked');
+
+        // The grid dispatches rowSelected events asynchronously via setTimeout
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        // All three rowSelected events (group + 2 leaves) should carry the browser event
+        expect(events.length).toBe(3);
+        for (const e of events) {
+            expect(e.event).toBe(mouseEvent);
+        }
+
+        // Verify the group and its children are all selected
+        await new GridRows(api, 'after group selection').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP selected id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"
+            │ ├── LEAF selected id:1 country:"Ireland" athlete:"Alice"
+            │ └── LEAF selected id:2 country:"Ireland" athlete:"Bob"
+            └─┬ LEAF_GROUP id:row-group-country-Italy ag-Grid-AutoColumn:"Italy"
+            · └── LEAF id:3 country:"Italy" athlete:"Carlo"
         `);
     });
 });

--- a/testing/behavioural/src/grouping-data/grouping-selection.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-selection.test.ts
@@ -349,21 +349,17 @@ describe('ag-grid grouping selection', () => {
 
         const groupNode = api.getRowNode('row-group-country-Ireland')!;
         const mouseEvent = new MouseEvent('click', { bubbles: true });
+        const { selectionSvc } = (groupNode as any).beans;
+        selectionSvc.handleSelectionEvent(mouseEvent, groupNode, 'rowClicked');
 
-        // Access the selection service via the internal bean collection
-        const beans = (groupNode as any).beans;
-        beans.selectionSvc.handleSelectionEvent(mouseEvent, groupNode, 'rowClicked');
-
-        // The grid dispatches rowSelected events asynchronously via setTimeout
+        // gridOptions callbacks are dispatched asynchronously via setTimeout
         await new Promise((resolve) => setTimeout(resolve, 0));
 
-        // All three rowSelected events (group + 2 leaves) should carry the browser event
         expect(events.length).toBe(3);
         for (const e of events) {
             expect(e.event).toBe(mouseEvent);
         }
 
-        // Verify the group and its children are all selected
         await new GridRows(api, 'after group selection').check(`
             ROOT id:ROOT_NODE_ID
             ├─┬ LEAF_GROUP selected id:row-group-country-Ireland ag-Grid-AutoColumn:"Ireland"


### PR DESCRIPTION
## Summary

- Thread the browser `Event` through `selectChildren()` and `updateGroupsFromChildrenSelections()` so that all `rowSelected` events fired when `groupSelects: 'descendants'` carry the originating click event
- Previously, clicking a group row produced `rowSelected` events with `event: null` for descendant leaf nodes and parent group nodes — only the directly-clicked group node had the browser event
- Add behavioural test verifying all three `rowSelected` events (group + 2 leaf descendants) carry the same `MouseEvent`

## Test plan

- [x] Behavioural test: `grouping-selection.test.ts` — all 5 tests pass
- [x] Selection test suite: all 433 selection-related behavioural tests pass (20 files)
- [x] Grouping test suite: all 2372 grouping-related behavioural tests pass (86 files)
- [x] Type-check: `build:types ag-grid-community` passes
- [x] Lint: `lint ag-grid-community` passes

Fix AG-17267