### PR TITLE
AG-14740 Prevent pagination panel text from changing size when navigating

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_footer.scss
+++ b/community-modules/styles/src/internal/base/parts/_footer.scss
@@ -38,6 +38,23 @@
         line-height: 0;
     }
 
+    .ag-paging-row-summary-panel {
+        display: inline-grid;
+
+        &::before {
+            content: var(--ag-internal-pagination-width-string);
+            grid-area: 1/1;
+            visibility: hidden;
+            font-weight: 500;
+            font-variant-numeric: tabular-nums;
+        }
+    }
+
+    .ag-paging-row-summary-content {
+        grid-area: 1/1;
+        justify-self: center;
+    }
+
     .ag-status-bar {
         border-top: var(--ag-borders) var(--ag-border-color);
         color: var(--ag-disabled-foreground-color);

--- a/packages/ag-grid-community/src/pagination/paginationComp.css
+++ b/packages/ag-grid-community/src/pagination/paginationComp.css
@@ -54,3 +54,20 @@
     /* avoids misalignment of buttons and text */
     line-height: 0;
 }
+
+.ag-paging-row-summary-panel {
+    display: inline-grid;
+
+    &::before {
+        content: var(--ag-internal-pagination-width-string);
+        grid-area: 1/1;
+        visibility: hidden;
+        font-weight: 500;
+        font-variant-numeric: tabular-nums;
+    }
+}
+
+.ag-paging-row-summary-content {
+    grid-area: 1/1;
+    justify-self: center;
+}

--- a/packages/ag-grid-community/src/pagination/paginationComp.css
+++ b/packages/ag-grid-community/src/pagination/paginationComp.css
@@ -57,14 +57,14 @@
 
 .ag-paging-row-summary-panel {
     display: inline-grid;
+}
 
-    &::before {
-        content: var(--ag-internal-pagination-width-string);
-        grid-area: 1/1;
-        visibility: hidden;
-        font-weight: 500;
-        font-variant-numeric: tabular-nums;
-    }
+.ag-paging-row-summary-panel::before {
+    content: var(--ag-internal-pagination-width-string);
+    grid-area: 1/1;
+    visibility: hidden;
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
 }
 
 .ag-paging-row-summary-content {

--- a/packages/ag-grid-community/src/pagination/rowSummaryComp.ts
+++ b/packages/ag-grid-community/src/pagination/rowSummaryComp.ts
@@ -123,9 +123,10 @@ export class RowSummaryComp extends Component {
         const strOf = localeTextFunc('of', 'of');
         this.ariaStatus = `${lbFirstRowOnPage} ${strTo} ${lbLastRowOnPage} ${strOf} ${lbRecordCount}`;
 
+        const esc = (s: string) => s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
         this.getGui().style.setProperty(
             '--ag-internal-pagination-width-string',
-            `'${lbRecordCount} ${strTo} ${lbRecordCount} ${strOf} ${lbRecordCount}'`.replaceAll(/\d/g, '0')
+            `'${lbRecordCount} ${esc(strTo)} ${lbRecordCount} ${esc(strOf)} ${lbRecordCount}'`.replaceAll(/\d/g, '0')
         );
     }
 }

--- a/packages/ag-grid-community/src/pagination/rowSummaryComp.ts
+++ b/packages/ag-grid-community/src/pagination/rowSummaryComp.ts
@@ -123,7 +123,7 @@ export class RowSummaryComp extends Component {
         const strOf = localeTextFunc('of', 'of');
         this.ariaStatus = `${lbFirstRowOnPage} ${strTo} ${lbLastRowOnPage} ${strOf} ${lbRecordCount}`;
 
-        const esc = (s: string) => s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+        const esc = (s: string) => s.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\s+/g, ' ');
         this.getGui().style.setProperty(
             '--ag-internal-pagination-width-string',
             `'${lbRecordCount} ${esc(strTo)} ${lbRecordCount} ${esc(strOf)} ${lbRecordCount}'`.replaceAll(/\d/g, '0')

--- a/packages/ag-grid-community/src/pagination/rowSummaryComp.ts
+++ b/packages/ag-grid-community/src/pagination/rowSummaryComp.ts
@@ -35,23 +35,29 @@ export class RowSummaryComp extends Component {
             children: [
                 {
                     tag: 'span',
-                    ref: 'lbFirstRowOnPage',
-                    cls: 'ag-paging-row-summary-panel-number',
-                    attrs: { id: `${idPrefix}-first-row` },
-                },
-                { tag: 'span', attrs: { id: `${idPrefix}-to` }, children: localeTextFunc('to', 'to') },
-                {
-                    tag: 'span',
-                    ref: 'lbLastRowOnPage',
-                    cls: 'ag-paging-row-summary-panel-number',
-                    attrs: { id: `${idPrefix}-last-row` },
-                },
-                { tag: 'span', attrs: { id: `${idPrefix}-of` }, children: localeTextFunc('of', 'of') },
-                {
-                    tag: 'span',
-                    ref: 'lbRecordCount',
-                    cls: 'ag-paging-row-summary-panel-number',
-                    attrs: { id: `${idPrefix}-row-count` },
+                    cls: 'ag-paging-row-summary-content',
+                    children: [
+                        {
+                            tag: 'span',
+                            ref: 'lbFirstRowOnPage',
+                            cls: 'ag-paging-row-summary-panel-number',
+                            attrs: { id: `${idPrefix}-first-row` },
+                        },
+                        { tag: 'span', attrs: { id: `${idPrefix}-to` }, children: localeTextFunc('to', 'to') },
+                        {
+                            tag: 'span',
+                            ref: 'lbLastRowOnPage',
+                            cls: 'ag-paging-row-summary-panel-number',
+                            attrs: { id: `${idPrefix}-last-row` },
+                        },
+                        { tag: 'span', attrs: { id: `${idPrefix}-of` }, children: localeTextFunc('of', 'of') },
+                        {
+                            tag: 'span',
+                            ref: 'lbRecordCount',
+                            cls: 'ag-paging-row-summary-panel-number',
+                            attrs: { id: `${idPrefix}-row-count` },
+                        },
+                    ],
                 },
             ],
         });
@@ -116,5 +122,10 @@ export class RowSummaryComp extends Component {
         const strTo = localeTextFunc('to', 'to');
         const strOf = localeTextFunc('of', 'of');
         this.ariaStatus = `${lbFirstRowOnPage} ${strTo} ${lbLastRowOnPage} ${strOf} ${lbRecordCount}`;
+
+        this.getGui().style.setProperty(
+            '--ag-internal-pagination-width-string',
+            `'${lbRecordCount} ${strTo} ${lbRecordCount} ${strOf} ${lbRecordCount}'`.replaceAll(/\d/g, '0')
+        );
     }
 }


### PR DESCRIPTION
Fix [AG-14740](https://ag-grid.atlassian.net/browse/AG-14740)

The row-summary text grows when navigating to the last page (e.g. `"1 to 10 of 8,618"` → `"8,611 to 8,618 of 8,618"`), causing the position of buttons to jump about.

This PR ensures that the width of the summary text is always large enough to handle the largest value so that it has a constant size