### PR TITLE
Fix: Viewport RM leaves nodes at stale indexes, orphaning row ctrls

### DIFF
--- a/packages/ag-grid-community/src/rendering/rowRenderer.ts
+++ b/packages/ag-grid-community/src/rendering/rowRenderer.ts
@@ -1027,8 +1027,24 @@ export class RowRenderer extends BeanStub implements NamedBean {
 
         // then clear out rowCompsByIndex, but before that take a copy, but index by id, not rowIndex
         const ctrlsByIdMap: RowCtrlByRowNodeIdMap = {};
-        for (const rowCtrl of Object.values(this.rowCtrlsByRowIndex)) {
+        for (const index of Object.keys(this.rowCtrlsByRowIndex)) {
+            const rowCtrl = this.rowCtrlsByRowIndex[index as any];
             const rowNode = rowCtrl.rowNode;
+            const existingCtrl = ctrlsByIdMap[rowNode.id!];
+            if (existingCtrl && existingCtrl !== rowCtrl) {
+                // two ctrls can reference the same row id when the row model moved a node to a new
+                // index while a stale reference remained at the old one (e.g. viewport row model with
+                // partial setRowData coverage). overwriting the map entry would orphan one ctrl without
+                // destroying it, leaking the ctrl together with its event listeners and framework
+                // components. keep the ctrl matching the node's current row index and destroy the other.
+                const keepCurrentCtrl = rowNode.rowIndex === Number(index);
+                const ctrlToDestroy = keepCurrentCtrl ? existingCtrl : rowCtrl;
+                ctrlToDestroy.destroyFirstPass(true);
+                ctrlToDestroy.destroySecondPass();
+                if (!keepCurrentCtrl) {
+                    continue;
+                }
+            }
             ctrlsByIdMap[rowNode.id!] = rowCtrl;
         }
         this.rowCtrlsByRowIndex = {};

--- a/packages/ag-grid-enterprise/src/viewportRowModel/viewportRowModel.ts
+++ b/packages/ag-grid-enterprise/src/viewportRowModel/viewportRowModel.ts
@@ -344,6 +344,13 @@ export class ViewportRowModel extends BeanStub implements NamedBean, IRowModel {
             }
 
             if (row) {
+                const previousIndex = row.rowIndex;
+                if (previousIndex != null && previousIndex !== i && this.rowNodesByIndex[previousIndex] === row) {
+                    // the node moved to a new index - remove the stale reference at its previous index,
+                    // otherwise the same node exists at two indexes and the row renderer later finds
+                    // two ctrls for one row id, orphaning (and leaking) one of them
+                    delete this.rowNodesByIndex[previousIndex];
+                }
                 row.updateData(data);
                 row.setRowIndex(i);
                 row.setRowTop(this.rowHeight * i);

--- a/testing/behavioural/src/rows/viewport-row-model-moved-nodes.test.ts
+++ b/testing/behavioural/src/rows/viewport-row-model-moved-nodes.test.ts
@@ -1,0 +1,57 @@
+import type { GridApi, IViewportDatasourceParams } from 'ag-grid-community';
+import { ViewportRowModelModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+
+describe('viewport row model moved nodes', () => {
+    const gridsManager = new TestGridsManager({ modules: [ViewportRowModelModule] });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    function rowDataFromIds(idsByIndex: Record<number, string>) {
+        const rowData: Record<number, { id: string; name: string }> = {};
+        for (const [index, id] of Object.entries(idsByIndex)) {
+            rowData[Number(index)] = { id, name: `name-${id}` };
+        }
+        return rowData;
+    }
+
+    test('a node moved to a new index is removed from its previous index when setRowData omits rows', async () => {
+        let datasourceParams: IViewportDatasourceParams | undefined;
+
+        const api: GridApi = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'name' }],
+            rowModelType: 'viewport',
+            getRowId: (params) => params.data.id,
+            viewportDatasource: {
+                init: (params) => {
+                    datasourceParams = params;
+                },
+                setViewportRange: () => {},
+            },
+        });
+
+        await asyncSetTimeout(0);
+
+        datasourceParams!.setRowCount(5);
+        datasourceParams!.setRowData(rowDataFromIds({ 0: 'a', 1: 'b', 2: 'c', 3: 'd', 4: 'e' }));
+        await asyncSetTimeout(0);
+
+        // 'e' moves to the top while index 4 is omitted from the update, mimicking a partial
+        // response from a server-side sorted feed. Without cleanup the node for 'e' would remain
+        // at index 4 as well as index 0, and the row renderer would then produce two row ctrls
+        // for one row id, silently dropping (and leaking) one of them on the next recycle.
+        datasourceParams!.setRowData(rowDataFromIds({ 0: 'e', 1: 'a', 2: 'b', 3: 'c' }));
+        await asyncSetTimeout(0);
+
+        const visitedIds: string[] = [];
+        api.forEachNode((node) => {
+            visitedIds.push(node.id!);
+        });
+
+        expect(visitedIds.filter((id) => id === 'e')).toHaveLength(1);
+        expect(new Set(visitedIds).size).toBe(visitedIds.length);
+    });
+});


### PR DESCRIPTION
## Bug

With `rowModelType="viewport"` + `getRowId`, a row id can end up referenced at two row indexes at once. When that happens the row renderer silently drops one of the two RowCtrls without destroying it. The dropped ctrl keeps its managed listeners registered (the global `modelUpdated` listener on the event service, and `dataChanged` on its rowNode, which is still live), so it is retained for the lifetime of the grid and keeps reacting to every data update.

This is a severe memory leak for long-lived grids on streaming data. In framework grids it is compounded: the orphaned ctrl keeps pushing render details into its (unmounted) framework cell components on every rowNode `dataChanged`; with React 18, every such `setState` on an unmounted fiber enqueues an update object that is never processed and never released. We traced a production renderer to 4GB this way: ~1,760 orphaned RowCtrls anchored solely by `allSyncListeners['modelUpdated']`, holding ~16,400 cell comps and 6.2M queued React state updates.

Affected: reproduced on 34.2.0; the relevant code is unchanged through 35.3.1.

## Root cause

1. `ViewportRowModel.setRowData` documents that omitted indexes are "left unchanged". When an id-matched node is found via `getRowId` and assigned a new index, nothing clears `rowNodesByIndex[previousIndex]`, so if the previous index is not covered by the same update, the **same RowNode object exists at two indexes**. This happens routinely with server-side sorted feeds (rows reshuffle every tick) combined with scrolling (range changes leave uncovered indexes).
2. `RowRenderer.getRowsToRecycle` then builds `ctrlsByIdMap[rowNode.id]` from `rowCtrlsByRowIndex`. Two indexes give two ctrls for one id: the second assignment overwrites the first, and the overwritten ctrl is never destroyed. It is no longer in any renderer map, `zombieRowCtrls`, or destroy queue, but its managed listeners keep it alive.

## Fix

- `viewportRowModel.setRowData`: when a node moved to a new index, delete the stale `rowNodesByIndex` entry at its previous index (root cause).
- `rowRenderer.getRowsToRecycle`: if two ctrls map to one row id, destroy the one that no longer matches the node's current rowIndex instead of silently overwriting it (defense in depth, protects any row model that produces a duplicate id).

## Repro / test

Added `testing/behavioural/src/rows/viewport-row-model-moved-nodes.test.ts`: seed a viewport grid, then apply a partial `setRowData` where an id moves to a new index while its old index is omitted. Without the fix, `api.forEachNode` visits the moved node twice (and the next recycle pass orphans a RowCtrl).

Manual repro of the leak itself: viewport grid on a feed that re-sorts ids across indexes, scroll up/down for a minute, then take a heap snapshot. `RowCtrl` instance count grows far past the rendered row count and never recovers, and in React it then grows unboundedly at idle (one retained state update per orphaned cell per data tick).
