### PR TITLE
Test(cell-editing): fix flaky sequential group-edit test

### DIFF
--- a/testing/behavioural/src/cell-editing/group-edit/group-edit-test-utils.ts
+++ b/testing/behavioural/src/cell-editing/group-edit/group-edit-test-utils.ts
@@ -55,7 +55,11 @@ export async function editCell(api: GridApi, rowNode: IRowNode, colId: string, n
 
     // Re-query the cell after startEditingCell — in jsdom, `ensureIndexVisible` can
     // trigger a row redraw that replaces cell DOM elements, making the original reference stale.
-    const input = await waitForInput(gridDiv, gridDiv);
+    // Scope the input lookup to this cell rather than the whole grid: when edits happen in
+    // sequence a previous editor's input can briefly linger in the DOM, and a grid-wide lookup
+    // would grab that stale input instead of the one just opened, silently dropping the edit.
+    const { cell } = locateCellElements(api, rowNode, colId);
+    const input = await waitForInput(gridDiv, cell);
     await userEvent.clear(input);
     await userEvent.type(input, `${newValue}{Enter}`);
     await asyncSetTimeout(0);


### PR DESCRIPTION
## What

The post-merge `latest` CI run [28932964256](https://github.com/ag-grid/ag-grid/actions/runs/28932964256) failed on `distribute-default.test.ts > editing different groups in sequence`, while the originating PR passed — a flaky test.

## Root cause

`editCell` (in `group-edit-test-utils.ts`) opened an editor with `startEditingCell` and then located the editor input with `waitForInput(gridDiv, gridDiv)`, searching the **entire grid** and returning the first `input`/`select`/`textarea` found.

When two edits run back-to-back (edit France, then USA), the previous editor's input can still linger in the DOM for a tick. The grid-wide lookup then grabs that stale input, so `clear`+`type("200{Enter}")` targets a detached editor and the USA edit is silently dropped. The failure matches exactly: the USA subtree was completely unchanged (Americas stayed `160` instead of `260`). It only surfaces under jsdom timing jitter, which is why it passed on the PR and flaked post-merge.

## Fix

Scope the input lookup to the actual editing cell (re-queried after `startEditingCell`) rather than the whole grid, so only the freshly-opened editor is matched.

## Verification

Change is test-infrastructure only. I have not run the suite locally (dev/verification commands are handled separately) — CI will exercise it.