### PR TITLE
RTI-3393 Add AI Skills documentation page

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs-nav/nav.json
+++ b/documentation/ag-grid-docs/src/content/docs-nav/nav.json
@@ -165,6 +165,11 @@
                     "type": "item",
                     "title": "MCP Server",
                     "path": "mcp-server"
+                },
+                {
+                    "type": "item",
+                    "title": "Skills",
+                    "path": "skills"
                 }
             ]
         },

--- a/documentation/ag-grid-docs/src/content/docs/skills/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/skills/index.mdoc
@@ -12,20 +12,18 @@ We are actively developing and releasing new versions of our skills. Feedback is
 
 ## Installation
 
-A skill is just a folder of files that can be installed in your project repo, or your home directory.
-
-The easiest way to install a skill is to ask your agent to copy the files:
+A skill is just a folder of files that can be installed in your project repo, or your home directory. Use the skills CLI to copy the files to your computer:
 
 ```
-Install the ag-update skill from the ag-grid/skills GitHub repo into this folder
+npx skills add ag-grid/skills
 ```
 
 ## Updating
 
-To update to the latest version, you can ask the skill to update itself. In your coding agent:
+Update to the latest version at any time:
 
 ```
-Ask the ag-update skill to update itself to the latest version
+npx skills update ag-grid/skills
 ```
 
 ## Using ag-update

--- a/documentation/ag-grid-docs/src/content/docs/skills/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/skills/index.mdoc
@@ -9,7 +9,9 @@ Our [AI skills](https://github.com/ag-grid/skills) give coding agents such as Cl
 We are actively developing and releasing new versions of our skills. Feedback is welcome — [open an issue](https://github.com/ag-grid/skills/issues) on GitHub.
 {% /note %}
 
-## Installation
+## Setup
+
+### Installation
 
 A skill is a folder of files that you install in your project repository or your home directory. Use the skills CLI to copy the files from the [ag-grid/skills](https://github.com/ag-grid/skills) repository to your machine:
 
@@ -17,7 +19,7 @@ A skill is a folder of files that you install in your project repository or your
 npx skills add ag-grid/skills
 ```
 
-## Updating
+### Updating
 
 We refine the skills and extend them to cover new AG Grid and AG Charts releases, so update at any time to pick up the latest guidance:
 
@@ -82,3 +84,7 @@ Mitigation: To restore the full development-time diagnostics, call `enableDevVal
 ```
 
 Review the generated files, then ask the agent to apply the plan. It bumps the versions in `package.json`, reinstalls dependencies, and validates the result against your build, typecheck, and dev server.
+
+## Upcoming skills
+
+We are expanding the set of skills to cover more of the AG Grid and AG Charts development workflow. Watch the [ag-grid/skills](https://github.com/ag-grid/skills) repository, or [open an issue](https://github.com/ag-grid/skills/issues) to suggest a skill.

--- a/documentation/ag-grid-docs/src/content/docs/skills/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/skills/index.mdoc
@@ -3,9 +3,7 @@ title: 'AG Grid AI Skills'
 description: 'Install and use the AG Grid AI skills to build and maintain grid applications with coding agents such as Claude and Codex.'
 ---
 
-AG Grid publishes a set of AI skills for building and maintaining grid applications with coding agents such as Claude and Codex.
-
-The first skill is [`ag-update`](#using-ag-update), which handles version upgrades. We plan to add more over time.
+Our [AI skills](https://github.com/ag-grid/skills) give coding agents such as Claude and Codex the expertise to build and maintain your AG Grid and AG Charts applications from our official guidance.
 
 {% note %}
 We are actively developing and releasing new versions of our skills. Feedback is welcome — [open an issue](https://github.com/ag-grid/skills/issues) on GitHub.
@@ -13,7 +11,7 @@ We are actively developing and releasing new versions of our skills. Feedback is
 
 ## Installation
 
-A skill is a folder of files that you install in your project repository or your home directory. Use the skills CLI to copy the files to your machine:
+A skill is a folder of files that you install in your project repository or your home directory. Use the skills CLI to copy the files from the [ag-grid/skills](https://github.com/ag-grid/skills) repository to your machine:
 
 ```bash
 npx skills add ag-grid/skills
@@ -21,28 +19,66 @@ npx skills add ag-grid/skills
 
 ## Updating
 
-Update to the latest version at any time:
+We refine the skills and extend them to cover new AG Grid and AG Charts releases, so update at any time to pick up the latest guidance:
 
 ```bash
 npx skills update ag-grid/skills
 ```
 
-## Using ag-update
+## Skills
 
-The `ag-update` skill analyses your codebase and produces a Markdown file listing the changes needed to move to a new version.
+Each skill teaches your coding agent how to carry out a specific task with AG Grid and AG Charts, following our official guidance. Once installed, invoke a skill by name and the agent works through it for you.
+
+## ag-update
+
+Upgrading across major versions normally means reading every release's breaking changes and working out which ones touch your code. The `ag-update` skill hands that work to your coding agent: it reads the AG Grid migration documentation, checks it against your repository, and produces a Markdown file listing the changes needed to move to a new version.
 
 To let the skill detect everything for you, invoke it from your coding agent:
 
 ```
-Use the ag-update skill
+Use the ag-update skill to upgrade my-app
 ```
 
-Alternatively, tell the skill exactly what to update:
+You can also tell it exactly what to update, down to individual projects and target versions.
 
 ```
 Use the ag-update skill to update all projects in this monorepo except apps/demo-app to AG Grid v36
 ```
 
-The skill cross-references your repository against the AG Grid breaking change documentation and writes a Markdown file listing the changes to apply. For optional changes, it asks whether you want to include them.
+### Example run
 
-Review the generated file, then ask your agent to build an implementation plan from it.
+A typical run, updating a single project to AG Grid v36, looks like this:
+
+```bash
+> Use the ag-update skill to update the performance/typescript project to AG Grid v36
+
+Determining scope → AG_UPDATE_SCOPE.md
+  - performance/typescript
+    - ag-grid-community@35.0.1 -> 36.0.0
+    - ag-charts-community@13.0.1 -> 14.0.0
+
+Determining changes → AG_UPDATE_CHANGES.md
+  Found changes to review before applying.
+
+Apply changes? yes
+  Updated package.json
+  $ pnpm install     ✓
+  $ pnpm typecheck   ✓
+  $ pnpm build       ✓
+
+Done — performance/typescript is on AG Grid 36.0.0 and AG Charts 14.0.0.
+```
+
+`AG_UPDATE_CHANGES.md` contains an entry for each change, grouped by product and version transition, labelled `BREAKING` or `BEHAVIOUR`, and paired with how to mitigate it:
+
+```md
+## Grid v35.x -> v36.x
+
+### BEHAVIOUR: ValidationModule no longer bundled by default
+
+Change: The `ValidationModule` is no longer included in the `AllCommunityModule` and `AllEnterpriseModule` bundles, keeping production bundles smaller by default. Without it, console messages are reduced to an error code and a documentation link.
+
+Mitigation: To restore the full development-time diagnostics, call `enableDevValidations()` before any grid is created.
+```
+
+Review the generated files, then ask the agent to apply the plan. It bumps the versions in `package.json`, reinstalls dependencies, and validates the result against your build, typecheck, and dev server.

--- a/documentation/ag-grid-docs/src/content/docs/skills/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/skills/index.mdoc
@@ -1,0 +1,49 @@
+---
+title: 'AG Skills'
+---
+
+We are building a set of AI skills for developing grid and charts applications using coding agents such as Claude and Codex.
+
+We currently publish one skill, [ag-update](#using-ag-update), which handles version upgrades. We plan to add more over time.
+
+{% note %}
+We are actively developing and releasing new versions of our skills. Feedback is welcome [open an issue](https://github.com/ag-grid/skills/issues) on GitHub.
+{% /note %}
+
+## Installation
+
+A skill is just a folder of files that can be installed in your project repo, or your home directory.
+
+The easiest way to install a skill is to ask your agent to copy the files:
+
+```
+Install the ag-update skill from the ag-grid/skills GitHub repo into this folder
+```
+
+## Updating
+
+To update to the latest version, you can ask the skill to update itself. In your coding agent:
+
+```
+Ask the ag-update skill to update itself to the latest version
+```
+
+## Using ag-update
+
+The skill produces a markdown file detailing all the changes that need to be applied to your project in order to update to a new version.
+
+In your coding agent you can invoke the skill and it will analyse your codebase and propose what updates can be applied:
+
+```
+Use the ag-update skill
+```
+
+Alternatively, tell the skill exactly what you want to update:
+
+```
+Use the ag-update skill to update all projects in this monorepo except apps/demo-app to ag grid v36
+```
+
+The skill will analyse your repo and our breaking change documentation and produce a markdown file containing a list of changes to apply. In the case of optional changes you'll be asked whether you want to apply them.
+
+You can then review the generated file and ask your agent to make an implementation plan based on it.

--- a/documentation/ag-grid-docs/src/content/docs/skills/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/skills/index.mdoc
@@ -1,20 +1,21 @@
 ---
-title: 'AG Skills'
+title: 'AG Grid AI Skills'
+description: 'Install and use the AG Grid AI skills to build and maintain grid applications with coding agents such as Claude and Codex.'
 ---
 
-We are building a set of AI skills for developing grid and charts applications using coding agents such as Claude and Codex.
+AG Grid publishes a set of AI skills for building and maintaining grid applications with coding agents such as Claude and Codex.
 
-We currently publish one skill, [ag-update](#using-ag-update), which handles version upgrades. We plan to add more over time.
+The first skill is [`ag-update`](#using-ag-update), which handles version upgrades. We plan to add more over time.
 
 {% note %}
-We are actively developing and releasing new versions of our skills. Feedback is welcome [open an issue](https://github.com/ag-grid/skills/issues) on GitHub.
+We are actively developing and releasing new versions of our skills. Feedback is welcome — [open an issue](https://github.com/ag-grid/skills/issues) on GitHub.
 {% /note %}
 
 ## Installation
 
-A skill is just a folder of files that can be installed in your project repo, or your home directory. Use the skills CLI to copy the files to your computer:
+A skill is a folder of files that you install in your project repository or your home directory. Use the skills CLI to copy the files to your machine:
 
-```
+```bash
 npx skills add ag-grid/skills
 ```
 
@@ -22,26 +23,26 @@ npx skills add ag-grid/skills
 
 Update to the latest version at any time:
 
-```
+```bash
 npx skills update ag-grid/skills
 ```
 
 ## Using ag-update
 
-The skill produces a markdown file detailing all the changes that need to be applied to your project in order to update to a new version.
+The `ag-update` skill analyses your codebase and produces a Markdown file listing the changes needed to move to a new version.
 
-In your coding agent you can invoke the skill and it will analyse your codebase and propose what updates can be applied:
+To let the skill detect everything for you, invoke it from your coding agent:
 
 ```
 Use the ag-update skill
 ```
 
-Alternatively, tell the skill exactly what you want to update:
+Alternatively, tell the skill exactly what to update:
 
 ```
-Use the ag-update skill to update all projects in this monorepo except apps/demo-app to ag grid v36
+Use the ag-update skill to update all projects in this monorepo except apps/demo-app to AG Grid v36
 ```
 
-The skill will analyse your repo and our breaking change documentation and produce a markdown file containing a list of changes to apply. In the case of optional changes you'll be asked whether you want to apply them.
+The skill cross-references your repository against the AG Grid breaking change documentation and writes a Markdown file listing the changes to apply. For optional changes, it asks whether you want to include them.
 
-You can then review the generated file and ask your agent to make an implementation plan based on it.
+Review the generated file, then ask your agent to build an implementation plan from it.


### PR DESCRIPTION
Fix [RTI-3393](https://ag-grid.atlassian.net/browse/RTI-3393)

Add a documentation page for the AG Grid AI skills published at [ag-grid/skills](https://github.com/ag-grid/skills), linked under the **AI Features** nav section.

The page covers what a skill is, how to install one (asking your agent to copy the files), how to update, and how to use the `ag-update` skill for version upgrades. We currently publish one skill and plan to add more.

