### PR TITLE
RTI-3360 Fix date-part chips not reorderable in row group panel

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/grouping-data/_examples/grouping-date-time/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grouping-data/_examples/grouping-date-time/example.spec.ts
@@ -59,6 +59,23 @@ test.agExample(import.meta, () => {
         await expect(agIdFor.columnSelectListItemCheckbox('Date (Year) Column')).toBeChecked();
     });
 
+    test.eachFramework('Example reordering date-part chips in the row group panel', async ({ agIdFor }) => {
+        const yearTopRowId = `row-group-${vcolPrefix}-date-year-2008`;
+        const monthTopRowId = `row-group-${vcolPrefix}-date-month-8`;
+
+        // Initially grouped year -> month, so the top-level group is a year
+        await expect(agIdFor.autoGroupCell(yearTopRowId)).toContainText('2008 (5)', { useInnerText: true });
+
+        // Drag the Month chip ahead of the Year chip within the Row Groups panel
+        await dragOverTo(
+            agIdFor.columnDropCellDragHandle('panel', 'Row Groups', 'Date (Month)'),
+            agIdFor.columnDropArea('panel', 'Row Groups').locator('.ag-column-drop-cell').first()
+        );
+
+        // The top-level group is now a month, confirming the chips are reorderable
+        await expect(agIdFor.autoGroupCell(monthTopRowId)).toContainText('8', { useInnerText: true });
+    });
+
     test.eachFramework('Example with formatted months', async ({ agIdFor, page }) => {
         const level0GroupRowId = `row-group-${vcolPrefix}-date-year-2008`;
 

--- a/packages/ag-grid-enterprise/src/groupHierarchy/groupHierarchyColService.ts
+++ b/packages/ag-grid-enterprise/src/groupHierarchy/groupHierarchyColService.ts
@@ -200,8 +200,10 @@ export class GroupHierarchyColService extends BeanStub implements NamedBean, IGr
             return _addColumnDefaultAndTypes(beans, part, colId, true);
         }
 
-        // hierarchy cols inherit the source col's pivot affordance so they stay draggable to the pivot area
-        const defaults: Partial<ColDef> = { enablePivot: sourceCol.colDef.enablePivot, hide: true, editable: false };
+        // hierarchy cols inherit the source col's row-group + pivot affordances so their chips stay draggable
+        // in the row-group / pivot drop zones
+        const { enableRowGroup, enablePivot } = sourceCol.colDef;
+        const defaults: Partial<ColDef> = { enableRowGroup, enablePivot, hide: true, editable: false };
 
         const config = gos.get('groupHierarchyConfig') ?? {};
         if (part in config) {

--- a/testing/behavioural/src/grouping-data/pivot-group-hierarchy.test.ts
+++ b/testing/behavioural/src/grouping-data/pivot-group-hierarchy.test.ts
@@ -502,6 +502,28 @@ describe('pivot with groupHierarchy (date-time)', () => {
         expect(api.getRowGroupColumns().map((c) => c.getColId())).toEqual([]);
     });
 
+    test('hierarchy virtuals inherit enableRowGroup so their row-group-panel chips stay draggable', async () => {
+        const api = gridsManager.createGrid('hierarchyEnableRowGroup', {
+            columnDefs: [
+                { field: 'country' },
+                { field: 'date', rowGroup: true, enableRowGroup: true, groupHierarchy: ['year', 'month'] },
+            ],
+            rowData: [
+                { country: 'USA', date: new Date(2020, 0, 1) },
+                { country: 'UK', date: new Date(2021, 5, 15) },
+            ],
+            groupDisplayType: 'multipleColumns',
+        });
+        await asyncSetTimeout(0);
+
+        // The row-group-panel drop zone only lets a chip drag when its column reports isAllowRowGroup();
+        // the date-part virtuals must inherit it from the source so they can be reordered.
+        const year = api.getColumn('ag-Grid-HierarchyColumn-date-year')!;
+        const month = api.getColumn('ag-Grid-HierarchyColumn-date-month')!;
+        expect(year.isAllowRowGroup()).toBe(true);
+        expect(month.isAllowRowGroup()).toBe(true);
+    });
+
     test('changing an inline hierarchy part def refreshes the hierarchy column in place (same colId)', async () => {
         const api = gridsManager.createGrid('hierarchyInlineRefresh', {
             columnDefs: [{ field: 'date', rowGroup: true, groupHierarchy: [{ colId: 'y', headerName: 'Year A' }] }],


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/RTI-3360

The 36.0.0 full-colmodel-rewrite dropped `enableRowGroup` inheritance from the source column when generating date-part hierarchy virtual columns (Month/Year/Day from a single DATE column with `groupHierarchy`), keeping only `enablePivot`. As a result `AgColumn.isAllowRowGroup()` returned `false` on the virtual chips, and `RowGroupDropZonePanel.isItemDroppable` rejected drag-reordering in the row group panel (cursor showed "not allowed"). Pivot-zone dragging still worked because `enablePivot` was retained.

This restores `enableRowGroup` inheritance from the source column into the virtual colDef defaults, matching v35.3. Per-part config overrides still spread over the defaults, so they are unaffected. 35.3's `rowGroup: true` inheritance is deliberately not re-added — virtual membership is now driven by the rewrite's seating logic.

Added a behavioural test asserting `isAllowRowGroup()` is true on the year/month virtuals (RED before, GREEN after).

Fix [RTI-3360](https://ag-grid.atlassian.net/browse/RTI-3360)