### PR TITLE
AG-17134 Allow ecommerce checkout origins (Firebase Auth + Realex) in grid CSP

### DIFF
--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
@@ -52,6 +52,16 @@ const SALESFORCE_FORM_ORIGIN: Record<CspEnv, string> = {
     production: 'https://webto.salesforce.com',
 };
 
+// The ecommerce checkout renders the Realex/Global Payments Hosted Payment Page
+// (rxp-hpp.js) in an iframe and POSTs the payment form to it — sandbox host in
+// non-prod, live host in production (see globalPaymentsServiceUrl in the
+// ag-grid-ecommerce frontend environments). Governs frame-src and form-action.
+const REALEX_HPP_ORIGIN: Record<CspEnv, string> = {
+    dev: 'https://pay.sandbox.realexpayments.com',
+    staging: 'https://pay.sandbox.realexpayments.com',
+    production: 'https://pay.realexpayments.com',
+};
+
 // Dev-server-only extras (HMR + cross-port preview). Never emitted for staging
 // or production.
 const DEV_SCRIPT_SRC = ['https://localhost:4610', 'https://localhost:4611'];
@@ -61,6 +71,7 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
     const { env } = options;
     const trialFormOrigin = options.trialFormOrigin ?? TRIAL_FORM_ORIGIN[env];
     const salesforceFormOrigin = SALESFORCE_FORM_ORIGIN[env];
+    const realexHppOrigin = REALEX_HPP_ORIGIN[env];
 
     const directives: CspDirectives = {
         'default-src': [SELF],
@@ -119,6 +130,8 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://www.google.com', // reCAPTCHA (api2/clr XHR)
             'https://cdn.cookielaw.org', // OneTrust config/JSON/asset XHR (GTM-injected, prod-only)
             'https://*.onetrust.com', // OneTrust geolocation + consent-receipt endpoints
+            'https://www.googleapis.com', // Firebase Auth (ecommerce checkout): identitytoolkit REST
+            'https://securetoken.googleapis.com', // Firebase Auth ID-token refresh
             trialFormOrigin,
         ],
         'frame-src': [
@@ -126,6 +139,7 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://www.googletagmanager.com',
             'https://www.youtube.com',
             'https://www.google.com', // reCAPTCHA challenge iframe
+            realexHppOrigin, // ecommerce checkout: Realex Hosted Payment Page iframe
         ],
         'media-src': [SELF, 'data:', 'blob:', 'https:'],
         'worker-src': [SELF, 'blob:'],
@@ -135,6 +149,7 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             SELF,
             trialFormOrigin,
             salesforceFormOrigin,
+            realexHppOrigin, // ecommerce checkout: payment form POST to Realex HPP
             'https://codesandbox.io', // example-runner "Open in CodeSandbox" form POST
             'https://plnkr.co', // example-runner "Open in Plunker" form POST
         ],


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17134

Follow-up to #13968. The grid **ecommerce / license-checkout** flow surfaced report-only CSP violations on production:

- **Firebase Auth** (the checkout signs in anonymously) — XHR to `www.googleapis.com/identitytoolkit/...`; the SDK (v8) also refreshes ID tokens via `securetoken.googleapis.com`. Added both to `connect-src`.
- **Realex / Global Payments Hosted Payment Page** (`rxp-hpp.js`) — rendered as an **iframe** and the payment form is **POSTed** to it. Added to `frame-src` + `form-action`, env-split (mirrors the existing trial-form pattern): `pay.sandbox.realexpayments.com` in dev/staging, `pay.realexpayments.com` in production.

Verified the generated production policy (live realex host) and staging policy (sandbox realex host). Report-only — no enforced behaviour change. Targeting `b35.3.1` to match production.
