### PR TITLE
RTI-3402 Fix semi-transparent header background in pinned sections

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -776,7 +776,6 @@
         top: 0;
         left: 0;
         right: 0;
-        background-color: var(--ag-header-background-color);
         border-bottom: var(--ag-borders-critical) var(--ag-border-color);
         // do not allow sticky rows to scroll in front of the header
         z-index: 1;

--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -366,7 +366,13 @@
         .ag-body-vertical-scroll-start-spacer {
             pointer-events: all;
             opacity: 1;
-            background-color: var(--ag-header-background-color);
+            // --ag-header-background-color might be semi-transparent so apply it on top of the known-opaque background color
+            background-color: var(--ag-background-color);
+            background-image: linear-gradient(
+                0deg,
+                var(--ag-header-background-color),
+                var(--ag-header-background-color)
+            );
         }
     }
 

--- a/community-modules/styles/src/internal/base/parts/_header.scss
+++ b/community-modules/styles/src/internal/base/parts/_header.scss
@@ -31,13 +31,19 @@
         }
 
         .ag-grid-pinned-right-cells {
-            border-left: var(--ag-borders-critical) var(--ag-border-color);
             overflow: visible;
+
+            .ag-grid-container-wrapper {
+                border-left: var(--ag-borders-critical) var(--ag-border-color);
+            }
         }
 
         .ag-grid-pinned-left-cells {
-            border-right: var(--ag-borders-critical) var(--ag-border-color);
             overflow: visible;
+
+            .ag-grid-container-wrapper {
+                border-right: var(--ag-borders-critical) var(--ag-border-color);
+            }
         }
     }
 

--- a/community-modules/styles/src/internal/base/parts/_header.scss
+++ b/community-modules/styles/src/internal/base/parts/_header.scss
@@ -11,10 +11,23 @@
         color: var(--ag-header-foreground-color);
         height: var(--ag-header-height);
 
-        .ag-grid-pinned-left-cells,
-        .ag-grid-scrolling-cells,
-        .ag-grid-pinned-right-cells {
+        .ag-grid-scrolling-cells {
             background-color: var(--ag-header-background-color);
+        }
+
+        // Pinned header sections need an opaque background, but --ag-header-background-color might be
+        // semi-transparent, so apply an opaque base and re-apply the header color on top
+        > .ag-grid-pinned-left-cells,
+        > .ag-grid-pinned-right-cells {
+            // apply an opaque background
+            background-image: linear-gradient(var(--ag-background-color), var(--ag-background-color));
+        }
+
+        .ag-grid-container-wrapper {
+            // re-apply the transparent header color over the opaque background
+            background-color: var(--ag-header-background-color);
+            width: 100%;
+            height: 100%;
         }
 
         .ag-grid-pinned-right-cells {

--- a/packages/ag-grid-community/src/headerRendering/row/headerRowComp.ts
+++ b/packages/ag-grid-community/src/headerRendering/row/headerRowComp.ts
@@ -20,8 +20,10 @@ export type HeaderRowType = 'group' | 'column' | 'filter';
 export class HeaderRowComp extends Component {
     private headerComps: { [key: HeaderCellCtrlInstanceId]: AbstractHeaderCellComp<AbstractHeaderCellCtrl> } = {};
     private readonly ePinnedLeftCells: HTMLElement;
+    private readonly ePinnedLeftWrapper: HTMLElement;
     private readonly eScrollingCells: HTMLElement;
     private readonly ePinnedRightCells: HTMLElement;
+    private readonly ePinnedRightWrapper: HTMLElement;
     private readonly pinnedWidthsCache: PinnedSectionWidthsCache = {
         pinnedLeftWidth: undefined,
         centerWidth: undefined,
@@ -36,16 +38,31 @@ export class HeaderRowComp extends Component {
             cls: 'ag-grid-pinned-left-cells',
             role: 'presentation',
         });
+        this.ePinnedLeftWrapper = _createElement({
+            tag: 'div',
+            cls: 'ag-grid-container-wrapper',
+            role: 'presentation',
+        });
+        this.ePinnedLeftCells.appendChild(this.ePinnedLeftWrapper);
+
         this.eScrollingCells = _createElement({
             tag: 'div',
             cls: 'ag-grid-scrolling-cells',
             role: 'presentation',
         });
+
         this.ePinnedRightCells = _createElement({
             tag: 'div',
             cls: 'ag-grid-pinned-right-cells',
             role: 'presentation',
         });
+        this.ePinnedRightWrapper = _createElement({
+            tag: 'div',
+            cls: 'ag-grid-container-wrapper',
+            role: 'presentation',
+        });
+        this.ePinnedRightCells.appendChild(this.ePinnedRightWrapper);
+
         this.getGui().append(this.ePinnedLeftCells, this.eScrollingCells, this.ePinnedRightCells);
     }
 
@@ -131,7 +148,7 @@ export class HeaderRowComp extends Component {
             right.sort(sortByLeft);
 
             _setDomChildOrder(
-                this.ePinnedLeftCells,
+                this.ePinnedLeftWrapper,
                 left.map((c) => c.getGui())
             );
             _setDomChildOrder(
@@ -139,7 +156,7 @@ export class HeaderRowComp extends Component {
                 center.map((c) => c.getGui())
             );
             _setDomChildOrder(
-                this.ePinnedRightCells,
+                this.ePinnedRightWrapper,
                 right.map((c) => c.getGui())
             );
         }
@@ -152,10 +169,10 @@ export class HeaderRowComp extends Component {
 
         const pinned = ctrl.column.getPinned();
         if (pinned === 'left') {
-            return this.ePinnedLeftCells;
+            return this.ePinnedLeftWrapper;
         }
         if (pinned === 'right') {
-            return this.ePinnedRightCells;
+            return this.ePinnedRightWrapper;
         }
         return this.eScrollingCells;
     }

--- a/packages/ag-grid-community/src/pinnedColumns/pinnedColumnModule.css
+++ b/packages/ag-grid-community/src/pinnedColumns/pinnedColumnModule.css
@@ -8,12 +8,12 @@
  * visually on the left
  */
 
-.ag-header-row .ag-grid-pinned-right-cells {
+.ag-header-row .ag-grid-pinned-right-cells .ag-grid-container-wrapper {
     /* rtl:ignore */
     border-left: var(--ag-pinned-column-border);
 }
 
-.ag-header-row .ag-grid-pinned-left-cells {
+.ag-header-row .ag-grid-pinned-left-cells .ag-grid-container-wrapper {
     /* rtl:ignore */
     border-right: var(--ag-pinned-column-border);
 }

--- a/packages/ag-grid-community/src/theming/core/css/_general.css
+++ b/packages/ag-grid-community/src/theming/core/css/_general.css
@@ -206,7 +206,10 @@
     .ag-body-vertical-scroll-start-spacer {
         pointer-events: all;
         opacity: 1;
-        background-color: var(--ag-header-background-color);
+
+        /* --ag-header-background-color might be semi-transparent so apply it on top of the known-opaque background color */
+        background-color: var(--ag-background-color);
+        background-image: linear-gradient(0deg, var(--ag-header-background-color), var(--ag-header-background-color));
     }
 }
 
@@ -276,7 +279,6 @@
     top: 0;
     left: 0;
     right: 0;
-    background-color: var(--ag-header-background-color);
     border-bottom: var(--ag-header-row-border);
 
     /* do not allow sticky rows to scroll in front of the header */

--- a/packages/ag-grid-community/src/theming/core/css/_header.css
+++ b/packages/ag-grid-community/src/theming/core/css/_header.css
@@ -1,10 +1,23 @@
 /* stylelint-disable selector-max-specificity */
 
 .ag-header-row {
-    .ag-grid-pinned-left-cells,
-    .ag-grid-scrolling-cells,
-    .ag-grid-pinned-right-cells {
+    .ag-grid-scrolling-cells {
         background-color: var(--ag-header-background-color);
+    }
+
+    /* Pinned header sections need an opaque background, but --ag-header-background-color might be
+       semi-transparent, so apply an opaque base and re-apply the header color on top */
+    > .ag-grid-pinned-left-cells,
+    > .ag-grid-pinned-right-cells {
+        /* apply an opaque background */
+        background-image: linear-gradient(var(--ag-background-color), var(--ag-background-color));
+    }
+
+    .ag-grid-container-wrapper {
+        /* re-apply the transparent header color over the opaque background */
+        background-color: var(--ag-header-background-color);
+        width: 100%;
+        height: 100%;
     }
 
     position: absolute;

--- a/packages/ag-grid-react/src/reactUi/header/headerRowComp.tsx
+++ b/packages/ag-grid-react/src/reactUi/header/headerRowComp.tsx
@@ -170,13 +170,17 @@ const HeaderRowComp = ({
     return (
         <div ref={setRef} className={ctrl.headerRowClass} role="row" tabIndex={tabIndex}>
             <div ref={ePinnedLeft} className="ag-grid-pinned-left-cells" role="presentation">
-                {leftCells.map(createCellJsx)}
+                <div className="ag-grid-container-wrapper" role="presentation">
+                    {leftCells.map(createCellJsx)}
+                </div>
             </div>
             <div ref={eScrolling} className="ag-grid-scrolling-cells" role="presentation">
                 {centerCells.map(createCellJsx)}
             </div>
             <div ref={ePinnedRight} className="ag-grid-pinned-right-cells" role="presentation">
-                {rightCells.map(createCellJsx)}
+                <div className="ag-grid-container-wrapper" role="presentation">
+                    {rightCells.map(createCellJsx)}
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
Fix [RTI-3402](https://ag-grid.atlassian.net/browse/RTI-3402)

When `--ag-header-background-color` is semi-transparent, scrolling center header cells were visible bleeding through the sticky pinned header sections. Data rows already handled this correctly via `ag-grid-container-wrapper` and the `background-image` opaque-base trick; headers were missing the same structure.

**Changes:**
- Add `ag-grid-container-wrapper` div inside pinned header sections in both the JS (`headerRowComp.ts`) and React (`headerRowComp.tsx`) renderers, mirroring the pattern used for data rows
- Apply `background-image: linear-gradient(--ag-background-color, ...)` as an opaque base on pinned header containers; re-apply `--ag-header-background-color` on the wrapper inside — same layering trick as rows
