### PR TITLE
ci: default free_disk_space to false in setup-nx

### DIFF
--- a/.github/actions/setup-nx/action.yml
+++ b/.github/actions/setup-nx/action.yml
@@ -30,9 +30,9 @@ inputs:
       - 'ro'
       - 'off'
   free_disk_space:
-    description: 'Delete large preinstalled toolchains to reclaim root-partition space (avoids runner ENOSPC). Set false on jobs that do not exhaust disk to skip the slow delete.'
+    description: 'Delete large preinstalled toolchains to reclaim root-partition space (avoids runner ENOSPC). Off by default: the delete is slow (~3 min) and unpredictable. Only set true on a job that actually exhausts disk.'
     required: false
-    default: 'true'
+    default: 'false'
     options:
       - 'true'
       - 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,6 @@ jobs:
         uses: ./.github/actions/setup-nx
         with:
           cache_mode: 'rw'
-          free_disk_space: false
 
       - name: Prepare Snapshot Branch
         uses: ./.github/actions/snapshot-prepare
@@ -231,7 +230,6 @@ jobs:
         uses: ./.github/actions/setup-nx
         with:
           cache_mode: ro
-          free_disk_space: false
 
       - name: nx test
         if: matrix.shard != 0
@@ -327,7 +325,6 @@ jobs:
         uses: ./.github/actions/setup-nx
         with:
           cache_mode: ro
-          free_disk_space: false
 
       - name: nx format:check
         id: format


### PR DESCRIPTION
## What

Flip the `setup-nx` composite action's `free_disk_space` default from `true` to `false`, and drop the now-redundant `free_disk_space: false` overrides from the snapshot, test and format jobs in `ci.yml`.

## Why

The disk-space reclaim step (deleting large preinstalled toolchains) is slow (~3 min) and unpredictable. It should be opt-in on the jobs that actually exhaust the runner's root partition, rather than paying the cost on every job by default.

Jobs that genuinely need the reclaim can still set `free_disk_space: true` explicitly.