### PR TITLE
AG-17750: add company field to contact form

### DIFF
--- a/external/ag-website-shared/src/components/contact-form/ContactForm.tsx
+++ b/external/ag-website-shared/src/components/contact-form/ContactForm.tsx
@@ -172,6 +172,10 @@ export const ContactForm: FunctionComponent<Props> = ({
                     </div>
                 </div>
             </div>
+            <div className="input-field">
+                <label htmlFor="company">Company</label>
+                <input id="company" type="text" placeholder="Company" {...register('company', { maxLength: 40 })} />
+            </div>
             <div className={classnames('input-field', { 'input-error': errors.email })}>
                 <label htmlFor="email">Work email</label>
                 <span className={styles.emailInputOuter}>
@@ -197,8 +201,11 @@ export const ContactForm: FunctionComponent<Props> = ({
             {enquiryTypeId && (
                 <div className={classnames('input-field', { 'input-error': errors[enquiryTypeId] })}>
                     <label htmlFor={enquiryTypeId}>Enquiry Type</label>
-                    <select id={enquiryTypeId} {...register(enquiryTypeId, { required: 'Enquiry type is required' })}>
-                        <option value="">--None--</option>
+                    <select
+                        id={enquiryTypeId}
+                        defaultValue="Sales"
+                        {...register(enquiryTypeId, { required: 'Enquiry type is required' })}
+                    >
                         {ENQUIRY_TYPE_OPTIONS.map((option) => (
                             <option key={option} value={option}>
                                 {option}


### PR DESCRIPTION
## Summary
- Adds an optional "Company" field to the contact form (AC1)
- Removes the "--None--" option from the "Enquiry type" select (AC2)
- Defaults the "Enquiry type" select to "Sales" on load (AC3)

## Test plan
- [ ] Load the contact form (About page / pricing pages / Contact page) and confirm the Company field renders, is optional, and submits as `company`
- [ ] Confirm the Enquiry Type select no longer has a `--None--` option
- [ ] Confirm the Enquiry Type select shows "Sales" selected by default on page load
- [ ] Submit the form successfully with Company left blank

(Supersedes #14343, closed when the branch was renamed to the correct AG-17750 prefix.)