### PR TITLE
test(ssrm): characterization coverage for pivot & tree-data operations

### DIFF
--- a/testing/behavioural/src/columnToolPanel/deferredPivotModeFakeServer.ts
+++ b/testing/behavioural/src/columnToolPanel/deferredPivotModeFakeServer.ts
@@ -153,10 +153,96 @@ export function createFakeServer(allData: IOlympicData[]) {
         return left.localeCompare(right, undefined, { numeric: true, sensitivity: 'base' });
     };
 
+    const matchesTextCondition = (value: unknown, condition: any): boolean => {
+        const filterValue = String(condition.filter ?? '').toLowerCase();
+        const cellValue = value == null ? '' : String(value).toLowerCase();
+        switch (condition.type) {
+            case 'equals':
+                return cellValue === filterValue;
+            case 'notEqual':
+                return cellValue !== filterValue;
+            case 'contains':
+                return cellValue.includes(filterValue);
+            case 'notContains':
+                return !cellValue.includes(filterValue);
+            case 'startsWith':
+                return cellValue.startsWith(filterValue);
+            case 'endsWith':
+                return cellValue.endsWith(filterValue);
+            case 'blank':
+                return cellValue === '';
+            case 'notBlank':
+                return cellValue !== '';
+            default:
+                return true;
+        }
+    };
+
+    const matchesNumberCondition = (value: unknown, condition: any): boolean => {
+        const num = toNumber(value);
+        const filterNum = toNumber(condition.filter);
+        if (num == null || filterNum == null) {
+            return true;
+        }
+        switch (condition.type) {
+            case 'equals':
+                return num === filterNum;
+            case 'notEqual':
+                return num !== filterNum;
+            case 'greaterThan':
+                return num > filterNum;
+            case 'greaterThanOrEqual':
+                return num >= filterNum;
+            case 'lessThan':
+                return num < filterNum;
+            case 'lessThanOrEqual':
+                return num <= filterNum;
+            case 'inRange': {
+                const to = toNumber(condition.filterTo);
+                return to == null ? num >= filterNum : num >= filterNum && num <= to;
+            }
+            default:
+                return true;
+        }
+    };
+
+    const matchesColumnFilter = (row: IOlympicData, colId: string, model: any): boolean => {
+        const value = (row as any)[colId];
+        if (model.filterType === 'set') {
+            const values: unknown[] = model.values ?? [];
+            const cellValue = value == null ? '' : String(value);
+            return values.map((entry) => String(entry)).includes(cellValue);
+        }
+        if (model.filterType === 'number') {
+            return matchesNumberCondition(value, model);
+        }
+        return matchesTextCondition(value, model);
+    };
+
+    const applyFilterModel = (rows: IOlympicData[], filterModel: Record<string, any>): IOlympicData[] => {
+        const colIds = Object.keys(filterModel);
+        if (!colIds.length) {
+            return rows;
+        }
+        return rows.filter((row) => {
+            for (let i = 0, len = colIds.length; i < len; i++) {
+                if (!matchesColumnFilter(row, colIds[i], filterModel[colIds[i]])) {
+                    return false;
+                }
+            }
+            return true;
+        });
+    };
+
     return {
         getData: (request: IServerSideGetRowsRequest): ServerResponse => {
             let rows = allData;
             const { rowGroupCols = [], pivotCols = [], groupKeys = [], valueCols = [], sortModel = [] } = request;
+
+            const filterModel = request.filterModel as Record<string, any> | null | undefined;
+            if (filterModel) {
+                rows = applyFilterModel(rows, filterModel);
+            }
 
             for (let i = 0; i < groupKeys.length; i++) {
                 const key = groupKeys[i];

--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-pivot-operations.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-pivot-operations.test.ts
@@ -249,7 +249,7 @@ describe('SSRM pivot-mode operations (characterization)', () => {
 
         // A filter triggers a fresh server request in pivot mode.
         expect(requests.length).toBeGreaterThan(requestsBeforeFilter);
-        // Pivot-specific: the re-request still carries the pivot metadata.
+        // Pivot-specific: the re-request still carries the pivot metadata AND the applied filterModel.
         const filterRequest = requests[requests.length - 1];
         expect(filterRequest.pivotMode).toBe(true);
         expect(filterRequest.pivotCols).toEqual(['year']);
@@ -261,15 +261,12 @@ describe('SSRM pivot-mode operations (characterization)', () => {
             country: { filterType: 'text', type: 'equals', filter: 'USA' },
         });
 
-        // Pivot result columns still present. Note: this shared Olympic fake server does NOT honour
-        // filterModel (its getData never reads request.filterModel), so the displayed rows are
-        // unchanged — both Russia and USA remain. The test pins that behaviour and instead asserts,
-        // above, that the filter is SENT on the request; it does not assert server-side filtering.
+        // The shared fake server applies the equals-USA filter server-side, so only the USA group
+        // remains; the generated pivot result columns are unaffected by the filter.
         expect(pivotCols(api)).toEqual(['2000_gold', '2004_gold']);
         await new GridRows(api, '4. filter in pivot mode').check(`
             ROOT id:<no-id>
-            ├── GROUP-leafGroup collapsed id:2 ag-Grid-AutoColumn:"Russia" 2000_gold:3 2004_gold:4
-            └── GROUP-leafGroup collapsed id:3 ag-Grid-AutoColumn:"USA" 2000_gold:1 2004_gold:2
+            └── GROUP-leafGroup collapsed id:2 ag-Grid-AutoColumn:"USA" 2000_gold:1 2004_gold:2
         `);
     });
 

--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-pivot-operations.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-pivot-operations.test.ts
@@ -1,0 +1,344 @@
+import type { GridApi, IServerSideGetRowsRequest } from 'ag-grid-community';
+import { ScrollApiModule, TextFilterModule } from 'ag-grid-community';
+import {
+    PivotModule,
+    RowGroupingModule,
+    ServerSideRowModelApiModule,
+    ServerSideRowModelModule,
+} from 'ag-grid-enterprise';
+
+import { createFakeServer, createServerSideDatasource } from '../../columnToolPanel/deferredPivotModeFakeServer';
+import { getColumnOrder } from '../../columns/column-test-utils';
+import { GridRows, TestGridsManager, waitForEvent } from '../../test-utils';
+import { asyncSetTimeout } from '../../test-utils/node-utils';
+import { countLoadingRows, waitForNoLoadingRows } from '../../test-utils/ssrm-test-utils';
+
+/**
+ * Characterization tests pinning the CURRENT behaviour of Server-Side Row Model operations while
+ * `pivotMode: true` is enabled: initial load, block eviction (maxBlocksInCache), client-side sort
+ * (serverSideEnableClientSideSort), filtering, refreshServerSide, and datasource failure.
+ *
+ * These are golden-master tests: whatever the grid does today is treated as the expected baseline
+ * (including any latent bugs). Each case asserts something PIVOT-SPECIFIC — that a re-request still
+ * carries pivotMode/pivotCols/valueCols, or that generated pivot result columns regenerate — rather
+ * than re-verifying flat/grouped SSRM behaviour already covered in sibling files. Where a pivot
+ * operation turns out to behave identically to the non-pivot baseline, that is pinned explicitly.
+ */
+
+interface RecordedRequest {
+    pivotMode: boolean;
+    pivotCols: string[];
+    valueCols: string[];
+    groupKeys: string[];
+    range: [number | undefined, number | undefined];
+}
+
+// Thin recorder around the shared Olympic pivot/agg fake server: captures the request stream so we
+// can assert the pivot flags carried on each re-request, and can be told to fail the next call.
+function createRecordingServer(allData: any[]) {
+    const server = createFakeServer(allData);
+    const requests: RecordedRequest[] = [];
+    let failNext = false;
+
+    const recording = {
+        getData: (request: IServerSideGetRowsRequest) => {
+            requests.push({
+                pivotMode: !!request.pivotMode,
+                pivotCols: (request.pivotCols ?? []).map((col) => col.id),
+                valueCols: (request.valueCols ?? []).map((col) => col.id),
+                groupKeys: [...(request.groupKeys ?? [])],
+                range: [request.startRow, request.endRow],
+            });
+            if (failNext) {
+                failNext = false;
+                return { success: false, rows: [], lastRow: 0 };
+            }
+            return server.getData(request);
+        },
+    };
+
+    return {
+        datasource: createServerSideDatasource(recording),
+        requests,
+        failOnce: () => {
+            failNext = true;
+        },
+    };
+}
+
+// Two countries x two years: pivot result columns are 2000_gold and 2004_gold.
+const SMALL_DATA = [
+    { athlete: 'a1', country: 'USA', year: 2000, gold: 1, silver: 0, bronze: 0, total: 1 },
+    { athlete: 'a2', country: 'USA', year: 2004, gold: 2, silver: 0, bronze: 0, total: 2 },
+    { athlete: 'a3', country: 'Russia', year: 2000, gold: 3, silver: 0, bronze: 0, total: 3 },
+    { athlete: 'a4', country: 'Russia', year: 2004, gold: 4, silver: 0, bronze: 0, total: 4 },
+];
+
+// Many countries (each with two years) so the root group store virtualises across several blocks
+// and maxBlocksInCache can evict. Country ids are zero-padded so string sort keeps a stable order.
+const MANY_COUNTRIES_DATA = Array.from({ length: 300 }, (_, i) => i).flatMap((i) => [
+    {
+        athlete: `x${i}`,
+        country: `C${String(i).padStart(3, '0')}`,
+        year: 2000,
+        gold: i + 1,
+        silver: 0,
+        bronze: 0,
+        total: i + 1,
+    },
+    {
+        athlete: `y${i}`,
+        country: `C${String(i).padStart(3, '0')}`,
+        year: 2004,
+        gold: i + 2,
+        silver: 0,
+        bronze: 0,
+        total: i + 2,
+    },
+]);
+
+const pivotCols = (api: GridApi) => getColumnOrder(api, 'all').filter((id) => id.endsWith('_gold'));
+
+describe('SSRM pivot-mode operations (characterization)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [
+            ServerSideRowModelApiModule,
+            ServerSideRowModelModule,
+            RowGroupingModule,
+            PivotModule,
+            ScrollApiModule,
+            TextFilterModule,
+        ],
+    });
+
+    beforeEach(() => gridsManager.reset());
+    afterEach(() => gridsManager.reset());
+
+    test('1. initial pivot load — request carries pivot flags and pivot result columns are generated', async () => {
+        const { datasource, requests } = createRecordingServer(SMALL_DATA);
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', pivot: true, hide: true },
+                { field: 'gold', aggFunc: 'sum', hide: true },
+            ],
+            pivotMode: true,
+            rowModelType: 'serverSide',
+            serverSideDatasource: datasource,
+        });
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        // Pivot-specific: the very first request already carries the pivot metadata.
+        expect(requests[0].pivotMode).toBe(true);
+        expect(requests[0].pivotCols).toEqual(['year']);
+        expect(requests[0].valueCols).toEqual(['gold']);
+
+        // Pivot result columns are generated from the datasource's pivotResultFields.
+        expect(pivotCols(api)).toEqual(['2000_gold', '2004_gold']);
+
+        // Country groups are leaf groups in pivot mode; sorted by count desc then key => Russia, USA.
+        await new GridRows(api, '1. initial pivot load').check(`
+            ROOT id:<no-id>
+            ├── GROUP-leafGroup collapsed id:0 ag-Grid-AutoColumn:"Russia" 2000_gold:3 2004_gold:4
+            └── GROUP-leafGroup collapsed id:1 ag-Grid-AutoColumn:"USA" 2000_gold:1 2004_gold:2
+        `);
+    });
+
+    test('2. block eviction (maxBlocksInCache) — re-request for evicted block still carries pivot flags', async () => {
+        const { datasource, requests } = createRecordingServer(MANY_COUNTRIES_DATA);
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', pivot: true, hide: true },
+                { field: 'gold', aggFunc: 'sum', hide: true },
+            ],
+            pivotMode: true,
+            rowModelType: 'serverSide',
+            cacheBlockSize: 100,
+            maxBlocksInCache: 1,
+            rowBuffer: 0,
+            suppressRowVirtualisation: false,
+            serverSideDatasource: datasource,
+        });
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        // Scroll to a far block; with maxBlocksInCache=1 this evicts the first block.
+        api.ensureIndexVisible(250, 'top');
+        await asyncSetTimeout(0);
+        await waitForNoLoadingRows(api);
+
+        // Scroll back to the top — the evicted first block must be re-requested.
+        const beforeReRequest = requests.length;
+        api.ensureIndexVisible(0, 'top');
+        await asyncSetTimeout(0);
+        await waitForNoLoadingRows(api);
+
+        expect(requests.length).toBeGreaterThan(beforeReRequest);
+        // Pivot-specific: the re-request for the re-fetched block still carries the pivot metadata.
+        const reRequest = requests[requests.length - 1];
+        expect(reRequest.pivotMode).toBe(true);
+        expect(reRequest.pivotCols).toEqual(['year']);
+        expect(reRequest.valueCols).toEqual(['gold']);
+        // Pivot result columns are unaffected by eviction/re-fetch.
+        expect(pivotCols(api)).toEqual(['2000_gold', '2004_gold']);
+    });
+
+    test('3. serverSideEnableClientSideSort — sorting a pivot value column', async () => {
+        const { datasource, requests } = createRecordingServer(SMALL_DATA);
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', pivot: true, hide: true },
+                { field: 'gold', aggFunc: 'sum', hide: true },
+            ],
+            pivotMode: true,
+            rowModelType: 'serverSide',
+            serverSideEnableClientSideSort: true,
+            serverSideDatasource: datasource,
+        });
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+        await asyncSetTimeout(50);
+
+        const requestsBeforeSort = requests.length;
+
+        // Sort ascending by a generated pivot value column. Default group order is Russia(4), USA(2);
+        // an ascending sort by 2004_gold would put USA(2) first — so the row order distinguishes a
+        // client-side re-sort from a no-op.
+        api.applyColumnState({ state: [{ colId: '2004_gold', sort: 'asc' }] });
+        await waitForNoLoadingRows(api);
+        await asyncSetTimeout(50);
+
+        // Pin whether sorting a pivot value column re-requests from the server or sorts client-side:
+        // no new request is issued (serverSideEnableClientSideSort keeps the sort on the client).
+        const requestsAfterSort = requests.length;
+        expect(requestsAfterSort).toBe(requestsBeforeSort);
+
+        // Pin the resulting group row order after client-side sorting the pivot value column ascending.
+        await new GridRows(api, '3. client-side sort on pivot value column').check(`
+            ROOT id:<no-id>
+            ├── GROUP-leafGroup collapsed id:1 ag-Grid-AutoColumn:"USA" 2000_gold:1 2004_gold:2
+            └── GROUP-leafGroup collapsed id:0 ag-Grid-AutoColumn:"Russia" 2000_gold:3 2004_gold:4
+        `);
+    });
+
+    test('4. filter in pivot mode — re-request preserves pivot flags and carries filterModel', async () => {
+        const { datasource, requests } = createRecordingServer(SMALL_DATA);
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true, filter: true },
+                { field: 'year', pivot: true, hide: true },
+                { field: 'gold', aggFunc: 'sum', hide: true },
+            ],
+            pivotMode: true,
+            rowModelType: 'serverSide',
+            serverSideDatasource: datasource,
+        });
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        const requestsBeforeFilter = requests.length;
+
+        api.setFilterModel({ country: { filterType: 'text', type: 'equals', filter: 'USA' } });
+        await waitForNoLoadingRows(api);
+        await asyncSetTimeout(50);
+
+        // A filter triggers a fresh server request in pivot mode.
+        expect(requests.length).toBeGreaterThan(requestsBeforeFilter);
+        // Pivot-specific: the re-request still carries the pivot metadata.
+        const filterRequest = requests[requests.length - 1];
+        expect(filterRequest.pivotMode).toBe(true);
+        expect(filterRequest.pivotCols).toEqual(['year']);
+        expect(filterRequest.valueCols).toEqual(['gold']);
+
+        // Only USA remains; pivot result columns still present.
+        expect(pivotCols(api)).toEqual(['2000_gold', '2004_gold']);
+        await new GridRows(api, '4. filter in pivot mode').check(`
+            ROOT id:<no-id>
+            ├── GROUP-leafGroup collapsed id:2 ag-Grid-AutoColumn:"Russia" 2000_gold:3 2004_gold:4
+            └── GROUP-leafGroup collapsed id:3 ag-Grid-AutoColumn:"USA" 2000_gold:1 2004_gold:2
+        `);
+    });
+
+    test('5. refreshServerSide({purge:true}) — pivot columns regenerate and request carries pivot flags', async () => {
+        const { datasource, requests } = createRecordingServer(SMALL_DATA);
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', pivot: true, hide: true },
+                { field: 'gold', aggFunc: 'sum', hide: true },
+            ],
+            pivotMode: true,
+            rowModelType: 'serverSide',
+            serverSideDatasource: datasource,
+        });
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        expect(pivotCols(api)).toEqual(['2000_gold', '2004_gold']);
+        const requestsBeforeRefresh = requests.length;
+
+        api.refreshServerSide({ purge: true });
+        await waitForNoLoadingRows(api);
+        await asyncSetTimeout(50);
+
+        // Purge re-requests from the server.
+        expect(requests.length).toBeGreaterThan(requestsBeforeRefresh);
+        // Pivot-specific: the purge re-request carries pivot metadata and pivot columns are regenerated.
+        const refreshRequest = requests[requests.length - 1];
+        expect(refreshRequest.pivotMode).toBe(true);
+        expect(refreshRequest.pivotCols).toEqual(['year']);
+        expect(refreshRequest.valueCols).toEqual(['gold']);
+        expect(pivotCols(api)).toEqual(['2000_gold', '2004_gold']);
+
+        await new GridRows(api, '5. after purge refresh in pivot mode').check(`
+            ROOT id:<no-id>
+            ├── GROUP-leafGroup collapsed id:2 ag-Grid-AutoColumn:"Russia" 2000_gold:3 2004_gold:4
+            └── GROUP-leafGroup collapsed id:3 ag-Grid-AutoColumn:"USA" 2000_gold:1 2004_gold:2
+        `);
+    });
+
+    test('6. datasource fail() on pivot load then recovery via purge refresh', async () => {
+        const { datasource, requests, failOnce } = createRecordingServer(SMALL_DATA);
+        failOnce();
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', pivot: true, hide: true },
+                { field: 'gold', aggFunc: 'sum', hide: true },
+            ],
+            pivotMode: true,
+            rowModelType: 'serverSide',
+            serverSideDatasource: datasource,
+        });
+        // firstDataRendered may never fire after a failed load — bound the wait instead.
+        await asyncSetTimeout(0);
+        await asyncSetTimeout(0);
+
+        // Pin failure state: the load was attempted with pivot flags, but no pivot columns generated.
+        expect(requests[0].pivotMode).toBe(true);
+        expect(requests[0].pivotCols).toEqual(['year']);
+        expect(pivotCols(api)).toEqual([]);
+        // Baseline: a failed pivot load leaves a single loading/stub row in place (the failed block
+        // is not cleared), rather than emptying the grid.
+        expect(countLoadingRows(api)).toBe(1);
+
+        // Recovery: a purge refresh re-requests successfully and regenerates pivot columns.
+        api.refreshServerSide({ purge: true });
+        await waitForNoLoadingRows(api);
+        await asyncSetTimeout(50);
+
+        const recoveryRequest = requests[requests.length - 1];
+        expect(recoveryRequest.pivotMode).toBe(true);
+        expect(recoveryRequest.pivotCols).toEqual(['year']);
+        expect(pivotCols(api)).toEqual(['2000_gold', '2004_gold']);
+
+        await new GridRows(api, '6. recovered pivot load after fail').check(`
+            ROOT id:<no-id>
+            ├── GROUP-leafGroup collapsed id:0 ag-Grid-AutoColumn:"Russia" 2000_gold:3 2004_gold:4
+            └── GROUP-leafGroup collapsed id:1 ag-Grid-AutoColumn:"USA" 2000_gold:1 2004_gold:2
+        `);
+    });
+});

--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-pivot-operations.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-pivot-operations.test.ts
@@ -31,6 +31,7 @@ interface RecordedRequest {
     valueCols: string[];
     groupKeys: string[];
     range: [number | undefined, number | undefined];
+    filterModel: any;
 }
 
 // Thin recorder around the shared Olympic pivot/agg fake server: captures the request stream so we
@@ -48,6 +49,7 @@ function createRecordingServer(allData: any[]) {
                 valueCols: (request.valueCols ?? []).map((col) => col.id),
                 groupKeys: [...(request.groupKeys ?? [])],
                 range: [request.startRow, request.endRow],
+                filterModel: request.filterModel,
             });
             if (failNext) {
                 failNext = false;
@@ -252,8 +254,17 @@ describe('SSRM pivot-mode operations (characterization)', () => {
         expect(filterRequest.pivotMode).toBe(true);
         expect(filterRequest.pivotCols).toEqual(['year']);
         expect(filterRequest.valueCols).toEqual(['gold']);
+        // The applied country filter is carried on the post-filter request's filterModel. This is the
+        // pivot-specific guarantee under test: were SSRM to stop sending filterModel on pivot requests,
+        // this assertion would catch it (the metadata-only checks above would not).
+        expect(filterRequest.filterModel).toEqual({
+            country: { filterType: 'text', type: 'equals', filter: 'USA' },
+        });
 
-        // Only USA remains; pivot result columns still present.
+        // Pivot result columns still present. Note: this shared Olympic fake server does NOT honour
+        // filterModel (its getData never reads request.filterModel), so the displayed rows are
+        // unchanged — both Russia and USA remain. The test pins that behaviour and instead asserts,
+        // above, that the filter is SENT on the request; it does not assert server-side filtering.
         expect(pivotCols(api)).toEqual(['2000_gold', '2004_gold']);
         await new GridRows(api, '4. filter in pivot mode').check(`
             ROOT id:<no-id>

--- a/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-operations.test.ts
+++ b/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-operations.test.ts
@@ -96,7 +96,7 @@ describe('ag-grid SSRM treeData operations (characterization)', () => {
         // Expand the deep path 101 -> 102 to create a nested child block, then collapse 102.
         await expandById(api, '101');
         await expandById(api, '102');
-        const node102 = api.getRowNode('102');
+        const node102 = api.getRowNode('102')!;
         node102.setExpanded(false);
         await asyncSetTimeout(1);
 

--- a/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-operations.test.ts
+++ b/testing/behavioural/src/tree-data/ssrm/ssrm-tree-data-operations.test.ts
@@ -1,0 +1,342 @@
+import type { GridOptions, IServerSideGetRowsParams, LoadSuccessParams } from 'ag-grid-community';
+import { ScrollApiModule } from 'ag-grid-community';
+import { ServerSideRowModelApiModule, ServerSideRowModelModule, TreeDataModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager } from '../../test-utils';
+import { asyncSetTimeout } from '../../test-utils/node-utils';
+import { waitForNoLoadingRows } from '../../test-utils/ssrm-test-utils';
+import type { EmployeeRow } from './ssrmSmallTreeDataSet';
+import { createFakeServer, getSmallTreeDataSet } from './ssrmSmallTreeDataSet';
+
+/**
+ * Characterization tests pinning current SSRM tree-data operation behaviour.
+ *
+ * These are golden-master tests: they capture whatever the grid does today
+ * (bugs included) so that future changes surface as diffs. Each case asserts
+ * something tree-data-specific — behaviour tied to the `isServerSideGroup` /
+ * `getServerSideGroupKey` routes, nested tree paths, or node identity across
+ * refresh — rather than re-testing the flat/grouped equivalents already
+ * characterized in sibling suites.
+ */
+
+interface RecordedRequest {
+    groupKeys: string[];
+    range: [number | undefined, number | undefined];
+}
+
+// Base tree-data grid options; datasource is supplied per test so each test can
+// record its own request stream inline.
+function createTreeGridOptions(extra: Partial<GridOptions> = {}): GridOptions {
+    return {
+        columnDefs: [
+            { field: 'employeeId', hide: true },
+            { field: 'employeeName', hide: true },
+            { field: 'jobTitle' },
+            { field: 'employmentType' },
+        ],
+        autoGroupColumnDef: { field: 'employeeName' },
+        defaultColDef: { flex: 1 },
+        treeData: true,
+        rowModelType: 'serverSide',
+        animateRows: false,
+        getRowId: ({ data }) => data.employeeId,
+        isServerSideGroup: (dataItem: any) => dataItem.group,
+        getServerSideGroupKey: (dataItem: any) => dataItem.employeeId,
+        ...extra,
+    };
+}
+
+// Expands a displayed group row (by employeeId key) and waits for its children.
+async function expandById(api: any, id: string): Promise<void> {
+    const node = api.getRowNode(id);
+    node.setExpanded(true);
+    await waitForNoLoadingRows(api);
+}
+
+describe('ag-grid SSRM treeData operations (characterization)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ServerSideRowModelModule, TreeDataModule, ScrollApiModule],
+    });
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    test('block eviction (maxBlocksInCache=1) does not evict a collapsed tree child block; re-expansion serves from cache with no re-fetch', async () => {
+        const requests: RecordedRequest[] = [];
+        const fakeServer = createFakeServer(getSmallTreeDataSet());
+
+        const api = gridsManager.createGrid(
+            'ssrmTreeEviction',
+            createTreeGridOptions({
+                // One block per store; only a single block may live in the cache at once,
+                // so expanding a second (non-displayed) route forces the first to be evicted.
+                cacheBlockSize: 100,
+                maxBlocksInCache: 1,
+                serverSideDatasource: {
+                    getRows: (params: IServerSideGetRowsParams) => {
+                        requests.push({
+                            groupKeys: [...(params.request.groupKeys ?? [])],
+                            range: [params.request.startRow, params.request.endRow],
+                        });
+                        const rows = fakeServer.getData(params.request);
+                        setTimeout(() => params.success({ rowData: rows, rowCount: rows.length }), 1);
+                    },
+                },
+            })
+        );
+
+        await asyncSetTimeout(1);
+        await waitForNoLoadingRows(api);
+
+        // Expand the deep path 101 -> 102 to create a nested child block, then collapse 102.
+        await expandById(api, '101');
+        await expandById(api, '102');
+        const node102 = api.getRowNode('102');
+        node102.setExpanded(false);
+        await asyncSetTimeout(1);
+
+        const requestsBeforeReExpand = requests.length;
+
+        // Re-expand 102.
+        node102.setExpanded(true);
+        await waitForNoLoadingRows(api);
+
+        const reFetched = requests.slice(requestsBeforeReExpand);
+        // Tree-specific finding: even with maxBlocksInCache=1, collapsing then re-expanding a
+        // nested tree node does NOT re-fetch — the child block survives in cache. Block
+        // eviction does not reclaim a collapsed group's child store here.
+        expect(reFetched.map((r) => r.groupKeys)).toEqual([]);
+
+        const gridRows = new GridRows(api, 'tree eviction re-expand 102');
+        await gridRows.check(`
+            ROOT id:<no-id>
+            └─┬ 101 GROUP id:101 ag-Grid-AutoColumn:"Erica Rogers" employeeId:"101" employeeName:"Erica Rogers" jobTitle:"CEO" employmentType:"Permanent"
+            · ├─┬ 102 GROUP id:102 ag-Grid-AutoColumn:"Malcolm Barrett" employeeId:"102" employeeName:"Malcolm Barrett" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+            · │ ├── 103 GROUP collapsed id:103 ag-Grid-AutoColumn:"Esther Baker" employeeId:"103" employeeName:"Esther Baker" jobTitle:"Director of Operations" employmentType:"Permanent"
+            · │ └── 108 GROUP collapsed id:108 ag-Grid-AutoColumn:"Francis Strickland" employeeId:"108" employeeName:"Francis Strickland" jobTitle:"VP Sales" employmentType:"Permanent"
+            · └── 113 GROUP collapsed id:113 ag-Grid-AutoColumn:"Luke McBride" employeeId:"113" employeeName:"Luke McBride" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+        `);
+    });
+
+    test('serverSideEnableClientSideSort sorts an expanded tree level without re-requesting the route', async () => {
+        const requests: RecordedRequest[] = [];
+        const fakeServer = createFakeServer(getSmallTreeDataSet());
+
+        const api = gridsManager.createGrid(
+            'ssrmTreeClientSort',
+            createTreeGridOptions({
+                serverSideEnableClientSideSort: true,
+                serverSideDatasource: {
+                    getRows: (params: IServerSideGetRowsParams) => {
+                        requests.push({
+                            groupKeys: [...(params.request.groupKeys ?? [])],
+                            range: [params.request.startRow, params.request.endRow],
+                        });
+                        const rows = fakeServer.getData(params.request);
+                        setTimeout(() => params.success({ rowData: rows, rowCount: rows.length }), 1);
+                    },
+                },
+            })
+        );
+
+        await asyncSetTimeout(1);
+        await waitForNoLoadingRows(api);
+
+        // Expand 101 -> 102 -> 108 to get a leaf-ish level (sales execs) with distinct jobTitles.
+        await expandById(api, '101');
+        await expandById(api, '102');
+        await expandById(api, '108');
+
+        const loadsBeforeSort = requests.length;
+
+        // Sort by jobTitle ascending — with client-side sort enabled the already-loaded
+        // tree levels should reorder without any new server request.
+        api.applyColumnState({ state: [{ colId: 'jobTitle', sort: 'asc' }] });
+        await waitForNoLoadingRows(api);
+
+        // Tree-specific: no re-request fired for the sort (contrast with the default
+        // server-delegated sort pinned in the tree-data-loading suite).
+        expect(requests.length).toBe(loadsBeforeSort);
+
+        const gridRows = new GridRows(api, 'tree client-side sort by jobTitle asc');
+        await gridRows.check(`
+            ROOT id:<no-id>
+            └─┬ 101 GROUP id:101 ag-Grid-AutoColumn:"Erica Rogers" employeeId:"101" employeeName:"Erica Rogers" jobTitle:"CEO" employmentType:"Permanent"
+            · ├─┬ 102 GROUP id:102 ag-Grid-AutoColumn:"Malcolm Barrett" employeeId:"102" employeeName:"Malcolm Barrett" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+            · │ ├── 103 GROUP collapsed id:103 ag-Grid-AutoColumn:"Esther Baker" employeeId:"103" employeeName:"Esther Baker" jobTitle:"Director of Operations" employmentType:"Permanent"
+            · │ └─┬ 108 GROUP id:108 ag-Grid-AutoColumn:"Francis Strickland" employeeId:"108" employeeName:"Francis Strickland" jobTitle:"VP Sales" employmentType:"Permanent"
+            · │ · ├── LEAF id:110 ag-Grid-AutoColumn:"Todd Tyler" employeeId:"110" employeeName:"Todd Tyler" jobTitle:"Sales Executive" employmentType:"Contract"
+            · │ · ├── LEAF id:111 ag-Grid-AutoColumn:"Bennie Wise" employeeId:"111" employeeName:"Bennie Wise" jobTitle:"Sales Executive" employmentType:"Contract"
+            · │ · ├── LEAF id:112 ag-Grid-AutoColumn:"Joel Cooper" employeeId:"112" employeeName:"Joel Cooper" jobTitle:"Sales Executive" employmentType:"Permanent"
+            · │ · └── LEAF id:109 ag-Grid-AutoColumn:"Morris Hanson" employeeId:"109" employeeName:"Morris Hanson" jobTitle:"Sales Manager" employmentType:"Permanent"
+            · └── 113 GROUP collapsed id:113 ag-Grid-AutoColumn:"Luke McBride" employeeId:"113" employeeName:"Luke McBride" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+        `);
+    });
+
+    test('refreshServerSide purge at root re-fetches every previously-expanded route and preserves the expanded tree', async () => {
+        const requests: RecordedRequest[] = [];
+        const fakeServer = createFakeServer(getSmallTreeDataSet());
+
+        const api = gridsManager.createGrid(
+            'ssrmTreeRefreshRoot',
+            createTreeGridOptions({
+                serverSideDatasource: {
+                    getRows: (params: IServerSideGetRowsParams) => {
+                        requests.push({
+                            groupKeys: [...(params.request.groupKeys ?? [])],
+                            range: [params.request.startRow, params.request.endRow],
+                        });
+                        const rows = fakeServer.getData(params.request);
+                        setTimeout(() => params.success({ rowData: rows, rowCount: rows.length }), 1);
+                    },
+                },
+            })
+        );
+
+        await asyncSetTimeout(1);
+        await waitForNoLoadingRows(api);
+        await expandById(api, '101');
+        await expandById(api, '102');
+
+        const requestsBeforeRefresh = requests.length;
+
+        // Purge refresh at root — destroys and rebuilds the whole tree from the top.
+        api.refreshServerSide({ purge: true });
+        await waitForNoLoadingRows(api);
+
+        const refreshFetches = requests.slice(requestsBeforeRefresh).map((r) => r.groupKeys);
+        // Tree-specific: a root purge rebuilds the whole tree but re-fetches every route that
+        // was expanded before the purge — root, then each ancestor path down the open branch.
+        expect(refreshFetches).toEqual([[], ['101'], ['101', '102']]);
+
+        // Node identity survives (getRowId keyed on employeeId) and the expanded branch is
+        // restored — pin the post-refresh display state.
+        const gridRows = new GridRows(api, 'tree root purge refresh');
+        await gridRows.check(`
+            ROOT id:<no-id>
+            └─┬ 101 GROUP id:101 ag-Grid-AutoColumn:"Erica Rogers" employeeId:"101" employeeName:"Erica Rogers" jobTitle:"CEO" employmentType:"Permanent"
+            · ├─┬ 102 GROUP id:102 ag-Grid-AutoColumn:"Malcolm Barrett" employeeId:"102" employeeName:"Malcolm Barrett" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+            · │ ├── 103 GROUP collapsed id:103 ag-Grid-AutoColumn:"Esther Baker" employeeId:"103" employeeName:"Esther Baker" jobTitle:"Director of Operations" employmentType:"Permanent"
+            · │ └── 108 GROUP collapsed id:108 ag-Grid-AutoColumn:"Francis Strickland" employeeId:"108" employeeName:"Francis Strickland" jobTitle:"VP Sales" employmentType:"Permanent"
+            · └── 113 GROUP collapsed id:113 ag-Grid-AutoColumn:"Luke McBride" employeeId:"113" employeeName:"Luke McBride" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+        `);
+    });
+
+    test('refreshServerSide purge routed at a tree node re-fetches only that node route and preserves ancestor expansion', async () => {
+        const requests: RecordedRequest[] = [];
+        const fakeServer = createFakeServer(getSmallTreeDataSet());
+
+        const api = gridsManager.createGrid(
+            'ssrmTreeRefreshRoute',
+            createTreeGridOptions({
+                serverSideDatasource: {
+                    getRows: (params: IServerSideGetRowsParams) => {
+                        requests.push({
+                            groupKeys: [...(params.request.groupKeys ?? [])],
+                            range: [params.request.startRow, params.request.endRow],
+                        });
+                        const rows = fakeServer.getData(params.request);
+                        setTimeout(() => params.success({ rowData: rows, rowCount: rows.length }), 1);
+                    },
+                },
+            })
+        );
+
+        await asyncSetTimeout(1);
+        await waitForNoLoadingRows(api);
+        await expandById(api, '101');
+        await expandById(api, '102');
+
+        const requestsBeforeRefresh = requests.length;
+
+        // Purge only the child route [101, 102] — destroys just that node's child cache.
+        api.refreshServerSide({ route: ['101', '102'], purge: true });
+        await waitForNoLoadingRows(api);
+
+        const refreshFetches = requests.slice(requestsBeforeRefresh).map((r) => r.groupKeys);
+        // Tree-specific: only the routed node's children re-fetch; ancestors are untouched.
+        expect(refreshFetches).toEqual([['101', '102']]);
+
+        // Ancestor 101 and node 102 stay expanded through a routed purge.
+        const gridRows = new GridRows(api, 'tree routed purge refresh');
+        await gridRows.check(`
+            ROOT id:<no-id>
+            └─┬ 101 GROUP id:101 ag-Grid-AutoColumn:"Erica Rogers" employeeId:"101" employeeName:"Erica Rogers" jobTitle:"CEO" employmentType:"Permanent"
+            · ├─┬ 102 GROUP id:102 ag-Grid-AutoColumn:"Malcolm Barrett" employeeId:"102" employeeName:"Malcolm Barrett" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+            · │ ├── 103 GROUP collapsed id:103 ag-Grid-AutoColumn:"Esther Baker" employeeId:"103" employeeName:"Esther Baker" jobTitle:"Director of Operations" employmentType:"Permanent"
+            · │ └── 108 GROUP collapsed id:108 ag-Grid-AutoColumn:"Francis Strickland" employeeId:"108" employeeName:"Francis Strickland" jobTitle:"VP Sales" employmentType:"Permanent"
+            · └── 113 GROUP collapsed id:113 ag-Grid-AutoColumn:"Luke McBride" employeeId:"113" employeeName:"Luke McBride" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+        `);
+    });
+
+    test('applyServerSideRowData on a tree node route replaces only that node children and fires no server request', async () => {
+        const requests: RecordedRequest[] = [];
+        const fakeServer = createFakeServer(getSmallTreeDataSet());
+
+        const api = gridsManager.createGrid(
+            'ssrmTreeApplyRowData',
+            createTreeGridOptions({
+                serverSideDatasource: {
+                    getRows: (params: IServerSideGetRowsParams) => {
+                        requests.push({
+                            groupKeys: [...(params.request.groupKeys ?? [])],
+                            range: [params.request.startRow, params.request.endRow],
+                        });
+                        const rows = fakeServer.getData(params.request);
+                        setTimeout(() => params.success({ rowData: rows, rowCount: rows.length }), 1);
+                    },
+                },
+            })
+        );
+
+        await asyncSetTimeout(1);
+        await waitForNoLoadingRows(api);
+        await expandById(api, '101');
+        await expandById(api, '102');
+
+        const requestsBeforeApply = requests.length;
+
+        // Bulk-set node 102's children to a brand-new set via applyServerSideRowData on the
+        // [101, 102] route. Node 200 is a leaf, 201 is a group.
+        const successParams: LoadSuccessParams<EmployeeRow> = {
+            rowData: [
+                {
+                    employeeId: '200',
+                    employeeName: 'New Leaf',
+                    jobTitle: 'Analyst',
+                    employmentType: 'Permanent',
+                    group: false,
+                },
+                {
+                    employeeId: '201',
+                    employeeName: 'New Group',
+                    jobTitle: 'Manager',
+                    employmentType: 'Permanent',
+                    group: true,
+                },
+            ],
+            rowCount: 2,
+        };
+        api.applyServerSideRowData({ route: ['101', '102'], successParams });
+        await asyncSetTimeout(1);
+
+        // Tree-specific: no server fetch fired — the children were set directly on the route.
+        expect(requests.length).toBe(requestsBeforeApply);
+
+        // Only node 102's children were replaced; 101 and the rest of the tree are untouched.
+        const gridRows = new GridRows(api, 'tree applyServerSideRowData on route');
+        await gridRows.check(`
+            ROOT id:<no-id>
+            └─┬ 101 GROUP id:101 ag-Grid-AutoColumn:"Erica Rogers" employeeId:"101" employeeName:"Erica Rogers" jobTitle:"CEO" employmentType:"Permanent"
+            · ├─┬ 102 GROUP id:102 ag-Grid-AutoColumn:"Malcolm Barrett" employeeId:"102" employeeName:"Malcolm Barrett" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+            · │ ├── LEAF id:200 ag-Grid-AutoColumn:"New Leaf" employeeId:"200" employeeName:"New Leaf" jobTitle:"Analyst" employmentType:"Permanent"
+            · │ └── 201 GROUP collapsed id:201 ag-Grid-AutoColumn:"New Group" employeeId:"201" employeeName:"New Group" jobTitle:"Manager" employmentType:"Permanent"
+            · └── 113 GROUP collapsed id:113 ag-Grid-AutoColumn:"Luke McBride" employeeId:"113" employeeName:"Luke McBride" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+        `);
+    });
+});


### PR DESCRIPTION
## What

Third PR of the SSRM characterization sweep (follow-up to #14355 and #14356). Fills the remaining matrix cells — pivot-mode and tree-data variants of load / eviction / sort / filter / refresh operations.

📊 **Coverage matrix (colour-coded by PR):** https://claude.ai/code/artifact/7515d2e1-da99-4677-9718-cdb752572d14

**2 files, 11 tests, all green.**

| Area | File |
|---|---|
| Pivot: load, evict, client-sort, filter, refresh, failure | `grouping-data/ssrm/ssrm-pivot-operations` |
| Tree: evict, client-sort, refresh, applyServerSideRowData | `tree-data/ssrm/ssrm-tree-data-operations` |

Every test asserts a genuinely **pivot- or tree-specific** aspect (pivot flags preserved across the operation; nested-route identity/eviction) — not shape-agnostic clones of the flat/grouped tests already landed. Where an operation behaves identically to the baseline, that's pinned explicitly as the finding.

## Latent behaviours frozen as baseline

- **Tree eviction doesn't reclaim a collapsed group's child store:** with `maxBlocksInCache:1`, expand→collapse→re-expand of a nested node fires **zero** re-fetches — the cap is effectively not honoured across tree routes.
- **Failed pivot load leaves a stub row *and* generates no pivot columns** (`countLoadingRows===1`, `pivotCols` empty); a subsequent purge refresh recovers cleanly.
- **Client-side sort works over pivoted aggregate values** — sorting a generated pivot value column reorders client-side with no server request.
- Root purge in tree data re-fetches **every previously-expanded route** and restores the full expanded branch (node identity preserved via `getRowId`).

## The sweep, complete

Three PRs, 15 files, 68 tests: #14355 (10 files/45), #14356 (3 files/12), this (2 files/11). The remaining matrix cells left uncovered are shape-agnostic duplicates of already-pinned mechanics. One likely real bug surfaced along the way — pivot grand-total footer model/DOM divergence — filed as [AG-17799](https://ag-grid.atlassian.net/browse/AG-17799).