### PR TITLE
Fix(ci): post JIRA comment when ticket added via PR edit

### DIFF
--- a/.github/workflows/gh-comment-hook.yml
+++ b/.github/workflows/gh-comment-hook.yml
@@ -7,6 +7,14 @@ on:
 permissions:
   contents: read
 
+# Serialise runs per PR so overlapping edits can't race the duplicate-comment
+# check (check-then-act): later edits wait for the in-flight run to post its
+# sentinel comment, then see it and skip. Do not cancel in progress, or a
+# cancelled run might skip posting while its replacement also skips.
+concurrency:
+  group: gh-comment-hook-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   expand-jira-links:
     if: github.repository == 'ag-grid/ag-grid'
@@ -16,7 +24,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        if: github.event.action == 'opened'
+        if: github.event.action == 'opened' || github.event.action == 'edited'
         uses: actions/checkout@v4
         with:
           sparse-checkout:
@@ -51,8 +59,10 @@ jobs:
                 await github.rest.issues.update({ owner, repo, issue_number, body });
             }
 
-            // Post a Jira comment only when the PR is first opened
-            if (eventAction !== 'opened') return;
+            // Post a Jira comment when the PR is opened, or when a JIRA reference is added
+            // later via an edit (e.g. auto-generated revert PRs, where the ticket is added
+            // after opening). The per-PR sentinel dedup below prevents duplicate comments.
+            if (eventAction !== 'opened' && eventAction !== 'edited') return;
             if (!process.env.JIRA_API_AUTH) return;
 
             const { addJiraComment, getJiraIssueComments } =


### PR DESCRIPTION
Post the JIRA mention comment on `edited` as well as `opened`, so a ticket reference added after a PR opens (e.g. auto-generated revert PRs) is picked up. Checkout runs on edits too, and a per-PR concurrency group prevents overlapping edits from racing the duplicate-comment check.