### PR TITLE
 [AG-6377] Fix(pagination): page input RTL and alignment fixes

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -1658,6 +1658,7 @@
     // */
     .ag-paging-panel {
         display: flex;
+        align-items: center;
     }
 
     .ag-paging-panel-content {

--- a/community-modules/styles/src/internal/base/parts/_footer.scss
+++ b/community-modules/styles/src/internal/base/parts/_footer.scss
@@ -29,6 +29,18 @@
         color: var(--ag-disabled-foreground-color);
     }
 
+    .ag-ltr .ag-number-field.ag-paging-number .ag-input-field-input {
+        text-align: right;
+        padding-right: var(--ag-input-padding-start);
+        padding-left: 0;
+    }
+
+    .ag-rtl .ag-number-field.ag-paging-number .ag-input-field-input {
+        text-align: left;
+        padding-left: var(--ag-input-padding-start);
+        padding-right: 0;
+    }
+
     @include ag.keyboard-focus((ag-paging-button), 0px);
 
     .ag-paging-button,

--- a/community-modules/styles/src/internal/base/parts/_footer.scss
+++ b/community-modules/styles/src/internal/base/parts/_footer.scss
@@ -30,13 +30,8 @@
     }
 
     .ag-number-field.ag-paging-number .ag-input-field-input {
-        @include ag.unthemed-rtl(
-            (
-                text-align: right,
-                padding-right: var(--ag-input-padding-start),
-                padding-left: 0,
-            )
-        );
+        text-align: end;
+        padding-inline: 0 var(--ag-input-padding-start);
     }
 
     @include ag.keyboard-focus((ag-paging-button), 0px);

--- a/community-modules/styles/src/internal/base/parts/_footer.scss
+++ b/community-modules/styles/src/internal/base/parts/_footer.scss
@@ -29,16 +29,14 @@
         color: var(--ag-disabled-foreground-color);
     }
 
-    .ag-ltr .ag-number-field.ag-paging-number .ag-input-field-input {
-        text-align: right;
-        padding-right: var(--ag-input-padding-start);
-        padding-left: 0;
-    }
-
-    .ag-rtl .ag-number-field.ag-paging-number .ag-input-field-input {
-        text-align: left;
-        padding-left: var(--ag-input-padding-start);
-        padding-right: 0;
+    .ag-number-field.ag-paging-number .ag-input-field-input {
+        @include ag.unthemed-rtl(
+            (
+                text-align: right,
+                padding-right: var(--ag-input-padding-start),
+                padding-left: 0,
+            )
+        );
     }
 
     @include ag.keyboard-focus((ag-paging-button), 0px);

--- a/packages/ag-grid-community/src/pagination/paginationComp.css
+++ b/packages/ag-grid-community/src/pagination/paginationComp.css
@@ -44,8 +44,16 @@
     display: inline-block;
 }
 
-:where(.ag-number-field.ag-paging-number) .ag-input-field-input {
+:where(.ag-ltr) .ag-number-field.ag-paging-number .ag-input-field-input {
     text-align: right;
+    padding-right: var(--ag-input-padding-start);
+    padding-left: 0;
+}
+
+:where(.ag-rtl) .ag-number-field.ag-paging-number .ag-input-field-input {
+    text-align: left;
+    padding-left: var(--ag-input-padding-start);
+    padding-right: 0;
 }
 
 .ag-paging-number,

--- a/packages/ag-grid-community/src/pagination/paginationComp.css
+++ b/packages/ag-grid-community/src/pagination/paginationComp.css
@@ -1,5 +1,6 @@
 .ag-paging-panel {
     display: flex;
+    align-items: center;
     height: var(--ag-pagination-panel-height);
     border-top: var(--ag-footer-row-border);
     overflow: auto hidden;

--- a/packages/ag-grid-community/src/pagination/paginationComp.css
+++ b/packages/ag-grid-community/src/pagination/paginationComp.css
@@ -45,16 +45,9 @@
     display: inline-block;
 }
 
-:where(.ag-ltr) .ag-number-field.ag-paging-number .ag-input-field-input {
-    text-align: right;
-    padding-right: var(--ag-input-padding-start);
-    padding-left: 0;
-}
-
-:where(.ag-rtl) .ag-number-field.ag-paging-number .ag-input-field-input {
-    text-align: left;
-    padding-left: var(--ag-input-padding-start);
-    padding-right: 0;
+:where(.ag-number-field.ag-paging-number) .ag-input-field-input {
+    text-align: end;
+    padding-inline: 0 var(--ag-input-padding-start);
 }
 
 .ag-paging-number,


### PR DESCRIPTION
- Add LTR/RTL-aware padding to the pagination page number input (`paginationComp.css`)
- Mirror LTR/RTL padding fix to the legacy Sass theme (`_footer.scss`)
- Vertically centre pagination panel content in Theming API CSS and legacy Sass theme

Fix [AG-6377](https://ag-grid.atlassian.net/browse/AG-6377)