### PR TITLE
Fix build warnings and align package exports ordering

### DIFF
--- a/community-modules/locale/package.json
+++ b/community-modules/locale/package.json
@@ -8,14 +8,14 @@
   "exports": {
     ".": {
       "import": "./dist/package/main.esm.mjs",
-      "require": "./dist/package/main.cjs.js",
       "types": "./dist/types/src/main.d.ts",
+      "require": "./dist/package/main.cjs.js",
       "default": "./dist/package/main.cjs.js"
     },
     "./*.js": {
       "import": "./dist/package/*.esm.mjs",
-      "require": "./dist/package/*.cjs.js",
       "types": "./dist/types/src/*.d.ts",
+      "require": "./dist/package/*.cjs.js",
       "default": "./dist/package/*.cjs.js"
     }
   },

--- a/community-modules/styles/package.json
+++ b/community-modules/styles/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "build:styles": "npm run build:sass -- --no-error-css && node post-build.js",
-    "build:sass": "sass --silence-deprecation=mixed-decls --no-source-map --load-path src/internal src:.",
+    "build:sass": "sass --no-source-map --load-path src/internal src:.",
     "watch": "npm-run-all build --parallel watch:sass watch:post-build",
     "watch:post-build": "chokidar '*.css' --ignore '*.min.css' --command 'node post-build.js'",
     "watch:sass": "npm run build:sass -- --watch",

--- a/community-modules/styles/project.json
+++ b/community-modules/styles/project.json
@@ -52,7 +52,7 @@
       ],
       "options": {
         "cwd": "{projectRoot}",
-        "command": "sass --silence-deprecation=mixed-decls --no-source-map --load-path src/internal src:."
+        "command": "sass --no-source-map --load-path src/internal src:."
       },
       "cache": true
     },

--- a/packages/ag-grid-react/package.json
+++ b/packages/ag-grid-react/package.json
@@ -7,8 +7,8 @@
   "module": "./dist/package/index.esm.mjs",
   "exports": {
     "import": "./dist/package/index.esm.mjs",
-    "require": "./dist/package/index.cjs.js",
     "types": "./dist/types/src/index.d.ts",
+    "require": "./dist/package/index.cjs.js",
     "default": "./dist/package/index.cjs.js"
   },
   "repository": {


### PR DESCRIPTION
Resolves build-output warnings and brings the `exports` field into a consistent order across all packages.

## What changed
- **`exports` ordering:** move the `types` condition before `require` in `community-modules/locale` and `packages/ag-grid-react`, matching the order already used in `ag-grid-community`, `ag-grid-enterprise`, `ag-stack`, and `ag-grid-vue3`. Node/bundler resolution expects `types` ahead of `require`, so this silences the "types condition unreachable" resolution warnings.
- **Sass:** drop the now-unneeded `--silence-deprecation=mixed-decls` flag from the styles `build:sass` script and its Nx target, cleaning up deprecation-suppression noise in the build output.

No runtime behaviour changes — build configuration and package metadata only.