### PR TITLE
fix(AG-17580): prevent auto-size resize-queue infinite loop

### DIFF
--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
@@ -573,9 +573,6 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
 
     public processResizeOperations(): void {
         this.shouldQueueResizeOperations = false;
-        // Snapshot and reset before draining: an operation may re-arm shouldQueueResizeOperations
-        // and re-queue itself, so draining the live array would never exhaust. Re-queued operations
-        // land in the fresh array and are drained by the next call.
         const operations = this.resizeOperationQueue;
         this.resizeOperationQueue = [];
         for (let i = 0, len = operations.length; i < len; ++i) {

--- a/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
+++ b/packages/ag-grid-community/src/columnAutosize/columnAutosizeService.ts
@@ -573,10 +573,14 @@ export class ColumnAutosizeService extends BeanStub implements NamedBean {
 
     public processResizeOperations(): void {
         this.shouldQueueResizeOperations = false;
-        for (const resizeOperation of this.resizeOperationQueue) {
-            resizeOperation();
-        }
+        // Snapshot and reset before draining: an operation may re-arm shouldQueueResizeOperations
+        // and re-queue itself, so draining the live array would never exhaust. Re-queued operations
+        // land in the fresh array and are drained by the next call.
+        const operations = this.resizeOperationQueue;
         this.resizeOperationQueue = [];
+        for (let i = 0, len = operations.length; i < len; ++i) {
+            operations[i]();
+        }
     }
 
     public pushResizeOperation(func: () => void): void {


### PR DESCRIPTION
## Summary

Fixes a synchronous infinite loop (tab freeze, unbounded memory growth) that occurs when two auto-size operations are pending during a row-data update on the React wrapper.

`ColumnAutosizeService.processResizeOperations` drained the **live** `resizeOperationQueue` with a `for...of` loop and only cleared it afterwards. The React `RenderStatusService` re-arms `shouldQueueResizeOperations` when `rowExpansionStateChanged` fires during the drain, so each queued `innerAutoSizeCols` saw the flag set and pushed itself back onto the array being iterated — the iterator never exhausted.

The fix snapshots and resets the queue **before** draining. Operations re-queued mid-drain land in the fresh array and are picked up by the next scheduled `processResizeOperations` call (every site that re-arms the flag also schedules a follow-up drain), so no work is lost.

## Test plan

- `yarn nx build:types ag-grid-community` — passes
- `yarn nx lint ag-grid-community` — passes
- Reproduction: Tree Data + React wrapper, `onRowDataUpdated` expands a collapsed group and triggers two `api.autoSizeColumns` calls; previously froze the tab, now expands and auto-sizes once while staying responsive.

Fix [AG-17580](https://ag-grid.atlassian.net/browse/AG-17580)