### PR TITLE
Fix(themes): correct input text vertical padding

### DIFF
--- a/community-modules/styles/src/internal/themes/material/_index.scss
+++ b/community-modules/styles/src/internal/themes/material/_index.scss
@@ -214,9 +214,10 @@
         }
     }
 
-    // Remove text-input mixin's padding-bottom so the page-number text stays centred
+    // Reduce text-input mixin's padding-bottom so the page-number text stays centred.
+    // Input text was vertically off by 1px all this time in the legacy theme; corrected here.
     .ag-paging-number .ag-input-field-input.ag-number-field-input {
-        padding-bottom: 0;
+        padding-bottom: 1px;
     }
 
     .ag-standard-button {

--- a/community-modules/styles/src/internal/themes/quartz/_index.scss
+++ b/community-modules/styles/src/internal/themes/quartz/_index.scss
@@ -25,11 +25,8 @@
         min-height: calc(var(--ag-grid-size) * 4);
         border-radius: var(--ag-border-radius);
 
-        @include ag.theme-rtl(
-            (
-                padding-left: var(--ag-grid-size),
-            )
-        );
+        // Input text was vertically off by 1px all this time in the legacy theme; corrected here
+        padding: 1px var(--ag-grid-size) 2px var(--ag-grid-size);
     }
 
     .ag-picker-field-wrapper {

--- a/packages/ag-grid-community/src/theming/parts/theme/quartz-adjustments.css
+++ b/packages/ag-grid-community/src/theming/parts/theme/quartz-adjustments.css
@@ -1,0 +1,4 @@
+:where(.ag-number-field.ag-paging-number) .ag-input-field-input {
+    /* Input text was vertically off by 1px; corrected here */
+    padding-bottom: 1px;
+}

--- a/packages/ag-grid-community/src/theming/parts/theme/themes.ts
+++ b/packages/ag-grid-community/src/theming/parts/theme/themes.ts
@@ -30,6 +30,7 @@ import { inputStyleBordered, inputStyleUnderlined } from '../input-style/input-s
 import type { TabStyleParams } from '../tab-style/tab-styles';
 import { tabStyleAlpine, tabStyleMaterial, tabStyleQuartz, tabStyleRolodex } from '../tab-style/tab-styles';
 import materialAdjustmentsCSS from './material-adjustments.css';
+import quartzAdjustmentsCSS from './quartz-adjustments.css';
 
 export type ThemeDefaultParams = CoreParams &
     ButtonStyleParams &
@@ -50,6 +51,14 @@ export const themeQuartzParams = () => ({
     fontFamily: [{ googleFont: 'IBM Plex Sans' }, ...defaultFontFamily()],
 });
 
+const makeStyleQuartzTreeShakeable = () =>
+    createPart({
+        feature: 'styleQuartz',
+        css: quartzAdjustmentsCSS,
+    });
+
+const styleQuartz = /*#__PURE__*/ makeStyleQuartzTreeShakeable();
+
 const makeThemeQuartzTreeShakeable = () =>
     createTheme()
         .withPart(buttonStyleQuartz)
@@ -59,6 +68,7 @@ const makeThemeQuartzTreeShakeable = () =>
         .withPart(tabStyleQuartz)
         .withPart(inputStyleBordered)
         .withPart(columnDropStyleBordered)
+        .withPart(styleQuartz)
         .withParams(themeQuartzParams());
 
 export const themeQuartz: Theme<ThemeDefaultParams> =


### PR DESCRIPTION
Corrects input text that was vertically off by 1px in the legacy Quartz and Material themes, and adds the matching 1px paging-number input correction to the Theming API Quartz theme.

<img width="441" height="155" alt="Screenshot 2026-06-23 at 13 02 36" src="https://github.com/user-attachments/assets/05365ba5-0031-476d-afd2-69af44d7350f" />
<img width="367" height="107" alt="Screenshot 2026-06-23 at 13 02 34" src="https://github.com/user-attachments/assets/ca9ae807-bc92-4790-90e7-e8df1fdee8b8" />
<img width="288" height="98" alt="Screenshot 2026-06-23 at 13 02 32" src="https://github.com/user-attachments/assets/5a28b87a-684a-4f3c-a222-8b8e9aacdb6d" />
<img width="379" height="74" alt="Screenshot 2026-06-23 at 13 02 29" src="https://github.com/user-attachments/assets/ffdb0e38-e7d3-4a74-bd59-134b6fa239d5" />
<img width="339" height="109" alt="Screenshot 2026-06-23 at 13 02 23" src="https://github.com/user-attachments/assets/1fe1d274-9888-4b30-bd06-fcdbee971c93" />
<img width="299" height="82" alt="Screenshot 2026-06-23 at 13 02 20" src="https://github.com/user-attachments/assets/8d4f8754-1d2e-4e54-8222-117b250c4142" />
<img width="316" height="114" alt="Screenshot 2026-06-23 at 13 02 17" src="https://github.com/user-attachments/assets/2c68d24e-8a0c-4eba-9a5b-2bd00df578de" />
<img width="241" height="80" alt="Screenshot 2026-06-23 at 13 02 15" src="https://github.com/user-attachments/assets/ba231db1-7575-4de5-8830-d91070d64af0" />


Fixes [RTI-3395](https://ag-grid.atlassian.net/browse/RTI-3395)