### PR TITLE
AG-3390 Only Slack-notify on success if the previous run failed

### DIFF
--- a/.github/workflows/post-deploy-verification.yml
+++ b/.github/workflows/post-deploy-verification.yml
@@ -111,20 +111,17 @@ jobs:
             --json headSha,conclusion \
             --jq '.[0] // {}')
 
-          PREV_SHA=$(echo "$PREV" | jq -r '.headSha // ""')
-          PREV_CONCLUSION=$(echo "$PREV" | jq -r '.conclusion // ""')
-          CURRENT="${{ steps.run_tests.outcome }}"
-
-          echo "sha=${PREV_SHA}" >> $GITHUB_OUTPUT
-
-          if [ "$PREV_CONCLUSION" != "$CURRENT" ]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
-          else
-            echo "changed=false" >> $GITHUB_OUTPUT
-          fi
+          echo "sha=$(echo "$PREV" | jq -r '.headSha // ""')" >> $GITHUB_OUTPUT
+          echo "outcome=$(echo "$PREV" | jq -r '.conclusion // ""')" >> $GITHUB_OUTPUT
 
       - name: Notify Slack
-        if: always() && steps.run_tests.outcome == 'failure'
+        # Always notify on failure. On success, only notify if the previous run
+        # failed - a "back to green" signal - so a routine passing run doesn't
+        # spam the channel.
+        if: >
+          always() &&
+          (steps.run_tests.outcome == 'failure' ||
+           (steps.run_tests.outcome == 'success' && steps.prev_run.outputs.outcome == 'failure'))
         uses: ./external/ag-shared/github/actions/slack-integration
         with:
           AG_LIBRARY: grid


### PR DESCRIPTION
## Summary
- The post-deploy-verification Slack step already fetched the previous run's conclusion (via `gh run list`) to compute a `changed` output, but that output was never consumed anywhere - the Slack step was hard-gated to `steps.run_tests.outcome == 'failure'`. A passing run after a failure produced no Slack signal at all.
- Replaced the dead `changed` boolean with the previous run's raw `outcome` string, and updated the `Notify Slack` step's `if` condition to fire on every failure (unchanged) **and** on success only when the previous run failed - a "back to green" recovery notification - without spamming the channel on routine consecutive passes.

## Test plan
- [x] Parsed the workflow YAML with `js-yaml` and confirmed the `Notify Slack` step's `if`/`with` block matches the intended condition exactly
- [x] Reviewed the diff - no other steps/outputs touched