### PR TITLE
test(ssrm): characterization coverage for grouped/tree failure, tree-data transactions & pivot grand-total

### DIFF
--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-failure-grouped.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-failure-grouped.test.ts
@@ -1,0 +1,344 @@
+import type { GetRowIdParams, IServerSideGetRowsParams } from 'ag-grid-community';
+import {
+    RowGroupingModule,
+    ServerSideRowModelApiModule,
+    ServerSideRowModelModule,
+    TreeDataModule,
+} from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, waitForEvent } from '../../test-utils';
+import { asyncSetTimeout } from '../../test-utils/node-utils';
+import { countLoadingRows, waitForNoLoadingRows } from '../../test-utils/ssrm-test-utils';
+
+/**
+ * CHARACTERIZATION tests (golden-master) pinning the CURRENT behaviour of the AG Grid
+ * SSRM datasource when a `getRows` call FAILS on a GROUP route or a TREE route — as
+ * distinct from a failure on the ROOT route.
+ *
+ * These are not aspirational tests: where the grid's current behaviour is arguably a bug
+ * (e.g. a failed child store shows perpetual loading rows rather than a failed indicator),
+ * the test pins that behaviour as the expected mechanics. When one of these assertions
+ * later changes, it is a deliberate behavioural change that should be reviewed, not a
+ * silent regression.
+ */
+
+// A single recorded datasource request. Captured inline (house style) so each test reads
+// top-to-bottom and the request stream is visible without a shared helper.
+interface RecordedRequest {
+    groupKeys: (string | null)[];
+    range: [number | undefined, number | undefined];
+}
+
+describe('SSRM datasource failure on GROUP routes (characterization)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ServerSideRowModelModule, RowGroupingModule],
+    });
+
+    beforeEach(() => gridsManager.reset());
+    afterEach(() => gridsManager.reset());
+
+    // UK/US leaf rows — expanding a country loads its athletes.
+    const LEAF_ROWS = [
+        { country: 'UK', athlete: 'Alice', gold: 3 },
+        { country: 'UK', athlete: 'Bob', gold: 7 },
+        { country: 'US', athlete: 'Carol', gold: 5 },
+        { country: 'US', athlete: 'Dan', gold: 3 },
+    ];
+
+    const getRowId = (p: GetRowIdParams) =>
+        p.data.athlete ? `${p.data.country}-${p.data.athlete}` : `group-${p.data.country}`;
+
+    test('failure on a child group route leaves that group loading while siblings and root are untouched, then retry recovers', async () => {
+        const requests: RecordedRequest[] = [];
+        // Per-route attempt counter — the target group's first load fails, later ones succeed.
+        const attempts: Record<string, number> = {};
+
+        const api = gridsManager.createGrid(null, {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'athlete' },
+                { field: 'gold', aggFunc: 'sum' },
+            ],
+            autoGroupColumnDef: { field: 'athlete' },
+            rowModelType: 'serverSide',
+            getRowId,
+            serverSideDatasource: {
+                getRows: (params: IServerSideGetRowsParams) => {
+                    const groupKeys = (params.request.groupKeys ?? []) as (string | null)[];
+                    const routeKey = groupKeys.join('/') || '<root>';
+                    requests.push({ groupKeys, range: [params.request.startRow, params.request.endRow] });
+                    attempts[routeKey] = (attempts[routeKey] ?? 0) + 1;
+
+                    if (groupKeys.length === 0) {
+                        const countries = Array.from(new Set(LEAF_ROWS.map((r) => r.country)));
+                        const rows = countries.map((country) => ({ country }));
+                        params.success({ rowData: rows, rowCount: rows.length });
+                        return;
+                    }
+
+                    // Fail the UK child route on its first attempt only.
+                    if (routeKey === 'UK' && attempts[routeKey] === 1) {
+                        params.fail();
+                        return;
+                    }
+
+                    const rows = LEAF_ROWS.filter((r) => r.country === groupKeys[0]);
+                    params.success({ rowData: rows, rowCount: rows.length });
+                },
+            },
+        });
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        // Expand only UK — its child load fails. US is left as an untouched sibling.
+        const ukNode = api.getRowNode('group-UK')!;
+        api.setRowNodeExpanded(ukNode, true);
+
+        // Let the (synchronous) datasource resolve.
+        await asyncSetTimeout(0);
+        await asyncSetTimeout(0);
+
+        // Pin: the failed UK route still shows a loading row (no failed indicator), while
+        // the untouched US sibling stays a collapsed group and the root is intact.
+        await new GridRows(api, 'grouped child-route failure: UK loading, US untouched').check(`
+            ROOT id:<no-id>
+            ├─┬ GROUP-leafGroup id:group-UK ag-Grid-AutoColumn:"UK" country:"UK"
+            │ └── filler id:rowIndex:1
+            └── GROUP-leafGroup collapsed id:group-US ag-Grid-AutoColumn:"US" country:"US"
+        `);
+
+        expect(countLoadingRows(api)).toBeGreaterThan(0);
+        expect(!!api.getRowNode('group-UK')).toBe(true);
+        expect(!!api.getRowNode('group-US')).toBe(true);
+        expect(!!api.getRowNode('UK-Alice')).toBe(false);
+        expect(!!api.getRowNode('UK-Bob')).toBe(false);
+
+        // Retry — re-requests the failed block. No awaitable storeRefreshed in jsdom, so
+        // flush a few synchronous ticks.
+        api.retryServerSideLoads();
+        await asyncSetTimeout(0);
+        await asyncSetTimeout(0);
+        await asyncSetTimeout(0);
+
+        // Pin: UK children now populate and no loading rows remain.
+        expect(countLoadingRows(api)).toBe(0);
+        expect(!!api.getRowNode('UK-Alice')).toBe(true);
+        expect(!!api.getRowNode('UK-Bob')).toBe(true);
+
+        await new GridRows(api, 'grouped child-route failure: recovered after retry').check(`
+            ROOT id:<no-id>
+            ├─┬ GROUP-leafGroup id:group-UK ag-Grid-AutoColumn:"UK" country:"UK"
+            │ ├── LEAF id:UK-Alice ag-Grid-AutoColumn:"Alice" country:"UK" athlete:"Alice" gold:3
+            │ └── LEAF id:UK-Bob ag-Grid-AutoColumn:"Bob" country:"UK" athlete:"Bob" gold:7
+            └── GROUP-leafGroup collapsed id:group-US ag-Grid-AutoColumn:"US" country:"US"
+        `);
+
+        // Pin: the UK route was requested twice (initial failure + retry); US never
+        // requested, since it was never expanded.
+        const ukRequests = requests.filter((r) => r.groupKeys.join('/') === 'UK');
+        const usRequests = requests.filter((r) => r.groupKeys.join('/') === 'US');
+        expect(ukRequests.length).toBe(2);
+        expect(usRequests.length).toBe(0);
+    });
+
+    test('failure on the ROOT group route leaves the whole grid loading, then retry recovers', async () => {
+        const requests: RecordedRequest[] = [];
+        const attempts: Record<string, number> = {};
+
+        const api = gridsManager.createGrid(null, {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'athlete' },
+                { field: 'gold', aggFunc: 'sum' },
+            ],
+            autoGroupColumnDef: { field: 'athlete' },
+            rowModelType: 'serverSide',
+            getRowId,
+            serverSideDatasource: {
+                getRows: (params: IServerSideGetRowsParams) => {
+                    const groupKeys = (params.request.groupKeys ?? []) as (string | null)[];
+                    const routeKey = groupKeys.join('/') || '<root>';
+                    requests.push({ groupKeys, range: [params.request.startRow, params.request.endRow] });
+                    attempts[routeKey] = (attempts[routeKey] ?? 0) + 1;
+
+                    // Fail the root (top-level) block on its first attempt only.
+                    if (groupKeys.length === 0 && attempts[routeKey] === 1) {
+                        params.fail();
+                        return;
+                    }
+
+                    if (groupKeys.length === 0) {
+                        const countries = Array.from(new Set(LEAF_ROWS.map((r) => r.country)));
+                        const rows = countries.map((country) => ({ country }));
+                        params.success({ rowData: rows, rowCount: rows.length });
+                        return;
+                    }
+
+                    const rows = LEAF_ROWS.filter((r) => r.country === groupKeys[0]);
+                    params.success({ rowData: rows, rowCount: rows.length });
+                },
+            },
+        });
+
+        // NB: on a root failure firstDataRendered never fires (no data ever renders), so we
+        // simply flush the synchronous datasource rather than awaiting that event.
+        await asyncSetTimeout(0);
+        await asyncSetTimeout(0);
+
+        // Pin: root failure leaves the grid showing a single top-level loading row; no
+        // group nodes exist at all (distinct from a child-route failure, where sibling
+        // groups remain fully intact).
+        await new GridRows(api, 'grouped root-route failure: whole grid loading').check(`
+            ROOT id:<no-id>
+            └── LEAF_GROUP collapsed id:rowIndex:0
+        `);
+
+        expect(countLoadingRows(api)).toBeGreaterThan(0);
+        expect(!!api.getRowNode('group-UK')).toBe(false);
+        expect(!!api.getRowNode('group-US')).toBe(false);
+
+        // Retry — re-requests the failed root block.
+        api.retryServerSideLoads();
+        await asyncSetTimeout(0);
+        await asyncSetTimeout(0);
+        await asyncSetTimeout(0);
+
+        // Pin: root groups now appear and no loading rows remain.
+        expect(countLoadingRows(api)).toBe(0);
+        expect(!!api.getRowNode('group-UK')).toBe(true);
+        expect(!!api.getRowNode('group-US')).toBe(true);
+
+        await new GridRows(api, 'grouped root-route failure: recovered after retry').check(`
+            ROOT id:<no-id>
+            ├── GROUP-leafGroup collapsed id:group-UK ag-Grid-AutoColumn:"UK" country:"UK"
+            └── GROUP-leafGroup collapsed id:group-US ag-Grid-AutoColumn:"US" country:"US"
+        `);
+
+        // Pin: the root route was requested twice (initial failure + retry).
+        const rootRequests = requests.filter((r) => r.groupKeys.length === 0);
+        expect(rootRequests.length).toBe(2);
+    });
+});
+
+describe('SSRM datasource failure on TREE routes (characterization)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ServerSideRowModelModule, TreeDataModule],
+    });
+
+    beforeEach(() => gridsManager.reset());
+    afterEach(() => gridsManager.reset());
+
+    // Minimal tree: a root group (Alice) with two leaf children; a sibling leaf (Eve).
+    interface TreeEmployee {
+        name: string;
+        employeeId: string;
+        group: boolean;
+        children?: TreeEmployee[];
+    }
+    const TREE: TreeEmployee[] = [
+        {
+            name: 'Alice',
+            employeeId: '1',
+            group: true,
+            children: [
+                { name: 'Charlie', employeeId: '3', group: false },
+                { name: 'Dave', employeeId: '4', group: false },
+            ],
+        },
+        { name: 'Eve', employeeId: '2', group: false },
+    ];
+
+    const extractTreeRows = (groupKeys: string[], data: TreeEmployee[]): TreeEmployee[] => {
+        if (groupKeys.length === 0) {
+            return data;
+        }
+        const parent = data.find((d) => d.name === groupKeys[0]);
+        return parent ? extractTreeRows(groupKeys.slice(1), parent.children ?? []) : [];
+    };
+
+    test('failure on a tree group route leaves that node loading, then retry recovers and requests the route twice', async () => {
+        const requests: RecordedRequest[] = [];
+        const attempts: Record<string, number> = {};
+
+        const api = gridsManager.createGrid(null, {
+            columnDefs: [
+                { field: 'employeeId', hide: true },
+                { field: 'name', hide: true },
+            ],
+            autoGroupColumnDef: { field: 'name' },
+            rowModelType: 'serverSide',
+            treeData: true,
+            getRowId: ({ data }: GetRowIdParams) => data.employeeId,
+            isServerSideGroup: (d: any) => d.group,
+            getServerSideGroupKey: (d: any) => d.name,
+            serverSideDatasource: {
+                getRows: (params: IServerSideGetRowsParams) => {
+                    const groupKeys = (params.request.groupKeys ?? []) as string[];
+                    const routeKey = groupKeys.join('/') || '<root>';
+                    requests.push({ groupKeys, range: [params.request.startRow, params.request.endRow] });
+                    attempts[routeKey] = (attempts[routeKey] ?? 0) + 1;
+
+                    // Fail the Alice child route on its first attempt only.
+                    if (routeKey === 'Alice' && attempts[routeKey] === 1) {
+                        params.fail();
+                        return;
+                    }
+
+                    const rows = extractTreeRows(groupKeys, TREE).map((d) => ({
+                        group: !!d.children?.length,
+                        employeeId: d.employeeId,
+                        name: d.name,
+                    }));
+                    params.success({ rowData: rows, rowCount: rows.length });
+                },
+            },
+        });
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        // Expand Alice — its child load fails.
+        const aliceNode = api.getRowNode('1')!;
+        api.setRowNodeExpanded(aliceNode, true);
+        await asyncSetTimeout(0);
+        await asyncSetTimeout(0);
+
+        // Pin: Alice stays loading (no children populated); sibling leaf Eve is untouched.
+        await new GridRows(api, 'tree child-route failure: Alice loading, Eve intact').check(`
+            ROOT id:<no-id>
+            ├─┬ Alice GROUP id:1 ag-Grid-AutoColumn:"Alice" employeeId:"1" name:"Alice"
+            │ └── filler id:rowIndex:1
+            └── LEAF id:2 ag-Grid-AutoColumn:"Eve" employeeId:"2" name:"Eve"
+        `);
+
+        expect(countLoadingRows(api)).toBeGreaterThan(0);
+        expect(!!api.getRowNode('1')).toBe(true);
+        expect(!!api.getRowNode('2')).toBe(true);
+        expect(!!api.getRowNode('3')).toBe(false);
+        expect(!!api.getRowNode('4')).toBe(false);
+
+        // Retry — re-requests the failed Alice block.
+        api.retryServerSideLoads();
+        await asyncSetTimeout(0);
+        await asyncSetTimeout(0);
+        await asyncSetTimeout(0);
+
+        // Pin: Alice's children now populate and no loading rows remain.
+        expect(countLoadingRows(api)).toBe(0);
+        expect(!!api.getRowNode('3')).toBe(true);
+        expect(!!api.getRowNode('4')).toBe(true);
+
+        await new GridRows(api, 'tree child-route failure: recovered after retry').check(`
+            ROOT id:<no-id>
+            ├─┬ Alice GROUP id:1 ag-Grid-AutoColumn:"Alice" employeeId:"1" name:"Alice"
+            │ ├── LEAF id:3 ag-Grid-AutoColumn:"Charlie" employeeId:"3" name:"Charlie"
+            │ └── LEAF id:4 ag-Grid-AutoColumn:"Dave" employeeId:"4" name:"Dave"
+            └── LEAF id:2 ag-Grid-AutoColumn:"Eve" employeeId:"2" name:"Eve"
+        `);
+
+        // Pin: the Alice route was requested twice (initial failure + retry).
+        const aliceRequests = requests.filter((r) => r.groupKeys.join('/') === 'Alice');
+        expect(aliceRequests.length).toBe(2);
+    });
+});

--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-pivot-grand-total.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-pivot-grand-total.test.ts
@@ -1,0 +1,215 @@
+import type { GetRowIdParams, IServerSideDatasource, IServerSideGetRowsParams } from 'ag-grid-community';
+import { GRAND_TOTAL_ROW_ID } from 'ag-grid-community';
+import { PivotModule, RowGroupingModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
+
+import { createFakeServer } from '../../columnToolPanel/deferredPivotModeFakeServer';
+import { GridColumns, GridRows, TestGridsManager, waitForEvent, waitForNoLoadingRows } from '../../test-utils';
+
+/**
+ * CHARACTERIZATION tests (golden-master) pinning the CURRENT behaviour of SSRM grand-total /
+ * footer rows while in PIVOT mode. These tests document what the grid actually does today —
+ * the `needsGrandTotal` request flag, `grandTotalRow` positioning (top / bottom) and the pivoted
+ * aggregate values carried on the total row across the generated pivot-result columns. Any
+ * assertion here reflects observed mechanics, not a specification: if behaviour looks buggy it is
+ * still pinned as the baseline so a future change surfaces as a diff.
+ */
+describe('SSRM pivot grand total row (characterization)', () => {
+    const gridManager = new TestGridsManager({
+        modules: [ServerSideRowModelModule, RowGroupingModule, PivotModule],
+    });
+
+    afterEach(() => {
+        gridManager.reset();
+    });
+
+    interface OlympicRow {
+        country: string;
+        year: number;
+        gold: number;
+    }
+
+    const rowData: OlympicRow[] = [
+        { country: 'USA', year: 2000, gold: 1 },
+        { country: 'USA', year: 2004, gold: 2 },
+        { country: 'Russia', year: 2000, gold: 3 },
+        { country: 'Russia', year: 2004, gold: 4 },
+    ];
+
+    // Column setup: country row-group, year pivot, gold summed.
+    const columnDefs = [
+        { field: 'country', rowGroup: true, hide: true },
+        { field: 'year', pivot: true },
+        { field: 'gold', aggFunc: 'sum' },
+    ];
+
+    // SSRM grouping requires a getRowId; group rows keyed by country, grand-total by its sentinel id.
+    const getRowId = (params: GetRowIdParams): string => {
+        const data = params.data as any;
+        if (data?.id === GRAND_TOTAL_ROW_ID) {
+            return GRAND_TOTAL_ROW_ID;
+        }
+        return [...(params.parentKeys ?? []), data.country].join('-');
+    };
+
+    // Wrap the Olympic pivot fake server so it honours needsGrandTotal: when requested, it computes
+    // the pivoted aggregate over ALL rows (grouping stripped) and returns it as a grand-total row.
+    function createPivotDatasourceWithGrandTotal(): {
+        datasource: IServerSideDatasource;
+        calls: { needsGrandTotal: boolean; groupKeys: string[]; pivotMode?: boolean; pivotColIds: string[] }[];
+    } {
+        const server = createFakeServer(rowData as any);
+        const calls: {
+            needsGrandTotal: boolean;
+            groupKeys: string[];
+            pivotMode?: boolean;
+            pivotColIds: string[];
+        }[] = [];
+        const datasource: IServerSideDatasource = {
+            getRows(params: IServerSideGetRowsParams) {
+                const { request } = params;
+                calls.push({
+                    needsGrandTotal: params.needsGrandTotal,
+                    groupKeys: [...request.groupKeys],
+                    pivotMode: request.pivotMode,
+                    pivotColIds: (request.pivotCols ?? []).map((c) => c.id),
+                });
+
+                const response = server.getData(request);
+                const rows: any[] = [...response.rows];
+
+                if (params.needsGrandTotal) {
+                    // Pivoted grand total = aggregate over all rows with grouping removed.
+                    const totalResponse = server.getData({ ...request, rowGroupCols: [], groupKeys: [] });
+                    const totalRow = { ...(totalResponse.rows[0] ?? {}), id: GRAND_TOTAL_ROW_ID };
+                    rows.push(totalRow);
+                }
+
+                setTimeout(() => {
+                    params.success({
+                        rowData: rows,
+                        rowCount: response.lastRow,
+                        pivotResultFields: response.pivotResultFields,
+                    });
+                }, 0);
+            },
+        };
+        return { datasource, calls };
+    }
+
+    // Scenario 1: pivot mode + grandTotalRow:'bottom'. Pin the grand-total row, its position at the
+    // bottom, the pivot flags on the request, and the pivoted total values / pivot result columns.
+    test('grand total at bottom in pivot mode', async () => {
+        const { datasource, calls } = createPivotDatasourceWithGrandTotal();
+        const api = gridManager.createGrid(null, {
+            columnDefs,
+            pivotMode: true,
+            rowModelType: 'serverSide',
+            serverSideDatasource: datasource,
+            getRowId,
+            grandTotalRow: 'bottom',
+        });
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        // Root store request carried pivot flags and needsGrandTotal.
+        const rootCall = calls.find((c) => c.groupKeys.length === 0)!;
+        expect(rootCall.pivotMode).toBe(true);
+        expect(rootCall.pivotColIds).toEqual(['year']);
+        expect(rootCall.needsGrandTotal).toBe(true);
+
+        // Pivot result columns generated from the pivot key + value col.
+        await new GridColumns(api, 'pivot grand total bottom columns').checkColumns(`
+            CENTER
+            ├── ag-Grid-AutoColumn "Group" width:200
+            ├─┬ "2000" GROUP
+            │ └── 2000_gold "Gold" width:200
+            └─┬ "2004" GROUP
+              └── 2004_gold "Gold" width:200
+        `);
+
+        // Grand total footer renders at the bottom. checkDom is disabled here because the pivoted
+        // total values diverge between the row model and the rendered DOM (see assertions below):
+        // the row-model / diagram reads null for the footer's pivot columns while the DOM renders
+        // the aggregated numbers. This is a latent-bug-shaped discrepancy pinned as baseline.
+        await new GridRows(api, 'pivot grand total bottom', { checkDom: false }).check(`
+            ROOT id:<no-id>
+            ├── GROUP-leafGroup collapsed id:Russia ag-Grid-AutoColumn:"Russia" 2000_gold:3 2004_gold:4
+            ├── GROUP-leafGroup collapsed id:USA ag-Grid-AutoColumn:"USA" 2000_gold:1 2004_gold:2
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total "
+        `);
+
+        // The grand-total footer node exists, is a footer, and its raw data carries the pivoted
+        // totals (2000 gold = 1+3 = 4, 2004 gold = 2+4 = 6) even though the diagram shows null.
+        const grandTotal = api.getRowNode(GRAND_TOTAL_ROW_ID);
+        expect(grandTotal?.footer).toBe(true);
+        expect(grandTotal?.data?.['2000_gold']).toBe(4);
+        expect(grandTotal?.data?.['2004_gold']).toBe(6);
+    });
+
+    // Scenario 2: grandTotalRow:'top' in pivot mode flips the total row to the top.
+    test('grand total at top in pivot mode', async () => {
+        const { datasource } = createPivotDatasourceWithGrandTotal();
+        const api = gridManager.createGrid(null, {
+            columnDefs,
+            pivotMode: true,
+            rowModelType: 'serverSide',
+            serverSideDatasource: datasource,
+            getRowId,
+            grandTotalRow: 'top',
+        });
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        await new GridRows(api, 'pivot grand total top', { checkDom: false }).check(`
+            ROOT id:<no-id>
+            ├─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total "
+            ├── GROUP-leafGroup collapsed id:Russia ag-Grid-AutoColumn:"Russia" 2000_gold:3 2004_gold:4
+            └── GROUP-leafGroup collapsed id:USA ag-Grid-AutoColumn:"USA" 2000_gold:1 2004_gold:2
+        `);
+    });
+
+    // Scenario 3: grand total alongside an expanded row group in pivot mode — pin how group rows and
+    // the grand total render together.
+    test('grand total with expanded row group in pivot mode', async () => {
+        const { datasource } = createPivotDatasourceWithGrandTotal();
+        const api = gridManager.createGrid(null, {
+            columnDefs,
+            pivotMode: true,
+            rowModelType: 'serverSide',
+            serverSideDatasource: datasource,
+            getRowId,
+            grandTotalRow: 'bottom',
+            groupTotalRow: 'bottom',
+        });
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        // Collapsed groups + grand total.
+        await new GridRows(api, 'pivot grand total groups collapsed', { checkDom: false }).check(`
+            ROOT id:<no-id>
+            ├── GROUP-leafGroup collapsed id:Russia ag-Grid-AutoColumn:"Russia" 2000_gold:3 2004_gold:4
+            ├── GROUP-leafGroup collapsed id:USA ag-Grid-AutoColumn:"USA" 2000_gold:1 2004_gold:2
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total "
+        `);
+
+        // In pivot mode the sole row-group level (country) is a LEAF group: it is not expandable, so
+        // setExpanded(true) is a no-op and no group-total rows appear despite groupTotalRow:'bottom'.
+        const usa = api.getRowNode('USA')!;
+        expect(usa.leafGroup).toBe(true);
+        expect(usa.isExpandable()).toBe(false);
+        usa.setExpanded(true);
+        await waitForNoLoadingRows(api);
+        expect(usa.expanded).toBe(false);
+
+        // Rows are unchanged: leaf group stays collapsed, only the grand total footer is present.
+        await new GridRows(api, 'pivot grand total group expanded', { checkDom: false }).check(`
+            ROOT id:<no-id>
+            ├── GROUP-leafGroup collapsed id:Russia ag-Grid-AutoColumn:"Russia" 2000_gold:3 2004_gold:4
+            ├── GROUP-leafGroup collapsed id:USA ag-Grid-AutoColumn:"USA" 2000_gold:1 2004_gold:2
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total "
+        `);
+    });
+});

--- a/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-transactions.test.ts
+++ b/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-transactions.test.ts
@@ -267,10 +267,11 @@ describe('ag-grid SSRM treeData transactions (characterization)', () => {
             }
         );
 
-        // Async transactions are batched; wait for the flush + any resulting loads.
-        for (let repeat = 0; callbackStatus === undefined && repeat < 500; ++repeat) {
-            await waitForNoLoadingRows(api);
-        }
+        // Async transactions are batched; force the batch to flush synchronously so the
+        // callback runs deterministically rather than depending on the batch timer, then
+        // wait for any resulting loads.
+        api.flushServerSideAsyncTransactions();
+        await waitForNoLoadingRows(api);
 
         // Pin: callback fires with the applied status and the node lands under the parent.
         expect(callbackStatus).toBe('Applied');

--- a/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-transactions.test.ts
+++ b/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-transactions.test.ts
@@ -1,0 +1,280 @@
+import type { GridOptions } from 'ag-grid-community';
+import { ServerSideRowModelApiModule, ServerSideRowModelModule, TreeDataModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, waitForEvent } from '../../test-utils';
+import { ssrmExpandAndLoadAll, waitForNoLoadingRows } from '../../test-utils/ssrm-test-utils';
+import { createFakeServer, createServerSideDatasource, getSmallTreeDataSet } from './ssrmSmallTreeDataSet';
+
+/**
+ * Characterization (golden-master) tests pinning the CURRENT behaviour of
+ * `api.applyServerSideTransaction(...)` (add / remove / update) and its async
+ * variant against tree-data server-side row groups.
+ *
+ * These tests document mechanics as they are today; any assertion that encodes
+ * a bug is intentional and should be treated as the baseline to compare future
+ * changes against, not as desired behaviour.
+ */
+describe('ag-grid SSRM treeData transactions (characterization)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ServerSideRowModelModule, TreeDataModule],
+    });
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    // Shared inline grid options for tree-data SSRM. `group` from the fake server
+    // drives `isServerSideGroup`; group keys are the employeeId route segments.
+    function createTreeDataGridOptions(): GridOptions {
+        return {
+            columnDefs: [
+                { field: 'employeeId', hide: true },
+                { field: 'employeeName', hide: true },
+                { field: 'jobTitle' },
+                { field: 'employmentType' },
+            ],
+            autoGroupColumnDef: {
+                field: 'employeeName',
+            },
+            defaultColDef: { flex: 1 },
+            treeData: true,
+            rowModelType: 'serverSide',
+            animateRows: false,
+            getRowId: ({ data }) => data.employeeId,
+            isServerSideGroup: (dataItem: any) => dataItem.group,
+            getServerSideGroupKey: (dataItem: any) => dataItem.employeeId,
+        };
+    }
+
+    test('ADD a child to an expanded tree group appears under the routed parent', async () => {
+        const api = gridsManager.createGrid('ssrmTxAdd', createTreeDataGridOptions());
+
+        const fakeServer = createFakeServer(getSmallTreeDataSet());
+        api.setGridOption('serverSideDatasource', createServerSideDatasource(fakeServer));
+
+        await waitForEvent('firstDataRendered', api);
+        // Expand and load every group so the target route ['101','102','108'] is a loaded store.
+        await ssrmExpandAndLoadAll(api);
+
+        const countBeforeAdd = api.getDisplayedRowCount();
+
+        // Add a new child under Francis Strickland (VP Sales) whose children are 109-112.
+        const result = api.applyServerSideTransaction({
+            route: ['101', '102', '108'],
+            add: [
+                {
+                    group: false,
+                    employeeId: '999',
+                    employeeName: 'New Hire',
+                    jobTitle: 'Sales Executive',
+                    employmentType: 'Contract',
+                },
+            ],
+        });
+
+        await waitForNoLoadingRows(api);
+
+        // Pin: the applied status string, that the node now exists and displayed count grew.
+        expect(result?.status).toBe('Applied');
+        expect(!!api.getRowNode('999')).toBe(true);
+        expect(api.getDisplayedRowCount()).toBe(countBeforeAdd + 1);
+
+        await new GridRows(api, 'ssrm tx add child').check(`
+            ROOT id:<no-id>
+            └─┬ 101 GROUP id:101 ag-Grid-AutoColumn:"Erica Rogers" employeeId:"101" employeeName:"Erica Rogers" jobTitle:"CEO" employmentType:"Permanent"
+            · ├─┬ 102 GROUP id:102 ag-Grid-AutoColumn:"Malcolm Barrett" employeeId:"102" employeeName:"Malcolm Barrett" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+            · │ ├─┬ 103 GROUP id:103 ag-Grid-AutoColumn:"Esther Baker" employeeId:"103" employeeName:"Esther Baker" jobTitle:"Director of Operations" employmentType:"Permanent"
+            · │ │ ├─┬ 104 GROUP id:104 ag-Grid-AutoColumn:"Brittany Hanson" employeeId:"104" employeeName:"Brittany Hanson" jobTitle:"Fleet Coordinator" employmentType:"Permanent"
+            · │ │ │ ├── LEAF id:105 ag-Grid-AutoColumn:"Leah Flowers" employeeId:"105" employeeName:"Leah Flowers" jobTitle:"Parts Technician" employmentType:"Contract"
+            · │ │ │ └── LEAF id:106 ag-Grid-AutoColumn:"Tammy Sutton" employeeId:"106" employeeName:"Tammy Sutton" jobTitle:"Service Technician" employmentType:"Contract"
+            · │ │ └── LEAF id:107 ag-Grid-AutoColumn:"Derek Paul" employeeId:"107" employeeName:"Derek Paul" jobTitle:"Inventory Control" employmentType:"Permanent"
+            · │ └─┬ 108 GROUP id:108 ag-Grid-AutoColumn:"Francis Strickland" employeeId:"108" employeeName:"Francis Strickland" jobTitle:"VP Sales" employmentType:"Permanent"
+            · │ · ├── LEAF id:109 ag-Grid-AutoColumn:"Morris Hanson" employeeId:"109" employeeName:"Morris Hanson" jobTitle:"Sales Manager" employmentType:"Permanent"
+            · │ · ├── LEAF id:110 ag-Grid-AutoColumn:"Todd Tyler" employeeId:"110" employeeName:"Todd Tyler" jobTitle:"Sales Executive" employmentType:"Contract"
+            · │ · ├── LEAF id:111 ag-Grid-AutoColumn:"Bennie Wise" employeeId:"111" employeeName:"Bennie Wise" jobTitle:"Sales Executive" employmentType:"Contract"
+            · │ · ├── LEAF id:112 ag-Grid-AutoColumn:"Joel Cooper" employeeId:"112" employeeName:"Joel Cooper" jobTitle:"Sales Executive" employmentType:"Permanent"
+            · │ · └── LEAF id:999 ag-Grid-AutoColumn:"New Hire" employeeId:"999" employeeName:"New Hire" jobTitle:"Sales Executive" employmentType:"Contract"
+            · └─┬ 113 GROUP id:113 ag-Grid-AutoColumn:"Luke McBride" employeeId:"113" employeeName:"Luke McBride" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+            · · ├─┬ 114 GROUP id:114 ag-Grid-AutoColumn:"Sarah Baker" employeeId:"114" employeeName:"Sarah Baker" jobTitle:"Director of Operations" employmentType:"Permanent"
+            · · │ ├─┬ 115 GROUP id:115 ag-Grid-AutoColumn:"Mason Hanson" employeeId:"115" employeeName:"Mason Hanson" jobTitle:"Fleet Coordinator" employmentType:"Permanent"
+            · · │ │ ├── LEAF id:116 ag-Grid-AutoColumn:"Hannah Flowers" employeeId:"116" employeeName:"Hannah Flowers" jobTitle:"Parts Technician" employmentType:"Contract"
+            · · │ │ └── LEAF id:117 ag-Grid-AutoColumn:"Rob Sutton" employeeId:"117" employeeName:"Rob Sutton" jobTitle:"Service Technician" employmentType:"Contract"
+            · · │ └── LEAF id:118 ag-Grid-AutoColumn:"Paul Smith" employeeId:"118" employeeName:"Paul Smith" jobTitle:"Inventory Control" employmentType:"Permanent"
+            · · └─┬ 119 GROUP id:119 ag-Grid-AutoColumn:"Adam Newman" employeeId:"119" employeeName:"Adam Newman" jobTitle:"VP Sales" employmentType:"Permanent"
+            · · · ├── LEAF id:120 ag-Grid-AutoColumn:"John Smith" employeeId:"120" employeeName:"John Smith" jobTitle:"Sales Manager" employmentType:"Permanent"
+            · · · ├── LEAF id:121 ag-Grid-AutoColumn:"Alice Grant" employeeId:"121" employeeName:"Alice Grant" jobTitle:"Sales Executive" employmentType:"Contract"
+            · · · ├── LEAF id:122 ag-Grid-AutoColumn:"Ben Hill" employeeId:"122" employeeName:"Ben Hill" jobTitle:"Sales Executive" employmentType:"Contract"
+            · · · └── LEAF id:123 ag-Grid-AutoColumn:"Joe Cooper" employeeId:"123" employeeName:"Joe Cooper" jobTitle:"Sales Executive" employmentType:"Permanent"
+        `);
+    });
+
+    test('REMOVE a leaf tree node removes it from the routed store', async () => {
+        const api = gridsManager.createGrid('ssrmTxRemoveLeaf', createTreeDataGridOptions());
+
+        const fakeServer = createFakeServer(getSmallTreeDataSet());
+        api.setGridOption('serverSideDatasource', createServerSideDatasource(fakeServer));
+
+        await waitForEvent('firstDataRendered', api);
+        await ssrmExpandAndLoadAll(api);
+
+        const countBeforeRemove = api.getDisplayedRowCount();
+        expect(!!api.getRowNode('112')).toBe(true);
+
+        // Remove leaf Joel Cooper (112) from the VP Sales (108) child store.
+        const result = api.applyServerSideTransaction({
+            route: ['101', '102', '108'],
+            remove: [{ employeeId: '112' }],
+        });
+
+        await waitForNoLoadingRows(api);
+
+        // Pin: applied status, node gone, displayed count shrank.
+        expect(result?.status).toBe('Applied');
+        expect(!!api.getRowNode('112')).toBe(false);
+        expect(api.getDisplayedRowCount()).toBe(countBeforeRemove - 1);
+    });
+
+    test('REMOVE a parent group node removes the group and its loaded descendants', async () => {
+        const api = gridsManager.createGrid('ssrmTxRemoveParent', createTreeDataGridOptions());
+
+        const fakeServer = createFakeServer(getSmallTreeDataSet());
+        api.setGridOption('serverSideDatasource', createServerSideDatasource(fakeServer));
+
+        await waitForEvent('firstDataRendered', api);
+        await ssrmExpandAndLoadAll(api);
+
+        const countBeforeRemove = api.getDisplayedRowCount();
+        expect(!!api.getRowNode('108')).toBe(true);
+        expect(!!api.getRowNode('109')).toBe(true);
+
+        // Remove the VP Sales group (108) from the Malcolm Barrett (102) child store.
+        const result = api.applyServerSideTransaction({
+            route: ['101', '102'],
+            remove: [{ employeeId: '108' }],
+        });
+
+        await waitForNoLoadingRows(api);
+
+        // Pin: applied status, group node gone. Children row nodes' fate is pinned below.
+        expect(result?.status).toBe('Applied');
+        expect(!!api.getRowNode('108')).toBe(false);
+
+        // Characterization: what happens to the removed group's children (109-112)?
+        // Characterization: removing the group also drops its loaded child row nodes.
+        const child109StillPresent = !!api.getRowNode('109');
+        const displayedAfterRemove = api.getDisplayedRowCount();
+        expect(child109StillPresent).toBe(false);
+        expect(displayedAfterRemove).toBe(countBeforeRemove - 5);
+    });
+
+    test('UPDATE a tree node reflects the changed data', async () => {
+        const api = gridsManager.createGrid('ssrmTxUpdate', createTreeDataGridOptions());
+
+        const fakeServer = createFakeServer(getSmallTreeDataSet());
+        api.setGridOption('serverSideDatasource', createServerSideDatasource(fakeServer));
+
+        await waitForEvent('firstDataRendered', api);
+        await ssrmExpandAndLoadAll(api);
+
+        const countBeforeUpdate = api.getDisplayedRowCount();
+
+        // Update leaf Joel Cooper (112) in the VP Sales (108) child store.
+        const result = api.applyServerSideTransaction({
+            route: ['101', '102', '108'],
+            update: [
+                {
+                    group: false,
+                    employeeId: '112',
+                    employeeName: 'Joel Cooper',
+                    jobTitle: 'Head of Sales',
+                    employmentType: 'Permanent',
+                },
+            ],
+        });
+
+        await waitForNoLoadingRows(api);
+
+        // Pin: applied status, count unchanged, and the new field value is reflected on the node.
+        expect(result?.status).toBe('Applied');
+        expect(api.getDisplayedRowCount()).toBe(countBeforeUpdate);
+        expect(api.getRowNode('112')?.data.jobTitle).toBe('Head of Sales');
+    });
+
+    test('transaction targeting an UNLOADED / unknown route yields StoreNotFound and changes nothing', async () => {
+        const api = gridsManager.createGrid('ssrmTxUnknownRoute', createTreeDataGridOptions());
+
+        const fakeServer = createFakeServer(getSmallTreeDataSet());
+        api.setGridOption('serverSideDatasource', createServerSideDatasource(fakeServer));
+
+        await waitForEvent('firstDataRendered', api);
+        await ssrmExpandAndLoadAll(api);
+
+        const countBefore = api.getDisplayedRowCount();
+
+        // Route through a group key that does not exist -> store cannot be found.
+        const result = api.applyServerSideTransaction({
+            route: ['101', 'does-not-exist'],
+            add: [
+                {
+                    group: false,
+                    employeeId: '888',
+                    employeeName: 'Ghost',
+                    jobTitle: 'Phantom',
+                    employmentType: 'Contract',
+                },
+            ],
+        });
+
+        await waitForNoLoadingRows(api);
+
+        // Pin: StoreNotFound status, nothing added, count unchanged.
+        expect(result?.status).toBe('StoreNotFound');
+        expect(!!api.getRowNode('888')).toBe(false);
+        expect(api.getDisplayedRowCount()).toBe(countBefore);
+    });
+
+    test('async variant applyServerSideTransactionAsync applies an add via its callback', async () => {
+        const api = gridsManager.createGrid('ssrmTxAsync', createTreeDataGridOptions());
+
+        const fakeServer = createFakeServer(getSmallTreeDataSet());
+        api.setGridOption('serverSideDatasource', createServerSideDatasource(fakeServer));
+
+        await waitForEvent('firstDataRendered', api);
+        await ssrmExpandAndLoadAll(api);
+
+        const countBefore = api.getDisplayedRowCount();
+
+        let callbackStatus: string | undefined;
+        api.applyServerSideTransactionAsync(
+            {
+                route: ['101', '102', '108'],
+                add: [
+                    {
+                        group: false,
+                        employeeId: '777',
+                        employeeName: 'Async Hire',
+                        jobTitle: 'Sales Executive',
+                        employmentType: 'Contract',
+                    },
+                ],
+            },
+            (res) => {
+                callbackStatus = res.status;
+            }
+        );
+
+        // Async transactions are batched; wait for the flush + any resulting loads.
+        for (let repeat = 0; callbackStatus === undefined && repeat < 500; ++repeat) {
+            await waitForNoLoadingRows(api);
+        }
+
+        // Pin: callback fires with the applied status and the node lands under the parent.
+        expect(callbackStatus).toBe('Applied');
+        expect(!!api.getRowNode('777')).toBe(true);
+        expect(api.getDisplayedRowCount()).toBe(countBefore + 1);
+    });
+});


### PR DESCRIPTION
## What

Follow-up to #14355 — fills the **distinct code-path** cells the first PR deferred. Golden-master **characterization** tests pinning current SSRM behaviour (bugs = expected mechanics).

📊 **Coverage matrix & findings:** https://claude.ai/code/artifact/7515d2e1-da99-4677-9718-cdb752572d14

**3 files, 12 tests, all green.**

| Area | File |
|---|---|
| fail()/retry on group & tree routes | `grouping-data/ssrm/ssrm-failure-grouped` |
| Tree-data transactions (add/remove/update/async) | `tree-data/ssrm/ssrm-tree-data-transactions` |
| Pivot grand-total row | `grouping-data/ssrm/ssrm-pivot-grand-total` |

These are genuinely different code paths from what #14355 covered (a failure on a *group/tree route* vs a root failure; tree-data transactions vs flat; pivoted totals vs plain group totals) — not shape-agnostic duplicates.

## Latent behaviours frozen as baseline

- **Child-route failure is scoped**, root-route failure is total: failing an expanded group/tree node leaves siblings + root intact; failing the root block collapses the grid to a single filler with **no group nodes at all** (and `firstDataRendered` never fires).
- **Removing a parent group via transaction silently discards all its loaded descendants** client-side (no re-fetch).
- Unknown/unloaded transaction route → `status: 'StoreNotFound'`, no change.
- **⚠️ Likely real bug — pivot grand-total footer:** the footer's raw `data` and the DOM both show the correct pivoted totals, but the **row model reads those pivot columns as null**. Pivot totals on the SSRM grand-total footer are not wired into the aggregation/model layer the way normal group rows are. Pinned explicitly (with `checkDom:false` on the snapshot) and worth a bug ticket.

## Context

Second of two PRs from an SSRM characterization sweep. #14355 covered block loading, refresh, transactions, cache knobs, sort/filter scope, pivot & tree-data loading. Remaining matrix cells are shape-agnostic duplicates of already-pinned mechanics and were intentionally left uncovered.