### PR TITLE
fix(e2e): correct dialog highlighting test to match suppress example

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-dialog-highlighting/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-dialog-highlighting/example.spec.ts
@@ -2,14 +2,14 @@ import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     test.eachFramework(
-        'dialog highlighting example opens the dialog and highlights the calculated column',
+        'suppress dialog highlighting example opens the dialog without highlighting the calculated column',
         async ({ agIdFor, page }) => {
             await expect(agIdFor.headerCell('profit')).toContainText('Profit');
             await expect(agIdFor.cell('0', 'profit')).toContainText('$46,000');
             await expect(agIdFor.cell('1', 'profit')).toContainText('$26,000');
             await expect(page.locator('.ag-calculated-column-form')).toBeVisible();
-            await expect(agIdFor.headerCell('profit')).toHaveClass(/ag-calculated-column-highlighted/);
-            await expect(agIdFor.cell('0', 'profit')).toHaveClass(/ag-calculated-column-highlighted/);
+            await expect(agIdFor.headerCell('profit')).not.toHaveClass(/ag-calculated-column-highlighted/);
+            await expect(agIdFor.cell('0', 'profit')).not.toHaveClass(/ag-calculated-column-highlighted/);
         }
     );
 });


### PR DESCRIPTION
## Summary
- The `calculated-columns-dialog-highlighting` example has `suppressColumnHighlighting: true`, demonstrating suppressed highlighting
- The E2E test incorrectly asserted that `ag-calculated-column-highlighted` class **was** present
- Flipped assertions to `not.toHaveClass` and updated the test name to match the example's intent

## Test plan
- [x] E2E test passes across all 6 frameworks (vanilla, typescript, react dev, react, angular, vue3)