### PR TITLE
AG-17521 Fix SHIFT+click range selection including hidden descendants of collapsed groups

### DIFF
--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
@@ -737,42 +737,40 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
 
     public getNodesInRangeForSelection(firstInRange: RowNode, lastInRange: RowNode): RowNode[] {
         let started = false;
-        let finished = false;
 
         const result: RowNode[] = [];
 
         const groupsSelectChildren = _getGroupSelectsDescendants(this.gos);
 
-        this.forEachNodeAfterFilterAndSort((rowNode) => {
-            // range has been closed, skip till end
-            if (finished) {
-                return;
-            }
+        // Iterate only displayed rows so that hidden descendants of collapsed groups are excluded
+        const { rowsToDisplay } = this;
+        for (let i = 0, len = rowsToDisplay.length; i < len; ++i) {
+            const rowNode = rowsToDisplay[i];
 
             if (started) {
                 if (rowNode === lastInRange || rowNode === firstInRange) {
                     // check if this is the last node we're going to be adding
-                    finished = true;
-
                     // if the final node was a group node, and we're doing groupSelectsChildren
                     // make the exception to select all of it's descendants too
                     if (groupsSelectChildren && rowNode.group) {
                         addAllLeafs(result, rowNode);
-                        return;
+                    } else {
+                        result.push(rowNode);
                     }
+                    break;
                 }
             }
 
             if (!started) {
                 if (rowNode !== lastInRange && rowNode !== firstInRange) {
                     // still haven't hit a boundary node, keep searching
-                    return;
+                    continue;
                 }
                 started = true;
 
                 // When the first and last node are the same we're already finished
                 if (lastInRange === firstInRange) {
-                    finished = true;
+                    break;
                 }
             }
 
@@ -781,7 +779,7 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
             if (includeThisNode) {
                 result.push(rowNode);
             }
-        });
+        }
 
         return result;
     }

--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
@@ -768,8 +768,13 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
                 }
                 started = true;
 
-                // When the first and last node are the same we're already finished
+                // When the first and last node are the same the range is just that single node
                 if (lastInRange === firstInRange) {
+                    if (groupsSelectChildren && rowNode.group) {
+                        addAllLeafs(result, rowNode);
+                    } else {
+                        result.push(rowNode);
+                    }
                     break;
                 }
             }

--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
@@ -736,53 +736,29 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
     }
 
     public getNodesInRangeForSelection(firstInRange: RowNode, lastInRange: RowNode): RowNode[] {
-        let started = false;
-
         const result: RowNode[] = [];
 
         const groupsSelectChildren = _getGroupSelectsDescendants(this.gos);
 
         // Iterate only displayed rows so that hidden descendants of collapsed groups are excluded
         const { rowsToDisplay } = this;
-        for (let i = 0, len = rowsToDisplay.length; i < len; ++i) {
+        const firstIdx = getDisplayedBoundaryIndex(rowsToDisplay, firstInRange);
+        const lastIdx = getDisplayedBoundaryIndex(rowsToDisplay, lastInRange);
+        if (firstIdx === -1 || lastIdx === -1) {
+            return result;
+        }
+
+        const start = Math.min(firstIdx, lastIdx);
+        const end = Math.max(firstIdx, lastIdx);
+
+        for (let i = start; i <= end; ++i) {
             const rowNode = rowsToDisplay[i];
-
-            if (started) {
-                if (rowNode === lastInRange || rowNode === firstInRange) {
-                    // check if this is the last node we're going to be adding
-                    // if the final node was a group node, and we're doing groupSelectsChildren
-                    // make the exception to select all of it's descendants too
-                    if (groupsSelectChildren && rowNode.group) {
-                        addAllLeafs(result, rowNode);
-                    } else {
-                        result.push(rowNode);
-                    }
-                    break;
-                }
-            }
-
-            if (!started) {
-                if (rowNode !== lastInRange && rowNode !== firstInRange) {
-                    // still haven't hit a boundary node, keep searching
-                    continue;
-                }
-                started = true;
-
-                // When the first and last node are the same the range is just that single node
-                if (lastInRange === firstInRange) {
-                    if (groupsSelectChildren && rowNode.group) {
-                        addAllLeafs(result, rowNode);
-                    } else {
-                        result.push(rowNode);
-                    }
-                    break;
-                }
-            }
-
-            // only select leaf nodes if groupsSelectChildren
-            const includeThisNode = !rowNode.group || !groupsSelectChildren;
-            if (includeThisNode) {
+            if (!groupsSelectChildren || !rowNode.group) {
                 result.push(rowNode);
+            } else if (i === end) {
+                // if the final node is a group node, and we're doing groupSelectsChildren,
+                // make the exception to select all of its descendants too
+                addAllLeafs(result, rowNode);
             }
         }
 
@@ -1254,6 +1230,20 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         this.onRowHeightChanged_debounced();
     }
 }
+
+/**
+ * Returns the index of the node in the displayed rows. A range boundary node may itself be
+ * hidden (e.g. the selection anchor was inside a group that has since been collapsed); in that
+ * case the nearest displayed ancestor is used as the boundary instead.
+ * @returns -1 if neither the node nor any of its ancestors are displayed.
+ */
+const getDisplayedBoundaryIndex = (rowsToDisplay: RowNode[], node: RowNode): number => {
+    let current: RowNode | null = node;
+    while (current && !current.displayed) {
+        current = current.parent;
+    }
+    return current ? rowsToDisplay.indexOf(current) : -1;
+};
 
 const addAllLeafs = (result: RowNode[], node: RowNode): void => {
     const childrenAfterGroup = node.childrenAfterGroup;

--- a/testing/behavioural/src/grouping-data/grouping-selection.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-selection.test.ts
@@ -476,20 +476,9 @@ describe('ag-grid grouping selection', () => {
         await actions.expandGroupAtIndex(8); // New York (shifted to idx 8) → inserts LEAF id:4 at idx 9
         await actions.expandGroupAtIndex(10); // Chicago (shifted to idx 10) → inserts LEAF id:5 at idx 11
 
-        // Final display:
-        //   0: North America  1: Canada
-        //   2: Montreal LEAF_GROUP (expanded)  3: LEAF id:1
-        //   4: Toronto LEAF_GROUP (collapsed)
-        //   5: Ottawa LEAF_GROUP (expanded)  6: LEAF id:3
-        //   7: United States
-        //   8: New York LEAF_GROUP (expanded)  9: LEAF id:4
-        //   10: Chicago LEAF_GROUP (expanded)  11: LEAF id:5
-        //   12: Los Angeles LEAF_GROUP (collapsed)
-
         actions.clickRowByIndex(3); // click LEAF id:1
-        actions.clickRowByIndex(12, { shiftKey: true }); // shift-click Los Angeles LEAF_GROUP
+        actions.clickRowByIndex(12, { shiftKey: true }); // shift-click Los Angeles LEAF_GROUP (idx 12)
 
-        // Range: idx 3–12 (all visible rows between the two clicks).
         // id:2 inside collapsed Toronto and id:6 inside collapsed Los Angeles must NOT be selected.
         await new GridRows(api, 'after shift-click with asymmetric multi-level expansion').check(`
             ROOT id:ROOT_NODE_ID

--- a/testing/behavioural/src/grouping-data/grouping-selection.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-selection.test.ts
@@ -654,7 +654,7 @@ describe('ag-grid grouping selection', () => {
         `);
     });
 
-    test('SHIFT-click when anchor is in a collapsed group selects only the clicked row', async () => {
+    test('SHIFT-click after anchor group is collapsed and re-expanded selects a normal range', async () => {
         const api = gridsManager.createGrid('myGrid', {
             columnDefs: threeLevelColDefs,
             animateRows: false,
@@ -670,10 +670,10 @@ describe('ag-grid grouping selection', () => {
         // Collapse North America — Canada (anchor) becomes hidden
         await actions.collapseGroupAtIndex(0);
 
-        // Re-expand so rows are visible again but anchor is still hidden inside the group context
+        // Re-expand so the anchor (Canada) is visible again
         await actions.expandGroupAtIndex(0);
 
-        // Now shift-click United States — anchor (Canada) is visible again, so this is a normal range
+        // Shift-click United States — the anchor is visible, so this is a normal range
         actions.clickRowByIndex(2, { shiftKey: true });
 
         await new GridRows(api, 'after anchor collapsed and re-expanded, then shift-click').check(`
@@ -693,6 +693,44 @@ describe('ag-grid grouping selection', () => {
             · · │ └── LEAF hidden id:5 region:"North America" country:"United States" city:"Chicago"
             · · └─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-United States-city-Los Angeles" ag-Grid-AutoColumn:"Los Angeles"
             · · · └── LEAF hidden id:6 region:"North America" country:"United States" city:"Los Angeles"
+        `);
+    });
+
+    test('SHIFT-click while anchor is hidden in a collapsed group uses the collapsed group as the range boundary', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'region', rowGroup: true, hide: true }, { field: 'city' }],
+            animateRows: false,
+            rowSelection: { mode: 'multiRow', enableClickSelection: true, checkboxes: false, headerCheckbox: false },
+            groupDefaultExpanded: 1,
+            rowData: cachedJSONObjects.array([
+                { id: '1', region: 'North America', city: 'Toronto' },
+                { id: '2', region: 'North America', city: 'New York' },
+                { id: '3', region: 'Europe', city: 'Paris' },
+                { id: '4', region: 'Europe', city: 'Berlin' },
+            ]),
+            getRowId: (params) => params.data.id,
+        });
+
+        const actions = new GridActions(api);
+        // Displayed rows: North America (0), Toronto (1), New York (2), Europe (3), Paris (4), Berlin (5)
+        actions.clickRowByIndex(1); // click Toronto (anchor)
+
+        // Collapse North America — the anchor is now hidden
+        await actions.collapseGroupAtIndex(0);
+
+        // Displayed rows: North America (0), Europe (1), Paris (2), Berlin (3)
+        // Shift-click North America — the hidden anchor resolves to its collapsed group,
+        // so the range is just North America; the rows below must not be selected
+        actions.clickRowByIndex(0, { shiftKey: true });
+
+        await new GridRows(api, 'after shift-click with hidden anchor').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP selected collapsed id:"row-group-region-North America" ag-Grid-AutoColumn:"North America"
+            │ ├── LEAF selected hidden id:1 region:"North America" city:"Toronto"
+            │ └── LEAF hidden id:2 region:"North America" city:"New York"
+            └─┬ LEAF_GROUP id:row-group-region-Europe ag-Grid-AutoColumn:"Europe"
+            · ├── LEAF id:3 region:"Europe" city:"Paris"
+            · └── LEAF id:4 region:"Europe" city:"Berlin"
         `);
     });
 });

--- a/testing/behavioural/src/grouping-data/grouping-selection.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-selection.test.ts
@@ -1,6 +1,7 @@
 import { ClientSideRowModelModule, RowSelectionModule, TextFilterModule } from 'ag-grid-community';
 import { RowGroupingModule } from 'ag-grid-enterprise';
 
+import { GridActions } from '../selection/utils';
 import { GridColumns, GridRows, TestGridsManager, applyTransactionChecked, cachedJSONObjects } from '../test-utils';
 
 describe('ag-grid grouping selection', () => {
@@ -316,6 +317,317 @@ describe('ag-grid grouping selection', () => {
             · │ └── LEAF id:4 country:"Italy" year:2020 athlete:"Mario Rossi" sport:"Soccer"
             · └─┬ LEAF_GROUP id:row-group-country-Italy-year-2021 ag-Grid-AutoColumn:2021
             · · └── LEAF id:5 country:"Italy" year:2021 athlete:"Luigi Verdi" sport:"Football"
+        `);
+    });
+
+    const threeLevel = () =>
+        cachedJSONObjects.array([
+            { id: '1', region: 'North America', country: 'Canada', city: 'Montreal' },
+            { id: '2', region: 'North America', country: 'Canada', city: 'Toronto' },
+            { id: '3', region: 'North America', country: 'Canada', city: 'Ottawa' },
+            { id: '4', region: 'North America', country: 'United States', city: 'New York' },
+            { id: '5', region: 'North America', country: 'United States', city: 'Chicago' },
+            { id: '6', region: 'North America', country: 'United States', city: 'Los Angeles' },
+        ]);
+
+    const threeLevelColDefs = [
+        { field: 'region', rowGroup: true, hide: true },
+        { field: 'country', rowGroup: true, hide: true },
+        { field: 'city', rowGroup: true, hide: true },
+    ];
+
+    test('SHIFT-click does not select hidden descendants of collapsed groups', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: threeLevelColDefs,
+            animateRows: false,
+            rowSelection: { mode: 'multiRow', enableClickSelection: true, checkboxes: false, headerCheckbox: false },
+            groupDefaultExpanded: 1,
+            rowData: threeLevel(),
+            getRowId: (params) => params.data.id,
+        });
+
+        // Displayed rows: North America (idx 0), Canada (idx 1), United States (idx 2)
+        // City rows are hidden inside collapsed country groups
+        const actions = new GridActions(api);
+        actions.clickRowByIndex(1); // click Canada
+        actions.clickRowByIndex(2, { shiftKey: true }); // shift-click United States
+
+        await new GridRows(api, 'after shift-click').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ filler id:"row-group-region-North America" ag-Grid-AutoColumn:"North America"
+            · ├─┬ filler selected collapsed id:"row-group-region-North America-country-Canada" ag-Grid-AutoColumn:"Canada"
+            · │ ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-Canada-city-Montreal" ag-Grid-AutoColumn:"Montreal"
+            · │ │ └── LEAF hidden id:1 region:"North America" country:"Canada" city:"Montreal"
+            · │ ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-Canada-city-Toronto" ag-Grid-AutoColumn:"Toronto"
+            · │ │ └── LEAF hidden id:2 region:"North America" country:"Canada" city:"Toronto"
+            · │ └─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-Canada-city-Ottawa" ag-Grid-AutoColumn:"Ottawa"
+            · │ · └── LEAF hidden id:3 region:"North America" country:"Canada" city:"Ottawa"
+            · └─┬ filler selected collapsed id:"row-group-region-North America-country-United States" ag-Grid-AutoColumn:"United States"
+            · · ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-United States-city-New York" ag-Grid-AutoColumn:"New York"
+            · · │ └── LEAF hidden id:4 region:"North America" country:"United States" city:"New York"
+            · · ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-United States-city-Chicago" ag-Grid-AutoColumn:"Chicago"
+            · · │ └── LEAF hidden id:5 region:"North America" country:"United States" city:"Chicago"
+            · · └─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-United States-city-Los Angeles" ag-Grid-AutoColumn:"Los Angeles"
+            · · · └── LEAF hidden id:6 region:"North America" country:"United States" city:"Los Angeles"
+        `);
+    });
+
+    test('SHIFT-click upward does not select hidden descendants of collapsed groups', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: threeLevelColDefs,
+            animateRows: false,
+            rowSelection: { mode: 'multiRow', enableClickSelection: true, checkboxes: false, headerCheckbox: false },
+            groupDefaultExpanded: 1,
+            rowData: threeLevel(),
+            getRowId: (params) => params.data.id,
+        });
+
+        // Displayed rows: North America (idx 0), Canada (idx 1), United States (idx 2)
+        // Shift-click upward: click United States first, then shift-click Canada
+        const actions = new GridActions(api);
+        actions.clickRowByIndex(2); // click United States
+        actions.clickRowByIndex(1, { shiftKey: true }); // shift-click Canada (upward)
+
+        await new GridRows(api, 'after upward shift-click').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ filler id:"row-group-region-North America" ag-Grid-AutoColumn:"North America"
+            · ├─┬ filler selected collapsed id:"row-group-region-North America-country-Canada" ag-Grid-AutoColumn:"Canada"
+            · │ ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-Canada-city-Montreal" ag-Grid-AutoColumn:"Montreal"
+            · │ │ └── LEAF hidden id:1 region:"North America" country:"Canada" city:"Montreal"
+            · │ ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-Canada-city-Toronto" ag-Grid-AutoColumn:"Toronto"
+            · │ │ └── LEAF hidden id:2 region:"North America" country:"Canada" city:"Toronto"
+            · │ └─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-Canada-city-Ottawa" ag-Grid-AutoColumn:"Ottawa"
+            · │ · └── LEAF hidden id:3 region:"North America" country:"Canada" city:"Ottawa"
+            · └─┬ filler selected collapsed id:"row-group-region-North America-country-United States" ag-Grid-AutoColumn:"United States"
+            · · ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-United States-city-New York" ag-Grid-AutoColumn:"New York"
+            · · │ └── LEAF hidden id:4 region:"North America" country:"United States" city:"New York"
+            · · ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-United States-city-Chicago" ag-Grid-AutoColumn:"Chicago"
+            · · │ └── LEAF hidden id:5 region:"North America" country:"United States" city:"Chicago"
+            · · └─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-United States-city-Los Angeles" ag-Grid-AutoColumn:"Los Angeles"
+            · · · └── LEAF hidden id:6 region:"North America" country:"United States" city:"Los Angeles"
+        `);
+    });
+
+    test('SHIFT-click range spanning mixed expanded and collapsed groups selects only visible rows', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: threeLevelColDefs,
+            animateRows: false,
+            rowSelection: { mode: 'multiRow', enableClickSelection: true, checkboxes: false, headerCheckbox: false },
+            groupDefaultExpanded: -1,
+            rowData: threeLevel(),
+            getRowId: (params) => params.data.id,
+        });
+
+        // All groups start expanded. Collapse United States (at idx 8) so its city children are hidden.
+        const actions = new GridActions(api);
+        await actions.collapseGroupAtIndex(8);
+
+        // Canada remains expanded (its city groups and leaves are visible).
+        // United States is now collapsed (its city children are hidden).
+        // Display: North America (0), Canada (1), Montreal LEAF_GROUP (2), Montreal leaf (3),
+        //          Toronto LEAF_GROUP (4), Toronto leaf (5), Ottawa LEAF_GROUP (6), Ottawa leaf (7),
+        //          United States (8, collapsed)
+        actions.clickRowByIndex(1); // click Canada
+        actions.clickRowByIndex(8, { shiftKey: true }); // shift-click United States
+
+        await new GridRows(api, 'after shift-click with mixed expansion').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ filler id:"row-group-region-North America" ag-Grid-AutoColumn:"North America"
+            · ├─┬ filler selected id:"row-group-region-North America-country-Canada" ag-Grid-AutoColumn:"Canada"
+            · │ ├─┬ LEAF_GROUP selected id:"row-group-region-North America-country-Canada-city-Montreal" ag-Grid-AutoColumn:"Montreal"
+            · │ │ └── LEAF selected id:1 region:"North America" country:"Canada" city:"Montreal"
+            · │ ├─┬ LEAF_GROUP selected id:"row-group-region-North America-country-Canada-city-Toronto" ag-Grid-AutoColumn:"Toronto"
+            · │ │ └── LEAF selected id:2 region:"North America" country:"Canada" city:"Toronto"
+            · │ └─┬ LEAF_GROUP selected id:"row-group-region-North America-country-Canada-city-Ottawa" ag-Grid-AutoColumn:"Ottawa"
+            · │ · └── LEAF selected id:3 region:"North America" country:"Canada" city:"Ottawa"
+            · └─┬ filler selected collapsed id:"row-group-region-North America-country-United States" ag-Grid-AutoColumn:"United States"
+            · · ├─┬ LEAF_GROUP hidden id:"row-group-region-North America-country-United States-city-New York" ag-Grid-AutoColumn:"New York"
+            · · │ └── LEAF hidden id:4 region:"North America" country:"United States" city:"New York"
+            · · ├─┬ LEAF_GROUP hidden id:"row-group-region-North America-country-United States-city-Chicago" ag-Grid-AutoColumn:"Chicago"
+            · · │ └── LEAF hidden id:5 region:"North America" country:"United States" city:"Chicago"
+            · · └─┬ LEAF_GROUP hidden id:"row-group-region-North America-country-United States-city-Los Angeles" ag-Grid-AutoColumn:"Los Angeles"
+            · · · └── LEAF hidden id:6 region:"North America" country:"United States" city:"Los Angeles"
+        `);
+    });
+
+    test('SHIFT-click with asymmetric expansion at multiple levels selects only visible rows at each depth', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: threeLevelColDefs,
+            animateRows: false,
+            rowSelection: { mode: 'multiRow', enableClickSelection: true, checkboxes: false, headerCheckbox: false },
+            groupDefaultExpanded: 2,
+            rowData: threeLevel(),
+            getRowId: (params) => params.data.id,
+        });
+
+        // groupDefaultExpanded: 2 expands region and country levels; city LEAF_GROUPs start collapsed.
+        // Initial display indices:
+        //   0: North America  1: Canada
+        //   2: Montreal LEAF_GROUP  3: Toronto LEAF_GROUP  4: Ottawa LEAF_GROUP
+        //   5: United States
+        //   6: New York LEAF_GROUP  7: Chicago LEAF_GROUP  8: Los Angeles LEAF_GROUP
+        const actions = new GridActions(api);
+
+        // Expand a subset of LEAF_GROUPs to create asymmetric depth across both country branches.
+        // Canada branch:   Montreal expanded (leaf visible), Toronto collapsed (leaf hidden), Ottawa expanded (leaf visible)
+        // US branch:       New York expanded (leaf visible), Chicago expanded (leaf visible), Los Angeles collapsed (leaf hidden)
+        await actions.expandGroupAtIndex(2); // Montreal → inserts LEAF id:1 at idx 3
+        await actions.expandGroupAtIndex(5); // Ottawa (shifted to idx 5) → inserts LEAF id:3 at idx 6
+        await actions.expandGroupAtIndex(8); // New York (shifted to idx 8) → inserts LEAF id:4 at idx 9
+        await actions.expandGroupAtIndex(10); // Chicago (shifted to idx 10) → inserts LEAF id:5 at idx 11
+
+        // Final display:
+        //   0: North America  1: Canada
+        //   2: Montreal LEAF_GROUP (expanded)  3: LEAF id:1
+        //   4: Toronto LEAF_GROUP (collapsed)
+        //   5: Ottawa LEAF_GROUP (expanded)  6: LEAF id:3
+        //   7: United States
+        //   8: New York LEAF_GROUP (expanded)  9: LEAF id:4
+        //   10: Chicago LEAF_GROUP (expanded)  11: LEAF id:5
+        //   12: Los Angeles LEAF_GROUP (collapsed)
+
+        actions.clickRowByIndex(3); // click LEAF id:1
+        actions.clickRowByIndex(12, { shiftKey: true }); // shift-click Los Angeles LEAF_GROUP
+
+        // Range: idx 3–12 (all visible rows between the two clicks).
+        // id:2 inside collapsed Toronto and id:6 inside collapsed Los Angeles must NOT be selected.
+        await new GridRows(api, 'after shift-click with asymmetric multi-level expansion').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ filler id:"row-group-region-North America" ag-Grid-AutoColumn:"North America"
+            · ├─┬ filler id:"row-group-region-North America-country-Canada" ag-Grid-AutoColumn:"Canada"
+            · │ ├─┬ LEAF_GROUP id:"row-group-region-North America-country-Canada-city-Montreal" ag-Grid-AutoColumn:"Montreal"
+            · │ │ └── LEAF selected id:1 region:"North America" country:"Canada" city:"Montreal"
+            · │ ├─┬ LEAF_GROUP selected collapsed id:"row-group-region-North America-country-Canada-city-Toronto" ag-Grid-AutoColumn:"Toronto"
+            · │ │ └── LEAF hidden id:2 region:"North America" country:"Canada" city:"Toronto"
+            · │ └─┬ LEAF_GROUP selected id:"row-group-region-North America-country-Canada-city-Ottawa" ag-Grid-AutoColumn:"Ottawa"
+            · │ · └── LEAF selected id:3 region:"North America" country:"Canada" city:"Ottawa"
+            · └─┬ filler selected id:"row-group-region-North America-country-United States" ag-Grid-AutoColumn:"United States"
+            · · ├─┬ LEAF_GROUP selected id:"row-group-region-North America-country-United States-city-New York" ag-Grid-AutoColumn:"New York"
+            · · │ └── LEAF selected id:4 region:"North America" country:"United States" city:"New York"
+            · · ├─┬ LEAF_GROUP selected id:"row-group-region-North America-country-United States-city-Chicago" ag-Grid-AutoColumn:"Chicago"
+            · · │ └── LEAF selected id:5 region:"North America" country:"United States" city:"Chicago"
+            · · └─┬ LEAF_GROUP selected collapsed id:"row-group-region-North America-country-United States-city-Los Angeles" ag-Grid-AutoColumn:"Los Angeles"
+            · · · └── LEAF hidden id:6 region:"North America" country:"United States" city:"Los Angeles"
+        `);
+    });
+
+    test('SHIFT-click with groupSelects descendants selects all descendants of groups in range', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: threeLevelColDefs,
+            animateRows: false,
+            rowSelection: {
+                mode: 'multiRow',
+                enableClickSelection: true,
+                checkboxes: false,
+                headerCheckbox: false,
+                groupSelects: 'descendants',
+            },
+            groupDefaultExpanded: 1,
+            rowData: threeLevel(),
+            getRowId: (params) => params.data.id,
+        });
+
+        // Displayed rows: North America (idx 0), Canada (idx 1), United States (idx 2)
+        // First click selects Canada + all its hidden descendants via groupSelects:descendants.
+        // Shift-click on United States extends the range to include United States, and
+        // groupSelects:descendants propagates that to all its hidden descendants too.
+        const actions = new GridActions(api);
+        actions.clickRowByIndex(1); // click Canada — selects Canada + hidden city children
+        actions.clickRowByIndex(2, { shiftKey: true }); // shift-click United States
+
+        await new GridRows(api, 'after shift-click with groupSelects descendants').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ filler selected id:"row-group-region-North America" ag-Grid-AutoColumn:"North America"
+            · ├─┬ filler selected collapsed id:"row-group-region-North America-country-Canada" ag-Grid-AutoColumn:"Canada"
+            · │ ├─┬ LEAF_GROUP selected collapsed hidden id:"row-group-region-North America-country-Canada-city-Montreal" ag-Grid-AutoColumn:"Montreal"
+            · │ │ └── LEAF selected hidden id:1 region:"North America" country:"Canada" city:"Montreal"
+            · │ ├─┬ LEAF_GROUP selected collapsed hidden id:"row-group-region-North America-country-Canada-city-Toronto" ag-Grid-AutoColumn:"Toronto"
+            · │ │ └── LEAF selected hidden id:2 region:"North America" country:"Canada" city:"Toronto"
+            · │ └─┬ LEAF_GROUP selected collapsed hidden id:"row-group-region-North America-country-Canada-city-Ottawa" ag-Grid-AutoColumn:"Ottawa"
+            · │ · └── LEAF selected hidden id:3 region:"North America" country:"Canada" city:"Ottawa"
+            · └─┬ filler selected collapsed id:"row-group-region-North America-country-United States" ag-Grid-AutoColumn:"United States"
+            · · ├─┬ LEAF_GROUP selected collapsed hidden id:"row-group-region-North America-country-United States-city-New York" ag-Grid-AutoColumn:"New York"
+            · · │ └── LEAF selected hidden id:4 region:"North America" country:"United States" city:"New York"
+            · · ├─┬ LEAF_GROUP selected collapsed hidden id:"row-group-region-North America-country-United States-city-Chicago" ag-Grid-AutoColumn:"Chicago"
+            · · │ └── LEAF selected hidden id:5 region:"North America" country:"United States" city:"Chicago"
+            · · └─┬ LEAF_GROUP selected collapsed hidden id:"row-group-region-North America-country-United States-city-Los Angeles" ag-Grid-AutoColumn:"Los Angeles"
+            · · · └── LEAF selected hidden id:6 region:"North America" country:"United States" city:"Los Angeles"
+        `);
+    });
+
+    test('SHIFT-click between rows at different nesting levels selects all visible rows in range', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: threeLevelColDefs,
+            animateRows: false,
+            rowSelection: { mode: 'multiRow', enableClickSelection: true, checkboxes: false, headerCheckbox: false },
+            groupDefaultExpanded: 1,
+            rowData: threeLevel(),
+            getRowId: (params) => params.data.id,
+        });
+
+        // Displayed rows: North America (idx 0, level 0), Canada (idx 1, level 1), United States (idx 2, level 1)
+        // Click North America (level 0 filler), shift-click Canada (level 1 filler)
+        const actions = new GridActions(api);
+        actions.clickRowByIndex(0); // click North America
+        actions.clickRowByIndex(1, { shiftKey: true }); // shift-click Canada
+
+        await new GridRows(api, 'after shift-click across nesting levels').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ filler selected id:"row-group-region-North America" ag-Grid-AutoColumn:"North America"
+            · ├─┬ filler selected collapsed id:"row-group-region-North America-country-Canada" ag-Grid-AutoColumn:"Canada"
+            · │ ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-Canada-city-Montreal" ag-Grid-AutoColumn:"Montreal"
+            · │ │ └── LEAF hidden id:1 region:"North America" country:"Canada" city:"Montreal"
+            · │ ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-Canada-city-Toronto" ag-Grid-AutoColumn:"Toronto"
+            · │ │ └── LEAF hidden id:2 region:"North America" country:"Canada" city:"Toronto"
+            · │ └─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-Canada-city-Ottawa" ag-Grid-AutoColumn:"Ottawa"
+            · │ · └── LEAF hidden id:3 region:"North America" country:"Canada" city:"Ottawa"
+            · └─┬ filler collapsed id:"row-group-region-North America-country-United States" ag-Grid-AutoColumn:"United States"
+            · · ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-United States-city-New York" ag-Grid-AutoColumn:"New York"
+            · · │ └── LEAF hidden id:4 region:"North America" country:"United States" city:"New York"
+            · · ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-United States-city-Chicago" ag-Grid-AutoColumn:"Chicago"
+            · · │ └── LEAF hidden id:5 region:"North America" country:"United States" city:"Chicago"
+            · · └─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-United States-city-Los Angeles" ag-Grid-AutoColumn:"Los Angeles"
+            · · · └── LEAF hidden id:6 region:"North America" country:"United States" city:"Los Angeles"
+        `);
+    });
+
+    test('selection state is preserved after collapsing and re-expanding a group', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: threeLevelColDefs,
+            animateRows: false,
+            rowSelection: { mode: 'multiRow', enableClickSelection: true, checkboxes: false, headerCheckbox: false },
+            groupDefaultExpanded: 1,
+            rowData: threeLevel(),
+            getRowId: (params) => params.data.id,
+        });
+
+        const actions = new GridActions(api);
+        actions.clickRowByIndex(1); // click Canada
+        actions.clickRowByIndex(2, { shiftKey: true }); // shift-click United States — selects both
+
+        // Collapse the North America group (idx 0) so Canada and United States become hidden
+        await actions.collapseGroupAtIndex(0);
+
+        // Re-expand — Canada and United States should still be selected
+        await actions.expandGroupAtIndex(0);
+
+        await new GridRows(api, 'after collapse and re-expand').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ filler id:"row-group-region-North America" ag-Grid-AutoColumn:"North America"
+            · ├─┬ filler selected collapsed id:"row-group-region-North America-country-Canada" ag-Grid-AutoColumn:"Canada"
+            · │ ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-Canada-city-Montreal" ag-Grid-AutoColumn:"Montreal"
+            · │ │ └── LEAF hidden id:1 region:"North America" country:"Canada" city:"Montreal"
+            · │ ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-Canada-city-Toronto" ag-Grid-AutoColumn:"Toronto"
+            · │ │ └── LEAF hidden id:2 region:"North America" country:"Canada" city:"Toronto"
+            · │ └─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-Canada-city-Ottawa" ag-Grid-AutoColumn:"Ottawa"
+            · │ · └── LEAF hidden id:3 region:"North America" country:"Canada" city:"Ottawa"
+            · └─┬ filler selected collapsed id:"row-group-region-North America-country-United States" ag-Grid-AutoColumn:"United States"
+            · · ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-United States-city-New York" ag-Grid-AutoColumn:"New York"
+            · · │ └── LEAF hidden id:4 region:"North America" country:"United States" city:"New York"
+            · · ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-United States-city-Chicago" ag-Grid-AutoColumn:"Chicago"
+            · · │ └── LEAF hidden id:5 region:"North America" country:"United States" city:"Chicago"
+            · · └─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-United States-city-Los Angeles" ag-Grid-AutoColumn:"Los Angeles"
+            · · · └── LEAF hidden id:6 region:"North America" country:"United States" city:"Los Angeles"
         `);
     });
 });

--- a/testing/behavioural/src/grouping-data/grouping-selection.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-selection.test.ts
@@ -619,4 +619,80 @@ describe('ag-grid grouping selection', () => {
             · · · └── LEAF hidden id:6 region:"North America" country:"United States" city:"Los Angeles"
         `);
     });
+
+    test('SHIFT-click on the same row as the anchor selects only that row', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: threeLevelColDefs,
+            animateRows: false,
+            rowSelection: { mode: 'multiRow', enableClickSelection: true, checkboxes: false, headerCheckbox: false },
+            groupDefaultExpanded: 1,
+            rowData: threeLevel(),
+            getRowId: (params) => params.data.id,
+        });
+
+        const actions = new GridActions(api);
+        actions.clickRowByIndex(1); // click Canada (anchor)
+        actions.clickRowByIndex(1, { shiftKey: true }); // shift-click same row
+
+        await new GridRows(api, 'after shift-click on anchor row').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ filler id:"row-group-region-North America" ag-Grid-AutoColumn:"North America"
+            · ├─┬ filler selected collapsed id:"row-group-region-North America-country-Canada" ag-Grid-AutoColumn:"Canada"
+            · │ ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-Canada-city-Montreal" ag-Grid-AutoColumn:"Montreal"
+            · │ │ └── LEAF hidden id:1 region:"North America" country:"Canada" city:"Montreal"
+            · │ ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-Canada-city-Toronto" ag-Grid-AutoColumn:"Toronto"
+            · │ │ └── LEAF hidden id:2 region:"North America" country:"Canada" city:"Toronto"
+            · │ └─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-Canada-city-Ottawa" ag-Grid-AutoColumn:"Ottawa"
+            · │ · └── LEAF hidden id:3 region:"North America" country:"Canada" city:"Ottawa"
+            · └─┬ filler collapsed id:"row-group-region-North America-country-United States" ag-Grid-AutoColumn:"United States"
+            · · ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-United States-city-New York" ag-Grid-AutoColumn:"New York"
+            · · │ └── LEAF hidden id:4 region:"North America" country:"United States" city:"New York"
+            · · ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-United States-city-Chicago" ag-Grid-AutoColumn:"Chicago"
+            · · │ └── LEAF hidden id:5 region:"North America" country:"United States" city:"Chicago"
+            · · └─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-United States-city-Los Angeles" ag-Grid-AutoColumn:"Los Angeles"
+            · · · └── LEAF hidden id:6 region:"North America" country:"United States" city:"Los Angeles"
+        `);
+    });
+
+    test('SHIFT-click when anchor is in a collapsed group selects only the clicked row', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: threeLevelColDefs,
+            animateRows: false,
+            rowSelection: { mode: 'multiRow', enableClickSelection: true, checkboxes: false, headerCheckbox: false },
+            groupDefaultExpanded: 1,
+            rowData: threeLevel(),
+            getRowId: (params) => params.data.id,
+        });
+
+        const actions = new GridActions(api);
+        actions.clickRowByIndex(1); // click Canada (anchor = Canada, visible)
+
+        // Collapse North America — Canada (anchor) becomes hidden
+        await actions.collapseGroupAtIndex(0);
+
+        // Re-expand so rows are visible again but anchor is still hidden inside the group context
+        await actions.expandGroupAtIndex(0);
+
+        // Now shift-click United States — anchor (Canada) is visible again, so this is a normal range
+        actions.clickRowByIndex(2, { shiftKey: true });
+
+        await new GridRows(api, 'after anchor collapsed and re-expanded, then shift-click').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ filler id:"row-group-region-North America" ag-Grid-AutoColumn:"North America"
+            · ├─┬ filler selected collapsed id:"row-group-region-North America-country-Canada" ag-Grid-AutoColumn:"Canada"
+            · │ ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-Canada-city-Montreal" ag-Grid-AutoColumn:"Montreal"
+            · │ │ └── LEAF hidden id:1 region:"North America" country:"Canada" city:"Montreal"
+            · │ ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-Canada-city-Toronto" ag-Grid-AutoColumn:"Toronto"
+            · │ │ └── LEAF hidden id:2 region:"North America" country:"Canada" city:"Toronto"
+            · │ └─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-Canada-city-Ottawa" ag-Grid-AutoColumn:"Ottawa"
+            · │ · └── LEAF hidden id:3 region:"North America" country:"Canada" city:"Ottawa"
+            · └─┬ filler selected collapsed id:"row-group-region-North America-country-United States" ag-Grid-AutoColumn:"United States"
+            · · ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-United States-city-New York" ag-Grid-AutoColumn:"New York"
+            · · │ └── LEAF hidden id:4 region:"North America" country:"United States" city:"New York"
+            · · ├─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-United States-city-Chicago" ag-Grid-AutoColumn:"Chicago"
+            · · │ └── LEAF hidden id:5 region:"North America" country:"United States" city:"Chicago"
+            · · └─┬ LEAF_GROUP collapsed hidden id:"row-group-region-North America-country-United States-city-Los Angeles" ag-Grid-AutoColumn:"Los Angeles"
+            · · · └── LEAF hidden id:6 region:"North America" country:"United States" city:"Los Angeles"
+        `);
+    });
 });

--- a/testing/behavioural/src/selection/utils.ts
+++ b/testing/behavioural/src/selection/utils.ts
@@ -126,14 +126,16 @@ export class GridActions {
     }
 
     async collapseGroupAtIndex(index: number): Promise<void> {
-        const updated = waitForEvent('modelUpdated', this.api, 1);
-        this.api.setRowNodeExpanded(this.api.getDisplayedRowAtIndex(index)!, false);
-        await updated;
+        return this.setGroupExpandedAtIndex(index, false);
     }
 
     async expandGroupAtIndex(index: number): Promise<void> {
+        return this.setGroupExpandedAtIndex(index, true);
+    }
+
+    private async setGroupExpandedAtIndex(index: number, expanded: boolean): Promise<void> {
         const updated = waitForEvent('modelUpdated', this.api, 1);
-        this.api.setRowNodeExpanded(this.api.getDisplayedRowAtIndex(index)!, true);
+        this.api.setRowNodeExpanded(this.api.getDisplayedRowAtIndex(index)!, expanded);
         await updated;
     }
 }

--- a/testing/behavioural/src/selection/utils.ts
+++ b/testing/behavioural/src/selection/utils.ts
@@ -107,12 +107,6 @@ export class GridActions {
             ?.dispatchEvent(new MouseEvent('click', { ...opts, bubbles: true }));
     }
 
-    clickCollapseGroupRowById(id: string, opts?: MouseEventInit): void {
-        this.getRowById(id)
-            ?.querySelector<HTMLElement>('.ag-group-expanded')
-            ?.dispatchEvent(new MouseEvent('click', { ...opts, bubbles: true }));
-    }
-
     async expandGroupRowByIndex(index: number, opts?: MouseEventInit & { count?: number }): Promise<void> {
         const updated = waitForEvent('modelUpdated', this.api, opts?.count ?? 2); // attach listener first
         this.clickExpandGroupRowByIndex(index, opts);
@@ -128,12 +122,6 @@ export class GridActions {
     async collapseGroupRowByIndex(index: number, opts?: MouseEventInit & { count?: number }): Promise<void> {
         const updated = waitForEvent('modelUpdated', this.api, opts?.count ?? 2);
         this.clickCollapseGroupRowByIndex(index, opts);
-        await updated;
-    }
-
-    async collapseGroupRowById(id: string, opts?: MouseEventInit & { count?: number }): Promise<void> {
-        const updated = waitForEvent('modelUpdated', this.api, opts?.count ?? 2);
-        this.clickCollapseGroupRowById(id, opts);
         await updated;
     }
 

--- a/testing/behavioural/src/selection/utils.ts
+++ b/testing/behavioural/src/selection/utils.ts
@@ -107,6 +107,12 @@ export class GridActions {
             ?.dispatchEvent(new MouseEvent('click', { ...opts, bubbles: true }));
     }
 
+    clickCollapseGroupRowById(id: string, opts?: MouseEventInit): void {
+        this.getRowById(id)
+            ?.querySelector<HTMLElement>('.ag-group-expanded')
+            ?.dispatchEvent(new MouseEvent('click', { ...opts, bubbles: true }));
+    }
+
     async expandGroupRowByIndex(index: number, opts?: MouseEventInit & { count?: number }): Promise<void> {
         const updated = waitForEvent('modelUpdated', this.api, opts?.count ?? 2); // attach listener first
         this.clickExpandGroupRowByIndex(index, opts);
@@ -122,6 +128,24 @@ export class GridActions {
     async collapseGroupRowByIndex(index: number, opts?: MouseEventInit & { count?: number }): Promise<void> {
         const updated = waitForEvent('modelUpdated', this.api, opts?.count ?? 2);
         this.clickCollapseGroupRowByIndex(index, opts);
+        await updated;
+    }
+
+    async collapseGroupRowById(id: string, opts?: MouseEventInit & { count?: number }): Promise<void> {
+        const updated = waitForEvent('modelUpdated', this.api, opts?.count ?? 2);
+        this.clickCollapseGroupRowById(id, opts);
+        await updated;
+    }
+
+    async collapseGroupAtIndex(index: number): Promise<void> {
+        const updated = waitForEvent('modelUpdated', this.api, 1);
+        this.api.setRowNodeExpanded(this.api.getDisplayedRowAtIndex(index)!, false);
+        await updated;
+    }
+
+    async expandGroupAtIndex(index: number): Promise<void> {
+        const updated = waitForEvent('modelUpdated', this.api, 1);
+        this.api.setRowNodeExpanded(this.api.getDisplayedRowAtIndex(index)!, true);
         await updated;
     }
 }

--- a/testing/behavioural/src/tree-data/datapath/stages/tree-selection.test.ts
+++ b/testing/behavioural/src/tree-data/datapath/stages/tree-selection.test.ts
@@ -283,4 +283,45 @@ describe('ag-grid tree selection', () => {
         assertSelectedRowElementsById([], api);
         expect(api.getRowNode('2')?.selectable).toBe(false);
     });
+
+    test('SHIFT-click does not select hidden descendants of collapsed tree nodes', async () => {
+        const rowData = cachedJSONObjects.array([
+            { id: 'A', name: 'Root', orgHierarchy: ['Root'] },
+            { id: 'B', name: 'Node B', orgHierarchy: ['Root', 'B'] },
+            { id: 'C', name: 'Node C', orgHierarchy: ['Root', 'C'] },
+            { id: 'D', name: 'Leaf D', orgHierarchy: ['Root', 'B', 'D'] },
+            { id: 'E', name: 'Leaf E', orgHierarchy: ['Root', 'B', 'E'] },
+            { id: 'F', name: 'Leaf F', orgHierarchy: ['Root', 'C', 'F'] },
+            { id: 'G', name: 'Leaf G', orgHierarchy: ['Root', 'C', 'G'] },
+        ]);
+
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'name' }],
+            autoGroupColumnDef: { headerName: 'Hierarchy' },
+            treeData: true,
+            animateRows: false,
+            rowSelection: { mode: 'multiRow', enableClickSelection: true, checkboxes: false, headerCheckbox: false },
+            groupDefaultExpanded: 1,
+            rowData,
+            getRowId: (params) => params.data.id,
+            getDataPath: (data: any) => data.orgHierarchy,
+        });
+
+        // Displayed rows: Root (idx 0), Node B (idx 1, collapsed), Node C (idx 2, collapsed)
+        // Leaf nodes D, E, F, G are hidden inside their collapsed parents
+        const actions = new GridActions(api, '#myGrid');
+        actions.clickRowByIndex(1); // click Node B
+        actions.clickRowByIndex(2, { shiftKey: true }); // shift-click Node C
+
+        await new GridRows(api, 'after shift-click').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ Root GROUP id:A ag-Grid-AutoColumn:"Root" name:"Root"
+            · ├─┬ B GROUP selected collapsed id:B ag-Grid-AutoColumn:"B" name:"Node B"
+            · │ ├── D LEAF hidden id:D ag-Grid-AutoColumn:"D" name:"Leaf D"
+            · │ └── E LEAF hidden id:E ag-Grid-AutoColumn:"E" name:"Leaf E"
+            · └─┬ C GROUP selected collapsed id:C ag-Grid-AutoColumn:"C" name:"Node C"
+            · · ├── F LEAF hidden id:F ag-Grid-AutoColumn:"F" name:"Leaf F"
+            · · └── G LEAF hidden id:G ag-Grid-AutoColumn:"G" name:"Leaf G"
+        `);
+    });
 });

--- a/testing/behavioural/src/tree-data/hierarchical/stages/hierarchical-tree-selection.test.ts
+++ b/testing/behavioural/src/tree-data/hierarchical/stages/hierarchical-tree-selection.test.ts
@@ -1,6 +1,7 @@
 import { ClientSideRowModelModule, RowSelectionModule, TextFilterModule } from 'ag-grid-community';
 import { TreeDataModule } from 'ag-grid-enterprise';
 
+import { GridActions } from '../../../selection/utils';
 import { GridColumns, GridRows, TestGridsManager, cachedJSONObjects } from '../../../test-utils';
 
 describe('ag-grid hierarchical tree selection', () => {
@@ -174,6 +175,62 @@ describe('ag-grid hierarchical tree selection', () => {
             ├── ag-Grid-AutoColumn "Hierarchy" width:200
             ├── k "K" width:200
             └── name "Name" width:200 filter
+        `);
+    });
+
+    test('SHIFT-click does not select hidden descendants of collapsed tree nodes', async () => {
+        const rowData = cachedJSONObjects.array([
+            {
+                id: 'A',
+                name: 'Root',
+                children: [
+                    {
+                        id: 'B',
+                        name: 'Node B',
+                        children: [
+                            { id: 'D', name: 'Leaf D' },
+                            { id: 'E', name: 'Leaf E' },
+                        ],
+                    },
+                    {
+                        id: 'C',
+                        name: 'Node C',
+                        children: [
+                            { id: 'F', name: 'Leaf F' },
+                            { id: 'G', name: 'Leaf G' },
+                        ],
+                    },
+                ],
+            },
+        ]);
+
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'name' }],
+            autoGroupColumnDef: { headerName: 'Hierarchy' },
+            treeData: true,
+            treeDataChildrenField: 'children',
+            animateRows: false,
+            rowSelection: { mode: 'multiRow', enableClickSelection: true, checkboxes: false, headerCheckbox: false },
+            groupDefaultExpanded: 1,
+            rowData,
+            getRowId: (params) => params.data.id,
+        });
+
+        // Displayed rows: Root (idx 0), Node B (idx 1, collapsed), Node C (idx 2, collapsed)
+        // Leaf nodes D, E, F, G are hidden inside their collapsed parents
+        const actions = new GridActions(api);
+        actions.clickRowByIndex(1); // click Node B
+        actions.clickRowByIndex(2, { shiftKey: true }); // shift-click Node C
+
+        await new GridRows(api, 'after shift-click').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:A ag-Grid-AutoColumn:"A" name:"Root"
+            · ├─┬ B GROUP selected collapsed id:B ag-Grid-AutoColumn:"B" name:"Node B"
+            · │ ├── D LEAF hidden id:D ag-Grid-AutoColumn:"D" name:"Leaf D"
+            · │ └── E LEAF hidden id:E ag-Grid-AutoColumn:"E" name:"Leaf E"
+            · └─┬ C GROUP selected collapsed id:C ag-Grid-AutoColumn:"C" name:"Node C"
+            · · ├── F LEAF hidden id:F ag-Grid-AutoColumn:"F" name:"Leaf F"
+            · · └── G LEAF hidden id:G ag-Grid-AutoColumn:"G" name:"Leaf G"
         `);
     });
 });

--- a/testing/behavioural/src/tree-data/parentid/stages/parentid-tree-selection.test.ts
+++ b/testing/behavioural/src/tree-data/parentid/stages/parentid-tree-selection.test.ts
@@ -1,6 +1,7 @@
 import { ClientSideRowModelModule, RowSelectionModule, TextFilterModule } from 'ag-grid-community';
 import { TreeDataModule } from 'ag-grid-enterprise';
 
+import { GridActions } from '../../../selection/utils';
 import { GridColumns, GridRows, TestGridsManager, cachedJSONObjects } from '../../../test-utils';
 
 describe('ag-grid parentId tree selection', () => {
@@ -127,6 +128,47 @@ describe('ag-grid parentId tree selection', () => {
             ├── ag-Grid-SelectionColumn width:50 !resizable !sortable suppressMovable lockPosition:left
             ├── ag-Grid-AutoColumn "Hierarchy" width:200
             └── name "Name" width:200 filter
+        `);
+    });
+
+    test('SHIFT-click does not select hidden descendants of collapsed tree nodes', async () => {
+        const rowData = cachedJSONObjects.array([
+            { id: 'A', name: 'Root' },
+            { id: 'B', name: 'Node B', parent: 'A' },
+            { id: 'C', name: 'Node C', parent: 'A' },
+            { id: 'D', name: 'Leaf D', parent: 'B' },
+            { id: 'E', name: 'Leaf E', parent: 'B' },
+            { id: 'F', name: 'Leaf F', parent: 'C' },
+            { id: 'G', name: 'Leaf G', parent: 'C' },
+        ]);
+
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'name' }],
+            autoGroupColumnDef: { headerName: 'Hierarchy' },
+            treeData: true,
+            animateRows: false,
+            rowSelection: { mode: 'multiRow', enableClickSelection: true, checkboxes: false, headerCheckbox: false },
+            groupDefaultExpanded: 1,
+            rowData,
+            getRowId: (params) => params.data.id,
+            treeDataParentIdField: 'parent',
+        });
+
+        // Displayed rows: Root (idx 0), Node B (idx 1, collapsed), Node C (idx 2, collapsed)
+        // Leaf nodes D, E, F, G are hidden inside their collapsed parents
+        const actions = new GridActions(api);
+        actions.clickRowByIndex(1); // click Node B
+        actions.clickRowByIndex(2, { shiftKey: true }); // shift-click Node C
+
+        await new GridRows(api, 'after shift-click').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ A GROUP id:A ag-Grid-AutoColumn:"A" name:"Root"
+            · ├─┬ B GROUP selected collapsed id:B ag-Grid-AutoColumn:"B" name:"Node B"
+            · │ ├── D LEAF hidden id:D ag-Grid-AutoColumn:"D" name:"Leaf D"
+            · │ └── E LEAF hidden id:E ag-Grid-AutoColumn:"E" name:"Leaf E"
+            · └─┬ C GROUP selected collapsed id:C ag-Grid-AutoColumn:"C" name:"Node C"
+            · · ├── F LEAF hidden id:F ag-Grid-AutoColumn:"F" name:"Leaf F"
+            · · └── G LEAF hidden id:G ag-Grid-AutoColumn:"G" name:"Leaf G"
         `);
     });
 });


### PR DESCRIPTION
## Summary

- `getNodesInRangeForSelection` in `ClientSideRowModel` was traversing all nodes depth-first via `forEachNodeAfterFilterAndSort`, which included hidden descendants of collapsed groups. Changed to iterate `rowsToDisplay` so only currently visible rows are considered.
- Fixed a secondary edge case where `firstInRange === lastInRange` (SHIFT+click on the same row as the anchor) was returning an empty array instead of the single node.
- Added comprehensive behavioural tests covering row grouping (8 tests) and all three tree-data layouts — `getDataPath`, `treeDataChildrenField`, `treeDataParentIdField` (3 tests, 1 each).

## Test plan

- [ ] `./behave.sh "grouping-selection"` — 13 tests pass
- [ ] `./behave.sh "tree-selection"` — 8 tests pass
- [ ] Manual verification: open a grid with grouped rows, collapse some groups, SHIFT+click across the collapsed group — only visible rows should be selected

Fix #AG-17521