### PR TITLE
AG-17559 Expose grid container element via GridAPI

### DIFF
--- a/documentation/ag-grid-docs/src/content/api-documentation/grid-api/api.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/grid-api/api.json
@@ -1203,6 +1203,7 @@
             "description": "Sets an ARIA property in the grid panel (element with `role=\"grid\"`), and removes an ARIA property when the value is null.<br /><br />Example:<br />`api.setGridAriaProperty('label', 'my grid')` will set `aria-label=\"my grid\"`.<br />`api.setGridAriaProperty('label', null)` will remove the `aria-label` attribute from the grid element."
         },
         "getGridId": {},
+        "getGridElement": {},
         "isModuleRegistered": {},
         "isAnimationFrameQueueEmpty": {}
     },

--- a/packages/ag-grid-community/src/api/coreApi.ts
+++ b/packages/ag-grid-community/src/api/coreApi.ts
@@ -1,5 +1,6 @@
 import type { BeanCollection } from '../context/context';
 import type { GridOptions } from '../entities/gridOptions';
+import { getGridElement as _getGridElement } from '../grid';
 import type { ManagedGridOptionKey, ManagedGridOptions } from '../gridOptionsInitial';
 import type { AgModuleName, ModuleName } from '../interfaces/iModule';
 
@@ -37,6 +38,10 @@ export function updateGridOptions<TDataUpdate = any>(
     // NOTE: The TDataUpdate generic is used to ensure that the update options match the generic passed into the GridApi above as TData.
     // This is required because if we just use TData directly then Typescript will get into an infinite loop due to callbacks which recursively include the GridApi.
     beans.gos.updateGridOptions({ options });
+}
+
+export function getGridElement(beans: BeanCollection): Element | undefined {
+    return _getGridElement(beans.gridApi);
 }
 
 export function isModuleRegistered(beans: BeanCollection, moduleName: AgModuleName): boolean {

--- a/packages/ag-grid-community/src/api/gridApi.ts
+++ b/packages/ag-grid-community/src/api/gridApi.ts
@@ -113,6 +113,9 @@ export interface _CoreGridApi<TData = any> {
      * Check if a Module is registered with the current grid instance via its equivalent string name.
      */
     isModuleRegistered(moduleName: AgModuleName): boolean;
+
+    /** Returns the outermost DOM element created by the grid. This is a direct child of the host element provided by the application. */
+    getGridElement(): Element | undefined;
 }
 
 export interface _RowSelectionGridApi<TData = any> {

--- a/packages/ag-grid-community/src/api/gridApiFunctions.ts
+++ b/packages/ag-grid-community/src/api/gridApiFunctions.ts
@@ -76,6 +76,7 @@ export const gridApiFunctionsMap: Record<keyof GridApi, ValidationModuleName> = 
         setGridOption: 0,
         updateGridOptions: 0,
         isModuleRegistered: 0,
+        getGridElement: 0,
     }),
     ...mod<_StateGridApi>('GridState', {
         getState: 0,

--- a/packages/ag-grid-community/src/gridCoreModule.ts
+++ b/packages/ag-grid-community/src/gridCoreModule.ts
@@ -1,6 +1,7 @@
 import { ApiFunctionService } from './api/apiFunctionService';
 import {
     destroy,
+    getGridElement,
     getGridId,
     getGridOption,
     isDestroyed,
@@ -104,6 +105,7 @@ export const CommunityCoreModule: _ModuleWithApi<_CoreGridApi> = {
     },
     apiFunctions: {
         getGridId,
+        getGridElement,
         destroy,
         isDestroyed,
         getGridOption,

--- a/testing/behavioural/src/grid-api-object/grid-api-object.test.tsx
+++ b/testing/behavioural/src/grid-api-object/grid-api-object.test.tsx
@@ -231,6 +231,21 @@ describe('ag-grid overlays state', () => {
         expect(getGridApi('#myGrid')).toBeUndefined();
     });
 
+    test('api.getGridElement() returns the correct wrapping DOM element', () => {
+        const element = document.getElementById('myGrid')!;
+
+        const api = createMyGrid(undefined, element);
+
+        const gridElement = api.getGridElement();
+        const helperElement = getGridElement(api);
+
+        expect(gridElement).toBeDefined();
+        expect(gridElement!.parentElement).toBe(element);
+        expect(gridElement).toBe(helperElement);
+
+        api.destroy();
+    });
+
     test('can get gridApi reference from DOM node (React)', () => {
         cleanup();
 


### PR DESCRIPTION
## Summary

- Add `api.getGridElement()` to the Grid API, returning the outermost DOM element created by the grid
- Delegates to the existing `getGridElement()` helper (WeakMap-based lookup), avoiding any new internal plumbing

## Test plan

- [x] Behavioural test verifying `api.getGridElement()` returns the correct element and matches the existing helper
- [x] Type-check passes (`ag-grid-community`)
- [x] Lint passes
- [x] All grid-api-object behavioural tests pass (12/12)

Fix AG-17559