### PR TITLE
refactor: introduce _clamp utility

### DIFF
--- a/packages/ag-grid-community/src/agWidgets/agList.ts
+++ b/packages/ag-grid-community/src/agWidgets/agList.ts
@@ -1,6 +1,7 @@
 import type { AgCoreBeanCollection, BaseEvents, BaseProperties, IPropertiesService } from 'ag-stack';
 import { AgComponentStub, KeyCode, _clearElement, _isVisible, _last, _setAriaRole } from 'ag-stack';
 
+import { _clamp } from '../utils/number';
 import agListCSS from './agList.css';
 import { AgListItem } from './agListItem';
 
@@ -260,7 +261,7 @@ export class AgList<
         } else {
             const currentIdx = listItems.indexOf(highlightedItem);
             let nextPos = currentIdx + (isDown ? 1 : -1);
-            nextPos = Math.min(Math.max(nextPos, 0), listItems.length - 1);
+            nextPos = _clamp(nextPos, 0, listItems.length - 1);
             itemToHighlight = listItems[nextPos];
         }
         this.highlightItem(itemToHighlight);

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
@@ -18,6 +18,7 @@ import type {
     SizeColumnsToContentStrategy,
 } from '../interfaces/autoSize';
 import { MIN_CENTER_VIEWPORT_WIDTH } from '../pinnedColumns/pinnedColumnService';
+import { _clamp } from '../utils/number';
 import { _warn } from '../validation/logging';
 import { TouchListener } from '../widgets/touchListener';
 
@@ -446,7 +447,7 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
             const maxOverride = widthOverride?.maxWidth ?? params?.defaultMaxWidth ?? Infinity;
 
             const colWidth = column.getActualWidth();
-            const targetWidth = Math.max(Math.min(colWidth, maxOverride), minOverride);
+            const targetWidth = _clamp(colWidth, minOverride, maxOverride);
 
             // NOTE: we assign values to `this.actualWidth` of each column without firing events
             // for this reason we need to manually dispatch resize events after the resize has been done for each column.

--- a/packages/ag-grid-community/src/columnResize/columnResizeService.ts
+++ b/packages/ag-grid-community/src/columnResize/columnResizeService.ts
@@ -7,6 +7,7 @@ import type { ColKey } from '../entities/colDef';
 import type { ColumnEventType } from '../events';
 import type { HeaderCellCtrl, IHeaderCellComp } from '../headerRendering/cells/column/headerCellCtrl';
 import type { IHeaderGroupCellComp } from '../headerRendering/cells/columnGroup/headerGroupCellCtrl';
+import { _clamp } from '../utils/number';
 import { _error } from '../validation/logging';
 import { GroupResizeFeature } from './groupResizeFeature';
 import { ResizeFeature } from './resizeFeature';
@@ -239,7 +240,7 @@ export class ColumnResizeService extends BeanStub implements NamedBean {
         const minWidth = column.getMinWidth();
         const maxWidth = column.getMaxWidth();
 
-        const newWidth = Math.min(Math.max(actualWidth + delta, minWidth), maxWidth);
+        const newWidth = _clamp(actualWidth + delta, minWidth, maxWidth);
 
         this.setColumnWidths([{ key: column, newWidth }], shiftKey, true, 'uiColumnResized');
     }

--- a/packages/ag-grid-community/src/columns/columnFlexService.ts
+++ b/packages/ag-grid-community/src/columns/columnFlexService.ts
@@ -3,6 +3,7 @@ import { BeanStub } from '../context/beanStub';
 import type { AgColumn } from '../entities/agColumn';
 import type { ColumnEventType } from '../events';
 import type { ColumnDelayRenderService } from '../rendering/columnDelayRenderService';
+import { _clamp } from '../utils/number';
 import { dispatchColumnResizedEvent } from './columnEventUtils';
 
 type FlexItem = {
@@ -158,7 +159,7 @@ export class ColumnFlexService extends BeanStub implements NamedBean {
                 }
 
                 const unclampedSize = item.targetSize;
-                const clampedSize = Math.min(Math.max(unclampedSize, item.min), item.max);
+                const clampedSize = _clamp(unclampedSize, item.min, item.max);
 
                 totalViolation += clampedSize - unclampedSize;
                 item.violationType =

--- a/packages/ag-grid-community/src/entities/agColumn.ts
+++ b/packages/ag-grid-community/src/entities/agColumn.ts
@@ -24,6 +24,7 @@ import type { IFrameworkEventListenerService } from '../interfaces/iFrameworkEve
 import type { IRowNode } from '../interfaces/iRowNode';
 import type { SortDef, SortDirection, SortType } from '../interfaces/iSort';
 import { _mergedEqual } from '../utils/mergeDeep';
+import { _clamp } from '../utils/number';
 import { _warn } from '../validation/logging';
 import type { AgColumnGroup } from './agColumnGroup';
 import type { AgProvidedColumnGroup } from './agProvidedColumnGroup';
@@ -330,7 +331,7 @@ export class AgColumn<TValue = any>
 
     private calculateColInitialWidth(colDef: ColDef): number {
         const width = colDef.width ?? colDef.initialWidth ?? 200;
-        return Math.max(Math.min(width, this.maxWidth), this.minWidth);
+        return _clamp(width, this.minWidth, this.maxWidth);
     }
 
     public isEmptyGroup(): false {

--- a/packages/ag-grid-community/src/gridBodyComp/gridBodyScrollFeature.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/gridBodyScrollFeature.ts
@@ -17,6 +17,7 @@ import { _isDomLayout } from '../gridOptionsUtils';
 import type { WithoutGridCommon } from '../interfaces/iCommon';
 import type { IRowNode, VerticalScrollPosition } from '../interfaces/iRowNode';
 import type { AnimationFrameService } from '../misc/animationFrameService';
+import { _clamp } from '../utils/number';
 import { _warn } from '../validation/logging';
 
 const VIEWPORT = 'Viewport';
@@ -449,7 +450,7 @@ export class GridBodyScrollFeature extends BeanStub {
 
     private clampHorizontalScrollPosition(scrollLeft: number): number {
         const maxScrollLeft = this.getMaxHorizontalScrollLeft();
-        return Math.max(0, Math.min(maxScrollLeft, scrollLeft));
+        return _clamp(scrollLeft, 0, maxScrollLeft);
     }
 
     public setVerticalScrollPosition(vScrollPosition: number): void {

--- a/packages/ag-grid-community/src/main-internal.ts
+++ b/packages/ag-grid-community/src/main-internal.ts
@@ -369,7 +369,7 @@ export {
 export { _createIcon, _createIconNoSpan } from './utils/icon';
 export { _consoleError, _warnOnce } from './utils/log';
 export { _mergeDeep, _mergedEqual } from './utils/mergeDeep';
-export { _formatNumberCommas } from './utils/number';
+export { _clamp, _formatNumberCommas } from './utils/number';
 export { _selectAllCells } from './utils/selection';
 export { _getValueUsingDotPath } from './utils/value';
 export { _errMsg, _error, _logPreInitWarn, _preInitErrMsg, _warn } from './validation/logging';

--- a/packages/ag-grid-community/src/navigation/navigationService.ts
+++ b/packages/ag-grid-community/src/navigation/navigationService.ts
@@ -19,6 +19,7 @@ import type { RowPosition } from '../interfaces/iRowPosition';
 import { CellCtrl } from '../rendering/cell/cellCtrl';
 import { RowCtrl } from '../rendering/row/rowCtrl';
 import { _focusNextGridCoreContainer, _isHeaderFocusSuppressed } from '../utils/gridFocus';
+import { _clamp } from '../utils/number';
 
 interface NavigateParams {
     /** The rowIndex to vertically scroll to. */
@@ -326,7 +327,7 @@ export class NavigationService extends BeanStub implements NamedBean {
             currentIndex += step;
         }
 
-        return Math.max(0, Math.min(currentIndex, lastRowIndex));
+        return _clamp(currentIndex, 0, lastRowIndex);
     }
 
     private getViewportHeight(): number {

--- a/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
@@ -52,6 +52,7 @@ import type { UserCompDetails } from '../../interfaces/iUserCompDetails';
 import type { GetNoteParams } from '../../interfaces/notes';
 import { calculateRowLevel } from '../../styling/rowStyleService';
 import { _isStopPropagationForAgGrid } from '../../utils/gridEvent';
+import { _clamp } from '../../utils/number';
 import type { Component } from '../../widgets/component';
 import { CellCtrl } from '../cell/cellCtrl';
 import type { ICellRenderer, ICellRendererParams } from '../cellRenderers/iCellRenderer';
@@ -1141,7 +1142,7 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         const minPixel = this.applyPaginationOffset(range.top, true) - 100;
         const maxPixel = this.applyPaginationOffset(range.bottom, true) + 100;
 
-        return Math.min(Math.max(minPixel, rowTop), maxPixel);
+        return _clamp(rowTop, minPixel, maxPixel);
     }
 
     public isRowRendered() {

--- a/packages/ag-grid-community/src/utils/number.ts
+++ b/packages/ag-grid-community/src/utils/number.ts
@@ -1,5 +1,10 @@
 import type { LocaleTextFunc } from 'ag-stack';
 
+/** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
+export function _clamp(value: number, min: number, max: number): number {
+    return Math.max(min, Math.min(value, max));
+}
+
 /**
  * the native method number.toLocaleString(undefined, {minimumFractionDigits: 0})
  * puts in decimal places in IE, so we use this method instead

--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterCtrl.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterCtrl.ts
@@ -8,7 +8,7 @@ import type {
     IPinnedSectionCompHost,
     PopupService,
 } from 'ag-grid-community';
-import { BeanStub } from 'ag-grid-community';
+import { BeanStub, _clamp } from 'ag-grid-community';
 
 import { Dialog } from '../widgets/dialog';
 import { AdvancedFilterComp } from './advancedFilterComp';
@@ -176,7 +176,7 @@ export class AdvancedFilterCtrl extends BeanStub<AdvancedFilterCtrlEvent> implem
         const maxWidth = Math.round(_getAbsoluteWidth(popupParent)) - 2; // assume 1 pixel border
         const maxHeight = Math.round(_getAbsoluteHeight(popupParent) * 0.75) - 2;
 
-        const width = Math.min(Math.max(700, minWidth), maxWidth);
+        const width = _clamp(700, minWidth, maxWidth);
         const height = Math.min(600, maxHeight);
 
         return { width, height, minWidth };

--- a/packages/ag-grid-enterprise/src/agStack/agPanel.ts
+++ b/packages/ag-grid-enterprise/src/agStack/agPanel.ts
@@ -19,6 +19,8 @@ import {
     _setDisplayed,
 } from 'ag-stack';
 
+import { _clamp } from 'ag-grid-community';
+
 import agPanelCSS from './agPanel.css';
 
 export interface AgPanelPostProcessPopupParams {
@@ -273,7 +275,7 @@ export class AgPanel<
             position = len;
         }
 
-        position = Math.max(0, Math.min(position, len));
+        position = _clamp(position, 0, len);
 
         button.addCss('ag-panel-title-bar-button');
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
@@ -13,7 +13,7 @@ import type {
     ColumnToolPanelState,
     ComponentSelector,
 } from 'ag-grid-community';
-import { Component, DragSourceType, _warn, isProvidedColumnGroup } from 'ag-grid-community';
+import { Component, DragSourceType, _clamp, _warn, isProvidedColumnGroup } from 'ag-grid-community';
 
 import type { VirtualListModel } from '../agStack/iVirtualList';
 import type { VirtualListDragItem } from '../agStack/iVirtualListDragFeature';
@@ -205,7 +205,7 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
             movePadding = expanded ? modelItem.children.length : 0;
         }
 
-        const nextItem = Math.min(Math.max(currentIndex + movePadding + diff, 0), this.displayedColsList.length - 1);
+        const nextItem = _clamp(currentIndex + movePadding + diff, 0, this.displayedColsList.length - 1);
 
         this.skipRefocus = true;
         moveItem(

--- a/packages/ag-grid-enterprise/src/excelExport/excelCreator.ts
+++ b/packages/ag-grid-enterprise/src/excelExport/excelCreator.ts
@@ -15,6 +15,7 @@ import type {
 import {
     BaseCreator,
     _addGridCommonParams,
+    _clamp,
     _getHeaderClassesFromColDef,
     _getHeaderRowCount,
     _warn,
@@ -271,7 +272,7 @@ const createExcelFileForExcel = (
     const { fontSize = 11, author = 'AG Grid', activeTab = 0, customMetadata, suppressPrependAuthorToNotes } = options;
 
     const len = data.length;
-    const activeTabWithinBounds = Math.max(Math.min(activeTab, len - 1), 0);
+    const activeTabWithinBounds = _clamp(activeTab, 0, len - 1);
 
     createExcelXMLCoreFolderStructure(zipContainer);
     createExcelXmlTables(zipContainer);

--- a/packages/ag-grid-enterprise/src/excelExport/files/ooxml/drawing.ts
+++ b/packages/ag-grid-enterprise/src/excelExport/files/ooxml/drawing.ts
@@ -1,4 +1,5 @@
 import type { ExcelImage, ExcelOOXMLTemplate, XmlElement } from 'ag-grid-community';
+import { _clamp } from 'ag-grid-community';
 
 import type { ExcelCalculatedImage, ImageAnchor, ImageBoxSize, ImageColor } from '../../assets/excelInterfaces';
 import { pixelsToEMU } from '../../assets/excelUtils';
@@ -172,7 +173,7 @@ const getBlipFill = (image: ExcelImage, index: number) => {
     let blipChildren: XmlElement[] | undefined;
 
     if (image.transparency) {
-        const transparency = Math.min(Math.max(image.transparency, 0), 100);
+        const transparency = _clamp(image.transparency, 0, 100);
         blipChildren = [
             {
                 name: 'a:alphaModFix',
@@ -266,7 +267,7 @@ const getSpPr = (image: ExcelImage, imageBoxSize: ImageBoxSize) => {
         const rotation = image.rotation;
         xfrm.properties = {
             rawMap: {
-                rot: Math.min(Math.max(rotation, 0), 360) * 60000,
+                rot: _clamp(rotation, 0, 360) * 60000,
             },
         };
     }

--- a/packages/ag-grid-enterprise/src/rowGrouping/rowGroupColsSvc.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/rowGroupColsSvc.ts
@@ -1,5 +1,5 @@
 import type { AgColumn, ColumnEventType, IRowGroupColsService, NamedBean } from 'ag-grid-community';
-import { _shouldUpdateColVisibilityAfterGroup, dispatchColumnVisibleEvent } from 'ag-grid-community';
+import { _clamp, _shouldUpdateColVisibilityAfterGroup, dispatchColumnVisibleEvent } from 'ag-grid-community';
 
 import { OrderedColsService } from '../columns/orderedColsService';
 
@@ -19,7 +19,7 @@ export class RowGroupColsSvc extends OrderedColsService implements NamedBean, IR
         if (len === 0 || fromIndex < 0 || fromIndex >= len) {
             return;
         }
-        toIndex = Math.max(0, Math.min(toIndex, len - 1));
+        toIndex = _clamp(toIndex, 0, len - 1);
         if (fromIndex === toIndex) {
             return;
         }

--- a/packages/ag-grid-enterprise/src/toolbar/agToolbar.ts
+++ b/packages/ag-grid-enterprise/src/toolbar/agToolbar.ts
@@ -28,6 +28,7 @@ import {
     ManagedFocusFeature,
     _addFocusableContainerListener,
     _addGridCommonParams,
+    _clamp,
     _createElement,
     _error,
     _unwrapUserComp,
@@ -192,7 +193,7 @@ class AgToolbar extends Component implements FocusableContainer, IToolbarComp {
                 break;
         }
 
-        nextIndex = Math.max(0, Math.min(nextIndex, items.length - 1));
+        nextIndex = _clamp(nextIndex, 0, items.length - 1);
         if (nextIndex !== currentIndex) {
             items[nextIndex].focus();
             e.preventDefault();

--- a/packages/ag-grid-enterprise/src/widgets/agRichSelect.ts
+++ b/packages/ag-grid-enterprise/src/widgets/agRichSelect.ts
@@ -41,6 +41,7 @@ import {
     AgPickerField,
     KeyCode,
     _addGridCommonParams,
+    _clamp,
     _createIconNoSpan,
     _getEditorRendererDetails,
     _stopPropagationForAgGrid,
@@ -976,7 +977,7 @@ export class AgRichSelect<TValue = any> extends AgPickerField<
 
         const widthSource = inputValue || placeholder || '';
         // keep the input compact beside pills but still large enough for the current text.
-        const nextSize = Math.max(1, Math.min(widthSource.length + 1, 32));
+        const nextSize = _clamp(widthSource.length + 1, 1, 32);
 
         if (inputEl.size !== nextSize) {
             inputEl.size = nextSize;

--- a/packages/ag-grid-enterprise/src/widgets/agRichSelectList.ts
+++ b/packages/ag-grid-enterprise/src/widgets/agRichSelectList.ts
@@ -9,7 +9,7 @@ import {
 } from 'ag-stack';
 
 import type { Component, RichSelectParams } from 'ag-grid-community';
-import { KeyCode, _createElement, _createIconNoSpan } from 'ag-grid-community';
+import { KeyCode, _clamp, _createElement, _createIconNoSpan } from 'ag-grid-community';
 
 import { resolveRichSelectValueFormatter } from './agRichSelect';
 import { RichSelectRow } from './agRichSelectRow';
@@ -215,7 +215,7 @@ export class AgRichSelectList<TValue, TEventType extends string = AgRichSelectLi
             const oldIndex = this.lastRowHovered;
 
             const diff = key === KeyCode.DOWN ? 1 : -1;
-            const newIndex = Math.min(Math.max(oldIndex === -1 ? 0 : oldIndex + diff, 0), len - 1);
+            const newIndex = _clamp(oldIndex === -1 ? 0 : oldIndex + diff, 0, len - 1);
             this.highlightIndex(newIndex);
             announceItem();
         });
@@ -458,7 +458,7 @@ export class AgRichSelectList<TValue, TEventType extends string = AgRichSelectLi
         const scrollTop = this.getScrollTop();
         const mouseY = e.clientY - rect.top + scrollTop;
 
-        return Math.min(Math.max(Math.floor(mouseY / this.getRowHeight()), 0), this.model.getRowCount() - 1);
+        return _clamp(Math.floor(mouseY / this.getRowHeight()), 0, this.model.getRowCount() - 1);
     }
 
     private onMouseMove(e: MouseEvent): void {


### PR DESCRIPTION
## Summary

- Adds `_clamp(value, min, max): number` to `packages/ag-grid-community/src/utils/number.ts` and exports it from `main-internal.ts`
- Replaces 19 scattered `Math.max(x, Math.min(y, z))` / `Math.min(Math.max(...))` clamping pairs across community and enterprise with `_clamp`
- No behavioural changes — `_clamp` is exactly `Math.max(min, Math.min(value, max))`

## Test plan

- [x] `yarn nx build:types ag-grid-community` — passes
- [x] `yarn nx build:types ag-grid-enterprise` — passes
- [ ] `yarn nx test ag-grid-community`
- [ ] `yarn nx test ag-grid-enterprise`