### PR TITLE
AG-17599 Default suppressContentVisibilityAuto to true

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-36/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-36/index.mdoc
@@ -21,7 +21,7 @@ NOTE: This will not show if the current library version is the same as the migra
 
 ## Behaviour Changes
 
-The default for the [suppressContentVisibilityAuto](./grid-options/#reference-rendering-suppressContentVisibilityAuto) grid option has changed from `false` to `true`, due to reports of rare issues with this feature in some apps. If your app has many grids active at once, but most are off the screen so the user can't see them, consider re-enabling this option for performance purposes.
+The default for the [suppressContentVisibilityAuto](./grid-options/#reference-rendering-suppressContentVisibilityAuto) grid option has changed from `false` to `true`, due to reports of rare issues with this feature in some apps. If your app has many grids active at once, but most are off the screen so the user can't see them, consider passing `false` for performance purposes.
 
 ## Removal of Deprecated APIs
 

--- a/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-36/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-36/index.mdoc
@@ -21,7 +21,7 @@ NOTE: This will not show if the current library version is the same as the migra
 
 ## Behaviour Changes
 
-There are no behaviour changes in AG Grid version {% migrationVersion() %}.
+The default for the [suppressContentVisibilityAuto](./grid-options/#reference-rendering-suppressContentVisibilityAuto) grid option has changed from `false` to `true`, due to reports of rare issues with this feature in some apps. If your app has many grids active at once, but most are off the screen so the user can't see them, consider re-enabling this option for performance purposes.
 
 ## Removal of Deprecated APIs
 

--- a/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/src/lib/ag-grid-angular.component.ts
@@ -1874,8 +1874,8 @@ export class AgGridAngular<TData = any, TColDef extends ColDef<TData> = ColDef<a
      * @initial
      */
     @Input({ transform: booleanAttribute }) public suppressRowTransform: boolean | undefined = undefined;
-    /** Set to `true` to suppress `content-visibility: auto` on the grid wrapper element. This degrades performance by causing the browser to render grids even when they are off screen, but may be necessary if your application depends on receiving resize events from hidden grids.
-     * @default false
+    /** Set to `false` to enable `content-visibility: auto` on the grid wrapper element. This improves performance by allowing the browser to skip rendering grids that are off screen, but may cause issues if your application depends on receiving resize events from hidden grids.
+     * @default true
      * @initial
      */
     @Input({ transform: booleanAttribute }) public suppressContentVisibilityAuto: boolean | undefined = undefined;

--- a/packages/ag-grid-community/src/entities/gridOptions.ts
+++ b/packages/ag-grid-community/src/entities/gridOptions.ts
@@ -2061,8 +2061,8 @@ export interface GridOptions<TData = any> {
      */
     suppressRowTransform?: boolean;
     /**
-     * Set to `true` to suppress `content-visibility: auto` on the grid wrapper element. This degrades performance by causing the browser to render grids even when they are off screen, but may be necessary if your application depends on receiving resize events from hidden grids.
-     * @default false
+     * Set to `false` to enable `content-visibility: auto` on the grid wrapper element. This improves performance by allowing the browser to skip rendering grids that are off screen, but may cause issues if your application depends on receiving resize events from hidden grids.
+     * @default true
      * @initial
      */
     suppressContentVisibilityAuto?: boolean;

--- a/packages/ag-grid-community/src/gridOptionsDefault.ts
+++ b/packages/ag-grid-community/src/gridOptionsDefault.ts
@@ -171,6 +171,7 @@ export const GRID_OPTION_DEFAULTS = {
     suppressMaintainUnsortedOrder: false,
     suppressRowHoverHighlight: false,
     suppressRowTransform: false,
+    suppressContentVisibilityAuto: true,
     columnHoverHighlight: false,
     deltaSort: false,
     enableGroupEdit: false,

--- a/packages/ag-grid-vue3/src/components/utils.ts
+++ b/packages/ag-grid-vue3/src/components/utils.ts
@@ -1696,8 +1696,8 @@ export interface Props<TData> {
          * @initial
          */
     suppressRowTransform?: boolean,
-    /** Set to `true` to suppress `content-visibility: auto` on the grid wrapper element. This degrades performance by causing the browser to render grids even when they are off screen, but may be necessary if your application depends on receiving resize events from hidden grids.
-         * @default false
+    /** Set to `false` to enable `content-visibility: auto` on the grid wrapper element. This improves performance by allowing the browser to skip rendering grids that are off screen, but may cause issues if your application depends on receiving resize events from hidden grids.
+         * @default true
          * @initial
          */
     suppressContentVisibilityAuto?: boolean,


### PR DESCRIPTION
Fix [AG-17599](https://ag-grid.atlassian.net/browse/AG-17599)

Flip the default of `suppressContentVisibilityAuto` to `true`, so the grid suppresses `content-visibility: auto` on the wrapper element unless the user explicitly opts in by setting it to `false`.