### PR TITLE
AG-17727 Move Products dropdown left of Demos and add Contact Us to top nav

### DIFF
--- a/documentation/ag-grid-docs/src/content/site-header/header.json
+++ b/documentation/ag-grid-docs/src/content/site-header/header.json
@@ -36,6 +36,10 @@
                 "path": "/license-pricing"
             },
             {
+                "title": "Contact Us",
+                "path": "/about/#contact-section"
+            },
+            {
                 "title": "GitHub",
                 "url": "https://github.com/ag-grid/ag-grid",
                 "icon": "github"

--- a/documentation/ag-grid-docs/src/styles/header-tokens/_site-header-tokens.scss
+++ b/documentation/ag-grid-docs/src/styles/header-tokens/_site-header-tokens.scss
@@ -1,7 +1,15 @@
-// No-op — forwards every header token unchanged. To override one or more for this
-// repo, delete the line below and uncomment the example beneath it.
-@forward '../../../../../external/ag-website-shared/src/design-system/site-header-tokens';
-
-// @forward '../../../../../external/ag-website-shared/src/design-system/site-header-tokens' with (
-//     $nav-collapse: 900px
-// );
+// AG Grid overrides for the header's per-repo-tunable breakpoints (see
+// external/ag-website-shared/src/components/site-header/_breakpoints.scss for what each
+// token controls). The Grid top nav carries more items than the shared defaults were
+// tuned for (Products switcher + 7 links), so both thresholds are raised:
+//
+// - $nav-collapse: the full inline nav + Products switcher only fit on a single row
+//   above this width; below it the header collapses to the mobile hamburger. Kept high
+//   enough that the Products switcher is never stranded on its own wrapped line.
+// - $docs-search-inline: the header only goes fully inline (search in the same row as
+//   the nav) once there is room for the search box at a usable width; below it the
+//   search box wraps to its own full-width row instead of being squeezed.
+@forward '../../../../../external/ag-website-shared/src/design-system/site-header-tokens' with (
+    $nav-collapse: 1120px,
+    $docs-search-inline: 1300px
+);

--- a/external/ag-website-shared/src/components/product-dropdown/ProductDropdown.module.scss
+++ b/external/ag-website-shared/src/components/product-dropdown/ProductDropdown.module.scss
@@ -7,8 +7,13 @@
 // $switcher-show and $switcher-popup-at control and why.
 .customMenu {
     display: none;
+    // While the header is a wrapping flex row (below $docs-search-inline) this auto
+    // margin keeps the switcher hard against the nav on the right — logo left, then
+    // switcher + nav as one right-aligned group — so the switcher can never be
+    // stranded mid-row or on a line of its own. Inert once the header becomes a grid
+    // (the switcher's track is content-sized), where grid-area handles placement.
+    margin-left: auto;
     padding-right: $spacing-size-2;
-    margin-right: auto;
     user-select: none;
     // Direct .headerInner grid child once the header goes fully inline — see
     // SiteHeader.module.scss's .headerInner grid-template-areas.

--- a/external/ag-website-shared/src/components/product-dropdown/ProductDropdown.module.scss
+++ b/external/ag-website-shared/src/components/product-dropdown/ProductDropdown.module.scss
@@ -13,7 +13,7 @@
     // stranded mid-row or on a line of its own. Inert once the header becomes a grid
     // (the switcher's track is content-sized), where grid-area handles placement.
     margin-left: auto;
-    padding-right: $spacing-size-2;
+    margin-right: -$spacing-size-5;
     user-select: none;
     // Direct .headerInner grid child once the header goes fully inline — see
     // SiteHeader.module.scss's .headerInner grid-template-areas.

--- a/external/ag-website-shared/src/components/search/Search.module.scss
+++ b/external/ag-website-shared/src/components/search/Search.module.scss
@@ -24,7 +24,7 @@
     font-weight: var(--text-semibold);
 
     @container site-header (min-width: #{$search-box-cap-at}) {
-        max-width: 512px;
+        max-width: 372px;
     }
 
     #{$selector-darkmode} & {

--- a/external/ag-website-shared/src/components/site-header/SiteHeader.module.scss
+++ b/external/ag-website-shared/src/components/site-header/SiteHeader.module.scss
@@ -47,13 +47,15 @@
     // this state intentionally stays flex.
     @container site-header (min-width: #{$docs-search-inline}) {
         // Above this width the header is a single row with four named regions: logo,
-        // product/site switcher, the docs+search cluster (flexible — absorbs whatever
-        // space the other three don't need), and the nav. Each region's own CSS rule
-        // declares its `grid-area` below rather than relying on flex order/margin
-        // tricks to land in the right place.
+        // the docs+search cluster (flexible — absorbs whatever space the other three
+        // don't need), the product/site switcher, and the nav. The switcher sits
+        // directly to the left of the nav so the "Products" dropdown reads as the item
+        // immediately before the first nav link. Each region's own CSS rule declares
+        // its `grid-area` below rather than relying on flex order/margin tricks to
+        // land in the right place.
         display: grid;
-        grid-template-columns: auto auto 1fr auto;
-        grid-template-areas: 'logo switcher docs-search nav';
+        grid-template-columns: auto 1fr auto auto;
+        grid-template-areas: 'logo docs-search switcher nav';
         align-items: center;
         column-gap: $spacing-size-4;
     }


### PR DESCRIPTION
## Summary

Implements [AG-17727](https://ag-grid.atlassian.net/browse/AG-17727).

- **Move the Products dropdown** so it sits directly to the left of **Demos** in the top navigation. Achieved by reordering the `site-header` grid template (`logo docs-search switcher nav`) so the product/site switcher region sits immediately before the nav. On docs pages the search cluster takes the freed flexible column next to the logo.
- **Add a Contact Us item** to the top navigation, positioned to the right of **Pricing**, linking to `/about/#contact-section` (matching the existing footer/demo links to the same anchor).

## Acceptance criteria

- **AC1** — Products dropdown appears immediately to the left of Demos ✅
- **AC2** — Contact Us appears to the right of Pricing ✅
- **AC3** — Contact Us links to `about/#contact-section` ✅

## Verification

Verified in the dev server on both the homepage and a docs page (React Quick Start) — DOM ordering and rendered layout confirm Products → Demos adjacency and Pricing → Contact Us adjacency, with the correct href.

Note: the grid reorder lives in the shared `external/ag-website-shared` site-header, so the same layout change applies to other AG sites consuming it.