### PR TITLE
AG-17134 Allow OneTrust, ZoomInfo blob + GA4 regional in grid CSP

### DIFF
--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
@@ -76,6 +76,8 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://www.google.com', // reCAPTCHA
             'https://www.gstatic.com', // reCAPTCHA
             'https://www.youtube.com', // YouTube iframe JS API (loads into the page)
+            'https://cdn.cookielaw.org', // OneTrust cookie-consent SDK (GTM-injected, prod-only)
+            'blob:', // ZoomInfo zi-tag.js bootstraps a blob: URL script
             UNSAFE_INLINE,
             UNSAFE_EVAL,
         ],
@@ -105,7 +107,7 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://plausible.io',
             'https://*.algolia.net',
             'https://*.algolianet.com',
-            'https://www.google-analytics.com',
+            'https://*.google-analytics.com', // GA4 incl. regional collect endpoints (region1/2.google-analytics.com)
             'https://*.analytics.google.com',
             'https://stats.g.doubleclick.net',
             'https://flagcdn.com',
@@ -115,6 +117,8 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://js.zi-scripts.com', // ZoomInfo
             'https://*.zoominfo.com', // ZoomInfo
             'https://www.google.com', // reCAPTCHA (api2/clr XHR)
+            'https://cdn.cookielaw.org', // OneTrust config/JSON/asset XHR (GTM-injected, prod-only)
+            'https://*.onetrust.com', // OneTrust geolocation + consent-receipt endpoints
             trialFormOrigin,
         ],
         'frame-src': [


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17134

Ports the charts production CSP report-only fixes (ag-grid/ag-charts#7018 + ag-grid/ag-charts#7021) to the grid root policy. www.ag-grid.com uses a single www-wide GTM container, so grid root pages fire the same production-only tags charts did:

- **OneTrust** cookie-consent SDK (GTM-injected): `cdn.cookielaw.org` in script-src; `cdn.cookielaw.org` + `*.onetrust.com` in connect-src.
- **ZoomInfo** `zi-tag.js` blob: URL script: `blob:` in script-src.
- **GA4** geo-routed regional collect endpoint: `www.google-analytics.com` → `*.google-analytics.com` in connect-src.

Report-only — no enforced behaviour change. Targeting `b35.3.1` to match production; will port to `latest` after production testing. To be validated against grid prod after deploy.

