### PR TITLE
AG-17134 Remove script-src 'unsafe-inline' from the site CSP

### DIFF
--- a/documentation/ag-grid-docs/public/scripts/gtm-init.js
+++ b/documentation/ag-grid-docs/public/scripts/gtm-init.js
@@ -1,0 +1,24 @@
+/*
+ * Google Tag Manager bootstrap. Externalised from an inline `define:vars` script
+ * (see GoogleTagManager.astro) so the site Content-Security-Policy can drop
+ * script-src 'unsafe-inline'. Configuration arrives via data- attributes on the
+ * loading <script> tag, so this file is static and served from 'self'.
+ *
+ * Must be loaded as a classic, non-deferred script: it reads
+ * document.currentScript, which is only set during synchronous execution.
+ */
+(function () {
+    var el = document.currentScript;
+    var id = el && el.dataset.gtmId;
+    if (!id) {
+        return;
+    }
+    var extraParams = el.dataset.gtmExtra || '';
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+    var firstScript = document.getElementsByTagName('script')[0];
+    var gtmScript = document.createElement('script');
+    gtmScript.async = true;
+    gtmScript.src = 'https://www.googletagmanager.com/gtm.js?id=' + id + extraParams + '&gtm_cookies_win=x';
+    firstScript.parentNode.insertBefore(gtmScript, firstScript);
+})();

--- a/documentation/ag-grid-docs/src/components/Plausible.astro
+++ b/documentation/ag-grid-docs/src/components/Plausible.astro
@@ -1,4 +1,6 @@
 ---
+import { PLAUSIBLE_INIT_SCRIPT } from '@utils/csp/inlineScripts';
+
 interface Props {
     domain: string;
 }
@@ -7,10 +9,5 @@ const { domain } = Astro.props as Props;
 ---
 
 <script defer data-domain={domain} src="https://plausible.io/js/script.tagged-events.outbound-links.js"></script>
-<script is:inline>
-    window.plausible =
-        window.plausible ||
-        function () {
-            (window.plausible.q = window.plausible.q || []).push(arguments);
-        };
-</script>
+{/* Authorised in script-src by SHA-256 hash (not 'unsafe-inline'); see @utils/csp/inlineScripts. */}
+<script is:inline set:html={PLAUSIBLE_INIT_SCRIPT} />

--- a/documentation/ag-grid-docs/src/layouts/Layout.astro
+++ b/documentation/ag-grid-docs/src/layouts/Layout.astro
@@ -8,6 +8,7 @@ import { getFavIconsData, getAppleTouchIconsData } from '@utils/favicons';
 import { getIsProduction, getIsArchive, getIsStaging, getIsDev } from '@utils/env';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 import Plausible from '@components/Plausible.astro';
+import { DARK_MODE_INIT_SCRIPT } from '@utils/csp/inlineScripts';
 import { Footer } from '@ag-website-shared/components/footer/Footer';
 import styles from '@layouts/Layout.module.scss';
 import { getApiPaths } from '@utils/apiMenuPath';
@@ -224,51 +225,11 @@ const announcementBannerProps = {
         </style>
     </head>
     <body data-is-homepage={isHomepage}>
-        <script is:inline>
-            const htmlEl = document.querySelector('html');
-            const localDarkmode = localStorage['documentation:darkmode'];
-            const isOSDarkmode = (
-                window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
-            ).toString();
-
-            if (localDarkmode === undefined) {
-                localStorage.setItem('documentation:darkmode', isOSDarkmode);
-            }
-
-            htmlEl.classList.add('no-transitions');
-            htmlEl.dataset.darkMode = localDarkmode !== undefined ? localDarkmode : isOSDarkmode;
-
-            const getDarkmode = () => htmlEl.dataset.darkMode === 'true';
-            htmlEl.dataset.agThemeMode = getDarkmode() ? 'dark-blue' : 'light';
-            htmlEl.offsetHeight; // Trigger a reflow, flushing the CSS changes
-            htmlEl.classList.remove('no-transitions');
-
-            // Set up dark mode on change listeners
-            const darkModeListeners = [];
-            globalThis.addDarkmodeOnChange = (onChange) => {
-                darkModeListeners.push(onChange);
-
-                // Run once on initialisation
-                onChange(getDarkmode());
-            };
-
-            // Listen to changes to html[data-dark-mode] attribute and notify listeners
-            const observer = new MutationObserver((mutations) => {
-                mutations.forEach((mutation) => {
-                    if (mutation.attributeName === 'data-dark-mode') {
-                        const newDarkmode = getDarkmode();
-                        darkModeListeners.forEach((listener) => {
-                            listener(newDarkmode);
-                        });
-                    }
-                });
-            });
-            observer.observe(htmlEl, { attributes: true });
-
-            if (localStorage.getItem('documentation:announcement-banner-dismissed') !== 'true') {
-                document.documentElement.dataset.showAnnouncement = 'true';
-            }
-        </script>
+        {
+            /* Authorised in script-src by SHA-256 hash (not 'unsafe-inline'); body lives in
+            @utils/csp/inlineScripts so the rendered bytes match the hashed source. */
+        }
+        <script is:inline set:html={DARK_MODE_INIT_SCRIPT} />
 
         {
             !isArchive && showAnnouncementBanner && (

--- a/documentation/ag-grid-docs/src/utils/csp/inlineScripts.ts
+++ b/documentation/ag-grid-docs/src/utils/csp/inlineScripts.ts
@@ -1,0 +1,72 @@
+/**
+ * Exact source of the main-page inline `<script>`s that are authorised by SHA-256
+ * hash in the Content-Security-Policy (instead of `'unsafe-inline'`).
+ *
+ * Single source of truth: these strings are rendered verbatim via
+ * `<script is:inline set:html={…} />` AND hashed for `script-src` in cspRules.ts.
+ * The browser hashes the exact bytes between `<script>` and `</script>`, so the
+ * rendered content and the hashed content MUST be identical — keep them flowing
+ * from this one constant and never edit the inline markup directly.
+ *
+ * Dependency-free (plain strings) so cspRules.ts can import it without pulling in
+ * the Astro/Vite build graph.
+ */
+
+// Dark-mode bootstrap. Runs render-blocking at the top of <body> so the first
+// paint is already in the correct theme (no flash); kept inline (not externalised)
+// to avoid adding a fetch before first paint. No server-injected values.
+export const DARK_MODE_INIT_SCRIPT = `
+    const htmlEl = document.querySelector('html');
+    const localDarkmode = localStorage['documentation:darkmode'];
+    const isOSDarkmode = (
+        window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+    ).toString();
+
+    if (localDarkmode === undefined) {
+        localStorage.setItem('documentation:darkmode', isOSDarkmode);
+    }
+
+    htmlEl.classList.add('no-transitions');
+    htmlEl.dataset.darkMode = localDarkmode !== undefined ? localDarkmode : isOSDarkmode;
+
+    const getDarkmode = () => htmlEl.dataset.darkMode === 'true';
+    htmlEl.dataset.agThemeMode = getDarkmode() ? 'dark-blue' : 'light';
+    htmlEl.offsetHeight; // Trigger a reflow, flushing the CSS changes
+    htmlEl.classList.remove('no-transitions');
+
+    // Set up dark mode on change listeners
+    const darkModeListeners = [];
+    globalThis.addDarkmodeOnChange = (onChange) => {
+        darkModeListeners.push(onChange);
+
+        // Run once on initialisation
+        onChange(getDarkmode());
+    };
+
+    // Listen to changes to html[data-dark-mode] attribute and notify listeners
+    const observer = new MutationObserver((mutations) => {
+        mutations.forEach((mutation) => {
+            if (mutation.attributeName === 'data-dark-mode') {
+                const newDarkmode = getDarkmode();
+                darkModeListeners.forEach((listener) => {
+                    listener(newDarkmode);
+                });
+            }
+        });
+    });
+    observer.observe(htmlEl, { attributes: true });
+
+    if (localStorage.getItem('documentation:announcement-banner-dismissed') !== 'true') {
+        document.documentElement.dataset.showAnnouncement = 'true';
+    }
+`;
+
+// Plausible analytics queue stub. The tagged-events script itself loads externally
+// (plausible.io, allow-listed); this only sets up window.plausible before it arrives.
+export const PLAUSIBLE_INIT_SCRIPT = `
+    window.plausible =
+        window.plausible ||
+        function () {
+            (window.plausible.q = window.plausible.q || []).push(arguments);
+        };
+`;

--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.test.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.test.ts
@@ -1,4 +1,10 @@
+import { createHash } from 'node:crypto';
+
+import { DARK_MODE_INIT_SCRIPT, PLAUSIBLE_INIT_SCRIPT } from '../csp/inlineScripts';
 import { CAMPAIGNS_PATH_CONDITION, getCspDirectives, getScopedCspHtaccessBlock } from './cspRules';
+
+const sha256Source = (source: string) => `'sha256-${createHash('sha256').update(source, 'utf8').digest('base64')}'`;
+const hasHash = (sources: string[]) => sources.some((s) => s.startsWith("'sha256-"));
 
 describe('cspRules', () => {
     describe('scope', () => {
@@ -28,29 +34,24 @@ describe('cspRules', () => {
             );
         });
 
-        it("scopes differ only by script-src 'unsafe-eval'", () => {
+        it('site and examples scopes differ only in script-src', () => {
             const site = getCspDirectives({ env: 'production', scope: 'site' });
             const examples = getCspDirectives({ env: 'production', scope: 'examples' });
 
             expect(Object.keys(examples)).toEqual(Object.keys(site));
-            const names = Object.keys(site);
-            for (let i = 0, len = names.length; i < len; ++i) {
-                const name = names[i];
-                if (name === 'script-src') {
-                    expect(examples[name]).toEqual([...site[name], "'unsafe-eval'"]);
-                } else {
-                    expect(examples[name]).toEqual(site[name]);
-                }
+            const otherNames = Object.keys(site).filter((name) => name !== 'script-src');
+            for (let i = 0, len = otherNames.length; i < len; ++i) {
+                expect(examples[otherNames[i]]).toEqual(site[otherNames[i]]);
             }
         });
 
-        it("both scopes keep 'unsafe-inline' in script-src and style-src", () => {
-            const site = getCspDirectives({ env: 'production', scope: 'site' });
-            const examples = getCspDirectives({ env: 'production', scope: 'examples' });
-            expect(site['script-src']).toContain("'unsafe-inline'");
-            expect(site['style-src']).toContain("'unsafe-inline'");
-            expect(examples['script-src']).toContain("'unsafe-inline'");
-            expect(examples['style-src']).toContain("'unsafe-inline'");
+        it("style-src keeps 'unsafe-inline' in every scope", () => {
+            const scopes = ['site', 'examples', 'campaigns'] as const;
+            for (let i = 0, len = scopes.length; i < len; ++i) {
+                expect(getCspDirectives({ env: 'production', scope: scopes[i] })['style-src']).toContain(
+                    "'unsafe-inline'"
+                );
+            }
         });
     });
 
@@ -68,21 +69,41 @@ describe('cspRules', () => {
             expect(campaigns['script-src']).not.toContain("'unsafe-eval'");
         });
 
-        it('differs from the site scope only by the bryntum.com origin', () => {
+        it('adds bryntum.com to style/font/connect-src on top of the site scope', () => {
             const site = getCspDirectives({ env: 'production', scope: 'site' });
             const campaigns = getCspDirectives({ env: 'production', scope: 'campaigns' });
 
-            expect(Object.keys(campaigns)).toEqual(Object.keys(site));
-            const names = Object.keys(site);
-            const broadened = ['script-src', 'style-src', 'font-src', 'connect-src'];
-            for (let i = 0, len = names.length; i < len; ++i) {
-                const name = names[i];
-                if (broadened.includes(name)) {
-                    expect(campaigns[name]).toEqual([...site[name], 'https://bryntum.com']);
-                } else {
-                    expect(campaigns[name]).toEqual(site[name]);
-                }
+            const broadened = ['style-src', 'font-src', 'connect-src'];
+            for (let i = 0, len = broadened.length; i < len; ++i) {
+                expect(campaigns[broadened[i]]).toEqual([...site[broadened[i]], 'https://bryntum.com']);
             }
+            // directives neither scope touches stay identical
+            expect(campaigns['frame-src']).toEqual(site['frame-src']);
+            expect(campaigns['form-action']).toEqual(site['form-action']);
+        });
+    });
+
+    describe("AG-17134 Phase B: script-src 'unsafe-inline' removed from the site scope", () => {
+        it('site scope authorises the inline scripts by hash, not unsafe-inline', () => {
+            const scriptSrc = getCspDirectives({ env: 'production', scope: 'site' })['script-src'];
+            expect(scriptSrc).not.toContain("'unsafe-inline'");
+            expect(scriptSrc).toContain(sha256Source(DARK_MODE_INIT_SCRIPT));
+            expect(scriptSrc).toContain(sha256Source(PLAUSIBLE_INIT_SCRIPT));
+        });
+
+        it('examples and campaigns keep unsafe-inline and carry no hashes', () => {
+            const scopes = ['examples', 'campaigns'] as const;
+            for (let i = 0, len = scopes.length; i < len; ++i) {
+                const scriptSrc = getCspDirectives({ env: 'production', scope: scopes[i] })['script-src'];
+                expect(scriptSrc).toContain("'unsafe-inline'");
+                expect(hasHash(scriptSrc)).toBe(false);
+            }
+        });
+
+        it('dev site keeps unsafe-inline (no hashes) for Vite/Astro HMR', () => {
+            const scriptSrc = getCspDirectives({ env: 'dev', scope: 'site' })['script-src'];
+            expect(scriptSrc).toContain("'unsafe-inline'");
+            expect(hasHash(scriptSrc)).toBe(false);
         });
     });
 

--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
@@ -37,6 +37,10 @@ export type CspDirectives = Record<string, string[]>;
 
 const SELF = "'self'";
 const NONE = "'none'";
+// In script-src, 'unsafe-inline' is now scope-specific: the 'site' policy
+// authorises its few known inline scripts by SHA-256 hash instead (see
+// SITE_SCRIPT_HASHES), while 'examples' and 'campaigns' still carry it. In
+// style-src it stays everywhere (Theming API runtime <style> injection).
 const UNSAFE_INLINE = "'unsafe-inline'";
 // Permits WebAssembly compilation without permitting JS eval() — narrower than
 // 'unsafe-eval'. Needed on every page: docs snippets are highlighted in the
@@ -51,6 +55,17 @@ const WASM_UNSAFE_EVAL = "'wasm-unsafe-eval'";
 // Ordinary site pages do not need it — the theme builder's CSS parser used to,
 // but now unescapes string literals without eval (see unescapeStringLiteral).
 const UNSAFE_EVAL = "'unsafe-eval'";
+
+// SHA-256 hashes authorising the main-page inline <script>s in the 'site' scope
+// instead of 'unsafe-inline' (sources in src/utils/csp/inlineScripts.ts; a unit
+// test recomputes these from the source strings to catch drift). Added ONLY to
+// the 'site' scope: per CSP2+, the presence of a hash makes the browser ignore
+// 'unsafe-inline', so the 'examples'/'campaigns' scopes — which still rely on
+// 'unsafe-inline' — must NOT carry them. Dev keeps 'unsafe-inline' (no hashes)
+// because the Vite/Astro dev server injects its own inline scripts.
+const DARK_MODE_SCRIPT_HASH = "'sha256-SWf+6gKXy9XEif5ewVdl93cg2NZaf7BwgIw95JlcJJQ='";
+const PLAUSIBLE_SCRIPT_HASH = "'sha256-yyPoC+PtF+Rve9JwzJ4PTIiap268jewQfmi4/JViA6I='";
+const SITE_SCRIPT_HASHES = [DARK_MODE_SCRIPT_HASH, PLAUSIBLE_SCRIPT_HASH];
 
 // The AG Grid × Bryntum partnership campaign pages embed a live Bryntum Gantt
 // demo that loads its bundle, stylesheet, Font Awesome webfonts and dataset from
@@ -142,8 +157,8 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://www.youtube.com', // YouTube iframe JS API (loads into the page)
             'https://cdn.cookielaw.org', // OneTrust cookie-consent SDK (GTM-injected, prod-only)
             'blob:', // ZoomInfo zi-tag.js bootstraps a blob: URL script
-            UNSAFE_INLINE,
             WASM_UNSAFE_EVAL,
+            // 'unsafe-inline' (examples/campaigns/dev) or SHA-256 hashes (site) added per scope below.
         ],
         // 'unsafe-inline' stays: the Theming API injects <style> elements at
         // runtime (live grids run directly on the homepage/demo pages), inline
@@ -215,13 +230,22 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
         'frame-ancestors': [SELF, AG_GRID_HOSTS], // allow *.ag-grid.com (e.g. blog) to embed examples
     };
 
+    // script-src inline handling, by scope (and environment for 'site').
     if (scope === 'examples') {
-        directives['script-src'].push(UNSAFE_EVAL);
+        directives['script-src'].push(UNSAFE_EVAL, UNSAFE_INLINE);
     } else if (scope === 'campaigns') {
-        directives['script-src'].push(BRYNTUM_HOST);
+        directives['script-src'].push(BRYNTUM_HOST, UNSAFE_INLINE);
         directives['style-src'].push(BRYNTUM_HOST);
         directives['font-src'].push(BRYNTUM_HOST);
         directives['connect-src'].push(BRYNTUM_HOST);
+    } else if (env === 'dev') {
+        // Dev server (Vite/Astro) injects its own inline scripts for HMR/hydration
+        // that the static build does not; keep 'unsafe-inline' locally rather than
+        // block them. The hash-based site policy is validated on staging/production.
+        directives['script-src'].push(UNSAFE_INLINE);
+    } else {
+        // 'site' on staging/production: authorise the known inline scripts by hash.
+        directives['script-src'].push(...SITE_SCRIPT_HASHES);
     }
 
     if (env === 'dev') {

--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
@@ -7,9 +7,13 @@
  *  - `htaccessRules.ts` to emit the `Content-Security-Policy` header into the
  *    generated `.htaccess`.
  *
- * Keep this module dependency-free so it can be imported by a standalone `tsx`
- * script without pulling in the Astro/Vite build graph.
+ * Keep this module free of Astro/Vite imports so it can be imported by a standalone
+ * `tsx` script without pulling in the build graph (Node built-ins and plain-string
+ * constants are fine — it is only ever imported build-side, never client-side).
  */
+import { createHash } from 'node:crypto';
+
+import { DARK_MODE_INIT_SCRIPT, PLAUSIBLE_INIT_SCRIPT } from '../csp/inlineScripts';
 
 export type CspEnv = 'dev' | 'staging' | 'production';
 export type CspMode = 'report-only' | 'enforce';
@@ -57,15 +61,20 @@ const WASM_UNSAFE_EVAL = "'wasm-unsafe-eval'";
 const UNSAFE_EVAL = "'unsafe-eval'";
 
 // SHA-256 hashes authorising the main-page inline <script>s in the 'site' scope
-// instead of 'unsafe-inline' (sources in src/utils/csp/inlineScripts.ts; a unit
-// test recomputes these from the source strings to catch drift). Added ONLY to
-// the 'site' scope: per CSP2+, the presence of a hash makes the browser ignore
+// instead of 'unsafe-inline'. Derived from the SAME constants the pages render
+// (src/utils/csp/inlineScripts.ts) so the policy can never drift from what is
+// served — edit the script and the hash follows automatically. Added ONLY to the
+// 'site' scope: per CSP2+, the presence of a hash makes the browser ignore
 // 'unsafe-inline', so the 'examples'/'campaigns' scopes — which still rely on
 // 'unsafe-inline' — must NOT carry them. Dev keeps 'unsafe-inline' (no hashes)
 // because the Vite/Astro dev server injects its own inline scripts.
-const DARK_MODE_SCRIPT_HASH = "'sha256-SWf+6gKXy9XEif5ewVdl93cg2NZaf7BwgIw95JlcJJQ='";
-const PLAUSIBLE_SCRIPT_HASH = "'sha256-yyPoC+PtF+Rve9JwzJ4PTIiap268jewQfmi4/JViA6I='";
-const SITE_SCRIPT_HASHES = [DARK_MODE_SCRIPT_HASH, PLAUSIBLE_SCRIPT_HASH];
+//
+// NB: this hashes the source string; the browser hashes the rendered bytes. They
+// match as long as Astro emits the inline script verbatim (verified in dev; the
+// production report-only window is the backstop before enforcing).
+const hashInlineScript = (source: string): string =>
+    `'sha256-${createHash('sha256').update(source, 'utf8').digest('base64')}'`;
+const SITE_SCRIPT_HASHES = [hashInlineScript(DARK_MODE_INIT_SCRIPT), hashInlineScript(PLAUSIBLE_INIT_SCRIPT)];
 
 // The AG Grid × Bryntum partnership campaign pages embed a live Bryntum Gantt
 // demo that loads its bundle, stylesheet, Font Awesome webfonts and dataset from

--- a/external/ag-website-shared/src/components/google-tag-manager/GoogleTagManager.astro
+++ b/external/ag-website-shared/src/components/google-tag-manager/GoogleTagManager.astro
@@ -1,5 +1,6 @@
 ---
 import { getIsStaging } from '@utils/env';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 
 interface Props {
     googleTagManagerId: string;
@@ -11,20 +12,13 @@ const { googleTagManagerId, googleTagManagerAuth, googleTagManagerPreview } = As
 const extraParams = getIsStaging() ? `&gtm_auth=${googleTagManagerAuth}&gtm_preview=${googleTagManagerPreview}` : '';
 ---
 
+{
+    /* Externalised (was an inline define:vars bootstrap) so the site CSP can drop
+    script-src 'unsafe-inline'; config passes via data- attributes. Must stay a
+    classic, non-deferred script so document.currentScript resolves in the loader. */
+}
 <script
-    define:vars={{
-        googleTagManagerId,
-        extraParams,
-    }}
->
-    (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
-        var f = d.getElementsByTagName(s)[0],
-            j = d.createElement(s),
-            dl = l != 'dataLayer' ? '&l=' + l : '';
-        j.async = true;
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl + extraParams + '&gtm_cookies_win=x';
-        f.parentNode.insertBefore(j, f);
-    })(window, document, 'script', 'dataLayer', googleTagManagerId);
-</script>
+    is:inline
+    src={urlWithBaseUrl('/scripts/gtm-init.js')}
+    data-gtm-id={googleTagManagerId}
+    data-gtm-extra={extraParams}></script>


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17134

## Summary

Phase B of the CSP tightening (follows the eval-removal work, now in production report-only). Removes `'unsafe-inline'` from the **`site`** scope `script-src`. `style-src 'unsafe-inline'` is untouched (permanent — Theming API injects `<style>` at runtime; static hosting rules out nonces).

Inline-script handling, by scope (reusing the Phase A path-scoped `<If>` machinery):

| scope | `script-src` inline handling |
|---|---|
| **site** | SHA-256 hash per inline script, **no** `'unsafe-inline'` |
| examples | `'unsafe-eval'` + `'unsafe-inline'` (example runner), no hashes |
| campaigns | `bryntum.com` + `'unsafe-inline'` (Bryntum demo), no hashes |

Per CSP2+, a hash in `script-src` makes the browser ignore `'unsafe-inline'`, so hashes go **only** in the `site` scope; the scopes that still rely on `'unsafe-inline'` carry no hashes. Dev keeps `'unsafe-inline'` (Vite/Astro inject their own inline scripts).

## The main-page inline scripts

- **Dark-mode bootstrap** + **Plausible stub** → kept inline, authorised by **SHA-256 hash**. Dark-mode is render-blocking and paint-critical, so externalising it (adding a fetch before first paint) was rejected. Bodies extracted to `src/utils/csp/inlineScripts.ts` — single source of truth, rendered via `set:html` so the rendered bytes equal the hashed source. The hashes are derived in `cspRules.ts` from those same source strings (build-only `node:crypto`), so the policy can never drift from what is rendered.
- **GTM bootstrap** (`define:vars`, shared `GoogleTagManager.astro`) → **externalised** to `/scripts/gtm-init.js`, config via `data-` attributes.

## Rollout

The `site` policy is still **report-only on production** via the existing `PRODUCTION_CSP_PHASE`, so this **reports, does not enforce**. Per the agreed plan, the enforce flip is gated on a **GTM container audit** (runtime Custom HTML tags can inject inline scripts the repo can't control) — the report-only window surfaces these.

## Test plan

- `nx run ag-grid-docs:test:vitest` — site scope has the two sha256 + no `unsafe-inline`; examples/campaigns keep `unsafe-inline` + no hashes; dev keeps `unsafe-inline`; hash drift guard. All 454 pass.
- Format + lint clean.
- Dev server: verified the rendered dark-mode inline script hashes **identically** to the CSP constant, and `/scripts/gtm-init.js` serves.
- **Before enforce:** confirm on a real build/report-only window that the prod (compressed-HTML) inline-script hashes still match, and watch for GTM-injected inline-script violations.

## Note for reviewers

The `GoogleTagManager.astro` change is in the **`ag-website-shared` subrepo** — it should be upstreamed via `git-subrepo` to the canonical repo so the grid/charts/studio copies don't drift. The same change is applied in the charts and studio PRs.