### PR TITLE
RTI-3374

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-api-save-restore-charts/_examples/saving-and-restoring-charts/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-api-save-restore-charts/_examples/saving-and-restoring-charts/example.spec.ts
@@ -168,4 +168,23 @@ test.agExample(import.meta, () => {
             expect(orderAfterRestore).toEqual(['Weight', 'Fat']);
         }
     );
+
+    // TC6 — moving a grid column must update the series order to follow the new column order
+    // (unlike sort/filter/group/hide, which preserve the user-defined order).
+    test.vanilla('TC6 - grid column move updates series order', async ({ page, remoteGrid }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        await openChartDataPanel(page);
+
+        const initialOrder = await getSeriesOrder(page);
+        expect(initialOrder).toEqual(['Sugar', 'Fat', 'Weight']);
+
+        // Move 'weight' before 'sugar' in the grid (grid order: country, sugar, fat, weight).
+        const remoteApi = remoteGrid(page);
+        await remoteApi.moveColumns(['weight'], 1);
+
+        const orderAfterMove = await getSeriesOrder(page);
+        expect(orderAfterMove).toEqual(['Weight', 'Sugar', 'Fat']);
+    });
 });

--- a/packages/ag-grid-enterprise/src/charts/chartComp/chartController.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/chartController.ts
@@ -71,7 +71,7 @@ export class ChartController extends BeanStub<ChartControllerEvent> {
                     this.updateForRangeChange();
                 }
             },
-            columnMoved: listener,
+            columnMoved: this.updateForGridChange.bind(this, { updateOrder: true }),
             columnPinned: listener,
             columnVisible: listener,
             columnRowGroupChanged: listener,
@@ -150,14 +150,18 @@ export class ChartController extends BeanStub<ChartControllerEvent> {
         }
     }
 
-    public updateForGridChange(params?: { maintainColState?: boolean; setColsFromRange?: boolean }): void {
+    public updateForGridChange(params?: {
+        maintainColState?: boolean;
+        setColsFromRange?: boolean;
+        updateOrder?: boolean;
+    }): void {
         if (this.model.unlinked) {
             return;
         }
 
-        const { maintainColState, setColsFromRange } = params ?? {};
+        const { maintainColState, setColsFromRange, updateOrder } = params ?? {};
 
-        this.model.updateCellRanges({ maintainColState, setColsFromRange });
+        this.model.updateCellRanges({ maintainColState, setColsFromRange, updateOrder });
         this.model.updateData();
         this.setChartRange();
     }

--- a/packages/ag-grid-enterprise/src/charts/chartComp/model/chartDataModel.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/model/chartDataModel.ts
@@ -177,8 +177,9 @@ export class ChartDataModel extends BeanStub {
         resetOrder?: boolean;
         maintainColState?: boolean;
         setColsFromRange?: boolean;
+        updateOrder?: boolean;
     }): void {
-        const { updatedColState, resetOrder, maintainColState, setColsFromRange } = params ?? {};
+        const { updatedColState, resetOrder, maintainColState, setColsFromRange, updateOrder } = params ?? {};
         if (this.valueCellRange) {
             this.referenceCellRange = this.valueCellRange;
         }
@@ -194,7 +195,7 @@ export class ChartDataModel extends BeanStub {
         this.setValueCellRange(valueCols, allColsFromRanges, setColsFromRange);
 
         if (!updatedColState && !maintainColState) {
-            this.resetColumnState();
+            this.resetColumnState(updateOrder);
             // dimension / category cell range could be out of sync after resetting column state when row grouping
             this.syncDimensionCellRange();
         }
@@ -375,14 +376,14 @@ export class ChartDataModel extends BeanStub {
         return { startRow, endRow };
     }
 
-    private resetColumnState(): void {
+    // `updateOrder` re-derives series order from the grid column order (column drag); otherwise the user-defined order is preserved.
+    private resetColumnState(updateOrder?: boolean): void {
         const { dimensionCols, valueCols } = this.chartColSvc.getChartColumns();
         const allCols = this.getAllColumnsFromRanges();
         const isInitialising = this.valueColState.length < 1;
 
-        const savedValueOrder = isInitialising
-            ? undefined
-            : new Map(this.valueColState.map((cs) => [cs.colId, cs.order]));
+        const savedValueOrder =
+            isInitialising || updateOrder ? undefined : new Map(this.valueColState.map((cs) => [cs.colId, cs.order]));
 
         this.dimensionColState = [];
         this.valueColState = [];


### PR DESCRIPTION
FIX RTI-3374

## Problem

Dragging a column across the grid re-renders an integrated chart but leaves the
series in their previous order. The series should reorder to follow the new grid
column order.

Reproduce on 36.0.0: [Range Chart → Switching Categories and Series](https://www.ag-grid.com/archive/36.0.0/javascript-data-grid/integrated-charts-range-chart/#switching-categories-and-series) — drag the *Jan* column across the grid.

- **Actual:** chart re-renders, series ordering unchanged.
- **Expected:** series ordering follows the dragged column.

## Cause

Regression introduced in **36.0.0** by AG-13924 (#13826) — absent in 35.3.0/35.3.1.

That change added a `savedValueOrder` snapshot in `resetColumnState()` to keep a
user-customised series order across sort/filter/group/hide events. It is driven by
a single shared grid listener, so it also fired on `columnMoved`, freezing the
series order against the very drag that should change it.

## Fix

`columnMoved` now passes `updateOrder: true`, threaded through
`updateCellRanges` → `resetColumnState`, which skips the `savedValueOrder` restore
for that event only. Series order is re-derived from the grid column order on a
column drag, while AG-13924's preservation is retained for sort/filter/group/visibility/restore.

## Changes

- `chartController.ts` — `columnMoved` listener passes `{ updateOrder: true }`.
- `chartDataModel.ts` — thread `updateOrder` through `updateCellRanges` → `resetColumnState`.
- `saving-and-restoring-charts/example.spec.ts` — add TC6 regression test.

## Testing

- New **TC6** asserts a grid column move updates series order.
- Existing **TC1–TC5** (AG-13924 preservation) still pass — preservation behaviour intact.
- `build:types`, `lint`, and the full `saving-and-restoring-charts` E2E suite (12 tests) pass.
