### PR TITLE
AG-17509 Fix header row gaining tabindex when suppressHeaderFocus is true

### DIFF
--- a/packages/ag-grid-community/src/headerRendering/row/headerRowComp.ts
+++ b/packages/ag-grid-community/src/headerRendering/row/headerRowComp.ts
@@ -1,6 +1,7 @@
 import { _setAriaRowIndex, _setDomChildOrder } from 'ag-stack';
 
 import { _createElement } from '../../utils/element';
+import { _isHeaderFocusSuppressed } from '../../utils/gridFocus';
 import { Component } from '../../widgets/component';
 import type { AbstractHeaderCellComp } from '../cells/abstractCell/abstractHeaderCellComp';
 import type { AbstractHeaderCellCtrl, HeaderCellCtrlInstanceId } from '../cells/abstractCell/abstractHeaderCellCtrl';
@@ -50,7 +51,15 @@ export class HeaderRowComp extends Component {
 
     public postConstruct(): void {
         const eGui = this.getGui();
-        eGui.setAttribute('tabindex', String(this.gos.get('tabIndex')));
+        const updateTabIndex = () => {
+            if (_isHeaderFocusSuppressed(this.beans)) {
+                eGui.removeAttribute('tabindex');
+            } else {
+                eGui.setAttribute('tabindex', String(this.gos.get('tabIndex')));
+            }
+        };
+        updateTabIndex();
+        this.addManagedPropertyListeners(['suppressHeaderFocus'], updateTabIndex);
         this.setRowIndex(this.ctrl.getAriaRowIndex());
 
         const compProxy: IHeaderRowComp = {

--- a/packages/ag-grid-community/src/main-internal.ts
+++ b/packages/ag-grid-community/src/main-internal.ts
@@ -362,6 +362,7 @@ export {
     _attemptToRestoreCellFocus,
     _focusGridInnerElement,
     _focusNextGridCoreContainer,
+    _isHeaderFocusSuppressed,
     _skipFocusableContainerListenerForAgGrid,
 } from './utils/gridFocus';
 export { _createIcon, _createIconNoSpan } from './utils/icon';

--- a/packages/ag-grid-community/src/utils/gridFocus.ts
+++ b/packages/ag-grid-community/src/utils/gridFocus.ts
@@ -36,6 +36,7 @@ export function _focusGridInnerElement(beans: BeanCollection, fromBottom?: boole
     return beans.ctrlsSvc.get('gridCtrl').focusInnerElement(fromBottom);
 }
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export function _isHeaderFocusSuppressed(beans: BeanCollection): boolean {
     return beans.gos.get('suppressHeaderFocus') || !!beans.overlays?.exclusive;
 }

--- a/packages/ag-grid-react/src/reactUi/header/headerRowComp.tsx
+++ b/packages/ag-grid-react/src/reactUi/header/headerRowComp.tsx
@@ -159,7 +159,8 @@ const HeaderRowComp = ({
         [ctrl.type]
     );
 
-    const tabIndex = gos.get('tabIndex');
+    const suppressHeaderFocus = gos.get('suppressHeaderFocus');
+    const tabIndex = suppressHeaderFocus ? undefined : gos.get('tabIndex');
 
     return (
         <div ref={setRef} className={ctrl.headerRowClass} role="row" tabIndex={tabIndex}>

--- a/packages/ag-grid-react/src/reactUi/header/headerRowComp.tsx
+++ b/packages/ag-grid-react/src/reactUi/header/headerRowComp.tsx
@@ -10,7 +10,12 @@ import type {
     IHeaderRowComp,
     PinnedSectionWidthsCache,
 } from 'ag-grid-community';
-import { _EmptyBean, _partitionByPinned, _updatePinnedSectionWidths } from 'ag-grid-community';
+import {
+    _EmptyBean,
+    _isHeaderFocusSuppressed,
+    _partitionByPinned,
+    _updatePinnedSectionWidths,
+} from 'ag-grid-community';
 
 import { BeansContext } from '../beansContext';
 import { agFlushSync, getNextValueIfDifferent } from '../utils';
@@ -38,7 +43,8 @@ const HeaderRowComp = ({
     ctrl: HeaderRowCtrl;
     setGuiRef?: (eGui: HTMLDivElement | null) => void;
 }) => {
-    const { context, visibleCols, gos } = useContext(BeansContext);
+    const beans = useContext(BeansContext);
+    const { context, visibleCols, gos } = beans;
 
     const eGui = useRef<HTMLDivElement | null>(null);
     const ePinnedLeft = useRef<HTMLDivElement | null>(null);
@@ -159,8 +165,7 @@ const HeaderRowComp = ({
         [ctrl.type]
     );
 
-    const suppressHeaderFocus = gos.get('suppressHeaderFocus');
-    const tabIndex = suppressHeaderFocus ? undefined : gos.get('tabIndex');
+    const tabIndex = _isHeaderFocusSuppressed(beans) ? undefined : gos.get('tabIndex');
 
     return (
         <div ref={setRef} className={ctrl.headerRowClass} role="row" tabIndex={tabIndex}>

--- a/testing/behavioural/src/navigation/suppress-header-focus-tab.test.ts
+++ b/testing/behavioural/src/navigation/suppress-header-focus-tab.test.ts
@@ -45,6 +45,7 @@ describe('suppressHeaderFocus tab navigation', () => {
             const headerRow = gridElement.querySelector<HTMLElement>('.ag-header-row')!;
 
             expect(headerRow).toBeTruthy();
+            expect(headerRow.hasAttribute('tabindex')).toBe(false);
 
             headerRow.focus();
             headerRow.dispatchEvent(


### PR DESCRIPTION
## Summary

- AG-15523 (34.2.0) unconditionally set `tabindex` on the header row element, causing it to appear in the browser tab order even when `suppressHeaderFocus: true`
- Guard the tabindex in both vanilla (`headerRowComp.ts`) and React (`headerRowComp.tsx`) renderers so it is only set when header focus is not suppressed
- Also reacts to runtime changes to `suppressHeaderFocus` via a managed property listener (vanilla only; React re-renders naturally)
- Extended existing behavioural test to assert the header row element has no `tabindex` attribute when `suppressHeaderFocus: true`

## Test plan

- [ ] `./behave.sh "suppress-header-focus"` — both tests pass
- [ ] Tab into a grid with `suppressHeaderFocus: true`: focus should skip the header row entirely
- [ ] Tab into a grid with `suppressHeaderFocus: true` and `suppressCellFocus: true`: focus skips the grid entirely

Fix [AG-17509](https://ag-grid.atlassian.net/browse/AG-17509)