### PR TITLE
Doc e2e test improvements

### DIFF
--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -212,15 +212,20 @@ jobs:
         with:
           path: combined-reports
 
+      - name: Normalise example test reports
+        run: node documentation/ag-grid-docs/scripts/normalise-ctrf-reports.mjs combined-reports
+
       - name: Publish Combined Test Report
         id: ctrf
         uses: ctrf-io/github-test-reporter@v1.0.17
         with:
           report-path: 'combined-reports/**/*.json'
           summary-report: true
+          failed-folded-report: true
           failed-report: true
           flaky-report: true
           skipped-report: false
+          group-by: filePath
           write-ctrf-to-file: ${{ env.CTRF_FILE }}
 
       - name: Get previous run commit SHA

--- a/documentation/ag-grid-docs/package.json
+++ b/documentation/ag-grid-docs/package.json
@@ -79,7 +79,7 @@
     "lucide-react": "^1.9.0",
     "nanostores": "^1.3.0",
     "node-html-parser": "^7.1.0",
-    "playwright-network-cache": "0.2.2",
+    "playwright-network-cache": "0.3.0",
     "react": "~18.2.0",
     "react-animate-height": "^3.2.3",
     "react-colorful": "^5.6.1",

--- a/documentation/ag-grid-docs/scripts/normalise-ctrf-reports.mjs
+++ b/documentation/ag-grid-docs/scripts/normalise-ctrf-reports.mjs
@@ -1,0 +1,133 @@
+// Normalise the CTRF reports produced by the documentation example tests before they are
+// fed to the GitHub test reporter.
+//
+// The playwright-ctrf-json-reporter records each test's `name` as the innermost test title,
+// which for the example tests is just the framework (e.g. "angular", "reactFunctionalTs").
+// The information that actually identifies the failure - the doc page, the example and the
+// browser - is buried in the `suite` string, and `filePath` points at the shared
+// test-utils.ts helper rather than the example spec. That makes the combined report a wall of
+// identically-named rows with no indication of which page/example broke.
+//
+// This script rewrites each test so that:
+//   - `name` reads "<page>/<example> › <test title> · <framework>/<browser>"
+//   - `filePath` points at the example spec, so the reporter can group failures by example.
+//
+// Reports whose suites don't match the example pattern (e.g. the public testing recipes) are
+// left untouched.
+import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const BROWSERS = new Set(['chromium', 'firefox', 'webkit', 'page-verification']);
+
+const rootDir = process.argv[2];
+if (!rootDir) {
+    // eslint-disable-next-line no-console
+    console.error('Usage: node normalise-ctrf-reports.mjs <reports-dir>');
+    process.exit(1);
+}
+
+const reportFiles = collectJsonFiles(rootDir);
+let normalisedTests = 0;
+let normalisedFiles = 0;
+
+for (let i = 0, len = reportFiles.length; i < len; ++i) {
+    const file = reportFiles[i];
+    const framework = frameworkFromFileName(file);
+    let report;
+    try {
+        report = JSON.parse(readFileSync(file, 'utf8'));
+    } catch {
+        continue;
+    }
+
+    const tests = report?.results?.tests;
+    if (!Array.isArray(tests)) {
+        continue;
+    }
+
+    let changed = false;
+    for (let t = 0, tLen = tests.length; t < tLen; ++t) {
+        if (normaliseTest(tests[t], framework)) {
+            changed = true;
+            normalisedTests++;
+        }
+    }
+
+    if (changed) {
+        writeFileSync(file, JSON.stringify(report), 'utf8');
+        normalisedFiles++;
+    }
+}
+
+// eslint-disable-next-line no-console
+console.log(`Normalised ${normalisedTests} test(s) across ${normalisedFiles} report file(s).`);
+
+function normaliseTest(test, framework) {
+    const parsed = parseSuite(test?.suite);
+    if (!parsed) {
+        return false;
+    }
+
+    const { browser, specPath, exampleId, title } = parsed;
+    const context = [framework, browser].filter(Boolean).join('/');
+    test.name = context ? `${exampleId} › ${title} · ${context}` : `${exampleId} › ${title}`;
+    test.filePath = specPath;
+    return true;
+}
+
+// Suites look like:
+//   "chromium > page/_examples/example/example.spec.ts > page/example > The test title"
+// Returns the browser, the example spec path, a "page/example" id and the test title.
+function parseSuite(suite) {
+    if (typeof suite !== 'string') {
+        return null;
+    }
+
+    const parts = suite.split(' > ').map((part) => part.trim());
+    if (parts.length < 2) {
+        return null;
+    }
+
+    const browser = BROWSERS.has(parts[0]) ? parts[0] : undefined;
+    const specIndex = parts.findIndex((part) => part.endsWith('.spec.ts'));
+    if (specIndex === -1) {
+        return null;
+    }
+
+    const specPath = parts[specIndex];
+    // Only the example specs suffer from the unhelpful `name` field (it records the framework
+    // rather than the test title). Other suites - e.g. the public testing recipes - already have
+    // meaningful names and a correct filePath, so leave them untouched.
+    if (!specPath.includes('/_examples/')) {
+        return null;
+    }
+
+    // Everything after the spec path is "<describe> > <test title>". The describe title on the
+    // example specs mirrors the example id, so keep only the innermost test title.
+    const title = parts.length > specIndex + 1 ? parts[parts.length - 1] : specPath;
+    const exampleId = specPath
+        .replace('/_examples/', '/')
+        .replace(/\/example\.spec\.ts$/, '')
+        .replace(/\.spec\.ts$/, '');
+
+    return { browser, specPath, exampleId, title };
+}
+
+function frameworkFromFileName(file) {
+    const match = /interactive-([^./]+)\.json$/.exec(file);
+    return match ? match[1] : undefined;
+}
+
+function collectJsonFiles(dir) {
+    const results = [];
+    const entries = readdirSync(dir);
+    for (let i = 0, len = entries.length; i < len; ++i) {
+        const fullPath = join(dir, entries[i]);
+        if (statSync(fullPath).isDirectory()) {
+            results.push(...collectJsonFiles(fullPath));
+        } else if (fullPath.endsWith('.json')) {
+            results.push(fullPath);
+        }
+    }
+    return results;
+}

--- a/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
@@ -261,6 +261,14 @@ const frameworkTest =
         testBody: (fixtures: TestFixtures) => Promise<void>,
         opts?: { allowedConsoleMessages?: string[] }
     ): void => {
+        // A single-framework test (test.typescript(...), etc.) hardcodes its framework, bypassing the
+        // FRAMEWORK filter that eachFramework applies via FILTERED_FRAMEWORKS. Declaring a test only to
+        // skip it at runtime when the CI job targets another framework produces a fake "skipped" result
+        // and still spins up a browser fixture, so don't declare it at all for a filtered-out framework.
+        if (!FILTERED_FRAMEWORKS.includes(agFramework)) {
+            return;
+        }
+
         extended.use({ agFramework });
 
         // cachedRoute needs to be destructured in testWrapper for Playwright to initialise it correctly
@@ -284,11 +292,6 @@ const frameworkTest =
                 throw new Error(
                     `Missing 'setAgExampleUrl(import.meta)' in the test file. This is required to set the example URL for the test.`
                 );
-            }
-
-            // Would be nice if this logic could be done so that the test is not even created rather than skipped
-            if (process.env.FRAMEWORK && process.env.FRAMEWORK !== agFramework) {
-                test.skip(true, `Skipping ${agFramework} as not the selected framework ${process.env.FRAMEWORK}.`);
             }
 
             await loadPage(page, agExampleUrl, agFramework, loadPageOptions, agModules);

--- a/yarn.lock
+++ b/yarn.lock
@@ -17311,7 +17311,7 @@ mime-db@^1.28.0, mime-db@^1.54.0:
   resolved "https://registry.ag-grid.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
 
-mime-types@2.1.35, mime-types@^2.0.1, mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.0.1, mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -19105,13 +19105,13 @@ playwright-ctrf-json-reporter@0.0.29:
   dependencies:
     ctrf "^0.2.0"
 
-playwright-network-cache@0.2.2:
-  version "0.2.2"
-  resolved "https://registry.ag-grid.com/playwright-network-cache/-/playwright-network-cache-0.2.2.tgz#070a36435a2bb148324019f0e8dc1f924e16c0ac"
-  integrity sha512-uVOZL8+KYRFh40d3u9TKBhlKyr+arYCANKaf97c5/yMUz+v6zMHk4gKgAH4x7mKgxY2tBbqNvJVlcwpk5noMmw==
+playwright-network-cache@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.ag-grid.com/playwright-network-cache/-/playwright-network-cache-0.3.0.tgz#f2d7ba5b06c5878fda36b73582fe3a148c41a654"
+  integrity sha512-vvmGLbvl7UVAk5o9HNMyaW6xQJ5bTwFQqtCRyLOiPw45SP9bSx3yASnem65ekbqIf5ToU575Iyu8cJDTe1WIgg==
   dependencies:
-    debug "^4.4.0"
-    mime-types "2.1.35"
+    debug "^4.4.3"
+    mime-types "^3.0.2"
 
 playwright@1.59.1, playwright@^1.59.1:
   version "1.59.1"
@@ -22086,16 +22086,7 @@ string-split-by@^1.0.0:
   dependencies:
     parenthesis "^3.1.5"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.ag-grid.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.ag-grid.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -22208,7 +22199,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.ag-grid.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -22221,13 +22212,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.ag-grid.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.2"
@@ -24572,7 +24556,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.ag-grid.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.ag-grid.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -24594,15 +24578,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.ag-grid.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.ag-grid.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Improvements to the documentation example e2e tests and their CI reporting.

- **Fix ENOENT cache race:** bump `playwright-network-cache` 0.2.2 → 0.3.0. In 0.2.2 the headers file (the cache-hit gate) was written before the body file, and the body write was not awaited, so a parallel worker could treat an entry as cached and read `body.js` before it existed — a failure that survived retries. 0.3.0 awaits the body write first, then writes the headers gate.
- **Remove fake skipped tests:** single-framework example tests (`test.typescript(...)`, etc.) hardcoded their framework and were declared in every CI framework job, then skipped at runtime — producing fake "skipped" results and spinning up a browser fixture each time. They now respect the `FRAMEWORK` filter at declaration time (matching `eachFramework`), and the dead runtime skip is removed.
- **Clearer CI reports:** normalise CTRF reports so each row names the doc page / example / framework / browser and groups by the example spec, instead of a wall of identically-named rows pointing at the shared `test-utils.ts` helper.

New report will be visible: https://github.com/ag-grid/ag-grid/actions/runs/29091050520