### PR TITLE
ci: GitHub-issue AI triage pipeline stub (manual dogfood, canary)

### DIFF
--- a/.github/workflows/github-triage-pipeline.yml
+++ b/.github/workflows/github-triage-pipeline.yml
@@ -45,6 +45,11 @@ on:
                 description: 'AITGH key (resume/execute)'
                 type: string
                 required: false
+            channel:
+                description: '@ag-grid/dev-prompts dist-tag'
+                type: choice
+                default: latest
+                options: [latest, canary]
 
 permissions:
     contents: read
@@ -58,11 +63,11 @@ concurrency:
     cancel-in-progress: false
 
 env:
-    # Pinned to canary during rollout/dogfood: the github-triage-pipeline action
-    # lands on the canary dist-tag first and reaches `latest` only on promotion.
-    # Per-workflow — the /fr pipeline (jira-agent-pipeline.yml) stays on latest.
-    # Flip to `latest` once the action has promoted + soaked.
-    DEV_PROMPTS_CHANNEL: canary
+    # Defaults to `latest` (inputs is empty on issues / repository_dispatch).
+    # During rollout/dogfood, test unpromoted action changes by manually
+    # dispatching with channel=canary — the github-triage-pipeline action lands
+    # on the canary dist-tag first and reaches `latest` only on promotion.
+    DEV_PROMPTS_CHANNEL: ${{ inputs.channel || 'latest' }}
 
 jobs:
     # -------------------------------------------------- preflight

--- a/.github/workflows/github-triage-pipeline.yml
+++ b/.github/workflows/github-triage-pipeline.yml
@@ -1,0 +1,133 @@
+name: GitHub issue AI triage
+
+# ============================================================================
+# GitHub-issue → AITGH triage pipeline (thin per-repo stub).
+#
+# A new issue labelled `triage` runs the /ag-product:github-issues brain
+# headlessly against a 1-1 AITGH mapping ticket; a human reviews on the AITGH
+# board and drags Needs Review → In Progress to approve. The heavy lifting lives
+# in the shared `github-triage-pipeline` composite action in @ag-grid/dev-prompts
+# (pulled via the GitHub Packages tarball, exactly like jira-agent-pipeline.yml).
+# This workflow owns triggers + eligibility gating only.
+#
+# Full design + operator reference:
+#   ag-dev-prompts → docs/github-triage-pipeline.md
+#
+# Triggers:
+#   issues (opened|labeled)            → triage    (the GitHub-native entry point)
+#   repository_dispatch gh-triage-resume → preflight routes execute | resume
+#       (from the single AITGH `→ In Progress` JIRA automation rule:
+#        POST /repos/ag-grid/ag-grid/dispatches
+#        {"event_type":"gh-triage-resume","client_payload":{"issue_key":"AITGH-XXX"}})
+#   workflow_dispatch                  → force a stage (dry-run / debugging)
+# ============================================================================
+
+on:
+    # Auto-triage of new triage-labelled issues — DISABLED for the initial manual
+    # dogfood (run via workflow_dispatch first). Uncomment to go live once the
+    # dispatch + drag paths are validated.
+    # issues:
+    #     types: [opened, labeled]
+    repository_dispatch:
+        types: [gh-triage-resume]
+    workflow_dispatch:
+        inputs:
+            stage:
+                description: 'Pipeline stage'
+                type: choice
+                default: triage
+                options: [triage, resume, execute]
+            gh_issue:
+                description: 'GitHub issue number (triage)'
+                type: string
+                required: false
+            issue_key:
+                description: 'AITGH key (resume/execute)'
+                type: string
+                required: false
+
+permissions:
+    contents: read
+    issues: write # execute posts the reply + closes + labels
+    packages: read # install @ag-grid/dev-prompts from GitHub Packages
+
+concurrency:
+    # Keyed on the GH issue number → a stable per-issue lock (no identity flip
+    # between first-triage and the resume/execute drag).
+    group: gh-triage-${{ github.event.issue.number || github.event.client_payload.gh_issue || inputs.gh_issue || github.event.client_payload.issue_key || inputs.issue_key }}
+    cancel-in-progress: false
+
+env:
+    # Pinned to canary during rollout/dogfood: the github-triage-pipeline action
+    # lands on the canary dist-tag first and reaches `latest` only on promotion.
+    # Per-workflow — the /fr pipeline (jira-agent-pipeline.yml) stays on latest.
+    # Flip to `latest` once the action has promoted + soaked.
+    DEV_PROMPTS_CHANNEL: canary
+
+jobs:
+    # -------------------------------------------------- preflight
+    # Only on the JIRA `→ In Progress` drag. Mechanical (no agent): reads the
+    # AITGH ticket's SUGGESTED-ACTION-READY marker + comments + bot-actor and
+    # emits `stage` (execute | resume | '' for suppress).
+    preflight:
+        if: github.event_name == 'repository_dispatch' && github.event.action == 'gh-triage-resume'
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        permissions:
+            contents: read
+            packages: read
+        outputs:
+            stage: ${{ steps.pf.outputs.stage }}
+            issue_key: ${{ steps.pf.outputs.issue_key }}
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 1
+            - name: Install @ag-grid/dev-prompts
+              uses: ./external/ag-shared/github/actions/install-ag-dev-prompts
+              with:
+                  channel: ${{ env.DEV_PROMPTS_CHANNEL }}
+            - id: pf
+              uses: ./.ag-dev-prompts/node_modules/@ag-grid/dev-prompts/.github/actions/github-triage-resume-preflight
+              with:
+                  issue_key: ${{ github.event.client_payload.issue_key }}
+                  jira_email: ${{ secrets.JIRA_AI_BOT_EMAIL }}
+                  jira_api_token: ${{ secrets.JIRA_AI_BOT_API_TOKEN }}
+                  jira_site_url: ${{ vars.JIRA_SITE_URL }}
+
+    # -------------------------------------------------- run
+    # The parameterised stage runner (triage / resume / execute). Runs on the
+    # issue event (triage), a forced dispatch, or a non-empty preflight route.
+    run:
+        needs: [preflight]
+        if: |
+            !cancelled() &&
+            (
+              (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'triage') && github.event.issue.state == 'open')
+              || github.event_name == 'workflow_dispatch'
+              || (github.event_name == 'repository_dispatch' && needs.preflight.outputs.stage != '')
+            )
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            issues: write
+            packages: read
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 1
+            - name: Install @ag-grid/dev-prompts
+              uses: ./external/ag-shared/github/actions/install-ag-dev-prompts
+              with:
+                  channel: ${{ env.DEV_PROMPTS_CHANNEL }}
+            - uses: ./.ag-dev-prompts/node_modules/@ag-grid/dev-prompts/.github/actions/github-triage-pipeline
+              with:
+                  stage: ${{ needs.preflight.outputs.stage || inputs.stage || 'triage' }}
+                  product: grid
+                  gh_issue: ${{ github.event.issue.number || github.event.client_payload.gh_issue || inputs.gh_issue }}
+                  issue_key: ${{ needs.preflight.outputs.issue_key || github.event.client_payload.issue_key || inputs.issue_key }}
+                  anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  jira_email: ${{ secrets.JIRA_AI_BOT_EMAIL }}
+                  jira_api_token: ${{ secrets.JIRA_AI_BOT_API_TOKEN }}
+                  jira_site_url: ${{ vars.JIRA_SITE_URL }}


### PR DESCRIPTION
## What this is

The thin per-repo stub for the **GitHub-issue → AITGH AI-triage pipeline**. A GitHub issue is triaged headlessly by the `/ag-product:github-issues` brain against a 1-1 **AITGH** mapping ticket; a human reviews on the board and (drag → In Progress) approves, and the pipeline **mechanically** creates the golden **AG** bug ticket (+ `ai-eligible`), links it, and replies/closes the GitHub issue.

All the logic lives in the shared `github-triage-pipeline` action in `@ag-grid/dev-prompts` (pulled via the GitHub Packages tarball, same pattern as `jira-agent-pipeline.yml`). This stub owns triggers + gating only. **Design/operator reference:** `ag-dev-prompts → docs/github-triage-pipeline.md`.

## Rollout notes (please read before merging)

- **Pinned to `DEV_PROMPTS_CHANNEL: canary`** (per-workflow — the `/fr` pipeline stays on `latest`). This is **required right now**: the action *and* the reworked triage brain live on the `canary` dist-tag and won't reach `latest` until the next promotion. Once promoted, flip this one line to `latest`.
- **Manual-first:** the `issues: [opened, labeled]` auto-trigger is **commented out** for the initial dogfood — merging this does **not** start auto-triaging incoming issues. Validate via `workflow_dispatch` first; uncomment the trigger to go live.
- **Secrets:** uses the existing `/fr`-pipeline secrets (`ANTHROPIC_API_KEY`, `JIRA_AI_BOT_EMAIL`/`_API_TOKEN`) + `JIRA_SITE_URL` var + the native `GITHUB_TOKEN`. **No new secret** (Zendesk is a deferred follow-up).
- **The `repository_dispatch` (drag → execute) path** additionally needs the single AITGH `→ In Progress → gh-triage-resume` JIRA automation rule — add it when ready; the manual `-f stage=execute` dispatch is the escape hatch meanwhile.

## Dry-run (once merged)

```
gh workflow run github-triage-pipeline.yml -f stage=triage -f gh_issue=<a real issue> -f product=grid
```

Triage is read-only — safe on any real issue. It creates AITGH-N → Needs Review; review it, then `-f stage=execute -f issue_key=AITGH-N -f gh_issue=<n>` (or drag on the board, with the JIRA rule) mints the AG ticket + replies/closes.

**Draft** until the team confirms the rollout plan above.
