### PR TITLE
fix(docs): inventory demo Hold Selling button raises grid error #5

### DIFF
--- a/documentation/ag-grid-docs/src/components/demos/examples/inventory/cell-renderers/ActionsCellRenderer.tsx
+++ b/documentation/ag-grid-docs/src/components/demos/examples/inventory/cell-renderers/ActionsCellRenderer.tsx
@@ -23,9 +23,9 @@ export const ActionsCellRenderer: FunctionComponent<CustomCellRendererProps> = (
             status: !isPaused ? 'paused' : !isOutOfStock ? 'active' : 'outOfStock',
         };
 
-        // Refresh the row to reflect the changes
-        api.applyTransaction({ update: [updatedRowData] });
-    }, [node, api]);
+        // Update the row node directly so the grid can locate the row without a getRowId
+        node.updateData(updatedRowData);
+    }, [node]);
 
     return (
         <div className={styles.buttonCell}>

--- a/documentation/ag-grid-docs/src/content/docs/example-demos.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/example-demos.spec.ts
@@ -70,6 +70,11 @@ test.describe(`Demo Examples`, async () => {
         await page.waitForSelector('.ag-root-wrapper', { state: 'visible' });
         await page.waitForTimeout(1000);
 
+        // Hold Selling triggers an in-cell row update; afterEach guards that it completes without console errors.
+        const firstRow = page.getByRole('row').filter({ hasText: 'Dreams of You' });
+        await firstRow.getByRole('button', { name: 'Hold Selling' }).click();
+        await expect(firstRow.getByText('On Hold')).toBeVisible();
+
         await page.getByRole('textbox', { name: 'Search product...' }).fill('Lon');
         await page.getByRole('button', { name: 'Active' }).click();
         await page.getByRole('button', { name: 'On Hold' }).click();


### PR DESCRIPTION
## Summary

The inventory demo's in-cell **Hold Selling** button raised AG Grid error #5 and silently dropped the status update.

`ActionsCellRenderer.onStopSellingClick` spread `node.data` into a fresh object and called `api.applyTransaction({ update: [...] })`. The demo grid has no `getRowId`, so transaction updates are matched by **reference**; the copy never matched the stored row, raising error #5 (`lookupNodeByData`) and dropping the update. A CSRM rework between 35.2 and 35.3 began surfacing this latent demo bug.

## Changes

- **`ActionsCellRenderer.tsx`** — replace the `applyTransaction({ update })` call with `node.updateData(updatedRowData)`, which targets the row node directly (no `getRowId` needed, no reference-equality lookup) and refreshes the row. The now-unused `api` is dropped from the callback deps. The neighbouring `remove` path already passes `node.data` by reference, so it was unaffected.
- **`example-demos.spec.ts`** — extend the `example-inventory` e2e test to click the first row's Hold Selling button and assert the status shows "On Hold". The suite's `afterEach` asserts zero console errors, so error #5 regressions are now caught.

## Test plan

- `yarn nx lint ag-grid-docs` passes.
- Re-run `./docs-e2e.sh "example-demos" --grep "example-inventory"` against a dev server serving **this** checkout to runtime-verify (the previously-running server was serving a different checkout).

Fix [AG-17583](https://ag-grid.atlassian.net/browse/AG-17583)