### PR TITLE
test(ssrm): characterization coverage for block loading, refresh, transactions, tree-data & pivot

### DIFF
--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-grouped-loading.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-grouped-loading.test.ts
@@ -1,0 +1,311 @@
+import type { IServerSideGetRowsParams } from 'ag-grid-community';
+import { ScrollApiModule } from 'ag-grid-community';
+import { ServerSideRowModelApiModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, waitForEvent } from '../../test-utils';
+import { ssrmExpandAndLoadAll, waitForNoLoadingRows } from '../../test-utils/ssrm-test-utils';
+
+/**
+ * CHARACTERIZATION (golden-master) tests pinning the CURRENT behaviour of AG Grid
+ * SSRM grouped block loading, cache eviction, and per-level store params.
+ *
+ * These are not aspirational specs: each assertion records what the grid actually
+ * does today (request routes, block ranges, eviction/re-request patterns). Where the
+ * current mechanics are surprising or arguably buggy, that behaviour is frozen here as
+ * the expected baseline so future regressions are caught. Do NOT "fix" a value to what
+ * you think it should be — if a value changes, that is a behavioural change to review.
+ */
+
+// A compact record of one getRows call: which group route it targets and the block range requested.
+interface RequestRecord {
+    groupKeys: string[];
+    range: [number, number];
+}
+
+describe('SSRM grouped block loading (characterization)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ScrollApiModule, ServerSideRowModelModule],
+    });
+
+    afterEach(() => gridsManager.reset());
+
+    // Two-level dataset: country -> athletes. Countries are the top-level group block;
+    // expanding a country requests that country's leaf children.
+    const LEAF_ROWS = [
+        { id: 'uk-alice', country: 'UK', athlete: 'Alice' },
+        { id: 'uk-bob', country: 'UK', athlete: 'Bob' },
+        { id: 'uk-carol', country: 'UK', athlete: 'Carol' },
+        { id: 'uk-dan', country: 'UK', athlete: 'Dan' },
+        { id: 'uk-eve', country: 'UK', athlete: 'Eve' },
+        { id: 'us-frank', country: 'US', athlete: 'Frank' },
+        { id: 'us-grace', country: 'US', athlete: 'Grace' },
+        { id: 'fr-heidi', country: 'FR', athlete: 'Heidi' },
+    ];
+
+    test('scenario 1: initial load requests root group block; expanding a group requests that group route', async () => {
+        // Record the request stream inline so we can assert WHICH group each block belongs to.
+        const requests: RequestRecord[] = [];
+
+        const api = gridsManager.createGrid(null, {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'athlete' },
+            ],
+            autoGroupColumnDef: { field: 'athlete' },
+            rowModelType: 'serverSide',
+            getRowId: (p) => p.data.id ?? `group-${p.data.country}`,
+            serverSideDatasource: {
+                getRows: (params: IServerSideGetRowsParams) => {
+                    const groupKeys = (params.request.groupKeys ?? []) as string[];
+                    requests.push({ groupKeys, range: [params.request.startRow!, params.request.endRow!] });
+                    if (groupKeys.length === 0) {
+                        // Top-level group rows: one row per country.
+                        const countries = Array.from(new Set(LEAF_ROWS.map((r) => r.country)));
+                        const rows = countries.map((country) => ({ id: `group-${country}`, country }));
+                        params.success({ rowData: [...rows], rowCount: rows.length });
+                        return;
+                    }
+                    // Child leaf rows for a specific country route.
+                    const rows = LEAF_ROWS.filter((r) => r.country === groupKeys[0]);
+                    params.success({ rowData: [...rows], rowCount: rows.length });
+                },
+            },
+        });
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        // Initial load requested exactly one block: the root/top-level group route (groupKeys []).
+        expect(requests).toEqual([{ groupKeys: [], range: [0, 100] }]);
+
+        // Expand the UK group — this must trigger a getRows for the ['UK'] route only.
+        api.getRowNode('group-UK')?.setExpanded(true);
+        await waitForNoLoadingRows(api);
+
+        expect(requests).toEqual([
+            { groupKeys: [], range: [0, 100] },
+            { groupKeys: ['UK'], range: [0, 100] },
+        ]);
+
+        await new GridRows(api, 'scenario 1 after expand UK').check(`
+            ROOT id:<no-id>
+            ├─┬ GROUP-leafGroup id:group-UK ag-Grid-AutoColumn:"UK" country:"UK"
+            │ ├── LEAF id:uk-alice ag-Grid-AutoColumn:"Alice" country:"UK" athlete:"Alice"
+            │ ├── LEAF id:uk-bob ag-Grid-AutoColumn:"Bob" country:"UK" athlete:"Bob"
+            │ ├── LEAF id:uk-carol ag-Grid-AutoColumn:"Carol" country:"UK" athlete:"Carol"
+            │ ├── LEAF id:uk-dan ag-Grid-AutoColumn:"Dan" country:"UK" athlete:"Dan"
+            │ └── LEAF id:uk-eve ag-Grid-AutoColumn:"Eve" country:"UK" athlete:"Eve"
+            ├── GROUP-leafGroup collapsed id:group-US ag-Grid-AutoColumn:"US" country:"US"
+            └── GROUP-leafGroup collapsed id:group-FR ag-Grid-AutoColumn:"FR" country:"FR"
+        `);
+    });
+
+    test('scenario 2: cacheBlockSize splits a child level into ranged blocks', async () => {
+        const requests: RequestRecord[] = [];
+
+        const api = gridsManager.createGrid(null, {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'athlete' },
+            ],
+            autoGroupColumnDef: { field: 'athlete' },
+            rowModelType: 'serverSide',
+            cacheBlockSize: 2, // child level (UK has 5 children) is requested in blocks of 2
+            getRowId: (p) => p.data.id ?? `group-${p.data.country}`,
+            serverSideDatasource: {
+                getRows: (params: IServerSideGetRowsParams) => {
+                    const groupKeys = (params.request.groupKeys ?? []) as string[];
+                    const start = params.request.startRow!;
+                    const end = params.request.endRow!;
+                    requests.push({ groupKeys, range: [start, end] });
+                    if (groupKeys.length === 0) {
+                        const countries = Array.from(new Set(LEAF_ROWS.map((r) => r.country)));
+                        const rows = countries.map((country) => ({ id: `group-${country}`, country }));
+                        params.success({ rowData: [...rows], rowCount: rows.length });
+                        return;
+                    }
+                    const all = LEAF_ROWS.filter((r) => r.country === groupKeys[0]);
+                    const page = all.slice(start, end);
+                    params.success({ rowData: [...page], rowCount: all.length });
+                },
+            },
+        });
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        // Root group block honours cacheBlockSize too — endRow is 2, not 100.
+        expect(requests).toEqual([{ groupKeys: [], range: [0, 2] }]);
+
+        api.getRowNode('group-UK')?.setExpanded(true);
+        await waitForNoLoadingRows(api);
+
+        // UK's 5 children are requested in blocks of 2 within the ['UK'] route: [0,2] [2,4] [4,6].
+        expect(requests).toEqual([
+            { groupKeys: [], range: [0, 2] },
+            { groupKeys: ['UK'], range: [0, 2] },
+            { groupKeys: ['UK'], range: [2, 4] },
+            { groupKeys: ['UK'], range: [4, 6] },
+        ]);
+
+        await new GridRows(api, 'scenario 2 blocked child load').check(`
+            ROOT id:<no-id>
+            ├─┬ GROUP-leafGroup id:group-UK ag-Grid-AutoColumn:"UK" country:"UK"
+            │ ├── LEAF id:uk-alice ag-Grid-AutoColumn:"Alice" country:"UK" athlete:"Alice"
+            │ ├── LEAF id:uk-bob ag-Grid-AutoColumn:"Bob" country:"UK" athlete:"Bob"
+            │ ├── LEAF id:uk-carol ag-Grid-AutoColumn:"Carol" country:"UK" athlete:"Carol"
+            │ ├── LEAF id:uk-dan ag-Grid-AutoColumn:"Dan" country:"UK" athlete:"Dan"
+            │ └── LEAF id:uk-eve ag-Grid-AutoColumn:"Eve" country:"UK" athlete:"Eve"
+            ├── GROUP-leafGroup collapsed id:group-US ag-Grid-AutoColumn:"US" country:"US"
+            └── GROUP-leafGroup collapsed id:group-FR ag-Grid-AutoColumn:"FR" country:"FR"
+        `);
+    });
+
+    test('scenario 3: maxBlocksInCache=1 thrashes the root group store, re-requesting the same blocks', async () => {
+        const requests: RequestRecord[] = [];
+
+        const api = gridsManager.createGrid(null, {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'athlete' },
+            ],
+            autoGroupColumnDef: { field: 'athlete' },
+            rowModelType: 'serverSide',
+            cacheBlockSize: 2,
+            maxBlocksInCache: 1, // only one block per store may be resident
+            getRowId: (p) => p.data.id ?? `group-${p.data.country}`,
+            serverSideDatasource: {
+                getRows: (params: IServerSideGetRowsParams) => {
+                    const groupKeys = (params.request.groupKeys ?? []) as string[];
+                    const start = params.request.startRow!;
+                    const end = params.request.endRow!;
+                    requests.push({ groupKeys, range: [start, end] });
+                    if (groupKeys.length === 0) {
+                        const countries = Array.from(new Set(LEAF_ROWS.map((r) => r.country)));
+                        const rows = countries.map((country) => ({ id: `group-${country}`, country }));
+                        params.success({ rowData: [...rows], rowCount: rows.length });
+                        return;
+                    }
+                    const all = LEAF_ROWS.filter((r) => r.country === groupKeys[0]);
+                    const page = all.slice(start, end);
+                    params.success({ rowData: [...page], rowCount: all.length });
+                },
+            },
+        });
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        api.getRowNode('group-UK')?.setExpanded(true);
+        await waitForNoLoadingRows(api);
+
+        // CHARACTERIZATION: maxBlocksInCache=1 caps each store at ONE resident block. The root
+        // group store holds 3 countries across two blocks ([0,2] and [2,4]); with a viewport tall
+        // enough to display them all it can never satisfy every visible group from a single block,
+        // so it THRASHES — loading a block, evicting it to load the sibling, then re-requesting the
+        // evicted one. The root route [0,2] is fetched three separate times below (indices 0, 2, 7)
+        // and [2,4] twice. This eviction/re-request churn is the current behaviour, frozen here as a
+        // latent inefficiency: maxBlocksInCache smaller than the displayed block span causes repeated
+        // server round-trips for the SAME ranges.
+        expect(requests).toEqual([
+            { groupKeys: [], range: [0, 2] },
+            { groupKeys: [], range: [2, 4] },
+            { groupKeys: [], range: [0, 2] }, // root block [0,2] re-requested after eviction
+            { groupKeys: ['UK'], range: [0, 2] },
+            { groupKeys: ['UK'], range: [2, 4] },
+            { groupKeys: ['UK'], range: [4, 6] },
+            { groupKeys: [], range: [2, 4] }, // root block [2,4] re-requested after eviction
+            { groupKeys: [], range: [0, 2] }, // root block [0,2] re-requested again
+        ]);
+    });
+
+    test('scenario 4: getServerSideGroupLevelParams overrides cacheBlockSize per level', async () => {
+        const requests: RequestRecord[] = [];
+
+        const api = gridsManager.createGrid(null, {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'athlete' },
+            ],
+            autoGroupColumnDef: { field: 'athlete' },
+            rowModelType: 'serverSide',
+            cacheBlockSize: 100, // default block size
+            // Per-level override: the child level (level 1) uses a block size of 3.
+            getServerSideGroupLevelParams: (params) => {
+                if (params.level === 1) {
+                    return { cacheBlockSize: 3 };
+                }
+                return {};
+            },
+            getRowId: (p) => p.data.id ?? `group-${p.data.country}`,
+            serverSideDatasource: {
+                getRows: (params: IServerSideGetRowsParams) => {
+                    const groupKeys = (params.request.groupKeys ?? []) as string[];
+                    const start = params.request.startRow!;
+                    const end = params.request.endRow!;
+                    requests.push({ groupKeys, range: [start, end] });
+                    if (groupKeys.length === 0) {
+                        const countries = Array.from(new Set(LEAF_ROWS.map((r) => r.country)));
+                        const rows = countries.map((country) => ({ id: `group-${country}`, country }));
+                        params.success({ rowData: [...rows], rowCount: rows.length });
+                        return;
+                    }
+                    const all = LEAF_ROWS.filter((r) => r.country === groupKeys[0]);
+                    const page = all.slice(start, end);
+                    params.success({ rowData: [...page], rowCount: all.length });
+                },
+            },
+        });
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        // Root level (level 0) uses the default block size of 100.
+        expect(requests).toEqual([{ groupKeys: [], range: [0, 100] }]);
+
+        api.getRowNode('group-UK')?.setExpanded(true);
+        await waitForNoLoadingRows(api);
+
+        // Child level (level 1) uses the overridden block size of 3: UK's 5 children -> [0,3] [3,6].
+        expect(requests).toEqual([
+            { groupKeys: [], range: [0, 100] },
+            { groupKeys: ['UK'], range: [0, 3] },
+            { groupKeys: ['UK'], range: [3, 6] },
+        ]);
+    });
+
+    test('scenario 5: ssrmExpandAndLoadAll walks every group route once', async () => {
+        const requests: RequestRecord[] = [];
+
+        const api = gridsManager.createGrid(null, {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'athlete' },
+            ],
+            autoGroupColumnDef: { field: 'athlete' },
+            rowModelType: 'serverSide',
+            getRowId: (p) => p.data.id ?? `group-${p.data.country}`,
+            serverSideDatasource: {
+                getRows: (params: IServerSideGetRowsParams) => {
+                    const groupKeys = (params.request.groupKeys ?? []) as string[];
+                    requests.push({ groupKeys, range: [params.request.startRow!, params.request.endRow!] });
+                    if (groupKeys.length === 0) {
+                        const countries = Array.from(new Set(LEAF_ROWS.map((r) => r.country)));
+                        const rows = countries.map((country) => ({ id: `group-${country}`, country }));
+                        params.success({ rowData: [...rows], rowCount: rows.length });
+                        return;
+                    }
+                    const rows = LEAF_ROWS.filter((r) => r.country === groupKeys[0]);
+                    params.success({ rowData: [...rows], rowCount: rows.length });
+                },
+            },
+        });
+        await waitForEvent('firstDataRendered', api);
+        await ssrmExpandAndLoadAll(api);
+        await waitForNoLoadingRows(api);
+
+        // Root plus one request per country route — every group is loaded exactly once.
+        expect(requests.map((r) => (r.groupKeys.length === 0 ? 'ROOT' : r.groupKeys.join('/')))).toEqual([
+            'ROOT',
+            'UK',
+            'US',
+            'FR',
+        ]);
+    });
+});

--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-grouped-loading.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-grouped-loading.test.ts
@@ -47,10 +47,7 @@ describe('SSRM grouped block loading (characterization)', () => {
         const requests: RequestRecord[] = [];
 
         const api = gridsManager.createGrid(null, {
-            columnDefs: [
-                { field: 'country', rowGroup: true, hide: true },
-                { field: 'athlete' },
-            ],
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
             autoGroupColumnDef: { field: 'athlete' },
             rowModelType: 'serverSide',
             getRowId: (p) => p.data.id ?? `group-${p.data.country}`,
@@ -103,10 +100,7 @@ describe('SSRM grouped block loading (characterization)', () => {
         const requests: RequestRecord[] = [];
 
         const api = gridsManager.createGrid(null, {
-            columnDefs: [
-                { field: 'country', rowGroup: true, hide: true },
-                { field: 'athlete' },
-            ],
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
             autoGroupColumnDef: { field: 'athlete' },
             rowModelType: 'serverSide',
             cacheBlockSize: 2, // child level (UK has 5 children) is requested in blocks of 2
@@ -163,10 +157,7 @@ describe('SSRM grouped block loading (characterization)', () => {
         const requests: RequestRecord[] = [];
 
         const api = gridsManager.createGrid(null, {
-            columnDefs: [
-                { field: 'country', rowGroup: true, hide: true },
-                { field: 'athlete' },
-            ],
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
             autoGroupColumnDef: { field: 'athlete' },
             rowModelType: 'serverSide',
             cacheBlockSize: 2,
@@ -220,10 +211,7 @@ describe('SSRM grouped block loading (characterization)', () => {
         const requests: RequestRecord[] = [];
 
         const api = gridsManager.createGrid(null, {
-            columnDefs: [
-                { field: 'country', rowGroup: true, hide: true },
-                { field: 'athlete' },
-            ],
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
             autoGroupColumnDef: { field: 'athlete' },
             rowModelType: 'serverSide',
             cacheBlockSize: 100, // default block size
@@ -274,10 +262,7 @@ describe('SSRM grouped block loading (characterization)', () => {
         const requests: RequestRecord[] = [];
 
         const api = gridsManager.createGrid(null, {
-            columnDefs: [
-                { field: 'country', rowGroup: true, hide: true },
-                { field: 'athlete' },
-            ],
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
             autoGroupColumnDef: { field: 'athlete' },
             rowModelType: 'serverSide',
             getRowId: (p) => p.data.id ?? `group-${p.data.country}`,

--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-pivot.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-pivot.test.ts
@@ -1,0 +1,180 @@
+import type { GridApi, IServerSideDatasource, IServerSideGetRowsRequest } from 'ag-grid-community';
+import { PivotModule, RowGroupingModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
+
+import { createFakeServer, createServerSideDatasource } from '../../columnToolPanel/deferredPivotModeFakeServer';
+import { GridColumns, GridRows, TestGridsManager, waitForNoLoadingRows } from '../../test-utils';
+
+/**
+ * Characterisation (golden-master) tests pinning the CURRENT behaviour of the Server-Side Row Model
+ * in pivot mode: the shape of the pivot-mode request (pivotMode / pivotCols / valueCols / rowGroupCols),
+ * the pivot result columns generated from the server's `pivotResultFields`, the effect of
+ * `serverSidePivotResultFieldSeparator`, and pivot leaf-group expansion.
+ *
+ * These tests document what the grid does today. Where an assertion encodes a quirk it is deliberate:
+ * the value is the observed mechanic, not a specification of desired behaviour.
+ */
+describe('SSRM pivot (characterisation)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [PivotModule, RowGroupingModule, ServerSideRowModelModule],
+    });
+
+    beforeEach(() => gridsManager.reset());
+    afterEach(() => gridsManager.reset());
+
+    const rowData = [
+        { athlete: 'a', country: 'USA', year: 2000, sport: 'Swimming', gold: 1, silver: 0, bronze: 0, total: 1 },
+        { athlete: 'b', country: 'USA', year: 2004, sport: 'Swimming', gold: 2, silver: 1, bronze: 0, total: 3 },
+        { athlete: 'c', country: 'USA', year: 2008, sport: 'Swimming', gold: 3, silver: 0, bronze: 1, total: 4 },
+        { athlete: 'd', country: 'Russia', year: 2000, sport: 'Swimming', gold: 4, silver: 0, bronze: 0, total: 4 },
+        { athlete: 'e', country: 'Russia', year: 2004, sport: 'Swimming', gold: 5, silver: 2, bronze: 0, total: 7 },
+    ];
+
+    // Records the raw SSRM requests so we can pin the pivot-mode request shape.
+    const recordingDatasource = (
+        requests: IServerSideGetRowsRequest[],
+        rows: typeof rowData
+    ): IServerSideDatasource => {
+        const inner = createServerSideDatasource(createFakeServer(rows as any));
+        return {
+            getRows: (params) => {
+                requests.push(params.request);
+                inner.getRows(params);
+            },
+        };
+    };
+
+    // --- Scenario 1: enabling pivot mode issues a pivotMode request and generates pivot result columns ---
+
+    test('pivot mode request carries pivotMode/pivotCols/valueCols and generates pivot result columns', async () => {
+        const requests: IServerSideGetRowsRequest[] = [];
+        const api: GridApi = await gridsManager.createGridAndWait('ssrm', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', pivot: true, hide: true },
+                { field: 'gold', aggFunc: 'sum', hide: true },
+            ],
+            pivotMode: true,
+            rowModelType: 'serverSide',
+            serverSideDatasource: recordingDatasource(requests, rowData),
+        });
+        await waitForNoLoadingRows(api);
+
+        // The initial (root) request runs in pivot mode and forwards the pivot/value/group column metadata.
+        const rootRequest = requests[0];
+        expect(rootRequest.pivotMode).toBe(true);
+        expect(rootRequest.pivotCols.map((c) => c.id)).toEqual(['year']);
+        expect(rootRequest.valueCols.map((c) => c.id)).toEqual(['gold']);
+        expect(rootRequest.valueCols.map((c) => c.aggFunc)).toEqual(['sum']);
+        expect(rootRequest.rowGroupCols.map((c) => c.id)).toEqual(['country']);
+        expect(rootRequest.groupKeys).toEqual([]);
+
+        // Pivot result columns are generated from the server's pivotResultFields (one per year x gold).
+        await new GridColumns(api, 'pivot result columns (default separator)').checkColumns(`
+            CENTER
+            ├── ag-Grid-AutoColumn "Group" width:200
+            ├─┬ "2000" GROUP
+            │ └── 2000_gold "Gold" width:200
+            ├─┬ "2004" GROUP
+            │ └── 2004_gold "Gold" width:200
+            └─┬ "2008" GROUP
+              └── 2008_gold "Gold" width:200
+        `);
+    });
+
+    // --- Scenario 2: serverSidePivotResultFieldSeparator changes the split of pivotResultFields ---
+
+    test('serverSidePivotResultFieldSeparator controls how pivot result fields are split into columns', async () => {
+        // Hand-rolled datasource returning pivotResultFields joined with the non-default '|' separator.
+        const separator = '|';
+        const requests: IServerSideGetRowsRequest[] = [];
+        const datasource: IServerSideDatasource = {
+            getRows: (params) => {
+                requests.push(params.request);
+                // Single group level (country) -> one pivoted row per country; pivot on year, value gold.
+                const years = ['2000', '2004', '2008'];
+                const pivotResultFields = years.map((y) => `${y}${separator}gold`);
+                const countries = Array.from(new Set(rowData.map((r) => r.country)));
+                const rows = countries.map((country) => {
+                    const row: any = { country };
+                    for (const y of years) {
+                        const match = rowData.filter((r) => r.country === country && String(r.year) === y);
+                        row[`${y}${separator}gold`] = match.reduce((s, r) => s + r.gold, 0);
+                    }
+                    return row;
+                });
+                setTimeout(() => {
+                    params.success({ rowData: rows, rowCount: rows.length, pivotResultFields });
+                }, 0);
+            },
+        };
+
+        const api: GridApi = await gridsManager.createGridAndWait('ssrm', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', pivot: true, hide: true },
+                { field: 'gold', aggFunc: 'sum', hide: true },
+            ],
+            pivotMode: true,
+            rowModelType: 'serverSide',
+            serverSidePivotResultFieldSeparator: separator,
+            serverSideDatasource: datasource,
+        });
+        await waitForNoLoadingRows(api);
+
+        // With the '|' separator the grid splits "2000|gold" into pivot-key "2000" + value col "gold";
+        // the generated colId keeps the raw field (still separator-joined).
+        await new GridColumns(api, 'pivot result columns (pipe separator)').checkColumns(`
+            CENTER
+            ├── ag-Grid-AutoColumn "Group" width:200
+            ├─┬ "2000" GROUP
+            │ └── 2000|gold "Gold" width:200
+            ├─┬ "2004" GROUP
+            │ └── 2004|gold "Gold" width:200
+            └─┬ "2008" GROUP
+              └── 2008|gold "Gold" width:200
+        `);
+    });
+
+    // --- Scenario 3: pivot leaf-group expansion requests the group route and returns pivoted rows ---
+
+    test('expanding a pivot row group requests the group route and returns pivoted child rows', async () => {
+        // Two row-group levels (country, year) so country is an expandable (non-leaf) group; pivot on sport.
+        const requests: IServerSideGetRowsRequest[] = [];
+        const api: GridApi = await gridsManager.createGridAndWait('ssrm', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', rowGroup: true, hide: true },
+                { field: 'sport', pivot: true, hide: true },
+                { field: 'gold', aggFunc: 'sum', hide: true },
+            ],
+            pivotMode: true,
+            rowModelType: 'serverSide',
+            serverSideDatasource: recordingDatasource(requests, rowData),
+            getRowId: ({ data, level, parentKeys }) => {
+                const key = level === 0 ? data.country : data.year;
+                return [...(parentKeys ?? []), key].join('-');
+            },
+        });
+        await waitForNoLoadingRows(api);
+
+        requests.length = 0;
+        api.getRowNode('USA')!.setExpanded(true);
+        await waitForNoLoadingRows(api);
+
+        // The expansion issues a request scoped to the USA group route, still in pivot mode.
+        const expandRequest = requests[0];
+        expect(expandRequest.pivotMode).toBe(true);
+        expect(expandRequest.groupKeys).toEqual(['USA']);
+        expect(expandRequest.rowGroupCols.map((c) => c.id)).toEqual(['country', 'year']);
+        expect(expandRequest.pivotCols.map((c) => c.id)).toEqual(['sport']);
+
+        await new GridRows(api, 'SSRM pivot expand USA').check(`
+            ROOT id:<no-id>
+            ├─┬ GROUP id:USA ag-Grid-AutoColumn:"USA" Swimming_gold:6
+            │ ├── GROUP-leafGroup collapsed id:USA-2000 ag-Grid-AutoColumn:"2000" Swimming_gold:1
+            │ ├── GROUP-leafGroup collapsed id:USA-2004 ag-Grid-AutoColumn:"2004" Swimming_gold:2
+            │ └── GROUP-leafGroup collapsed id:USA-2008 ag-Grid-AutoColumn:"2008" Swimming_gold:3
+            └── GROUP collapsed id:Russia ag-Grid-AutoColumn:"Russia" Swimming_gold:9
+        `);
+    });
+});

--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-sort-filter-scope.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-sort-filter-scope.test.ts
@@ -158,7 +158,10 @@ describe('SSRM sort/filter refresh-scope characterisation', () => {
 
     test('serverSideSortAllLevels true: applying a sort re-requests all expanded levels', async () => {
         const requests: Request[] = [];
-        const api = gridsManager.createGrid(null, createGroupedGridOptions(requests, { serverSideSortAllLevels: true }));
+        const api = gridsManager.createGrid(
+            null,
+            createGroupedGridOptions(requests, { serverSideSortAllLevels: true })
+        );
         await waitForEvent('firstDataRendered', api);
 
         await expandGroupByKey(api, 'UK');

--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-sort-filter-scope.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-sort-filter-scope.test.ts
@@ -1,0 +1,252 @@
+import type { GridApi, GridOptions, IServerSideGetRowsParams } from 'ag-grid-community';
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, waitForEvent } from '../../test-utils';
+import { waitForNoLoadingRows } from '../../test-utils/ssrm-test-utils';
+
+/**
+ * Characterisation tests (golden-master) pinning the CURRENT sort/filter refresh-scope
+ * behaviour of the SSRM grid options `serverSideSortAllLevels`,
+ * `serverSideOnlyRefreshFilteredGroups` and `purgeClosedRowNodes`.
+ *
+ * These tests document mechanics as they exist today — including any quirks. A failing
+ * assertion here means behaviour changed, not necessarily that it is wrong; update the
+ * baseline deliberately.
+ */
+
+// A two-group-level dataset: country -> sport -> athlete leaves.
+// Distinct scores give an unambiguous asc ordering; gold is the aggregated value column.
+const LEAF_ROWS = [
+    { country: 'UK', sport: 'Cycling', athlete: 'Alice', gold: 3, score: 30 },
+    { country: 'UK', sport: 'Cycling', athlete: 'Bob', gold: 7, score: 10 },
+    { country: 'UK', sport: 'Rowing', athlete: 'Carol', gold: 2, score: 20 },
+    { country: 'US', sport: 'Swimming', athlete: 'Dan', gold: 5, score: 50 },
+    { country: 'US', sport: 'Swimming', athlete: 'Eve', gold: 1, score: 40 },
+];
+
+type Request = {
+    groupKeys: string[];
+    sort: unknown;
+    filter: unknown;
+};
+
+// Records every getRows request so tests can assert WHICH group routes get re-requested
+// and what sort/filter each carries.
+function createGroupedGridOptions(requests: Request[], overrides: Partial<GridOptions> = {}): GridOptions {
+    return {
+        columnDefs: [
+            { field: 'country', rowGroup: true, hide: true },
+            { field: 'sport', rowGroup: true, hide: true },
+            { field: 'athlete' },
+            // Plain leaf column (no aggFunc, not a group column): sorting/filtering it does not
+            // set valueColChanged, so the refresh-scope flags become observable.
+            { field: 'score', filter: 'agNumberColumnFilter' },
+            { field: 'gold', aggFunc: 'sum' },
+        ],
+        autoGroupColumnDef: { field: 'athlete' },
+        rowModelType: 'serverSide',
+        cacheBlockSize: 500000,
+        getRowId: (p) => {
+            const { country, sport, athlete } = p.data;
+            if (athlete) {
+                return `leaf-${country}-${sport}-${athlete}`;
+            }
+            if (sport) {
+                return `g-${country}-${sport}`;
+            }
+            return `g-${country}`;
+        },
+        serverSideDatasource: {
+            getRows: (params: IServerSideGetRowsParams) => {
+                const groupKeys = params.request.groupKeys ?? [];
+                requests.push({
+                    groupKeys: [...groupKeys],
+                    sort: params.request.sortModel,
+                    filter: params.request.filterModel,
+                });
+
+                if (groupKeys.length === 0) {
+                    const countries = Array.from(new Set(LEAF_ROWS.map((r) => r.country)));
+                    const rows = countries.map((country) => ({ country }));
+                    params.success({ rowData: rows, rowCount: rows.length });
+                    return;
+                }
+                if (groupKeys.length === 1) {
+                    const country = groupKeys[0];
+                    const sports = Array.from(
+                        new Set(LEAF_ROWS.filter((r) => r.country === country).map((r) => r.sport))
+                    );
+                    const rows = sports.map((sport) => ({ country, sport }));
+                    params.success({ rowData: rows, rowCount: rows.length });
+                    return;
+                }
+                const [country, sport] = groupKeys;
+                const rows = LEAF_ROWS.filter((r) => r.country === country && r.sport === sport);
+                params.success({ rowData: [...rows], rowCount: rows.length });
+            },
+        },
+        ...overrides,
+    };
+}
+
+// Expand a displayed group by its key, waiting for the child load to settle.
+async function expandGroupByKey(api: GridApi, key: string): Promise<void> {
+    for (let i = 0, len = api.getDisplayedRowCount(); i < len; ++i) {
+        const node = api.getDisplayedRowAtIndex(i);
+        if (node?.key === key && !node.expanded) {
+            api.setRowNodeExpanded(node, true);
+            await waitForNoLoadingRows(api);
+            return;
+        }
+    }
+}
+
+async function collapseGroupByKey(api: GridApi, key: string): Promise<void> {
+    for (let i = 0, len = api.getDisplayedRowCount(); i < len; ++i) {
+        const node = api.getDisplayedRowAtIndex(i);
+        if (node?.key === key && node.expanded) {
+            api.setRowNodeExpanded(node, false);
+            return;
+        }
+    }
+}
+
+// Normalise the recorded request stream to the group-route strings, for readable assertions.
+function routes(requests: Request[]): string[] {
+    return requests.map((r) => (r.groupKeys.length === 0 ? '<root>' : r.groupKeys.join('/')));
+}
+
+describe('SSRM sort/filter refresh-scope characterisation', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [AllEnterpriseModule],
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    // --- Scenario 1: serverSideSortAllLevels -------------------------------------------------
+
+    test('serverSideSortAllLevels default (false): sorting a leaf column re-requests only the affected leaf store', async () => {
+        const requests: Request[] = [];
+        const api = gridsManager.createGrid(null, createGroupedGridOptions(requests));
+        await waitForEvent('firstDataRendered', api);
+
+        // Expand two group levels: UK -> Cycling.
+        await expandGroupByKey(api, 'UK');
+        await expandGroupByKey(api, 'Cycling');
+
+        // Clear the setup/expansion requests so we only observe the sort refresh.
+        requests.length = 0;
+
+        api.applyColumnState({ state: [{ colId: 'score', sort: 'asc' }] });
+        await waitForNoLoadingRows(api);
+
+        // Flag OFF: a leaf-column sort only refreshes the leaf store — the group stores are untouched.
+        expect(routes(requests)).toEqual(['UK/Cycling']);
+
+        await new GridRows(api, 'sortAllLevels-false after sort').check(`
+            ROOT id:<no-id>
+            ├─┬ GROUP id:g-UK ag-Grid-AutoColumn:"UK" country:"UK"
+            │ ├─┬ GROUP-leafGroup id:g-UK-Cycling ag-Grid-AutoColumn:"Cycling" country:"UK" sport:"Cycling"
+            │ │ ├── LEAF id:leaf-UK-Cycling-Alice ag-Grid-AutoColumn:"Alice" country:"UK" sport:"Cycling" athlete:"Alice" score:30 gold:3
+            │ │ └── LEAF id:leaf-UK-Cycling-Bob ag-Grid-AutoColumn:"Bob" country:"UK" sport:"Cycling" athlete:"Bob" score:10 gold:7
+            │ └── GROUP-leafGroup collapsed id:g-UK-Rowing ag-Grid-AutoColumn:"Rowing" country:"UK" sport:"Rowing"
+            └── GROUP collapsed id:g-US ag-Grid-AutoColumn:"US" country:"US"
+        `);
+    });
+
+    test('serverSideSortAllLevels true: applying a sort re-requests all expanded levels', async () => {
+        const requests: Request[] = [];
+        const api = gridsManager.createGrid(null, createGroupedGridOptions(requests, { serverSideSortAllLevels: true }));
+        await waitForEvent('firstDataRendered', api);
+
+        await expandGroupByKey(api, 'UK');
+        await expandGroupByKey(api, 'Cycling');
+
+        requests.length = 0;
+
+        api.applyColumnState({ state: [{ colId: 'score', sort: 'asc' }] });
+        await waitForNoLoadingRows(api);
+
+        // Flag ON: every expanded store is refreshed, even for a leaf-only sort column.
+        expect(routes(requests).sort()).toEqual(['<root>', 'UK', 'UK/Cycling'].sort());
+    });
+
+    // --- Scenario 2: serverSideOnlyRefreshFilteredGroups -------------------------------------
+
+    test('serverSideOnlyRefreshFilteredGroups default (false): applying a filter re-requests all expanded levels', async () => {
+        const requests: Request[] = [];
+        const api = gridsManager.createGrid(null, createGroupedGridOptions(requests));
+        await waitForEvent('firstDataRendered', api);
+
+        await expandGroupByKey(api, 'UK');
+        await expandGroupByKey(api, 'Cycling');
+
+        requests.length = 0;
+
+        api.setFilterModel({ score: { filterType: 'number', type: 'greaterThan', filter: 25 } });
+        await waitForNoLoadingRows(api);
+
+        // Flag OFF: a filter refreshes every expanded store regardless of which groups match.
+        expect(routes(requests).sort()).toEqual(['<root>', 'UK', 'UK/Cycling'].sort());
+    });
+
+    test('serverSideOnlyRefreshFilteredGroups true: applying a filter narrows the re-requested routes', async () => {
+        const requests: Request[] = [];
+        const api = gridsManager.createGrid(
+            null,
+            createGroupedGridOptions(requests, { serverSideOnlyRefreshFilteredGroups: true })
+        );
+        await waitForEvent('firstDataRendered', api);
+
+        await expandGroupByKey(api, 'UK');
+        await expandGroupByKey(api, 'Cycling');
+
+        requests.length = 0;
+
+        api.setFilterModel({ score: { filterType: 'number', type: 'greaterThan', filter: 25 } });
+        await waitForNoLoadingRows(api);
+
+        // Flag ON: a leaf-column filter narrows the refresh to just the affected leaf store.
+        expect(routes(requests)).toEqual(['UK/Cycling']);
+    });
+
+    // --- Scenario 3: purgeClosedRowNodes -----------------------------------------------------
+
+    test('purgeClosedRowNodes default (false): collapsed group children are retained (not re-requested on re-expand)', async () => {
+        const requests: Request[] = [];
+        const api = gridsManager.createGrid(null, createGroupedGridOptions(requests));
+        await waitForEvent('firstDataRendered', api);
+
+        // Expand UK -> Cycling (loads Cycling children).
+        await expandGroupByKey(api, 'UK');
+        await expandGroupByKey(api, 'Cycling');
+
+        requests.length = 0;
+
+        // Collapse then re-expand Cycling.
+        await collapseGroupByKey(api, 'Cycling');
+        await expandGroupByKey(api, 'Cycling');
+
+        // With the flag OFF, the Cycling block is NOT re-fetched — children were retained.
+        expect(routes(requests)).toEqual([]);
+    });
+
+    test('purgeClosedRowNodes true: collapsed group children are discarded (re-requested on re-expand)', async () => {
+        const requests: Request[] = [];
+        const api = gridsManager.createGrid(null, createGroupedGridOptions(requests, { purgeClosedRowNodes: true }));
+        await waitForEvent('firstDataRendered', api);
+
+        await expandGroupByKey(api, 'UK');
+        await expandGroupByKey(api, 'Cycling');
+
+        requests.length = 0;
+
+        await collapseGroupByKey(api, 'Cycling');
+        await expandGroupByKey(api, 'Cycling');
+
+        // With the flag ON, the Cycling block is re-fetched on re-expand.
+        expect(routes(requests)).toEqual(['UK/Cycling']);
+    });
+});

--- a/testing/behavioural/src/row-data/ssrm-async-transactions.test.ts
+++ b/testing/behavioural/src/row-data/ssrm-async-transactions.test.ts
@@ -1,0 +1,261 @@
+import type { GridOptions, ServerSideTransactionResult } from 'ag-grid-community';
+import { ScrollApiModule } from 'ag-grid-community';
+import { ServerSideRowModelApiModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
+
+import { GridColumns, GridRows, TestGridsManager, waitForEvent } from '../test-utils';
+
+/**
+ * Characterization (golden-master) tests for AG Grid SSRM ASYNC transactions:
+ *   - api.applyServerSideTransactionAsync(...)
+ *   - api.flushServerSideAsyncTransactions()
+ *   - the isApplyServerSideTransaction grid-option callback (cancel/allow).
+ *
+ * These tests pin the CURRENT observed behaviour of the grid. Any value asserted
+ * here (result `status` strings, displayed counts, ordering, flush timing) is a
+ * snapshot of what the grid does today, not a statement of what it ideally should
+ * do. If a behaviour that looks like a bug is frozen here, that is intentional:
+ * these tests exist to detect unintended change, so update them only when a
+ * behavioural change is deliberate.
+ */
+describe('SSRM Async Transactions (characterization)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ScrollApiModule, ServerSideRowModelModule],
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    test('applyServerSideTransactionAsync add then flush adds the row', async () => {
+        const rowData = Array.from({ length: 10 }, (_, i) => ({ id: i, value: `Row ${i}` }));
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide' as const,
+            getRowId: (params: any) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params: any) => {
+                    const rowDataS = rowData.slice(params.request.startRow, params.request.endRow);
+                    params.success({ rowData: rowDataS, rowCount: rowData.length });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await new GridColumns(api, `async add setup`).checkColumns(`
+            CENTER
+            ├── id "Id" width:200
+            └── value "Value" width:200
+        `);
+        await waitForEvent('firstDataRendered', api);
+        expect(api.getDisplayedRowCount()).toBe(10);
+
+        const results: ServerSideTransactionResult[] = [];
+        const flushed = waitForEvent('asyncTransactionsFlushed', api);
+        // Async transactions are batched; flush forces synchronous-ish application.
+        api.applyServerSideTransactionAsync({ add: [{ id: 100, value: 'Added' }] }, (r) => results.push(r));
+        api.flushServerSideAsyncTransactions();
+        await flushed;
+
+        expect(api.getDisplayedRowCount()).toBe(11);
+        expect(!!api.getRowNode('100')).toBe(true);
+        expect(results.length).toBe(1);
+        expect(results[0].status).toBe('Applied');
+
+        await new GridRows(api, `async add final`).check(`
+            ROOT id:<no-id>
+            ├── LEAF id:0 id:0 value:"Row 0"
+            ├── LEAF id:1 id:1 value:"Row 1"
+            ├── LEAF id:2 id:2 value:"Row 2"
+            ├── LEAF id:3 id:3 value:"Row 3"
+            ├── LEAF id:4 id:4 value:"Row 4"
+            ├── LEAF id:5 id:5 value:"Row 5"
+            ├── LEAF id:6 id:6 value:"Row 6"
+            ├── LEAF id:7 id:7 value:"Row 7"
+            ├── LEAF id:8 id:8 value:"Row 8"
+            ├── LEAF id:9 id:9 value:"Row 9"
+            └── LEAF id:100 id:100 value:"Added"
+        `);
+    });
+
+    test('multiple async transactions batched into one flush all apply in order', async () => {
+        const rowData = Array.from({ length: 5 }, (_, i) => ({ id: i, value: `Row ${i}` }));
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide' as const,
+            getRowId: (params: any) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params: any) => {
+                    const rowDataS = rowData.slice(params.request.startRow, params.request.endRow);
+                    params.success({ rowData: rowDataS, rowCount: rowData.length });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await new GridColumns(api, `async batch setup`).checkColumns(`
+            CENTER
+            ├── id "Id" width:200
+            └── value "Value" width:200
+        `);
+        await waitForEvent('firstDataRendered', api);
+        expect(api.getDisplayedRowCount()).toBe(5);
+
+        const results: ServerSideTransactionResult[] = [];
+        const flushed = waitForEvent('asyncTransactionsFlushed', api);
+        api.applyServerSideTransactionAsync({ add: [{ id: 100, value: 'A' }] }, (r) => results.push(r));
+        api.applyServerSideTransactionAsync({ add: [{ id: 101, value: 'B' }] }, (r) => results.push(r));
+        api.applyServerSideTransactionAsync({ add: [{ id: 102, value: 'C' }] }, (r) => results.push(r));
+        api.flushServerSideAsyncTransactions();
+        await flushed;
+
+        expect(api.getDisplayedRowCount()).toBe(8);
+        expect(results.length).toBe(3);
+        expect(results.map((r) => r.status)).toEqual(['Applied', 'Applied', 'Applied']);
+
+        await new GridRows(api, `async batch final`).check(`
+            ROOT id:<no-id>
+            ├── LEAF id:0 id:0 value:"Row 0"
+            ├── LEAF id:1 id:1 value:"Row 1"
+            ├── LEAF id:2 id:2 value:"Row 2"
+            ├── LEAF id:3 id:3 value:"Row 3"
+            ├── LEAF id:4 id:4 value:"Row 4"
+            ├── LEAF id:100 id:100 value:"A"
+            ├── LEAF id:101 id:101 value:"B"
+            └── LEAF id:102 id:102 value:"C"
+        `);
+    });
+
+    test('applyServerSideTransactionAsync remove then flush removes the row', async () => {
+        const rowData = Array.from({ length: 5 }, (_, i) => ({ id: i, value: `Row ${i}` }));
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide' as const,
+            getRowId: (params: any) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params: any) => {
+                    const rowDataS = rowData.slice(params.request.startRow, params.request.endRow);
+                    params.success({ rowData: rowDataS, rowCount: rowData.length });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await new GridColumns(api, `async remove setup`).checkColumns(`
+            CENTER
+            ├── id "Id" width:200
+            └── value "Value" width:200
+        `);
+        await waitForEvent('firstDataRendered', api);
+        expect(api.getDisplayedRowCount()).toBe(5);
+
+        const results: ServerSideTransactionResult[] = [];
+        const flushed = waitForEvent('asyncTransactionsFlushed', api);
+        api.applyServerSideTransactionAsync({ remove: [{ id: 2 }] }, (r) => results.push(r));
+        api.flushServerSideAsyncTransactions();
+        await flushed;
+
+        expect(api.getDisplayedRowCount()).toBe(4);
+        expect(!!api.getRowNode('2')).toBe(false);
+        expect(results.length).toBe(1);
+        expect(results[0].status).toBe('Applied');
+
+        await new GridRows(api, `async remove final`).check(`
+            ROOT id:<no-id>
+            ├── LEAF id:0 id:0 value:"Row 0"
+            ├── LEAF id:1 id:1 value:"Row 1"
+            ├── LEAF id:3 id:3 value:"Row 3"
+            └── LEAF id:4 id:4 value:"Row 4"
+        `);
+    });
+
+    test('isApplyServerSideTransaction returning false cancels the transaction', async () => {
+        const rowData = Array.from({ length: 5 }, (_, i) => ({ id: i, value: `Row ${i}` }));
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide' as const,
+            getRowId: (params: any) => String(params.data.id),
+            // Cancel every async transaction.
+            isApplyServerSideTransaction: () => false,
+            serverSideDatasource: {
+                getRows: (params: any) => {
+                    const rowDataS = rowData.slice(params.request.startRow, params.request.endRow);
+                    params.success({ rowData: rowDataS, rowCount: rowData.length });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await new GridColumns(api, `async cancel setup`).checkColumns(`
+            CENTER
+            ├── id "Id" width:200
+            └── value "Value" width:200
+        `);
+        await waitForEvent('firstDataRendered', api);
+        expect(api.getDisplayedRowCount()).toBe(5);
+
+        const results: ServerSideTransactionResult[] = [];
+        const flushed = waitForEvent('asyncTransactionsFlushed', api);
+        api.applyServerSideTransactionAsync({ add: [{ id: 100, value: 'Blocked' }] }, (r) => results.push(r));
+        api.flushServerSideAsyncTransactions();
+        await flushed;
+
+        // Cancelled transaction leaves the rows unchanged.
+        expect(api.getDisplayedRowCount()).toBe(5);
+        expect(!!api.getRowNode('100')).toBe(false);
+        expect(results.length).toBe(1);
+        expect(results[0].status).toBe('Cancelled');
+
+        await new GridRows(api, `async cancel final`).check(`
+            ROOT id:<no-id>
+            ├── LEAF id:0 id:0 value:"Row 0"
+            ├── LEAF id:1 id:1 value:"Row 1"
+            ├── LEAF id:2 id:2 value:"Row 2"
+            ├── LEAF id:3 id:3 value:"Row 3"
+            └── LEAF id:4 id:4 value:"Row 4"
+        `);
+    });
+
+    test('async transaction targeting an unknown route reports StoreNotFound', async () => {
+        const rowData = Array.from({ length: 5 }, (_, i) => ({ id: i, value: `Row ${i}` }));
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide' as const,
+            getRowId: (params: any) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params: any) => {
+                    const rowDataS = rowData.slice(params.request.startRow, params.request.endRow);
+                    params.success({ rowData: rowDataS, rowCount: rowData.length });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await new GridColumns(api, `async route setup`).checkColumns(`
+            CENTER
+            ├── id "Id" width:200
+            └── value "Value" width:200
+        `);
+        await waitForEvent('firstDataRendered', api);
+        expect(api.getDisplayedRowCount()).toBe(5);
+
+        const results: ServerSideTransactionResult[] = [];
+        const flushed = waitForEvent('asyncTransactionsFlushed', api);
+        api.applyServerSideTransactionAsync(
+            { route: ['does-not-exist'], add: [{ id: 100, value: 'X' }] },
+            (r) => results.push(r)
+        );
+        api.flushServerSideAsyncTransactions();
+        await flushed;
+
+        // Unknown route: nothing changes at root, and the callback reports the failure status.
+        expect(api.getDisplayedRowCount()).toBe(5);
+        expect(!!api.getRowNode('100')).toBe(false);
+        expect(results.length).toBe(1);
+        expect(results[0].status).toBe('StoreNotFound');
+    });
+});

--- a/testing/behavioural/src/row-data/ssrm-async-transactions.test.ts
+++ b/testing/behavioural/src/row-data/ssrm-async-transactions.test.ts
@@ -245,9 +245,8 @@ describe('SSRM Async Transactions (characterization)', () => {
 
         const results: ServerSideTransactionResult[] = [];
         const flushed = waitForEvent('asyncTransactionsFlushed', api);
-        api.applyServerSideTransactionAsync(
-            { route: ['does-not-exist'], add: [{ id: 100, value: 'X' }] },
-            (r) => results.push(r)
+        api.applyServerSideTransactionAsync({ route: ['does-not-exist'], add: [{ id: 100, value: 'X' }] }, (r) =>
+            results.push(r)
         );
         api.flushServerSideAsyncTransactions();
         await flushed;

--- a/testing/behavioural/src/row-data/ssrm-block-loading.test.ts
+++ b/testing/behavioural/src/row-data/ssrm-block-loading.test.ts
@@ -1,0 +1,187 @@
+import type { GridApi, GridOptions, IServerSideGetRowsRequest } from 'ag-grid-community';
+import { ScrollApiModule } from 'ag-grid-community';
+import { ServerSideRowModelApiModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, waitForEvent } from '../test-utils';
+
+/**
+ * Characterization tests for SSRM block loading and cache eviction.
+ *
+ * These pin the *request stream* the grid emits to the datasource — the block
+ * ranges it asks for, in the order it asks for them — which is the behaviour
+ * unique to SSRM being async and block-based, and which no existing test
+ * asserts on (existing tests only check the final rendered rows).
+ *
+ * Requests are recorded inline (not via a shared factory) so each test reads
+ * top-to-bottom, per the behavioural-suite house style. The recorder is a plain
+ * array push: it exposes behaviour rather than hiding setup.
+ *
+ * If the grid's block-loading behaviour changes intentionally, the asserted
+ * ranges below must be updated deliberately — that is the point of a
+ * characterization baseline.
+ */
+describe('SSRM block loading', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ScrollApiModule, ServerSideRowModelModule],
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    /** Compact, comparable projection of a request's block range. */
+    function blockRange(request: IServerSideGetRowsRequest): [number, number] {
+        return [request.startRow!, request.endRow!];
+    }
+
+    test('initial load requests viewport blocks up front', async () => {
+        const totalRows = 500;
+        const rowData = Array.from({ length: totalRows }, (_, i) => ({ id: i, value: `Row ${i}` }));
+        const requests: [number, number][] = [];
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            cacheBlockSize: 100,
+            getRowId: (params) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params) => {
+                    requests.push(blockRange(params.request));
+                    const slice = rowData.slice(params.request.startRow, params.request.endRow);
+                    params.success({ rowData: slice, rowCount: totalRows });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await waitForEvent('firstDataRendered', api);
+
+        // The grid pre-loads enough blocks to fill the viewport plus buffer — two
+        // blocks here, not just the first.
+        expect(requests).toEqual([
+            [0, 100],
+            [100, 200],
+        ]);
+        expect(api.getDisplayedRowCount()).toBe(totalRows);
+    });
+
+    test('scrolling to a distant index requests the intervening blocks in order', async () => {
+        const totalRows = 500;
+        const rowData = Array.from({ length: totalRows }, (_, i) => ({ id: i, value: `Row ${i}` }));
+        const requests: [number, number][] = [];
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            cacheBlockSize: 100,
+            rowBuffer: 0,
+            suppressRowVirtualisation: false,
+            getRowId: (params) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params) => {
+                    requests.push(blockRange(params.request));
+                    const slice = rowData.slice(params.request.startRow, params.request.endRow);
+                    params.success({ rowData: slice, rowCount: totalRows });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await waitForEvent('firstDataRendered', api);
+        expect(requests).toEqual([[0, 100]]);
+
+        api.ensureIndexVisible(250);
+        await waitForEvent('modelUpdated', api);
+
+        // Row 250 sits in block [200,300); the grid loads the block(s) needed for
+        // the new viewport. Pin exactly which ranges were requested.
+        expect(requests).toEqual([
+            [0, 100],
+            [200, 300],
+        ]);
+    });
+
+    test('maxBlocksInCache evicts the least-recently-used block once the cap is exceeded', async () => {
+        const totalRows = 500;
+        const rowData = Array.from({ length: totalRows }, (_, i) => ({ id: i, value: `Row ${i}` }));
+        const requests: [number, number][] = [];
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            cacheBlockSize: 100,
+            maxBlocksInCache: 2,
+            rowBuffer: 0,
+            suppressRowVirtualisation: false,
+            getRowId: (params) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params) => {
+                    requests.push(blockRange(params.request));
+                    const slice = rowData.slice(params.request.startRow, params.request.endRow);
+                    params.success({ rowData: slice, rowCount: totalRows });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await waitForEvent('firstDataRendered', api);
+
+        // Block 0 is loaded and its rows are in the cache. Compare booleans, not the
+        // RowNode itself — a failing assertion would otherwise try to serialize the
+        // (large, circular) node and crash the reporter.
+        expect(!!api.getRowNode('0')).toBe(true);
+
+        // Touch two further blocks so three blocks have been loaded — exceeding the
+        // cap of 2 and forcing the least-recently-used block (0) out of the cache.
+        api.ensureIndexVisible(250);
+        await waitForEvent('modelUpdated', api);
+        api.ensureIndexVisible(450);
+        await waitForEvent('modelUpdated', api);
+
+        // The far block is present; block 0 has been evicted, so its node is gone.
+        expect(!!api.getRowNode('450')).toBe(true);
+        expect(!!api.getRowNode('0')).toBe(false);
+
+        // Eviction is observable in the request stream: scrolling block 0 back into
+        // view forces a fresh fetch for [0,100] — it is requested a second time.
+        const block0RequestsBefore = requests.filter(([start]) => start === 0).length;
+        api.ensureIndexVisible(0);
+        await waitForEvent('modelUpdated', api);
+        const block0RequestsAfter = requests.filter(([start]) => start === 0).length;
+        expect(block0RequestsAfter).toBe(block0RequestsBefore + 1);
+    });
+
+    test('row model shows a single filler before load and leaf rows after', async () => {
+        const totalRows = 3;
+        const rowData = Array.from({ length: totalRows }, (_, i) => ({ id: i, value: `Row ${i}` }));
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            cacheBlockSize: 100,
+            getRowId: (params) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params) => {
+                    const slice = rowData.slice(params.request.startRow, params.request.endRow);
+                    params.success({ rowData: slice, rowCount: totalRows });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+
+        await new GridRows(api, 'ssrm block loading before load').check(`
+            ROOT id:<no-id>
+            └── filler id:rowIndex:0
+        `);
+
+        await waitForEvent('firstDataRendered', api);
+
+        await new GridRows(api, 'ssrm block loading after load').check(`
+            ROOT id:<no-id>
+            ├── LEAF id:0 id:0 value:"Row 0"
+            ├── LEAF id:1 id:1 value:"Row 1"
+            └── LEAF id:2 id:2 value:"Row 2"
+        `);
+    });
+});

--- a/testing/behavioural/src/row-data/ssrm-block-loading.test.ts
+++ b/testing/behavioural/src/row-data/ssrm-block-loading.test.ts
@@ -1,4 +1,4 @@
-import type { GridApi, GridOptions, IServerSideGetRowsRequest } from 'ag-grid-community';
+import type { GridOptions, IServerSideGetRowsRequest } from 'ag-grid-community';
 import { ScrollApiModule } from 'ag-grid-community';
 import { ServerSideRowModelApiModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
 

--- a/testing/behavioural/src/row-data/ssrm-cache-config.test.ts
+++ b/testing/behavioural/src/row-data/ssrm-cache-config.test.ts
@@ -1,0 +1,258 @@
+import type { GridOptions, IServerSideGetRowsParams } from 'ag-grid-community';
+import { ScrollApiModule } from 'ag-grid-community';
+import { ServerSideRowModelApiModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, waitForEvent } from '../test-utils';
+import { asyncSetTimeout } from '../test-utils/node-utils';
+
+/**
+ * Characterization (golden-master) tests pinning the CURRENT behaviour of the
+ * SSRM cache/loading configuration knobs:
+ *   - serverSideInitialRowCount
+ *   - cacheOverflowSize
+ *   - blockLoadDebounceMillis
+ *   - maxConcurrentDatasourceRequests
+ *
+ * These pin whatever the grid does today (bugs included) so that any future
+ * change to cache/loading mechanics surfaces as a deliberate snapshot update
+ * rather than a silent behavioural drift. They do NOT assert on any "ideal"
+ * value — the asserted numbers were adopted from the actual runtime output.
+ *
+ * House style: setup is inline per test (no shared datasource factory) so each
+ * test reads top-to-bottom; the request stream is recorded with a plain array
+ * push. RowNode objects are never asserted directly (that crashes the reporter
+ * on failure) — only booleans and counts.
+ */
+describe('SSRM cache config', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ScrollApiModule, ServerSideRowModelModule],
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    test('serverSideInitialRowCount pre-populates filler rows before the first block resolves', async () => {
+        const totalRows = 500;
+        const rowData = Array.from({ length: totalRows }, (_, i) => ({ id: i, value: `Row ${i}` }));
+
+        // Deferred datasource: stash the params so the first block stays in-flight
+        // and we can observe the pre-load display state.
+        const pending: IServerSideGetRowsParams[] = [];
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            cacheBlockSize: 100,
+            serverSideInitialRowCount: 42,
+            getRowId: (params) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params) => {
+                    pending.push(params);
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        // Let the initial block dispatch without resolving it.
+        await asyncSetTimeout(30);
+
+        // Before any block resolves the grid sizes itself to the configured
+        // initial row count — 42 filler rows are displayed.
+        expect(api.getDisplayedRowCount()).toBe(42);
+
+        // Register the listener BEFORE draining — success() dispatches modelUpdated
+        // synchronously, so attaching after would miss it and hang.
+        const modelUpdated = waitForEvent('modelUpdated', api);
+        // Drain the in-flight request(s) with the real slice + true row count.
+        for (let i = 0, len = pending.length; i < len; ++i) {
+            const request = pending[i].request;
+            const slice = rowData.slice(request.startRow!, request.endRow!);
+            pending[i].success({ rowData: slice, rowCount: totalRows });
+        }
+        await modelUpdated;
+
+        // Once the real row count arrives the display count reflects it.
+        expect(api.getDisplayedRowCount()).toBe(totalRows);
+    });
+
+    test('cacheOverflowSize lets the model extend past the known rows so more can be scrolled into', async () => {
+        // With cacheOverflowSize the grid does not yet know the true row count
+        // and pads the model by up to N extra rows so the user can scroll beyond
+        // the last loaded block. The datasource deliberately never returns a
+        // rowCount, forcing the "infinite / unknown total" branch.
+        const knownRows = 100;
+        const rowData = Array.from({ length: 1000 }, (_, i) => ({ id: i, value: `Row ${i}` }));
+        const requests: [number, number][] = [];
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            cacheBlockSize: 100,
+            cacheOverflowSize: 5,
+            rowBuffer: 0,
+            suppressRowVirtualisation: false,
+            getRowId: (params) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params) => {
+                    requests.push([params.request.startRow!, params.request.endRow!]);
+                    // Return a full block but NEVER a rowCount, so the total stays
+                    // unknown and the overflow padding is what governs the model size.
+                    const slice = rowData.slice(params.request.startRow!, params.request.startRow! + knownRows);
+                    params.success({ rowData: slice });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await waitForEvent('firstDataRendered', api);
+
+        // One block of real rows is loaded; because the total is unknown the model
+        // is padded so the last row is not yet reached and the next block stays
+        // reachable by scrolling. Pinned behaviour: the padding adds exactly ONE
+        // extra (filler) row here, NOT cacheOverflowSize (5) rows — cacheOverflowSize
+        // caps how far ahead blocks may be created, it is not a straight row pad.
+        expect(api.getDisplayedRowCount()).toBe(knownRows + 1);
+        expect(requests).toEqual([[0, 100]]);
+    });
+
+    test('blockLoadDebounceMillis coalesces rapid scroll-driven block loads within the debounce window', async () => {
+        const totalRows = 2000;
+        const rowData = Array.from({ length: totalRows }, (_, i) => ({ id: i, value: `Row ${i}` }));
+        const requests: [number, number][] = [];
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            cacheBlockSize: 100,
+            blockLoadDebounceMillis: 200,
+            rowBuffer: 0,
+            suppressRowVirtualisation: false,
+            getRowId: (params) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params) => {
+                    requests.push([params.request.startRow!, params.request.endRow!]);
+                    const slice = rowData.slice(params.request.startRow!, params.request.endRow!);
+                    params.success({ rowData: slice, rowCount: totalRows });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await waitForEvent('firstDataRendered', api);
+        const requestsAfterInitial = requests.length;
+
+        // Rapidly hop through several distant viewports. Each hop targets a block
+        // that would otherwise be fetched immediately; the debounce window should
+        // suppress the intermediate loads.
+        api.ensureIndexVisible(500);
+        api.ensureIndexVisible(1000);
+        api.ensureIndexVisible(1500);
+
+        // Sample the request count while still inside the debounce window: the
+        // intermediate blocks have NOT been fetched yet.
+        await asyncSetTimeout(50);
+        const requestsDuringWindow = requests.length - requestsAfterInitial;
+        expect(requestsDuringWindow).toBe(0);
+
+        // After the debounce window elapses the (final) block load fires.
+        await asyncSetTimeout(400);
+        const requestsAfterWindow = requests.length - requestsAfterInitial;
+        expect(requestsAfterWindow).toBeGreaterThan(0);
+        // The debounce coalesced the three rapid hops into far fewer than three
+        // fetches — pin that it did not fetch every intermediate block.
+        expect(requestsAfterWindow).toBeLessThan(3);
+    });
+
+    test('maxConcurrentDatasourceRequests caps how many getRows calls are in-flight at once', async () => {
+        const totalRows = 2000;
+        const rowData = Array.from({ length: totalRows }, (_, i) => ({ id: i, value: `Row ${i}` }));
+
+        // Deferred datasource: stash every params so nothing resolves. The number
+        // of getRows invocations in-flight before any resolve == the concurrency cap.
+        //
+        // The cap only bites when several blocks are demanded at once, so we prime
+        // a known row count (serverSideInitialRowCount) and use a tiny block size —
+        // the initial viewport then spans several blocks, all queued together, and
+        // the cap decides how many actually reach the datasource simultaneously.
+        const pending: IServerSideGetRowsParams[] = [];
+
+        function makeGrid(cap: number): void {
+            const gridOptions: GridOptions = {
+                columnDefs: [{ field: 'id' }, { field: 'value' }],
+                rowModelType: 'serverSide',
+                cacheBlockSize: 2,
+                serverSideInitialRowCount: 500,
+                maxConcurrentDatasourceRequests: cap,
+                getRowId: (params) => String(params.data.id),
+                serverSideDatasource: {
+                    getRows: (params) => {
+                        pending.push(params);
+                    },
+                },
+            };
+            gridsManager.createGrid(null, gridOptions);
+        }
+
+        function drain(): void {
+            for (let i = 0, len = pending.length; i < len; ++i) {
+                const request = pending[i].request;
+                pending[i].success({ rowData: rowData.slice(request.startRow!, request.endRow!), rowCount: totalRows });
+            }
+        }
+
+        // Cap of 1: only a single request may be in-flight at a time.
+        makeGrid(1);
+        await asyncSetTimeout(30);
+        expect(pending.length).toBe(1);
+
+        drain();
+        gridsManager.reset();
+        pending.length = 0;
+
+        // Cap of 2: exactly two requests may be in-flight simultaneously.
+        makeGrid(2);
+        await asyncSetTimeout(30);
+        expect(pending.length).toBe(2);
+
+        drain();
+    });
+
+    test('serverSideInitialRowCount filler rows render as stubs in the row model', async () => {
+        const totalRows = 500;
+        const pending: IServerSideGetRowsParams[] = [];
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            cacheBlockSize: 100,
+            serverSideInitialRowCount: 3,
+            getRowId: (params) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params) => {
+                    pending.push(params);
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await asyncSetTimeout(30);
+
+        // The initial rows are filler/stub rows awaiting their block. Pin the
+        // pre-load model shape via GridRows.
+        await new GridRows(api, 'ssrm initial row count before load').check(`
+            ROOT id:<no-id>
+            ├── filler id:rowIndex:0
+            ├── filler id:rowIndex:1
+            └── filler id:rowIndex:2
+        `);
+
+        // Drain the in-flight request so the deferred datasource does not leak past
+        // the test; afterEach handles final teardown.
+        const rowData = Array.from({ length: totalRows }, (_, i) => ({ id: i, value: `Row ${i}` }));
+        for (let i = 0, len = pending.length; i < len; ++i) {
+            const request = pending[i].request;
+            pending[i].success({ rowData: rowData.slice(request.startRow!, request.endRow!), rowCount: totalRows });
+        }
+    });
+});

--- a/testing/behavioural/src/row-data/ssrm-failure-retry.test.ts
+++ b/testing/behavioural/src/row-data/ssrm-failure-retry.test.ts
@@ -1,4 +1,4 @@
-import type { GridApi, GridOptions } from 'ag-grid-community';
+import type { GridOptions } from 'ag-grid-community';
 import { ScrollApiModule } from 'ag-grid-community';
 import { ServerSideRowModelApiModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
 

--- a/testing/behavioural/src/row-data/ssrm-failure-retry.test.ts
+++ b/testing/behavioural/src/row-data/ssrm-failure-retry.test.ts
@@ -1,0 +1,203 @@
+import type { GridApi, GridOptions } from 'ag-grid-community';
+import { ScrollApiModule } from 'ag-grid-community';
+import { ServerSideRowModelApiModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, waitForEvent } from '../test-utils';
+import { asyncSetTimeout } from '../test-utils/node-utils';
+import { countLoadingRows } from '../test-utils/ssrm-test-utils';
+
+/**
+ * Characterization tests pinning the current SSRM failure/retry mechanics.
+ *
+ * These are golden-master tests: they record whatever the grid does *today*
+ * when a datasource load fails via `params.fail()` and when the failed load is
+ * re-driven via `api.retryServerSideLoads()`. Any behaviour that looks like a
+ * latent bug (e.g. a failed load leaving loading rows in place) is frozen here
+ * as the expected baseline — the point is to detect change, not to prescribe
+ * the "correct" behaviour.
+ *
+ * Setup is inline per the behavioural-suite house style: each test records its
+ * own request stream and branches on an attempt counter to make the first load
+ * fail and later loads succeed.
+ */
+describe('SSRM failure and retry', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ScrollApiModule, ServerSideRowModelModule],
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    /** Flush a few microtask/macrotask turns so a fail() settles without waiting forever. */
+    async function flush(times = 3): Promise<void> {
+        for (let i = 0; i < times; ++i) {
+            await asyncSetTimeout(0);
+        }
+    }
+
+    test('first load calls params.fail() — grid state after the failure', async () => {
+        const totalRows = 3;
+        const rowData = Array.from({ length: totalRows }, (_, i) => ({ id: i, value: `Row ${i}` }));
+        const requests: [number, number][] = [];
+        let attempt = 0;
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            cacheBlockSize: 100,
+            getRowId: (params) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params) => {
+                    requests.push([params.request.startRow!, params.request.endRow!]);
+                    attempt++;
+                    if (attempt === 1) {
+                        params.fail();
+                        return;
+                    }
+                    const slice = rowData.slice(params.request.startRow, params.request.endRow);
+                    params.success({ rowData: slice, rowCount: totalRows });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+
+        // Let the first (failing) load settle.
+        await flush();
+
+        // The block was requested exactly once and then failed.
+        expect(requests).toEqual([[0, 100]]);
+
+        // Pin what the row model looks like after a failed load: the single filler
+        // (loading) row remains in place — the failure does not clear it.
+        await new GridRows(api, 'ssrm failure after fail').check(`
+            ROOT id:<no-id>
+            └── filler id:rowIndex:0
+        `);
+
+        // Concrete counts characterising the post-failure state.
+        expect(countLoadingRows(api)).toBe(1);
+        expect(api.getDisplayedRowCount()).toBe(1);
+        // No leaf node exists yet — the data never arrived.
+        expect(!!api.getRowNode('0')).toBe(false);
+    });
+
+    test('retryServerSideLoads re-requests the failed block and renders rows on success', async () => {
+        const totalRows = 3;
+        const rowData = Array.from({ length: totalRows }, (_, i) => ({ id: i, value: `Row ${i}` }));
+        const requests: [number, number][] = [];
+        let attempt = 0;
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            cacheBlockSize: 100,
+            getRowId: (params) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params) => {
+                    requests.push([params.request.startRow!, params.request.endRow!]);
+                    attempt++;
+                    if (attempt === 1) {
+                        params.fail();
+                        return;
+                    }
+                    const slice = rowData.slice(params.request.startRow, params.request.endRow);
+                    params.success({ rowData: slice, rowCount: totalRows });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+
+        // First load fails.
+        await flush();
+        expect(requests).toEqual([[0, 100]]);
+        expect(countLoadingRows(api)).toBe(1);
+
+        // Retry re-drives the failed block; the second attempt succeeds.
+        api.retryServerSideLoads();
+        await flush();
+
+        // The failed block is requested a second time.
+        expect(requests).toEqual([
+            [0, 100],
+            [0, 100],
+        ]);
+
+        // Rows now render and no loading rows remain.
+        expect(countLoadingRows(api)).toBe(0);
+        expect(api.getDisplayedRowCount()).toBe(totalRows);
+        expect(!!api.getRowNode('0')).toBe(true);
+
+        await new GridRows(api, 'ssrm retry after success').check(`
+            ROOT id:<no-id>
+            ├── LEAF id:0 id:0 value:"Row 0"
+            ├── LEAF id:1 id:1 value:"Row 1"
+            └── LEAF id:2 id:2 value:"Row 2"
+        `);
+    });
+
+    test('failure on a second block leaves block 0 intact; retry recovers block 2', async () => {
+        const totalRows = 500;
+        const rowData = Array.from({ length: totalRows }, (_, i) => ({ id: i, value: `Row ${i}` }));
+        const requests: [number, number][] = [];
+        // Fail only the load for block 2 ([200,300)) the first time it is requested.
+        let block2Attempts = 0;
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            cacheBlockSize: 100,
+            rowBuffer: 0,
+            suppressRowVirtualisation: false,
+            getRowId: (params) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params) => {
+                    const startRow = params.request.startRow!;
+                    requests.push([startRow, params.request.endRow!]);
+                    if (startRow === 200) {
+                        block2Attempts++;
+                        if (block2Attempts === 1) {
+                            params.fail();
+                            return;
+                        }
+                    }
+                    const slice = rowData.slice(params.request.startRow, params.request.endRow);
+                    params.success({ rowData: slice, rowCount: totalRows });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await waitForEvent('firstDataRendered', api);
+
+        // Block 0 loaded successfully on the initial render.
+        expect(!!api.getRowNode('0')).toBe(true);
+
+        // Scroll to row 250 (block 2). That load fails.
+        api.ensureIndexVisible(250);
+        await flush();
+
+        // Block 0 rows are still present after the block 2 failure.
+        expect(!!api.getRowNode('0')).toBe(true);
+        // Block 2 rows never arrived — its nodes are loading/absent.
+        expect(!!api.getRowNode('250')).toBe(false);
+        // At least one loading row remains for the failed block.
+        expect(countLoadingRows(api)).toBeGreaterThan(0);
+
+        const block2RequestsBefore = requests.filter(([start]) => start === 200).length;
+        expect(block2RequestsBefore).toBe(1);
+
+        // Retry re-drives the failed block; this time it succeeds.
+        api.retryServerSideLoads();
+        await flush();
+
+        // Block 2 was requested again and now resolves.
+        const block2RequestsAfter = requests.filter(([start]) => start === 200).length;
+        expect(block2RequestsAfter).toBe(block2RequestsBefore + 1);
+        expect(!!api.getRowNode('250')).toBe(true);
+        // Block 0 remained available throughout.
+        expect(!!api.getRowNode('0')).toBe(true);
+    });
+});

--- a/testing/behavioural/src/row-data/ssrm-refresh-purge.test.ts
+++ b/testing/behavioural/src/row-data/ssrm-refresh-purge.test.ts
@@ -129,11 +129,7 @@ describe('SSRM refreshServerSide purge semantics (characterization)', () => {
         // Records the request groupKeys for every getRows call.
         const groupRequests: string[][] = [];
         const api = gridsManager.createGrid('myGrid', {
-            columnDefs: [
-                { field: 'country', rowGroup: true, hide: true },
-                { field: 'id' },
-                { field: 'value' },
-            ],
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'id' }, { field: 'value' }],
             autoGroupColumnDef: { field: 'country' },
             rowModelType: 'serverSide',
             getRowId: (params) => {

--- a/testing/behavioural/src/row-data/ssrm-refresh-purge.test.ts
+++ b/testing/behavioural/src/row-data/ssrm-refresh-purge.test.ts
@@ -1,0 +1,190 @@
+import type { GridOptions, IServerSideGetRowsParams } from 'ag-grid-community';
+import { ScrollApiModule } from 'ag-grid-community';
+import { ServerSideRowModelApiModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, waitForEvent } from '../test-utils';
+import { waitForNoLoadingRows } from '../test-utils/ssrm-test-utils';
+
+/**
+ * CHARACTERIZATION tests (golden-master) for AG Grid SSRM `refreshServerSide` purge semantics.
+ *
+ * These tests pin the CURRENT observable behaviour of the grid. They are NOT specifications of
+ * desired behaviour: where the grid exhibits a quirk (or a latent bug), the quirk is deliberately
+ * frozen here as the expected value. If a change to production code alters one of these snapshots,
+ * that is a signal to consciously decide whether the behavioural change is intended — not simply to
+ * "fix" the test.
+ *
+ * Async flushing notes (see harness facts):
+ * - Initial load is awaited via `firstDataRendered`.
+ * - A NON-PURGE refresh does not create stub rows, so it is awaited via `storeRefreshed` (the
+ *   promise must be captured BEFORE calling refresh).
+ * - A PURGE refresh creates stub (loading) rows, so `waitForNoLoadingRows` reliably settles it.
+ */
+describe('SSRM refreshServerSide purge semantics (characterization)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ScrollApiModule, ServerSideRowModelModule],
+    });
+
+    afterEach(() => gridsManager.reset());
+
+    const totalRows = 5;
+    const rowData = Array.from({ length: totalRows }, (_, i) => ({ id: String(i), value: `Row ${i}` }));
+
+    // Flat (non-grouped) SSRM setup. Records every block request as [startRow, endRow].
+    function createFlatGridOptions(requests: number[][]): GridOptions {
+        return {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            getRowId: (params) => params.data.id,
+            serverSideDatasource: {
+                getRows: (params: IServerSideGetRowsParams) => {
+                    requests.push([params.request.startRow!, params.request.endRow!]);
+                    const slice = rowData.slice(params.request.startRow!, params.request.endRow!);
+                    params.success({ rowData: slice, rowCount: totalRows });
+                },
+            },
+        };
+    }
+
+    test('purge:true at root re-requests the block and shows loading rows again', async () => {
+        const requests: number[][] = [];
+        const api = gridsManager.createGrid('myGrid', createFlatGridOptions(requests));
+        await waitForEvent('firstDataRendered', api);
+
+        // Initial load requested exactly one block from the root store.
+        expect(requests).toEqual([[0, 100]]);
+        expect(!!api.getRowNode('0')).toBe(true);
+
+        // A purge refresh discards the cached block, so the row node is gone until re-fetched.
+        api.refreshServerSide({ purge: true });
+        expect(!!api.getRowNode('0')).toBe(false);
+
+        await waitForNoLoadingRows(api);
+
+        // The block is re-requested from the server.
+        expect(requests).toEqual([
+            [0, 100],
+            [0, 100],
+        ]);
+        expect(!!api.getRowNode('0')).toBe(true);
+
+        await new GridRows(api, 'purge:true after re-fetch').check(`
+            ROOT id:<no-id>
+            ├── LEAF id:0 id:"0" value:"Row 0"
+            ├── LEAF id:1 id:"1" value:"Row 1"
+            ├── LEAF id:2 id:"2" value:"Row 2"
+            ├── LEAF id:3 id:"3" value:"Row 3"
+            └── LEAF id:4 id:"4" value:"Row 4"
+        `);
+    });
+
+    test('purge:false at root re-requests the block but keeps cached rows throughout', async () => {
+        const requests: number[][] = [];
+        const api = gridsManager.createGrid('myGrid', createFlatGridOptions(requests));
+        await waitForEvent('firstDataRendered', api);
+
+        expect(requests).toEqual([[0, 100]]);
+        expect(!!api.getRowNode('0')).toBe(true);
+
+        // Non-purge refresh: capture the storeRefreshed promise BEFORE triggering the refresh.
+        const refreshed = waitForEvent('storeRefreshed', api);
+        api.refreshServerSide({ purge: false });
+
+        // Cached rows are retained (no stub rows) across a non-purge refresh.
+        expect(!!api.getRowNode('0')).toBe(true);
+
+        await refreshed;
+
+        // The block is still re-requested from the server.
+        expect(requests).toEqual([
+            [0, 100],
+            [0, 100],
+        ]);
+        expect(!!api.getRowNode('0')).toBe(true);
+
+        await new GridRows(api, 'purge:false after refresh').check(`
+            ROOT id:<no-id>
+            ├── LEAF id:0 id:"0" value:"Row 0"
+            ├── LEAF id:1 id:"1" value:"Row 1"
+            ├── LEAF id:2 id:"2" value:"Row 2"
+            ├── LEAF id:3 id:"3" value:"Row 3"
+            └── LEAF id:4 id:"4" value:"Row 4"
+        `);
+    });
+
+    test('routed purge:true refreshes only the targeted group block, leaving siblings untouched', async () => {
+        // Grouped SSRM setup: one row group column (country), two countries each with leaf rows.
+        const groupedData: Record<string, { id: string; value: string }[]> = {
+            Ireland: [
+                { id: 'ie-0', value: 'Dublin' },
+                { id: 'ie-1', value: 'Cork' },
+            ],
+            Spain: [
+                { id: 'es-0', value: 'Madrid' },
+                { id: 'es-1', value: 'Seville' },
+            ],
+        };
+        const countries = Object.keys(groupedData);
+
+        // Records the request groupKeys for every getRows call.
+        const groupRequests: string[][] = [];
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'id' },
+                { field: 'value' },
+            ],
+            autoGroupColumnDef: { field: 'country' },
+            rowModelType: 'serverSide',
+            getRowId: (params) => {
+                if (params.data.country != null && params.data.id == null) {
+                    return `group-${params.data.country}`;
+                }
+                return params.data.id;
+            },
+            serverSideDatasource: {
+                getRows: (params: IServerSideGetRowsParams) => {
+                    const groupKeys = params.request.groupKeys ?? [];
+                    groupRequests.push([...groupKeys]);
+                    if (groupKeys.length === 0) {
+                        // Root: return the country groups.
+                        const groups = countries.map((c) => ({ country: c }));
+                        params.success({ rowData: groups, rowCount: groups.length });
+                        return;
+                    }
+                    // Leaf level for a specific country.
+                    const leaves = groupedData[groupKeys[0]] ?? [];
+                    const rows = leaves.map((leaf) => ({ ...leaf, country: groupKeys[0] }));
+                    params.success({ rowData: rows, rowCount: rows.length });
+                },
+            },
+        });
+        await waitForEvent('firstDataRendered', api);
+
+        // Expand both groups so their leaf blocks are loaded.
+        api.getRowNode('group-Ireland')!.setExpanded(true);
+        await waitForNoLoadingRows(api);
+        api.getRowNode('group-Spain')!.setExpanded(true);
+        await waitForNoLoadingRows(api);
+
+        // Initial requests: root, then each group's leaves.
+        expect(groupRequests).toEqual([[], ['Ireland'], ['Spain']]);
+
+        // Routed purge refresh of just the Ireland group.
+        api.refreshServerSide({ route: ['Ireland'], purge: true });
+        await waitForNoLoadingRows(api);
+
+        // Only Ireland's block was re-requested; the root and Spain blocks were untouched.
+        expect(groupRequests).toEqual([[], ['Ireland'], ['Spain'], ['Ireland']]);
+
+        await new GridRows(api, 'routed purge:true on Ireland group').check(`
+            ROOT id:<no-id>
+            ├─┬ GROUP-leafGroup id:group-Ireland ag-Grid-AutoColumn:"Ireland" country:"Ireland"
+            │ ├── LEAF id:ie-0 ag-Grid-AutoColumn:"Ireland" country:"Ireland" id:"ie-0" value:"Dublin"
+            │ └── LEAF id:ie-1 ag-Grid-AutoColumn:"Ireland" country:"Ireland" id:"ie-1" value:"Cork"
+            └─┬ GROUP-leafGroup id:group-Spain ag-Grid-AutoColumn:"Spain" country:"Spain"
+            · ├── LEAF id:es-0 ag-Grid-AutoColumn:"Spain" country:"Spain" id:"es-0" value:"Madrid"
+            · └── LEAF id:es-1 ag-Grid-AutoColumn:"Spain" country:"Spain" id:"es-1" value:"Seville"
+        `);
+    });
+});

--- a/testing/behavioural/src/row-data/ssrm-set-row-data.test.ts
+++ b/testing/behavioural/src/row-data/ssrm-set-row-data.test.ts
@@ -114,7 +114,7 @@ describe('SSRM bulk row-data setting (characterisation)', () => {
         expect(api.getDisplayedRowAtIndex(2)?.data.value).toBe('Row 2');
     });
 
-    test('applyServerSideRowData with a route sets only that group\'s children', async () => {
+    test("applyServerSideRowData with a route sets only that group's children", async () => {
         const leafRows = [
             { id: 0, group: 'A', value: 'a0' },
             { id: 1, group: 'A', value: 'a1' },
@@ -125,9 +125,8 @@ describe('SSRM bulk row-data setting (characterisation)', () => {
             columnDefs: [{ field: 'group', rowGroup: true, hide: true }, { field: 'value' }],
             autoGroupColumnDef: { field: 'value' },
             rowModelType: 'serverSide',
-            getRowId: (p: any) => (p.data.group !== undefined && p.data.id === undefined
-                ? `group-${p.data.group}`
-                : String(p.data.id)),
+            getRowId: (p: any) =>
+                p.data.group !== undefined && p.data.id === undefined ? `group-${p.data.group}` : String(p.data.id),
             serverSideDatasource: {
                 getRows: (params: any) => {
                     const groupKeys: string[] = params.request.groupKeys;

--- a/testing/behavioural/src/row-data/ssrm-set-row-data.test.ts
+++ b/testing/behavioural/src/row-data/ssrm-set-row-data.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Characterisation tests (golden-master) pinning the CURRENT behaviour of bulk
+ * row-data setting in the Server-Side Row Model:
+ *   - `api.applyServerSideRowData({ successParams, route?, startRow? })` — setting a
+ *     route's rows directly without a further datasource getRows call.
+ *   - `api.setRowCount(rowCount, maxRowFound?)` — server-side row count changes.
+ *
+ * These tests pin whatever the grid currently does. Where an assertion encodes a
+ * bug or a surprising quirk, that is intentional: the value recorded is the current
+ * mechanic, not the ideal one.
+ */
+import type { GridOptions } from 'ag-grid-community';
+import { ScrollApiModule } from 'ag-grid-community';
+import { RowGroupingModule, ServerSideRowModelApiModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, waitForEvent } from '../test-utils';
+
+describe('SSRM bulk row-data setting (characterisation)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ScrollApiModule, ServerSideRowModelModule, RowGroupingModule],
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    test('applyServerSideRowData at root replaces rows without a further getRows call', async () => {
+        const rowData = Array.from({ length: 10 }, (_, i) => ({ id: i, value: `Row ${i}` }));
+
+        // Record every datasource request so we can assert the stream does not grow.
+        const requests: Array<{ startRow: number | undefined; endRow: number | undefined }> = [];
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            getRowId: (p: any) => String(p.data.id),
+            serverSideDatasource: {
+                getRows: (params: any) => {
+                    requests.push({ startRow: params.request.startRow, endRow: params.request.endRow });
+                    const slice = rowData.slice(params.request.startRow, params.request.endRow);
+                    params.success({ rowData: slice, rowCount: rowData.length });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await waitForEvent('firstDataRendered', api);
+
+        expect(api.getDisplayedRowCount()).toBe(10);
+        const requestsAfterInitialLoad = requests.length;
+
+        // Bulk-set the root rows directly.
+        const newRows = [
+            { id: 100, value: 'A' },
+            { id: 101, value: 'B' },
+            { id: 102, value: 'C' },
+        ];
+        api.applyServerSideRowData({ successParams: { rowData: newRows, rowCount: newRows.length } });
+
+        await new GridRows(api, 'applyServerSideRowData root replace').check(`
+            ROOT id:<no-id>
+            ├── LEAF id:100 id:100 value:"A"
+            ├── LEAF id:101 id:101 value:"B"
+            └── LEAF id:102 id:102 value:"C"
+        `);
+
+        // Pin: setting rows directly does NOT trigger another datasource request.
+        expect(requests.length).toBe(requestsAfterInitialLoad);
+        expect(api.getDisplayedRowCount()).toBe(3);
+        expect(api.getDisplayedRowAtIndex(0)?.data.id).toBe(100);
+    });
+
+    test('applyServerSideRowData with a different rowCount updates the displayed count', async () => {
+        const rowData = Array.from({ length: 5 }, (_, i) => ({ id: i, value: `Row ${i}` }));
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            getRowId: (p: any) => String(p.data.id),
+            serverSideDatasource: {
+                getRows: (params: any) => {
+                    const slice = rowData.slice(params.request.startRow, params.request.endRow);
+                    params.success({ rowData: slice, rowCount: rowData.length });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await waitForEvent('firstDataRendered', api);
+
+        expect(api.getDisplayedRowCount()).toBe(5);
+
+        // Supply fewer rows than the declared rowCount: rowCount larger than rowData.
+        api.applyServerSideRowData({
+            successParams: {
+                rowData: [
+                    { id: 200, value: 'X' },
+                    { id: 201, value: 'Y' },
+                ],
+                rowCount: 8,
+            },
+        });
+
+        await new GridRows(api, 'applyServerSideRowData higher rowCount').check(`skip-snapshot`);
+
+        // Pin: displayed count follows the supplied rowCount, remaining rows are fillers.
+        expect(api.getDisplayedRowCount()).toBe(8);
+        expect(api.getDisplayedRowAtIndex(0)?.data.id).toBe(200);
+        expect(api.getDisplayedRowAtIndex(1)?.data.id).toBe(201);
+        // Surprising: declaring rowCount 8 while supplying only 2 rows fires a
+        // datasource getRows to backfill the remainder, so index 2 is NOT a filler —
+        // it carries a row from the ORIGINAL datasource, mixed in with the directly-set rows.
+        expect(api.getDisplayedRowAtIndex(2)?.data.id).toBe(2);
+        expect(api.getDisplayedRowAtIndex(2)?.data.value).toBe('Row 2');
+    });
+
+    test('applyServerSideRowData with a route sets only that group\'s children', async () => {
+        const leafRows = [
+            { id: 0, group: 'A', value: 'a0' },
+            { id: 1, group: 'A', value: 'a1' },
+            { id: 2, group: 'B', value: 'b0' },
+        ];
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'group', rowGroup: true, hide: true }, { field: 'value' }],
+            autoGroupColumnDef: { field: 'value' },
+            rowModelType: 'serverSide',
+            getRowId: (p: any) => (p.data.group !== undefined && p.data.id === undefined
+                ? `group-${p.data.group}`
+                : String(p.data.id)),
+            serverSideDatasource: {
+                getRows: (params: any) => {
+                    const groupKeys: string[] = params.request.groupKeys;
+                    if (groupKeys.length === 0) {
+                        // Top-level: the two groups A and B.
+                        const groups = [{ group: 'A' }, { group: 'B' }];
+                        params.success({ rowData: groups, rowCount: groups.length });
+                        return;
+                    }
+                    const key = groupKeys[0];
+                    const children = leafRows.filter((r) => r.group === key);
+                    params.success({ rowData: children, rowCount: children.length });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await waitForEvent('firstDataRendered', api);
+
+        // Expand group A so its route is materialised.
+        const groupA = api.getRowNode('group-A');
+        expect(!!groupA).toBe(true);
+        api.setRowNodeExpanded(groupA!, true);
+        await waitForEvent('modelUpdated', api);
+
+        await new GridRows(api, 'route setup expanded group A').check(`skip-snapshot`);
+
+        // Now bulk-set group A's children via its route.
+        api.applyServerSideRowData({
+            route: ['A'],
+            successParams: {
+                rowData: [
+                    { id: 10, group: 'A', value: 'a-new-0' },
+                    { id: 11, group: 'A', value: 'a-new-1' },
+                    { id: 12, group: 'A', value: 'a-new-2' },
+                ],
+                rowCount: 3,
+            },
+        });
+
+        await new GridRows(api, 'route replace group A children').check(`skip-snapshot`);
+
+        // Pin: group A now shows the new children, group B untouched.
+        expect(!!api.getRowNode('10')).toBe(true);
+        expect(!!api.getRowNode('11')).toBe(true);
+        expect(!!api.getRowNode('12')).toBe(true);
+        expect(!!api.getRowNode('0')).toBe(false);
+        expect(!!api.getRowNode('group-B')).toBe(true);
+    });
+
+    test('setRowCount raises the displayed count with fillers for the extra rows', async () => {
+        const rowData = Array.from({ length: 5 }, (_, i) => ({ id: i, value: `Row ${i}` }));
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            getRowId: (p: any) => String(p.data.id),
+            serverSideDatasource: {
+                getRows: (params: any) => {
+                    const slice = rowData.slice(params.request.startRow, params.request.endRow);
+                    params.success({ rowData: slice, rowCount: rowData.length });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await waitForEvent('firstDataRendered', api);
+
+        expect(api.getDisplayedRowCount()).toBe(5);
+
+        api.setRowCount(12);
+        await new GridRows(api, 'setRowCount raise').check(`skip-snapshot`);
+
+        expect(api.getDisplayedRowCount()).toBe(12);
+        // Existing loaded rows are preserved.
+        expect(api.getDisplayedRowAtIndex(0)?.data.id).toBe(0);
+        // Extra rows beyond the loaded block are fillers.
+        expect(!!api.getDisplayedRowAtIndex(11)?.data).toBe(false);
+    });
+
+    test('setRowCount below the loaded count truncates the displayed rows', async () => {
+        const rowData = Array.from({ length: 5 }, (_, i) => ({ id: i, value: `Row ${i}` }));
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            getRowId: (p: any) => String(p.data.id),
+            serverSideDatasource: {
+                getRows: (params: any) => {
+                    const slice = rowData.slice(params.request.startRow, params.request.endRow);
+                    params.success({ rowData: slice, rowCount: rowData.length });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await waitForEvent('firstDataRendered', api);
+
+        expect(api.getDisplayedRowCount()).toBe(5);
+
+        api.setRowCount(2);
+        await new GridRows(api, 'setRowCount truncate').check(`skip-snapshot`);
+
+        expect(api.getDisplayedRowCount()).toBe(2);
+        expect(api.getDisplayedRowAtIndex(0)?.data.id).toBe(0);
+        expect(api.getDisplayedRowAtIndex(1)?.data.id).toBe(1);
+    });
+});

--- a/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-loading.test.ts
+++ b/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-loading.test.ts
@@ -103,7 +103,7 @@ describe('ag-grid SSRM treeData lazy loading (characterization)', () => {
         `);
     });
 
-    test('expanding a group node lazily requests ONLY that node\'s children', async () => {
+    test("expanding a group node lazily requests ONLY that node's children", async () => {
         const { api, requests } = createTreeGrid('ssrmExpandOne');
 
         await asyncSetTimeout(1);

--- a/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-loading.test.ts
+++ b/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-loading.test.ts
@@ -1,0 +1,259 @@
+import type { GridOptions, IServerSideDatasource, IServerSideGetRowsParams } from 'ag-grid-community';
+import { TextFilterModule } from 'ag-grid-community';
+import { ServerSideRowModelApiModule, ServerSideRowModelModule, TreeDataModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, asyncSetTimeout } from '../../test-utils';
+import { ssrmExpandAndLoadAll, waitForNoLoadingRows } from '../../test-utils/ssrm-test-utils';
+import { createFakeServer, getSmallTreeDataSet } from './ssrmSmallTreeDataSet';
+
+/**
+ * CHARACTERIZATION tests (golden-master) pinning the CURRENT behaviour of the
+ * Server-Side Row Model (SSRM) with tree data.
+ *
+ * These are NOT specification tests: each assertion records what the grid does
+ * today (node identification via `isServerSideGroup` + `getServerSideGroupKey`,
+ * lazy child loading on expand, and sort/filter re-request behaviour). If a
+ * value looks bug-shaped it is still pinned as the baseline; a future change to
+ * these values will surface as a failure to be reviewed, not silently accepted.
+ */
+describe('ag-grid SSRM treeData lazy loading (characterization)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ServerSideRowModelModule, TreeDataModule, TextFilterModule],
+    });
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    // Shared inline setup: builds a tree-data SSRM grid whose datasource records
+    // every getRows request (groupKeys + range) so we can assert which node's
+    // children were requested and when.
+    function createTreeGrid(gridId: string, extraOptions?: Partial<GridOptions>) {
+        const data = getSmallTreeDataSet();
+        const fakeServer = createFakeServer(data);
+
+        // Record the request stream inline: the path (groupKeys) and range for
+        // each getRows call the grid makes against the server.
+        const requests: { groupKeys: string[]; range: [number | undefined, number | undefined] }[] = [];
+
+        const datasource: IServerSideDatasource = {
+            getRows: (params: IServerSideGetRowsParams) => {
+                const request = params.request;
+                requests.push({
+                    groupKeys: request.groupKeys ?? [],
+                    range: [request.startRow, request.endRow],
+                });
+                const allRows = fakeServer.getData(request);
+                const doingInfinite = request.startRow != null && request.endRow != null;
+                const result = doingInfinite
+                    ? { rowData: allRows.slice(request.startRow, request.endRow), rowCount: allRows.length }
+                    : { rowData: allRows };
+                setTimeout(() => {
+                    params.success(result);
+                }, 1);
+            },
+        };
+
+        const gridOptions: GridOptions = {
+            columnDefs: [
+                { field: 'employeeId', hide: true },
+                { field: 'employeeName', hide: true },
+                { field: 'jobTitle', filter: true },
+                { field: 'employmentType' },
+            ],
+            autoGroupColumnDef: {
+                field: 'employeeName',
+            },
+            defaultColDef: { flex: 1, sortable: true },
+            treeData: true,
+            rowModelType: 'serverSide',
+            animateRows: false,
+            getRowId: ({ data: rowData }) => rowData.employeeId,
+            isServerSideGroup: (dataItem: any) => dataItem.group,
+            getServerSideGroupKey: (dataItem: any) => dataItem.employeeId,
+            ...extraOptions,
+        };
+
+        const api = gridsManager.createGrid(gridId, gridOptions);
+        api.setGridOption('serverSideDatasource', datasource);
+        return { api, requests, fakeServer };
+    }
+
+    test('initial load requests the root children (groupKeys: []) and marks groups expandable', async () => {
+        const { api, requests } = createTreeGrid('ssrmInitial');
+
+        await asyncSetTimeout(1);
+        await waitForNoLoadingRows(api);
+
+        // Only the root children are requested on initial load.
+        expect(requests).toEqual([{ groupKeys: [], range: [0, 100] }]);
+
+        // Node identification: the single top-level node is a server-side group
+        // (isServerSideGroup returned truthy), keyed by its employeeId.
+        expect(!!api.getRowNode('101')).toBe(true);
+        expect(api.getRowNode('101')!.isExpandable()).toBe(true);
+
+        await new GridRows(api, 'initial root children').check(`
+            ROOT id:<no-id>
+            └── 101 GROUP collapsed id:101 ag-Grid-AutoColumn:"Erica Rogers" employeeId:"101" employeeName:"Erica Rogers" jobTitle:"CEO" employmentType:"Permanent"
+        `);
+    });
+
+    test('expanding a group node lazily requests ONLY that node\'s children', async () => {
+        const { api, requests } = createTreeGrid('ssrmExpandOne');
+
+        await asyncSetTimeout(1);
+        await waitForNoLoadingRows(api);
+        requests.length = 0; // discard the initial root request
+
+        api.getRowNode('101')!.setExpanded(true);
+        await waitForNoLoadingRows(api);
+
+        // The expand triggers exactly one request, scoped to the expanded node's path.
+        expect(requests).toEqual([{ groupKeys: ['101'], range: [0, 100] }]);
+
+        await new GridRows(api, 'expanded 101').check(`
+            ROOT id:<no-id>
+            └─┬ 101 GROUP id:101 ag-Grid-AutoColumn:"Erica Rogers" employeeId:"101" employeeName:"Erica Rogers" jobTitle:"CEO" employmentType:"Permanent"
+            · ├── 102 GROUP collapsed id:102 ag-Grid-AutoColumn:"Malcolm Barrett" employeeId:"102" employeeName:"Malcolm Barrett" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+            · └── 113 GROUP collapsed id:113 ag-Grid-AutoColumn:"Luke McBride" employeeId:"113" employeeName:"Luke McBride" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+        `);
+    });
+
+    test('expanding a nested node requests its full groupKeys path', async () => {
+        const { api, requests } = createTreeGrid('ssrmExpandNested');
+
+        await asyncSetTimeout(1);
+        await waitForNoLoadingRows(api);
+
+        api.getRowNode('101')!.setExpanded(true);
+        await waitForNoLoadingRows(api);
+        api.getRowNode('102')!.setExpanded(true);
+        await waitForNoLoadingRows(api);
+        requests.length = 0; // discard everything up to the 2-level-deep expand
+
+        // Expand a node that is 2 levels deep (101 -> 102 -> 103).
+        api.getRowNode('103')!.setExpanded(true);
+        await waitForNoLoadingRows(api);
+
+        // The requested path is the full route to the expanded node.
+        expect(requests).toEqual([{ groupKeys: ['101', '102', '103'], range: [0, 100] }]);
+
+        await new GridRows(api, 'expanded nested 103').check(`
+            ROOT id:<no-id>
+            └─┬ 101 GROUP id:101 ag-Grid-AutoColumn:"Erica Rogers" employeeId:"101" employeeName:"Erica Rogers" jobTitle:"CEO" employmentType:"Permanent"
+            · ├─┬ 102 GROUP id:102 ag-Grid-AutoColumn:"Malcolm Barrett" employeeId:"102" employeeName:"Malcolm Barrett" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+            · │ ├─┬ 103 GROUP id:103 ag-Grid-AutoColumn:"Esther Baker" employeeId:"103" employeeName:"Esther Baker" jobTitle:"Director of Operations" employmentType:"Permanent"
+            · │ │ ├── 104 GROUP collapsed id:104 ag-Grid-AutoColumn:"Brittany Hanson" employeeId:"104" employeeName:"Brittany Hanson" jobTitle:"Fleet Coordinator" employmentType:"Permanent"
+            · │ │ └── LEAF id:107 ag-Grid-AutoColumn:"Derek Paul" employeeId:"107" employeeName:"Derek Paul" jobTitle:"Inventory Control" employmentType:"Permanent"
+            · │ └── 108 GROUP collapsed id:108 ag-Grid-AutoColumn:"Francis Strickland" employeeId:"108" employeeName:"Francis Strickland" jobTitle:"VP Sales" employmentType:"Permanent"
+            · └── 113 GROUP collapsed id:113 ag-Grid-AutoColumn:"Luke McBride" employeeId:"113" employeeName:"Luke McBride" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+        `);
+    });
+
+    test('applying a sort re-requests loaded blocks from the server', async () => {
+        const { api, requests } = createTreeGrid('ssrmSort');
+
+        await asyncSetTimeout(1);
+        await waitForNoLoadingRows(api);
+        api.getRowNode('101')!.setExpanded(true);
+        await waitForNoLoadingRows(api);
+        requests.length = 0; // discard load requests, keep only sort-induced requests
+
+        // Sort by jobTitle descending.
+        api.applyColumnState({ state: [{ colId: 'jobTitle', sort: 'desc' }] });
+        await waitForNoLoadingRows(api);
+
+        // Pin whether/how the sort re-requests the server. The fake server ignores
+        // the sortModel, so re-requested rows come back in their original order.
+        expect(requests).toEqual([
+            { groupKeys: [], range: [0, 100] },
+            { groupKeys: ['101'], range: [0, 100] },
+        ]);
+
+        await new GridRows(api, 'after sort jobTitle desc').check(`
+            ROOT id:<no-id>
+            └─┬ 101 GROUP id:101 ag-Grid-AutoColumn:"Erica Rogers" employeeId:"101" employeeName:"Erica Rogers" jobTitle:"CEO" employmentType:"Permanent"
+            · ├── 102 GROUP collapsed id:102 ag-Grid-AutoColumn:"Malcolm Barrett" employeeId:"102" employeeName:"Malcolm Barrett" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+            · └── 113 GROUP collapsed id:113 ag-Grid-AutoColumn:"Luke McBride" employeeId:"113" employeeName:"Luke McBride" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+        `);
+    });
+
+    test('applying a filter re-requests from the server', async () => {
+        const { api, requests } = createTreeGrid('ssrmFilter');
+
+        await asyncSetTimeout(1);
+        await waitForNoLoadingRows(api);
+        requests.length = 0; // discard initial load
+
+        // Apply a text filter on jobTitle.
+        api.setFilterModel({ jobTitle: { filterType: 'text', type: 'contains', filter: 'CEO' } });
+        await waitForNoLoadingRows(api);
+
+        // Pin the re-request. The fake server ignores the filterModel, so the
+        // returned rows are unchanged; this pins that filtering is delegated to
+        // the server rather than applied client-side.
+        expect(requests).toEqual([{ groupKeys: [], range: [0, 100] }]);
+
+        await new GridRows(api, 'after filter jobTitle CEO').check(`
+            ROOT id:<no-id>
+            └── 101 GROUP collapsed id:101 ag-Grid-AutoColumn:"Erica Rogers" employeeId:"101" employeeName:"Erica Rogers" jobTitle:"CEO" employmentType:"Permanent"
+        `);
+    });
+
+    test('expand-and-load-all walks the whole tree, one request per group node', async () => {
+        const { api, requests } = createTreeGrid('ssrmExpandAll');
+
+        await asyncSetTimeout(1);
+        await ssrmExpandAndLoadAll(api);
+
+        // Every group node in the dataset produces exactly one children request.
+        // Pin the set of requested paths (order-independent).
+        const paths = requests.map((r) => r.groupKeys.join('/')).sort();
+        expect(paths).toEqual(
+            [
+                '',
+                '101',
+                '101/102',
+                '101/102/103',
+                '101/102/103/104',
+                '101/102/108',
+                '101/113',
+                '101/113/114',
+                '101/113/114/115',
+                '101/113/119',
+            ].sort()
+        );
+
+        await new GridRows(api, 'fully expanded tree').check(`
+            ROOT id:<no-id>
+            └─┬ 101 GROUP id:101 ag-Grid-AutoColumn:"Erica Rogers" employeeId:"101" employeeName:"Erica Rogers" jobTitle:"CEO" employmentType:"Permanent"
+            · ├─┬ 102 GROUP id:102 ag-Grid-AutoColumn:"Malcolm Barrett" employeeId:"102" employeeName:"Malcolm Barrett" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+            · │ ├─┬ 103 GROUP id:103 ag-Grid-AutoColumn:"Esther Baker" employeeId:"103" employeeName:"Esther Baker" jobTitle:"Director of Operations" employmentType:"Permanent"
+            · │ │ ├─┬ 104 GROUP id:104 ag-Grid-AutoColumn:"Brittany Hanson" employeeId:"104" employeeName:"Brittany Hanson" jobTitle:"Fleet Coordinator" employmentType:"Permanent"
+            · │ │ │ ├── LEAF id:105 ag-Grid-AutoColumn:"Leah Flowers" employeeId:"105" employeeName:"Leah Flowers" jobTitle:"Parts Technician" employmentType:"Contract"
+            · │ │ │ └── LEAF id:106 ag-Grid-AutoColumn:"Tammy Sutton" employeeId:"106" employeeName:"Tammy Sutton" jobTitle:"Service Technician" employmentType:"Contract"
+            · │ │ └── LEAF id:107 ag-Grid-AutoColumn:"Derek Paul" employeeId:"107" employeeName:"Derek Paul" jobTitle:"Inventory Control" employmentType:"Permanent"
+            · │ └─┬ 108 GROUP id:108 ag-Grid-AutoColumn:"Francis Strickland" employeeId:"108" employeeName:"Francis Strickland" jobTitle:"VP Sales" employmentType:"Permanent"
+            · │ · ├── LEAF id:109 ag-Grid-AutoColumn:"Morris Hanson" employeeId:"109" employeeName:"Morris Hanson" jobTitle:"Sales Manager" employmentType:"Permanent"
+            · │ · ├── LEAF id:110 ag-Grid-AutoColumn:"Todd Tyler" employeeId:"110" employeeName:"Todd Tyler" jobTitle:"Sales Executive" employmentType:"Contract"
+            · │ · ├── LEAF id:111 ag-Grid-AutoColumn:"Bennie Wise" employeeId:"111" employeeName:"Bennie Wise" jobTitle:"Sales Executive" employmentType:"Contract"
+            · │ · └── LEAF id:112 ag-Grid-AutoColumn:"Joel Cooper" employeeId:"112" employeeName:"Joel Cooper" jobTitle:"Sales Executive" employmentType:"Permanent"
+            · └─┬ 113 GROUP id:113 ag-Grid-AutoColumn:"Luke McBride" employeeId:"113" employeeName:"Luke McBride" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+            · · ├─┬ 114 GROUP id:114 ag-Grid-AutoColumn:"Sarah Baker" employeeId:"114" employeeName:"Sarah Baker" jobTitle:"Director of Operations" employmentType:"Permanent"
+            · · │ ├─┬ 115 GROUP id:115 ag-Grid-AutoColumn:"Mason Hanson" employeeId:"115" employeeName:"Mason Hanson" jobTitle:"Fleet Coordinator" employmentType:"Permanent"
+            · · │ │ ├── LEAF id:116 ag-Grid-AutoColumn:"Hannah Flowers" employeeId:"116" employeeName:"Hannah Flowers" jobTitle:"Parts Technician" employmentType:"Contract"
+            · · │ │ └── LEAF id:117 ag-Grid-AutoColumn:"Rob Sutton" employeeId:"117" employeeName:"Rob Sutton" jobTitle:"Service Technician" employmentType:"Contract"
+            · · │ └── LEAF id:118 ag-Grid-AutoColumn:"Paul Smith" employeeId:"118" employeeName:"Paul Smith" jobTitle:"Inventory Control" employmentType:"Permanent"
+            · · └─┬ 119 GROUP id:119 ag-Grid-AutoColumn:"Adam Newman" employeeId:"119" employeeName:"Adam Newman" jobTitle:"VP Sales" employmentType:"Permanent"
+            · · · ├── LEAF id:120 ag-Grid-AutoColumn:"John Smith" employeeId:"120" employeeName:"John Smith" jobTitle:"Sales Manager" employmentType:"Permanent"
+            · · · ├── LEAF id:121 ag-Grid-AutoColumn:"Alice Grant" employeeId:"121" employeeName:"Alice Grant" jobTitle:"Sales Executive" employmentType:"Contract"
+            · · · ├── LEAF id:122 ag-Grid-AutoColumn:"Ben Hill" employeeId:"122" employeeName:"Ben Hill" jobTitle:"Sales Executive" employmentType:"Contract"
+            · · · └── LEAF id:123 ag-Grid-AutoColumn:"Joe Cooper" employeeId:"123" employeeName:"Joe Cooper" jobTitle:"Sales Executive" employmentType:"Permanent"
+        `);
+    });
+});


### PR DESCRIPTION
## What

Golden-master **characterization** tests for the Server-Side Row Model. These pin *current* behaviour — bugs treated as expected mechanics — so future refactors change behaviour loudly and deliberately rather than silently.

📊 **Coverage matrix & findings:** https://claude.ai/code/artifact/7515d2e1-da99-4677-9718-cdb752572d14

Existing SSRM tests were left untouched (immovable baseline); this only fills previously-empty coverage cells.

**10 files, 45 tests, all green.**

| Area | File |
|---|---|
| Flat block load / scroll / LRU eviction | `row-data/ssrm-block-loading` |
| refreshServerSide purge / route | `row-data/ssrm-refresh-purge` |
| fail() + retryServerSideLoads | `row-data/ssrm-failure-retry` |
| Async transactions, isApply cancel | `row-data/ssrm-async-transactions` |
| applyServerSideRowData / setRowCount | `row-data/ssrm-set-row-data` |
| Cache/loading knobs | `row-data/ssrm-cache-config` |
| Grouped loading, per-level params, eviction | `grouping-data/ssrm/ssrm-grouped-loading` |
| Pivot request shape / separator / expansion | `grouping-data/ssrm/ssrm-pivot` |
| Sort/filter refresh-scope flags | `grouping-data/ssrm/ssrm-sort-filter-scope` |
| Tree-data lazy loading | `tree-data/ssrm/ssrm-tree-data-loading` |

## Approach

Each file records the `IServerSideGetRowsRequest` stream **inline** (a plain array push — no shared factory), per the behavioural-suite house style of readable top-to-bottom setup. Assertions are on the request stream, `GridRows` snapshots, and boolean/count API checks (never on RowNode objects — serialising the circular node crashes the reporter).

## Latent behaviours frozen as baseline

Several pinned behaviours are surprising / bug-shaped and worth a look — candidates for follow-up tickets:

- A failed load (`fail()`) is indistinguishable from a still-loading one — the loading row just stays.
- `refreshServerSide({purge:false})` still issues an identical block request to the server.
- `maxBlocksInCache` smaller than the displayed block span causes eviction **thrash** (repeated identical re-fetches).
- Sort/filter is fully server-delegated — a server that ignores `sortModel`/`filterModel` silently shows unsorted/unfiltered data.
- `serverSideSortAllLevels` / `serverSideOnlyRefreshFilteredGroups` are masked by aggregated columns (`valueColChanged` short-circuits `isServerRefreshNeeded`).
- `applyServerSideRowData` with an over-declared `rowCount` silently re-pulls the datasource to backfill.
- `cacheOverflowSize` caps block *creation*, it is not a row pad (100 known + overflow 5 → 101 rows, not 105).
- Custom `serverSidePivotResultFieldSeparator` survives verbatim into generated pivot column ids.

## Follow-up

Remaining matrix cells (failure on group/tree routes, tree-data transactions, pivot grand-total, plus some shape-agnostic duplicates) will land in a separate PR.