### PR TITLE
AG-3390 Fix expanding-section TypeError on pages with multiple sections

### DIFF
--- a/external/ag-website-shared/src/components/expanding-section/ExpandingSection.astro
+++ b/external/ag-website-shared/src/components/expanding-section/ExpandingSection.astro
@@ -29,4 +29,4 @@ const { headerText, isOpen = false } = Astro.props as Props;
     </details>
 </expanding-section>
 
-<script is:inline src={urlWithBaseUrl('/scripts/expanding-section.js')}></script>
+<script is:inline defer src={urlWithBaseUrl('/scripts/expanding-section.js')}></script>


### PR DESCRIPTION
## Summary

Fixes a `TypeError: Cannot read properties of null (reading 'addEventListener')` thrown by `expanding-section.js` on docs pages with more than one expanding section (e.g. [upgrading-to-ag-grid-33](https://ag-grid.com/react-data-grid/upgrading-to-ag-grid-33/)). The first section worked; the 2nd and later ones threw.

## Root cause

Not a CSP issue. Externalising the ExpandingSection script in AG-17134 changed it from a plain Astro `<script>` (compiled to a **deferred ES module**) into `<script is:inline src=...>` — a **parser-blocking classic script** that executes the instant the parser reaches it, right after the first section.

The custom-element constructor inspects its own children:

```js
this.#summary = this.querySelector('summary');
...
this.#summary.addEventListener('click', ...);   // throws when null
```

That is only valid on the **upgrade** path (element defined *after* its DOM exists), not the **parser-creation** path. With the module script, `customElements.define()` ran after the whole page was parsed, so every `<expanding-section>` upgraded with its children present. With the classic script, `define()` runs mid-parse:

- 1st section: already fully parsed → upgrades fine.
- 2nd+ sections: element already defined → parser runs the constructor *before* parsing the children → `querySelector('summary')` returns `null` → `null.addEventListener` → `TypeError`.

## Fix

Add `defer` to the `<script>` so it executes after parsing again (restoring the implicit deferral the module script had). Every `<expanding-section>` takes the upgrade path, with children present. One-line change; the script body is untouched and the existing define-guard keeps the repeated includes safe.

## Test plan

- [ ] Open a page with multiple expanding sections (e.g. `upgrading-to-ag-grid-33`) — no console error, all sections expand/collapse.