### PR TITLE
AG-15464 Convert cell position & row edit style features to functions

### DIFF
--- a/packages/ag-grid-community/src/edit/editService.ts
+++ b/packages/ag-grid-community/src/edit/editService.ts
@@ -32,7 +32,6 @@ import type {
     _SetEditingCellsParams,
 } from '../interfaces/iEditService';
 import type { IRowNode } from '../interfaces/iRowNode';
-import type { IRowStyleFeature } from '../interfaces/iRowStyleFeature';
 import type { CellValueChange } from '../interfaces/iUndoRedo';
 import type { UserCompDetails } from '../interfaces/iUserCompDetails';
 import { CellCtrl } from '../rendering/cell/cellCtrl';
@@ -43,7 +42,7 @@ import type { EditModelService } from './editModelService';
 import type { BaseEditStrategy } from './strategy/baseEditStrategy';
 import { isCellEditable, isFullRowCellEditable, shouldStartEditing } from './strategy/strategyUtils';
 import { _applyCellEditStyles } from './styles/cellEditStyleFeature';
-import { RowEditStyleFeature } from './styles/rowEditStyleFeature';
+import { _applyRowEditStyles } from './styles/rowEditStyleFeature';
 import { _addStopEditingWhenGridLosesFocus, _getCellCtrl } from './utils/controllers';
 import {
     UNEDITED,
@@ -962,7 +961,7 @@ export class EditService extends BeanStub implements NamedBean {
             cellCtrl.refreshCell(FORCE_REFRESH);
             // refresh the styles directly rather than through refreshRow as that causes the group cell renderer to
             // be recreated and would discard future mouse click events
-            cellCtrl.rowCtrl.rowEditStyleFeature?.applyRowStyles();
+            this.applyRowEditStyles(cellCtrl.rowCtrl);
         }
 
         let invalid = false;
@@ -1504,8 +1503,8 @@ export class EditService extends BeanStub implements NamedBean {
         _applyCellEditStyles(this.beans, cellCtrl);
     }
 
-    public createRowStyleFeature(rowCtrl: RowCtrl): IRowStyleFeature {
-        return new RowEditStyleFeature(rowCtrl, this.beans);
+    public applyRowEditStyles(rowCtrl: RowCtrl): void {
+        _applyRowEditStyles(this.beans, rowCtrl);
     }
 
     public setEditingCells(cells: EditingCellPosition[], params?: _SetEditingCellsParams): void {

--- a/packages/ag-grid-community/src/edit/styles/rowEditStyleFeature.ts
+++ b/packages/ag-grid-community/src/edit/styles/rowEditStyleFeature.ts
@@ -1,72 +1,49 @@
-import { BeanStub } from '../../context/beanStub';
 import type { BeanCollection } from '../../context/context';
-import type { IRowStyleFeature } from '../../interfaces/iRowStyleFeature';
 import type { RowCtrl } from '../../rendering/row/rowCtrl';
-import type { EditModelService } from '../editModelService';
-import type { EditService } from '../editService';
 import { _hasEdits, _hasLeafEdits, _hasPinnedEdits } from './style-utils';
 
-export class RowEditStyleFeature extends BeanStub implements IRowStyleFeature {
-    private readonly editSvc?: EditService;
-    private readonly editModelSvc?: EditModelService;
+export function _applyRowEditStyles(beans: BeanCollection, rowCtrl: RowCtrl): void {
+    const { editModelSvc } = beans;
 
-    constructor(
-        private readonly rowCtrl: RowCtrl,
-        beans: BeanCollection
-    ) {
-        super();
+    let rowNode = rowCtrl.rowNode;
+    let edits = editModelSvc?.getEditRow(rowNode);
+    const hasErrors = editModelSvc?.getRowValidationModel().hasRowValidation({ rowNode });
 
-        this.beans = beans;
-        this.gos = beans.gos;
-        this.editSvc = beans.editSvc;
-        this.editModelSvc = beans.editModelSvc;
+    if (!edits && rowNode.pinnedSibling) {
+        rowNode = rowNode.pinnedSibling!;
+        edits = editModelSvc?.getEditRow(rowNode);
+    }
+    if (edits) {
+        const editing = Array.from(edits.keys()).some((column) => {
+            const position = { rowNode, column };
+            return (
+                _hasEdits(beans, position, true) || _hasLeafEdits(beans, position) || _hasPinnedEdits(beans, position)
+            );
+        });
+
+        applyStyle(beans, rowCtrl, hasErrors, editing);
+
+        return;
     }
 
-    public applyRowStyles() {
-        const { rowCtrl, editModelSvc, beans } = this;
+    applyStyle(beans, rowCtrl, hasErrors);
+}
 
-        let rowNode = rowCtrl.rowNode;
-        let edits = editModelSvc?.getEditRow(rowNode);
-        const hasErrors = this.editModelSvc?.getRowValidationModel().hasRowValidation({ rowNode });
+function applyStyle(beans: BeanCollection, rowCtrl: RowCtrl, hasErrors: boolean = false, editing: boolean = false) {
+    const batchEdit = !!beans.editSvc?.isBatchEditing();
+    const fullRow = beans.gos.get('editType') === 'fullRow';
 
-        if (!edits && rowNode.pinnedSibling) {
-            rowNode = rowNode.pinnedSibling!;
-            edits = editModelSvc?.getEditRow(rowNode);
-        }
-        if (edits) {
-            const editing = Array.from(edits.keys()).some((column) => {
-                const position = { rowNode, column };
-                return (
-                    _hasEdits(beans, position, true) ||
-                    _hasLeafEdits(beans, position) ||
-                    _hasPinnedEdits(beans, position)
-                );
-            });
-
-            this.applyStyle(hasErrors, editing);
-
-            return;
-        }
-
-        this.applyStyle(hasErrors);
+    const rowComp = rowCtrl.getGui()?.rowComp;
+    if (!rowComp) {
+        return;
     }
 
-    private applyStyle(hasErrors: boolean = false, editing: boolean = false) {
-        const batchEdit = !!this.editSvc?.isBatchEditing();
-        const fullRow = this.gos.get('editType') === 'fullRow';
+    rowComp.toggleCss('ag-row-editing', fullRow && editing);
+    rowComp.toggleCss('ag-row-batch-edit', fullRow && editing && batchEdit);
 
-        const rowComp = this.rowCtrl.getGui()?.rowComp;
-        if (!rowComp) {
-            return;
-        }
+    // required for Material theme
+    rowComp.toggleCss('ag-row-inline-editing', editing);
+    rowComp.toggleCss('ag-row-not-inline-editing', !editing);
 
-        rowComp.toggleCss('ag-row-editing', fullRow && editing);
-        rowComp.toggleCss('ag-row-batch-edit', fullRow && editing && batchEdit);
-
-        // required for Material theme
-        rowComp.toggleCss('ag-row-inline-editing', editing);
-        rowComp.toggleCss('ag-row-not-inline-editing', !editing);
-
-        rowComp.toggleCss('ag-row-editing-invalid', fullRow && editing && hasErrors);
-    }
+    rowComp.toggleCss('ag-row-editing-invalid', fullRow && editing && hasErrors);
 }

--- a/packages/ag-grid-community/src/edit/styles/rowEditStyleFeature.ts
+++ b/packages/ag-grid-community/src/edit/styles/rowEditStyleFeature.ts
@@ -3,7 +3,7 @@ import type { RowCtrl } from '../../rendering/row/rowCtrl';
 import { _hasEdits, _hasLeafEdits, _hasPinnedEdits } from './style-utils';
 
 export function _applyRowEditStyles(beans: BeanCollection, rowCtrl: RowCtrl): void {
-    const { editModelSvc } = beans;
+    const editModelSvc = beans.editModelSvc;
 
     let rowNode = rowCtrl.rowNode;
     let edits = editModelSvc?.getEditRow(rowNode);
@@ -29,7 +29,12 @@ export function _applyRowEditStyles(beans: BeanCollection, rowCtrl: RowCtrl): vo
     applyStyle(beans, rowCtrl, hasErrors);
 }
 
-function applyStyle(beans: BeanCollection, rowCtrl: RowCtrl, hasErrors: boolean = false, editing: boolean = false) {
+function applyStyle(
+    beans: BeanCollection,
+    rowCtrl: RowCtrl,
+    hasErrors: boolean = false,
+    editing: boolean = false
+): void {
     const batchEdit = !!beans.editSvc?.isBatchEditing();
     const fullRow = beans.gos.get('editType') === 'fullRow';
 

--- a/packages/ag-grid-community/src/edit/utils/editors.ts
+++ b/packages/ag-grid-community/src/edit/utils/editors.ts
@@ -738,7 +738,7 @@ export function _populateModelValidationErrors(beans: BeanCollection, force?: bo
     }
 
     for (const rowCtrl of rowCtrlSet.values()) {
-        rowCtrl.rowEditStyleFeature?.applyRowStyles();
+        beans.editSvc?.applyRowEditStyles(rowCtrl);
         for (const cellCtrl of rowCtrl.getAllCellCtrls()) {
             cellCtrl.tooltipFeature?.refreshTooltip(true);
             cellCtrl.editorTooltipFeature?.refreshTooltip(true);

--- a/packages/ag-grid-community/src/interfaces/iRowStyleFeature.ts
+++ b/packages/ag-grid-community/src/interfaces/iRowStyleFeature.ts
@@ -1,7 +1,0 @@
-import type { AgBaseBean } from 'ag-stack';
-
-import type { BeanCollection } from '../context/context';
-
-export interface IRowStyleFeature extends AgBaseBean<BeanCollection> {
-    applyRowStyles(): void;
-}

--- a/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
@@ -607,7 +607,6 @@ export class CellCtrl extends BeanStub {
     // + rowRenderer: api softRefreshView() {}
     public refreshCell(params?: RefreshCellsParams & { newData?: boolean }): void {
         const {
-            rowCtrl: { rowEditStyleFeature },
             beans: { cellFlashSvc, filterManager, cellStyles },
             column,
             comp,
@@ -668,7 +667,7 @@ export class CellCtrl extends BeanStub {
             this.editSvc?.applyCellEditStyles(this);
             cellStyles?.applyCellUserStyles(this);
             cellStyles?.applyCellClassesFromColDef(this);
-            rowEditStyleFeature?.applyRowStyles();
+            this.editSvc?.applyRowEditStyles(this.rowCtrl);
 
             this.checkFormulaError();
         }

--- a/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
@@ -53,7 +53,13 @@ import type { CellSpan } from '../spanning/rowSpanCache';
 import { _createCellEvent } from './cellEvent';
 import { _onCellKeyDown, _processCellCharacter } from './cellKeyboardListenerFeature';
 import { _onCellMouseEvent } from './cellMouseListenerFeature';
-import { CellPositionFeature } from './cellPositionFeature';
+import {
+    _getColSpanningList,
+    _initCellPosition,
+    _onCellLeftChanged,
+    _onCellWidthChanged,
+    _setupCellPosition,
+} from './cellPositionFeature';
 
 const CSS_CELL = 'ag-cell';
 const CSS_AUTO_HEIGHT = 'ag-cell-auto-height';
@@ -116,10 +122,13 @@ export class CellCtrl extends BeanStub {
 
     public lastIPadMouseClickEvent = 0;
 
+    // per-cell positioning state, owned by the cell position functions (rendering/cell/cellPositionFeature)
+    public colsSpanning?: AgColumn[];
+    public rowSpan = 1;
+
     public rangeFeature: ICellRangeFeature | undefined = undefined;
     private rowResizeFeature: IRowNumbersRowResizeFeature | undefined = undefined;
     private notesFeature: INotesFeature | undefined = undefined;
-    private positionFeature: CellPositionFeature | undefined = undefined;
     private calculatedColumnCssApplied = false;
     private calculatedColumnHighlightedCssApplied = false;
 
@@ -166,7 +175,7 @@ export class CellCtrl extends BeanStub {
 
         this.createCellPosition();
         this.updateAndFormatValue(false);
-        this.positionFeature = new CellPositionFeature(this, beans);
+        _setupCellPosition(beans, this);
     }
 
     private addFeatures(): void {
@@ -262,7 +271,7 @@ export class CellCtrl extends BeanStub {
         this.refreshAriaRowIndex();
         this.refreshAriaColIndex();
 
-        this.positionFeature?.init();
+        _initCellPosition(this.beans, this);
         this.beans.cellStyles?.setupCellCustomStyle(this);
         this.editSvc?.applyCellEditStyles(this);
         this.tooltipFeature?.refreshTooltip();
@@ -767,14 +776,14 @@ export class CellCtrl extends BeanStub {
     }
 
     public getColSpanningList(): AgColumn[] {
-        return this.positionFeature?.getColSpanningList() ?? [];
+        return _getColSpanningList(this.beans, this);
     }
 
     public onLeftChanged(): void {
         if (!this.comp) {
             return;
         }
-        this.positionFeature?.onLeftChanged();
+        _onCellLeftChanged(this.beans, this);
     }
 
     public onDisplayedColumnsChanged(): void {
@@ -795,7 +804,7 @@ export class CellCtrl extends BeanStub {
     }
 
     public onWidthChanged(): void {
-        return this.positionFeature?.onWidthChanged();
+        _onCellWidthChanged(this);
     }
 
     public getRowPosition(): RowPosition {
@@ -1085,7 +1094,7 @@ export class CellCtrl extends BeanStub {
     public override destroy(): void {
         this.onCompAttachedFuncs = [];
         this.onEditorAttachedFuncs = [];
-        const { focusSvc, context } = this.beans;
+        const { focusSvc } = this.beans;
 
         // if this was focused; (e.g cell span status changes) then we need to restore focus
         if (this.isCellFocused() && this.hasBrowserFocus()) {
@@ -1093,8 +1102,6 @@ export class CellCtrl extends BeanStub {
         }
 
         super.destroy();
-
-        this.positionFeature = context.destroyBean(this.positionFeature);
     }
 
     public hasBrowserFocus(): boolean {

--- a/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
@@ -175,6 +175,7 @@ export class CellCtrl extends BeanStub {
 
         this.createCellPosition();
         this.updateAndFormatValue(false);
+        // must stay in the constructor, not setComp — see _setupCellPosition
         _setupCellPosition(beans, this);
     }
 
@@ -1094,11 +1095,10 @@ export class CellCtrl extends BeanStub {
     public override destroy(): void {
         this.onCompAttachedFuncs = [];
         this.onEditorAttachedFuncs = [];
-        const { focusSvc } = this.beans;
 
         // if this was focused; (e.g cell span status changes) then we need to restore focus
         if (this.isCellFocused() && this.hasBrowserFocus()) {
-            focusSvc.attemptToRecoverFocus();
+            this.beans.focusSvc.attemptToRecoverFocus();
         }
 
         super.destroy();

--- a/packages/ag-grid-community/src/rendering/cell/cellPositionFeature.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellPositionFeature.ts
@@ -38,25 +38,6 @@ function setupRowSpan(beans: BeanCollection, cellCtrl: CellCtrl): void {
     cellCtrl.addManagedListeners(beans.eventSvc, { newColumnsLoaded: () => onNewColumnsLoaded(beans, cellCtrl) });
 }
 
-function setupColSpan(beans: BeanCollection, cellCtrl: CellCtrl): void {
-    // if no col span is active, then we don't set it up, as it would be wasteful of CPU
-    if (cellCtrl.column.colDef.colSpan == null) {
-        return;
-    }
-
-    cellCtrl.colsSpanning = _getColSpanningList(beans, cellCtrl);
-
-    cellCtrl.addManagedListeners(beans.eventSvc, {
-        // because we are col spanning, a reorder of the cols can change what cols we are spanning over
-        displayedColumnsChanged: () => onDisplayColumnsChanged(beans, cellCtrl),
-        // because we are spanning over multiple cols, we check for width any time any cols width changes.
-        // this is expensive - really we should be explicitly checking only the cols we are spanning over
-        // instead of every col, however it would be tricky code to track the cols we are spanning over, so
-        // because hardly anyone will be using colSpan, am favouring this easier way for more maintainable code.
-        displayedColumnsWidthChanged: () => _onCellWidthChanged(cellCtrl),
-    });
-}
-
 // Called each time the cell component attaches (initial mount and any remount).
 export function _initCellPosition(beans: BeanCollection, cellCtrl: CellCtrl): void {
     _onCellLeftChanged(beans, cellCtrl);
@@ -95,6 +76,25 @@ function onDisplayColumnsChanged(beans: BeanCollection, cellCtrl: CellCtrl): voi
         _onCellWidthChanged(cellCtrl);
         _onCellLeftChanged(beans, cellCtrl); // left changes when doing RTL
     }
+}
+
+function setupColSpan(beans: BeanCollection, cellCtrl: CellCtrl): void {
+    // if no col span is active, then we don't set it up, as it would be wasteful of CPU
+    if (cellCtrl.column.colDef.colSpan == null) {
+        return;
+    }
+
+    cellCtrl.colsSpanning = _getColSpanningList(beans, cellCtrl);
+
+    cellCtrl.addManagedListeners(beans.eventSvc, {
+        // because we are col spanning, a reorder of the cols can change what cols we are spanning over
+        displayedColumnsChanged: () => onDisplayColumnsChanged(beans, cellCtrl),
+        // because we are spanning over multiple cols, we check for width any time any cols width changes.
+        // this is expensive - really we should be explicitly checking only the cols we are spanning over
+        // instead of every col, however it would be tricky code to track the cols we are spanning over, so
+        // because hardly anyone will be using colSpan, am favouring this easier way for more maintainable code.
+        displayedColumnsWidthChanged: () => _onCellWidthChanged(cellCtrl),
+    });
 }
 
 export function _onCellWidthChanged(cellCtrl: CellCtrl): void {

--- a/packages/ag-grid-community/src/rendering/cell/cellPositionFeature.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellPositionFeature.ts
@@ -1,9 +1,7 @@
 import { _areEqual, _missing } from 'ag-stack';
 
-import { BeanStub } from '../../context/beanStub';
 import type { BeanCollection } from '../../context/context';
 import type { AgColumn } from '../../entities/agColumn';
-import type { RowNode } from '../../entities/rowNode';
 import { _getRowHeightAsNumber } from '../../gridOptionsUtils';
 import { applyHorizontalPosition, getResolvedHorizontalOffset } from '../features/horizontalPositionUtils';
 import type { CellSpan } from '../spanning/rowSpanCache';
@@ -15,213 +13,190 @@ import type { CellCtrl } from './cellCtrl';
  *  #) Cell Height (when doing row span, otherwise we don't touch the height as it's just row height)
  *  #) Cell Left (the horizontal positioning of the cell, the vertical positioning is on the row)
  */
-export class CellPositionFeature extends BeanStub {
-    private readonly column: AgColumn;
-    private readonly rowNode: RowNode;
-
-    private colsSpanning: AgColumn[];
-    private rowSpan: number;
-
-    constructor(
-        private readonly cellCtrl: CellCtrl,
-        beans: BeanCollection
-    ) {
-        super();
-
-        this.beans = beans;
-
-        this.column = cellCtrl.column;
-        this.rowNode = cellCtrl.rowNode;
-
-        // Listener setup runs in the constructor (before the cell component attaches) so that
-        // getColSpanningList() is available as soon as the CellCtrl exists. This is required in
-        // React, where setComp() is called asynchronously, but navigation normalisation may query
-        // the position feature synchronously before the first render completes.
-        const cellSpan = cellCtrl.getCellSpan();
-        if (cellSpan) {
-            const refreshSpanHeight = this.refreshSpanHeight.bind(this, cellSpan);
-            this.addManagedListeners(this.beans.eventSvc, {
-                paginationChanged: refreshSpanHeight,
-                recalculateRowBounds: refreshSpanHeight,
-                pinnedHeightChanged: refreshSpanHeight,
-            });
-        } else {
-            this.setupColSpan();
-            this.setupRowSpan();
-        }
-    }
-
-    private setupRowSpan(): void {
-        this.rowSpan = this.column.getRowSpan(this.rowNode);
-
-        this.addManagedListeners(this.beans.eventSvc, { newColumnsLoaded: () => this.onNewColumnsLoaded() });
-    }
-
-    // Called each time the cell component attaches (initial mount and any remount).
-    public init(): void {
-        this.onLeftChanged();
-        this.onWidthChanged();
-        const cellSpan = this.cellCtrl.getCellSpan();
-        if (cellSpan) {
-            this.refreshSpanHeight(cellSpan);
-        } else {
-            this._legacyApplyRowSpan();
-        }
-    }
-
-    private refreshSpanHeight(cellSpan: CellSpan) {
-        const spanHeight = cellSpan.getCellHeight();
-        const eContent = this.cellCtrl.eGui;
-        if (spanHeight != null && eContent) {
-            eContent.style.height = `${spanHeight}px`;
-        }
-    }
-
-    private onNewColumnsLoaded(): void {
-        const rowSpan = this.column.getRowSpan(this.rowNode);
-        if (this.rowSpan === rowSpan) {
-            return;
-        }
-
-        this.rowSpan = rowSpan;
-        this._legacyApplyRowSpan(true);
-    }
-
-    private onDisplayColumnsChanged(): void {
-        const colsSpanning = this.getColSpanningList();
-
-        if (!_areEqual(this.colsSpanning, colsSpanning)) {
-            this.colsSpanning = colsSpanning;
-            this.onWidthChanged();
-            this.onLeftChanged(); // left changes when doing RTL
-        }
-    }
-
-    private setupColSpan(): void {
-        // if no col span is active, then we don't set it up, as it would be wasteful of CPU
-        if (this.column.colDef.colSpan == null) {
-            return;
-        }
-
-        this.colsSpanning = this.getColSpanningList();
-
-        this.addManagedListeners(this.beans.eventSvc, {
-            // because we are col spanning, a reorder of the cols can change what cols we are spanning over
-            displayedColumnsChanged: this.onDisplayColumnsChanged.bind(this),
-            // because we are spanning over multiple cols, we check for width any time any cols width changes.
-            // this is expensive - really we should be explicitly checking only the cols we are spanning over
-            // instead of every col, however it would be tricky code to track the cols we are spanning over, so
-            // because hardly anyone will be using colSpan, am favouring this easier way for more maintainable code.
-            displayedColumnsWidthChanged: this.onWidthChanged.bind(this),
+export function _setupCellPosition(beans: BeanCollection, cellCtrl: CellCtrl): void {
+    // Listener setup runs from the CellCtrl constructor (before the cell component attaches) so that
+    // getColSpanningList() is available as soon as the CellCtrl exists. This is required in
+    // React, where setComp() is called asynchronously, but navigation normalisation may query
+    // the cell position synchronously before the first render completes.
+    const cellSpan = cellCtrl.getCellSpan();
+    if (cellSpan) {
+        const refreshSpanHeight = () => applySpanHeight(cellCtrl, cellSpan);
+        cellCtrl.addManagedListeners(beans.eventSvc, {
+            paginationChanged: refreshSpanHeight,
+            recalculateRowBounds: refreshSpanHeight,
+            pinnedHeightChanged: refreshSpanHeight,
         });
+    } else {
+        setupColSpan(beans, cellCtrl);
+        setupRowSpan(beans, cellCtrl);
+    }
+}
+
+function setupRowSpan(beans: BeanCollection, cellCtrl: CellCtrl): void {
+    cellCtrl.rowSpan = cellCtrl.column.getRowSpan(cellCtrl.rowNode);
+
+    cellCtrl.addManagedListeners(beans.eventSvc, { newColumnsLoaded: () => onNewColumnsLoaded(beans, cellCtrl) });
+}
+
+function setupColSpan(beans: BeanCollection, cellCtrl: CellCtrl): void {
+    // if no col span is active, then we don't set it up, as it would be wasteful of CPU
+    if (cellCtrl.column.colDef.colSpan == null) {
+        return;
     }
 
-    public onWidthChanged(): void {
-        const eContent = this.cellCtrl.eGui;
-        if (!eContent) {
-            return;
-        }
-        eContent.style.width = `${this.getCellWidth()}px`;
+    cellCtrl.colsSpanning = _getColSpanningList(beans, cellCtrl);
+
+    cellCtrl.addManagedListeners(beans.eventSvc, {
+        // because we are col spanning, a reorder of the cols can change what cols we are spanning over
+        displayedColumnsChanged: () => onDisplayColumnsChanged(beans, cellCtrl),
+        // because we are spanning over multiple cols, we check for width any time any cols width changes.
+        // this is expensive - really we should be explicitly checking only the cols we are spanning over
+        // instead of every col, however it would be tricky code to track the cols we are spanning over, so
+        // because hardly anyone will be using colSpan, am favouring this easier way for more maintainable code.
+        displayedColumnsWidthChanged: () => _onCellWidthChanged(cellCtrl),
+    });
+}
+
+// Called each time the cell component attaches (initial mount and any remount).
+export function _initCellPosition(beans: BeanCollection, cellCtrl: CellCtrl): void {
+    _onCellLeftChanged(beans, cellCtrl);
+    _onCellWidthChanged(cellCtrl);
+    const cellSpan = cellCtrl.getCellSpan();
+    if (cellSpan) {
+        applySpanHeight(cellCtrl, cellSpan);
+    } else {
+        legacyApplyRowSpan(beans, cellCtrl);
+    }
+}
+
+function applySpanHeight(cellCtrl: CellCtrl, cellSpan: CellSpan): void {
+    const spanHeight = cellSpan.getCellHeight();
+    const eContent = cellCtrl.eGui;
+    if (spanHeight != null && eContent) {
+        eContent.style.height = `${spanHeight}px`;
+    }
+}
+
+function onNewColumnsLoaded(beans: BeanCollection, cellCtrl: CellCtrl): void {
+    const rowSpan = cellCtrl.column.getRowSpan(cellCtrl.rowNode);
+    if (cellCtrl.rowSpan === rowSpan) {
+        return;
     }
 
-    private getCellWidth(): number {
-        if (!this.colsSpanning) {
-            return this.column.getActualWidth();
-        }
-        const cols = this.colsSpanning;
-        let width = 0;
-        for (let i = 0, len = cols.length; i < len; ++i) {
-            width += cols[i].actualWidth;
-        }
-        return width;
+    cellCtrl.rowSpan = rowSpan;
+    legacyApplyRowSpan(beans, cellCtrl, true);
+}
+
+function onDisplayColumnsChanged(beans: BeanCollection, cellCtrl: CellCtrl): void {
+    const colsSpanning = _getColSpanningList(beans, cellCtrl);
+
+    if (!_areEqual(cellCtrl.colsSpanning, colsSpanning)) {
+        cellCtrl.colsSpanning = colsSpanning;
+        _onCellWidthChanged(cellCtrl);
+        _onCellLeftChanged(beans, cellCtrl); // left changes when doing RTL
     }
+}
 
-    public getColSpanningList(): AgColumn[] {
-        const { column, rowNode } = this;
-        const colSpan = column.getColSpan(rowNode);
-        const colsSpanning: AgColumn[] = [];
+export function _onCellWidthChanged(cellCtrl: CellCtrl): void {
+    const eContent = cellCtrl.eGui;
+    if (!eContent) {
+        return;
+    }
+    eContent.style.width = `${getCellWidth(cellCtrl)}px`;
+}
 
-        // if just one col, the col span is just the column we are in
-        if (colSpan === 1) {
-            colsSpanning.push(column);
-        } else {
-            let pointer: AgColumn | null = column;
-            const pinned = column.getPinned();
-            for (let i = 0; pointer && i < colSpan; i++) {
-                colsSpanning.push(pointer);
-                pointer = this.beans.visibleCols.getColAfter(pointer);
-                if (!pointer || _missing(pointer)) {
-                    break;
-                }
-                // we do not allow col spanning to span outside of pinned areas
-                if (pinned !== pointer.getPinned()) {
-                    break;
-                }
+function getCellWidth(cellCtrl: CellCtrl): number {
+    const { colsSpanning, column } = cellCtrl;
+    if (!colsSpanning) {
+        return column.getActualWidth();
+    }
+    let width = 0;
+    for (let i = 0, len = colsSpanning.length; i < len; ++i) {
+        width += colsSpanning[i].actualWidth;
+    }
+    return width;
+}
+
+export function _getColSpanningList(beans: BeanCollection, cellCtrl: CellCtrl): AgColumn[] {
+    const { column, rowNode } = cellCtrl;
+    const colSpan = column.getColSpan(rowNode);
+    const colsSpanning: AgColumn[] = [];
+
+    // if just one col, the col span is just the column we are in
+    if (colSpan === 1) {
+        colsSpanning.push(column);
+    } else {
+        let pointer: AgColumn | null = column;
+        const pinned = column.getPinned();
+        for (let i = 0; pointer && i < colSpan; i++) {
+            colsSpanning.push(pointer);
+            pointer = beans.visibleCols.getColAfter(pointer);
+            if (!pointer || _missing(pointer)) {
+                break;
+            }
+            // we do not allow col spanning to span outside of pinned areas
+            if (pinned !== pointer.getPinned()) {
+                break;
             }
         }
-
-        return colsSpanning;
     }
 
-    public onLeftChanged(): void {
-        const eSetLeft = this.cellCtrl.getRootElement();
-        if (!eSetLeft) {
-            return;
-        }
-        const { gos, visibleCols } = this.beans;
-        const left = getResolvedHorizontalOffset({
-            left: this.getCellLeft(),
-            pinned: this.column.getPinned(),
-            width: this.getCellWidth(),
-            isPrintLayout: this.cellCtrl.printLayout,
-            isRtl: gos.get('enableRtl'),
-            visibleCols,
-        });
-        if (left == null) {
-            return;
-        }
+    return colsSpanning;
+}
 
-        this.setHorizontalPosition(eSetLeft, left);
+export function _onCellLeftChanged(beans: BeanCollection, cellCtrl: CellCtrl): void {
+    const eSetLeft = cellCtrl.getRootElement();
+    if (!eSetLeft) {
+        return;
+    }
+    const { gos, visibleCols } = beans;
+    const left = getResolvedHorizontalOffset({
+        left: getCellLeft(cellCtrl),
+        pinned: cellCtrl.column.getPinned(),
+        width: getCellWidth(cellCtrl),
+        isPrintLayout: cellCtrl.printLayout,
+        isRtl: gos.get('enableRtl'),
+        visibleCols,
+    });
+    if (left == null) {
+        return;
     }
 
-    private getCellLeft(): number | null {
-        // column.getLeft() is "distance from start edge" — in both LTR and RTL,
-        // this.column is the start-edge column of any col-spanning range.
-        return this.column.getLeft();
+    setHorizontalPosition(beans, cellCtrl, eSetLeft, left);
+}
+
+function getCellLeft(cellCtrl: CellCtrl): number | null {
+    // column.getLeft() is "distance from start edge" — in both LTR and RTL,
+    // the cell's column is the start-edge column of any col-spanning range.
+    return cellCtrl.column.getLeft();
+}
+
+function setHorizontalPosition(beans: BeanCollection, cellCtrl: CellCtrl, eSetLeft: HTMLElement, left: number): void {
+    const { gos, visibleCols } = beans;
+    applyHorizontalPosition(eSetLeft, {
+        offset: left,
+        pinned: cellCtrl.column.getPinned(),
+        width: getCellWidth(cellCtrl),
+        isPrintLayout: cellCtrl.printLayout,
+        isRtl: gos.get('enableRtl'),
+        visibleCols,
+    });
+}
+
+function legacyApplyRowSpan(beans: BeanCollection, cellCtrl: CellCtrl, force?: boolean): void {
+    if (cellCtrl.rowSpan === 1 && !force) {
+        return;
     }
 
-    private setHorizontalPosition(eSetLeft: HTMLElement, left: number): void {
-        const { gos, visibleCols } = this.beans;
-        applyHorizontalPosition(eSetLeft, {
-            offset: left,
-            pinned: this.column.getPinned(),
-            width: this.getCellWidth(),
-            isPrintLayout: this.cellCtrl.printLayout,
-            isRtl: gos.get('enableRtl'),
-            visibleCols,
-        });
+    const eContent = cellCtrl.eGui;
+    if (!eContent) {
+        return;
     }
 
-    private _legacyApplyRowSpan(force?: boolean): void {
-        if (this.rowSpan === 1 && !force) {
-            return;
-        }
+    const singleRowHeight = _getRowHeightAsNumber(beans);
+    const totalRowHeight = singleRowHeight * cellCtrl.rowSpan;
 
-        const eContent = this.cellCtrl.eGui;
-        if (!eContent) {
-            return;
-        }
-
-        const singleRowHeight = _getRowHeightAsNumber(this.beans);
-        const totalRowHeight = singleRowHeight * this.rowSpan;
-
-        eContent.style.height = `${totalRowHeight}px`;
-        // row-spanned cell content must sit above normal cells in the same row.
-        eContent.style.zIndex = '1';
-    }
-
-    // overriding to make public, as we don't dispose this bean via context
-    public override destroy() {
-        super.destroy();
-    }
+    eContent.style.height = `${totalRowHeight}px`;
+    // row-spanned cell content must sit above normal cells in the same row.
+    eContent.style.zIndex = '1';
 }

--- a/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
@@ -47,7 +47,6 @@ import type { WithoutGridCommon } from '../../interfaces/iCommon';
 import type { HorizontalSection, HorizontalSectionMap } from '../../interfaces/iGridSection';
 import type { DataChangedEvent, IRowNode } from '../../interfaces/iRowNode';
 import type { RowPosition } from '../../interfaces/iRowPosition';
-import type { IRowStyleFeature } from '../../interfaces/iRowStyleFeature';
 import type { UserCompDetails } from '../../interfaces/iUserCompDetails';
 import type { GetNoteParams } from '../../interfaces/notes';
 import { calculateRowLevel } from '../../styling/rowStyleService';
@@ -142,7 +141,6 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
     /** sanitised */
     public businessKey: string | null = null;
     private businessKeyForNodeFunc: ((node: IRowNode<any>) => string) | undefined;
-    public rowEditStyleFeature?: IRowStyleFeature;
 
     public isEmbeddedFullWidth = false;
     public embeddedSectionHasContent: HorizontalSectionMap<boolean> = {
@@ -176,8 +174,6 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         this.setAnimateFlags(animateIn);
         this.rowStyles = this.processStylesFromGridOptions();
         this.rowModeFeature = this.createRowModeFeature();
-
-        this.rowEditStyleFeature = beans.editSvc?.createRowStyleFeature(this);
 
         this.addListeners();
 
@@ -376,7 +372,6 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         this.rowDragComps.push(rowDragBean);
         rowGui.compBean.addDestroyFunc(() => {
             this.rowDragComps = this.rowDragComps.filter((r) => r !== rowDragBean);
-            this.rowEditStyleFeature = this.destroyBean(this.rowEditStyleFeature, this.beans.context);
             this.destroyBean(rowDragBean, this.beans.context);
         });
     }
@@ -653,7 +648,6 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
 
         this.addDestroyFunc(() => {
             this.rowDragComps = this.destroyBeans(this.rowDragComps, context);
-            this.rowEditStyleFeature = this.destroyBean(this.rowEditStyleFeature, context);
         });
 
         this.addManagedPropertyListeners(
@@ -698,7 +692,7 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         this.setStylesFromGridOptions(true);
         this.postProcessClassesFromGridOptions();
         this.postProcessRowClassRules();
-        this.rowEditStyleFeature?.applyRowStyles();
+        this.beans.editSvc?.applyRowEditStyles(this);
         this.postProcessRowDragging();
     }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-15464

Second pass of the AG-15464 feature-class→function conversion (follows #14215). Converts two more per-instance feature helpers in `ag-grid-community` from classes to stateless module-level functions, relocating their per-instance state onto the controller:

- **`RowEditStyleFeature`** → `_applyRowEditStyles(beans, rowCtrl)`, exposed via `EditService.applyRowEditStyles` (mirrors the existing `applyCellEditStyles`). `IRowStyleFeature` removed.
- **`CellPositionFeature`** → module functions (`_setupCellPosition`, `_initCellPosition`, `_getColSpanningList`, `_onCellLeftChanged`, `_onCellWidthChanged`). `colsSpanning`/`rowSpan` state moved onto `CellCtrl`; the position event-listeners now register via `cellCtrl.addManagedListeners` — identical lifetime, they die with the cell. Setup stays in the `CellCtrl` constructor (commented) to preserve the React invariant that `getColSpanningList()` is queryable before first render.

Removes one allocation per rendered cell/row (memory) plus the class shells (bundle). Behaviour-preserving, with one deliberate exception below.

### Intentional incidental fix
Removes a redundant `rowEditStyleFeature` teardown bundled into `addRowDraggerToRow`'s `compBean` destroy callback (added incidentally in #10772 — empty PR body, no rationale in PR/JIRA). A second canonical teardown already exists on `RowCtrl`'s own destroy. In the old code that callback could null the feature on a draggable row whose GUI was torn down while the `RowCtrl` survived, permanently silencing its row-edit styling — but that state isn't reachable via public API in vanilla (the recycle path either destroys the ctrl or stops editing first), so this is dead/redundant teardown, not a user-facing behaviour change. The function form simply has no object to null.

### Performance
Incremental A/B (parent vs this branch, 60k unvirtualised cells): allocated bytes/cycle **−3.2%**, live JS heap **−2.0%** (both tight sd); JS script time trended down (within noise). Bundle size also reduced.

### Test plan
- `yarn nx build:types ag-grid-community`, `yarn nx lint ag-grid-community` — green
- Behavioural: spanning (56), columns (1230), navigation (134), pinning/RTL (2609), cell-editing (777), full-row + batch-edit styles (32) — all green

Fix [AG-15464](https://ag-grid.atlassian.net/browse/AG-15464)