### PR TITLE
AG-17134 Authorise the GTM-injected ZoomInfo inline script by hash

### DIFF
--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.test.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.test.ts
@@ -107,6 +107,15 @@ describe('cspRules', () => {
             expect(scriptSrc).toContain("'sha256-BF0290pkb3jxQsE7z00xR8Imp8X34FLC88L0lkMnrGw='"); // client:idle
         });
 
+        it('site scope authorises the GTM-injected ZoomInfo bootstrap by hash', () => {
+            // Authored in the shared GTM container (not this repo); hash captured from
+            // the browser CSP violation. Site only — examples keeps unsafe-inline.
+            const site = getCspDirectives({ env: 'production', scope: 'site' })['script-src'];
+            expect(site).toContain("'sha256-41l+jvtOjBgKy9345IStB4j1gGPGFMVXADMHn1Acs6E='");
+            const examples = getCspDirectives({ env: 'production', scope: 'examples' })['script-src'];
+            expect(examples).not.toContain("'sha256-41l+jvtOjBgKy9345IStB4j1gGPGFMVXADMHn1Acs6E='");
+        });
+
         it('examples and campaigns keep unsafe-inline and carry no hashes', () => {
             const scopes = ['examples', 'campaigns'] as const;
             for (let i = 0, len = scopes.length; i < len; ++i) {

--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
@@ -106,10 +106,25 @@ const ASTRO_HYDRATION_SCRIPT_HASHES = [
     "'sha256-BrDhGE1lwa85arfXcrBxSo+n37uVSX5CAROXnIM6Q+g='", // <astro-island> hydration runtime
 ];
 
+// SHA-256 of the inline ZoomInfo (WebSights) bootstrap that the shared Google Tag
+// Manager container injects as a Custom HTML tag once the visitor accepts functional
+// cookie consent. Unlike the scripts above, this one is authored in GTM, not this
+// repo — so the value is taken from the browser's CSP violation report, NOT by
+// hashing the GTM source (GTM normalises the injected bytes, so the source does not
+// reproduce this digest).
+//
+// FRAGILE — this pins ZoomInfo's exact bytes. If the ZoomInfo tag in GTM is edited,
+// or ZoomInfo regenerates its loader snippet, the hash stops matching and ZoomInfo
+// silently fails to load for consenting users. The GTM tag carries a note pointing
+// back here; if it changes, replace this with the new console-reported hash (here and
+// in the ag-studio / ag-charts CSPs — the GTM container is shared). AG-17134.
+const GTM_ZOOMINFO_HASH = "'sha256-41l+jvtOjBgKy9345IStB4j1gGPGFMVXADMHn1Acs6E='";
+
 const SITE_SCRIPT_HASHES = [
     hashInlineScript(DARK_MODE_INIT_SCRIPT),
     hashInlineScript(PLAUSIBLE_INIT_SCRIPT),
     ...ASTRO_HYDRATION_SCRIPT_HASHES,
+    GTM_ZOOMINFO_HASH,
 ];
 
 // The AG Grid × Bryntum partnership campaign pages embed a live Bryntum Gantt


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17134

Follow-up to #14118 (Phase B). That PR removed `script-src 'unsafe-inline'` from the `site` scope and externalised every inline script we author. One site-scope inline-script violation remained: the **ZoomInfo (WebSights) bootstrap** injected as a **Custom HTML tag** by the shared GTM container once a visitor accepts **functional cookie consent**.

It has a unique per-snippet body and is authored in GTM (not this repo), so it can't be externalised here — this authorises it by **SHA-256 hash** instead.

### Notes
- The hash (`sha256-41l+jvtOjBgKy9345IStB4j1gGPGFMVXADMHn1Acs6E=`) is taken from the **browser's CSP violation report**, not by hashing the GTM source — GTM normalises the injected bytes, so the source string does not reproduce the digest.
- Added to the **`site` scope only**; `examples` keeps `'unsafe-inline'`.
- **Fragile by design:** it pins ZoomInfo's exact bytes, so a GTM tag edit or a ZoomInfo snippet regeneration will break it (ZoomInfo then silently fails to load for consenting users). The ZoomInfo tag in GTM carries a note pointing back to `cspRules.ts`; if it changes, replace the value with the new console-reported hash here **and** in the ag-studio / ag-charts CSPs (shared GTM container).
- Longer-term, the robust fix is to have GTM load ZoomInfo via an external `<script src>` (the `zi-scripts.com` / `*.zoominfo.com` origins are already allow-listed), removing the inline hash entirely — deferred to the GTM container owner.

### Test plan
- `cspRules.test.ts`: added a case asserting the `site` scope carries the ZoomInfo hash and `examples` does not. Full file 18/18 passing.

