### PR TITLE
test(ssrm): de-flake initial-row-count EXCEEDS test (racy mid-load block snapshot)

### DIFF
--- a/testing/behavioural/src/row-data/ssrm-initial-row-count.test.ts
+++ b/testing/behavioural/src/row-data/ssrm-initial-row-count.test.ts
@@ -107,17 +107,16 @@ describe('SSRM initial row count (characterization)', () => {
         await waitForEvent('firstDataRendered', api);
 
         // The real total (500) supersedes the initial guess (42): the grid now sizes to
-        // the full server total, and the first request was for block [0,100].
+        // the full server total, the first request was for block [0,100], and that block's
+        // real data has replaced the initial-count stubs.
         expect(api.getDisplayedRowCount()).toBe(realTotal);
         expect(requests[0]).toEqual([0, 100]);
-
-        // Latent behaviour pinned: on initial load only the first two viewport blocks are
-        // fetched (200 real leaves), so of the 500 displayed rows the remaining 300 stay as
-        // loading/stub filler rows until scrolled into view (no eager full load).
-        expect(countLoadingRows(api)).toBe(300);
         expect(!!api.getRowNode('0')).toBe(true);
-        expect(!!api.getRowNode('199')).toBe(true);
-        expect(!!api.getRowNode('200')).toBe(false);
+
+        // Note: how many *further* blocks have loaded by this point is not asserted. With a
+        // synchronous datasource the grid keeps fetching subsequent blocks tick-by-tick, so
+        // the count of loaded blocks / remaining loading stubs at `firstDataRendered` is a
+        // transient, timing-dependent value (see the skipped sibling in ssrm-block-loading).
     });
 
     test('after load, real total is SMALLER than the initial count: the grid shrinks to the real total and trailing placeholders are removed', async () => {


### PR DESCRIPTION
## Problem

The SSRM characterization test `after load, real total EXCEEDS the initial count` is flaky. It failed in CI ([run 29004048718](https://github.com/ag-grid/ag-grid/actions/runs/29004048718/job/86072674058)) with:

```
AssertionError: expected 400 to be 300 // Object.is equality
 ❯ testing/behavioural/src/row-data/ssrm-initial-row-count.test.ts
   SSRM initial row count (characterization) > after load, real total EXCEEDS the initial count
```

## Root cause

The test waited only for `firstDataRendered`, then pinned a **transient mid-flight** state:

```ts
expect(countLoadingRows(api)).toBe(300);   // 500 displayed − 200 loaded (2 blocks)
expect(!!api.getRowNode('199')).toBe(true); // block [100,200] loaded
expect(!!api.getRowNode('200')).toBe(false);
```

Instrumenting the grid shows that with a synchronous datasource it does **not** stop at two viewport blocks — it keeps fetching subsequent blocks tick-by-tick (`[200,300]`, `[300,400]`, `[400,500]`) until the whole dataset is loaded and `loading = 0`. So the number of blocks resolved by the time `firstDataRendered` fires is purely timing-dependent:

- Locally / usually: blocks `[0,100]` and `[100,200]` are both requested before `firstDataRendered` → 300 stubs (test passes).
- Under CI scheduling pressure: only `[0,100]` has resolved → 400 stubs → **`expected 400 to be 300`**.

The old `// ...no eager full load` comment was also factually wrong.

This is the same race the sibling `ssrm-block-loading.test.ts` already hit and `test.skip`-ped (`initial load requests viewport blocks up front`), with a matching comment.

## Fix

Keep the assertions that are deterministic at `firstDataRendered` and characterize the actual EXCEEDS-reconciliation story:

- displayed count becomes the real total (500, superseding the guess of 42),
- the first request is block `[0,100]`,
- block 0's real data has replaced the initial-count stubs (`getRowNode('0')`).

Drop the racy block-count snapshot (`countLoadingRows === 300`, nodes 199/200) and document why the loaded-block count at `firstDataRendered` is not asserted.

## Verification

- `./behave.sh "ssrm-initial-row-count"` → 4 passed (ran repeatedly).
- `yarn nx lint ag-behavioural-testing` → pass.
- `yarn nx build:test ag-behavioural-testing` (tsc typecheck) → pass.
- `yarn nx format` applied.
