### PR TITLE
AG-17134 - Exempt staging /branch-builds/ from CSP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,12 @@ jobs:
               - 'nx.json'
               - 'tsconfig.*.json'
               - 'jest.preset.js'
+              # The .htaccess / CSP generation lives under documentation/ but is exercised
+              # by code-CI jobs — the e2e htaccess harness (test:htaccess) and its own unit
+              # tests (cspRules/htaccessRules .test.ts) — so route changes here through full
+              # code CI rather than the docs-only path, where both would be skipped.
+              - 'documentation/ag-grid-docs/src/utils/htaccess/**'
+              - 'documentation/ag-grid-docs/src/utils/csp/**'
             ci:
               - '.github/**'
             docs:

--- a/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -2770,6 +2770,14 @@ Header always set Content-Security-Policy "default-src 'self'; script-src 'self'
     Header always set Content-Security-Policy "default-src 'self'; script-src 'self' https://*.ag-grid.com https://plausible.io https://www.googletagmanager.com https://www.google-analytics.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://js.zi-scripts.com https://*.zoominfo.com https://www.google.com https://www.gstatic.com https://apis.google.com https://www.youtube.com https://cdn.cookielaw.org blob: 'wasm-unsafe-eval' https://bryntum.com 'unsafe-inline'; style-src 'self' https://fonts.googleapis.com https://use.fontawesome.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com 'unsafe-inline' https://bryntum.com; font-src 'self' https://fonts.gstatic.com https://use.fontawesome.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com data: https://bryntum.com; img-src 'self' data: blob: https:; connect-src 'self' https://*.ag-grid.com https://plausible.io https://*.algolia.net https://*.algolianet.com https://*.google-analytics.com https://*.analytics.google.com https://analytics.google.com https://stats.g.doubleclick.net https://flagcdn.com https://www.googletagmanager.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://js.zi-scripts.com https://*.zoominfo.com https://www.google.com https://cdn.cookielaw.org https://*.onetrust.com https://www.googleapis.com https://securetoken.googleapis.com https://us-central1-stripe-testing-19784.cloudfunctions.net https://bryntum.com; frame-src 'self' https://www.googletagmanager.com https://www.youtube.com https://www.google.com https://pay.sandbox.realexpayments.com https://stripe-testing-19784.firebaseapp.com; media-src 'self' data: blob: https:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self' https://us-central1-stripe-testing-19784.cloudfunctions.net https://test.salesforce.com https://pay.sandbox.realexpayments.com https://codesandbox.io https://plnkr.co; frame-ancestors 'self' https://*.ag-grid.com"
 </If>
 
+# /branch-builds/ holds preserved per-branch documentation builds (staging only):
+# arbitrary historical snapshots, internal and password-protected, whose pages predate
+# the tightened policy (e.g. inline event handlers, which CSP can't authorise by hash).
+# Drop the CSP entirely for them rather than force-fit a scope.
+<If "%{REQUEST_URI} =~ m#^/branch-builds/#">
+    Header always unset Content-Security-Policy
+</If>
+
 Options -Indexes
 "
 `;

--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.test.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.test.ts
@@ -4,9 +4,11 @@ import { createHash } from 'node:crypto';
 import { DARK_MODE_INIT_SCRIPT, PLAUSIBLE_INIT_SCRIPT } from '../csp/inlineScripts';
 import {
     ASTRO_HYDRATION_HASHES_VERIFIED_FOR,
+    BRANCH_BUILDS_PATH_CONDITION,
     CAMPAIGNS_PATH_CONDITION,
     CAMPAIGNS_PATH_REGEXP,
     EXAMPLES_PATH_REGEXP,
+    getBranchBuildsCspIfOverride,
     getCspDirectives,
     getScopedCspHtaccessBlock,
 } from './cspRules';
@@ -177,6 +179,36 @@ describe('cspRules', () => {
             //      scripts log their missing 'sha256-...' hashes in the console.
             //   4. update ASTRO_HYDRATION_SCRIPT_HASHES and ASTRO_HYDRATION_HASHES_VERIFIED_FOR.
             expect(astroPackageJson.version).toBe(ASTRO_HYDRATION_HASHES_VERIFIED_FOR);
+        });
+    });
+
+    describe('AG-17134: /branch-builds/ CSP exemption (staging-only)', () => {
+        it('matches only paths under /branch-builds/', () => {
+            const matches = (uri: string) =>
+                new RegExp(BRANCH_BUILDS_PATH_CONDITION.replace('%{REQUEST_URI} =~ m#', '').replace(/#$/, '')).test(
+                    uri
+                );
+            expect(matches('/branch-builds/')).toBe(true);
+            expect(matches('/branch-builds/my-branch/getting-started/')).toBe(true);
+            // A branch build's own /examples/ paths live under /branch-builds/, so they
+            // must NOT be picked up by the site-wide examples/campaigns conditions.
+            expect(EXAMPLES_PATH_REGEXP.test('/branch-builds/my-branch/examples/foo/')).toBe(false);
+            expect(CAMPAIGNS_PATH_REGEXP.test('/branch-builds/my-branch/campaigns/bryntum-gantt/')).toBe(false);
+            expect(matches('/getting-started/')).toBe(false);
+        });
+
+        it('unsets the CSP header without re-setting one (no policy served)', () => {
+            const block = getBranchBuildsCspIfOverride('enforce');
+            expect(block).toContain(`<If "${BRANCH_BUILDS_PATH_CONDITION}">`);
+            expect(block).toContain('Header always unset Content-Security-Policy');
+            // Exempt, not scoped: nothing is re-set inside the override.
+            expect(block).not.toContain('Header always set Content-Security-Policy');
+        });
+
+        it('clears the header form matching the mode', () => {
+            expect(getBranchBuildsCspIfOverride('report-only')).toContain(
+                'Header always unset Content-Security-Policy-Report-Only'
+            );
         });
     });
 

--- a/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/cspRules.ts
@@ -148,6 +148,19 @@ export const EXAMPLES_PATH_CONDITION = '%{REQUEST_URI} =~ m#^/(examples|archive)
 // /archive/<version> prefix covers the archived snapshots.
 export const CAMPAIGNS_PATH_CONDITION = '%{REQUEST_URI} =~ m#^(?:/archive/[^/]+)?/campaigns/#';
 
+// Apache <If> expression matching the staging-only /branch-builds/ tree: a directory
+// of full per-branch documentation builds, preserved across deployments (backed up
+// and restored by scripts/deployments/*) rather than produced by this build. Each is
+// an arbitrary historical snapshot of the docs at whatever code — and CSP needs —
+// existed when that branch was built: old example HTML carries inline event handlers
+// (onclick=, onchange=, …) and eval that the tightened site policy blocks, and CSP
+// cannot authorise inline event handlers by hash at all. The tree is internal and
+// password-protected, so it is exempted from the CSP entirely (see
+// getBranchBuildsCspIfOverride) rather than force-fitted to a scope. Staging-only:
+// the tree does not exist on production www. No JS PATH_REGEXP counterpart because
+// the dev/preview middleware never serves these paths.
+export const BRANCH_BUILDS_PATH_CONDITION = '%{REQUEST_URI} =~ m#^/branch-builds/#';
+
 // JS equivalents of the *_PATH_CONDITION Apache rules above, for the dev-server
 // (agDevCsp) and preview-server (preview-csp) middleware that scope the served
 // CSP by URL path. Keep these in sync with the Apache conditions.
@@ -425,6 +438,31 @@ export function getCampaignsCspIfOverride(options: Omit<CspOptions, 'scope'>, mo
         { ...options, scope: 'campaigns' },
         mode
     );
+}
+
+/**
+ * The `<If>` override that drops the CSP header entirely for the staging-only
+ * /branch-builds/ tree matched by BRANCH_BUILDS_PATH_CONDITION.
+ *
+ * Unlike the examples/campaigns overrides — which unset the inherited header and
+ * re-set a relaxed-but-still-restrictive policy — this one only unsets it, leaving
+ * no Content-Security-Policy for these paths. Branch builds are arbitrary, internal,
+ * password-protected snapshots of past documentation builds whose pages predate (and
+ * cannot satisfy) the tightened site policy; notably their example HTML uses inline
+ * event handlers, which CSP cannot authorise by hash. `mode` selects which header
+ * form to clear so this drops whichever header the site-wide block set for the page.
+ */
+export function getBranchBuildsCspIfOverride(mode: CspMode): string {
+    const headerName = getCspHeaderName(mode);
+    return [
+        '# /branch-builds/ holds preserved per-branch documentation builds (staging only):',
+        '# arbitrary historical snapshots, internal and password-protected, whose pages predate',
+        "# the tightened policy (e.g. inline event handlers, which CSP can't authorise by hash).",
+        '# Drop the CSP entirely for them rather than force-fit a scope.',
+        `<If "${BRANCH_BUILDS_PATH_CONDITION}">`,
+        `    Header always unset ${headerName}`,
+        '</If>',
+    ].join('\n');
 }
 
 /**

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
@@ -1,4 +1,4 @@
-import { CAMPAIGNS_PATH_CONDITION, EXAMPLES_PATH_CONDITION } from './cspRules';
+import { BRANCH_BUILDS_PATH_CONDITION, CAMPAIGNS_PATH_CONDITION, EXAMPLES_PATH_CONDITION } from './cspRules';
 import { PRODUCTION_CSP_PHASE, getHtaccessContent } from './htaccessRules';
 import { SITE_301_REDIRECTS } from './redirects';
 
@@ -340,6 +340,33 @@ describe('htaccessRules', () => {
                 expect(ifBlock).toContain('Header always set Content-Security-Policy "');
             });
         }
+    });
+
+    describe('AG-17134: /branch-builds/ CSP exemption', () => {
+        const branchBuildsIfOpen = `<If "${BRANCH_BUILDS_PATH_CONDITION}">`;
+
+        const branchBuildsIfBlock = (content: string) => {
+            const start = content.indexOf(branchBuildsIfOpen);
+            expect(start).toBeGreaterThan(-1);
+            return content.slice(start, content.indexOf('</If>', start));
+        };
+
+        it('staging: drops the CSP entirely for /branch-builds/ (unset, no re-set)', () => {
+            const ifBlock = branchBuildsIfBlock(stagingContent);
+            expect(ifBlock).toContain('Header always unset Content-Security-Policy');
+            expect(ifBlock).not.toContain('Header always set Content-Security-Policy');
+        });
+
+        it('staging: the branch-builds override trails the site-wide set so it wins for those paths', () => {
+            const setIndex = stagingContent.indexOf('Header always set Content-Security-Policy "');
+            const ifIndex = stagingContent.indexOf(branchBuildsIfOpen);
+            expect(setIndex).toBeGreaterThan(-1);
+            expect(ifIndex).toBeGreaterThan(setIndex);
+        });
+
+        it('production: no /branch-builds/ override (the tree is staging-only)', () => {
+            expect(productionContent).not.toContain(branchBuildsIfOpen);
+        });
     });
 
     describe('basic structure', () => {

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
@@ -1,6 +1,11 @@
 import { urlWithBaseUrl } from '../urlWithBaseUrl';
 import type { CspEnv } from './cspRules';
-import { getCampaignsCspIfOverride, getCspHtaccessBlock, getScopedCspHtaccessBlock } from './cspRules';
+import {
+    getBranchBuildsCspIfOverride,
+    getCampaignsCspIfOverride,
+    getCspHtaccessBlock,
+    getScopedCspHtaccessBlock,
+} from './cspRules';
 import { SITE_301_REDIRECTS, SITE_SINGLE_HOP_REWRITES } from './redirects';
 
 export type HtaccessEnv = Extract<CspEnv, 'staging' | 'production'>;
@@ -181,6 +186,8 @@ function getStagingHtaccessContent(): string {
 # Content-Security-Policy — enforced, path-scoped. Unsets the legacy wildcard CSP on
 # the staging vhost so this tightened policy is the only one in effect.
 ${getScopedCspHtaccessBlock({ env: 'staging' }, 'enforce')}
+
+${getBranchBuildsCspIfOverride('enforce')}
 
 Options -Indexes
 `;


### PR DESCRIPTION
## Summary

Fixes the CSP "inline event handler" violations on `https://grid-staging.ag-grid.com/branch-builds/`.

`/branch-builds/` is a **staging-only** directory of preserved per-branch documentation builds — backed up and restored across deploys by `scripts/deployments/*`, not produced by the current build. Each entry is a frozen historical snapshot whose example pages carry inline event handlers (`onclick=`, `onchange=`, …) and `eval`, which the tightened site CSP blocks. Per the CSP spec, inline event handlers **cannot be authorised by hash** — only `unsafe-inline`/`unsafe-hashes` or rewriting the HTML would allow them, and we can't rewrite frozen snapshots.

Since the tree is internal and password-protected, this exempts it from CSP entirely via an Apache `<If>` that **unsets** the header for matching paths, rather than force-fitting it to a scope.

## Changes

- `cspRules.ts` — add `BRANCH_BUILDS_PATH_CONDITION` and `getBranchBuildsCspIfOverride(mode)` (only unsets the header — no relaxed policy re-set, unlike the examples/campaigns overrides).
- `htaccessRules.ts` — wire it into `getStagingHtaccessContent()` only. The override trails the site-wide `set`, so it wins for `/branch-builds/` paths.
- Tests + updated staging `.htaccess` snapshot.

Generated staging `.htaccess` now ends with:

```apache
<If "%{REQUEST_URI} =~ m#^/branch-builds/#">
    Header always unset Content-Security-Policy
</If>
```

## Scope / safety

- **Staging-only** — the `/branch-builds/` tree does not exist on production `www`, and a test asserts production emits no such override.
- The main AG-17134 goal (tightening CSP on production `www`) is untouched.

## Testing

- `cspRules` + `htaccessRules` unit tests: **77 passed** (8 new).
- Lint clean; format applied.
