### PR TITLE
[AG-6377] Fix(pagination): page input fixes

### DIFF
--- a/packages/ag-grid-community/src/pagination/pageSummaryComp.ts
+++ b/packages/ag-grid-community/src/pagination/pageSummaryComp.ts
@@ -1,13 +1,101 @@
+import type { AgElementParams, LocaleTextFunc } from 'ag-stack';
 import { KeyCode, RefPlaceholder, _setAriaDisabled, _setAriaLabel, _setAriaRole } from 'ag-stack';
 
 import { AgInputNumberFieldSelector } from '../agWidgets/agInputNumberField';
 import type { BeanCollection } from '../context/context';
 import type { IRowModel } from '../interfaces/iRowModel';
 import { _createIconNoSpan } from '../utils/icon';
+import type { AgComponentSelectorType } from '../widgets/component';
 import { Component } from '../widgets/component';
 import type { GridInputNumberField } from '../widgets/gridWidgetTypes';
 import type { PaginationService } from './paginationService';
 import { _formatPaginationNumber } from './paginationUtils';
+
+function buildPageSummaryTemplate(
+    idPrefix: string,
+    noInput: boolean,
+    localeTextFunc: LocaleTextFunc
+): AgElementParams<AgComponentSelectorType> {
+    const pageNumberChild = {
+        cls: 'ag-paging-number',
+        attrs: { id: `${idPrefix}-start-page-number` },
+        tag: noInput ? 'span' : 'ag-input-number-field',
+        ref: noInput ? 'lbCurrentStatic' : 'lbCurrentInput',
+    } as const;
+
+    return {
+        tag: 'span',
+        cls: 'ag-paging-page-summary-panel',
+        role: 'presentation',
+        children: [
+            {
+                tag: 'div',
+                ref: 'btFirst',
+                cls: 'ag-button ag-paging-button',
+                role: 'button',
+                attrs: { 'aria-label': localeTextFunc('firstPage', 'First Page') },
+            },
+            {
+                tag: 'div',
+                ref: 'btPrevious',
+                cls: 'ag-button ag-paging-button',
+                role: 'button',
+                attrs: { 'aria-label': localeTextFunc('previousPage', 'Previous Page') },
+            },
+            {
+                tag: 'span',
+                cls: 'ag-paging-description',
+                children: [
+                    {
+                        tag: 'span',
+                        attrs: { id: `${idPrefix}-start-page` },
+                        children: localeTextFunc('page', 'Page'),
+                    },
+                    pageNumberChild,
+                    {
+                        tag: 'span',
+                        attrs: { id: `${idPrefix}-of-page` },
+                        children: localeTextFunc('of', 'of'),
+                    },
+                    {
+                        tag: 'span',
+                        ref: 'lbTotal',
+                        cls: 'ag-paging-number',
+                        attrs: { id: `${idPrefix}-of-page-number` },
+                    },
+                ],
+            },
+            {
+                tag: 'div',
+                ref: 'btNext',
+                cls: 'ag-button ag-paging-button',
+                role: 'button',
+                attrs: { 'aria-label': localeTextFunc('nextPage', 'Next Page') },
+            },
+            {
+                tag: 'div',
+                ref: 'btLast',
+                cls: 'ag-button ag-paging-button',
+                role: 'button',
+                attrs: { 'aria-label': localeTextFunc('lastPage', 'Last Page') },
+            },
+        ],
+    };
+}
+
+function insertNavIcons(
+    isRtl: boolean,
+    beans: BeanCollection,
+    btFirst: HTMLElement,
+    btPrevious: HTMLElement,
+    btNext: HTMLElement,
+    btLast: HTMLElement
+): void {
+    btFirst.insertAdjacentElement('afterbegin', _createIconNoSpan(isRtl ? 'last' : 'first', beans)!);
+    btPrevious.insertAdjacentElement('afterbegin', _createIconNoSpan(isRtl ? 'next' : 'previous', beans)!);
+    btNext.insertAdjacentElement('afterbegin', _createIconNoSpan(isRtl ? 'previous' : 'next', beans)!);
+    btLast.insertAdjacentElement('afterbegin', _createIconNoSpan(isRtl ? 'first' : 'last', beans)!);
+}
 
 export class PageSummaryComp extends Component {
     private rowModel: IRowModel;
@@ -41,86 +129,21 @@ export class PageSummaryComp extends Component {
     }
 
     public postConstruct(): void {
-        const noInput = this.suppressPageInput;
-        const idPrefix = this.idPrefix;
         const localeTextFunc = this.getLocaleTextFunc();
-        const pageNumberChild = {
-            cls: 'ag-paging-number',
-            attrs: { id: `${idPrefix}-start-page-number` },
-            tag: noInput ? 'span' : 'ag-input-number-field',
-            ref: noInput ? 'lbCurrentStatic' : 'lbCurrentInput',
-        } as const;
-
         this.setTemplate(
-            {
-                tag: 'span',
-                cls: 'ag-paging-page-summary-panel',
-                role: 'presentation',
-                children: [
-                    {
-                        tag: 'div',
-                        ref: 'btFirst',
-                        cls: 'ag-button ag-paging-button',
-                        role: 'button',
-                        attrs: { 'aria-label': localeTextFunc('firstPage', 'First Page') },
-                    },
-                    {
-                        tag: 'div',
-                        ref: 'btPrevious',
-                        cls: 'ag-button ag-paging-button',
-                        role: 'button',
-                        attrs: { 'aria-label': localeTextFunc('previousPage', 'Previous Page') },
-                    },
-                    {
-                        tag: 'span',
-                        cls: 'ag-paging-description',
-                        children: [
-                            {
-                                tag: 'span',
-                                attrs: { id: `${idPrefix}-start-page` },
-                                children: localeTextFunc('page', 'Page'),
-                            },
-                            pageNumberChild,
-                            {
-                                tag: 'span',
-                                attrs: { id: `${idPrefix}-of-page` },
-                                children: localeTextFunc('of', 'of'),
-                            },
-                            {
-                                tag: 'span',
-                                ref: 'lbTotal',
-                                cls: 'ag-paging-number',
-                                attrs: { id: `${idPrefix}-of-page-number` },
-                            },
-                        ],
-                    },
-                    {
-                        tag: 'div',
-                        ref: 'btNext',
-                        cls: 'ag-button ag-paging-button',
-                        role: 'button',
-                        attrs: { 'aria-label': localeTextFunc('nextPage', 'Next Page') },
-                    },
-                    {
-                        tag: 'div',
-                        ref: 'btLast',
-                        cls: 'ag-button ag-paging-button',
-                        role: 'button',
-                        attrs: { 'aria-label': localeTextFunc('lastPage', 'Last Page') },
-                    },
-                ],
-            },
+            buildPageSummaryTemplate(this.idPrefix, this.suppressPageInput, localeTextFunc),
             this.suppressPageInput ? [] : [AgInputNumberFieldSelector]
         );
+        insertNavIcons(this.gos.get('enableRtl'), this.beans, this.btFirst, this.btPrevious, this.btNext, this.btLast);
+        this.initNavButtons();
+        if (!this.suppressPageInput) {
+            this.initPageInput();
+        }
+        this.refresh();
+    }
 
-        const { gos, btFirst, btPrevious, btNext, btLast, beans } = this;
-        const isRtl = gos.get('enableRtl');
-
-        btFirst.insertAdjacentElement('afterbegin', _createIconNoSpan(isRtl ? 'last' : 'first', beans)!);
-        btPrevious.insertAdjacentElement('afterbegin', _createIconNoSpan(isRtl ? 'next' : 'previous', beans)!);
-        btNext.insertAdjacentElement('afterbegin', _createIconNoSpan(isRtl ? 'previous' : 'next', beans)!);
-        btLast.insertAdjacentElement('afterbegin', _createIconNoSpan(isRtl ? 'first' : 'last', beans)!);
-
+    private initNavButtons(): void {
+        const { btFirst, btPrevious, btNext, btLast } = this;
         this.activateTabIndex([btFirst, btPrevious, btNext, btLast]);
         for (const { el, fn } of [
             { el: btFirst, fn: this.onBtFirst.bind(this) },
@@ -138,46 +161,47 @@ export class PageSummaryComp extends Component {
                 },
             });
         }
+    }
 
-        if (!this.suppressPageInput) {
-            const { lbCurrentInput } = this;
-            const eInput = lbCurrentInput.getInputElement();
-            _setAriaRole(eInput, 'spinbutton');
-            this.addManagedListeners(eInput, {
-                keydown: (e: KeyboardEvent) => {
-                    const { key } = e;
-                    if (key !== KeyCode.ENTER && key !== KeyCode.ESCAPE && key !== KeyCode.UP && key !== KeyCode.DOWN) {
-                        return;
-                    }
-                    e.preventDefault();
-                    switch (key) {
-                        case KeyCode.ENTER:
+    private initPageInput(): void {
+        const { lbCurrentInput } = this;
+        const eInput = lbCurrentInput.getInputElement();
+        _setAriaRole(eInput, 'spinbutton');
+        this.addManagedListeners(eInput, {
+            keydown: (e: KeyboardEvent) => {
+                const { key } = e;
+                if (key !== KeyCode.ENTER && key !== KeyCode.ESCAPE && key !== KeyCode.UP && key !== KeyCode.DOWN) {
+                    return;
+                }
+                e.preventDefault();
+                switch (key) {
+                    case KeyCode.ENTER:
+                        this.commitPageInput();
+                        break;
+                    case KeyCode.ESCAPE:
+                        lbCurrentInput.setValue(String(this.pagination.getCurrentPage() + 1), true);
+                        eInput.blur();
+                        break;
+                    case KeyCode.UP: {
+                        const next = this.pagination.getCurrentPage() + 2;
+                        if (next <= this.pagination.getTotalPages()) {
+                            lbCurrentInput.setValue(String(next), true);
                             this.commitPageInput();
-                            break;
-                        case KeyCode.ESCAPE:
-                            lbCurrentInput.setValue(String(this.pagination.getCurrentPage() + 1), true);
-                            eInput.blur();
-                            break;
-                        case KeyCode.UP:
-                            const next = this.pagination.getCurrentPage() + 2;
-                            if (next <= this.pagination.getTotalPages()) {
-                                lbCurrentInput.setValue(String(next), true);
-                                this.commitPageInput();
-                            }
-                            break;
-                        case KeyCode.DOWN:
-                            const prev = this.pagination.getCurrentPage();
-                            if (prev > 0) {
-                                lbCurrentInput.setValue(String(prev), true);
-                                this.commitPageInput();
-                            }
-                            break;
+                        }
+                        break;
                     }
-                },
-                blur: () => this.commitPageInput(),
-            });
-        }
-        this.refresh();
+                    case KeyCode.DOWN: {
+                        const prev = this.pagination.getCurrentPage();
+                        if (prev > 0) {
+                            lbCurrentInput.setValue(String(prev), true);
+                            this.commitPageInput();
+                        }
+                        break;
+                    }
+                }
+            },
+            blur: () => this.commitPageInput(),
+        });
     }
 
     private onBtFirst(): void {

--- a/packages/ag-grid-community/src/pagination/pageSummaryComp.ts
+++ b/packages/ag-grid-community/src/pagination/pageSummaryComp.ts
@@ -78,7 +78,7 @@ export class PageSummaryComp extends Component {
     }
 
     private initPageInput(): void {
-        const { lbCurrentInput } = this;
+        const { lbCurrentInput, pagination } = this;
         const eInput = lbCurrentInput.getInputElement();
         _setAriaRole(eInput, 'spinbutton');
         this.addManagedListeners(eInput, {
@@ -88,30 +88,31 @@ export class PageSummaryComp extends Component {
                     return;
                 }
                 e.preventDefault();
+                let targetPage: number | null = null;
+                const current = pagination.getCurrentPage();
+                const maxPage = pagination.getTotalPages();
                 switch (key) {
                     case KeyCode.ENTER:
                         this.commitPageInput();
                         break;
                     case KeyCode.ESCAPE:
-                        lbCurrentInput.setValue(String(this.pagination.getCurrentPage() + 1), true);
+                        lbCurrentInput.setValue(String(current + 1), true); // needs to happen before blur below
                         eInput.blur();
                         break;
-                    case KeyCode.UP: {
-                        const next = this.pagination.getCurrentPage() + 2;
-                        if (next <= this.pagination.getTotalPages()) {
-                            lbCurrentInput.setValue(String(next), true);
-                            this.commitPageInput();
+                    case KeyCode.UP:
+                        if (current + 2 <= maxPage) {
+                            targetPage = current + 2;
                         }
                         break;
-                    }
-                    case KeyCode.DOWN: {
-                        const prev = this.pagination.getCurrentPage();
-                        if (prev > 0) {
-                            lbCurrentInput.setValue(String(prev), true);
-                            this.commitPageInput();
+                    case KeyCode.DOWN:
+                        if (current !== 0) {
+                            targetPage = current;
                         }
                         break;
-                    }
+                }
+                if (targetPage !== null) {
+                    lbCurrentInput.setValue(String(targetPage), true);
+                    this.commitPageInput();
                 }
             },
             blur: () => this.commitPageInput(),

--- a/packages/ag-grid-community/src/pagination/pageSummaryComp.ts
+++ b/packages/ag-grid-community/src/pagination/pageSummaryComp.ts
@@ -1,4 +1,4 @@
-import { KeyCode, RefPlaceholder, _setAriaDisabled } from 'ag-stack';
+import { KeyCode, RefPlaceholder, _setAriaDisabled, _setAriaLabel, _setAriaRole } from 'ag-stack';
 
 import { AgInputNumberFieldSelector } from '../agWidgets/agInputNumberField';
 import type { BeanCollection } from '../context/context';
@@ -141,13 +141,34 @@ export class PageSummaryComp extends Component {
 
         if (!this.suppressPageInput) {
             const { lbCurrentInput } = this;
-            lbCurrentInput.onValueChange(this.onInputPage.bind(this));
-            this.addManagedListeners(lbCurrentInput.getInputElement(), {
-                blur: () => {
-                    if (!lbCurrentInput.getInputElement().value.trim()) {
+            const eInput = lbCurrentInput.getInputElement();
+            _setAriaRole(eInput, 'spinbutton');
+            this.addManagedListeners(eInput, {
+                keydown: (e: KeyboardEvent) => {
+                    if (e.key === KeyCode.ENTER) {
+                        e.preventDefault();
+                        this.commitPageInput();
+                    } else if (e.key === KeyCode.ESCAPE) {
+                        e.preventDefault();
                         lbCurrentInput.setValue(String(this.pagination.getCurrentPage() + 1), true);
+                        eInput.blur();
+                    } else if (e.key === KeyCode.UP) {
+                        e.preventDefault();
+                        const next = this.pagination.getCurrentPage() + 2;
+                        if (next <= this.pagination.getTotalPages()) {
+                            lbCurrentInput.setValue(String(next), true);
+                            this.commitPageInput();
+                        }
+                    } else if (e.key === KeyCode.DOWN) {
+                        e.preventDefault();
+                        const prev = this.pagination.getCurrentPage();
+                        if (prev > 0) {
+                            lbCurrentInput.setValue(String(prev), true);
+                            this.commitPageInput();
+                        }
                     }
                 },
+                blur: () => this.commitPageInput(),
             });
         }
         this.refresh();
@@ -177,20 +198,23 @@ export class PageSummaryComp extends Component {
         }
     }
 
-    private onInputPage(): void {
+    private commitPageInput(): void {
         const { pagination, lbCurrentInput } = this;
+        const currentPage = pagination.getCurrentPage() + 1;
         const rawValue = lbCurrentInput.getValue(true);
         if (!rawValue?.trim()) {
+            lbCurrentInput.setValue(String(currentPage), true);
             return;
         }
         const rawValueNum = Number(rawValue);
-        let value = Number.isFinite(rawValueNum) ? rawValueNum : pagination.getCurrentPage() + 1;
         const total = pagination.getTotalPages();
-        value = Math.max(1, Math.min(value, total));
-        if (rawValueNum !== value) {
-            lbCurrentInput.setValue(String(value), true);
+        const isValid =
+            Number.isFinite(rawValueNum) && Number.isInteger(rawValueNum) && rawValueNum >= 1 && rawValueNum <= total;
+        if (!isValid) {
+            lbCurrentInput.setValue(String(currentPage), true);
+            return;
         }
-        pagination.goToPage(value - 1);
+        pagination.goToPage(rawValueNum - 1);
     }
 
     public refresh(): void {
@@ -249,6 +273,14 @@ export class PageSummaryComp extends Component {
             lbCurrentInput.setMax(pageCount);
             lbCurrentInput.getInputElement().style.width = `${Math.floor(Math.log10(pageCount) + 3)}ch`; // log10 returns number of digits (as an integer part + fraction) - 1
             lbCurrentInput.setValue(lbCurrentValue.toString());
+            const eInput = lbCurrentInput.getInputElement();
+            _setAriaLabel(
+                eInput,
+                `${localeTextFunc('page', 'Page')} ${localeTextFunc('number', 'number')}, ${lbCurrentValue} ${localeTextFunc('of', 'of')} ${lbTotalStr}`
+            );
+            eInput.setAttribute('aria-valuenow', String(lbCurrentValue));
+            eInput.setAttribute('aria-valuemin', '1');
+            eInput.setAttribute('aria-valuemax', String(pageCount));
         }
 
         const strPage = localeTextFunc('page', 'Page');

--- a/packages/ag-grid-community/src/pagination/pageSummaryComp.ts
+++ b/packages/ag-grid-community/src/pagination/pageSummaryComp.ts
@@ -145,27 +145,33 @@ export class PageSummaryComp extends Component {
             _setAriaRole(eInput, 'spinbutton');
             this.addManagedListeners(eInput, {
                 keydown: (e: KeyboardEvent) => {
-                    if (e.key === KeyCode.ENTER) {
-                        e.preventDefault();
-                        this.commitPageInput();
-                    } else if (e.key === KeyCode.ESCAPE) {
-                        e.preventDefault();
-                        lbCurrentInput.setValue(String(this.pagination.getCurrentPage() + 1), true);
-                        eInput.blur();
-                    } else if (e.key === KeyCode.UP) {
-                        e.preventDefault();
-                        const next = this.pagination.getCurrentPage() + 2;
-                        if (next <= this.pagination.getTotalPages()) {
-                            lbCurrentInput.setValue(String(next), true);
+                    const { key } = e;
+                    if (key !== KeyCode.ENTER && key !== KeyCode.ESCAPE && key !== KeyCode.UP && key !== KeyCode.DOWN) {
+                        return;
+                    }
+                    e.preventDefault();
+                    switch (key) {
+                        case KeyCode.ENTER:
                             this.commitPageInput();
-                        }
-                    } else if (e.key === KeyCode.DOWN) {
-                        e.preventDefault();
-                        const prev = this.pagination.getCurrentPage();
-                        if (prev > 0) {
-                            lbCurrentInput.setValue(String(prev), true);
-                            this.commitPageInput();
-                        }
+                            break;
+                        case KeyCode.ESCAPE:
+                            lbCurrentInput.setValue(String(this.pagination.getCurrentPage() + 1), true);
+                            eInput.blur();
+                            break;
+                        case KeyCode.UP:
+                            const next = this.pagination.getCurrentPage() + 2;
+                            if (next <= this.pagination.getTotalPages()) {
+                                lbCurrentInput.setValue(String(next), true);
+                                this.commitPageInput();
+                            }
+                            break;
+                        case KeyCode.DOWN:
+                            const prev = this.pagination.getCurrentPage();
+                            if (prev > 0) {
+                                lbCurrentInput.setValue(String(prev), true);
+                                this.commitPageInput();
+                            }
+                            break;
                     }
                 },
                 blur: () => this.commitPageInput(),

--- a/packages/ag-grid-community/src/pagination/pageSummaryComp.ts
+++ b/packages/ag-grid-community/src/pagination/pageSummaryComp.ts
@@ -11,92 +11,6 @@ import type { GridInputNumberField } from '../widgets/gridWidgetTypes';
 import type { PaginationService } from './paginationService';
 import { _formatPaginationNumber } from './paginationUtils';
 
-function buildPageSummaryTemplate(
-    idPrefix: string,
-    noInput: boolean,
-    localeTextFunc: LocaleTextFunc
-): AgElementParams<AgComponentSelectorType> {
-    const pageNumberChild = {
-        cls: 'ag-paging-number',
-        attrs: { id: `${idPrefix}-start-page-number` },
-        tag: noInput ? 'span' : 'ag-input-number-field',
-        ref: noInput ? 'lbCurrentStatic' : 'lbCurrentInput',
-    } as const;
-
-    return {
-        tag: 'span',
-        cls: 'ag-paging-page-summary-panel',
-        role: 'presentation',
-        children: [
-            {
-                tag: 'div',
-                ref: 'btFirst',
-                cls: 'ag-button ag-paging-button',
-                role: 'button',
-                attrs: { 'aria-label': localeTextFunc('firstPage', 'First Page') },
-            },
-            {
-                tag: 'div',
-                ref: 'btPrevious',
-                cls: 'ag-button ag-paging-button',
-                role: 'button',
-                attrs: { 'aria-label': localeTextFunc('previousPage', 'Previous Page') },
-            },
-            {
-                tag: 'span',
-                cls: 'ag-paging-description',
-                children: [
-                    {
-                        tag: 'span',
-                        attrs: { id: `${idPrefix}-start-page` },
-                        children: localeTextFunc('page', 'Page'),
-                    },
-                    pageNumberChild,
-                    {
-                        tag: 'span',
-                        attrs: { id: `${idPrefix}-of-page` },
-                        children: localeTextFunc('of', 'of'),
-                    },
-                    {
-                        tag: 'span',
-                        ref: 'lbTotal',
-                        cls: 'ag-paging-number',
-                        attrs: { id: `${idPrefix}-of-page-number` },
-                    },
-                ],
-            },
-            {
-                tag: 'div',
-                ref: 'btNext',
-                cls: 'ag-button ag-paging-button',
-                role: 'button',
-                attrs: { 'aria-label': localeTextFunc('nextPage', 'Next Page') },
-            },
-            {
-                tag: 'div',
-                ref: 'btLast',
-                cls: 'ag-button ag-paging-button',
-                role: 'button',
-                attrs: { 'aria-label': localeTextFunc('lastPage', 'Last Page') },
-            },
-        ],
-    };
-}
-
-function insertNavIcons(
-    isRtl: boolean,
-    beans: BeanCollection,
-    btFirst: HTMLElement,
-    btPrevious: HTMLElement,
-    btNext: HTMLElement,
-    btLast: HTMLElement
-): void {
-    btFirst.insertAdjacentElement('afterbegin', _createIconNoSpan(isRtl ? 'last' : 'first', beans)!);
-    btPrevious.insertAdjacentElement('afterbegin', _createIconNoSpan(isRtl ? 'next' : 'previous', beans)!);
-    btNext.insertAdjacentElement('afterbegin', _createIconNoSpan(isRtl ? 'previous' : 'next', beans)!);
-    btLast.insertAdjacentElement('afterbegin', _createIconNoSpan(isRtl ? 'first' : 'last', beans)!);
-}
-
 export class PageSummaryComp extends Component {
     private rowModel: IRowModel;
     private pagination: PaginationService;
@@ -321,4 +235,90 @@ export class PageSummaryComp extends Component {
     private formatNumber(value: number): string {
         return _formatPaginationNumber(value, this.gos, this.getLocaleTextFunc.bind(this));
     }
+}
+
+function buildPageSummaryTemplate(
+    idPrefix: string,
+    noInput: boolean,
+    localeTextFunc: LocaleTextFunc
+): AgElementParams<AgComponentSelectorType> {
+    const pageNumberChild = {
+        cls: 'ag-paging-number',
+        attrs: { id: `${idPrefix}-start-page-number` },
+        tag: noInput ? 'span' : 'ag-input-number-field',
+        ref: noInput ? 'lbCurrentStatic' : 'lbCurrentInput',
+    } as const;
+
+    return {
+        tag: 'span',
+        cls: 'ag-paging-page-summary-panel',
+        role: 'presentation',
+        children: [
+            {
+                tag: 'div',
+                ref: 'btFirst',
+                cls: 'ag-button ag-paging-button',
+                role: 'button',
+                attrs: { 'aria-label': localeTextFunc('firstPage', 'First Page') },
+            },
+            {
+                tag: 'div',
+                ref: 'btPrevious',
+                cls: 'ag-button ag-paging-button',
+                role: 'button',
+                attrs: { 'aria-label': localeTextFunc('previousPage', 'Previous Page') },
+            },
+            {
+                tag: 'span',
+                cls: 'ag-paging-description',
+                children: [
+                    {
+                        tag: 'span',
+                        attrs: { id: `${idPrefix}-start-page` },
+                        children: localeTextFunc('page', 'Page'),
+                    },
+                    pageNumberChild,
+                    {
+                        tag: 'span',
+                        attrs: { id: `${idPrefix}-of-page` },
+                        children: localeTextFunc('of', 'of'),
+                    },
+                    {
+                        tag: 'span',
+                        ref: 'lbTotal',
+                        cls: 'ag-paging-number',
+                        attrs: { id: `${idPrefix}-of-page-number` },
+                    },
+                ],
+            },
+            {
+                tag: 'div',
+                ref: 'btNext',
+                cls: 'ag-button ag-paging-button',
+                role: 'button',
+                attrs: { 'aria-label': localeTextFunc('nextPage', 'Next Page') },
+            },
+            {
+                tag: 'div',
+                ref: 'btLast',
+                cls: 'ag-button ag-paging-button',
+                role: 'button',
+                attrs: { 'aria-label': localeTextFunc('lastPage', 'Last Page') },
+            },
+        ],
+    };
+}
+
+function insertNavIcons(
+    isRtl: boolean,
+    beans: BeanCollection,
+    btFirst: HTMLElement,
+    btPrevious: HTMLElement,
+    btNext: HTMLElement,
+    btLast: HTMLElement
+): void {
+    btFirst.insertAdjacentElement('afterbegin', _createIconNoSpan(isRtl ? 'last' : 'first', beans)!);
+    btPrevious.insertAdjacentElement('afterbegin', _createIconNoSpan(isRtl ? 'next' : 'previous', beans)!);
+    btNext.insertAdjacentElement('afterbegin', _createIconNoSpan(isRtl ? 'previous' : 'next', beans)!);
+    btLast.insertAdjacentElement('afterbegin', _createIconNoSpan(isRtl ? 'first' : 'last', beans)!);
 }

--- a/packages/ag-grid-community/src/pagination/paginationComp.css
+++ b/packages/ag-grid-community/src/pagination/paginationComp.css
@@ -44,6 +44,10 @@
     display: inline-block;
 }
 
+:where(.ag-number-field.ag-paging-number) .ag-input-field-input {
+    text-align: right;
+}
+
 .ag-paging-number,
 .ag-paging-row-summary-panel-number {
     font-weight: 500;

--- a/testing/behavioural/src/pagination/pagination-panels.test.ts
+++ b/testing/behavioural/src/pagination/pagination-panels.test.ts
@@ -146,7 +146,7 @@ describe('paginationPanels', () => {
             expect(pageNumbers[1].textContent).toBe('5'); // total pages
         });
 
-        test('page input navigates on value change', () => {
+        test('typing alone does not navigate', () => {
             const api = createPaginationGrid(gridsManager);
             const panel = getPagingPanel(api)!;
             const input = panel.querySelector<HTMLInputElement>('.ag-paging-page-summary-panel input')!;
@@ -154,20 +154,98 @@ describe('paginationPanels', () => {
             input.value = '3';
             input.dispatchEvent(new Event('input'));
 
+            expect(api.paginationGetCurrentPage()).toBe(0);
+        });
+
+        test('Enter key navigates to typed page', () => {
+            const api = createPaginationGrid(gridsManager);
+            const panel = getPagingPanel(api)!;
+            const input = panel.querySelector<HTMLInputElement>('.ag-paging-page-summary-panel input')!;
+
+            input.value = '3';
+            input.dispatchEvent(new Event('input'));
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
             expect(api.paginationGetCurrentPage()).toBe(2);
         });
 
-        test('clearing the input does not navigate', () => {
+        test('blur navigates to typed page', () => {
+            const api = createPaginationGrid(gridsManager);
+            const panel = getPagingPanel(api)!;
+            const input = panel.querySelector<HTMLInputElement>('.ag-paging-page-summary-panel input')!;
+
+            input.value = '3';
+            input.dispatchEvent(new Event('input'));
+            input.dispatchEvent(new Event('blur'));
+
+            expect(api.paginationGetCurrentPage()).toBe(2);
+        });
+
+        test('Escape cancels edit and restores current page without navigating', () => {
+            const api = createPaginationGrid(gridsManager);
+            const panel = getPagingPanel(api)!;
+            const input = panel.querySelector<HTMLInputElement>('.ag-paging-page-summary-panel input')!;
+
+            api.paginationGoToPage(1);
+
+            input.value = '5';
+            input.dispatchEvent(new Event('input'));
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+            expect(api.paginationGetCurrentPage()).toBe(1);
+            expect(input.value).toBe('2');
+        });
+
+        test('ArrowUp navigates to next page', () => {
+            const api = createPaginationGrid(gridsManager);
+            const panel = getPagingPanel(api)!;
+            const input = panel.querySelector<HTMLInputElement>('.ag-paging-page-summary-panel input')!;
+
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+
+            expect(api.paginationGetCurrentPage()).toBe(1);
+        });
+
+        test('ArrowDown navigates to previous page', () => {
             const api = createPaginationGrid(gridsManager);
             const panel = getPagingPanel(api)!;
             const input = panel.querySelector<HTMLInputElement>('.ag-paging-page-summary-panel input')!;
 
             api.paginationGoToPage(2);
 
-            input.value = '';
-            input.dispatchEvent(new Event('input'));
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
 
-            expect(api.paginationGetCurrentPage()).toBe(2);
+            expect(api.paginationGetCurrentPage()).toBe(1);
+        });
+
+        test('invalid input resets to current page without navigating', () => {
+            const api = createPaginationGrid(gridsManager);
+            const panel = getPagingPanel(api)!;
+            const input = panel.querySelector<HTMLInputElement>('.ag-paging-page-summary-panel input')!;
+
+            api.paginationGoToPage(1);
+
+            input.value = '0';
+            input.dispatchEvent(new Event('input'));
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+            expect(api.paginationGetCurrentPage()).toBe(1);
+            expect(input.value).toBe('2');
+        });
+
+        test('out-of-range input resets to current page without navigating', () => {
+            const api = createPaginationGrid(gridsManager);
+            const panel = getPagingPanel(api)!;
+            const input = panel.querySelector<HTMLInputElement>('.ag-paging-page-summary-panel input')!;
+
+            api.paginationGoToPage(1);
+
+            input.value = '99';
+            input.dispatchEvent(new Event('input'));
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+            expect(api.paginationGetCurrentPage()).toBe(1);
+            expect(input.value).toBe('2');
         });
 
         test('blurring with empty input resets to current page', () => {
@@ -183,6 +261,28 @@ describe('paginationPanels', () => {
 
             expect(api.paginationGetCurrentPage()).toBe(2);
             expect(input.value).toBe('3');
+        });
+
+        test('page input has spinbutton role and correct ARIA attributes', () => {
+            const api = createPaginationGrid(gridsManager);
+            const panel = getPagingPanel(api)!;
+            const input = panel.querySelector<HTMLInputElement>('.ag-paging-page-summary-panel input')!;
+
+            expect(input.getAttribute('role')).toBe('spinbutton');
+            expect(input.getAttribute('aria-valuenow')).toBe('1');
+            expect(input.getAttribute('aria-valuemin')).toBe('1');
+            expect(input.getAttribute('aria-valuemax')).toBe('5');
+            expect(input.getAttribute('aria-label')).toContain('1');
+        });
+
+        test('ARIA attributes update when page changes', () => {
+            const api = createPaginationGrid(gridsManager);
+            const panel = getPagingPanel(api)!;
+            const input = panel.querySelector<HTMLInputElement>('.ag-paging-page-summary-panel input')!;
+
+            api.paginationGoToPage(3);
+
+            expect(input.getAttribute('aria-valuenow')).toBe('4');
         });
     });
 


### PR DESCRIPTION
- Navigate only on Enter/blur, not on every keystroke
- Escape restores current page without navigating
- ArrowUp/Down increment/decrement page
- Add `role=spinbutton`, `aria-valuenow/min/max`, and `aria-label` kept in sync
- Right-align the page number value inside the input

Fix [AG-6377](https://ag-grid.atlassian.net/browse/AG-6377)