### PR TITLE
AG-14628 - [Tooltip] Inherit colDef tooltips in groupRows (full-width) display path

### DIFF
--- a/packages/ag-grid-community/src/rendering/row/fullWidthRowFeature.ts
+++ b/packages/ag-grid-community/src/rendering/row/fullWidthRowFeature.ts
@@ -220,8 +220,8 @@ export class FullWidthRowFeature extends BeanStub implements IRowModeFeature {
 
         this.setupFullWidthRowTooltip(
             () => {
+                const displayValue = valueSvc.getDisplayValue(undefined, rowNode, 'edit');
                 if (tooltipValueGetter) {
-                    const { value } = valueSvc.getValueForDisplay({ node: rowNode, from: 'edit' });
                     return tooltipValueGetter(
                         _addGridCommonParams(gos, {
                             location: 'fullWidthRow',
@@ -230,7 +230,7 @@ export class FullWidthRowFeature extends BeanStub implements IRowModeFeature {
                             rowIndex: rowNode.rowIndex ?? 0,
                             node: rowNode,
                             data: rowNode.data,
-                            value,
+                            value: displayValue,
                             valueFormatted: undefined,
                         })
                     );
@@ -245,7 +245,7 @@ export class FullWidthRowFeature extends BeanStub implements IRowModeFeature {
                         ? _getValueUsingDotField(data, tooltipField)
                         : (data as Record<string, unknown>)[tooltipField];
                 }
-                return undefined;
+                return displayValue;
             },
             undefined,
             () => ({ colDef })

--- a/packages/ag-grid-community/src/rendering/row/fullWidthRowFeature.ts
+++ b/packages/ag-grid-community/src/rendering/row/fullWidthRowFeature.ts
@@ -6,6 +6,8 @@ import {
     _isFocusableFormField,
 } from 'ag-stack';
 
+import type { RowNode } from 'ag-grid-community';
+
 import {
     _getFullWidthCellRendererDetails,
     _getFullWidthDetailCellRendererDetails,
@@ -199,7 +201,20 @@ export class FullWidthRowFeature extends BeanStub implements IRowModeFeature {
         );
     }
 
-    private setupGroupRowsTooltip(rowNode: RowCtrl['rowNode']): void {
+    /**
+     * Wires up the tooltip for a full-width group row (`groupDisplayType: 'groupRows'`), inheriting the
+     * tooltip configuration from the owning group column rather than from an individual cell.
+     *
+     * The tooltip source colDef is the row-group column's colDef for regular grouping, or the
+     * `autoGroupColumnDef` for tree data (where there is no `rowGroupColumn`). If that colDef declares no
+     * `tooltipValueGetter`, `tooltipField`, or `tooltipComponent`, no tooltip is set up.
+     *
+     * Resolution order, mirroring the standard cell tooltip path, with values lazily computed on hover:
+     * - `tooltipValueGetter` — invoked with the group's display value/formatted value and full row context.
+     * - `tooltipField` — read directly from `node.data`, honouring `suppressFieldDotNotation` for dotted fields.
+     * - otherwise — falls back to the group display value, also passed to any inherited `tooltipComponent`.
+     */
+    private setupGroupRowsTooltip(rowNode: RowNode): void {
         const groupCol = rowNode.rowGroupColumn as AgColumn | undefined;
         const { gos } = this;
 

--- a/packages/ag-grid-community/src/rendering/row/fullWidthRowFeature.ts
+++ b/packages/ag-grid-community/src/rendering/row/fullWidthRowFeature.ts
@@ -218,9 +218,12 @@ export class FullWidthRowFeature extends BeanStub implements IRowModeFeature {
         const { valueSvc } = this.beans;
         gos.assertModuleRegistered('Tooltip', 3);
 
+        const getDisplay = () =>
+            valueSvc.getValueForDisplay({ node: rowNode, includeValueFormatted: true, from: 'edit' });
+
         this.setupFullWidthRowTooltip(
             () => {
-                const displayValue = valueSvc.getDisplayValue(undefined, rowNode, 'edit');
+                const { value, valueFormatted } = getDisplay();
                 if (tooltipValueGetter) {
                     return tooltipValueGetter(
                         _addGridCommonParams(gos, {
@@ -230,8 +233,8 @@ export class FullWidthRowFeature extends BeanStub implements IRowModeFeature {
                             rowIndex: rowNode.rowIndex ?? 0,
                             node: rowNode,
                             data: rowNode.data,
-                            value: displayValue,
-                            valueFormatted: undefined,
+                            value,
+                            valueFormatted: valueFormatted ?? undefined,
                         })
                     );
                 }
@@ -240,15 +243,24 @@ export class FullWidthRowFeature extends BeanStub implements IRowModeFeature {
                     if (!data) {
                         return undefined;
                     }
-                    const containsDots = groupCol ? groupCol.tooltipFieldContainsDots : tooltipField.includes('.');
+                    const containsDots = groupCol
+                        ? groupCol.tooltipFieldContainsDots
+                        : !gos.get('suppressFieldDotNotation') && tooltipField.includes('.');
                     return containsDots
                         ? _getValueUsingDotField(data, tooltipField)
                         : (data as Record<string, unknown>)[tooltipField];
                 }
-                return displayValue;
+                return value;
             },
             undefined,
-            () => ({ colDef })
+            () => ({
+                colDef,
+                column: groupCol,
+                rowIndex: rowNode.rowIndex ?? 0,
+                node: rowNode,
+                data: rowNode.data,
+                valueFormatted: getDisplay().valueFormatted ?? undefined,
+            })
         );
     }
 

--- a/packages/ag-grid-community/src/rendering/row/fullWidthRowFeature.ts
+++ b/packages/ag-grid-community/src/rendering/row/fullWidthRowFeature.ts
@@ -6,8 +6,6 @@ import {
     _isFocusableFormField,
 } from 'ag-stack';
 
-import type { RowNode } from 'ag-grid-community';
-
 import {
     _getFullWidthCellRendererDetails,
     _getFullWidthDetailCellRendererDetails,
@@ -16,6 +14,7 @@ import {
 } from '../../components/framework/userCompUtils';
 import { BeanStub } from '../../context/beanStub';
 import type { AgColumn } from '../../entities/agColumn';
+import type { RowNode } from '../../entities/rowNode';
 import type { CellFocusedEvent } from '../../events';
 import { _addGridCommonParams } from '../../gridOptionsUtils';
 import type { CellPosition } from '../../interfaces/iCellPosition';

--- a/packages/ag-grid-community/src/rendering/row/fullWidthRowFeature.ts
+++ b/packages/ag-grid-community/src/rendering/row/fullWidthRowFeature.ts
@@ -1,4 +1,10 @@
-import { _findNextFocusableElement, _getActiveDomElement, _isBrowserSafari, _isFocusableFormField } from 'ag-stack';
+import {
+    _findNextFocusableElement,
+    _getActiveDomElement,
+    _getValueUsingDotField,
+    _isBrowserSafari,
+    _isFocusableFormField,
+} from 'ag-stack';
 
 import {
     _getFullWidthCellRendererDetails,
@@ -16,7 +22,7 @@ import type { ColumnPinnedType } from '../../interfaces/iColumn';
 import type { WithoutGridCommon } from '../../interfaces/iCommon';
 import type { UserCompDetails } from '../../interfaces/iUserCompDetails';
 import type { INotesFeature } from '../../interfaces/notes';
-import type { TooltipFeature } from '../../tooltip/tooltipFeature';
+import type { ITooltipCtrlParams, TooltipFeature } from '../../tooltip/tooltipFeature';
 import { _isStopPropagationForAgGrid } from '../../utils/gridEvent';
 import type { CellCtrl } from '../cell/cellCtrl';
 import type { ICellRenderer, ICellRendererParams } from '../cellRenderers/iCellRenderer';
@@ -142,7 +148,7 @@ export class FullWidthRowFeature extends BeanStub implements IRowModeFeature {
                 this.addFullWidthRowDragging(rowDraggerElement, dragStartPixels, value, rowDragEntireRow),
             setTooltip: (value, shouldDisplayTooltip) => {
                 gos.assertModuleRegistered('Tooltip', 3);
-                this.setupFullWidthRowTooltip(value, shouldDisplayTooltip);
+                this.setupFullWidthRowTooltip(() => value, shouldDisplayTooltip);
             },
         } as WithoutGridCommon<ICellRendererParams>);
 
@@ -158,6 +164,7 @@ export class FullWidthRowFeature extends BeanStub implements IRowModeFeature {
                 });
                 params.value = value;
                 params.valueFormatted = valueFormatted;
+                this.setupGroupRowsTooltip(rowNode);
                 return _getFullWidthGroupCellRendererDetails(compFactory, params)!;
             }
             case 'FullWidthLoading':
@@ -174,7 +181,11 @@ export class FullWidthRowFeature extends BeanStub implements IRowModeFeature {
         this.beans.masterDetailSvc?.setupDetailRowAutoHeight(this.rowCtrl, eDetailGui);
     }
 
-    private setupFullWidthRowTooltip(value: string, shouldDisplayTooltip?: () => boolean) {
+    private setupFullWidthRowTooltip(
+        getTooltipValue: () => any,
+        shouldDisplayTooltip?: () => boolean,
+        getAdditionalParams?: () => ITooltipCtrlParams
+    ) {
         if (!this.rowCtrl.getCurrentRowElement()) {
             return;
         }
@@ -182,8 +193,62 @@ export class FullWidthRowFeature extends BeanStub implements IRowModeFeature {
         this.tooltipFeature = this.beans.tooltipSvc?.setupFullWidthRowTooltip(
             this.tooltipFeature,
             this.rowCtrl,
-            value,
-            shouldDisplayTooltip
+            getTooltipValue,
+            shouldDisplayTooltip,
+            getAdditionalParams
+        );
+    }
+
+    private setupGroupRowsTooltip(rowNode: RowCtrl['rowNode']): void {
+        const groupCol = rowNode.rowGroupColumn as AgColumn | undefined;
+        const { gos } = this;
+
+        // Regular row grouping: read tooltip config from the row-group column's colDef.
+        // Tree data (no rowGroupColumn): fall back to the auto-group column def.
+        const colDef = groupCol?.colDef ?? gos.get('autoGroupColumnDef');
+        if (!colDef) {
+            return;
+        }
+
+        const { tooltipValueGetter, tooltipField, tooltipComponent } = colDef;
+        if (!tooltipValueGetter && !tooltipField && !tooltipComponent) {
+            return;
+        }
+
+        const { valueSvc } = this.beans;
+        gos.assertModuleRegistered('Tooltip', 3);
+
+        this.setupFullWidthRowTooltip(
+            () => {
+                if (tooltipValueGetter) {
+                    const { value } = valueSvc.getValueForDisplay({ node: rowNode, from: 'edit' });
+                    return tooltipValueGetter(
+                        _addGridCommonParams(gos, {
+                            location: 'fullWidthRow',
+                            colDef,
+                            column: groupCol,
+                            rowIndex: rowNode.rowIndex ?? 0,
+                            node: rowNode,
+                            data: rowNode.data,
+                            value,
+                            valueFormatted: undefined,
+                        })
+                    );
+                }
+                if (tooltipField) {
+                    const data = rowNode.data;
+                    if (!data) {
+                        return undefined;
+                    }
+                    const containsDots = groupCol ? groupCol.tooltipFieldContainsDots : tooltipField.includes('.');
+                    return containsDots
+                        ? _getValueUsingDotField(data, tooltipField)
+                        : (data as Record<string, unknown>)[tooltipField];
+                }
+                return undefined;
+            },
+            undefined,
+            () => ({ colDef })
         );
     }
 

--- a/packages/ag-grid-community/src/tooltip/tooltipService.ts
+++ b/packages/ag-grid-community/src/tooltip/tooltipService.ts
@@ -360,14 +360,16 @@ export class TooltipService extends BeanStub implements NamedBean {
     public setupFullWidthRowTooltip(
         existingTooltipFeature: TooltipFeature | undefined,
         ctrl: RowCtrl,
-        value: string,
-        shouldDisplayTooltip?: () => boolean
+        getTooltipValue: () => any,
+        shouldDisplayTooltip?: () => boolean,
+        getAdditionalParams?: () => ITooltipCtrlParams
     ): TooltipFeature | undefined {
         const tooltipParams: ITooltipCtrl = {
             getGui: () => ctrl.getRowContentElement()!,
-            getTooltipValue: () => value,
+            getTooltipValue,
             getLocation: () => 'fullWidthRow',
             shouldDisplayTooltip,
+            ...(getAdditionalParams ? { getAdditionalParams } : {}),
         };
 
         const beans = this.beans;

--- a/testing/behavioural/src/tooltip/tooltip-group-col-inheritance.test.ts
+++ b/testing/behavioural/src/tooltip/tooltip-group-col-inheritance.test.ts
@@ -487,4 +487,94 @@ describe('Tooltip inheritance in group columns', () => {
             · └── au-syd LEAF hidden id:au-syd
         `);
     });
+
+    // P1 fix: tooltipValueGetter receives params.value from the owning group column, not the outer group
+    test('full-width group row tooltipValueGetter receives value from the owning column (groupRows + multiple groups)', async () => {
+        const countryTooltips: string[] = [];
+        const yearTooltips: string[] = [];
+        const gridOptions: GridOptions = {
+            columnDefs: [
+                {
+                    field: 'country',
+                    rowGroup: true,
+                    hide: true,
+                    tooltipValueGetter: (params) => {
+                        countryTooltips.push(String(params.value));
+                        return `country:${params.value}`;
+                    },
+                },
+                {
+                    field: 'year',
+                    rowGroup: true,
+                    hide: true,
+                    tooltipValueGetter: (params) => {
+                        yearTooltips.push(String(params.value));
+                        return `year:${params.value}`;
+                    },
+                },
+                { field: 'athlete' },
+            ],
+            rowData: [{ country: 'Australia', year: 2020, athlete: 'Alice' }],
+            groupDisplayType: 'groupRows',
+            tooltipShowDelay: TOOLTIP_SHOW_DELAY,
+        };
+
+        const api = await gridMgr.createGridAndWait('tooltip-group-rows-multi-group', gridOptions);
+        api.setRowNodeExpanded(api.getRowNode('row-group-country-Australia')!, true);
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const yearRow = await waitFor(() =>
+            getByTestId(gridDiv, agTestIdFor.rowNode('row-group-country-Australia-year-2020'))
+        );
+
+        await userEvent.hover(yearRow);
+        await asyncSetTimeout(TOOLTIP_SHOW_DELAY + 50);
+        await waitForTooltips(1);
+        // The year group row must show the year value (2020), not the country value (Australia)
+        expect(getTooltips()[0]).toHaveTextContent('year:2020');
+    });
+
+    // P2 fix: tooltipComponent alone receives the group display value, not undefined
+    test('full-width group row passes group display value to tooltipComponent when no getter or field (groupRows)', async () => {
+        let capturedValue: unknown = 'not-set';
+
+        class CaptureTooltip implements ITooltipComp {
+            private eGui!: HTMLElement;
+            init(params: ITooltipParams) {
+                capturedValue = params.value;
+                this.eGui = document.createElement('div');
+                this.eGui.className = 'ag-tooltip-custom capture-tooltip';
+                this.eGui.textContent = `captured:${params.value}`;
+            }
+            getGui() {
+                return this.eGui;
+            }
+        }
+
+        const gridOptions: GridOptions = {
+            columnDefs: [
+                {
+                    field: 'country',
+                    rowGroup: true,
+                    hide: true,
+                    tooltipComponent: CaptureTooltip,
+                },
+                { field: 'athlete' },
+            ],
+            rowData: [{ country: 'Australia', athlete: 'Alice' }],
+            groupDisplayType: 'groupRows',
+            tooltipShowDelay: TOOLTIP_SHOW_DELAY,
+        };
+
+        const api = await gridMgr.createGridAndWait('tooltip-group-rows-component-only', gridOptions);
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const groupRow = await waitFor(() => getByTestId(gridDiv, agTestIdFor.rowNode('row-group-country-Australia')));
+
+        await userEvent.hover(groupRow);
+        await asyncSetTimeout(TOOLTIP_SHOW_DELAY + 50);
+        await waitForTooltips(1);
+        expect(document.querySelector('.capture-tooltip')).not.toBeNull();
+        // params.value must be the group display value, not undefined
+        expect(capturedValue).toBe('Australia');
+    });
 });

--- a/testing/behavioural/src/tooltip/tooltip-group-col-inheritance.test.ts
+++ b/testing/behavioural/src/tooltip/tooltip-group-col-inheritance.test.ts
@@ -3,14 +3,14 @@ import { userEvent } from '@testing-library/user-event';
 
 import { GROUP_AUTO_COLUMN_ID, TooltipModule, agTestIdFor, getGridElement, setupAgTestIds } from 'ag-grid-community';
 import type { GridOptions, ITooltipComp, ITooltipParams, Module } from 'ag-grid-community';
-import { RowGroupingModule } from 'ag-grid-enterprise';
+import { RowGroupingModule, TreeDataModule } from 'ag-grid-enterprise';
 
 import { GridColumns, GridRows, TestGridsManager, asyncSetTimeout } from '../test-utils';
 
 describe('Tooltip inheritance in group columns', () => {
     const gridMgr = new TestGridsManager({
         includeDefaultModules: true,
-        modules: [TooltipModule, RowGroupingModule] as Module[],
+        modules: [TooltipModule, RowGroupingModule, TreeDataModule] as Module[],
     });
 
     beforeAll(() => setupAgTestIds());
@@ -310,10 +310,10 @@ describe('Tooltip inheritance in group columns', () => {
         const api = await gridMgr.createGridAndWait('tooltip-group-selector-multiple', gridOptions);
         await new GridColumns(api, 'group column inherits tooltipComponentSelector (multipleColumns) setup')
             .checkColumns(`
-            CENTER
-            ├── ag-Grid-AutoColumn-country "Country" width:200
-            └── athlete "Athlete" width:200
-        `);
+                CENTER
+                ├── ag-Grid-AutoColumn-country "Country" width:200
+                └── athlete "Athlete" width:200
+            `);
         await new GridRows(api, 'group column inherits tooltipComponentSelector (multipleColumns) setup').check(`
             ROOT id:ROOT_NODE_ID ag-Grid-AutoColumn-country:null
             └─┬ LEAF_GROUP collapsed id:row-group-country-Australia ag-Grid-AutoColumn-country:"Australia"
@@ -372,16 +372,16 @@ describe('Tooltip inheritance in group columns', () => {
         const api = await gridMgr.createGridAndWait('tooltip-group-selector-single', gridOptions);
         await new GridColumns(api, 'group cell uses tooltipComponentSelector from source column (singleColumn) setup')
             .checkColumns(`
-            CENTER
-            ├── ag-Grid-AutoColumn "Group" width:200
-            └── athlete "Athlete" width:200
-        `);
+                CENTER
+                ├── ag-Grid-AutoColumn "Group" width:200
+                └── athlete "Athlete" width:200
+            `);
         await new GridRows(api, 'group cell uses tooltipComponentSelector from source column (singleColumn) setup')
             .check(`
-            ROOT id:ROOT_NODE_ID
-            └─┬ LEAF_GROUP collapsed id:row-group-country-Australia ag-Grid-AutoColumn:"Australia"
-            · └── LEAF hidden id:0 country:"Australia" athlete:"Alice"
-        `);
+                ROOT id:ROOT_NODE_ID
+                └─┬ LEAF_GROUP collapsed id:row-group-country-Australia ag-Grid-AutoColumn:"Australia"
+                · └── LEAF hidden id:0 country:"Australia" athlete:"Alice"
+            `);
 
         const gridDiv = getGridElement(api)! as HTMLElement;
         const groupCell = await waitFor(() =>
@@ -400,6 +400,91 @@ describe('Tooltip inheritance in group columns', () => {
             ROOT id:ROOT_NODE_ID
             └─┬ LEAF_GROUP collapsed id:row-group-country-Australia ag-Grid-AutoColumn:"Australia"
             · └── LEAF hidden id:0 country:"Australia" athlete:"Alice"
+        `);
+    });
+
+    // TC3 – groupDisplayType: 'groupRows': full-width row inherits tooltipValueGetter from colDef
+    test('full-width group row inherits tooltipValueGetter (groupRows)', async () => {
+        const gridOptions: GridOptions = {
+            columnDefs: [
+                {
+                    field: 'country',
+                    rowGroup: true,
+                    hide: true,
+                    tooltipValueGetter: (params) => `Tooltip: ${params.value}`,
+                },
+                { field: 'athlete' },
+            ],
+            rowData: [{ country: 'Australia', athlete: 'Alice' }],
+            groupDisplayType: 'groupRows',
+            tooltipShowDelay: TOOLTIP_SHOW_DELAY,
+        };
+
+        const api = await gridMgr.createGridAndWait('tooltip-group-rows-valuegetter', gridOptions);
+        await new GridColumns(api, 'full-width group row inherits tooltipValueGetter (groupRows) setup').checkColumns(`
+            CENTER
+            └── athlete "Athlete" width:200
+        `);
+        await new GridRows(api, 'full-width group row inherits tooltipValueGetter (groupRows) setup').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ LEAF_GROUP collapsed id:row-group-country-Australia
+            · └── LEAF hidden id:0 country:"Australia" athlete:"Alice"
+        `);
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const groupRow = await waitFor(() => getByTestId(gridDiv, agTestIdFor.rowNode('row-group-country-Australia')));
+
+        await userEvent.hover(groupRow);
+        await asyncSetTimeout(TOOLTIP_SHOW_DELAY + 50);
+        await waitForTooltips(1);
+        expect(getTooltips()[0]).toHaveTextContent('Tooltip: Australia');
+        await new GridRows(api, 'full-width group row inherits tooltipValueGetter (groupRows) final state').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ LEAF_GROUP collapsed id:row-group-country-Australia
+            · └── LEAF hidden id:0 country:"Australia" athlete:"Alice"
+        `);
+    });
+
+    // TC3 – groupDisplayType: 'groupRows': full-width row reads tooltipField from node.data,
+    // not from the group display value — verified with tree data where the two differ
+    test('full-width group row reads tooltipField from node.data, not display value (groupRows + tree data)', async () => {
+        const gridOptions: GridOptions = {
+            treeData: true,
+            treeDataParentIdField: 'parentId',
+            getRowId: (params) => params.data.id,
+            // autoGroupColumnDef.tooltipField is 'description', distinct from the display field 'name'
+            autoGroupColumnDef: {
+                field: 'name',
+                tooltipField: 'description',
+            },
+            columnDefs: [],
+            rowData: [
+                { id: 'au', parentId: null, name: 'Australia', description: 'Commonwealth of Australia' },
+                { id: 'au-syd', parentId: 'au', name: 'Sydney', description: 'Harbour City' },
+            ],
+            groupDisplayType: 'groupRows',
+            tooltipShowDelay: TOOLTIP_SHOW_DELAY,
+        };
+
+        const api = await gridMgr.createGridAndWait('tooltip-group-rows-field', gridOptions);
+        await new GridRows(api, 'full-width group row reads tooltipField from data setup').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ au GROUP collapsed id:au
+            · └── au-syd LEAF hidden id:au-syd
+        `);
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const groupRow = await waitFor(() => getByTestId(gridDiv, agTestIdFor.rowNode('au')));
+
+        await userEvent.hover(groupRow);
+        await asyncSetTimeout(TOOLTIP_SHOW_DELAY + 50);
+        await waitForTooltips(1);
+        // tooltip comes from data.description ('Commonwealth of Australia'), not from data.name ('Australia')
+        expect(getTooltips()[0]).toHaveTextContent('Commonwealth of Australia');
+        await new GridRows(api, 'full-width group row reads tooltipField from data final state').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ au GROUP collapsed id:au
+            · └── au-syd LEAF hidden id:au-syd
         `);
     });
 });

--- a/testing/behavioural/src/tooltip/tooltip-group-col-inheritance.test.ts
+++ b/testing/behavioural/src/tooltip/tooltip-group-col-inheritance.test.ts
@@ -577,4 +577,49 @@ describe('Tooltip inheritance in group columns', () => {
         // params.value must be the group display value, not undefined
         expect(capturedValue).toBe('Australia');
     });
+
+    // getAdditionalParams must expose the group column's formatted value to a custom tooltipComponent,
+    // matching the formatter output (not the raw display value) as the standard cell tooltip path does.
+    test('full-width group row passes formatted value to tooltipComponent params.valueFormatted (groupRows)', async () => {
+        let capturedValueFormatted: unknown = 'not-set';
+
+        class CaptureTooltip implements ITooltipComp {
+            private eGui!: HTMLElement;
+            init(params: ITooltipParams) {
+                capturedValueFormatted = params.valueFormatted;
+                this.eGui = document.createElement('div');
+                this.eGui.className = 'ag-tooltip-custom capture-tooltip';
+                this.eGui.textContent = `captured:${params.valueFormatted}`;
+            }
+            getGui() {
+                return this.eGui;
+            }
+        }
+
+        const gridOptions: GridOptions = {
+            columnDefs: [
+                {
+                    field: 'country',
+                    rowGroup: true,
+                    hide: true,
+                    valueFormatter: (params) => `formatted:${params.value}`,
+                    tooltipComponent: CaptureTooltip,
+                },
+                { field: 'athlete' },
+            ],
+            rowData: [{ country: 'Australia', athlete: 'Alice' }],
+            groupDisplayType: 'groupRows',
+            tooltipShowDelay: TOOLTIP_SHOW_DELAY,
+        };
+
+        const api = await gridMgr.createGridAndWait('tooltip-group-rows-value-formatted', gridOptions);
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const groupRow = await waitFor(() => getByTestId(gridDiv, agTestIdFor.rowNode('row-group-country-Australia')));
+
+        await userEvent.hover(groupRow);
+        await asyncSetTimeout(TOOLTIP_SHOW_DELAY + 50);
+        await waitForTooltips(1);
+        expect(document.querySelector('.capture-tooltip')).not.toBeNull();
+        expect(capturedValueFormatted).toBe('formatted:Australia');
+    });
 });


### PR DESCRIPTION
This PR extends tooltip inheritance to the `groupDisplayType: 'groupRows'` display path, where group rows render as full-width rows instead of cells in an auto group column.

Previously, `groupRows` used a separate rendering path via `FullWidthRowFeature`, which bypassed the tooltip inheritance logic used by the auto group column path. As a result, `tooltipValueGetter`, `tooltipField`, and `tooltipComponent` configured on the source row-group column’s `colDef` were silently ignored.

Relates to [AG-14628](https://ag-grid.atlassian.net/browse/AG-14628)