### PR TITLE
AG-17134 Backport: remove unsafe-eval from the main-site CSP

### DIFF
--- a/documentation/ag-grid-docs/astro.config.mjs
+++ b/documentation/ag-grid-docs/astro.config.mjs
@@ -16,6 +16,7 @@ import agSitemapLastmod from '../../external/ag-website-shared/plugins/agSitemap
 import agSourcemapCors from '../../external/ag-website-shared/plugins/agSourcemapCors';
 import { SITEMAP_CACHE_DIR } from '../../external/ag-website-shared/src/constants';
 import buildTime from './plugins/agBuildTime';
+import agDevCsp from './plugins/agDevCsp';
 import agHotModuleReload from './plugins/agHotModuleReload';
 import agHtaccessGen from './plugins/agHtaccessGen';
 import agRedirectsChecker from './plugins/agRedirectsChecker';
@@ -154,7 +155,7 @@ console.log(
     )
 );
 
-const plugins = [agSourcemapCors(), svgr(), agHotModuleReload()];
+const plugins = [agSourcemapCors(), svgr(), agHotModuleReload(), agDevCsp()];
 if (NODE_ENV !== 'test') {
     plugins.push(mkcert()); // mkcert is not necessary for tests
 }
@@ -199,15 +200,8 @@ export default defineConfig({
                 ],
             },
             headers: {
-                'Content-Security-Policy': [
-                    "default-src 'self'",
-                    "script-src 'self' https://*.ag-grid.com https://localhost:4610 https://localhost:4611 https://www.googletagmanager.com https://cdn.jsdelivr.net 'unsafe-inline' 'unsafe-eval'",
-                    "style-src 'self' https://fonts.googleapis.com https://use.fontawesome.com 'unsafe-inline'",
-                    "font-src 'self' https://fonts.gstatic.com https://use.fontawesome.com data:",
-                    "img-src 'self' data: blob: https:",
-                    "connect-src 'self' https:",
-                    "worker-src 'self' blob:",
-                ].join('; '),
+                // Content-Security-Policy is served per request by agDevCsp so
+                // example paths can get a different policy from ordinary pages.
                 'X-Content-Type-Options': 'nosniff',
             },
         },

--- a/documentation/ag-grid-docs/eslint.config.mjs
+++ b/documentation/ag-grid-docs/eslint.config.mjs
@@ -13,6 +13,7 @@ export default [
     {
         ignores: [
             '.astro/',
+            'packages/', // gitignored copy of built grid packages, served to local examples
             '**/_examples/',
             'scripts/showcase-github/tmp/',
             '**/.angular',

--- a/documentation/ag-grid-docs/plugins/agDevCsp.ts
+++ b/documentation/ag-grid-docs/plugins/agDevCsp.ts
@@ -1,0 +1,29 @@
+import type { Plugin, ViteDevServer } from 'vite';
+
+import { getCspValue } from '../src/utils/htaccess/cspRules';
+
+const SITE_CSP = getCspValue({ env: 'dev', scope: 'site' });
+const EXAMPLES_CSP = getCspValue({ env: 'dev', scope: 'examples' });
+
+// Mirrors EXAMPLES_PATH_CONDITION in cspRules.ts, which scopes the served
+// .htaccess policy by URL path on staging/production.
+const EXAMPLES_PATH = /^\/(examples|archive)\//;
+
+/**
+ * Vite plugin serving the dev server's Content-Security-Policy header with the
+ * same path-scoped split as the generated .htaccess: ordinary pages get the
+ * 'site' policy (no 'unsafe-eval'), example-runner documents get the relaxed
+ * 'examples' policy. Keeps local development honest about main-page eval use.
+ */
+export default function agDevCsp(): Plugin {
+    return {
+        name: 'ag-dev-csp',
+        configureServer(server: ViteDevServer) {
+            server.middlewares.use((req, res, next) => {
+                const csp = EXAMPLES_PATH.test(req.url ?? '') ? EXAMPLES_CSP : SITE_CSP;
+                res.setHeader('Content-Security-Policy', csp);
+                next();
+            });
+        },
+    };
+}

--- a/documentation/ag-grid-docs/scripts/csp/generate-csp.ts
+++ b/documentation/ag-grid-docs/scripts/csp/generate-csp.ts
@@ -2,13 +2,8 @@
 /* eslint-disable no-console */
 import { writeFileSync } from 'fs';
 
-import type { CspEnv, CspMode } from '../../src/utils/htaccess/cspRules';
-import {
-    getCspHeaderName,
-    getCspHtaccessBlock,
-    getCspHtaccessLine,
-    getCspValue,
-} from '../../src/utils/htaccess/cspRules';
+import type { CspEnv, CspMode, CspScope } from '../../src/utils/htaccess/cspRules';
+import { getCspHeaderName, getCspValue, getScopedCspHtaccessBlock } from '../../src/utils/htaccess/cspRules';
 
 /**
  * Generate the Content-Security-Policy for a given environment
@@ -18,6 +13,7 @@ import {
  *       [--env=staging|production|dev]
  *       [--mode=report-only|enforce]
  *       [--format=htaccess|header|value]
+ *       [--scope=site|examples]    (header/value formats only; htaccess emits both)
  *       [--out=<file>]
  *
  * Run via Nx:
@@ -37,6 +33,7 @@ type Format = 'htaccess' | 'header' | 'value';
 const ENVS: CspEnv[] = ['dev', 'staging', 'production'];
 const MODES: CspMode[] = ['report-only', 'enforce'];
 const FORMATS: Format[] = ['htaccess', 'header', 'value'];
+const SCOPES: CspScope[] = ['site', 'examples'];
 
 function assertOneOf<T extends string>(value: string | undefined, allowed: T[], flag: string): T {
     if (value === undefined || !allowed.includes(value as T)) {
@@ -45,10 +42,11 @@ function assertOneOf<T extends string>(value: string | undefined, allowed: T[], 
     return value as T;
 }
 
-function parseArgs(argv: string[]): { env: CspEnv; mode: CspMode; format: Format; out?: string } {
+function parseArgs(argv: string[]): { env: CspEnv; mode: CspMode; format: Format; scope: CspScope; out?: string } {
     let env: CspEnv = 'staging';
     let mode: CspMode = 'report-only';
     let format: Format = 'htaccess';
+    let scope: CspScope = 'site';
     let out: string | undefined;
 
     for (let i = 0, len = argv.length; i < len; ++i) {
@@ -61,6 +59,8 @@ function parseArgs(argv: string[]): { env: CspEnv; mode: CspMode; format: Format
             mode = assertOneOf(value, MODES, '--mode');
         } else if (key === '--format') {
             format = assertOneOf(value, FORMATS, '--format');
+        } else if (key === '--scope') {
+            scope = assertOneOf(value, SCOPES, '--scope');
         } else if (key === '--out') {
             out = value;
         } else {
@@ -68,24 +68,24 @@ function parseArgs(argv: string[]): { env: CspEnv; mode: CspMode; format: Format
         }
     }
 
-    return { env, mode, format, out };
+    return { env, mode, format, scope, out };
 }
 
-function render(format: Format, env: CspEnv, mode: CspMode): string {
+function render(format: Format, env: CspEnv, mode: CspMode, scope: CspScope): string {
     if (format === 'value') {
-        return getCspValue({ env });
+        return getCspValue({ env, scope });
     }
     if (format === 'header') {
-        return `${getCspHeaderName(mode)}: ${getCspValue({ env })}`;
+        return `${getCspHeaderName(mode)}: ${getCspValue({ env, scope })}`;
     }
-    // Staging unsets the legacy vhost wildcard and fully owns the policy (block);
-    // production runs dual-policy during its report-only window (bare line).
-    return env === 'staging' ? getCspHtaccessBlock({ env }, mode) : getCspHtaccessLine({ env }, mode);
+    // The htaccess format emits the full path-scoped block (site policy plus the
+    // <If> override for example/archive paths) — what ships in the generated file.
+    return getScopedCspHtaccessBlock({ env }, mode);
 }
 
 function main(): void {
-    const { env, mode, format, out } = parseArgs(process.argv.slice(2));
-    const output = render(format, env, mode);
+    const { env, mode, format, scope, out } = parseArgs(process.argv.slice(2));
+    const output = render(format, env, mode, scope);
 
     if (out) {
         writeFileSync(out, `${output}\n`);

--- a/documentation/ag-grid-docs/src/components/example-grid/config/colDefs.ts
+++ b/documentation/ag-grid-docs/src/components/example-grid/config/colDefs.ts
@@ -1,4 +1,6 @@
 import type {
+    CellClassParams,
+    CellClassRules,
     CellStyleFunc,
     ColDef,
     ColGroupDef,
@@ -10,27 +12,35 @@ import type {
 import { COUNTRY_NAMES, LANGUAGES, type RowItem, games, months } from '../data';
 import { CountryCellRenderer, RatingRenderer } from './renderers';
 
-//put in the month cols
-const monthCols = months.map((month) => {
-    const child: ColDef = {
-        field: month,
-        width: 120,
-        enableValue: true,
-        aggFunc: 'sum',
-        cellClassRules: {
-            'good-score': 'typeof x === "number" && x > 50000',
-            'bad-score': 'typeof x === "number" && x < 10000',
-            'currency-cell': 'typeof x === "number" && x >= 10000 && x <= 50000',
-        },
-        cellDataType: 'currency',
-        filter: 'agNumberColumnFilter',
-        filterParams: {
-            buttons: ['reset'],
-            inRangeInclusive: true,
-        },
-    };
-    return child;
-});
+// Function-based cell class rules rather than string expressions: string
+// expressions are evaluated with `new Function`, which requires the CSP
+// `script-src 'unsafe-eval'` that this site no longer allows.
+const isCurrency = (params: CellClassParams): boolean => typeof params.value === 'number';
+
+const currencyCellClassRules: CellClassRules = {
+    'currency-cell': isCurrency,
+};
+
+const scoreCellClassRules: CellClassRules = {
+    'good-score': (params) => typeof params.value === 'number' && params.value > 50000,
+    'bad-score': (params) => typeof params.value === 'number' && params.value < 10000,
+    'currency-cell': (params) => typeof params.value === 'number' && params.value >= 10000 && params.value <= 50000,
+};
+
+const monthColBase: ColDef = {
+    width: 120,
+    minWidth: 120,
+    enableValue: true,
+    cellClassRules: scoreCellClassRules,
+    cellDataType: 'currency',
+    filter: 'agNumberColumnFilter',
+    filterParams: {
+        buttons: ['reset'],
+        inRangeInclusive: true,
+    },
+};
+
+const monthCols = months.map((month): ColDef => ({ ...monthColBase, field: month, aggFunc: 'sum' }));
 
 const currencyCssFunc: CellStyleFunc = (params) => {
     if (params.value != null && params.value < 0) {
@@ -134,9 +144,7 @@ const mobileDefaultCols: ColDef<RowItem>[] = [
     {
         field: 'bankBalance',
         width: 180,
-        cellClassRules: {
-            'currency-cell': 'typeof x == "number"',
-        },
+        cellClassRules: currencyCellClassRules,
         enableValue: true,
         cellDataType: 'currency',
         filter: 'agNumberColumnFilter',
@@ -146,9 +154,7 @@ const mobileDefaultCols: ColDef<RowItem>[] = [
         filter: 'agNumberColumnFilter',
         width: 170,
         enableValue: true,
-        cellClassRules: {
-            'currency-cell': 'typeof x == "number"',
-        },
+        cellClassRules: currencyCellClassRules,
         cellStyle: currencyCssFunc,
         cellDataType: 'currency',
     },
@@ -268,9 +274,7 @@ const desktopDefaultCols: (ColDef<RowItem> | ColGroupDef<RowItem>)[] = [
             {
                 field: 'bankBalance',
                 width: 150,
-                cellClassRules: {
-                    'currency-cell': 'typeof x == "number"',
-                },
+                cellClassRules: currencyCellClassRules,
                 enableValue: true,
                 aggFunc: 'avg',
                 cellDataType: 'currency',
@@ -301,9 +305,7 @@ const desktopDefaultCols: (ColDef<RowItem> | ColGroupDef<RowItem>)[] = [
         width: 200,
         enableValue: true,
         aggFunc: 'sum',
-        cellClassRules: {
-            'currency-cell': 'typeof x == "number"',
-        },
+        cellClassRules: currencyCellClassRules,
         cellDataType: 'currency',
         cellStyle: currencyCssFunc,
     },

--- a/documentation/ag-grid-docs/src/components/theme-builder/model/parseThemeCode.test.ts
+++ b/documentation/ag-grid-docs/src/components/theme-builder/model/parseThemeCode.test.ts
@@ -123,6 +123,12 @@ test('parses various param value types and formats', () => {
         chromeBackgroundColor: { ref: 'foo' },
     });
 
+    // Escape sequences in string values are unescaped
+    expect(parseThemeCode(String.raw`{ fontFamily: "Foo \"Bar\" é\n", accentColor: '#4EF222' }`).params).toEqual({
+        fontFamily: 'Foo "Bar" é\n',
+        accentColor: '#4EF222',
+    });
+
     // Array as property of object within value
     expect(parseThemeCode(`{ chromeBackgroundColor: { items: [1, 2, 3] } }`).params).toEqual({
         chromeBackgroundColor: { items: [1, 2, 3] },

--- a/documentation/ag-grid-docs/src/components/theme-builder/model/parseThemeCode.ts
+++ b/documentation/ag-grid-docs/src/components/theme-builder/model/parseThemeCode.ts
@@ -6,6 +6,7 @@ import { RGBAColor } from '../components/editors/RGBAColor';
 import { type Preset, darkModePreset, lightModePreset } from '../components/presets/presets';
 import { allParamModels } from './ParamModel';
 import { allFeatureModels } from './PartModel';
+import { unescapeStringLiteral } from './utils';
 
 export type ParseThemeSuccess = {
     success: true;
@@ -244,8 +245,7 @@ function tokenizeThemeCode(code: string): Token[] {
         if ((match[0] === '"' || match[0] === "'") && match.length > 1) {
             type = 'string';
             try {
-                // eslint-disable-next-line no-eval -- input is validated by TOKEN_PATTERN to always be a string literal
-                value = (0, eval)(match);
+                value = unescapeStringLiteral(match);
             } catch {
                 type = 'punctuation';
                 value = match;

--- a/documentation/ag-grid-docs/src/components/theme-builder/model/utils.test.ts
+++ b/documentation/ag-grid-docs/src/components/theme-builder/model/utils.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 
-import { titleCase } from './utils';
+import { titleCase, unescapeStringLiteral } from './utils';
 
 test.each([
     ['foo', 'Foo'],
@@ -13,4 +13,41 @@ test.each([
     ['This-is-FOO', 'This Is FOO'],
 ])('titleCase(%s) -> %s', (input, expected) => {
     expect(titleCase(input)).toBe(expected);
+});
+
+test.each([
+    [`""`, ''],
+    [`"hello"`, 'hello'],
+    [`'hello'`, 'hello'],
+    [String.raw`"it\'s"`, "it's"],
+    [String.raw`'it\'s'`, "it's"],
+    [String.raw`"a \"quote\""`, 'a "quote"'],
+    [String.raw`"back\\slash"`, 'back\\slash'],
+    ['"tick\\`"', 'tick`'],
+    [String.raw`"a\nb\tc\rd"`, 'a\nb\tc\rd'],
+    [String.raw`"\b\f\v"`, '\b\f\v'],
+    [String.raw`"nul\0!"`, 'nul\0!'],
+    [String.raw`"\x41\x62"`, 'Ab'],
+    [String.raw`"\u00e9A"`, 'éA'],
+    [String.raw`"\u{e9}"`, 'é'],
+    [String.raw`"\u{1F600}"`, '\u{1F600}'],
+    ['"line \\\ncontinuation"', 'line continuation'],
+    ['"line \\\r\ncontinuation"', 'line continuation'],
+    [String.raw`"identity \a\/\ "`, 'identity a/ '],
+])('unescapeStringLiteral(%s) -> %s', (input, expected) => {
+    expect(unescapeStringLiteral(input)).toBe(expected);
+});
+
+test.each([
+    [String.raw`"\x4"`], // too few hex digits
+    [String.raw`"\xZZ"`], // not hex
+    [String.raw`"\u12"`], // too few hex digits
+    [String.raw`"\u{}"`], // empty code point
+    [String.raw`"\u{ZZ}"`], // not hex
+    [String.raw`"\u{110000}"`], // beyond max code point
+    [String.raw`"\u{1F600"`], // unterminated code point
+    [String.raw`"\101"`], // octal escape
+    [String.raw`"\07"`], // octal escape
+])('unescapeStringLiteral(%s) throws', (input) => {
+    expect(() => unescapeStringLiteral(input)).toThrow(SyntaxError);
 });

--- a/documentation/ag-grid-docs/src/components/theme-builder/model/utils.ts
+++ b/documentation/ag-grid-docs/src/components/theme-builder/model/utils.ts
@@ -46,6 +46,103 @@ export const logErrorMessageOnce = (message: string) => {
 export const indexBy = <T, K extends keyof T>(list: readonly T[], property: K): Record<string, T> =>
     Object.fromEntries(list.map((item) => [String(item[property]), item]));
 
+/**
+ * Unescape a single- or double-quoted JavaScript string literal, including its
+ * surrounding quotes. Evaluating the literal would give the same result, but
+ * eval requires the CSP script-src 'unsafe-eval', which the site does not allow.
+ *
+ * Throws SyntaxError on malformed escape sequences, as evaluating would.
+ */
+export const unescapeStringLiteral = (literal: string): string => {
+    const content = literal.slice(1, -1);
+    let result = '';
+    let i = 0;
+    const len = content.length;
+    while (i < len) {
+        const char = content[i];
+        if (char !== '\\') {
+            result += char;
+            i++;
+            continue;
+        }
+        if (i + 1 >= len) {
+            throw new SyntaxError('Unterminated escape sequence');
+        }
+        const escaped = content[i + 1];
+        i += 2;
+        switch (escaped) {
+            case 'n':
+                result += '\n';
+                break;
+            case 't':
+                result += '\t';
+                break;
+            case 'r':
+                result += '\r';
+                break;
+            case 'b':
+                result += '\b';
+                break;
+            case 'f':
+                result += '\f';
+                break;
+            case 'v':
+                result += '\v';
+                break;
+            case 'x':
+                result += String.fromCharCode(parseHexEscape(content.slice(i, i + 2), 2));
+                i += 2;
+                break;
+            case 'u':
+                if (content[i] === '{') {
+                    const end = content.indexOf('}', i + 1);
+                    if (end === -1) {
+                        throw new SyntaxError('Unterminated Unicode code point escape');
+                    }
+                    const codePoint = parseHexEscape(content.slice(i + 1, end), end - i - 1);
+                    if (codePoint > 0x10ffff) {
+                        throw new SyntaxError('Unicode code point escape out of range');
+                    }
+                    result += String.fromCodePoint(codePoint);
+                    i = end + 1;
+                } else {
+                    result += String.fromCharCode(parseHexEscape(content.slice(i, i + 4), 4));
+                    i += 4;
+                }
+                break;
+            case '0':
+                if (/\d/.test(content[i] ?? '')) {
+                    throw new SyntaxError('Octal escape sequences are not supported');
+                }
+                result += '\0';
+                break;
+            case '\r':
+                // line continuation, \r\n counts as one line terminator
+                if (content[i] === '\n') {
+                    i++;
+                }
+                break;
+            case '\n':
+            case '\u2028':
+            case '\u2029':
+                break; // line continuation
+            default:
+                if (/\d/.test(escaped)) {
+                    throw new SyntaxError('Octal escape sequences are not supported');
+                }
+                result += escaped; // identity escape, e.g. \' \" \\ \a
+        }
+    }
+    return result;
+};
+
+const parseHexEscape = (hex: string, expectedLength: number): number => {
+    if (hex.length !== expectedLength || expectedLength === 0 || !/^[0-9a-fA-F]+$/.test(hex)) {
+        throw new SyntaxError('Invalid hexadecimal escape sequence');
+    }
+    return parseInt(hex, 16);
+};
+
 export const memoize = <R, A = void>(fn: (arg: A) => R): ((arg: A) => R) => {
     const values = new Map<A, R>();
     return (a) => {

--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.test.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.test.ts
@@ -1,0 +1,76 @@
+import { getCspDirectives, getScopedCspHtaccessBlock } from './cspRules';
+
+describe('cspRules', () => {
+    describe('scope', () => {
+        it("site scope omits 'unsafe-eval' from script-src", () => {
+            const directives = getCspDirectives({ env: 'production', scope: 'site' });
+            expect(directives['script-src']).not.toContain("'unsafe-eval'");
+        });
+
+        it("examples scope includes 'unsafe-eval' in script-src", () => {
+            const directives = getCspDirectives({ env: 'production', scope: 'examples' });
+            expect(directives['script-src']).toContain("'unsafe-eval'");
+        });
+
+        it("both scopes include 'wasm-unsafe-eval' for browser-side Shiki highlighting", () => {
+            // Narrower than 'unsafe-eval'; the site scope relies on it for WASM.
+            expect(getCspDirectives({ env: 'production', scope: 'site' })['script-src']).toContain(
+                "'wasm-unsafe-eval'"
+            );
+            expect(getCspDirectives({ env: 'production', scope: 'examples' })['script-src']).toContain(
+                "'wasm-unsafe-eval'"
+            );
+        });
+
+        it('defaults to site scope', () => {
+            expect(getCspDirectives({ env: 'production' })).toEqual(
+                getCspDirectives({ env: 'production', scope: 'site' })
+            );
+        });
+
+        it("scopes differ only by script-src 'unsafe-eval'", () => {
+            const site = getCspDirectives({ env: 'production', scope: 'site' });
+            const examples = getCspDirectives({ env: 'production', scope: 'examples' });
+
+            expect(Object.keys(examples)).toEqual(Object.keys(site));
+            const names = Object.keys(site);
+            for (let i = 0, len = names.length; i < len; ++i) {
+                const name = names[i];
+                if (name === 'script-src') {
+                    expect(examples[name]).toEqual([...site[name], "'unsafe-eval'"]);
+                } else {
+                    expect(examples[name]).toEqual(site[name]);
+                }
+            }
+        });
+
+        it("both scopes keep 'unsafe-inline' in script-src and style-src", () => {
+            const site = getCspDirectives({ env: 'production', scope: 'site' });
+            const examples = getCspDirectives({ env: 'production', scope: 'examples' });
+            expect(site['script-src']).toContain("'unsafe-inline'");
+            expect(site['style-src']).toContain("'unsafe-inline'");
+            expect(examples['script-src']).toContain("'unsafe-inline'");
+            expect(examples['style-src']).toContain("'unsafe-inline'");
+        });
+    });
+
+    describe('getScopedCspHtaccessBlock', () => {
+        it('enforce mode unsets and re-sets the enforced header inside the <If> override', () => {
+            const block = getScopedCspHtaccessBlock({ env: 'production' }, 'enforce');
+            const ifIndex = block.indexOf('<If');
+            expect(ifIndex).toBeGreaterThan(-1);
+            const ifBlock = block.slice(ifIndex);
+            expect(ifBlock).toContain('Header always unset Content-Security-Policy\n');
+            expect(ifBlock).toContain('Header always set Content-Security-Policy "');
+        });
+
+        it('report-only mode never unsets the enforced header', () => {
+            const block = getScopedCspHtaccessBlock({ env: 'production' }, 'report-only');
+            const lines = block.split('\n');
+            const enforcedUnset = lines.find((l) => l.trim() === 'Header always unset Content-Security-Policy');
+            expect(enforcedUnset).toBeUndefined();
+            expect(block).not.toContain('Header always set Content-Security-Policy "');
+            expect(block).toContain('Header always set Content-Security-Policy-Report-Only "');
+        });
+    });
+});

--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
@@ -2,10 +2,10 @@
  * Single source of truth for the site's Content-Security-Policy
  *
  * Consumed by:
- *  - `scripts/csp/generate-csp.ts` to emit the policy string for hand-placing
- *    on staging and (in future) for generating the deploy-time config.
- *  - `htaccessRules.ts` (planned) to emit the `Content-Security-Policy` header
- *    into the generated `.htaccess`.
+ *  - `scripts/csp/generate-csp.ts` to emit the policy string for inspection or
+ *    hand-placing on a vhost.
+ *  - `htaccessRules.ts` to emit the `Content-Security-Policy` header into the
+ *    generated `.htaccess`.
  *
  * Keep this module dependency-free so it can be imported by a standalone `tsx`
  * script without pulling in the Astro/Vite build graph.
@@ -14,8 +14,17 @@
 export type CspEnv = 'dev' | 'staging' | 'production';
 export type CspMode = 'report-only' | 'enforce';
 
+/**
+ * 'site' is the default policy for ordinary pages. 'examples' additionally
+ * allows 'unsafe-eval' and applies only to the standalone example-runner
+ * documents (and archived doc versions) — see EXAMPLES_PATH_CONDITION.
+ */
+export type CspScope = 'site' | 'examples';
+
 export interface CspOptions {
     env: CspEnv;
+    /** Which policy variant to build. Defaults to 'site'. */
+    scope?: CspScope;
     /** Override the trial-licence form origin. Defaults to the per-env value. */
     trialFormOrigin?: string;
 }
@@ -26,9 +35,24 @@ export type CspDirectives = Record<string, string[]>;
 const SELF = "'self'";
 const NONE = "'none'";
 const UNSAFE_INLINE = "'unsafe-inline'";
-// Required by the theme-builder CSS parser and the Angular example-runner (JIT
-// compilation). Removing it is tracked separately and is larger than a one-liner.
+// Permits WebAssembly compilation without permitting JS eval() — narrower than
+// 'unsafe-eval'. Needed on every page: docs snippets are highlighted in the
+// browser by Shiki, whose oniguruma engine instantiates a WASM module
+// (see CodeShiki.tsx). Browsers that predate this token fall back to requiring
+// 'unsafe-eval' for WASM.
+const WASM_UNSAFE_EVAL = "'wasm-unsafe-eval'";
+// Allowed only in the 'examples' scope: the standalone example-runner documents
+// load modules with legacy SystemJS (fetches source over XHR and evals it), and
+// the Angular (JIT compiler) and Vue (runtime template compiler) examples also
+// compile code in the browser. Archived doc versions ship the same runner.
+// Ordinary site pages do not need it — the theme builder's CSS parser used to,
+// but now unescapes string literals without eval (see unescapeStringLiteral).
 const UNSAFE_EVAL = "'unsafe-eval'";
+
+// Apache <If> expression matching the URL paths that get the 'examples' scope:
+// the standalone example-runner documents and archived doc versions (uploaded
+// separately but served from this vhost, so they inherit the root .htaccess).
+export const EXAMPLES_PATH_CONDITION = '%{REQUEST_URI} =~ m#^/(examples|archive)/#';
 
 // 'self' resolves to grid-staging.ag-grid.com on staging / localhost in dev, so
 // cross-subdomain references to the production host need an explicit allowance.
@@ -79,6 +103,7 @@ const DEV_CONNECT_SRC = ['https://localhost:4610', 'https://localhost:4611', 'ws
 
 export function getCspDirectives(options: CspOptions): CspDirectives {
     const { env } = options;
+    const scope = options.scope ?? 'site';
     const trialFormOrigin = options.trialFormOrigin ?? TRIAL_FORM_ORIGIN[env];
     const salesforceFormOrigin = SALESFORCE_FORM_ORIGIN[env];
     const realexHppOrigin = REALEX_HPP_ORIGIN[env];
@@ -103,8 +128,12 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://cdn.cookielaw.org', // OneTrust cookie-consent SDK (GTM-injected, prod-only)
             'blob:', // ZoomInfo zi-tag.js bootstraps a blob: URL script
             UNSAFE_INLINE,
-            UNSAFE_EVAL,
+            WASM_UNSAFE_EVAL,
         ],
+        // 'unsafe-inline' stays: the Theming API injects <style> elements at
+        // runtime (live grids run directly on the homepage/demo pages), inline
+        // style attributes are pervasive, and static Apache hosting rules out
+        // per-request nonces.
         'style-src': [
             SELF,
             'https://fonts.googleapis.com',
@@ -171,6 +200,10 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
         'frame-ancestors': [SELF, AG_GRID_HOSTS], // allow *.ag-grid.com (e.g. blog) to embed examples
     };
 
+    if (scope === 'examples') {
+        directives['script-src'].push(UNSAFE_EVAL);
+    }
+
     if (env === 'dev') {
         directives['script-src'].push(...DEV_SCRIPT_SRC);
         directives['connect-src'].push(...DEV_CONNECT_SRC);
@@ -221,4 +254,28 @@ export function getCspHtaccessBlock(options: CspOptions, mode: CspMode): string 
     lines.push('Header always unset Content-Security-Policy-Report-Only');
     lines.push(getCspHtaccessLine(options, mode));
     return lines.join('\n');
+}
+
+/**
+ * Build the full `.htaccess` CSP block with the path-scoped policy split: the
+ * 'site' policy (no 'unsafe-eval') for ordinary pages, replaced by the
+ * 'examples' policy for the paths matched by EXAMPLES_PATH_CONDITION.
+ *
+ * A second CSP policy can only tighten (browsers enforce the intersection), so
+ * the relaxation must unset and re-set the header rather than add another one.
+ */
+export function getScopedCspHtaccessBlock(options: Omit<CspOptions, 'scope'>, mode: CspMode): string {
+    const headerName = getCspHeaderName(mode);
+    return [
+        getCspHtaccessBlock({ ...options, scope: 'site' }, mode),
+        '',
+        "# Example-runner documents and archived doc versions additionally need 'unsafe-eval'",
+        '# (SystemJS eval-loads modules; the Angular JIT and Vue runtime template compilers',
+        '# also compile in the browser). <If> sections merge after all other configuration,',
+        '# so this unset+set replaces the header set above for matching requests.',
+        `<If "${EXAMPLES_PATH_CONDITION}">`,
+        `    Header always unset ${headerName}`,
+        `    ${getCspHtaccessLine({ ...options, scope: 'examples' }, mode)}`,
+        '</If>',
+    ].join('\n');
 }

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
@@ -1,4 +1,5 @@
-import { getHtaccessContent } from './htaccessRules';
+import { EXAMPLES_PATH_CONDITION } from './cspRules';
+import { PRODUCTION_CSP_PHASE, getHtaccessContent } from './htaccessRules';
 import { SITE_301_REDIRECTS } from './redirects';
 
 describe('htaccessRules', () => {
@@ -190,6 +191,94 @@ describe('htaccessRules', () => {
             expect(productionContent).toContain('Content-Security-Policy');
             expect(stagingContent).toContain('Content-Security-Policy');
         });
+    });
+
+    describe("AG-17134: 'unsafe-eval' removed from the main-site policy", () => {
+        const ifOpen = `<If "${EXAMPLES_PATH_CONDITION}">`;
+
+        // The <If> contents are indented, so unconditional directives are the
+        // lines starting at column 0.
+        const unconditionalLines = (content: string) => content.split('\n').filter((l) => !l.startsWith(' '));
+
+        const extractIfBlock = (content: string) => {
+            const start = content.indexOf(ifOpen);
+            const end = content.indexOf('</If>', start);
+            expect(start).toBeGreaterThan(-1);
+            expect(end).toBeGreaterThan(start);
+            return content.slice(start, end);
+        };
+
+        it('staging: unconditional enforced policy has no unsafe-eval but keeps unsafe-inline', () => {
+            const setLine = unconditionalLines(stagingContent).find((l) =>
+                l.startsWith('Header always set Content-Security-Policy "')
+            );
+            expect(setLine).toBeDefined();
+            expect(setLine).not.toContain("'unsafe-eval'");
+            expect(setLine).toContain("'unsafe-inline'");
+        });
+
+        it('staging: <If> override re-sets the enforced policy with unsafe-eval for example/archive paths', () => {
+            const ifBlock = extractIfBlock(stagingContent);
+            expect(ifBlock).toContain('Header always unset Content-Security-Policy\n');
+            expect(ifBlock).toContain("'unsafe-eval'");
+        });
+
+        it('staging: site-wide set precedes the <If> override', () => {
+            const setIndex = stagingContent.indexOf('Header always set Content-Security-Policy "');
+            const ifIndex = stagingContent.indexOf(ifOpen);
+            expect(setIndex).toBeGreaterThan(-1);
+            expect(setIndex).toBeLessThan(ifIndex);
+        });
+
+        if (PRODUCTION_CSP_PHASE === 'report-only') {
+            it('production (report-only window): keeps enforcing the previous policy with unsafe-eval', () => {
+                const enforcedLine = unconditionalLines(productionContent).find((l) =>
+                    l.startsWith('Header always set Content-Security-Policy "')
+                );
+                expect(enforcedLine).toBeDefined();
+                expect(enforcedLine).toContain("'unsafe-eval'");
+            });
+
+            it('production (report-only window): reports on the tightened site policy', () => {
+                const reportOnlyLine = unconditionalLines(productionContent).find((l) =>
+                    l.startsWith('Header always set Content-Security-Policy-Report-Only "')
+                );
+                expect(reportOnlyLine).toBeDefined();
+                expect(reportOnlyLine).not.toContain("'unsafe-eval'");
+            });
+
+            it('production (report-only window): <If> override only swaps the report-only header', () => {
+                const ifBlock = extractIfBlock(productionContent);
+                expect(ifBlock).toContain('Header always unset Content-Security-Policy-Report-Only\n');
+                expect(ifBlock).toContain('Header always set Content-Security-Policy-Report-Only "');
+                expect(ifBlock).not.toContain('Header always set Content-Security-Policy "');
+            });
+
+            it('production (report-only window): the report-only block does not unset the enforced header', () => {
+                const lines = unconditionalLines(productionContent);
+                const enforcedSetIndex = lines.findIndex((l) =>
+                    l.startsWith('Header always set Content-Security-Policy "')
+                );
+                const laterUnset = lines
+                    .slice(enforcedSetIndex + 1)
+                    .find((l) => l.trim() === 'Header always unset Content-Security-Policy');
+                expect(laterUnset).toBeUndefined();
+            });
+        } else {
+            it('production (enforced): unconditional enforced policy has no unsafe-eval', () => {
+                const enforcedLine = unconditionalLines(productionContent).find((l) =>
+                    l.startsWith('Header always set Content-Security-Policy "')
+                );
+                expect(enforcedLine).toBeDefined();
+                expect(enforcedLine).not.toContain("'unsafe-eval'");
+            });
+
+            it('production (enforced): <If> override re-sets the enforced policy with unsafe-eval', () => {
+                const ifBlock = extractIfBlock(productionContent);
+                expect(ifBlock).toContain('Header always unset Content-Security-Policy\n');
+                expect(ifBlock).toContain("'unsafe-eval'");
+            });
+        }
     });
 
     describe('basic structure', () => {

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
@@ -1,9 +1,17 @@
 import { urlWithBaseUrl } from '../urlWithBaseUrl';
 import type { CspEnv } from './cspRules';
-import { getCspHtaccessBlock } from './cspRules';
+import { getCspHtaccessBlock, getScopedCspHtaccessBlock } from './cspRules';
 import { SITE_301_REDIRECTS } from './redirects';
 
 export type HtaccessEnv = Extract<CspEnv, 'staging' | 'production'>;
+
+// Rollout state for removing 'unsafe-eval' from the production main-site CSP.
+// While 'report-only', production keeps enforcing the previous policy (which
+// allows 'unsafe-eval' everywhere) and reports violations of the tightened
+// path-scoped split. Flip to 'enforce' once the report-only window is clean.
+// Staging always enforces the split. Exported for the tests, which assert
+// different output per phase.
+export const PRODUCTION_CSP_PHASE: 'report-only' | 'enforce' = 'report-only';
 
 const modExpiresRules = `
 <IfModule mod_expires.c>
@@ -153,9 +161,9 @@ AddType application/x-gzip .gz .tgz
 function getStagingHtaccessContent(): string {
     return `${baseRules}
 
-# Content-Security-Policy — enforced. Unsets the legacy wildcard CSP on the staging
-# vhost so this tightened policy is the only one in effect.
-${getCspHtaccessBlock({ env: 'staging' }, 'enforce')}
+# Content-Security-Policy — enforced, path-scoped. Unsets the legacy wildcard CSP on
+# the staging vhost so this tightened policy is the only one in effect.
+${getScopedCspHtaccessBlock({ env: 'staging' }, 'enforce')}
 
 Options -Indexes
 `;
@@ -173,12 +181,7 @@ ${getModRewriteRules()}
 Header always set Referrer-Policy "strict-origin-when-cross-origin"
 Header always set Permissions-Policy "geolocation=(), microphone=(), camera=()"
 
-# Content-Security-Policy — enforced (the report-only validation window is complete).
-# The block unsets the inherited headers (incl. the legacy wildcard CSP on the vhost)
-# and sets this tightened policy as the enforced CSP. If the vhost wildcard lingers as a
-# separate header, browsers enforce the intersection, so the tightened policy still wins;
-# removing the vhost wildcard line is a follow-up infra cleanup.
-${getCspHtaccessBlock({ env: 'production' }, 'enforce')}
+${getProductionCspContent()}
 
 # CORS settings
 Header add Access-Control-Allow-Origin "*"
@@ -186,6 +189,26 @@ Header add Access-Control-Allow-Methods: "GET,POST,OPTIONS,DELETE,PUT"
 
 Options -Indexes
 `;
+}
+
+function getProductionCspContent(): string {
+    if (PRODUCTION_CSP_PHASE === 'enforce') {
+        return `# Content-Security-Policy — enforced, path-scoped (the report-only validation window
+# for removing 'unsafe-eval' from the main-site policy is complete). The block unsets
+# the inherited headers (incl. the legacy wildcard CSP on the vhost) and sets this
+# tightened policy as the enforced CSP. If the vhost wildcard lingers as a separate
+# header, browsers enforce the intersection, so the tightened policy still wins;
+# removing the vhost wildcard line is a follow-up infra cleanup.
+${getScopedCspHtaccessBlock({ env: 'production' }, 'enforce')}`;
+    }
+    return `# Content-Security-Policy — dual policy while removing 'unsafe-eval' from the
+# main-site policy is validated: keep enforcing the previous tightened policy (which
+# allows 'unsafe-eval' on every page) and report violations of the path-scoped split
+# via Report-Only. The Report-Only <If> override matters: without it, every
+# example-runner page would report eval violations and drown the signal.
+${getCspHtaccessBlock({ env: 'production', scope: 'examples' }, 'enforce')}
+
+${getScopedCspHtaccessBlock({ env: 'production' }, 'report-only')}`;
 }
 
 export function getHtaccessContent(options: { env: HtaccessEnv }): string {

--- a/testing/csp/e2e/eval-scope.spec.ts
+++ b/testing/csp/e2e/eval-scope.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test';
+
+import { goToExampleUrl, setupIntrinsicAssertions } from './util';
+
+const UNSAFE_EVAL = "'unsafe-eval'";
+
+const CSP_VIOLATION_PATTERN = /violates the following Content Security Policy|Content[- ]Security[- ]Policy/i;
+
+/**
+ * The tightened path-scoped policy under test: served as Report-Only during a
+ * production validation window, as the enforced header everywhere else.
+ */
+function tightenedPolicy(headers: Record<string, string>): string {
+    const policy = headers['content-security-policy-report-only'] ?? headers['content-security-policy'];
+    expect(policy, 'expected a Content-Security-Policy header on the response').toBeTruthy();
+    return policy!;
+}
+
+test.describe("unsafe-eval path scoping: 'site' vs 'examples' policy", () => {
+    test('main pages are served the site policy, without unsafe-eval', async ({ page }) => {
+        const response = await page.goto('/');
+        expect(tightenedPolicy(response!.headers())).not.toContain(UNSAFE_EVAL);
+    });
+
+    test('example documents are served the relaxed policy, with unsafe-eval', async ({ page }) => {
+        const response = await page.goto('/examples/getting-started/quick-start-example/vanilla');
+        expect(tightenedPolicy(response!.headers())).toContain(UNSAFE_EVAL);
+    });
+});
+
+test.describe('main pages produce no CSP violations under the site policy', () => {
+    const mainPages = ['/', '/example/', '/theme-builder/', '/javascript-data-grid/getting-started/'];
+
+    for (const pagePath of mainPages) {
+        test(`${pagePath} loads without CSP violations`, async ({ page }) => {
+            const violations: string[] = [];
+            page.on('console', (msg) => {
+                if (CSP_VIOLATION_PATTERN.test(msg.text())) {
+                    violations.push(msg.text());
+                }
+            });
+            await page.goto(pagePath);
+            await page.waitForLoadState('networkidle');
+            expect(violations).toEqual([]);
+        });
+    }
+});
+
+test.describe('example runner frameworks work under the relaxed policy', () => {
+    setupIntrinsicAssertions();
+
+    // Angular (JIT compiler) and vue3 (runtime template compiler) are the
+    // frameworks that depend on unsafe-eval, beyond SystemJS module loading.
+    const frameworks = ['vanilla', 'typescript', 'reactFunctionalTs', 'angular', 'vue3'];
+
+    for (const framework of frameworks) {
+        test(`quick-start-example (${framework}) renders the grid`, async ({ page }) => {
+            await goToExampleUrl({
+                page,
+                pageName: 'getting-started',
+                example: 'quick-start-example',
+                framework,
+            });
+            await expect(page.locator('.ag-root-wrapper')).toBeVisible({ timeout: 10000 });
+        });
+    }
+});

--- a/testing/csp/e2e/util.ts
+++ b/testing/csp/e2e/util.ts
@@ -31,19 +31,35 @@ export function setupIntrinsicAssertions() {
 
         page.on('console', (msg) => {
             // We only care about warnings/errors.
-            if (msg.type() !== 'warning' && msg.type() !== 'error') return;
+            if (msg.type() !== 'warning' && msg.type() !== 'error') {
+                return;
+            }
 
             // We don't care about the AG license error message.
-            if (msg.text().startsWith('*')) return;
+            if (msg.text().startsWith('*')) {
+                return;
+            }
 
             // Ignore Firefox Quirks Mode warning.
-            if (msg.text().includes('This page is in Quirks Mode')) return;
+            if (msg.text().includes('This page is in Quirks Mode')) {
+                return;
+            }
+
+            // Ignore Report-Only CSP violation reports — they are expected while a
+            // tightened policy is being validated; only enforced violations fail.
+            if (msg.text().includes('[Report Only]')) {
+                return;
+            }
 
             // Ignore 404s when expected
             const notFoundMatcher = /the server responded with a status of 404 \(Not Found\)/;
-            if (msg.location().url.includes('/favicon.ico')) return;
+            if (msg.location().url.includes('/favicon.ico')) {
+                return;
+            }
             if (notFoundMatcher.test(msg.text())) {
-                if (config.ignore404s) return;
+                if (config.ignore404s) {
+                    return;
+                }
                 expect(`${msg.location().url} - ${msg.text()}`).not.toMatch(notFoundMatcher);
             }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17134

Backport of #14029 to the `b35.3.1` release branch (cherry-pick of `f13be5c1bc3`).

Splits the site CSP into a `site` scope (no `'unsafe-eval'`) applied site-wide and an `examples` scope (keeps `'unsafe-eval'`) re-set for `/examples/` and `/archive/` paths via an Apache `<If>` override. Adds `'wasm-unsafe-eval'` to the shared `script-src` so browser-side Shiki highlighting keeps working, replaces the theme-builder's `eval`-based string unescaping with a manual unescaper, and converts the demo grid's string `cellClassRules` to functions. Staging enforces the split; production stays on the previous policy and reports the split via Report-Only, gated by `PRODUCTION_CSP_PHASE` (`'report-only'` until the window is clean).

The one cherry-pick conflict (demo-grid `colDefs.ts`) was resolved in favour of the function-based `cellClassRules`.

CSP + theme-builder unit tests pass (50 + 39).