### PR TITLE
AG-17134 Enforce grid staging CSP on latest (production stays report-only)

### DIFF
--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
@@ -155,9 +155,10 @@ AddType application/x-gzip .gz .tgz
 function getStagingHtaccessContent(): string {
     return `${baseRules}
 
-# Content-Security-Policy — report-only while validating on staging. Unsets the
-# legacy wildcard CSP on the staging vhost so this is the only policy in effect.
-${getCspHtaccessBlock({ env: 'staging' }, 'report-only')}
+# Content-Security-Policy — enforced. Unsets the legacy wildcard CSP on the staging
+# vhost so this tightened policy is the only one in effect. Production stays
+# report-only on latest until the release enforce rollout is verified.
+${getCspHtaccessBlock({ env: 'staging' }, 'enforce')}
 
 Options -Indexes
 `;


### PR DESCRIPTION
## What

Enable the tightened CSP in **enforce** mode on **staging only** on `latest`. Production stays **report-only** on `latest` for now — it will be flipped to enforce after the release-branch enforce rollout (charts → studio → grid) is deployed and verified in production.

Flips `getStagingHtaccessContent()` from `getCspHtaccessBlock({ env: 'staging' }, 'report-only')` to `'enforce'`. In enforce mode the block unsets the inherited headers (incl. the legacy wildcard CSP on the staging vhost) and sets the tightened policy as the enforced `Content-Security-Policy`.

`getProductionHtaccessContent()` is untouched (still the report-only line).

## Why staging can land independently

Staging is a separate host with no cross-product CSP inheritance (unlike production, where `/charts` and `/studio` inherit the grid-root policy). So the production deploy-order constraint does not apply to staging — grid staging can enforce without waiting on charts/studio.

## Testing

Generated `dist/.htaccess` for both envs and confirmed:
- **staging:** `Header always unset Content-Security-Policy` + `Header always unset Content-Security-Policy-Report-Only` + `Header always set Content-Security-Policy "…"` (enforced)
- **production:** unchanged — still `Content-Security-Policy-Report-Only`

Formatter applied; file lints clean.

Part of AG-17134.
