### PR TITLE
[RTI-3352] Docs(show-values-as): clarify enablement, headings and links

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/_examples/row-grouping/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/_examples/row-grouping/main.ts
@@ -35,7 +35,7 @@ const gridOptions: GridOptions<IOlympicData> = {
         { field: 'year', filter: 'agNumberColumnFilter' },
         // Each value as a share of its parent group.
         { field: 'gold', aggFunc: 'sum', showValuesAs: 'percentOfParentRowTotal' },
-        { field: 'silver', aggFunc: 'sum' },
+        { field: 'silver', aggFunc: 'sum', hide: true },
         // Each value as a share of the whole column.
         { field: 'total', aggFunc: 'sum', showValuesAs: 'percentOfGrandTotal' },
     ],

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/_examples/show-values-as-overview/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/_examples/show-values-as-overview/main.ts
@@ -65,6 +65,7 @@ const gridOptions: GridOptions<IOlympicData> = {
         const destPath = ['United States', '2008'];
         return route.every((item, idx) => destPath[idx] === item);
     },
+    suppressAggFuncInHeader: true,
 };
 
 // setup the grid after the page has finished loading

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-show-values-as/index.mdoc
@@ -13,13 +13,13 @@ A mode can be chosen by the user from the column menu, set on the column definit
 
 This example groups Olympic winners by country and year, then shows raw medal totals alongside the same values as a percentage of their parent group.
 
-## Enabling Show Values As
+{% note %}
+Show Values As requires the `ShowValuesAsModule` and is only supported with the [Client-Side Row Model](./row-models/#client-side).
+{% /note %}
 
-Show Values As requires the `ShowValuesAsModule` and only works with the [Client-Side Row Model](./row-models/#client-side).
+## Column Menu
 
-## Choosing a Mode from the Column Menu
-
-The Show Values As submenu is off by default. To let the user switch mode from the [Column Menu](./column-menu/), register the `ColumnMenuModule` and set `enableShowValuesAs: true` on the required columns. Switching mode only repaints the affected cells — it does not re-aggregate, re-sort or re-filter.
+The Show Values As submenu is off by default. To let the user switch mode from the [Column Menu](./column-menu/), register the `ColumnMenuModule` and set `enableShowValuesAs: true` on the required columns. Switching mode only updates the affected column — it does not re-aggregate, re-sort or re-filter.
 
 The effect depends on where you set it:
 
@@ -51,11 +51,11 @@ A numeric column that is not yet aggregated is promoted to a value column when a
 
 `percentOfGrandTotal` and `percentOfColumnTotal` give the same result outside [Pivot](./pivoting/) mode, where there is a single column total. They diverge only while pivoting: `percentOfGrandTotal` keeps the whole column's grand total as the denominator, whereas `percentOfColumnTotal` uses each pivot column's own total, so every pivot column sums to 100%.
 
-A mode that is not meaningful in the current view — for example `percentOfParentRowTotal` on a grid with no grouping — shows `#N/A` rather than a transformed value. In the column menu it appears greyed and cannot be selected. If a mode was already active when the grid left the view that supports it, the selection is kept — its cells show `#N/A`.
+If a mode was already active when the grid left the view that supports it, the selection is kept — its cells show `#N/A`. In the column menu it appears greyed and cannot be selected.
 
-## Setting the Mode in Code
+## Setting the Mode
 
-Set `showValuesAs` on a value column to the mode you want. Use `initialShowValuesAs` instead to set only the starting mode and leave the user free to change it from the menu.
+Set `showValuesAs` on a value column to the mode you want. Use [`initialShowValuesAs`](./column-updating-definitions/#changing-column-state) instead to set only the starting mode and leave the user free to change it from the menu.
 
 ```{% frameworkTransform=true %}
 const gridOptions = {
@@ -67,7 +67,7 @@ const gridOptions = {
 };
 ```
 
-The object form also takes an optional `precision` to override the configured decimal places for that selection:
+The object form takes an optional `precision` to override the configured decimal places for that selection:
 
 ```{% frameworkTransform=true %}
 const colDef = {
@@ -91,7 +91,7 @@ api.applyColumnState({ state: [{ colId: 'gold', showValuesAs: null }] });
 
 ### Reading the Transformed Value
 
-The value is transformed only for display, export and the column menu — `api.getCellValue` and `rowNode.getDataValue` return the raw aggregate by default. To read the transformed value, pass `transformValues: true` to `api.getCellValue`, or `'transformed'` to `rowNode.getDataValue`:
+The methods `api.getCellValue` and `rowNode.getDataValue` return the raw aggregate by default. To read the transformed value, pass `transformValues: true` to `api.getCellValue`, or `'transformed'` to `rowNode.getDataValue`:
 
 ```{% frameworkTransform=true %}
 const shown = api.getCellValue({ rowNode, colKey: 'gold', transformValues: true });
@@ -110,7 +110,7 @@ const gridOptions = {
 };
 ```
 
-To turn Show Values As off for a column, set `showValuesAsDef` to `null` — on a single column, or on `defaultColDef` for every column. This disables the feature entirely: no transform, no menu, and any `showValuesAs` selection is ignored:
+To turn Show Values As off for a column, set `showValuesAsDef` to `null` — on a single column, or on `defaultColDef` for every column:
 
 ```{% frameworkTransform=true %}
 const gridOptions = {
@@ -124,8 +124,6 @@ const gridOptions = {
     ],
 };
 ```
-
-`enableShowValuesAs` controls only the column menu (see [Choosing a Mode from the Column Menu](#choosing-a-mode-from-the-column-menu)). A mode applied through `showValuesAs` or [Column State](./column-state/) still transforms the displayed value.
 
 ## Row Grouping
 
@@ -141,7 +139,7 @@ Show Values As does not require grouping. On a flat grid each row can be shown a
 
 ## Tree Data
 
-With [Tree Data](./tree-data/), aggregates are populated on parent nodes, so each node's value can be shown as a share of the folder that contains it.
+With [Tree Data](./tree-data/), aggregates are populated on parent nodes, so each node's value can be shown as a percentage of its parent row total.
 
 {% gridExampleRunner title="Show Values As with Tree Data" name="tree-data" /%}
 

--- a/documentation/ag-grid-docs/src/content/docs/column-updating-definitions/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-updating-definitions/index.mdoc
@@ -61,7 +61,7 @@ All stateful attributes of Column Definitions are as follows:
 | pivot              | initialPivot         | If this column should be a pivot.                                     |
 | pivotIndex         | initialPivotIndex    | Whether this column should be a pivot and in what order.              |
 | aggFunc            | initialAggFunc       | The function to aggregate this column by if row grouping or pivoting. |
-| showValuesAs       | initialShowValuesAs  | The mode used to show this column's values as relative figures.       |
+| showValuesAs       | initialShowValuesAs  | The mode used to show this column's values relative to another value. |
 
 {% note %}
 If you are interested in changing Column State only and not the other parts of the column definitions, then consider


### PR DESCRIPTION
Fix [RTI-3352](https://ag-grid.atlassian.net/browse/RTI-3352)

## Summary

Documentation clarity pass on the **Aggregation – Show Values As** page and related references.

- Overview example now sets `enableRowGroup` on dimension columns and `enableValue`/`enableShowValuesAs` on value columns, so the tool panel / column menu no longer offers nonsensical combinations.
- Clarified where `enableShowValuesAs` takes effect (selective on `defaultColDef` vs forced on a single column).
- Shortened verbose headings to noun phrases: *Choosing a Mode from the Column Menu* → **Column Menu**, *Setting the Mode in Code* → **Setting the Mode** (cross-reference anchor updated).
- Linked `initialShowValuesAs` to the column-state docs section.
- Reworded the `showValuesAs` row in *column-updating-definitions* ("relative to another value").
- Converted the Client-Side Row Model restriction into a `note` callout.
- Used **parent row total** terminology in the Tree Data section.

## Notes

Docs/examples only — no runtime code changes. Base branch: `b36.0.0`.