### PR TITLE
AG-17682 add Columns feature group to license pricing matrix

### DIFF
--- a/external/ag-website-shared/src/content/license-features/gridFeaturesMatrix.json
+++ b/external/ag-website-shared/src/content/license-features/gridFeaturesMatrix.json
@@ -299,6 +299,15 @@
                 "community": false,
                 "enterprise": true,
                 "chartsGrid": true
+            },
+            {
+                "label": {
+                    "name": "Cell Notes",
+                    "link": "https://www.ag-grid.com/react-data-grid/notes"
+                },
+                "community": false,
+                "enterprise": true,
+                "chartsGrid": true
             }
         ]
     },

--- a/external/ag-website-shared/src/content/license-features/gridFeaturesMatrix.json
+++ b/external/ag-website-shared/src/content/license-features/gridFeaturesMatrix.json
@@ -60,6 +60,91 @@
     },
     {
         "group": {
+            "name": "Columns"
+        },
+        "items": [
+            {
+                "name": "Basic Column Operations",
+                "isSubGroup": true,
+                "items": [
+                    {
+                        "label": {
+                            "name": "Headers",
+                            "link": "https://www.ag-grid.com/react-data-grid/column-headers/"
+                        },
+                        "community": true,
+                        "enterprise": true,
+                        "chartsGrid": true
+                    },
+                    {
+                        "label": {
+                            "name": "Groups",
+                            "link": "https://www.ag-grid.com/react-data-grid/column-groups/"
+                        },
+                        "community": true,
+                        "enterprise": true,
+                        "chartsGrid": true
+                    },
+                    {
+                        "label": {
+                            "name": "Sizing",
+                            "link": "https://www.ag-grid.com/react-data-grid/column-sizing/"
+                        },
+                        "community": true,
+                        "enterprise": true,
+                        "chartsGrid": true
+                    },
+                    {
+                        "label": {
+                            "name": "Moving",
+                            "link": "https://www.ag-grid.com/react-data-grid/column-moving/"
+                        },
+                        "community": true,
+                        "enterprise": true,
+                        "chartsGrid": true
+                    },
+                    {
+                        "label": {
+                            "name": "Pinning",
+                            "link": "https://www.ag-grid.com/react-data-grid/column-pinning/"
+                        },
+                        "community": true,
+                        "enterprise": true,
+                        "chartsGrid": true
+                    },
+                    {
+                        "label": {
+                            "name": "Spanning",
+                            "link": "https://www.ag-grid.com/react-data-grid/column-spanning/"
+                        },
+                        "community": true,
+                        "enterprise": true,
+                        "chartsGrid": true
+                    }
+                ]
+            },
+            {
+                "label": {
+                    "name": "Auto-Generate Columns",
+                    "link": "https://www.ag-grid.com/react-data-grid/auto-generate-columns/"
+                },
+                "community": true,
+                "enterprise": true,
+                "chartsGrid": true
+            },
+            {
+                "label": {
+                    "name": "Calculated Columns",
+                    "link": "https://www.ag-grid.com/react-data-grid/calculated-columns/"
+                },
+                "community": false,
+                "enterprise": true,
+                "chartsGrid": true
+            }
+        ]
+    },
+    {
+        "group": {
             "name": "Filtering"
         },
         "items": [


### PR DESCRIPTION
## Summary
Backport of #14245 to `b36.0.0`. Adds a new **COLUMNS** feature group to the license-pricing comparison table, positioned directly above **FILTERING** per AG-17682.

- **Basic Column Operations** sub-group: Headers, Groups, Sizing, Moving, Pinning, Spanning (all community)
- Top-level items: Auto-Generate Columns (community), Calculated Columns (enterprise-only)

Links use the full `https://www.ag-grid.com/react-data-grid/...` URL format used by this branch's matrix file.

[AG-17682](https://ag-grid.atlassian.net/browse/AG-17682)