### PR TITLE
AG-17728 Products dropdown: click activation & mobile nav

### DIFF
--- a/documentation/ag-grid-docs/src/content/site-header/header.json
+++ b/documentation/ag-grid-docs/src/content/site-header/header.json
@@ -2,6 +2,11 @@
     "header": {
         "items": [
             {
+                "title": "AG Grid",
+                "url": "https://www.ag-grid.com",
+                "isCollapsed": true
+            },
+            {
                 "title": "AG Charts",
                 "url": "https://www.ag-grid.com/charts",
                 "isCollapsed": true
@@ -9,6 +14,11 @@
             {
                 "title": "AG Studio",
                 "url": "https://www.ag-grid.com/studio",
+                "isCollapsed": true
+            },
+            {
+                "title": "Bryntum Gantt",
+                "url": "https://www.ag-grid.com/campaigns/bryntum-gantt",
                 "isCollapsed": true
             },
             {

--- a/external/ag-website-shared/src/components/product-dropdown/ProductDropdown.module.scss
+++ b/external/ag-website-shared/src/components/product-dropdown/ProductDropdown.module.scss
@@ -89,7 +89,7 @@
     z-index: 2;
     // Closed (resting) state. Opening flips these via the parent `.open`
     // class — opacity, translate and scale animate. The same transitions
-    // also play in reverse on close, so hover-out mirrors hover-in.
+    // also play in reverse on close, so closing mirrors opening.
     // `visibility` is delayed until the fade-out finishes so the dropdown
     // is removed from the accessibility tree without snap-cutting the
     // visual transition.

--- a/external/ag-website-shared/src/components/product-dropdown/ProductDropdown.module.scss
+++ b/external/ag-website-shared/src/components/product-dropdown/ProductDropdown.module.scss
@@ -53,6 +53,14 @@
     background: rgba(255, 255, 255, 0.1);
     border: none;
     border-radius: var(--radius-3xl);
+
+    // In dark mode the trigger sits on --color-bg-primary (see the base rule
+    // above), whose higher specificity would otherwise swallow this hover.
+    // Mirror the light-mode 10% white overlay by lightening that surface.
+    #{$selector-darkmode}:has([data-is-homepage='false']) &,
+    #{$selector-darkmode}:has([data-is-homepage='true'] :global(.header-scrolled)) & {
+        background-color: color-mix(in srgb, var(--color-bg-primary), var(--color-fg-white) 7.5%);
+    }
 }
 
 .customTrigger.open .arrow {

--- a/external/ag-website-shared/src/components/product-dropdown/ProductDropdown.tsx
+++ b/external/ag-website-shared/src/components/product-dropdown/ProductDropdown.tsx
@@ -135,16 +135,7 @@ export const ProductDropdown = ({ items, children }: { items: ProductMenu; child
     };
 
     return (
-        <div
-            ref={dropdownRef}
-            className={`${styles.customMenu} ${isOpen ? styles.open : ''}`}
-            onMouseEnter={() => {
-                setIsOpen(true);
-            }}
-            onMouseLeave={() => {
-                setIsOpen(false);
-            }}
-        >
+        <div ref={dropdownRef} className={`${styles.customMenu} ${isOpen ? styles.open : ''}`}>
             <button className={`${styles.customTrigger} ${isOpen ? styles.open : ''}`} onClick={handleMenuToggle}>
                 Products
                 <span className={styles.arrow}></span>


### PR DESCRIPTION
## AG-17728 — Products dropdown improvements: click activation & mobile nav

https://ag-grid.atlassian.net/browse/AG-17728

### Changes

**AC1 — Products dropdown opens only on click, not hover**
- Removed the `onMouseEnter` / `onMouseLeave` handlers from the `ProductDropdown` wrapper. The dropdown now toggles only via the trigger button's `onClick`; the existing click-outside handler still closes it.

**AC2 — All products appear within the mobile navigation**
- Added **AG Grid** and **Bryntum Gantt** to the site header (`header.json`) as `isCollapsed` items. Collapsed items are hidden from the desktop nav (where the products dropdown covers them) and shown only in the mobile nav, matching the existing AG Charts / AG Studio pattern. All four products from the dropdown now appear in the mobile navigation.

**Follow-up polish**
- Added a dark-mode hover state to the products dropdown trigger. The dark-mode base rule set the trigger background at a higher specificity than the plain `:hover`, so hovering previously gave no feedback in dark mode; a nested dark-mode hover now lightens the surface to mirror the light-mode white overlay.

### Notes
- `external/ag-website-shared/` is shared code, so the dropdown changes will propagate to the other AG sites via the normal ag-shared sync.
- The optional UX design item on the ticket (marking mobile nav items as products) is flagged optional / pending a design decision and was not done.

### Testing
- `nx format` and `nx lint ag-grid-docs` pass.
- Verified on the local dev server: hover no longer opens the dropdown (click does; click-outside closes); all four products appear in the mobile nav; dark-mode trigger hover shows a highlight matching light mode.
