### PR TITLE
RTI-3359 Link calculated columns docs to formula reference operators and functions

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/index.mdoc
@@ -143,7 +143,7 @@ const gridOptions = {
 
 ## Advanced Calculated Columns
 
-Calculated columns can use the same operators and functions as [formulas](./formulas/), and can reference other calculated columns in the same row. This allows chained derived values such as profit, margin and status.
+Calculated columns can use the same [Mathematical Operators](./formula-reference/#mathematical-operators) and [Provided Functions](./formula-reference/#provided-functions) as [formulas](./formulas/), and can reference other calculated columns in the same row. This allows chained derived values such as profit, margin and status.
 
 ```{% frameworkTransform=true %}
 const gridOptions = {


### PR DESCRIPTION
## Issue

[RTI-3359](https://ag-grid.atlassian.net/browse/RTI-3359) — Operators and Functions are not explained well on the Calculated Columns page. The dialog's Functions and Operators pickers list bare symbols/names without explaining what they do.

## Change

Links the "Advanced Calculated Columns" section of the Calculated Columns docs to the relevant sections of the Formula Reference, where operators and provided functions are documented:

- `[Mathematical Operators](./formula-reference/#mathematical-operators)`
- `[Provided Functions](./formula-reference/#provided-functions)`

This gives users a direct path from calculated columns to the explanations of each operator and function.

## Notes

This addresses the documentation/discoverability side of the ticket. If the product owner also wants in-dialog descriptions/labels for the pickers themselves, that would be a separate change.

Relates to [RTI-3359](https://ag-grid.atlassian.net/browse/RTI-3359)