### PR TITLE
AG-14628 - [Tooltip] Inherit tooltipField on full-width group rows (regular grouping)

### DIFF
--- a/packages/ag-grid-community/src/rendering/row/fullWidthRowFeature.ts
+++ b/packages/ag-grid-community/src/rendering/row/fullWidthRowFeature.ts
@@ -255,7 +255,9 @@ export class FullWidthRowFeature extends BeanStub implements IRowModeFeature {
                 if (tooltipField) {
                     const data = rowNode.data;
                     if (!data) {
-                        return undefined;
+                        // Regular row-grouping group nodes carry no `data`; fall back to the group
+                        // display value, matching the auto group column's `tooltipField` behaviour.
+                        return value;
                     }
                     const containsDots = groupCol
                         ? groupCol.tooltipFieldContainsDots

--- a/testing/behavioural/src/tooltip/tooltip-group-col-inheritance.test.ts
+++ b/testing/behavioural/src/tooltip/tooltip-group-col-inheritance.test.ts
@@ -488,6 +488,46 @@ describe('Tooltip inheritance in group columns', () => {
         `);
     });
 
+    // TC3 – groupDisplayType: 'groupRows' with regular row grouping: a group node carries no `node.data`,
+    // so `tooltipField` must fall back to the group display value rather than producing no tooltip.
+    test('full-width group row inherits tooltipField from underlying colDef (groupRows, regular grouping)', async () => {
+        const gridOptions: GridOptions = {
+            columnDefs: [
+                {
+                    field: 'country',
+                    rowGroup: true,
+                    tooltipField: 'country',
+                },
+                { field: 'bronze' },
+            ],
+            rowData: [
+                { country: 'United States', bronze: 1 },
+                { country: 'United States', bronze: 2 },
+            ],
+            groupDefaultExpanded: -1,
+            groupDisplayType: 'groupRows',
+            tooltipShowDelay: TOOLTIP_SHOW_DELAY,
+        };
+
+        const api = await gridMgr.createGridAndWait('tooltip-group-rows-field-regular', gridOptions);
+        await new GridRows(api, 'full-width group row inherits tooltipField (regular grouping) setup').check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ LEAF_GROUP id:"row-group-country-United States"
+            · ├── LEAF id:0 country:"United States" bronze:1
+            · └── LEAF id:1 country:"United States" bronze:2
+        `);
+
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const groupRow = await waitFor(() =>
+            getByTestId(gridDiv, agTestIdFor.rowNode('row-group-country-United States'))
+        );
+
+        await userEvent.hover(groupRow);
+        await asyncSetTimeout(TOOLTIP_SHOW_DELAY + 50);
+        await waitForTooltips(1);
+        expect(getTooltips()[0]).toHaveTextContent('United States');
+    });
+
     // P1 fix: tooltipValueGetter receives params.value from the owning group column, not the outer group
     test('full-width group row tooltipValueGetter receives value from the owning column (groupRows + multiple groups)', async () => {
         const countryTooltips: string[] = [];


### PR DESCRIPTION
Fixes `tooltipField` inheritance for `groupDisplayType: 'groupRows'` under regular row grouping, where group nodes carry no `node.data` and previously produced no tooltip — now falling back to the group display value, matching the auto group column behaviour.

Fix [AG-14628](https://ag-grid.atlassian.net/browse/AG-14628)