### PR TITLE
RTI-3350

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-row-groups/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-row-groups/example.spec.ts
@@ -1,17 +1,19 @@
 import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('calculated columns evaluate on group rows and leaf rows', async ({ agIdFor }) => {
+    test.eachFramework('calculated columns evaluate on leaf rows; aggFunc aggregates onto groups', async ({ agIdFor }) => {
         const solarGroupId = 'row-group-productType-Solar';
 
         await expect(agIdFor.autoGroupCell(solarGroupId)).toContainText('Solar (2)', { useInnerText: true });
         await expect(agIdFor.cell(solarGroupId, 'revenue')).toContainText('$220,000');
         await expect(agIdFor.cell(solarGroupId, 'cost')).toContainText('$148,000');
-        // Calculated columns derive from the group's aggregated revenue/cost.
+        // profit has an aggFunc, so the group aggregates the per-leaf profit; margin (no aggFunc) is blank.
         await expect(agIdFor.cell(solarGroupId, 'profit')).toContainText('$72,000');
-        await expect(agIdFor.cell(solarGroupId, 'margin')).toContainText('33%');
+        await expect(agIdFor.cell(solarGroupId, 'margin')).toHaveText('');
 
+        // Both calculated columns evaluate on the leaf rows.
         await expect(agIdFor.cell('0', 'profit')).toContainText('$46,000');
         await expect(agIdFor.cell('1', 'profit')).toContainText('$26,000');
+        await expect(agIdFor.cell('0', 'margin')).toContainText('32%');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-row-groups/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-row-groups/example.spec.ts
@@ -1,15 +1,15 @@
 import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('calculated columns are blank on group rows and evaluate on leaf rows', async ({ agIdFor }) => {
+    test.eachFramework('calculated columns evaluate on group rows and leaf rows', async ({ agIdFor }) => {
         const solarGroupId = 'row-group-productType-Solar';
 
         await expect(agIdFor.autoGroupCell(solarGroupId)).toContainText('Solar (2)', { useInnerText: true });
         await expect(agIdFor.cell(solarGroupId, 'revenue')).toContainText('$220,000');
         await expect(agIdFor.cell(solarGroupId, 'cost')).toContainText('$148,000');
-        // Calculated columns show no value on group rows.
-        await expect(agIdFor.cell(solarGroupId, 'profit')).toHaveText('');
-        await expect(agIdFor.cell(solarGroupId, 'margin')).toHaveText('');
+        // Calculated columns derive from the group's aggregated revenue/cost.
+        await expect(agIdFor.cell(solarGroupId, 'profit')).toContainText('$72,000');
+        await expect(agIdFor.cell(solarGroupId, 'margin')).toContainText('33%');
 
         await expect(agIdFor.cell('0', 'profit')).toContainText('$46,000');
         await expect(agIdFor.cell('1', 'profit')).toContainText('$26,000');

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-row-groups/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-row-groups/example.spec.ts
@@ -1,19 +1,22 @@
 import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('calculated columns evaluate on leaf rows; aggFunc aggregates onto groups', async ({ agIdFor }) => {
-        const solarGroupId = 'row-group-productType-Solar';
+    test.eachFramework(
+        'calculated columns evaluate on leaf rows; aggFunc aggregates onto groups',
+        async ({ agIdFor }) => {
+            const solarGroupId = 'row-group-productType-Solar';
 
-        await expect(agIdFor.autoGroupCell(solarGroupId)).toContainText('Solar (2)', { useInnerText: true });
-        await expect(agIdFor.cell(solarGroupId, 'revenue')).toContainText('$220,000');
-        await expect(agIdFor.cell(solarGroupId, 'cost')).toContainText('$148,000');
-        // profit has an aggFunc, so the group aggregates the per-leaf profit; margin (no aggFunc) is blank.
-        await expect(agIdFor.cell(solarGroupId, 'profit')).toContainText('$72,000');
-        await expect(agIdFor.cell(solarGroupId, 'margin')).toHaveText('');
+            await expect(agIdFor.autoGroupCell(solarGroupId)).toContainText('Solar (2)', { useInnerText: true });
+            await expect(agIdFor.cell(solarGroupId, 'revenue')).toContainText('$220,000');
+            await expect(agIdFor.cell(solarGroupId, 'cost')).toContainText('$148,000');
+            // profit has an aggFunc, so the group aggregates the per-leaf profit; margin (no aggFunc) is blank.
+            await expect(agIdFor.cell(solarGroupId, 'profit')).toContainText('$72,000');
+            await expect(agIdFor.cell(solarGroupId, 'margin')).toHaveText('');
 
-        // Both calculated columns evaluate on the leaf rows.
-        await expect(agIdFor.cell('0', 'profit')).toContainText('$46,000');
-        await expect(agIdFor.cell('1', 'profit')).toContainText('$26,000');
-        await expect(agIdFor.cell('0', 'margin')).toContainText('32%');
-    });
+            // Both calculated columns evaluate on the leaf rows.
+            await expect(agIdFor.cell('0', 'profit')).toContainText('$46,000');
+            await expect(agIdFor.cell('1', 'profit')).toContainText('$26,000');
+            await expect(agIdFor.cell('0', 'margin')).toContainText('32%');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-row-groups/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-row-groups/main.ts
@@ -60,6 +60,8 @@ const columnDefs: ColDef<SalesRow>[] = [
         colId: 'profit',
         headerName: 'Profit',
         calculatedExpression: '[revenue] - [cost]',
+        // aggFunc lets the calculated column aggregate its per-leaf results onto group rows.
+        aggFunc: 'sum',
         cellDataType: 'number',
         filter: 'agNumberColumnFilter',
         valueFormatter: currencyFormatter,
@@ -67,6 +69,7 @@ const columnDefs: ColDef<SalesRow>[] = [
     {
         colId: 'margin',
         headerName: 'Margin',
+        // No aggFunc: a ratio does not aggregate, so margin evaluates on leaf rows and is blank on groups.
         calculatedExpression: '[profit] / [revenue]',
         cellDataType: 'number',
         valueFormatter: percentageFormatter,

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/index.mdoc
@@ -48,6 +48,8 @@ To aggregate the per-row results instead, give the calculated column an `aggFunc
 
 Under [Pivoting](./pivoting/), a calculated column with an `aggFunc` is a value column: it evaluates per leaf and its results aggregate into the pivot result columns, the same as a column with a `valueGetter`. Without an `aggFunc` it is not a value column, so it has no pivot result column and is absent from the cross-tab, like any other non-value column.
 
+A calculated column can also be a pivot column (`pivot: true`): its per-row result becomes the pivot key, so the grid creates a result column for each distinct calculated value — the same as pivoting on a column with a `valueGetter`.
+
 {% gridExampleRunner title="Row Groups with Calculated Columns" name="calculated-columns-row-groups" /%}
 
 ## References with Column Groups

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/index.mdoc
@@ -40,11 +40,9 @@ Calculated columns are always read-only. They cannot be edited through cell edit
 
 Calculated columns are full columns, so [Row Grouping](./grouping/), [Tree Data](./tree-data/), [Sorting](./row-sorting/) and [Filtering](./filtering/), [Text Formatting](./value-formatters/) and [Cell Components](./component-cell-renderer/) apply to them the same way as any other column.
 
-A calculated column also evaluates on group rows, Tree Data parents, group footers and the grand-total row. On each of these it uses the values its referenced columns show on the same row. For a group those are the aggregated values, so a group's `[revenue]` is the aggregated revenue of its children. If the referenced columns are blank on the row, the calculated cell is blank too.
+A calculated column evaluates on rows that have their own data: leaf rows, and Tree Data parents that carry data. It stays blank on rows without data — row group rows, group footers, the grand-total row, and Tree Data filler nodes.
 
-The inputs are aggregated first, then the expression is evaluated once. For an additive expression this matches the total of the leaf results, so a group's `[revenue] - [cost]` equals the sum of its rows' profits. For a ratio it gives the group's own ratio of totals: `[revenue] / [cost]` on a group is `sum(revenue) / sum(cost)` — the group-level margin, not the average of each leaf row's ratio.
-
-To aggregate the per-row results instead, give the calculated column an `aggFunc`. Each leaf still evaluates the expression, and the group combines those leaf results with the chosen function. For example `{ calculatedExpression: '[revenue] - [cost]', aggFunc: 'avg' }` shows the average of its rows' profits on a group, rather than the profit of the group's totals.
+To show a value on group rows, give the calculated column an `aggFunc`. Each leaf evaluates the expression, and the group aggregates those per-leaf results with the chosen function — the same as a column with a `valueGetter`. For example `{ calculatedExpression: '[revenue] - [cost]', aggFunc: 'sum' }` shows the total of its rows' profits on a group. A ratio has no meaningful aggregation, so a column like `[profit] / [revenue]` is left without an `aggFunc` and stays blank on group rows.
 
 Under [Pivoting](./pivoting/), a calculated column with an `aggFunc` is a value column: it evaluates per leaf and its results aggregate into the pivot result columns, the same as a column with a `valueGetter`. Without an `aggFunc` it is not a value column, so it has no pivot result column and is absent from the cross-tab, like any other non-value column.
 

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/index.mdoc
@@ -40,9 +40,13 @@ Calculated columns are always read-only. They cannot be edited through cell edit
 
 Calculated columns are full columns, so [Row Grouping](./grouping/), [Tree Data](./tree-data/), [Sorting](./row-sorting/) and [Filtering](./filtering/), [Text Formatting](./value-formatters/) and [Cell Components](./component-cell-renderer/) apply to them the same way as any other column.
 
-Calculated values appear on leaf rows only. Row group rows, Tree Data parents (including parents that carry their own data), group footers and the grand-total row show no calculated value.
+A calculated column also evaluates on group rows, Tree Data parents, group footers and the grand-total row. On each of these it uses the values its referenced columns show on the same row. For a group those are the aggregated values, so a group's `[revenue]` is the aggregated revenue of its children. If the referenced columns are blank on the row, the calculated cell is blank too.
 
-This avoids a misleading result. Evaluating the expression against aggregated inputs does not match the aggregate of the per-row results for non-linear expressions: `[revenue] / [cost]` on a group would be `sum(revenue) / sum(cost)`, not the average of each leaf row's ratio.
+The inputs are aggregated first, then the expression is evaluated once. For an additive expression this matches the total of the leaf results, so a group's `[revenue] - [cost]` equals the sum of its rows' profits. For a ratio it gives the group's own ratio of totals: `[revenue] / [cost]` on a group is `sum(revenue) / sum(cost)` — the group-level margin, not the average of each leaf row's ratio.
+
+To aggregate the per-row results instead, give the calculated column an `aggFunc`. Each leaf still evaluates the expression, and the group combines those leaf results with the chosen function. For example `{ calculatedExpression: '[revenue] - [cost]', aggFunc: 'avg' }` shows the average of its rows' profits on a group, rather than the profit of the group's totals.
+
+Under [Pivoting](./pivoting/), a calculated column with an `aggFunc` is a value column: it evaluates per leaf and its results aggregate into the pivot result columns, the same as a column with a `valueGetter`. Without an `aggFunc` it is not a value column, so it has no pivot result column and is absent from the cross-tab, like any other non-value column.
 
 {% gridExampleRunner title="Row Groups with Calculated Columns" name="calculated-columns-row-groups" /%}
 

--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -335,8 +335,8 @@ export class ColumnModel extends BeanStub implements NamedBean {
         this.hasMarryChildren = pivotResultCols ? pivotResultCols.pivotHasMarryChildren : this.colDefHasMarryChildren;
         this.colsGroupsById = pivotResultCols ? pivotResultCols.pivotGroupsById : this.colDefGroupsById;
         this.colsAllGroups = pivotResultCols ? pivotResultCols.pivotAllGroups : this.colDefAllGroups;
-        // Service refresh runs in dependency order
-        beans.formula?.setFormulasActive(sourceList);
+        // Service refresh runs in dependency order; formulas operate on the primary cols (colDefList).
+        beans.formula?.setFormulasActive(colDefList);
         const autoCols = beans.autoColSvc?.refreshCols(source);
         const selectionCol = beans.selectionColSvc?.refreshCols();
         const rowNumberCol = beans.rowNumbersSvc?.refreshCols();

--- a/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
+++ b/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
@@ -781,8 +781,6 @@ export const AG_GRID_ERRORS = {
         `Invalid calculatedColumns.dataTypes entry "${dataType}" - it must be a built-in data type or registered via dataTypeDefinitions. It has been ignored.` as const,
     305: () =>
         `The file input overlay is shown but no 'processFileInput' is configured. The overlay will not work without a 'processFileInput'.` as const,
-    306: ({ blockedService }: { blockedService: string }) =>
-        `colDef.calculatedExpression is not supported with ${blockedService}. Calculated Columns has been turned off.`,
 };
 
 export type ErrorMap = typeof AG_GRID_ERRORS;

--- a/packages/ag-grid-community/src/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.ts
@@ -280,9 +280,9 @@ export class ValueService extends BeanStub implements NamedBean {
     // aggregation) must pre-resolve via `_resolvePivotColumnForRow`. Run the getValue benchmark to verify.
     // This does NOT resolve pending edit values (edit or batch)
     public getValueFromData(column: AgColumn, rowNode: IRowNode, ignoreAggData: boolean = false): any {
-        // A calc col with an aggFunc aggregates its per-leaf results, so group rows read aggData
-        // instead of re-evaluating the formula.
-        const evaluateFormula = column.isCalculatedCol && !(column.aggFunc && rowNode.group);
+        // An actively-aggregating calc col aggregates its per-leaf results, so group rows read aggData
+        // instead of re-evaluating the formula (gated on the active state, not just a defined aggFunc).
+        const evaluateFormula = column.isCalculatedCol && !(column.aggregationActive && rowNode.group);
         let result = evaluateFormula
             ? this.formula?.resolveValue(column, rowNode as RowNode)
             : this.resolveCoreValue(column, rowNode, ignoreAggData);

--- a/packages/ag-grid-community/src/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.ts
@@ -280,7 +280,10 @@ export class ValueService extends BeanStub implements NamedBean {
     // aggregation) must pre-resolve via `_resolvePivotColumnForRow`. Run the getValue benchmark to verify.
     // This does NOT resolve pending edit values (edit or batch)
     public getValueFromData(column: AgColumn, rowNode: IRowNode, ignoreAggData: boolean = false): any {
-        let result = column.isCalculatedCol
+        // A calc col with an aggFunc aggregates its per-leaf results, so group rows read aggData
+        // instead of re-evaluating the formula.
+        const evaluateFormula = column.isCalculatedCol && !(column.aggFunc && rowNode.group);
+        let result = evaluateFormula
             ? this.formula?.resolveValue(column, rowNode as RowNode)
             : this.resolveCoreValue(column, rowNode, ignoreAggData);
 

--- a/packages/ag-grid-enterprise/src/formula/formulaService.ts
+++ b/packages/ag-grid-enterprise/src/formula/formulaService.ts
@@ -11,7 +11,7 @@ import type {
     RowNodeDataChangedEvent,
     _ChangedRowNodes,
 } from 'ag-grid-community';
-import { BeanStub, _convertColumnEventSourceType, _resolvePivotColumnForRow, _warn } from 'ag-grid-community';
+import { BeanStub, _convertColumnEventSourceType, _warn } from 'ag-grid-community';
 
 import { parseFormula } from './ast/parsers';
 import { serializeFormula } from './ast/serializer';
@@ -738,9 +738,31 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
         if (col.isCalculatedCol) {
             return col.calculatedExpression?.trim() ? undefined : '';
         }
-        // Resolve a referenced pivot result column like every other value read (getCellValue, edit,
-        // aggregation): redirect to the source column on leaves; group rows keep it and read aggData.
-        return this.beans.valueSvc.getValueFromData(_resolvePivotColumnForRow(col, row), row);
+        const valueSvc = this.beans.valueSvc;
+        // A referenced pivot result column gives the row's contribution to that bucket: aggregate on a group,
+        // source on an in-bucket leaf, blank otherwise. (Shared resolver stays source-uniform; read-only here.)
+        const pivotValueCol = col.pivotValueColumn;
+        if (pivotValueCol && !row.group && !row.rowPinned && this.leafInPivotBucket(col, row)) {
+            return valueSvc.getValueFromData(pivotValueCol, row);
+        }
+        return valueSvc.getValueFromData(col, row);
+    }
+
+    /** True if leaf `row` falls in pivot result column `resultCol`'s bucket — its pivot-dimension keys match. */
+    private leafInPivotBucket(resultCol: AgColumn, row: RowNode): boolean {
+        const beans = this.beans;
+        const pivotCols = beans.pivotColsSvc?.columns;
+        const pivotKeys = resultCol.colDef.pivotKeys;
+        if (!pivotCols || !pivotKeys) {
+            return false;
+        }
+        const valueSvc = beans.valueSvc;
+        for (let i = 0, len = pivotKeys.length; i < len; ++i) {
+            if (valueSvc.getKeyForNode(pivotCols[i], row) !== pivotKeys[i]) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/packages/ag-grid-enterprise/src/formula/formulaService.ts
+++ b/packages/ag-grid-enterprise/src/formula/formulaService.ts
@@ -760,7 +760,8 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
         }
         const valueSvc = beans.valueSvc;
         for (let i = 0, len = pivotKeys.length; i < len; ++i) {
-            if (valueSvc.getKeyForNode(pivotCols[i], row) !== pivotKeys[i]) {
+            const pivotCol = pivotCols[i];
+            if (!pivotCol || valueSvc.getKeyForNode(pivotCol, row) !== pivotKeys[i]) {
                 return false;
             }
         }

--- a/packages/ag-grid-enterprise/src/formula/formulaService.ts
+++ b/packages/ag-grid-enterprise/src/formula/formulaService.ts
@@ -126,8 +126,9 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
         this.formulaColumnsPresent = formulaColumnsPresent;
         const editableFormulasCompatible =
             editableFormulaColumnsPresent && this.checkForEditableFormulaIncompatibleServices(columns);
-        const calculatedColumnsCompatible =
-            calculatedColumnsPresent && this.checkForCalculatedColumnIncompatibleServices(columns);
+        // Calculated columns work with pivot in every role: as a pivot value (aggFunc) feeding the result
+        // columns, alongside a pivot, and as a pivot dimension (its per-leaf formula result is the key).
+        const calculatedColumnsCompatible = calculatedColumnsPresent && this.checkForBaseIncompatibleServices();
         const editableFormulasSupported = this.beans.rowModel.getType() === 'clientSide';
         const active = editableFormulasCompatible && editableFormulasSupported;
         const calculatedColumnsActive = calculatedColumnsCompatible;
@@ -152,20 +153,6 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
         if (this.gos.get('enableCellExpressions')) {
             _warn(295, { blockedService: 'Cell Expressions' });
             return false;
-        }
-        return true;
-    }
-
-    private checkForCalculatedColumnIncompatibleServices(columns: AgColumn[]): boolean {
-        if (!this.checkForBaseIncompatibleServices()) {
-            return false;
-        }
-        for (let i = 0, len = columns.length; i < len; ++i) {
-            const col = columns[i];
-            if (col.isCalculatedCol && col.pivotActive) {
-                _warn(306, { blockedService: 'Column Pivoting' });
-                return false;
-            }
         }
         return true;
     }
@@ -751,6 +738,8 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
         if (col.isCalculatedCol) {
             return col.calculatedExpression?.trim() ? undefined : '';
         }
+        // Resolve a referenced pivot result column like every other value read (getCellValue, edit,
+        // aggregation): redirect to the source column on leaves; group rows keep it and read aggData.
         return this.beans.valueSvc.getValueFromData(_resolvePivotColumnForRow(col, row), row);
     }
 

--- a/packages/ag-grid-enterprise/src/formula/formulaService.ts
+++ b/packages/ag-grid-enterprise/src/formula/formulaService.ts
@@ -11,7 +11,7 @@ import type {
     RowNodeDataChangedEvent,
     _ChangedRowNodes,
 } from 'ag-grid-community';
-import { BeanStub, _convertColumnEventSourceType, _warn } from 'ag-grid-community';
+import { BeanStub, _convertColumnEventSourceType, _resolvePivotColumnForRow, _warn } from 'ag-grid-community';
 
 import { parseFormula } from './ast/parsers';
 import { serializeFormula } from './ast/serializer';
@@ -24,7 +24,6 @@ import SUPPORTED_FUNCTIONS from './functions/supportedFuncs';
 import { shiftNode } from './functions/utils';
 import type { FormulaErrorId, FormulaErrorType } from './i18n';
 import { isValidFunctionName } from './refUtils';
-import { isFormulaRowAvailable } from './rowAccess';
 
 /** Shared params object for `rowRenderer.refreshCells`, hoisted to avoid per-call allocation. */
 const REFRESH_CELLS_PARAMS = { suppressFlash: true, force: true } as const;
@@ -163,7 +162,7 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
         }
         for (let i = 0, len = columns.length; i < len; ++i) {
             const col = columns[i];
-            if (col.isPivotActive()) {
+            if (col.isCalculatedCol && col.pivotActive) {
                 _warn(306, { blockedService: 'Column Pivoting' });
                 return false;
             }
@@ -690,7 +689,16 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
     }
 
     private ensureCalculatedCellFormula(row: RowNode, col: AgColumn, calculatedExpression: string): CellFormula | null {
-        if (!isFormulaRowAvailable(row) || row.group) {
+        if (row.stub || row.failedLoad) {
+            return null;
+        }
+        // An aggFunc calc col's group row shows the aggregated value, not a formula evaluation.
+        if (col.aggFunc && row.group) {
+            return null;
+        }
+        // No source to evaluate against (leaf data, or a group's aggData/own data) stays blank, not error.
+        const hasSource = row.group ? row.aggData != null || row.data != null : row.data != null;
+        if (!hasSource) {
             return null;
         }
 
@@ -743,10 +751,7 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
         if (col.isCalculatedCol) {
             return col.calculatedExpression?.trim() ? undefined : '';
         }
-
-        // Calculated columns are incompatible with pivot (see checkForCalculatedColumnIncompatibleServices),
-        // so `col` is never a pivot result column here — no redirect needed.
-        return this.beans.valueSvc.getValueFromData(col, row);
+        return this.beans.valueSvc.getValueFromData(_resolvePivotColumnForRow(col, row), row);
     }
 
     /**

--- a/packages/ag-grid-enterprise/src/formula/formulaService.ts
+++ b/packages/ag-grid-enterprise/src/formula/formulaService.ts
@@ -679,13 +679,14 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
         if (row.stub || row.failedLoad) {
             return null;
         }
-        // An aggFunc calc col's group row shows the aggregated value, not a formula evaluation.
-        if (col.aggFunc && row.group) {
+        // An actively-aggregating calc col's group row shows the aggregated value, not a formula evaluation.
+        // Gate on the active state (not just a defined aggFunc), matching getValueFromData.
+        if (col.aggregationActive && row.group) {
             return null;
         }
-        // No source to evaluate against (leaf data, or a group's aggData/own data) stays blank, not error.
-        const hasSource = row.group ? row.aggData != null || row.data != null : row.data != null;
-        if (!hasSource) {
+        // Execute only on rows with their own data — leaf rows and Tree Data parents that carry data.
+        // Synthetic rows without data (group rows, footers, tree filler nodes) stay blank.
+        if (!row.data) {
             return null;
         }
 
@@ -740,10 +741,11 @@ export class FormulaService extends BeanStub implements IFormulaService, NamedBe
         }
         const valueSvc = this.beans.valueSvc;
         // A referenced pivot result column gives the row's contribution to that bucket: aggregate on a group,
-        // source on an in-bucket leaf, blank otherwise. (Shared resolver stays source-uniform; read-only here.)
+        // and on a leaf its source measure if it falls in the bucket, else blank (it contributes nothing).
+        // The blank is returned explicitly — not via getValueFromData, which can resolve the source value.
         const pivotValueCol = col.pivotValueColumn;
-        if (pivotValueCol && !row.group && !row.rowPinned && this.leafInPivotBucket(col, row)) {
-            return valueSvc.getValueFromData(pivotValueCol, row);
+        if (pivotValueCol && !row.group && !row.rowPinned) {
+            return this.leafInPivotBucket(col, row) ? valueSvc.getValueFromData(pivotValueCol, row) : undefined;
         }
         return valueSvc.getValueFromData(col, row);
     }

--- a/packages/ag-grid-enterprise/src/pivot/pivotColDefService.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotColDefService.ts
@@ -433,6 +433,10 @@ export class PivotColDefService extends BeanStub implements NamedBean, IPivotCol
             // even if original column was hidden, we always show the pivot value column, otherwise it would be
             // very confusing for people thinking the pivot is broken
             colDef.hide = false;
+
+            // A pivot result column is a plain value column, never a calc/formula column: it aggregates.
+            colDef.calculatedExpression = undefined;
+            colDef.allowFormula = undefined;
         }
 
         colDef.headerName = headerName;

--- a/packages/ag-grid-enterprise/src/pivot/pivotColDefService.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotColDefService.ts
@@ -434,9 +434,12 @@ export class PivotColDefService extends BeanStub implements NamedBean, IPivotCol
             // very confusing for people thinking the pivot is broken
             colDef.hide = false;
 
-            // A pivot result column is a plain value column, never a calc/formula column: it aggregates.
-            colDef.calculatedExpression = undefined;
-            colDef.allowFormula = undefined;
+            // A pivot result column aggregates its source's per-leaf values. If the source is a calculated
+            // column, drop its calc-col fields so the result aggregates instead of re-evaluating the formula.
+            if (valueColumn.isCalculatedCol) {
+                colDef.calculatedExpression = undefined;
+                colDef.allowFormula = undefined;
+            }
         }
 
         colDef.headerName = headerName;

--- a/testing/behavioural/src/columns/row-span.test.ts
+++ b/testing/behavioural/src/columns/row-span.test.ts
@@ -670,7 +670,7 @@ describe('row spanning', () => {
             await new GridColumns(api, 'calc-add columns after').checkColumns(`
                 CENTER
                 ├── athlete "Athlete" width:200 spanRows
-                └── copy width:200 spanRows
+                └── copy width:200 ƒ spanRows
             `);
             await new GridRows(api, 'calc-add rows after').check(`
                 ROOT id:ROOT_NODE_ID

--- a/testing/behavioural/src/formulas/calculated-columns-ordering.test.ts
+++ b/testing/behavioural/src/formulas/calculated-columns-ordering.test.ts
@@ -201,7 +201,7 @@ describe('calculated columns - display ordering', () => {
         await new GridColumns(api, 'static calc col keeps its declared position among regular columns').checkColumns(`
             CENTER
             ├── revenue "Revenue" width:200
-            ├── profit width:200
+            ├── profit width:200 ƒ
             └── cost "Cost" width:200
         `);
     });
@@ -222,9 +222,9 @@ describe('calculated columns - display ordering', () => {
             CENTER
             ├── revenue "Revenue" width:200
             ├── cost "Cost" width:200
-            ├── profit width:200
-            ├── margin width:200
-            └── status width:200
+            ├── profit width:200 ƒ
+            ├── margin width:200 ƒ
+            └── status width:200 ƒ
         `);
     });
 
@@ -257,7 +257,7 @@ describe('calculated columns - display ordering', () => {
                 CENTER
                 └─┬ GROUP
                   ├── revenue "Revenue" width:200
-                  ├── profit width:200
+                  ├── profit width:200 ƒ
                   └── cost "Cost" width:200
             `);
     });
@@ -312,7 +312,7 @@ describe('calculated columns - display ordering', () => {
             CENTER
             ├── revenue "Revenue" width:200
             ├── cost "Cost" width:200
-            └── profit width:200
+            └── profit width:200 ƒ
         `);
     });
 
@@ -338,8 +338,8 @@ describe('calculated columns - display ordering', () => {
             CENTER
             ├── revenue "Revenue" width:200
             ├── cost "Cost" width:200
-            ├── profit width:200
-            └── margin width:200
+            ├── profit width:200 ƒ
+            └── margin width:200 ƒ
         `);
     });
 
@@ -360,7 +360,7 @@ describe('calculated columns - display ordering', () => {
         expect(c2).toBe('calculated_2');
         await new GridColumns(api, 'unanchored calc col stays top-level, not in group').checkColumns(`
             CENTER
-            ├── calculated_2 "Untitled" width:200
+            ├── calculated_2 "Untitled" width:200 ƒ
             └─┬ "G" GROUP
               ├── a "A" width:200
               └── b "B" width:200
@@ -383,7 +383,7 @@ describe('calculated columns - display ordering', () => {
                 ├── c "C" width:200
                 ├── a "A" width:200
                 ├── b "B" width:200
-                └── sum width:200
+                └── sum width:200 ƒ
             `);
     });
 
@@ -471,7 +471,7 @@ describe('calculated columns - display ordering', () => {
         await new GridColumns(api, 'dialog add lands immediately after the anchor leaf column').checkColumns(`
             CENTER
             ├── revenue "Revenue" width:200
-            ├── calculated_1 "Untitled" width:200
+            ├── calculated_1 "Untitled" width:200 ƒ
             └── cost "Cost" width:200
         `);
     });
@@ -511,7 +511,7 @@ describe('calculated columns - display ordering', () => {
             CENTER
             ├── athlete "Athlete" width:200
             ├── age "Age" width:200
-            └── calculated_1 "Untitled" width:200
+            └── calculated_1 "Untitled" width:200 ƒ
         `);
         await new GridRows(api, 'dialog add preserves unpinned state - rows').check(`
             ROOT id:ROOT_NODE_ID
@@ -538,7 +538,7 @@ describe('calculated columns - display ordering', () => {
             CENTER
             ├── a "A" width:200 sort:desc
             ├── b "B" width:200
-            └── calculated_1 "Untitled" width:200
+            └── calculated_1 "Untitled" width:200 ƒ
         `);
         await new GridRows(api, 'preserved runtime sort after calc add - rows').check(`
             ROOT id:ROOT_NODE_ID
@@ -564,7 +564,7 @@ describe('calculated columns - display ordering', () => {
             CENTER
             ├── a "A" width:250
             ├── b "B" width:200
-            └── calculated_1 "Untitled" width:200
+            └── calculated_1 "Untitled" width:200 ƒ
         `);
         await new GridRows(api, 'preserved runtime width after calc add - rows').check(`
             ROOT id:ROOT_NODE_ID
@@ -626,7 +626,7 @@ describe('calculated columns - display ordering', () => {
             CENTER
             └─┬ GROUP
               ├── revenue "Revenue" width:200
-              ├── calculated_1 "Untitled" width:200
+              ├── calculated_1 "Untitled" width:200 ƒ
               └── cost "Cost" width:200
         `);
     });
@@ -744,7 +744,7 @@ describe('calculated columns - display ordering', () => {
                 CENTER
                 ├── c "C" width:200
                 ├── a "A" width:200
-                ├── calculated_2 "Untitled" width:200
+                ├── calculated_2 "Untitled" width:200 ƒ
                 └── b "B" width:200
             `);
     });
@@ -765,8 +765,8 @@ describe('calculated columns - display ordering', () => {
         await new GridColumns(api, 'dialog add anchored on another calculated column chains after it').checkColumns(`
             CENTER
             ├── revenue "Revenue" width:200
-            ├── calculated_1 "Untitled" width:200
-            ├── calculated_2 "Untitled" width:200
+            ├── calculated_1 "Untitled" width:200 ƒ
+            ├── calculated_2 "Untitled" width:200 ƒ
             └── cost "Cost" width:200
         `);
     });
@@ -791,8 +791,8 @@ describe('calculated columns - display ordering', () => {
         expect(order(api)).toEqual([first, second, 'revenue', 'cost']);
         await new GridColumns(api, 'chain after anchor move').checkColumns(`
             CENTER
-            ├── calculated_1 "Untitled" width:200
-            ├── calculated_2 "Untitled" width:200
+            ├── calculated_1 "Untitled" width:200 ƒ
+            ├── calculated_2 "Untitled" width:200 ƒ
             ├── revenue "Revenue" width:200
             └── cost "Cost" width:200
         `);
@@ -818,8 +818,8 @@ describe('calculated columns - display ordering', () => {
         ).checkColumns(`
             CENTER
             ├── revenue "Revenue" width:200
-            ├── calculated_2 "Untitled" width:200
-            ├── calculated_1 "Untitled" width:200
+            ├── calculated_2 "Untitled" width:200 ƒ
+            ├── calculated_1 "Untitled" width:200 ƒ
             └── cost "Cost" width:200
         `);
     });
@@ -848,7 +848,7 @@ describe('calculated columns - display ordering', () => {
         await new GridColumns(api, 'calc after auto-group anchor').checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
-            ├── calculated_1 "Untitled" width:200
+            ├── calculated_1 "Untitled" width:200 ƒ
             ├── revenue "Revenue" width:200 aggFunc:sum
             └── cost "Cost" width:200 aggFunc:sum
         `);
@@ -872,8 +872,8 @@ describe('calculated columns - display ordering', () => {
         await new GridColumns(api, 'repeated calc adds from auto-group anchor').checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
-            ├── calculated_2 "Untitled" width:200
-            ├── calculated_1 "Untitled" width:200
+            ├── calculated_2 "Untitled" width:200 ƒ
+            ├── calculated_1 "Untitled" width:200 ƒ
             ├── revenue "Revenue" width:200 aggFunc:sum
             └── cost "Cost" width:200 aggFunc:sum
         `);
@@ -902,9 +902,9 @@ describe('calculated columns - display ordering', () => {
         expect(order(api)).toEqual([first, 'ag-Grid-AutoColumn', second, 'region', 'revenue', 'cost']);
         await new GridColumns(api, 'add from moved auto-group anchor').checkColumns(`
             CENTER
-            ├── calculated_1 "Untitled" width:200
+            ├── calculated_1 "Untitled" width:200 ƒ
             ├── ag-Grid-AutoColumn "Group" width:200
-            ├── calculated_2 "Untitled" width:200
+            ├── calculated_2 "Untitled" width:200 ƒ
             ├── revenue "Revenue" width:200 aggFunc:sum
             └── cost "Cost" width:200 aggFunc:sum
         `);
@@ -941,7 +941,7 @@ describe('calculated columns - display ordering', () => {
             ├── qty "Qty" width:200
             ├── revenue "Revenue" width:200
             ├── cost "Cost" width:200
-            └── calculated_1 "Untitled" width:200
+            └── calculated_1 "Untitled" width:200 ƒ
         `);
     });
 
@@ -970,7 +970,7 @@ describe('calculated columns - display ordering', () => {
             ├── revenue "Revenue" width:200 !resizable
             ├── cost "Cost" width:200 !resizable
             ├── qty "Qty" width:200 !resizable
-            └── calculated_1 "Untitled" width:200 !resizable
+            └── calculated_1 "Untitled" width:200 ƒ !resizable
         `);
     });
 
@@ -1002,7 +1002,7 @@ describe('calculated columns - display ordering', () => {
             CENTER
             ├── a "A" width:200 sort:asc
             ├── revenue "Revenue" width:200
-            ├── calculated_1 "Untitled" width:200
+            ├── calculated_1 "Untitled" width:200 ƒ
             ├── cost "Cost" width:200
             └── b "B" width:200
         `);
@@ -1028,7 +1028,7 @@ describe('calculated columns - display ordering', () => {
         await new GridColumns(api, 'mid-list calc preserved with maintainColumnOrder').checkColumns(`
             CENTER
             ├── revenue "Revenue" width:200 !resizable
-            ├── calculated_1 "Untitled" width:200 !resizable
+            ├── calculated_1 "Untitled" width:200 ƒ !resizable
             ├── cost "Cost" width:200 !resizable
             └── qty "Qty" width:200 !resizable
         `);
@@ -1055,7 +1055,7 @@ describe('calculated columns - display ordering', () => {
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
             ├── revenue "Revenue" width:200
-            ├── calculated_1 "Untitled" width:200
+            ├── calculated_1 "Untitled" width:200 ƒ
             └── cost "Cost" width:200
         `);
     });
@@ -1082,7 +1082,7 @@ describe('calculated columns - display ordering', () => {
         await new GridColumns(api, 'removing the anchor calc col keeps its orphaned dependent in place').checkColumns(`
             CENTER
             ├── revenue "Revenue" width:200
-            ├── calculated_2 "Untitled" width:200
+            ├── calculated_2 "Untitled" width:200 ƒ
             └── cost "Cost" width:200
         `);
     });
@@ -1109,7 +1109,7 @@ describe('calculated columns - display ordering', () => {
             .checkColumns(`
                 CENTER
                 ├── revenue "Revenue" width:200
-                ├── calculated_2 "Untitled" width:200
+                ├── calculated_2 "Untitled" width:200 ƒ
                 ├── cost "Cost" width:200
                 └── tax "Tax" width:200
             `);
@@ -1143,7 +1143,7 @@ describe('calculated columns - display ordering', () => {
             CENTER
             ├── revenue "Revenue" width:200
             ├── cost "Cost" width:200
-            └── margin width:200
+            └── margin width:200 ƒ
         `);
     });
 
@@ -1220,7 +1220,7 @@ describe('calculated columns - display ordering', () => {
                 CENTER
                 ├── revenue "Revenue" width:200
                 ├── cost "Cost" width:200
-                └── profit width:200
+                └── profit width:200 ƒ
             `);
     });
 
@@ -1248,7 +1248,7 @@ describe('calculated columns - display ordering', () => {
             CENTER
             ├── revenue "Revenue" width:200
             ├── cost "Cost" width:200
-            └── profit width:200
+            └── profit width:200 ƒ
         `);
     });
 });

--- a/testing/behavioural/src/formulas/calculated-columns-pivot.test.ts
+++ b/testing/behavioural/src/formulas/calculated-columns-pivot.test.ts
@@ -7,10 +7,10 @@ import { CalculatedColumnsModule, FormulaModule, PivotModule, RowGroupingModule 
 
 import { GridColumns, TestGridsManager, asyncSetTimeout } from '../test-utils';
 
-// Characterization of calculated-column behaviour in PIVOT mode. These lock in the CURRENT behaviour
-// so the one-tree collapse (which re-runs the whole tree build on every pivot change) can be verified
-// to preserve it. Pivot has a distinct flow: colsList = pivot result cols, while the calc col lives
-// in the primary tree (colDefList) and surfaces alongside the pivot result.
+// Calculated-column behaviour in PIVOT mode. A calculated column stays active under pivot, evaluating
+// against the primary columns on leaf rows. Without an aggFunc it is a non-value primary column (no pivot
+// result column, absent from the cross-tab); with an aggFunc its per-leaf values aggregate into pivot
+// result columns, exactly like a valueGetter value column.
 
 describe('calculated columns - pivot mode', () => {
     const gridsManager = new TestGridsManager({
@@ -49,10 +49,6 @@ describe('calculated columns - pivot mode', () => {
         return api.getAllGridColumns()!.map((col) => col.getColId());
     }
 
-    function warningText(): string {
-        return vi.mocked(console.warn).mock.calls.flat().join('\n');
-    }
-
     const rowData = [
         { id: 'r1', country: 'US', year: 2020, revenue: 10, cost: 3 },
         { id: 'r2', country: 'UK', year: 2020, revenue: 20, cost: 5 },
@@ -66,7 +62,7 @@ describe('calculated columns - pivot mode', () => {
         { field: 'cost', aggFunc: 'sum' },
     ];
 
-    test('calc col is gated by an active pivot column, not by enablePivot or pivot mode alone', async () => {
+    test('calc col stays active under an active pivot and remains a resolvable primary column', async () => {
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
         const api = createGrid('pivot-enabled-runtime-toggle', {
             defaultColDef: { enablePivot: true, enableRowGroup: true, enableValue: true },
@@ -93,16 +89,15 @@ describe('calculated columns - pivot mode', () => {
         expect(profit()).toBe(7);
         expect(warn).not.toHaveBeenCalled();
 
-        // Assigning a pivot column at runtime activates the pivot, so the calc col is turned off
-        // while remaining a resolvable primary column.
+        // Assigning a pivot column at runtime activates the pivot. The calc col (no aggFunc, not the pivot
+        // dimension) stays active: it keeps evaluating against the primary columns on leaf rows.
         api.applyColumnState({ state: [{ colId: 'country', pivot: true }] });
         await asyncSetTimeout(10);
-        expect(warningText()).toContain('colDef.calculatedExpression is not supported with Column Pivoting');
-        expect(warningText()).not.toContain('colDef.allowFormula is not supported with Column Pivoting');
+        expect(profit()).toBe(7);
+        expect(warn).not.toHaveBeenCalled();
         expect(api.getColumn('profit')).toBeTruthy();
 
-        // Removing the pivot column re-enables calc evaluation.
-        warn.mockClear();
+        // Removing the pivot column leaves calc evaluation unchanged.
         api.applyColumnState({ state: [{ colId: 'country', pivot: false }] });
         api.setGridOption('pivotMode', false);
         await asyncSetTimeout(10);
@@ -111,7 +106,6 @@ describe('calculated columns - pivot mode', () => {
     });
 
     test('calc col is absent from the pivot display but remains a resolvable primary column', async () => {
-        vi.spyOn(console, 'warn').mockImplementation(() => {});
         const api = createGrid('pivot-static-calc', {
             rowData,
             columnDefs: [
@@ -138,8 +132,8 @@ describe('calculated columns - pivot mode', () => {
         `);
     });
 
-    test('calculated value column in pivot mode warns about calculatedExpression, not allowFormula or generated field conflicts', async () => {
-        vi.spyOn(console, 'warn').mockImplementation(() => {});
+    test('calculated value column in pivot mode produces no incompatibility or validation warnings', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
         createGrid('pivot-calc-warning-text', {
             rowData: [
                 { id: 'r1', country: 'US', year: 2020, gold: 1, silver: 2 },
@@ -166,12 +160,10 @@ describe('calculated columns - pivot mode', () => {
         });
         await asyncSetTimeout(10);
 
-        const text = warningText();
-        expect(text).toContain('colDef.calculatedExpression is not supported with Column Pivoting');
-        expect(text).not.toContain('colDef.allowFormula is not supported with Column Pivoting');
-        expect(text).not.toContain(
-            'colDef.calculatedExpression is used as the value source and should not be combined with field, valueGetter or valueSetter.'
-        );
+        // A calc value column aggregates under pivot like a valueGetter column, so no incompatibility or
+        // validation warning fires at all (the old "not supported with Column Pivoting", misleading
+        // allowFormula, and value-source messages are all gone).
+        expect(warn).not.toHaveBeenCalled();
     });
 
     test('addCalculatedColumn while pivot active keeps the pivot result intact', async () => {
@@ -198,7 +190,6 @@ describe('calculated columns - pivot mode', () => {
     });
 
     test('pivot mode off then on restores the calc col among the primary cols', async () => {
-        vi.spyOn(console, 'warn').mockImplementation(() => {});
         const api = createGrid('pivot-toggle', {
             rowData,
             columnDefs: [
@@ -231,9 +222,29 @@ describe('calculated columns - pivot mode', () => {
         expect(order(api).some((c) => c.startsWith('pivot_year_2020'))).toBe(true);
     });
 
-    test('calc col referencing a pivot result column id does not read it on a leaf', async () => {
+    test('calc col referencing primary columns evaluates on leaf rows under an active pivot', async () => {
+        const api = createGrid('pivot-calc-primary-ref', {
+            rowData,
+            columnDefs: [
+                ...pivotColumnDefs,
+                {
+                    colId: 'doubledRevenue',
+                    calculatedExpression: '[revenue] * 2',
+                    cellDataType: 'number',
+                },
+            ],
+            pivotMode: true,
+        });
+        await asyncSetTimeout(10);
+
+        expect(
+            api.getCellValue({ rowNode: api.getRowNode('r1')!, colKey: 'doubledRevenue', useFormatter: false })
+        ).toBe(20);
+    });
+
+    test('calc col referencing a pivot result column id resolves via the source column on leaf rows', async () => {
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        const api = createGrid('pivot-calc-refs-pivot-col', {
+        const api = createGrid('pivot-calc-result-ref', {
             rowData,
             columnDefs: [
                 ...pivotColumnDefs,
@@ -247,11 +258,10 @@ describe('calculated columns - pivot mode', () => {
         });
         await asyncSetTimeout(10);
 
-        const doubledOf = (id: string) =>
-            api.getCellValue({ rowNode: api.getRowNode(id)!, colKey: 'doubled', useFormatter: false });
-
-        expect(doubledOf('r1')).toBeUndefined();
-        expect(warningText()).toContain('colDef.calculatedExpression is not supported with Column Pivoting');
-        warn.mockRestore();
+        // A reference to a pivot result column redirects to its source value column on leaf rows, so the
+        // calc col reads the leaf's own revenue (10 * 2) rather than resolving to a silent blank — and no
+        // pivot-incompatibility warning fires.
+        expect(api.getCellValue({ rowNode: api.getRowNode('r1')!, colKey: 'doubled', useFormatter: false })).toBe(20);
+        expect(warn).not.toHaveBeenCalled();
     });
 });

--- a/testing/behavioural/src/formulas/calculated-columns-pivot.test.ts
+++ b/testing/behavioural/src/formulas/calculated-columns-pivot.test.ts
@@ -166,6 +166,45 @@ describe('calculated columns - pivot mode', () => {
         expect(warn).not.toHaveBeenCalled();
     });
 
+    test('calc value column aggregates like a valueGetter under a runtime-activated pivot, no warnings', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const api = createGrid('pivot-tc2-runtime', {
+            rowData: [
+                { id: 'r1', country: 'US', year: 2020, gold: 1, silver: 2 },
+                { id: 'r2', country: 'US', year: 2021, gold: 3, silver: 4 },
+            ],
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year' },
+                { field: 'gold', aggFunc: 'sum' },
+                { field: 'silver', aggFunc: 'sum' },
+                { colId: 'calc', aggFunc: 'sum', calculatedExpression: '[gold] + [silver]', cellDataType: 'number' },
+                {
+                    colId: 'vg',
+                    aggFunc: 'sum',
+                    valueGetter: (p) => (p.data ? p.data.gold + p.data.silver : undefined),
+                    cellDataType: 'number',
+                },
+            ],
+        });
+        await asyncSetTimeout(10);
+
+        // Enable pivot mode and drag YEAR into the pivot at runtime (the column-tool-panel path).
+        api.setGridOption('pivotMode', true);
+        api.applyColumnState({ state: [{ colId: 'year', pivot: true }] });
+        await asyncSetTimeout(10);
+
+        // The calc value column's per-year pivot result aggregates its per-leaf (gold+silver), matching the
+        // valueGetter column under every year — and no incompatibility/validation warning fires.
+        await new GridRows(api, 'TC2 runtime pivot calc aggregates', { useFormatter: false }).check(`
+            ROOT id:ROOT_NODE_ID pivot_year_2020_gold:1 pivot_year_2020_silver:2 pivot_year_2020_calc:3 pivot_year_2020_vg:3 pivot_year_2021_gold:3 pivot_year_2021_silver:4 pivot_year_2021_calc:7 pivot_year_2021_vg:7
+            └─┬ LEAF_GROUP collapsed id:row-group-country-US ag-Grid-AutoColumn:"US" pivot_year_2020_gold:1 pivot_year_2020_silver:2 pivot_year_2020_calc:3 pivot_year_2020_vg:3 pivot_year_2021_gold:3 pivot_year_2021_silver:4 pivot_year_2021_calc:7 pivot_year_2021_vg:7
+            · ├── LEAF hidden id:r1 pivot_year_2020_gold:1 pivot_year_2020_silver:2 pivot_year_2020_calc:3 pivot_year_2020_vg:3 pivot_year_2021_gold:1 pivot_year_2021_silver:2 pivot_year_2021_calc:3 pivot_year_2021_vg:3
+            · └── LEAF hidden id:r2 pivot_year_2020_gold:3 pivot_year_2020_silver:4 pivot_year_2020_calc:7 pivot_year_2020_vg:7 pivot_year_2021_gold:3 pivot_year_2021_silver:4 pivot_year_2021_calc:7 pivot_year_2021_vg:7
+        `);
+        expect(warn).not.toHaveBeenCalled();
+    });
+
     test('a calculated column can be a pivot dimension: its per-leaf formula result is the pivot key', async () => {
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
         const api = createGrid('pivot-by-calc', {
@@ -277,15 +316,15 @@ describe('calculated columns - pivot mode', () => {
         ).toBe(20);
     });
 
-    test('calc col referencing a pivot result column id resolves it like getCellValue (group bucket, leaf source)', async () => {
+    test('calc col referencing a pivot result column id reads the row contribution to that bucket', async () => {
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
         const api = createGrid('pivot-calc-result-ref', {
             rowData,
             columnDefs: [
                 ...pivotColumnDefs,
                 {
-                    colId: 'doubled',
-                    calculatedExpression: '[pivot_year_2020_revenue] * 2',
+                    colId: 'ref2020',
+                    calculatedExpression: '[pivot_year_2020_revenue]',
                     cellDataType: 'number',
                 },
             ],
@@ -293,15 +332,15 @@ describe('calculated columns - pivot mode', () => {
         });
         await asyncSetTimeout(10);
 
-        const doubled = (id: string) =>
-            api.getCellValue({ rowNode: api.getRowNode(id)!, colKey: 'doubled', useFormatter: false });
-        // The reference resolves exactly as getCellValue does: a group reads the 2020-revenue bucket from
-        // aggData (US 2020 = 10 → 20, UK 2020 = 20 → 40); a leaf redirects to its source revenue (r1 = 10 → 20,
-        // r3 = 15 → 30) — the same source-redirect the grid uses everywhere for pivot result columns on leaves.
-        expect(doubled('row-group-country-US')).toBe(20);
-        expect(doubled('row-group-country-UK')).toBe(40);
-        expect(doubled('r1')).toBe(20);
-        expect(doubled('r3')).toBe(30);
+        const ref2020 = (id: string) =>
+            api.getCellValue({ rowNode: api.getRowNode(id)!, colKey: 'ref2020', useFormatter: false });
+        // The reference resolves to each row's contribution to the 2020-revenue bucket: a group reads the
+        // bucket aggregate (US = 10, UK = 20); a leaf in the bucket reads its source revenue (r1 = 10); a
+        // leaf outside it (r3 is a 2021 row) is blank — it contributes nothing to 2020.
+        expect(ref2020('row-group-country-US')).toBe(10);
+        expect(ref2020('row-group-country-UK')).toBe(20);
+        expect(ref2020('r1')).toBe(10);
+        expect(ref2020('r3')).toBeUndefined();
         expect(warn).not.toHaveBeenCalled();
     });
 

--- a/testing/behavioural/src/formulas/calculated-columns-pivot.test.ts
+++ b/testing/behavioural/src/formulas/calculated-columns-pivot.test.ts
@@ -316,7 +316,7 @@ describe('calculated columns - pivot mode', () => {
         ).toBe(20);
     });
 
-    test('calc col referencing a pivot result column id reads the row contribution to that bucket', async () => {
+    test('calc col referencing a pivot result column id is bucket-aware on leaves; blank on group rows', async () => {
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
         const api = createGrid('pivot-calc-result-ref', {
             rowData,
@@ -334,11 +334,11 @@ describe('calculated columns - pivot mode', () => {
 
         const ref2020 = (id: string) =>
             api.getCellValue({ rowNode: api.getRowNode(id)!, colKey: 'ref2020', useFormatter: false });
-        // The reference resolves to each row's contribution to the 2020-revenue bucket: a group reads the
-        // bucket aggregate (US = 10, UK = 20); a leaf in the bucket reads its source revenue (r1 = 10); a
-        // leaf outside it (r3 is a 2021 row) is blank — it contributes nothing to 2020.
-        expect(ref2020('row-group-country-US')).toBe(10);
-        expect(ref2020('row-group-country-UK')).toBe(20);
+        // Group rows have no data of their own, so the calc col stays blank there. On a leaf the reference
+        // is its contribution to the 2020 bucket: a leaf in the bucket reads its source revenue (r1 = 10);
+        // a leaf outside it (r3 is a 2021 row) is blank.
+        expect(ref2020('row-group-country-US')).toBeUndefined();
+        expect(ref2020('row-group-country-UK')).toBeUndefined();
         expect(ref2020('r1')).toBe(10);
         expect(ref2020('r3')).toBeUndefined();
         expect(warn).not.toHaveBeenCalled();

--- a/testing/behavioural/src/formulas/calculated-columns-pivot.test.ts
+++ b/testing/behavioural/src/formulas/calculated-columns-pivot.test.ts
@@ -5,12 +5,12 @@ import type { ColDef, GridApi, GridOptions, Module } from 'ag-grid-community';
 import { ClientSideRowModelModule, ValidationModule } from 'ag-grid-community';
 import { CalculatedColumnsModule, FormulaModule, PivotModule, RowGroupingModule } from 'ag-grid-enterprise';
 
-import { GridColumns, TestGridsManager, asyncSetTimeout } from '../test-utils';
+import { GridColumns, GridRows, TestGridsManager, asyncSetTimeout } from '../test-utils';
 
 // Calculated-column behaviour in PIVOT mode. A calculated column stays active under pivot, evaluating
-// against the primary columns on leaf rows. Without an aggFunc it is a non-value primary column (no pivot
-// result column, absent from the cross-tab); with an aggFunc its per-leaf values aggregate into pivot
-// result columns, exactly like a valueGetter value column.
+// against the primary columns on leaf rows, and works in every pivot role: as a non-value primary column
+// (no aggFunc → no result column), as a pivot value (aggFunc → per-leaf values aggregate into result
+// columns like a valueGetter), and as a pivot dimension (its per-leaf formula result is the pivot key).
 
 describe('calculated columns - pivot mode', () => {
     const gridsManager = new TestGridsManager({
@@ -166,6 +166,41 @@ describe('calculated columns - pivot mode', () => {
         expect(warn).not.toHaveBeenCalled();
     });
 
+    test('a calculated column can be a pivot dimension: its per-leaf formula result is the pivot key', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const api = createGrid('pivot-by-calc', {
+            rowData,
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'revenue', aggFunc: 'sum' },
+                { colId: 'band', calculatedExpression: 'IF([revenue] > 12, "High", "Low")', pivot: true },
+            ],
+            pivotMode: true,
+        });
+        await asyncSetTimeout(10);
+
+        // The calc col's per-leaf result (High/Low) is used as the pivot key, exactly like pivoting by a
+        // valueGetter column: revenue aggregates into a result column per distinct band. No warning fires.
+        await new GridColumns(api, 'pivot by calc col').checkColumns(`
+            CENTER
+            ├── ag-Grid-AutoColumn "Group" width:200
+            ├─┬ "High" GROUP
+            │ └── pivot_band_High_revenue "Revenue" width:200 columnGroupShow:open
+            └─┬ "Low" GROUP
+              └── pivot_band_Low_revenue "Revenue" width:200 columnGroupShow:open
+        `);
+        // US has r1 (rev 10 → Low) and r3 (rev 15 → High); UK has r2 (rev 20 → High).
+        await new GridRows(api, 'pivot by calc col values', { useFormatter: false }).check(`
+            ROOT id:ROOT_NODE_ID pivot_band_High_revenue:35 pivot_band_Low_revenue:10
+            ├─┬ LEAF_GROUP collapsed id:row-group-country-US ag-Grid-AutoColumn:"US" pivot_band_High_revenue:15 pivot_band_Low_revenue:10
+            │ ├── LEAF hidden id:r1 pivot_band_High_revenue:10 pivot_band_Low_revenue:10
+            │ └── LEAF hidden id:r3 pivot_band_High_revenue:15 pivot_band_Low_revenue:15
+            └─┬ LEAF_GROUP collapsed id:row-group-country-UK ag-Grid-AutoColumn:"UK" pivot_band_High_revenue:20 pivot_band_Low_revenue:null
+            · └── LEAF hidden id:r2 pivot_band_High_revenue:20 pivot_band_Low_revenue:20
+        `);
+        expect(warn).not.toHaveBeenCalled();
+    });
+
     test('addCalculatedColumn while pivot active keeps the pivot result intact', async () => {
         const api = createGrid('pivot-add-calc', {
             rowData,
@@ -212,7 +247,7 @@ describe('calculated columns - pivot mode', () => {
             ├── year "Year" width:200 pivot
             ├── revenue "Revenue" width:200 aggFunc:sum
             ├── cost "Cost" width:200 aggFunc:sum
-            └── profit width:200
+            └── profit width:200 ƒ
         `);
 
         api.setGridOption('pivotMode', true);
@@ -242,7 +277,7 @@ describe('calculated columns - pivot mode', () => {
         ).toBe(20);
     });
 
-    test('calc col referencing a pivot result column id resolves via the source column on leaf rows', async () => {
+    test('calc col referencing a pivot result column id resolves it like getCellValue (group bucket, leaf source)', async () => {
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
         const api = createGrid('pivot-calc-result-ref', {
             rowData,
@@ -258,10 +293,36 @@ describe('calculated columns - pivot mode', () => {
         });
         await asyncSetTimeout(10);
 
-        // A reference to a pivot result column redirects to its source value column on leaf rows, so the
-        // calc col reads the leaf's own revenue (10 * 2) rather than resolving to a silent blank — and no
-        // pivot-incompatibility warning fires.
-        expect(api.getCellValue({ rowNode: api.getRowNode('r1')!, colKey: 'doubled', useFormatter: false })).toBe(20);
+        const doubled = (id: string) =>
+            api.getCellValue({ rowNode: api.getRowNode(id)!, colKey: 'doubled', useFormatter: false });
+        // The reference resolves exactly as getCellValue does: a group reads the 2020-revenue bucket from
+        // aggData (US 2020 = 10 → 20, UK 2020 = 20 → 40); a leaf redirects to its source revenue (r1 = 10 → 20,
+        // r3 = 15 → 30) — the same source-redirect the grid uses everywhere for pivot result columns on leaves.
+        expect(doubled('row-group-country-US')).toBe(20);
+        expect(doubled('row-group-country-UK')).toBe(40);
+        expect(doubled('r1')).toBe(20);
+        expect(doubled('r3')).toBe(30);
         expect(warn).not.toHaveBeenCalled();
+    });
+
+    test('pivot result columns keep allowFormula from a non-calc source but drop calc fields for a calc source', async () => {
+        const api = createGrid('pivot-result-allowformula', {
+            rowData,
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', pivot: true },
+                { field: 'revenue', aggFunc: 'sum', allowFormula: true },
+                { colId: 'calc', aggFunc: 'sum', calculatedExpression: '[revenue]', cellDataType: 'number' },
+            ],
+            pivotMode: true,
+        });
+        await asyncSetTimeout(10);
+
+        // The result column of an ordinary formula-enabled value column keeps allowFormula...
+        expect(api.getColumn('pivot_year_2020_revenue')!.isAllowFormula()).toBe(true);
+        // ...while the calc column's result column is a plain aggregation: no allowFormula, no expression.
+        const calcResult = api.getColumn('pivot_year_2020_calc')!;
+        expect(calcResult.isAllowFormula()).toBe(false);
+        expect(calcResult.getColDef().calculatedExpression).toBeUndefined();
     });
 });

--- a/testing/behavioural/src/formulas/calculated-columns.test.ts
+++ b/testing/behavioural/src/formulas/calculated-columns.test.ts
@@ -387,9 +387,9 @@ describe('ag-grid calculated columns', () => {
             ├── cost "Cost" width:200
             ├── first "First" width:200
             ├── last "Last" width:200
-            ├── profit "Profit" width:200
-            ├── profitable width:200
-            └── name width:200
+            ├── profit "Profit" width:200 ƒ
+            ├── profitable width:200 ƒ
+            └── name width:200 ƒ
         `);
 
         api.getRowNode('r1')!.setDataValue('revenueCol', 15);
@@ -575,9 +575,14 @@ describe('ag-grid calculated columns', () => {
                 const rowNode = api.getDisplayedRowAtIndex(0)!;
                 const profitColumn = api.getColumn('profit')!;
 
+                // No `calculated` token: the column is a plain editable field, not a calculated column.
+                await new GridColumns(api, id).checkColumns(`
+                    CENTER
+                    ├── revenue "Revenue" width:200
+                    ├── cost "Cost" width:200
+                    └── profit "Profit" width:200 editable
+                `);
                 expect(api.getCellValue({ rowNode, colKey: 'profit', useFormatter: false })).toBe(999);
-                expect(profitColumn.isCalculatedCol).toBe(false);
-                expect(profitColumn.isCellEditable(rowNode)).toBe(true);
                 expect(profitColumn.isSuppressPaste(rowNode)).toBe(false);
                 expect(consoleWarnSpy).toHaveBeenCalledWith(
                     expect.stringContaining(
@@ -604,19 +609,37 @@ describe('ag-grid calculated columns', () => {
             });
             const rowNode = api.getDisplayedRowAtIndex(0)!;
 
-            expect(api.getColumn('profit')!.isCalculatedCol).toBe(false);
+            // calculatedColumns off: no `calculated` token and the expression is not evaluated.
+            await new GridColumns(api, 'toggle off (initial)').checkColumns(`
+                CENTER
+                ├── revenue "Revenue" width:200
+                ├── cost "Cost" width:200
+                └── profit width:200
+            `);
             expect(api.getCellValue({ rowNode, colKey: 'profit', useFormatter: false })).toBeUndefined();
 
             api.setGridOption('calculatedColumns', true);
             await asyncSetTimeout(1);
 
-            expect(api.getColumn('profit')!.isCalculatedCol).toBe(true);
+            // calculatedColumns on: the column becomes calculated and the expression evaluates.
+            await new GridColumns(api, 'toggle on').checkColumns(`
+                CENTER
+                ├── revenue "Revenue" width:200
+                ├── cost "Cost" width:200
+                └── profit width:200 ƒ
+            `);
             expect(api.getCellValue({ rowNode, colKey: 'profit', useFormatter: false })).toBe(7);
 
             api.setGridOption('calculatedColumns', false);
             await asyncSetTimeout(1);
 
-            expect(api.getColumn('profit')!.isCalculatedCol).toBe(false);
+            // Toggling off again drops the `calculated` token and stops evaluation.
+            await new GridColumns(api, 'toggle off (again)').checkColumns(`
+                CENTER
+                ├── revenue "Revenue" width:200
+                ├── cost "Cost" width:200
+                └── profit width:200
+            `);
             expect(api.getCellValue({ rowNode, colKey: 'profit', useFormatter: false })).toBeUndefined();
         } finally {
             consoleWarnSpy.mockRestore();
@@ -702,7 +725,7 @@ describe('ag-grid calculated columns', () => {
             CENTER
             ├── revenue "Revenue" width:200
             ├── cost "Cost" width:200
-            └── profit width:200 sort:desc filter
+            └── profit width:200 sort:desc ƒ filter
         `);
     });
 
@@ -838,7 +861,7 @@ describe('ag-grid calculated columns', () => {
                 CENTER
                 ├── revenue "Revenue" width:200
                 ├── cost "Cost" width:200
-                └── profit width:200
+                └── profit width:200 ƒ
             `);
     });
 
@@ -919,8 +942,8 @@ describe('ag-grid calculated columns', () => {
             CENTER
             ├── revenue "Revenue" width:200
             ├── cost "Cost" width:200
-            ├── profit "Profit" width:200
-            └── calculated_1 "Untitled" width:200
+            ├── profit "Profit" width:200 ƒ
+            └── calculated_1 "Untitled" width:200 ƒ
         `);
     });
 
@@ -967,7 +990,7 @@ describe('ag-grid calculated columns', () => {
             CENTER
             ├── revenue "Revenue" width:200
             ├── cost "Cost" width:200
-            └── profitable "Profitable" width:200
+            └── profitable "Profitable" width:200 ƒ
         `);
     });
 
@@ -985,7 +1008,7 @@ describe('ag-grid calculated columns', () => {
             CENTER
             ├── revenue "Revenue" width:200
             ├── cost "Cost" width:200
-            └── profit width:200
+            └── profit width:200 ƒ
         `);
         await new GridRows(api, `grid api refreshes calculated-only formula caches setup`).check(`
             ROOT id:ROOT_NODE_ID
@@ -1047,8 +1070,8 @@ describe('ag-grid calculated columns', () => {
             ├── ag-Grid-AutoColumn "Group" width:200
             ├── revenue "Revenue" width:200 aggFunc:sum
             ├── cost "Cost" width:200 aggFunc:sum
-            ├── profit width:200
-            └── doubleProfit width:200
+            ├── profit width:200 ƒ
+            └── doubleProfit width:200 ƒ
         `);
         // Group rows derive from aggregated revenue/cost; leaf rows evaluate from their own data.
         await new GridRows(api, `calculated columns evaluate on row group rows`).check(`
@@ -1148,8 +1171,8 @@ describe('ag-grid calculated columns', () => {
             ├── ag-Grid-AutoColumn "Group" width:200
             ├── revenue "Revenue" width:200 aggFunc:sum
             ├── cost "Cost" width:200 aggFunc:sum
-            ├── profit width:200
-            └── maxProfit width:200 aggFunc:max
+            ├── profit width:200 ƒ
+            └── maxProfit width:200 aggFunc:max ƒ
         `);
         await new GridRows(api, `calculated columns with an aggFunc`).check(`
             ROOT id:ROOT_NODE_ID
@@ -1497,6 +1520,77 @@ describe('ag-grid calculated columns', () => {
         expect(api.getCellValue({ rowNode: grandTotal, colKey: 'profit', useFormatter: false })).toBe(29);
     });
 
+    test('aggregate-after calculated columns read aggData on group and grand-total footer rows', async () => {
+        const api = createGrid('calculated-aggfunc-footers', {
+            rowData: [
+                { id: 'r1', region: 'EMEA', revenue: 10, cost: 3 },
+                { id: 'r2', region: 'EMEA', revenue: 20, cost: 8 },
+                { id: 'r3', region: 'APAC', revenue: 15, cost: 5 },
+            ],
+            columnDefs: [
+                { field: 'region', rowGroup: true, hide: true },
+                { field: 'revenue', aggFunc: 'sum' },
+                { field: 'cost', aggFunc: 'sum' },
+                {
+                    colId: 'maxProfit',
+                    calculatedExpression: '[revenue] - [cost]',
+                    aggFunc: 'max',
+                    cellDataType: 'number',
+                },
+            ],
+            groupDefaultExpanded: -1,
+            groupTotalRow: 'bottom',
+            grandTotalRow: 'bottom',
+        });
+        await asyncSetTimeout(1);
+
+        // Footers/grand-total are group rows holding aggData, so agg-after reads the aggregated per-leaf
+        // max on each (EMEA & grand = 12), not the agg-first sum(rev)-sum(cost).
+        await new GridRows(api, 'aggfunc footers', gridRowsOpts).check(`
+            ROOT id:ROOT_NODE_ID revenue:45 cost:16 maxProfit:12
+            ├─┬ LEAF_GROUP id:row-group-region-EMEA ag-Grid-AutoColumn:"EMEA"
+            │ ├── LEAF id:r1 region:"EMEA" revenue:10 cost:3 maxProfit:7
+            │ ├── LEAF id:r2 region:"EMEA" revenue:20 cost:8 maxProfit:12
+            │ └─ footer id:rowGroupFooter_row-group-region-EMEA ag-Grid-AutoColumn:"EMEA" revenue:30 cost:11 maxProfit:12
+            ├─┬ LEAF_GROUP id:row-group-region-APAC ag-Grid-AutoColumn:"APAC"
+            │ ├── LEAF id:r3 region:"APAC" revenue:15 cost:5 maxProfit:10
+            │ └─ footer id:rowGroupFooter_row-group-region-APAC ag-Grid-AutoColumn:"APAC" revenue:15 cost:5 maxProfit:10
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:null revenue:45 cost:16 maxProfit:12
+        `);
+    });
+
+    test('aggregate-after calculated columns read aggData on a flat grid grand-total row', async () => {
+        const api = createGrid('calculated-aggfunc-flat-grandtotal', {
+            rowData: [
+                { id: 'r1', revenue: 10, cost: 3 },
+                { id: 'r2', revenue: 20, cost: 8 },
+                { id: 'r3', revenue: 15, cost: 5 },
+            ],
+            columnDefs: [
+                { field: 'revenue', aggFunc: 'sum' },
+                { field: 'cost', aggFunc: 'sum' },
+                {
+                    colId: 'maxProfit',
+                    calculatedExpression: '[revenue] - [cost]',
+                    aggFunc: 'max',
+                    cellDataType: 'number',
+                },
+            ],
+            grandTotalRow: 'bottom',
+        });
+        await asyncSetTimeout(1);
+
+        // Even with no row grouping the grand-total row is a group row with aggData: agg-after reads
+        // max(7,12,10)=12, not the agg-first sum(rev)-sum(cost)=45-16=29.
+        await new GridRows(api, 'aggfunc flat grand total', gridRowsOpts).check(`
+            ROOT id:ROOT_NODE_ID revenue:45 cost:16 maxProfit:12
+            ├── LEAF id:r1 revenue:10 cost:3 maxProfit:7
+            ├── LEAF id:r2 revenue:20 cost:8 maxProfit:12
+            ├── LEAF id:r3 revenue:15 cost:5 maxProfit:10
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID revenue:45 cost:16 maxProfit:12
+        `);
+    });
+
     test('grid api adds a calculated column while grouped and it evaluates on group and leaf rows', async () => {
         const api = createGrid('calculated-api-while-grouped', {
             rowData: [
@@ -1674,7 +1768,7 @@ describe('ag-grid calculated columns', () => {
                 CENTER
                 ├── revenue "Revenue" width:200
                 ├── cost "Cost" width:200
-                └── profit width:200
+                └── profit width:200 ƒ
             `
         );
         await new GridRows(api, `server-side store updates invalidate calculated column caches setup`).check(`
@@ -2201,7 +2295,7 @@ describe('ag-grid calculated columns', () => {
             CENTER
             ├─┬ "2025" GROUP
             │ ├── revenue_2025 "Revenue" width:200
-            │ ├── calculated_1 "Untitled" width:200
+            │ ├── calculated_1 "Untitled" width:200 ƒ
             │ └── cost_2025 "Cost" width:200
             └─┬ "2026" GROUP
               ├── revenue_2026 "Revenue" width:200
@@ -2244,7 +2338,7 @@ describe('ag-grid calculated columns', () => {
         ).checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
-            ├── calculated_1 "Untitled" width:200
+            ├── calculated_1 "Untitled" width:200 ƒ
             ├── revenue "Revenue" width:200
             └── cost "Cost" width:200
         `);
@@ -2273,7 +2367,7 @@ describe('ag-grid calculated columns', () => {
         await new GridColumns(api, 'auto-group toggle - after add').checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
-            ├── calculated_1 "Untitled" width:200
+            ├── calculated_1 "Untitled" width:200 ƒ
             ├── revenue "Revenue" width:200
             └── cost "Cost" width:200
         `);
@@ -2282,7 +2376,7 @@ describe('ag-grid calculated columns', () => {
         await asyncSetTimeout(1);
         await new GridColumns(api, 'auto-group toggle - ungrouped').checkColumns(`
             CENTER
-            ├── calculated_1 "Untitled" width:200
+            ├── calculated_1 "Untitled" width:200 ƒ
             ├── productType "Product Type" width:200
             ├── revenue "Revenue" width:200
             └── cost "Cost" width:200
@@ -2293,7 +2387,7 @@ describe('ag-grid calculated columns', () => {
         await new GridColumns(api, 'auto-group toggle - re-grouped').checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
-            ├── calculated_1 "Untitled" width:200
+            ├── calculated_1 "Untitled" width:200 ƒ
             ├── revenue "Revenue" width:200
             └── cost "Cost" width:200
         `);
@@ -2329,7 +2423,7 @@ describe('ag-grid calculated columns', () => {
         await new GridColumns(api, 'two auto-group toggle - after add').checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn-productType "Product Type" width:200
-            ├── calculated_1 "Untitled" width:200
+            ├── calculated_1 "Untitled" width:200 ƒ
             ├── ag-Grid-AutoColumn-country "Country" width:200
             ├── revenue "Revenue" width:200
             └── cost "Cost" width:200
@@ -2339,7 +2433,7 @@ describe('ag-grid calculated columns', () => {
         await asyncSetTimeout(1);
         await new GridColumns(api, 'two auto-group toggle - ungrouped').checkColumns(`
             CENTER
-            ├── calculated_1 "Untitled" width:200
+            ├── calculated_1 "Untitled" width:200 ƒ
             ├── productType "Product Type" width:200
             ├── country "Country" width:200
             ├── revenue "Revenue" width:200
@@ -2352,7 +2446,7 @@ describe('ag-grid calculated columns', () => {
             CENTER
             ├── ag-Grid-AutoColumn-productType "Product Type" width:200
             ├── ag-Grid-AutoColumn-country "Country" width:200
-            ├── calculated_1 "Untitled" width:200
+            ├── calculated_1 "Untitled" width:200 ƒ
             ├── revenue "Revenue" width:200
             └── cost "Cost" width:200
         `);
@@ -2401,7 +2495,7 @@ describe('ag-grid calculated columns', () => {
         ).checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn-productType "Product Type" width:200
-            ├── calculated_1 "Untitled" width:200
+            ├── calculated_1 "Untitled" width:200 ƒ
             ├── ag-Grid-AutoColumn-country "Country" width:200
             ├── revenue "Revenue" width:200
             └── cost "Cost" width:200
@@ -2455,7 +2549,7 @@ describe('ag-grid calculated columns', () => {
             ├── revenue "Revenue" width:200
             ├── cost "Cost" width:200
             ├── other "Other" width:200
-            └── calculated_1 "Untitled" width:200
+            └── calculated_1 "Untitled" width:200 ƒ
         `);
     });
 
@@ -2501,9 +2595,9 @@ describe('ag-grid calculated columns', () => {
             .checkColumns(`
                 CENTER
                 ├── ag-Grid-AutoColumn-productType "Product Type" width:200
-                ├── calculated_1 "Untitled" width:200
+                ├── calculated_1 "Untitled" width:200 ƒ
                 ├── ag-Grid-AutoColumn-country "Country" width:200
-                ├── calculated_2 "Untitled" width:200
+                ├── calculated_2 "Untitled" width:200 ƒ
                 ├── revenue "Revenue" width:200
                 └── cost "Cost" width:200
             `);
@@ -2631,7 +2725,7 @@ describe('ag-grid calculated columns', () => {
                 CENTER
                 ├── revenue "Revenue" width:200
                 ├── cost "Cost" width:200
-                └── profit width:200 sort:desc
+                └── profit width:200 sort:desc ƒ
             `);
     });
 
@@ -2702,7 +2796,7 @@ describe('ag-grid calculated columns', () => {
             ├── revenue "Revenue" width:200
             └── cost "Cost" width:200
             RIGHT
-            └── margin width:260
+            └── margin width:260 ƒ
         `);
     });
 
@@ -2726,7 +2820,7 @@ describe('ag-grid calculated columns', () => {
             CENTER
             ├── revenue "Revenue" width:200
             ├── cost "Cost" width:200
-            └── profit width:200
+            └── profit width:200 ƒ
         `);
         await new GridRows(api, `dispatches lifecycle events for invalid calculated column columnDefs mutations setup`)
             .check(`
@@ -2781,7 +2875,7 @@ describe('ag-grid calculated columns', () => {
             CENTER
             ├── revenue "Revenue" width:200
             ├── cost "Cost" width:200
-            └── profit "Profit" width:200
+            └── profit "Profit" width:200 ƒ
         `);
         await new GridRows(api, `dispatches calculated column UI update and remove events setup`).check(`
             ROOT id:ROOT_NODE_ID
@@ -2843,7 +2937,7 @@ describe('ag-grid calculated columns', () => {
             CENTER
             ├── revenue "Revenue" width:200
             ├── cost "Cost" width:200
-            └── profit width:200
+            └── profit width:200 ƒ
         `);
         await new GridRows(
             api,
@@ -2920,7 +3014,7 @@ describe('ag-grid calculated columns', () => {
             CENTER
             ├── revenue "Revenue" width:200
             ├── cost "Cost" width:200
-            └── profit width:200
+            └── profit width:200 ƒ
         `);
         await new GridRows(api, `calculated column menu items are grouped by separators setup`).check(`
             ROOT id:ROOT_NODE_ID
@@ -3567,7 +3661,7 @@ describe('ag-grid calculated columns', () => {
                 CENTER
                 ├── revenue "Revenue" width:200
                 ├── cost "Cost" width:200
-                └── profit width:200
+                └── profit width:200 ƒ
             `);
     });
 
@@ -3673,7 +3767,7 @@ describe('ag-grid calculated columns', () => {
             ├── c "C" width:200
             ├── a "A" width:200
             ├── b "B" width:200
-            └── sum width:200
+            └── sum width:200 ƒ
         `);
         await new GridRows(api, 'reorder + addCalculatedColumn rows', gridRowsOpts).check(`
             ROOT id:ROOT_NODE_ID
@@ -3708,7 +3802,7 @@ describe('ag-grid calculated columns', () => {
             ├─┬ "G" GROUP
             │ ├── a "A" width:200
             │ └── b "B" width:200
-            └── sum width:200
+            └── sum width:200 ƒ
         `);
         await new GridRows(api, 'group + reorder + addCalculatedColumn rows', gridRowsOpts).check(`
             ROOT id:ROOT_NODE_ID
@@ -3746,7 +3840,7 @@ describe('ag-grid calculated columns', () => {
             ├── c "C" width:200
             ├── a "A" width:200
             ├── b "B" width:200
-            └── sum width:200
+            └── sum width:200 ƒ
         `);
         await new GridRows(api, 'applyOrder + addCalculatedColumn rows', gridRowsOpts).check(`
             ROOT id:ROOT_NODE_ID
@@ -3803,7 +3897,7 @@ describe('ag-grid calculated columns', () => {
             ├── country "Country" width:200
             ├── date "Date" width:200
             ├── amount "Amount" width:200
-            └── doubled width:200
+            └── doubled width:200 ƒ
         `);
         await new GridRows(api, 'hierarchy + addCalculatedColumn rows', {
             ...gridRowsOpts,
@@ -3869,7 +3963,7 @@ describe('ag-grid calculated columns', () => {
             ├── c "C" width:200
             ├── a "A" width:200
             ├── b "B" width:200
-            └── sum width:200
+            └── sum width:200 ƒ
         `);
         await new GridRows(api, 'maintainColumnOrder=true: move + addCalcCol rows', gridRowsOpts).check(`
             ROOT id:ROOT_NODE_ID
@@ -3897,7 +3991,7 @@ describe('ag-grid calculated columns', () => {
             ├── c "C" width:200
             ├── a "A" width:200
             ├── b "B" width:200
-            └── sum width:200
+            └── sum width:200 ƒ
         `);
         await new GridRows(api, 'maintainColumnOrder=false: move + addCalcCol rows', gridRowsOpts).check(`
             ROOT id:ROOT_NODE_ID
@@ -3928,7 +4022,7 @@ describe('ag-grid calculated columns', () => {
             ├── c "C" width:200
             ├── a "A" width:200
             ├── b "B" width:200
-            └── sum width:200
+            └── sum width:200 ƒ
         `);
         await new GridRows(api, 'maintainColumnOrder=true: updateColDefs + addCalcCol rows', gridRowsOpts).check(`
             ROOT id:ROOT_NODE_ID
@@ -3979,7 +4073,7 @@ describe('ag-grid calculated columns', () => {
             ├── ag-Grid-AutoColumn "Category" width:200
             ├── revenue "Revenue" width:200
             ├── cost "Cost" width:200
-            └── profit width:200
+            └── profit width:200 ƒ
         `);
         // Expand a group so leaves render and the calc col's per-row evaluation appears.
         // `forceSync=true` skips the async dispatch so the snapshot below sees the expanded
@@ -4053,7 +4147,7 @@ describe('ag-grid calculated columns', () => {
             ├── ag-Grid-SelectionColumn width:50 !resizable !sortable suppressMovable lockPosition:left
             ├── revenue "Revenue" width:200
             ├── cost "Cost" width:200
-            └── profit width:200
+            └── profit width:200 ƒ
         `);
         await new GridRows(api, 'rowSelection + calc col rows', gridRowsOpts).check(`
             ROOT id:ROOT_NODE_ID
@@ -4082,7 +4176,7 @@ describe('ag-grid calculated columns', () => {
             CENTER
             ├── revenue "Revenue" width:200
             ├── cost "Cost" width:200
-            └── profit width:200
+            └── profit width:200 ƒ
         `);
         await new GridRows(api, 'rowNumbers + calc col rows', gridRowsOpts).check(`
             ROOT id:ROOT_NODE_ID
@@ -4111,11 +4205,11 @@ describe('ag-grid calculated columns', () => {
 
         await new GridColumns(api, 'moveColumns on calc col + subsequent add').checkColumns(`
             CENTER
-            ├── sum width:200
+            ├── sum width:200 ƒ
             ├── a "A" width:200
             ├── b "B" width:200
             ├── c "C" width:200
-            └── avg width:200
+            └── avg width:200 ƒ
         `);
         await new GridRows(api, 'moveColumns on calc col + subsequent add rows', gridRowsOpts).check(`
             ROOT id:ROOT_NODE_ID

--- a/testing/behavioural/src/formulas/calculated-columns.test.ts
+++ b/testing/behavioural/src/formulas/calculated-columns.test.ts
@@ -1049,7 +1049,7 @@ describe('ag-grid calculated columns', () => {
         expect(sourceCell).toHaveClass(flashCssClass);
     });
 
-    test('calculated columns evaluate on row group rows from aggregated values', async () => {
+    test('calculated columns stay blank on row group rows; leaf rows evaluate', async () => {
         const api = createGrid('calculated-row-groups', {
             rowData: [
                 { id: 'r1', region: 'EMEA', revenue: 10, cost: 3 },
@@ -1065,7 +1065,7 @@ describe('ag-grid calculated columns', () => {
             ],
             groupDefaultExpanded: -1,
         });
-        await new GridColumns(api, `calculated columns evaluate on row group rows setup`).checkColumns(`
+        await new GridColumns(api, `calculated columns blank on row group rows setup`).checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
             ├── revenue "Revenue" width:200 aggFunc:sum
@@ -1073,44 +1073,35 @@ describe('ag-grid calculated columns', () => {
             ├── profit width:200 ƒ
             └── doubleProfit width:200 ƒ
         `);
-        // Group rows derive from aggregated revenue/cost; leaf rows evaluate from their own data.
-        await new GridRows(api, `calculated columns evaluate on row group rows`).check(`
+        // Group rows have no data of their own, so calc cols stay blank; leaf rows evaluate from their data.
+        await new GridRows(api, `calculated columns blank on row group rows`).check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-region-EMEA ag-Grid-AutoColumn:"EMEA" revenue:30 cost:11 profit:19 doubleProfit:38
+            ├─┬ LEAF_GROUP id:row-group-region-EMEA ag-Grid-AutoColumn:"EMEA" revenue:30 cost:11
             │ ├── LEAF id:r1 region:"EMEA" revenue:10 cost:3 profit:7 doubleProfit:14
             │ └── LEAF id:r2 region:"EMEA" revenue:20 cost:8 profit:12 doubleProfit:24
-            └─┬ LEAF_GROUP id:row-group-region-APAC ag-Grid-AutoColumn:"APAC" revenue:15 cost:5 profit:10 doubleProfit:20
+            └─┬ LEAF_GROUP id:row-group-region-APAC ag-Grid-AutoColumn:"APAC" revenue:15 cost:5
             · └── LEAF id:r3 region:"APAC" revenue:15 cost:5 profit:10 doubleProfit:20
         `);
         await asyncSetTimeout(1);
 
-        let emeaGroup: any;
-        let apacGroup: any;
-        api.forEachNodeAfterFilterAndSort((node) => {
-            if (node.group && node.key === 'EMEA') {
-                emeaGroup = node;
-            }
-            if (node.group && node.key === 'APAC') {
-                apacGroup = node;
-            }
-        });
-
+        const emeaGroup = api.getRowNode('row-group-region-EMEA')!;
         expect(emeaGroup.group).toBe(true);
-        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'profit', useFormatter: false })).toBe(19);
-        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'doubleProfit', useFormatter: false })).toBe(38);
-        expect(apacGroup.group).toBe(true);
-        expect(api.getCellValue({ rowNode: apacGroup, colKey: 'profit', useFormatter: false })).toBe(10);
+        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'profit', useFormatter: false })).toBeUndefined();
+        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'doubleProfit', useFormatter: false })).toBeUndefined();
         expect(api.getCellValue({ rowNode: api.getRowNode('r1')!, colKey: 'profit', useFormatter: false })).toBe(7);
         expect(api.getCellValue({ rowNode: api.getRowNode('r1')!, colKey: 'doubleProfit', useFormatter: false })).toBe(
             14
         );
 
-        // A transaction that re-aggregates the group must refresh its calculated value.
+        // A transaction updates the leaf's own calculated values; the group stays blank.
         applyTransactionChecked(api, { update: [{ id: 'r1', region: 'EMEA', revenue: 100, cost: 3 }] });
         await asyncSetTimeout(1);
 
-        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'profit', useFormatter: false })).toBe(109);
-        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'doubleProfit', useFormatter: false })).toBe(218);
+        expect(api.getCellValue({ rowNode: api.getRowNode('r1')!, colKey: 'profit', useFormatter: false })).toBe(97);
+        expect(api.getCellValue({ rowNode: api.getRowNode('r1')!, colKey: 'doubleProfit', useFormatter: false })).toBe(
+            194
+        );
+        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'profit', useFormatter: false })).toBeUndefined();
     });
 
     test('calculated columns stay blank on row groups without aggregate source values while leaf rows still evaluate', async () => {
@@ -1154,7 +1145,7 @@ describe('ag-grid calculated columns', () => {
                 { field: 'region', rowGroup: true, hide: true },
                 { field: 'revenue', aggFunc: 'sum' },
                 { field: 'cost', aggFunc: 'sum' },
-                // No aggFunc: the group derives from the aggregated revenue/cost (aggregate-first).
+                // No aggFunc: the group stays blank (it has no data of its own); leaves still evaluate.
                 { colId: 'profit', calculatedExpression: '[revenue] - [cost]', cellDataType: 'number' },
                 // With aggFunc: the per-leaf profit is aggregated on the group (aggregate-after).
                 {
@@ -1176,17 +1167,17 @@ describe('ag-grid calculated columns', () => {
         `);
         await new GridRows(api, `calculated columns with an aggFunc`).check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-region-EMEA ag-Grid-AutoColumn:"EMEA" revenue:30 cost:11 profit:19 maxProfit:12
+            ├─┬ LEAF_GROUP id:row-group-region-EMEA ag-Grid-AutoColumn:"EMEA" revenue:30 cost:11 maxProfit:12
             │ ├── LEAF id:r1 region:"EMEA" revenue:10 cost:3 profit:7 maxProfit:7
             │ └── LEAF id:r2 region:"EMEA" revenue:20 cost:8 profit:12 maxProfit:12
-            └─┬ LEAF_GROUP id:row-group-region-APAC ag-Grid-AutoColumn:"APAC" revenue:15 cost:5 profit:10 maxProfit:10
+            └─┬ LEAF_GROUP id:row-group-region-APAC ag-Grid-AutoColumn:"APAC" revenue:15 cost:5 maxProfit:10
             · └── LEAF id:r3 region:"APAC" revenue:15 cost:5 profit:10 maxProfit:10
         `);
 
         const emeaGroup = api.getRowNode('row-group-region-EMEA')!;
-        // aggregate-first: sum(revenue) - sum(cost) = 30 - 11 = 19.
-        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'profit', useFormatter: false })).toBe(19);
-        // aggregate-after: max of the leaf profits = max(7, 12) = 12, distinct from aggregate-first's 19.
+        // No aggFunc: the group has no data of its own, so profit stays blank.
+        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'profit', useFormatter: false })).toBeUndefined();
+        // aggregate-after: max of the leaf profits = max(7, 12) = 12.
         expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'maxProfit', useFormatter: false })).toBe(12);
         // Leaves evaluate the formula regardless of aggFunc.
         expect(api.getCellValue({ rowNode: api.getRowNode('r1')!, colKey: 'maxProfit', useFormatter: false })).toBe(7);
@@ -1489,7 +1480,7 @@ describe('ag-grid calculated columns', () => {
         `);
     });
 
-    test('calculated columns evaluate on group and grand total footer rows from aggregated values', async () => {
+    test('calculated columns stay blank on group and grand total footer rows', async () => {
         const api = createGrid('calculated-row-group-footers', {
             rowData: [
                 { id: 'r1', region: 'EMEA', revenue: 10, cost: 3 },
@@ -1512,12 +1503,13 @@ describe('ag-grid calculated columns', () => {
         const apacFooter = api.getRowNode('rowGroupFooter_row-group-region-APAC')!;
         const grandTotal = api.getRowNode('rowGroupFooter_ROOT_NODE_ID')!;
 
+        // Footers and the grand total have no data of their own, so a no-aggFunc calc col stays blank.
         expect(emeaFooter).toBeTruthy();
-        expect(api.getCellValue({ rowNode: emeaFooter, colKey: 'profit', useFormatter: false })).toBe(19);
+        expect(api.getCellValue({ rowNode: emeaFooter, colKey: 'profit', useFormatter: false })).toBeUndefined();
         expect(apacFooter).toBeTruthy();
-        expect(api.getCellValue({ rowNode: apacFooter, colKey: 'profit', useFormatter: false })).toBe(10);
+        expect(api.getCellValue({ rowNode: apacFooter, colKey: 'profit', useFormatter: false })).toBeUndefined();
         expect(grandTotal).toBeTruthy();
-        expect(api.getCellValue({ rowNode: grandTotal, colKey: 'profit', useFormatter: false })).toBe(29);
+        expect(api.getCellValue({ rowNode: grandTotal, colKey: 'profit', useFormatter: false })).toBeUndefined();
     });
 
     test('aggregate-after calculated columns read aggData on group and grand-total footer rows', async () => {
@@ -1591,7 +1583,7 @@ describe('ag-grid calculated columns', () => {
         `);
     });
 
-    test('grid api adds a calculated column while grouped and it evaluates on group and leaf rows', async () => {
+    test('grid api adds a calculated column while grouped and it evaluates on leaf rows', async () => {
         const api = createGrid('calculated-api-while-grouped', {
             rowData: [
                 { id: 'r1', region: 'EMEA', revenue: 10, cost: 3 },
@@ -1617,8 +1609,8 @@ describe('ag-grid calculated columns', () => {
         await asyncSetTimeout(1);
 
         const emeaGroup = api.getRowNode('row-group-region-EMEA')!;
-        // The group row derives from aggregated revenue/cost; the leaf rows evaluate from their own data.
-        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'profit', useFormatter: false })).toBe(19);
+        // The group row has no data of its own, so it stays blank; the leaf rows evaluate from their data.
+        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'profit', useFormatter: false })).toBeUndefined();
         expect(api.getCellValue({ rowNode: api.getRowNode('r1')!, colKey: 'profit', useFormatter: false })).toBe(7);
         expect(api.getCellValue({ rowNode: api.getRowNode('r3')!, colKey: 'profit', useFormatter: false })).toBe(10);
     });

--- a/testing/behavioural/src/formulas/calculated-columns.test.ts
+++ b/testing/behavioural/src/formulas/calculated-columns.test.ts
@@ -1026,7 +1026,7 @@ describe('ag-grid calculated columns', () => {
         expect(sourceCell).toHaveClass(flashCssClass);
     });
 
-    test('calculated columns stay blank on row group rows while leaf rows evaluate', async () => {
+    test('calculated columns evaluate on row group rows from aggregated values', async () => {
         const api = createGrid('calculated-row-groups', {
             rowData: [
                 { id: 'r1', region: 'EMEA', revenue: 10, cost: 3 },
@@ -1042,7 +1042,7 @@ describe('ag-grid calculated columns', () => {
             ],
             groupDefaultExpanded: -1,
         });
-        await new GridColumns(api, `calculated columns stay blank on row group rows setup`).checkColumns(`
+        await new GridColumns(api, `calculated columns evaluate on row group rows setup`).checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
             ├── revenue "Revenue" width:200 aggFunc:sum
@@ -1050,13 +1050,13 @@ describe('ag-grid calculated columns', () => {
             ├── profit width:200
             └── doubleProfit width:200
         `);
-        // Group rows show no calculated value; leaf rows still evaluate.
-        await new GridRows(api, `calculated columns stay blank on row group rows`).check(`
+        // Group rows derive from aggregated revenue/cost; leaf rows evaluate from their own data.
+        await new GridRows(api, `calculated columns evaluate on row group rows`).check(`
             ROOT id:ROOT_NODE_ID
-            ├─┬ LEAF_GROUP id:row-group-region-EMEA ag-Grid-AutoColumn:"EMEA" revenue:30 cost:11
+            ├─┬ LEAF_GROUP id:row-group-region-EMEA ag-Grid-AutoColumn:"EMEA" revenue:30 cost:11 profit:19 doubleProfit:38
             │ ├── LEAF id:r1 region:"EMEA" revenue:10 cost:3 profit:7 doubleProfit:14
             │ └── LEAF id:r2 region:"EMEA" revenue:20 cost:8 profit:12 doubleProfit:24
-            └─┬ LEAF_GROUP id:row-group-region-APAC ag-Grid-AutoColumn:"APAC" revenue:15 cost:5
+            └─┬ LEAF_GROUP id:row-group-region-APAC ag-Grid-AutoColumn:"APAC" revenue:15 cost:5 profit:10 doubleProfit:20
             · └── LEAF id:r3 region:"APAC" revenue:15 cost:5 profit:10 doubleProfit:20
         `);
         await asyncSetTimeout(1);
@@ -1073,14 +1073,21 @@ describe('ag-grid calculated columns', () => {
         });
 
         expect(emeaGroup.group).toBe(true);
-        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'profit', useFormatter: false })).toBeUndefined();
-        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'doubleProfit', useFormatter: false })).toBeUndefined();
+        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'profit', useFormatter: false })).toBe(19);
+        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'doubleProfit', useFormatter: false })).toBe(38);
         expect(apacGroup.group).toBe(true);
-        expect(api.getCellValue({ rowNode: apacGroup, colKey: 'profit', useFormatter: false })).toBeUndefined();
+        expect(api.getCellValue({ rowNode: apacGroup, colKey: 'profit', useFormatter: false })).toBe(10);
         expect(api.getCellValue({ rowNode: api.getRowNode('r1')!, colKey: 'profit', useFormatter: false })).toBe(7);
         expect(api.getCellValue({ rowNode: api.getRowNode('r1')!, colKey: 'doubleProfit', useFormatter: false })).toBe(
             14
         );
+
+        // A transaction that re-aggregates the group must refresh its calculated value.
+        applyTransactionChecked(api, { update: [{ id: 'r1', region: 'EMEA', revenue: 100, cost: 3 }] });
+        await asyncSetTimeout(1);
+
+        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'profit', useFormatter: false })).toBe(109);
+        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'doubleProfit', useFormatter: false })).toBe(218);
     });
 
     test('calculated columns stay blank on row groups without aggregate source values while leaf rows still evaluate', async () => {
@@ -1113,8 +1120,185 @@ describe('ag-grid calculated columns', () => {
         expect(api.getCellValue({ rowNode: api.getRowNode('r2')!, colKey: 'profit', useFormatter: false })).toBe(26000);
     });
 
-    test('calculated columns evaluate on tree data leaves and stay blank on parent and filler groups', async () => {
-        const parentApi = createGrid('calculated-tree-data-parent', {
+    test('calculated columns with an aggFunc aggregate their per-leaf results (aggregate-after)', async () => {
+        const api = createGrid('calculated-row-groups-aggfunc', {
+            rowData: [
+                { id: 'r1', region: 'EMEA', revenue: 10, cost: 3 },
+                { id: 'r2', region: 'EMEA', revenue: 20, cost: 8 },
+                { id: 'r3', region: 'APAC', revenue: 15, cost: 5 },
+            ],
+            columnDefs: [
+                { field: 'region', rowGroup: true, hide: true },
+                { field: 'revenue', aggFunc: 'sum' },
+                { field: 'cost', aggFunc: 'sum' },
+                // No aggFunc: the group derives from the aggregated revenue/cost (aggregate-first).
+                { colId: 'profit', calculatedExpression: '[revenue] - [cost]', cellDataType: 'number' },
+                // With aggFunc: the per-leaf profit is aggregated on the group (aggregate-after).
+                {
+                    colId: 'maxProfit',
+                    calculatedExpression: '[revenue] - [cost]',
+                    aggFunc: 'max',
+                    cellDataType: 'number',
+                },
+            ],
+            groupDefaultExpanded: -1,
+        });
+        await new GridColumns(api, `calculated columns with an aggFunc setup`).checkColumns(`
+            CENTER
+            ├── ag-Grid-AutoColumn "Group" width:200
+            ├── revenue "Revenue" width:200 aggFunc:sum
+            ├── cost "Cost" width:200 aggFunc:sum
+            ├── profit width:200
+            └── maxProfit width:200 aggFunc:max
+        `);
+        await new GridRows(api, `calculated columns with an aggFunc`).check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-region-EMEA ag-Grid-AutoColumn:"EMEA" revenue:30 cost:11 profit:19 maxProfit:12
+            │ ├── LEAF id:r1 region:"EMEA" revenue:10 cost:3 profit:7 maxProfit:7
+            │ └── LEAF id:r2 region:"EMEA" revenue:20 cost:8 profit:12 maxProfit:12
+            └─┬ LEAF_GROUP id:row-group-region-APAC ag-Grid-AutoColumn:"APAC" revenue:15 cost:5 profit:10 maxProfit:10
+            · └── LEAF id:r3 region:"APAC" revenue:15 cost:5 profit:10 maxProfit:10
+        `);
+
+        const emeaGroup = api.getRowNode('row-group-region-EMEA')!;
+        // aggregate-first: sum(revenue) - sum(cost) = 30 - 11 = 19.
+        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'profit', useFormatter: false })).toBe(19);
+        // aggregate-after: max of the leaf profits = max(7, 12) = 12, distinct from aggregate-first's 19.
+        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'maxProfit', useFormatter: false })).toBe(12);
+        // Leaves evaluate the formula regardless of aggFunc.
+        expect(api.getCellValue({ rowNode: api.getRowNode('r1')!, colKey: 'maxProfit', useFormatter: false })).toBe(7);
+        expect(api.getCellValue({ rowNode: api.getRowNode('r2')!, colKey: 'maxProfit', useFormatter: false })).toBe(12);
+    });
+
+    test('aggregate-after calculated columns aggregate across nested groups, footers and after transactions', async () => {
+        const api = createGrid('calculated-aggfunc-nested', {
+            rowData: [
+                { id: 'r1', region: 'EMEA', country: 'UK', revenue: 10, cost: 3 },
+                { id: 'r2', region: 'EMEA', country: 'UK', revenue: 20, cost: 8 },
+                { id: 'r3', region: 'EMEA', country: 'DE', revenue: 15, cost: 5 },
+                { id: 'r4', region: 'APAC', country: 'JP', revenue: 30, cost: 12 },
+            ],
+            columnDefs: [
+                { field: 'region', rowGroup: true, hide: true },
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'revenue', aggFunc: 'sum' },
+                { field: 'cost', aggFunc: 'sum' },
+                {
+                    colId: 'maxProfit',
+                    calculatedExpression: '[revenue] - [cost]',
+                    aggFunc: 'max',
+                    cellDataType: 'number',
+                },
+            ],
+            groupDefaultExpanded: -1,
+            groupTotalRow: 'bottom',
+            grandTotalRow: 'bottom',
+        });
+        await asyncSetTimeout(1);
+
+        // Leaf profits r1=7, r2=12, r3=10, r4=18. `max` bubbles up the group-total rows at every level
+        // (agg-after); the totals are not the agg-first `sum(rev)-sum(cost)` (which would be 29/47).
+        await new GridRows(api, `nested aggfunc group totals`, gridRowsOpts).check(`
+            ROOT id:ROOT_NODE_ID revenue:75 cost:28 maxProfit:18
+            ├─┬ filler id:row-group-region-EMEA ag-Grid-AutoColumn:"EMEA"
+            │ ├─┬ LEAF_GROUP id:row-group-region-EMEA-country-UK ag-Grid-AutoColumn:"UK"
+            │ │ ├── LEAF id:r1 region:"EMEA" country:"UK" revenue:10 cost:3 maxProfit:7
+            │ │ ├── LEAF id:r2 region:"EMEA" country:"UK" revenue:20 cost:8 maxProfit:12
+            │ │ └─ footer id:rowGroupFooter_row-group-region-EMEA-country-UK ag-Grid-AutoColumn:"UK" revenue:30 cost:11 maxProfit:12
+            │ ├─┬ LEAF_GROUP id:row-group-region-EMEA-country-DE ag-Grid-AutoColumn:"DE"
+            │ │ ├── LEAF id:r3 region:"EMEA" country:"DE" revenue:15 cost:5 maxProfit:10
+            │ │ └─ footer id:rowGroupFooter_row-group-region-EMEA-country-DE ag-Grid-AutoColumn:"DE" revenue:15 cost:5 maxProfit:10
+            │ └─ footer id:rowGroupFooter_row-group-region-EMEA ag-Grid-AutoColumn:"EMEA" revenue:45 cost:16 maxProfit:12
+            ├─┬ filler id:row-group-region-APAC ag-Grid-AutoColumn:"APAC"
+            │ ├─┬ LEAF_GROUP id:row-group-region-APAC-country-JP ag-Grid-AutoColumn:"JP"
+            │ │ ├── LEAF id:r4 region:"APAC" country:"JP" revenue:30 cost:12 maxProfit:18
+            │ │ └─ footer id:rowGroupFooter_row-group-region-APAC-country-JP ag-Grid-AutoColumn:"JP" revenue:30 cost:12 maxProfit:18
+            │ └─ footer id:rowGroupFooter_row-group-region-APAC ag-Grid-AutoColumn:"APAC" revenue:30 cost:12 maxProfit:18
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:null revenue:75 cost:28 maxProfit:18
+        `);
+
+        // A transaction that re-aggregates must refresh the agg-after totals at every level:
+        // UK profit max becomes 97, which bubbles up to the EMEA and grand totals.
+        applyTransactionChecked(api, { update: [{ id: 'r1', region: 'EMEA', country: 'UK', revenue: 100, cost: 3 }] });
+        await asyncSetTimeout(1);
+
+        const ukFooter = api.getRowNode('rowGroupFooter_row-group-region-EMEA-country-UK')!;
+        const emeaFooter = api.getRowNode('rowGroupFooter_row-group-region-EMEA')!;
+        const grandTotal = api.getRowNode('rowGroupFooter_ROOT_NODE_ID')!;
+        expect(api.getCellValue({ rowNode: ukFooter, colKey: 'maxProfit', useFormatter: false })).toBe(97);
+        expect(api.getCellValue({ rowNode: emeaFooter, colKey: 'maxProfit', useFormatter: false })).toBe(97);
+        expect(api.getCellValue({ rowNode: grandTotal, colKey: 'maxProfit', useFormatter: false })).toBe(97);
+    });
+
+    test('aggregate-after calculated columns ride the standard pipeline (avg parity with a plain value column)', async () => {
+        const api = createGrid('calculated-aggfunc-avg-parity', {
+            rowData: [
+                { id: 'r1', region: 'EMEA', revenue: 10, cost: 3, profitData: 7 },
+                { id: 'r2', region: 'EMEA', revenue: 20, cost: 8, profitData: 12 },
+            ],
+            columnDefs: [
+                { field: 'region', rowGroup: true, hide: true },
+                { field: 'revenue' },
+                { field: 'cost' },
+                // Plain value column holding the same per-row profit, aggregated with avg.
+                { field: 'profitData', aggFunc: 'avg' },
+                // Calculated column computing the same profit, aggregated with avg.
+                { colId: 'profit', calculatedExpression: '[revenue] - [cost]', aggFunc: 'avg', cellDataType: 'number' },
+            ],
+            groupDefaultExpanded: -1,
+        });
+        await asyncSetTimeout(1);
+
+        const emeaGroup = api.getRowNode('row-group-region-EMEA')!;
+        const calc = api.getCellValue({ rowNode: emeaGroup, colKey: 'profit', useFormatter: false });
+        const plain = api.getCellValue({ rowNode: emeaGroup, colKey: 'profitData', useFormatter: false });
+        // The calculated column's avg aggregation is identical to a plain value column's, wrapper and all.
+        expect(calc).toEqual(plain);
+        // The displayed value is the average of the leaf profits: (7 + 12) / 2 = 9.5.
+        expect(`${calc}`).toBe('9.5');
+    });
+
+    test('a calculated column with an aggFunc matches a valueGetter value column on group rows', async () => {
+        const api = createGrid('calculated-aggfunc-valuegetter-parity', {
+            rowData: [
+                { id: 'r1', country: 'US', gold: 1, silver: 2 },
+                { id: 'r2', country: 'US', gold: 3, silver: 4 },
+                { id: 'r3', country: 'UK', gold: 5, silver: 6 },
+            ],
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'gold', aggFunc: 'sum' },
+                { field: 'silver', aggFunc: 'sum' },
+                {
+                    colId: 'calc',
+                    aggFunc: 'sum',
+                    calculatedExpression: '[gold] + [silver]',
+                    cellDataType: 'number',
+                },
+                {
+                    colId: 'vg',
+                    aggFunc: 'sum',
+                    valueGetter: (p) => (p.data ? p.data.gold + p.data.silver : undefined),
+                    cellDataType: 'number',
+                },
+            ],
+            groupDefaultExpanded: -1,
+        });
+        await asyncSetTimeout(1);
+
+        // The calculated column aggregates its per-leaf (gold+silver) exactly like the valueGetter column.
+        await new GridRows(api, 'calc aggFunc matches valueGetter', gridRowsOpts).check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ LEAF_GROUP id:row-group-country-US ag-Grid-AutoColumn:"US" gold:4 silver:6 calc:10 vg:10
+            │ ├── LEAF id:r1 country:"US" gold:1 silver:2 calc:3 vg:3
+            │ └── LEAF id:r2 country:"US" gold:3 silver:4 calc:7 vg:7
+            └─┬ LEAF_GROUP id:row-group-country-UK ag-Grid-AutoColumn:"UK" gold:5 silver:6 calc:11 vg:11
+            · └── LEAF id:r3 country:"UK" gold:5 silver:6 calc:11 vg:11
+        `);
+    });
+
+    test('calculated columns evaluate on tree data group rows that carry their own data', async () => {
+        const api = createGrid('calculated-tree-data-parent', {
             treeData: true,
             treeDataChildrenField: 'children',
             rowData: [
@@ -1136,15 +1320,17 @@ describe('ag-grid calculated columns', () => {
         });
         await asyncSetTimeout(1);
 
-        // A tree parent is a non-leaf row, so it shows no calculated value even though it carries its own data.
-        expect(
-            parentApi.getCellValue({ rowNode: parentApi.getRowNode('parent')!, colKey: 'profit', useFormatter: false })
-        ).toBeUndefined();
-        expect(
-            parentApi.getCellValue({ rowNode: parentApi.getRowNode('child')!, colKey: 'profit', useFormatter: false })
-        ).toBe(20);
+        // No aggFunc: the parent group carries its own data, so it evaluates the formula from that data
+        // (100 - 40 = 60), exactly as the revenue/cost cells show the parent's own values.
+        await new GridRows(api, `tree data group with own data`, gridRowsOpts).check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ parent GROUP id:parent ag-Grid-AutoColumn:"parent" name:"Parent" revenue:100 cost:40 profit:60
+            · └── child LEAF id:child ag-Grid-AutoColumn:"child" name:"Child" revenue:30 cost:10 profit:20
+        `);
+    });
 
-        const fillerApi = createGrid('calculated-tree-data-filler', {
+    test('calculated columns stay blank on tree data filler groups that carry no data', async () => {
+        const api = createGrid('calculated-tree-data-filler', {
             treeData: true,
             getDataPath: (data) => data.path,
             rowData: [{ id: 'leaf', path: ['Dept', 'Team', 'Leaf'], revenue: 30, cost: 10 }],
@@ -1157,21 +1343,130 @@ describe('ag-grid calculated columns', () => {
         });
         await asyncSetTimeout(1);
 
-        let fillerGroup: any;
-        fillerApi.forEachNode((node) => {
-            if (node.group && !node.data && !fillerGroup) {
-                fillerGroup = node;
-            }
-        });
-
-        expect(fillerGroup).toBeTruthy();
-        expect(fillerApi.getCellValue({ rowNode: fillerGroup, colKey: 'profit', useFormatter: false })).toBeUndefined();
-        expect(
-            fillerApi.getCellValue({ rowNode: fillerApi.getRowNode('leaf')!, colKey: 'profit', useFormatter: false })
-        ).toBe(20);
+        // Filler groups (Dept, Team) carry no data and have no aggData, so they stay blank; the leaf evaluates.
+        await new GridRows(api, `tree data filler groups`, gridRowsOpts).check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ Dept filler id:row-group-0-Dept ag-Grid-AutoColumn:"Dept"
+            · └─┬ Team filler id:row-group-0-Dept-1-Team ag-Grid-AutoColumn:"Team"
+            · · └── Leaf LEAF id:leaf ag-Grid-AutoColumn:"Leaf" revenue:30 cost:10 profit:20
+        `);
     });
 
-    test('calculated columns stay blank on group and grand total footer rows', async () => {
+    test('aggregate-after calculated columns aggregate over tree data descendants', async () => {
+        const api = createGrid('calculated-tree-data-aggfunc', {
+            treeData: true,
+            treeDataChildrenField: 'children',
+            rowData: [
+                {
+                    id: 'parent',
+                    name: 'Parent',
+                    revenue: 100,
+                    cost: 40,
+                    children: [
+                        { id: 'a', name: 'A', revenue: 30, cost: 10 },
+                        { id: 'b', name: 'B', revenue: 50, cost: 15 },
+                    ],
+                },
+            ],
+            columnDefs: [
+                { field: 'name' },
+                { field: 'revenue', aggFunc: 'sum' },
+                { field: 'cost', aggFunc: 'sum' },
+                {
+                    colId: 'maxProfit',
+                    calculatedExpression: '[revenue] - [cost]',
+                    aggFunc: 'max',
+                    cellDataType: 'number',
+                },
+            ],
+            groupDefaultExpanded: -1,
+        });
+        await asyncSetTimeout(1);
+
+        // With an aggFunc the parent aggregates its descendants (a, b), not its own data: revenue/cost
+        // are the children's sums and maxProfit is max(20, 35) = 35 — identical to the plain value columns.
+        await new GridRows(api, `tree data aggregate-after`, gridRowsOpts).check(`
+            ROOT id:ROOT_NODE_ID
+            └─┬ parent GROUP id:parent ag-Grid-AutoColumn:"parent" name:"Parent" revenue:80 cost:25 maxProfit:35
+            · ├── a LEAF id:a ag-Grid-AutoColumn:"a" name:"A" revenue:30 cost:10 maxProfit:20
+            · └── b LEAF id:b ag-Grid-AutoColumn:"b" name:"B" revenue:50 cost:15 maxProfit:35
+        `);
+    });
+
+    test('a calculated column without an aggFunc has no pivot result column and is absent from the pivot display', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            const api = createGrid('calculated-pivot-no-aggfunc', {
+                pivotMode: true,
+                rowData: [
+                    { id: 'r1', country: 'US', year: 2020, revenue: 10, cost: 3 },
+                    { id: 'r2', country: 'US', year: 2021, revenue: 20, cost: 8 },
+                ],
+                columnDefs: [
+                    { field: 'country', rowGroup: true, hide: true },
+                    { field: 'year', pivot: true },
+                    { field: 'revenue', aggFunc: 'sum' },
+                    { field: 'cost', aggFunc: 'sum' },
+                    { colId: 'profit', calculatedExpression: '[revenue] - [cost]', cellDataType: 'number' },
+                ],
+                groupDefaultExpanded: -1,
+            });
+            await asyncSetTimeout(10);
+
+            // Without an aggFunc the calc column is a non-value primary column, so pivot produces no result
+            // column for it — it is absent from the cross-tab, like any other non-value primary column.
+            await new GridRows(api, `calc column without aggFunc under pivot`, gridRowsOpts).check(`
+                ROOT id:ROOT_NODE_ID pivot_year_2020_revenue:10 pivot_year_2020_cost:3 pivot_year_2021_revenue:20 pivot_year_2021_cost:8
+                └─┬ LEAF_GROUP collapsed id:row-group-country-US ag-Grid-AutoColumn:"US" pivot_year_2020_revenue:10 pivot_year_2020_cost:3 pivot_year_2021_revenue:20 pivot_year_2021_cost:8
+                · ├── LEAF hidden id:r1 pivot_year_2020_revenue:10 pivot_year_2020_cost:3 pivot_year_2021_revenue:10 pivot_year_2021_cost:3
+                · └── LEAF hidden id:r2 pivot_year_2020_revenue:20 pivot_year_2020_cost:8 pivot_year_2021_revenue:20 pivot_year_2021_cost:8
+            `);
+            // It is a value-less calc column under pivot, not the blocked-formula case, so no warning fires.
+            expect(warnSpy).not.toHaveBeenCalledWith(
+                expect.stringContaining('warning #295'),
+                expect.stringContaining('Column Pivoting'),
+                expect.anything()
+            );
+        } finally {
+            warnSpy.mockRestore();
+        }
+    });
+
+    test('a calculated column with an aggFunc aggregates under pivot like a valueGetter value column', async () => {
+        const api = createGrid('calculated-pivot-aggfunc', {
+            pivotMode: true,
+            rowData: [
+                { id: 'r1', country: 'US', year: 2020, gold: 1, silver: 2 },
+                { id: 'r2', country: 'US', year: 2021, gold: 3, silver: 4 },
+            ],
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', pivot: true },
+                { field: 'gold', aggFunc: 'sum' },
+                { field: 'silver', aggFunc: 'sum' },
+                { colId: 'calc', aggFunc: 'sum', calculatedExpression: '[gold] + [silver]', cellDataType: 'number' },
+                {
+                    colId: 'vg',
+                    aggFunc: 'sum',
+                    valueGetter: (p) => (p.data ? p.data.gold + p.data.silver : undefined),
+                    cellDataType: 'number',
+                },
+            ],
+            groupDefaultExpanded: -1,
+        });
+        await asyncSetTimeout(10);
+
+        // Each pivot result column for the calculated column aggregates its per-leaf (gold+silver),
+        // matching the valueGetter column under every year: calc == vg everywhere.
+        await new GridRows(api, `calc aggFunc under pivot`, gridRowsOpts).check(`
+            ROOT id:ROOT_NODE_ID pivot_year_2020_gold:1 pivot_year_2020_silver:2 pivot_year_2020_calc:3 pivot_year_2020_vg:3 pivot_year_2021_gold:3 pivot_year_2021_silver:4 pivot_year_2021_calc:7 pivot_year_2021_vg:7
+            └─┬ LEAF_GROUP collapsed id:row-group-country-US ag-Grid-AutoColumn:"US" pivot_year_2020_gold:1 pivot_year_2020_silver:2 pivot_year_2020_calc:3 pivot_year_2020_vg:3 pivot_year_2021_gold:3 pivot_year_2021_silver:4 pivot_year_2021_calc:7 pivot_year_2021_vg:7
+            · ├── LEAF hidden id:r1 pivot_year_2020_gold:1 pivot_year_2020_silver:2 pivot_year_2020_calc:3 pivot_year_2020_vg:3 pivot_year_2021_gold:1 pivot_year_2021_silver:2 pivot_year_2021_calc:3 pivot_year_2021_vg:3
+            · └── LEAF hidden id:r2 pivot_year_2020_gold:3 pivot_year_2020_silver:4 pivot_year_2020_calc:7 pivot_year_2020_vg:7 pivot_year_2021_gold:3 pivot_year_2021_silver:4 pivot_year_2021_calc:7 pivot_year_2021_vg:7
+        `);
+    });
+
+    test('calculated columns evaluate on group and grand total footer rows from aggregated values', async () => {
         const api = createGrid('calculated-row-group-footers', {
             rowData: [
                 { id: 'r1', region: 'EMEA', revenue: 10, cost: 3 },
@@ -1195,14 +1490,14 @@ describe('ag-grid calculated columns', () => {
         const grandTotal = api.getRowNode('rowGroupFooter_ROOT_NODE_ID')!;
 
         expect(emeaFooter).toBeTruthy();
-        expect(api.getCellValue({ rowNode: emeaFooter, colKey: 'profit', useFormatter: false })).toBeUndefined();
+        expect(api.getCellValue({ rowNode: emeaFooter, colKey: 'profit', useFormatter: false })).toBe(19);
         expect(apacFooter).toBeTruthy();
-        expect(api.getCellValue({ rowNode: apacFooter, colKey: 'profit', useFormatter: false })).toBeUndefined();
+        expect(api.getCellValue({ rowNode: apacFooter, colKey: 'profit', useFormatter: false })).toBe(10);
         expect(grandTotal).toBeTruthy();
-        expect(api.getCellValue({ rowNode: grandTotal, colKey: 'profit', useFormatter: false })).toBeUndefined();
+        expect(api.getCellValue({ rowNode: grandTotal, colKey: 'profit', useFormatter: false })).toBe(29);
     });
 
-    test('grid api adds a calculated column while grouped and it evaluates on leaf rows', async () => {
+    test('grid api adds a calculated column while grouped and it evaluates on group and leaf rows', async () => {
         const api = createGrid('calculated-api-while-grouped', {
             rowData: [
                 { id: 'r1', region: 'EMEA', revenue: 10, cost: 3 },
@@ -1228,8 +1523,8 @@ describe('ag-grid calculated columns', () => {
         await asyncSetTimeout(1);
 
         const emeaGroup = api.getRowNode('row-group-region-EMEA')!;
-        // Group rows stay blank; the leaf rows under them evaluate the newly added column.
-        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'profit', useFormatter: false })).toBeUndefined();
+        // The group row derives from aggregated revenue/cost; the leaf rows evaluate from their own data.
+        expect(api.getCellValue({ rowNode: emeaGroup, colKey: 'profit', useFormatter: false })).toBe(19);
         expect(api.getCellValue({ rowNode: api.getRowNode('r1')!, colKey: 'profit', useFormatter: false })).toBe(7);
         expect(api.getCellValue({ rowNode: api.getRowNode('r3')!, colKey: 'profit', useFormatter: false })).toBe(10);
     });

--- a/testing/behavioural/src/grouping-data/grouping-show-values-as-clipboard.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-show-values-as-clipboard.test.ts
@@ -46,7 +46,7 @@ describe('showValuesAs copies the transformed value to the clipboard', () => {
         await new GridColumns(api, 'clipboard percentOfGrandTotal').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'clipboard percentOfGrandTotal').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"
@@ -86,7 +86,7 @@ describe('showValuesAs copies the transformed value to the clipboard', () => {
         await new GridColumns(api, 'edit before').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal editable
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal editable
         `);
         await new GridRows(api, 'edit before').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"
@@ -107,7 +107,7 @@ describe('showValuesAs copies the transformed value to the clipboard', () => {
         await new GridColumns(api, 'edit after — re-rendered transformed').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal editable
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal editable
         `);
         await new GridRows(api, 'edit after — re-rendered transformed').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"

--- a/testing/behavioural/src/grouping-data/grouping-show-values-as-display.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-show-values-as-display.test.ts
@@ -35,7 +35,7 @@ describe('showValuesAs displayed values (GridRows + GridColumns snapshots)', () 
         await new GridColumns(api, 'flat percentOfGrandTotal').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'flat percentOfGrandTotal').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"
@@ -63,7 +63,7 @@ describe('showValuesAs displayed values (GridRows + GridColumns snapshots)', () 
         await new GridColumns(api, 'grouped percentOfGrandTotal').checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'grouped percentOfGrandTotal').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"
@@ -93,7 +93,7 @@ describe('showValuesAs displayed values (GridRows + GridColumns snapshots)', () 
         await new GridColumns(api, 'grouped percentOfParentRowTotal').checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfParentRowTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfParentRowTotal
         `);
         await new GridRows(api, 'grouped percentOfParentRowTotal').check(`
             ROOT id:ROOT_NODE_ID amount:null
@@ -122,7 +122,7 @@ describe('showValuesAs displayed values (GridRows + GridColumns snapshots)', () 
         await new GridColumns(api, 'tree percentOfParentRowTotal').checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfParentRowTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfParentRowTotal
         `);
         await new GridRows(api, 'tree percentOfParentRowTotal').check(`
             ROOT id:ROOT_NODE_ID amount:null
@@ -150,7 +150,7 @@ describe('showValuesAs displayed values (GridRows + GridColumns snapshots)', () 
         await new GridColumns(api, 'flat dormant parent mode').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfParentRowTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfParentRowTotal
         `);
         await new GridRows(api, 'flat dormant parent mode').check(`
             ROOT id:ROOT_NODE_ID amount:"#N/A"
@@ -182,9 +182,9 @@ describe('showValuesAs displayed values (GridRows + GridColumns snapshots)', () 
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
             ├─┬ "2020" GROUP
-            │ └── pivot_year_2020_amount "Amount" width:200 showValuesAs:percentOfColumnTotal columnGroupShow:open
+            │ └── pivot_year_2020_amount "Amount" width:200 %:percentOfColumnTotal columnGroupShow:open
             └─┬ "2021" GROUP
-              └── pivot_year_2021_amount "Amount" width:200 showValuesAs:percentOfColumnTotal columnGroupShow:open
+              └── pivot_year_2021_amount "Amount" width:200 %:percentOfColumnTotal columnGroupShow:open
         `);
         await new GridRows(api, 'pivot percentOfColumnTotal', {
             forcedColumns: ['ag-Grid-AutoColumn', 'pivot_year_2020_amount', 'pivot_year_2021_amount'],

--- a/testing/behavioural/src/grouping-data/grouping-show-values-as-export.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-show-values-as-export.test.ts
@@ -48,7 +48,7 @@ describe('showValuesAs exports the transformed value', () => {
         await new GridColumns(api, 'csv percentOfGrandTotal').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'csv percentOfGrandTotal').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"
@@ -79,7 +79,7 @@ describe('showValuesAs exports the transformed value', () => {
         await new GridColumns(api, 'excel percentOfGrandTotal').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'excel percentOfGrandTotal').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"

--- a/testing/behavioural/src/grouping-data/grouping-show-values-as-guardrails.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-show-values-as-guardrails.test.ts
@@ -47,7 +47,7 @@ describe('showValuesAs breaking-change guardrails', () => {
             CENTER
             ├── country "Country" width:200
             ├── units "Units" width:200 aggFunc:sum
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'bc2 sibling unaffected').check(`
             ROOT id:ROOT_NODE_ID units:10 amount:"100.00%"
@@ -89,7 +89,7 @@ describe('showValuesAs breaking-change guardrails', () => {
         await new GridColumns(api, 'bc4 after sort asc columns').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            └── amount "Amount" width:200 sort:asc aggFunc:sum showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 sort:asc aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'bc4 after sort asc').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"
@@ -134,7 +134,7 @@ describe('showValuesAs breaking-change guardrails', () => {
         await new GridColumns(api, 'bc5 after sort desc columns').checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
-            └── amount "Amount" width:200 sort:desc aggFunc:custom showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 sort:desc aggFunc:custom %:percentOfGrandTotal
         `);
         await new GridRows(api, 'bc5 after sort desc').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"
@@ -158,7 +158,7 @@ describe('showValuesAs breaking-change guardrails', () => {
         await new GridColumns(api, 'bc5 after mode switch').checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
-            └── amount "Amount" width:200 sort:desc aggFunc:custom showValuesAs:percentOfParentRowTotal
+            └── amount "Amount" width:200 sort:desc aggFunc:custom %:percentOfParentRowTotal
         `);
         await new GridRows(api, 'bc5 after mode switch').check(`
             ROOT id:ROOT_NODE_ID amount:null
@@ -195,7 +195,7 @@ describe('showValuesAs breaking-change guardrails', () => {
         await new GridColumns(api, 't3 avg semantics columns').checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
-            └── amount "Amount" width:200 aggFunc:avg showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 aggFunc:avg %:percentOfGrandTotal
         `);
         await new GridRows(api, 't3 avg semantics').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"

--- a/testing/behavioural/src/grouping-data/grouping-show-values-as-indicator.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-show-values-as-indicator.test.ts
@@ -56,10 +56,10 @@ describe('showValuesAs header indicator', () => {
         // amount/cost (%grandTotal) applying → percentages; units (%parentTotal, flat) dormant → raw; price has no mode.
         await new GridColumns(api, 'indicator mixed modes').checkColumns(`
             CENTER
-            ├── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
-            ├── units "Units" width:200 aggFunc:sum showValuesAs:percentOfParentRowTotal
+            ├── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal
+            ├── units "Units" width:200 aggFunc:sum %:percentOfParentRowTotal
             ├── price "Price" width:200 aggFunc:sum
-            └── cost "Cost" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
+            └── cost "Cost" width:200 aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'indicator mixed modes').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%" units:"#N/A" price:3 cost:"100.00%"
@@ -133,7 +133,7 @@ describe('showValuesAs header indicator', () => {
         await new GridColumns(api, 'flat dormant').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfParentRowTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfParentRowTotal
         `);
         await new GridRows(api, 'flat dormant').check(`
             ROOT id:ROOT_NODE_ID amount:"#N/A"
@@ -151,7 +151,7 @@ describe('showValuesAs header indicator', () => {
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
             ├── country "Country" width:200 rowGroup
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfParentRowTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfParentRowTotal
         `);
         await new GridRows(api, 'after grouping added').check(`
             ROOT id:ROOT_NODE_ID amount:null

--- a/testing/behavioural/src/grouping-data/grouping-show-values-as-menu.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-show-values-as-menu.test.ts
@@ -263,7 +263,7 @@ describe('showValuesAs column menu', () => {
         await new GridColumns(api, 'promote percentOfGrandTotal').checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'promote percentOfGrandTotal').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"
@@ -358,7 +358,7 @@ describe('showValuesAs column menu', () => {
         await new GridColumns(api, 'switch to percentOfParentRowTotal').checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
-            └── amount "Amount" width:200 aggFunc:custom showValuesAs:percentOfParentRowTotal
+            └── amount "Amount" width:200 aggFunc:custom %:percentOfParentRowTotal
         `);
         await new GridRows(api, 'switch to percentOfParentRowTotal').check(`
             ROOT id:ROOT_NODE_ID amount:null

--- a/testing/behavioural/src/grouping-data/grouping-show-values-as-modes.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-show-values-as-modes.test.ts
@@ -47,7 +47,7 @@ describe('showValuesAs built-in modes', () => {
         await new GridColumns(api, 'percentOfParentRowTotal').checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfParentRowTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfParentRowTotal
         `);
         await new GridRows(api, 'percentOfParentRowTotal').check(`
             ROOT id:ROOT_NODE_ID amount:null
@@ -340,7 +340,7 @@ describe('showValuesAs bigint support', () => {
         await new GridColumns(api, 'bigint percentOfGrandTotal').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'bigint percentOfGrandTotal').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"
@@ -386,7 +386,7 @@ describe('showValuesAs interaction with filtering', () => {
         await new GridColumns(api, 'filter default parent total').checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfParentRowTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfParentRowTotal
         `);
         await new GridRows(api, 'filter default before filter').check(`
             ROOT id:ROOT_NODE_ID amount:null
@@ -435,7 +435,7 @@ describe('showValuesAs interaction with filtering', () => {
         await new GridColumns(api, 'suppressAggFilteredOnly').checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfParentRowTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfParentRowTotal
         `);
         await new GridRows(api, 'suppress before filter').check(`
             ROOT id:ROOT_NODE_ID amount:null

--- a/testing/behavioural/src/grouping-data/grouping-show-values-as.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-show-values-as.test.ts
@@ -119,10 +119,8 @@ describe('showValuesAs transform', () => {
         // Apply the mode dynamically (the column-menu path), starting from no mode.
         api.applyColumnState({ state: [{ colId: 'calc', showValuesAs: 'percentOfGrandTotal' }] });
 
-        // The displayed leaf cells show the calc value as a percentage of the grand total — not blank. (The ROOT
-        // is a group node, where calculated columns stay blank — but it is not a displayed row here.)
         await new GridRows(api, 'flat calc percentOfGrandTotal').check(`
-            ROOT id:ROOT_NODE_ID gold:70 silver:30 calc:null
+            ROOT id:ROOT_NODE_ID gold:70 silver:30 calc:"100.00%"
             ├── LEAF id:1 country:"A" gold:10 silver:5 calc:"15.00%"
             └── LEAF id:2 country:"B" gold:60 silver:25 calc:"85.00%"
         `);
@@ -133,7 +131,7 @@ describe('showValuesAs transform', () => {
         expect(api.getCellValue({ rowNode: leaf(api, '2'), colKey: 'calc', transformValues: true })).toBeCloseTo(0.85);
     });
 
-    test('calculated column: leaves transform under percentOfGrandTotal; group rows stay blank (calc-column limitation)', async () => {
+    test('calculated column with aggFunc: leaves and group rows both transform under percentOfGrandTotal', async () => {
         const api = gridsManager.createGrid('sva-calc-grouped', {
             calculatedColumns: true,
             groupDefaultExpanded: -1,
@@ -160,9 +158,7 @@ describe('showValuesAs transform', () => {
         // Leaf rows evaluate the calc, so the transform applies: 15/100, 55/100.
         expect(leaf(api, '1').getDataValue('calc', 'transformed')).toBeCloseTo(0.15);
         expect(api.getCellValue({ rowNode: leaf(api, '3'), colKey: 'calc', transformValues: true })).toBeCloseTo(0.55);
-        // Calculated columns stay blank on group rows by design (see calculated-columns.test.ts: "calculated columns
-        // stay blank on row group rows"). Show Values As has no underlying value to transform there.
-        expect(group(api, 'A').getDataValue('calc', 'transformed')).toBeNull();
+        expect(group(api, 'A').getDataValue('calc', 'transformed')).toBeCloseTo(0.45);
     });
 
     test('percentOfGrandTotal across group rows and leaves', async () => {

--- a/testing/behavioural/src/grouping-data/grouping-show-values-as.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-show-values-as.test.ts
@@ -63,7 +63,7 @@ describe('showValuesAs transform', () => {
         await new GridColumns(api, 'flat grand total').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'flat grand total').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"
@@ -179,7 +179,7 @@ describe('showValuesAs transform', () => {
         await new GridColumns(api, 'grouped grand total').checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'grouped grand total').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"
@@ -219,7 +219,7 @@ describe('showValuesAs transform', () => {
         await new GridColumns(api, 'parent dormant').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfParentRowTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfParentRowTotal
         `);
         await new GridRows(api, 'parent dormant').check(`
             ROOT id:ROOT_NODE_ID amount:"#N/A"
@@ -274,7 +274,7 @@ describe('showValuesAs transform', () => {
         await new GridColumns(api, 'promote value column').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'promote value column').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"
@@ -320,7 +320,7 @@ describe('showValuesAs transform', () => {
         await new GridColumns(api, 'after promote state').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'after promote state').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"
@@ -352,7 +352,7 @@ describe('showValuesAs transform', () => {
         await new GridColumns(api, 'round-trip initial').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'round-trip initial').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"
@@ -383,7 +383,7 @@ describe('showValuesAs transform', () => {
         await new GridColumns(api, 'round-trip restored').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'round-trip restored').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"
@@ -447,9 +447,9 @@ describe('showValuesAs transform', () => {
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
             ├─┬ "2020" GROUP
-            │ └── pivot_year_2020_gold "Gold" width:200 showValuesAs:percentOfRowTotal columnGroupShow:open
+            │ └── pivot_year_2020_gold "Gold" width:200 %:percentOfRowTotal columnGroupShow:open
             └─┬ "2021" GROUP
-              └── pivot_year_2021_gold "Gold" width:200 showValuesAs:percentOfRowTotal columnGroupShow:open
+              └── pivot_year_2021_gold "Gold" width:200 %:percentOfRowTotal columnGroupShow:open
         `);
         await new GridRows(api, 'percentOfRowTotal', {
             forcedColumns: ['ag-Grid-AutoColumn', goldCol(2020).getColId(), goldCol(2021).getColId()],
@@ -474,7 +474,7 @@ describe('showValuesAs transform', () => {
         await new GridColumns(api, 'row total dormant').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            └── gold "Gold" width:200 aggFunc:sum showValuesAs:percentOfRowTotal
+            └── gold "Gold" width:200 aggFunc:sum %:percentOfRowTotal
         `);
         await new GridRows(api, 'row total dormant').check(`
             ROOT id:ROOT_NODE_ID gold:"#N/A"
@@ -516,11 +516,11 @@ describe('showValuesAs transform', () => {
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
             ├─┬ "2020" GROUP
-            │ ├── pivot_year_2020_gold "Gold" width:200 showValuesAs:percentOfGrandTotal columnGroupShow:open
-            │ └── pivot_year_2020_silver "Silver" width:200 showValuesAs:percentOfColumnTotal columnGroupShow:open
+            │ ├── pivot_year_2020_gold "Gold" width:200 %:percentOfGrandTotal columnGroupShow:open
+            │ └── pivot_year_2020_silver "Silver" width:200 %:percentOfColumnTotal columnGroupShow:open
             └─┬ "2021" GROUP
-              ├── pivot_year_2021_gold "Gold" width:200 showValuesAs:percentOfGrandTotal columnGroupShow:open
-              └── pivot_year_2021_silver "Silver" width:200 showValuesAs:percentOfColumnTotal columnGroupShow:open
+              ├── pivot_year_2021_gold "Gold" width:200 %:percentOfGrandTotal columnGroupShow:open
+              └── pivot_year_2021_silver "Silver" width:200 %:percentOfColumnTotal columnGroupShow:open
         `);
         await new GridRows(api, 'pivot grand-vs-column', {
             forcedColumns: ['ag-Grid-AutoColumn', col('gold', 2020).getColId(), col('silver', 2020).getColId(), col('gold', 2021).getColId(), col('silver', 2021).getColId()], // prettier-ignore
@@ -557,7 +557,7 @@ describe('showValuesAs transform', () => {
         await new GridColumns(api, 'column total flat').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfColumnTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfColumnTotal
         `);
         await new GridRows(api, 'column total flat').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"
@@ -595,7 +595,7 @@ describe('showValuesAs transform', () => {
         await new GridColumns(api, 'formatter isolation').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'formatter isolation').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"
@@ -628,7 +628,7 @@ describe('showValuesAs transform', () => {
 
         await new GridColumns(api, 'inherit defaultColDef').checkColumns(`
             CENTER
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'inherit defaultColDef').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"
@@ -674,16 +674,16 @@ describe('showValuesAs transform', () => {
             ├── ag-Grid-AutoColumn "Group" width:200
             ├─┬ "EU" GROUP closed
             │ ├─┬ "2020" GROUP hidden
-            │ │ └── pivot_region-year_EU-2020_amount "Amount" width:200 showValuesAs:percentOfParentColumnTotal columnGroupShow:open hidden
+            │ │ └── pivot_region-year_EU-2020_amount "Amount" width:200 %:percentOfParentColumnTotal columnGroupShow:open hidden
             │ ├─┬ "2021" GROUP hidden
-            │ │ └── pivot_region-year_EU-2021_amount "Amount" width:200 showValuesAs:percentOfParentColumnTotal columnGroupShow:open hidden
-            │ └── pivot_region-year_EU_amount "Amount" width:200 showValuesAs:percentOfParentColumnTotal columnGroupShow:closed
+            │ │ └── pivot_region-year_EU-2021_amount "Amount" width:200 %:percentOfParentColumnTotal columnGroupShow:open hidden
+            │ └── pivot_region-year_EU_amount "Amount" width:200 %:percentOfParentColumnTotal columnGroupShow:closed
             └─┬ "US" GROUP closed
               ├─┬ "2020" GROUP hidden
-              │ └── pivot_region-year_US-2020_amount "Amount" width:200 showValuesAs:percentOfParentColumnTotal columnGroupShow:open hidden
+              │ └── pivot_region-year_US-2020_amount "Amount" width:200 %:percentOfParentColumnTotal columnGroupShow:open hidden
               ├─┬ "2021" GROUP hidden
-              │ └── pivot_region-year_US-2021_amount "Amount" width:200 showValuesAs:percentOfParentColumnTotal columnGroupShow:open hidden
-              └── pivot_region-year_US_amount "Amount" width:200 showValuesAs:percentOfParentColumnTotal columnGroupShow:closed
+              │ └── pivot_region-year_US-2021_amount "Amount" width:200 %:percentOfParentColumnTotal columnGroupShow:open hidden
+              └── pivot_region-year_US_amount "Amount" width:200 %:percentOfParentColumnTotal columnGroupShow:closed
         `);
         await new GridRows(api, 'percentOfParentColumnTotal', {
             forcedColumns: ['ag-Grid-AutoColumn', leafCol('EU', 2020).getColId(), leafCol('EU', 2021).getColId(), leafCol('US', 2020).getColId(), leafCol('US', 2021).getColId()], // prettier-ignore
@@ -870,8 +870,8 @@ describe('showValuesAs transform', () => {
         await new GridColumns(api, 'precision').checkColumns(`
             CENTER
             ├── country "Country" width:200
-            ├── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
-            └── units "Units" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
+            ├── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal
+            └── units "Units" width:200 aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'precision').check(`
             ROOT id:ROOT_NODE_ID amount:"100%" units:"100.000%"
@@ -902,7 +902,7 @@ describe('showValuesAs transform', () => {
         await new GridColumns(api, 'no-mutate').checkColumns(`
             CENTER
             ├── ag-Grid-AutoColumn "Group" width:200
-            └── amount "Amount" width:200 aggFunc:sum showValuesAs:percentOfGrandTotal
+            └── amount "Amount" width:200 aggFunc:sum %:percentOfGrandTotal
         `);
         await new GridRows(api, 'no-mutate').check(`
             ROOT id:ROOT_NODE_ID amount:"100.00%"

--- a/testing/behavioural/src/test-utils/gridColumns/columns-diagram/formatting.ts
+++ b/testing/behavioural/src/test-utils/gridColumns/columns-diagram/formatting.ts
@@ -8,8 +8,8 @@ import type { AgColumn, Column, ColumnGroup, GridApi } from 'ag-grid-community';
  * Properties shown (when non-default):
  *   width:N, flex:N,
  *   sort:asc|desc, sortIndex:N,
- *   rowGroup, rowGroupIndex:N, pivot, pivotIndex:N, aggFunc:name,
- *   filter, columnGroupShow:open|closed, hidden, !visible,
+ *   rowGroup, rowGroupIndex:N, pivot, pivotIndex:N, aggFunc:name, ƒ (calculated column),
+ *   %:mode (showValuesAs), filter, columnGroupShow:open|closed, hidden, !visible,
  *   editable, !resizable, !sortable, suppressMovable, lockPosition:left|right
  *
  * `hidden` means not in the displayed set — visibility off or a child of a collapsed group.
@@ -67,10 +67,15 @@ export function columnDiagram(col: Column, api: GridApi, isHidden: boolean): str
         parts.push('aggFunc:' + (typeof aggFunc === 'string' ? aggFunc : 'custom'));
     }
 
+    // Calculated column (formula-derived, read-only)
+    if ((col as AgColumn).isCalculatedCol) {
+        parts.push('ƒ');
+    }
+
     // Show Values As mode (the active selector)
     const showValuesAs = (col as AgColumn).showValuesAs;
     if (showValuesAs != null) {
-        parts.push('showValuesAs:' + showValuesAs.type);
+        parts.push('%:' + showValuesAs.type);
     }
 
     // Filter active


### PR DESCRIPTION
FIX RTI-3350 

Calculated columns work with row grouping, Tree Data and pivot

## Problem

Calculated columns were effectively leaf-only: blank on every non-leaf row, and turned off
entirely under pivot.

## What changed

- **Evaluates on rows with their own data** — leaf rows, and Tree Data parents that carry data.
  It stays **blank on rows without data**: row group rows, group footers, the grand-total row,
  and Tree Data filler nodes.
- **With an `aggFunc` (agg-after):** each leaf evaluates and the group aggregates those per-leaf
  results — the same as a `valueGetter` value column. This is how a calc col shows a value on
  group rows (a ratio has no meaningful aggregation, so it's left without an `aggFunc`).
- **Under pivot:** works in every role — pivot value (`aggFunc`), non-value primary column
  (no `aggFunc` → absent from the cross-tab), or pivot dimension (`pivot: true` → its per-leaf
  result is the pivot key, one result column per distinct value).

## How it was solved

- **`columnModel`** — `setFormulasActive` always gets the primary columns (`colDefList`), so
  formulas keep evaluating per leaf under pivot.
- **`formulaService.ensureCalculatedCellFormula`** — executes only on rows with their own data
  (`row.data != null`); a row without data stays blank. An actively-aggregating calc col on a
  group is formula-free (the group shows the agg-after aggregate, read from `aggData`). The
  pivot-incompatibility block (warning 306) is removed — calc cols are compatible with pivot in
  every role.
- **`valueService.getValueFromData`** — an actively-aggregating calc col on a group reads
  `aggData` (agg-after); gated on `aggregationActive`, not just a defined `aggFunc`.
- **`pivotColDefService`** — a pivot result column drops a calc source's calc-col fields
  (`calculatedExpression`, `allowFormula`) so it plainly aggregates; ordinary formula-enabled
  value columns keep `allowFormula`.
- **Formula references to a pivot result column** are bucket-aware (see Design note).

## Tests

Behavioural coverage: leaves evaluate while group rows / footers / grand-total / Tree Data filler
nodes stay blank; Tree Data parents with data evaluate; `aggFunc` agg-after across nested groups,
footers and transactions, with `valueGetter` parity; and the three pivot roles. New `GridColumns`
diagram tokens `ƒ` (calculated) and `%:mode` (showValuesAs); suite snapshots regenerated. Docs and
the row-groups example updated.

## Design note — pivot result column references

A formula referencing a specific pivot result column id (`[pivot_year_2020_revenue]`) resolves to
the row's contribution to that bucket: the bucket aggregate on a group, the source measure on a
leaf inside the bucket, and blank on a leaf outside it. This bucket-aware resolution lives only in
the formula read path.

The shared `_resolvePivotColumnForRow` (used by `getCellValue`, editing, and inverse aggregation) is
left unchanged — it deliberately resolves a pivot result column to its source measure uniformly on
groups and leaves, which inverse-aggregation distribution depends on. The two answer different
questions: a formula reads the row's bucket value; the resolver gives the underlying source.
