### PR TITLE
RTI-3390 Clarify allowShowChangeAfterFilter only affects cell flashing

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-delta-aggregation/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-delta-aggregation/main.ts
@@ -87,7 +87,6 @@ const gridOptions: GridOptions = {
     },
     groupDefaultExpanded: 1,
     suppressAggFuncInHeader: true,
-    allowShowChangeAfterFilter: true,
     getRowId: (params: GetRowIdParams) => String(params.data.id),
     onGridReady: (params) => {
         params.api.setGridOption('rowData', createRowData());

--- a/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-filter-sort-group/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-filter-sort-group/main.ts
@@ -66,7 +66,6 @@ const gridOptions: GridOptions = {
     rowData: getRowData(),
     groupDefaultExpanded: 1,
     suppressAggFuncInHeader: true,
-    allowShowChangeAfterFilter: true,
     onCellValueChanged: onCellValueChanged,
 };
 

--- a/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-groups/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-groups/main.ts
@@ -63,7 +63,6 @@ const gridOptions: GridOptions = {
     rowData: getRowData(),
     groupDefaultExpanded: 1,
     suppressAggFuncInHeader: true,
-    allowShowChangeAfterFilter: true,
 };
 
 function getRowData() {

--- a/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-pivot/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/change-detection/_examples/change-detection-pivot/main.ts
@@ -57,7 +57,6 @@ const gridOptions: GridOptions = {
     rowData: getRowData(),
     pivotMode: true,
     groupDefaultExpanded: 1,
-    allowShowChangeAfterFilter: true,
     getRowId: (params: GetRowIdParams) => String(params.data.student),
     onGridReady: (params: GridReadyEvent) => {
         (document.getElementById('pivot-mode') as HTMLInputElement).checked = true;

--- a/documentation/ag-grid-docs/src/content/docs/change-detection/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/change-detection/index.mdoc
@@ -101,7 +101,7 @@ This property triggers the necessary regroup, sort and filter refresh after the 
 By default, the grid does not flash cells when filtering is applied, even if the value in the aggregated cell has changed.
 To change this behaviour, set the grid property `allowShowChangeAfterFilter=true`.
 
-All examples on this page set `allowShowChangeAfterFilter` to `true` to clearly see value changes while experimenting with filters.
+This only affects cell flashing (`enableCellChangeFlash`). The [Value Getters example](#example-change-detection-and-value-getters) above sets `allowShowChangeAfterFilter=true`, so that flashing remains visible while filtering. The other examples on this page use [animation cell renderers](./change-cell-renderers/) instead of flashing, so the property has no effect on them.
 
 ### Example: Re-Aggregation of Groups
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/RTI-3390

The change-detection docs claimed all examples set `allowShowChangeAfterFilter`, but the property only suppresses cell *flashing* during filtering and has no effect on animate-change cell renderers (`agAnimateShowChangeCellRenderer`).

- Removed the no-op `allowShowChangeAfterFilter: true` from the four animate-renderer examples (`change-detection-groups`, `change-detection-filter-sort-group`, `change-detection-delta-aggregation`, `change-detection-pivot`).
- Kept it on `change-detection-value-getters`, where `enableCellChangeFlash` makes it effective.
- Rewrote the prose to explain the property only affects cell flashing and point to the value-getters example.

Fix [RTI-3390](https://ag-grid.atlassian.net/browse/RTI-3390)