### PR TITLE
[RTI-3393] Point migration docs at ag-update AI skill

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/codemods/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/codemods/index.mdoc
@@ -4,10 +4,12 @@ title: "Codemods"
 
 ## How to Upgrade AG Grid Version
 
-All AG Grid releases from v31 onwards come with an accompanying Codemod to help automate the upgrade process.
+AG Grid releases from v31 to v35 come with an accompanying Codemod to help automate the upgrade process.
 Codemods are scripts that fix the project's source files to address the majority of breaking changes and deprecations when upgrading from an older version.
 
-This is the easiest way to make sure projects stay up-to-date with the latest AG Grid changes.
+{% note %}
+We now recommend the [`ag-update` AI skill](./skills) to automate upgrades to any version. There is no Codemod for v36 or later.
+{% /note %}
 
 ## Framework Coverage
 

--- a/documentation/ag-grid-docs/src/content/docs/migration/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/migration/index.mdoc
@@ -6,15 +6,13 @@ Learn how to upgrade AG Grid to a specific version.
 
 These guides explain how to move from one version of AG Grid to another. They outline breaking changes, new features, and the adjustments you need to make in your code.
 
-{% note %}
-If you are developing with **AI** you can use our [MCP Server](./mcp-server) to aid your AI tooling with migrating your AG Grid applications. See our MCP documentation on [migrating to new versions](./mcp-server/#migrate-to-a-new-version) for more information.
-{% /note %}
+## Automating Upgrades
 
-## Codemods
+If you are developing with **AI**, the [`ag-update` skill](./skills/#ag-update) automates upgrades to any version. It reads the migration documentation, checks it against your repository, and produces a plan of the changes needed.
 
-All AG Grid releases from v31 onwards come with an accompanying Codemod to help automate the upgrade process. Codemods are scripts that fix the project's source files to address the majority of breaking changes and deprecations when upgrading from an older version.
+### Codemods
 
-Each of the migration guides listed below will include details on how to use Codemods to upgrade to that version. If you want to learn more about Codemods please review our dedicated [Codemods documentation](./codemods).
+For releases from v31 to v35, Codemods are an alternative: scripts that fix the project's source files to address the majority of breaking changes and deprecations. Each of the migration guides for those versions includes details on how to use them, and our [Codemods documentation](./codemods) covers them in full. There is no Codemod for v36 or later.
 
 ## Version 36
 

--- a/documentation/ag-grid-docs/src/content/docs/skills/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/skills/index.mdoc
@@ -3,20 +3,20 @@ title: 'AG Grid AI Skills'
 description: 'Install and use the AG Grid AI skills to build and maintain grid applications with coding agents such as Claude and Codex.'
 ---
 
-Our [AI skills](https://github.com/ag-grid/skills) give coding agents such as Claude and Codex the expertise to build and maintain your AG Grid and AG Charts applications from our official guidance.
+Our [AI skills](https://github.com/ag-grid/ag-skills) give coding agents such as Claude and Codex the expertise to build and maintain your AG Grid and AG Charts applications from our official guidance.
 
 {% note %}
-We are actively developing and releasing new versions of our skills. Feedback is welcome — [open an issue](https://github.com/ag-grid/skills/issues) on GitHub.
+We are actively developing and releasing new versions of our skills. Feedback is welcome — [open an issue](https://github.com/ag-grid/ag-skills/issues) on GitHub.
 {% /note %}
 
 ## Setup
 
 ### Installation
 
-A skill is a folder of files that you install in your project repository or your home directory. Use the skills CLI to copy the files from the [ag-grid/skills](https://github.com/ag-grid/skills) repository to your machine:
+A skill is a folder of files that you install in your project repository or your home directory. Use the skills CLI to copy the files from the [ag-grid/ag-skills](https://github.com/ag-grid/ag-skills) repository to your machine:
 
 ```bash
-npx skills add ag-grid/skills
+npx skills add ag-grid/ag-skills
 ```
 
 ### Updating
@@ -24,7 +24,7 @@ npx skills add ag-grid/skills
 We refine the skills and extend them to cover new AG Grid and AG Charts releases, so update at any time to pick up the latest guidance:
 
 ```bash
-npx skills update ag-grid/skills
+npx skills update ag-grid/ag-skills
 ```
 
 ## Skills
@@ -87,4 +87,4 @@ Review the generated files, then ask the agent to apply the plan. It bumps the v
 
 ## Upcoming skills
 
-We are expanding the set of skills to cover more of the AG Grid and AG Charts development workflow. Watch the [ag-grid/skills](https://github.com/ag-grid/skills) repository, or [open an issue](https://github.com/ag-grid/skills/issues) to suggest a skill.
+We are expanding the set of skills to cover more of the AG Grid and AG Charts development workflow. Watch the [ag-grid/ag-skills](https://github.com/ag-grid/ag-skills) repository, or [open an issue](https://github.com/ag-grid/ag-skills/issues) to suggest a skill.

--- a/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-36/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-36/index.mdoc
@@ -17,6 +17,10 @@ NOTE: This will not show if the current library version is the same as the migra
 
 {% documentationArchiveSection version=migrationVersionPatch() /%}
 
+{% note %}
+To automate the upgrade, use the [`ag-update` AI skill](./skills), which reads this migration guide, checks it against your repository, and produces a plan of the changes needed.
+{% /note %}
+
 ## Breaking Changes
 
 ### Frameworks


### PR DESCRIPTION
## Summary

Updates the migration documentation to recommend the new `ag-update` AI skill as the primary, recommended path for automating upgrades, replacing the previous emphasis on the MCP Server and Codemods.

- **Migration landing page**: new "Automating Upgrades" section leads with the `ag-update` skill (works for any version); Codemods demoted to a subsection scoped to v31–v35. Removed the MCP Server migration note.
- **Codemods page**: note recommending the `ag-update` skill; clarifies there is no Codemod for v36 or later.
- **Upgrading to v36 page**: note pointing to the `ag-update` skill (no Codemod for v36).
- **Skills page**: updated repo references from `ag-grid/skills` to the renamed `ag-grid/ag-skills`.

## Test plan

- Docs-only change. Verify the `./skills` links and `{% note %}` blocks render correctly on the migration, codemods, and upgrading-to-v36 pages.

Fix [RTI-3393](https://ag-grid.atlassian.net/browse/RTI-3393)