### PR TITLE
AG-15505 [Integrated Charts] - Adapt padding panel to ag-charts Padding type

### DIFF
--- a/packages/ag-grid-enterprise/src/charts/chartComp/menu/format/chart/paddingPanel.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/menu/format/chart/paddingPanel.ts
@@ -1,4 +1,4 @@
-import type { AgChartPaddingOptions, AgChartThemeOverrides } from 'ag-charts-types';
+import type { AgChartThemeOverrides, PaddingOptions } from 'ag-charts-types';
 import { RefPlaceholder } from 'ag-stack';
 
 import type { BeanCollection } from 'ag-grid-community';
@@ -35,7 +35,7 @@ export class PaddingPanel extends Component {
             title: this.chartTranslation.translate('padding'),
             suppressEnabledCheckbox: true,
         };
-        const getSliderParams = (property: keyof AgChartPaddingOptions) =>
+        const getSliderParams = (property: keyof PaddingOptions) =>
             this.chartMenuUtils.getDefaultSliderParams('padding.' + property, property, 200);
 
         this.setTemplate(
@@ -67,7 +67,10 @@ export class PaddingPanel extends Component {
     private updateTopPadding(chartOptions: AgChartThemeOverrides) {
         // keep 'top' padding in sync with chart as toggling chart title on / off change the 'top' padding
         const topPadding = [...this.chartController.getChartSeriesTypes(), 'common']
-            .map((seriesType: ChartThemeOverridesSeriesType) => chartOptions?.[seriesType]?.padding?.top)
+            .map((seriesType: ChartThemeOverridesSeriesType) => {
+                const padding = chartOptions?.[seriesType]?.padding;
+                return typeof padding === 'number' ? padding : padding?.top;
+            })
             .find((value) => value != null);
         if (topPadding != null) {
             this.paddingTopSlider.setValue(`${topPadding}`);


### PR DESCRIPTION
## What

Fixes the `ag-grid-enterprise` build failure against **ag-charts `latest`**, caught by the [Integrated Charts Test](https://github.com/ag-grid/ag-charts/actions/runs/27674001474/job/81844771830) scheduled check in the ag-charts repo.

## Why

ag-charts [`AG-15505`](https://github.com/ag-grid/ag-charts/commit/ef43127e34c46f3fcfe1a235bdd471f849fc978c) replaced the exported `AgChartPaddingOptions` interface with the `Padding` type (`number | PaddingOptions`) on themeable chart options. `paddingPanel.ts` still:

1. imported the now-removed `AgChartPaddingOptions`, and
2. assumed the `padding` theme override was always an object (`padding?.top`),

producing 4 TypeScript errors (`TS2724`, `TS2469`, `TS2345`, `TS2339`).

## Changes

- Import `PaddingOptions` in place of `AgChartPaddingOptions`. It is structurally identical, so `keyof PaddingOptions` yields the same `'top' | 'right' | 'bottom' | 'left'` slider keys.
- When reading the top padding, handle `padding` now being a single `number` (uniform padding) as well as an object.

## Forward compatibility

The change compiles against **both** ag-charts `latest` (where `padding` is `number | PaddingOptions`) and the currently pinned `ag-charts-types` beta (where `padding` is still object-only) — `PaddingOptions` has existed since well before the pinned version, and the `typeof === 'number'` guard is valid TypeScript in both. So merge ordering relative to the ag-charts release is unconstrained.

## Verification

`nx build:types ag-grid-enterprise` compiles `paddingPanel.ts` cleanly against the installed beta. The authoritative cross-repo check is the ag-charts *Integrated Charts Test* workflow (`workflow_dispatch` enabled), which re-clones this branch's target and rebuilds.