### PR TITLE
AG-17134 Enforce grid root CSP (report-only → enforce)

### DIFF
--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
@@ -1,6 +1,6 @@
 import { urlWithBaseUrl } from '../urlWithBaseUrl';
 import type { CspEnv } from './cspRules';
-import { getCspHtaccessBlock, getCspHtaccessLine } from './cspRules';
+import { getCspHtaccessBlock } from './cspRules';
 import { SITE_301_REDIRECTS } from './redirects';
 
 export type HtaccessEnv = Extract<CspEnv, 'staging' | 'production'>;
@@ -155,9 +155,9 @@ AddType application/x-gzip .gz .tgz
 function getStagingHtaccessContent(): string {
     return `${baseRules}
 
-# Content-Security-Policy — report-only while validating on staging. Unsets the
-# legacy wildcard CSP on the staging vhost so this is the only policy in effect.
-${getCspHtaccessBlock({ env: 'staging' }, 'report-only')}
+# Content-Security-Policy — enforced. Unsets the legacy wildcard CSP on the staging
+# vhost so this tightened policy is the only one in effect.
+${getCspHtaccessBlock({ env: 'staging' }, 'enforce')}
 
 Options -Indexes
 `;
@@ -175,11 +175,12 @@ ${getModRewriteRules()}
 Header always set Referrer-Policy "strict-origin-when-cross-origin"
 Header always set Permissions-Policy "geolocation=(), microphone=(), camera=()"
 
-# Content-Security-Policy — report-only while validating the tightened policy on production.
-# Ships alongside the existing loose enforcing CSP on the vhost: that one still allows
-# everything (nothing breaks), this one reports what the tightened policy would block.
-# Flip to enforce + remove the vhost wildcard once the report-only window is clean.
-${getCspHtaccessLine({ env: 'production' }, 'report-only')}
+# Content-Security-Policy — enforced (the report-only validation window is complete).
+# The block unsets the inherited headers (incl. the legacy wildcard CSP on the vhost)
+# and sets this tightened policy as the enforced CSP. If the vhost wildcard lingers as a
+# separate header, browsers enforce the intersection, so the tightened policy still wins;
+# removing the vhost wildcard line is a follow-up infra cleanup.
+${getCspHtaccessBlock({ env: 'production' }, 'enforce')}
 
 # CORS settings
 Header add Access-Control-Allow-Origin "*"


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17134

⚠️ **DRAFT / DEPLOY LAST.** Do not merge+deploy until **charts (#7039-equiv enforce PR) and studio enforce PRs are live in production**. `/charts` and `/studio` inherit the grid root CSP; if grid root enforces while they're still report-only, grid's policy would govern those subdirs and break them (missing `esm.sh`, `bryntum.com`, charts-specific origins).

Flips grid root from **report-only to enforced**: production `.htaccess` switches from a bare report-only header (`getCspHtaccessLine`) to `getCspHtaccessBlock` in `enforce` mode (matching staging + charts/studio). It unsets the inherited headers (incl. the legacy vhost wildcard) and sets the tightened policy as the enforced `Content-Security-Policy`. Staging flipped to enforce too; unused `getCspHtaccessLine` import dropped.

**Note on the vhost wildcard:** the loose enforcing CSP is still set on the Apache vhost via `Header add` (onsuccess table). `Header always unset` may not remove an onsuccess-added header, in which case the response carries both — browsers enforce the **intersection**, so the tightened policy still wins (no extra breakage). Removing the vhost wildcard line is a follow-up infra cleanup.

**Pre-deploy check:** grid prod report-only window clean, incl. consent-accept (GA analytics.js #13979) and the ecommerce checkout (Firebase Auth + Realex payment) flow.

Fix [AG-17134](https://ag-grid.atlassian.net/browse/AG-17134)