### PR TITLE
AG-17725 tree data multi-descendant-select-dragging

### DIFF
--- a/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragComp.ts
@@ -9,6 +9,7 @@ import { _createIconNoSpan } from '../utils/icon';
 import { Component } from '../widgets/component';
 import type { GridDragSource } from './dragAndDropService';
 import { DragSourceType } from './dragAndDropService';
+import { getRowDragMultiRowNodes } from './rowDragFeature';
 import type { RowDraggingEvent } from './rowDragTypes';
 
 const RowDragElement: ElementParams = {
@@ -137,15 +138,7 @@ export class RowDragComp extends Component {
     }
 
     private getSelectedNodes(): RowNode[] {
-        const rowNode = this.rowNode;
-        const isRowDragMultiRow = this.gos.get('rowDragMultiRow');
-        if (!isRowDragMultiRow) {
-            return [rowNode];
-        }
-
-        const selection = this.beans.selectionSvc?.getSelectedNodes() ?? [];
-
-        return selection.indexOf(rowNode) !== -1 ? selection : [rowNode];
+        return getRowDragMultiRowNodes(this.rowNode, this.gos, this.beans.selectionSvc);
     }
 
     private getDragItem(): IRowDragItem {

--- a/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
+++ b/packages/ag-grid-community/src/dragAndDrop/rowDragFeature.ts
@@ -8,10 +8,12 @@ import type { RowNode } from '../entities/rowNode';
 import { _prevOrNextDisplayedRow } from '../entities/rowNodeUtils';
 import type { RowDragEvent, RowDragEventType } from '../events';
 import { _getNormalisedMousePosition } from '../gridBodyComp/mouseEventUtils';
+import type { GridOptionsService } from '../gridOptionsService';
 import { _getRowIdCallback, _isClientSideRowModel } from '../gridOptionsUtils';
 import type { IClientSideRowModel } from '../interfaces/iClientSideRowModel';
 import type { IRowModel } from '../interfaces/iRowModel';
 import type { IRowNode } from '../interfaces/iRowNode';
+import type { ISelectionService } from '../interfaces/iSelectionService';
 import { _warn } from '../validation/logging';
 import type { DragAndDropIcon, DropTarget } from './dragAndDropService';
 import { DragSourceType } from './dragAndDropService';
@@ -134,17 +136,11 @@ export class RowDragFeature extends BeanStub implements DropTarget {
     }
 
     private getRowNodes(draggingEvent: RowDraggingEvent): RowNode[] {
-        if (!this.isFromThisGrid(draggingEvent)) {
-            return (draggingEvent.dragItem.rowNodes || []) as RowNode[];
+        const nodes = (draggingEvent.dragItem.rowNodes || []) as RowNode[];
+        if (!this.isFromThisGrid(draggingEvent) || nodes.length <= 1) {
+            return nodes;
         }
-        const currentNode = draggingEvent.dragItem.rowNode! as RowNode;
-        if (this.gos.get('rowDragMultiRow')) {
-            const selectedNodes = this.beans.selectionSvc?.getSelectedNodes();
-            if (selectedNodes && selectedNodes.indexOf(currentNode) >= 0) {
-                return selectedNodes.slice().sort(compareRowIndex);
-            }
-        }
-        return [currentNode];
+        return nodes.slice().sort(compareRowIndex);
     }
 
     public onDragEnter(draggingEvent: RowDraggingEvent): void {
@@ -711,8 +707,29 @@ const rowsDropChanged = (a: RowsDrop | null | undefined, b: RowsDrop): boolean =
         a?.newParent !== b.newParent ||
         !_areEqual(a?.rows, b.rows));
 
-const compareRowIndex = ({ rowIndex: a }: IRowNode, { rowIndex: b }: IRowNode): number =>
-    a !== null && b !== null ? a - b : 0;
+/** Display order, falling back to source (data) order for non-displayed nodes (rowIndex null, e.g. collapsed). */
+const compareRowIndex = (a: IRowNode, b: IRowNode): number =>
+    (a.rowIndex ?? 0x7fffffff) - (b.rowIndex ?? 0x7fffffff) || a.sourceRowIndex - b.sourceRowIndex;
+
+/** Drag payload for a selected row under `rowDragMultiRow`. Tree data drags the top-most selected
+ * nodes so subtrees relocate intact; dragging the raw leaf selection would tear them apart on drop. */
+export const getRowDragMultiRowNodes = (
+    rowNode: RowNode,
+    gos: GridOptionsService,
+    selectionSvc: ISelectionService | undefined
+): RowNode[] => {
+    if (!gos.get('rowDragMultiRow') || !selectionSvc || !rowNode.isSelected()) {
+        return [rowNode];
+    }
+    if (gos.get('treeData') && _isClientSideRowModel(gos)) {
+        const bestCost = selectionSvc.getBestCostNodeSelection();
+        if (bestCost?.length) {
+            return bestCost;
+        }
+    }
+    const selection = selectionSvc.getSelectedNodes();
+    return selection.length ? selection : [rowNode];
+};
 
 const setRowNodesDragging = (rowNodes: IRowNode[] | null | undefined, dragging: boolean): void => {
     for (let i = 0, len = rowNodes?.length || 0; i < len; ++i) {

--- a/testing/behavioural/src/drag-n-drop/grouping/managed-row-group-drag-edit-selection.test.ts
+++ b/testing/behavioural/src/drag-n-drop/grouping/managed-row-group-drag-edit-selection.test.ts
@@ -437,4 +437,48 @@ describe.each(DRAG_NO_MOVE_INTERACTION_CASES)('drag groups selection flows noMov
         expect(api.getRowNode('b2')?.data.level1).toBe('Gamma');
         expect(api.getRowNode('b1')?.data.level1).toBe('Beta');
     });
+
+    test('groupSelects descendants: grabbing a cascade-selected group drags the full selection', async () => {
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'group', rowGroup: true, hide: true }, { field: 'value' }],
+            autoGroupColumnDef: { headerName: 'Group', rowDrag: true },
+            rowData: [
+                { id: '1', group: 'A', value: 'A1' },
+                { id: '2', group: 'A', value: 'A2' },
+                { id: '3', group: 'B', value: 'B1' },
+                { id: '4', group: 'C', value: 'C1' },
+            ],
+            rowSelection: { mode: 'multiRow', groupSelects: 'descendants' },
+            rowDragManaged: true,
+            rowDragMultiRow: true,
+            suppressMoveWhenRowDragging: noMove,
+            groupDefaultExpanded: 1,
+            getRowId: (params) => params.data.id,
+        };
+
+        const api = gridsManager.createGrid('row-group-select-descendants', gridOptions);
+
+        api.setNodesSelected({
+            nodes: [api.getRowNode('row-group-group-A')!, api.getRowNode('row-group-group-B')!],
+            newValue: true,
+        });
+        await asyncSetTimeout(0);
+
+        expect(
+            api
+                .getSelectedNodes()
+                .map((node) => node.id)
+                .sort()
+        ).toEqual(['1', '2', '3']);
+
+        const dispatcher = new RowDragDispatcher({ api, eventType });
+        await dispatcher.start('row-group-group-A');
+        await dispatcher.move('row-group-group-C', { yOffsetPercent: 0.7 });
+        await dispatcher.finish();
+        await asyncSetTimeout(0);
+
+        // event.nodes is the full selection (the leaves, matching getSelectedNodes), not just the grabbed group.
+        const draggedIds = (dispatcher.rowDragEndEvents.at(-1)?.nodes ?? []).map((node) => node.id).sort();
+        expect(draggedIds).toEqual(['1', '2', '3']);
+    });
 });

--- a/testing/behavioural/src/drag-n-drop/tree-data/tree-data-managed-row-drag-multi.test.ts
+++ b/testing/behavioural/src/drag-n-drop/tree-data/tree-data-managed-row-drag-multi.test.ts
@@ -52,6 +52,73 @@ describe.each([false, true])('tree drag multi flows (suppress move %s)', (suppre
         return gridsManager.createGrid(id, gridOptions);
     };
 
+    test('dragging a selected parent plus children of another parent moves the subtree intact and re-parents the children', async () => {
+        const mixed = [
+            {
+                id: 'target',
+                name: 'Target',
+                type: 'folder',
+                children: [{ id: 'tc1', name: 'TC1', type: 'file', children: [] }],
+            },
+            {
+                id: 'P',
+                name: 'P',
+                type: 'folder',
+                children: [
+                    { id: 'pc1', name: 'PC1', type: 'file', children: [] },
+                    { id: 'pc2', name: 'PC2', type: 'file', children: [] },
+                ],
+            },
+            {
+                id: 'Q',
+                name: 'Q',
+                type: 'folder',
+                children: [
+                    { id: 'qc1', name: 'QC1', type: 'file', children: [] },
+                    { id: 'qc2', name: 'QC2', type: 'file', children: [] },
+                    { id: 'qc3', name: 'QC3', type: 'file', children: [] },
+                ],
+            },
+        ];
+
+        const api = createGrid('tree-mixed', mixed, {
+            rowSelection: { mode: 'multiRow' },
+            rowDragMultiRow: true,
+        });
+
+        // Select parent P (which keeps its own subtree) plus 3 children of a different parent Q.
+        api.setNodesSelected({
+            nodes: [api.getRowNode('P')!, api.getRowNode('qc1')!, api.getRowNode('qc2')!, api.getRowNode('qc3')!],
+            newValue: true,
+        });
+        await asyncSetTimeout(0);
+
+        const dispatcher = new RowDragDispatcher({ api });
+        await dispatcher.start('P');
+        await dispatcher.move('target', { yOffsetPercent: 0.4 });
+        await dispatcher.move('target', { center: true });
+        await dispatcher.finish();
+        await asyncSetTimeout(0);
+
+        // Payload is the top-most selected set: the grabbed folder P (not its leaves) and Q's 3 children.
+        const draggedIds = (dispatcher.rowDragEndEvents.at(-1)?.nodes ?? []).map((n) => n.id).sort();
+        expect(draggedIds).toEqual(['P', 'qc1', 'qc2', 'qc3']);
+
+        // P relocates into target with its subtree intact; qc1/qc2/qc3 re-parent into target; Q is left empty.
+        await new GridRows(api, 'mixed after drop').check(`
+            ROOT id:ROOT_NODE_ID
+            ├─┬ target GROUP id:target ag-Grid-AutoColumn:"Target" type:"folder"
+            │ ├─┬ P GROUP selected id:P ag-Grid-AutoColumn:"P" type:"folder"
+            │ │ ├── pc1 LEAF id:pc1 ag-Grid-AutoColumn:"PC1" type:"file"
+            │ │ └── pc2 LEAF id:pc2 ag-Grid-AutoColumn:"PC2" type:"file"
+            │ ├── qc1 LEAF selected id:qc1 ag-Grid-AutoColumn:"QC1" type:"file"
+            │ ├── qc2 LEAF selected id:qc2 ag-Grid-AutoColumn:"QC2" type:"file"
+            │ ├── qc3 LEAF selected id:qc3 ag-Grid-AutoColumn:"QC3" type:"file"
+            │ └── tc1 LEAF id:tc1 ag-Grid-AutoColumn:"TC1" type:"file"
+            └── Q LEAF id:Q ag-Grid-AutoColumn:"Q" type:"folder"
+        `);
+    });
+
     test('multi-row drag moves every selected node', async () => {
         const rowData = [
             {
@@ -413,5 +480,201 @@ describe.each([false, true])('tree drag multi flows (suppress move %s)', (suppre
         expect(dropInfo?.position).toBe('above');
         expect(dropInfo?.newParent?.id).toBe('beta');
         expect(api.getRowNode('alpha-item')?.parent?.id).toBe('beta');
+    });
+
+    describe('groupSelects filteredDescendants', () => {
+        const groupSelectRowData = [
+            {
+                id: 'p1',
+                name: 'Parent 1',
+                type: 'folder',
+                children: [
+                    { id: 'p1-c1', name: 'Child 1a', type: 'file', children: [] },
+                    { id: 'p1-c2', name: 'Child 1b', type: 'file', children: [] },
+                ],
+            },
+            {
+                id: 'p2',
+                name: 'Parent 2',
+                type: 'folder',
+                children: [{ id: 'p2-c1', name: 'Child 2a', type: 'file', children: [] }],
+            },
+            { id: 'p3', name: 'Parent 3', type: 'folder', children: [] },
+        ];
+
+        test('dragging a selected parent that has children drags the whole selection', async () => {
+            const api = createGrid('tree-group-selects-parent', groupSelectRowData, {
+                rowSelection: { mode: 'multiRow', groupSelects: 'filteredDescendants' },
+                rowDragMultiRow: true,
+            });
+
+            api.setNodesSelected({ nodes: [api.getRowNode('p1')!, api.getRowNode('p3')!], newValue: true });
+            await asyncSetTimeout(0);
+
+            await new GridRows(api, 'selected').check(`
+                ROOT id:ROOT_NODE_ID
+                ├─┬ p1 GROUP selected id:p1 ag-Grid-AutoColumn:"Parent 1" type:"folder"
+                │ ├── p1-c1 LEAF selected id:p1-c1 ag-Grid-AutoColumn:"Child 1a" type:"file"
+                │ └── p1-c2 LEAF selected id:p1-c2 ag-Grid-AutoColumn:"Child 1b" type:"file"
+                ├─┬ p2 GROUP id:p2 ag-Grid-AutoColumn:"Parent 2" type:"folder"
+                │ └── p2-c1 LEAF id:p2-c1 ag-Grid-AutoColumn:"Child 2a" type:"file"
+                └── p3 LEAF selected id:p3 ag-Grid-AutoColumn:"Parent 3" type:"folder"
+            `);
+
+            const dispatcher = new RowDragDispatcher({ api });
+            await dispatcher.start('p1');
+            // Ghost reflects the top-most selected nodes (the folder p1 + leaf p3), so subtrees move intact.
+            await waitFor(() => expect(dispatcher.getDragGhostLabel()).toBe('2 rows'));
+            await dispatcher.move('p3', { yOffsetPercent: 0.7 });
+            await dispatcher.finish();
+            await asyncSetTimeout(0);
+
+            // event.nodes is the top-most selected set: the grabbed folder p1 (not its leaves) and p3.
+            const draggedIds = (dispatcher.rowDragEndEvents.at(-1)?.nodes ?? []).map((node) => node.id).sort();
+            expect(draggedIds).toEqual(['p1', 'p3']);
+        });
+
+        test('dragging one of several selected parents with children drags every selected row', async () => {
+            const api = createGrid('tree-group-selects-multi-parent', groupSelectRowData, {
+                rowSelection: { mode: 'multiRow', groupSelects: 'filteredDescendants' },
+                rowDragMultiRow: true,
+            });
+
+            // p1 and p2 both have children; grabbing p1 must still include the non-grabbed p2.
+            api.setNodesSelected({ nodes: [api.getRowNode('p1')!, api.getRowNode('p2')!], newValue: true });
+            await asyncSetTimeout(0);
+
+            const dispatcher = new RowDragDispatcher({ api });
+            await dispatcher.start('p1');
+            await waitFor(() => expect(dispatcher.getDragGhostLabel()).toBe('2 rows'));
+            await dispatcher.move('p3', { yOffsetPercent: 0.7 });
+            await dispatcher.finish();
+            await asyncSetTimeout(0);
+
+            // Both selected folders drag as units (their subtrees follow), not the individual leaves.
+            const draggedIds = (dispatcher.rowDragEndEvents.at(-1)?.nodes ?? []).map((node) => node.id).sort();
+            expect(draggedIds).toEqual(['p1', 'p2']);
+        });
+
+        test('dragging a selected parent with a multi-level subtree relocates the whole subtree', async () => {
+            const nestedRowData = [
+                { id: 'dst', name: 'Destination', type: 'folder', children: [] },
+                {
+                    id: 'src',
+                    name: 'Source',
+                    type: 'folder',
+                    children: [
+                        {
+                            id: 'src-a',
+                            name: 'Source A',
+                            type: 'folder',
+                            children: [
+                                { id: 'src-a-1', name: 'Leaf A1', type: 'file', children: [] },
+                                { id: 'src-a-2', name: 'Leaf A2', type: 'file', children: [] },
+                            ],
+                        },
+                    ],
+                },
+            ];
+
+            const api = createGrid('tree-group-selects-nested', nestedRowData, {
+                rowSelection: { mode: 'multiRow', groupSelects: 'filteredDescendants' },
+                rowDragMultiRow: true,
+            });
+
+            api.setNodesSelected({ nodes: [api.getRowNode('src')!], newValue: true });
+            await asyncSetTimeout(0);
+
+            await new GridRows(api, 'nested selected').check(`
+                ROOT id:ROOT_NODE_ID
+                ├── dst LEAF id:dst ag-Grid-AutoColumn:"Destination" type:"folder"
+                └─┬ src GROUP selected id:src ag-Grid-AutoColumn:"Source" type:"folder"
+                · └─┬ src-a GROUP selected id:src-a ag-Grid-AutoColumn:"Source A" type:"folder"
+                · · ├── src-a-1 LEAF selected id:src-a-1 ag-Grid-AutoColumn:"Leaf A1" type:"file"
+                · · └── src-a-2 LEAF selected id:src-a-2 ag-Grid-AutoColumn:"Leaf A2" type:"file"
+            `);
+
+            const dispatcher = new RowDragDispatcher({ api });
+            await dispatcher.start('src');
+            // event.nodes is the grabbed folder (a single top-most selected node), not its leaves.
+            const draggedIds = () => (dispatcher.rowDragEnterEvents.at(-1)?.nodes ?? []).map((node) => node.id);
+            await dispatcher.move('dst', { yOffsetPercent: 0.2 });
+            expect(draggedIds()).toEqual(['src']);
+            await dispatcher.finish();
+            await asyncSetTimeout(0);
+
+            // The whole subtree relocates intact above dst; no leaves are torn out to the root.
+            await new GridRows(api, 'nested after drop').check(`
+                ROOT id:ROOT_NODE_ID
+                ├─┬ src GROUP selected id:src ag-Grid-AutoColumn:"Source" type:"folder"
+                │ └─┬ src-a GROUP selected id:src-a ag-Grid-AutoColumn:"Source A" type:"folder"
+                │ · ├── src-a-1 LEAF selected id:src-a-1 ag-Grid-AutoColumn:"Leaf A1" type:"file"
+                │ · └── src-a-2 LEAF selected id:src-a-2 ag-Grid-AutoColumn:"Leaf A2" type:"file"
+                └── dst LEAF id:dst ag-Grid-AutoColumn:"Destination" type:"folder"
+            `);
+        });
+    });
+});
+
+describe('tree drag multi with per-node rowDrag and custom rowDragText', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowDragModule, RowSelectionModule, TreeDataModule],
+    });
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    test('grabbing one of several selected parents drags all of them, counted as parents', async () => {
+        const rowDragTextCounts: number[] = [];
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'medal' }],
+            autoGroupColumnDef: {
+                headerName: 'Athlete',
+                // Per-node rowDrag: only the parent athlete rows are draggable.
+                rowDrag: ({ data }) => data?.parentId === null,
+                rowDragText: (params, dragItemCount) => {
+                    rowDragTextCounts.push(dragItemCount);
+                    return dragItemCount > 1 ? `${dragItemCount} athletes` : (params.rowNode?.data?.athlete ?? '');
+                },
+            },
+            rowData: [
+                { id: 'phelps', athlete: 'Michael Phelps', parentId: null },
+                { id: 'phelps-g1', medal: 'Gold 200m', parentId: 'phelps' },
+                { id: 'phelps-g2', medal: 'Gold 400m', parentId: 'phelps' },
+                { id: 'nemov', athlete: 'Aleksey Nemov', parentId: null },
+                { id: 'nemov-g1', medal: 'Gold Vault', parentId: 'nemov' },
+                { id: 'other', athlete: 'Other Athlete', parentId: null },
+                { id: 'other-g1', medal: 'Silver', parentId: 'other' },
+            ],
+            rowSelection: { mode: 'multiRow', groupSelects: 'filteredDescendants' },
+            rowDragMultiRow: true,
+            treeData: true,
+            treeDataParentIdField: 'parentId',
+            groupDefaultExpanded: -1,
+            getRowId: ({ data }) => data.id,
+        };
+
+        const api = gridsManager.createGrid('tree-parentid-rowdrag-text', gridOptions);
+
+        api.setNodesSelected({ nodes: [api.getRowNode('phelps')!, api.getRowNode('nemov')!], newValue: true });
+        await asyncSetTimeout(0);
+
+        const dispatcher = new RowDragDispatcher({ api });
+        await dispatcher.start('phelps');
+        // Both selected athletes drag; the ghost counts the athletes (2), not their medals.
+        await waitFor(() => expect(dispatcher.getDragGhostLabel()).toBe('2 athletes'));
+        await dispatcher.move('other', { yOffsetPercent: 0.7 });
+        await dispatcher.finish();
+        await asyncSetTimeout(0);
+
+        const draggedIds = (dispatcher.rowDragEndEvents.at(-1)?.nodes ?? []).map((node) => node.id).sort();
+        expect(draggedIds).toEqual(['nemov', 'phelps']);
+        expect(rowDragTextCounts.length).toBeGreaterThan(0);
+        expect(rowDragTextCounts.every((count) => count === 2)).toBe(true);
     });
 });

--- a/testing/behavioural/src/theming/style-injection.test.ts
+++ b/testing/behavioural/src/theming/style-injection.test.ts
@@ -35,12 +35,28 @@ const injectionVersions = () => (globalThis as WindowState).agStyleInjectionVers
 describe('theme style injection across grids', () => {
     const gridsManager = new TestGridsManager({ modules: [] });
 
+    // jsdom's CSS parser rejects the Theming API's modern CSS (nested rules, @layer, color-mix), reporting
+    // "Could not parse CSS stylesheet" via console.error; real browsers accept it. Swallow only that error and
+    // count it (so the test can prove injection happened), letting every other console.error through.
+    let cssParseErrors = 0;
+    let realConsoleError: typeof console.error;
+
     // IS_SSR is true under jsdom (no document.fonts) so grids don't inject by default; force it on here.
     beforeEach(() => {
         _setStyleInjectionEnabledForTesting(true);
+        cssParseErrors = 0;
+        realConsoleError = console.error;
+        console.error = (...args: unknown[]): void => {
+            if (typeof args[0] === 'string' && args[0].includes('Could not parse CSS stylesheet')) {
+                cssParseErrors++;
+                return;
+            }
+            realConsoleError.apply(console, args);
+        };
     });
 
     afterEach(() => {
+        console.error = realConsoleError;
         gridsManager.reset();
     });
 
@@ -64,6 +80,9 @@ describe('theme style injection across grids', () => {
         // Grid A injects its input-style part css and its own params.
         expect(inputStyleDebugIds()).toHaveLength(1);
         expect(paramsDebugIds()).toEqual(['ag-theme-params-1']);
+
+        // jsdom rejected the injected (nested) part css — proof real theme css reached the DOM.
+        expect(cssParseErrors).toBeGreaterThan(0);
 
         const inputStyleA = inputStyleDebugIds()[0];
         const styleCountAfterA = allDebugIds().length;

--- a/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-drag-n-drop.test.ts
+++ b/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-drag-n-drop.test.ts
@@ -135,4 +135,39 @@ describe('ag-grid SSRM treeData managed drag and drop', () => {
             expect(rowDragCancelEvents[0].node?.id).toBe('105');
         }
     });
+
+    test('multi-row drag reports the full selection in event.nodes', async () => {
+        const data = getSmallTreeDataSet();
+        const fakeServer = createFakeServer(data);
+        const datasource = createServerSideDatasource(fakeServer);
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'employeeName', rowDrag: true }, { field: 'employeeId' }, { field: 'jobTitle' }],
+            treeData: true,
+            rowModelType: 'serverSide',
+            getRowId: ({ data }) => data.employeeId,
+            isServerSideGroup: (dataItem: any) => !!dataItem.group,
+            getServerSideGroupKey: (dataItem: any) => dataItem.employeeId,
+            autoGroupColumnDef: { field: 'employeeName' },
+            rowSelection: { mode: 'multiRow' },
+            rowDragMultiRow: true,
+        };
+
+        const api = gridsManager.createGrid('ssrm-managed-dnd-multi', gridOptions);
+        api.setGridOption('serverSideDatasource', datasource);
+        await ssrmExpandAndLoadAll(api);
+        await waitForNoLoadingRows(api);
+
+        // 105 and 107 are leaves under different parent groups.
+        api.setNodesSelected({ nodes: [api.getRowNode('105')!, api.getRowNode('107')!], newValue: true });
+
+        const dispatcher = new RowDragDispatcher({ api });
+        await dispatcher.start('105');
+        await dispatcher.move('107');
+        await dispatcher.finish();
+        await waitForNoLoadingRows(api);
+
+        const draggedIds = (dispatcher.rowDragEndEvents.at(-1)?.nodes ?? []).map((node) => node.id).sort();
+        expect(draggedIds).toEqual(['105', '107']);
+    });
 });


### PR DESCRIPTION
FIX [AG-17725](https://ag-grid.atlassian.net/browse/AG-17725)

## Bug

With `rowDragMultiRow` on tree data and `rowSelection.groupSelects: 'descendants' | 'filteredDescendants'`, dragging from a multi-row selection that includes a **parent with children** dragged only the grabbed row instead of the whole selection:

- `event.nodes.length === 1` (while `api.getSelectedNodes()` still returned the full selection)
- the drag ghost / `rowDragText` `dragItemCount` collapsed to `1`

Cause: the payload gated on `selectedNodes.indexOf(grabbedNode) >= 0`. Under `groupSelects`, a selected parent's state is *derived* from its children, so the parent isn't literally in `getSelectedNodes()` — the check failed and it fell back to single-row. Removing `groupSelects` (so every selected row is its own node) hid the bug.

## Fix

- Payload now gates on `rowNode.isSelected()` (so a cascade-selected parent counts) and, for tree data, uses `getBestCostNodeSelection()` — the **top-most** selected nodes. So grabbing 2 selected athletes reports `event.nodes.length === 2` and the ghost reads "2 athletes", and dragging a selected folder relocates its whole subtree intact instead of tearing the leaves out.

## Changes vs `latest`

- **`rowDragComp.ts` / `rowDragFeature.ts`**
  - New shared `getRowDragMultiRowNodes` helper: `isSelected()` gate + top-most nodes (`getBestCostNodeSelection`) for CSRM tree data.
  - `getRowNodes` reuses the payload already resolved in `getDragItem` instead of recomputing it — no second selection traversal per drag.
  - `compareRowIndex` falls back to `sourceRowIndex` for non-displayed nodes (rowIndex `null`, e.g. collapsed) so the `event.nodes` order stays meaningful.

- **Tests**
  - Tree data: dragging a selected parent (single / multiple / nested subtree / parent + children of another parent) moves subtrees intact and re-parents individually selected children; ghost / `rowDragText` counts the top-most nodes.
  - Row grouping: cascade-selected groups drag the full leaf selection.
  - SSRM: multi-row drag reports the full selection in `event.nodes`.

## Not covered

- Grid-to-grid (cross-tree) drag is unchanged and still not fully supported for tree data; non-tree cross-grid drag is unaffected.

## Unrelated fix (included)

- **`style-injection.test.ts`** — jsdom's CSS parser can't handle the Theming API's nested CSS and logged `"Could not parse CSS stylesheet"` to stderr on every run. The test now intercepts only that error, asserts it fires (proving real css was injected), and lets all other errors through. Not fixable by upgrading jsdom (its `rrweb-cssom` parser has no nested-CSS support).

