### PR TITLE
ci(pr-review): default to the claude driver (AG-17768)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -24,6 +24,17 @@ on:
                 description: 'PR number to review'
                 type: string
                 required: true
+            driver:
+                description: 'Review engine. claude (default) = Claude Code orchestrates a chunked Codex review — same standard pass, split across per-turn-safe chunks (survives large PRs that exceed Codex per-turn input limits). codex = legacy single-turn Codex review (can fail on large PRs that exceed the per-turn input limit).'
+                type: choice
+                options: [claude, codex]
+                default: claude
+                required: false
+            quiet:
+                description: 'Quiet/soak mode: post nothing to the PR; upload the review as an artifact (pr-review-<driver>-<pr#>) instead. Use to compare drivers without touching the PR.'
+                type: boolean
+                default: false
+                required: false
 
 permissions:
     contents: read
@@ -108,3 +119,10 @@ jobs:
                   pr-author: ${{ steps.pr-meta.outputs.pr-author }}
                   github-token: ${{ github.token }}
                   inline-comments: 'true'
+                  # claude is the default driver. pull_request / plain /pr-review supply
+                  # no driver input, so they fall through to the `|| 'claude'` default.
+                  # To force codex on a one-off, dispatch with driver=codex. quiet stays
+                  # false → claude reviews post to the PR as normal.
+                  driver: ${{ inputs.driver || 'claude' }}
+                  quiet: ${{ inputs.quiet || 'false' }}
+                  anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Why

The Claude-orchestrated PR-review driver has been the default in **ag-charts since 2026-06-26** and soaked well: 72 success / 1 failure / 17 skipped across the week. The one failure was the `ag-jira-agent-ci` bot actor being rejected by claude-code-action — fixed upstream in ag-grid/ag-dev-prompts#455, which should be promoted to `latest` before this merges.

This brings ag-grid in line (AG-17768). The claude driver fixes recurring Codex input-size failures on large PRs: Claude Code chunks the diff and runs the same standard Codex review pass per chunk, then merges — Codex stays the reviewer.

## What

Mirrors ag-charts' `pr-review.yml`:
- `driver` (default **claude**) + `quiet` workflow_dispatch inputs
- passes `driver`/`quiet`/`anthropic-api-key` (org secret, already available) to the review step

`driver=codex` stays available via dispatch as an escape hatch.

## Merge ordering

⚠️ Merge only after ag-dev-prompts#455 is on the `latest` channel (this repo pins `latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)