### PR TITLE
AG-17002 Add theme style injection tests

### DIFF
--- a/packages/ag-stack/src/main-internal.ts
+++ b/packages/ag-stack/src/main-internal.ts
@@ -73,6 +73,7 @@ export { AgPositionableFeature } from './rendering/agPositionableFeature';
 export type { PositionableOptions, ResizableSides, ResizableStructure } from './rendering/agPositionableFeature';
 export { AutoScrollService } from './rendering/autoScrollService';
 export { CssClassManager } from './rendering/cssClassManager';
+export { _setStyleInjectionEnabledForTesting } from './theming/inject';
 export { defaultFontFamily, defaultLightColorSchemeParams, sharedDefaults } from './theming/shared/shared-css';
 export type { SharedThemeParams } from './theming/shared/shared-css';
 export {

--- a/packages/ag-stack/src/theming/inject.test.ts
+++ b/packages/ag-stack/src/theming/inject.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 import type { IEnvironment } from '../interfaces/iEnvironment';
-import { _injectGlobalCSS, _unregisterInstanceUsingThemingAPI, _useParamsCss } from './inject';
+import {
+    _injectGlobalCSS,
+    _setStyleInjectionEnabledForTesting,
+    _unregisterInstanceUsingThemingAPI,
+    _useParamsCss,
+} from './inject';
 
 // jsdom does not implement the CSS namespace, patch it.
 if (typeof (globalThis as { CSS?: unknown }).CSS === 'undefined') {
@@ -17,6 +22,11 @@ const injectedStyles = (container: HTMLElement): HTMLStyleElement[] =>
 
 const injectedCssTexts = (container: HTMLElement): string[] =>
     injectedStyles(container).map((el) => el.textContent ?? '');
+
+// IS_SSR is true under jsdom (no document.fonts), so injection is off by default; force it on for these tests.
+beforeAll(() => {
+    _setStyleInjectionEnabledForTesting(true);
+});
 
 describe('style injection', () => {
     it('deduplicates by css content', () => {

--- a/packages/ag-stack/src/theming/inject.test.ts
+++ b/packages/ag-stack/src/theming/inject.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import type { IEnvironment } from '../interfaces/iEnvironment';
+import { _injectGlobalCSS, _unregisterInstanceUsingThemingAPI, _useParamsCss } from './inject';
+
+// jsdom does not implement the CSS namespace, patch it.
+if (typeof (globalThis as { CSS?: unknown }).CSS === 'undefined') {
+    (globalThis as { CSS: Pick<typeof CSS, 'escape'> }).CSS = {
+        escape: (value: string) => value.replace(/[^\w-]/g, '\\$&'),
+    };
+}
+
+const createEnvironment = (): IEnvironment => ({}) as IEnvironment;
+
+const injectedStyles = (container: HTMLElement): HTMLStyleElement[] =>
+    Array.from(container.querySelectorAll<HTMLStyleElement>('style[data-ag-css]'));
+
+const injectedCssTexts = (container: HTMLElement): string[] =>
+    injectedStyles(container).map((el) => el.textContent ?? '');
+
+describe('style injection', () => {
+    it('deduplicates by css content', () => {
+        const container = document.createElement('div');
+
+        _injectGlobalCSS('.a {}', container, 'feature-a', undefined, 0, undefined);
+        _injectGlobalCSS('.a {}', container, 'feature-a', undefined, 0, undefined);
+        expect(injectedStyles(container)).toHaveLength(1);
+
+        _injectGlobalCSS('.b {}', container, 'feature-b', undefined, 0, undefined);
+        expect(injectedStyles(container)).toHaveLength(2);
+    });
+
+    it('orders injected styles by ascending priority regardless of insertion order', () => {
+        const ascending = document.createElement('div');
+        _injectGlobalCSS('.shared {}', ascending, 'shared', undefined, 0, undefined);
+        _injectGlobalCSS('.params {}', ascending, 'params', undefined, 2, undefined);
+        expect(injectedStyles(ascending).map((el) => el.dataset.agCss)).toEqual(['shared', 'params']);
+
+        const descending = document.createElement('div');
+        _injectGlobalCSS('.params {}', descending, 'params', undefined, 2, undefined);
+        _injectGlobalCSS('.shared {}', descending, 'shared', undefined, 0, undefined);
+        expect(injectedStyles(descending).map((el) => el.dataset.agCss)).toEqual(['shared', 'params']);
+    });
+
+    it('wraps css in @layer without escaping periods', () => {
+        const container = document.createElement('div');
+
+        _injectGlobalCSS('.a { color: red; }', container, 'feature-a', 'ag grid.base', 0, undefined);
+
+        // Should escape space, not period
+        expect(injectedCssTexts(container)[0]).toBe('@layer ag\\ grid.base { .a { color: red; } }');
+    });
+
+    it('AG-17001: does not remove @layer wrapped styles when still in use', () => {
+        const container = document.createElement('div');
+        const paramsCss = '.params { --c: red; }';
+        const envA = createEnvironment();
+        const envB = createEnvironment();
+
+        _useParamsCss(envA, paramsCss, 'params-shared', container, 'my-layer', undefined);
+        _useParamsCss(envB, paramsCss, 'params-shared', container, 'my-layer', undefined);
+
+        // envB still needs the params. Stale detection must match on raw css, not the
+        // layer-wrapped css, or it would wrongly remove the still-in-use style.
+        _unregisterInstanceUsingThemingAPI(envA);
+
+        expect(injectedCssTexts(container)).toEqual([`@layer my-layer { ${paramsCss} }`]);
+    });
+
+    it('inserts as sibling after the container it is a style element', () => {
+        const parent = document.createElement('div');
+        const before = parent.appendChild(document.createElement('div'));
+        const styleContainer = parent.appendChild(document.createElement('style'));
+        const after = parent.appendChild(document.createElement('div'));
+
+        _injectGlobalCSS('.a {}', styleContainer, 'feature-a', undefined, 0, undefined);
+
+        const injected = styleContainer.nextElementSibling;
+        expect(injected?.getAttribute('data-ag-css')).toBe('feature-a');
+        expect(injected?.nextElementSibling).toBe(after);
+        expect(before.nextElementSibling).toBe(styleContainer);
+    });
+
+    it('replaces stale params css when a grid updates its params', () => {
+        const container = document.createElement('div');
+        const env = createEnvironment();
+
+        _useParamsCss(env, '.params { --c: red; }', 'params-1', container, undefined, undefined);
+        _useParamsCss(env, '.params { --c: blue; }', 'params-1', container, undefined, undefined);
+
+        expect(injectedCssTexts(container)).toEqual(['.params { --c: blue; }']);
+    });
+});

--- a/packages/ag-stack/src/theming/inject.ts
+++ b/packages/ag-stack/src/theming/inject.ts
@@ -2,7 +2,7 @@ import type { IEnvironment } from '../interfaces/iEnvironment';
 import { VERSION } from '../version';
 import sharedCSS from './shared/shared.css';
 
-export const IS_SSR = typeof window !== 'object' || !window?.document?.fonts?.forEach;
+export const IS_SSR = typeof window !== 'object' || typeof document !== 'object';
 
 /** For testing, if true, only Vanilla examples will work and they will use legacy themes. */
 export const FORCE_LEGACY_THEMES = false;

--- a/packages/ag-stack/src/theming/inject.ts
+++ b/packages/ag-stack/src/theming/inject.ts
@@ -10,9 +10,10 @@ export const FORCE_LEGACY_THEMES = false;
 let styleInjectionForcedForTesting = false;
 
 /**
- * @internal Test hook — force CSS injection to run even when IS_SSR is true (e.g.
- * jsdom, which lacks document.fonts). Lets theming tests exercise real injection
- * without enabling it for the rest of the test suite.
+ * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
+ * Test hook — force CSS injection to run even when IS_SSR is true (e.g. jsdom, which
+ * lacks document.fonts). Lets theming tests exercise real injection without enabling
+ * it for the rest of the test suite.
  */
 export const _setStyleInjectionEnabledForTesting = (enabled: boolean): void => {
     styleInjectionForcedForTesting = enabled;

--- a/packages/ag-stack/src/theming/inject.ts
+++ b/packages/ag-stack/src/theming/inject.ts
@@ -2,10 +2,25 @@ import type { IEnvironment } from '../interfaces/iEnvironment';
 import { VERSION } from '../version';
 import sharedCSS from './shared/shared.css';
 
-export const IS_SSR = typeof window !== 'object' || typeof document !== 'object';
+const IS_SSR = typeof window !== 'object' || !window?.document?.fonts?.forEach;
 
 /** For testing, if true, only Vanilla examples will work and they will use legacy themes. */
 export const FORCE_LEGACY_THEMES = false;
+
+let styleInjectionForcedForTesting = false;
+
+/**
+ * @internal Test hook — force CSS injection to run even when IS_SSR is true (e.g.
+ * jsdom, which lacks document.fonts). Lets theming tests exercise real injection
+ * without enabling it for the rest of the test suite.
+ */
+export const _setStyleInjectionEnabledForTesting = (enabled: boolean): void => {
+    styleInjectionForcedForTesting = enabled;
+};
+
+/** @internal True when injection must be skipped: no DOM (unless force-enabled for tests) or legacy themes. */
+export const _isStyleInjectionDisabled = (): boolean =>
+    (IS_SSR && !styleInjectionForcedForTesting) || FORCE_LEGACY_THEMES;
 
 type InjectedStyle = {
     rawCss: string;
@@ -24,7 +39,7 @@ export const _injectGlobalCSS = (
     nonce: string | undefined,
     isParams: boolean = false
 ) => {
-    if (IS_SSR || FORCE_LEGACY_THEMES) {
+    if (_isStyleInjectionDisabled()) {
         return;
     }
 
@@ -94,7 +109,7 @@ export const _useParamsCss = (
     layer: string | undefined,
     nonce: string | undefined
 ) => {
-    if (IS_SSR || FORCE_LEGACY_THEMES) {
+    if (_isStyleInjectionDisabled()) {
         return;
     }
 

--- a/packages/ag-stack/src/theming/inject.ts
+++ b/packages/ag-stack/src/theming/inject.ts
@@ -11,9 +11,6 @@ let styleInjectionForcedForTesting = false;
 
 /**
  * @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time.
- * Test hook — force CSS injection to run even when IS_SSR is true (e.g. jsdom, which
- * lacks document.fonts). Lets theming tests exercise real injection without enabling
- * it for the rest of the test suite.
  */
 export const _setStyleInjectionEnabledForTesting = (enabled: boolean): void => {
     styleInjectionForcedForTesting = enabled;

--- a/packages/ag-stack/src/theming/themeImpl.ts
+++ b/packages/ag-stack/src/theming/themeImpl.ts
@@ -1,4 +1,10 @@
-import { FORCE_LEGACY_THEMES, IS_SSR, _injectCoreAndModuleCSS, _injectGlobalCSS, getInjectionState } from './inject';
+import {
+    FORCE_LEGACY_THEMES,
+    _injectCoreAndModuleCSS,
+    _injectGlobalCSS,
+    _isStyleInjectionDisabled,
+    getInjectionState,
+} from './inject';
 import type { Part } from './part';
 import { PartImpl, createPart, defaultModeName } from './partImpl';
 import { sharedDefaults } from './shared/shared-css';
@@ -70,11 +76,7 @@ export class ThemeImpl {
     }
 
     _startUse({ styleContainer, cssLayer, nonce, loadThemeGoogleFonts, moduleCss }: themeUseArgs): void {
-        if (IS_SSR) {
-            return;
-        }
-
-        if (FORCE_LEGACY_THEMES) {
+        if (_isStyleInjectionDisabled()) {
             return;
         }
 

--- a/testing/behavioural/src/theming/style-injection.test.ts
+++ b/testing/behavioural/src/theming/style-injection.test.ts
@@ -1,0 +1,100 @@
+import { vi } from 'vitest';
+
+import { inputStyleBordered, inputStyleUnderlined, themeQuartz } from 'ag-grid-community';
+
+import { TestGridsManager } from '../test-utils';
+import { VERSION } from '../version';
+
+// The version map is registered as an import-time side effect of inject.ts (its
+// module-level getInjectionState() call), not at grid creation. Seed a foreign
+// version before that import runs to prove a newly-loaded version reuses the
+// existing map rather than replacing it - hence vi.hoisted, which executes before
+// the imports above; a beforeEach would run too late.
+const { DUMMY_VERSION } = vi.hoisted(() => {
+    const windowState = globalThis as WindowState;
+    if (windowState.agStyleInjectionVersions) {
+        throw new Error('This should have run before the ag import');
+    }
+    const DUMMY_VERSION = '0.0.0-dummy';
+    windowState.agStyleInjectionVersions = new Map([[DUMMY_VERSION, {}]]);
+    return { DUMMY_VERSION };
+});
+
+const agStyles = (): HTMLStyleElement[] =>
+    Array.from(document.head.querySelectorAll<HTMLStyleElement>('style[data-ag-css]'));
+
+const allDebugIds = () => agStyles().map((el) => el.dataset.agCss ?? '');
+const paramsDebugIds = () => allDebugIds().filter((id) => id.startsWith('ag-theme-params'));
+const inputStyleDebugIds = () => allDebugIds().filter((id) => id.startsWith('ag-theme-inputStyle'));
+
+const cssFor = (debugId: string): string => agStyles().find((el) => el.dataset.agCss === debugId)?.textContent ?? '';
+
+const injectionVersions = () => (globalThis as WindowState).agStyleInjectionVersions!;
+
+describe('theme style injection across grids', () => {
+    const gridsManager = new TestGridsManager({ modules: [] });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    it('shares per-version state across grids with different parts and cleans up styles incrementally', async () => {
+        const columnDefs = [{ field: 'a' }];
+        const rowData = [{ a: 1 }];
+
+        const gridA = await gridsManager.createGridAndWait('gridA', {
+            theme: themeQuartz.withPart(inputStyleBordered),
+            columnDefs,
+            rowData,
+        });
+
+        // The grid added its own version alongside the seeded dummy, without replacing the map.
+        expect(injectionVersions()).toBeInstanceOf(Map);
+        expect(Array.from(injectionVersions().keys())).toEqual([DUMMY_VERSION, VERSION]);
+
+        // Every injected style is tagged with the current version.
+        expect(agStyles().every((el) => el.dataset.agCssVersion === VERSION)).toBe(true);
+
+        // Grid A injects its input-style part css and its own params.
+        expect(inputStyleDebugIds()).toHaveLength(1);
+        expect(paramsDebugIds()).toEqual(['ag-theme-params-1']);
+
+        const inputStyleA = inputStyleDebugIds()[0];
+        const styleCountAfterA = allDebugIds().length;
+
+        const gridB = await gridsManager.createGridAndWait('gridB', {
+            theme: themeQuartz.withPart(inputStyleUnderlined),
+            columnDefs,
+            rowData,
+        });
+
+        // B shares A's version entry — no new key.
+        expect(Array.from(injectionVersions().keys())).toEqual([DUMMY_VERSION, VERSION]);
+
+        // B injects a second, distinct input-style part with different css — real part-css injection.
+        expect(inputStyleDebugIds()).toHaveLength(2);
+        expect(inputStyleDebugIds()[0]).toEqual(inputStyleA);
+        const inputStyleB = inputStyleDebugIds()[1];
+        expect(cssFor(inputStyleA)).toBeTruthy();
+        expect(cssFor(inputStyleA)).not.toBe(cssFor(inputStyleB));
+
+        // B adds its own params; the default parts it shares with A are deduped, not re-injected.
+        expect(paramsDebugIds()).toEqual(['ag-theme-params-1', 'ag-theme-params-2']);
+        const styleCountAfterB = allDebugIds().length;
+        // B should only have added its params and an input style
+        expect(styleCountAfterB).toEqual(styleCountAfterA + 2);
+
+        // Destroying A removes ONLY its params; its part css and the shared css survive while B lives.
+        gridA.destroy();
+        expect(allDebugIds()).not.toContain('ag-theme-params-1');
+        expect(allDebugIds().length).toBe(styleCountAfterB - 1);
+
+        // Destroying the last grid clears every injected style from the head.
+        gridB.destroy();
+        expect(agStyles()).toHaveLength(0);
+    });
+});
+
+type WindowState = {
+    agStyleInjectionVersions?: Map<string, unknown>;
+};

--- a/testing/behavioural/src/theming/style-injection.test.ts
+++ b/testing/behavioural/src/theming/style-injection.test.ts
@@ -1,3 +1,4 @@
+import { _setStyleInjectionEnabledForTesting } from 'ag-stack';
 import { vi } from 'vitest';
 
 import { inputStyleBordered, inputStyleUnderlined, themeQuartz } from 'ag-grid-community';
@@ -33,6 +34,11 @@ const injectionVersions = () => (globalThis as WindowState).agStyleInjectionVers
 
 describe('theme style injection across grids', () => {
     const gridsManager = new TestGridsManager({ modules: [] });
+
+    // IS_SSR is true under jsdom (no document.fonts) so grids don't inject by default; force it on here.
+    beforeEach(() => {
+        _setStyleInjectionEnabledForTesting(true);
+    });
 
     afterEach(() => {
         gridsManager.reset();


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17002

Adds automated coverage around the theme style-injection mechanism (`packages/ag-stack/src/theming/inject.ts`), an area with a history of cross-version and CSS-layer regressions (AG-14716, AG-16090, AG-16789, AG-17001).

**Unit tests** (`packages/ag-stack/src/theming/inject.test.ts`) — exercise the low-level functions directly:
- content-based dedup
- ascending-priority ordering regardless of insertion order
- `@layer` wrapping without escaping periods
- sibling insertion when the container is itself a `<style>` element
- stale params removal matching on raw css rather than the layer-wrapped css — regression guard for the AG-17001 layer bug

**Behavioural test** (`testing/behavioural/src/theming/style-injection.test.ts`) — drives real grids via `TestGridsManager`:
- a foreign version seeded into `window.agStyleInjectionVersions` is not clobbered, and a same-version grid reuses the entry
- per-part and per-grid styles inject as expected; shared default parts dedupe across grids
- destroying one of two grids removes only its params; destroying the last clears the head

**Enabling injection under jsdom:** `IS_SSR` (via `document.fonts`) is `true` under jsdom, so theme injection is normally a no-op in tests. Rather than change that globally (which makes jsdom choke on the injected CSS and breaks suites asserting on console output), this adds an internal runtime switch `_setStyleInjectionEnabledForTesting(enabled)` and routes the SSR/legacy guards through a shared `_isStyleInjectionDisabled()` predicate. The theming tests flip it on for their own file only; per-file Vitest module isolation keeps injection off for every other test. No production behaviour change.

Fix [AG-17002](https://ag-grid.atlassian.net/browse/AG-17002)