### PR TITLE
AG-3390 - Reserve widest-word width in FrameworkTextAnimation to avoid hero layout shift

### DIFF
--- a/external/ag-website-shared/src/components/framework-text-animation/FrameworkTextAnimation.module.scss
+++ b/external/ag-website-shared/src/components/framework-text-animation/FrameworkTextAnimation.module.scss
@@ -1,15 +1,27 @@
 @use 'design-system' as *;
 
 .animatedWordsOuter {
-    --word-height: 1.3em;
+    --word-height: 1.2em;
 
-    position: relative;
-    display: inline-flex;
-    align-items: flex-end;
+    display: inline-grid;
     height: var(--word-height);
     margin-bottom: -0.2em;
     text-align: left;
     overflow: hidden;
+    vertical-align: bottom;
+
+    // Stack the sizer and the visible word in the same cell: the grid track sizes to the
+    // widest child (the sizer), so the container width stays fixed as words cycle.
+    > * {
+        grid-area: 1 / 1;
+        align-self: end;
+    }
+}
+
+// Reserves the width of the widest word without being shown or announced (aria-hidden
+// in the markup). Kept in the layout so its width defines the container.
+.sizer {
+    visibility: hidden;
 }
 
 .animatedWord {
@@ -23,7 +35,7 @@
 
 @keyframes framework-word-in {
     from {
-        transform: translateY(100%);
+        transform: translateY(-100%);
         opacity: 0;
     }
 

--- a/external/ag-website-shared/src/components/framework-text-animation/FrameworkTextAnimation.tsx
+++ b/external/ag-website-shared/src/components/framework-text-animation/FrameworkTextAnimation.tsx
@@ -20,6 +20,12 @@ const WORDS: { text: string; className: string }[] = [
 
 const CYCLE_MS = 2500;
 
+// The widest word, used by an invisible sizer to reserve a stable width so the heading
+// doesn't reflow (layout shift / CLS) as words cycle. Picked by character length, which
+// is a safe proxy here because 'JavaScript' is clearly the longest of the set; if the
+// word list changes such that width no longer tracks length, revisit this.
+const LONGEST_WORD = WORDS.reduce((longest, w) => (w.text.length > longest.length ? w.text : longest), '');
+
 export const FrameworkTextAnimation: FunctionComponent<Props> = ({ prefix, suffix }) => {
     const [wordIndex, setWordIndex] = useState(0);
 
@@ -36,10 +42,16 @@ export const FrameworkTextAnimation: FunctionComponent<Props> = ({ prefix, suffi
 
     const word = WORDS[wordIndex];
 
-    // One word lives in the DOM at a time so the H1 reads as a single clean heading
-    // for crawlers and screen readers. `key` retriggers the entry animation on swap.
+    // One visible word at a time so the H1 reads as a single clean heading for crawlers
+    // and screen readers. The sizer is an aria-hidden copy of the widest word that stays
+    // in the DOM purely to reserve width — the two are stacked in the same grid cell, so
+    // the container width is fixed to the widest word and never shifts as words cycle.
+    // `key` retriggers the entry animation on swap.
     return (
         <span className={styles.animatedWordsOuter}>
+            <span aria-hidden="true" className={styles.sizer}>
+                {`${prefixText}${LONGEST_WORD}${suffixText}`}
+            </span>
             <span key={wordIndex} className={classnames(styles.animatedWord, word.className)}>
                 {`${prefixText}${word.text}${suffixText}`}
             </span>


### PR DESCRIPTION
Render an aria-hidden sizer holding the longest word alongside the visible animated word, stacked in a single grid cell, so the container width is fixed to the widest word server-side. Prevents CLS as words cycle (PR #14301 review).

Animate FrameworkTextAnimation words top-down to match previous behaviour.

Ported from https://github.com/ag-grid/ag-grid/pull/14301