### PR TITLE
AG-17134 Port grid production CSP report-only fixes to latest

### DIFF
--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
@@ -52,6 +52,16 @@ const SALESFORCE_FORM_ORIGIN: Record<CspEnv, string> = {
     production: 'https://webto.salesforce.com',
 };
 
+// The ecommerce checkout renders the Realex/Global Payments Hosted Payment Page
+// (rxp-hpp.js) in an iframe and POSTs the payment form to it — sandbox host in
+// non-prod, live host in production (see globalPaymentsServiceUrl in the
+// ag-grid-ecommerce frontend environments). Governs frame-src and form-action.
+const REALEX_HPP_ORIGIN: Record<CspEnv, string> = {
+    dev: 'https://pay.sandbox.realexpayments.com',
+    staging: 'https://pay.sandbox.realexpayments.com',
+    production: 'https://pay.realexpayments.com',
+};
+
 // Dev-server-only extras (HMR + cross-port preview). Never emitted for staging
 // or production.
 const DEV_SCRIPT_SRC = ['https://localhost:4610', 'https://localhost:4611'];
@@ -61,6 +71,7 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
     const { env } = options;
     const trialFormOrigin = options.trialFormOrigin ?? TRIAL_FORM_ORIGIN[env];
     const salesforceFormOrigin = SALESFORCE_FORM_ORIGIN[env];
+    const realexHppOrigin = REALEX_HPP_ORIGIN[env];
 
     const directives: CspDirectives = {
         'default-src': [SELF],
@@ -119,6 +130,8 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://www.google.com', // reCAPTCHA (api2/clr XHR)
             'https://cdn.cookielaw.org', // OneTrust config/JSON/asset XHR (GTM-injected, prod-only)
             'https://*.onetrust.com', // OneTrust geolocation + consent-receipt endpoints
+            'https://www.googleapis.com', // Firebase Auth (ecommerce checkout): identitytoolkit REST
+            'https://securetoken.googleapis.com', // Firebase Auth ID-token refresh
             trialFormOrigin,
         ],
         'frame-src': [
@@ -126,6 +139,7 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://www.googletagmanager.com',
             'https://www.youtube.com',
             'https://www.google.com', // reCAPTCHA challenge iframe
+            realexHppOrigin, // ecommerce checkout: Realex Hosted Payment Page iframe
         ],
         'media-src': [SELF, 'data:', 'blob:', 'https:'],
         'worker-src': [SELF, 'blob:'],
@@ -135,6 +149,7 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             SELF,
             trialFormOrigin,
             salesforceFormOrigin,
+            realexHppOrigin, // ecommerce checkout: payment form POST to Realex HPP
             'https://codesandbox.io', // example-runner "Open in CodeSandbox" form POST
             'https://plnkr.co', // example-runner "Open in Plunker" form POST
         ],

--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
@@ -76,6 +76,8 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://www.google.com', // reCAPTCHA
             'https://www.gstatic.com', // reCAPTCHA
             'https://www.youtube.com', // YouTube iframe JS API (loads into the page)
+            'https://cdn.cookielaw.org', // OneTrust cookie-consent SDK (GTM-injected, prod-only)
+            'blob:', // ZoomInfo zi-tag.js bootstraps a blob: URL script
             UNSAFE_INLINE,
             UNSAFE_EVAL,
         ],
@@ -105,7 +107,7 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://plausible.io',
             'https://*.algolia.net',
             'https://*.algolianet.com',
-            'https://www.google-analytics.com',
+            'https://*.google-analytics.com', // GA4 incl. regional collect endpoints (region1/2.google-analytics.com)
             'https://*.analytics.google.com',
             'https://stats.g.doubleclick.net',
             'https://flagcdn.com',
@@ -115,6 +117,8 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://js.zi-scripts.com', // ZoomInfo
             'https://*.zoominfo.com', // ZoomInfo
             'https://www.google.com', // reCAPTCHA (api2/clr XHR)
+            'https://cdn.cookielaw.org', // OneTrust config/JSON/asset XHR (GTM-injected, prod-only)
+            'https://*.onetrust.com', // OneTrust geolocation + consent-receipt endpoints
             trialFormOrigin,
         ],
         'frame-src': [

--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
@@ -80,6 +80,7 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             AG_GRID_HOSTS,
             'https://plausible.io',
             'https://www.googletagmanager.com',
+            'https://www.google-analytics.com', // Universal Analytics analytics.js (GTM-injected after cookie consent)
             'https://cdn.jsdelivr.net',
             'https://cdnjs.cloudflare.com',
             'https://js.zi-scripts.com', // ZoomInfo tag (injected via GTM)


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17134

Forward-ports the AG-17134 CSP report-only fixes that were made on `b35.3.1` and validated on grid production. Cherry-picks (cspRules.ts only):

- #13968 — OneTrust cookie-consent + ZoomInfo `blob:` script + GA4 regional (`*.google-analytics.com`)
- #13970 — ecommerce checkout: Firebase Auth (`www.googleapis.com` + `securetoken.googleapis.com`) and Realex/Global Payments HPP (`frame-src` + `form-action`, env-split sandbox/prod)
- #13979 — GA `analytics.js` in script-src (post-consent)

All GTM-injected / checkout-flow, production-only. Report-only — no enforced behaviour change.