### PR TITLE
[AG-16228] Fix(column-tool-panel): preserve custom layout on columnDefs reset

### DIFF
--- a/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
@@ -71,6 +71,7 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
     private hasLoadedInitialState: boolean = false;
     private isInitialState: boolean = false;
     private skipRefocus: boolean = false;
+    private customColumnLayout: AbstractColDef[] | null = null;
 
     constructor() {
         super({ tag: 'div', cls: PRIMARY_COLS_LIST_PANEL_CLASS, role: 'presentation' });
@@ -266,6 +267,8 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
 
         if (shouldSyncColumnLayoutWithGrid) {
             this.buildTreeFromWhatGridIsDisplaying();
+        } else if (this.customColumnLayout && !pivotModeActive) {
+            this.applyColumnLayout(this.customColumnLayout);
         } else {
             this.buildTreeFromProvidedColumnDefs();
         }
@@ -338,7 +341,7 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
         if (deferApply && this.beans.columnStateUpdateStrategy.hasDeferredColumnOrder(deferApply)) {
             const columnOrder = this.beans.columnStateUpdateStrategy.getPrimaryColumns(deferApply);
             if (columnOrder.length > 0) {
-                syncLayoutWithColumns(columnOrder, this.setColumnLayout.bind(this));
+                syncLayoutWithColumns(columnOrder, this.applyColumnLayout.bind(this));
                 return;
             }
         }
@@ -346,10 +349,16 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
             this.buildTreeFromProvidedColumnDefs();
             return;
         }
-        syncLayoutWithGrid(this.colModel, this.setColumnLayout.bind(this));
+        syncLayoutWithGrid(this.colModel, this.applyColumnLayout.bind(this));
     }
 
     public setColumnLayout(colDefs: AbstractColDef[]): void {
+        // Retain the user-provided layout so it survives grid-driven rebuilds while decoupled from grid order.
+        this.customColumnLayout = colDefs;
+        this.applyColumnLayout(colDefs);
+    }
+
+    private applyColumnLayout(colDefs: AbstractColDef[]): void {
         const columnTree = toolPanelCreateColumnTree(this.colModel, colDefs);
         this.buildListModel(columnTree);
 

--- a/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/agPrimaryColsList.ts
@@ -268,7 +268,10 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
         if (shouldSyncColumnLayoutWithGrid) {
             this.buildTreeFromWhatGridIsDisplaying();
         } else if (this.customColumnLayout && !pivotModeActive) {
-            this.applyColumnLayout(this.customColumnLayout);
+            // A custom layout set via setColumnLayout owns the panel: grid column changes leave it untouched
+            // until the app calls setColumnLayout again to pick up added/removed columns.
+            this.isInitialState = false;
+            return;
         } else {
             this.buildTreeFromProvidedColumnDefs();
         }
@@ -353,7 +356,7 @@ export class AgPrimaryColsList extends Component<AgPrimaryColsListEvent> {
     }
 
     public setColumnLayout(colDefs: AbstractColDef[]): void {
-        // Retain the user-provided layout so it survives grid-driven rebuilds while decoupled from grid order.
+        // Marks the panel as owned by a custom layout so later grid column changes leave it frozen.
         this.customColumnLayout = colDefs;
         this.applyColumnLayout(colDefs);
     }

--- a/testing/behavioural/src/columnToolPanel/custom-layout-preservation.test.ts
+++ b/testing/behavioural/src/columnToolPanel/custom-layout-preservation.test.ts
@@ -1,3 +1,5 @@
+import type { MockInstance } from 'vitest';
+
 import type { ColDef, GridApi } from 'ag-grid-community';
 import { AllEnterpriseModule } from 'ag-grid-enterprise';
 
@@ -82,5 +84,92 @@ describe('column tool panel custom layout preservation', () => {
         await asyncSetTimeout(50);
 
         expect(getDisplayedPrimaryColumnOrder(toolPanel)).toEqual(['sport', 'athlete', 'country']);
+    });
+
+    // Option 1 semantics: setColumnLayout owns the panel. A columnDefs reset that changes the set of
+    // columns leaves the panel frozen (removed 'sport' stays, added 'gold' is not shown) and emits no
+    // invalid colId warning, since the panel is not rebuilt from the grid.
+    test('columnDefs reset that adds/removes columns leaves the custom layout frozen and warns nothing', async () => {
+        const consoleWarnSpy: MockInstance = vitest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        try {
+            const { gridApi, toolPanel } = await createGrid();
+
+            gridApi.getToolPanelInstance('columns')!.setColumnLayout(alphabeticalLayout);
+            await asyncSetTimeout(50);
+
+            expect(getDisplayedPrimaryColumnOrder(toolPanel)).toEqual(['athlete', 'country', 'sport']);
+
+            consoleWarnSpy.mockClear();
+
+            // drop 'sport', add 'gold'
+            gridApi.setGridOption('columnDefs', [{ field: 'country' }, { field: 'athlete' }, { field: 'gold' }]);
+            await asyncSetTimeout(50);
+
+            // panel stays exactly as set: removed 'sport' remains, added 'gold' is not shown
+            expect(getDisplayedPrimaryColumnOrder(toolPanel)).toEqual(['athlete', 'country', 'sport']);
+
+            expect(consoleWarnSpy).not.toHaveBeenCalled();
+        } finally {
+            consoleWarnSpy.mockRestore();
+        }
+    });
+
+    // Mirrors AG-16228 TC step 3b under Option 1: once setColumnLayout is called the panel is frozen -
+    // a columnDefs reset that adds/removes columns must NOT alter the panel; it stays exactly as set until
+    // the app calls setColumnLayout again. Removed 'sport' stays; added 'gold' does not appear.
+    test('AG-16228 TC 3b (Option 1): columnDefs add/remove reset leaves the custom layout frozen', async () => {
+        const fiveColDefs: ColDef[] = [
+            { field: 'sport' },
+            { field: 'year' },
+            { field: 'country' },
+            { field: 'age' },
+            { field: 'athlete' },
+        ];
+        const customOrder: ColDef[] = [
+            { field: 'age' },
+            { field: 'athlete' },
+            { field: 'country' },
+            { field: 'sport' },
+            { field: 'year' },
+        ];
+
+        const gridApi = await gridMgr.createGridAndWait('tcGrid', {
+            columnDefs: fiveColDefs,
+            rowData: [{ age: 23, athlete: 'A', country: 'US', sport: 'Swimming', year: 2004 }],
+            sideBar: {
+                toolPanels: [
+                    {
+                        id: 'columns',
+                        labelDefault: 'Columns',
+                        labelKey: 'columns',
+                        iconKey: 'columns',
+                        toolPanel: 'agColumnsToolPanel',
+                        toolPanelParams: { suppressSyncLayoutWithGrid: true },
+                    },
+                ],
+                defaultToolPanel: 'columns',
+            },
+        });
+        await asyncSetTimeout(50);
+        const toolPanel = gridApi.getToolPanelInstance('columns') as any;
+
+        // step 2: custom order
+        gridApi.getToolPanelInstance('columns')!.setColumnLayout(customOrder);
+        await asyncSetTimeout(50);
+        expect(getDisplayedPrimaryColumnOrder(toolPanel)).toEqual(['age', 'athlete', 'country', 'sport', 'year']);
+
+        // step 3b: reset columnDefs removing 'sport', adding 'gold'
+        gridApi.setGridOption('columnDefs', [
+            { field: 'gold' },
+            { field: 'year' },
+            { field: 'country' },
+            { field: 'age' },
+            { field: 'athlete' },
+        ]);
+        await asyncSetTimeout(50);
+
+        // Option 1: panel stays exactly as set in step 2
+        expect(getDisplayedPrimaryColumnOrder(toolPanel)).toEqual(['age', 'athlete', 'country', 'sport', 'year']);
     });
 });

--- a/testing/behavioural/src/columnToolPanel/custom-layout-preservation.test.ts
+++ b/testing/behavioural/src/columnToolPanel/custom-layout-preservation.test.ts
@@ -1,0 +1,86 @@
+import type { ColDef, GridApi } from 'ag-grid-community';
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+
+describe('column tool panel custom layout preservation', () => {
+    const gridMgr = new TestGridsManager({
+        modules: [AllEnterpriseModule],
+    });
+
+    const rowData = [
+        { athlete: 'Michael Phelps', country: 'United States', sport: 'Swimming' },
+        { athlete: 'Julian Weber', country: 'Romania', sport: 'Gymnastics' },
+    ];
+
+    // grid receives an "unsorted" order
+    const baseColumnDefs: ColDef[] = [{ field: 'country' }, { field: 'athlete' }, { field: 'sport' }];
+
+    // custom tool panel layout, alphabetical and independent of grid order
+    const alphabeticalLayout: ColDef[] = [{ field: 'athlete' }, { field: 'country' }, { field: 'sport' }];
+
+    afterEach(() => {
+        gridMgr.reset();
+    });
+
+    async function createGrid(): Promise<{ gridApi: GridApi; toolPanel: any }> {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: baseColumnDefs,
+            rowData,
+            sideBar: {
+                toolPanels: [
+                    {
+                        id: 'columns',
+                        labelDefault: 'Columns',
+                        labelKey: 'columns',
+                        iconKey: 'columns',
+                        toolPanel: 'agColumnsToolPanel',
+                        toolPanelParams: {
+                            suppressSyncLayoutWithGrid: true,
+                        },
+                    },
+                ],
+                defaultToolPanel: 'columns',
+            },
+        });
+
+        await asyncSetTimeout(50);
+
+        const toolPanel = gridApi.getToolPanelInstance('columns') as any;
+        return { gridApi, toolPanel };
+    }
+
+    function getDisplayedPrimaryColumnOrder(toolPanel: any): string[] {
+        return toolPanel.primaryColsPanel.primaryColsListPanel
+            .getDisplayedColsList()
+            .filter((item: any) => !item.group)
+            .map((item: any) => item.column.getColId());
+    }
+
+    test('custom layout is preserved when columnDefs are programmatically reset', async () => {
+        const { gridApi, toolPanel } = await createGrid();
+
+        gridApi.getToolPanelInstance('columns')!.setColumnLayout(alphabeticalLayout);
+        await asyncSetTimeout(50);
+
+        expect(getDisplayedPrimaryColumnOrder(toolPanel)).toEqual(['athlete', 'country', 'sport']);
+
+        // reset columnDefs to a different order
+        gridApi.setGridOption('columnDefs', [{ field: 'sport' }, { field: 'athlete' }, { field: 'country' }]);
+        await asyncSetTimeout(50);
+
+        // panel retains the custom alphabetical layout, not the new grid order
+        expect(getDisplayedPrimaryColumnOrder(toolPanel)).toEqual(['athlete', 'country', 'sport']);
+    });
+
+    test('without a custom layout, columnDefs reset adopts the new colDef order', async () => {
+        const { gridApi, toolPanel } = await createGrid();
+
+        expect(getDisplayedPrimaryColumnOrder(toolPanel)).toEqual(['country', 'athlete', 'sport']);
+
+        gridApi.setGridOption('columnDefs', [{ field: 'sport' }, { field: 'athlete' }, { field: 'country' }]);
+        await asyncSetTimeout(50);
+
+        expect(getDisplayedPrimaryColumnOrder(toolPanel)).toEqual(['sport', 'athlete', 'country']);
+    });
+});


### PR DESCRIPTION
preserve custom column tool panel layout when `columnDefs` is reset.

Fixes [AG-16228](https://ag-grid.atlassian.net/browse/AG-16228)