### PR TITLE
AG-17512 Fix RTL header columns offset by vertical scrollbar width

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -831,7 +831,6 @@
 
     .ag-rtl .ag-row .ag-grid-scrolling-cells {
         // when scrollable, offset for the vertical scrollbar on the left in rtl.
-        // scoped to body rows: header rows have no vertical scrollbar of their own.
         margin-left: var(--ag-internal-pinned-left-sticky-offset, 0px);
     }
 

--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -829,8 +829,9 @@
         }
     }
 
-    .ag-rtl .ag-grid-scrolling-cells {
+    .ag-rtl .ag-row .ag-grid-scrolling-cells {
         // when scrollable, offset for the vertical scrollbar on the left in rtl.
+        // scoped to body rows: header rows have no vertical scrollbar of their own.
         margin-left: var(--ag-internal-pinned-left-sticky-offset, 0px);
     }
 

--- a/packages/ag-grid-community/src/theming/core/css/_general.css
+++ b/packages/ag-grid-community/src/theming/core/css/_general.css
@@ -345,7 +345,6 @@
 
     :where(.ag-row .ag-grid-scrolling-cells) {
         /* when scrollable, offset for the vertical scrollbar on the left in rtl. */
-        /* scoped to body rows: header rows have no vertical scrollbar of their own. */
         margin-left: var(--ag-internal-pinned-left-sticky-offset, 0);
     }
 }

--- a/packages/ag-grid-community/src/theming/core/css/_general.css
+++ b/packages/ag-grid-community/src/theming/core/css/_general.css
@@ -343,8 +343,9 @@
         }
     }
 
-    :where(.ag-grid-scrolling-cells) {
+    :where(.ag-row .ag-grid-scrolling-cells) {
         /* when scrollable, offset for the vertical scrollbar on the left in rtl. */
+        /* scoped to body rows: header rows have no vertical scrollbar of their own. */
         margin-left: var(--ag-internal-pinned-left-sticky-offset, 0);
     }
 }


### PR DESCRIPTION
Fix [AG-17512](https://ag-grid.atlassian.net/browse/AG-17512)

In RTL, the column header row (and the select-all header checkbox) was misaligned with the body — shifted right by the width of the vertical scrollbar.

The cause was that `margin-left: var(--ag-internal-pinned-left-sticky-offset)` on `.ag-grid-scrolling-cells` should only apply to the body, not the header.