### PR TITLE
AG-5835 Enable export in context menu on iOS

### DIFF
--- a/packages/ag-grid-enterprise/src/menu/contextMenu.ts
+++ b/packages/ag-grid-enterprise/src/menu/contextMenu.ts
@@ -1,4 +1,4 @@
-import { _exists, _isIOSUserAgent } from 'ag-stack';
+import { _exists } from 'ag-stack';
 
 import type {
     AgColumn,
@@ -143,8 +143,7 @@ export class ContextMenuService extends BeanStub implements NamedBean, IContextM
 
             const suppressExcel = gos.get('suppressExcelExport') || !excelCreator;
             const suppressCsv = gos.get('suppressCsvExport') || !csvCreator;
-            const onIPad = _isIOSUserAgent();
-            const anyExport = !onIPad && (!suppressExcel || !suppressCsv);
+            const anyExport = !suppressExcel || !suppressCsv;
             if (anyExport) {
                 defaultMenuOptions.push('export');
             }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-5835

The `<a download>` attribute has been supported in Safari on iOS since iOS 13 (September 2019). AG Grid's browser support policy covers the two latest major iOS versions (iOS 17 and iOS 18 as of mid-2026), both well past this threshold.

Remove the `_isIOSUserAgent()` guard that was suppressing the Export option in the context menu on iOS devices. Users on iOS can now access CSV and Excel exports via the context menu.

Fix [AG-5835](https://ag-grid.atlassian.net/browse/AG-5835)