### PR TITLE
[RTI-3352] Docs(show-values-as): fix review feedback on descriptions and wording

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/index.mdoc
@@ -11,7 +11,7 @@ A mode can be chosen by the user from the column menu, set on the column definit
 
 {% gridExampleRunner title="Show Values As Overview" name="show-values-as-overview" exampleHeight=540 /%}
 
-This example groups Olympic winners by country and year, then shows raw gold medal totals alongside the same values as a percentage of their parent group. It also shows total medals as a percentage of the grand total.
+This example groups Olympic winners by country and year, then shows raw medal totals alongside the same values as a percentage of their parent group.
 
 ## Enabling Show Values As
 
@@ -60,7 +60,7 @@ A numeric column that is not yet aggregated is promoted to a value column when a
 
 `percentOfGrandTotal` and `percentOfColumnTotal` give the same result outside [Pivot](./pivoting/) mode, where there is a single column total. They diverge only while pivoting: `percentOfGrandTotal` keeps the whole column's grand total as the denominator, whereas `percentOfColumnTotal` uses each pivot column's own total, so every pivot column sums to 100%.
 
-A mode that is not meaningful in the current view — for example `percentOfParentRowTotal` on a grid with no grouping — shows `#N/A` rather than a transformed value. In the column menu it appears greyed but stays selectable, so it can be chosen ahead of the grouping or pivoting that activates it.
+A mode that is not meaningful in the current view — for example `percentOfParentRowTotal` on a grid with no grouping — shows `#N/A` rather than a transformed value, and in the column menu it appears greyed out.
 
 ## Setting the Mode in Code
 
@@ -138,7 +138,7 @@ const gridOptions = {
 
 ## Row Grouping
 
-This example groups Olympic winners by country and year, then shows raw gold medal totals alongside the same values as a percentage of their parent group. It also shows total medals as a percentage of the grand total.
+This example groups Olympic winners by country and year, then shows raw medal totals alongside the same values as a percentage of their parent group.
 
 {% gridExampleRunner title="Show Values As with Row Grouping" name="row-grouping" /%}
 

--- a/documentation/ag-grid-docs/src/content/docs/column-updating-definitions/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-updating-definitions/index.mdoc
@@ -61,7 +61,7 @@ All stateful attributes of Column Definitions are as follows:
 | pivot              | initialPivot         | If this column should be a pivot.                                     |
 | pivotIndex         | initialPivotIndex    | Whether this column should be a pivot and in what order.              |
 | aggFunc            | initialAggFunc       | The function to aggregate this column by if row grouping or pivoting. |
-| showValuesAs       | initialShowValuesAs  | The mode used to show this column's value as a relative figure.       |
+| showValuesAs       | initialShowValuesAs  | The mode used to show this column's values as relative figures.       |
 
 {% note %}
 If you are interested in changing Column State only and not the other parts of the column definitions, then consider

--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -908,8 +908,7 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
      * column, `true` always shows it; use this when the grid cannot infer that the column returns numbers, for
      * example with a `valueGetter` or custom `aggFunc`. `false` hides the submenu.
      * <br /><br />
-     * This controls menu visibility only. Modes set through `showValuesAs` or Column State still apply and still show
-     * the header indicator unless `showValuesAsDef.suppressHeaderIndicator` is set.
+     * This controls menu visibility only. Modes set through `showValuesAs` or Column State still apply.
      * @default false
      * @agModule `ShowValuesAsModule`
      */


### PR DESCRIPTION
## Summary

Addresses the release-testing review feedback on [RTI-3352](https://ag-grid.atlassian.net/browse/RTI-3352) (TC1–TC4):

- **TC1** – Corrected the "Show Values As Overview" example description: it shows raw **medal** totals (not gold) as a percentage of their parent group, and removed the incorrect grand-total sentence (the example has no grand-total column).
- **TC2** – Reworded the non-applicable-mode note: "…shows `#N/A` rather than a transformed value, and in the column menu it appears greyed out." (removed the inaccurate "stays selectable" claim).
- **TC3** – Removed the trailing header-indicator / `suppressHeaderIndicator` clause from the `enableShowValuesAs` JSDoc (feeds the API reference table).
- **TC4** – Fixed the `showValuesAs` description in the column state table: "this column's values as relative figures".

## Test plan

- Docs-only / JSDoc wording changes. `build:types` for `ag-grid-community` regenerates the reference table from the updated JSDoc.

Fix [RTI-3352](https://ag-grid.atlassian.net/browse/RTI-3352)