### PR TITLE
AG-17778 - fix no grid data showing in print layout

### DIFF
--- a/packages/ag-grid-community/src/gridBodyComp/gridBodyCtrl.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/gridBodyCtrl.ts
@@ -313,7 +313,6 @@ export class GridBodyCtrl extends BeanStub {
         } = this;
         classList.toggle('ag-body-vertical-content-no-gap', !scrollVisibleSvc.verticalScrollGap);
         classList.toggle('ag-body-horizontal-content-no-gap', !scrollVisibleSvc.horizontalScrollGap);
-        classList.toggle('ag-body-horizontal-scroll', scrollVisibleSvc.horizontalScrollShowing);
         classList.toggle('ag-has-left-pinned-cols', visibleCols.getLeftStickyColumnContainerWidth() > 0);
         classList.toggle('ag-has-right-pinned-cols', visibleCols.getRightStickyColumnContainerWidth() > 0);
     }


### PR DESCRIPTION
Fix [AG-17778](https://ag-grid.atlassian.net/browse/AG-17778)

Fix for a regression in 36.0, the class `ag-body-horizontal-scroll` was applied to `ag-root` as a state class, present when the scrollbar was showing. This is not a state class, it's a component class applied to the horizontal scrollbars.

Print layout hides these elements (`.ag-layout-print .ag-body-horizontal-scroll { display: none }`) leading to the grid body being hidden in print layout.