### PR TITLE
[AG-17385] Fix(column-tool-panel): regenerate value column when re-added in deferred pivot mode

### DIFF
--- a/packages/ag-grid-enterprise/src/columnToolPanel/updates/columnStateUpdateExecutionStrategy.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/updates/columnStateUpdateExecutionStrategy.ts
@@ -364,7 +364,10 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
             }
         }
 
-        const sortedEntries = operations.sort((a, b) => a.seq - b.seq);
+        // aggFuncs must apply after aggregation: setColumnAggFunc adds the value column, which turns a
+        // same-seq aggregation setColumns into a no-op and skips the pivot result-column refresh.
+        const commitRank = (operation: CommitOperation) => (operation.type === 'aggFuncs' ? 1 : 0);
+        const sortedEntries = operations.sort((a, b) => a.seq - b.seq || commitRank(a) - commitRank(b));
 
         // Batch the role-column operations (rowGroup/aggregation/pivot) so consecutive ones share one
         // refresh. Order-sensitive ops read live model state that a deferred role op leaves stale until

--- a/testing/behavioural/src/columnToolPanel/deferred-pivot-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-pivot-mode.test.ts
@@ -1988,6 +1988,50 @@ describe('deferred column tool panel pivot mode', () => {
         expect(getApplyButton(toolPanelGui).disabled).toBe(false);
     });
 
+    test('re-adding a value column in pivot mode without an active pivot regenerates its column after Apply', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [
+                { field: 'athlete', enableRowGroup: true, enablePivot: true },
+                { field: 'country', rowGroup: true, enableRowGroup: true, enablePivot: true },
+                { field: 'silver', hide: true, enableValue: true, aggFunc: 'sum' },
+                { field: 'bronze', hide: true, enableValue: true, aggFunc: 'sum' },
+            ],
+            rowData,
+            pivotMode: true,
+            sideBar: {
+                toolPanels: [
+                    {
+                        id: 'columns',
+                        labelDefault: 'Columns',
+                        labelKey: 'columns',
+                        iconKey: 'columns',
+                        toolPanel: 'agColumnsToolPanel',
+                        toolPanelParams: { buttons: ['apply', 'cancel'] as const },
+                    },
+                ],
+                defaultToolPanel: 'columns',
+            },
+        });
+        await asyncSetTimeout(50);
+
+        const toolPanel = gridApi.getToolPanelInstance('columns') as any;
+        const silver = gridApi.getColumn('silver')! as AgColumn;
+        const bronze = gridApi.getColumn('bronze')! as AgColumn;
+        const strategy = getUpdateStrategy(toolPanel);
+
+        strategy.setValueColumns(true, [silver], 'toolPanelUi');
+        commitChanges(toolPanel);
+
+        expect(getValueColumnIds(gridApi)).toEqual(['silver']);
+        expect(gridApi.getAllDisplayedColumns().some((col) => col.getColId() === 'bronze')).toBe(false);
+
+        strategy.setValueColumns(true, [silver, bronze], 'toolPanelUi');
+        commitChanges(toolPanel);
+
+        expect(getValueColumnIds(gridApi)).toEqual(['silver', 'bronze']);
+        expect(gridApi.getAllDisplayedColumns().some((col) => col.getColId() === 'bronze')).toBe(true);
+    });
+
     // AG-9664: pivotSort from a deferred panel pill stages until Apply, mirroring the synchronous coverage in
     // sorting/pivot-column-sort.test.ts.
     async function createDeferredPivotSortGrid(): Promise<{ gridApi: GridApi; toolPanel: any }> {


### PR DESCRIPTION
Re-adding a value column in deferred pivot mode (pivot mode active, no active pivot column) updated the value-column model but left the table stale - the aggregation never appeared after Apply.

On commit, `aggFuncs` was applied before `aggregation`; `setColumnAggFunc` added the value column early, turning the same-seq `aggregation` `setColumns` into a no-op that skipped the pivot result-column refresh. Ordering `aggregation` before `aggFuncs` fixes it.

Follow-up to #14276, which enabled the Apply button but not the actual re-add. 

Fix [AG-17385](https://ag-grid.atlassian.net/browse/AG-17385)