### PR TITLE
AG-17587: Clear selectable filters when restoring grid state

### DIFF
--- a/packages/ag-grid-community/src/interfaces/gridState.ts
+++ b/packages/ag-grid-community/src/interfaces/gridState.ts
@@ -6,6 +6,13 @@ import type { RowPosition } from './iRowPosition';
 import type { SortModelItem } from './iSortModelItem';
 import type { ServerSideRowGroupSelectionState, ServerSideRowSelectionState } from './selectionState';
 
+/**
+ * Currently selected filters when using the new filter tool panel with `agSelectableColumnFilter`, keyed by column id.
+ */
+export interface SelectableFilterState {
+    [colId: string]: number;
+}
+
 export interface FilterState {
     /**
      * Filter model for Column Filters
@@ -22,7 +29,7 @@ export interface FilterState {
     /**
      * Currently selected filter when using new filter tool panel with `agSelectableColumnFilter`
      */
-    selectableFilters?: { [colId: string]: number };
+    selectableFilters?: SelectableFilterState;
 }
 
 export interface CellSelectionCellState {

--- a/packages/ag-grid-community/src/interfaces/iNewFiltersToolPanel.ts
+++ b/packages/ag-grid-community/src/interfaces/iNewFiltersToolPanel.ts
@@ -2,7 +2,7 @@ import type { IEventEmitter } from 'ag-stack';
 
 import type { AgColumn } from '../entities/agColumn';
 import type { ValueGetterFunc } from '../entities/colDef';
-import type { NewFiltersToolPanelState } from './gridState';
+import type { NewFiltersToolPanelState, SelectableFilterState } from './gridState';
 import type { IAfterGuiAttachedParams } from './iAfterGuiAttachedParams';
 import type { FilterAction, FilterWrapperParams, IFilterDef } from './iFilter';
 import type { IToolPanel, IToolPanelNewFiltersCompParams } from './iToolPanel';
@@ -99,6 +99,6 @@ export interface ISelectableFilterService extends IEventEmitter<'selectedFilterC
     ): { filterDefs: SelectableFilterDef[]; activeFilterDef: SelectableFilterDef } | undefined;
     setActive(colId: string, filterDefs: SelectableFilterDef[], activeFilterDef: SelectableFilterDef): void;
     clearActive(colId: string): void;
-    getState(): { [colId: string]: number };
-    setState(state: { [colId: string]: number }): void;
+    getState(): SelectableFilterState | undefined;
+    setState(state: SelectableFilterState | undefined): void;
 }

--- a/packages/ag-grid-community/src/main.ts
+++ b/packages/ag-grid-community/src/main.ts
@@ -636,6 +636,7 @@ export type {
     RowGroupState,
     RowPinningState,
     ScrollState,
+    SelectableFilterState,
     SideBarState,
     SortState,
 } from './interfaces/gridState';

--- a/packages/ag-grid-community/src/misc/state/stateService.ts
+++ b/packages/ag-grid-community/src/misc/state/stateService.ts
@@ -635,7 +635,7 @@ export class StateService extends BeanStub implements NamedBean {
             advancedFilterModel: null,
         };
         if (selectableFilters !== undefined) {
-            selectableFilter?.setState(selectableFilters ?? {});
+            selectableFilter?.setState(selectableFilters);
         }
         if (filterModel !== undefined || columnFilterState !== undefined) {
             filterManager?.setFilterState(filterModel ?? null, columnFilterState ?? null, 'columnFilter');

--- a/packages/ag-grid-community/src/misc/state/stateService.ts
+++ b/packages/ag-grid-community/src/misc/state/stateService.ts
@@ -633,9 +633,10 @@ export class StateService extends BeanStub implements NamedBean {
             filterModel: null,
             columnFilterState: null,
             advancedFilterModel: null,
+            selectableFilters: null,
         };
         if (selectableFilters !== undefined) {
-            selectableFilter?.setState(selectableFilters);
+            selectableFilter?.setState(selectableFilters ?? undefined);
         }
         if (filterModel !== undefined || columnFilterState !== undefined) {
             filterManager?.setFilterState(filterModel ?? null, columnFilterState ?? null, 'columnFilter');

--- a/packages/ag-grid-enterprise/src/filterToolPanel/newFilterToolPanel/selectableFilterService.ts
+++ b/packages/ag-grid-enterprise/src/filterToolPanel/newFilterToolPanel/selectableFilterService.ts
@@ -5,6 +5,7 @@ import type {
     NamedBean,
     SelectableFilterDef,
     SelectableFilterParams,
+    SelectableFilterState,
     ValueGetterFunc,
 } from 'ag-grid-community';
 import {
@@ -172,19 +173,21 @@ export class SelectableFilterService
         this.onChange();
     }
 
-    public getState(): { [colId: string]: number } {
-        return Object.fromEntries(this.selectedFilters);
+    public getState(): SelectableFilterState | undefined {
+        return this.selectedFilters.size > 0 ? Object.fromEntries(this.selectedFilters) : undefined;
     }
 
-    public setState(state: { [colId: string]: number }): void {
+    public setState(state: SelectableFilterState | undefined): void {
         this.clearAll();
-        const colModel = this.beans.colModel;
-        for (const colId of Object.keys(state)) {
-            const column = colModel.getNonPivotColById(colId);
-            if (column) {
-                const defs = this.getDefs(column, column.colDef, state[colId]);
-                if (defs) {
-                    this.setActive(colId, defs.filterDefs, defs.activeFilterDef, true);
+        if (state) {
+            const colModel = this.beans.colModel;
+            for (const colId of Object.keys(state)) {
+                const column = colModel.getNonPivotColById(colId);
+                if (column) {
+                    const defs = this.getDefs(column, column.colDef, state[colId]);
+                    if (defs) {
+                        this.setActive(colId, defs.filterDefs, defs.activeFilterDef, true);
+                    }
                 }
             }
         }

--- a/testing/behavioural/src/grid-state/grid-state-full.test.ts
+++ b/testing/behavioural/src/grid-state/grid-state-full.test.ts
@@ -81,12 +81,7 @@ describe('Grid State Full Snapshot', () => {
                 ],
             },
             columnVisibility: undefined,
-            filter: {
-                advancedFilterModel: undefined,
-                columnFilterState: undefined,
-                filterModel: undefined,
-                selectableFilters: {},
-            },
+            filter: undefined,
             focusedCell: undefined,
             pagination: {
                 page: 0,
@@ -240,12 +235,7 @@ describe('Grid State Full Snapshot', () => {
             columnVisibility: {
                 hiddenColIds: ['age'],
             },
-            filter: {
-                advancedFilterModel: undefined,
-                columnFilterState: undefined,
-                filterModel: undefined,
-                selectableFilters: {},
-            },
+            filter: undefined,
             pagination: {
                 page: 0,
                 pageSize: 2,

--- a/testing/behavioural/src/grid-state/grid-state.test.ts
+++ b/testing/behavioural/src/grid-state/grid-state.test.ts
@@ -1122,12 +1122,7 @@ describe('StateService - Grid State Management', () => {
                 └── LEAF id:4 id:"5" name:"Eve" age:32 sport:"Swimming"
             `);
 
-            expect(api.getState().filter).toEqual({
-                advancedFilterModel: undefined,
-                columnFilterState: undefined,
-                filterModel: undefined,
-                selectableFilters: {},
-            });
+            expect(api.getState().filter).toBeUndefined();
 
             // Apply filter - using the filter manager API
             api.setFilterModel({
@@ -1150,8 +1145,47 @@ describe('StateService - Grid State Management', () => {
                         type: 'startsWith',
                     },
                 },
-                selectableFilters: {},
+                selectableFilters: undefined,
             });
+        });
+
+        test('setState with an empty filter state clears active filters', async () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: defaultColumnDefs,
+                rowData: defaultRowData,
+                defaultColDef: { filter: 'agTextColumnFilter' },
+            });
+
+            // Apply a filter and capture the state with filters active
+            api.setFilterModel({ name: { filterType: 'text', type: 'startsWith', filter: 'A' } });
+            await asyncSetTimeout(50);
+            const stateWithFilter = api.getState();
+
+            // Clear filters and capture the state with no filters
+            api.setFilterModel(null);
+            await asyncSetTimeout(50);
+            const stateWithoutFilter = api.getState();
+            expect(stateWithoutFilter.filter).toBeUndefined();
+
+            // Restore the filtered state
+            api.setState(stateWithFilter);
+            await asyncSetTimeout(50);
+            await new GridRows(api, `setState restores filter`).check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:0 id:"1" name:"Alice" age:30 sport:"Football"
+            `);
+
+            // Restoring the empty state must clear the active filters
+            api.setState(stateWithoutFilter);
+            await asyncSetTimeout(50);
+            await new GridRows(api, `setState clears filter`).check(`
+                ROOT id:ROOT_NODE_ID
+                ├── LEAF id:0 id:"1" name:"Alice" age:30 sport:"Football"
+                ├── LEAF id:1 id:"2" name:"Bob" age:25 sport:"Tennis"
+                ├── LEAF id:2 id:"3" name:"Charlie" age:35 sport:"Golf"
+                ├── LEAF id:3 id:"4" name:"David" age:28 sport:"Basketball"
+                └── LEAF id:4 id:"5" name:"Eve" age:32 sport:"Swimming"
+            `);
         });
 
         test('should serialise bigint filter state and rehydrate on setState', async () => {

--- a/testing/behavioural/src/grid-state/grid-state.test.ts
+++ b/testing/behavioural/src/grid-state/grid-state.test.ts
@@ -1188,6 +1188,27 @@ describe('StateService - Grid State Management', () => {
             `);
         });
 
+        test('setState with an empty state clears active selectable filters', async () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: defaultColumnDefs,
+                rowData: defaultRowData,
+                defaultColDef: { filter: 'agSelectableColumnFilter' },
+                sideBar: 'filters-new',
+                enableFilterHandlers: true,
+            });
+            await asyncSetTimeout(50);
+
+            // Activate a selectable filter via state restore
+            api.setState({ filter: { selectableFilters: { name: 0 } } });
+            await asyncSetTimeout(50);
+            expect(api.getState().filter?.selectableFilters).toEqual({ name: 0 });
+
+            // Restoring a state without a filter section must clear the active selectable filter
+            api.setState({});
+            await asyncSetTimeout(50);
+            expect(api.getState().filter).toBeUndefined();
+        });
+
         test('should serialise bigint filter state and rehydrate on setState', async () => {
             const columnDefs = [{ field: 'id', cellDataType: 'bigint', filter: 'agBigIntColumnFilter' }];
             const rowData = [{ id: 1n }, { id: 2n }, { id: 3n }];


### PR DESCRIPTION
## Summary

`api.setState(...)` (and state restore generally) failed to clear active **selectable filters** when the restored state had no filter section, even though it correctly cleared column filters. This left a selectable filter active after restoring a "no filters" snapshot — inconsistent with column-filter behaviour and a regression versus the prior empty-object (`{}`) state shape.

## Changes

- **`FilterState` typing** — extracted the selectable-filter map into an exported `SelectableFilterState` interface; `ISelectableFilterService.getState/setState` and the new public export updated accordingly.
- **`SelectableFilterService.getState()`** now returns `undefined` (not `{}`) when no selectable filters are active, so an empty filter state serialises to `filter: undefined`.
- **`StateService.setFilterState()`** — when restoring a state with no filter section, the selectable-filter restore now resolves to `undefined` and calls `setState(undefined)`, clearing any active selectable filters. This mirrors the column-filter path (which clears via a `null` default). Previously the caller's `!== undefined` guard skipped the call entirely, leaving the `setState(undefined)` handling unreachable.

## Test plan

- Updated `grid-state-full` and `grid-state` expectations to reflect `filter: undefined` for the empty case.
- Added behavioural test: restoring an empty column-filter state clears active column filters.
- Added behavioural test: restoring an empty state clears active selectable filters (verified to fail without the `StateService` fix).
- `yarn nx build:types` + `yarn nx lint` green for community and enterprise; full `grid-state` behavioural suite (39 tests) passing.

Fix [AG-17587](https://ag-grid.atlassian.net/browse/AG-17587)