### PR TITLE
AG-3390 Fix Plunker example CSS failing to load on dev server

### DIFF
--- a/documentation/ag-grid-docs/astro.config.mjs
+++ b/documentation/ag-grid-docs/astro.config.mjs
@@ -17,6 +17,7 @@ import agSourcemapCors from '../../external/ag-website-shared/plugins/agSourcema
 import { SITEMAP_CACHE_DIR } from '../../external/ag-website-shared/src/constants';
 import buildTime from './plugins/agBuildTime';
 import agDevCsp from './plugins/agDevCsp';
+import agDevExampleAssetCors from './plugins/agDevExampleAssetCors';
 import agHotModuleReload from './plugins/agHotModuleReload';
 import agHtaccessGen from './plugins/agHtaccessGen';
 import agRedirectsChecker from './plugins/agRedirectsChecker';
@@ -155,7 +156,7 @@ console.log(
     )
 );
 
-const plugins = [agSourcemapCors(), svgr(), agHotModuleReload(), agDevCsp()];
+const plugins = [agSourcemapCors(), svgr(), agHotModuleReload(), agDevCsp(), agDevExampleAssetCors()];
 if (NODE_ENV !== 'test') {
     plugins.push(mkcert()); // mkcert is not necessary for tests
 }

--- a/documentation/ag-grid-docs/plugins/agDevExampleAssetCors.ts
+++ b/documentation/ag-grid-docs/plugins/agDevExampleAssetCors.ts
@@ -1,0 +1,49 @@
+import type { Connect, Plugin, ViteDevServer } from 'vite';
+
+import { FILES_BASE_PATH } from '../src/constants';
+
+const FILES_PREFIX = `${FILES_BASE_PATH}/`;
+
+/**
+ * Astro 6's dev-server `secFetchMiddleware` rejects (403) any cross-site
+ * subresource request that does not carry an `Origin` matching
+ * `security.allowedDomains`. That is the right policy for pages, but it breaks
+ * examples opened on an external host (Plunker, CodeSandbox):
+ *
+ *  - SystemJS fetches the library JS over XHR (a CORS request) so it sends
+ *    `Origin: https://run.plnkr.co`, matches the allow-list, and loads fine.
+ *  - `import '…/styles/ag-grid.css'` is loaded with a `<link rel="stylesheet">`
+ *    — a *no-cors* request that sends NO `Origin` header, so it can never match
+ *    the allow-list and is blocked, surfacing in the example as
+ *    "Error loading CSS file."
+ *
+ * Every example dependency asset is served under `${FILES_BASE_PATH}/…` and is
+ * a public, read-only library file that is *meant* to be loaded by those
+ * external hosts. This plugin lets only those requests through `secFetch` by
+ * clearing the `sec-fetch-site` header before Astro's middleware inspects it
+ * (Astro short-circuits to `next()` when the header is absent). No other path
+ * is relaxed, so ordinary pages and routes keep the full cross-origin guard.
+ *
+ * Ordering is load-bearing: Astro registers `secFetch` by unshifting it to the
+ * front of the connect stack in a `configureServer` post-hook. Vite runs
+ * post-hooks in sorted-plugin order, so an `enforce: 'post'` plugin that also
+ * unshifts lands in front of Astro's entry and is guaranteed to run first.
+ */
+export default function agDevExampleAssetCors(): Plugin {
+    return {
+        name: 'ag-dev-example-asset-cors',
+        enforce: 'post',
+        configureServer(server: ViteDevServer) {
+            return () => {
+                const allowExampleAssetCors: Connect.NextHandleFunction = (req, _res, next) => {
+                    const pathname = (req.url ?? '').split('?')[0];
+                    if (req.headers['sec-fetch-site'] != null && pathname.startsWith(FILES_PREFIX)) {
+                        delete req.headers['sec-fetch-site'];
+                    }
+                    next();
+                };
+                server.middlewares.stack.unshift({ route: '', handle: allowExampleAssetCors });
+            };
+        },
+    };
+}


### PR DESCRIPTION
## Summary

Opening a TypeScript (or any CSS-importing) example in Plunker / CodeSandbox from the **local dev server** failed to load the AG Grid stylesheets:

```
Error loading https://localhost:4610/files/ag-grid-community/styles/ag-grid.css … from https://run.plnkr.co/preview/…/main.ts
Error: Error loading CSS file.
```

**Root cause:** Astro 6's dev-server `secFetchMiddleware` returns `403` for any cross-site subresource request that doesn't carry an `Origin` matching `security.allowedDomains`.

- Example **JS loads fine** — SystemJS fetches modules with `fetch()` (CORS mode), which sends `Origin: https://run.plnkr.co` and matches the allow-list.
- Example **CSS fails** — `import '…/ag-grid.css'` is loaded via a `<link rel="stylesheet">`, a *no-cors* request that sends **no `Origin` header**, so it can never match the allow-list → `403` → `link.onerror`.

## Fix

A dev-only Vite plugin (`agDevExampleAssetCors`) lets cross-origin subresource requests for static example assets under `/files/` through `secFetch`, by clearing the `sec-fetch-site` header before Astro's middleware inspects it. These are public, read-only library files that are *meant* to be loaded by external example hosts; no other path is relaxed, so ordinary pages keep the full guard.

`enforce: 'post'` is load-bearing: Astro registers `secFetch` by unshifting it to the front of the connect stack in a `configureServer` post-hook, and Vite runs post-hooks in sorted-plugin order — so an `enforce: 'post'` plugin that also unshifts lands in front and runs first.

## Test plan

- Confirmed the dev server `403`s a cross-site `<link>`-style request (`Sec-Fetch-Site: cross-site`, no `Origin`) for `/files/.../ag-grid.css`, and `200`s the same with an allow-listed `Origin`.
- Verified against the real Astro `secFetchMiddleware` and a real Vite dev server (actual plugin ordering): `/files/…` cross-site/no-origin → `200`; a non-`/files` page request → still `403`.
- Manually confirmed by the reporter: TypeScript example opens in Plunker from local dev with styles loading correctly.

Scope: dev server only (`configureServer`); no effect on production builds or the generated `.htaccess` CSP.