### PR TITLE
Fix(ci): exclude PR author from JIRA reviewer list

### DIFF
--- a/.github/workflows/update-jira-ticket.yml
+++ b/.github/workflows/update-jira-ticket.yml
@@ -82,11 +82,12 @@ jobs:
                 const owner = context.repo.owner;
                 const repo = context.repo.repo;
                 const getReviewers = async (pr) => {
+                    const author = pr.user?.login || '';
                     const reviewers = [...new Set((await github.rest.pulls.listReviews({
                         owner,
                         repo,
                         pull_number
-                    })).data?.map(r => r.user.login) || [])];
+                    })).data?.map(r => r.user.login) || [])].filter((r) => r !== author);
                     const mergedBy = pr.merged_by?.login || '';
                     return {reviewers, mergedBy}
                 };


### PR DESCRIPTION

The JIRA-update automation (`.github/workflows/update-jira-ticket.yml`) posts a comment like `Reviewed by @X@Y. Merged by @Y.`. The reviewer list is built from `pulls.listReviews`, which includes the PR author when they submit a review/comment on their own PR — so the author was being listed as a reviewer.