### PR TITLE
AG-16692 fix display issues with tool panels in external parents

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_sidebar.scss
+++ b/community-modules/styles/src/internal/base/parts/_sidebar.scss
@@ -30,7 +30,6 @@
 
     .ag-tool-panel-external {
         width: 100%;
-        height: 100%;
         display: flex;
         flex-direction: row;
     }

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
@@ -202,6 +202,37 @@ If you are using the long form (providing a `SideBarDef` object) then it is poss
 
 By default, Tool Panels are rendered inside the Side Bar. If you want to render Tool Panels in a different location, you can set the [parent](./side-bar#reference-ToolPanelDef-parent) property in the `ToolPanelDef`. This is useful if you want to render Tool Panel in a different part of your application, such as a popup window or a separate section of your page.
 
+{% note %}
+To ensure correct panel sizing, AG Grid adds a CSS class to the parent element. If your component also sets the parent class it may overwrite this, so include the `ag-tool-panel-external` class when setting the parent class:
+
+{% if isFramework("react") %}
+
+```jsx
+<div ref={toolPanelParent}
+     className="your-app-class ag-tool-panel-external"></div>
+```
+{% /if %}
+
+{% if isFramework("javascript") %}
+```html
+<div id="toolPanelParent" class="your-app-class ag-tool-panel-external"></div>
+```
+{% /if %}
+
+{% if isFramework("angular") %}
+```html
+<div #toolPanelParent class="your-app-class ag-tool-panel-external"></div>
+```
+{% /if %}
+
+{% if isFramework("vue") %}
+```html
+<div ref="toolPanelParent" class="your-app-class ag-tool-panel-external"></div>
+```
+{% /if %}
+
+{% /note %}
+
 The [Popup Parent](./context-menu/#popup-parent) must also be set to an element that contains both the Tool Panel parent and the grid.
 
 You can also provide a parent for the tool panel in the call to openToolPanel method:

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/index.mdoc
@@ -211,24 +211,31 @@ To ensure correct panel sizing, AG Grid adds a CSS class to the parent element. 
 <div ref={toolPanelParent}
      className="your-app-class ag-tool-panel-external"></div>
 ```
+
 {% /if %}
 
 {% if isFramework("javascript") %}
+
 ```html
 <div id="toolPanelParent" class="your-app-class ag-tool-panel-external"></div>
 ```
+
 {% /if %}
 
 {% if isFramework("angular") %}
+
 ```html
 <div #toolPanelParent class="your-app-class ag-tool-panel-external"></div>
 ```
+
 {% /if %}
 
 {% if isFramework("vue") %}
+
 ```html
 <div ref="toolPanelParent" class="your-app-class ag-tool-panel-external"></div>
 ```
+
 {% /if %}
 
 {% /note %}

--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.css
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.css
@@ -24,7 +24,6 @@
 
 .ag-tool-panel-external {
     width: 100%;
-    height: 100%;
     display: flex;
     flex-direction: row;
     background-color: var(--ag-wrapper-background-color);

--- a/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/agSideBar.ts
@@ -365,6 +365,7 @@ class AgSideBar extends Component implements ISideBar, FocusableContainer {
         const correctParent = externalParent ?? wrapper.getDefParent() ?? this.getGui();
         if (correctParent !== this.getGui()) {
             wrapper.ensureStyledRoot();
+            correctParent.classList.add('ag-tool-panel-external');
         }
         const wrapperGui = wrapper.getGui();
         if (wrapperGui.parentElement !== correctParent) {

--- a/packages/ag-grid-enterprise/src/sideBar/toolPanelWrapper.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/toolPanelWrapper.ts
@@ -69,9 +69,7 @@ export class ToolPanelWrapper extends Component {
         }
         this.hasStyledRoot = true;
         const innerGui = this.getGui();
-        const externalDiv = _createAgElement({ tag: 'div', cls: 'ag-tool-panel-external' });
-        externalDiv.appendChild(innerGui);
-        const [styledRootOuter, styledRootDestroy] = _initDetachedStyledRoot(this.beans.environment, externalDiv);
+        const [styledRootOuter, styledRootDestroy] = _initDetachedStyledRoot(this.beans.environment, innerGui);
         this.addDestroyFunc(styledRootDestroy);
         // transfer displayed state the new root
         const displayed = this.isDisplayed();

--- a/packages/ag-grid-enterprise/src/sideBar/toolPanelWrapper.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/toolPanelWrapper.ts
@@ -1,4 +1,4 @@
-import { RefPlaceholder, _createAgElement, _initDetachedStyledRoot } from 'ag-stack';
+import { RefPlaceholder, _createAgElement, _initDetachedStyledRoot, _setDisplayed } from 'ag-stack';
 
 import type {
     ComponentType,
@@ -73,7 +73,11 @@ export class ToolPanelWrapper extends Component {
         externalDiv.appendChild(innerGui);
         const [styledRootOuter, styledRootDestroy] = _initDetachedStyledRoot(this.beans.environment, externalDiv);
         this.addDestroyFunc(styledRootDestroy);
+        // transfer displayed state the new root
+        const displayed = this.isDisplayed();
+        _setDisplayed(innerGui, true);
         this.setGui(styledRootOuter);
+        this.setDisplayed(displayed);
     }
 
     public getToolPanelId(): string {

--- a/packages/ag-grid-enterprise/src/sideBar/toolPanelWrapper.ts
+++ b/packages/ag-grid-enterprise/src/sideBar/toolPanelWrapper.ts
@@ -1,4 +1,4 @@
-import { RefPlaceholder, _createAgElement, _initDetachedStyledRoot, _setDisplayed } from 'ag-stack';
+import { RefPlaceholder, _initDetachedStyledRoot, _setDisplayed } from 'ag-stack';
 
 import type {
     ComponentType,


### PR DESCRIPTION
Fix [AG-16692](https://ag-grid.atlassian.net/browse/AG-16692)

In the [External Tool Panel Parent example](https://grid-staging.ag-grid.com/react-data-grid/side-bar/#example-tool-panel-parent) neither filters nor columns tool panels were displayed.

Two root causes, fixed by this PR:

1. When a tool panel changes from being internal (the default at init) to external, a stale ag-hidden class was left on the panel causing it never to be visible
2. An earlier PR changed the behaviour of `ag-tool-panel-external` causing tool panels to be zero height if the external parent does not have an explicit height defined. Restore the old behaviour. The old behaviour is potentially buggy under react re-renders, since I couldn't find a way of removing this without breaking apps, I've instead documented the requirement that apps set `ag-tool-panel-external` on a provided tool panel parent. This isn't a breaking change per se, just documenting a requirement that's always been there.