### PR TITLE
AG-17134 Enforce grid production CSP on latest

### DIFF
--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
@@ -1,6 +1,6 @@
 import { urlWithBaseUrl } from '../urlWithBaseUrl';
 import type { CspEnv } from './cspRules';
-import { getCspHtaccessBlock, getCspHtaccessLine } from './cspRules';
+import { getCspHtaccessBlock } from './cspRules';
 import { SITE_301_REDIRECTS } from './redirects';
 
 export type HtaccessEnv = Extract<CspEnv, 'staging' | 'production'>;
@@ -154,8 +154,7 @@ function getStagingHtaccessContent(): string {
     return `${baseRules}
 
 # Content-Security-Policy — enforced. Unsets the legacy wildcard CSP on the staging
-# vhost so this tightened policy is the only one in effect. Production stays
-# report-only on latest until the release enforce rollout is verified.
+# vhost so this tightened policy is the only one in effect.
 ${getCspHtaccessBlock({ env: 'staging' }, 'enforce')}
 
 Options -Indexes
@@ -174,11 +173,12 @@ ${getModRewriteRules()}
 Header always set Referrer-Policy "strict-origin-when-cross-origin"
 Header always set Permissions-Policy "geolocation=(), microphone=(), camera=()"
 
-# Content-Security-Policy — report-only while validating the tightened policy on production.
-# Ships alongside the existing loose enforcing CSP on the vhost: that one still allows
-# everything (nothing breaks), this one reports what the tightened policy would block.
-# Flip to enforce + remove the vhost wildcard once the report-only window is clean.
-${getCspHtaccessLine({ env: 'production' }, 'report-only')}
+# Content-Security-Policy — enforced (the report-only validation window is complete).
+# The block unsets the inherited headers (incl. the legacy wildcard CSP on the vhost)
+# and sets this tightened policy as the enforced CSP. If the vhost wildcard lingers as a
+# separate header, browsers enforce the intersection, so the tightened policy still wins;
+# removing the vhost wildcard line is a follow-up infra cleanup.
+${getCspHtaccessBlock({ env: 'production' }, 'enforce')}
 
 # CORS settings
 Header add Access-Control-Allow-Origin "*"


### PR DESCRIPTION
## What

Port the **production** enforce flip to `latest`. `latest` already enforces on staging (#14003); this flips production to enforce too, bringing `latest` in line with the release-branch enforce state now that the rollout is **deployed and verified clean in production** across all three products (charts, studio, grid root).

Switches `getProductionHtaccessContent()` from the bare report-only header (`getCspHtaccessLine(..., 'report-only')`) to `getCspHtaccessBlock({ env: 'production' }, 'enforce')` — matching staging and the release branch. The block unsets the inherited headers (incl. the legacy vhost wildcard) and sets the tightened policy as the enforced `Content-Security-Policy`. Drops the now-unused `getCspHtaccessLine` import and the stale "production stays report-only on latest" note on the staging block.

## Production verification (already done on the release branch)

Live checks on `https://www.ag-grid.com/` after the release deploy:
- enforced `Content-Security-Policy` header (no report-only); value byte-identical to the generated `production --mode=enforce` policy
- 0 CSP violations across 12 representative routes incl. `/ecommerce/`
- `/charts/` and `/studio/` still serve their own enforced policies (subdir isolation intact)

## Notes

- If the loose vhost wildcard CSP lingers as a separate header, browsers enforce the **intersection** so the tightened policy still wins. Removing the vhost wildcard is a follow-up infra cleanup (off-repo).

Completes the AG-17134 enforce rollout on `latest`.
