### PR TITLE
Exempt test files from no-restricted-properties lint rule

### DIFF
--- a/packages/ag-grid-community/eslint.config.mjs
+++ b/packages/ag-grid-community/eslint.config.mjs
@@ -49,7 +49,7 @@ export default [
                 },
             ],
             'no-restricted-properties': [
-                'warn',
+                'error',
                 { property: 'innerText', message: 'Prefer textContent where possible' },
                 { property: 'innerHTML', message: 'Prefer textContent where possible' },
                 {
@@ -73,6 +73,13 @@ export default [
             'no-console': 'error',
 
             'unicorn/prefer-modern-dom-apis': 'error',
+        },
+    },
+    {
+        // Test files are exempt from the runtime-focused restrictions above.
+        files: ['**/*.test.ts', '**/*.test.tsx'],
+        rules: {
+            'no-restricted-properties': 'off',
         },
     },
     {

--- a/packages/ag-grid-community/src/rendering/autoWidthCalculator.ts
+++ b/packages/ag-grid-community/src/rendering/autoWidthCalculator.ts
@@ -3,6 +3,7 @@ import { BeanStub } from '../context/beanStub';
 import type { AgColumn } from '../entities/agColumn';
 import type { AgColumnGroup } from '../entities/agColumnGroup';
 import type { RowContainerCtrl } from '../gridBodyComp/rowContainer/rowContainerCtrl';
+import { _createElement } from '../utils/element';
 
 export class AutoWidthCalculator extends BeanStub implements NamedBean {
     beanName = 'autoWidthCalc' as const;
@@ -52,7 +53,7 @@ export class AutoWidthCalculator extends BeanStub implements NamedBean {
         // this element has to be a form, otherwise form elements within a cell
         // will be validated while being cloned. This can cause issues such as
         // radio buttons being reset and losing their values.
-        const eDummyContainer = document.createElement('form');
+        const eDummyContainer = _createElement<HTMLFormElement>({ tag: 'form' });
         // position fixed, so it isn't restricted to the boundaries of the parent
         eDummyContainer.style.position = 'fixed';
 
@@ -97,7 +98,7 @@ export class AutoWidthCalculator extends BeanStub implements NamedBean {
         // we put the cell into a containing div, as otherwise the cells would just line up
         // on the same line, standard flow layout, by putting them into divs, they are laid
         // out one per line
-        const eCloneParent = document.createElement('div');
+        const eCloneParent = _createElement({ tag: 'div' });
         const eCloneParentClassList = eCloneParent.classList;
         const isHeader = ['ag-header-cell', 'ag-header-group-cell'].some((cls) => eCellClone.classList.contains(cls));
 

--- a/packages/ag-grid-community/src/validation/errorMessages/errorText.test.ts
+++ b/packages/ag-grid-community/src/validation/errorMessages/errorText.test.ts
@@ -4,7 +4,6 @@ import { AG_GRID_ERRORS } from './errorText';
 const trimTrailingSpaces = (s: string) => s.replace(/ +\n/g, '\n');
 
 describe('Validate AG_GRID_ERRORS', () => {
-    // eslint-disable-next-line no-restricted-properties
     test.each(Object.entries(AG_GRID_ERRORS))(
         'Calling with no params should not throw for Astro generation: ErrorKey=%i',
         (key, errorTextFn) => {

--- a/packages/ag-grid-enterprise/eslint.config.mjs
+++ b/packages/ag-grid-enterprise/eslint.config.mjs
@@ -35,7 +35,7 @@ export default [
             '@typescript-eslint/no-this-alias': 'off',
             '@typescript-eslint/no-for-in-array': 'error',
             'no-restricted-properties': [
-                'warn',
+                'error',
                 { property: 'innerText', message: 'Prefer textContent where possible.' },
                 { property: 'innerHTML', message: 'Prefer textContent where possible.' },
                 {
@@ -92,6 +92,13 @@ export default [
             'sonarjs/use-type-alias': 0,
             'sonarjs/no-nested-template-literals': 0,
             'unicorn/prefer-modern-dom-apis': 'error',
+        },
+    },
+    {
+        // Test files are exempt from the runtime-focused restrictions above.
+        files: ['**/*.test.ts', '**/*.test.tsx'],
+        rules: {
+            'no-restricted-properties': 'off',
         },
     },
     {

--- a/packages/ag-grid-enterprise/src/charts/chartComp/menu/settings/chartSettingsPanel.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/menu/settings/chartSettingsPanel.ts
@@ -1,7 +1,7 @@
 import type { AgChartThemePalette } from 'ag-charts-types';
 import { RefPlaceholder, _areEqual, _clearElement, _getAbsoluteWidth, _radioCssClass, _setDisplayed } from 'ag-stack';
 
-import { Component, _createIconNoSpan } from 'ag-grid-community';
+import { Component, _createElement, _createIconNoSpan } from 'ag-grid-community';
 
 import type { AgChartsExports } from '../../../agChartsExports';
 import type { ChartController } from '../../chartController';
@@ -130,8 +130,7 @@ export class ChartSettingsPanel extends Component {
     }
 
     private addCardLink(index: number): void {
-        const link = document.createElement('div');
-        link.classList.add('ag-chart-settings-card-item');
+        const link = _createElement({ tag: 'div', cls: 'ag-chart-settings-card-item' });
 
         this.addManagedElementListeners(link, {
             click: () => {

--- a/packages/ag-grid-enterprise/src/charts/chartComp/menu/settings/miniChartsContainer.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/menu/settings/miniChartsContainer.ts
@@ -2,7 +2,7 @@ import type { AgColorType } from 'ag-charts-types';
 import { _setAriaLabel } from 'ag-stack';
 
 import type { BeanCollection, ChartGroupsDef, ChartType } from 'ag-grid-community';
-import { Component, KeyCode, _warn } from 'ag-grid-community';
+import { Component, KeyCode, _createElement, _warn } from 'ag-grid-community';
 
 import { AgGroupComponent } from '../../../../agStack/agGroupComponent';
 import type { GroupComponent } from '../../../../widgets/gridEnterpriseWidgetTypes';
@@ -258,10 +258,12 @@ export class MiniChartsContainer extends Component {
 
             for (const menuItem of items) {
                 const { miniChart: MiniClass, chartType } = menuItem.icon;
-                const miniWrapper = document.createElement('div');
-                miniWrapper.classList.add('ag-chart-mini-thumbnail');
-                miniWrapper.setAttribute('tabindex', '0');
-                miniWrapper.setAttribute('role', 'button');
+                const miniWrapper = _createElement({
+                    tag: 'div',
+                    cls: 'ag-chart-mini-thumbnail',
+                    role: 'button',
+                    attrs: { tabindex: '0' },
+                });
 
                 const miniClassChartType: ChartType = chartType;
                 const listener = () => {

--- a/packages/ag-grid-enterprise/src/widgets/agRichSelect.test.ts
+++ b/packages/ag-grid-enterprise/src/widgets/agRichSelect.test.ts
@@ -16,7 +16,6 @@ const flushMicrotasks = async (): Promise<void> => {
 
 describe('AgRichSelect', () => {
     afterEach(() => {
-        // eslint-disable-next-line no-restricted-properties
         document.body.innerHTML = '';
     });
 


### PR DESCRIPTION
Test files were being flagged by the `no-restricted-properties` ESLint rule (e.g. `document.createElement`), which exists to steer runtime code toward the `_createElement` helper. That guidance is irrelevant to tests, so test files are now exempt.

- Add a `**/*.test.ts` / `**/*.test.tsx` override turning off `no-restricted-properties` in the community and enterprise ESLint configs.
- Remove the now-redundant `eslint-disable no-restricted-properties` directives from `errorText.test.ts` and `agRichSelect.test.ts`.
- The rule is now enforced as `error` (was `warn`); the few non-test violations this surfaced are replaced with the `_createElement` helper in `autoWidthCalculator`, `chartSettingsPanel`, and `miniChartsContainer`.