### PR TITLE
AG-17514: Return null instead of undefined for sortType in getColumnState()

### DIFF
--- a/packages/ag-grid-community/src/columns/columnStateUtils.ts
+++ b/packages/ag-grid-community/src/columns/columnStateUtils.ts
@@ -40,7 +40,7 @@ export interface ColumnStateParams {
     /** The sort direction of the column */
     sort?: SortDirection;
     /** The type of sort applied to the column */
-    sortType?: SortType;
+    sortType?: SortType | null;
     /** The order of the sort, if sorting by many columns */
     sortIndex?: number | null;
     /** The aggregation function applied */
@@ -506,7 +506,7 @@ export function _getColumnState(beans: BeanCollection): ColumnState[] {
             hide: !column.isVisible(),
             pinned: column.getPinned(),
             sort: column.getSort(),
-            sortType: column.getSortDef()?.type,
+            sortType: column.getSortDef()?.type ?? null,
             sortIndex,
             aggFunc,
             rowGroup: column.isRowGroupActive(),

--- a/packages/ag-grid-community/src/misc/state/stateUtils.ts
+++ b/packages/ag-grid-community/src/misc/state/stateUtils.ts
@@ -52,7 +52,7 @@ export function convertColumnState(
         } = columnState[i];
         columns.push(colId);
         if (sort) {
-            sortColumns[sortIndex ?? defaultSortIndex++] = { colId, sort, type: sortType };
+            sortColumns[sortIndex ?? defaultSortIndex++] = { colId, sort, type: sortType ?? undefined };
         }
         if (rowGroup) {
             groupColIds[rowGroupIndex ?? 0] = colId;

--- a/testing/behavioural/src/columns/column-mutations/apply-column-state.test.ts
+++ b/testing/behavioural/src/columns/column-mutations/apply-column-state.test.ts
@@ -1960,6 +1960,37 @@ describe('Column Mutations - applyColumnState', () => {
                 └── a width:200 sort:desc
             `);
         });
+
+        test('unsorted column returns sortType as null for JSON serialization safety', () => {
+            const api = gridsManager.createGrid('sortTypeNull', {
+                columnDefs: [{ colId: 'a' }],
+            });
+            const a = api.getColumnState().find((s) => s.colId === 'a')!;
+            expect(a.sort).toBeNull();
+            expect(a.sortType).toBeNull();
+
+            const roundTripped = JSON.parse(JSON.stringify(api.getColumnState()));
+            api.applyColumnState({ state: roundTripped });
+            const after = api.getColumnState().find((s) => s.colId === 'a')!;
+            expect(after.sort).toBeNull();
+            expect(after.sortType).toBeNull();
+        });
+
+        test('getColumnState never contains undefined values — all unset properties use null', () => {
+            const api = gridsManager.createGrid('noUndefined', {
+                columnDefs: [{ colId: 'a' }, { colId: 'b' }],
+            });
+            const states = api.getColumnState();
+            for (const state of states) {
+                for (const [key, value] of Object.entries(state)) {
+                    expect({ colId: state.colId, key, isUndefined: value === undefined }).toEqual({
+                        colId: state.colId,
+                        key,
+                        isUndefined: false,
+                    });
+                }
+            }
+        });
     });
 
     describe('applyColumnState pivotIndex ordering', () => {


### PR DESCRIPTION
## Summary

- `getColumnState()` returned `sortType: undefined` for unsorted columns while all other nullable properties returned `null`. This broke JSON serialisation round-trips (`JSON.stringify` drops `undefined` values), causing spurious diffs when comparing column state before and after a save/restore cycle.
- Changed `sortType` to return `null` for unsorted columns, aligned the `ColumnStateParams` type (`SortType | null`), and added a guard test ensuring no `ColumnState` property ever uses `undefined`.

## Test plan

- [x] Behavioural test: unsorted column returns `sortType: null` and survives JSON round-trip
- [x] Behavioural test: structural guard verifying all `ColumnState` properties use `null` (not `undefined`) when unset
- [x] Existing sort normalisation test still passes
- [x] `build:types ag-grid-community` passes
- [x] All state-related behavioural tests pass (219 tests)

Fix [AG-17514](https://ag-grid.atlassian.net/browse/AG-17514)