### PR TITLE
test(ssrm): characterize master/detail, selection-state & getChildCount (PR5)

### DIFF
--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-get-child-count.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-get-child-count.test.ts
@@ -1,0 +1,184 @@
+import type { IServerSideGetRowsParams } from 'ag-grid-community';
+import { RowGroupingModule, ServerSideRowModelApiModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
+
+import { GridRows, TestGridsManager, waitForEvent } from '../../test-utils';
+import { waitForNoLoadingRows } from '../../test-utils/ssrm-test-utils';
+
+/**
+ * CHARACTERIZATION (golden-master) tests pinning the CURRENT behaviour of the SSRM
+ * `getChildCount` callback.
+ *
+ * `setChildCountIntoRowNode` (blockUtils.ts) calls `getChildCount(rowNode.data)` and
+ * feeds the result into `rowNode.setAllChildrenCount()` when a group node's own block
+ * loads — i.e. when the group row itself is created, BEFORE it is expanded and BEFORE
+ * its children are requested. These tests freeze that pre-sizing behaviour and contrast
+ * it against the default (no callback) case.
+ *
+ * These are not aspirational specs: each assertion records what the grid actually does
+ * today. Do NOT "fix" a value to what you think it should be — a changed value is a
+ * behavioural change to review.
+ */
+
+interface RequestRecord {
+    groupKeys: string[];
+    range: [number, number];
+}
+
+describe('SSRM getChildCount callback (characterization)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ServerSideRowModelModule, RowGroupingModule],
+    });
+
+    afterEach(() => gridsManager.reset());
+
+    // country -> athletes. UK has 5 leaves, US has 2, FR has 1.
+    const LEAF_ROWS = [
+        { id: 'uk-alice', country: 'UK', athlete: 'Alice' },
+        { id: 'uk-bob', country: 'UK', athlete: 'Bob' },
+        { id: 'uk-carol', country: 'UK', athlete: 'Carol' },
+        { id: 'uk-dan', country: 'UK', athlete: 'Dan' },
+        { id: 'uk-eve', country: 'UK', athlete: 'Eve' },
+        { id: 'us-frank', country: 'US', athlete: 'Frank' },
+        { id: 'us-grace', country: 'US', athlete: 'Grace' },
+        { id: 'fr-heidi', country: 'FR', athlete: 'Heidi' },
+    ];
+
+    const CHILD_COUNTS: Record<string, number> = { UK: 5, US: 2, FR: 1 };
+
+    function makeDatasource(requests: RequestRecord[], blockSize?: number) {
+        return {
+            getRows: (params: IServerSideGetRowsParams) => {
+                const groupKeys = (params.request.groupKeys ?? []) as string[];
+                const start = params.request.startRow!;
+                const end = params.request.endRow!;
+                requests.push({ groupKeys, range: [start, end] });
+                if (groupKeys.length === 0) {
+                    const countries = Array.from(new Set(LEAF_ROWS.map((r) => r.country)));
+                    const rows = countries.map((country) => ({ id: `group-${country}`, country }));
+                    params.success({ rowData: [...rows], rowCount: rows.length });
+                    return;
+                }
+                const all = LEAF_ROWS.filter((r) => r.country === groupKeys[0]);
+                const page = blockSize != null ? all.slice(start, end) : all;
+                params.success({ rowData: [...page], rowCount: all.length });
+            },
+        };
+    }
+
+    test('scenario 1: getChildCount pre-sizes a group node before it is expanded', async () => {
+        const requests: RequestRecord[] = [];
+
+        const api = gridsManager.createGrid(null, {
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
+            autoGroupColumnDef: { field: 'athlete' },
+            rowModelType: 'serverSide',
+            getChildCount: (data) => CHILD_COUNTS[data.country],
+            getRowId: (p) => p.data.id ?? `group-${p.data.country}`,
+            serverSideDatasource: makeDatasource(requests),
+        });
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        // Only the root group block was requested — no child routes loaded yet.
+        expect(requests).toEqual([{ groupKeys: [], range: [0, 100] }]);
+
+        // The grid trusts getChildCount: each group reports its child count without loading children.
+        expect(api.getRowNode('group-UK')!.allChildrenCount).toBe(5);
+        expect(api.getRowNode('group-US')!.allChildrenCount).toBe(2);
+        expect(api.getRowNode('group-FR')!.allChildrenCount).toBe(1);
+
+        // Only the 3 collapsed group rows are displayed; children not loaded.
+        expect(api.getDisplayedRowCount()).toBe(3);
+    });
+
+    test('scenario 2: expanding a pre-sized group requests its child blocks by cacheBlockSize', async () => {
+        const requests: RequestRecord[] = [];
+
+        const api = gridsManager.createGrid(null, {
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
+            autoGroupColumnDef: { field: 'athlete' },
+            rowModelType: 'serverSide',
+            cacheBlockSize: 2,
+            getChildCount: (data) => CHILD_COUNTS[data.country],
+            getRowId: (p) => p.data.id ?? `group-${p.data.country}`,
+            serverSideDatasource: makeDatasource(requests, 2),
+        });
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        expect(api.getRowNode('group-UK')!.allChildrenCount).toBe(5);
+
+        api.getRowNode('group-UK')!.setExpanded(true);
+        await waitForNoLoadingRows(api);
+
+        // UK's 5 children are loaded in blocks of 2 within the ['UK'] route.
+        expect(requests).toEqual([
+            { groupKeys: [], range: [0, 2] },
+            { groupKeys: ['UK'], range: [0, 2] },
+            { groupKeys: ['UK'], range: [2, 4] },
+            { groupKeys: ['UK'], range: [4, 6] },
+        ]);
+
+        // After load the reported child count stays 5 and the children are displayed.
+        expect(api.getRowNode('group-UK')!.allChildrenCount).toBe(5);
+        expect(api.getDisplayedRowCount()).toBe(8);
+
+        await new GridRows(api, 'scenario 2 after expand UK').check(`
+            ROOT id:<no-id>
+            ├─┬ GROUP-leafGroup id:group-UK ag-Grid-AutoColumn:"UK" country:"UK"
+            │ ├── LEAF id:uk-alice ag-Grid-AutoColumn:"Alice" country:"UK" athlete:"Alice"
+            │ ├── LEAF id:uk-bob ag-Grid-AutoColumn:"Bob" country:"UK" athlete:"Bob"
+            │ ├── LEAF id:uk-carol ag-Grid-AutoColumn:"Carol" country:"UK" athlete:"Carol"
+            │ ├── LEAF id:uk-dan ag-Grid-AutoColumn:"Dan" country:"UK" athlete:"Dan"
+            │ └── LEAF id:uk-eve ag-Grid-AutoColumn:"Eve" country:"UK" athlete:"Eve"
+            ├── GROUP-leafGroup collapsed id:group-US ag-Grid-AutoColumn:"US" country:"US"
+            └── GROUP-leafGroup collapsed id:group-FR ag-Grid-AutoColumn:"FR" country:"FR"
+        `);
+    });
+
+    test('scenario 3: getChildCount value is independent of the actual children returned', async () => {
+        const requests: RequestRecord[] = [];
+
+        // Deliberately report a child count that does NOT match the real number of leaf rows.
+        const api = gridsManager.createGrid(null, {
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
+            autoGroupColumnDef: { field: 'athlete' },
+            rowModelType: 'serverSide',
+            getChildCount: () => 42,
+            getRowId: (p) => p.data.id ?? `group-${p.data.country}`,
+            serverSideDatasource: makeDatasource(requests),
+        });
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        // The grid reports whatever getChildCount says, regardless of true leaf count.
+        expect(api.getRowNode('group-UK')!.allChildrenCount).toBe(42);
+        expect(api.getRowNode('group-US')!.allChildrenCount).toBe(42);
+    });
+
+    test('scenario 4: without getChildCount allChildrenCount stays null even after children load', async () => {
+        const requests: RequestRecord[] = [];
+
+        const api = gridsManager.createGrid(null, {
+            columnDefs: [{ field: 'country', rowGroup: true, hide: true }, { field: 'athlete' }],
+            autoGroupColumnDef: { field: 'athlete' },
+            rowModelType: 'serverSide',
+            getRowId: (p) => p.data.id ?? `group-${p.data.country}`,
+            serverSideDatasource: makeDatasource(requests),
+        });
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+
+        // No callback: the group's child count is unknown before it is loaded.
+        expect(api.getRowNode('group-UK')!.allChildrenCount).toBe(null);
+
+        api.getRowNode('group-UK')!.setExpanded(true);
+        await waitForNoLoadingRows(api);
+
+        // CHARACTERIZATION: even after the children load, allChildrenCount is NOT populated
+        // from the loaded rows — it remains null. Only getChildCount sets this value in SSRM.
+        expect(api.getRowNode('group-UK')!.allChildrenCount).toBe(null);
+        // The children are nonetheless loaded and displayed.
+        expect(api.getDisplayedRowCount()).toBe(8);
+    });
+});

--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-master-detail.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-master-detail.test.ts
@@ -1,4 +1,10 @@
-import type { GetDetailRowDataParams, GetRowIdParams, GridOptions, IServerSideGetRowsParams } from 'ag-grid-community';
+import type {
+    GetDetailRowDataParams,
+    GetRowIdParams,
+    GridOptions,
+    IRowNode,
+    IServerSideGetRowsParams,
+} from 'ag-grid-community';
 import { DETAIL_ROW_ID_PREFIX } from 'ag-grid-community';
 import { MasterDetailModule, ServerSideRowModelApiModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
 
@@ -123,10 +129,10 @@ describe('ag-grid SSRM flat master-detail load & refresh (characterization)', ()
         expect(detailNode?.data?.id).toBe('A');
 
         // Detail grid received the master's records (A0, A1) via successCallback.
-        const detailApi = detailNode!.detailGridInfo!.api!;
+        const detailApi = api.getDetailGridInfo(DETAIL_ROW_ID_PREFIX + 'A')!.api!;
         expect(detailApi.getDisplayedRowCount()).toBe(2);
         const detailIds: string[] = [];
-        detailApi.forEachNode((n) => detailIds.push(n.id!));
+        detailApi.forEachNode((n: IRowNode) => detailIds.push(n.id!));
         expect(detailIds.sort()).toEqual(['A0', 'A1']);
     });
 

--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-master-detail.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-master-detail.test.ts
@@ -1,0 +1,235 @@
+import type { GetDetailRowDataParams, GetRowIdParams, GridOptions, IServerSideGetRowsParams } from 'ag-grid-community';
+import { DETAIL_ROW_ID_PREFIX } from 'ag-grid-community';
+import { MasterDetailModule, ServerSideRowModelApiModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, waitForNoLoadingRows } from '../../test-utils';
+
+/**
+ * CHARACTERIZATION (golden-master) tests pinning CURRENT flat SSRM master/detail behaviour:
+ * detail-datasource load + refresh mechanics. These assert what the grid DOES today (bugs
+ * included). RowNode objects are never asserted directly (circular → RangeError); existence /
+ * shape is checked via booleans, scalar counts, and ids. This is a FLAT master-detail SSRM grid
+ * (rowData is a plain list of master account rows) — NOT tree data (a tree-data md smoke test
+ * already lives in tree-data/ssrm/ssrm-tree-data-master-detail.test.ts).
+ */
+
+interface RecordedRequest {
+    groupKeys: string[];
+    range: [number | undefined, number | undefined];
+}
+
+interface MasterRow {
+    id: string;
+    name: string;
+    records: { name: string; value: number }[];
+}
+
+describe('ag-grid SSRM flat master-detail load & refresh (characterization)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ServerSideRowModelModule, MasterDetailModule],
+    });
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    function createMasterRows(): MasterRow[] {
+        return [
+            {
+                id: 'A',
+                name: 'Account A',
+                records: [
+                    { name: 'A0', value: 1 },
+                    { name: 'A1', value: 2 },
+                ],
+            },
+            { id: 'B', name: 'Account B', records: [] },
+            { id: 'C', name: 'Account C', records: [{ name: 'C0', value: 3 }] },
+        ];
+    }
+
+    // Base flat master-detail SSRM grid options. Each test supplies its own datasource / detail
+    // counters inline (house style — no shared datasource factory).
+    function createGridOptions(extra: Partial<GridOptions> = {}): GridOptions {
+        return {
+            columnDefs: [{ field: 'id' }, { field: 'name' }],
+            rowModelType: 'serverSide',
+            animateRows: false,
+            masterDetail: true,
+            getRowId: (params: GetRowIdParams) => params.data.id,
+            isRowMaster: (dataItem: MasterRow) => !!dataItem?.records?.length,
+            ...extra,
+        };
+    }
+
+    test('expanding a master row invokes getDetailRowData once and the detail row appears with correct data', async () => {
+        const masterRows = createMasterRows();
+        const requests: RecordedRequest[] = [];
+        let detailCalls = 0;
+        const detailRequestedFor: string[] = [];
+
+        const api = gridsManager.createGrid(
+            'ssrmMdExpand',
+            createGridOptions({
+                detailCellRendererParams: {
+                    detailGridOptions: {
+                        columnDefs: [{ field: 'name' }, { field: 'value' }],
+                        getRowId: ({ data }: GetRowIdParams) => data.name,
+                    },
+                    getDetailRowData: (params: GetDetailRowDataParams) => {
+                        ++detailCalls;
+                        detailRequestedFor.push(params.data.id);
+                        params.successCallback(params.data.records);
+                    },
+                },
+                serverSideDatasource: {
+                    getRows: (params: IServerSideGetRowsParams) => {
+                        requests.push({
+                            groupKeys: [...(params.request.groupKeys ?? [])],
+                            range: [params.request.startRow, params.request.endRow],
+                        });
+                        setTimeout(() => params.success({ rowData: masterRows, rowCount: masterRows.length }), 1);
+                    },
+                },
+            })
+        );
+
+        await waitForNoLoadingRows(api);
+
+        // Master rows loaded via a single root request (empty groupKeys). Only A and C are masters
+        // (B has no records → isRowMaster false), so 3 master rows displayed, none expanded yet.
+        expect(requests.length).toBe(1);
+        expect(requests[0].groupKeys).toEqual([]);
+        expect(api.getDisplayedRowCount()).toBe(3);
+        expect(detailCalls).toBe(0);
+        expect(api.getRowNode('A')!.master).toBe(true);
+        expect(api.getRowNode('B')!.master).toBe(false);
+
+        // Expand master A → the detail row appears and getDetailRowData is called exactly once for A.
+        api.getRowNode('A')!.setExpanded(true);
+        await waitForNoLoadingRows(api);
+
+        expect(detailCalls).toBe(1);
+        expect(detailRequestedFor).toEqual(['A']);
+        // 3 masters + 1 detail row = 4 displayed.
+        expect(api.getDisplayedRowCount()).toBe(4);
+
+        const detailNode = api.getRowNode(DETAIL_ROW_ID_PREFIX + 'A');
+        expect(detailNode?.detail).toBe(true);
+        expect(detailNode?.data?.id).toBe('A');
+
+        // Detail grid received the master's records (A0, A1) via successCallback.
+        const detailApi = detailNode!.detailGridInfo!.api!;
+        expect(detailApi.getDisplayedRowCount()).toBe(2);
+        const detailIds: string[] = [];
+        detailApi.forEachNode((n) => detailIds.push(n.id!));
+        expect(detailIds.sort()).toEqual(['A0', 'A1']);
+    });
+
+    test('collapse then re-expand the same master RE-FETCHES detail data (getDetailRowData called again)', async () => {
+        const masterRows = createMasterRows();
+        let detailCalls = 0;
+
+        const api = gridsManager.createGrid(
+            'ssrmMdReExpand',
+            createGridOptions({
+                detailCellRendererParams: {
+                    detailGridOptions: {
+                        columnDefs: [{ field: 'name' }, { field: 'value' }],
+                        getRowId: ({ data }: GetRowIdParams) => data.name,
+                    },
+                    getDetailRowData: (params: GetDetailRowDataParams) => {
+                        ++detailCalls;
+                        params.successCallback(params.data.records);
+                    },
+                },
+                serverSideDatasource: {
+                    getRows: (params: IServerSideGetRowsParams) => {
+                        setTimeout(() => params.success({ rowData: masterRows, rowCount: masterRows.length }), 1);
+                    },
+                },
+            })
+        );
+
+        await waitForNoLoadingRows(api);
+
+        api.getRowNode('A')!.setExpanded(true);
+        await waitForNoLoadingRows(api);
+        expect(detailCalls).toBe(1);
+
+        // Collapse A.
+        api.getRowNode('A')!.setExpanded(false);
+        await waitForNoLoadingRows(api);
+        expect(api.getDisplayedRowCount()).toBe(3);
+
+        // Re-expand A. Surprising pin: the SSRM detail node is NOT cached across collapse — the
+        // detail row is destroyed on collapse and getDetailRowData is called AGAIN on re-expand.
+        api.getRowNode('A')!.setExpanded(true);
+        await waitForNoLoadingRows(api);
+
+        expect(detailCalls).toBe(2);
+        expect(api.getDisplayedRowCount()).toBe(4);
+        expect(api.getRowNode(DETAIL_ROW_ID_PREFIX + 'A')?.detail).toBe(true);
+    });
+
+    test('refreshServerSide({purge:true}) re-issues the master getRows while the open detail survives', async () => {
+        const masterRows = createMasterRows();
+        const requests: RecordedRequest[] = [];
+        let detailCalls = 0;
+
+        const api = gridsManager.createGrid(
+            'ssrmMdRefreshPurge',
+            createGridOptions({
+                detailCellRendererParams: {
+                    detailGridOptions: {
+                        columnDefs: [{ field: 'name' }, { field: 'value' }],
+                        getRowId: ({ data }: GetRowIdParams) => data.name,
+                    },
+                    getDetailRowData: (params: GetDetailRowDataParams) => {
+                        ++detailCalls;
+                        params.successCallback(params.data.records);
+                    },
+                },
+                serverSideDatasource: {
+                    getRows: (params: IServerSideGetRowsParams) => {
+                        requests.push({
+                            groupKeys: [...(params.request.groupKeys ?? [])],
+                            range: [params.request.startRow, params.request.endRow],
+                        });
+                        setTimeout(() => params.success({ rowData: masterRows, rowCount: masterRows.length }), 1);
+                    },
+                },
+            })
+        );
+
+        await waitForNoLoadingRows(api);
+        expect(requests.length).toBe(1);
+
+        // Open detail on A.
+        api.getRowNode('A')!.setExpanded(true);
+        await waitForNoLoadingRows(api);
+        expect(detailCalls).toBe(1);
+        expect(api.getDisplayedRowCount()).toBe(4);
+
+        // Purge refresh reloads the master rows: a second root getRows is issued (empty groupKeys).
+        api.refreshServerSide({ purge: true });
+        await waitForNoLoadingRows(api);
+
+        expect(requests.length).toBe(2);
+        expect(requests[1].groupKeys).toEqual([]);
+
+        // Surprising pin: after a purge refresh the previously-open detail SURVIVES — master A
+        // stays expanded and the detail row is auto-restored (displayed count remains 4 = 3
+        // masters + 1 detail). The detail node for A still exists.
+        expect(api.getDisplayedRowCount()).toBe(4);
+        expect(api.getRowNode('A')!.expanded).toBe(true);
+        expect(api.getRowNode(DETAIL_ROW_ID_PREFIX + 'A')?.detail).toBe(true);
+
+        // Restoring the detail after purge re-runs getDetailRowData (fresh master store → refetch).
+        expect(detailCalls).toBe(2);
+    });
+});

--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-selection-state.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-selection-state.test.ts
@@ -1,0 +1,182 @@
+import type { GridOptions, IServerSideGetRowsParams } from 'ag-grid-community';
+import { RowSelectionModule } from 'ag-grid-community';
+import { ServerSideRowModelApiModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../../test-utils';
+import { waitForNoLoadingRows } from '../../test-utils/ssrm-test-utils';
+
+/**
+ * CHARACTERIZATION (golden-master) tests pinning CURRENT SSRM selection-STATE-API behaviour on a
+ * flat (non-grouped) server-side row model with `rowSelection: { mode: 'multiRow' }`:
+ *
+ *   - `getServerSideSelectionState()` shape after interaction-level selection.
+ *   - round-trip through `setServerSideSelectionState()`.
+ *   - selectAll-then-deselect-one shape.
+ *   - whether selection survives `refreshServerSide({ purge: false })` and `{ purge: true }`.
+ *
+ * These assert what the grid DOES today, bugs included. RowNode objects are never asserted
+ * directly (circular -> RangeError); selection is checked via scalar counts / sorted id arrays.
+ */
+
+interface DataItem {
+    id: string;
+    name: string;
+}
+
+function getFlatDataSet(): DataItem[] {
+    return [
+        { id: 'a', name: 'Alpha' },
+        { id: 'b', name: 'Bravo' },
+        { id: 'c', name: 'Charlie' },
+        { id: 'd', name: 'Delta' },
+        { id: 'e', name: 'Echo' },
+    ];
+}
+
+function selectedIds(api: any): string[] {
+    return api
+        .getSelectedNodes()
+        .map((n: any) => n.id)
+        .sort();
+}
+
+describe('ag-grid SSRM selection-state API (characterization)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ServerSideRowModelApiModule, ServerSideRowModelModule, RowSelectionModule],
+    });
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    function createFlatGridOptions(extra: Partial<GridOptions> = {}): GridOptions {
+        const data = getFlatDataSet();
+        return {
+            columnDefs: [{ field: 'name' }],
+            defaultColDef: { flex: 1 },
+            rowModelType: 'serverSide',
+            animateRows: false,
+            rowSelection: { mode: 'multiRow' },
+            getRowId: ({ data: d }) => d.id,
+            serverSideDatasource: {
+                getRows: (params: IServerSideGetRowsParams) => {
+                    setTimeout(() => params.success({ rowData: data, rowCount: data.length }), 1);
+                },
+            },
+            ...extra,
+        };
+    }
+
+    async function createAndLoad(gridId: string, extra: Partial<GridOptions> = {}) {
+        const api = gridsManager.createGrid(gridId, createFlatGridOptions(extra));
+        await asyncSetTimeout(1);
+        await waitForNoLoadingRows(api);
+        return api;
+    }
+
+    test('getServerSideSelectionState() returns {selectAll:false, toggledNodes:[...ids]} after selecting rows', async () => {
+        const api = await createAndLoad('ssrmSelStateBasic');
+
+        api.getRowNode('b')!.setSelected(true);
+        api.getRowNode('d')!.setSelected(true);
+
+        expect(selectedIds(api)).toEqual(['b', 'd']);
+
+        const state = api.getServerSideSelectionState() as any;
+        expect(state.selectAll).toBe(false);
+        expect([...state.toggledNodes].sort()).toEqual(['b', 'd']);
+    });
+
+    test('round-trip: capture state, deselect all, setServerSideSelectionState restores the same selection', async () => {
+        const api = await createAndLoad('ssrmSelStateRoundTrip');
+
+        api.getRowNode('a')!.setSelected(true);
+        api.getRowNode('c')!.setSelected(true);
+        const captured = api.getServerSideSelectionState();
+
+        api.deselectAll();
+        expect(selectedIds(api)).toEqual([]);
+
+        api.setServerSideSelectionState(captured!);
+        await asyncSetTimeout(1);
+
+        // Surprising pin: the default SSRM strategy does NOT rebuild its selectedNodes map from
+        // a state restore, so getSelectedNodes() stays empty even though the rows read as selected.
+        expect(selectedIds(api)).toEqual([]);
+        expect(api.getRowNode('a')!.isSelected()).toBe(true);
+        expect(api.getRowNode('c')!.isSelected()).toBe(true);
+        expect(api.getRowNode('b')!.isSelected()).toBe(false);
+        // The state itself round-trips exactly.
+        const restored = api.getServerSideSelectionState() as any;
+        expect(restored.selectAll).toBe(false);
+        expect([...restored.toggledNodes].sort()).toEqual(['a', 'c']);
+    });
+
+    test('selectAll then deselect one -> {selectAll:true, toggledNodes:[thatId]}; round-trips', async () => {
+        const api = await createAndLoad('ssrmSelStateSelectAll');
+
+        api.selectAll();
+        api.getRowNode('c')!.setSelected(false);
+
+        // Surprising pin: under selectAll the strategy tracks only toggled (deselected) nodes, so
+        // getSelectedNodes() is empty; conceptual selection is read via isSelected()/state.
+        expect(selectedIds(api)).toEqual([]);
+        expect(api.getRowNode('a')!.isSelected()).toBe(true);
+        expect(api.getRowNode('c')!.isSelected()).toBe(false);
+
+        const state = api.getServerSideSelectionState() as any;
+        expect(state.selectAll).toBe(true);
+        expect([...state.toggledNodes].sort()).toEqual(['c']);
+
+        api.deselectAll();
+        expect(api.getRowNode('a')!.isSelected()).toBe(false);
+
+        api.setServerSideSelectionState(state);
+        await asyncSetTimeout(1);
+        expect(api.getRowNode('a')!.isSelected()).toBe(true);
+        expect(api.getRowNode('c')!.isSelected()).toBe(false);
+        const restored = api.getServerSideSelectionState() as any;
+        expect(restored.selectAll).toBe(true);
+        expect([...restored.toggledNodes].sort()).toEqual(['c']);
+    });
+
+    test('selection SURVIVES refreshServerSide({purge:false})', async () => {
+        const api = await createAndLoad('ssrmSelStateRefreshNoPurge');
+
+        api.getRowNode('b')!.setSelected(true);
+        api.getRowNode('e')!.setSelected(true);
+        expect(selectedIds(api)).toEqual(['b', 'e']);
+
+        api.refreshServerSide({ purge: false });
+        await asyncSetTimeout(1);
+        await waitForNoLoadingRows(api);
+
+        // Pinned: selection survives a non-purge refresh (stable getRowId identity).
+        expect(selectedIds(api)).toEqual(['b', 'e']);
+        const state = api.getServerSideSelectionState() as any;
+        expect(state.selectAll).toBe(false);
+        expect([...state.toggledNodes].sort()).toEqual(['b', 'e']);
+    });
+
+    test('selection across refreshServerSide({purge:true})', async () => {
+        const api = await createAndLoad('ssrmSelStateRefreshPurge');
+
+        api.getRowNode('b')!.setSelected(true);
+        api.getRowNode('e')!.setSelected(true);
+        expect(selectedIds(api)).toEqual(['b', 'e']);
+
+        api.refreshServerSide({ purge: true });
+        await asyncSetTimeout(1);
+        await waitForNoLoadingRows(api);
+
+        // Pinned: with a stable getRowId, the selection STATE persists across a purge refresh.
+        expect(selectedIds(api)).toEqual(['b', 'e']);
+        const state = api.getServerSideSelectionState() as any;
+        expect(state.selectAll).toBe(false);
+        expect([...state.toggledNodes].sort()).toEqual(['b', 'e']);
+    });
+});


### PR DESCRIPTION
## SSRM characterization sweep — PR5

Follows the merged sweep (PRs #14355 / #14356 / #14357 / #14367). An **independent coverage re-audit** (mechanic-surface from source × assertions actually made) confirmed the primary Operation×Data-shape plane is genuinely covered, but surfaced three cells the sweep counted as done that were only partial or blind. This PR fills them.

### `ssrm-master-detail.test.ts` (flat SSRM master/detail — 3 tests)
The only prior master/detail SSRM coverage was tree-data render smoke; detail-datasource mechanics were untested.

### `ssrm-selection-state.test.ts` (selection-state API — 5 tests)
Interaction selection + `groupSelects` cascade were covered; the state API and refresh-survival were not.

### `ssrm-get-child-count.test.ts` (`getChildCount` callback — 4 tests)
No dedicated test existed.

### Coverage matrix
Updated to add a Master/Detail row and downgrade Selection to partial: https://claude.ai/code/artifact/7515d2e1-da99-4677-9718-cdb752572d14
