### PR TITLE
SE-50, SE-48, SE-49, SE-45, SE-47: SEO Work

### DIFF
--- a/documentation/ag-grid-docs/src/layouts/DebugLayout.astro
+++ b/documentation/ag-grid-docs/src/layouts/DebugLayout.astro
@@ -5,9 +5,9 @@ const { title } = Astro.props;
 ---
 
 <Layout title={title}>
-    <main id="debug-main" class="layout-page-max-width container">
+    <div id="debug-main" class="layout-page-max-width container">
         <slot />
-    </main>
+    </div>
 </Layout>
 
 <style lang="scss">

--- a/documentation/ag-grid-docs/src/layouts/Layout.astro
+++ b/documentation/ag-grid-docs/src/layouts/Layout.astro
@@ -66,7 +66,12 @@ const {
 } = Astro.props;
 
 const path = Astro.url.pathname;
-const socialImage = urlWithBaseUrl(overrideSocialImage ?? metadata.socialImage);
+const siteRoot = siteRootUrl(metadata.canonicalUrlBase);
+// Open Graph and Twitter crawlers require absolute image URLs, so resolve the social image against the site root.
+const socialImagePathOrUrl = urlWithBaseUrl(overrideSocialImage ?? metadata.socialImage);
+const socialImage = socialImagePathOrUrl.startsWith('http')
+    ? socialImagePathOrUrl
+    : `${siteRoot}${socialImagePathOrUrl.replace(/^\//, '')}`;
 
 const lightModeCSSUrl = `url("${urlWithBaseUrl('/images/sun.svg')}")`;
 const darkModeCSSUrl = `url("${urlWithBaseUrl('/images/moon.svg')}")`;
@@ -77,7 +82,6 @@ const includeStructuredData = !hidePageFromSearchEngines && !isArchive;
 const sameAsUrls = includeStructuredData
     ? footerItems.flatMap((group) => group.links.filter((link) => link.iconName).map((link) => link.url))
     : [];
-const siteRoot = siteRootUrl(metadata.canonicalUrlBase);
 const organizationLogoUrl = `${siteRoot}images/ag-logos/png-logos/AG-Grid-Logo_Light-Theme_476_140.png`;
 const licensePricingUrl = `${siteRoot}license-pricing/`;
 const structuredData: JsonLdObject[] = includeStructuredData
@@ -129,7 +133,7 @@ const announcementBannerProps = {
     <head>
         <meta charset="UTF-8" />
         <meta name="description" content={description} />
-        <meta name="viewport" content="width=device-width" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         {
             getFavIconsData().map(({ size, icon }: any) => (
                 <link rel="icon" type="image/png" sizes={`${size}x${size}`} href={icon} />
@@ -244,7 +248,9 @@ const announcementBannerProps = {
 
         <div id="mainContainer" class:list={styles.mainContainer}>
             {!hideHeader && <SiteHeader showSearchBar={showSearchBar} showDocsNav={showDocsNav} apiPaths={apiPaths} />}
-            <slot />
+            <main class:list={styles.pageMain}>
+                <slot />
+            </main>
         </div>
 
         {

--- a/documentation/ag-grid-docs/src/layouts/Layout.module.scss
+++ b/documentation/ag-grid-docs/src/layouts/Layout.module.scss
@@ -15,3 +15,10 @@ html {
         overflow-x: hidden;
     }
 }
+
+// The <main> landmark wraps the page slot for accessibility. `display: contents`
+// removes its box so the page sections remain direct flex children of .mainContainer,
+// preserving the existing layout while still exposing a single main landmark.
+.pageMain {
+    display: contents;
+}

--- a/documentation/ag-grid-docs/src/pages/campaigns/power-of-ag-charts.astro
+++ b/documentation/ag-grid-docs/src/pages/campaigns/power-of-ag-charts.astro
@@ -71,7 +71,7 @@ const MAILTO_HREF = `mailto:info@ag-grid.com?subject=AG Charts Enterprise: ${CAM
         </div>
     </div>
 
-    <main class={styles.campaignOuter}>
+    <div class={styles.campaignOuter}>
         <div class={styles.autoICExample}>
             <AutomatedIntegratedCharts client:load visibilityThreshold={0.8} />
         </div>
@@ -195,7 +195,7 @@ const MAILTO_HREF = `mailto:info@ag-grid.com?subject=AG Charts Enterprise: ${CAM
                 <a href={MAILTO_HREF}>info@ag-grid.com</a>.
             </div>
         </div>
-    </main>
+    </div>
 </Layout>
 
 <script>

--- a/documentation/ag-grid-docs/src/pages/community/lets-cook.astro
+++ b/documentation/ag-grid-docs/src/pages/community/lets-cook.astro
@@ -13,7 +13,7 @@ import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
     showSearchBar={true}
     hidePageFromSearchEngines={true}
 >
-    <main class={styles.letsCookPage}>
+    <div class={styles.letsCookPage}>
         <div class={styles.letsCookInner}>
             <div class={styles.copy}>
                 <h1 class={styles.title}>Now you're cooking</h1>
@@ -60,5 +60,5 @@ import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
                 height="566"
             />
         </div>
-    </main>
+    </div>
 </Layout>

--- a/documentation/ag-grid-docs/src/pages/index.astro
+++ b/documentation/ag-grid-docs/src/pages/index.astro
@@ -22,10 +22,19 @@ import { AutomatedIntegratedCharts } from '@ag-website-shared/components/automat
 import { FrameworkTextAnimation } from '@ag-website-shared/components/framework-text-animation/FrameworkTextAnimation';
 import LogoMark from '@components/logo/LogoMark';
 import { urlWithPrefix } from '@utils/urlWithPrefix';
+import { buildFAQPage, siteRootUrl } from '@ag-website-shared/utils/structuredData';
 
 const { data: versionsData } = (await getEntry('versions', 'ag-grid-versions')) as CollectionEntry<'versions'>;
 const { data: faqData } = (await getEntry('faqs', 'homepage')) as CollectionEntry<'faqs'>;
+const { data: metadata } = (await getEntry('metadata', 'metadata')) as CollectionEntry<'metadata'>;
 const { blogPrefix } = whatsNewData['grid'];
+
+// Strip markdown link syntax ([text](url)) so the FAQ structured data carries clean plain-text answers.
+const toPlainText = (markdown: string): string => markdown.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1');
+const faqStructuredData = buildFAQPage({
+    pageUrl: siteRootUrl(metadata.canonicalUrlBase),
+    items: faqData.map(({ question, answer }) => ({ question, answer: toPlainText(answer) })),
+});
 
 const frameworksData = [
     {
@@ -73,6 +82,7 @@ const frameworksData = [
     description={'AG Grid is a feature-rich Data Grid for all major JavaScript frameworks, offering filtering, grouping, pivoting, and more. Free and open-source. Upgrade to Enterprise for advanced features.'}
     showSearchBar={false}
     showDocsNav={false}
+    pageStructuredData={[faqStructuredData]}
 >
     <div class={styles.homepageHero}>
         <section class:list={[styles.heroInner, 'layout-max-width-small']}>

--- a/documentation/ag-grid-docs/src/pages/index.astro
+++ b/documentation/ag-grid-docs/src/pages/index.astro
@@ -29,8 +29,17 @@ const { data: faqData } = (await getEntry('faqs', 'homepage')) as CollectionEntr
 const { data: metadata } = (await getEntry('metadata', 'metadata')) as CollectionEntry<'metadata'>;
 const { blogPrefix } = whatsNewData['grid'];
 
-// Strip markdown link syntax ([text](url)) so the FAQ structured data carries clean plain-text answers.
-const toPlainText = (markdown: string): string => markdown.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1');
+// Reduce the markdown FAQ answers to plain text so the structured data matches the visible answer and
+// stays valid for rich results. Covers the inline markdown used in these answers: images, links,
+// bold/italic emphasis, inline code, and line-leading heading/quote/list markers.
+const toPlainText = (markdown: string): string =>
+    markdown
+        .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1') // images -> alt text
+        .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // links -> link text
+        .replace(/(\*\*|__)(.*?)\1/g, '$2') // bold
+        .replace(/(\*|_)(.*?)\1/g, '$2') // italic
+        .replace(/`([^`]+)`/g, '$1') // inline code
+        .replace(/^\s{0,3}(?:#{1,6}|>|[-*+]|\d+\.)\s+/gm, ''); // heading / quote / list markers
 const faqStructuredData = buildFAQPage({
     pageUrl: siteRootUrl(metadata.canonicalUrlBase),
     items: faqData.map(({ question, answer }) => ({ question, answer: toPlainText(answer) })),

--- a/external/ag-website-shared/src/components/footer/Footer.module.scss
+++ b/external/ag-website-shared/src/components/footer/Footer.module.scss
@@ -53,7 +53,8 @@
     margin-bottom: $spacing-size-10;
     width: var(--layout-width-4-4);
 
-    h2 {
+    .menuColumnTitle {
+        display: block;
         font-size: var(--text-fs-base);
         line-height: var(--text-lh-base);
         font-weight: var(--text-semibold);

--- a/external/ag-website-shared/src/components/footer/Footer.tsx
+++ b/external/ag-website-shared/src/components/footer/Footer.tsx
@@ -18,7 +18,7 @@ const MenuColumns = ({ footerItems }: { footerItems: FooterItem[] }) => {
 
     return footerItems.map(({ title, links }) => (
         <div key={title} className={styles.menuColumn}>
-            <h2>{title}</h2>
+            <span className={styles.menuColumnTitle}>{title}</span>
             <ul className="list-style-none">
                 {links.map(({ name, url, newTab, iconName }: any) => (
                     <li key={`${title}_${name}`}>

--- a/external/ag-website-shared/src/components/footer/Footer.tsx
+++ b/external/ag-website-shared/src/components/footer/Footer.tsx
@@ -16,25 +16,32 @@ interface FooterProps {
 const MenuColumns = ({ footerItems }: { footerItems: FooterItem[] }) => {
     const slugger = new GithubSlugger();
 
-    return footerItems.map(({ title, links }) => (
-        <div key={title} className={styles.menuColumn}>
-            <span className={styles.menuColumnTitle}>{title}</span>
-            <ul className="list-style-none">
-                {links.map(({ name, url, newTab, iconName }: any) => (
-                    <li key={`${title}_${name}`}>
-                        <a
-                            id={`${slugger.slug(name)}-nav`}
-                            href={urlWithBaseUrl(url)}
-                            {...(newTab ? { target: '_blank', rel: 'noreferrer' } : {})}
-                        >
-                            {iconName && <Icon name={iconName} />}
-                            {name}
-                        </a>
-                    </li>
-                ))}
-            </ul>
-        </div>
-    ));
+    return footerItems.map(({ title, links }) => {
+        // Associate each link list with its (non-heading) title so assistive tech still announces the
+        // group label. SE-45 deliberately drops the <h2> to keep these out of the page heading outline.
+        const titleId = `footer-${new GithubSlugger().slug(title)}`;
+        return (
+            <div key={title} className={styles.menuColumn}>
+                <span className={styles.menuColumnTitle} id={titleId}>
+                    {title}
+                </span>
+                <ul className="list-style-none" aria-labelledby={titleId}>
+                    {links.map(({ name, url, newTab, iconName }: any) => (
+                        <li key={`${title}_${name}`}>
+                            <a
+                                id={`${slugger.slug(name)}-nav`}
+                                href={urlWithBaseUrl(url)}
+                                {...(newTab ? { target: '_blank', rel: 'noreferrer' } : {})}
+                            >
+                                {iconName && <Icon name={iconName} />}
+                                {name}
+                            </a>
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        );
+    });
 };
 
 export const Footer = ({ showMicrosoftMessage, footerItems }: FooterProps) => {

--- a/external/ag-website-shared/src/utils/structuredData.ts
+++ b/external/ag-website-shared/src/utils/structuredData.ts
@@ -57,6 +57,16 @@ interface BreadcrumbListInput {
     items: BreadcrumbItem[];
 }
 
+export interface FaqItem {
+    question: string;
+    answer: string;
+}
+
+interface FAQPageInput {
+    pageUrl: string;
+    items: FaqItem[];
+}
+
 /**
  * Return `canonicalUrlBase` with a trailing slash, so callers can append a
  * site-root-relative path or fragment without worrying about the input form
@@ -78,6 +88,7 @@ export const getSoftwareApplicationId = (canonicalUrlBase: string): string =>
 
 const ARTICLE_ID_FRAGMENT = '#article';
 const BREADCRUMB_ID_FRAGMENT = '#breadcrumb';
+const FAQ_ID_FRAGMENT = '#faq';
 
 export function buildOrganization({ canonicalUrlBase, name, logoUrl, sameAs }: OrgInput): JsonLdObject {
     return {
@@ -159,6 +170,26 @@ export function buildBreadcrumbList({ pageUrl, items }: BreadcrumbListInput): Js
             position: index + 1,
             name: item.name,
             item: item.url,
+        })),
+    };
+}
+
+/**
+ * Build a `FAQPage` node from question/answer pairs. Answers should be plain
+ * text (strip any markdown before passing them in) — schema.org allows limited
+ * HTML, but the surrounding `serializeJsonLd` does not expect markdown markup.
+ */
+export function buildFAQPage({ pageUrl, items }: FAQPageInput): JsonLdObject {
+    return {
+        '@type': 'FAQPage',
+        '@id': `${pageUrl}${FAQ_ID_FRAGMENT}`,
+        mainEntity: items.map((item) => ({
+            '@type': 'Question',
+            name: item.question,
+            acceptedAnswer: {
+                '@type': 'Answer',
+                text: item.answer,
+            },
         })),
     };
 }


### PR DESCRIPTION
```
SE-50 viewport width=device-width, initial-scale=1 on home, docs, and both converted pages                                              
SE-48 social images   og:image + twitter:image absolute (https://www.ag-grid.com/...) on all pages                                                                                                                       
SE-49 <main> landmark Exactly one <main> per page (home, getting-started, lets-cook, power-of-ag-charts), all HTTP 200                         
SE-45 footer Column titles render as <span class="menuColumnTitle">, no <h2>                                                          
SE-47 FAQPage Valid JSON-LD @graph (Organization/WebSite/Soft)
```