### PR TITLE
Prevent firing both click and longTap events in iOS touch UIs

### DIFF
--- a/packages/ag-grid-community/src/widgets/touchListener.ts
+++ b/packages/ag-grid-community/src/widgets/touchListener.ts
@@ -114,7 +114,7 @@ export class TouchListener implements IEventEmitter<TouchListenerEvent> {
             this.longPressTimer = 0;
             if (this.touchStart === touchStart && !this.moved) {
                 this.moved = true;
-                this.longTapFired = true;
+                this.longTapFired = this.longTapListeners > 0;
                 this.eventSvc?.dispatchEvent<LongTapEvent>({ type: 'longTap', touchStart, touchEvent });
             }
         }, LONG_PRESS_MILLISECONDS);
@@ -145,7 +145,7 @@ export class TouchListener implements IEventEmitter<TouchListenerEvent> {
 
         // a fired long tap (e.g. opening a context menu) must not also emit the emulated mouse
         // click iOS dispatches on release, which would otherwise activate the element under the finger
-        if (this.preventClick || (this.longTapFired && this.longTapListeners > 0)) {
+        if (this.preventClick || this.longTapFired) {
             preventEventDefault(touchEvent);
         }
 

--- a/packages/ag-grid-community/src/widgets/touchListener.ts
+++ b/packages/ag-grid-community/src/widgets/touchListener.ts
@@ -50,6 +50,8 @@ export class TouchListener implements IEventEmitter<TouchListenerEvent> {
     private lastTapTime: number | null = null;
     private longPressTimer: number = 0;
     private moved: boolean = false;
+    private longTapFired: boolean = false;
+    private longTapListeners = 0;
 
     constructor(
         private eElement: Element,
@@ -68,10 +70,16 @@ export class TouchListener implements IEventEmitter<TouchListenerEvent> {
             this.eElement.addEventListener('touchstart', startListener, { passive: true });
         }
         eventSvc.addEventListener(eventType, listener);
+        if (eventType === 'longTap') {
+            this.longTapListeners++;
+        }
     }
 
     public removeEventListener<T extends TouchListenerEvent>(eventType: T, listener: IEventListener<T>): void {
         this.eventSvc?.removeEventListener(eventType, listener);
+        if (eventType === 'longTap') {
+            this.longTapListeners--;
+        }
     }
 
     private onTouchStart(touchEvent: TouchEvent): void {
@@ -106,6 +114,7 @@ export class TouchListener implements IEventEmitter<TouchListenerEvent> {
             this.longPressTimer = 0;
             if (this.touchStart === touchStart && !this.moved) {
                 this.moved = true;
+                this.longTapFired = true;
                 this.eventSvc?.dispatchEvent<LongTapEvent>({ type: 'longTap', touchStart, touchEvent });
             }
         }, LONG_PRESS_MILLISECONDS);
@@ -134,8 +143,10 @@ export class TouchListener implements IEventEmitter<TouchListenerEvent> {
             this.checkDoubleTap(touchStart);
         }
 
-        if (this.preventClick) {
-            preventEventDefault(touchEvent); // stops the tap from also been processed as a mouse click
+        // a fired long tap (e.g. opening a context menu) must not also emit the emulated mouse
+        // click iOS dispatches on release, which would otherwise activate the element under the finger
+        if (this.preventClick || (this.longTapFired && this.longTapListeners > 0)) {
+            preventEventDefault(touchEvent);
         }
 
         this.cancel();
@@ -177,6 +188,7 @@ export class TouchListener implements IEventEmitter<TouchListenerEvent> {
             this.longPressTimer = 0;
         }
         this.moved = false;
+        this.longTapFired = false;
     }
 
     public destroy(): void {

--- a/packages/ag-grid-enterprise/src/agStack/agMenuItemComponent.ts
+++ b/packages/ag-grid-enterprise/src/agStack/agMenuItemComponent.ts
@@ -12,8 +12,8 @@ import type {
 } from 'ag-stack';
 import { AgBeanStub, _setAriaDisabled, _setAriaExpanded, _setAriaHasPopup, _setAriaRole } from 'ag-stack';
 
-import type { AgEvent, AgPromise, IComponent, IMenuConfigParams, IMenuItem } from 'ag-grid-community';
-import { KeyCode, _createElement } from 'ag-grid-community';
+import type { AgEvent, AgPromise, IComponent, IMenuConfigParams, IMenuItem, TapEvent } from 'ag-grid-community';
+import { KeyCode, TouchListener, _createElement } from 'ag-grid-community';
 
 import { AgMenuList } from './agMenuList';
 import { AgMenuPanel } from './agMenuPanel';
@@ -224,6 +224,9 @@ export class AgMenuItemComponent<
     private addListeners(eGui: HTMLElement, params?: IMenuConfigParams): void {
         if (!params?.suppressClick) {
             this.addManagedElementListeners(eGui, { click: (e) => this.onItemSelected(e!) });
+            const touchListener = new TouchListener(eGui, true);
+            this.addManagedListeners(touchListener, { tap: (e: TapEvent) => this.onItemSelected(e.touchStart) });
+            this.addDestroyFunc(() => touchListener.destroy());
         }
         if (!params?.suppressKeyboardSelect) {
             this.addManagedElementListeners(eGui, {
@@ -257,7 +260,7 @@ export class AgMenuItemComponent<
         return !!this.params.disabled;
     }
 
-    public openSubMenu(activateFirstItem = false, event?: MouseEvent | KeyboardEvent): void {
+    public openSubMenu(activateFirstItem = false, event?: MouseEvent | KeyboardEvent | Touch): void {
         this.closeSubMenu();
 
         if (!this.params.subMenu) {
@@ -342,7 +345,7 @@ export class AgMenuItemComponent<
             popupSvc?.positionPopupForMenu({
                 eventSource,
                 ePopup,
-                event: event instanceof MouseEvent ? event : undefined,
+                event: event instanceof KeyboardEvent ? undefined : event,
                 additionalParams: this.callbacks.getPostProcessPopupParams(this.contextParams),
             });
         };
@@ -455,7 +458,7 @@ export class AgMenuItemComponent<
         return this.eSubMenuGui;
     }
 
-    private onItemSelected(event: MouseEvent | KeyboardEvent): void {
+    private onItemSelected(event?: MouseEvent | KeyboardEvent | Touch): void {
         this.menuItemComp.select?.();
         if (this.params.action) {
             this.beans.frameworkOverrides.wrapOutgoing(() =>
@@ -466,14 +469,14 @@ export class AgMenuItemComponent<
                 )
             );
         } else {
-            this.openSubMenu(event?.type === 'keydown', event);
+            this.openSubMenu(event instanceof KeyboardEvent && event.type === 'keydown', event);
         }
 
         if ((this.params.subMenu && !this.params.action) || this.params.suppressCloseOnSelect) {
             return;
         }
 
-        this.closeMenu(event);
+        this.closeMenu(event instanceof MouseEvent || event instanceof KeyboardEvent ? event : undefined);
     }
 
     private closeMenu(event?: MouseEvent | KeyboardEvent): void {

--- a/packages/ag-stack/src/interfaces/iPopup.ts
+++ b/packages/ag-stack/src/interfaces/iPopup.ts
@@ -83,5 +83,5 @@ export interface AgMousePopupPositionParams<TParams> extends AgPopupPositionPara
 
 export interface AgMenuPopupPositionParams<TParams> extends BasePopupPositionParams<TParams> {
     eventSource: HTMLElement;
-    event?: MouseEvent | KeyboardEvent;
+    event?: MouseEvent | KeyboardEvent | Touch;
 }

--- a/packages/ag-stack/src/popup/basePopupService.ts
+++ b/packages/ag-stack/src/popup/basePopupService.ts
@@ -216,7 +216,7 @@ export abstract class BasePopupService<
                     'subMenu',
                     ePopup,
                     eventSource,
-                    event instanceof MouseEvent ? event : undefined
+                    event instanceof KeyboardEvent ? undefined : event
                 ),
         });
     }


### PR DESCRIPTION
Fix [AG-5835](https://ag-grid.atlassian.net/browse/AG-5835)

When firing a long press event on a TouchListener, suppress the native click event that happens on touchend, to prevent both click and long press handlers from firing.

Note, as part of the implementation we've widened a public API type (AgMenuPopupPositionParams.event) but since this is an input type it's a backwards compatible change.