### PR TITLE
[AG-17385] Fix(aggregation): refresh dependent columns when setColumnAggFunc activates a value column

### DIFF
--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -286,8 +286,8 @@ export class ColumnModel extends BeanStub implements NamedBean {
     }
 
     /** Refresh once (if needed) + dispatch each touched service. Fires immediately, or defers to {@link endColBatch}
-     *  when batched. `refresh` accumulates into {@link pendingRefresh}: membership passes `true`, order/aggFunc-only
-     *  (`moveColumn`/`setColumnAggFunc`) pass `false` to dispatch without a rebuild. */
+     *  when batched. `refresh` accumulates into {@link pendingRefresh}: membership passes `true`, order-only or a
+     *  func change on an already-active col (`moveColumn`, `setColumnAggFunc`) pass `false` to dispatch without a rebuild. */
     public flushColChanges(source: ColumnEventType, refresh: boolean): void {
         if (refresh) {
             this.pendingRefresh = true;

--- a/packages/ag-grid-enterprise/src/aggregation/valueColsSvc.ts
+++ b/packages/ag-grid-enterprise/src/aggregation/valueColsSvc.ts
@@ -92,10 +92,14 @@ export class ValueColsSvc extends BaseColsService implements NamedBean, IValueCo
     public setColumnAggFunc(key: ColKey | undefined, aggFunc: ColAggFunc, source: ColumnEventType): void {
         if (key) {
             const column = this.colModel.getNonPivotCol(key);
-            if (column && this.applyAggFunc(column, aggFunc, source)) {
-                // aggFunc/activation only — stage + flush without a refresh; re-aggregation is event-driven.
-                this.stageColChange([column]);
-                this.colModel.flushColChanges(source, false);
+            if (column) {
+                const { changed, membershipChanged } = this.applyAggFunc(column, aggFunc, source);
+                if (changed) {
+                    // Membership changes ((de)activation) alter the value-column set, so pivot result columns must
+                    // rebuild; a func-only change on an already-active col re-aggregates event-driven, no refresh.
+                    this.stageColChange([column]);
+                    this.colModel.flushColChanges(source, membershipChanged);
+                }
             }
         }
     }
@@ -175,13 +179,20 @@ export class ValueColsSvc extends BaseColsService implements NamedBean, IValueCo
         }
     }
 
-    private applyAggFunc(column: AgColumn, aggFunc: ColAggFunc, source: ColumnEventType): boolean {
+    /** `changed`: any state moved (dispatch a change). `membershipChanged`: the col was (de)activated, so the
+     *  value-column set changed and callers must refresh dependent (pivot result) columns. */
+    private applyAggFunc(
+        column: AgColumn,
+        aggFunc: ColAggFunc,
+        source: ColumnEventType
+    ): { changed: boolean; membershipChanged: boolean } {
         if (aggFunc != null && aggFunc !== '') {
             const aggFuncChanged = this.writeAggFunc(column, aggFunc);
             const activeChanged = this.setColActive(column, true, source);
-            return aggFuncChanged || activeChanged;
+            return { changed: aggFuncChanged || activeChanged, membershipChanged: activeChanged };
         }
-        return this.setColActive(column, false, source);
+        const activeChanged = this.setColActive(column, false, source);
+        return { changed: activeChanged, membershipChanged: activeChanged };
     }
 
     private writeAggFunc(column: AgColumn, aggFunc: ColAggFunc): boolean {

--- a/packages/ag-grid-enterprise/src/columnToolPanel/updates/columnStateUpdateExecutionStrategy.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/updates/columnStateUpdateExecutionStrategy.ts
@@ -364,10 +364,7 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
             }
         }
 
-        // aggFuncs must apply after aggregation: setColumnAggFunc adds the value column, which turns a
-        // same-seq aggregation setColumns into a no-op and skips the pivot result-column refresh.
-        const commitRank = (operation: CommitOperation) => (operation.type === 'aggFuncs' ? 1 : 0);
-        const sortedEntries = operations.sort((a, b) => a.seq - b.seq || commitRank(a) - commitRank(b));
+        const sortedEntries = operations.sort((a, b) => a.seq - b.seq);
 
         // Batch the role-column operations (rowGroup/aggregation/pivot) so consecutive ones share one
         // refresh. Order-sensitive ops read live model state that a deferred role op leaves stale until

--- a/testing/behavioural/src/columnToolPanel/deferred-pivot-mode.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-pivot-mode.test.ts
@@ -2032,6 +2032,49 @@ describe('deferred column tool panel pivot mode', () => {
         expect(gridApi.getAllDisplayedColumns().some((col) => col.getColId() === 'bronze')).toBe(true);
     });
 
+    test('deferred setColumnAggFunc activating a value column in pivot mode regenerates pivot result columns after Apply', async () => {
+        const gridApi = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', pivot: true, hide: true },
+                { field: 'gold', enableValue: true },
+            ],
+            rowData: [
+                { country: 'UK', year: 2000, gold: 5 },
+                { country: 'UK', year: 2004, gold: 3 },
+            ],
+            pivotMode: true,
+            sideBar: {
+                toolPanels: [
+                    {
+                        id: 'columns',
+                        labelDefault: 'Columns',
+                        labelKey: 'columns',
+                        iconKey: 'columns',
+                        toolPanel: 'agColumnsToolPanel',
+                        toolPanelParams: { buttons: ['apply', 'cancel'] as const },
+                    },
+                ],
+                defaultToolPanel: 'columns',
+            },
+        });
+        await asyncSetTimeout(50);
+
+        const toolPanel = gridApi.getToolPanelInstance('columns') as any;
+        const gold = gridApi.getColumn('gold')! as AgColumn;
+        const strategy = getUpdateStrategy(toolPanel);
+
+        // gold has no aggFunc → not a value column → its pivot result columns carry no measure.
+        expect(getValueColumnIds(gridApi)).toEqual([]);
+        expect(gridApi.getAllDisplayedColumns().some((col) => col.getColId().endsWith('_gold'))).toBe(false);
+
+        strategy.setColumnAggFunc(true, gold, 'sum', 'toolPanelUi');
+        commitChanges(toolPanel);
+
+        expect(getValueColumnIds(gridApi)).toEqual(['gold']);
+        expect(gridApi.getAllDisplayedColumns().some((col) => col.getColId().endsWith('_gold'))).toBe(true);
+    });
+
     // AG-9664: pivotSort from a deferred panel pill stages until Apply, mirroring the synchronous coverage in
     // sorting/pivot-column-sort.test.ts.
     async function createDeferredPivotSortGrid(): Promise<{ gridApi: GridApi; toolPanel: any }> {

--- a/testing/behavioural/src/columns/column-api-extended.test.ts
+++ b/testing/behavioural/src/columns/column-api-extended.test.ts
@@ -302,6 +302,90 @@ describe('Column API — extended coverage', () => {
         });
     });
 
+    describe('setColumnAggFunc', () => {
+        test('activating a value column in pivot mode regenerates the pivot result columns', async () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [
+                    { field: 'country', rowGroup: true, hide: true },
+                    { field: 'year', pivot: true, hide: true },
+                    { field: 'gold', enableValue: true },
+                ],
+                pivotMode: true,
+                rowData: [
+                    { country: 'UK', year: 2000, gold: 5 },
+                    { country: 'UK', year: 2004, gold: 3 },
+                ],
+            });
+            // gold has no aggFunc yet → not a value column → pivot result columns carry no measure ("-").
+            await new GridColumns(api, `no value column, no measure in pivot result columns`).checkColumns(`
+                CENTER
+                ├── ag-Grid-AutoColumn "Group" width:200
+                ├─┬ "2000" GROUP
+                │ └── pivot_year_2000_ "-" width:200
+                └─┬ "2004" GROUP
+                  └── pivot_year_2004_ "-" width:200
+            `);
+
+            api.setColumnAggFunc('gold', 'sum');
+            await new GridColumns(api, `setColumnAggFunc activates gold → pivot result columns rebuild`).checkColumns(`
+                CENTER
+                ├── ag-Grid-AutoColumn "Group" width:200
+                ├─┬ "2000" GROUP
+                │ └── pivot_year_2000_gold "Gold" width:200 columnGroupShow:open
+                └─┬ "2004" GROUP
+                  └── pivot_year_2004_gold "Gold" width:200 columnGroupShow:open
+            `);
+
+            api.setColumnAggFunc('gold', null);
+            await new GridColumns(api, `setColumnAggFunc deactivates gold → pivot result columns lose the measure`)
+                .checkColumns(`
+                CENTER
+                ├── ag-Grid-AutoColumn "Group" width:200
+                ├─┬ "2000" GROUP
+                │ └── pivot_year_2000_ "-" width:200
+                └─┬ "2004" GROUP
+                  └── pivot_year_2004_ "-" width:200
+            `);
+        });
+
+        test('changing the aggFunc of an active value column re-aggregates without a column rebuild', async () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [
+                    { field: 'country', rowGroup: true, hide: true },
+                    { field: 'gold', aggFunc: 'sum' },
+                ],
+                rowData: [
+                    { country: 'UK', gold: 4 },
+                    { country: 'UK', gold: 2 },
+                ],
+            });
+            await new GridRows(api, `sum setup`).check(`
+                ROOT id:ROOT_NODE_ID
+                └─┬ LEAF_GROUP collapsed id:row-group-country-UK ag-Grid-AutoColumn:"UK" gold:6
+                · ├── LEAF hidden id:0 country:"UK" gold:4
+                · └── LEAF hidden id:1 country:"UK" gold:2
+            `);
+
+            const everythingChanged = vitest.fn();
+            const valueChanged = vitest.fn();
+            api.addEventListener('columnEverythingChanged', everythingChanged);
+            api.addEventListener('columnValueChanged', valueChanged);
+
+            api.setColumnAggFunc('gold', 'avg');
+            await asyncSetTimeout(0);
+
+            // Func-only change: dispatches columnValueChanged (drives re-aggregation) but no column rebuild.
+            expect(valueChanged).toHaveBeenCalled();
+            expect(everythingChanged).not.toHaveBeenCalled();
+            await new GridRows(api, `avg after func-only change`).check(`
+                ROOT id:ROOT_NODE_ID
+                └─┬ LEAF_GROUP collapsed id:row-group-country-UK ag-Grid-AutoColumn:"UK" gold:{"count":2,"value":3}
+                · ├── LEAF hidden id:0 country:"UK" gold:4
+                · └── LEAF hidden id:1 country:"UK" gold:2
+            `);
+        });
+    });
+
     describe('setValueColumns', () => {
         test('replaces the value-column set wholesale', async () => {
             const api = gridsManager.createGrid('myGrid', {


### PR DESCRIPTION
Root-cause follow-up to #14310.

`valueColsSvc.setColumnAggFunc` always flushed without a column rebuild, even when it **activated** a column. Activation is a membership change, so in pivot mode the derived pivot result columns went stale — the AG-17385 symptom.

`applyAggFunc` now reports `membershipChanged` separately, and the flush refreshes only on (de)activation, preserving the func-only fast path (`re-aggregation is event-driven`). This matches `flushColChanges`'s documented contract.

Because the aggFuncs op now requests its own refresh, the same-seq commit-ordering tie-break added in #14310 is redundant and **reverted**. That test still passes with the band-aid removed, proving this fix subsumes it.

Fix [AG-17385](https://ag-grid.atlassian.net/browse/AG-17385)