### PR TITLE
Add "Choosing a Test Layer" guidance to the testing rule

### DIFF
--- a/.rulesync/rules/testing.md
+++ b/.rulesync/rules/testing.md
@@ -24,7 +24,7 @@ Behavioural tests in `testing/behavioural/` are the primary test suite for AG Gr
 
 **These are signs you're testing internals — write a behavioural test instead:** casting to `as any` for private state, hand-building `beans`/`gos`/`ctrlsSvc`, calling a private method to reach a branch, or spying on an internal method as the assertion. Such tests pass even when the real code path never runs.
 
-Grep `testing/behavioural` for an existing harness before assuming a behaviour can't be black-box tested (e.g. `DragEventDispatcher` drives real header drags); extend the harness rather than dropping to a unit test.
+Search `testing/behavioural` for an existing harness before assuming a behaviour can't be black-box tested (e.g. `DragEventDispatcher` drives real header drags); extend the harness rather than dropping to a unit test.
 
 Behavioural tests are a separate nx project — `yarn nx test <package>` does **not** run them. Use `./behave.sh` or the affected gate (`yarn nx affected -t test`).
 

--- a/.rulesync/rules/testing.md
+++ b/.rulesync/rules/testing.md
@@ -20,20 +20,13 @@ Behavioural tests in `testing/behavioural/` are the primary test suite for AG Gr
 
 ## Choosing a Test Layer
 
-**Default to a behavioural test.** A package-level `*.test.ts` that instantiates a feature class directly is only appropriate for genuinely pure, self-contained logic — a formatter, comparator, parser, or maths helper — that has no grid-integration surface. Anything that only manifests through the running grid (drag interactions, rendering, focus, selection, drag-image icons, event dispatch) belongs in `testing/behavioural/`, driven through the public `GridApi` and real DOM.
+**Default to a behavioural test.** A package `*.test.ts` that instantiates a feature class directly is only for pure logic (formatter, comparator, parser) with no grid-integration surface. Anything that manifests through the running grid belongs in `testing/behavioural/`, driven via the public `GridApi`.
 
-**Red flags that mean you are testing internals — stop and write a behavioural test instead:**
+**These are signs you're testing internals — write a behavioural test instead:** casting to `as any` for private state, hand-building `beans`/`gos`/`ctrlsSvc`, calling a private method to reach a branch, or spying on an internal method as the assertion. Such tests pass even when the real code path never runs.
 
-- Casting the unit to `as any` to read or set private fields.
-- Hand-building `beans`, `gos`, `ctrlsSvc`, `gridBodyCon`, or other collaborators by hand.
-- Calling a private method directly (e.g. `moveInterval()`) to reach a branch.
-- Spying on an internal method (e.g. `setDragImageCompIcon`) and asserting it was/wasn't called, in place of observing the grid's actual output.
+Grep `testing/behavioural` for an existing harness before assuming a behaviour can't be black-box tested (e.g. `DragEventDispatcher` drives real header drags); extend the harness rather than dropping to a unit test.
 
-These tests pass even when the real code path never reaches the branch under test, so they prove nothing about the behaviour a user sees.
-
-**Behavioural tests are a separate nx project (`ag-behavioural-testing`) — remember to run them.** `yarn nx test <package>` (e.g. `yarn nx test ag-grid-community`) only runs that package's own `src/**/*.test.ts`; it does **not** execute anything under `testing/behavioural/`. Run behavioural tests with `./behave.sh` (or the affected gate, `yarn nx affected -t test`, which includes the behavioural project). A green `yarn nx test ag-grid-community` says nothing about your behavioural tests.
-
-**Before concluding a behaviour "can't be tested as a black box", grep `testing/behavioural` for an existing harness.** Interactions usually already have one — e.g. `DragEventDispatcher` and `testing/behavioural/src/columns/order/column-move-drag.test.ts` drive a real header drag through `DragService → dragAndDropService → MoveColumnFeature`, and drag-image icons are observable in the drag-ghost DOM. If the harness does not yet cover your scenario, **extend the harness** (see the note under GridRows snapshots: our test framework and `mockGridLayout.ts` are written as we go and must be updated when a new scenario needs them) rather than dropping down to a white-box unit test.
+Behavioural tests are a separate nx project — `yarn nx test <package>` does **not** run them. Use `./behave.sh` or the affected gate (`yarn nx affected -t test`).
 
 ## Test Structure
 

--- a/.rulesync/rules/testing.md
+++ b/.rulesync/rules/testing.md
@@ -31,6 +31,8 @@ Behavioural tests in `testing/behavioural/` are the primary test suite for AG Gr
 
 These tests pass even when the real code path never reaches the branch under test, so they prove nothing about the behaviour a user sees.
 
+**Behavioural tests are a separate nx project (`ag-behavioural-testing`) — remember to run them.** `yarn nx test <package>` (e.g. `yarn nx test ag-grid-community`) only runs that package's own `src/**/*.test.ts`; it does **not** execute anything under `testing/behavioural/`. Run behavioural tests with `./behave.sh` (or the affected gate, `yarn nx affected -t test`, which includes the behavioural project). A green `yarn nx test ag-grid-community` says nothing about your behavioural tests.
+
 **Before concluding a behaviour "can't be tested as a black box", grep `testing/behavioural` for an existing harness.** Interactions usually already have one — e.g. `DragEventDispatcher` and `testing/behavioural/src/columns/order/column-move-drag.test.ts` drive a real header drag through `DragService → dragAndDropService → MoveColumnFeature`, and drag-image icons are observable in the drag-ghost DOM. If the harness does not yet cover your scenario, **extend the harness** (see the note under GridRows snapshots: our test framework and `mockGridLayout.ts` are written as we go and must be updated when a new scenario needs them) rather than dropping down to a white-box unit test.
 
 ## Test Structure

--- a/.rulesync/rules/testing.md
+++ b/.rulesync/rules/testing.md
@@ -18,6 +18,21 @@ Behavioural tests in `testing/behavioural/` are the primary test suite for AG Gr
 - **Avoid mocking** — prefer fakes instead (e.g., fake DOM)
 - Test at the edges of the system to ensure real integration using public APIs
 
+## Choosing a Test Layer
+
+**Default to a behavioural test.** A package-level `*.test.ts` that instantiates a feature class directly is only appropriate for genuinely pure, self-contained logic — a formatter, comparator, parser, or maths helper — that has no grid-integration surface. Anything that only manifests through the running grid (drag interactions, rendering, focus, selection, drag-image icons, event dispatch) belongs in `testing/behavioural/`, driven through the public `GridApi` and real DOM.
+
+**Red flags that mean you are testing internals — stop and write a behavioural test instead:**
+
+- Casting the unit to `as any` to read or set private fields.
+- Hand-building `beans`, `gos`, `ctrlsSvc`, `gridBodyCon`, or other collaborators by hand.
+- Calling a private method directly (e.g. `moveInterval()`) to reach a branch.
+- Spying on an internal method (e.g. `setDragImageCompIcon`) and asserting it was/wasn't called, in place of observing the grid's actual output.
+
+These tests pass even when the real code path never reaches the branch under test, so they prove nothing about the behaviour a user sees.
+
+**Before concluding a behaviour "can't be tested as a black box", grep `testing/behavioural` for an existing harness.** Interactions usually already have one — e.g. `DragEventDispatcher` and `testing/behavioural/src/columns/order/column-move-drag.test.ts` drive a real header drag through `DragService → dragAndDropService → MoveColumnFeature`, and drag-image icons are observable in the drag-ghost DOM. If the harness does not yet cover your scenario, **extend the harness** (see the note under GridRows snapshots: our test framework and `mockGridLayout.ts` are written as we go and must be updated when a new scenario needs them) rather than dropping down to a white-box unit test.
+
 ## Test Structure
 
 ### Directory Layout


### PR DESCRIPTION
## Summary

Adds a **Choosing a Test Layer** section to `.rulesync/rules/testing.md`, making the black-box preference an actionable rule rather than an aspiration:

- Default to a behavioural test (`testing/behavioural/`, public `GridApi`, real DOM); a package `*.test.ts` beside the source is only for pure logic with no grid-integration surface.
- Lists the white-box tells that mean you've reached into internals — `as any`, hand-built `beans`/`gos`/`ctrlsSvc`/`gridBodyCon`, direct private-method calls, spying on an internal method as the assertion — and why those tests prove nothing (they pass even when the real path never reaches the branch).
- Tells the agent to grep `testing/behavioural` for an existing harness (e.g. `DragEventDispatcher` / `column-move-drag.test.ts`) and extend it, rather than dropping to a unit test.

## Motivation

An agent-authored fix (AG-16723) added a white-box unit test in `ag-grid-community` that mocked internals instead of a behavioural test, despite a real drag harness already existing. The testing rule said "test as a black box" but gave no decision rule or red flags, so it read as aspirational. This makes it binding.

The companion `/fr`-skill change (which steers the pipeline's test-writing step to the same default) is upstreamed separately in ag-grid/ag-dev-prompts#516.

## Notes

- Only the source `.rulesync/rules/testing.md` is committed; the generated `.claude/rules/testing.md` is produced by `setup-prompts.sh` at `yarn` time.