### PR TITLE
RTI-3400 Use 'Header set' for CORS to avoid duplicate Access-Control-Allow-Origin

### DIFF
--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
@@ -187,6 +187,13 @@ describe('htaccessRules', () => {
             expect(stagingContent).not.toContain('Access-Control-Allow-Origin');
         });
 
+        it("should use 'Header set' for CORS so the vhost value is replaced, not appended (RTI-3400)", () => {
+            // 'Header add' appends, producing a duplicate Access-Control-Allow-Origin
+            // header ('*, *') that browsers reject. 'set' replaces any inherited value.
+            expect(productionContent).toContain('Header set Access-Control-Allow-Origin "*"');
+            expect(productionContent).not.toContain('Header add Access-Control-Allow-Origin');
+        });
+
         it('should include CSP in both environments', () => {
             expect(productionContent).toContain('Content-Security-Policy');
             expect(stagingContent).toContain('Content-Security-Policy');

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
@@ -183,9 +183,11 @@ Header always set Permissions-Policy "geolocation=(), microphone=(), camera=()"
 
 ${getProductionCspContent()}
 
-# CORS settings
-Header add Access-Control-Allow-Origin "*"
-Header add Access-Control-Allow-Methods: "GET,POST,OPTIONS,DELETE,PUT"
+# CORS settings — use 'set' (not 'add') so any value inherited from the server vhost is
+# replaced rather than appended. 'add' produced a duplicate Access-Control-Allow-Origin
+# header ('*, *'), which browsers reject as multiple values (RTI-3400).
+Header set Access-Control-Allow-Origin "*"
+Header set Access-Control-Allow-Methods "GET,POST,OPTIONS,DELETE,PUT"
 
 Options -Indexes
 `;


### PR DESCRIPTION
## Summary

Fixes [RTI-3400](https://ag-grid.atlassian.net/browse/RTI-3400) — plnkr examples from archived docs fail to load with:

> Access to script at '…/archive/36.0.0/files/ag-grid-enterprise/dist/ag-grid-enterprise.min.js' from origin 'https://run.plnkr.co' has been blocked by CORS policy: The 'Access-Control-Allow-Origin' header contains multiple values '*, *', but only one is allowed.

## Root cause

The production `.htaccess` set CORS headers with Apache's `Header add`, which **appends** rather than replaces. Archive bundles are created from `documentation/ag-grid-docs/dist`, which includes this generated `.htaccess` at their root. A request under `/archive/<version>/` is therefore governed by **two** cascading `.htaccess` files — the root (`latest`) deploy and the archive snapshot — both using `Header add`. Two `add` directives for the same header emit two header lines → `Access-Control-Allow-Origin: *, *`, which browsers reject.

## Fix

- `Header add` → `Header set` for both CORS headers. `set` removes any inherited value before setting, collapsing the cascade to a single header. Because the most-specific (archive) `.htaccess` runs last, its `set` produces exactly one header regardless of the parent.
- Dropped a stray colon on the `Access-Control-Allow-Methods` line.
- Added a regression test asserting `Header set` is used and `Header add` is gone.

## Scope / follow-ups

- This PR targets **`b36.0.0`** only. The same `add`→`set` change should be applied to `latest` **after release** (tracked separately), so the root deploy and all future archives are correct.
- The already-published `/archive/36.0.0/` carries the old `Header add` `.htaccess`; it needs a rebuild + redeploy of that archive for the live fix to take effect.

## Testing

- `htaccessRules.test.ts` — 47/47 pass (incl. new regression test)
- prettier: clean; eslint: clean