### PR TITLE
AG-17682 Add Cell Notes under Cells section on pricing page

### DIFF
--- a/external/ag-website-shared/src/content/license-features/gridFeaturesMatrix.json
+++ b/external/ag-website-shared/src/content/license-features/gridFeaturesMatrix.json
@@ -299,6 +299,15 @@
                 "community": false,
                 "enterprise": true,
                 "chartsGrid": true
+            },
+            {
+                "label": {
+                    "name": "Cell Notes",
+                    "link": "grid:./notes"
+                },
+                "community": false,
+                "enterprise": true,
+                "chartsGrid": true
             }
         ]
     },


### PR DESCRIPTION
## Summary

Adds **Cell Notes** to the **Cells** section of the pricing comparison table, as part of AG-17682.

## Details

- Adds a `Cell Notes` entry to the `Cells` group in `gridFeaturesMatrix.json`, linking to the Notes docs page (`grid:./notes`).
- Tier availability matches the feature's enterprise status: Community ✗, Enterprise ✓, Enterprise Bundle ✓.
- Placed after `Find`, consistent with the other enterprise cell features.

## Note

This file lives under `external/ag-website-shared/`, which is shared across AG repos — may need syncing to other consumers.