### PR TITLE
AG-17406 allow-updating-col-def-without-losing-ui-state

### DIFF
--- a/packages/ag-grid-community/src/columns/buildColumnTree.ts
+++ b/packages/ag-grid-community/src/columns/buildColumnTree.ts
@@ -28,6 +28,8 @@ export interface ColumnTreeBuild {
     /** Cols keyed by `colId` / `userProvidedColDef` ref / `field`; for O(1) reuse. */
     colsByKey: Map<string | ColDef, AgColumn>;
     source: ColumnEventType;
+    /** True = user (re)set the definitions, so reused cols re-apply stateful attrs; see {@link AgColumn.reapplyColDef}. */
+    newColDefs: boolean;
     buildToken: number;
     /** Padding-wrapper cache for the editable (hierarchy/calc) path; `null` for pivot result trees
      *  (a one-shot build that never splices). */
@@ -48,6 +50,7 @@ export function _buildColumnTree(
     existingColsByKey: Map<string | ColDef, AgColumn>,
     existingColsById: { readonly [id: string]: AgColumn },
     source: ColumnEventType,
+    newColDefs: boolean,
     buildToken: number,
     wrapperCache: ColWrapperCache | null
 ): ColumnTreeBuild {
@@ -160,7 +163,7 @@ export function _buildColumnTree(
                 if (isReusableUserCol(existing) && userDef && userDef.colId == null && userDef.field == null) {
                     allocatedKeys.add(id);
                     existing.buildToken = buildToken;
-                    existing.reapplyColDef(def, source);
+                    existing.reapplyColDef(def, source, newColDefs);
                     return existing;
                 }
                 continue;
@@ -177,7 +180,7 @@ export function _buildColumnTree(
         const keyed = existingColsByKey.get(base);
         if (keyed?.colId === base && isReusableUserCol(keyed)) {
             keyed.buildToken = buildToken;
-            keyed.reapplyColDef(def, source);
+            keyed.reapplyColDef(def, source, newColDefs);
             return keyed;
         }
         let count = 0;
@@ -201,7 +204,7 @@ export function _buildColumnTree(
             }
             if (existing !== undefined) {
                 existing.buildToken = buildToken;
-                existing.reapplyColDef(def, source);
+                existing.reapplyColDef(def, source, newColDefs);
                 return existing;
             }
             return _createUserColumn(beans, def, id, primaryColumns, buildToken);
@@ -230,7 +233,7 @@ export function _buildColumnTree(
         }
         if (column !== undefined) {
             column.buildToken = buildToken;
-            column.reapplyColDef(def, source);
+            column.reapplyColDef(def, source, newColDefs);
         } else {
             const field = def.field;
             column = colId == null && field == null ? buildAnonymousColumn(def) : buildKeyedColumn(def, colId, field);
@@ -275,6 +278,7 @@ export function _buildColumnTree(
             groupsById: newGroupsById,
             colsByKey: newColsByKey,
             source,
+            newColDefs,
             buildToken,
             wrapperCache,
         };
@@ -489,6 +493,7 @@ export function _buildColumnTree(
         groupsById: newGroupsById,
         colsByKey: newColsByKey,
         source,
+        newColDefs,
         buildToken,
         wrapperCache,
     };

--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -185,14 +185,15 @@ export class ColumnModel extends BeanStub implements NamedBean {
 
         const builder = _buildColumnTree(
             beans,
-            colDefs,
-            true,
-            this.colDefGroupsById,
-            this.colDefColsByKey,
-            this.colsById,
-            source,
-            this.nextBuildToken(),
-            this.hierarchyWrapperCache
+            /* defs */ colDefs,
+            /* primaryColumns */ true,
+            /* existingGroupsById */ this.colDefGroupsById,
+            /* existingColsByKey */ this.colDefColsByKey,
+            /* existingColsById */ this.colsById,
+            /* source */ source,
+            /* newColDefs */ newColDefs,
+            /* buildToken */ this.nextBuildToken(),
+            /* wrapperCache */ this.hierarchyWrapperCache
         );
         groupHierarchyColSvc?.contributeTo(builder);
         calculatedColsSvc?.contributeTo(builder);

--- a/packages/ag-grid-community/src/entities/agColumn.ts
+++ b/packages/ag-grid-community/src/entities/agColumn.ts
@@ -220,24 +220,27 @@ export class AgColumn<TValue = any>
         return true;
     }
 
-    /** Re-apply `def` to `column`, keeping its colDef and runtime state in sync. */
-    public reapplyColDef(def: ColDef, source: ColumnEventType): void {
+    /** Re-apply `def` to a reused column. Stateful attrs are only (re)applied when the user authored the
+     *  definitions (`newColDefs`); an internal rebuild (e.g. calc-col add) must leave live state intact. */
+    public reapplyColDef(def: ColDef, source: ColumnEventType, newColDefs: boolean): void {
         const merged = _addColumnDefaultAndTypes(this.beans, def, this.colId);
         this.setColDef(merged, def, source);
-        updateSomeColumnState(
-            this.beans,
-            this,
-            merged.hide,
-            merged.sort,
-            merged.sortIndex,
-            merged.pinned,
-            merged.flex,
-            source
-        );
-        // Width is owned by the flex layout while flexing, so only set it when not.
-        const colFlex = this.flex;
-        if (colFlex == null || colFlex <= 0) {
-            this.setActualWidth(merged.width ?? this.actualWidth, source);
+        if (newColDefs) {
+            updateSomeColumnState(
+                this.beans,
+                this,
+                merged.hide,
+                merged.sort,
+                merged.sortIndex,
+                merged.pinned,
+                merged.flex,
+                source
+            );
+            // Read `flex` after the state update so a flex→fixed switch applies before width.
+            const colFlex = this.flex;
+            if (colFlex == null || colFlex <= 0) {
+                this.setActualWidth(merged.width ?? this.actualWidth, source);
+            }
         }
     }
 

--- a/packages/ag-grid-enterprise/src/calculatedColumns/calculatedColumnsService.ts
+++ b/packages/ag-grid-enterprise/src/calculatedColumns/calculatedColumnsService.ts
@@ -330,8 +330,9 @@ export class CalculatedColumnsService extends BeanStub implements NamedBean, ICa
         // missing/removed anchor (or none) falls back to a plain append.
         const source = build.source;
         const buildToken = build.buildToken;
+        const newColDefs = build.newColDefs;
         dynamicColumns.forEach((dc, colId) => {
-            const agCol = this.getOrCreateAgColumn(dc, colId, buildToken, source);
+            const agCol = this.getOrCreateAgColumn(dc, colId, buildToken, source, newColDefs);
             agCol.buildToken = buildToken; // So the post-build sweep keeps the col alive.
             const anchorId = dc.anchorColId;
             if (anchorId != null && anchorId !== colId && staticColOverrides.get(anchorId) !== null) {
@@ -389,7 +390,8 @@ export class CalculatedColumnsService extends BeanStub implements NamedBean, ICa
         dc: DynamicCalculatedColumn,
         colId: string,
         buildToken: number,
-        source: ColumnEventType
+        source: ColumnEventType,
+        newColDefs: boolean
     ): AgColumn {
         const beans = this.beans;
         const existing = dc.instance;
@@ -397,7 +399,7 @@ export class CalculatedColumnsService extends BeanStub implements NamedBean, ICa
             // Reuse the owned instance (always alive: contributed/stamped every refresh, nulled when
             // parked/removed). Restamp + refresh colDef in case expression/cellDataType changed.
             existing.buildToken = buildToken;
-            existing.reapplyColDef(dc.colDef, source);
+            existing.reapplyColDef(dc.colDef, source, newColDefs);
             return existing;
         }
         const agCol = _createUserColumn(beans, dc.colDef, colId, true, buildToken);

--- a/packages/ag-grid-enterprise/src/pivot/pivotResultColsService.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotResultColsService.ts
@@ -185,14 +185,16 @@ export class PivotResultColsService extends BeanStub implements NamedBean, IPivo
         const buildToken = beans.colModel.nextBuildToken();
         const balanced = _buildColumnTree(
             beans,
-            colDefs,
-            false,
-            this.pivotGroupsById,
-            this.pivotColsByKey,
-            beans.colModel.colsById,
-            source,
-            buildToken,
-            null
+            /* defs */ colDefs,
+            /* primaryColumns */ false,
+            /* existingGroupsById */ this.pivotGroupsById,
+            /* existingColsByKey */ this.pivotColsByKey,
+            /* existingColsById */ beans.colModel.colsById,
+            /* source */ source,
+            // Generated cols: re-apply their stateful attrs each pivot rebuild (pre-live-state-flag behaviour).
+            /* newColDefs */ true,
+            /* buildToken */ buildToken,
+            /* wrapperCache */ null
         );
         // `previousTree` (not `currentPivotTree`) covers the clear/restore window where `currentPivotTree` is
         // null but saved bean refs survive. Skip the sweep when the tree is missing or unchanged.

--- a/testing/behavioural/src/columns/column-model-rewrite-p2.test.ts
+++ b/testing/behavioural/src/columns/column-model-rewrite-p2.test.ts
@@ -19,6 +19,7 @@ describe('column-model rewrite edge cases', () => {
     afterEach(() => {
         pivotGridsManager.reset();
         gridsManager.reset();
+        vi.restoreAllMocks();
     });
 
     const defColIds = (defs: (ColDef | any)[] | undefined): string[] => (defs ?? []).map((d) => d.colId ?? d.field);
@@ -54,6 +55,8 @@ describe('column-model rewrite edge cases', () => {
     // A pivot build must not reuse a user (primary) column whose colId collides with a generated pivot
     // colId — reuse is scoped to the same build kind (primary vs pivot result), not just colKind 'user'.
     test('pivot build does not reuse a user column that shares a generated pivot colId', async () => {
+        // The colliding colId is expected to raise warning #273 (colId suffixed) — capture and assert it.
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
         const api = pivotGridsManager.createGrid('g', {
             columnDefs: [
                 { field: 'country', rowGroup: true },
@@ -76,6 +79,9 @@ describe('column-model rewrite edge cases', () => {
         const pivotResult = api.getPivotResultColumns() ?? [];
         expect(pivotResult).not.toContain(userCol);
         expect(pivotResult.some((c) => c.getColId() === 'pivot_b_x_total_1')).toBe(true);
+
+        // Verify the suffixing warning was actually raised (not silently swallowed).
+        expect(warnSpy.mock.calls.some((args) => String(args[0]).includes('warning #273'))).toBe(true);
     });
 
     // P2-2: colId is imperative for REUSE — a column with a colId is never reused by field. Changing a

--- a/testing/behavioural/src/columns/column-mutations/setColumnDefs.test.ts
+++ b/testing/behavioural/src/columns/column-mutations/setColumnDefs.test.ts
@@ -1979,4 +1979,46 @@ describe('Column Mutations', () => {
             expect(colB.isAlive()).toBe(false);
         });
     });
+
+    describe('setColumnDefs: stateful colDef attrs still apply on update (BC)', () => {
+        test('a present pinned colDef re-applies, overwriting a runtime unpin', async () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [{ colId: 'a', pinned: 'left' }, { colId: 'b' }],
+            });
+            await new GridColumns(api, 'pinned via colDef').checkColumns(`
+                LEFT
+                └── a width:200
+                CENTER
+                └── b width:200
+            `);
+
+            api.setColumnsPinned(['a'], null);
+            await asyncSetTimeout(0);
+            expect(api.getColumn('a')!.getPinned()).toBeNull();
+
+            api.setGridOption('columnDefs', [{ colId: 'a', pinned: 'left' }, { colId: 'b' }]);
+            await asyncSetTimeout(0);
+            expect(api.getColumn('a')!.getPinned()).toBe('left');
+            await new GridColumns(api, 'pinned re-applied on update').checkColumns(`
+                LEFT
+                └── a width:200
+                CENTER
+                └── b width:200
+            `);
+        });
+
+        test('an absent pinned colDef preserves a runtime pin', async () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [{ colId: 'a' }, { colId: 'b' }],
+            });
+
+            api.setColumnsPinned(['a'], 'left');
+            await asyncSetTimeout(0);
+            expect(api.getColumn('a')!.getPinned()).toBe('left');
+
+            api.setGridOption('columnDefs', [{ colId: 'a', headerName: 'Alpha' }, { colId: 'b' }]);
+            await asyncSetTimeout(0);
+            expect(api.getColumn('a')!.getPinned()).toBe('left');
+        });
+    });
 });

--- a/testing/behavioural/src/columns/column-mutations/setColumnDefs.test.ts
+++ b/testing/behavioural/src/columns/column-mutations/setColumnDefs.test.ts
@@ -1983,6 +1983,7 @@ describe('Column Mutations', () => {
     describe('setColumnDefs: stateful colDef attrs still apply on update (BC)', () => {
         test('a present pinned colDef re-applies, overwriting a runtime unpin', async () => {
             const api = gridsManager.createGrid('myGrid', {
+                rowData: [{ a: 1, b: 2 }],
                 columnDefs: [{ colId: 'a', pinned: 'left' }, { colId: 'b' }],
             });
             await new GridColumns(api, 'pinned via colDef').checkColumns(`
@@ -2005,10 +2006,15 @@ describe('Column Mutations', () => {
                 CENTER
                 └── b width:200
             `);
+            await new GridRows(api, 'pinned re-applied on update - rows').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0
+            `);
         });
 
         test('an absent pinned colDef preserves a runtime pin', async () => {
             const api = gridsManager.createGrid('myGrid', {
+                rowData: [{ a: 1, b: 2 }],
                 columnDefs: [{ colId: 'a' }, { colId: 'b' }],
             });
 
@@ -2019,6 +2025,16 @@ describe('Column Mutations', () => {
             api.setGridOption('columnDefs', [{ colId: 'a', headerName: 'Alpha' }, { colId: 'b' }]);
             await asyncSetTimeout(0);
             expect(api.getColumn('a')!.getPinned()).toBe('left');
+            await new GridColumns(api, 'runtime pin preserved on absent-pinned update').checkColumns(`
+                LEFT
+                └── a "Alpha" width:200
+                CENTER
+                └── b width:200
+            `);
+            await new GridRows(api, 'runtime pin preserved on absent-pinned update - rows').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0
+            `);
         });
     });
 });

--- a/testing/behavioural/src/columns/order/pivot.test.ts
+++ b/testing/behavioural/src/columns/order/pivot.test.ts
@@ -1785,6 +1785,16 @@ describe('pivotMode=true', () => {
 
             expect(api.getColumn('country')!.getPinned()).toBeNull();
             expect(api.getColumn('country')!.getActualWidth()).toBe(333);
+            await new GridColumns(api, 'primary live state preserved after pivot toggle').checkColumns(`
+                CENTER
+                ├── country "Country" width:333
+                ├── sport "Sport" width:200 pivot
+                └── val "Val" width:200 aggFunc:sum
+            `);
+            await new GridRows(api, 'primary live state preserved after pivot toggle - rows').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 country:"US" sport:"swim" val:1
+            `);
         });
     });
 });

--- a/testing/behavioural/src/columns/order/pivot.test.ts
+++ b/testing/behavioural/src/columns/order/pivot.test.ts
@@ -2,7 +2,7 @@ import type { ColDef, ColGroupDef } from 'ag-grid-community';
 import { ClientSideRowModelModule, NumberFilterModule, TextFilterModule } from 'ag-grid-community';
 import { PivotModule } from 'ag-grid-enterprise';
 
-import { GridColumns, GridRows, TestGridsManager, applyTransactionChecked } from '../../test-utils';
+import { GridColumns, GridRows, TestGridsManager, applyTransactionChecked, asyncSetTimeout } from '../../test-utils';
 import { getAutoGroupColumnIds, getColumnOrder, getColumnOrderFromState } from '../column-test-utils';
 
 describe('pivotMode=true', () => {
@@ -1758,5 +1758,33 @@ describe('pivotMode=true', () => {
         api.setGridOption('pivotMode', true);
 
         expect(pivotOrder(api)).toEqual([...first].reverse());
+    });
+
+    describe('pivot toggle preserves primary column live state', () => {
+        test('runtime pinned + width on a primary column survive toggling pivotMode on then off', async () => {
+            const api = gridsManager.createGrid('myGrid', {
+                rowData: [{ country: 'US', sport: 'swim', val: 1 }],
+                columnDefs: [
+                    { field: 'country', pinned: 'left' },
+                    { field: 'sport', pivot: true },
+                    { field: 'val', aggFunc: 'sum' },
+                ],
+            });
+            await asyncSetTimeout(0);
+
+            api.setColumnsPinned(['country'], null);
+            api.applyColumnState({ state: [{ colId: 'country', width: 333 }] });
+            await asyncSetTimeout(0);
+            expect(api.getColumn('country')!.getPinned()).toBeNull();
+            expect(api.getColumn('country')!.getActualWidth()).toBe(333);
+
+            api.setGridOption('pivotMode', true);
+            await asyncSetTimeout(0);
+            api.setGridOption('pivotMode', false);
+            await asyncSetTimeout(0);
+
+            expect(api.getColumn('country')!.getPinned()).toBeNull();
+            expect(api.getColumn('country')!.getActualWidth()).toBe(333);
+        });
     });
 });

--- a/testing/behavioural/src/formulas/calculated-columns-ordering.test.ts
+++ b/testing/behavioural/src/formulas/calculated-columns-ordering.test.ts
@@ -388,6 +388,76 @@ describe('calculated columns - display ordering', () => {
         `);
     });
 
+    test('dialog add preserves runtime unpinned state from an initially pinned colDef', async () => {
+        const api = createGrid('calculated-dialog-preserves-unpinned-state', {
+            rowData: [{ id: 'r1', athlete: 'Michael Phelps', age: 23 }],
+            columnDefs: [{ field: 'athlete', pinned: 'left' }, { field: 'age' }],
+        });
+
+        await new GridColumns(api, 'dialog add preserves unpinned state setup').checkColumns(`
+            LEFT
+            └── athlete "Athlete" width:200
+            CENTER
+            └── age "Age" width:200
+        `);
+
+        api.setColumnsPinned(['athlete'], null);
+        await asyncSetTimeout(0);
+
+        await new GridColumns(api, 'dialog add preserves unpinned state after unpin').checkColumns(`
+            CENTER
+            ├── athlete "Athlete" width:200
+            └── age "Age" width:200
+        `);
+
+        api.showColumnMenu('age');
+        await asyncSetTimeout(10);
+        await clickColumnMenuItem('Add Calculated Column');
+        await asyncSetTimeout(1);
+
+        setExpression('[Age] * 2');
+        clickDialogButton('Apply');
+        await asyncSetTimeout(1);
+
+        await new GridColumns(api, 'dialog add preserves unpinned state after calculated column add').checkColumns(`
+            CENTER
+            ├── athlete "Athlete" width:200
+            ├── age "Age" width:200
+            └── calculated_1 "New title" width:200
+        `);
+    });
+
+    test('dialog add preserves a runtime sort that diverged from the colDef sort', async () => {
+        const api = createGrid('calculated-dialog-preserves-sort', {
+            rowData: [{ id: 'r1', a: 1, b: 2 }],
+            columnDefs: [{ field: 'a', sort: 'asc' }, { field: 'b' }],
+        });
+
+        api.applyColumnState({ state: [{ colId: 'a', sort: 'desc' }] });
+        await asyncSetTimeout(0);
+        expect(api.getColumn('a')!.getSort()).toBe('desc');
+
+        await addViaDialog(api, 'b', '[a] + [b]');
+
+        // Adding a calc col must not reset 'a' back to its colDef sort ('asc').
+        expect(api.getColumn('a')!.getSort()).toBe('desc');
+    });
+
+    test('dialog add preserves a runtime column width that diverged from the colDef width', async () => {
+        const api = createGrid('calculated-dialog-preserves-width', {
+            rowData: [{ id: 'r1', a: 1, b: 2 }],
+            columnDefs: [{ field: 'a', width: 150 }, { field: 'b' }],
+        });
+
+        api.applyColumnState({ state: [{ colId: 'a', width: 250 }] });
+        await asyncSetTimeout(0);
+        expect(api.getColumn('a')!.getActualWidth()).toBe(250);
+
+        await addViaDialog(api, 'b', '[a] + [b]');
+
+        expect(api.getColumn('a')!.getActualWidth()).toBe(250);
+    });
+
     test('two calc cols from the same anchor stack newest-first (tree + display agree)', async () => {
         const api = createGrid('dialog-same-anchor', {
             rowData: [{ id: 'r1', revenue: 10, cost: 3 }],

--- a/testing/behavioural/src/formulas/calculated-columns-ordering.test.ts
+++ b/testing/behavioural/src/formulas/calculated-columns-ordering.test.ts
@@ -425,6 +425,10 @@ describe('calculated columns - display ordering', () => {
             ├── age "Age" width:200
             └── calculated_1 "New title" width:200
         `);
+        await new GridRows(api, 'dialog add preserves unpinned state - rows').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 athlete:"Michael Phelps" age:23 calculated_1:46
+        `);
     });
 
     test('dialog add preserves a runtime sort that diverged from the colDef sort', async () => {
@@ -437,10 +441,21 @@ describe('calculated columns - display ordering', () => {
         await asyncSetTimeout(0);
         expect(api.getColumn('a')!.getSort()).toBe('desc');
 
-        await addViaDialog(api, 'b', '[a] + [b]');
+        const calc = await addViaDialog(api, 'b', '[a] + [b]');
 
         // Adding a calc col must not reset 'a' back to its colDef sort ('asc').
         expect(api.getColumn('a')!.getSort()).toBe('desc');
+        expect(order(api)).toEqual(['a', 'b', calc]);
+        await new GridColumns(api, 'preserved runtime sort after calc add').checkColumns(`
+            CENTER
+            ├── a "A" width:200 sort:desc
+            ├── b "B" width:200
+            └── calculated_1 "New title" width:200
+        `);
+        await new GridRows(api, 'preserved runtime sort after calc add - rows').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 a:1 b:2 calculated_1:3
+        `);
     });
 
     test('dialog add preserves a runtime column width that diverged from the colDef width', async () => {
@@ -453,9 +468,20 @@ describe('calculated columns - display ordering', () => {
         await asyncSetTimeout(0);
         expect(api.getColumn('a')!.getActualWidth()).toBe(250);
 
-        await addViaDialog(api, 'b', '[a] + [b]');
+        const calc = await addViaDialog(api, 'b', '[a] + [b]');
 
         expect(api.getColumn('a')!.getActualWidth()).toBe(250);
+        expect(order(api)).toEqual(['a', 'b', calc]);
+        await new GridColumns(api, 'preserved runtime width after calc add').checkColumns(`
+            CENTER
+            ├── a "A" width:250
+            ├── b "B" width:200
+            └── calculated_1 "New title" width:200
+        `);
+        await new GridRows(api, 'preserved runtime width after calc add - rows').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 a:1 b:2 calculated_1:3
+        `);
     });
 
     test('two calc cols from the same anchor stack newest-first (tree + display agree)', async () => {


### PR DESCRIPTION
Calculated columns need to reapply colDef without overriding the state for the UI changeable properties like pinning, width and so on - and this happens during tree rebuild and applying new colDef for the calc columns

We already pass a flag around that is newColDef during rebuild tree - we can use this to change how reapplyColDef behaves