### PR TITLE
[RTI-3352] Docs(show-values-as): clarify percent modes and add state attribute

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/_examples/show-values-as-overview/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/_examples/show-values-as-overview/example.spec.ts
@@ -1,0 +1,11 @@
+import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+
+test.agExample(import.meta, () => {
+    test.eachFramework('Example', async ({ page }) => {
+        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+        await clickAllButtons(page);
+        // END PLACEHOLDER
+    });
+});

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/_examples/show-values-as-overview/index.html
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/_examples/show-values-as-overview/index.html
@@ -1,0 +1,1 @@
+<div id="myGrid" style="height: 100%"></div>

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/_examples/show-values-as-overview/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/_examples/show-values-as-overview/main.ts
@@ -1,0 +1,73 @@
+import type { GridApi, GridOptions } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    ModuleRegistry,
+    NumberFilterModule,
+    TextFilterModule,
+    ValidationModule,
+    createGrid,
+} from 'ag-grid-community';
+import {
+    ColumnMenuModule,
+    ColumnsToolPanelModule,
+    ContextMenuModule,
+    RowGroupingModule,
+    ShowValuesAsModule,
+} from 'ag-grid-enterprise';
+
+ModuleRegistry.registerModules([
+    ClientSideRowModelModule,
+    TextFilterModule,
+    NumberFilterModule,
+    ColumnMenuModule,
+    ContextMenuModule,
+    ColumnsToolPanelModule,
+    RowGroupingModule,
+    ShowValuesAsModule,
+    ...(process.env.NODE_ENV !== 'production' ? [ValidationModule] : []),
+]);
+
+let gridApi: GridApi<IOlympicData>;
+
+const gridOptions: GridOptions<IOlympicData> = {
+    columnDefs: [
+        { field: 'country', rowGroup: true, hide: true },
+        { field: 'year', rowGroup: true, hide: true },
+        { field: 'athlete', rowGroup: true, hide: true },
+        { field: 'total', headerName: 'Total', aggFunc: 'sum' },
+        {
+            field: 'total',
+            colId: 'totalPercentOfParent',
+            headerName: 'Total of Parent',
+            aggFunc: 'sum',
+            showValuesAs: 'percentOfParentRowTotal',
+        },
+    ],
+    defaultColDef: {
+        flex: 1,
+        minWidth: 130,
+        enableValue: true,
+        enableRowGroup: true,
+        enableShowValuesAs: true,
+    },
+    autoGroupColumnDef: {
+        minWidth: 220,
+    },
+    groupDefaultExpanded: 1,
+    grandTotalRow: 'top',
+    isGroupOpenByDefault: (params) => {
+        const route = params.rowNode.getRoute();
+        const destPath = ['United States', '2008'];
+        return route.every((item, idx) => destPath[idx] === item);
+    },
+};
+
+// setup the grid after the page has finished loading
+document.addEventListener('DOMContentLoaded', () => {
+    const gridDiv = document.querySelector<HTMLElement>('#myGrid')!;
+    gridApi = createGrid(gridDiv, gridOptions);
+
+    fetch('https://www.ag-grid.com/example-assets/small-olympic-winners.json')
+        .then((response) => response.json())
+        .then((data: IOlympicData[]) => gridApi!.setGridOption('rowData', data));
+});

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/index.mdoc
@@ -50,13 +50,13 @@ A numeric column that is not yet aggregated is promoted to a value column when a
 
 ## Built-in Modes
 
-| Mode                         | Shows each value as               | Applies when                 |
-|------------------------------|-----------------------------------|------------------------------|
-| `percentOfGrandTotal`        | Share of the column's grand total | Value or numeric column      |
-| `percentOfColumnTotal`       | Share of its column total         | Value or numeric column      |
-| `percentOfRowTotal`          | Share of the row total            | Pivoting                     |
-| `percentOfParentRowTotal`    | Share of its parent row group     | Row grouping or tree data    |
-| `percentOfParentColumnTotal` | Share of its parent pivot column  | Pivoting                     |
+| Mode                         | Shows each value as               | Applies when              |
+| ---------------------------- | --------------------------------- | ------------------------- |
+| `percentOfGrandTotal`        | Share of the column's grand total | Value or numeric column   |
+| `percentOfColumnTotal`       | Share of its column total         | Value or numeric column   |
+| `percentOfRowTotal`          | Share of the row total            | Pivoting                  |
+| `percentOfParentRowTotal`    | Share of its parent row group     | Row grouping or tree data |
+| `percentOfParentColumnTotal` | Share of its parent pivot column  | Pivoting                  |
 
 `percentOfGrandTotal` and `percentOfColumnTotal` give the same result outside [Pivot](./pivoting/) mode, where there is a single column total. They diverge only while pivoting: `percentOfGrandTotal` keeps the whole column's grand total as the denominator, whereas `percentOfColumnTotal` uses each pivot column's own total, so every pivot column sums to 100%.
 

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/index.mdoc
@@ -47,12 +47,14 @@ A numeric column that is not yet aggregated is promoted to a value column when a
 ## Built-in Modes
 
 | Mode                         | Shows each value as                                                        |
-| ---------------------------- | -------------------------------------------------------------------------- |
+|------------------------------|----------------------------------------------------------------------------|
 | `percentOfGrandTotal`        | a share of the column's grand total                                        |
 | `percentOfColumnTotal`       | a share of the column total — while pivoting each pivot column totals 100% |
 | `percentOfRowTotal`          | a share of the row total across the pivot columns (pivoting only)          |
 | `percentOfParentRowTotal`    | a share of its parent group (requires row grouping or tree data)           |
 | `percentOfParentColumnTotal` | a share of its parent pivot column (pivoting only)                         |
+
+`percentOfGrandTotal` and `percentOfColumnTotal` give the same result outside [Pivot](./pivoting/) mode, where there is a single column total. They diverge only while pivoting: `percentOfGrandTotal` keeps the whole column's grand total as the denominator, whereas `percentOfColumnTotal` uses each pivot column's own total, so every pivot column sums to 100%. This matters for a grid the user can toggle in and out of pivot mode: in a sales grid pivoted by year, `percentOfColumnTotal` reads each region as its share of *that year's* sales, then reverts to its share of all-time sales when pivot is switched off — so the percentage always reads against the total in view without the user re-choosing the mode.
 
 A mode that is not meaningful in the current view — for example `percentOfParentRowTotal` on a grid with no grouping — shows `#N/A` rather than a transformed value. In the column menu it appears greyed but stays selectable, so it can be chosen ahead of the grouping or pivoting that activates it.
 

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/index.mdoc
@@ -9,6 +9,10 @@ Show each value as a relative figure, such as a percentage of the grand total or
 
 A mode can be chosen by the user from the column menu, set on the column definition, or applied through [Column State](./column-state/).
 
+{% gridExampleRunner title="Show Values As Overview" name="show-values-as-overview" exampleHeight=540 /%}
+
+This example groups Olympic winners by country and year, then shows raw gold medal totals alongside the same values as a percentage of their parent group. It also shows total medals as a percentage of the grand total.
+
 ## Enabling Show Values As
 
 Show Values As is provided by the enterprise `ShowValuesAsModule` and works with the [Client-Side Row Model](./row-models/#client-side) only.
@@ -46,15 +50,15 @@ A numeric column that is not yet aggregated is promoted to a value column when a
 
 ## Built-in Modes
 
-| Mode                         | Shows each value as                                                        |
-|------------------------------|----------------------------------------------------------------------------|
-| `percentOfGrandTotal`        | a share of the column's grand total                                        |
-| `percentOfColumnTotal`       | a share of its column total — when pivoting, of each pivot column's own total, so every pivot column sums to 100% |
-| `percentOfRowTotal`          | a share of the row total across the pivot columns (pivoting only)          |
-| `percentOfParentRowTotal`    | a share of its parent group (requires row grouping or tree data)           |
-| `percentOfParentColumnTotal` | a share of its parent pivot column (pivoting only)                         |
+| Mode                         | Shows each value as               | Applies when                 |
+|------------------------------|-----------------------------------|------------------------------|
+| `percentOfGrandTotal`        | Share of the column's grand total | Value or numeric column      |
+| `percentOfColumnTotal`       | Share of its column total         | Value or numeric column      |
+| `percentOfRowTotal`          | Share of the row total            | Pivoting                     |
+| `percentOfParentRowTotal`    | Share of its parent row group     | Row grouping or tree data    |
+| `percentOfParentColumnTotal` | Share of its parent pivot column  | Pivoting                     |
 
-`percentOfGrandTotal` and `percentOfColumnTotal` give the same result outside [Pivot](./pivoting/) mode, where there is a single column total. They diverge only while pivoting: `percentOfGrandTotal` keeps the whole column's grand total as the denominator, whereas `percentOfColumnTotal` uses each pivot column's own total, so every pivot column sums to 100%. This matters for a grid the user can toggle in and out of pivot mode: in a sales grid pivoted by year, `percentOfColumnTotal` reads each region as its share of *that year's* sales, then reverts to its share of all-time sales when pivot is switched off - so the percentage always reads against the total in view without the user re-choosing the mode.
+`percentOfGrandTotal` and `percentOfColumnTotal` give the same result outside [Pivot](./pivoting/) mode, where there is a single column total. They diverge only while pivoting: `percentOfGrandTotal` keeps the whole column's grand total as the denominator, whereas `percentOfColumnTotal` uses each pivot column's own total, so every pivot column sums to 100%.
 
 A mode that is not meaningful in the current view — for example `percentOfParentRowTotal` on a grid with no grouping — shows `#N/A` rather than a transformed value. In the column menu it appears greyed but stays selectable, so it can be chosen ahead of the grouping or pivoting that activates it.
 
@@ -130,11 +134,11 @@ const gridOptions = {
 };
 ```
 
-`enableShowValuesAs` controls only the column menu (see [Choosing a Mode from the Column Menu](#choosing-a-mode-from-the-column-menu)). A mode applied through `showValuesAs` or [Column State](./column-state/) still transforms the displayed value and shows the header indicator regardless — suppress the indicator with `showValuesAsDef.suppressHeaderIndicator`.
+`enableShowValuesAs` controls only the column menu (see [Choosing a Mode from the Column Menu](#choosing-a-mode-from-the-column-menu)). A mode applied through `showValuesAs` or [Column State](./column-state/) still transforms the displayed value.
 
 ## Row Grouping
 
-With [Row Grouping](./grouping/), parent and grand totals are available, so a value can be shown as a share of its group or of the whole column.
+This example groups Olympic winners by country and year, then shows raw gold medal totals alongside the same values as a percentage of their parent group. It also shows total medals as a percentage of the grand total.
 
 {% gridExampleRunner title="Show Values As with Row Grouping" name="row-grouping" /%}
 

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/index.mdoc
@@ -49,12 +49,12 @@ A numeric column that is not yet aggregated is promoted to a value column when a
 | Mode                         | Shows each value as                                                        |
 |------------------------------|----------------------------------------------------------------------------|
 | `percentOfGrandTotal`        | a share of the column's grand total                                        |
-| `percentOfColumnTotal`       | a share of the column total — while pivoting each pivot column totals 100% |
+| `percentOfColumnTotal`       | a share of its column total — when pivoting, of each pivot column's own total, so every pivot column sums to 100% |
 | `percentOfRowTotal`          | a share of the row total across the pivot columns (pivoting only)          |
 | `percentOfParentRowTotal`    | a share of its parent group (requires row grouping or tree data)           |
 | `percentOfParentColumnTotal` | a share of its parent pivot column (pivoting only)                         |
 
-`percentOfGrandTotal` and `percentOfColumnTotal` give the same result outside [Pivot](./pivoting/) mode, where there is a single column total. They diverge only while pivoting: `percentOfGrandTotal` keeps the whole column's grand total as the denominator, whereas `percentOfColumnTotal` uses each pivot column's own total, so every pivot column sums to 100%. This matters for a grid the user can toggle in and out of pivot mode: in a sales grid pivoted by year, `percentOfColumnTotal` reads each region as its share of *that year's* sales, then reverts to its share of all-time sales when pivot is switched off — so the percentage always reads against the total in view without the user re-choosing the mode.
+`percentOfGrandTotal` and `percentOfColumnTotal` give the same result outside [Pivot](./pivoting/) mode, where there is a single column total. They diverge only while pivoting: `percentOfGrandTotal` keeps the whole column's grand total as the denominator, whereas `percentOfColumnTotal` uses each pivot column's own total, so every pivot column sums to 100%. This matters for a grid the user can toggle in and out of pivot mode: in a sales grid pivoted by year, `percentOfColumnTotal` reads each region as its share of *that year's* sales, then reverts to its share of all-time sales when pivot is switched off - so the percentage always reads against the total in view without the user re-choosing the mode.
 
 A mode that is not meaningful in the current view — for example `percentOfParentRowTotal` on a grid with no grouping — shows `#N/A` rather than a transformed value. In the column menu it appears greyed but stays selectable, so it can be chosen ahead of the grouping or pivoting that activates it.
 

--- a/documentation/ag-grid-docs/src/content/docs/column-updating-definitions/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-updating-definitions/index.mdoc
@@ -61,6 +61,7 @@ All stateful attributes of Column Definitions are as follows:
 | pivot              | initialPivot         | If this column should be a pivot.                                     |
 | pivotIndex         | initialPivotIndex    | Whether this column should be a pivot and in what order.              |
 | aggFunc            | initialAggFunc       | The function to aggregate this column by if row grouping or pivoting. |
+| showValuesAs       | initialShowValuesAs  | The mode used to show this column's value as a relative figure.       |
 
 {% note %}
 If you are interested in changing Column State only and not the other parts of the column definitions, then consider

--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -881,10 +881,9 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
      * <br /><br />
      * Shows the column's aggregated value relative to another total, for example as a percentage of the grand total,
      * column total, row total or parent total. This changes only the displayed value; the underlying value used by
-     * `getDataValue`, charts and clipboard data is unchanged.
+     * `getDataValue` and charts is unchanged.
      * <br /><br />
-     * Use a built-in mode name, or the object form `{ type, params, precision }`. Set `null` for no active mode. The
-     * column menu and Column State can still select a mode, and per-column config lives on `showValuesAsDef`.
+     * Use a built-in mode name, or the object form `{ type, params, precision }`. Set `null` for no active mode.
      * @agModule `ShowValuesAsModule`
      */
     showValuesAs?: ShowValuesAsType | ShowValuesAs | null;

--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -463,7 +463,7 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
      * the built-in {@link distributeGroupValue | distributeGroupValue} is used automatically.
      *
      * Columns with `groupRowEditable` or `groupRowValueSetter` do not require `field` or
-     * `valueSetter` — the group row value setter handles the edit entirely.
+     * `valueSetter` - the group row value setter handles the edit entirely.
      *
      * Note: if `groupRowValueSetter` resolves to `false` or `null` (via `distribution: false`,
      * a per-aggFunc record entry, or `groupRowValueSetter: false`), the cell is treated as not
@@ -480,7 +480,7 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
      * - **`false`**: Explicitly disables group row value distribution and makes the cell not editable,
      *   even if `groupRowEditable` is defined.
      * - **Function**: A custom callback that receives a {@link GroupRowValueSetterParams} and pushes
-     *   edits down to descendants. The column does not need `field` or `valueSetter` — the callback
+     *   edits down to descendants. The column does not need `field` or `valueSetter` - the callback
      *   handles the edit entirely.
      * - **Options object**: Uses the built-in distribution logic with a {@link GroupRowValueSetterOptions}
      *   configuration. When `distribution` resolves to `false` or `null` for the column's aggFunc,
@@ -877,14 +877,14 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
      */
     allowedAggFuncs?: string[];
     /**
-     * The active "Show Values As" mode — display this column's aggregated value relative to another
-     * aggregated value, e.g. as a percentage of the grand / column / row /
-     * parent total. A presentation-layer transform: it changes the displayed value only — the raw value
-     * (`getDataValue`, charts, clipboard-of-data) is unchanged. Can be changed at runtime (menu / column state).
-     *
-     * A built-in mode name, or the object form `{ type, params, precision }`. `null` selects no active mode — the
-     * column menu and column state can still select one.
-     * Per-column config (`precision`, `suppressHeaderIndicator`, custom `modes`) lives on `showValuesAsDef`.
+     * The active "Show Values As" mode for this column.
+     * <br /><br />
+     * Shows the column's aggregated value relative to another total, for example as a percentage of the grand total,
+     * column total, row total or parent total. This changes only the displayed value; the underlying value used by
+     * `getDataValue`, charts and clipboard data is unchanged.
+     * <br /><br />
+     * Use a built-in mode name, or the object form `{ type, params, precision }`. Set `null` for no active mode. The
+     * column menu and Column State can still select a mode, and per-column config lives on `showValuesAsDef`.
      * @agModule `ShowValuesAsModule`
      */
     showValuesAs?: ShowValuesAsType | ShowValuesAs | null;
@@ -903,13 +903,14 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
      */
     showValuesAsDef?: ShowValuesAsDef<TData, TValue> | null;
     /**
-     * Whether to offer the "Show Values As" selection menu in this column's menu. Off by default. On `defaultColDef`,
-     * `true` enables it grid-wide but only for columns that support it — a value column (any `aggFunc`) or a numeric
-     * column. Set `true` directly on a column to force the menu on for any column type — use this for a column whose
-     * numeric value the grid can't detect statically, such as a `valueGetter` or custom `aggFunc` that produces a
-     * number from string or object data. `false` always hides it. This gates only the menu — a mode applied via
-     * `showValuesAs` / Column State still transforms the displayed value and shows the header indicator (suppress that
-     * separately via `showValuesAsDef.suppressHeaderIndicator`).
+     * Shows the "Show Values As" submenu in the column menu.
+     * <br /><br />
+     * On `defaultColDef`, `true` shows the submenu only for value columns and numeric columns. On an individual
+     * column, `true` always shows it; use this when the grid cannot infer that the column returns numbers, for
+     * example with a `valueGetter` or custom `aggFunc`. `false` hides the submenu.
+     * <br /><br />
+     * This controls menu visibility only. Modes set through `showValuesAs` or Column State still apply and still show
+     * the header indicator unless `showValuesAsDef.suppressHeaderIndicator` is set.
      * @default false
      * @agModule `ShowValuesAsModule`
      */


### PR DESCRIPTION
Fix [RTI-3352](https://ag-grid.atlassian.net/browse/RTI-3352)


<img width="1039" height="561" alt="Screenshot 2026-06-23 at 16 14 27" src="https://github.com/user-attachments/assets/5d64a23a-a330-48c8-b828-9d498019bc7b" />
<img width="1027" height="944" alt="Screenshot 2026-06-23 at 16 14 22" src="https://github.com/user-attachments/assets/28f558a9-abc5-4114-ae74-11ab0a50af33" />
<img width="1018" height="1060" alt="Screenshot 2026-06-23 at 16 16 33" src="https://github.com/user-attachments/assets/08833182-1138-47b5-82bb-728472452341" />
