### PR TITLE
AG-15209 Restore default pagination panel height to 42px

### DIFF
--- a/packages/ag-grid-community/src/theming/core/core-css.ts
+++ b/packages/ag-grid-community/src/theming/core/core-css.ts
@@ -928,7 +928,7 @@ export const coreDefaults: Readonly<Omit<CoreParams, keyof SharedThemeParams>> =
     },
     rowVerticalPaddingScale: 1,
     paginationPanelHeight: {
-        calc: 'pickerFieldHeight + spacing * 2',
+        calc: 'pickerFieldHeight + spacing * 1.25',
     },
     dragHandleColor: foregroundMix(0.7),
     headerColumnResizeHandleHeight: '30%',


### PR DESCRIPTION
Fix [AG-15209](https://ag-grid.atlassian.net/browse/AG-15209)

The previous implementation of AG-15209 changed the default pagination panel height in Quartz. Update the expression calculating the default height to make it 42px, unchanged from v35.3