### PR TITLE
RTI-3383-flex-clamp-fix

### DIFF
--- a/packages/ag-grid-community/src/columns/columnFlexService.ts
+++ b/packages/ag-grid-community/src/columns/columnFlexService.ts
@@ -3,7 +3,6 @@ import { BeanStub } from '../context/beanStub';
 import type { AgColumn } from '../entities/agColumn';
 import type { ColumnEventType } from '../events';
 import type { ColumnDelayRenderService } from '../rendering/columnDelayRenderService';
-import { _clamp } from '../utils/number';
 import { dispatchColumnResizedEvent } from './columnEventUtils';
 
 type FlexItem = {
@@ -159,7 +158,8 @@ export class ColumnFlexService extends BeanStub implements NamedBean {
                 }
 
                 const unclampedSize = item.targetSize;
-                const clampedSize = _clamp(unclampedSize, item.min, item.max);
+                // max applied last to match setActualWidth: when min > max, max wins, else the frozen size leaks space
+                const clampedSize = Math.min(Math.max(unclampedSize, item.min), item.max);
 
                 totalViolation += clampedSize - unclampedSize;
                 item.violationType =

--- a/testing/behavioural/src/columns/column-flex.test.ts
+++ b/testing/behavioural/src/columns/column-flex.test.ts
@@ -207,6 +207,27 @@ describe('Column Flex', () => {
         );
     });
 
+    test('maxWidth below an inherited minWidth caps at maxWidth and still fills the viewport', async () => {
+        // defaultColDef.minWidth (150) exceeds the per-col maxWidth on b/c, an incoherent config.
+        // maxWidth must win and the freed space must flow to the unconstrained flex cols (no gap).
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { colId: 'a', flex: 1 },
+                { colId: 'b', flex: 1, maxWidth: 120 },
+                { colId: 'c', flex: 1, maxWidth: 100 },
+                { colId: 'd', flex: 1 },
+            ],
+            defaultColDef: { flex: 1, minWidth: 150 },
+        });
+        // GridColumns snapshot is skipped: its validator (correctly) rejects the incoherent min>max config.
+        const widths = ['a', 'b', 'c', 'd'].map((id) => api.getColumn(id)!.getActualWidth());
+        expect(widths.reduce((s, w) => s + w, 0)).toBe(1000);
+        expect(api.getColumn('b')!.getActualWidth()).toBe(120);
+        expect(api.getColumn('c')!.getActualWidth()).toBe(100);
+        expect(api.getColumn('a')!.getActualWidth()).toBe(390);
+        expect(api.getColumn('d')!.getActualWidth()).toBe(390);
+    });
+
     test('all flex cols hit maxWidth: total stays under viewport', async () => {
         const api = gridsManager.createGrid('myGrid', {
             columnDefs: [


### PR DESCRIPTION
FIX RTI-3383

# Fix: flex columns don't fill viewport when an inherited `minWidth` exceeds a column's `maxWidth`

When `defaultColDef.minWidth` is larger than a column's own `maxWidth` (`min > max`), flex columns leave a gap on the right instead of filling the grid.

**Cause (regression from #14043):** that PR swapped the flex clamp from `Math.min(Math.max(v, min), max)` (max wins) to `_clamp` (`Math.max(min, Math.min(v, max))`, min wins). These differ only when `min > max`. `setActualWidth` clamps max-wins, so the column rendered at `max` while flex's space accounting deducted `min` — the difference leaked as a gap.

**Fix:** restore the max-last clamp at this site so it matches `setActualWidth`. (Other #14043 sites are unaffected: width sites are re-clamped by `setActualWidth` downstream; index/scroll sites correctly want min-wins.)

Added a behavioural regression test in `column-flex.test.ts`.
