### PR TITLE
ci(setup-nx): run yarn postinstall under cache_mode: ro

### DIFF
--- a/.github/actions/setup-nx/action.yml
+++ b/.github/actions/setup-nx/action.yml
@@ -165,22 +165,15 @@ runs:
           with:
               node-version-file: package.json
 
-        # NOTE: `if:` is intentionally NOT gated on cache_mode — the input is
-        # documented as "Always ensure yarn postinstall is run." Gating it on
-        # `cache_mode == 'rw'` (the previous behaviour) silently skipped
-        # postinstall under `cache_mode: ro`, so repo-local postinstall steps
-        # (e.g. setup-prompts.sh, which renders .claude/settings.json for the
-        # JIRA agent pipeline) never ran on a read-only cache hit.
+        # Not gated on cache_mode: yarn_postinstall is documented as "always", and gating
+        # on rw skipped postinstall (e.g. setup-prompts.sh) on read-only cache hits.
         - name: yarn install
           if: inputs.yarn_postinstall == 'true'
           id: yarn_install_slow
           shell: bash
           env:
-              # 'true' only on an exact key hit; an inexact restore-keys fallback can carry a stale hoisting layout.
-              # Compare each step's output explicitly against 'true' rather than relying on string truthiness:
-              # `actions/cache` sets cache-hit to the string 'false' on a restore-key fallback (which is truthy in
-              # GHA expressions), and a skipped cache step yields ''. The active step (rw xor ro) is the only one
-              # with a non-empty value, so an explicit `== 'true'` on each is unambiguous regardless of which ran.
+              # Exact key hit only — a restore-key fallback reports the string 'false' and the inactive
+              # step (rw xor ro) yields '', so compare each explicitly against 'true' rather than truthiness.
               EXACT_CACHE_HIT: ${{ steps.cache_rw.outputs.cache-hit == 'true' || steps.cache_ro.outputs.cache-hit == 'true' }}
           run: |
               if [[ "${EXACT_CACHE_HIT}" != "true" ]] ; then

--- a/.github/actions/setup-nx/action.yml
+++ b/.github/actions/setup-nx/action.yml
@@ -177,7 +177,11 @@ runs:
           shell: bash
           env:
               # 'true' only on an exact key hit; an inexact restore-keys fallback can carry a stale hoisting layout.
-              EXACT_CACHE_HIT: ${{ steps.cache_rw.outputs.cache-hit || steps.cache_ro.outputs.cache-hit }}
+              # Compare each step's output explicitly against 'true' rather than relying on string truthiness:
+              # `actions/cache` sets cache-hit to the string 'false' on a restore-key fallback (which is truthy in
+              # GHA expressions), and a skipped cache step yields ''. The active step (rw xor ro) is the only one
+              # with a non-empty value, so an explicit `== 'true'` on each is unambiguous regardless of which ran.
+              EXACT_CACHE_HIT: ${{ steps.cache_rw.outputs.cache-hit == 'true' || steps.cache_ro.outputs.cache-hit == 'true' }}
           run: |
               if [[ "${EXACT_CACHE_HIT}" != "true" ]] ; then
                 # Fallback restore: wipe node_modules so install rebuilds hoisting from this lockfile, avoiding stale-layout cache poisoning.

--- a/.github/actions/setup-nx/action.yml
+++ b/.github/actions/setup-nx/action.yml
@@ -62,7 +62,7 @@ runs:
           shell: bash
           run: |
             set -x
-            
+
             branch=$(git branch --show-current)
             if [[ ${branch} == 'latest' ]] ; then
               # Latest
@@ -165,12 +165,34 @@ runs:
           with:
               node-version-file: package.json
 
+        # NOTE: `if:` is intentionally NOT gated on cache_mode — the input is
+        # documented as "Always ensure yarn postinstall is run." Gating it on
+        # `cache_mode == 'rw'` (the previous behaviour) silently skipped
+        # postinstall under `cache_mode: ro`, so repo-local postinstall steps
+        # (e.g. setup-prompts.sh, which renders .claude/settings.json for the
+        # JIRA agent pipeline) never ran on a read-only cache hit.
         - name: yarn install
-          if: inputs.cache_mode == 'rw' && inputs.yarn_postinstall == 'true'
+          if: inputs.yarn_postinstall == 'true'
           id: yarn_install_slow
           shell: bash
+          env:
+              # 'true' only on an exact key hit; an inexact restore-keys fallback can carry a stale hoisting layout.
+              EXACT_CACHE_HIT: ${{ steps.cache_rw.outputs.cache-hit || steps.cache_ro.outputs.cache-hit }}
           run: |
-              (yarn check --integrity && yarn postinstall) || yarn install --ci
+              if [[ "${EXACT_CACHE_HIT}" != "true" ]] ; then
+                # Fallback restore: wipe node_modules so install rebuilds hoisting from this lockfile, avoiding stale-layout cache poisoning.
+                rm -rf node_modules packages/*/node_modules plugins/*/node_modules community-modules/*/node_modules testing/*/node_modules documentation/*/node_modules external/*/node_modules
+                yarn install --ci
+                yarn check --integrity
+              elif (yarn check --integrity) ; then
+                yarn postinstall
+              else
+                yarn install --ci
+
+                # Ensure that the integrity check passes after install to avoid
+                # cache polution with entries that will fail future integrity checks.
+                yarn check --integrity
+              fi
 
         - name: yarn install (skipping postinstall)
           if: inputs.cache_mode == 'rw' && inputs.yarn_postinstall != 'true'


### PR DESCRIPTION
## Problem

`setup-nx`'s `yarn install` step is gated on `cache_mode == 'rw'`:

```yaml
- name: yarn install
  if: inputs.cache_mode == 'rw' && inputs.yarn_postinstall == 'true'
```

Under `cache_mode: ro` (a read-only cache hit), **neither** install branch matches, so `yarn install`/`yarn postinstall` never run. That silently skips every repo-local postinstall step on read-only runs — in particular `external/ag-shared/scripts/setup-prompts/setup-prompts.sh`, which renders `.claude/settings.json`.

The **JIRA agent pipeline** invokes `setup-nx` with `cache_mode: ro`, then its `setup-jira-agent` precondition fails:

```
[setup-jira-agent] .claude/settings.json not found in workspace.
```

Failing run: https://github.com/ag-grid/ag-grid/actions/runs/27624859897 (job `agent-run`)

This contradicts the input's own documented contract — *"Always ensure yarn postinstall is run."* — and diverges from `ag-charts`' `setup-nx`, where the postinstall step is not cache_mode-gated.

## Fix

- Drop the `cache_mode == 'rw' &&` clause from the postinstall step's `if:` so it fires whenever `yarn_postinstall == 'true'`, regardless of cache mode.
- Adopt ag-charts' `EXACT_CACHE_HIT`-aware install body: an exact key hit runs just `yarn postinstall`; an inexact `restore-keys` fallback wipes `node_modules` and does a full `yarn install --ci` (avoids stale-hoisting cache poisoning). The `rm -rf` glob list uses **ag-grid's** workspace dirs; **cache keys are unchanged**.
- The "skipping postinstall" branch stays `cache_mode == 'rw'`-gated, so `ro + non-true` callers are unaffected.

### Behavior matrix

| cache_mode | yarn_postinstall | before | after |
|---|---|---|---|
| `ro` | `true` (pipeline) | nothing ran ❌ | install block → `yarn postinstall` ✅ |
| `rw` | `true` | install+postinstall | same (now stale-hoisting-safe) |
| `rw` | non-true | skipping branch | unchanged |
| `ro` | non-true | nothing | unchanged |

Only the broken cell changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)