### PR TITLE
Add missing ag-stack.tgz to framework package test install

### DIFF
--- a/testing/shared/run.sh
+++ b/testing/shared/run.sh
@@ -144,7 +144,7 @@ if ${production} ; then
     npm i ag-grid-${fw} @playwright/test@${playwright_version} --cache ${cache_location}
 else
     echo ">>> npm i ../ag-grid*.tgz"
-    npm i ../ag-grid-stack.tgz ../ag-grid-community.tgz ../ag-grid-enterprise.tgz ../ag-grid-${fw}.tgz @playwright/test@${playwright_version} --cache ${cache_location} --registry http://52.50.158.57:4873
+    npm i ../ag-stack.tgz ../ag-grid-community.tgz ../ag-grid-enterprise.tgz ../ag-grid-${fw}.tgz @playwright/test@${playwright_version} --cache ${cache_location} --registry http://52.50.158.57:4873
 fi
 
 patch_dir=../patches

--- a/testing/shared/run.sh
+++ b/testing/shared/run.sh
@@ -144,7 +144,7 @@ if ${production} ; then
     npm i ag-grid-${fw} @playwright/test@${playwright_version} --cache ${cache_location}
 else
     echo ">>> npm i ../ag-grid*.tgz"
-    npm i ../ag-grid-community.tgz ../ag-grid-enterprise.tgz ../ag-grid-${fw}.tgz @playwright/test@${playwright_version} --cache ${cache_location} --registry http://52.50.158.57:4873
+    npm i ../ag-grid-stack.tgz ../ag-grid-community.tgz ../ag-grid-enterprise.tgz ../ag-grid-${fw}.tgz @playwright/test@${playwright_version} --cache ${cache_location} --registry http://52.50.158.57:4873
 fi
 
 patch_dir=../patches


### PR DESCRIPTION
## Summary
- The non-production framework package tests (`testing/shared/run.sh`) were missing `ag-stack.tgz` from the `npm install` command
- `ag-stack` is a dependency of `ag-grid-community`/`ag-grid-enterprise`, so omitting it caused install failures when running framework tests against local `.tgz` builds

## Test plan
- [ ] Framework package tests (React, Angular, Vue) pass with local `.tgz` builds