### PR TITLE
AG-17586 Preserve pinned grand total row across pinned-row state reset

### DIFF
--- a/packages/ag-grid-community/src/pinnedRowModel/manualPinnedRowModel.ts
+++ b/packages/ag-grid-community/src/pinnedRowModel/manualPinnedRowModel.ts
@@ -11,7 +11,7 @@ import type { RowPinningState } from '../interfaces/gridState';
 import type { IClientSideRowModel } from '../interfaces/iClientSideRowModel';
 import type { IPinnedRowModel } from '../interfaces/iPinnedRowModel';
 import type { RowPinnedType } from '../interfaces/iRowNode';
-import { PinnedRows, _shouldHidePinnedRows } from './manualPinnedRowUtils';
+import { PinnedRows, _isPinnedNodeGrandTotal, _shouldHidePinnedRows } from './manualPinnedRowUtils';
 
 export class ManualPinnedRowModel extends BeanStub implements IPinnedRowModel {
     private top: PinnedRows;
@@ -98,10 +98,22 @@ export class ManualPinnedRowModel extends BeanStub implements IPinnedRowModel {
     public reset(dispatch = true): void {
         this.forContainers((container) => {
             const nodesToUnpin: RowNode[] = [];
-            container.forEach((n) => nodesToUnpin.push(n));
+            // The grand total row is owned by the `grandTotalRow` option, not manual row-pinning
+            // state, so preserve it across a manual-pin reset; on destroy (dispatch false) clear it too.
+            let grandTotalNode: RowNode | undefined;
+            container.forEach((n) => {
+                if (dispatch && _isPinnedNodeGrandTotal(n)) {
+                    grandTotalNode = n;
+                } else {
+                    nodesToUnpin.push(n);
+                }
+            });
             // Have to collect up the nodes to unpin because unpinning mutates the container
             nodesToUnpin.forEach((n) => this.pinRow(n, null));
             container.clear();
+            if (grandTotalNode) {
+                container.add(grandTotalNode);
+            }
         });
         if (dispatch) {
             this.dispatchRowPinnedEvents();
@@ -273,6 +285,11 @@ export class ManualPinnedRowModel extends BeanStub implements IPinnedRowModel {
         const buildState = (floating: NonNullable<RowPinnedType>) => {
             const list: string[] = [];
             this.forEachPinnedRow(floating, (node) => {
+                // The grand total row is driven by the `grandTotalRow` option, not manual
+                // row-pinning state, so it must not be serialised as a pinned row id.
+                if (_isPinnedNodeGrandTotal(node)) {
+                    return;
+                }
                 const id = node.pinnedSibling?.id;
                 if (id != null) {
                     list.push(id);

--- a/packages/ag-grid-community/src/pinnedRowModel/manualPinnedRowUtils.ts
+++ b/packages/ag-grid-community/src/pinnedRowModel/manualPinnedRowUtils.ts
@@ -165,7 +165,7 @@ function _isNodeGrandTotal(node: RowNode): boolean {
     return !!node.footer && node.level === -1;
 }
 
-function _isPinnedNodeGrandTotal(node: RowNode): boolean {
+export function _isPinnedNodeGrandTotal(node: RowNode): boolean {
     return !!node.pinnedSibling && _isNodeGrandTotal(node.pinnedSibling);
 }
 

--- a/testing/behavioural/src/grouping-data/grand-total-row-setstate.test.ts
+++ b/testing/behavioural/src/grouping-data/grand-total-row-setstate.test.ts
@@ -80,7 +80,7 @@ describe('grand total row survives setState', () => {
         const options: GridOptions<RowData> = {
             ...baseOptions(),
             onFirstDataRendered: (event) => {
-                Promise.resolve().then(() => {
+                void Promise.resolve().then(() => {
                     event.api.setState(savedState);
                 });
             },

--- a/testing/behavioural/src/grouping-data/grand-total-row-setstate.test.ts
+++ b/testing/behavioural/src/grouping-data/grand-total-row-setstate.test.ts
@@ -1,0 +1,121 @@
+import type { GridApi, GridOptions, GridState, RowNode } from 'ag-grid-community';
+import { ClientSideRowModelModule, GridStateModule, PinnedRowModule } from 'ag-grid-community';
+import { RowGroupingModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout, cachedJSONObjects } from '../test-utils';
+
+interface RowData {
+    category: string;
+    region: string;
+    product: string;
+    revenue: number;
+}
+
+/**
+ * Restoring grid state via `api.setState` with no `rowPinning` section calls
+ * `pinnedRowModel.reset()`. The pinned grand total row is derived from the
+ * `grandTotalRow` option rather than manual row-pinning state, so it must survive
+ * such a reset — otherwise it disappears until the next user interaction.
+ */
+describe('grand total row survives setState', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, GridStateModule, RowGroupingModule, PinnedRowModule],
+    });
+
+    beforeEach(() => gridsManager.reset());
+    afterEach(() => gridsManager.reset());
+
+    const createRowData = (): RowData[] =>
+        cachedJSONObjects.array([
+            { category: 'Electronics', region: 'EMEA', product: 'Laptop', revenue: 1200 },
+            { category: 'Electronics', region: 'APAC', product: 'Phone', revenue: 800 },
+            { category: 'Furniture', region: 'AMER', product: 'Desk', revenue: 500 },
+            { category: 'Furniture', region: 'EMEA', product: 'Chair', revenue: 300 },
+        ]);
+
+    const baseOptions = (): GridOptions<RowData> => ({
+        columnDefs: [
+            { field: 'category', rowGroup: true, hide: true },
+            { field: 'region' },
+            { field: 'product' },
+            { field: 'revenue', aggFunc: 'sum' },
+        ],
+        rowData: createRowData(),
+        getRowId: (params) => params.data.product,
+        grandTotalRow: 'pinnedTop',
+        groupDefaultExpanded: 1,
+    });
+
+    const savedState: GridState = {
+        rowGroup: { groupColIds: ['region'] },
+    };
+
+    const expectGrandTotalPinnedTop = (api: GridApi<RowData>) => {
+        expect(api.getPinnedTopRowCount()).toBe(1);
+        const pinned = api.getPinnedTopRow(0) as RowNode | undefined;
+        // The pinned row must be the grand total footer (root-level footer), not a stray group row.
+        expect(pinned?.footer).toBe(true);
+        expect(pinned?.level).toBe(-1);
+    };
+
+    const expectGrandTotalPinnedBottom = (api: GridApi<RowData>) => {
+        expect(api.getPinnedBottomRowCount()).toBe(1);
+        const pinned = api.getPinnedBottomRow(0) as RowNode | undefined;
+        expect(pinned?.footer).toBe(true);
+        expect(pinned?.level).toBe(-1);
+    };
+
+    test('synchronous setState keeps the pinned grand total row', async () => {
+        const api = await gridsManager.createGridAndWait('myGrid', baseOptions());
+        expectGrandTotalPinnedTop(api);
+
+        api.setState(savedState);
+        await asyncSetTimeout(5);
+
+        expect(api.getRowGroupColumns().map((c) => c.getColId())).toEqual(['region']);
+        expectGrandTotalPinnedTop(api);
+    });
+
+    test('asynchronous setState from onFirstDataRendered keeps the pinned grand total row', async () => {
+        const options: GridOptions<RowData> = {
+            ...baseOptions(),
+            onFirstDataRendered: (event) => {
+                Promise.resolve().then(() => {
+                    event.api.setState(savedState);
+                });
+            },
+        };
+        const api = gridsManager.createGrid<RowData>('myGrid', options);
+
+        // let firstDataRendered + the microtask + setState's deferred setTimeout flush
+        await asyncSetTimeout(20);
+
+        expect(api.getRowGroupColumns().map((c) => c.getColId())).toEqual(['region']);
+        expectGrandTotalPinnedTop(api);
+    });
+
+    test('grand total row is not serialised into rowPinning state', async () => {
+        const api = await gridsManager.createGridAndWait('myGrid', baseOptions());
+        expectGrandTotalPinnedTop(api);
+
+        // The grand total is driven by the `grandTotalRow` option, so it must not leak into
+        // the manual row-pinning state returned by getState().
+        expect(api.getState().rowPinning).toEqual({ top: [], bottom: [] });
+    });
+
+    test('pinnedBottom grand total survives setState and is not serialised into rowPinning state', async () => {
+        const api = await gridsManager.createGridAndWait('myGrid', {
+            ...baseOptions(),
+            grandTotalRow: 'pinnedBottom',
+        });
+        expectGrandTotalPinnedBottom(api);
+        expect(api.getState().rowPinning).toEqual({ top: [], bottom: [] });
+
+        api.setState(savedState);
+        await asyncSetTimeout(5);
+
+        expect(api.getRowGroupColumns().map((c) => c.getColId())).toEqual(['region']);
+        expectGrandTotalPinnedBottom(api);
+        expect(api.getState().rowPinning).toEqual({ top: [], bottom: [] });
+    });
+});

--- a/testing/behavioural/src/grouping-data/grand-total-row-setstate.test.ts
+++ b/testing/behavioural/src/grouping-data/grand-total-row-setstate.test.ts
@@ -103,6 +103,30 @@ describe('grand total row survives setState', () => {
         expect(api.getState().rowPinning).toEqual({ top: [], bottom: [] });
     });
 
+    test('explicit empty rowPinning state keeps the pinned grand total row', async () => {
+        const api = await gridsManager.createGridAndWait('myGrid', baseOptions());
+        expectGrandTotalPinnedTop(api);
+
+        // A full state object serialises the grand total as empty `rowPinning` arrays. Restoring
+        // that state takes the explicit `setPinnedState` path (not `reset`), which must not clear
+        // the grand total row driven by the `grandTotalRow` option.
+        api.setState({ ...savedState, rowPinning: { top: [], bottom: [] } });
+        await asyncSetTimeout(5);
+
+        expect(api.getRowGroupColumns().map((c) => c.getColId())).toEqual(['region']);
+        expectGrandTotalPinnedTop(api);
+    });
+
+    test('round-tripping getState through setState keeps the pinned grand total row', async () => {
+        const api = await gridsManager.createGridAndWait('myGrid', baseOptions());
+        expectGrandTotalPinnedTop(api);
+
+        api.setState(api.getState());
+        await asyncSetTimeout(5);
+
+        expectGrandTotalPinnedTop(api);
+    });
+
     test('pinnedBottom grand total survives setState and is not serialised into rowPinning state', async () => {
         const api = await gridsManager.createGridAndWait('myGrid', {
             ...baseOptions(),


### PR DESCRIPTION
## Summary

With `grandTotalRow="pinnedTop"` (or `"pinnedBottom"`), calling `api.setState()` with a state object that has **no** `rowPinning` section made the pinned grand-total row vanish until the next user interaction. This was most visible when `setState` was called asynchronously (e.g. from a `.then()` in `onFirstDataRendered`).

**Root cause:** `setState` with no `rowPinning` calls `pinnedRowModel.reset()`, which cleared **all** pinned rows. But the grand total row is derived from the `grandTotalRow` *option*, not from manual row-pinning state — so `reset()` should not touch it. Its restoration normally rides the next `modelUpdated`; because `setState` applies that slice in a deferred `setTimeout` after the last `modelUpdated`, nothing re-pinned it until a later interaction fired a fresh `modelUpdated`.

A related inconsistency: `getPinnedState()` was also serialising the grand total into the `rowPinning` state, even though the option owns it.

## Changes

- `reset()` preserves the option-derived grand total row, clearing only genuine manual pins. On destroy (`dispatch === false`) it is cleared too.
- `getPinnedState()` excludes the grand total from serialisation — `rowPinning` now tracks only manual pins, and the `grandTotalRow` option is the single source of truth in both directions.

## Test plan

- New behavioural regression test `grand-total-row-setstate.test.ts` with 4 cases: synchronous `setState`, asynchronous `setState` from `onFirstDataRendered`, no-leak into `rowPinning` state, and `pinnedBottom` survival + no-leak. All pass with the fix and fail on baseline.
- `yarn nx test ag-grid-community`, behavioural pinned/grid-state/grand-total suites, plus `format`/`lint`/`build:types` clean.

Fix [AG-17586](https://ag-grid.atlassian.net/browse/AG-17586)