### PR TITLE
AG-17682 add Columns feature group to license pricing matrix

### DIFF
--- a/external/ag-website-shared/src/content/license-features/gridFeaturesMatrix.json
+++ b/external/ag-website-shared/src/content/license-features/gridFeaturesMatrix.json
@@ -60,6 +60,91 @@
     },
     {
         "group": {
+            "name": "Columns"
+        },
+        "items": [
+            {
+                "name": "Basic Column Operations",
+                "isSubGroup": true,
+                "items": [
+                    {
+                        "label": {
+                            "name": "Headers",
+                            "link": "grid:./column-headers/"
+                        },
+                        "community": true,
+                        "enterprise": true,
+                        "chartsGrid": true
+                    },
+                    {
+                        "label": {
+                            "name": "Groups",
+                            "link": "grid:./column-groups/"
+                        },
+                        "community": true,
+                        "enterprise": true,
+                        "chartsGrid": true
+                    },
+                    {
+                        "label": {
+                            "name": "Sizing",
+                            "link": "grid:./column-sizing/"
+                        },
+                        "community": true,
+                        "enterprise": true,
+                        "chartsGrid": true
+                    },
+                    {
+                        "label": {
+                            "name": "Moving",
+                            "link": "grid:./column-moving/"
+                        },
+                        "community": true,
+                        "enterprise": true,
+                        "chartsGrid": true
+                    },
+                    {
+                        "label": {
+                            "name": "Pinning",
+                            "link": "grid:./column-pinning/"
+                        },
+                        "community": true,
+                        "enterprise": true,
+                        "chartsGrid": true
+                    },
+                    {
+                        "label": {
+                            "name": "Spanning",
+                            "link": "grid:./column-spanning/"
+                        },
+                        "community": true,
+                        "enterprise": true,
+                        "chartsGrid": true
+                    }
+                ]
+            },
+            {
+                "label": {
+                    "name": "Auto-Generate Columns",
+                    "link": "grid:./auto-generate-columns/"
+                },
+                "community": true,
+                "enterprise": true,
+                "chartsGrid": true
+            },
+            {
+                "label": {
+                    "name": "Calculated Columns",
+                    "link": "grid:./calculated-columns/"
+                },
+                "community": false,
+                "enterprise": true,
+                "chartsGrid": true
+            }
+        ]
+    },
+    {
+        "group": {
             "name": "Filtering"
         },
         "items": [


### PR DESCRIPTION
## Summary
Adds a new **COLUMNS** feature group to the license-pricing comparison table ([gridFeaturesMatrix.json](external/ag-website-shared/src/content/license-features/gridFeaturesMatrix.json)), positioned directly above **FILTERING** per AG-17682.

- **Basic Column Operations** sub-group: Headers, Groups, Sizing, Moving, Pinning, Spanning (all community)
- Top-level items: Auto-Generate Columns (community), Calculated Columns (enterprise-only)

All slugs link to existing docs pages via the `grid:./<slug>/` convention.

## Notes
- Group heading uses Title Case `"Columns"` (rendered uppercase by table styling), matching existing groups.
- Calculated Columns is enterprise-only (`community: false`), following the established `false|true|true` pattern.

[AG-17682](https://ag-grid.atlassian.net/browse/AG-17682)