### PR TITLE
[RTI-3352] Show Values As: make inapplicable menu modes non-selectable

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/_examples/flat/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/_examples/flat/main.ts
@@ -7,22 +7,15 @@ import {
     ValidationModule,
     createGrid,
 } from 'ag-grid-community';
-import {
-    ColumnMenuModule,
-    ColumnsToolPanelModule,
-    ContextMenuModule,
-    RowGroupingModule,
-    ShowValuesAsModule,
-} from 'ag-grid-enterprise';
+import { ColumnMenuModule, ContextMenuModule, RowGroupingModule, ShowValuesAsModule } from 'ag-grid-enterprise';
 
 ModuleRegistry.registerModules([
     ClientSideRowModelModule,
     TextFilterModule,
     NumberFilterModule,
+    RowGroupingModule,
     ColumnMenuModule,
     ContextMenuModule,
-    ColumnsToolPanelModule,
-    RowGroupingModule,
     ShowValuesAsModule,
     ...(process.env.NODE_ENV !== 'production' ? [ValidationModule] : []),
 ]);
@@ -46,7 +39,6 @@ const gridOptions: GridOptions<IOlympicData> = {
         floatingFilter: true,
     },
     grandTotalRow: 'bottom',
-    sideBar: 'columns',
 };
 
 // setup the grid after the page has finished loading

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/_examples/pivot/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/_examples/pivot/main.ts
@@ -30,7 +30,7 @@ const gridOptions: GridOptions<IOlympicData> = {
     ],
     defaultColDef: {
         flex: 1,
-        minWidth: 130,
+        minWidth: 160,
         enableValue: true,
         enableShowValuesAs: true,
     },
@@ -38,7 +38,10 @@ const gridOptions: GridOptions<IOlympicData> = {
         minWidth: 200,
     },
     pivotMode: true,
-    sideBar: 'columns',
+    sideBar: {
+        toolPanels: ['columns'],
+        defaultToolPanel: undefined,
+    },
 };
 
 // setup the grid after the page has finished loading

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/_examples/row-grouping/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/_examples/row-grouping/main.ts
@@ -41,7 +41,7 @@ const gridOptions: GridOptions<IOlympicData> = {
     ],
     defaultColDef: {
         flex: 1,
-        minWidth: 130,
+        minWidth: 160,
         enableValue: true,
         enableShowValuesAs: true,
         filter: true,
@@ -51,7 +51,11 @@ const gridOptions: GridOptions<IOlympicData> = {
         minWidth: 220,
     },
     groupDefaultExpanded: 1,
-    sideBar: 'columns',
+    grandTotalRow: 'bottom',
+    sideBar: {
+        toolPanels: ['columns'],
+        defaultToolPanel: undefined,
+    },
 };
 
 // setup the grid after the page has finished loading
@@ -59,7 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const gridDiv = document.querySelector<HTMLElement>('#myGrid')!;
     gridApi = createGrid(gridDiv, gridOptions);
 
-    fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
+    fetch('https://www.ag-grid.com/example-assets/small-olympic-winners.json')
         .then((response) => response.json())
         .then((data: IOlympicData[]) => gridApi!.setGridOption('rowData', data));
 });

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/_examples/show-values-as-overview/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/_examples/show-values-as-overview/main.ts
@@ -31,24 +31,29 @@ let gridApi: GridApi<IOlympicData>;
 
 const gridOptions: GridOptions<IOlympicData> = {
     columnDefs: [
-        { field: 'country', rowGroup: true, hide: true },
-        { field: 'year', rowGroup: true, hide: true },
-        { field: 'athlete', rowGroup: true, hide: true },
-        { field: 'total', headerName: 'Total', aggFunc: 'sum' },
+        { field: 'country', rowGroup: true, hide: true, enableRowGroup: true },
+        { field: 'year', rowGroup: true, hide: true, enableRowGroup: true },
+        { field: 'athlete' },
+        {
+            field: 'total',
+            headerName: 'Total',
+            aggFunc: 'sum',
+            enableValue: true,
+            enableShowValuesAs: true,
+        },
         {
             field: 'total',
             colId: 'totalPercentOfParent',
             headerName: 'Total of Parent',
             aggFunc: 'sum',
             showValuesAs: 'percentOfParentRowTotal',
+            enableValue: true,
+            enableShowValuesAs: true,
         },
     ],
     defaultColDef: {
         flex: 1,
         minWidth: 130,
-        enableValue: true,
-        enableRowGroup: true,
-        enableShowValuesAs: true,
     },
     autoGroupColumnDef: {
         minWidth: 220,

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/index.mdoc
@@ -15,11 +15,11 @@ This example groups Olympic winners by country and year, then shows raw medal to
 
 ## Enabling Show Values As
 
-**Show Values As** requires the `ShowValuesAsModule` and only works with the [Client-Side Row Model](./row-models/#client-side).
+Show Values As requires the `ShowValuesAsModule` and only works with the [Client-Side Row Model](./row-models/#client-side).
 
 ## Choosing a Mode from the Column Menu
 
-The **Show Values As** submenu is off by default. To let the user switch mode from the [Column Menu](./column-menu/), register the `ColumnMenuModule` and set `enableShowValuesAs: true` on the required columns. Switching mode only repaints the affected cells — it does not re-aggregate, re-sort or re-filter.
+The Show Values As submenu is off by default. To let the user switch mode from the [Column Menu](./column-menu/), register the `ColumnMenuModule` and set `enableShowValuesAs: true` on the required columns. Switching mode only repaints the affected cells — it does not re-aggregate, re-sort or re-filter.
 
 The effect depends on where you set it:
 
@@ -129,7 +129,7 @@ const gridOptions = {
 
 ## Row Grouping
 
-This example groups Olympic winners by country and year, then shows raw medal totals alongside the same values as a percentage of their parent group.
+This example groups Olympic winners by country, showing gold medals as a percentage of their parent group and the medal total as a percentage of the column's grand total.
 
 {% gridExampleRunner title="Show Values As with Row Grouping" name="row-grouping" /%}
 

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/index.mdoc
@@ -15,25 +15,16 @@ This example groups Olympic winners by country and year, then shows raw medal to
 
 ## Enabling Show Values As
 
-Show Values As is provided by the enterprise `ShowValuesAsModule` and works with the [Client-Side Row Model](./row-models/#client-side) only.
-
-```ts
-import { ModuleRegistry, ClientSideRowModelModule } from 'ag-grid-community';
-import { ShowValuesAsModule } from 'ag-grid-enterprise';
-
-ModuleRegistry.registerModules([ClientSideRowModelModule, ShowValuesAsModule]);
-```
-
-To let the user switch mode from the [Column Menu](./column-menu/), also register the `ColumnMenuModule` and set `enableShowValuesAs: true` on the columns (or on `defaultColDef`).
+**Show Values As** requires the `ShowValuesAsModule` and only works with the [Client-Side Row Model](./row-models/#client-side).
 
 ## Choosing a Mode from the Column Menu
 
-The **Show Values As** submenu is off by default. Set `enableShowValuesAs: true` to add it to a column's [Column Menu](./column-menu/), listing the available modes so the user can switch at runtime. Switching mode only repaints the affected cells — it does not re-aggregate, re-sort or re-filter.
+The **Show Values As** submenu is off by default. To let the user switch mode from the [Column Menu](./column-menu/), register the `ColumnMenuModule` and set `enableShowValuesAs: true` on the required columns. Switching mode only repaints the affected cells — it does not re-aggregate, re-sort or re-filter.
 
-Where `enableShowValuesAs` is set matters:
+The effect depends on where you set it:
 
-- On `defaultColDef`, the submenu is offered only where the column supports it — a value column (any `aggFunc`) or a numeric column — so it never appears where it can't be used.
-- Directly on a column, it forces the submenu on for any column type. Use this for a column whose numeric value the grid can't detect statically, such as a `valueGetter` or custom `aggFunc` that produces a number from string or object data.
+- **On `defaultColDef`** - the grid applies `enableShowValuesAs` selectively only to columns that have a numeric type or an `aggFunc`.
+- **On a single column** - always applied, whatever the column type. Use this when the column type cannot be inferred, such as a `valueGetter` or custom `aggFunc` that returns a number from string or object data.
 
 ```{% frameworkTransform=true %}
 const gridOptions = {
@@ -60,7 +51,7 @@ A numeric column that is not yet aggregated is promoted to a value column when a
 
 `percentOfGrandTotal` and `percentOfColumnTotal` give the same result outside [Pivot](./pivoting/) mode, where there is a single column total. They diverge only while pivoting: `percentOfGrandTotal` keeps the whole column's grand total as the denominator, whereas `percentOfColumnTotal` uses each pivot column's own total, so every pivot column sums to 100%.
 
-A mode that is not meaningful in the current view — for example `percentOfParentRowTotal` on a grid with no grouping — shows `#N/A` rather than a transformed value. In the column menu it appears greyed and cannot be selected. If a mode was already active when the grid left the view that supports it, the selection is kept — its cells show `#N/A` and it stays selectable so it can be changed away from.
+A mode that is not meaningful in the current view — for example `percentOfParentRowTotal` on a grid with no grouping — shows `#N/A` rather than a transformed value. In the column menu it appears greyed and cannot be selected. If a mode was already active when the grid left the view that supports it, the selection is kept — its cells show `#N/A`.
 
 ## Setting the Mode in Code
 

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/index.mdoc
@@ -60,7 +60,7 @@ A numeric column that is not yet aggregated is promoted to a value column when a
 
 `percentOfGrandTotal` and `percentOfColumnTotal` give the same result outside [Pivot](./pivoting/) mode, where there is a single column total. They diverge only while pivoting: `percentOfGrandTotal` keeps the whole column's grand total as the denominator, whereas `percentOfColumnTotal` uses each pivot column's own total, so every pivot column sums to 100%.
 
-A mode that is not meaningful in the current view — for example `percentOfParentRowTotal` on a grid with no grouping — shows `#N/A` rather than a transformed value, and in the column menu it appears greyed out.
+A mode that is not meaningful in the current view — for example `percentOfParentRowTotal` on a grid with no grouping — shows `#N/A` rather than a transformed value. In the column menu it appears greyed and cannot be selected. If a mode was already active when the grid left the view that supports it, the selection is kept — its cells show `#N/A` and it stays selectable so it can be changed away from.
 
 ## Setting the Mode in Code
 

--- a/packages/ag-grid-community/src/entities/colDef-showValuesAs.ts
+++ b/packages/ag-grid-community/src/entities/colDef-showValuesAs.ts
@@ -21,9 +21,9 @@ export type ShowValuesAsType = ShowValuesAsBuiltInType | (string & {});
  * Whether a mode applies in the current view (the result of {@link ShowValuesAsModeDef.applicability}). Drives both the
  * transform (an inapplicable mode shows the raw value) and how the mode appears in the column menu.
  * - `true` / `'enabled'` (default `true`): applicable - the transform runs and the menu shows it normally.
- * - `'inapplicable'`: not applicable in this view - shown greyed and non-interactive, except while it is the
- *   active selection, when it stays selectable so it can be changed away from (it is dormant, showing the raw
- *   value, until the view that activates it is in place).
+ * - `'inapplicable'`: not applicable in this view - shown greyed and non-interactive (it shows the raw value).
+ *   An active selection that becomes inapplicable still shows checked, but is changed away from by choosing an
+ *   applicable mode.
  * - `'disabled'`: not applicable - shown greyed and non-interactive (the menu item is disabled altogether).
  * - `'hide'` / `false`: not applicable - omitted from the menu, except the active selection, which is kept (greyed
  *   but still selectable) so it stays visible and changeable.

--- a/packages/ag-grid-community/src/entities/colDef-showValuesAs.ts
+++ b/packages/ag-grid-community/src/entities/colDef-showValuesAs.ts
@@ -21,8 +21,9 @@ export type ShowValuesAsType = ShowValuesAsBuiltInType | (string & {});
  * Whether a mode applies in the current view (the result of {@link ShowValuesAsModeDef.applicability}). Drives both the
  * transform (an inapplicable mode shows the raw value) and how the mode appears in the column menu.
  * - `true` / `'enabled'` (default `true`): applicable - the transform runs and the menu shows it normally.
- * - `'inapplicable'`: not applicable in this view - shown greyed but still selectable, so it can be chosen ahead
- *   of the view that activates it (it stays dormant, showing the raw value, until then).
+ * - `'inapplicable'`: not applicable in this view - shown greyed and non-interactive, except while it is the
+ *   active selection, when it stays selectable so it can be changed away from (it is dormant, showing the raw
+ *   value, until the view that activates it is in place).
  * - `'disabled'`: not applicable - shown greyed and non-interactive (the menu item is disabled altogether).
  * - `'hide'` / `false`: not applicable - omitted from the menu, except the active selection, which is kept (greyed
  *   but still selectable) so it stays visible and changeable.

--- a/packages/ag-grid-enterprise/src/showValuesAs/showValuesAsBuiltInModes.ts
+++ b/packages/ag-grid-enterprise/src/showValuesAs/showValuesAsBuiltInModes.ts
@@ -39,12 +39,12 @@ const showValuesAsPercentFormatter = (params: ShowValuesAsFormatterParams): stri
 const num = (p: ShowValuesAsTransformParams): number | null => numericOrNull(p.rawValue);
 
 /** Parent-row modes need a row hierarchy (grouping or tree data). Built-ins are never hidden — inapplicable (greyed
- *  but still selectable) otherwise, so one can be chosen ahead of the grouping that activates it. */
+ *  and non-selectable) otherwise. */
 const whenParentHierarchy = (p: ShowValuesAsApplicabilityParams): ShowValuesAsApplicability =>
     p.rowGroupActive || p.treeData ? true : 'inapplicable';
 
-/** Pivot-axis modes need a pivot column axis. Built-ins are never hidden — inapplicable (greyed-but-selectable) when
- *  not pivoting. */
+/** Pivot-axis modes need a pivot column axis. Built-ins are never hidden — inapplicable (greyed and non-selectable)
+ *  when not pivoting. */
 const whenPivot = (p: ShowValuesAsApplicabilityParams): ShowValuesAsApplicability =>
     p.pivotActive ? true : 'inapplicable';
 

--- a/packages/ag-grid-enterprise/src/showValuesAs/showValuesAsService.ts
+++ b/packages/ag-grid-enterprise/src/showValuesAs/showValuesAsService.ts
@@ -633,13 +633,15 @@ export class ShowValuesAsService extends BeanStub implements NamedBean, IShowVal
                     ? only.action
                     : () => this.setColumnShowValuesAs(column, type);
         }
-        if (menuState === 'disabled') {
-            // Greyed AND non-interactive — the menu item is disabled altogether.
+        if (menuState === 'disabled' || (menuState === 'inapplicable' && !isActive)) {
+            // Greyed AND non-interactive. An inapplicable mode stays interactive only while it is the active
+            // selection, so a mode chosen in one view (e.g. pivot) can still be changed away from once that
+            // view is removed.
             item.disabled = true;
         } else if (menuState !== 'enabled') {
-            // `'inapplicable'`, or a `'hidden'` mode kept because it is the active selection: greyed like a
-            // disabled item but still selectable, so it can be chosen ahead of the view that activates it (it
-            // stays dormant — raw value — until then) or changed away from.
+            // The active selection in a view where it no longer applies (or a `'hidden'` mode kept because it
+            // is active): greyed to show it is dormant — raw value / `#N/A` — but still selectable so it can
+            // be changed away from.
             item.cssClasses = ['ag-show-values-as-inapplicable'];
         }
         return item;

--- a/packages/ag-grid-enterprise/src/showValuesAs/showValuesAsService.ts
+++ b/packages/ag-grid-enterprise/src/showValuesAs/showValuesAsService.ts
@@ -633,15 +633,14 @@ export class ShowValuesAsService extends BeanStub implements NamedBean, IShowVal
                     ? only.action
                     : () => this.setColumnShowValuesAs(column, type);
         }
-        if (menuState === 'disabled' || (menuState === 'inapplicable' && !isActive)) {
-            // Greyed AND non-interactive. An inapplicable mode stays interactive only while it is the active
-            // selection, so a mode chosen in one view (e.g. pivot) can still be changed away from once that
-            // view is removed.
+        if (menuState === 'disabled' || menuState === 'inapplicable') {
+            // Greyed AND non-interactive — a mode that does not apply in the current view cannot be selected.
+            // An active selection that has become inapplicable still shows checked but is changed away from by
+            // choosing an applicable mode.
             item.disabled = true;
         } else if (menuState !== 'enabled') {
-            // The active selection in a view where it no longer applies (or a `'hidden'` mode kept because it
-            // is active): greyed to show it is dormant — raw value / `#N/A` — but still selectable so it can
-            // be changed away from.
+            // A `'hidden'` mode kept because it is the active selection: greyed to show it is dormant — raw
+            // value / `#N/A` — but still selectable so it stays visible and can be changed away from.
             item.cssClasses = ['ag-show-values-as-inapplicable'];
         }
         return item;
@@ -703,7 +702,7 @@ export class ShowValuesAsService extends BeanStub implements NamedBean, IShowVal
     private buildApplicabilityParams(column: AgColumn): ShowValuesAsApplicabilityParams {
         // `undefined` ⇒ that hierarchy's module is not registered; `false` ⇒ registered but inactive. The `hasX`
         // flags distinguish the two, letting a custom `applicability` callback hide a mode its module can't support.
-        // The built-ins never hide: they stay inapplicable-but-selectable in either case.
+        // The built-ins never hide: they stay greyed and non-interactive in either case.
         const groupStage = this.groupStage;
         return _addGridCommonParams(this.gos, {
             column,

--- a/testing/behavioural/src/grouping-data/grouping-show-values-as-menu.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-show-values-as-menu.test.ts
@@ -370,9 +370,9 @@ describe('showValuesAs column menu', () => {
         `);
     });
 
-    test('an inapplicable built-in mode is shown greyed but still selectable — never hidden', async () => {
-        // Flat grid: the parent modes are inapplicable (no row hierarchy). They appear greyed but stay selectable,
-        // so the user can choose one ahead of the grouping that activates it.
+    test('an inapplicable built-in mode is shown greyed and non-interactive — never hidden', async () => {
+        // Flat grid: the parent modes are inapplicable (no row hierarchy). They appear greyed and cannot be
+        // selected — only the grouping/pivoting that activates them makes them available.
         const api = await gridMgr.createGridAndWait('sva-menu-inapplicable', {
             columnDefs: [
                 { field: 'country' },
@@ -390,20 +390,17 @@ describe('showValuesAs column menu', () => {
 
         const parentRow = menuOption('% of Parent Row Total');
         expect(parentRow).toBeTruthy(); // inapplicable, but NOT hidden
-        expect(parentRow!.classList.contains('ag-show-values-as-inapplicable')).toBe(true); // greyed
-        expect(parentRow!.classList.contains('ag-menu-option-disabled')).toBe(false); // and still selectable
+        expect(parentRow!.classList.contains('ag-menu-option-disabled')).toBe(true); // greyed AND non-interactive
 
-        // Selecting it parks it dormant: applied as the active mode, but the raw value shows until grouping
-        // makes it applicable.
+        // Clicking it does nothing — an inapplicable, non-active mode cannot be selected.
         parentRow!.click();
         await asyncSetTimeout(10);
-        expect(api.getColumnState().find((s) => s.colId === 'amount')?.showValuesAs).toBe('percentOfParentRowTotal');
-        expect(api.getCellValue({ rowNode: leaf(api, '1'), colKey: 'amount', transformValues: true })).toBe(25); // raw
+        expect(api.getColumnState().find((s) => s.colId === 'amount')?.showValuesAs).toBe('percentOfGrandTotal');
     });
 
-    test('built-in modes stay inapplicable-but-selectable even when their required module is not registered', async () => {
+    test('built-in modes stay inapplicable-and-non-interactive even when their required module is not registered', async () => {
         // This suite registers RowGrouping but not Pivot/TreeData. Built-in modes are never hidden for being in the
-        // wrong view — pivot-axis modes show greyed-but-selectable here too, so the feature stays discoverable.
+        // wrong view — pivot-axis modes show greyed-and-disabled here too, so the feature stays discoverable.
         const api = await gridMgr.createGridAndWait('sva-menu-unregistered-module', {
             columnDefs: [
                 { field: 'country' },
@@ -418,12 +415,11 @@ describe('showValuesAs column menu', () => {
         await openShowValuesAsSubmenu(api, 'amount');
 
         // Pivot-axis modes (Pivot module not registered) and the parent-row mode (RowGrouping inactive) all stay
-        // greyed-but-selectable — never hidden.
+        // greyed-and-disabled — never hidden.
         for (const name of ['% of Row Total', '% of Parent Column Total', '% of Parent Row Total']) {
             const option = menuOption(name);
             expect(option).toBeTruthy();
-            expect(option!.classList.contains('ag-show-values-as-inapplicable')).toBe(true); // greyed
-            expect(option!.classList.contains('ag-menu-option-disabled')).toBe(false); // still selectable
+            expect(option!.classList.contains('ag-menu-option-disabled')).toBe(true); // greyed AND non-interactive
         }
     });
 

--- a/testing/behavioural/src/grouping-data/grouping-show-values-as-menu.test.ts
+++ b/testing/behavioural/src/grouping-data/grouping-show-values-as-menu.test.ts
@@ -398,6 +398,32 @@ describe('showValuesAs column menu', () => {
         expect(api.getColumnState().find((s) => s.colId === 'amount')?.showValuesAs).toBe('percentOfGrandTotal');
     });
 
+    test('an active built-in mode that becomes inapplicable is greyed, checked, and non-interactive', async () => {
+        // Flat grid with an inapplicable mode active (e.g. left over from a grouped view). The menu shows it
+        // checked but disabled — it is changed away from by choosing an applicable mode, not by re-selecting it.
+        const api = await gridMgr.createGridAndWait('sva-menu-inapplicable-active', {
+            columnDefs: [
+                { field: 'country' },
+                { field: 'amount', aggFunc: 'sum', showValuesAs: 'percentOfParentRowTotal', enableShowValuesAs: true },
+            ],
+            getRowId: ({ data }) => data.id,
+            rowData: [
+                { id: '1', country: 'A', amount: 25 },
+                { id: '2', country: 'B', amount: 75 },
+            ],
+        });
+        await openShowValuesAsSubmenu(api, 'amount');
+
+        const active = menuOption('% of Parent Row Total');
+        expect(active).toBeTruthy();
+        expect(active!.classList.contains('ag-menu-option-disabled')).toBe(true); // greyed AND non-interactive
+
+        // Clicking the active inapplicable mode does nothing — it stays put, to be changed away from.
+        active!.click();
+        await asyncSetTimeout(10);
+        expect(api.getColumnState().find((s) => s.colId === 'amount')?.showValuesAs).toBe('percentOfParentRowTotal');
+    });
+
     test('built-in modes stay inapplicable-and-non-interactive even when their required module is not registered', async () => {
         // This suite registers RowGrouping but not Pivot/TreeData. Built-in modes are never hidden for being in the
         // wrong view — pivot-axis modes show greyed-and-disabled here too, so the feature stays discoverable.


### PR DESCRIPTION
## Summary

Follow-up to the RTI-3352 docs work. A built-in Show Values As mode that is not meaningful in the current view (e.g. `percentOfParentRowTotal` with no grouping) was shown greyed **but still selectable**, using a bespoke `ag-show-values-as-inapplicable` style. This let a mode be pre-selected before the view that activates it existed, and the custom greyed-but-selectable styling was inconsistent with the rest of the menu.

Inapplicable modes are now **disabled** in the menu (standard `ag-menu-option-disabled` styling), with one exception: when the inapplicable mode is the **active selection**, it stays selectable so it can be changed away from. This covers the case where a mode was chosen while pivoting/grouping and the grid then leaves that view — the selection is kept, cells show `#N/A`, and the user can switch it off from the menu (or via "None").

The explicit `applicability: 'disabled'` integrator option is unchanged (fully non-interactive, including when active).

### Trade-off
Pre-selecting an inapplicable mode ahead of the view that activates it is no longer possible. This was not an intentional capability and was the source of the styling/UX inconsistency.

## Changes
- `showValuesAsService.ts` — `buildModeMenuItem` disables inapplicable, non-active modes.
- `colDef-showValuesAs.ts` — `ShowValuesAsApplicability` `'inapplicable'` JSDoc updated.
- `aggregation-show-values-as` docs — describe the new menu behaviour.
- `grouping-show-values-as-menu.test.ts` — two tests updated to assert disabled-when-not-active.

## Test plan
- `./behave.sh "grouping-show-values-as"` — 85/85 pass.

Fix [RTI-3352](https://ag-grid.atlassian.net/browse/RTI-3352)