### PR TITLE
RTI-3353 Ship a .htaccess with archive builds

### DIFF
--- a/documentation/ag-grid-docs/.env.build.archive
+++ b/documentation/ag-grid-docs/.env.build.archive
@@ -1,5 +1,13 @@
 # PUBLIC_BASE_URL provided via TeamCity = ie PUBLIC_BASE_URL=/archive/31.1.0
 PUBLIC_SITE_URL=https://www.ag-grid.com # Same as production
+# Archived versions are deployed to /archive/<version>/ on the production host
+# (www.ag-grid.com). Generating the production .htaccess here ships each archive with
+# its own CSP, so a freshly-deployed archive carries the current policy instead of
+# inheriting the (potentially stale) top-level .htaccess. Apache applies .htaccess
+# parent->child and the block does `Header always unset`+`set`, so the archive's own
+# policy wins for that subtree while the live site keeps the top-level file. This is
+# what lets the archived /campaigns/ pages pick up the bryntum.com CSP allowances.
+HTACCESS=production
 PUBLIC_ALGOLIA_APP_ID=O1K1ESGB5K
 PUBLIC_ALGOLIA_SEARCH_KEY=01142fe24ea5d2e36f4eb66b0b2ff872
 PUBLIC_ALGOLIA_INDEX_PREFIX=ag-grid-dev


### PR DESCRIPTION
Ports [ag-studio#1835 (SR-281)](https://github.com/ag-grid/ag-studio/pull/1835) to grid. Companion to #14165 (the CSP rule change that allows `bryntum.com` on archived `/campaigns/` pages).

## Problem

Archived versions are deployed to `/archive/<version>/` on the production host (`www.ag-grid.com`). But the archive build (`-c archive`) set **no** `HTACCESS`, so `agHtaccessGen` skipped `.htaccess` generation (`astro.config.mjs` defaults `HTACCESS = 'false'`) and the archive carried **no `.htaccess` of its own** — it inherited the top-level root `.htaccess`.

That root file is only refreshed on a full production deploy. So a freshly-built/redeployed archive is served a potentially **stale** policy. Concretely: the `bryntum.com` CSP allowances for archived `/campaigns/` pages added in #14165 only reach the archive once the root `.htaccess` is regenerated and deployed — re-running just the archive build wouldn't pick them up.

## Fix

Set `HTACCESS=production` in `.env.build.archive` so each archive build emits its own `.htaccess` at `/archive/<version>/`.

- Apache applies `.htaccess` parent→child, and the generated block does `Header always unset` + `set`, so the archive's own policy **wins for that subtree** while the live, non-archive pages keep the top-level file (which never matches the `/archive/` `<If>`).
- The CSP content is base-URL-independent. The redirect lines are base-prefixed (`urlWithBaseUrl` → `/archive/<version>/…`) and so scoped harmlessly to the archive subtree.

## Verification

Generated the archive production `.htaccess` with `PUBLIC_BASE_URL=/archive/36.0.0` and confirmed:
- The file generates cleanly (full production block).
- The campaigns `<If>` condition (`m#^(?:/archive/[^/]+)?/campaigns/#`) is present and `https://bryntum.com` is granted (still no `'unsafe-eval'`).
- Redirects are correctly base-prefixed to `/archive/36.0.0/…`.

## Deploy hygiene (TeamCity archive job)

As with studio: the archive bundle must include the generated dotfile and be unzipped **only** into `/archive/<version>/`, never the web root (which would clobber the live top-level `.htaccess`).
