### PR TITLE
RTI-3353 Allow bryntum.com on archived campaign pages in the CSP

### DIFF
--- a/documentation/ag-grid-docs/plugins/agDevCsp.ts
+++ b/documentation/ag-grid-docs/plugins/agDevCsp.ts
@@ -7,11 +7,14 @@ const EXAMPLES_CSP = getCspValue({ env: 'dev', scope: 'examples' });
 const CAMPAIGNS_CSP = getCspValue({ env: 'dev', scope: 'campaigns' });
 
 function getDevCsp(url: string): string {
-    if (EXAMPLES_PATH_REGEXP.test(url)) {
-        return EXAMPLES_CSP;
-    }
+    // Campaigns first: archived campaign pages (/archive/<version>/campaigns/) match
+    // BOTH regexps, and must get the bryntum-allowing campaigns policy — mirroring the
+    // Apache <If> precedence where the campaigns block trails (and so overrides) examples.
     if (CAMPAIGNS_PATH_REGEXP.test(url)) {
         return CAMPAIGNS_CSP;
+    }
+    if (EXAMPLES_PATH_REGEXP.test(url)) {
+        return EXAMPLES_CSP;
     }
     return SITE_CSP;
 }

--- a/documentation/ag-grid-docs/scripts/csp/preview-csp.ts
+++ b/documentation/ag-grid-docs/scripts/csp/preview-csp.ts
@@ -114,11 +114,14 @@ function makeCspResolver(env: CspEnv): (url: string) => string {
     const examples = getCspValue({ env, scope: 'examples' });
     const campaigns = getCspValue({ env, scope: 'campaigns' });
     return (url: string): string => {
-        if (EXAMPLES_PATH_REGEXP.test(url)) {
-            return examples;
-        }
+        // Campaigns first: archived campaign pages (/archive/<version>/campaigns/) match
+        // BOTH regexps and must get the bryntum-allowing campaigns policy — mirroring the
+        // Apache <If> precedence where the campaigns block trails (and so overrides) examples.
         if (CAMPAIGNS_PATH_REGEXP.test(url)) {
             return campaigns;
+        }
+        if (EXAMPLES_PATH_REGEXP.test(url)) {
+            return examples;
         }
         return site;
     };

--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.test.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.test.ts
@@ -5,6 +5,8 @@ import { DARK_MODE_INIT_SCRIPT, PLAUSIBLE_INIT_SCRIPT } from '../csp/inlineScrip
 import {
     ASTRO_HYDRATION_HASHES_VERIFIED_FOR,
     CAMPAIGNS_PATH_CONDITION,
+    CAMPAIGNS_PATH_REGEXP,
+    EXAMPLES_PATH_REGEXP,
     getCspDirectives,
     getScopedCspHtaccessBlock,
 } from './cspRules';
@@ -86,6 +88,34 @@ describe('cspRules', () => {
             // directives neither scope touches stay identical
             expect(campaigns['frame-src']).toEqual(site['frame-src']);
             expect(campaigns['form-action']).toEqual(site['form-action']);
+        });
+    });
+
+    describe('RTI-3353: campaigns path matching covers archived campaign pages', () => {
+        // The live campaign page and its archived snapshots both embed the Bryntum
+        // demo, so both must resolve to the campaigns scope. An archived campaign path
+        // matches EXAMPLES_PATH_REGEXP too (it lives under /archive/), so the middleware
+        // resolvers test campaigns first — these assertions pin the matchers down.
+        it('matches the live and archived campaign pages', () => {
+            expect(CAMPAIGNS_PATH_REGEXP.test('/campaigns/bryntum-gantt/')).toBe(true);
+            expect(CAMPAIGNS_PATH_REGEXP.test('/archive/36.0.0/campaigns/bryntum-gantt/')).toBe(true);
+        });
+
+        it('does not match plain archived doc pages (they stay on the examples scope)', () => {
+            expect(CAMPAIGNS_PATH_REGEXP.test('/archive/36.0.0/getting-started/')).toBe(false);
+            // ...which the examples scope still covers.
+            expect(EXAMPLES_PATH_REGEXP.test('/archive/36.0.0/getting-started/')).toBe(true);
+        });
+
+        it('archived campaign paths match both regexps, so campaigns must take precedence', () => {
+            const archivedCampaign = '/archive/36.0.0/campaigns/bryntum-gantt/';
+            expect(CAMPAIGNS_PATH_REGEXP.test(archivedCampaign)).toBe(true);
+            expect(EXAMPLES_PATH_REGEXP.test(archivedCampaign)).toBe(true);
+        });
+
+        it('the Apache condition string carries the optional /archive/<version> prefix', () => {
+            expect(CAMPAIGNS_PATH_CONDITION).toContain('/archive/');
+            expect(CAMPAIGNS_PATH_CONDITION).toContain('/campaigns/');
         });
     });
 

--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
@@ -141,14 +141,22 @@ const BRYNTUM_HOST = 'https://bryntum.com';
 export const EXAMPLES_PATH_CONDITION = '%{REQUEST_URI} =~ m#^/(examples|archive)/#';
 
 // Apache <If> expression matching the partnership campaign pages that get the
-// 'campaigns' scope (e.g. /campaigns/bryntum-gantt/).
-export const CAMPAIGNS_PATH_CONDITION = '%{REQUEST_URI} =~ m#^/campaigns/#';
+// 'campaigns' scope — both the live page (/campaigns/bryntum-gantt/) and its
+// archived copies (/archive/<version>/campaigns/bryntum-gantt/), which are served
+// from the same vhost and would otherwise fall under the 'examples' scope (matched
+// by EXAMPLES_PATH_CONDITION) and lose the bryntum.com allowances. The optional
+// /archive/<version> prefix covers the archived snapshots.
+export const CAMPAIGNS_PATH_CONDITION = '%{REQUEST_URI} =~ m#^(?:/archive/[^/]+)?/campaigns/#';
 
 // JS equivalents of the *_PATH_CONDITION Apache rules above, for the dev-server
 // (agDevCsp) and preview-server (preview-csp) middleware that scope the served
 // CSP by URL path. Keep these in sync with the Apache conditions.
 export const EXAMPLES_PATH_REGEXP = /^\/(examples|archive)\//;
-export const CAMPAIGNS_PATH_REGEXP = /^\/campaigns\//;
+// Matches /campaigns/ and archived /archive/<version>/campaigns/ — see
+// CAMPAIGNS_PATH_CONDITION. An archived campaign path matches BOTH this and
+// EXAMPLES_PATH_REGEXP, so the middleware resolvers must test campaigns first
+// (mirroring the Apache <If> precedence where the campaigns block trails examples).
+export const CAMPAIGNS_PATH_REGEXP = /^(?:\/archive\/[^/]+)?\/campaigns\//;
 
 // 'self' resolves to grid-staging.ag-grid.com on staging / localhost in dev, so
 // cross-subdomain references to the production host need an explicit allowance.

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
@@ -298,6 +298,15 @@ describe('htaccessRules', () => {
             expect(ifBlock).not.toContain("'unsafe-eval'");
         });
 
+        it('RTI-3353: the campaigns <If> condition also covers archived campaign pages', () => {
+            // Archived campaign pages (/archive/<version>/campaigns/) otherwise fall under
+            // the examples scope and lose the bryntum.com allowances. The condition carries
+            // the optional /archive/<version> prefix so the override applies to them too.
+            expect(campaignsIfOpen).toContain('/archive/');
+            expect(stagingContent).toContain(campaignsIfOpen);
+            expect(productionContent).toContain(campaignsIfOpen);
+        });
+
         it('production: allows bryntum.com for /campaigns/ without unsafe-eval (either phase)', () => {
             const ifBlock = firstCampaignsIfBlock(productionContent);
             expect(ifBlock).toContain('https://bryntum.com');


### PR DESCRIPTION
## Problem

CSP violations on archived campaign pages, e.g. `https://www.ag-grid.com/archive/36.0.0/campaigns/bryntum-gantt/`:

```
Loading the stylesheet 'https://bryntum.com/products/gantt/build/gantt.css' violates ... style-src ...
Loading the script 'https://bryntum.com/products/gantt/build/gantt.umd.js' violates ... script-src ...
```

The `campaigns` CSP scope (added in AG-17134) allows the `bryntum.com` origin on `script-src`/`style-src`/`font-src`/`connect-src`, but only for paths matching `CAMPAIGNS_PATH_CONDITION` = `^/campaigns/`.

Archived copies of the campaign page live under `/archive/<version>/campaigns/...`. That URL matches `EXAMPLES_PATH_CONDITION` (`^/(examples|archive)/`) → it gets the `examples` scope (no bryntum), but never matches the campaigns condition → the embedded Bryntum Gantt demo's script/stylesheet/font requests get blocked and reported.

## Fix

- **`cspRules.ts`** — broaden both campaigns matchers to also cover the optional `/archive/<version>` prefix:
  - `CAMPAIGNS_PATH_CONDITION` → `m#^(?:/archive/[^/]+)?/campaigns/#`
  - `CAMPAIGNS_PATH_REGEXP` → `/^(?:\/archive\/[^/]+)?\/campaigns\//`
- **`agDevCsp.ts`** / **`preview-csp.ts`** — reorder the dev/preview middleware resolvers to test `campaigns` **before** `examples`. An archived campaign path matches both regexps, so campaigns must win — mirroring the Apache `<If>` precedence where the campaigns block already trails (and so overrides) the examples block.

Net effect: archived campaign pages get the **same** `campaigns` policy as the live page (`bryntum.com` allowed, still **no** `'unsafe-eval'`). Plain archived doc pages keep the `examples` scope and are unaffected.

## Tests

- `cspRules.test.ts` — assert the campaigns matchers cover `/archive/<v>/campaigns/...` and the live `/campaigns/...`, and do **not** match plain archived doc paths.
- `htaccessRules.test.ts` — assert the generated campaigns `<If>` condition carries the archive prefix in both staging and the production report-only window.

## Verification

- `nx test ag-grid-docs --testPathPattern="cspRules|htaccessRules"` → all pass.
- Generated production `.htaccess` confirmed: the campaigns `<If>` now matches `/archive/.../campaigns/`, sits after the examples `<If>`, and grants `bryntum.com` without `'unsafe-eval'`.
- `nx format`, `nx lint ag-grid-docs` → clean.

> _Note: `nx build-tsc ag-grid-docs` fails on a pre-existing `TouchEvent` type error in `ag-grid-community` (`filterMenuFactory.ts` / `touchListener.ts`) that reproduces on the clean base branch — unrelated to this change._
