### PR TITLE
RTI-3403 Move font and colour styles from ag-header-row to ag-header

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -772,6 +772,7 @@
         right: 0;
         background-color: var(--ag-header-background-color);
         border-bottom: var(--ag-borders-critical) var(--ag-border-color);
+        color: var(--ag-header-foreground-color);
         // do not allow sticky rows to scroll in front of the header
         z-index: 1;
     }

--- a/community-modules/styles/src/internal/base/parts/_header.scss
+++ b/community-modules/styles/src/internal/base/parts/_header.scss
@@ -8,7 +8,6 @@
 
     .ag-header-row {
         border-bottom: none;
-        color: var(--ag-header-foreground-color);
         height: var(--ag-header-height);
 
         .ag-grid-pinned-left-cells,

--- a/packages/ag-grid-community/src/theming/core/css/_header.css
+++ b/packages/ag-grid-community/src/theming/core/css/_header.css
@@ -1,5 +1,12 @@
 /* stylelint-disable selector-max-specificity */
 
+.ag-header {
+    font-size: var(--ag-header-font-size);
+    font-family: var(--ag-header-font-family);
+    font-weight: var(--ag-header-font-weight);
+    color: var(--ag-header-text-color);
+}
+
 .ag-header-row {
     .ag-grid-pinned-left-cells,
     .ag-grid-scrolling-cells,
@@ -9,17 +16,12 @@
 
     position: absolute;
     height: var(--ag-header-height);
-    color: var(--ag-header-text-color);
     border-bottom: none;
 
     .ag-grid-pinned-left-cells,
     .ag-grid-pinned-right-cells {
         overflow: visible;
     }
-
-    font-size: var(--ag-header-font-size);
-    font-family: var(--ag-header-font-family);
-    font-weight: var(--ag-header-font-weight);
 }
 
 /* stylelint-enable selector-max-specificity */


### PR DESCRIPTION
Fix [RTI-3403](https://ag-grid.atlassian.net/browse/RTI-3403)

Move `font-size`, `font-family`, `font-weight`, and `color` declarations from `.ag-header-row` to `.ag-header`.

Previously, applications that set these properties directly on `.ag-header` found their values blocked by the explicit re-declarations on `.ag-header-row`. Moving the declarations to the parent element allows the values to be inherited by header cells as expected.