### PR TITLE
Fix broken showValueAsConfig doc link after custom-modes removal

### DIFF
--- a/documentation/ag-grid-docs/src/content/api-documentation/column-properties/properties.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/column-properties/properties.json
@@ -559,8 +559,8 @@
         "showValueAsInitial": {},
         "showValueAsConfig": {
             "more": {
-                "name": "Custom Modes",
-                "url": "./aggregation-show-values-as/#custom-modes"
+                "name": "Configuration",
+                "url": "./aggregation-show-values-as/#configuration"
             }
         }
     },


### PR DESCRIPTION
## Summary

- The `#custom-modes` anchor was removed from the `aggregation-show-values-as` page in #14090 (AG-17573), leaving a dangling link in `column-properties/properties.json`.
- Updated `showValueAsConfig`'s `more` link to point to the `#configuration` section, which is the relevant section for this property.

## Test plan

- [ ] Verify the docs build passes without "Invalid links found" errors.
- [ ] Confirm `showValueAsConfig` in the Column Properties API reference links correctly to the Configuration section of the Show Values As page.