### PR TITLE
Free disk space in setup-nx to avoid runner ENOSPC

### DIFF
--- a/.github/actions/setup-nx/action.yml
+++ b/.github/actions/setup-nx/action.yml
@@ -40,6 +40,12 @@ outputs:
 runs:
     using: 'composite'
     steps:
+        - name: Free disk space
+          if: runner.os == 'Linux'
+          shell: bash
+          run: |
+              sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
+
         - name: Set Nx parallelization
           shell: bash
           run: |


### PR DESCRIPTION
Adds a Linux-only `Free disk space` step at the start of the `setup-nx` composite action, removing large preinstalled toolchains (dotnet, android, ghc, boost, hosted tool cache) before the disk-heavy `node_modules`/Nx cache restore and `yarn install`.

### Why
CI has intermittently failed with `System.IO.IOException: No space left on device` during the shared Setup step. Jobs run on standard `ubuntu-24.04` runners (~14 GB free disk); the cache restore + install can exhaust it. Centralising the cleanup in `setup-nx` means every job that uses it benefits.

### Notes
- Guarded with `if: runner.os == 'Linux'` so it is a no-op on non-Linux (e.g. macOS) runners.
- `shell: bash` is required for composite-action `run` steps.