### PR TITLE
Docs(skills): update links for repo rename to skills

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/skills/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/skills/index.mdoc
@@ -3,20 +3,20 @@ title: 'AG Grid AI Skills'
 description: 'Install and use the AG Grid AI skills to build and maintain grid applications with coding agents such as Claude and Codex.'
 ---
 
-Our [AI skills](https://github.com/ag-grid/ag-skills) give coding agents such as Claude and Codex the expertise to build and maintain your AG Grid and AG Charts applications from our official guidance.
+Our [AI skills](https://github.com/ag-grid/skills) give coding agents such as Claude and Codex the expertise to build and maintain your AG Grid and AG Charts applications from our official guidance.
 
 {% note %}
-We are actively developing and releasing new versions of our skills. Feedback is welcome — [open an issue](https://github.com/ag-grid/ag-skills/issues) on GitHub.
+We are actively developing and releasing new versions of our skills. Feedback is welcome — [open an issue](https://github.com/ag-grid/skills/issues) on GitHub.
 {% /note %}
 
 ## Setup
 
 ### Installation
 
-A skill is a folder of files that you install in your project repository or your home directory. Use the skills CLI to copy the files from the [ag-grid/ag-skills](https://github.com/ag-grid/ag-skills) repository to your machine:
+A skill is a folder of files that you install in your project repository or your home directory. Use the skills CLI to copy the files from the [ag-grid/skills](https://github.com/ag-grid/skills) repository to your machine:
 
 ```bash
-npx skills add ag-grid/ag-skills
+npx skills add ag-grid/skills
 ```
 
 ### Updating
@@ -24,7 +24,7 @@ npx skills add ag-grid/ag-skills
 We refine the skills and extend them to cover new AG Grid and AG Charts releases, so update at any time to pick up the latest guidance:
 
 ```bash
-npx skills update ag-grid/ag-skills
+npx skills update ag-grid/skills
 ```
 
 ## Skills
@@ -87,4 +87,4 @@ Review the generated files, then ask the agent to apply the plan. It bumps the v
 
 ## Upcoming skills
 
-We are expanding the set of skills to cover more of the AG Grid and AG Charts development workflow. Watch the [ag-grid/ag-skills](https://github.com/ag-grid/ag-skills) repository, or [open an issue](https://github.com/ag-grid/ag-skills/issues) to suggest a skill.
+We are expanding the set of skills to cover more of the AG Grid and AG Charts development workflow. Watch the [ag-grid/skills](https://github.com/ag-grid/skills) repository, or [open an issue](https://github.com/ag-grid/skills/issues) to suggest a skill.


### PR DESCRIPTION
The `ag-skills` repository was renamed to `skills`. Update the AI Skills documentation page so all GitHub links and `npx skills` commands point at `ag-grid/skills`.

All references were contained in a single page (`documentation/ag-grid-docs/src/content/docs/skills/index.mdoc`): 3 markdown links, 2 CLI commands, and 2 issue links.