### PR TITLE
[AG-17603] Fix(types): allow valueFormatter to return null | undefined

### DIFF
--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -1325,7 +1325,7 @@ export interface ValueFormatterParams<TData = any, TValue = any, TContext = any>
 
 export type ValueFormatterFunc<TData = any, TValue = any, TContext = any> = (
     params: ValueFormatterParams<TData, TValue, TContext>
-) => string;
+) => string | null | undefined;
 
 export type EqualsFunc<TValue = any> = (
     valueA: TValue | null | undefined,

--- a/packages/ag-grid-community/src/interfaces/iSetFilter.ts
+++ b/packages/ag-grid-community/src/interfaces/iSetFilter.ts
@@ -1,6 +1,6 @@
 import type { AgPromise } from 'ag-stack';
 
-import type { ColDef, KeyCreatorParams, ValueFormatterParams } from '../entities/colDef';
+import type { ColDef, KeyCreatorParams, ValueFormatterFunc } from '../entities/colDef';
 import type { FilterUiChangedEvent } from '../events';
 import type { IProvidedFilter, IProvidedFilterParams, ProvidedFilterModel } from '../filter/provided/iProvidedFilter';
 import type { Column } from '../interfaces/iColumn';
@@ -196,7 +196,7 @@ export interface ISetFilterParams<TData = any, V = string> extends IProvidedFilt
      * If specified, this formats the value before it is displayed in the Filter List.
      * If a Key Creator is provided (see `keyCreator`), this must also be provided.
      */
-    valueFormatter?: (params: ValueFormatterParams) => string | null | undefined;
+    valueFormatter?: ValueFormatterFunc;
     /**
      * Function to return a string key for a value. This is required when the filter values are complex objects,
      * or when `treeList = true` and the column is a group column with Tree Data or Grouping enabled.

--- a/packages/ag-grid-community/src/interfaces/iSetFilter.ts
+++ b/packages/ag-grid-community/src/interfaces/iSetFilter.ts
@@ -196,7 +196,7 @@ export interface ISetFilterParams<TData = any, V = string> extends IProvidedFilt
      * If specified, this formats the value before it is displayed in the Filter List.
      * If a Key Creator is provided (see `keyCreator`), this must also be provided.
      */
-    valueFormatter?: (params: ValueFormatterParams) => string;
+    valueFormatter?: (params: ValueFormatterParams) => string | null | undefined;
     /**
      * Function to return a string key for a value. This is required when the filter values are complex objects,
      * or when `treeList = true` and the column is a group column with Tree Data or Grouping enabled.

--- a/packages/ag-grid-community/src/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.ts
@@ -486,7 +486,7 @@ export class ValueService extends BeanStub implements NamedBean {
         column: AgColumn,
         node: IRowNode | null,
         value: any,
-        suppliedFormatter?: (value: any) => string,
+        suppliedFormatter?: (value: any) => string | null | undefined,
         useFormatterFromColumn = true
     ): string | null {
         let result: string | null = null;
@@ -503,7 +503,7 @@ export class ValueService extends BeanStub implements NamedBean {
                 column,
             };
             if (typeof formatter === 'function') {
-                result = formatter(params);
+                result = formatter(params) ?? null;
             } else {
                 const expressionSvc = this.expressionSvc;
                 result = expressionSvc ? expressionSvc.evaluate(formatter, params) : null;

--- a/packages/ag-grid-enterprise/src/rowNumbers/rowNumbersService.ts
+++ b/packages/ag-grid-enterprise/src/rowNumbers/rowNumbersService.ts
@@ -324,7 +324,7 @@ export class RowNumbersService
     private createDummyElement(column: AgColumn): HTMLDivElement {
         const div = _createElement<HTMLDivElement>({ tag: 'div', cls: 'ag-cell-value ag-cell' });
 
-        let value = String(this.beans.rowModel.getRowCount() + 1);
+        let value: string | null = String(this.beans.rowModel.getRowCount() + 1);
         const rowNumberOverrides = this.rowNumberOverrides;
         if (typeof rowNumberOverrides?.valueFormatter === 'function') {
             const valueFormatterParams: ValueFormatterParams = _addGridCommonParams(this.gos, {
@@ -334,7 +334,7 @@ export class RowNumbersService
                 column,
                 colDef: column.colDef,
             });
-            value = rowNumberOverrides.valueFormatter(valueFormatterParams) ?? value;
+            value = rowNumberOverrides.valueFormatter(valueFormatterParams) ?? null;
         }
 
         div.textContent = value;

--- a/packages/ag-grid-enterprise/src/rowNumbers/rowNumbersService.ts
+++ b/packages/ag-grid-enterprise/src/rowNumbers/rowNumbersService.ts
@@ -334,7 +334,7 @@ export class RowNumbersService
                 column,
                 colDef: column.colDef,
             });
-            value = rowNumberOverrides.valueFormatter(valueFormatterParams);
+            value = rowNumberOverrides.valueFormatter(valueFormatterParams) ?? value;
         }
 
         div.textContent = value;

--- a/packages/ag-grid-enterprise/src/setFilter/flatSetDisplayValueModel.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/flatSetDisplayValueModel.ts
@@ -1,4 +1,4 @@
-import type { AgColumn, TextFormatter, ValueFormatterParams, ValueService } from 'ag-grid-community';
+import type { AgColumn, TextFormatter, ValueFormatterFunc, ValueService } from 'ag-grid-community';
 
 import type { ISetDisplayValueModel } from './iSetDisplayValueModel';
 import { SET_FILTER_ADD_SELECTION_TO_FILTER, SET_FILTER_SELECT_ALL } from './iSetDisplayValueModel';
@@ -9,9 +9,7 @@ export class FlatSetDisplayValueModel<V> implements ISetDisplayValueModel<V> {
 
     constructor(
         private readonly valueSvc: ValueService,
-        private readonly getValueFormatter: () =>
-            | ((params: ValueFormatterParams) => string | null | undefined)
-            | undefined,
+        private readonly getValueFormatter: () => ValueFormatterFunc | undefined,
         private readonly formatter: TextFormatter,
         private readonly column: AgColumn
     ) {}

--- a/packages/ag-grid-enterprise/src/setFilter/flatSetDisplayValueModel.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/flatSetDisplayValueModel.ts
@@ -9,7 +9,9 @@ export class FlatSetDisplayValueModel<V> implements ISetDisplayValueModel<V> {
 
     constructor(
         private readonly valueSvc: ValueService,
-        private readonly getValueFormatter: () => ((params: ValueFormatterParams) => string) | undefined,
+        private readonly getValueFormatter: () =>
+            | ((params: ValueFormatterParams) => string | null | undefined)
+            | undefined,
         private readonly formatter: TextFormatter,
         private readonly column: AgColumn
     ) {}

--- a/packages/ag-grid-enterprise/src/setFilter/setFilterHandler.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilterHandler.ts
@@ -42,7 +42,7 @@ export class SetFilterHandler<TValue = string>
     private treeDataTreeList = false;
     private groupingTreeList = false;
     private caseSensitive: boolean = false;
-    public valueFormatter?: (params: ValueFormatterParams) => string;
+    public valueFormatter?: (params: ValueFormatterParams) => string | null | undefined;
     private noValueFormatterSupplied = false;
 
     public init(params: FilterHandlerParams<any, any, SetFilterModel, ISetFilterParams<any, TValue>>): void {
@@ -394,7 +394,7 @@ export class SetFilterHandler<TValue = string>
     }
 
     private setValueFormatter(
-        providedValueFormatter: ((params: ValueFormatterParams) => string) | undefined,
+        providedValueFormatter: ((params: ValueFormatterParams) => string | null | undefined) | undefined,
         keyCreator: ((params: KeyCreatorParams<any, any>) => string) | undefined,
         treeList: boolean,
         isRefData: boolean

--- a/packages/ag-grid-enterprise/src/setFilter/setFilterHandler.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilterHandler.ts
@@ -12,7 +12,7 @@ import type {
     RowNode,
     SetFilterModel,
     SetFilterModelValue,
-    ValueFormatterParams,
+    ValueFormatterFunc,
 } from 'ag-grid-community';
 import { BeanStub, _addGridCommonParams, _error, _isClientSideRowModel } from 'ag-grid-community';
 
@@ -42,7 +42,7 @@ export class SetFilterHandler<TValue = string>
     private treeDataTreeList = false;
     private groupingTreeList = false;
     private caseSensitive: boolean = false;
-    public valueFormatter?: (params: ValueFormatterParams) => string | null | undefined;
+    public valueFormatter?: ValueFormatterFunc;
     private noValueFormatterSupplied = false;
 
     public init(params: FilterHandlerParams<any, any, SetFilterModel, ISetFilterParams<any, TValue>>): void {
@@ -394,7 +394,7 @@ export class SetFilterHandler<TValue = string>
     }
 
     private setValueFormatter(
-        providedValueFormatter: ((params: ValueFormatterParams) => string | null | undefined) | undefined,
+        providedValueFormatter: ValueFormatterFunc | undefined,
         keyCreator: ((params: KeyCreatorParams<any, any>) => string) | undefined,
         treeList: boolean,
         isRefData: boolean

--- a/packages/ag-grid-enterprise/src/setFilter/setFilterListItem.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilterListItem.ts
@@ -24,7 +24,7 @@ import type {
     ITooltipCtrlParams,
     SetFilterModel,
     TooltipFeature,
-    ValueFormatterParams,
+    ValueFormatterFunc,
 } from 'ag-grid-community';
 import {
     AgCheckboxSelector,
@@ -59,7 +59,7 @@ export interface SetFilterListItemParams<V> {
     value: V | null | (() => string);
     params: ISetFilterParams<any, V> & FilterDisplayParams<any, any, SetFilterModel>;
     translate: (key: SetFilterLocaleTextKey) => string;
-    valueFormatter?: (params: ValueFormatterParams) => string | null | undefined;
+    valueFormatter?: ValueFormatterFunc;
     item: SetFilterModelTreeItem | string | null;
     isSelected: boolean | undefined;
     isTree?: boolean;
@@ -108,7 +108,7 @@ export class SetFilterListItem<V> extends Component<SetFilterListItemEvent> {
     private readonly value: V | null | (() => string);
     private readonly params: ISetFilterParams<any, V> & FilterDisplayParams<any, any, SetFilterModel>;
     private readonly translate: (key: SetFilterLocaleTextKey) => string;
-    private readonly valueFormatter?: (params: ValueFormatterParams) => string | null | undefined;
+    private readonly valueFormatter?: ValueFormatterFunc;
     private readonly isTree?: boolean;
     private readonly depth: number;
     private readonly isGroup?: boolean;

--- a/packages/ag-grid-enterprise/src/setFilter/setFilterListItem.ts
+++ b/packages/ag-grid-enterprise/src/setFilter/setFilterListItem.ts
@@ -59,7 +59,7 @@ export interface SetFilterListItemParams<V> {
     value: V | null | (() => string);
     params: ISetFilterParams<any, V> & FilterDisplayParams<any, any, SetFilterModel>;
     translate: (key: SetFilterLocaleTextKey) => string;
-    valueFormatter?: (params: ValueFormatterParams) => string;
+    valueFormatter?: (params: ValueFormatterParams) => string | null | undefined;
     item: SetFilterModelTreeItem | string | null;
     isSelected: boolean | undefined;
     isTree?: boolean;
@@ -108,7 +108,7 @@ export class SetFilterListItem<V> extends Component<SetFilterListItemEvent> {
     private readonly value: V | null | (() => string);
     private readonly params: ISetFilterParams<any, V> & FilterDisplayParams<any, any, SetFilterModel>;
     private readonly translate: (key: SetFilterLocaleTextKey) => string;
-    private readonly valueFormatter?: (params: ValueFormatterParams) => string;
+    private readonly valueFormatter?: (params: ValueFormatterParams) => string | null | undefined;
     private readonly isTree?: boolean;
     private readonly depth: number;
     private readonly isGroup?: boolean;


### PR DESCRIPTION
This pr enables the valueFormatter return type to accept string | null | undefined without assertions, matching the behaviour the runtime already supports


Fix [AG-17603](https://ag-grid.atlassian.net/browse/AG-17603)