### PR TITLE
AG-17535 - [Fill Handle] - fix readOnlyEdit fill handle using wrong source for boolean/dateString columns

### DIFF
--- a/packages/ag-grid-enterprise/src/rangeSelection/agFillHandle.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/agFillHandle.ts
@@ -348,6 +348,8 @@ export class AgFillHandle extends AbstractSelectionHandle {
         ) => {
             let currentValue: any;
             let skipValue: boolean = false;
+            let pushColumn: AgColumn = col;
+            let pushRowNode: RowNode = rowNode;
 
             if (withinInitialRange) {
                 currentValue = valueSvc.getValue(col, rowNode, 'edit');
@@ -368,6 +370,13 @@ export class AgFillHandle extends AbstractSelectionHandle {
                     rowNode,
                     idx: idx++,
                 });
+
+                if (sourceCol) {
+                    pushColumn = sourceCol;
+                }
+                if (sourceRowNode) {
+                    pushRowNode = sourceRowNode;
+                }
 
                 currentValue = value;
                 if (col.isCellEditable(rowNode)) {
@@ -410,8 +419,8 @@ export class AgFillHandle extends AbstractSelectionHandle {
             if (!skipValue) {
                 currentValues.push({
                     value: currentValue,
-                    column: col,
-                    rowNode,
+                    column: pushColumn,
+                    rowNode: pushRowNode,
                 });
             }
         };

--- a/packages/ag-grid-enterprise/src/rangeSelection/agFillHandle.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/agFillHandle.ts
@@ -348,8 +348,10 @@ export class AgFillHandle extends AbstractSelectionHandle {
         ) => {
             let currentValue: any;
             let skipValue: boolean = false;
-            let pushColumn: AgColumn = col;
-            let pushRowNode: RowNode = rowNode;
+            // ValueContext entries feed the cyclic source lookup in processValues, so a filled
+            // cell must record the cell its value originated from, not the cell being written.
+            let valueSourceCol: AgColumn = col;
+            let valueSourceRowNode: RowNode = rowNode;
 
             if (withinInitialRange) {
                 currentValue = valueSvc.getValue(col, rowNode, 'edit');
@@ -371,12 +373,8 @@ export class AgFillHandle extends AbstractSelectionHandle {
                     idx: idx++,
                 });
 
-                if (sourceCol) {
-                    pushColumn = sourceCol;
-                }
-                if (sourceRowNode) {
-                    pushRowNode = sourceRowNode;
-                }
+                valueSourceCol = sourceCol ?? col;
+                valueSourceRowNode = sourceRowNode ?? rowNode;
 
                 currentValue = value;
                 if (col.isCellEditable(rowNode)) {
@@ -419,8 +417,8 @@ export class AgFillHandle extends AbstractSelectionHandle {
             if (!skipValue) {
                 currentValues.push({
                     value: currentValue,
-                    column: pushColumn,
-                    rowNode: pushRowNode,
+                    column: valueSourceCol,
+                    rowNode: valueSourceRowNode,
                 });
             }
         };

--- a/testing/behavioural/src/cell-editing/clipboard/clipboard-fill-handle.test.ts
+++ b/testing/behavioural/src/cell-editing/clipboard/clipboard-fill-handle.test.ts
@@ -360,7 +360,8 @@ describe('Clipboard Paste Behaviour: fill handle', () => {
             await userEvent.dblClick(fillHandle);
             await fillEnd;
 
-            const sourceValue = field === 'text' ? 'Source' : field === 'bool' ? 'true' : '2024-01-15';
+            const sourceValues: Record<string, string> = { text: 'Source', bool: 'true', date: '2024-01-15' };
+            const sourceValue = sourceValues[field];
             expect(editRequests, `fill for ${field} column`).toEqual([
                 `ROW_1:${field}:${sourceValue}`,
                 `ROW_2:${field}:${sourceValue}`,
@@ -412,8 +413,10 @@ describe('Clipboard Paste Behaviour: fill handle', () => {
             await userEvent.dblClick(fillHandle);
             await fillEnd;
 
-            const val0 = field === 'text' ? 'A' : field === 'bool' ? 'true' : '2024-01-15';
-            const val1 = field === 'text' ? 'B' : field === 'bool' ? 'false' : '2024-06-20';
+            const expectedRow0: Record<string, string> = { text: 'A', bool: 'true', date: '2024-01-15' };
+            const expectedRow1: Record<string, string> = { text: 'B', bool: 'false', date: '2024-06-20' };
+            const val0 = expectedRow0[field];
+            const val1 = expectedRow1[field];
             expect(editRequests, `cyclic fill for ${field} column`).toEqual([
                 `ROW_2:${field}:${val0}`,
                 `ROW_3:${field}:${val1}`,

--- a/testing/behavioural/src/cell-editing/clipboard/clipboard-fill-handle.test.ts
+++ b/testing/behavioural/src/cell-editing/clipboard/clipboard-fill-handle.test.ts
@@ -316,4 +316,109 @@ describe('Clipboard Paste Behaviour: fill handle', () => {
 
         expect(editRequests).toEqual(['ROW_1:field:Top Value', 'ROW_2:field:Top Value']);
     });
+
+    test('readOnlyEdit fill handle uses source cell value for all column types', async () => {
+        const editRequests: string[] = [];
+
+        const api = await gridMgr.createGridAndWait('clipboardGridReadOnlyFillTypes', {
+            readOnlyEdit: true,
+            cellSelection: {
+                handle: {
+                    mode: 'fill',
+                },
+            },
+            columnDefs: [
+                { field: 'text', editable: true },
+                { field: 'bool', editable: true },
+                { field: 'date', editable: true, cellDataType: 'dateString' },
+            ],
+            rowData: [
+                { id: 'ROW_0', text: 'Source', bool: true, date: '2024-01-15' },
+                { id: 'ROW_1', text: 'Other1', bool: false, date: '2024-06-20' },
+                { id: 'ROW_2', text: 'Other2', bool: false, date: '2024-12-25' },
+            ],
+            getRowId: (params) => params.data.id,
+            onCellEditRequest: (event) => {
+                editRequests.push(`${event.node?.id ?? 'unknown'}:${event.colDef.field}:${event.newValue}`);
+            },
+        });
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+
+        for (const field of ['text', 'bool', 'date']) {
+            editRequests.length = 0;
+
+            await asyncSetTimeout(1);
+            const cell = getByTestId(gridDiv, agTestIdFor.cell('ROW_0', field));
+            const cellSelectionChanged = waitForEvent('cellSelectionChanged', api);
+            cell.dispatchEvent(new MouseEvent('touchstart', { bubbles: true }));
+            await cellSelectionChanged;
+            await asyncSetTimeout(1);
+
+            const fillHandle = getByTestId(gridDiv, agTestIdFor.fillHandle());
+            const fillEnd = waitForEvent('fillEnd', api);
+            await userEvent.dblClick(fillHandle);
+            await fillEnd;
+
+            const sourceValue = field === 'text' ? 'Source' : field === 'bool' ? 'true' : '2024-01-15';
+            expect(editRequests, `fill for ${field} column`).toEqual([
+                `ROW_1:${field}:${sourceValue}`,
+                `ROW_2:${field}:${sourceValue}`,
+            ]);
+        }
+    });
+
+    test('readOnlyEdit fill handle cycles multi-row selection pattern for all column types', async () => {
+        const editRequests: string[] = [];
+
+        const api = await gridMgr.createGridAndWait('clipboardGridReadOnlyFillCyclic', {
+            readOnlyEdit: true,
+            cellSelection: {
+                handle: {
+                    mode: 'fill',
+                },
+            },
+            columnDefs: [
+                { field: 'text', editable: true },
+                { field: 'bool', editable: true },
+                { field: 'date', editable: true, cellDataType: 'dateString' },
+            ],
+            rowData: [
+                { id: 'ROW_0', text: 'A', bool: true, date: '2024-01-15' },
+                { id: 'ROW_1', text: 'B', bool: false, date: '2024-06-20' },
+                { id: 'ROW_2', text: 'X', bool: false, date: '2024-12-25' },
+                { id: 'ROW_3', text: 'Y', bool: false, date: '2024-12-31' },
+                { id: 'ROW_4', text: 'Z', bool: true, date: '2024-03-01' },
+            ],
+            getRowId: (params) => params.data.id,
+            onCellEditRequest: (event) => {
+                editRequests.push(`${event.node?.id ?? 'unknown'}:${event.colDef.field}:${event.newValue}`);
+            },
+        });
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+
+        for (const field of ['text', 'bool', 'date']) {
+            editRequests.length = 0;
+            api.clearCellSelection();
+
+            const cellSelectionChanged = waitForEvent('cellSelectionChanged', api);
+            api.addCellRange({ rowStartIndex: 0, rowEndIndex: 1, columns: [field] });
+            await cellSelectionChanged;
+            await asyncSetTimeout(1);
+
+            const fillHandle = getByTestId(gridDiv, agTestIdFor.fillHandle());
+            const fillEnd = waitForEvent('fillEnd', api);
+            await userEvent.dblClick(fillHandle);
+            await fillEnd;
+
+            const val0 = field === 'text' ? 'A' : field === 'bool' ? 'true' : '2024-01-15';
+            const val1 = field === 'text' ? 'B' : field === 'bool' ? 'false' : '2024-06-20';
+            expect(editRequests, `cyclic fill for ${field} column`).toEqual([
+                `ROW_2:${field}:${val0}`,
+                `ROW_3:${field}:${val1}`,
+                `ROW_4:${field}:${val0}`,
+            ]);
+        }
+    });
 });


### PR DESCRIPTION
## Summary

- Fix fill handle in `readOnlyEdit` mode producing incorrect `newValue` for boolean and dateString columns in `onCellEditRequest`
- The internal values array was storing target row references instead of source row references, causing `getValueForDisplay` to read stale data from unfilled rows
- Add behavioural tests for single-source and multi-row cyclic fill across string, boolean, and dateString column types

## Test plan

- [x] Behavioural tests: single-source fill verifies consistent `newValue` across all column types
- [x] Behavioural tests: multi-row cyclic fill verifies A,B,A pattern cycles correctly
- [x] Existing fill handle tests pass (7/7)
- [x] `build:types ag-grid-enterprise` passes
- [x] `lint ag-grid-enterprise` passes

Fix AG-17535