### PR TITLE
AG-17520 fix alignment of embedded full width rows

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -792,6 +792,13 @@
         z-index: 0;
     }
 
+    .ag-row.ag-embedded-full-width-row > .ag-grid-scrolling-cells {
+        flex: 1 0 auto;
+
+        /* rtl:ignore */
+        margin-right: var(--ag-internal-pinned-right-sticky-offset, 0px);
+    }
+
     .ag-grid-pinned-left-cells,
     .ag-grid-pinned-right-cells {
         position: sticky;

--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -795,7 +795,6 @@
     .ag-row.ag-embedded-full-width-row > .ag-grid-scrolling-cells {
         flex: 1 0 auto;
 
-        /* rtl:ignore */
         margin-right: var(--ag-internal-pinned-right-sticky-offset, 0px);
     }
 

--- a/documentation/ag-grid-docs/src/content/docs/filter-advanced/_examples/external-parent/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/filter-advanced/_examples/external-parent/styles.css
@@ -2,6 +2,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
+    padding-left: 5px;
 }
 
 #myGrid {

--- a/packages/ag-grid-community/src/rendering/row/rowComp.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowComp.ts
@@ -118,20 +118,16 @@ export class RowComp extends Component {
             eCenter.style.width = `${widths.centerWidth}px`;
         }
 
-        const isFullWidth = this.rowCtrl.isFullWidth();
-
-        const refreshPinnedSection = (eSection: HTMLElement | undefined, width: number, method: 'after' | 'before') => {
+        const refreshPinnedSection = (
+            eSection: HTMLElement | undefined,
+            width: number,
+            shouldRender: boolean,
+            method: 'after' | 'before'
+        ) => {
             if (!eSection) {
                 return;
             }
-            if (
-                // Skip rendering pinned cell containers when there are no pinned
-                // columns to improve rendering performance
-                width <= 0 &&
-                // Render always for full width rows, because the row renderer
-                // requires a reference to these even if they are empty
-                !isFullWidth
-            ) {
+            if (!shouldRender) {
                 eSection.remove();
                 return;
             }
@@ -141,8 +137,8 @@ export class RowComp extends Component {
             }
         };
 
-        refreshPinnedSection(this.ePinnedLeftSection, widths.leftWidth, 'before');
-        refreshPinnedSection(this.ePinnedRightSection, widths.rightWidth, 'after');
+        refreshPinnedSection(this.ePinnedLeftSection, widths.leftWidth, widths.renderLeft, 'before');
+        refreshPinnedSection(this.ePinnedRightSection, widths.rightWidth, widths.renderRight, 'after');
     }
 
     private setInitialStyle(container: HTMLElement): void {

--- a/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
@@ -100,6 +100,11 @@ export interface RowGui {
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export type PinnedCellGroupWidths = PinnedSectionWidths;
 
+interface MappedPinnedCellGroupWidths extends PinnedCellGroupWidths {
+    renderLeft: boolean;
+    renderRight: boolean;
+}
+
 type RowCtrlEvent = RenderedRowEvent;
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class RowCtrl extends BeanStub<RowCtrlEvent> {
@@ -473,21 +478,30 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         rowGui.rowComp.refreshPinnedSections();
     }
 
-    public getMappedPinnedCellGroupWidths(): PinnedCellGroupWidths {
-        const baseWidths = this.getPinnedCellGroupWidths();
+    public getMappedPinnedCellGroupWidths(): MappedPinnedCellGroupWidths {
+        let { leftWidth, centerWidth, rightWidth } = this.getPinnedCellGroupWidths();
 
-        if (!this.isEmbeddedFullWidth) {
-            return baseWidths;
+        if (this.isEmbeddedFullWidth) {
+            const hasLeft = this.embeddedSectionHasContent.left;
+            const hasRight = this.embeddedSectionHasContent.right;
+
+            centerWidth = centerWidth + (hasLeft ? 0 : leftWidth) + (hasRight ? 0 : rightWidth);
+            leftWidth = hasLeft ? leftWidth : 0;
+            rightWidth = hasRight ? rightWidth : 0;
         }
 
-        const hasLeft = this.embeddedSectionHasContent.left;
-        const hasRight = this.embeddedSectionHasContent.right;
+        const isFullWidth = this.isFullWidth();
 
         return {
-            leftWidth: hasLeft ? baseWidths.leftWidth : 0,
-            centerWidth:
-                baseWidths.centerWidth + (hasLeft ? 0 : baseWidths.leftWidth) + (hasRight ? 0 : baseWidths.rightWidth),
-            rightWidth: hasRight ? baseWidths.rightWidth : 0,
+            leftWidth,
+            centerWidth,
+            rightWidth,
+            // Pinned lanes are omitted from the DOM when they have no width to
+            // improve rendering performance. Full width rows always render the
+            // lanes, because the row renderer requires a reference to them even
+            // when they are empty.
+            renderLeft: leftWidth > 0 || isFullWidth,
+            renderRight: rightWidth > 0 || isFullWidth,
         };
     }
 

--- a/packages/ag-grid-community/src/theming/core/css/_general.css
+++ b/packages/ag-grid-community/src/theming/core/css/_general.css
@@ -299,6 +299,13 @@
     z-index: 0;
 }
 
+:where(.ag-row.ag-embedded-full-width-row) > .ag-grid-scrolling-cells {
+    flex: 1 0 auto;
+
+    /* rtl:ignore */
+    margin-right: var(--ag-internal-pinned-right-sticky-offset, 0);
+}
+
 .ag-grid-pinned-left-cells,
 .ag-grid-pinned-right-cells {
     position: sticky;

--- a/packages/ag-grid-react/src/reactUi/rows/rowComp.tsx
+++ b/packages/ag-grid-react/src/reactUi/rows/rowComp.tsx
@@ -382,7 +382,7 @@ const RowComp = ({ rowCtrl, containerType }: { rowCtrl: RowCtrl; containerType: 
         };
     }, [cellCtrlsMerged]);
 
-    const { leftWidth, centerWidth, rightWidth } = rowCtrl.getMappedPinnedCellGroupWidths();
+    const { leftWidth, centerWidth, rightWidth, renderLeft, renderRight } = rowCtrl.getMappedPinnedCellGroupWidths();
 
     const reactFullWidthCellRendererStateless = useMemo(() => {
         const res =
@@ -438,17 +438,10 @@ const RowComp = ({ rowCtrl, containerType }: { rowCtrl: RowCtrl; containerType: 
         ref: React.Ref<HTMLDivElement>,
         width: number,
         children: React.ReactNode,
-        pinned: boolean = false
+        pinned: boolean = false,
+        shouldRender: boolean = true
     ) => {
-        if (
-            // Detach pinned cell containers when there are no pinned columns to
-            // improve rendering performance
-            pinned &&
-            width <= 0 &&
-            // Unless we're rendering a full width rows, because the row
-            // renderer is passed a reference to these even if they are empty
-            !isFullWidth
-        ) {
+        if (!shouldRender) {
             return null;
         }
         if (pinned) {
@@ -476,50 +469,29 @@ const RowComp = ({ rowCtrl, containerType }: { rowCtrl: RowCtrl; containerType: 
             row-id={rowId}
             row-business-key={rowBusinessKey}
         >
-            {showCells ? (
+            {showCells || showEmbeddedFullWidth ? (
                 <>
                     {renderCellSection(
                         'ag-grid-pinned-left-cells',
                         ePinnedLeftCells,
                         leftWidth,
-                        showCellsJsx(leftCellCtrls),
-                        true
+                        showCells ? showCellsJsx(leftCellCtrls) : showEmbeddedFrameworkSection('left'),
+                        true,
+                        renderLeft
                     )}
                     {renderCellSection(
                         'ag-grid-scrolling-cells',
                         eScrollingCells,
                         centerWidth,
-                        showCellsJsx(centerCellCtrls)
+                        showCells ? showCellsJsx(centerCellCtrls) : showEmbeddedFrameworkSection('center')
                     )}
                     {renderCellSection(
                         'ag-grid-pinned-right-cells',
                         ePinnedRightCells,
                         rightWidth,
-                        showCellsJsx(rightCellCtrls),
-                        true
-                    )}
-                </>
-            ) : showEmbeddedFullWidth ? (
-                <>
-                    {renderCellSection(
-                        'ag-grid-pinned-left-cells',
-                        ePinnedLeftCells,
-                        leftWidth,
-                        showEmbeddedFrameworkSection('left'),
-                        true
-                    )}
-                    {renderCellSection(
-                        'ag-grid-scrolling-cells',
-                        eScrollingCells,
-                        centerWidth,
-                        showEmbeddedFrameworkSection('center')
-                    )}
-                    {renderCellSection(
-                        'ag-grid-pinned-right-cells',
-                        ePinnedRightCells,
-                        rightWidth,
-                        showEmbeddedFrameworkSection('right'),
-                        true
+                        showCells ? showCellsJsx(rightCellCtrls) : showEmbeddedFrameworkSection('right'),
+                        true,
+                        renderRight
                     )}
                 </>
             ) : showFullWidthFramework ? (


### PR DESCRIPTION
Fix [AG-17520](https://ag-grid.atlassian.net/browse/AG-17520)

- **Fix alignment of embedded full-width rows.** The centre scrolling lane of an embedded full-width row now grows to fill available space (`flex: 1 0 auto`) and accounts for the right pinned sticky offset, so embedded full-width content aligns correctly.