### PR TITLE
AG-17617 - Clarify getValue parameter naming in ValueGetterParams

### DIFF
--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -1240,8 +1240,8 @@ export interface ValueGetterParams<TData = any, TValue = any, TContext = any> ex
     TValue,
     TContext
 > {
-    /** A utility method for getting other column values */
-    getValue: (field: string) => any;
+    /** A utility method for getting other column values via their `ColKey` */
+    getValue: (colKey: ColKey<TData>) => any;
 }
 export type ValueGetterFunc<TData = any, TValue = any, TContext = any> = (
     params: ValueGetterParams<TData, TValue, TContext>

--- a/packages/ag-grid-community/src/filter/filterValueService.ts
+++ b/packages/ag-grid-community/src/filter/filterValueService.ts
@@ -35,8 +35,8 @@ export class FilterValueService extends BeanStub implements NamedBean {
                 node: rowNode,
                 column,
                 colDef,
-                getValue: (field) => {
-                    const col = colModel.getCol(field);
+                getValue: (colKey) => {
+                    const col = colModel.getCol(colKey);
                     // arbitrary user-requested field: may be a pivot result column, so resolve it
                     return col ? valueSvc.getValueFromData(_resolvePivotColumnForRow(col, rowNode), rowNode) : null;
                 },

--- a/packages/ag-grid-community/src/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.ts
@@ -11,6 +11,7 @@ import type { AgColumn } from '../entities/agColumn';
 import { _resolvePivotColumnForRow } from '../entities/agColumn';
 import type {
     ColDef,
+    ColKey,
     KeyCreatorParams,
     ValueFormatterParams,
     ValueGetterParams,
@@ -853,7 +854,7 @@ export class ValueService extends BeanStub implements NamedBean {
             node: rowNode,
             column: column,
             colDef: column.colDef,
-            getValue: (field) => this.getValueCallback(rowNode, field),
+            getValue: (colKey) => this.getValueCallback(rowNode, colKey),
         };
 
         const result =
@@ -865,8 +866,8 @@ export class ValueService extends BeanStub implements NamedBean {
         return result;
     }
 
-    private getValueCallback(node: IRowNode, field: string): any {
-        const otherColumn = this.colModel.getCol(field);
+    private getValueCallback(node: IRowNode, colKey: ColKey): any {
+        const otherColumn = this.colModel.getCol(colKey);
         return otherColumn ? this.getValueFromData(_resolvePivotColumnForRow(otherColumn, node), node) : null;
     }
 


### PR DESCRIPTION
## Summary

`ValueGetterParams.getValue` previously typed its parameter as `field: string`, implying lookup by the column's `field` key. In fact the lookup goes through `colModel.getCol`, which resolves by `colId` (the explicit `colDef.colId`, or the field-derived colId when none is set) — so passing a `field` value fails when a column has a distinct `colId`.

This renames the parameter `field` → `colKey` and types it as `ColKey` across the public interface and both internal call sites, and updates the JSDoc (which drives the auto-generated column-properties reference docs).

## Changes

- `colDef.ts` — `getValue: (field: string) => any` → `getValue: (colKey: ColKey<TData>) => any`, with a clarified doc comment.
- `valueService.ts` / `filterValueService.ts` — rename the callback parameter and type it as `ColKey` to match.

## Notes

- Behaviour is unchanged — `getCol` already accepts `ColKey` (`string | ColDef | Column`); this only renames/retypes.
- Backward compatible for TypeScript users: the grid provides this callback (users only call it), and `ColKey` widens the accepted parameter type, so existing string-colId callers still type-check.

## Test plan

- `yarn nx build:types ag-grid-community` — passes
- `yarn nx lint ag-grid-community` — passes

Fix [AG-17617](https://ag-grid.atlassian.net/browse/AG-17617)