### PR TITLE
RTI-3369 Fix broken doc anchor links and harden link checker

### DIFF
--- a/documentation/ag-grid-docs/src/components/license-setup/components/LicenseSetup.tsx
+++ b/documentation/ag-grid-docs/src/components/license-setup/components/LicenseSetup.tsx
@@ -97,6 +97,10 @@ export const LicenseSetup: FunctionComponent<Props> = ({ library, framework, pat
 
     return (
         <>
+            <h2 id="request-trial-licence">
+                Request a Trial Licence
+                <LinkIcon href="#request-trial-licence" />
+            </h2>
             <Note>
                 You can test AG Grid Enterprise locally without a licence. To test in production, access support and
                 remove the watermark & console warnings,{' '}

--- a/documentation/ag-grid-docs/src/content/api-documentation/grid-events/events.json
+++ b/documentation/ag-grid-docs/src/content/api-documentation/grid-events/events.json
@@ -126,13 +126,13 @@
         "rowSelected": {
             "more": {
                 "name": "Selection Events",
-                "url": "./row-selection-api-reference/#reference--rowSelected"
+                "url": "./row-selection-api-reference/#reference-selection-rowSelected"
             }
         },
         "selectionChanged": {
             "more": {
                 "name": "Selection Events",
-                "url": "./row-selection-api-reference/#reference--selectionChanged"
+                "url": "./row-selection-api-reference/#reference-selection-selectionChanged"
             }
         },
         "cellContextMenu": {},
@@ -145,13 +145,13 @@
         "fillStart": {
             "more": {
                 "name": "Fill Range Event",
-                "url": "./cell-selection-fill-handle/#reference--fillStart"
+                "url": "./cell-selection-fill-handle/#reference-selection-fillStart"
             }
         },
         "fillEnd": {
             "more": {
                 "name": "Fill Range Event",
-                "url": "./cell-selection-fill-handle/#reference--fillEnd"
+                "url": "./cell-selection-fill-handle/#reference-selection-fillEnd"
             }
         }
     },

--- a/documentation/ag-grid-docs/src/content/docs/cell-data-types/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/cell-data-types/index.mdoc
@@ -246,7 +246,7 @@ Data type definitions support inheritance via the `extendsDataType` property. Ea
 
 [Column Types](./column-definitions/#default-column-definitions) can be set via the `columnTypes` property to allow other column definition properties to be set for the data type. By default, these will replace any column types against the parent definition. To allow these to be appended to the parent definition column types, `appendColumnTypes = true` can be set.
 
-To allow [Inferring Cell Data Types](#inferring-cell-data-types) to work for custom types, the `dataTypeMatcher` property can be set. This returns `true` if the value is of the correct type. Note that the data type matchers will be called in the order they are provided in `dataTypeDefinitions` (for custom only), and then the pre-defined data type matchers will be called.
+To allow [Inferring Cell Data Types](#inferring-data-types) to work for custom types, the `dataTypeMatcher` property can be set. This returns `true` if the value is of the correct type. Note that the data type matchers will be called in the order they are provided in `dataTypeDefinitions` (for custom only), and then the pre-defined data type matchers will be called.
 
 The following example demonstrates providing custom cell data types:
 

--- a/documentation/ag-grid-docs/src/content/docs/license-install/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/license-install/index.mdoc
@@ -5,6 +5,9 @@ headings:
     - slug: 'top'
       text: 'Installing Your License Key'
       depth: 1
+    - slug: 'request-trial-licence'
+      text: 'Request a Trial Licence'
+      depth: 2
     - slug: 'validate-your-license'
       text: 'Validate Your License'
       depth: 2

--- a/documentation/ag-grid-docs/src/content/docs/license-install/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/license-install/index.mdoc
@@ -8,9 +8,6 @@ headings:
     - slug: 'validate-your-license'
       text: 'Validate Your License'
       depth: 2
-    - slug: 'request-trial-licence'
-      text: 'Request Trial Licence'
-      depth: 3
     - slug: 'configure-your-application'
       text: 'Configure Your Application'
       depth: 3

--- a/documentation/ag-grid-docs/src/content/docs/mcp-server/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/mcp-server/index.mdoc
@@ -135,7 +135,7 @@ To learn more, see the [Claude MCP documentation](https://docs.claude.com/en/doc
 
 ## Getting Started
 
-Once the MCP is installed, your LLM will automatically leverage the AG MCP Server to access additional context, based on your prompt. [Tools](#tools), [Prompts](#prompts) and [Resources](#resources) can also be accessed directly, as demonstrated below.
+Once the MCP is installed, your LLM will automatically leverage the AG MCP Server to access additional context, based on your prompt. [Tools](#tools), [Prompts](#prompts) and [Resources](#resources-docs-api--example-search) can also be accessed directly, as demonstrated below.
 
 Refer to your LLM documentation for specific instructions on accessing MCP features.
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-colors/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-colors/index.mdoc
@@ -6,7 +6,7 @@ Control the overall colour scheme and colour of individual elements
 
 ## Overview
 
-- Change individual [colour parameters](#color-parameters)
+- Change individual [colour parameters](#colour-parameters)
 - Switch between [light and dark colour schemes](#colour-schemes) using parts
 - Integrate with a website that has a dark mode toggle using [theme modes](#theme-modes)
 - Make unrestricted [customisations using CSS](./theming-css/#custom-css-rules)

--- a/documentation/ag-grid-docs/src/content/docs/theming-css/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-css/index.mdoc
@@ -8,7 +8,7 @@ While the grid provides [parameters](./theming-parameters/) and [parts](./themin
 
 ## Custom CSS Rules
 
-A running grid instance contains thousands of DOM elements, and each of them has class names like `ag-header` and `ag-row`. You can target these class names with your own CSS rules, allowing limitless customisation.
+A running grid instance contains hundreds of DOM elements, and each of them has class names like `ag-header` and `ag-row`. You can target these class names with your own CSS rules, allowing limitless customisation.
 
 If your designer has specified, for example, animated rainbow text on the header, that's achievable:
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-migration/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-migration/index.mdoc
@@ -271,7 +271,7 @@ For Angular, consider using [ViewEncapsulation.ShadowDom](https://angular.dev/gu
 
 If you are familiar with the method of theming applications used in v32 and earlier, the following technical context will help you understand what is changing and what remains the same.
 
-The grid is styled using CSS. A running grid instance contains thousands of DOM elements, and each of them has class names like `ag-header` and `ag-row` that can be used in CSS rules that change the style of that element. The grid package from NPM contains CSS that set up a default grid style and expose CSS custom properties (variables) that allow configuration of colours, borders, padding, fonts etc. When you want to go beyond what is possible with the custom properties, you write your own CSS rules targeting the grid's class names.
+The grid is styled using CSS. A running grid instance contains hundreds of DOM elements, and each of them has class names like `ag-header` and `ag-row` that can be used in CSS rules that change the style of that element. The grid package from NPM contains CSS that set up a default grid style and expose CSS custom properties (variables) that allow configuration of colours, borders, padding, fonts etc. When you want to go beyond what is possible with the custom properties, you write your own CSS rules targeting the grid's class names.
 
 None of this is changing - the grid is still styled with CSS and CSS custom properties, and you can still extend it with your own CSS rules. What the Theming API changes is the following:
 

--- a/documentation/ag-grid-docs/src/content/docs/theming-v32-customisation-sass-legacy/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/theming-v32-customisation-sass-legacy/index.mdoc
@@ -59,7 +59,7 @@ Note how this example includes the structural styles (`ag-gris.scss`) before the
 
 Theme Parameters are arguments to a theme that change its appearance. Some parameters have effects that would be very hard to achieve using CSS rules. Parameters can be set through the Sass API, and colour parameters can additionally be set with CSS variables.
 
-Here are some of the most important theme parameters. There is a [full list](#base-theme-parameters) further down this page.
+Here are some of the most important theme parameters. There is a [full list](#full-list-of-theme-parameters) further down this page.
 
 - `grid-size` is the main control for affecting how tightly data and UI elements are packed together. All padding and spacing in the grid is defined as a multiple of grid-size, so increasing it will make most components larger by increasing their internal white space while leaving the size of text and icons unchanged.
 
@@ -143,7 +143,7 @@ The best way to find the right class name to use in a CSS rule is using the brow
 
 ### Referencing parameter values in CSS rules
 
-If you're using Sass, you can reference theme parameters in your own CSS rules using the [ag-param function](#ag-param) or [ag-color-property mixin](#ag-color-property). These will be replaced at compile time with the value of the parameter.
+If you're using Sass, you can reference theme parameters in your own CSS rules using the [ag-param function](#function-ag-param) or [ag-color-property mixin](#mixin-ag-color-property). These will be replaced at compile time with the value of the parameter.
 
 ### Understanding CSS rule maintenance and breaking changes
 
@@ -172,7 +172,7 @@ find the default values for your theme by inspecting its source code in the grid
 
 Note that some values are defined relative to other values using the `ag-derived` helper function, so
 `data-color: ag-derived(foreground-color)` means that if you don't set the `data-color` property it
-will default to the value of `foreground-color`. See the [ag-derived docs](#ag-derived) for more information.
+will default to the value of `foreground-color`. See the [ag-derived docs](#function-ag-derived) for more information.
 
 ```scss
 // Colour of text and icons in primary UI elements like menus

--- a/documentation/ag-grid-docs/src/content/docs/toolbar/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/index.mdoc
@@ -9,7 +9,7 @@ The Toolbar appears above the grid and provides quick access to common grid acti
 
 ## Configuring the Toolbar
 
-Set the `toolbar` grid option to a [Toolbar](#reference-Toolbar) object. The `items` array accepts built-in item names, [Action Buttons](#action-buttons), and [Custom Components](#custom-components).
+Set the `toolbar` grid option to a [Toolbar](./grid-options/#reference-accessories-toolbar) object. The `items` array accepts built-in item names, [Action Buttons](#action-buttons), and [Custom Components](#custom-components).
 
 ```{% frameworkTransform=true %}
 const gridOptions = {
@@ -136,7 +136,7 @@ The example below shows icon-only buttons with tooltips for sizing columns, sort
 
 For controls beyond a button, such as toggles, inputs, or any stateful UI, set `toolbarItem` to a custom component. Custom components can render arbitrary HTML and call any grid API, so they suit cases that the [Action Button](#action-buttons) shorthand cannot express.
 
-The example below defines two custom items: checkbox toggles that apply column filters on the left, and a radio group that opens [Side Bar](./tool-panel/) tool panels on the right. The radio group's `setSelected` method is called via [`getToolbarItemInstance`](#reference-getToolbarItemInstance) in `onToolPanelVisibleChanged` to stay in sync when a panel is opened or closed elsewhere, such as via a sidebar tab.
+The example below defines two custom items: checkbox toggles that apply column filters on the left, and a radio group that opens [Side Bar](./tool-panel/) tool panels on the right. The radio group's `setSelected` method is called via [`getToolbarItemInstance`](#reference-accessories-getToolbarItemInstance) in `onToolPanelVisibleChanged` to stay in sync when a panel is opened or closed elsewhere, such as via a sidebar tab.
 
 {% gridExampleRunner title="Custom Toolbar Item" name="toolbar-custom" /%}
 

--- a/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-33/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-33/index.mdoc
@@ -10,7 +10,7 @@ Reductions in bundle size, updated theming, column header content customisation.
 
 AG Grid {% migrationVersion() %} significantly reduces bundle size via modularization and enhances functionality, theming and accessibility as described in the [release post](https://blog.ag-grid.com/whats-new-in-ag-grid-33/). These major improvements require certain breaking changes as listed below.
 
-Please use the [codemods](#codemods) to start your migration, then review the changes to [modules](#changes-to-modules) and [themes](#theming).
+Please use the [codemods](#codemods) to start your migration, then review the changes to [modules](#changes-to-modules--packages) and [themes](#theming).
 
 {% note %}
 AG Grid {% migrationVersion() %} is aimed at addressing long-standing community feedback around bundle size and theming. Naturally, given the significance of these changes, AG Grid {% migrationVersion() %} has introduced more breaking changes than usual. We recognise that not all users can immediately benefit from these improvements.

--- a/documentation/ag-grid-docs/src/utils/markdoc/getHeadings.ts
+++ b/documentation/ag-grid-docs/src/utils/markdoc/getHeadings.ts
@@ -46,9 +46,10 @@ function isHeadingTag(node: Node) {
     );
 }
 
-// Only show ApiDocumentation headings if it's not showing a section
+// Only show ApiDocumentation headings if it's not showing a section and the header isn't hidden
+// (a hidden header renders no id, so a heading would point at a non-existent anchor)
 function isApiDocsHeadingNode(node: Node) {
-    return node.tag === 'apiDocumentation' && !node.attributes.section;
+    return node.tag === 'apiDocumentation' && !node.attributes.section && !node.attributes.config?.hideHeader;
 }
 
 function isIfNode(node: Node) {

--- a/external/ag-website-shared/plugins/agLinkChecker.ts
+++ b/external/ag-website-shared/plugins/agLinkChecker.ts
@@ -123,21 +123,21 @@ const checkLinks = async (dir: string, files: string[], options: Options) => {
         const processTag = (tag: string) => {
             // A fragment (#foo) resolves to the first element with id="foo",
             // and failing that an <a name="foo">. Record both as valid targets.
-            const idMatch = /(?:^|\s)id="([^"]*)"/i.exec(tag);
+            const idMatch = /(?:^|\s)id=(["'])(.*?)\1/i.exec(tag);
             if (idMatch) {
-                anchors.add(`${thisFileUrl}#${idMatch[1]}`);
+                anchors.add(`${thisFileUrl}#${idMatch[2]}`);
             }
 
             const tagName = /^([a-zA-Z][\w-]*)/.exec(tag)?.[1]?.toLowerCase();
             if (tagName === 'a') {
-                const nameMatch = /(?:^|\s)name="([^"]*)"/i.exec(tag);
+                const nameMatch = /(?:^|\s)name=(["'])(.*?)\1/i.exec(tag);
                 if (nameMatch) {
-                    anchors.add(`${thisFileUrl}#${nameMatch[1]}`);
+                    anchors.add(`${thisFileUrl}#${nameMatch[2]}`);
                 }
 
-                const hrefMatch = /(?:^|\s)href="([^"]*)"/i.exec(tag);
+                const hrefMatch = /(?:^|\s)href=(["'])(.*?)\1/i.exec(tag);
                 if (hrefMatch) {
-                    recordUsage(hrefMatch[1]);
+                    recordUsage(hrefMatch[2]);
                 }
             }
         };

--- a/external/ag-website-shared/plugins/agLinkChecker.ts
+++ b/external/ag-website-shared/plugins/agLinkChecker.ts
@@ -13,12 +13,6 @@ type Options = {
 };
 
 const IGNORED_PATHS = ['/archive'];
-const HREF_PATTERNS_TO_IGNORE = [
-    '?', // Links with queries
-    '#reference-', // API references, as it is rendered client side
-    '#example-', // Example references, as they aren't headings
-    '#contact-section', // Contact form on about page
-];
 
 const isCI =
     process.env.NX_TASK_TARGET_CONFIGURATION === 'ci' || process.env.NX_TASK_TARGET_CONFIGURATION === 'staging';
@@ -88,66 +82,91 @@ const checkLinks = async (dir: string, files: string[], options: Options) => {
             continue;
         }
 
-        const anchorTags: string[] = [];
+        const thisFileUrl = filePathToUrl(filePath);
 
-        // uses a stream as ingesting the entire file was causing memory crashes.
-        // State is held in the closure here (not inside an event handler) so it
-        // survives across stream chunks — otherwise tags that straddle a chunk
-        // boundary are silently dropped.
-        const fileStream = fs.createReadStream(join(dir, filePath), { encoding: 'utf8' });
-        let prev: string | undefined;
-        let active = false;
-        let str = '';
-        for await (const chunk of fileStream) {
-            const strChunk = chunk as string;
-            for (let i = 0; i < strChunk.length; i++) {
-                const chr = strChunk[i];
-                if (!prev || prev === '<') {
-                    if (chr === 'a') {
-                        active = true;
-                    }
-                } else if (active && chr === '>') {
-                    active = false;
-                    anchorTags.push(str);
-                    str = '';
-                }
-
-                if (active) {
-                    str += chr;
-
-                    if (str.length >= 2 && !str.startsWith('a ')) {
-                        active = false;
-                        str = '';
-                    }
-                }
-
-                prev = chr;
+        const recordUsage = (href: string) => {
+            // Strip any query string (?...) while keeping the path and fragment,
+            // so "/page/?ref=blog#foo" still validates the page and the #foo
+            // anchor. Only treat '?' as the query start when it precedes the
+            // fragment — a '?' after '#' is part of the fragment itself.
+            const firstHash = href.indexOf('#');
+            const queryIndex = href.indexOf('?');
+            if (queryIndex !== -1 && (firstHash === -1 || queryIndex < firstHash)) {
+                href = href.slice(0, queryIndex) + (firstHash !== -1 ? href.slice(firstHash) : '');
             }
-        }
-
-        anchorTags.forEach((tag) => {
-            const regex = /.*href="(.*?)".*/g;
-            const match = regex.exec(tag);
-            if (match) {
-                const href = match[1];
-                if (HREF_PATTERNS_TO_IGNORE.some((pattern) => href.includes(pattern))) {
+            // An empty fragment (#) or #top both scroll to the top of the page;
+            // they always resolve and have no target element to check against.
+            const hashIndex = href.indexOf('#');
+            if (hashIndex !== -1) {
+                const fragment = href.slice(hashIndex + 1);
+                if (fragment === '' || fragment.toLowerCase() === 'top') {
                     return;
                 }
+            }
+            // Same-page (#foo) links resolve against this page; absolute
+            // (/page#foo) links resolve against another page. Anything else
+            // (external, relative) is left to the file-existence checks below.
+            let link: string | undefined;
+            if (href.startsWith('#')) {
+                link = `${thisFileUrl}${href}`;
+            } else if (href.startsWith('/')) {
+                link = href;
+            }
+            if (link == null) {
+                return;
+            }
+            const filePaths = linksToValidate[link]?.filePaths ?? new Set();
+            filePaths.add(filePath);
+            linksToValidate[link] = { filePaths };
+        };
 
-                if (href.startsWith('#')) {
-                    const thisFileUrl = filePathToUrl(filePath);
-                    const thisHash = href;
-                    anchors.add(`${thisFileUrl}${thisHash}`);
-                } else if (href.startsWith('/')) {
-                    const filePaths = linksToValidate[href]?.filePaths ?? new Set();
-                    filePaths.add(filePath);
+        const processTag = (tag: string) => {
+            // A fragment (#foo) resolves to the first element with id="foo",
+            // and failing that an <a name="foo">. Record both as valid targets.
+            const idMatch = /(?:^|\s)id="([^"]*)"/i.exec(tag);
+            if (idMatch) {
+                anchors.add(`${thisFileUrl}#${idMatch[1]}`);
+            }
 
-                    linksToValidate[href] = {
-                        filePaths,
-                    };
+            const tagName = /^([a-zA-Z][\w-]*)/.exec(tag)?.[1]?.toLowerCase();
+            if (tagName === 'a') {
+                const nameMatch = /(?:^|\s)name="([^"]*)"/i.exec(tag);
+                if (nameMatch) {
+                    anchors.add(`${thisFileUrl}#${nameMatch[1]}`);
+                }
+
+                const hrefMatch = /(?:^|\s)href="([^"]*)"/i.exec(tag);
+                if (hrefMatch) {
+                    recordUsage(hrefMatch[1]);
                 }
             }
-        });
+        };
+
+        // Stream the file rather than reading it whole (large files caused OOM
+        // crashes). We accumulate one tag at a time, from '<' to '>', and
+        // process it the moment it closes. The accumulator state lives outside
+        // the chunk loop so a tag straddling a chunk boundary isn't dropped.
+        const fileStream = fs.createReadStream(join(dir, filePath), { encoding: 'utf8' });
+        let inTag = false;
+        let tag = '';
+        for await (const chunk of fileStream) {
+            const strChunk = chunk as string;
+            for (let i = 0, len = strChunk.length; i < len; ++i) {
+                const chr = strChunk[i];
+                if (inTag) {
+                    if (chr === '>') {
+                        inTag = false;
+                        processTag(tag);
+                        tag = '';
+                    } else {
+                        tag += chr;
+                    }
+                } else if (chr === '<') {
+                    inTag = true;
+                    tag = '';
+                }
+            }
+        }
     }
 
     // for junit reporting

--- a/external/ag-website-shared/src/components/policies/pages/privacy.astro
+++ b/external/ag-website-shared/src/components/policies/pages/privacy.astro
@@ -47,9 +47,6 @@ const { name } = Astro.props;
                 <nav>
                     <ul class="list-style-none">
                         <li>
-                            <a href="# active">Guide</a>
-                        </li>
-                        <li>
                             <a href="#intro-privacy">Introduction</a>
                         </li>
                         <li>


### PR DESCRIPTION
Fix [RTI-3369](https://ag-grid.atlassian.net/browse/RTI-3369)

Fixes the broken anchor link reported in RTI-3369 (Theming / Colours page links to `#color-parameters`, but the heading slug is `#colour-parameters`) **and** the root cause the ticket flagged: *why didn't the build catch this?*

The link checker treated any same-page `<a href="#x">` as **proof** that anchor `x` existed, so it never validated same-page anchors — it could only catch cross-page ones. It worked by accident, because every heading's auto-generated link icon emits a self-referential `<a href="#id">`.

### Checker changes (`agLinkChecker.ts`)
- Collect real fragment targets — `id` on any element, `name` on `<a>` — per the HTML spec's fragment-resolution order, instead of inferring targets from `<a href="#…">` usages.
- Validate **every** `#`-link (same-page and cross-page) against those targets.
- Special-case the empty fragment (`#`) and `#top`, both of which resolve to the top of the document per spec.
- Strip query strings before validation (`/page/?ref=blog#foo` now validates the page and `#foo`) instead of skipping any URL containing `?`.
- Remove the stale `#reference-`/`#example-`/`#contact-section` ignores — those targets are server-rendered now, so they validate properly.

### TOC fix (`getHeadings.ts`)
- Don't emit an "On this page" heading for `apiDocumentation` sections rendered with `hideHeader` — the hidden header renders no `id`, so the heading pointed at a non-existent anchor.

### Broken links fixed
17 broken anchor links surfaced by the hardened checker, across `theming-colors`, `cell-data-types`, `mcp-server`, `theming-v32-customisation-sass-legacy`, `upgrading-to-ag-grid-33`, `toolbar`, `grid-events` (events.json), plus removal of a malformed link on the privacy page and a stale TOC entry on license-install.

Also includes two minor copy edits on `theming-css`/`theming-migration` ("thousands" → "hundreds").