### PR TITLE
AG-17408 fix(e2e): open calculated column dialog via menu in highlighting test

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-dialog-highlighting/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-dialog-highlighting/example.spec.ts
@@ -7,6 +7,13 @@ test.agExample(import.meta, () => {
             await expect(agIdFor.headerCell('profit')).toContainText('Profit');
             await expect(agIdFor.cell('0', 'profit')).toContainText('$46,000');
             await expect(agIdFor.cell('1', 'profit')).toContainText('$26,000');
+
+            // Open the calculated column dialog via the column header menu
+            const profitHeader = agIdFor.headerCell('profit');
+            await profitHeader.hover();
+            await profitHeader.locator('.ag-header-cell-menu-button').click();
+            await page.locator('.ag-menu-option-text', { hasText: 'Edit Calculated Column' }).click();
+
             await expect(page.locator('.ag-calculated-column-form')).toBeVisible();
             await expect(agIdFor.headerCell('profit')).not.toHaveClass(/ag-calculated-column-highlighted/);
             await expect(agIdFor.cell('0', 'profit')).not.toHaveClass(/ag-calculated-column-highlighted/);


### PR DESCRIPTION
## Summary

- `openCalculatedColumnDialog` was removed from the public `GridApi` in the AG-17408 API cleanup, but the E2E test for the `calculated-columns-dialog-highlighting` example still expected the dialog to be visible on load (previously opened via `params.api.openCalculatedColumnDialog` in `onFirstDataRendered`).
- Updated the test to open the dialog through the column header menu — hover the Profit header, click the menu button, then select "Edit Calculated Column" — which is the real user interaction this example is demonstrating.

## Test plan

- [x] `./docs-e2e.sh "calculated-columns-dialog-highlighting" --framework vanilla` passes locally

Fix [AG-17408](https://ag-grid.atlassian.net/browse/AG-17408)