### PR TITLE
Speed up documentation tests CI workflow

### DIFF
--- a/.github/actions/test-framework-examples/action.yml
+++ b/.github/actions/test-framework-examples/action.yml
@@ -27,18 +27,61 @@ runs:
       with:
         fetch-depth: 1
 
+    # These tests run Playwright against a remote deployed site (base_url), so they need
+    # node_modules for Playwright + the test specs, but NOT the example generators or
+    # setup-prompts. The `initialise` job warms the node_modules cache (rw); here we consume
+    # it read-only and skip postinstall. nx_restore stays on so the ag-grid-community build
+    # below is served from the Nx cache. The test harness (src/utils/grid/test-utils.ts)
+    # imports ag-grid-community at runtime, so its package output must exist.
     - name: Setup
       id: setup
       uses: ./.github/actions/setup-nx
       with:
         cache_mode: ro
+        yarn_postinstall: 'false'
+        nx_restore: 'true'
+        tidy_nx_cache: 'false'
 
+    - name: Build ag-grid-community (for the test harness import)
+      shell: bash
+      run: yarn nx run-many -p ag-grid-community -t build:package build:types
+
+    # Restore the Playwright browser binaries warmed by the `initialise` job (all three
+    # browsers, so the key matches regardless of this job's browser set). OS libraries are not
+    # part of the cache, so on a hit we only run install-deps; on a miss (e.g. the warm cache
+    # was evicted) fall back to a full install so the job is still self-sufficient.
+    - name: Resolve Playwright version
+      id: pw
+      shell: bash
+      run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
+
+    - name: Restore Playwright browsers
+      id: pw-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+    - name: Install Playwright browsers
+      shell: bash
+      working-directory: documentation/ag-grid-docs
+      env:
+        PW_BROWSERS: ${{ inputs.browsers == 'all' && 'chromium firefox webkit' || 'chromium' }}
+      run: |
+        if [ "${{ steps.pw-cache.outputs.cache-hit }}" = "true" ]; then
+          npx playwright install-deps ${PW_BROWSERS}
+        else
+          npx playwright install --with-deps ${PW_BROWSERS}
+        fi
+
+    # Run Playwright directly via ./docs-e2e.sh (bypasses Nx) so we avoid the Nx target's
+    # dependsOn on ag-grid-community:build:types/build:package, which is unnecessary for
+    # tests that hit a remote deployed site.
     - name: Run ${{ inputs.framework }} Examples
       env:
-        FRAMEWORK: ${{ inputs.framework }}
-        BASE_URL: ${{ inputs.base_url || 'https://grid-staging.ag-grid.com/' }}
+        CI: 'true'
       shell: bash
-      run: yarn nx run ag-grid-docs:test:interactive:${{ inputs.browsers }} ${{inputs.test_pattern}} --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+      run: ./docs-e2e.sh ${{ inputs.test_pattern }} --framework ${{ inputs.framework }} --url "${{ inputs.base_url || 'https://grid-staging.ag-grid.com/' }}" ${{ inputs.browsers == 'all' && '--all-browsers' || '' }} --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
     
     - name: Upload Test Report
       id: upload-recipes-report

--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -71,15 +71,60 @@ permissions:
 
 jobs:
 
+  # Warms the node_modules cache once (rw) so the framework test jobs below can consume it
+  # read-only in parallel — avoids 7 concurrent full installs and cache-write races on a cold
+  # cache. Runs whenever at least one framework is not skipped (always true on schedule).
+  initialise:
+    if: >-
+      ${{ github.event.inputs.skip_vanilla != 'true'
+        || github.event.inputs.skip_typescript != 'true'
+        || github.event.inputs.skip_reactFunctionalTs != 'true'
+        || github.event.inputs.skip_angular != 'true'
+        || github.event.inputs.skip_vue3 != 'true' }}
+    name: Initialise dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Warm node_modules and Nx caches
+        uses: ./.github/actions/setup-nx
+        with:
+          cache_mode: rw
+          yarn_postinstall: 'false'
+          nx_restore: 'true'
+          tidy_nx_cache: 'false'
+      # Pre-build the package the test harness imports at runtime, so the seven test jobs
+      # restore it from the Nx cache instead of each rebuilding it.
+      - name: Pre-build ag-grid-community
+        run: yarn nx run-many -p ag-grid-community -t build:package build:types
+      # Download the Playwright browser binaries once and cache them (all three browsers, so
+      # both chromium-only and all-browser jobs can restore the same cache). The test jobs
+      # restore this and only need `install-deps` for OS libraries — no per-job download.
+      - name: Resolve Playwright version
+        id: pw
+        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+      - name: Install Playwright browsers
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        working-directory: documentation/ag-grid-docs
+        run: npx playwright install chromium firefox webkit
+
   test-vanilla:
+    needs: initialise
     if: ${{ github.event.inputs.skip_vanilla != 'true' }}
     name: Test vanilla Examples
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1]
-        shardTotal: [1]
+        shardIndex: [1, 2]
+        shardTotal: [2]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test-framework-examples
@@ -90,6 +135,7 @@ jobs:
           test_pattern: ${{github.event.inputs.test_pattern}}
 
   test-typescript:
+    needs: initialise
     if: ${{ github.event.inputs.skip_typescript != 'true' }}
     name: Test typescript Examples
     runs-on: ubuntu-latest
@@ -108,14 +154,15 @@ jobs:
           test_pattern: ${{github.event.inputs.test_pattern}}
 
   test-reactFunctionalTs:
+    needs: initialise
     if: ${{ github.event.inputs.skip_reactFunctionalTs != 'true' }}
     name: Test reactFunctionalTs Examples
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2]
-        shardTotal: [2]
+        shardIndex: [1, 2, 3]
+        shardTotal: [3]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test-framework-examples
@@ -126,6 +173,7 @@ jobs:
           test_pattern: ${{github.event.inputs.test_pattern}}
 
   test-vue3:
+    needs: initialise
     if: ${{ github.event.inputs.skip_vue3 != 'true' }}
     name: Test vue3 Examples
     runs-on: ubuntu-latest
@@ -144,6 +192,7 @@ jobs:
           test_pattern: ${{github.event.inputs.test_pattern}}
 
   test-angular:
+    needs: initialise
     if: ${{ github.event.inputs.skip_angular != 'true' }}
     name: Test angular Examples
     runs-on: ubuntu-latest
@@ -222,7 +271,6 @@ jobs:
           report-path: 'combined-reports/**/*.json'
           summary-report: true
           failed-folded-report: true
-          failed-report: true
           flaky-report: true
           skipped-report: false
           group-by: filePath


### PR DESCRIPTION
Reduces per-job setup time in the Documentation Tests workflow from ~4.5 min to ~50s, and shards the two slowest (all-browser) jobs.

The framework example tests run Playwright against a remote deployed site, so they don't need the example generators, `setup-prompts`, or a local grid build beyond the `ag-grid-community` package the test harness imports at runtime.

**Changes**

- Add an `initialise` job that warms the `node_modules` and Nx caches once (rw) and pre-builds `ag-grid-community`. The framework test jobs `needs: initialise` and consume the caches read-only, so the expensive install happens once instead of racing across all jobs.
- Skip `postinstall` in the test jobs (no generators / `setup-prompts` — the latter was failing in CI anyway), building only `ag-grid-community` (served from the warmed Nx cache) for the harness import.
- Run Playwright via `./docs-e2e.sh`, bypassing the Nx target's grid-build `dependsOn`.
- Cache Playwright browser binaries keyed on version + browser set, so downloads become a near-noop.
- Shard `vanilla` into 2 and `reactFunctionalTs` into 3 to cut wall-clock on the all-browser jobs.

Validated with a dispatch run: `node_modules` and Nx caches hit on the exact key, community build served from cache, and per-job setup dropped to ~50s.