### PR TITLE
[AG-17118] Fix(pagination): consistent page number styling across page counts

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_footer.scss
+++ b/community-modules/styles/src/internal/base/parts/_footer.scss
@@ -69,15 +69,11 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        padding: 0 var(--ag-grid-size);
+        padding: var(--ag-grid-size);
         margin: 0 calc(var(--ag-grid-size) * 0.25);
         border-radius: var(--ag-border-radius);
         cursor: pointer;
         font-variant-numeric: tabular-nums;
-    }
-
-    .ag-paging-page-numbers-truncated .ag-paging-page-number {
-        padding: var(--ag-grid-size);
     }
 
     .ag-paging-page-number:hover {

--- a/packages/ag-grid-community/src/pagination/pageNumbersComp.css
+++ b/packages/ag-grid-community/src/pagination/pageNumbersComp.css
@@ -15,14 +15,10 @@
     align-items: center;
     justify-content: center;
     min-width: var(--ag-icon-size);
-    padding: var(--ag-spacing) calc(var(--ag-spacing) * 0.5);
+    padding: var(--ag-spacing);
     border-radius: var(--ag-border-radius);
     cursor: pointer;
     font-variant-numeric: tabular-nums;
-}
-
-:where(.ag-paging-page-numbers-truncated) .ag-paging-page-number {
-    padding-inline: var(--ag-spacing);
 }
 
 .ag-paging-page-number:hover {
@@ -45,11 +41,7 @@
     align-items: center;
     justify-content: center;
     min-width: var(--ag-icon-size);
-    padding: var(--ag-spacing) calc(var(--ag-spacing) * 0.5);
+    padding: var(--ag-spacing);
     pointer-events: none;
     font-variant-numeric: tabular-nums;
-}
-
-:where(.ag-paging-page-numbers-truncated) .ag-paging-page-number-ellipsis {
-    padding-inline: var(--ag-spacing);
 }

--- a/packages/ag-grid-community/src/pagination/pageNumbersComp.css
+++ b/packages/ag-grid-community/src/pagination/pageNumbersComp.css
@@ -15,14 +15,14 @@
     align-items: center;
     justify-content: center;
     min-width: var(--ag-icon-size);
-    padding: 0 calc(var(--ag-spacing) * 0.5);
+    padding: var(--ag-spacing) calc(var(--ag-spacing) * 0.5);
     border-radius: var(--ag-border-radius);
     cursor: pointer;
     font-variant-numeric: tabular-nums;
 }
 
 :where(.ag-paging-page-numbers-truncated) .ag-paging-page-number {
-    padding: var(--ag-spacing);
+    padding-inline: var(--ag-spacing);
 }
 
 .ag-paging-page-number:hover {
@@ -45,11 +45,11 @@
     align-items: center;
     justify-content: center;
     min-width: var(--ag-icon-size);
-    padding: 0 calc(var(--ag-spacing) * 0.5);
+    padding: var(--ag-spacing) calc(var(--ag-spacing) * 0.5);
     pointer-events: none;
     font-variant-numeric: tabular-nums;
 }
 
 :where(.ag-paging-page-numbers-truncated) .ag-paging-page-number-ellipsis {
-    padding: var(--ag-spacing);
+    padding-inline: var(--ag-spacing);
 }

--- a/packages/ag-grid-community/src/pagination/pageNumbersComp.ts
+++ b/packages/ag-grid-community/src/pagination/pageNumbersComp.ts
@@ -151,7 +151,6 @@ export class PageNumbersComp extends Component {
         const restoreFocus = eNumbers.contains(_getActiveDomElement(this.beans));
 
         eNumbers.replaceChildren();
-        eNumbers.classList.toggle('ag-paging-page-numbers-truncated', items.includes('ellipsis'));
 
         const pageLabel = localeTextFunc('page', 'Page');
         let eCurrentPage: HTMLElement | undefined;


### PR DESCRIPTION
Fixes TC7: the page-number panel was styled differently depending on page count — the `ag-paging-page-numbers-truncated` modifier (only present when an ellipsis renders, i.e. multi-page) overrode the number padding, so single-page grids had smaller, shorter number boxes than multi-page grids.

Page numbers (and the ellipsis) now use a uniform `var(--ag-spacing)` / `var(--ag-grid-size)` (8px) padding in every case:

- Removed the `ag-paging-page-numbers-truncated` padding overrides from the Theming API CSS and the legacy Sass.
- Removed the now-unused `ag-paging-page-numbers-truncated` class toggle from `PageNumbersComp`.

Styling is now identical whether the grid has one page or many. Applied to both the Theming API and legacy themes.

Fix [AG-17118](https://ag-grid.atlassian.net/browse/AG-17118)

<img width="642" height="163" alt="Screenshot 2026-07-07 at 13 26 23" src="https://github.com/user-attachments/assets/06d4366b-3574-47c8-8010-f09f34ce0507" />
<img width="923" height="165" alt="Screenshot 2026-07-07 at 13 26 20" src="https://github.com/user-attachments/assets/eac6be68-8c36-48eb-91d2-29a1342b7845" />
<img width="571" height="170" alt="Screenshot 2026-07-07 at 13 25 54" src="https://github.com/user-attachments/assets/b013d538-817d-4e26-9a6a-a8a83dddb0cb" />
<img width="529" height="234" alt="Screenshot 2026-07-07 at 13 25 43" src="https://github.com/user-attachments/assets/9cfac338-6e4c-4777-9d1b-f9508281ed99" />
