### PR TITLE
AG-3390: Make page-verification smoke tests fail only on real breakage

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/page-verification.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/page-verification.spec.ts
@@ -2,12 +2,15 @@ import { expect, test } from '@playwright/test';
 import type { Page } from '@playwright/test';
 
 const isCspIssue = (msg: string) => /Content-Security-Policy|Refused to (load|execute|connect)/i.test(msg);
-// An actual enforced block ("Refused to load/execute/connect ...") as opposed to a
-// report-only policy that's merely being monitored ahead of enforcement — browsers
-// prefix/suffix report-only violation messages with "report-only" or "[Report Only]"
-// text (Chrome/Chromium use a space, not a hyphen, in the "[Report Only]" prefix).
-const isEnforcedCspViolation = (msg: string) =>
-    /Refused to (load|execute|connect)/i.test(msg) && !/report[ -]only/i.test(msg);
+// An actual enforced block, as opposed to a report-only policy that's merely being
+// monitored ahead of enforcement. Enforced CSP violation messages vary in verb by
+// directive ("Refused to load/execute/connect...", "Refused to apply inline style...",
+// "Refused to frame...", "Refused to create a worker from...", "Refused to evaluate a
+// string as JavaScript...", etc.) so rather than enumerate every verb, treat any
+// CSP-related message that isn't marked report-only as enforced. Browsers prefix/suffix
+// report-only violation messages with "report-only" or "[Report Only]" text
+// (Chrome/Chromium use a space, not a hyphen, in the "[Report Only]" prefix).
+const isEnforcedCspViolation = (msg: string) => isCspIssue(msg) && !/report[ -]only/i.test(msg);
 
 // Console messages that are known browser/environment noise unrelated to the
 // site under test. Matched by substring so new message formats stay filtered.

--- a/documentation/ag-grid-docs/src/content/docs/page-verification.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/page-verification.spec.ts
@@ -6,7 +6,8 @@ const isCspIssue = (msg: string) => /Content-Security-Policy|Refused to (load|ex
 // report-only policy that's merely being monitored ahead of enforcement — browsers
 // prefix/suffix report-only violation messages with "report-only" or "[Report Only]"
 // text (Chrome/Chromium use a space, not a hyphen, in the "[Report Only]" prefix).
-const isEnforcedCspViolation = (msg: string) => /Refused to (load|execute|connect)/i.test(msg) && !/report[ -]only/i.test(msg);
+const isEnforcedCspViolation = (msg: string) =>
+    /Refused to (load|execute|connect)/i.test(msg) && !/report[ -]only/i.test(msg);
 
 // Console messages that are known browser/environment noise unrelated to the
 // site under test. Matched by substring so new message formats stay filtered.

--- a/documentation/ag-grid-docs/src/content/docs/page-verification.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/page-verification.spec.ts
@@ -4,8 +4,9 @@ import type { Page } from '@playwright/test';
 const isCspIssue = (msg: string) => /Content-Security-Policy|Refused to (load|execute|connect)/i.test(msg);
 // An actual enforced block ("Refused to load/execute/connect ...") as opposed to a
 // report-only policy that's merely being monitored ahead of enforcement — browsers
-// prefix/suffix report-only violation messages with "report-only" text.
-const isEnforcedCspViolation = (msg: string) => /Refused to (load|execute|connect)/i.test(msg) && !/report-only/i.test(msg);
+// prefix/suffix report-only violation messages with "report-only" or "[Report Only]"
+// text (Chrome/Chromium use a space, not a hyphen, in the "[Report Only]" prefix).
+const isEnforcedCspViolation = (msg: string) => /Refused to (load|execute|connect)/i.test(msg) && !/report[ -]only/i.test(msg);
 
 // Console messages that are known browser/environment noise unrelated to the
 // site under test. Matched by substring so new message formats stay filtered.

--- a/documentation/ag-grid-docs/src/content/docs/page-verification.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/page-verification.spec.ts
@@ -2,6 +2,10 @@ import { expect, test } from '@playwright/test';
 import type { Page } from '@playwright/test';
 
 const isCspIssue = (msg: string) => /Content-Security-Policy|Refused to (load|execute|connect)/i.test(msg);
+// An actual enforced block ("Refused to load/execute/connect ...") as opposed to a
+// report-only policy that's merely being monitored ahead of enforcement — browsers
+// prefix/suffix report-only violation messages with "report-only" text.
+const isEnforcedCspViolation = (msg: string) => /Refused to (load|execute|connect)/i.test(msg) && !/report-only/i.test(msg);
 
 // Console messages that are known browser/environment noise unrelated to the
 // site under test. Matched by substring so new message formats stay filtered.
@@ -20,23 +24,36 @@ const KNOWN_NOISE = [
     '**************************************',
 ];
 
-// Sets up console error/warning collection, uncaught exception capture,
-// and blocks the cookie-consent banner. Returns the hard-error array.
-// CSP violations are routed to test.info() annotations (warnings) rather than
-// hard failures.
+// This is a smoke test suite: a page actually failing to load or render
+// (checked via the assertions in each test below) is the main way a test
+// fails. The one other hard-fail signal is a genuinely enforced CSP
+// violation — something the browser actively blocked — since that's a
+// real, actionable break we need to know about immediately, distinct from
+// routine console noise. Everything else (console errors/warnings, uncaught
+// exceptions, and report-only CSP monitoring that hasn't blocked anything
+// yet) is surfaced as a test annotation for visibility in reports without
+// failing the test. KNOWN_NOISE just keeps expected noise out of the
+// annotations; it's report hygiene, not a safety mechanism.
 async function setupPage(page: Page): Promise<string[]> {
-    const errors: string[] = [];
+    const cspViolations: string[] = [];
+
+    const handle = (text: string, annotationPrefix: string) => {
+        if (KNOWN_NOISE.some((n) => text.includes(n))) {
+            return;
+        }
+        if (isEnforcedCspViolation(text)) {
+            cspViolations.push(text);
+            return;
+        }
+        const prefix = isCspIssue(text) ? '[CSP]' : annotationPrefix;
+        test.info().annotations.push({ type: 'warning', description: `${prefix} ${text}` });
+    };
 
     page.on('console', (msg) => {
         if (msg.type() !== 'error' && msg.type() !== 'warning') {
             return;
         }
-        const text = msg.text();
-        if (isCspIssue(text)) {
-            test.info().annotations.push({ type: 'warning', description: `[CSP] ${text}` });
-        } else if (!KNOWN_NOISE.some((n) => text.includes(n))) {
-            errors.push(text);
-        }
+        handle(msg.text(), '[Console]');
     });
 
     // Fulfill rather than abort so the browser doesn't log net::ERR_FAILED to the console.
@@ -44,117 +61,114 @@ async function setupPage(page: Page): Promise<string[]> {
         route.fulfill({ status: 200, contentType: 'application/javascript', body: '' })
     );
     page.on('pageerror', (error) => {
-        const msg = `Uncaught exception: ${error.message}`;
-        if (isCspIssue(msg)) {
-            test.info().annotations.push({ type: 'warning', description: `[CSP] ${msg}` });
-        } else {
-            errors.push(msg);
-        }
+        handle(`Uncaught exception: ${error.message}`, '[Exception]');
     });
 
-    return errors;
+    return cspViolations;
 }
 
 test.describe('Page Verification', () => {
     // --- Homepage ---
 
     test('homepage loads with title and header visible', async ({ page }) => {
-        const errors = await setupPage(page);
+        const cspViolations = await setupPage(page);
 
         await page.goto('/');
         await expect(page).toHaveTitle(/AG Grid/);
         await expect(page.locator('.site-header')).toBeVisible();
         await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
 
-        expect(errors, 'Console Errors').toEqual([]);
+        expect(cspViolations, 'CSP violations').toEqual([]);
     });
 
     test('homepage shows Docs and Demos navigation links', async ({ page }) => {
-        const errors = await setupPage(page);
+        const cspViolations = await setupPage(page);
 
         await page.goto('/');
         // Both links appear in the large and small nav – use first() to target the large (desktop) nav
         await expect(page.locator('.site-header').getByRole('link', { name: 'AG Grid Docs' }).first()).toBeVisible();
         await expect(page.locator('.site-header').getByRole('link', { name: 'AG Grid Demos' }).first()).toBeVisible();
 
-        expect(errors, 'Console Errors').toEqual([]);
+        expect(cspViolations, 'CSP violations').toEqual([]);
     });
 
     // --- Core pages ---
 
     test('demos page loads with an example grid', async ({ page }) => {
-        const errors = await setupPage(page);
+        const cspViolations = await setupPage(page);
 
         await page.goto('/example');
         await page.waitForSelector('.ag-root-wrapper', { state: 'visible' });
         await expect(page.locator('.ag-root-wrapper')).toBeVisible();
 
-        expect(errors, 'Console Errors').toEqual([]);
+        expect(cspViolations, 'CSP violations').toEqual([]);
     });
 
     test('theme builder page loads', async ({ page }) => {
-        const errors = await setupPage(page);
+        const cspViolations = await setupPage(page);
 
         await page.goto('/theme-builder/');
         await expect(page).toHaveTitle(/Theme Builder/);
         await expect(page.locator('.site-header')).toBeVisible();
 
-        expect(errors, 'Console Errors').toEqual([]);
+        expect(cspViolations, 'CSP violations').toEqual([]);
     });
 
     test('API reference page loads', async ({ page }) => {
-        const errors = await setupPage(page);
+        const cspViolations = await setupPage(page);
 
         await page.goto('/react-data-grid/reference/');
         await expect(page).toHaveTitle(/Reference/);
         await expect(page.locator('#docs-mobile-nav-collapser')).toBeVisible();
         await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
 
-        expect(errors, 'Console Errors').toEqual([]);
+        expect(cspViolations, 'CSP violations').toEqual([]);
     });
 
     test('community page loads', async ({ page }) => {
-        await setupPage(page);
+        const cspViolations = await setupPage(page);
 
         await page.goto('/community/');
         await expect(page).toHaveTitle(/Community/);
         await expect(page.locator('.site-header')).toBeVisible();
+
+        expect(cspViolations, 'CSP violations').toEqual([]);
     });
 
     test('about page loads', async ({ page }) => {
-        const errors = await setupPage(page);
+        const cspViolations = await setupPage(page);
 
         await page.goto('/about/');
         await expect(page).toHaveTitle(/About AG Grid/);
         await expect(page.locator('.site-header')).toBeVisible();
 
-        expect(errors, 'Console Errors').toEqual([]);
+        expect(cspViolations, 'CSP violations').toEqual([]);
     });
 
     test('contact page loads', async ({ page }) => {
-        const errors = await setupPage(page);
+        const cspViolations = await setupPage(page);
 
         await page.goto('/contact/');
         await expect(page).toHaveTitle(/Contact AG Grid/);
         await expect(page.locator('.site-header')).toBeVisible();
 
-        expect(errors, 'Console Errors').toEqual([]);
+        expect(cspViolations, 'CSP violations').toEqual([]);
     });
 
     test('pricing page loads', async ({ page }) => {
-        const errors = await setupPage(page);
+        const cspViolations = await setupPage(page);
 
         await page.goto('/license-pricing/');
         await expect(page).toHaveTitle(/Licence and Pricing/);
         await expect(page.locator('.site-header')).toBeVisible();
 
-        expect(errors, 'Console Errors').toEqual([]);
+        expect(cspViolations, 'CSP violations').toEqual([]);
     });
 
     // --- Docs pages ---
 
     test('docs getting-started page loads', async ({ page }) => {
-        const errors = await setupPage(page);
+        const cspViolations = await setupPage(page);
 
         await page.goto('/react-data-grid/getting-started/');
         await expect(page).toHaveTitle(/Quick Start/);
@@ -162,11 +176,11 @@ test.describe('Page Verification', () => {
         await expect(page.locator('#docs-mobile-nav-collapser')).toBeVisible();
         await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
 
-        expect(errors, 'Console Errors').toEqual([]);
+        expect(cspViolations, 'CSP violations').toEqual([]);
     });
 
     test('clicking a left-nav link navigates to the correct doc page', async ({ page }) => {
-        const errors = await setupPage(page);
+        const cspViolations = await setupPage(page);
 
         await page.goto('/react-data-grid/getting-started/');
         // 'Key Features' is a flat (non-grouped) item in the Getting Started section
@@ -174,11 +188,11 @@ test.describe('Page Verification', () => {
         await expect(page).toHaveURL(/key-features/);
         await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
 
-        expect(errors, 'Console Errors').toEqual([]);
+        expect(cspViolations, 'CSP violations').toEqual([]);
     });
 
     test('docs page with an inline example renders a grid', async ({ page }) => {
-        const errors = await setupPage(page);
+        const cspViolations = await setupPage(page);
 
         await page.goto('/react-data-grid/row-sorting/');
         await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
@@ -194,13 +208,13 @@ test.describe('Page Verification', () => {
         const exampleFrame = page.locator('iframe.exampleRunner').first().contentFrame();
         await expect(exampleFrame.locator('.ag-root-wrapper')).toBeVisible({ timeout: 30_000 });
 
-        expect(errors, 'Console Errors').toEqual([]);
+        expect(cspViolations, 'CSP violations').toEqual([]);
     });
 
     // --- Product switcher ---
 
     test('product switcher opens and shows AG products', async ({ page }) => {
-        const errors = await setupPage(page);
+        const cspViolations = await setupPage(page);
 
         await page.goto('/');
         // The Products button opens the dropdown on hover (onMouseEnter)
@@ -209,6 +223,6 @@ test.describe('Page Verification', () => {
         await expect(page.getByRole('link', { name: /AG Charts/ }).first()).toBeVisible();
         await expect(page.getByRole('link', { name: /AG Studio/ }).first()).toBeVisible();
 
-        expect(errors, 'Console Errors').toEqual([]);
+        expect(cspViolations, 'CSP violations').toEqual([]);
     });
 });


### PR DESCRIPTION
## Summary
- Console errors/warnings and uncaught exceptions in `page-verification.spec.ts` no longer fail the test — they're surfaced as `test.info()` annotations instead. This suite is meant to be a smoke test ("does the page load, is anything actually broken"), and routine browser/library console noise unrelated to real breakage (a new deprecation warning, a different 404 asset, a third-party script quirk) was turning into whack-a-mole `KNOWN_NOISE` allowlist maintenance and producing false failures on post-deploy verification.
- Pass/fail is now driven by the existing structural/functional assertions per page (title, header, key selectors, iframe grid rendering, nav interactions) — these already directly prove a page loaded and works.
- One console-based hard-fail signal remains: a genuinely **enforced** CSP violation (an actual `Refused to load/execute/connect...` block, not a report-only monitoring message). This is a real, actionable break that should be known about immediately, and failing the test reuses the existing `post-deploy-verification.yml` → `#teamcity_status` Slack alert with no new infrastructure needed. Report-only CSP messages (future/stricter policy still being monitored, nothing actually blocked yet) remain non-blocking, same as other console noise.

## Test plan
- [x] `npx eslint src/content/docs/page-verification.spec.ts` — clean
- [x] Ran `./docs-e2e.sh --project=page-verification --url https://www.ag-grid.com` — 13/13 passed
- [x] Ran the same suite against `https://grid-staging.ag-grid.com` — 13/13 passed
- [x] Verified in isolation that the enforced-vs-report-only CSP regex correctly separates a real block from a `[Report Only]`-flagged message