### PR TITLE
AG-17735 Fix unresolvable JSDoc @link targets in published types + TypeDoc link-validation test

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
       "plugins/ag-grid-generate-example-files",
       "plugins/ag-grid-task-autogen",
       "testing/behavioural",
+      "testing/typedoc-links",
       "testing/module-size",
       "testing/module-size-angular",
       "testing/angular-package-tests",

--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -460,7 +460,7 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
      * a callback to control editability per row.
      *
      * When `groupRowEditable` is defined and no explicit `groupRowValueSetter` is provided,
-     * the built-in {@link distributeGroupValue | distributeGroupValue} is used automatically.
+     * the built-in `distributeGroupValue` (exported from `ag-grid-enterprise`) is used automatically.
      *
      * Columns with `groupRowEditable` or `groupRowValueSetter` do not require `field` or
      * `valueSetter` - the group row value setter handles the edit entirely.
@@ -475,7 +475,7 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
     /**
      * Controls how a group row value edit is distributed to descendant rows.
      *
-     * - **`true`**: Uses the built-in {@link distributeGroupValue | distributeGroupValue} with default settings.
+     * - **`true`**: Uses the built-in `distributeGroupValue` (exported from `ag-grid-enterprise`) with default settings.
      *   Also enabled implicitly when `groupRowEditable` is defined and `groupRowValueSetter` is not set.
      * - **`false`**: Explicitly disables group row value distribution and makes the cell not editable,
      *   even if `groupRowEditable` is defined.

--- a/packages/ag-grid-community/src/valueService/valueService.ts
+++ b/packages/ag-grid-community/src/valueService/valueService.ts
@@ -300,7 +300,7 @@ export class ValueService extends BeanStub implements NamedBean {
     /**
      * Reads a cell value honouring pending edits for non-`'data'` sources. Does NOT redirect pivot result
      * columns — display/selection callers only ever pair them with group rows (no redirect needed). The
-     * value APIs that accept an arbitrary node ({@link getCellValue}, {@link getDataValue}) pre-resolve via
+     * value APIs that accept an arbitrary node (`getCellValue`, `getDataValue`) pre-resolve via
      * `_resolvePivotColumnForRow` since they can be handed a leaf. Hot committed-data reads of a known column
      * should call {@link getValueFromData} directly to skip the edit-state lookup too.
      */

--- a/testing/typedoc-links/README.md
+++ b/testing/typedoc-links/README.md
@@ -1,0 +1,45 @@
+# ag-grid-typedoc-links
+
+Guards the JSDoc `{@link}` references in our **published** type declarations.
+
+Many consumers generate their API documentation with [TypeDoc](https://typedoc.org/) pointed at our
+shipped `.d.ts` files. If a JSDoc comment contains a `{@link Target}` that TypeDoc cannot resolve, their
+build prints `Failed to resolve link to "Target"`. This project reproduces that environment: it runs
+TypeDoc against the built `main.d.ts` of `ag-grid-community` and `ag-grid-enterprise` and fails if any
+link is unresolved.
+
+## Running
+
+```bash
+yarn nx test ag-grid-typedoc-links
+```
+
+The `test` target depends on `ag-grid-community:build:types` and `ag-grid-enterprise:build:types`, so the
+declarations are built first. CI picks it up via `nx affected -t test` like the other test projects.
+
+## Fixing a failure
+
+A failure names the symbol and the comment it appears in, e.g.:
+
+```
+Failed to resolve link to "distributeGroupValue" in comment for ColDef.groupRowValueSetter
+```
+
+The fix is almost always in the **source** JSDoc (`packages/ag-grid-*/src/...`), not here:
+
+- **Referencing a symbol not exported from that package** (e.g. an `ag-grid-enterprise` export such as
+  `distributeGroupValue` referenced from an `ag-grid-community` type) — TypeDoc has no symbol in scope to
+  link to. Reference it as inline code (`` `distributeGroupValue` ``) instead.
+- **Referencing an internal method/type not on the public surface** (e.g. a cross-service method) — same
+  fix: use inline code. Only `{@link}` symbols that are exported from the same package or in scope.
+- **A typo** in the target symbol name — correct it.
+
+Do **not** try to fix this via TypeDoc's `externalSymbolLinkMappings`: that only fires once TypeDoc has
+resolved the name to a real declaration, so it cannot rescue a bare symbol that is out of scope.
+
+## Notes
+
+- The TypeDoc version is pinned exactly — link-resolution behaviour varies between versions, so bump it
+  deliberately.
+- Only `invalidLink` validation is enabled. `notExported`/`notDocumented` are off because they flag the
+  many intentional internal (`_`-prefixed) API types and would drown the real signal.

--- a/testing/typedoc-links/eslint.config.js
+++ b/testing/typedoc-links/eslint.config.js
@@ -1,0 +1,15 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+    { ignores: ['dist'] },
+    {
+        extends: [js.configs.recommended, ...tseslint.configs.recommended],
+        files: ['**/*.ts'],
+        languageOptions: {
+            ecmaVersion: 2022,
+            globals: globals.node,
+        },
+    }
+);

--- a/testing/typedoc-links/package.json
+++ b/testing/typedoc-links/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ag-grid-typedoc-links",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Validates that AG Grid's published .d.ts JSDoc {@link} references resolve under TypeDoc, reproducing the environment downstream consumers build their API docs in.",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typedoc": "0.28.19",
+    "typescript": "~5.8.3",
+    "vitest": "2.1.9"
+  }
+}

--- a/testing/typedoc-links/project.json
+++ b/testing/typedoc-links/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "ag-grid-typedoc-links",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "testing/typedoc-links",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "command": "eslint",
+      "options": {
+        "cwd": "{projectRoot}"
+      }
+    },
+    "test": {
+      "command": "npx vitest run",
+      "dependsOn": ["ag-grid-community:build:types", "ag-grid-enterprise:build:types"],
+      "outputs": ["{workspaceRoot}/reports/ag-grid-typedoc-links.xml"],
+      "options": {
+        "cwd": "{projectRoot}",
+        "config": "vitest.config.ts"
+      },
+      "configurations": {
+        "ci": {
+          "outputFile": "../../reports/ag-grid-typedoc-links.xml",
+          "reporters": ["junit"]
+        },
+        "run": {
+          "watch": false
+        }
+      }
+    }
+  },
+  "implicitDependencies": ["ag-grid-community", "ag-grid-enterprise"],
+  "tags": ["test", "module"]
+}

--- a/testing/typedoc-links/src/typedoc-links.test.ts
+++ b/testing/typedoc-links/src/typedoc-links.test.ts
@@ -1,0 +1,84 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Application, type LogLevel, Logger, TSConfigReader } from 'typedoc';
+import { describe, expect, it } from 'vitest';
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(thisDir, '..');
+const repoRoot = path.resolve(projectRoot, '../..');
+
+interface Package {
+    name: string;
+    entryPoint: string;
+    tsconfig: string;
+}
+
+const PACKAGES: Package[] = [
+    {
+        name: 'ag-grid-community',
+        entryPoint: path.join(repoRoot, 'packages/ag-grid-community/dist/types/src/main.d.ts'),
+        tsconfig: path.join(projectRoot, 'tsconfig.community.json'),
+    },
+    {
+        name: 'ag-grid-enterprise',
+        entryPoint: path.join(repoRoot, 'packages/ag-grid-enterprise/dist/types/src/main.d.ts'),
+        tsconfig: path.join(projectRoot, 'tsconfig.enterprise.json'),
+    },
+];
+
+/** Collects every message TypeDoc logs so we can assert on link-resolution warnings. */
+class CapturingLogger extends Logger {
+    public readonly messages: string[] = [];
+
+    public override log(message: string, level: LogLevel): void {
+        this.messages.push(message);
+        super.log(message, level);
+    }
+}
+
+/** Runs TypeDoc against a package's built declarations and returns every "Failed to resolve link" warning. */
+async function getUnresolvedLinks(pkg: Package): Promise<string[]> {
+    const logger = new CapturingLogger();
+    const app = await Application.bootstrap(
+        {
+            entryPoints: [pkg.entryPoint],
+            tsconfig: pkg.tsconfig,
+            // Resolve and validate links without type-checking the declarations or writing HTML.
+            skipErrorChecking: true,
+            emit: 'none',
+            // Only care about link resolution here. `notExported`/`notDocumented` would flag the
+            // many intentional internal (`_`-prefixed) API types and drown the real signal.
+            validation: {
+                invalidLink: true,
+                notExported: false,
+                notDocumented: false,
+            },
+        },
+        [new TSConfigReader()]
+    );
+    app.logger = logger;
+
+    const project = await app.convert();
+    if (project) {
+        // Link resolution warnings are emitted during validation, not conversion.
+        app.validate(project);
+    }
+
+    return logger.messages.filter((message) => message.includes('Failed to resolve link'));
+}
+
+describe('published .d.ts JSDoc {@link} references', () => {
+    it.each(PACKAGES)('$name built declarations exist (run `nx build:types` first)', ({ entryPoint }) => {
+        expect(existsSync(entryPoint), `Missing ${entryPoint}`).toBe(true);
+    });
+
+    // A {@link} target that TypeDoc cannot resolve emits "Failed to resolve link" for every
+    // downstream consumer generating API docs from our published types. The usual cause is a
+    // reference to a symbol not exported from that package (e.g. an ag-grid-enterprise export
+    // referenced from ag-grid-community). Reference such symbols as inline code instead.
+    it.each(PACKAGES)('$name has no unresolved {@link} references', async (pkg) => {
+        const unresolved = await getUnresolvedLinks(pkg);
+        expect(unresolved).toEqual([]);
+    });
+});

--- a/testing/typedoc-links/tsconfig.community.json
+++ b/testing/typedoc-links/tsconfig.community.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "strict": false,
+    "moduleResolution": "node",
+    "noEmit": true
+  },
+  "files": ["../../packages/ag-grid-community/dist/types/src/main.d.ts"]
+}

--- a/testing/typedoc-links/tsconfig.enterprise.json
+++ b/testing/typedoc-links/tsconfig.enterprise.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "strict": false,
+    "moduleResolution": "node",
+    "noEmit": true
+  },
+  "files": ["../../packages/ag-grid-enterprise/dist/types/src/main.d.ts"]
+}

--- a/testing/typedoc-links/tsconfig.json
+++ b/testing/typedoc-links/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ES2022",
+    "moduleResolution": "Node",
+    "types": ["vitest/globals", "node"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "vitest.config.ts"]
+}

--- a/testing/typedoc-links/vitest.config.ts
+++ b/testing/typedoc-links/vitest.config.ts
@@ -1,0 +1,19 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { defineConfig } from 'vitest/config';
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: 'node',
+        root: thisDir,
+        dir: path.resolve(thisDir, 'src'),
+        include: ['**/*.test.ts'],
+        watch: false,
+        reporters: ['basic'],
+        // Converting the full public API with TypeDoc takes several seconds per package.
+        testTimeout: 120_000,
+    },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3256,6 +3256,17 @@
   resolved "https://registry.ag-grid.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
+"@gerrit0/mini-shiki@^3.23.0":
+  version "3.23.0"
+  resolved "https://registry.yarnpkg.com/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz#d9414f3080b88303b18f3a311846e37e424d800c"
+  integrity sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==
+  dependencies:
+    "@shikijs/engine-oniguruma" "^3.23.0"
+    "@shikijs/langs" "^3.23.0"
+    "@shikijs/themes" "^3.23.0"
+    "@shikijs/types" "^3.23.0"
+    "@shikijs/vscode-textmate" "^10.0.2"
+
 "@headlessui/vue@^1.7.22":
   version "1.7.23"
   resolved "https://registry.ag-grid.com/@headlessui/vue/-/vue-1.7.23.tgz#7fe19dbeca35de9e6270c82c78c4864e6a6f7391"
@@ -6653,12 +6664,27 @@
     "@shikijs/types" "4.0.2"
     "@shikijs/vscode-textmate" "^10.0.2"
 
+"@shikijs/engine-oniguruma@^3.23.0":
+  version "3.23.0"
+  resolved "https://registry.yarnpkg.com/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz#789421048d66ac1b33613169d6d18b9cc6e340ed"
+  integrity sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==
+  dependencies:
+    "@shikijs/types" "3.23.0"
+    "@shikijs/vscode-textmate" "^10.0.2"
+
 "@shikijs/langs@4.0.2":
   version "4.0.2"
   resolved "https://registry.ag-grid.com/@shikijs/langs/-/langs-4.0.2.tgz#1ac31a223d74729cf230441f9bb7d7975384101f"
   integrity sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==
   dependencies:
     "@shikijs/types" "4.0.2"
+
+"@shikijs/langs@^3.23.0":
+  version "3.23.0"
+  resolved "https://registry.yarnpkg.com/@shikijs/langs/-/langs-3.23.0.tgz#00959d8b16c7f671221ae79b3ad8cde7e6a5c112"
+  integrity sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==
+  dependencies:
+    "@shikijs/types" "3.23.0"
 
 "@shikijs/primitive@4.0.2":
   version "4.0.2"
@@ -6675,6 +6701,21 @@
   integrity sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==
   dependencies:
     "@shikijs/types" "4.0.2"
+
+"@shikijs/themes@^3.23.0":
+  version "3.23.0"
+  resolved "https://registry.yarnpkg.com/@shikijs/themes/-/themes-3.23.0.tgz#fd96ca5ad52639057995bc2093682884e1846f27"
+  integrity sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==
+  dependencies:
+    "@shikijs/types" "3.23.0"
+
+"@shikijs/types@3.23.0", "@shikijs/types@^3.23.0":
+  version "3.23.0"
+  resolved "https://registry.yarnpkg.com/@shikijs/types/-/types-3.23.0.tgz#d441571a058641926018ae3de99866f39e5bbdf2"
+  integrity sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==
+  dependencies:
+    "@shikijs/vscode-textmate" "^10.0.2"
+    "@types/hast" "^3.0.4"
 
 "@shikijs/types@4.0.2":
   version "4.0.2"
@@ -16268,6 +16309,13 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.ag-grid.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+linkify-it@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.2.tgz#d3be0a693af3da9df3883f1e346a0e97461a8c19"
+  integrity sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==
+  dependencies:
+    uc.micro "^2.0.0"
+
 listr2@9.0.1:
   version "9.0.1"
   resolved "https://registry.ag-grid.com/listr2/-/listr2-9.0.1.tgz#3cad12d81d998f8024621d9b35c969dba5da4103"
@@ -16523,6 +16571,11 @@ lucide-react@^1.9.0:
   resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-1.9.0.tgz#3c8324e6b574131624c1869cbd38829d9c659627"
   integrity sha512-6qVAmbgCjcJz7sAGSPSSJ++RAwjlK2XCbRrZKv63Ciko1KT8jX0//CXxgI3jg2HlJu8tADqdYlNDebmYjeoruA==
 
+lunr@^2.3.9:
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
+  integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
+
 luxon@^3.2.1:
   version "3.7.2"
   resolved "https://registry.ag-grid.com/luxon/-/luxon-3.7.2.tgz#d697e48f478553cca187a0f8436aff468e3ba0ba"
@@ -16659,6 +16712,18 @@ map-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.ag-grid.com/map-stream/-/map-stream-0.0.7.tgz#8a1f07896d82b10926bd3744a2420009f88974a8"
   integrity sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==
+
+markdown-it@^14.1.1:
+  version "14.3.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-14.3.0.tgz#8542fa5506e3530f7e2b08dc3885630135c5620e"
+  integrity sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==
+  dependencies:
+    argparse "^2.0.1"
+    entities "^4.5.0"
+    linkify-it "^5.0.2"
+    mdurl "^2.0.0"
+    punycode.js "^2.3.1"
+    uc.micro "^2.1.0"
 
 markdown-table@^3.0.0:
   version "3.0.4"
@@ -16891,6 +16956,11 @@ mdn-data@^2.25.0:
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.28.0.tgz#e6c1270e55958f9e9b16ff816bfad5a8dc583d1e"
   integrity sha512-uy9AS1yt+wW5eUEefgE3lOpqPghanUttycV0GXKbiXyBjwvbeE8XPj4u1C+voRfz7dEjwU4NDHTMfZ/s/JtZrQ==
+
+mdurl@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-2.0.0.tgz#80676ec0433025dd3e17ee983d0fe8de5a2237e0"
+  integrity sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -19852,6 +19922,11 @@ pump@^3.0.3:
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
+
+punycode.js@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode.js/-/punycode.js-2.3.1.tgz#6b53e56ad75588234e79f4affa90972c7dd8cdb7"
+  integrity sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==
 
 punycode@^1.4.1:
   version "1.4.1"
@@ -23104,6 +23179,17 @@ typed-array-length@^1.0.7:
     possible-typed-array-names "^1.0.0"
     reflect.getprototypeof "^1.0.6"
 
+typedoc@0.28.19:
+  version "0.28.19"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.28.19.tgz#0940c6b98eafae27cba71e57855d593f88a80649"
+  integrity sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==
+  dependencies:
+    "@gerrit0/mini-shiki" "^3.23.0"
+    lunr "^2.3.9"
+    markdown-it "^14.1.1"
+    minimatch "^10.2.5"
+    yaml "^2.8.3"
+
 typesafe-path@^0.2.2:
   version "0.2.2"
   resolved "https://registry.ag-grid.com/typesafe-path/-/typesafe-path-0.2.2.tgz#91a436681b2f514badb114061b6a5e5c2b8943b1"
@@ -23145,6 +23231,11 @@ ua-parser-js@^0.7.30:
   version "0.7.41"
   resolved "https://registry.ag-grid.com/ua-parser-js/-/ua-parser-js-0.7.41.tgz#9f6dee58c389e8afababa62a4a2dc22edb69a452"
   integrity sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==
+
+uc.micro@^2.0.0, uc.micro@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-2.1.0.tgz#f8d3f7d0ec4c3dea35a7e3c8efa4cb8b45c9e7ee"
+  integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
 
 ufo@^1.6.1:
   version "1.6.1"
@@ -24648,6 +24739,11 @@ yaml@^2.8.2:
   version "2.8.3"
   resolved "https://registry.ag-grid.com/yaml/-/yaml-2.8.3.tgz#a0d6bd2efb3dd03c59370223701834e60409bd7d"
   integrity sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==
+
+yaml@^2.8.3:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
+  integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
 
 yargs-parser@21.1.1, yargs-parser@^21.1.1:
   version "21.1.1"


### PR DESCRIPTION
Fix [AG-17735](https://ag-grid.atlassian.net/browse/AG-17735)

## Problem

A downstream consumer generating API docs with TypeDoc against our published `.d.ts` hit `Failed to resolve link` warnings. Root cause: JSDoc `{@link}` targets that TypeDoc can't resolve when processing `ag-grid-community`:

- `ColDef.groupRowEditable` / `ColDef.groupRowValueSetter` link `distributeGroupValue`, which is exported from **`ag-grid-enterprise`**, not community — so it's out of scope in the community `.d.ts`.
- `ValueService.getValue`'s JSDoc links `getCellValue` / `getDataValue`, cross-service methods not on the local scope.

`externalSymbolLinkMappings` can't rescue these (verified) — it only fires once TypeDoc resolves the name to a real declaration, which never happens for a bare out-of-scope symbol. The correct fix is to reference them as inline code.

## Changes

- **Fix**: converted the four unresolvable `{@link}`s to inline code. `{@link getValueFromData}` (a local, resolvable method) is left intact.
- **Test**: new `testing/typedoc-links` project runs TypeDoc against the built `main.d.ts` of both community and enterprise and asserts zero unresolved links. Depends on `build:types`; picked up by CI via `nx affected -t test`.
  - TypeDoc pinned exactly (link-resolution behaviour is version-specific).
  - Only `invalidLink` validation enabled — `notExported`/`notDocumented` are off to avoid drowning the signal in intentional internal (`_`-prefixed) API types.
  - `README.md` documents how to read/fix a failure.

## Verification

- `nx test ag-grid-typedoc-links` — green (4 tests).
- Confirmed the guard fails on a reintroduced bad link with a clear message, then passes once fixed.
- `nx lint ag-grid-typedoc-links` clean; `nx format` applied.
- Source change is comment-only (no runtime impact).