### PR TITLE
Make l10n translation review comment less verbose

### DIFF
--- a/external/ag-shared/scripts/l10n/review-translations.mjs
+++ b/external/ag-shared/scripts/l10n/review-translations.mjs
@@ -114,7 +114,7 @@ async function main() {
         'Review ONLY the changed lines shown in the diffs, using en-US.ts for context.',
         'Flag: mistranslations or wrong meaning; altered, missing, or mistranslated placeholders/formatters; inappropriate tone or register for product UI / screen-reader text; obviously unnatural phrasing.',
         'Do NOT flag stylistic preferences where the translation is correct, or anything outside the changed lines.',
-        'Output concise GitHub-flavoured Markdown grouped by locale, each finding as a bullet citing the key. If a locale has no issues, say so in one line. If nothing is concerning across all locales, respond with a single line stating translations look correct.',
+        'Output concise GitHub-flavoured Markdown. If nothing is concerning across all locales, respond with a single line stating translations look correct. Otherwise, add a `### <locale>` section ONLY for locales that have issues, each finding as a bullet citing the key; then end with one line listing all the locales with no issues together, e.g. "No issues found in: de-DE, fr-FR, ja-JP." Never give a clean locale its own heading.',
     ].join('\n');
 
     const userText = `## en-US.ts (source of truth, for context)\n\n\`\`\`typescript\n${enUs}\n\`\`\`\n\n## Changed translations to review\n\n${diffs}`;


### PR DESCRIPTION
**Stacked on #14110** (which introduces the review script to this repo via ag-shared). Base is `at/l10n-advisory-review`.

Tweaks the advisory l10n translation-review output so it no longer adds a `### <locale>` heading for every locale. Now: a single line when all clean; otherwise only locales **with** findings get a section, and all clean locales are summarised on one line (e.g. "No issues found in: de-DE, fr-FR, ja-JP"). Previously every locale — including clean ones — got its own block, making the comment very long on PRs touching all 31 locales.

One-line change to the shared review script's system prompt. The change is already on the `ag-shared` source (`latest`) via the companion ag-charts PR (#7142) `subrepo push`; this commit mirrors it so Grid carries it now rather than waiting for the next ag-shared pull. The content is byte-identical to the ag-shared source, so a future `subrepo pull` reconciles cleanly.