### PR TITLE
AG-17633 fix enableDevValidations import in formula examples

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/formula-editor-component/_examples/formula-editor-component-disabled/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/formula-editor-component/_examples/formula-editor-component-disabled/main.ts
@@ -5,6 +5,7 @@ import {
     NumberEditorModule,
     TextEditorModule,
     createGrid,
+    enableDevValidations,
 } from 'ag-grid-community';
 import { FormulaModule } from 'ag-grid-enterprise';
 
@@ -18,7 +19,6 @@ ModuleRegistry.registerModules([
     FormulaModule,
     NumberEditorModule,
     TextEditorModule,
-    enableDevValidations,
 ]);
 
 let gridApi: GridApi;

--- a/documentation/ag-grid-docs/src/content/docs/formula-editor-component/_examples/formula-editor-component-disabled/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/formula-editor-component/_examples/formula-editor-component-disabled/main.ts
@@ -14,12 +14,7 @@ if (process.env.NODE_ENV !== 'production') {
     enableDevValidations();
 }
 
-ModuleRegistry.registerModules([
-    ClientSideRowModelModule,
-    FormulaModule,
-    NumberEditorModule,
-    TextEditorModule,
-]);
+ModuleRegistry.registerModules([ClientSideRowModelModule, FormulaModule, NumberEditorModule, TextEditorModule]);
 
 let gridApi: GridApi;
 

--- a/documentation/ag-grid-docs/src/content/docs/formula-editor-component/_examples/formula-editor-component-validation/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/formula-editor-component/_examples/formula-editor-component-validation/main.ts
@@ -5,6 +5,7 @@ import {
     NumberEditorModule,
     TextEditorModule,
     createGrid,
+    enableDevValidations,
 } from 'ag-grid-community';
 import { CellSelectionModule, FormulaModule } from 'ag-grid-enterprise';
 
@@ -19,7 +20,6 @@ ModuleRegistry.registerModules([
     FormulaModule,
     NumberEditorModule,
     TextEditorModule,
-    enableDevValidations,
 ]);
 
 let gridApi: GridApi;

--- a/documentation/ag-grid-docs/src/content/docs/formula-editor-component/_examples/formula-editor-component/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/formula-editor-component/_examples/formula-editor-component/main.ts
@@ -5,6 +5,7 @@ import {
     NumberEditorModule,
     TextEditorModule,
     createGrid,
+    enableDevValidations,
 } from 'ag-grid-community';
 import { CellSelectionModule, FormulaModule } from 'ag-grid-enterprise';
 
@@ -19,7 +20,6 @@ ModuleRegistry.registerModules([
     FormulaModule,
     NumberEditorModule,
     TextEditorModule,
-    enableDevValidations,
 ]);
 
 let gridApi: GridApi;

--- a/documentation/ag-grid-docs/src/content/docs/formulas/_examples/formulas-formula-data-source/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/formulas/_examples/formulas-formula-data-source/main.ts
@@ -6,6 +6,7 @@ import {
     RowApiModule,
     TextEditorModule,
     createGrid,
+    enableDevValidations,
 } from 'ag-grid-community';
 import { FormulaModule } from 'ag-grid-enterprise';
 
@@ -20,7 +21,6 @@ ModuleRegistry.registerModules([
     FormulaModule,
     NumberEditorModule,
     TextEditorModule,
-    enableDevValidations,
 ]);
 
 type RowData = {

--- a/documentation/ag-grid-docs/src/content/docs/formulas/_examples/formulas/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/formulas/_examples/formulas/main.ts
@@ -5,6 +5,7 @@ import {
     NumberEditorModule,
     TextEditorModule,
     createGrid,
+    enableDevValidations,
 } from 'ag-grid-community';
 import { CellSelectionModule, FormulaModule } from 'ag-grid-enterprise';
 
@@ -19,7 +20,6 @@ ModuleRegistry.registerModules([
     FormulaModule,
     NumberEditorModule,
     TextEditorModule,
-    enableDevValidations,
 ]);
 
 let gridApi: GridApi;


### PR DESCRIPTION
The `enableDevValidations` standardisation (#14224) left `enableDevValidations` listed inside `ModuleRegistry.registerModules([...])` and omitted the import from `ag-grid-community` in five formula examples. At runtime this threw a `ReferenceError`, failing the docs E2E tests:

- `formula-editor-component/formula-editor-component`
- `formula-editor-component/formula-editor-component-disabled`
- `formula-editor-component/formula-editor-component-validation`
- `formulas/formulas`
- `formulas/formulas-formula-data-source`

This adds the missing import and removes the bogus `registerModules` entry. All 60 docs E2E tests across the affected examples now pass locally.

Fix [AG-17633](https://ag-grid.atlassian.net/browse/AG-17633)