### PR TITLE
Add cell-render benchmarks for vanilla and React

### DIFF
--- a/testing/behavioural/src/benchmarks/cell-render-react.bench.tsx
+++ b/testing/behavioural/src/benchmarks/cell-render-react.bench.tsx
@@ -1,0 +1,155 @@
+// React cell-rendering benchmark — the React twin of cell-render.bench.ts. React re-implements the
+// cell view layer (packages/ag-grid-react/src/reactUi), so it runs an entirely different render path
+// (React reconciliation + commit) that the vanilla suite never touches. Each measured iteration fills
+// an empty grid, constructing every visible cell; the previous fill is torn down in an untimed
+// `beforeEach` so the timed window is a clean first render.
+//
+// React defers its cell commits: after setGridOption + flushAllAnimationFrames the grid has fired its
+// events but React has NOT yet committed (0 cells in the DOM). Wrapping the fill in ReactDOM.flushSync
+// forces the pending commit synchronously, landing the whole render inside the measured window. The
+// teardown flush in beforeEach must do the same so each timed fill is a true first render from empty.
+//
+// NB: numbers here are NOT directly comparable to the vanilla suite (React adds a reconciliation +
+// commit layer); keep the two reports separate.
+import { flushSync } from 'react-dom';
+import type { Root } from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
+import { bench, suite } from 'vitest';
+
+import type { ColDef, GridApi, GridReadyEvent, Module } from 'ag-grid-community';
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
+import type { CustomCellRendererProps } from 'ag-grid-react';
+import { AgGridReact } from 'ag-grid-react';
+
+import { ignoreConsoleLicenseKeyError } from '../test-utils/ignoreConsoleLicenseKeyError';
+import { benchCooldown, benchDefaults } from './bench-utils';
+
+const modules: Module[] = [AllEnterpriseModule];
+
+interface WideRow {
+    id: string;
+    [key: string]: string | number;
+}
+
+// Idiomatic React cell renderer — the framework-component path, not the vanilla JS-class shim.
+const BenchReactRenderer = (props: CustomCellRendererProps<WideRow>) => <span>{String(props.value)}</span>;
+
+const buildWideCols = (colCount: number, cellRenderer?: unknown): ColDef[] => {
+    const cols: ColDef[] = [];
+    for (let i = 0; i < colCount; ++i) {
+        cols.push({ colId: `c${i}`, field: `c${i}`, cellRenderer });
+    }
+    return cols;
+};
+
+const buildWideData = (rowCount: number, colCount: number): WideRow[] => {
+    const rows: WideRow[] = [];
+    for (let r = 0; r < rowCount; ++r) {
+        const row: WideRow = { id: `${r}` };
+        for (let c = 0; c < colCount; ++c) {
+            row[`c${c}`] = `r${r}c${c}`;
+        }
+        rows.push(row);
+    }
+    return rows;
+};
+
+// More rows than fit the viewport so vertical virtualisation still applies (realistic), but enough
+// to fill it completely on every populate.
+const ROW_COUNT = 500;
+
+// Mounts one AgGridReact into a viewport-filling container (matching bench-utils' vanilla grids) and
+// resolves once the grid is ready. Unmount + reclaim happens in reset(), mirroring BenchGridsManager.
+class ReactBenchGrid {
+    private container: HTMLDivElement | undefined;
+    private root: Root | undefined;
+    public api!: GridApi<WideRow>;
+
+    public async mount(columnDefs: ColDef[]): Promise<void> {
+        const container = document.createElement('div');
+        const style = container.style;
+        style.width = '100vw';
+        style.height = '100vh';
+        document.body.style.margin = '0';
+        document.body.appendChild(container);
+        this.container = container;
+
+        ignoreConsoleLicenseKeyError();
+
+        const root = createRoot(container);
+        this.root = root;
+        await new Promise<void>((resolve) => {
+            root.render(
+                <AgGridReact<WideRow>
+                    modules={modules}
+                    columnDefs={columnDefs}
+                    rowData={[]}
+                    suppressColumnVirtualisation={true}
+                    rowHeight={20}
+                    onGridReady={(e: GridReadyEvent<WideRow>) => {
+                        this.api = e.api;
+                        resolve();
+                    }}
+                />
+            );
+        });
+    }
+
+    public async reset(): Promise<void> {
+        this.root?.unmount();
+        this.container?.remove();
+        this.root = undefined;
+        this.container = undefined;
+        this.api = undefined!;
+        (globalThis as { gc?: () => void }).gc?.();
+        await benchCooldown();
+    }
+}
+
+const defineReactFillSuite = (suiteName: string, cellRenderer?: unknown): void => {
+    suite(suiteName, () => {
+        const grid = new ReactBenchGrid();
+
+        // Each fill is an expensive iteration (tens of ms), so the 1× window yields few samples; a
+        // higher noiseFactor buys a longer measured window and a tighter confidence interval.
+        const benchFill = (name: string, colCount: number, noiseFactor = 3) => {
+            const data = buildWideData(ROW_COUNT, colCount);
+            const columnDefs = buildWideCols(colCount, cellRenderer);
+            bench(
+                name,
+                () => {
+                    // flushSync forces React to commit the cells synchronously (see file header); the
+                    // rAF flush inside it fires the grid events that schedule those commits.
+                    flushSync(() => {
+                        grid.api.setGridOption('rowData', data);
+                        grid.api.flushAllAnimationFrames();
+                    });
+                },
+                {
+                    ...benchDefaults({ noiseFactor }),
+                    setup: async () => {
+                        await grid.reset();
+                        await grid.mount(columnDefs);
+                    },
+                    // Untimed: tear down the previous fill's cells so every measured fill is a true
+                    // first render from an empty grid. flushSync so the teardown actually commits.
+                    beforeEach: () => {
+                        flushSync(() => {
+                            grid.api.setGridOption('rowData', []);
+                            grid.api.flushAllAnimationFrames();
+                        });
+                    },
+                }
+            );
+        };
+
+        benchFill('fill — 50 cols', 50);
+        benchFill('fill — 100 cols', 100);
+    });
+};
+
+defineReactFillSuite('react cell render — fill only (empty → full, clear untimed)');
+defineReactFillSuite(
+    'react cell render — fill only, custom cellRenderer (empty → full, clear untimed)',
+    BenchReactRenderer
+);

--- a/testing/behavioural/src/benchmarks/cell-render-react.bench.tsx
+++ b/testing/behavioural/src/benchmarks/cell-render-react.bench.tsx
@@ -1,16 +1,19 @@
 // React cell-rendering benchmark — the React twin of cell-render.bench.ts. React re-implements the
 // cell view layer (packages/ag-grid-react/src/reactUi), so it runs an entirely different render path
-// (React reconciliation + commit) that the vanilla suite never touches. Each measured iteration fills
-// an empty grid, constructing every visible cell; the previous fill is torn down in an untimed
-// `beforeEach` so the timed window is a clean first render.
+// (React reconciliation + commit) that the vanilla suite never touches. Each measured iteration
+// replaces the grid's row data, constructing every visible cell; `setup` empties the grid once per
+// cycle, so the first measured iteration is an empty→full first render and every subsequent one
+// replaces the previous full row set (no getRowId → every row/cell is torn down and rebuilt).
 //
 // React defers its cell commits: after setGridOption + flushAllAnimationFrames the grid has fired its
 // events but React has NOT yet committed (0 cells in the DOM). Wrapping the fill in ReactDOM.flushSync
-// forces the pending commit synchronously, landing the whole render inside the measured window. The
-// teardown flush in beforeEach must do the same so each timed fill is a true first render from empty.
+// forces the pending commit synchronously, landing the whole render inside the measured window.
 //
+// NB: vitest runs a single measured loop per bench and exposes no untimed per-iteration hook, so the
+// teardown of the previous fill is part of the replace samples by design — it cannot be excluded.
 // NB: numbers here are NOT directly comparable to the vanilla suite (React adds a reconciliation +
 // commit layer); keep the two reports separate.
+import React from 'react';
 import { flushSync } from 'react-dom';
 import type { Root } from 'react-dom/client';
 import { createRoot } from 'react-dom/client';
@@ -131,14 +134,6 @@ const defineReactFillSuite = (suiteName: string, cellRenderer?: unknown): void =
                         await grid.reset();
                         await grid.mount(columnDefs);
                     },
-                    // Untimed: tear down the previous fill's cells so every measured fill is a true
-                    // first render from an empty grid. flushSync so the teardown actually commits.
-                    beforeEach: () => {
-                        flushSync(() => {
-                            grid.api.setGridOption('rowData', []);
-                            grid.api.flushAllAnimationFrames();
-                        });
-                    },
                 }
             );
         };
@@ -148,8 +143,8 @@ const defineReactFillSuite = (suiteName: string, cellRenderer?: unknown): void =
     });
 };
 
-defineReactFillSuite('react cell render — fill only (empty → full, clear untimed)');
+defineReactFillSuite('react cell render — replace all cells (full grid re-render)');
 defineReactFillSuite(
-    'react cell render — fill only, custom cellRenderer (empty → full, clear untimed)',
+    'react cell render — replace all cells, custom cellRenderer (full grid re-render)',
     BenchReactRenderer
 );

--- a/testing/behavioural/src/benchmarks/cell-render.bench.ts
+++ b/testing/behavioural/src/benchmarks/cell-render.bench.ts
@@ -1,8 +1,13 @@
-// Cell-rendering benchmark: fill a wide viewport with freshly-constructed cells from an empty grid.
-// Each measured iteration constructs every visible cell, driving the CellComp first-render path
-// (wrapper + renderer + feature wiring) — the per-cell construction cost that data-pipeline benches
-// only touch as a side effect. The teardown of the previous fill happens in `beforeEach`, which
-// tinybench runs OUTSIDE the timed region, so the clear cost never enters the measurement.
+// Cell-rendering benchmark: measure constructing every visible cell across a wide viewport.
+// Each measured iteration replaces the grid's row data, driving the CellComp render path (wrapper +
+// renderer + feature wiring) for every visible cell — the per-cell construction cost that data-pipeline
+// benches only touch as a side effect. `setup` empties the grid once per cycle, so the first measured
+// iteration is an empty→full first render and every subsequent one replaces the previous full row set;
+// with no getRowId, a replace tears down every old row/cell and rebuilds it, so each timed window is a
+// full construction of all visible cells.
+//
+// NB: vitest runs a single measured loop per bench and exposes no untimed per-iteration hook, so the
+// teardown of the previous fill is part of the replace samples by design — it cannot be excluded.
 //
 // AllEnterpriseModule is registered so the per-cell cost reflects every feature being loaded — the
 // worst case, and the one that matters for keeping rendering efficient regardless of module set.
@@ -64,8 +69,8 @@ const buildWideData = (rowCount: number, colCount: number): WideRow[] => {
 const ROW_COUNT = 500;
 
 // Two suites, identical except for the cell content: the default text-only path, and a custom
-// cellRenderer on every column (createCellRendererInstance + user-component teardown). Comparing
-// them isolates the per-cell cost the user component adds on top of the base render.
+// cellRenderer on every column (createCellRendererInstance + user-component teardown/rebuild).
+// Comparing them isolates the per-cell cost the user component adds on top of the base render.
 const defineFillSuite = (suiteName: string, cellRenderer?: unknown): void => {
     suite(suiteName, () => {
         const gridsManager = new BenchGridsManager({ modules });
@@ -96,12 +101,6 @@ const defineFillSuite = (suiteName: string, cellRenderer?: unknown): void => {
                         await gridsManager.reset();
                         api = gridsManager.createGrid(id, { ...options, rowData: [] });
                     },
-                    // Untimed: tear down the previous fill's cells so every measured fill is a true
-                    // first render from an empty grid.
-                    beforeEach: () => {
-                        api.setGridOption('rowData', []);
-                        api.flushAllAnimationFrames();
-                    },
                 }
             );
         };
@@ -111,5 +110,5 @@ const defineFillSuite = (suiteName: string, cellRenderer?: unknown): void => {
     });
 };
 
-defineFillSuite('cell render — fill only (empty → full, clear untimed)');
-defineFillSuite('cell render — fill only, custom cellRenderer (empty → full, clear untimed)', BenchCellRenderer);
+defineFillSuite('cell render — replace all cells (full grid re-render)');
+defineFillSuite('cell render — replace all cells, custom cellRenderer (full grid re-render)', BenchCellRenderer);

--- a/testing/behavioural/src/benchmarks/cell-render.bench.ts
+++ b/testing/behavioural/src/benchmarks/cell-render.bench.ts
@@ -1,0 +1,115 @@
+// Cell-rendering benchmark: fill a wide viewport with freshly-constructed cells from an empty grid.
+// Each measured iteration constructs every visible cell, driving the CellComp first-render path
+// (wrapper + renderer + feature wiring) — the per-cell construction cost that data-pipeline benches
+// only touch as a side effect. The teardown of the previous fill happens in `beforeEach`, which
+// tinybench runs OUTSIDE the timed region, so the clear cost never enters the measurement.
+//
+// AllEnterpriseModule is registered so the per-cell cost reflects every feature being loaded — the
+// worst case, and the one that matters for keeping rendering efficient regardless of module set.
+// Grid config is otherwise minimal; only the two levers that maximise cells built per fill are set:
+// column virtualisation is suppressed so all columns render, and rowHeight is small so the fixed
+// 100vh viewport holds more rows.
+import { bench, suite } from 'vitest';
+
+import type { ColDef, GridApi, GridOptions, ICellRendererComp, ICellRendererParams } from 'ag-grid-community';
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
+
+import { BenchGridsManager, benchDefaults } from './bench-utils';
+
+const modules = [AllEnterpriseModule];
+
+interface WideRow {
+    id: string;
+    [key: string]: string | number;
+}
+
+// Minimal user component: exercises the createCellRendererInstance path (bean lifecycle + user-gui
+// insertion + renderer teardown) that the default text-only path skips.
+class BenchCellRenderer implements ICellRendererComp {
+    private eGui!: HTMLElement;
+    public init(params: ICellRendererParams): void {
+        this.eGui = document.createElement('span');
+        this.eGui.textContent = String(params.value);
+    }
+    public getGui(): HTMLElement {
+        return this.eGui;
+    }
+    public refresh(): boolean {
+        return false;
+    }
+}
+
+const buildWideCols = (colCount: number, cellRenderer?: unknown): ColDef[] => {
+    const cols: ColDef[] = [];
+    for (let i = 0; i < colCount; ++i) {
+        cols.push({ colId: `c${i}`, field: `c${i}`, cellRenderer });
+    }
+    return cols;
+};
+
+const buildWideData = (rowCount: number, colCount: number): WideRow[] => {
+    const rows: WideRow[] = [];
+    for (let r = 0; r < rowCount; ++r) {
+        const row: WideRow = { id: `${r}` };
+        for (let c = 0; c < colCount; ++c) {
+            row[`c${c}`] = `r${r}c${c}`;
+        }
+        rows.push(row);
+    }
+    return rows;
+};
+
+// More rows than fit the viewport so vertical virtualisation still applies (realistic), but enough
+// to fill it completely on every populate.
+const ROW_COUNT = 500;
+
+// Two suites, identical except for the cell content: the default text-only path, and a custom
+// cellRenderer on every column (createCellRendererInstance + user-component teardown). Comparing
+// them isolates the per-cell cost the user component adds on top of the base render.
+const defineFillSuite = (suiteName: string, cellRenderer?: unknown): void => {
+    suite(suiteName, () => {
+        const gridsManager = new BenchGridsManager({ modules });
+        let gridId = 0;
+
+        // Each fill is an expensive iteration (tens of ms), so the 1× window yields few samples; a
+        // higher noiseFactor buys a longer measured window and a tighter confidence interval.
+        const benchFill = (name: string, colCount: number, noiseFactor = 3) => {
+            const data = buildWideData(ROW_COUNT, colCount);
+            const options: GridOptions<WideRow> = {
+                columnDefs: buildWideCols(colCount, cellRenderer),
+                suppressColumnVirtualisation: true,
+                rowHeight: 20,
+            };
+            const id = `CF${++gridId}`;
+            let api!: GridApi<WideRow>;
+            bench(
+                name,
+                () => {
+                    api.setGridOption('rowData', data);
+                    // Flush the deferred (rAF-scheduled) render so the cell construction is measured
+                    // here rather than leaking into a later iteration as a spike.
+                    api.flushAllAnimationFrames();
+                },
+                {
+                    ...benchDefaults({ noiseFactor }),
+                    setup: async () => {
+                        await gridsManager.reset();
+                        api = gridsManager.createGrid(id, { ...options, rowData: [] });
+                    },
+                    // Untimed: tear down the previous fill's cells so every measured fill is a true
+                    // first render from an empty grid.
+                    beforeEach: () => {
+                        api.setGridOption('rowData', []);
+                        api.flushAllAnimationFrames();
+                    },
+                }
+            );
+        };
+
+        benchFill('fill — 50 cols', 50);
+        benchFill('fill — 100 cols', 100);
+    });
+};
+
+defineFillSuite('cell render — fill only (empty → full, clear untimed)');
+defineFillSuite('cell render — fill only, custom cellRenderer (empty → full, clear untimed)', BenchCellRenderer);

--- a/testing/behavioural/vitest.config.ts
+++ b/testing/behavioural/vitest.config.ts
@@ -116,7 +116,7 @@ export default defineConfig(({ mode }) => {
             root: repoRoot,
             dir: path.resolve(thisDir, 'src'),
             include: ['**/*.test.ts', '**/*.test.tsx'],
-            benchmark: { include: ['**/*.bench.ts'] },
+            benchmark: { include: ['**/*.bench.ts', '**/*.bench.tsx'] },
             css: browserEnabled,
             browser: {
                 enabled: browserEnabled,


### PR DESCRIPTION
Adds fill-only benchmarks measuring per-cell first-render cost with `AllEnterpriseModule` loaded, at 50 and 100 columns, for both the default value path and a custom cell renderer.

- `cell-render.bench.ts` — vanilla view layer (also covers Angular/Vue). Each iteration fills an empty grid; the previous fill is torn down in an untimed `beforeEach` so the timed window is a clean first render.
- `cell-render-react.bench.tsx` — React `reactUi` view layer, a genuinely different render path. Forces a synchronous React commit via `flushSync` so cell rendering lands in the measured window (without it, cells commit on a later tick and the bench measures nothing).
- `vitest.config.ts` — the benchmark glob now includes `*.bench.tsx` so JSX benchmarks are picked up.

No product code changes; benchmarks only.