### PR TITLE
AG-15464 Add on-demand CellCtrl memory benchmark (debug tool)

### DIFF
--- a/scripts/ci/_utils.mjs
+++ b/scripts/ci/_utils.mjs
@@ -87,6 +87,58 @@ export function getStats(parsedReport, context) {
         : '';
 }
 
+function formatMemoryBytes(bytes) {
+    const abs = Math.abs(bytes);
+    if (abs < 1024) {
+        return `${bytes} B`;
+    }
+    if (abs < 1024 * 1024) {
+        return `${(bytes / 1024).toFixed(1)} KB`;
+    }
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// Render any `memory`-type annotations (from informational memory benchmarks, e.g.
+// cell-memory.spec.ts) into the PR comment. Returns '' when there are none, so timing-only
+// runs are unaffected.
+export function getMemoryStats(parsedReport, context, section) {
+    const tests = parsedReport?.results?.tests;
+    if (!tests) {
+        return '';
+    }
+
+    const blocks = [];
+    for (const test of tests) {
+        const annotation = test.extra?.annotations?.find((a) => a && a.type === 'memory');
+        if (!annotation) {
+            continue;
+        }
+
+        let summary;
+        try {
+            summary =
+                typeof annotation.description === 'string'
+                    ? JSON.parse(annotation.description)
+                    : annotation.description;
+        } catch {
+            continue;
+        }
+        if (!summary?.control || !summary?.variant) {
+            continue;
+        }
+
+        const { control, variant } = summary;
+        const lines = [
+            summary.scenario,
+            `allocated/run  ${control.version}: ${formatMemoryBytes(control.allocBytes)}  ${variant.version}: ${formatMemoryBytes(variant.allocBytes)}  Δ ${summary.allocDeltaPct.toFixed(1)}%`,
+            `retained (GC)  ${control.version}: ${formatMemoryBytes(control.retainedBytes)}  ${variant.version}: ${formatMemoryBytes(variant.retainedBytes)}  Δ ${formatMemoryBytes(summary.retainedDeltaBytes)}`,
+        ];
+        blocks.push(section(lines.join('\n')));
+    }
+
+    return blocks.length ? context('Memory benchmarks (informational)') + blocks.join('') : '';
+}
+
 const JIRA_API_URL = 'https://ag-grid.atlassian.net/rest/api/2';
 
 // Transition an issue to a new status

--- a/scripts/ci/gen-gh-comment.mjs
+++ b/scripts/ci/gen-gh-comment.mjs
@@ -9,6 +9,7 @@ import {
     getGitDiffLinks,
     getGitHashFromTest,
     getHeader,
+    getMemoryStats,
     getStats,
     parseCtrfReport,
 } from './_utils.mjs';
@@ -40,8 +41,9 @@ const header = getHeader(
     section
 );
 const statsTemplate = getStats(parsedReport, context);
+const memoryStats = getMemoryStats(parsedReport, context, section);
 const diffLinks = getGitDiffLinks(repoUrl, currentCommitSha, previousCommitSha, context, section, mdLink, parsedReport);
-const content = [header, statsTemplate, diffLinks].join('\n').trim();
+const content = [header, statsTemplate, memoryStats, diffLinks].filter(Boolean).join('\n').trim();
 
 fs.writeFileSync(commentFileName, content + '\n');
 

--- a/testing/performance/cdp.utils.ts
+++ b/testing/performance/cdp.utils.ts
@@ -1,0 +1,115 @@
+import type { CDPSession, Page } from '@playwright/test';
+
+export interface HeapUsage {
+    usedSize: number;
+    totalSize: number;
+}
+
+export interface AllocationProfile {
+    /** Total bytes allocated (sampled) during the profiled action */
+    totalAllocatedBytes: number;
+}
+
+export interface PerformanceCounters {
+    [name: string]: number;
+}
+
+/**
+ * Create a Chrome DevTools Protocol session for low-level browser instrumentation.
+ */
+export async function createCDPSession(page: Page): Promise<CDPSession> {
+    return page.context().newCDPSession(page);
+}
+
+/**
+ * Get precise V8 heap usage via Runtime.getHeapUsage.
+ */
+export async function getHeapUsage(cdp: CDPSession): Promise<HeapUsage> {
+    const result = await cdp.send('Runtime.getHeapUsage');
+    return {
+        usedSize: result.usedSize,
+        totalSize: result.totalSize,
+    };
+}
+
+/**
+ * Force a garbage collection cycle via HeapProfiler.collectGarbage.
+ */
+export async function forceGC(cdp: CDPSession): Promise<void> {
+    await cdp.send('HeapProfiler.collectGarbage');
+}
+
+/**
+ * Double-GC: two collection cycles to ensure weak references and
+ * weak collections are fully cleaned up.
+ */
+export async function doubleGC(cdp: CDPSession): Promise<void> {
+    await forceGC(cdp);
+    await forceGC(cdp);
+}
+
+/**
+ * Enable V8 performance counter collection.
+ */
+export async function enablePerformanceMetrics(cdp: CDPSession): Promise<void> {
+    await cdp.send('Performance.enable', { timeDomain: 'timeTicks' });
+}
+
+/**
+ * Get V8 performance counters (JSHeapUsedSize, ScriptDuration, etc.)
+ * as a flat key→value map.
+ */
+export async function getPerformanceMetrics(cdp: CDPSession): Promise<PerformanceCounters> {
+    const { metrics } = await cdp.send('Performance.getMetrics');
+    const result: PerformanceCounters = {};
+    for (let i = 0, len = metrics.length; i < len; i++) {
+        result[metrics[i].name] = metrics[i].value;
+    }
+    return result;
+}
+
+/**
+ * Run an action while capturing a heap allocation sampling profile.
+ * Returns the total bytes allocated (sampled at the given interval).
+ */
+export async function captureAllocationProfile(
+    cdp: CDPSession,
+    action: () => Promise<void>,
+    samplingInterval: number = 256
+): Promise<AllocationProfile> {
+    await cdp.send('HeapProfiler.startSampling', { samplingInterval });
+
+    await action();
+
+    const { profile } = await cdp.send('HeapProfiler.stopSampling');
+
+    // Walk the allocation profile tree and sum selfSize at every node
+    let totalAllocatedBytes = 0;
+    function walkNodes(node: { selfSize: number; children: (typeof node)[] }): void {
+        totalAllocatedBytes += node.selfSize || 0;
+        const children = node.children || [];
+        for (let i = 0, len = children.length; i < len; i++) {
+            walkNodes(children[i]);
+        }
+    }
+    walkNodes(profile.head);
+
+    return { totalAllocatedBytes };
+}
+
+/**
+ * Format bytes into a human-readable string.
+ */
+export function formatBytes(bytes: number): string {
+    if (Math.abs(bytes) < 1024) {
+        return `${bytes} B`;
+    }
+    const units = ['KB', 'MB', 'GB'];
+    let value = bytes;
+    let unitIndex = -1;
+    do {
+        value /= 1024;
+        unitIndex++;
+    } while (Math.abs(value) >= 1024 && unitIndex < units.length - 1);
+    return `${value.toFixed(1)} ${units[unitIndex]}`;
+}

--- a/testing/performance/cdp.utils.ts
+++ b/testing/performance/cdp.utils.ts
@@ -14,6 +14,11 @@ export interface PerformanceCounters {
     [name: string]: number;
 }
 
+interface AllocationNode {
+    selfSize: number;
+    children?: AllocationNode[];
+}
+
 /**
  * Create a Chrome DevTools Protocol session for low-level browser instrumentation.
  */
@@ -79,20 +84,28 @@ export async function captureAllocationProfile(
 ): Promise<AllocationProfile> {
     await cdp.send('HeapProfiler.startSampling', { samplingInterval });
 
-    await action();
-
-    const { profile } = await cdp.send('HeapProfiler.stopSampling');
+    let head: AllocationNode | undefined;
+    try {
+        await action();
+    } finally {
+        // always stop the sampler, even if the action throws or times out — otherwise it
+        // stays enabled and contaminates later measurements
+        const { profile } = await cdp.send('HeapProfiler.stopSampling');
+        head = profile.head;
+    }
 
     // Walk the allocation profile tree and sum selfSize at every node
     let totalAllocatedBytes = 0;
-    function walkNodes(node: { selfSize: number; children: (typeof node)[] }): void {
+    function walkNodes(node: AllocationNode): void {
         totalAllocatedBytes += node.selfSize || 0;
-        const children = node.children || [];
+        const children = node.children ?? [];
         for (let i = 0, len = children.length; i < len; i++) {
             walkNodes(children[i]);
         }
     }
-    walkNodes(profile.head);
+    if (head) {
+        walkNodes(head);
+    }
 
     return { totalAllocatedBytes };
 }

--- a/testing/performance/e2e/cell-memory.cron.spec.ts
+++ b/testing/performance/e2e/cell-memory.cron.spec.ts
@@ -1,0 +1,147 @@
+import type { Page } from '@playwright/test';
+import { test } from '@playwright/test';
+
+import { getCdnUrl } from '../benchmarking';
+import type { Version } from '../benchmarking';
+import {
+    captureAllocationProfile,
+    createCDPSession,
+    doubleGC,
+    enablePerformanceMetrics,
+    formatBytes,
+    getHeapUsage,
+    getPerformanceMetrics,
+} from '../cdp.utils';
+import type { AllocationProfile } from '../cdp.utils';
+import { gotoUrl, waitFor } from '../playwright.utils';
+
+// Informational CI memory benchmark for the per-cell/per-row CellCtrl footprint (AG-15464).
+// Scrolling a non-column-virtualised 100k-row grid churns row virtualisation, so cell
+// controllers (and their feature state) are created/destroyed repeatedly — the path the
+// feature->function conversions affect. We compare published prod vs staging so each
+// scheduled run is a self-contained delta; no cross-run store is needed.
+//
+// This spec never throws: it records numbers as annotations (surfaced in CTRF under
+// test.extra.annotations) and logs a human-readable report. It is intentionally NOT a
+// gate — adding a threshold later would turn it into a regression guard.
+
+const scrollPage = `/testing/performance/e2e/scroll-benchmark.html`;
+const gridReadyCheck = () => document.querySelector('.ag-row') !== null;
+
+const CONTROL: Version = 'prod';
+const VARIANT: Version = 'staging';
+
+const SCROLL_BURSTS = 5;
+const SCROLL_FROM = 100;
+const SCROLL_TO = 500;
+const SCROLL_STEP = 20;
+
+interface VersionResult {
+    version: Version;
+    allocations: AllocationProfile;
+    /** Heap retained after scroll + GC, relative to the pre-scroll baseline (leak indicator). */
+    retainedBytes: number;
+    scriptMs: number;
+}
+
+async function attachGridScripts(page: Page, version: Version): Promise<void> {
+    await page.addScriptTag({ url: getCdnUrl('ag-grid-community', version), type: 'text/javascript' });
+    await waitFor(() => typeof (globalThis as any).agGrid !== 'undefined', page, { timeout: 10_000 });
+}
+
+async function measureVersion(page: Page, version: Version): Promise<VersionResult> {
+    const cdp = await createCDPSession(page);
+    await enablePerformanceMetrics(cdp);
+
+    await gotoUrl(page, scrollPage);
+    await attachGridScripts(page, version);
+    await page.getByText('Run grid').click({ force: true });
+    await waitFor(gridReadyCheck, page);
+
+    // warm-up scroll to JIT-compile the hot paths before measuring
+    await page.evaluate(() => (window as any).scrollToRow(50));
+    await page.waitForTimeout(200);
+    await page.evaluate(() => (window as any).scrollToRow(0));
+    await page.waitForTimeout(200);
+
+    await doubleGC(cdp);
+    const heapBefore = await getHeapUsage(cdp);
+    const metricsBefore = await getPerformanceMetrics(cdp);
+
+    const allocations = await captureAllocationProfile(cdp, async () => {
+        for (let i = 0; i < SCROLL_BURSTS; i++) {
+            await page.evaluate(() => (window as any).scrollToRow(0));
+            await page.waitForTimeout(50);
+            await page.evaluate(
+                ([from, to, step]: [number, number, number]) => (window as any).scrollBurst(from, to, step),
+                [SCROLL_FROM, SCROLL_TO, SCROLL_STEP] as [number, number, number]
+            );
+        }
+    });
+
+    // retained memory after a GC — a leak indicator distinct from transient allocation
+    await doubleGC(cdp);
+    const heapAfterGC = await getHeapUsage(cdp);
+    const metricsAfter = await getPerformanceMetrics(cdp);
+
+    await cdp.detach();
+
+    const scriptMs = ((metricsAfter['ScriptDuration'] ?? 0) - (metricsBefore['ScriptDuration'] ?? 0)) * 1000;
+
+    return {
+        version,
+        allocations,
+        retainedBytes: heapAfterGC.usedSize - heapBefore.usedSize,
+        scriptMs,
+    };
+}
+
+function pctDelta(control: number, variant: number): number {
+    return control !== 0 ? ((variant - control) / control) * 100 : 0;
+}
+
+test.describe('CellCtrl memory footprint (scroll churn)', () => {
+    test.setTimeout(10 * 60_000);
+
+    test(`Scheduled: scroll-churn memory — ${CONTROL} vs ${VARIANT}`, async ({ page }, testInfo) => {
+        const control = await measureVersion(page, CONTROL);
+        const variant = await measureVersion(page, VARIANT);
+
+        const allocControl = control.allocations.totalAllocatedBytes;
+        const allocVariant = variant.allocations.totalAllocatedBytes;
+
+        const summary = {
+            scenario: 'scroll-churn (20 cols, 100k rows, 5 bursts)',
+            control: {
+                version: CONTROL,
+                allocBytes: allocControl,
+                retainedBytes: control.retainedBytes,
+                scriptMs: control.scriptMs,
+            },
+            variant: {
+                version: VARIANT,
+                allocBytes: allocVariant,
+                retainedBytes: variant.retainedBytes,
+                scriptMs: variant.scriptMs,
+            },
+            allocDeltaPct: pctDelta(allocControl, allocVariant),
+            retainedDeltaPct: pctDelta(control.retainedBytes, variant.retainedBytes),
+        };
+
+        // Structured numbers → CTRF (test.extra.annotations). Informational; this test never fails.
+        testInfo.annotations.push({ type: 'memory', description: JSON.stringify(summary) });
+
+        // Human-readable → run logs / CTRF stdout.
+        const lines = [
+            '',
+            'CellCtrl scroll-churn memory benchmark (informational)',
+            `  scenario: ${summary.scenario}`,
+            `  allocated/run   ${CONTROL}: ${formatBytes(allocControl)}   ${VARIANT}: ${formatBytes(allocVariant)}   Δ ${summary.allocDeltaPct.toFixed(1)}%`,
+            `  retained (GC)   ${CONTROL}: ${formatBytes(control.retainedBytes)}   ${VARIANT}: ${formatBytes(variant.retainedBytes)}   Δ ${summary.retainedDeltaPct.toFixed(1)}%`,
+            `  scriptMs (noisy)${CONTROL}: ${control.scriptMs.toFixed(1)}ms   ${VARIANT}: ${variant.scriptMs.toFixed(1)}ms`,
+            '',
+        ];
+
+        console.log(lines.join('\n'));
+    });
+});

--- a/testing/performance/e2e/cell-memory.cron.spec.ts
+++ b/testing/performance/e2e/cell-memory.cron.spec.ts
@@ -104,6 +104,9 @@ test.describe('CellCtrl memory footprint (scroll churn)', () => {
     test.setTimeout(10 * 60_000);
 
     test(`Scheduled: scroll-churn memory — ${CONTROL} vs ${VARIANT}`, async ({ page }, testInfo) => {
+        // Measured sequentially in one browser process. Each version is independently warmed up
+        // and takes a post-GC baseline, but cross-run V8 state isn't fully isolated — acceptable
+        // for an informational metric.
         const control = await measureVersion(page, CONTROL);
         const variant = await measureVersion(page, VARIANT);
 
@@ -125,7 +128,9 @@ test.describe('CellCtrl memory footprint (scroll churn)', () => {
                 scriptMs: variant.scriptMs,
             },
             allocDeltaPct: pctDelta(allocControl, allocVariant),
-            retainedDeltaPct: pctDelta(control.retainedBytes, variant.retainedBytes),
+            // retained is a post-GC heap delta that can be ~0 or negative, so a percentage would
+            // mislead (or invert sign) near a zero baseline — report the absolute byte delta instead
+            retainedDeltaBytes: variant.retainedBytes - control.retainedBytes,
         };
 
         // Structured numbers → CTRF (test.extra.annotations). Informational; this test never fails.
@@ -137,7 +142,7 @@ test.describe('CellCtrl memory footprint (scroll churn)', () => {
             'CellCtrl scroll-churn memory benchmark (informational)',
             `  scenario: ${summary.scenario}`,
             `  allocated/run   ${CONTROL}: ${formatBytes(allocControl)}   ${VARIANT}: ${formatBytes(allocVariant)}   Δ ${summary.allocDeltaPct.toFixed(1)}%`,
-            `  retained (GC)   ${CONTROL}: ${formatBytes(control.retainedBytes)}   ${VARIANT}: ${formatBytes(variant.retainedBytes)}   Δ ${summary.retainedDeltaPct.toFixed(1)}%`,
+            `  retained (GC)   ${CONTROL}: ${formatBytes(control.retainedBytes)}   ${VARIANT}: ${formatBytes(variant.retainedBytes)}   Δ ${formatBytes(summary.retainedDeltaBytes)}`,
             `  scriptMs (noisy)${CONTROL}: ${control.scriptMs.toFixed(1)}ms   ${VARIANT}: ${variant.scriptMs.toFixed(1)}ms`,
             '',
         ];

--- a/testing/performance/e2e/cell-memory.spec.ts
+++ b/testing/performance/e2e/cell-memory.spec.ts
@@ -15,21 +15,24 @@ import {
 import type { AllocationProfile } from '../cdp.utils';
 import { gotoUrl, waitFor } from '../playwright.utils';
 
-// Informational CI memory benchmark for the per-cell/per-row CellCtrl footprint (AG-15464).
+// Debug tool: memory footprint of the per-cell/per-row CellCtrl features (AG-15464).
 // Scrolling a non-column-virtualised 100k-row grid churns row virtualisation, so cell
 // controllers (and their feature state) are created/destroyed repeatedly — the path the
-// feature->function conversions affect. We compare published prod vs staging so each
-// scheduled run is a self-contained delta; no cross-run store is needed.
+// feature->function conversions affect. We compare `staging` (≈ latest, the baseline) against
+// `local` — the working-tree/PR build — so the delta isolates the code under test:
+//   - run locally: the perf webServer serves your local build as `local`
+//   - run via the `/benchmarks` PR comment: the workflow checks out + builds the PR as `local`
 //
-// This spec never throws: it records numbers as annotations (surfaced in CTRF under
-// test.extra.annotations) and logs a human-readable report. It is intentionally NOT a
-// gate — adding a threshold later would turn it into a regression guard.
+// Not a `*.cron.spec.ts`, so it does NOT run on the daily schedule — only locally or on demand via
+// `/benchmarks` (alongside the timing benchmarks). It never throws: it records numbers as
+// annotations (surfaced in CTRF under test.extra.annotations, and rendered into the PR comment by
+// scripts/ci/gen-gh-comment.mjs) and logs a human-readable report. Intentionally NOT a gate.
 
 const scrollPage = `/testing/performance/e2e/scroll-benchmark.html`;
 const gridReadyCheck = () => document.querySelector('.ag-row') !== null;
 
-const CONTROL: Version = 'prod';
-const VARIANT: Version = 'staging';
+const CONTROL: Version = 'staging';
+const VARIANT: Version = 'local';
 
 const SCROLL_BURSTS = 5;
 const SCROLL_FROM = 100;
@@ -103,7 +106,7 @@ function pctDelta(control: number, variant: number): number {
 test.describe('CellCtrl memory footprint (scroll churn)', () => {
     test.setTimeout(10 * 60_000);
 
-    test(`Scheduled: scroll-churn memory — ${CONTROL} vs ${VARIANT}`, async ({ page }, testInfo) => {
+    test(`scroll-churn memory — ${CONTROL} vs ${VARIANT}`, async ({ page }, testInfo) => {
         // Measured sequentially in one browser process. Each version is independently warmed up
         // and takes a post-GC baseline, but cross-run V8 state isn't fully isolated — acceptable
         // for an informational metric.

--- a/testing/performance/e2e/scroll-benchmark.html
+++ b/testing/performance/e2e/scroll-benchmark.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Typescript Example - Performance Test - Scroll Benchmark</title>
+    </head>
+    <body>
+        <div class="test-container" style="height: 100%; display: flex; flex-direction: column">
+            <div>
+                <button onclick="run()">Run grid</button>
+                <button onclick="onScroll()">Scroll</button>
+                <span id="output">Ready</span>
+            </div>
+            <div id="myGrid" style="flex-grow: 1; height: 100vh"></div>
+        </div>
+
+        <script>
+            let gridApi;
+
+            function repeat(arr, n) {
+                return Array(n).fill(arr).flat();
+            }
+
+            const cols = [
+                { field: 'athlete' },
+                { field: 'gold' },
+                { field: 'silver' },
+                { field: 'bronze' },
+                { field: 'date' },
+            ];
+
+            const ROW_COUNT = 100_000;
+            const columnDefs = repeat(cols, 4); // 20 columns
+
+            // Pre-allocate row data so generation is not part of the measured path
+            const rowData = [];
+            for (let i = 0; i < ROW_COUNT; i++) {
+                rowData.push({
+                    athlete: 'Athlete ' + i,
+                    gold: (i * 7) % 10,
+                    silver: (i * 3) % 8,
+                    bronze: (i * 11) % 6,
+                    date: '2024-01-' + String((i % 28) + 1).padStart(2, '0'),
+                });
+            }
+
+            function run() {
+                const gridOptions = {
+                    columnDefs: columnDefs,
+                    rowData: rowData,
+                    suppressColumnVirtualisation: true,
+                    rowBuffer: 10,
+                };
+                const myGridElement = document.querySelector('#myGrid');
+                gridApi = agGrid.createGrid(myGridElement, gridOptions);
+                window.gridApi = gridApi;
+                document.getElementById('output').textContent = 'Grid ready';
+            }
+
+            // Scroll to a specific row index
+            window.scrollToRow = function (index) {
+                gridApi.ensureIndexVisible(index, 'top');
+            };
+
+            // Scroll in increments, wrapped in performance.measure for timing benchmark
+            window.scrollBurst = function (from, to, step) {
+                return new Promise(function (resolve) {
+                    performance.mark('scroll-burst-start');
+                    let current = from;
+
+                    function nextStep() {
+                        if (current > to) {
+                            performance.measure('scroll-burst', 'scroll-burst-start');
+                            resolve();
+                            return;
+                        }
+                        gridApi.ensureIndexVisible(current, 'top');
+                        current += step;
+                        requestAnimationFrame(nextStep);
+                    }
+
+                    requestAnimationFrame(nextStep);
+                });
+            };
+
+            function onScroll() {
+                window.scrollBurst(0, 500, 20).then(function () {
+                    document.getElementById('output').textContent = 'Scroll complete';
+                });
+            }
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-15464

Part of AG-15464 (companion to the conversions in #14215 / #14222). An on-demand memory **debug tool** for the per-cell/per-row `CellCtrl` footprint those conversions target — for use when changing that code, not a constantly-running CI benchmark.

The CDP helper (`cdp.utils.ts`) and scroll harness (`scroll-benchmark.html`) are adapted from @StephenCooper's spike branch https://github.com/ag-grid/ag-grid/tree/AG-15464-cellctrl-feature-performance; the spec is derived from his `scroll-gc.spec.ts`, reworked to use the repo's existing CTRF-annotation pattern.

### What it does
- Scrolls a non-column-virtualised 100k-row grid (20 cols) so cell controllers are repeatedly created/destroyed — the path these conversions affect — measuring **allocated bytes** + **retained-heap-post-GC** (leak indicator) + ScriptDuration via CDP.
- Compares **`staging` (≈ latest baseline) vs `local` (the branch/PR build)**, so the delta isolates the code under test.
- **Not** a `*.cron.spec.ts`, so it never runs on the daily schedule. It runs:
  - **locally** — `npx playwright test -c testing/performance/playwright.config.ts testing/performance/e2e/cell-memory.spec.ts`
  - **on demand** — the `/benchmarks` PR comment (the workflow checks out + builds the PR and serves it as `local`).
- Records numbers via `testInfo.annotations` → CTRF, **rendered into the `/benchmarks` PR comment** (`scripts/ci/gen-gh-comment.mjs`), and logs a readable report. **Never throws** — informational, not a merge gate.

### Notes for reviewers
- Shared-CI touch is additive: `gen-gh-comment.mjs` / `_utils.mjs` gain a memory-annotation renderer that returns nothing for timing-only runs (no effect on existing benchmarks).
- Memory (allocated/retained) is more stable in CI than ops/s, but this is a debug aid — not a gate or a trend dashboard. Deferred (not in this PR): artifact retention for trending, and an optional regression threshold.
- Codex review: the P1 ("self-referential type fails tsc") is a verified false positive (`tsc` is clean); the two P2s (stop sampling in `finally`; retained reported as absolute bytes) are addressed.