### PR TITLE
AG-17134 Allow bryntum.com on /campaigns/ pages in the site CSP

### DIFF
--- a/documentation/ag-grid-docs/plugins/agDevCsp.ts
+++ b/documentation/ag-grid-docs/plugins/agDevCsp.ts
@@ -4,24 +4,36 @@ import { getCspValue } from '../src/utils/htaccess/cspRules';
 
 const SITE_CSP = getCspValue({ env: 'dev', scope: 'site' });
 const EXAMPLES_CSP = getCspValue({ env: 'dev', scope: 'examples' });
+const CAMPAIGNS_CSP = getCspValue({ env: 'dev', scope: 'campaigns' });
 
-// Mirrors EXAMPLES_PATH_CONDITION in cspRules.ts, which scopes the served
-// .htaccess policy by URL path on staging/production.
+// Mirror EXAMPLES_PATH_CONDITION / CAMPAIGNS_PATH_CONDITION in cspRules.ts, which
+// scope the served .htaccess policy by URL path on staging/production.
 const EXAMPLES_PATH = /^\/(examples|archive)\//;
+const CAMPAIGNS_PATH = /^\/campaigns\//;
+
+function getDevCsp(url: string): string {
+    if (EXAMPLES_PATH.test(url)) {
+        return EXAMPLES_CSP;
+    }
+    if (CAMPAIGNS_PATH.test(url)) {
+        return CAMPAIGNS_CSP;
+    }
+    return SITE_CSP;
+}
 
 /**
  * Vite plugin serving the dev server's Content-Security-Policy header with the
  * same path-scoped split as the generated .htaccess: ordinary pages get the
  * 'site' policy (no 'unsafe-eval'), example-runner documents get the relaxed
- * 'examples' policy. Keeps local development honest about main-page eval use.
+ * 'examples' policy, and partnership campaign pages get the 'campaigns' policy
+ * (bryntum.com allowed). Keeps local development honest about main-page eval use.
  */
 export default function agDevCsp(): Plugin {
     return {
         name: 'ag-dev-csp',
         configureServer(server: ViteDevServer) {
             server.middlewares.use((req, res, next) => {
-                const csp = EXAMPLES_PATH.test(req.url ?? '') ? EXAMPLES_CSP : SITE_CSP;
-                res.setHeader('Content-Security-Policy', csp);
+                res.setHeader('Content-Security-Policy', getDevCsp(req.url ?? ''));
                 next();
             });
         },

--- a/documentation/ag-grid-docs/scripts/csp/generate-csp.ts
+++ b/documentation/ag-grid-docs/scripts/csp/generate-csp.ts
@@ -13,7 +13,7 @@ import { getCspHeaderName, getCspValue, getScopedCspHtaccessBlock } from '../../
  *       [--env=staging|production|dev]
  *       [--mode=report-only|enforce]
  *       [--format=htaccess|header|value]
- *       [--scope=site|examples]    (header/value formats only; htaccess emits both)
+ *       [--scope=site|examples|campaigns]  (header/value formats only; htaccess emits all)
  *       [--out=<file>]
  *
  * Run via Nx:
@@ -33,7 +33,7 @@ type Format = 'htaccess' | 'header' | 'value';
 const ENVS: CspEnv[] = ['dev', 'staging', 'production'];
 const MODES: CspMode[] = ['report-only', 'enforce'];
 const FORMATS: Format[] = ['htaccess', 'header', 'value'];
-const SCOPES: CspScope[] = ['site', 'examples'];
+const SCOPES: CspScope[] = ['site', 'examples', 'campaigns'];
 
 function assertOneOf<T extends string>(value: string | undefined, allowed: T[], flag: string): T {
     if (value === undefined || !allowed.includes(value as T)) {

--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.test.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.test.ts
@@ -1,4 +1,4 @@
-import { getCspDirectives, getScopedCspHtaccessBlock } from './cspRules';
+import { CAMPAIGNS_PATH_CONDITION, getCspDirectives, getScopedCspHtaccessBlock } from './cspRules';
 
 describe('cspRules', () => {
     describe('scope', () => {
@@ -54,6 +54,38 @@ describe('cspRules', () => {
         });
     });
 
+    describe('campaigns scope (AG-17134: Bryntum partnership pages)', () => {
+        it('adds the bryntum.com origin to script/style/font/connect-src', () => {
+            const campaigns = getCspDirectives({ env: 'production', scope: 'campaigns' });
+            expect(campaigns['script-src']).toContain('https://bryntum.com');
+            expect(campaigns['style-src']).toContain('https://bryntum.com');
+            expect(campaigns['font-src']).toContain('https://bryntum.com');
+            expect(campaigns['connect-src']).toContain('https://bryntum.com');
+        });
+
+        it("does not add 'unsafe-eval' (Bryntum hosts only, no eval)", () => {
+            const campaigns = getCspDirectives({ env: 'production', scope: 'campaigns' });
+            expect(campaigns['script-src']).not.toContain("'unsafe-eval'");
+        });
+
+        it('differs from the site scope only by the bryntum.com origin', () => {
+            const site = getCspDirectives({ env: 'production', scope: 'site' });
+            const campaigns = getCspDirectives({ env: 'production', scope: 'campaigns' });
+
+            expect(Object.keys(campaigns)).toEqual(Object.keys(site));
+            const names = Object.keys(site);
+            const broadened = ['script-src', 'style-src', 'font-src', 'connect-src'];
+            for (let i = 0, len = names.length; i < len; ++i) {
+                const name = names[i];
+                if (broadened.includes(name)) {
+                    expect(campaigns[name]).toEqual([...site[name], 'https://bryntum.com']);
+                } else {
+                    expect(campaigns[name]).toEqual(site[name]);
+                }
+            }
+        });
+    });
+
     describe('getScopedCspHtaccessBlock', () => {
         it('enforce mode unsets and re-sets the enforced header inside the <If> override', () => {
             const block = getScopedCspHtaccessBlock({ env: 'production' }, 'enforce');
@@ -71,6 +103,16 @@ describe('cspRules', () => {
             expect(enforcedUnset).toBeUndefined();
             expect(block).not.toContain('Header always set Content-Security-Policy "');
             expect(block).toContain('Header always set Content-Security-Policy-Report-Only "');
+        });
+
+        it('emits a /campaigns/ <If> override allowing bryntum.com without unsafe-eval', () => {
+            const block = getScopedCspHtaccessBlock({ env: 'production' }, 'enforce');
+            const campaignsIfOpen = `<If "${CAMPAIGNS_PATH_CONDITION}">`;
+            const start = block.indexOf(campaignsIfOpen);
+            expect(start).toBeGreaterThan(-1);
+            const ifBlock = block.slice(start, block.indexOf('</If>', start));
+            expect(ifBlock).toContain('https://bryntum.com');
+            expect(ifBlock).not.toContain("'unsafe-eval'");
         });
     });
 });

--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
@@ -15,11 +15,14 @@ export type CspEnv = 'dev' | 'staging' | 'production';
 export type CspMode = 'report-only' | 'enforce';
 
 /**
- * 'site' is the default policy for ordinary pages. 'examples' additionally
- * allows 'unsafe-eval' and applies only to the standalone example-runner
- * documents (and archived doc versions) — see EXAMPLES_PATH_CONDITION.
+ * - 'site': the default policy for ordinary pages.
+ * - 'examples': additionally allows 'unsafe-eval'; applies only to the standalone
+ *   example-runner documents (and archived doc versions) — see EXAMPLES_PATH_CONDITION.
+ * - 'campaigns': additionally allows the bryntum.com origin (script/style/font/
+ *   connect) for the partnership campaign pages' embedded Gantt demo — without
+ *   'unsafe-eval'. See CAMPAIGNS_PATH_CONDITION.
  */
-export type CspScope = 'site' | 'examples';
+export type CspScope = 'site' | 'examples' | 'campaigns';
 
 export interface CspOptions {
     env: CspEnv;
@@ -49,10 +52,22 @@ const WASM_UNSAFE_EVAL = "'wasm-unsafe-eval'";
 // but now unescapes string literals without eval (see unescapeStringLiteral).
 const UNSAFE_EVAL = "'unsafe-eval'";
 
+// The AG Grid × Bryntum partnership campaign pages embed a live Bryntum Gantt
+// demo that loads its bundle, stylesheet, Font Awesome webfonts and dataset from
+// bryntum.com. Allowed only in the 'campaigns' scope so the rest of the site does
+// not trust this third-party origin. The pages are deliberately NOT granted
+// 'unsafe-eval': if the Bryntum bundle's runtime new Function() path turns out to
+// be exercised, re-allowing it is a separate, conscious decision.
+const BRYNTUM_HOST = 'https://bryntum.com';
+
 // Apache <If> expression matching the URL paths that get the 'examples' scope:
 // the standalone example-runner documents and archived doc versions (uploaded
 // separately but served from this vhost, so they inherit the root .htaccess).
 export const EXAMPLES_PATH_CONDITION = '%{REQUEST_URI} =~ m#^/(examples|archive)/#';
+
+// Apache <If> expression matching the partnership campaign pages that get the
+// 'campaigns' scope (e.g. /campaigns/bryntum-gantt/).
+export const CAMPAIGNS_PATH_CONDITION = '%{REQUEST_URI} =~ m#^/campaigns/#';
 
 // 'self' resolves to grid-staging.ag-grid.com on staging / localhost in dev, so
 // cross-subdomain references to the production host need an explicit allowance.
@@ -202,6 +217,11 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
 
     if (scope === 'examples') {
         directives['script-src'].push(UNSAFE_EVAL);
+    } else if (scope === 'campaigns') {
+        directives['script-src'].push(BRYNTUM_HOST);
+        directives['style-src'].push(BRYNTUM_HOST);
+        directives['font-src'].push(BRYNTUM_HOST);
+        directives['connect-src'].push(BRYNTUM_HOST);
     }
 
     if (env === 'dev') {
@@ -257,25 +277,70 @@ export function getCspHtaccessBlock(options: CspOptions, mode: CspMode): string 
 }
 
 /**
- * Build the full `.htaccess` CSP block with the path-scoped policy split: the
- * 'site' policy (no 'unsafe-eval') for ordinary pages, replaced by the
- * 'examples' policy for the paths matched by EXAMPLES_PATH_CONDITION.
+ * Build an Apache `<If>` block that replaces the CSP header for the requests
+ * matching `condition` with the given scope's policy.
  *
- * A second CSP policy can only tighten (browsers enforce the intersection), so
- * the relaxation must unset and re-set the header rather than add another one.
+ * A second CSP policy can only tighten (browsers enforce the intersection), so a
+ * relaxation must unset and re-set the header rather than add another one. <If>
+ * sections merge after all other configuration, so this unset+set deterministically
+ * replaces whatever header was set site-wide for matching requests.
+ */
+function getCspIfOverride(condition: string, comment: string[], options: CspOptions, mode: CspMode): string {
+    const headerName = getCspHeaderName(mode);
+    return [
+        ...comment,
+        `<If "${condition}">`,
+        `    Header always unset ${headerName}`,
+        `    ${getCspHtaccessLine(options, mode)}`,
+        '</If>',
+    ].join('\n');
+}
+
+/**
+ * The `<If>` override re-allowing 'unsafe-eval' for the example-runner documents
+ * and archived doc versions matched by EXAMPLES_PATH_CONDITION.
+ */
+export function getExamplesCspIfOverride(options: Omit<CspOptions, 'scope'>, mode: CspMode): string {
+    return getCspIfOverride(
+        EXAMPLES_PATH_CONDITION,
+        [
+            "# Example-runner documents and archived doc versions additionally need 'unsafe-eval'",
+            '# (SystemJS eval-loads modules; the Angular JIT and Vue runtime template compilers',
+            '# also compile in the browser).',
+        ],
+        { ...options, scope: 'examples' },
+        mode
+    );
+}
+
+/**
+ * The `<If>` override allowing the bryntum.com origin for the partnership campaign
+ * pages matched by CAMPAIGNS_PATH_CONDITION (no extra 'unsafe-eval').
+ */
+export function getCampaignsCspIfOverride(options: Omit<CspOptions, 'scope'>, mode: CspMode): string {
+    return getCspIfOverride(
+        CAMPAIGNS_PATH_CONDITION,
+        [
+            '# Partnership campaign pages embed a live Bryntum Gantt demo that loads its bundle,',
+            '# stylesheet, Font Awesome webfonts and dataset from bryntum.com.',
+        ],
+        { ...options, scope: 'campaigns' },
+        mode
+    );
+}
+
+/**
+ * Build the full `.htaccess` CSP block with the path-scoped policy split: the
+ * 'site' policy (no 'unsafe-eval', no third-party embeds) for ordinary pages,
+ * replaced by the 'examples' policy for EXAMPLES_PATH_CONDITION paths and the
+ * 'campaigns' policy for CAMPAIGNS_PATH_CONDITION paths.
  */
 export function getScopedCspHtaccessBlock(options: Omit<CspOptions, 'scope'>, mode: CspMode): string {
-    const headerName = getCspHeaderName(mode);
     return [
         getCspHtaccessBlock({ ...options, scope: 'site' }, mode),
         '',
-        "# Example-runner documents and archived doc versions additionally need 'unsafe-eval'",
-        '# (SystemJS eval-loads modules; the Angular JIT and Vue runtime template compilers',
-        '# also compile in the browser). <If> sections merge after all other configuration,',
-        '# so this unset+set replaces the header set above for matching requests.',
-        `<If "${EXAMPLES_PATH_CONDITION}">`,
-        `    Header always unset ${headerName}`,
-        `    ${getCspHtaccessLine({ ...options, scope: 'examples' }, mode)}`,
-        '</If>',
+        getExamplesCspIfOverride(options, mode),
+        '',
+        getCampaignsCspIfOverride(options, mode),
     ].join('\n');
 }

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
@@ -1,4 +1,4 @@
-import { EXAMPLES_PATH_CONDITION } from './cspRules';
+import { CAMPAIGNS_PATH_CONDITION, EXAMPLES_PATH_CONDITION } from './cspRules';
 import { PRODUCTION_CSP_PHASE, getHtaccessContent } from './htaccessRules';
 import { SITE_301_REDIRECTS } from './redirects';
 
@@ -277,6 +277,38 @@ describe('htaccessRules', () => {
                 const ifBlock = extractIfBlock(productionContent);
                 expect(ifBlock).toContain('Header always unset Content-Security-Policy\n');
                 expect(ifBlock).toContain("'unsafe-eval'");
+            });
+        }
+    });
+
+    describe('AG-17134: Bryntum campaign pages CSP override', () => {
+        const campaignsIfOpen = `<If "${CAMPAIGNS_PATH_CONDITION}">`;
+
+        // In every phase the first /campaigns/ <If> is the enforced override, so it
+        // governs what the campaign pages actually load.
+        const firstCampaignsIfBlock = (content: string) => {
+            const start = content.indexOf(campaignsIfOpen);
+            expect(start).toBeGreaterThan(-1);
+            return content.slice(start, content.indexOf('</If>', start));
+        };
+
+        it('staging: <If> override allows bryntum.com for /campaigns/ without unsafe-eval', () => {
+            const ifBlock = firstCampaignsIfBlock(stagingContent);
+            expect(ifBlock).toContain('https://bryntum.com');
+            expect(ifBlock).not.toContain("'unsafe-eval'");
+        });
+
+        it('production: allows bryntum.com for /campaigns/ without unsafe-eval (either phase)', () => {
+            const ifBlock = firstCampaignsIfBlock(productionContent);
+            expect(ifBlock).toContain('https://bryntum.com');
+            expect(ifBlock).not.toContain("'unsafe-eval'");
+        });
+
+        if (PRODUCTION_CSP_PHASE === 'report-only') {
+            it('production (report-only window): re-sets the ENFORCED header for /campaigns/ so bryntum.com loads during the window', () => {
+                const ifBlock = firstCampaignsIfBlock(productionContent);
+                expect(ifBlock).toContain('Header always unset Content-Security-Policy\n');
+                expect(ifBlock).toContain('Header always set Content-Security-Policy "');
             });
         }
     });

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
@@ -1,6 +1,6 @@
 import { urlWithBaseUrl } from '../urlWithBaseUrl';
 import type { CspEnv } from './cspRules';
-import { getCspHtaccessBlock, getScopedCspHtaccessBlock } from './cspRules';
+import { getCampaignsCspIfOverride, getCspHtaccessBlock, getScopedCspHtaccessBlock } from './cspRules';
 import { SITE_301_REDIRECTS } from './redirects';
 
 export type HtaccessEnv = Extract<CspEnv, 'staging' | 'production'>;
@@ -207,6 +207,11 @@ ${getScopedCspHtaccessBlock({ env: 'production' }, 'enforce')}`;
 # via Report-Only. The Report-Only <If> override matters: without it, every
 # example-runner page would report eval violations and drown the signal.
 ${getCspHtaccessBlock({ env: 'production', scope: 'examples' }, 'enforce')}
+
+# The campaign pages' embedded Bryntum demo needs the bryntum.com origin allowed even
+# during the report-only window: the enforced policy above does not include it, so
+# re-set the enforced header for /campaigns/ here (still without 'unsafe-eval').
+${getCampaignsCspIfOverride({ env: 'production' }, 'enforce')}
 
 ${getScopedCspHtaccessBlock({ env: 'production' }, 'report-only')}`;
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17134

## Summary

The Bryntum partnership campaign pages (e.g. `/campaigns/bryntum-gantt/`, added in AG-17355) embed a **live Bryntum Gantt demo** that loads its bundle, stylesheet, Font Awesome webfonts and dataset from `bryntum.com`. Tightening the main-site CSP in AG-17134 (#14029) removed the permissive wildcard, so `script-src` / `style-src` / `font-src` / `connect-src` now block those resources and the demo fails to load on staging.

This adds a path-scoped **`campaigns`** CSP variant that allows the `bryntum.com` origin on those four directives for `/campaigns/` paths only — via an Apache `<If>` override, mirroring the existing `examples`/`archive` split — so the rest of the site does not trust the third-party origin.

| Directive | What loads from bryntum.com |
|---|---|
| `script-src` | `gantt.umd.js` |
| `style-src` | `gantt.css`, theme + Font Awesome CSS |
| `font-src` | Font Awesome webfonts |
| `connect-src` | `fetch()` of the demo dataset |

The override is emitted for **staging**, **production enforce**, and the **production report-only enforced header** (so the demo keeps working through the report-only window, during which the global enforced policy otherwise omits `bryntum.com`).

## Scope decision: hosts only, no `unsafe-eval`

Deliberately scoped to the `bryntum.com` origin **without `'unsafe-eval'`**. The Bryntum bundle does contain a runtime `new Function()` path (locale loader), but whether this demo exercises it will be confirmed by browser-checking staging once the hosts are allowed — before any decision to re-allow eval on `/campaigns/`. If it turns out to be needed, that's a separate, conscious follow-up.

## Test plan

- `nx run ag-grid-docs:test:vitest` — added unit coverage for the `campaigns` scope (bryntum on 4 directives, no eval, differs from `site` only by the origin) and the generated `<If>` block across staging + both production phases. All 451 pass.
- Format + lint clean.
- **After deploy:** browser-check `https://grid-staging.ag-grid.com/campaigns/bryntum-gantt/` — confirm the Gantt renders with no CSP violations, and specifically watch for an `unsafe-eval` / `new Function` violation that would mean eval is required after all.
