### PR TITLE
AG-3390 - Create staging captcha sitekey

### DIFF
--- a/external/ag-website-shared/src/components/contact-form/ContactForm.tsx
+++ b/external/ag-website-shared/src/components/contact-form/ContactForm.tsx
@@ -1,12 +1,6 @@
 import { initCaptcha } from '@ag-website-shared/components/contact-form/initCaptcha';
 import { Icon } from '@ag-website-shared/components/icon/Icon';
-import {
-    CONTACT_FORM_DATA,
-    PRIVACY_POLICY_URL,
-    RECAPTCHA_SITE_KEY,
-    RECAPTCHA_URL,
-    STUDIO_FORM_DATA,
-} from '@ag-website-shared/constants';
+import { CONTACT_FORM_DATA, PRIVACY_POLICY_URL, RECAPTCHA_URL, STUDIO_FORM_DATA } from '@ag-website-shared/constants';
 import { LIBRARY } from '@constants';
 import { getIsDev, getIsProduction } from '@utils/env';
 import classnames from 'classnames';
@@ -27,6 +21,7 @@ const {
     messagePlaceholder,
     formLocationId,
     enquiryTypeId,
+    captchaSiteKey,
     captchaSettingsKeyName,
 } = getIsProduction() ? contactFormData.production : contactFormData.default;
 
@@ -238,7 +233,7 @@ export const ContactForm: FunctionComponent<Props> = ({
                 </div>
             )}
             <div className={classnames('input-field', { 'input-error': captchaError })}>
-                <div className="g-recaptcha" data-sitekey={RECAPTCHA_SITE_KEY} />
+                <div className="g-recaptcha" data-sitekey={captchaSiteKey} />
                 <div className={styles.errorContainer}>
                     {captchaError && <p className="error">Please click on the reCAPTCHA checkbox</p>}
                 </div>

--- a/external/ag-website-shared/src/constants.ts
+++ b/external/ag-website-shared/src/constants.ts
@@ -5,7 +5,6 @@ export const MIGRATION_DOCUMENTATION_NAV_DATA = {
     text: 'Documentation',
 };
 
-export const RECAPTCHA_SITE_KEY = '6LfvTQosAAAAABkPY-cWnx2mr29q8xWuQs-bMIu-';
 export const RECAPTCHA_URL = 'https://www.google.com/recaptcha/api.js';
 export const CONTACT_FORM_DATA = {
     default: {
@@ -16,6 +15,7 @@ export const CONTACT_FORM_DATA = {
         messagePlaceholder: 'Tell us about your interest in AG Grid',
         formLocationId: '00NS900000BCx1C',
         enquiryTypeId: '00NS900000IEZRl',
+        captchaSiteKey: '6Ld_ro4sAAAAACjXUk0goeMBFJvD630upERER7pr',
         captchaSettingsKeyName: 'agGridStagingV2',
     },
     production: {
@@ -26,6 +26,7 @@ export const CONTACT_FORM_DATA = {
         leadSource: 'AG Grid Contact Form',
         formLocationId: '00NQ500000CVgqT',
         enquiryTypeId: '00NQ500000IALbt',
+        captchaSiteKey: '6LfvTQosAAAAABkPY-cWnx2mr29q8xWuQs-bMIu-',
         captchaSettingsKeyName: 'agGridComV2',
     },
 };
@@ -39,6 +40,7 @@ export const STUDIO_FORM_DATA = {
         messagePlaceholder: 'Tell us about your interest in AG Studio',
         formLocationId: '00NS900000BCx1C',
         enquiryTypeId: null,
+        captchaSiteKey: '6Ld_ro4sAAAAACjXUk0goeMBFJvD630upERER7pr',
         captchaSettingsKeyName: 'agGridStagingV2',
     },
     production: {
@@ -49,6 +51,7 @@ export const STUDIO_FORM_DATA = {
         messagePlaceholder: 'Tell us about your interest in AG Studio',
         formLocationId: '00NQ500000CVgqT',
         enquiryTypeId: null,
+        captchaSiteKey: '6LfvTQosAAAAABkPY-cWnx2mr29q8xWuQs-bMIu-',
         captchaSettingsKeyName: 'agGridComV2',
     },
 };


### PR DESCRIPTION
## Summary

Introduces a separate reCAPTCHA site key per environment for the contact form, rather than sharing a single global key across staging and production.

- Replaces the global `RECAPTCHA_SITE_KEY` constant with a per-environment `captchaSiteKey` field on each form-data config (`CONTACT_FORM_DATA` and `STUDIO_FORM_DATA`, both `default`/staging and `production`).
- Staging/`default` now uses a dedicated staging site key (`6Ld_ro4s...`); `production` retains the existing key (`6LfvTQos...`).
- `ContactForm` now reads `captchaSiteKey` from the resolved environment form data instead of the global constant.

## Notes

The same change is being ported manually to the `ag-studio` repo (separate PR), rather than via an `ag-website-shared` sync.