### PR TITLE
Remove editing helper from core bundle

### DIFF
--- a/packages/ag-grid-community/src/edit/editService.ts
+++ b/packages/ag-grid-community/src/edit/editService.ts
@@ -925,6 +925,11 @@ export class EditService extends BeanStub implements NamedBean {
         return 'continue';
     }
 
+    /** Calls through to standalone method for treeshaking via the editService */
+    public populateModelValidationErrors() {
+        _populateModelValidationErrors(this.beans);
+    }
+
     public revertSingleCellEdit(cellPosition: Required<EditPosition>, focus = false): void {
         const cellCtrl = _getCellCtrl(this.beans, cellPosition);
         if (!cellCtrl?.comp?.getCellEditor()) {

--- a/packages/ag-grid-community/src/edit/strategy/fullRowEditStrategy.ts
+++ b/packages/ag-grid-community/src/edit/strategy/fullRowEditStrategy.ts
@@ -6,12 +6,7 @@ import type { EditPosition, EditRowPosition, StartEditWithPositionParams } from 
 import type { IRowNode } from '../../interfaces/iRowNode';
 import type { CellCtrl } from '../../rendering/cell/cellCtrl';
 import { _getCellCtrl, _getRowCtrl } from '../utils/controllers';
-import {
-    _destroyEditor,
-    _populateModelValidationErrors,
-    _setupEditor,
-    _sourceAndPendingDiffer,
-} from '../utils/editors';
+import { _destroyEditor, _setupEditor, _sourceAndPendingDiffer } from '../utils/editors';
 import type { EditValidationAction, EditValidationResult } from './baseEditStrategy';
 import { BaseEditStrategy } from './baseEditStrategy';
 
@@ -140,7 +135,7 @@ export class FullRowEditStrategy extends BaseEditStrategy {
     }
 
     public override stopCommitted(event: Event | null, commit: boolean): boolean {
-        const { rowNode, beans, model, editSvc } = this;
+        const { rowNode, model, editSvc } = this;
         if (rowNode && !model.hasEdits()) {
             return false;
         }
@@ -159,7 +154,7 @@ export class FullRowEditStrategy extends BaseEditStrategy {
             }
         });
 
-        _populateModelValidationErrors(beans);
+        editSvc.populateModelValidationErrors();
         if (editSvc.checkNavWithValidation({ rowNode }) === 'block-stop') {
             return false;
         }

--- a/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
@@ -226,8 +226,8 @@ export class CellCtrl extends BeanStub {
         if (this.editorTooltipFeature) {
             this.disableEditorTooltipFeature();
         }
-        const tooltipSvc = this.beans.tooltipSvc;
-        this.editorTooltipFeature = tooltipSvc?.setupCellEditorTooltip(this, editor);
+        this.editorTooltipFeature = this.beans.tooltipSvc?.setupCellEditorTooltip(this, editor);
+
         this.editSvc?.populateModelValidationErrors();
     }
 

--- a/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
@@ -16,7 +16,6 @@ import { BeanStub } from '../../context/beanStub';
 import type { BeanCollection } from '../../context/context';
 import type { RowDragComp } from '../../dragAndDrop/rowDragComp';
 import type { EditService } from '../../edit/editService';
-import { _populateModelValidationErrors } from '../../edit/utils/editors';
 import type { AgColumn } from '../../entities/agColumn';
 import type { CellStyle, CheckboxSelectionCallback, ColDef } from '../../entities/colDef';
 import type { RowNode } from '../../entities/rowNode';
@@ -227,9 +226,9 @@ export class CellCtrl extends BeanStub {
         if (this.editorTooltipFeature) {
             this.disableEditorTooltipFeature();
         }
-        this.editorTooltipFeature = this.beans.tooltipSvc?.setupCellEditorTooltip(this, editor);
-
-        _populateModelValidationErrors(this.beans);
+        const tooltipSvc = this.beans.tooltipSvc;
+        this.editorTooltipFeature = tooltipSvc?.setupCellEditorTooltip(this, editor);
+        this.editSvc?.populateModelValidationErrors();
     }
 
     public disableEditorTooltipFeature(): void {

--- a/packages/ag-grid-community/src/rendering/cell/cellKeyboardListenerFeature.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellKeyboardListenerFeature.ts
@@ -3,7 +3,6 @@ import { KeyCode, _isMacOsUserAgent } from 'ag-stack';
 import { isRowNumberCol } from '../../columns/columnUtils';
 import { BeanStub } from '../../context/beanStub';
 import type { BeanCollection } from '../../context/context';
-import { _populateModelValidationErrors } from '../../edit/utils/editors';
 import type { AgColumn } from '../../entities/agColumn';
 import type { RowNode } from '../../entities/rowNode';
 import { _isCellSelectionEnabled, _isRowSelection } from '../../gridOptionsUtils';
@@ -173,7 +172,7 @@ export class CellKeyboardListenerFeature extends BeanStub {
             }
 
             // re-run ALL validations, Enter key is used to commit the edit, so we want to ensure it's valid
-            _populateModelValidationErrors(beans);
+            editSvc?.populateModelValidationErrors();
 
             if (editSvc?.checkNavWithValidation(undefined, event) === 'block-stop') {
                 return;
@@ -232,7 +231,7 @@ export class CellKeyboardListenerFeature extends BeanStub {
         if (editing) {
             // re-run ALL validations, F2 is used to initiate a new edit. If we have one already in progress,
             // we want to ensure it's valid before initiating a new edit cycle
-            _populateModelValidationErrors(this.beans);
+            editSvc?.populateModelValidationErrors();
 
             if (editSvc?.checkNavWithValidation(undefined, event) === 'block-stop') {
                 return;


### PR DESCRIPTION
As `_populateModelValidationErrors` was directly called from CellCtrl it meant all of the editing validation was always present in core even when editing is not being used.

Instead have moved this behind the `editSvc` so that it can be dropped if editing is not enabled.