### PR TITLE
fix(column-delay-render): prevent retry from mutating requesters in SSRM + treeData

### DIFF
--- a/packages/ag-grid-community/src/rendering/columnDelayRenderService.ts
+++ b/packages/ag-grid-community/src/rendering/columnDelayRenderService.ts
@@ -47,13 +47,33 @@ export class ColumnDelayRenderService extends BeanStub implements NamedBean {
             return;
         }
 
+        this.checkAndReveal();
+    }
+
+    /**
+     * Checks whether headers are rendered and reveals the grid if so. Separated from
+     * `revealColumns` so that retries do not mutate `requesters` — re-entrant callers
+     * (e.g. an auto-group column triggering a second flex recalculation in SSRM + tree
+     * data mode) legitimately re-add keys to `requesters` after the initial reveal was
+     * scheduled, and the retry must not silently remove those keys.
+     */
+    private checkAndReveal(): void {
+        if (this.alreadyRevealed || !this.isAlive()) {
+            return;
+        }
+        if (this.requesters.size > 0) {
+            // A new requester was added while we were waiting for headers to render.
+            // It will call revealColumns when done, which will invoke checkAndReveal again.
+            return;
+        }
+
         const { renderStatus, ctrlsSvc } = this.beans;
         if (renderStatus) {
             // For React, we need to check that the headers are actually rendered before revealing them.
             // We add a fail safe to only try this 5 times, after that we reveal anyway.
             if (!renderStatus.areHeaderCellsRendered() && this.timesRetried < 5) {
                 this.timesRetried++;
-                setTimeout(() => this.revealColumns(key));
+                setTimeout(() => this.checkAndReveal());
                 return;
             }
             this.timesRetried = 0;


### PR DESCRIPTION
## Problem

Closes #14255

In React + SSRM + `treeData: true` grids with flex columns, `ag-delay-render` is never removed from `.ag-root`, leaving all rows permanently invisible (`visibility: hidden`).

### Root cause

`ColumnDelayRenderService.revealColumns(key)` schedules a retry via:

```ts
setTimeout(() => this.revealColumns(key));
```

The retry calls `this.revealColumns(key)` which **starts by deleting `key` from `requesters`**. This is incorrect because `key` may have been legitimately re-added to `requesters` between the retry being scheduled and firing.

In SSRM + `treeData` mode, generating the auto-group column triggers an additional flex recalculation cycle. The sequence is:

1. `revealColumns('colFlex')` called — requesters becomes empty, headers not yet rendered → schedule retry
2. Auto-group column generation calls `hideColumns('colFlex')` → re-adds `'colFlex'` to requesters (legitimate!)
3. Retry fires and calls `revealColumns('colFlex')` → **deletes the legitimate `'colFlex'` entry**
4. If other keys are now in requesters: early return with `requesters.size > 0`, and `timesRetried` is NOT incremented → the fail-safe that should force-reveal after 5 retries stalls

This cycle can repeat indefinitely, `ag-delay-render` is never removed, rows stay invisible.

### Fix

Extract the header-readiness check into a private `checkAndReveal()` method that **only reads** `requesters` and never mutates it. `revealColumns` calls `checkAndReveal()` after clearing its own key. Retries call `checkAndReveal()` directly — so they never touch `requesters`.

If a new requester is present when `checkAndReveal` runs (because `hideColumns` was called between the retry scheduling and firing), it returns early and waits. When that requester eventually calls `revealColumns`, it will invoke `checkAndReveal` again. `timesRetried` is only incremented when requesters is genuinely empty and headers haven't rendered yet, correctly counting actual header-wait retries.

## Affected configuration

- `rowModelType: 'serverSide'`
- `treeData: true`
- React renderer (requires `areHeaderCellsRendered()` / `RenderStatusService`)
- Flex columns (`flex: 1` in `defaultColDef`)
- `domLayout: 'normal'` (large datasets — `autoHeight` grids render all rows and are not affected)

Other SSRM grids (no `treeData`) and client-side grids are not affected because they don't generate an auto-group column mid-init.

## Testing

To reproduce before this fix: render a React SSRM + `treeData` grid with `flex` columns and load enough rows to trigger `domLayout: 'normal'`. The grid body renders blank (all rows `visibility: hidden`) and never recovers. After this fix, the grid reveals normally.