### PR TITLE
test(ssrm): characterization coverage for partial-coverage matrix cells

### DIFF
--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-grouped-initial-row-count.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-grouped-initial-row-count.test.ts
@@ -1,0 +1,244 @@
+import type { IServerSideGetRowsParams } from 'ag-grid-community';
+import { ScrollApiModule } from 'ag-grid-community';
+import { ServerSideRowModelApiModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, waitForEvent } from '../../test-utils';
+import { asyncSetTimeout } from '../../test-utils/node-utils';
+import { countLoadingRows, waitForNoLoadingRows } from '../../test-utils/ssrm-test-utils';
+
+/**
+ * CHARACTERIZATION (golden-master) tests pinning the CURRENT behaviour of how
+ * `serverSideInitialRowCount` shapes the INITIAL LOAD DISPLAY of a GROUPED SSRM
+ * grid (one rowGroup column, groups collapsed).
+ *
+ * The flat-data angle on `serverSideInitialRowCount` is already covered by
+ * `row-data/ssrm-cache-config.test.ts`; this file characterizes the GROUPED
+ * root-level display case and whether the initial guess propagates to child
+ * levels when a group is expanded.
+ *
+ * These assertions record what the grid actually DOES today (bugs included).
+ * Do NOT "fix" a value to what you think it should be — a changed value is a
+ * behavioural change to review. RowNode objects are never asserted directly
+ * (that crashes the reporter); only booleans and scalar counts.
+ */
+
+// A compact record of one getRows call: the group route and the requested block range.
+interface RequestRecord {
+    groupKeys: string[];
+    rowGroupColIds: string[];
+    range: [number, number];
+}
+
+describe('SSRM grouped initial row count (characterization)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ScrollApiModule, ServerSideRowModelModule],
+    });
+
+    afterEach(() => gridsManager.reset());
+
+    // Grouped dataset: country -> athletes. Top level is one row per country.
+    const LEAF_ROWS = [
+        { id: 'uk-alice', country: 'UK', athlete: 'Alice' },
+        { id: 'uk-bob', country: 'UK', athlete: 'Bob' },
+        { id: 'us-frank', country: 'US', athlete: 'Frank' },
+        { id: 'us-grace', country: 'US', athlete: 'Grace' },
+        { id: 'fr-heidi', country: 'FR', athlete: 'Heidi' },
+    ];
+
+    test('before the root block resolves: serverSideInitialRowCount top-level loading rows and first request shape', async () => {
+        const requests: RequestRecord[] = [];
+        // Deferred datasource: stash params so the root block stays in-flight and we
+        // can observe the pre-load display state.
+        const pending: IServerSideGetRowsParams[] = [];
+
+        const api = gridsManager.createGrid(null, {
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
+            autoGroupColumnDef: { field: 'athlete' },
+            rowModelType: 'serverSide',
+            serverSideInitialRowCount: 5,
+            getRowId: (p) => p.data.id ?? `group-${p.data.country}`,
+            serverSideDatasource: {
+                getRows: (params: IServerSideGetRowsParams) => {
+                    requests.push({
+                        groupKeys: (params.request.groupKeys ?? []) as string[],
+                        rowGroupColIds: (params.request.rowGroupCols ?? []).map((c) => c.id),
+                        range: [params.request.startRow!, params.request.endRow!],
+                    });
+                    pending.push(params);
+                },
+            },
+        });
+        // Let the initial block dispatch without resolving it.
+        await asyncSetTimeout(30);
+
+        // Before the root resolves the grid sizes the top level to the configured
+        // initial row count: 5 loading/stub group rows displayed.
+        expect(api.getDisplayedRowCount()).toBe(5);
+        expect(countLoadingRows(api)).toBe(5);
+
+        // First (and only) request so far is the root route: empty groupKeys, with
+        // the rowGroupCols carrying the grouped 'country' column.
+        expect(requests).toEqual([{ groupKeys: [], rowGroupColIds: ['country'], range: [0, 100] }]);
+
+        await new GridRows(api, 'grouped initial row count before root resolves').check(`
+            ROOT id:<no-id>
+            ├── LEAF_GROUP collapsed id:rowIndex:0
+            ├── LEAF_GROUP collapsed id:rowIndex:1
+            ├── LEAF_GROUP collapsed id:rowIndex:2
+            ├── LEAF_GROUP collapsed id:rowIndex:3
+            └── LEAF_GROUP collapsed id:rowIndex:4
+        `);
+
+        // Drain the in-flight root request so the deferred datasource does not leak.
+        const modelUpdated = waitForEvent('modelUpdated', api);
+        const countries = Array.from(new Set(LEAF_ROWS.map((r) => r.country)));
+        const rows = countries.map((country) => ({ id: `group-${country}`, country }));
+        for (let i = 0, len = pending.length; i < len; ++i) {
+            pending[i].success({ rowData: [...rows], rowCount: rows.length });
+        }
+        await modelUpdated;
+    });
+
+    test('after the root resolves: displayed count reflects real group count, groups collapsed', async () => {
+        const requests: RequestRecord[] = [];
+
+        const api = gridsManager.createGrid(null, {
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
+            autoGroupColumnDef: { field: 'athlete' },
+            rowModelType: 'serverSide',
+            serverSideInitialRowCount: 5, // guess is higher than the real 3 groups
+            getRowId: (p) => p.data.id ?? `group-${p.data.country}`,
+            serverSideDatasource: {
+                getRows: (params: IServerSideGetRowsParams) => {
+                    const groupKeys = (params.request.groupKeys ?? []) as string[];
+                    requests.push({
+                        groupKeys,
+                        rowGroupColIds: (params.request.rowGroupCols ?? []).map((c) => c.id),
+                        range: [params.request.startRow!, params.request.endRow!],
+                    });
+                    if (groupKeys.length === 0) {
+                        const countries = Array.from(new Set(LEAF_ROWS.map((r) => r.country)));
+                        const rows = countries.map((country) => ({ id: `group-${country}`, country }));
+                        params.success({ rowData: [...rows], rowCount: rows.length });
+                        return;
+                    }
+                    const rows = LEAF_ROWS.filter((r) => r.country === groupKeys[0]);
+                    params.success({ rowData: [...rows], rowCount: rows.length });
+                },
+            },
+        });
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        // Real group count (3) replaces the initial guess (5).
+        expect(api.getDisplayedRowCount()).toBe(3);
+        expect(countLoadingRows(api)).toBe(0);
+
+        await new GridRows(api, 'grouped initial row count after root resolves').check(`
+            ROOT id:<no-id>
+            ├── GROUP-leafGroup collapsed id:group-UK ag-Grid-AutoColumn:"UK" country:"UK"
+            ├── GROUP-leafGroup collapsed id:group-US ag-Grid-AutoColumn:"US" country:"US"
+            └── GROUP-leafGroup collapsed id:group-FR ag-Grid-AutoColumn:"FR" country:"FR"
+        `);
+    });
+
+    test('reconciliation: real group count larger than the initial guess', async () => {
+        const requests: RequestRecord[] = [];
+        const COUNTRIES = ['UK', 'US', 'FR', 'DE', 'IT', 'ES', 'PT'];
+
+        const api = gridsManager.createGrid(null, {
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
+            autoGroupColumnDef: { field: 'athlete' },
+            rowModelType: 'serverSide',
+            serverSideInitialRowCount: 2, // guess is lower than the real 7 groups
+            getRowId: (p) => p.data.id ?? `group-${p.data.country}`,
+            serverSideDatasource: {
+                getRows: (params: IServerSideGetRowsParams) => {
+                    const groupKeys = (params.request.groupKeys ?? []) as string[];
+                    requests.push({
+                        groupKeys,
+                        rowGroupColIds: (params.request.rowGroupCols ?? []).map((c) => c.id),
+                        range: [params.request.startRow!, params.request.endRow!],
+                    });
+                    const rows = COUNTRIES.map((country) => ({ id: `group-${country}`, country }));
+                    params.success({ rowData: [...rows], rowCount: rows.length });
+                },
+            },
+        });
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        // The model grows from the initial guess (2) to the real group count (7).
+        expect(api.getDisplayedRowCount()).toBe(7);
+        expect(countLoadingRows(api)).toBe(0);
+    });
+
+    test('serverSideInitialRowCount propagation to child level when a group is expanded', async () => {
+        const requests: RequestRecord[] = [];
+        // Deferred child datasource: resolve the root immediately, but hold the child
+        // block in-flight so we can observe whether the initial guess pads the child level.
+        const pendingChild: IServerSideGetRowsParams[] = [];
+
+        const api = gridsManager.createGrid(null, {
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
+            autoGroupColumnDef: { field: 'athlete' },
+            rowModelType: 'serverSide',
+            serverSideInitialRowCount: 4,
+            getRowId: (p) => p.data.id ?? `group-${p.data.country}`,
+            serverSideDatasource: {
+                getRows: (params: IServerSideGetRowsParams) => {
+                    const groupKeys = (params.request.groupKeys ?? []) as string[];
+                    requests.push({
+                        groupKeys,
+                        rowGroupColIds: (params.request.rowGroupCols ?? []).map((c) => c.id),
+                        range: [params.request.startRow!, params.request.endRow!],
+                    });
+                    if (groupKeys.length === 0) {
+                        const countries = Array.from(new Set(LEAF_ROWS.map((r) => r.country)));
+                        const rows = countries.map((country) => ({ id: `group-${country}`, country }));
+                        params.success({ rowData: [...rows], rowCount: rows.length });
+                        return;
+                    }
+                    // Hold the child block open to observe the pre-load child display.
+                    pendingChild.push(params);
+                },
+            },
+        });
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        // Root resolved to 3 real groups.
+        expect(api.getDisplayedRowCount()).toBe(3);
+
+        // Expand UK (2 children); the child block dispatches but stays in-flight.
+        api.getRowNode('group-UK')?.setExpanded(true);
+        await asyncSetTimeout(30);
+
+        // CHARACTERIZATION: pin how many loading child rows appear under the expanded
+        // group before the child block resolves — i.e. whether serverSideInitialRowCount
+        // pads the child level too, or only the root.
+        expect(countLoadingRows(api)).toBe(1);
+        expect(api.getDisplayedRowCount()).toBe(4);
+
+        await new GridRows(api, 'grouped initial row count child level before resolve').check(`
+            ROOT id:<no-id>
+            ├─┬ GROUP-leafGroup id:group-UK ag-Grid-AutoColumn:"UK" country:"UK"
+            │ └── filler id:rowIndex:1
+            ├── GROUP-leafGroup collapsed id:group-US ag-Grid-AutoColumn:"US" country:"US"
+            └── GROUP-leafGroup collapsed id:group-FR ag-Grid-AutoColumn:"FR" country:"FR"
+        `);
+
+        // Drain the child block.
+        const modelUpdated = waitForEvent('modelUpdated', api);
+        for (let i = 0, len = pendingChild.length; i < len; ++i) {
+            const groupKeys = (pendingChild[i].request.groupKeys ?? []) as string[];
+            const rows = LEAF_ROWS.filter((r) => r.country === groupKeys[0]);
+            pendingChild[i].success({ rowData: [...rows], rowCount: rows.length });
+        }
+        await modelUpdated;
+
+        // Child level resolved to UK's 2 real children.
+        expect(countLoadingRows(api)).toBe(0);
+        expect(api.getDisplayedRowCount()).toBe(5);
+    });
+});

--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-pivot-sort-expand.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-pivot-sort-expand.test.ts
@@ -1,0 +1,220 @@
+import type { GridApi, IServerSideGetRowsRequest } from 'ag-grid-community';
+import { ScrollApiModule, TextFilterModule } from 'ag-grid-community';
+import {
+    PivotModule,
+    RowGroupingModule,
+    ServerSideRowModelApiModule,
+    ServerSideRowModelModule,
+} from 'ag-grid-enterprise';
+
+import { createFakeServer, createServerSideDatasource } from '../../columnToolPanel/deferredPivotModeFakeServer';
+import { getColumnOrder } from '../../columns/column-test-utils';
+import { GridRows, TestGridsManager, waitForEvent } from '../../test-utils';
+import { asyncSetTimeout } from '../../test-utils/node-utils';
+import { waitForNoLoadingRows } from '../../test-utils/ssrm-test-utils';
+
+/**
+ * Characterization tests pinning the CURRENT behaviour of two Server-Side Row Model pivot-mode cells
+ * that the sibling `ssrm-pivot-operations.test.ts` deliberately does NOT cover:
+ *
+ *  - SERVER-SIDE sort WITHOUT `serverSideEnableClientSideSort` (contrast to that file's client-side
+ *    case): applying a sort must round-trip to the server (request count increases) carrying the
+ *    sortModel AND the pivot flags, and the group rows re-render in the new order.
+ *  - Expand/collapse of an expandable pivot row group WITH `purgeClosedRowNodes: true`: children are
+ *    purged on collapse and re-fetched from the server on re-expand.
+ *
+ * Golden-master: whatever the grid does today is the baseline (bugs included). Assertions pin what the
+ * grid DOES, not what it "should" do.
+ */
+
+interface RecordedRequest {
+    pivotMode: boolean;
+    pivotCols: string[];
+    valueCols: string[];
+    rowGroupCols: string[];
+    groupKeys: string[];
+    sortModel: { colId: string; sort: string }[];
+}
+
+// Thin recorder around the shared Olympic pivot/agg fake server: captures the request stream so we can
+// assert the sortModel and pivot flags carried on each re-request.
+function createRecordingServer(allData: any[]) {
+    const server = createFakeServer(allData);
+    const requests: RecordedRequest[] = [];
+
+    const recording = {
+        getData: (request: IServerSideGetRowsRequest) => {
+            requests.push({
+                pivotMode: !!request.pivotMode,
+                pivotCols: (request.pivotCols ?? []).map((col) => col.id),
+                valueCols: (request.valueCols ?? []).map((col) => col.id),
+                rowGroupCols: (request.rowGroupCols ?? []).map((col) => col.id),
+                groupKeys: [...(request.groupKeys ?? [])],
+                sortModel: (request.sortModel ?? []).map((s) => ({ colId: s.colId, sort: s.sort })),
+            });
+            return server.getData(request);
+        },
+    };
+
+    return {
+        datasource: createServerSideDatasource(recording),
+        requests,
+    };
+}
+
+// Two countries x two years: pivot result columns are 2000_gold and 2004_gold. Russia's 2004 gold (4)
+// outranks USA's 2004 gold (2), while the default group order (count desc, then key asc) is Russia, USA
+// — so an ascending sort on 2004_gold flips the order to USA, Russia.
+const SORT_DATA = [
+    { athlete: 'a1', country: 'USA', year: 2000, sport: 'Swimming', gold: 1, silver: 0, bronze: 0, total: 1 },
+    { athlete: 'a2', country: 'USA', year: 2004, sport: 'Swimming', gold: 2, silver: 0, bronze: 0, total: 2 },
+    { athlete: 'a3', country: 'Russia', year: 2000, sport: 'Swimming', gold: 3, silver: 0, bronze: 0, total: 3 },
+    { athlete: 'a4', country: 'Russia', year: 2004, sport: 'Swimming', gold: 4, silver: 0, bronze: 0, total: 4 },
+];
+
+// Two row-group levels (country, sport) so country groups are expandable (non-leaf); pivot on year.
+// USA has three athletes across two sports; Russia one — so USA sorts first (count desc).
+const EXPAND_DATA = [
+    { athlete: 'b1', country: 'USA', year: 2000, sport: 'Swimming', gold: 1, silver: 0, bronze: 0, total: 1 },
+    { athlete: 'b2', country: 'USA', year: 2004, sport: 'Swimming', gold: 2, silver: 0, bronze: 0, total: 2 },
+    { athlete: 'b3', country: 'USA', year: 2000, sport: 'Athletics', gold: 5, silver: 0, bronze: 0, total: 5 },
+    { athlete: 'b4', country: 'Russia', year: 2000, sport: 'Swimming', gold: 4, silver: 0, bronze: 0, total: 4 },
+];
+
+const pivotCols = (api: GridApi) => getColumnOrder(api, 'all').filter((id) => id.endsWith('_gold'));
+
+describe('SSRM pivot-mode sort and expand/collapse (characterization)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [
+            ServerSideRowModelApiModule,
+            ServerSideRowModelModule,
+            RowGroupingModule,
+            PivotModule,
+            ScrollApiModule,
+            TextFilterModule,
+        ],
+    });
+
+    beforeEach(() => gridsManager.reset());
+    afterEach(() => gridsManager.reset());
+
+    test('1. server-side sort in pivot mode (no serverSideEnableClientSideSort) — fresh request carries sortModel + pivot flags and rows re-render', async () => {
+        const { datasource, requests } = createRecordingServer(SORT_DATA);
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', pivot: true, hide: true },
+                { field: 'gold', aggFunc: 'sum', hide: true },
+            ],
+            pivotMode: true,
+            rowModelType: 'serverSide',
+            serverSideDatasource: datasource,
+        });
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+        await asyncSetTimeout(50);
+
+        const requestsBeforeSort = requests.length;
+
+        // Sort ascending by a generated pivot value column. Without serverSideEnableClientSideSort this
+        // must round-trip to the server rather than sorting in place on the client.
+        api.applyColumnState({ state: [{ colId: '2004_gold', sort: 'asc' }] });
+        await waitForNoLoadingRows(api);
+        await asyncSetTimeout(50);
+
+        // Distinguishing behaviour vs the client-side case: a NEW server request is issued.
+        expect(requests.length).toBeGreaterThan(requestsBeforeSort);
+        const sortRequest = requests[requests.length - 1];
+        // The re-request carries the sortModel...
+        expect(sortRequest.sortModel).toEqual([{ colId: '2004_gold', sort: 'asc' }]);
+        // ...AND still carries the pivot metadata.
+        expect(sortRequest.pivotMode).toBe(true);
+        expect(sortRequest.pivotCols).toEqual(['year']);
+        expect(sortRequest.valueCols).toEqual(['gold']);
+        expect(sortRequest.rowGroupCols).toEqual(['country']);
+        // Pivot result columns are unaffected by the sort.
+        expect(pivotCols(api)).toEqual(['2000_gold', '2004_gold']);
+
+        // Groups re-render in the server-sorted order (ascending by 2004_gold => USA(2), Russia(4)).
+        await new GridRows(api, '1. server-side sort on pivot value column').check(`
+            ROOT id:<no-id>
+            ├── GROUP-leafGroup collapsed id:2 ag-Grid-AutoColumn:"USA" 2000_gold:1 2004_gold:2
+            └── GROUP-leafGroup collapsed id:3 ag-Grid-AutoColumn:"Russia" 2000_gold:3 2004_gold:4
+        `);
+    });
+
+    test('2. expand/collapse an expandable pivot group with purgeClosedRowNodes — children purged on collapse and re-fetched on re-expand', async () => {
+        const { datasource, requests } = createRecordingServer(EXPAND_DATA);
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'sport', rowGroup: true, hide: true },
+                { field: 'year', pivot: true, hide: true },
+                { field: 'gold', aggFunc: 'sum', hide: true },
+            ],
+            pivotMode: true,
+            rowModelType: 'serverSide',
+            purgeClosedRowNodes: true,
+            serverSideDatasource: datasource,
+            getRowId: ({ data, level, parentKeys }) => {
+                const key = level === 0 ? data.country : data.sport;
+                return [...(parentKeys ?? []), key].join('-');
+            },
+        });
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        // Two-level pivot groups: country groups are expandable (non-leaf); sport groups are leaf groups.
+        await new GridRows(api, '2a. collapsed root groups').check(`
+            ROOT id:<no-id>
+            ├── GROUP collapsed id:USA ag-Grid-AutoColumn:"USA" 2000_gold:6 2004_gold:2
+            └── GROUP collapsed id:Russia ag-Grid-AutoColumn:"Russia" 2000_gold:4 2004_gold:0
+        `);
+
+        // Expand USA — a fresh request scoped to the USA group route loads its sport leaf groups.
+        const beforeExpand = requests.length;
+        api.getRowNode('USA')!.setExpanded(true);
+        await waitForNoLoadingRows(api);
+        await asyncSetTimeout(50);
+
+        expect(requests.length).toBeGreaterThan(beforeExpand);
+        const expandRequest = requests[requests.length - 1];
+        expect(expandRequest.pivotMode).toBe(true);
+        expect(expandRequest.groupKeys).toEqual(['USA']);
+        expect(expandRequest.rowGroupCols).toEqual(['country', 'sport']);
+        expect(expandRequest.pivotCols).toEqual(['year']);
+
+        await new GridRows(api, '2b. USA expanded').check(`
+            ROOT id:<no-id>
+            ├─┬ GROUP id:USA ag-Grid-AutoColumn:"USA" 2000_gold:6 2004_gold:2
+            │ ├── GROUP-leafGroup collapsed id:USA-Athletics ag-Grid-AutoColumn:"Athletics" 2000_gold:5 2004_gold:0
+            │ └── GROUP-leafGroup collapsed id:USA-Swimming ag-Grid-AutoColumn:"Swimming" 2000_gold:1 2004_gold:2
+            └── GROUP collapsed id:Russia ag-Grid-AutoColumn:"Russia" 2000_gold:4 2004_gold:0
+        `);
+
+        // Collapse USA. With purgeClosedRowNodes the loaded children are discarded...
+        api.getRowNode('USA')!.setExpanded(false);
+        await asyncSetTimeout(50);
+        expect(!!api.getRowNode('USA-Swimming')).toBe(false);
+        expect(!!api.getRowNode('USA-Athletics')).toBe(false);
+
+        // ...so re-expanding must issue ANOTHER fresh server request to reload them.
+        const beforeReExpand = requests.length;
+        api.getRowNode('USA')!.setExpanded(true);
+        await waitForNoLoadingRows(api);
+        await asyncSetTimeout(50);
+
+        expect(requests.length).toBeGreaterThan(beforeReExpand);
+        const reExpandRequest = requests[requests.length - 1];
+        expect(reExpandRequest.pivotMode).toBe(true);
+        expect(reExpandRequest.groupKeys).toEqual(['USA']);
+
+        await new GridRows(api, '2c. USA re-expanded after purge').check(`
+            ROOT id:<no-id>
+            ├─┬ GROUP id:USA ag-Grid-AutoColumn:"USA" 2000_gold:6 2004_gold:2
+            │ ├── GROUP-leafGroup collapsed id:USA-Athletics ag-Grid-AutoColumn:"Athletics" 2000_gold:5 2004_gold:0
+            │ └── GROUP-leafGroup collapsed id:USA-Swimming ag-Grid-AutoColumn:"Swimming" 2000_gold:1 2004_gold:2
+            └── GROUP collapsed id:Russia ag-Grid-AutoColumn:"Russia" 2000_gold:4 2004_gold:0
+        `);
+    });
+});

--- a/testing/behavioural/src/row-data/ssrm-flat-sort-filter.test.ts
+++ b/testing/behavioural/src/row-data/ssrm-flat-sort-filter.test.ts
@@ -1,0 +1,260 @@
+import type {
+    GridOptions,
+    IServerSideGetRowsParams,
+    IServerSideGetRowsRequest,
+    SortModelItem,
+} from 'ag-grid-community';
+import { NumberFilterModule, TextFilterModule } from 'ag-grid-community';
+import { ServerSideRowModelApiModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, waitForEvent } from '../test-utils';
+import { waitForNoLoadingRows } from '../test-utils/ssrm-test-utils';
+
+/**
+ * Characterization tests (golden-master) pinning the CURRENT behaviour of SERVER-DELEGATED
+ * sort and filter on a FLAT (no rowGroup, no pivot) Server-Side Row Model grid.
+ *
+ * The sibling file `grouping-data/ssrm/ssrm-sort-filter-scope.test.ts` covers the GROUPED
+ * refresh-SCOPE flags (which group routes re-request). This file is the FLAT case: there are
+ * no group stores, so the interesting behaviour is that a sort/filter change purges the single
+ * root store and issues ONE fresh request carrying the new sortModel/filterModel, and that the
+ * server-sorted/-filtered rows re-render.
+ *
+ * The datasource is defined INLINE and honours sortModel + filterModel server-side (sorts and
+ * filters the row array, pages by startRow/endRow, reports lastRow). The full request stream is
+ * recorded inline (a plain array push) per the behavioural-suite house style; each test reads
+ * top-to-bottom. Whatever the grid does today is the baseline — a failing assertion means the
+ * behaviour changed, not that it is wrong.
+ */
+
+interface FlatRow {
+    id: number;
+    name: string;
+    category: string;
+}
+
+// Distinct names/ids give an unambiguous sort order; two categories make the filter observable.
+const ROWS: FlatRow[] = [
+    { id: 0, name: 'Delta', category: 'X' },
+    { id: 1, name: 'Bravo', category: 'Y' },
+    { id: 2, name: 'Echo', category: 'X' },
+    { id: 3, name: 'Alpha', category: 'Y' },
+    { id: 4, name: 'Charlie', category: 'X' },
+];
+
+interface RecordedRequest {
+    startRow: number | undefined;
+    endRow: number | undefined;
+    sortModel: SortModelItem[];
+    filterModel: any;
+}
+
+// Inline recorder: captures every getRows request so tests can assert the sortModel/filterModel
+// carried on each server round-trip, and how many round-trips occurred.
+function createFlatDatasource(requests: RecordedRequest[]) {
+    return {
+        getRows: (params: IServerSideGetRowsParams) => {
+            const request: IServerSideGetRowsRequest = params.request;
+            requests.push({
+                startRow: request.startRow,
+                endRow: request.endRow,
+                sortModel: (request.sortModel ?? []).map((s) => ({ colId: s.colId, sort: s.sort })),
+                filterModel: request.filterModel,
+            });
+
+            // Filter server-side.
+            let rows = ROWS.slice();
+            const filterModel = request.filterModel as Record<string, any> | undefined;
+            if (filterModel && filterModel.category) {
+                const wanted = filterModel.category.filter;
+                rows = rows.filter((r) => r.category === wanted);
+            }
+            if (filterModel && filterModel.id) {
+                const threshold = filterModel.id.filter;
+                rows = rows.filter((r) => r.id >= threshold);
+            }
+
+            // Sort server-side (single sort column is enough for these cases).
+            const sort = request.sortModel?.[0];
+            if (sort) {
+                const dir = sort.sort === 'desc' ? -1 : 1;
+                rows.sort((a, b) => {
+                    const av = (a as any)[sort.colId];
+                    const bv = (b as any)[sort.colId];
+                    if (av < bv) {
+                        return -1 * dir;
+                    }
+                    if (av > bv) {
+                        return 1 * dir;
+                    }
+                    return 0;
+                });
+            }
+
+            const lastRow = rows.length;
+            const slice = rows.slice(request.startRow, request.endRow);
+            params.success({ rowData: slice, rowCount: lastRow });
+        },
+    };
+}
+
+function baseGridOptions(requests: RecordedRequest[], overrides: Partial<GridOptions> = {}): GridOptions {
+    return {
+        columnDefs: [
+            { field: 'id', filter: 'agNumberColumnFilter' },
+            { field: 'name' },
+            { field: 'category', filter: 'agTextColumnFilter' },
+        ],
+        rowModelType: 'serverSide',
+        cacheBlockSize: 100,
+        getRowId: (params) => String(params.data.id),
+        serverSideDatasource: createFlatDatasource(requests),
+        ...overrides,
+    };
+}
+
+describe('SSRM flat sort/filter (characterization)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ServerSideRowModelModule, TextFilterModule, NumberFilterModule],
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    test('applying a column sort issues a fresh request carrying sortModel and re-renders server-sorted', async () => {
+        const requests: RecordedRequest[] = [];
+        const api = gridsManager.createGrid(null, baseGridOptions(requests));
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        // Initial load carries an empty sortModel.
+        expect(requests[0].sortModel).toEqual([]);
+        const requestsBeforeSort = requests.length;
+
+        api.applyColumnState({ state: [{ colId: 'name', sort: 'asc' }] });
+        await waitForNoLoadingRows(api);
+
+        // A fresh server request is issued and carries the exact sortModel.
+        expect(requests.length).toBeGreaterThan(requestsBeforeSort);
+        expect(requests[requests.length - 1].sortModel).toEqual([{ colId: 'name', sort: 'asc' }]);
+
+        // Rows re-render in server-sorted (name asc) order: Alpha, Bravo, Charlie, Delta, Echo.
+        await new GridRows(api, 'flat sort name asc').check(`
+            ROOT id:<no-id>
+            ├── LEAF id:3 id:3 name:"Alpha" category:"Y"
+            ├── LEAF id:1 id:1 name:"Bravo" category:"Y"
+            ├── LEAF id:4 id:4 name:"Charlie" category:"X"
+            ├── LEAF id:0 id:0 name:"Delta" category:"X"
+            └── LEAF id:2 id:2 name:"Echo" category:"X"
+        `);
+    });
+
+    test('toggling sort asc -> desc -> none round-trips to the server each time', async () => {
+        const requests: RecordedRequest[] = [];
+        const api = gridsManager.createGrid(null, baseGridOptions(requests));
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        api.applyColumnState({ state: [{ colId: 'name', sort: 'asc' }] });
+        await waitForNoLoadingRows(api);
+        expect(requests[requests.length - 1].sortModel).toEqual([{ colId: 'name', sort: 'asc' }]);
+        const afterAsc = requests.length;
+
+        api.applyColumnState({ state: [{ colId: 'name', sort: 'desc' }] });
+        await waitForNoLoadingRows(api);
+        expect(requests.length).toBeGreaterThan(afterAsc);
+        expect(requests[requests.length - 1].sortModel).toEqual([{ colId: 'name', sort: 'desc' }]);
+        const afterDesc = requests.length;
+
+        // Clearing the sort re-requests with an empty sortModel.
+        api.applyColumnState({ state: [{ colId: 'name', sort: null }] });
+        await waitForNoLoadingRows(api);
+        expect(requests.length).toBeGreaterThan(afterDesc);
+        expect(requests[requests.length - 1].sortModel).toEqual([]);
+
+        // Back to the datasource's natural (id) order after the sort is cleared.
+        await new GridRows(api, 'flat sort cleared').check(`
+            ROOT id:<no-id>
+            ├── LEAF id:0 id:0 name:"Delta" category:"X"
+            ├── LEAF id:1 id:1 name:"Bravo" category:"Y"
+            ├── LEAF id:2 id:2 name:"Echo" category:"X"
+            ├── LEAF id:3 id:3 name:"Alpha" category:"Y"
+            └── LEAF id:4 id:4 name:"Charlie" category:"X"
+        `);
+    });
+
+    test('applying a filter issues a fresh request carrying filterModel and re-renders filtered', async () => {
+        const requests: RecordedRequest[] = [];
+        const api = gridsManager.createGrid(null, baseGridOptions(requests));
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        expect(api.getDisplayedRowCount()).toBe(5);
+        const requestsBeforeFilter = requests.length;
+
+        api.setFilterModel({ category: { filterType: 'text', type: 'equals', filter: 'X' } });
+        await waitForNoLoadingRows(api);
+
+        // A fresh server request is issued and carries the applied filterModel.
+        expect(requests.length).toBeGreaterThan(requestsBeforeFilter);
+        expect(requests[requests.length - 1].filterModel).toEqual({
+            category: { filterType: 'text', type: 'equals', filter: 'X' },
+        });
+
+        // Only category X rows remain (ids 0, 2, 4), in the datasource's natural order.
+        expect(api.getDisplayedRowCount()).toBe(3);
+        await new GridRows(api, 'flat filter category X').check(`
+            ROOT id:<no-id>
+            ├── LEAF id:0 id:0 name:"Delta" category:"X"
+            ├── LEAF id:2 id:2 name:"Echo" category:"X"
+            └── LEAF id:4 id:4 name:"Charlie" category:"X"
+        `);
+    });
+
+    test('sort + filter combined are carried on a single request together', async () => {
+        const requests: RecordedRequest[] = [];
+        const api = gridsManager.createGrid(null, baseGridOptions(requests));
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        api.setFilterModel({ category: { filterType: 'text', type: 'equals', filter: 'X' } });
+        await waitForNoLoadingRows(api);
+        api.applyColumnState({ state: [{ colId: 'name', sort: 'asc' }] });
+        await waitForNoLoadingRows(api);
+
+        // The latest request carries BOTH the sortModel and the filterModel.
+        const last = requests[requests.length - 1];
+        expect(last.sortModel).toEqual([{ colId: 'name', sort: 'asc' }]);
+        expect(last.filterModel).toEqual({
+            category: { filterType: 'text', type: 'equals', filter: 'X' },
+        });
+
+        // Category X rows sorted by name asc: Charlie, Delta, Echo.
+        expect(api.getDisplayedRowCount()).toBe(3);
+        await new GridRows(api, 'flat sort+filter combined').check(`
+            ROOT id:<no-id>
+            ├── LEAF id:4 id:4 name:"Charlie" category:"X"
+            ├── LEAF id:0 id:0 name:"Delta" category:"X"
+            └── LEAF id:2 id:2 name:"Echo" category:"X"
+        `);
+    });
+
+    test('without a client-side-sort option, every sort change round-trips to the server', async () => {
+        const requests: RecordedRequest[] = [];
+        const api = gridsManager.createGrid(null, baseGridOptions(requests));
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        const before = requests.length;
+        api.applyColumnState({ state: [{ colId: 'id', sort: 'desc' }] });
+        await waitForNoLoadingRows(api);
+        const afterFirst = requests.length;
+        expect(afterFirst).toBeGreaterThan(before);
+
+        api.applyColumnState({ state: [{ colId: 'name', sort: 'asc' }] });
+        await waitForNoLoadingRows(api);
+        // A second distinct sort forces another server round-trip (sort is not done client-side).
+        expect(requests.length).toBeGreaterThan(afterFirst);
+    });
+});

--- a/testing/behavioural/src/row-data/ssrm-initial-row-count.test.ts
+++ b/testing/behavioural/src/row-data/ssrm-initial-row-count.test.ts
@@ -1,0 +1,197 @@
+import type { GridOptions, IServerSideGetRowsParams, IServerSideGetRowsRequest } from 'ag-grid-community';
+import { ScrollApiModule } from 'ag-grid-community';
+import { ServerSideRowModelApiModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, waitForEvent } from '../test-utils';
+import { asyncSetTimeout } from '../test-utils/node-utils';
+import { countLoadingRows } from '../test-utils/ssrm-test-utils';
+
+/**
+ * Characterization (golden-master) tests pinning how `gridOptions.serverSideInitialRowCount`
+ * shapes the INITIAL LOAD DISPLAY of a FLAT (no rowGroup) SSRM grid:
+ *   - the placeholder/loading (stub) rows shown before the first block resolves,
+ *   - which block the first server request asks for, and
+ *   - how the model reconciles once the real total arrives — both when the real
+ *     total EXCEEDS the initial guess and when it is SMALLER.
+ *
+ * These pin whatever the grid does today (bugs included) so any future change to
+ * initial-load sizing/reconciliation surfaces as a deliberate snapshot update. The
+ * asserted numbers were adopted from the actual runtime output, not an "ideal".
+ *
+ * Sibling `ssrm-cache-config.test.ts` also touches `serverSideInitialRowCount`, but
+ * from the cache-knob angle (displayed-count == N pre-load, filler stub shape). This
+ * file's angle is the initial-load request stream + the reconciliation delta between
+ * the initial guess and the real server total — deliberately not re-asserting those.
+ *
+ * House style: inline datasource + inline request-stream recorder (no shared factory)
+ * so each test reads top-to-bottom. RowNode objects are never asserted directly — only
+ * scalar counts/booleans — as serializing a circular node crashes the reporter on failure.
+ */
+describe('SSRM initial row count (characterization)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ScrollApiModule, ServerSideRowModelModule],
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    /** Compact, comparable projection of a request's block range. */
+    function blockRange(request: IServerSideGetRowsRequest): [number, number] {
+        return [request.startRow!, request.endRow!];
+    }
+
+    test('before the first block resolves: initial-count filler rows are displayed as loading stubs and the first request is for block [0,100]', async () => {
+        const initialCount = 42;
+        const requests: [number, number][] = [];
+        // Deferred datasource: stash params so the first block stays in-flight and the
+        // pre-resolve display state can be observed.
+        const pending: IServerSideGetRowsParams[] = [];
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            cacheBlockSize: 100,
+            serverSideInitialRowCount: initialCount,
+            getRowId: (params) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params) => {
+                    requests.push(blockRange(params.request));
+                    pending.push(params);
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        // Let the initial block dispatch without resolving it.
+        await asyncSetTimeout(30);
+
+        // The grid sizes itself to the configured initial row count before any block
+        // resolves, and every one of those rows is a loading/stub row.
+        expect(api.getDisplayedRowCount()).toBe(initialCount);
+        expect(countLoadingRows(api)).toBe(initialCount);
+
+        // The first (and only) server request so far is for the block starting at row 0.
+        expect(requests[0]).toEqual([0, 100]);
+
+        // Drain the in-flight request so the deferred datasource does not leak past the test.
+        const rowData = Array.from({ length: 500 }, (_, i) => ({ id: i, value: `Row ${i}` }));
+        for (let i = 0, len = pending.length; i < len; ++i) {
+            const request = pending[i].request;
+            pending[i].success({ rowData: rowData.slice(request.startRow!, request.endRow!), rowCount: 500 });
+        }
+    });
+
+    test('after load, real total EXCEEDS the initial count: displayed count reflects the real total, not the initial guess', async () => {
+        const initialCount = 42;
+        const realTotal = 500;
+        const rowData = Array.from({ length: realTotal }, (_, i) => ({ id: i, value: `Row ${i}` }));
+        const requests: [number, number][] = [];
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            cacheBlockSize: 100,
+            serverSideInitialRowCount: initialCount,
+            getRowId: (params) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params) => {
+                    requests.push(blockRange(params.request));
+                    const slice = rowData.slice(params.request.startRow!, params.request.endRow!);
+                    params.success({ rowData: slice, rowCount: realTotal });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await waitForEvent('firstDataRendered', api);
+
+        // The real total (500) supersedes the initial guess (42): the grid now sizes to
+        // the full server total, and the first request was for block [0,100].
+        expect(api.getDisplayedRowCount()).toBe(realTotal);
+        expect(requests[0]).toEqual([0, 100]);
+
+        // Latent behaviour pinned: on initial load only the first two viewport blocks are
+        // fetched (200 real leaves), so of the 500 displayed rows the remaining 300 stay as
+        // loading/stub filler rows until scrolled into view (no eager full load).
+        expect(countLoadingRows(api)).toBe(300);
+        expect(!!api.getRowNode('0')).toBe(true);
+        expect(!!api.getRowNode('199')).toBe(true);
+        expect(!!api.getRowNode('200')).toBe(false);
+    });
+
+    test('after load, real total is SMALLER than the initial count: the grid shrinks to the real total and trailing placeholders are removed', async () => {
+        const initialCount = 42;
+        const realTotal = 3;
+        const rowData = Array.from({ length: realTotal }, (_, i) => ({ id: i, value: `Row ${i}` }));
+        const requests: [number, number][] = [];
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            cacheBlockSize: 100,
+            serverSideInitialRowCount: initialCount,
+            getRowId: (params) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params) => {
+                    requests.push(blockRange(params.request));
+                    const slice = rowData.slice(params.request.startRow!, params.request.endRow!);
+                    params.success({ rowData: slice, rowCount: realTotal });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await waitForEvent('firstDataRendered', api);
+
+        // Reconciliation: the initial guess of 42 shrinks to the real total of 3; the
+        // trailing 39 placeholder rows are removed and no loading stubs remain.
+        expect(api.getDisplayedRowCount()).toBe(realTotal);
+        expect(countLoadingRows(api)).toBe(0);
+        expect(requests[0]).toEqual([0, 100]);
+
+        await new GridRows(api, 'smaller: shrunk to real total=3').check(`
+            ROOT id:<no-id>
+            ├── LEAF id:0 id:0 value:"Row 0"
+            ├── LEAF id:1 id:1 value:"Row 1"
+            └── LEAF id:2 id:2 value:"Row 2"
+        `);
+    });
+
+    test('baseline without serverSideInitialRowCount: a single filler row shows before load, then the real total', async () => {
+        const realTotal = 3;
+        const rowData = Array.from({ length: realTotal }, (_, i) => ({ id: i, value: `Row ${i}` }));
+        // Deferred datasource to observe the pre-resolve display state.
+        const pending: IServerSideGetRowsParams[] = [];
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            cacheBlockSize: 100,
+            getRowId: (params) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params) => {
+                    pending.push(params);
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await asyncSetTimeout(30);
+
+        // Contrast with the initial-count cases: without serverSideInitialRowCount the
+        // grid shows a single filler/stub row before the first block resolves.
+        expect(api.getDisplayedRowCount()).toBe(1);
+        expect(countLoadingRows(api)).toBe(1);
+
+        const modelUpdated = waitForEvent('modelUpdated', api);
+        for (let i = 0, len = pending.length; i < len; ++i) {
+            const request = pending[i].request;
+            pending[i].success({ rowData: rowData.slice(request.startRow!, request.endRow!), rowCount: realTotal });
+        }
+        await modelUpdated;
+
+        expect(api.getDisplayedRowCount()).toBe(realTotal);
+        expect(countLoadingRows(api)).toBe(0);
+    });
+});

--- a/testing/behavioural/src/row-data/ssrm-sync-transactions.test.ts
+++ b/testing/behavioural/src/row-data/ssrm-sync-transactions.test.ts
@@ -1,0 +1,308 @@
+import type { GridOptions, IServerSideDatasource, IServerSideGetRowsParams } from 'ag-grid-community';
+import { ScrollApiModule } from 'ag-grid-community';
+import { RowGroupingModule, ServerSideRowModelApiModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
+
+import { GridColumns, GridRows, TestGridsManager, waitForEvent } from '../test-utils';
+import { ssrmExpandAndLoadAll, waitForNoLoadingRows } from '../test-utils/ssrm-test-utils';
+
+/**
+ * Characterization (golden-master) tests for AG Grid SSRM SYNCHRONOUS transactions:
+ *   - api.applyServerSideTransaction({ add, remove, update, route })
+ *
+ * The async variant (applyServerSideTransactionAsync / flushServerSideAsyncTransactions)
+ * is covered separately in ssrm-async-transactions.test.ts and is deliberately NOT
+ * duplicated here.
+ *
+ * These tests pin the CURRENT observed behaviour of the grid (result `status` strings,
+ * displayed counts, ordering, cell values). Any value asserted here is a snapshot of what
+ * the grid does today, not a statement of what it ideally should do. If a behaviour that
+ * looks like a bug is frozen here, that is intentional: these tests exist to detect
+ * unintended change, so update them only when a behavioural change is deliberate.
+ */
+describe('SSRM Sync Transactions (characterization)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ScrollApiModule, ServerSideRowModelModule, RowGroupingModule],
+    });
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    describe('Flat store', () => {
+        // Inline flat datasource: a single (root) store serving `rowData` by range.
+        function createFlatGridOptions(rowData: Array<{ id: number; value: string }>): GridOptions {
+            return {
+                columnDefs: [{ field: 'id' }, { field: 'value' }],
+                rowModelType: 'serverSide' as const,
+                getRowId: (params: any) => String(params.data.id),
+                serverSideDatasource: {
+                    getRows: (params: any) => {
+                        const rows = rowData.slice(params.request.startRow, params.request.endRow);
+                        params.success({ rowData: rows, rowCount: rowData.length });
+                    },
+                },
+            };
+        }
+
+        test('ADD appends the row to the end of the flat store and returns status Applied', async () => {
+            const rowData = Array.from({ length: 5 }, (_, i) => ({ id: i, value: `Row ${i}` }));
+            const api = gridsManager.createGrid(null, createFlatGridOptions(rowData));
+
+            await new GridColumns(api, `flat add setup`).checkColumns(`
+                CENTER
+                ├── id "Id" width:200
+                └── value "Value" width:200
+            `);
+            await waitForEvent('firstDataRendered', api);
+            expect(api.getDisplayedRowCount()).toBe(5);
+
+            const result = api.applyServerSideTransaction({ add: [{ id: 100, value: 'Added' }] });
+            await waitForNoLoadingRows(api);
+
+            // Pin the returned status object's scalar fields (never the whole object).
+            expect(result?.status).toBe('Applied');
+            expect(result?.add?.length).toBe(1);
+            // Untouched operation arrays are left undefined on the result (not empty arrays).
+            expect(result?.remove).toBeUndefined();
+            expect(result?.update).toBeUndefined();
+
+            // Pin: the row exists, count grew, and it was appended at the END.
+            expect(!!api.getRowNode('100')).toBe(true);
+            expect(api.getDisplayedRowCount()).toBe(6);
+
+            await new GridRows(api, `flat add final`).check(`
+                ROOT id:<no-id>
+                ├── LEAF id:0 id:0 value:"Row 0"
+                ├── LEAF id:1 id:1 value:"Row 1"
+                ├── LEAF id:2 id:2 value:"Row 2"
+                ├── LEAF id:3 id:3 value:"Row 3"
+                ├── LEAF id:4 id:4 value:"Row 4"
+                └── LEAF id:100 id:100 value:"Added"
+            `);
+        });
+
+        test('REMOVE deletes the node from the flat store and returns status Applied', async () => {
+            const rowData = Array.from({ length: 5 }, (_, i) => ({ id: i, value: `Row ${i}` }));
+            const api = gridsManager.createGrid(null, createFlatGridOptions(rowData));
+
+            await waitForEvent('firstDataRendered', api);
+            expect(api.getDisplayedRowCount()).toBe(5);
+            expect(!!api.getRowNode('2')).toBe(true);
+
+            const result = api.applyServerSideTransaction({ remove: [{ id: 2 }] });
+            await waitForNoLoadingRows(api);
+
+            expect(result?.status).toBe('Applied');
+            expect(result?.remove?.length).toBe(1);
+
+            // Pin: node gone (boolean, never assert the node object) and count shrank.
+            expect(!!api.getRowNode('2')).toBe(false);
+            expect(api.getDisplayedRowCount()).toBe(4);
+
+            await new GridRows(api, `flat remove final`).check(`
+                ROOT id:<no-id>
+                ├── LEAF id:0 id:0 value:"Row 0"
+                ├── LEAF id:1 id:1 value:"Row 1"
+                ├── LEAF id:3 id:3 value:"Row 3"
+                └── LEAF id:4 id:4 value:"Row 4"
+            `);
+        });
+
+        test('UPDATE changes a field value on the node and returns status Applied', async () => {
+            const rowData = Array.from({ length: 5 }, (_, i) => ({ id: i, value: `Row ${i}` }));
+            const api = gridsManager.createGrid(null, createFlatGridOptions(rowData));
+
+            await waitForEvent('firstDataRendered', api);
+            expect(api.getDisplayedRowCount()).toBe(5);
+
+            const result = api.applyServerSideTransaction({ update: [{ id: 2, value: 'Updated' }] });
+            await waitForNoLoadingRows(api);
+
+            expect(result?.status).toBe('Applied');
+            expect(result?.update?.length).toBe(1);
+
+            // Pin: count unchanged, and the new field value is reflected.
+            expect(api.getDisplayedRowCount()).toBe(5);
+            expect(api.getRowNode('2')?.data.value).toBe('Updated');
+
+            await new GridRows(api, `flat update final`).check(`
+                ROOT id:<no-id>
+                ├── LEAF id:0 id:0 value:"Row 0"
+                ├── LEAF id:1 id:1 value:"Row 1"
+                ├── LEAF id:2 id:2 value:"Updated"
+                ├── LEAF id:3 id:3 value:"Row 3"
+                └── LEAF id:4 id:4 value:"Row 4"
+            `);
+        });
+    });
+
+    describe('Grouped store (single rowGroup column)', () => {
+        interface LeafRow {
+            id: string;
+            country: string;
+            athlete: string;
+            medals: number;
+        }
+
+        const groupedRows: LeafRow[] = [
+            { id: 'usa-1', country: 'USA', athlete: 'Alice', medals: 1 },
+            { id: 'usa-2', country: 'USA', athlete: 'Bob', medals: 2 },
+            { id: 'uk-1', country: 'UK', athlete: 'Charlie', medals: 3 },
+            { id: 'uk-2', country: 'UK', athlete: 'Dave', medals: 4 },
+        ];
+
+        // Inline grouped datasource: one rowGroup column (country). With no groupKeys we serve
+        // the distinct country group rows; with a groupKey we serve that country's leaf rows.
+        function createGroupedDatasource(rows: LeafRow[]): IServerSideDatasource {
+            return {
+                getRows(params: IServerSideGetRowsParams) {
+                    const { request } = params;
+                    const groupKeys = request.groupKeys ?? [];
+                    if (groupKeys.length === 0) {
+                        const countries: string[] = [];
+                        for (let i = 0, len = rows.length; i < len; ++i) {
+                            const country = rows[i].country;
+                            if (!countries.includes(country)) {
+                                countries.push(country);
+                            }
+                        }
+                        const groupRows = countries.map((country) => ({ country }));
+                        params.success({ rowData: groupRows, rowCount: groupRows.length });
+                        return;
+                    }
+                    const country = groupKeys[0];
+                    const leaves = rows.filter((row) => row.country === country);
+                    params.success({ rowData: leaves, rowCount: leaves.length });
+                },
+            };
+        }
+
+        function createGroupedGridOptions(rows: LeafRow[]): GridOptions {
+            return {
+                columnDefs: [
+                    { field: 'country', rowGroup: true, hide: true },
+                    { field: 'athlete' },
+                    { field: 'medals' },
+                ],
+                autoGroupColumnDef: { field: 'athlete' },
+                rowModelType: 'serverSide' as const,
+                animateRows: false,
+                getRowId: (params: any) => {
+                    if (params.data.id) {
+                        return params.data.id;
+                    }
+                    // Group level row: key by the country group value.
+                    return `group-${params.data.country}`;
+                },
+                serverSideDatasource: createGroupedDatasource(rows),
+            };
+        }
+
+        test('ADD to a routed group appends a child under that group; sibling group unaffected', async () => {
+            const api = gridsManager.createGrid(null, createGroupedGridOptions(groupedRows));
+
+            await waitForEvent('firstDataRendered', api);
+            await ssrmExpandAndLoadAll(api);
+
+            const countBefore = api.getDisplayedRowCount();
+
+            const result = api.applyServerSideTransaction({
+                route: ['USA'],
+                add: [{ id: 'usa-3', country: 'USA', athlete: 'Eve', medals: 5 }],
+            });
+            await waitForNoLoadingRows(api);
+
+            expect(result?.status).toBe('Applied');
+            expect(result?.add?.length).toBe(1);
+
+            // Pin: new child exists under the USA route; sibling UK children untouched.
+            expect(!!api.getRowNode('usa-3')).toBe(true);
+            expect(!!api.getRowNode('uk-1')).toBe(true);
+            expect(!!api.getRowNode('uk-2')).toBe(true);
+            expect(api.getDisplayedRowCount()).toBe(countBefore + 1);
+
+            await new GridRows(api, `grouped add final`).check(`
+                ROOT id:<no-id>
+                ├─┬ GROUP-leafGroup id:group-USA ag-Grid-AutoColumn:"USA" country:"USA"
+                │ ├── LEAF id:usa-1 ag-Grid-AutoColumn:"Alice" country:"USA" athlete:"Alice" medals:1
+                │ ├── LEAF id:usa-2 ag-Grid-AutoColumn:"Bob" country:"USA" athlete:"Bob" medals:2
+                │ └── LEAF id:usa-3 ag-Grid-AutoColumn:"Eve" country:"USA" athlete:"Eve" medals:5
+                └─┬ GROUP-leafGroup id:group-UK ag-Grid-AutoColumn:"UK" country:"UK"
+                · ├── LEAF id:uk-1 ag-Grid-AutoColumn:"Charlie" country:"UK" athlete:"Charlie" medals:3
+                · └── LEAF id:uk-2 ag-Grid-AutoColumn:"Dave" country:"UK" athlete:"Dave" medals:4
+            `);
+        });
+
+        test('UPDATE a child in a routed group changes its field value; returns status Applied', async () => {
+            const api = gridsManager.createGrid(null, createGroupedGridOptions(groupedRows));
+
+            await waitForEvent('firstDataRendered', api);
+            await ssrmExpandAndLoadAll(api);
+
+            const countBefore = api.getDisplayedRowCount();
+
+            const result = api.applyServerSideTransaction({
+                route: ['USA'],
+                update: [{ id: 'usa-1', country: 'USA', athlete: 'Alice', medals: 99 }],
+            });
+            await waitForNoLoadingRows(api);
+
+            expect(result?.status).toBe('Applied');
+            expect(result?.update?.length).toBe(1);
+            expect(api.getDisplayedRowCount()).toBe(countBefore);
+            expect(api.getRowNode('usa-1')?.data.medals).toBe(99);
+        });
+
+        test('REMOVE a child from a routed group drops it; sibling group unaffected', async () => {
+            const api = gridsManager.createGrid(null, createGroupedGridOptions(groupedRows));
+
+            await waitForEvent('firstDataRendered', api);
+            await ssrmExpandAndLoadAll(api);
+
+            const countBefore = api.getDisplayedRowCount();
+            expect(!!api.getRowNode('usa-2')).toBe(true);
+
+            const result = api.applyServerSideTransaction({
+                route: ['USA'],
+                remove: [{ id: 'usa-2' }],
+            });
+            await waitForNoLoadingRows(api);
+
+            expect(result?.status).toBe('Applied');
+            expect(result?.remove?.length).toBe(1);
+            expect(!!api.getRowNode('usa-2')).toBe(false);
+            // Sibling UK children remain.
+            expect(!!api.getRowNode('uk-1')).toBe(true);
+            expect(api.getDisplayedRowCount()).toBe(countBefore - 1);
+        });
+
+        test('transaction targeting a NOT-YET-LOADED group route yields StoreNotFound and changes nothing', async () => {
+            const api = gridsManager.createGrid(null, createGroupedGridOptions(groupedRows));
+
+            await waitForEvent('firstDataRendered', api);
+            await waitForNoLoadingRows(api);
+            // Note: groups are collapsed, so no child store for 'USA' has been created yet.
+
+            const countBefore = api.getDisplayedRowCount();
+
+            const result = api.applyServerSideTransaction({
+                route: ['USA'],
+                add: [{ id: 'usa-ghost', country: 'USA', athlete: 'Ghost', medals: 0 }],
+            });
+            await waitForNoLoadingRows(api);
+
+            // LATENT QUIRK: even though the 'USA' group is collapsed and its child store has NOT
+            // been loaded, the transaction is reported as 'Applied' (NOT 'StoreNotFound') — the
+            // child store object exists lazily. However the added row is NOT retained: getRowNode
+            // returns nothing for it and the displayed count is unchanged. So an 'Applied' status
+            // here does not imply the row survived.
+            expect(result?.status).toBe('Applied');
+            expect(!!api.getRowNode('usa-ghost')).toBe(false);
+            expect(api.getDisplayedRowCount()).toBe(countBefore);
+        });
+    });
+});

--- a/testing/behavioural/src/tree-data/ssrm/ssrm-tree-grand-total.test.ts
+++ b/testing/behavioural/src/tree-data/ssrm/ssrm-tree-grand-total.test.ts
@@ -1,0 +1,229 @@
+import type { GridOptions, IServerSideDatasource, IServerSideGetRowsParams } from 'ag-grid-community';
+import { GRAND_TOTAL_ROW_ID } from 'ag-grid-community';
+import {
+    RowGroupingModule,
+    ServerSideRowModelApiModule,
+    ServerSideRowModelModule,
+    TreeDataModule,
+} from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, asyncSetTimeout } from '../../test-utils';
+import { waitForNoLoadingRows } from '../../test-utils/ssrm-test-utils';
+
+/**
+ * CHARACTERIZATION tests (golden-master) pinning the CURRENT behaviour of the
+ * grand-total / group-total (footer) rows for a TREE-DATA Server-Side Row Model
+ * (SSRM) grid with a numeric aggFunc column.
+ *
+ * These are NOT specification tests: each assertion records what the grid does
+ * today — where the grand-total footer renders (top / bottom), the aggregated
+ * values it carries, whether it stays pinned while a group is expanded, and how
+ * `groupTotalRow` produces per-group footers. If a value looks bug-shaped it is
+ * still pinned as the baseline so a future change surfaces as a diff to review.
+ *
+ * Any model-vs-DOM divergence in the total values is pinned and NOTED (mirroring
+ * the AG-17799 pivot grand-total divergence), never fixed here.
+ */
+describe('ag-grid SSRM treeData grand total / footer (characterization)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ServerSideRowModelModule, TreeDataModule, RowGroupingModule],
+    });
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    interface TreeRow {
+        id: string;
+        name: string;
+        value?: number;
+        group?: boolean;
+    }
+
+    // A small tree: two groups, each with numeric leaves. The grand-total sum of
+    // all leaves is 10 + 20 + 30 = 60; group A = 30, group B = 30.
+    const tree: Record<string, TreeRow[]> = {
+        '': [
+            { id: 'A', name: 'Group A', group: true },
+            { id: 'B', name: 'Group B', group: true },
+        ],
+        A: [
+            { id: 'A1', name: 'Alice', value: 10 },
+            { id: 'A2', name: 'Bob', value: 20 },
+        ],
+        B: [{ id: 'B1', name: 'Carol', value: 30 }],
+    };
+
+    // Inline request-stream recorder + tree datasource. When needsGrandTotal is
+    // set (root store only), the server appends a grand-total row summing every
+    // leaf in the tree.
+    function createTreeGrid(gridId: string, extraOptions?: Partial<GridOptions>) {
+        const requests: { groupKeys: string[]; needsGrandTotal: boolean }[] = [];
+
+        const datasource: IServerSideDatasource = {
+            getRows: (params: IServerSideGetRowsParams) => {
+                const { request } = params;
+                const groupKeys = request.groupKeys ?? [];
+                requests.push({ groupKeys: [...groupKeys], needsGrandTotal: params.needsGrandTotal });
+
+                const key = groupKeys.length === 0 ? '' : groupKeys[groupKeys.length - 1];
+                const rowData: any[] = (tree[key] ?? []).map((r) => ({ ...r }));
+
+                if (params.needsGrandTotal) {
+                    const total = Object.values(tree)
+                        .flat()
+                        .reduce((sum, r) => sum + (r.value ?? 0), 0);
+                    rowData.push({ id: GRAND_TOTAL_ROW_ID, value: total });
+                }
+
+                setTimeout(() => {
+                    params.success({ rowData, rowCount: rowData.length });
+                }, 1);
+            },
+        };
+
+        const gridOptions: GridOptions = {
+            columnDefs: [
+                { field: 'id', hide: true },
+                { field: 'value', aggFunc: 'sum' },
+            ],
+            autoGroupColumnDef: { field: 'name' },
+            defaultColDef: { flex: 1 },
+            treeData: true,
+            rowModelType: 'serverSide',
+            animateRows: false,
+            getRowId: ({ data }) => data.id,
+            isServerSideGroup: (data: any) => data.group,
+            getServerSideGroupKey: (data: any) => data.id,
+            serverSideDatasource: datasource,
+            ...extraOptions,
+        };
+
+        const api = gridsManager.createGrid(gridId, gridOptions);
+        return { api, requests };
+    }
+
+    test('grandTotalRow:bottom renders a footer at the bottom with the summed leaf total', async () => {
+        const { api, requests } = createTreeGrid('ssrmTreeGtBottom', { grandTotalRow: 'bottom' });
+
+        await asyncSetTimeout(1);
+        await waitForNoLoadingRows(api);
+
+        // Only the root store requests the grand total.
+        expect(requests[0]).toEqual({ groupKeys: [], needsGrandTotal: true });
+
+        const grandTotal = api.getRowNode(GRAND_TOTAL_ROW_ID);
+        expect(grandTotal?.footer).toBe(true);
+        expect(grandTotal?.level).toBe(-1);
+        expect(grandTotal?.data?.value).toBe(60);
+
+        await new GridRows(api, 'tree grand total bottom').check(`
+            ROOT id:<no-id>
+            ├── A GROUP collapsed id:A ag-Grid-AutoColumn:"Group A" id:"A"
+            ├── B GROUP collapsed id:B ag-Grid-AutoColumn:"Group B" id:"B"
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " id:"rowGroupFooter_ROOT_NODE_ID" value:60
+        `);
+    });
+
+    test('grandTotalRow:top renders the footer at the top', async () => {
+        const { api } = createTreeGrid('ssrmTreeGtTop', { grandTotalRow: 'top' });
+
+        await asyncSetTimeout(1);
+        await waitForNoLoadingRows(api);
+
+        expect(api.getRowNode(GRAND_TOTAL_ROW_ID)?.data?.value).toBe(60);
+
+        await new GridRows(api, 'tree grand total top').check(`
+            ROOT id:<no-id>
+            ├─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " id:"rowGroupFooter_ROOT_NODE_ID" value:60
+            ├── A GROUP collapsed id:A ag-Grid-AutoColumn:"Group A" id:"A"
+            └── B GROUP collapsed id:B ag-Grid-AutoColumn:"Group B" id:"B"
+        `);
+    });
+
+    test('grand total stays pinned and unchanged when a tree group is expanded', async () => {
+        const { api, requests } = createTreeGrid('ssrmTreeGtExpand', { grandTotalRow: 'bottom' });
+
+        await asyncSetTimeout(1);
+        await waitForNoLoadingRows(api);
+
+        const grandTotalIdBefore = api.getRowNode(GRAND_TOTAL_ROW_ID)?.id;
+        const valueBefore = api.getRowNode(GRAND_TOTAL_ROW_ID)?.data?.value;
+        requests.length = 0;
+
+        api.getRowNode('A')!.setExpanded(true);
+        await waitForNoLoadingRows(api);
+        await asyncSetTimeout(10);
+
+        // Expanding a group loads only that group's children — needsGrandTotal is
+        // NOT requested again, and the root grand-total node is the same instance
+        // carrying the same value.
+        expect(requests).toEqual([{ groupKeys: ['A'], needsGrandTotal: false }]);
+        expect(api.getRowNode(GRAND_TOTAL_ROW_ID)?.id).toBe(grandTotalIdBefore);
+        expect(api.getRowNode(GRAND_TOTAL_ROW_ID)?.data?.value).toBe(valueBefore);
+
+        await new GridRows(api, 'tree grand total after expand A').check(`
+            ROOT id:<no-id>
+            ├─┬ A GROUP id:A ag-Grid-AutoColumn:"Group A" id:"A"
+            │ ├── LEAF id:A1 ag-Grid-AutoColumn:"Alice" id:"A1" value:10
+            │ └── LEAF id:A2 ag-Grid-AutoColumn:"Bob" id:"A2" value:20
+            ├── B GROUP collapsed id:B ag-Grid-AutoColumn:"Group B" id:"B"
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " id:"rowGroupFooter_ROOT_NODE_ID" value:60
+        `);
+    });
+
+    test('groupTotalRow:bottom adds a per-group footer alongside the grand total', async () => {
+        const { api } = createTreeGrid('ssrmTreeGroupTotal', {
+            grandTotalRow: 'bottom',
+            groupTotalRow: 'bottom',
+        });
+
+        await asyncSetTimeout(1);
+        await waitForNoLoadingRows(api);
+
+        api.getRowNode('A')!.setExpanded(true);
+        await waitForNoLoadingRows(api);
+        await asyncSetTimeout(10);
+
+        // DIVERGENCE (pinned, not fixed): despite aggFunc:'sum', neither the tree
+        // group rows (A / B) nor the per-group footer (rowGroupFooter_A) carry an
+        // aggregated `value` — SSRM does not client-side aggregate the loaded tree
+        // leaves, so those cells render empty. Only the server-supplied grand-total
+        // footer shows a value (60). A future change enabling group aggregation
+        // would surface here as A=30 / group footer=30.
+        await new GridRows(api, 'tree group total bottom expanded A').check(`
+            ROOT id:<no-id>
+            ├─┬ A GROUP id:A ag-Grid-AutoColumn:"Group A" id:"A"
+            │ ├── LEAF id:A1 ag-Grid-AutoColumn:"Alice" id:"A1" value:10
+            │ ├── LEAF id:A2 ag-Grid-AutoColumn:"Bob" id:"A2" value:20
+            │ └─ footer id:rowGroupFooter_A ag-Grid-AutoColumn:"Total Group A" id:"A"
+            ├── B GROUP collapsed id:B ag-Grid-AutoColumn:"Group B" id:"B"
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " id:"rowGroupFooter_ROOT_NODE_ID" value:60
+        `);
+    });
+
+    test('MODEL-VS-DOM: grand-total value is on the model node; displayed count includes the footer', async () => {
+        const { api } = createTreeGrid('ssrmTreeGtDivergence', { grandTotalRow: 'bottom' });
+
+        await asyncSetTimeout(1);
+        await waitForNoLoadingRows(api);
+
+        // The footer's aggregated value lives on the model node's raw data.
+        const grandTotal = api.getRowNode(GRAND_TOTAL_ROW_ID);
+        expect(grandTotal?.data?.value).toBe(60);
+
+        // The grand-total footer occupies a display index: 2 groups + 1 footer = 3.
+        expect(api.getDisplayedRowCount()).toBe(3);
+
+        await new GridRows(api, 'tree grand total divergence').check(`
+            ROOT id:<no-id>
+            ├── A GROUP collapsed id:A ag-Grid-AutoColumn:"Group A" id:"A"
+            ├── B GROUP collapsed id:B ag-Grid-AutoColumn:"Group B" id:"B"
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID ag-Grid-AutoColumn:"Total " id:"rowGroupFooter_ROOT_NODE_ID" value:60
+        `);
+    });
+});

--- a/testing/behavioural/src/tree-data/ssrm/ssrm-tree-initial-and-selection.test.ts
+++ b/testing/behavioural/src/tree-data/ssrm/ssrm-tree-initial-and-selection.test.ts
@@ -1,0 +1,327 @@
+import type { GridOptions, IServerSideGetRowsParams } from 'ag-grid-community';
+import { RowSelectionModule } from 'ag-grid-community';
+import { ServerSideRowModelApiModule, ServerSideRowModelModule, TreeDataModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, asyncSetTimeout } from '../../test-utils';
+import { countLoadingRows, waitForNoLoadingRows } from '../../test-utils/ssrm-test-utils';
+import { createFakeServer, getSmallTreeDataSet } from './ssrmSmallTreeDataSet';
+
+/**
+ * CHARACTERIZATION (golden-master) tests pinning CURRENT SSRM tree-data behaviour for two cells:
+ *
+ *   (A) INITIAL LOAD with `serverSideInitialRowCount` on tree data — how many top-level
+ *       placeholder/loading rows show BEFORE the root store resolves, the first request
+ *       shape (empty groupKeys), and how the displayed top-level count RECONCILES once the
+ *       real number of tree roots arrives (both larger and smaller than the initial guess).
+ *       Also pins whether the initial-count guess applies to child levels on expand.
+ *
+ *   (B) SELECTION with `rowSelection: { mode: 'multiRow', groupSelects: 'descendants' }`
+ *       (the modern replacement for the old boolean `groupSelectsChildren`) on tree data —
+ *       which nodes become selected when a group is selected, `getSelectedNodes().length`
+ *       and their ids, how NOT-yet-loaded descendants behave (select the parent BEFORE
+ *       expanding, then load), and selecting a leaf vs a group.
+ *
+ * These assert what the grid DOES today, bugs included. RowNode objects are never asserted
+ * directly (circular → RangeError); existence is checked via booleans and selection via
+ * scalar counts / id arrays. GridRows inline snapshots are generated via --update-grid-rows.
+ */
+
+interface RecordedRequest {
+    groupKeys: string[];
+    range: [number | undefined, number | undefined];
+}
+
+describe('ag-grid SSRM treeData initial-load & selection (characterization)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ServerSideRowModelModule, TreeDataModule, RowSelectionModule],
+    });
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    // Base tree-data SSRM grid options; datasource is supplied per test so each test records
+    // its own request stream inline (house style — no shared datasource factory).
+    function createTreeGridOptions(extra: Partial<GridOptions> = {}): GridOptions {
+        return {
+            columnDefs: [
+                { field: 'employeeId', hide: true },
+                { field: 'employeeName', hide: true },
+                { field: 'jobTitle' },
+                { field: 'employmentType' },
+            ],
+            autoGroupColumnDef: { field: 'employeeName' },
+            defaultColDef: { flex: 1 },
+            treeData: true,
+            rowModelType: 'serverSide',
+            animateRows: false,
+            getRowId: ({ data }) => data.employeeId,
+            isServerSideGroup: (dataItem: any) => dataItem.group,
+            getServerSideGroupKey: (dataItem: any) => dataItem.employeeId,
+            ...extra,
+        };
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // (A) INITIAL LOAD × Tree-data
+    // ---------------------------------------------------------------------------------------
+    describe('initial load (serverSideInitialRowCount) x tree-data', () => {
+        test('before the root resolves: serverSideInitialRowCount top-level placeholder rows show and the first request has empty groupKeys', async () => {
+            const initialCount = 7;
+            const requests: RecordedRequest[] = [];
+            // Deferred datasource: stash params so the root store stays in-flight and the
+            // pre-resolve display state can be observed.
+            const pending: IServerSideGetRowsParams[] = [];
+            const fakeServer = createFakeServer(getSmallTreeDataSet());
+
+            const api = gridsManager.createGrid(
+                'ssrmTreeInitialPending',
+                createTreeGridOptions({
+                    serverSideInitialRowCount: initialCount,
+                    serverSideDatasource: {
+                        getRows: (params: IServerSideGetRowsParams) => {
+                            requests.push({
+                                groupKeys: [...(params.request.groupKeys ?? [])],
+                                range: [params.request.startRow, params.request.endRow],
+                            });
+                            pending.push(params);
+                        },
+                    },
+                })
+            );
+
+            // Let the root request dispatch without resolving it.
+            await asyncSetTimeout(30);
+
+            // The grid sizes its top level to the configured initial row count before the
+            // root store resolves, and every one of those rows is a loading/stub row.
+            expect(api.getDisplayedRowCount()).toBe(initialCount);
+            expect(countLoadingRows(api)).toBe(initialCount);
+
+            // The first (and only) request so far is for the root children: empty groupKeys.
+            expect(requests.length).toBe(1);
+            expect(requests[0].groupKeys).toEqual([]);
+
+            // Drain the in-flight request so the deferred datasource does not leak past the test.
+            for (let i = 0, len = pending.length; i < len; ++i) {
+                const rows = fakeServer.getData(pending[i].request);
+                pending[i].success({ rowData: rows, rowCount: rows.length });
+            }
+        });
+
+        test('after the root resolves: displayed top-level count reflects the single real tree root (initial guess of 7 shrinks to 1)', async () => {
+            const initialCount = 7;
+            const requests: RecordedRequest[] = [];
+            const fakeServer = createFakeServer(getSmallTreeDataSet());
+
+            const api = gridsManager.createGrid(
+                'ssrmTreeInitialShrink',
+                createTreeGridOptions({
+                    serverSideInitialRowCount: initialCount,
+                    serverSideDatasource: {
+                        getRows: (params: IServerSideGetRowsParams) => {
+                            requests.push({
+                                groupKeys: [...(params.request.groupKeys ?? [])],
+                                range: [params.request.startRow, params.request.endRow],
+                            });
+                            const rows = fakeServer.getData(params.request);
+                            setTimeout(() => params.success({ rowData: rows, rowCount: rows.length }), 1);
+                        },
+                    },
+                })
+            );
+
+            await asyncSetTimeout(1);
+            await waitForNoLoadingRows(api);
+
+            // Reconciliation: the dataset has a single root (id 101), so the initial guess of 7
+            // shrinks to 1 once the real root children resolve. No loading stubs remain.
+            expect(api.getDisplayedRowCount()).toBe(1);
+            expect(countLoadingRows(api)).toBe(0);
+            expect(!!api.getRowNode('101')).toBe(true);
+            expect(requests[0].groupKeys).toEqual([]);
+
+            await new GridRows(api, 'tree initial-count shrunk to 1 real root').check(`
+                ROOT id:<no-id>
+                └── 101 GROUP collapsed id:101 ag-Grid-AutoColumn:"Erica Rogers" employeeId:"101" employeeName:"Erica Rogers" jobTitle:"CEO" employmentType:"Permanent"
+            `);
+        });
+
+        test('serverSideInitialRowCount does NOT pre-size a child level on expand: an expanded group shows its real children directly, no top-level-sized placeholders', async () => {
+            const initialCount = 7;
+            const requests: RecordedRequest[] = [];
+            // Defer only the child (expand) request so the child-level pre-resolve state is observable.
+            let deferChild = false;
+            const pendingChild: IServerSideGetRowsParams[] = [];
+            const fakeServer = createFakeServer(getSmallTreeDataSet());
+
+            const api = gridsManager.createGrid(
+                'ssrmTreeInitialChildLevel',
+                createTreeGridOptions({
+                    serverSideInitialRowCount: initialCount,
+                    serverSideDatasource: {
+                        getRows: (params: IServerSideGetRowsParams) => {
+                            requests.push({
+                                groupKeys: [...(params.request.groupKeys ?? [])],
+                                range: [params.request.startRow, params.request.endRow],
+                            });
+                            if (deferChild && (params.request.groupKeys?.length ?? 0) > 0) {
+                                pendingChild.push(params);
+                                return;
+                            }
+                            const rows = fakeServer.getData(params.request);
+                            setTimeout(() => params.success({ rowData: rows, rowCount: rows.length }), 1);
+                        },
+                    },
+                })
+            );
+
+            await asyncSetTimeout(1);
+            await waitForNoLoadingRows(api);
+
+            // Expand 101 but hold the child request in-flight to observe the child level's pre-resolve size.
+            deferChild = true;
+            api.getRowNode('101')!.setExpanded(true);
+            await asyncSetTimeout(30);
+
+            // Child-level finding: serverSideInitialRowCount does NOT apply to child stores. While
+            // 101's children load, exactly ONE loading row shows under it (not `initialCount`), so
+            // the displayed count is the root (1) + a single child placeholder (1) = 2.
+            expect(countLoadingRows(api)).toBe(1);
+            expect(api.getDisplayedRowCount()).toBe(2);
+
+            // Resolve the deferred child request.
+            for (let i = 0, len = pendingChild.length; i < len; ++i) {
+                const rows = fakeServer.getData(pendingChild[i].request);
+                pendingChild[i].success({ rowData: rows, rowCount: rows.length });
+            }
+            await waitForNoLoadingRows(api);
+
+            expect(countLoadingRows(api)).toBe(0);
+
+            await new GridRows(api, 'tree expanded child level (no initial-count pre-size)').check(`
+                ROOT id:<no-id>
+                └─┬ 101 GROUP id:101 ag-Grid-AutoColumn:"Erica Rogers" employeeId:"101" employeeName:"Erica Rogers" jobTitle:"CEO" employmentType:"Permanent"
+                · ├── 102 GROUP collapsed id:102 ag-Grid-AutoColumn:"Malcolm Barrett" employeeId:"102" employeeName:"Malcolm Barrett" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+                · └── 113 GROUP collapsed id:113 ag-Grid-AutoColumn:"Luke McBride" employeeId:"113" employeeName:"Luke McBride" jobTitle:"Exec. Vice President" employmentType:"Permanent"
+            `);
+        });
+    });
+
+    // ---------------------------------------------------------------------------------------
+    // (B) SELECTION (groupSelects: 'descendants') × Tree-data
+    // ---------------------------------------------------------------------------------------
+    describe('selection (groupSelects descendants) x tree-data', () => {
+        function createSelectionGrid(gridId: string) {
+            const requests: RecordedRequest[] = [];
+            const fakeServer = createFakeServer(getSmallTreeDataSet());
+            const api = gridsManager.createGrid(
+                gridId,
+                createTreeGridOptions({
+                    rowSelection: { mode: 'multiRow', groupSelects: 'descendants' },
+                    serverSideDatasource: {
+                        getRows: (params: IServerSideGetRowsParams) => {
+                            requests.push({
+                                groupKeys: [...(params.request.groupKeys ?? [])],
+                                range: [params.request.startRow, params.request.endRow],
+                            });
+                            const rows = fakeServer.getData(params.request);
+                            setTimeout(() => params.success({ rowData: rows, rowCount: rows.length }), 1);
+                        },
+                    },
+                })
+            );
+            return { api, requests };
+        }
+
+        async function expandById(api: any, id: string): Promise<void> {
+            api.getRowNode(id)!.setExpanded(true);
+            await waitForNoLoadingRows(api);
+        }
+
+        test('selecting a fully-loaded group selects the group and all its loaded descendants', async () => {
+            const { api } = createSelectionGrid('ssrmTreeSelectLoadedGroup');
+
+            await asyncSetTimeout(1);
+            await waitForNoLoadingRows(api);
+            // Expand the branch 101 -> 102 -> 108 so all of 108's descendants (leaves) are loaded.
+            await expandById(api, '101');
+            await expandById(api, '102');
+            await expandById(api, '108');
+
+            // Select group 108 — with groupSelects:'descendants' its loaded leaf children are selected too.
+            api.getRowNode('108')!.setSelected(true);
+
+            const selectedIds = api
+                .getSelectedNodes()
+                .map((n: any) => n.id)
+                .sort();
+            // Pin: group 108 plus its four loaded leaf children (109-112) become selected.
+            expect(selectedIds).toEqual(['108', '109', '110', '111', '112'].sort());
+            expect(api.getSelectedNodes().length).toBe(5);
+        });
+
+        test('selecting a group BEFORE its descendants are loaded: only the group is selected now; children get selected once later loaded on expand', async () => {
+            const { api } = createSelectionGrid('ssrmTreeSelectUnloadedGroup');
+
+            await asyncSetTimeout(1);
+            await waitForNoLoadingRows(api);
+            await expandById(api, '101');
+            // 102 is loaded (child of 101) but NOT expanded, so 102's own descendants are unloaded.
+
+            // Select group 102 while its descendants are still unloaded.
+            api.getRowNode('102')!.setSelected(true);
+
+            // Latent behaviour (unloaded descendants): at select time only the group node itself
+            // counts as selected — the not-yet-loaded descendants cannot be enumerated.
+            const selectedBefore = api
+                .getSelectedNodes()
+                .map((n: any) => n.id)
+                .sort();
+            expect(selectedBefore).toEqual(['102']);
+            expect(api.getSelectedNodes().length).toBe(1);
+
+            // Now expand 102 so its children load. Pin whether the descendants inherit the
+            // group's selection once they arrive.
+            await expandById(api, '102');
+
+            const selectedAfter = api
+                .getSelectedNodes()
+                .map((n: any) => n.id)
+                .sort();
+            // Latent behaviour pinned: on load, the newly-arrived children of the selected group
+            // ARE auto-selected (103, 108 join 102).
+            expect(selectedAfter).toEqual(['102', '103', '108'].sort());
+            expect(api.getSelectedNodes().length).toBe(3);
+        });
+
+        test('selecting a leaf selects only that leaf (no descendants, no ancestor cascade)', async () => {
+            const { api } = createSelectionGrid('ssrmTreeSelectLeaf');
+
+            await asyncSetTimeout(1);
+            await waitForNoLoadingRows(api);
+            await expandById(api, '101');
+            await expandById(api, '102');
+            await expandById(api, '108');
+
+            // Select a single leaf (109).
+            api.getRowNode('109')!.setSelected(true);
+
+            const selectedIds = api
+                .getSelectedNodes()
+                .map((n: any) => n.id)
+                .sort();
+            // Pin: a leaf selection is just that one node — no descendants, and the parent group
+            // 108 is NOT auto-selected from a single child (partial selection, not full).
+            expect(selectedIds).toEqual(['109']);
+            expect(api.getSelectedNodes().length).toBe(1);
+            // Latent behaviour: isSelected() on the not-fully-selected parent group returns
+            // `undefined` here (indeterminate), not `false`.
+            expect(api.getRowNode('108')!.isSelected()).toBe(undefined);
+        });
+    });
+});


### PR DESCRIPTION
## Characterization coverage — partial-coverage matrix cells (PR4)

Fourth and final pass of the SSRM golden-master coverage sweep. This PR converts the **11 partial ("thin") cells** in the [coverage matrix](https://claude.ai/code/artifact/7515d2e1-da99-4677-9718-cdb752572d14) into dedicated, fully-characterized coverage.

Follows the same conventions as PRs [#14355](https://github.com/ag-grid/ag-grid/pull/14355) / [#14356](https://github.com/ag-grid/ag-grid/pull/14356) / [#14357](https://github.com/ag-grid/ag-grid/pull/14357): golden-master (pins current behaviour, bugs included), inline request-stream recorder per file, `GridRows` snapshots.

### 7 new files · 33 tests

| File | Cells → green | Tests |
|---|---|---|
| `row-data/ssrm-initial-row-count` | Initial load × Flat | 4 |
| `row-data/ssrm-flat-sort-filter` | Sort-server × Flat, Filter × Flat | 5 |
| `row-data/ssrm-sync-transactions` | Transaction-sync × Flat & Grouped | 7 |
| `grouping-data/ssrm/ssrm-grouped-initial-row-count` | Initial load × Grouped | 4 |
| `grouping-data/ssrm/ssrm-pivot-sort-expand` | Sort-server × Pivot, Expand/collapse × Pivot | 2 |
| `tree-data/ssrm/ssrm-tree-initial-and-selection` | Initial load × Tree, Selection × Tree | 6 |
| `tree-data/ssrm/ssrm-tree-grand-total` | Grand total × Tree | 5 |

### Latent behaviours pinned as baseline (not fixed)
- **Grouped initial stubs** render as `LEAF_GROUP collapsed` group stubs, not plain `filler` (flat init stubs are `filler`). `serverSideInitialRowCount` pads only the root level, not child levels.
- **Sync `applyServerSideTransaction` to an unloaded/collapsed route** returns `status: 'Applied'` yet silently drops the row — an `'Applied'` status does not guarantee the row survived.
- **Server-side re-sort mints fresh root node ids** (store refetched, not reordered in place).
- **Tree group rows & group footers carry no client-side aggregation** despite `aggFunc` — SSRM does not aggregate loaded tree leaves, so those cells render empty (AG-17799-style model-vs-DOM divergence). Only the server-supplied grand total shows a value.
- **Selection propagates to descendants as they load**: selecting a group before expanding selects only the group; newly-loaded children are auto-selected on arrival. `getSelectedNodes` warns 202 under `groupSelects`+SSRM but still returns the nodes.

All 7 files green locally.
