### PR TITLE
Replace placeholder SSRM example specs with behavioural tests

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-changing-columns/_examples/changing-columns/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-changing-columns/_examples/changing-columns/example.spec.ts
@@ -1,11 +1,23 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'Toggling a column checkbox and clicking Apply adds/removes that column',
+        async ({ agIdFor, page }) => {
+            await waitForGridContent(page);
+
+            // All columns start checked, so the Gold column is displayed in the grouped grid.
+            await expect(agIdFor.headerCell('gold')).toBeVisible();
+
+            // Unchecking Gold and applying rebuilds the columnDefs without it, so its header disappears.
+            await page.locator('#gold').uncheck();
+            await page.getByRole('button', { name: 'Apply' }).click();
+            await expect(agIdFor.headerCell('gold')).toHaveCount(0);
+
+            // Re-checking Gold and applying brings the column header back.
+            await page.locator('#gold').check();
+            await page.getByRole('button', { name: 'Apply' }).click();
+            await expect(agIdFor.headerCell('gold')).toBeVisible();
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-configuration/_examples/additional-row-data/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-configuration/_examples/additional-row-data/example.spec.ts
@@ -1,11 +1,22 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('applyServerSideRowData injects the first rows without an initial getRows', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const dataRow = (index: number) => page.locator(`.ag-row[row-index="${index}"]`);
+
+        // The first 100 rows are supplied up-front via applyServerSideRowData, so real
+        // olympic data (not loading placeholders) is present immediately.
+        await expect(dataRow(0).locator('[col-id="athlete"]')).toContainText('Michael Phelps');
+        await expect(dataRow(0).locator('[col-id="country"]')).toContainText('United States');
+        await expect(dataRow(0).locator('[col-id="gold"]')).toContainText('8');
+
+        await expect(dataRow(1).locator('[col-id="gold"]')).toContainText('6');
+        await expect(dataRow(2).locator('[col-id="gold"]')).toContainText('4');
+        await expect(dataRow(3).locator('[col-id="athlete"]')).toContainText('Natalie Coughlin');
+
+        // No loading placeholder rows are shown for the injected block.
+        await expect(page.locator('.ag-row-loading')).toHaveCount(0);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-configuration/_examples/block-load-debounce/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-configuration/_examples/block-load-debounce/example.spec.ts
@@ -1,11 +1,38 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('blockLoadDebounceMillis delays block loads then resolves to data', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const dataRow = (index: number) => page.locator(`.ag-row[row-index="${index}"]`);
+
+        // The first block loads (despite the debounce) with real olympic data.
+        await expect(dataRow(0).locator('[col-id="athlete"]')).toContainText('Michael Phelps');
+        await expect(dataRow(0).locator('[col-id="id"]')).toContainText('0');
+
+        // Scroll into a fresh, not-yet-loaded block. Because of blockLoadDebounceMillis:1000
+        // the grid shows loading placeholders before the block request fires and resolves.
+        await page.locator('.ag-grid-viewport').evaluate((el) => {
+            el.scrollTop = el.scrollHeight;
+        });
+
+        // A loading placeholder appears during the debounce window...
+        await expect(page.locator('.ag-row-loading').first()).toBeVisible({ timeout: 3000 });
+
+        // ...and eventually resolves: the loading placeholders clear and the deep block
+        // renders real data whose id column matches the row index.
+        await expect(page.locator('.ag-row-loading')).toHaveCount(0, { timeout: 10000 });
+
+        const renderedIndex = await page.evaluate(() => {
+            const rows = Array.from(document.querySelectorAll('.ag-row')) as HTMLElement[];
+            const deep = rows
+                .map((r) => Number(r.getAttribute('row-index')))
+                .filter((i) => Number.isFinite(i) && i >= 100)
+                .sort((a, b) => a - b);
+            return deep[0];
+        });
+        expect(renderedIndex).toBeGreaterThanOrEqual(100);
+        await expect(dataRow(renderedIndex).locator('[col-id="id"]')).toContainText(String(renderedIndex));
+        await expect(dataRow(renderedIndex).locator('[col-id="athlete"]')).not.toBeEmpty();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-configuration/_examples/cache-block-state/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-configuration/_examples/cache-block-state/example.spec.ts
@@ -1,11 +1,34 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('cache blocks load on demand as the grid is scrolled', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const dataRow = (index: number) => page.locator(`.ag-row[row-index="${index}"]`);
+
+        // First block is fetched from the server on demand.
+        await expect(dataRow(0).locator('[col-id="athlete"]')).toContainText('Michael Phelps');
+        await expect(dataRow(0).locator('[col-id="id"]')).toContainText('0');
+
+        // Scrolling down forces a later block to be fetched (its cache block enters the
+        // loading state, showing a placeholder) which then resolves to real data.
+        await page.locator('.ag-grid-viewport').evaluate((el) => {
+            el.scrollTop = 6000;
+        });
+
+        await expect(page.locator('.ag-row-loading').first()).toBeVisible({ timeout: 3000 });
+        await expect(page.locator('.ag-row-loading')).toHaveCount(0, { timeout: 10000 });
+
+        const renderedIndex = await page.evaluate(() => {
+            const rows = Array.from(document.querySelectorAll('.ag-row')) as HTMLElement[];
+            const deep = rows
+                .map((r) => Number(r.getAttribute('row-index')))
+                .filter((i) => Number.isFinite(i) && i >= 100)
+                .sort((a, b) => a - b);
+            return deep[0];
+        });
+        expect(renderedIndex).toBeGreaterThanOrEqual(100);
+        await expect(dataRow(renderedIndex).locator('[col-id="id"]')).toContainText(String(renderedIndex));
+        await expect(dataRow(renderedIndex).locator('[col-id="athlete"]')).not.toBeEmpty();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-configuration/_examples/cache-configurations/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-configuration/_examples/cache-configurations/example.spec.ts
@@ -1,11 +1,44 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('cacheBlockSize blocks load on demand while scrolling', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const dataRow = (index: number) => page.locator(`.ag-row[row-index="${index}"]`);
+
+        // First 50-row block loads on demand with real olympic data.
+        await expect(dataRow(0).locator('[col-id="athlete"]')).toContainText('Michael Phelps');
+        await expect(dataRow(0).locator('[col-id="id"]')).toContainText('0');
+
+        // The last row is unknown up-front, so the grid can only scroll one block at a time.
+        // Repeatedly scroll to the bottom to force successive blocks to be fetched on demand.
+        const deepestRenderedIndex = async () =>
+            page.evaluate(() => {
+                const rows = Array.from(document.querySelectorAll('.ag-row')) as HTMLElement[];
+                const indices = rows.map((r) => Number(r.getAttribute('row-index'))).filter((i) => Number.isFinite(i));
+                return indices.length ? Math.max(...indices) : -1;
+            });
+
+        for (let i = 0; i < 6; i++) {
+            await page.locator('.ag-grid-viewport').evaluate((el) => {
+                el.scrollTop = el.scrollHeight;
+            });
+            await expect(page.locator('.ag-row-loading')).toHaveCount(0, { timeout: 10000 });
+            if ((await deepestRenderedIndex()) >= 100) {
+                break;
+            }
+        }
+
+        const renderedIndex = await page.evaluate(() => {
+            const rows = Array.from(document.querySelectorAll('.ag-row')) as HTMLElement[];
+            const deep = rows
+                .map((r) => Number(r.getAttribute('row-index')))
+                .filter((i) => Number.isFinite(i) && i >= 100)
+                .sort((a, b) => a - b);
+            return deep[0];
+        });
+        expect(renderedIndex).toBeGreaterThanOrEqual(100);
+        await expect(dataRow(renderedIndex).locator('[col-id="id"]')).toContainText(String(renderedIndex));
+        await expect(dataRow(renderedIndex).locator('[col-id="athlete"]')).not.toBeEmpty();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-configuration/_examples/cache-configurations/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-configuration/_examples/cache-configurations/example.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
+// A row index comfortably past the first 50-row block, so reaching it proves a further block was
+// fetched on demand while scrolling. Kept low enough to reach reliably within the test budget.
+const DEEP_INDEX = 60;
+
 test.agExample(import.meta, () => {
     test.eachFramework('cacheBlockSize blocks load on demand while scrolling', async ({ page }) => {
         await waitForGridContent(page);
@@ -10,34 +14,46 @@ test.agExample(import.meta, () => {
         await expect(dataRow(0).locator('[col-id="athlete"]')).toContainText('Michael Phelps');
         await expect(dataRow(0).locator('[col-id="id"]')).toContainText('0');
 
-        // The last row is unknown up-front, so the grid can only scroll one block at a time.
-        // Repeatedly scroll to the bottom to force successive blocks to be fetched on demand.
-        const deepestRenderedIndex = async () =>
+        const deepestRenderedIndex = () =>
             page.evaluate(() => {
-                const rows = Array.from(document.querySelectorAll('.ag-row')) as HTMLElement[];
-                const indices = rows.map((r) => Number(r.getAttribute('row-index'))).filter((i) => Number.isFinite(i));
+                const indices = Array.from(document.querySelectorAll('.ag-row'))
+                    .map((r) => Number(r.getAttribute('row-index')))
+                    .filter((idx) => Number.isFinite(idx));
                 return indices.length ? Math.max(...indices) : -1;
             });
 
-        for (let i = 0; i < 6; i++) {
+        // The last row is unknown up-front, so the grid can only fetch one block at a time. Scroll to
+        // the bottom repeatedly, each time waiting until the deepest rendered row index actually
+        // advances (real data progress) before scrolling again — tolerating the occasional scroll
+        // that lands mid-load without failing.
+        for (let i = 0; i < 10 && (await deepestRenderedIndex()) < DEEP_INDEX; i++) {
+            const before = await deepestRenderedIndex();
             await page.locator('.ag-grid-viewport').evaluate((el) => {
                 el.scrollTop = el.scrollHeight;
             });
-            await expect(page.locator('.ag-row-loading')).toHaveCount(0, { timeout: 10000 });
-            if ((await deepestRenderedIndex()) >= 100) {
-                break;
-            }
+            await page
+                .waitForFunction(
+                    (prev) => {
+                        const indices = Array.from(document.querySelectorAll('.ag-row'))
+                            .map((r) => Number(r.getAttribute('row-index')))
+                            .filter((idx) => Number.isFinite(idx));
+                        return indices.length > 0 && Math.max(...indices) > prev;
+                    },
+                    before,
+                    { timeout: 5000 }
+                )
+                .catch(() => {});
         }
 
-        const renderedIndex = await page.evaluate(() => {
-            const rows = Array.from(document.querySelectorAll('.ag-row')) as HTMLElement[];
-            const deep = rows
+        const renderedIndex = await page.evaluate((min) => {
+            const deep = Array.from(document.querySelectorAll('.ag-row'))
                 .map((r) => Number(r.getAttribute('row-index')))
-                .filter((i) => Number.isFinite(i) && i >= 100)
+                .filter((idx) => Number.isFinite(idx) && idx >= min)
                 .sort((a, b) => a - b);
             return deep[0];
-        });
-        expect(renderedIndex).toBeGreaterThanOrEqual(100);
+        }, DEEP_INDEX);
+        expect(renderedIndex).toBeGreaterThanOrEqual(DEEP_INDEX);
+        // A block beyond the first was fetched on demand: the deep row carries its real id and data.
         await expect(dataRow(renderedIndex).locator('[col-id="id"]')).toContainText(String(renderedIndex));
         await expect(dataRow(renderedIndex).locator('[col-id="athlete"]')).not.toBeEmpty();
     });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-configuration/_examples/initial-scroll-position/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-configuration/_examples/initial-scroll-position/example.spec.ts
@@ -1,11 +1,22 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('grid opens scrolled to the initial row via ensureIndexVisible', async ({ page }) => {
+        await page.setViewportSize({ width: 1280, height: 300 });
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const dataRow = (index: number) => page.locator(`.ag-row[row-index="${index}"]`);
+
+        // serverSideInitialRowCount:5500 sizes the scrollable area up-front and
+        // ensureIndexVisible(5000, 'top') scrolls the viewport to row 5000 on load, so row 0
+        // is far above the viewport and not rendered.
+        await expect(dataRow(0)).toHaveCount(0);
+
+        // The block around row 5000 is fetched and rendered near the top of the viewport.
+        await expect(dataRow(5000).locator('[col-id="athlete"]')).not.toBeEmpty({ timeout: 10000 });
+
+        // The viewport has actually scrolled a long way down.
+        const scrollTop = await page.locator('.ag-grid-viewport').evaluate((el) => el.scrollTop);
+        expect(scrollTop).toBeGreaterThan(100000);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-datasource/_examples/simple/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-datasource/_examples/simple/example.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
+// A row index comfortably past the first 100-row block, so reaching it proves a further block was
+// fetched on demand while scrolling. Kept low enough to reach reliably within the test budget.
+const DEEP_INDEX = 60;
+
 test.agExample(import.meta, () => {
     test.eachFramework('server-side datasource loads the first block and more on scroll', async ({ page }) => {
         await waitForGridContent(page);
@@ -12,34 +16,45 @@ test.agExample(import.meta, () => {
         await expect(dataRow(0).locator('[col-id="gold"]')).toContainText('8');
         await expect(dataRow(3).locator('[col-id="athlete"]')).toContainText('Natalie Coughlin');
 
-        // The last row is not known up-front, so scroll to the bottom repeatedly to force
-        // further blocks to be fetched on demand.
-        const deepestRenderedIndex = async () =>
+        const deepestRenderedIndex = () =>
             page.evaluate(() => {
-                const rows = Array.from(document.querySelectorAll('.ag-row')) as HTMLElement[];
-                const indices = rows.map((r) => Number(r.getAttribute('row-index'))).filter((i) => Number.isFinite(i));
+                const indices = Array.from(document.querySelectorAll('.ag-row'))
+                    .map((r) => Number(r.getAttribute('row-index')))
+                    .filter((idx) => Number.isFinite(idx));
                 return indices.length ? Math.max(...indices) : -1;
             });
 
-        for (let i = 0; i < 6; i++) {
+        // The last row is not known up-front, so scroll to the bottom repeatedly, each time waiting
+        // until the deepest rendered row index actually advances (real data progress) before scrolling
+        // again — tolerating the occasional scroll that lands mid-load without failing.
+        for (let i = 0; i < 10 && (await deepestRenderedIndex()) < DEEP_INDEX; i++) {
+            const before = await deepestRenderedIndex();
             await page.locator('.ag-grid-viewport').evaluate((el) => {
                 el.scrollTop = el.scrollHeight;
             });
-            await expect(page.locator('.ag-row-loading')).toHaveCount(0, { timeout: 10000 });
-            if ((await deepestRenderedIndex()) >= 100) {
-                break;
-            }
+            await page
+                .waitForFunction(
+                    (prev) => {
+                        const indices = Array.from(document.querySelectorAll('.ag-row'))
+                            .map((r) => Number(r.getAttribute('row-index')))
+                            .filter((idx) => Number.isFinite(idx));
+                        return indices.length > 0 && Math.max(...indices) > prev;
+                    },
+                    before,
+                    { timeout: 5000 }
+                )
+                .catch(() => {});
         }
 
-        const renderedIndex = await page.evaluate(() => {
-            const rows = Array.from(document.querySelectorAll('.ag-row')) as HTMLElement[];
-            const deep = rows
+        const renderedIndex = await page.evaluate((min) => {
+            const deep = Array.from(document.querySelectorAll('.ag-row'))
                 .map((r) => Number(r.getAttribute('row-index')))
-                .filter((i) => Number.isFinite(i) && i >= 100)
+                .filter((idx) => Number.isFinite(idx) && idx >= min)
                 .sort((a, b) => a - b);
             return deep[0];
-        });
-        expect(renderedIndex).toBeGreaterThanOrEqual(100);
+        }, DEEP_INDEX);
+        expect(renderedIndex).toBeGreaterThanOrEqual(DEEP_INDEX);
+        // A further block was fetched on demand: the deep row renders real data.
         await expect(dataRow(renderedIndex).locator('[col-id="athlete"]')).not.toBeEmpty();
         await expect(dataRow(renderedIndex).locator('[col-id="country"]')).not.toBeEmpty();
     });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-datasource/_examples/simple/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-datasource/_examples/simple/example.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
-// A row index comfortably past the first 100-row block, so reaching it proves a further block was
-// fetched on demand while scrolling. Kept low enough to reach reliably within the test budget.
-const DEEP_INDEX = 60;
+// A row index past the first 100-row block, so reaching it proves a further block was fetched on
+// demand while scrolling. Kept just past the boundary to reach reliably within the test budget.
+const DEEP_INDEX = 120;
 
 test.agExample(import.meta, () => {
     test.eachFramework('server-side datasource loads the first block and more on scroll', async ({ page }) => {

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-datasource/_examples/simple/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-datasource/_examples/simple/example.spec.ts
@@ -1,11 +1,46 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('server-side datasource loads the first block and more on scroll', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const dataRow = (index: number) => page.locator(`.ag-row[row-index="${index}"]`);
+
+        // The first block is fetched on demand from the datasource with real olympic data.
+        await expect(dataRow(0).locator('[col-id="athlete"]')).toContainText('Michael Phelps');
+        await expect(dataRow(0).locator('[col-id="country"]')).toContainText('United States');
+        await expect(dataRow(0).locator('[col-id="gold"]')).toContainText('8');
+        await expect(dataRow(3).locator('[col-id="athlete"]')).toContainText('Natalie Coughlin');
+
+        // The last row is not known up-front, so scroll to the bottom repeatedly to force
+        // further blocks to be fetched on demand.
+        const deepestRenderedIndex = async () =>
+            page.evaluate(() => {
+                const rows = Array.from(document.querySelectorAll('.ag-row')) as HTMLElement[];
+                const indices = rows.map((r) => Number(r.getAttribute('row-index'))).filter((i) => Number.isFinite(i));
+                return indices.length ? Math.max(...indices) : -1;
+            });
+
+        for (let i = 0; i < 6; i++) {
+            await page.locator('.ag-grid-viewport').evaluate((el) => {
+                el.scrollTop = el.scrollHeight;
+            });
+            await expect(page.locator('.ag-row-loading')).toHaveCount(0, { timeout: 10000 });
+            if ((await deepestRenderedIndex()) >= 100) {
+                break;
+            }
+        }
+
+        const renderedIndex = await page.evaluate(() => {
+            const rows = Array.from(document.querySelectorAll('.ag-row')) as HTMLElement[];
+            const deep = rows
+                .map((r) => Number(r.getAttribute('row-index')))
+                .filter((i) => Number.isFinite(i) && i >= 100)
+                .sort((a, b) => a - b);
+            return deep[0];
+        });
+        expect(renderedIndex).toBeGreaterThanOrEqual(100);
+        await expect(dataRow(renderedIndex).locator('[col-id="athlete"]')).not.toBeEmpty();
+        await expect(dataRow(renderedIndex).locator('[col-id="country"]')).not.toBeEmpty();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/_examples/advanced-filter/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/_examples/advanced-filter/example.spec.ts
@@ -1,11 +1,23 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Advanced Filter expression reloads only matching rows from the server', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const athleteCells = page.locator('.ag-row [col-id="athlete"]');
+
+        // Unfiltered data includes many different athletes.
+        await expect(athleteCells.filter({ hasNotText: 'Phelps' }).first()).toBeVisible();
+
+        // Enter an Advanced Filter expression and apply it. With the SSRM the expression
+        // is sent to the server as an Advanced Filter Model.
+        const filterInput = page.locator('.ag-advanced-filter input[type=text]');
+        await filterInput.fill('[Athlete] contains "phelps"');
+        await page.keyboard.press('Escape');
+        await page.locator('.ag-advanced-filter-buttons').getByText('Apply').click();
+
+        // Only Michael Phelps rows remain.
+        await expect(athleteCells.first()).toBeVisible();
+        await expect(athleteCells.filter({ hasNotText: 'Phelps' })).toHaveCount(0);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/_examples/global-apply/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/_examples/global-apply/example.spec.ts
@@ -1,11 +1,36 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'New Filters Tool Panel batches edits until the global Apply is clicked',
+        async ({ agIdFor, page }) => {
+            await waitForGridContent(page);
+
+            const athleteCells = page.locator('.ag-row [col-id="athlete"]');
+            const nonPhelps = athleteCells.filter({ hasText: 'Natalie Coughlin' });
+
+            // Unfiltered: non-Phelps athletes (e.g. Natalie Coughlin) are present.
+            await expect(nonPhelps.first()).toBeVisible();
+
+            // Add an Athlete filter in the tool panel and edit it to contain "phelps".
+            await agIdFor.filterToolPanelAddFilterButton().click();
+            await page.getByRole('option', { name: 'Athlete' }).locator('div').click();
+
+            const athleteFilterInput = agIdFor.textFilterInstanceInput({
+                source: 'filter-toolpanel',
+                colLabel: 'Athlete',
+            });
+            await athleteFilterInput.fill('phelps');
+            await athleteFilterInput.press('Enter');
+
+            // The edit is batched: no server request yet, so the rows are unchanged.
+            await expect(nonPhelps.first()).toBeVisible();
+
+            // Clicking the global Apply sends a single request and the rows update.
+            await agIdFor.filterToolPanel().getByRole('button', { name: 'Apply' }).click();
+
+            await expect(athleteCells.first()).toBeVisible();
+            await expect(athleteCells.filter({ hasNotText: 'Phelps' })).toHaveCount(0);
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/_examples/infinite-set/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/_examples/infinite-set/example.spec.ts
@@ -1,11 +1,27 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'Set Filter supplies country values asynchronously and filters rows to the selection',
+        async ({ agIdFor, page }) => {
+            await waitForGridContent(page);
+
+            const countryCells = page.locator('.ag-row [col-id="country"]');
+            const item = (label: string) => agIdFor.setFilterInstanceItem({ source: 'column-filter' }, label);
+
+            // Open the Country Set Filter. Values are supplied asynchronously (500ms server delay).
+            await agIdFor.headerFilterButton('country').click();
+            await expect(item('Australia')).toBeVisible({ timeout: 8000 });
+            await expect(item('Austria')).toBeVisible();
+
+            // Deselect everything, then select only Australia, and apply.
+            await item('(Select All)').uncheck();
+            await item('Australia').check();
+            await agIdFor.setFilterApplyPanelButton({ source: 'column-filter' }, 'Apply').click();
+
+            // The server reloads with only Australian rows.
+            await expect(countryCells.filter({ hasText: 'Australia' }).first()).toBeVisible();
+            await expect(countryCells.filter({ hasNotText: 'Australia' })).toHaveCount(0);
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/_examples/infinite-simple/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-filtering/_examples/infinite-simple/example.spec.ts
@@ -1,11 +1,25 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'applying a simple text column filter reloads only matching rows from the server',
+        async ({ agIdFor, page }) => {
+            await waitForGridContent(page);
+
+            const athleteCells = page.locator('.ag-row [col-id="athlete"]');
+
+            // Unfiltered data starts with Michael Phelps.
+            await expect(athleteCells.filter({ hasText: 'Michael Phelps' }).first()).toBeVisible();
+
+            // Open the Athlete column's Text Filter and filter to names containing "Fred".
+            // With the SSRM this sends a new request; the server returns only matching rows.
+            await agIdFor.headerFilterButton('athlete').click();
+            await agIdFor.textFilterInstanceInput({ source: 'column-filter' }).fill('Fred');
+            await page.keyboard.press('Escape');
+
+            // Only matching rows remain: a "Fred" athlete is present, Michael Phelps is gone.
+            await expect(athleteCells.filter({ hasText: 'Fred' }).first()).toBeVisible();
+            await expect(athleteCells.filter({ hasText: 'Michael Phelps' })).toHaveCount(0);
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/child-counts/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/child-counts/example.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('getChildCount renders the child count beside each group name', async ({ agIdFor, page }) => {
+    test.eachFramework('getChildCount renders the child count beside each group name', async ({ page }) => {
         await waitForGridContent(page);
 
         const groupRow = (name: string) =>
@@ -12,8 +12,7 @@ test.agExample(import.meta, () => {
 
         // Top level is grouped by Country. getChildCount surfaces the server 'childCount'
         // which the grid renders as "GroupName (N)" in the auto group column.
-        await expect(agIdFor.autoGroupCell('0')).toContainText('United States', { useInnerText: true });
-        await expect(agIdFor.autoGroupCell('0')).toContainText(/\(\d+\)/, { useInnerText: true });
+        await expect(groupRow('United States')).toContainText(/United States\s*\(\d+\)/, { useInnerText: true });
 
         // The child-count suffix appears on other country groups too.
         await expect(groupRow('Russia')).toContainText(/Russia\s*\(\d+\)/, { useInnerText: true });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/child-counts/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/child-counts/example.spec.ts
@@ -1,11 +1,21 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('getChildCount renders the child count beside each group name', async ({ agIdFor, page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        // Top level is grouped by Country. getChildCount surfaces the server 'childCount'
+        // which the grid renders as "GroupName (N)" in the auto group column.
+        await expect(agIdFor.autoGroupCell('0')).toContainText('United States', { useInnerText: true });
+        await expect(agIdFor.autoGroupCell('0')).toContainText(/\(\d+\)/, { useInnerText: true });
+
+        // The child-count suffix appears on other country groups too.
+        await expect(groupRow('Russia')).toContainText(/Russia\s*\(\d+\)/, { useInnerText: true });
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/complex-objects/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/complex-objects/example.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('groups by a nested object field via valueGetter', async ({ agIdFor, page }) => {
+    test.eachFramework('groups by a nested object field via valueGetter', async ({ page }) => {
         await waitForGridContent(page);
 
         const groupRow = (name: string) =>
@@ -12,11 +12,16 @@ test.agExample(import.meta, () => {
 
         // Country is a complex object { name, code }; the valueGetter 'data.country.name'
         // means groups display the plain country name, not "[object Object]".
-        await expect(agIdFor.autoGroupCell('0')).toContainText('United States', { useInnerText: true });
-        await expect(agIdFor.autoGroupCell('0')).not.toContainText('[object Object]', { useInnerText: true });
+        const usa = groupRow('United States');
+        await expect(usa.locator('[col-id="ag-Grid-AutoColumn"]')).toContainText('United States', {
+            useInnerText: true,
+        });
+        await expect(usa.locator('[col-id="ag-Grid-AutoColumn"]')).not.toContainText('[object Object]', {
+            useInnerText: true,
+        });
 
         // Aggregated medal totals are computed server-side for the group.
-        await expect(agIdFor.cell('0', 'gold')).toContainText('552');
+        await expect(usa.locator('.ag-cell[col-id="gold"]')).toContainText('552');
         await expect(groupRow('Russia')).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/complex-objects/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/complex-objects/example.spec.ts
@@ -1,11 +1,22 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('groups by a nested object field via valueGetter', async ({ agIdFor, page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        // Country is a complex object { name, code }; the valueGetter 'data.country.name'
+        // means groups display the plain country name, not "[object Object]".
+        await expect(agIdFor.autoGroupCell('0')).toContainText('United States', { useInnerText: true });
+        await expect(agIdFor.autoGroupCell('0')).not.toContainText('[object Object]', { useInnerText: true });
+
+        // Aggregated medal totals are computed server-side for the group.
+        await expect(agIdFor.cell('0', 'gold')).toContainText('552');
+        await expect(groupRow('Russia')).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/deferred-apply-mode/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/deferred-apply-mode/example.spec.ts
@@ -1,11 +1,34 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Columns Tool Panel stages changes until Apply is clicked', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        // Grid renders grouped by Country (top level), and the Columns Tool Panel is present.
+        await expect(groupRow('United States')).toBeVisible();
+        await expect(page.locator('.ag-column-select')).toBeVisible();
+
+        // The 'Age' column starts visible in the grid.
+        const ageHeader = page.locator('.ag-header-cell[col-id="age"]');
+        await expect(ageHeader).toBeVisible();
+
+        // Unchecking 'Age' in the tool panel stages the change but does NOT apply it —
+        // the column stays visible in the grid until Apply is clicked.
+        const ageToolPanelCheckbox = page
+            .locator('.ag-column-select-column')
+            .filter({ hasText: 'Age' })
+            .locator('.ag-checkbox-input');
+        await ageToolPanelCheckbox.click();
+        await expect(ageHeader).toBeVisible();
+
+        // Clicking Apply commits the staged change and the column is removed.
+        await page.getByRole('button', { name: 'Apply' }).click();
+        await expect(ageHeader).toBeHidden();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/expand-all-affects-all-rows/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/expand-all-affects-all-rows/example.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent, waitForRowAnimations } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     test.eachFramework('ssrmExpandAllAffectsAllRows enables Expand All to expand every level', async ({ page }) => {
@@ -19,6 +19,9 @@ test.agExample(import.meta, () => {
         // deepest Year level never appears.
         await page.getByRole('button', { name: 'Expand rows' }).click();
         await expect(sportGroups).not.toHaveCount(0);
+        // Let the Sport children finish loading/animating so that, if a regression made expandAll
+        // recurse into them, their Year rows would have appeared — then assert they did not.
+        await waitForRowAnimations(page);
         await expect(yearGroups).toHaveCount(0);
 
         // Enabling ssrmExpandAllAffectsAllRows makes expandAll() expand every level, including groups

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/expand-all-affects-all-rows/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/expand-all-affects-all-rows/example.spec.ts
@@ -1,11 +1,34 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('ssrmExpandAllAffectsAllRows enables Expand All to expand every level', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Grouped Country -> Sport -> Year. Level classes: country=0, sport=1, year=2.
+        const sportGroups = page.locator('.ag-row.ag-row-level-1');
+        const yearGroups = page.locator('.ag-row.ag-row-level-2');
+
+        // Wait until the first Country group has actually loaded (real group value, not a loading
+        // placeholder) — expandAll() with the flag off only expands groups already loaded, so the
+        // click below is a no-op unless the top level has arrived from the server.
+        await expect(page.locator('.ag-row.ag-row-level-0 .ag-group-value').first()).toHaveText(/\S/);
+
+        // With ssrmExpandAllAffectsAllRows unchecked (default false), expandAll() expands only the
+        // groups already loaded into the client: the loaded Country groups expand and their Sport
+        // children load in, but those newly-loaded Sport groups are NOT recursively expanded — so the
+        // deepest Year level never appears.
+        await page.getByRole('button', { name: 'Expand rows' }).click();
+        await expect(sportGroups).not.toHaveCount(0);
+        await expect(yearGroups).toHaveCount(0);
+
+        // Enabling ssrmExpandAllAffectsAllRows makes expandAll() expand every level, including groups
+        // not yet loaded — so the deepest Year (level-2) groups now become visible too.
+        await page.locator('#ssrmExpandAllAffectsAllRows').check();
+        await page.getByRole('button', { name: 'Expand rows' }).click();
+        await expect(yearGroups).not.toHaveCount(0);
+
+        // Collapse rows collapses every level again.
+        await page.getByRole('button', { name: 'Collapse rows' }).click();
+        await expect(sportGroups).toHaveCount(0);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/expand-all/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/expand-all/example.spec.ts
@@ -1,11 +1,26 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Expand All / Collapse All expand and hide loaded groups', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        // Top level is grouped by Year; nested groups (Country) are collapsed initially.
+        await expect(groupRow('2000')).toBeVisible();
+        await expect(groupRow('United States')).toBeHidden();
+
+        // Expand All expands the loaded groups, revealing the nested Country groups.
+        await page.getByRole('button', { name: 'Expand All' }).click();
+        await expect(groupRow('United States')).toBeVisible();
+
+        // Collapse All hides the nested groups again.
+        await page.getByRole('button', { name: 'Collapse All' }).click();
+        await expect(groupRow('United States')).toBeHidden();
+        await expect(groupRow('2000')).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/filtering/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/filtering/example.spec.ts
@@ -1,11 +1,29 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('applying a filter refreshes and narrows the visible groups', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        // Grouped by Country then Sport. Both United States and Russia groups are present.
+        await expect(groupRow('United States')).toBeVisible();
+        await expect(groupRow('Russia')).toBeVisible();
+
+        // Filter the leaf-level 'gold' column via its floating filter to gold == 8
+        // (only achieved by a United States athlete). serverSideOnlyRefreshFilteredGroups
+        // refreshes the groups so only matching countries remain.
+        const goldFloatingFilter = page.locator(
+            '.ag-header-cell[col-id="gold"] .ag-floating-filter-input input[type="number"]'
+        );
+        await goldFloatingFilter.fill('8');
+        await goldFloatingFilter.press('Enter');
+
+        await expect(groupRow('United States')).toBeVisible();
+        await expect(groupRow('Russia')).toBeHidden();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/grand-total-getrows/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/grand-total-getrows/example.spec.ts
@@ -1,11 +1,24 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Grand total row shows server-aggregated medal totals', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Top level is grouped by Country with server-side aggregated medal totals.
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+        await expect(groupRow('United States')).toBeVisible();
+
+        // grandTotalRow: 'bottom' — the fake server aggregates across the entire dataset and
+        // returns the grand total via getRows. The footer may be mirrored across pinned/centre
+        // containers, so scope to the first matching grand-total row.
+        const grandTotalRow = page.locator('[row-id="rowGroupFooter_ROOT_NODE_ID"]').first();
+        await expect(grandTotalRow).toBeVisible();
+        await expect(grandTotalRow.locator('[col-id="gold"]')).toContainText('3143');
+        await expect(grandTotalRow.locator('[col-id="silver"]')).toContainText('3131');
+        await expect(grandTotalRow.locator('[col-id="bronze"]')).toContainText('3255');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/grand-total-transactions/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/grand-total-transactions/example.spec.ts
@@ -1,11 +1,20 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Grand total row is maintained via server-side transactions', async ({ agIdFor, page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Flat SSRM grid — the first data block loads athlete rows (ids are `row-<index>`).
+        await expect(agIdFor.cell('row-0', 'athlete')).toContainText('Michael Phelps');
+
+        // The grand total is fetched separately and added back with an `add` transaction after a
+        // simulated backend delay, so the footer appears a moment after the first rows. The
+        // aggregation covers the entire dataset. The footer is mirrored across containers so
+        // scope to the first matching grand-total row.
+        const grandTotalRow = page.locator('[row-id="rowGroupFooter_ROOT_NODE_ID"]').first();
+        await expect(grandTotalRow).toBeVisible({ timeout: 15000 });
+        await expect(grandTotalRow.locator('[col-id="gold"]')).toContainText('3143', { timeout: 15000 });
+        await expect(grandTotalRow.locator('[col-id="silver"]')).toContainText('3131');
+        await expect(grandTotalRow.locator('[col-id="bronze"]')).toContainText('3255');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/group-footer-multiple-cols/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/group-footer-multiple-cols/example.spec.ts
@@ -1,11 +1,43 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'groupTotalRow bottom renders footers across separate per-level group columns',
+        async ({ page }) => {
+            await waitForGridContent(page);
+
+            // groupDisplayType: 'multipleColumns' gives one auto group column per level.
+            await expect(page.locator('[col-id="ag-Grid-AutoColumn-country"]').first()).toBeVisible();
+            await expect(page.locator('[col-id="ag-Grid-AutoColumn-sport"]').first()).toBeVisible();
+
+            const groupRow = (name: string) =>
+                page
+                    .locator('.ag-row')
+                    .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                    .first();
+            await expect(groupRow('United States')).toBeVisible();
+
+            // Expanding a country lazy-loads its Sport subgroups; groupTotalRow: 'bottom' appends a
+            // footer after the group's children.
+            await groupRow('United States').locator('.ag-group-contracted').first().click();
+            await expect(groupRow('Swimming')).toBeVisible();
+
+            // The footer sits below all 40 US sports — scroll it into the rendered range.
+            await page.evaluate(() => {
+                const vp = document.querySelector('.ag-body-viewport') as HTMLElement;
+                if (vp) {
+                    vp.scrollTop = 1700;
+                }
+            });
+
+            // The top-level footer's "Total <country>" lands in the country group column, the sport
+            // group column is a separate (empty) cell, and the aggregated medals follow.
+            const footer = page.locator('.ag-row-footer').filter({ hasText: 'Total United States' }).first();
+            await expect(footer.locator('[col-id="ag-Grid-AutoColumn-country"]')).toContainText('Total United States');
+            await expect(footer.locator('[col-id="ag-Grid-AutoColumn-sport"]')).toHaveText('');
+            await expect(footer.locator('[col-id="gold"]')).toContainText('552');
+            await expect(footer.locator('[col-id="silver"]')).toContainText('440');
+            await expect(footer.locator('[col-id="bronze"]')).toContainText('320');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/group-footer/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/group-footer/example.spec.ts
@@ -1,11 +1,34 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('groupTotalRow bottom renders a per-group footer with aggregated medals', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+        await expect(groupRow('United States')).toBeVisible();
+
+        // Expanding a country lazy-loads its Sport subgroups; with groupTotalRow: 'bottom' a footer
+        // row is appended after the group's children.
+        await groupRow('United States').locator('.ag-group-contracted').first().click();
+        await expect(groupRow('Swimming')).toBeVisible();
+
+        // The footer sits below all 40 US sports — scroll it into the rendered range.
+        await page.evaluate(() => {
+            const vp = document.querySelector('.ag-body-viewport') as HTMLElement;
+            if (vp) {
+                vp.scrollTop = 1700;
+            }
+        });
+
+        // The footer shows "Total <group>" and the group's server-aggregated medal totals.
+        const footer = page.locator('.ag-row-footer').filter({ hasText: 'Total United States' }).first();
+        await expect(footer).toContainText('Total United States');
+        await expect(footer.locator('[col-id="gold"]')).toContainText('552');
+        await expect(footer.locator('[col-id="silver"]')).toContainText('440');
+        await expect(footer.locator('[col-id="bronze"]')).toContainText('320');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/hide-open-parents/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/hide-open-parents/example.spec.ts
@@ -1,11 +1,43 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'groupHideOpenParents hides an expanded group row and restores it on collapse',
+        async ({ page }) => {
+            await waitForGridContent(page);
+
+            // Before expanding, United States is a top-level (level-0) group row of its own.
+            const usTopLevel = () =>
+                page
+                    .locator('.ag-row-level-0')
+                    .filter({ has: page.locator('.ag-group-value', { hasText: 'United States' }) })
+                    .first();
+            await expect(usTopLevel()).toBeVisible();
+            await expect(usTopLevel().locator('.ag-group-contracted').first()).toBeVisible();
+
+            // Expand United States.
+            await usTopLevel().locator('.ag-group-contracted').first().click();
+
+            // groupHideOpenParents: the open United States group row is removed and its first child
+            // (the Swimming sport group) takes its place, carrying the open parent's "United States"
+            // context in the same group cell alongside the child's own value and aggregates.
+            const firstChild = page.locator('.ag-row-level-1').filter({ hasText: 'Swimming' }).first();
+            await expect(firstChild).toBeVisible();
+            await expect(firstChild).toContainText('United States');
+            await expect(firstChild).toContainText('Swimming');
+            await expect(firstChild.locator('[col-id="gold"]')).toContainText('139');
+            // The standalone level-0 United States group row is no longer displayed.
+            await expect(
+                page
+                    .locator('.ag-row-level-0')
+                    .filter({ has: page.locator('.ag-group-value', { hasText: 'United States' }) })
+            ).toHaveCount(0);
+
+            // Collapsing (via the open parent's expanded chevron) restores the level-0 group row.
+            await firstChild.locator('.ag-group-expanded').first().click();
+            await expect(usTopLevel()).toBeVisible();
+            await expect(usTopLevel().locator('.ag-group-contracted').first()).toBeVisible();
+            await expect(page.locator('.ag-row-level-1').filter({ hasText: 'Swimming' })).toHaveCount(0);
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/open-by-default/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/open-by-default/example.spec.ts
@@ -1,11 +1,34 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'isServerSideGroupOpenByDefault auto-expands the configured routes on load',
+        async ({ page }) => {
+            await waitForGridContent(page);
+
+            const groupRow = (name: string) =>
+                page
+                    .locator('.ag-row')
+                    .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                    .first();
+
+            // Route 'Zimbabwe' is opened by default — no click needed, its chevron is expanded.
+            const zimbabwe = groupRow('Zimbabwe');
+            await expect(zimbabwe).toBeVisible();
+            await expect(zimbabwe.locator('.ag-group-expanded').first()).toBeVisible();
+
+            // Route 'Zimbabwe,Swimming' is also opened by default — the Swimming subgroup under
+            // Zimbabwe is expanded, revealing its lazy-loaded leaf rows (Zimbabwe only competes in
+            // Swimming, and its two medal-winning years load automatically).
+            const zimbabweSwimming = page.locator('.ag-row-level-1').filter({ hasText: 'Swimming' }).first();
+            await expect(zimbabweSwimming.locator('.ag-group-expanded').first()).toBeVisible();
+            const leaf2008 = page.locator('.ag-row-level-2').filter({ hasText: '2008' }).first();
+            await expect(leaf2008).toBeVisible();
+            await expect(leaf2008.locator('[col-id="gold"]')).toContainText('1');
+            await expect(page.locator('.ag-row-level-2').filter({ hasText: '2004' }).first()).toBeVisible();
+
+            // Routes not listed stay collapsed — United States is not opened by default.
+            await expect(groupRow('United States').locator('.ag-group-contracted').first()).toBeVisible();
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/row-grouping/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/row-grouping/example.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Server-side row grouping loads groups and lazy-loads children', async ({ agIdFor, page }) => {
+    test.eachFramework('Server-side row grouping loads groups and lazy-loads children', async ({ page }) => {
         await waitForGridContent(page);
 
         // Locate a group row by its displayed group value — robust to the positional
@@ -13,15 +13,18 @@ test.agExample(import.meta, () => {
                 .first();
 
         // Top level is grouped by Country, with server-side aggregated medal totals.
-        await expect(agIdFor.autoGroupCell('0')).toContainText('United States', { useInnerText: true });
-        await expect(agIdFor.cell('0', 'gold')).toContainText('552');
-        await expect(agIdFor.cell('0', 'silver')).toContainText('440');
-        await expect(agIdFor.cell('0', 'bronze')).toContainText('320');
+        const usa = groupRow('United States');
+        await expect(usa.locator('[col-id="ag-Grid-AutoColumn"]')).toContainText('United States', {
+            useInnerText: true,
+        });
+        await expect(usa.locator('.ag-cell[col-id="gold"]')).toContainText('552');
+        await expect(usa.locator('.ag-cell[col-id="silver"]')).toContainText('440');
+        await expect(usa.locator('.ag-cell[col-id="bronze"]')).toContainText('320');
         await expect(groupRow('Russia')).toBeVisible();
 
         // Expanding a country lazy-loads the second group level (Sport) from the server.
-        await groupRow('United States').locator('.ag-group-contracted').first().click();
+        await usa.locator('.ag-group-contracted').first().click();
         await expect(groupRow('Swimming')).toBeVisible();
-        await expect(agIdFor.cell('United States-0', 'gold')).toContainText('139');
+        await expect(groupRow('Swimming').locator('.ag-cell[col-id="gold"]')).toContainText('139');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/row-grouping/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/row-grouping/example.spec.ts
@@ -1,11 +1,27 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Server-side row grouping loads groups and lazy-loads children', async ({ agIdFor, page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Locate a group row by its displayed group value — robust to the positional
+        // row-ids the SSRM assigns to group rows.
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        // Top level is grouped by Country, with server-side aggregated medal totals.
+        await expect(agIdFor.autoGroupCell('0')).toContainText('United States', { useInnerText: true });
+        await expect(agIdFor.cell('0', 'gold')).toContainText('552');
+        await expect(agIdFor.cell('0', 'silver')).toContainText('440');
+        await expect(agIdFor.cell('0', 'bronze')).toContainText('320');
+        await expect(groupRow('Russia')).toBeVisible();
+
+        // Expanding a country lazy-loads the second group level (Sport) from the server.
+        await groupRow('United States').locator('.ag-group-contracted').first().click();
+        await expect(groupRow('Swimming')).toBeVisible();
+        await expect(agIdFor.cell('United States-0', 'gold')).toContainText('139');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/unbalanced-groups/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/unbalanced-groups/example.spec.ts
@@ -1,11 +1,28 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('unbalanced rows with an empty group key appear at the top level', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        // Rows with a real country still form normal groups.
+        await expect(groupRow('United States')).toBeVisible();
+        await expect(groupRow('Australia')).toBeVisible();
+
+        // groupAllowUnbalanced: true means rows with an empty ('') country key are not
+        // put into a group — they render as leaf rows at the top level. Those rows have
+        // no group toggle but do show their (non-grouped) sport value.
+        // groupAllowUnbalanced: true means rows whose country key is empty ('') are not
+        // wrapped in a group. They render at the top level as plain leaf rows, keyed with
+        // the grid's "missing key" id, showing their (non-grouped) sport value.
+        const unbalancedLeafRow = page.locator('.ag-row[row-id^="ag-Grid-MissingKey"]');
+        await expect(unbalancedLeafRow.first()).toBeVisible();
+        await expect(unbalancedLeafRow.first()).not.toHaveClass(/ag-row-group/);
+        await expect(unbalancedLeafRow.filter({ hasText: 'Gymnastics' }).first()).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/unbalanced-groups/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/unbalanced-groups/example.spec.ts
@@ -14,12 +14,9 @@ test.agExample(import.meta, () => {
         await expect(groupRow('United States')).toBeVisible();
         await expect(groupRow('Australia')).toBeVisible();
 
-        // groupAllowUnbalanced: true means rows with an empty ('') country key are not
-        // put into a group — they render as leaf rows at the top level. Those rows have
-        // no group toggle but do show their (non-grouped) sport value.
-        // groupAllowUnbalanced: true means rows whose country key is empty ('') are not
-        // wrapped in a group. They render at the top level as plain leaf rows, keyed with
-        // the grid's "missing key" id, showing their (non-grouped) sport value.
+        // groupAllowUnbalanced: true means rows whose country key is empty ('') are not wrapped in a
+        // group. They render at the top level as plain leaf rows, keyed with the grid's "missing key"
+        // id, showing their (non-grouped) sport value.
         const unbalancedLeafRow = page.locator('.ag-row[row-id^="ag-Grid-MissingKey"]');
         await expect(unbalancedLeafRow.first()).toBeVisible();
         await expect(unbalancedLeafRow.first()).not.toHaveClass(/ag-row-group/);

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-master-detail/_examples/auto-detail-row-height/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-master-detail/_examples/auto-detail-row-height/example.spec.ts
@@ -1,11 +1,33 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('detailRowAutoHeight sizes the detail row to fit all its call records', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const masterRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('[col-id="name"]', { hasText: name }) })
+                .first();
+
+        // Liam Padberg has 15 call records.
+        await expect(masterRow('Liam Padberg')).toBeVisible();
+        await masterRow('Liam Padberg').locator('.ag-group-contracted').first().click();
+
+        const detail = page
+            .locator('.ag-details-row')
+            .filter({ has: page.locator('[col-id="callId"]', { hasText: '2000' }) })
+            .first();
+        await expect(detail).toBeVisible();
+
+        // With detailRowAutoHeight all 15 records render inside the detail grid — the detail
+        // row auto-sizes to fit them, so nothing is clipped by a fixed detail row height.
+        await expect(detail.locator('.ag-row')).toHaveCount(15);
+
+        // The details row is far taller than the default fixed detail row height (~300px),
+        // proving it grew to fit all 15 records.
+        const box = await detail.boundingBox();
+        expect(box).not.toBeNull();
+        expect(box!.height).toBeGreaterThan(400);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-master-detail/_examples/dynamic-detail-row-height/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-master-detail/_examples/dynamic-detail-row-height/example.spec.ts
@@ -1,11 +1,42 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('getRowHeight sizes each detail row by its number of call records', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const masterRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('[col-id="name"]', { hasText: name }) })
+                .first();
+
+        // Liam Padberg has 15 call records; expand his master row.
+        await expect(masterRow('Liam Padberg')).toBeVisible();
+        await masterRow('Liam Padberg').locator('.ag-group-contracted').first().click();
+
+        // Helene Ferry (29 call records) is auto-expanded on load via onGridReady.
+        const detailShort = page
+            .locator('.ag-details-row')
+            .filter({ has: page.locator('[col-id="callId"]', { hasText: '2000' }) })
+            .first();
+        const detailTall = page
+            .locator('.ag-details-row')
+            .filter({ has: page.locator('[col-id="callId"]', { hasText: '2015' }) })
+            .first();
+
+        await expect(detailShort).toBeVisible();
+        await expect(detailTall).toBeVisible();
+
+        // Detail grids use autoHeight so every record renders: 15 vs 29 rows.
+        await expect(detailShort.locator('.ag-row')).toHaveCount(15);
+        await expect(detailTall.locator('.ag-row')).toHaveCount(29);
+
+        // getRowHeight scales the detail row height by callRecords.length, so the 29-record
+        // detail is measurably taller than the 15-record detail.
+        const boxShort = await detailShort.boundingBox();
+        const boxTall = await detailTall.boundingBox();
+        expect(boxShort).not.toBeNull();
+        expect(boxTall).not.toBeNull();
+        expect(boxTall!.height).toBeGreaterThan(boxShort!.height + 200);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-master-detail/_examples/infinite-scrolling/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-master-detail/_examples/infinite-scrolling/example.spec.ts
@@ -1,11 +1,31 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Master row expands to a nested detail grid of call records', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Master rows are individual accounts loaded lazily by the server-side row model.
+        const masterRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('[col-id="name"]', { hasText: name }) })
+                .first();
+
+        // First account in the fake server dataset.
+        await expect(masterRow('Liam Padberg')).toBeVisible();
+
+        // Expand the master row via the group cell renderer icon on the accountId column.
+        await masterRow('Liam Padberg').locator('.ag-group-contracted').first().click();
+
+        // The detail grid renders as a nested grid inside the details row, showing the
+        // account's call records (first record for Liam Padberg has callId 2000, direction IN).
+        const detail = page
+            .locator('.ag-details-row')
+            .filter({ has: page.locator('[col-id="callId"]', { hasText: '2000' }) })
+            .first();
+        await expect(detail).toBeVisible();
+        await expect(detail.locator('.ag-root-wrapper')).toBeVisible();
+        await expect(detail.locator('.ag-row').first()).toBeVisible();
+        await expect(detail.locator('.ag-cell[col-id="direction"]').first()).toContainText('IN');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-master-detail/_examples/row-grouping/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-master-detail/_examples/row-grouping/example.spec.ts
@@ -1,11 +1,38 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Expanding a country group then a leaf account reveals its detail grid', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Top level is grouped by Country on the server.
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        await expect(groupRow('Turkey')).toBeVisible();
+
+        // Expand the country group to lazy-load its account (leaf) rows.
+        await groupRow('Turkey').locator('.ag-group-contracted').first().click();
+
+        // Leaf account rows appear under the country.
+        const leafRow = page
+            .locator('.ag-row')
+            .filter({ has: page.locator('[col-id="name"]', { hasText: 'Liam Padberg' }) })
+            .first();
+        await expect(leafRow).toBeVisible();
+
+        // Expand the leaf account's master/detail row.
+        await leafRow.locator('.ag-group-contracted').first().click();
+
+        // The detail grid renders the account's call records (first callId for Liam is 2000).
+        const detail = page
+            .locator('.ag-details-row')
+            .filter({ has: page.locator('[col-id="callId"]', { hasText: '2000' }) })
+            .first();
+        await expect(detail).toBeVisible();
+        await expect(detail.locator('.ag-root-wrapper')).toBeVisible();
+        await expect(detail.locator('.ag-row').first()).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-master-detail/_examples/tree-data-master-detail/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-master-detail/_examples/tree-data-master-detail/example.spec.ts
@@ -1,11 +1,35 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Tree hierarchy and a master row both expand from the Name column', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Tree nodes are shown in the Name auto-group column.
+        const nameRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        await expect(nameRow('Root 1')).toBeVisible();
+        await expect(nameRow('Root 3')).toBeVisible();
+
+        // Expand the tree group 'Root 1' to lazy-load its children from the server.
+        await nameRow('Root 1').locator('.ag-group-contracted').first().click();
+        await expect(nameRow('Child 1.1')).toBeVisible();
+        await expect(nameRow('Child 1.2')).toBeVisible();
+
+        // 'Root 3' is a master row (has detail records but no children); expand its detail grid.
+        await nameRow('Root 3').locator('.ag-group-contracted').first().click();
+        const detail = page.locator('.ag-details-row').filter({ hasText: 'Detail F' }).first();
+        await expect(detail).toBeVisible();
+        await expect(detail.locator('.ag-root-wrapper')).toBeVisible();
+        await expect(detail).toContainText('Value F');
+
+        // detailRowHeight is fixed at 220px.
+        const box = await detail.boundingBox();
+        expect(box).not.toBeNull();
+        expect(box!.height).toBeGreaterThan(200);
+        expect(box!.height).toBeLessThan(240);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-pagination/_examples/paginate-child-rows/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-pagination/_examples/paginate-child-rows/example.spec.ts
@@ -1,11 +1,38 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
+
+const TOTAL_PAGES_SELECTOR = '.ag-paging-page-summary-panel .ag-paging-number[data-ref="lbTotal"]';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'paginateChildRows keeps page size fixed and pushes overflow to more pages',
+        async ({ page }) => {
+            await waitForGridContent(page);
+
+            // Row summary numbers: [0] first row, [1] last row on page, [2] record count.
+            const lastRowOnPage = page.locator('.ag-paging-row-summary-panel-number').nth(1);
+            const totalPages = page.locator(TOTAL_PAGES_SELECTOR);
+
+            // Wait for both to settle to numbers (SSRM shows "more" until the last row is known).
+            await expect(lastRowOnPage).toHaveText(/^\d+$/);
+            await expect(totalPages).toHaveText(/^\d+$/);
+            const pageSize = (await lastRowOnPage.textContent())!.trim();
+            const totalBefore = Number((await totalPages.textContent())!.trim());
+
+            // Expand the first top-level group; with paginateChildRows the children count
+            // toward pagination, so overflow is pushed onto additional pages.
+            await page.locator('.ag-row .ag-group-contracted').first().click();
+
+            await page.waitForFunction(
+                ([selector, before]) => {
+                    const el = document.querySelector(selector as string);
+                    const n = Number(el?.textContent?.trim());
+                    return Number.isInteger(n) && n > (before as number);
+                },
+                [TOTAL_PAGES_SELECTOR, totalBefore] as const
+            );
+
+            // The per-page row count stays fixed at the page size.
+            await expect(lastRowOnPage).toHaveText(pageSize);
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-pagination/_examples/pagination-with-groups/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-pagination/_examples/pagination-with-groups/example.spec.ts
@@ -1,11 +1,29 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('expanding a top-level group keeps its children on the same page', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Pagination splits by top-level (Country) groups only, so the total page
+        // count is fixed by the number of groups regardless of expansion.
+        const totalPages = page.locator('.ag-paging-page-summary-panel .ag-paging-number[data-ref="lbTotal"]');
+        const currentPage = page.locator('.ag-paging-page-summary-panel input');
+
+        // Wait for the last row to be reached so the count settles to a number (not "more").
+        await expect(totalPages).toHaveText(/^\d+$/);
+        const totalBefore = (await totalPages.textContent())!.trim();
+        await expect(currentPage).toHaveValue('1');
+
+        // Leaf (athlete) cells are empty until a group is expanded.
+        const athleteLeaf = page.locator('.ag-cell[col-id="athlete"]').filter({ hasText: /\S/ });
+        await expect(athleteLeaf).toHaveCount(0);
+
+        // Expand the first top-level group; its children lazy-load onto the same page.
+        await page.locator('.ag-row .ag-group-contracted').first().click();
+        await expect(athleteLeaf.first()).toBeVisible();
+
+        // Children appear on the same page: page count and current page are unchanged.
+        await expect(totalPages).toHaveText(totalBefore);
+        await expect(currentPage).toHaveValue('1');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-pagination/_examples/pagination/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-pagination/_examples/pagination/example.spec.ts
@@ -1,11 +1,26 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('server-side pagination advances pages and swaps the row set', async ({ agIdFor, page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // `id` value cells (exact match so "1" does not match "21" etc.)
+        const idCell = (id: string) => page.locator('.ag-cell[col-id="id"]').filter({ hasText: new RegExp(`^${id}$`) });
+
+        // Page one: paginationPageSize=20 so rows 1..20 of the dataset are shown.
+        await expect(agIdFor.paginationSummaryPanelCurrentPage('1')).toBeVisible();
+        await expect(agIdFor.paginationPanelFirstRowOnPage('1')).toBeVisible();
+        await expect(agIdFor.paginationPanelLastRowOnPage('20')).toBeVisible();
+        await expect(idCell('1')).toBeVisible();
+        await expect(idCell('21')).toHaveCount(0);
+
+        // Advancing to page two re-requests rows 21..40 from the server.
+        await page.getByRole('button', { name: 'Next Page' }).click();
+
+        await expect(agIdFor.paginationSummaryPanelCurrentPage('2')).toBeVisible();
+        await expect(agIdFor.paginationPanelFirstRowOnPage('21')).toBeVisible();
+        await expect(agIdFor.paginationPanelLastRowOnPage('40')).toBeVisible();
+        await expect(idCell('21')).toBeVisible();
+        await expect(idCell('1')).toHaveCount(0);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/_examples/creating_pivot_result_columns/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/_examples/creating_pivot_result_columns/example.spec.ts
@@ -1,11 +1,34 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'App-built pivot result columns (setPivotResultColumns) render nested year -> medal groups',
+        async ({ page }) => {
+            await waitForGridContent(page);
+
+            const groupRow = (name: string) =>
+                page
+                    .locator('.ag-row')
+                    .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                    .first();
+
+            // Grid is grouped by Country on the server side.
+            await expect(groupRow('United States')).toBeVisible();
+            await expect(groupRow('Russia')).toBeVisible();
+
+            // createPivotResultColumns() builds a year column group per distinct year,
+            // each nesting gold/silver/bronze value children.
+            await expect(page.locator('.ag-header-group-cell').filter({ hasText: '2000' }).first()).toBeVisible();
+            await expect(page.locator('.ag-header-group-cell').filter({ hasText: '2004' }).first()).toBeVisible();
+            await expect(page.locator('.ag-header-cell-text').filter({ hasText: 'Gold' }).first()).toBeVisible();
+            await expect(page.locator('.ag-header-cell-text').filter({ hasText: 'Silver' }).first()).toBeVisible();
+            await expect(page.locator('.ag-header-cell-text').filter({ hasText: 'Bronze' }).first()).toBeVisible();
+
+            // The Country row shows the pivoted, aggregated medal counts against those columns.
+            await expect(groupRow('United States').locator('[col-id="2000_gold"]')).toContainText('130');
+            await expect(groupRow('United States').locator('[col-id="2000_silver"]')).toContainText('61');
+            await expect(groupRow('United States').locator('[col-id="2000_bronze"]')).toContainText('52');
+            await expect(groupRow('United States').locator('[col-id="2004_gold"]')).toContainText('118');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/_examples/pivot-column-groups/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/_examples/pivot-column-groups/example.spec.ts
@@ -1,11 +1,34 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Expandable pivot column groups reveal medal children on open', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        // Grid is row-grouped by Country (first level) and pivoted into year column groups.
+        await expect(groupRow('United States')).toBeVisible();
+        await expect(page.locator('.ag-header-group-cell').filter({ hasText: '2000' }).first()).toBeVisible();
+
+        // Collapsed: processPivotResultColDef sets columnGroupShow='open' on non-total columns,
+        // so only the aggregated Total child is shown for each year, and no medal children.
+        await expect(page.locator('.ag-header-cell-text').filter({ hasText: 'Total' }).first()).toBeVisible();
+        await expect(page.locator('.ag-header-cell-text').filter({ hasText: 'Gold' })).toHaveCount(0);
+        await expect(page.locator('.ag-header-cell-text').filter({ hasText: 'Silver' })).toHaveCount(0);
+        await expect(page.locator('.ag-header-cell-text').filter({ hasText: 'Bronze' })).toHaveCount(0);
+
+        // Expanding the 2000 column group reveals its gold/silver/bronze medal children.
+        await page.getByRole('button', { name: 'Expand 2000', exact: true }).click();
+        await expect(page.locator('.ag-header-cell-text').filter({ hasText: 'Gold' }).first()).toBeVisible();
+        await expect(page.locator('.ag-header-cell-text').filter({ hasText: 'Silver' }).first()).toBeVisible();
+        await expect(page.locator('.ag-header-cell-text').filter({ hasText: 'Bronze' }).first()).toBeVisible();
+
+        // Collapsing again hides the medal children.
+        await page.getByRole('button', { name: 'Collapse 2000', exact: true }).click();
+        await expect(page.locator('.ag-header-cell-text').filter({ hasText: 'Gold' })).toHaveCount(0);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/_examples/slice-and-dice/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/_examples/slice-and-dice/example.spec.ts
@@ -1,11 +1,30 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'Slice-and-dice grid starts grouped Country -> Year with aggregated medal totals',
+        async ({ page }) => {
+            await waitForGridContent(page);
+
+            const groupRow = (name: string) =>
+                page
+                    .locator('.ag-row')
+                    .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                    .first();
+
+            // Grid opens grouped by Country, with server-side summed medal totals.
+            await expect(groupRow('United States')).toBeVisible();
+            await expect(groupRow('United States').locator('[col-id="gold"]')).toContainText('552');
+            await expect(groupRow('United States').locator('[col-id="silver"]')).toContainText('440');
+            await expect(groupRow('United States').locator('[col-id="bronze"]')).toContainText('320');
+
+            // Expanding a Country lazy-loads the second group level (Year) with its own aggregated totals.
+            await groupRow('United States').locator('.ag-group-contracted').first().click();
+            await expect(groupRow('United States').locator('.ag-group-expanded').first()).toBeVisible();
+            await expect(groupRow('2000')).toBeVisible();
+            await expect(groupRow('2000').locator('[col-id="gold"]')).toContainText('130');
+            await expect(groupRow('2000').locator('[col-id="silver"]')).toContainText('61');
+            await expect(groupRow('2000').locator('[col-id="bronze"]')).toContainText('52');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/_examples/supplying_pivot_result_fields/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/_examples/supplying_pivot_result_fields/example.spec.ts
@@ -1,11 +1,34 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'SSRM auto-generates pivot result columns from the datasource pivotResultFields',
+        async ({ page }) => {
+            await waitForGridContent(page);
+
+            const groupRow = (name: string) =>
+                page
+                    .locator('.ag-row')
+                    .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                    .first();
+
+            // Grid is grouped by Country on the server side.
+            await expect(groupRow('United States')).toBeVisible();
+            await expect(groupRow('Russia')).toBeVisible();
+
+            // The '<year>_<medal>' pivotResultFields are split on '_' into year column groups,
+            // each with gold/silver/bronze children.
+            await expect(page.locator('.ag-header-group-cell').filter({ hasText: '2000' }).first()).toBeVisible();
+            await expect(page.locator('.ag-header-group-cell').filter({ hasText: '2004' }).first()).toBeVisible();
+            await expect(page.locator('.ag-header-cell-text').filter({ hasText: 'Gold' }).first()).toBeVisible();
+            await expect(page.locator('.ag-header-cell-text').filter({ hasText: 'Silver' }).first()).toBeVisible();
+            await expect(page.locator('.ag-header-cell-text').filter({ hasText: 'Bronze' }).first()).toBeVisible();
+
+            // The Country group row shows the pivoted, aggregated medal counts per year.
+            await expect(groupRow('United States').locator('[col-id="2000_gold"]')).toContainText('130');
+            await expect(groupRow('United States').locator('[col-id="2000_silver"]')).toContainText('61');
+            await expect(groupRow('United States').locator('[col-id="2000_bronze"]')).toContainText('52');
+            await expect(groupRow('United States').locator('[col-id="2004_gold"]')).toContainText('118');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-retry/_examples/retry-infinite/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-retry/_examples/retry-infinite/example.spec.ts
@@ -1,11 +1,38 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('failed SSRM loads recover via Retry Failed Loads', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Locate a group row by its displayed group value — robust to the positional
+        // row-ids the SSRM assigns to group rows.
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        // Top-level country groups load successfully to begin with.
+        const usRow = groupRow('United States');
+        await expect(usRow).toBeVisible();
+
+        // Turn on simulated load failures, then expand a country. The child (Sport)
+        // block request will fail.
+        await page.locator('#failLoad').check();
+        await usRow.locator('.ag-group-contracted').first().click();
+
+        // A failed load renders a full-width error placeholder row (text "ERR") and no
+        // real child rows — the Swimming subgroup never appears.
+        const failedRow = page.locator('.ag-row-loading', { hasText: 'ERR' });
+        await expect(failedRow).toBeVisible();
+        await expect(groupRow('Swimming')).toHaveCount(0);
+
+        // Turn failures off and retry — the previously failed load now succeeds,
+        // the error placeholder clears and the child rows populate.
+        await page.locator('#failLoad').uncheck();
+        await page.getByRole('button', { name: 'Retry Failed Loads' }).click();
+
+        await expect(groupRow('Swimming')).toBeVisible();
+        await expect(failedRow).toHaveCount(0);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/auto-row-height/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/auto-row-height/example.spec.ts
@@ -8,34 +8,36 @@ test.agExample(import.meta, () => {
         await expect(page.locator('.ag-row').nth(6)).toBeVisible();
 
         // The autoA / autoB columns use wrapText + autoHeight, so each row is sized to fit its
-        // (randomly generated, variable-length) wrapped text. Measure, per rendered row, whether
-        // each cell's full content fits within its rendered height, plus the row height.
-        const rows = await page.evaluate(() => {
-            const result: { clipped: boolean; height: number }[] = [];
-            for (const row of document.querySelectorAll('.ag-row')) {
-                const cells = [row.querySelector('[col-id="autoA"]'), row.querySelector('[col-id="autoB"]')].filter(
-                    (c): c is HTMLElement => c instanceof HTMLElement
-                );
-                if (cells.length === 0) {
-                    continue;
+        // (randomly generated, variable-length) wrapped text. Wait until the autoHeight pass has
+        // settled: more than 5 rows are measured and no autoA/autoB cell's wrapped content overflows
+        // its box (scrollHeight > clientHeight) — clipping is exactly what autoHeight prevents. This
+        // auto-retries, so it can't sample mid-reflow.
+        await page.waitForFunction(
+            () => {
+                const measuredRows = Array.from(document.querySelectorAll('.ag-row'))
+                    .map((row) =>
+                        [row.querySelector('[col-id="autoA"]'), row.querySelector('[col-id="autoB"]')].filter(
+                            (c): c is HTMLElement => c instanceof HTMLElement
+                        )
+                    )
+                    .filter((cells) => cells.length > 0);
+                if (measuredRows.length <= 5) {
+                    return false;
                 }
-                // A cell whose wrapped content overflows its box (scrollHeight > clientHeight) is
-                // clipped — which is exactly what autoHeight prevents by sizing the row to the content.
-                const clipped = cells.some((c) => c.scrollHeight > c.clientHeight + 2);
-                result.push({ clipped, height: row.getBoundingClientRect().height });
-            }
-            return result;
-        });
+                return measuredRows.every((cells) => cells.every((c) => c.scrollHeight <= c.clientHeight + 2));
+            },
+            undefined,
+            { timeout: 15000 }
+        );
 
-        // Enough rows rendered to make the measurement meaningful.
-        expect(rows.length).toBeGreaterThan(5);
-
-        // autoHeight sizes every row to fit its content: no cell's wrapped text is clipped.
-        expect(rows.every((r) => !r.clipped)).toBe(true);
-
-        // Heights genuinely vary across rows (auto-height is doing per-row measurement of the
-        // variable-length content, not applying a single fixed height).
-        const heights = rows.map((r) => r.height);
+        // Heights genuinely vary across rows (auto-height did per-row measurement of the
+        // variable-length content, not a single fixed height).
+        const heights = await page.evaluate(() =>
+            Array.from(document.querySelectorAll('.ag-row'))
+                .filter((row) => row.querySelector('[col-id="autoA"]'))
+                .map((row) => row.getBoundingClientRect().height)
+        );
+        expect(heights.length).toBeGreaterThan(5);
         expect(Math.max(...heights)).toBeGreaterThan(Math.min(...heights));
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/auto-row-height/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/auto-row-height/example.spec.ts
@@ -1,11 +1,41 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('autoHeight + wrapText measures SSRM row heights from content', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Wait for the server-side blocks to load several group rows before measuring.
+        await expect(page.locator('.ag-row').nth(6)).toBeVisible();
+
+        // The autoA / autoB columns use wrapText + autoHeight, so each row is sized to fit
+        // its (randomly generated, variable-length) wrapped text. Correlate the amount of
+        // text in each rendered row with its measured height.
+        const rows = await page.evaluate(() => {
+            const result: { textLen: number; height: number }[] = [];
+            for (const row of document.querySelectorAll('.ag-row')) {
+                const a = row.querySelector('[col-id="autoA"]')?.textContent ?? '';
+                const b = row.querySelector('[col-id="autoB"]')?.textContent ?? '';
+                result.push({ textLen: a.length + b.length, height: row.getBoundingClientRect().height });
+            }
+            return result;
+        });
+
+        // Enough rows rendered to make the comparison meaningful.
+        expect(rows.length).toBeGreaterThan(5);
+
+        const byText = [...rows].sort((x, y) => x.textLen - y.textLen);
+        const shortest = byText[0];
+        const longest = byText[byText.length - 1];
+
+        // There is a real spread of text lengths to compare.
+        expect(longest.textLen).toBeGreaterThan(shortest.textLen);
+
+        // The row with the most wrapped text renders taller than the row with the least.
+        expect(longest.height).toBeGreaterThan(shortest.height);
+
+        // Heights genuinely vary across rows (auto-height is doing per-row measurement,
+        // not applying a single fixed height).
+        const heights = rows.map((r) => r.height);
+        expect(Math.max(...heights)).toBeGreaterThan(Math.min(...heights));
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/auto-row-height/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/auto-row-height/example.spec.ts
@@ -7,34 +7,34 @@ test.agExample(import.meta, () => {
         // Wait for the server-side blocks to load several group rows before measuring.
         await expect(page.locator('.ag-row').nth(6)).toBeVisible();
 
-        // The autoA / autoB columns use wrapText + autoHeight, so each row is sized to fit
-        // its (randomly generated, variable-length) wrapped text. Correlate the amount of
-        // text in each rendered row with its measured height.
+        // The autoA / autoB columns use wrapText + autoHeight, so each row is sized to fit its
+        // (randomly generated, variable-length) wrapped text. Measure, per rendered row, whether
+        // each cell's full content fits within its rendered height, plus the row height.
         const rows = await page.evaluate(() => {
-            const result: { textLen: number; height: number }[] = [];
+            const result: { clipped: boolean; height: number }[] = [];
             for (const row of document.querySelectorAll('.ag-row')) {
-                const a = row.querySelector('[col-id="autoA"]')?.textContent ?? '';
-                const b = row.querySelector('[col-id="autoB"]')?.textContent ?? '';
-                result.push({ textLen: a.length + b.length, height: row.getBoundingClientRect().height });
+                const cells = [row.querySelector('[col-id="autoA"]'), row.querySelector('[col-id="autoB"]')].filter(
+                    (c): c is HTMLElement => c instanceof HTMLElement
+                );
+                if (cells.length === 0) {
+                    continue;
+                }
+                // A cell whose wrapped content overflows its box (scrollHeight > clientHeight) is
+                // clipped — which is exactly what autoHeight prevents by sizing the row to the content.
+                const clipped = cells.some((c) => c.scrollHeight > c.clientHeight + 2);
+                result.push({ clipped, height: row.getBoundingClientRect().height });
             }
             return result;
         });
 
-        // Enough rows rendered to make the comparison meaningful.
+        // Enough rows rendered to make the measurement meaningful.
         expect(rows.length).toBeGreaterThan(5);
 
-        const byText = [...rows].sort((x, y) => x.textLen - y.textLen);
-        const shortest = byText[0];
-        const longest = byText[byText.length - 1];
+        // autoHeight sizes every row to fit its content: no cell's wrapped text is clipped.
+        expect(rows.every((r) => !r.clipped)).toBe(true);
 
-        // There is a real spread of text lengths to compare.
-        expect(longest.textLen).toBeGreaterThan(shortest.textLen);
-
-        // The row with the most wrapped text renders taller than the row with the least.
-        expect(longest.height).toBeGreaterThan(shortest.height);
-
-        // Heights genuinely vary across rows (auto-height is doing per-row measurement,
-        // not applying a single fixed height).
+        // Heights genuinely vary across rows (auto-height is doing per-row measurement of the
+        // variable-length content, not applying a single fixed height).
         const heights = rows.map((r) => r.height);
         expect(Math.max(...heights)).toBeGreaterThan(Math.min(...heights));
     });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/dynamic-row-height/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/dynamic-row-height/example.spec.ts
@@ -1,11 +1,43 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('getRowHeight sizes SSRM rows by group depth', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Locate a group row by its displayed group value — robust to the positional
+        // row-ids the SSRM assigns to group rows.
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        const heightOf = async (locator: ReturnType<typeof groupRow>) => {
+            const box = await locator.boundingBox();
+            expect(box).not.toBeNull();
+            return box!.height;
+        };
+
+        // Top level (level 0) is grouped by Country — getRowHeight returns 80px.
+        const usRow = groupRow('United States');
+        await expect(usRow).toBeVisible();
+        const level0Height = await heightOf(usRow);
+        expect(level0Height).toBeGreaterThan(77);
+        expect(level0Height).toBeLessThan(83);
+
+        // Expanding a country lazy-loads the second group level (Year) — getRowHeight returns 60px.
+        // Year group rows are identified by a 4-digit group value (countries never are).
+        await usRow.locator('.ag-group-contracted').first().click();
+        const yearRow = page
+            .locator('.ag-row')
+            .filter({ has: page.locator('.ag-group-value', { hasText: /^\d{4}$/ }) })
+            .first();
+        await expect(yearRow).toBeVisible();
+        const level1Height = await heightOf(yearRow);
+        expect(level1Height).toBeGreaterThan(57);
+        expect(level1Height).toBeLessThan(63);
+
+        // Deeper levels are shorter than shallower ones.
+        expect(level0Height).toBeGreaterThan(level1Height);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/resetting-row-height/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-row-height/_examples/resetting-row-height/example.spec.ts
@@ -1,11 +1,28 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('clicking a row sets its height to 100px and Reset restores it', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // getRowHeight sizes each row via a sine curve (max 80px), so no row is naturally 100px.
+        const topRow = page.locator('.ag-row[row-index="0"]').first();
+        // Wait for the top row to hold real data before interacting with it.
+        await expect(topRow.locator('.ag-cell').first()).toHaveText(/\S/);
+
+        const originalHeight = (await topRow.boundingBox())!.height;
+        // Sanity: the natural height is clearly below the 100px click height.
+        expect(originalHeight).toBeLessThan(90);
+
+        // onRowClicked sets the clicked node's height to 100px.
+        await topRow.locator('.ag-cell').first().click();
+        await expect(topRow).toHaveCSS('height', '100px');
+
+        // "Reset Row Heights" recalculates heights from getRowHeight, discarding the
+        // manual 100px height set by the click.
+        await page.getByRole('button', { name: 'Reset Row Heights' }).click();
+        await expect(topRow).not.toHaveCSS('height', '100px');
+        const resetHeight = (await topRow.boundingBox())!.height;
+        // The manual 100px height is discarded and the row returns to its (sub-90px) getRowHeight value.
+        expect(resetHeight).toBeLessThan(90);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-selection/_examples/api-group-selects-children/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-selection/_examples/api-group-selects-children/example.spec.ts
@@ -1,11 +1,37 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('groupSelects descendants reflects full and partial group selection', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+        const groupCheckbox = (name: string) => groupRow(name).locator('.ag-checkbox-input-wrapper').first();
+
+        // With groupSelects: 'descendants' the applied state selects all children except within
+        // United States, where only the 2004 subgroup is fully selected. So United States is
+        // partially selected (indeterminate), while its 2004 subgroup is fully selected.
+        await expect(groupRow('United States')).not.toHaveClass(/ag-row-selected/);
+        await expect(groupCheckbox('United States')).toHaveClass(/ag-indeterminate/);
+
+        await expect(groupRow('2004')).toHaveClass(/ag-row-selected/);
+        await expect(groupCheckbox('2004')).toHaveClass(/ag-checked/);
+
+        // A sibling year subgroup with no selected children is not selected.
+        await expect(groupRow('2008')).not.toHaveClass(/ag-row-selected/);
+
+        // Save the current selection, clear it, then reload it.
+        await page.getByRole('button', { name: 'Save Selection' }).click();
+
+        await page.getByRole('button', { name: 'Clear Selection' }).click();
+        await expect(groupCheckbox('United States')).not.toHaveClass(/ag-indeterminate/);
+        await expect(groupRow('2004')).not.toHaveClass(/ag-row-selected/);
+
+        await page.getByRole('button', { name: 'Load Selection' }).click();
+        await expect(groupCheckbox('United States')).toHaveClass(/ag-indeterminate/);
+        await expect(groupRow('2004')).toHaveClass(/ag-row-selected/);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-selection/_examples/api-select-all/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-selection/_examples/api-select-all/example.spec.ts
@@ -1,11 +1,35 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('setServerSideSelectionState selects all rows with exceptions', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        // onFirstDataRendered applies { selectAll: true, toggledNodes: [United States, United States/2004] }.
+        // Without groupSelects, selection is per-node: everything is selected except the two
+        // explicitly toggled group nodes. United States and its 2004 subgroup are the exceptions;
+        // the other year subgroups (e.g. 2008) and all leaf rows remain selected.
+        await expect(groupRow('United States')).not.toHaveClass(/ag-row-selected/);
+        await expect(groupRow('2004')).not.toHaveClass(/ag-row-selected/);
+        await expect(groupRow('2008')).toHaveClass(/ag-row-selected/);
+        await expect(groupRow('Michael Phelps')).toHaveClass(/ag-row-selected/);
+
+        // Save the current selection, clear it, then reload it.
+        await page.getByRole('button', { name: 'Save Selection' }).click();
+
+        await page.getByRole('button', { name: 'Clear Selection' }).click();
+        await expect(groupRow('2008')).not.toHaveClass(/ag-row-selected/);
+        await expect(groupRow('Michael Phelps')).not.toHaveClass(/ag-row-selected/);
+
+        await page.getByRole('button', { name: 'Load Selection' }).click();
+        await expect(groupRow('2008')).toHaveClass(/ag-row-selected/);
+        await expect(groupRow('Michael Phelps')).toHaveClass(/ag-row-selected/);
+        await expect(groupRow('United States')).not.toHaveClass(/ag-row-selected/);
+        await expect(groupRow('2004')).not.toHaveClass(/ag-row-selected/);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-selection/_examples/click-selection/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-selection/_examples/click-selection/example.spec.ts
@@ -1,11 +1,29 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Click selection is preserved across filtering', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Wait for the first server-side block to load, then select a leaf row by
+        // clicking it (rowSelection mode is 'multiRow').
+        const firstRow = page.locator('.ag-row[row-id^="leaf-"]').first();
+        await expect(firstRow).toBeVisible();
+        const rowId = await firstRow.getAttribute('row-id');
+        expect(rowId).toBeTruthy();
+
+        await firstRow.locator('.ag-cell').first().click();
+        const selectedRow = page.locator(`.ag-row[row-id="${rowId}"]`).first();
+        await expect(selectedRow).toHaveClass(/ag-row-selected/);
+
+        // Apply a filter that matches nothing, emptying the grid of data rows.
+        const countryFilter = page.locator('.ag-floating-filter[col-id="country"] input').first();
+        await countryFilter.fill('no-such-country');
+        await expect(page.locator('.ag-row[row-id^="leaf-"]')).toHaveCount(0);
+
+        // Remove the filter — the row returns and its selection is preserved.
+        await countryFilter.fill('');
+        const rowAfterClear = page.locator(`.ag-row[row-id="${rowId}"]`).first();
+        await expect(rowAfterClear).toBeVisible();
+        await expect(rowAfterClear).toHaveClass(/ag-row-selected/);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-selection/_examples/group-selects-children-transactions/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-selection/_examples/group-selects-children-transactions/example.spec.ts
@@ -1,11 +1,33 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Rows added by transaction inherit the parent group selection', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const aggressiveGroup = page
+            .locator('.ag-row')
+            .filter({ has: page.locator('.ag-group-value', { hasText: 'Aggressive' }) })
+            .first();
+        await expect(aggressiveGroup).toBeVisible();
+
+        // The Aggressive group is open by default with children tradeId 0 and 1.
+        await expect(page.locator('.ag-row[row-id="0"]')).toBeVisible();
+        await expect(page.locator('.ag-row[row-id="1"]')).toBeVisible();
+
+        // Select the Aggressive group — with groupSelects: 'descendants' this selects the
+        // group and all of its existing children.
+        await aggressiveGroup.locator('.ag-checkbox-input').first().click();
+        await expect(page.locator('.ag-row[row-id="Aggressive"]')).toHaveClass(/ag-row-selected/);
+        await expect(page.locator('.ag-row[row-id="0"]')).toHaveClass(/ag-row-selected/);
+        await expect(page.locator('.ag-row[row-id="1"]')).toHaveClass(/ag-row-selected/);
+
+        // Add a new child to the selected group via a server-side transaction. The new row
+        // (tradeId 11) inherits the parent group's selection.
+        await page.getByRole('button', { name: "Add new 'Aggressive'" }).click();
+
+        const newRow = page.locator('.ag-row[row-id="11"]');
+        await expect(newRow).toBeVisible();
+        await expect(newRow.locator('[col-id="book"]')).toContainText('GL-1');
+        await expect(newRow).toHaveClass(/ag-row-selected/);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-selection/_examples/select-all/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-selection/_examples/select-all/example.spec.ts
@@ -1,11 +1,28 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Header checkbox selects all rows across pages', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Rows are country groups. Wait for the first block to load.
+        const groupRows = page.locator('.ag-row[row-id^="group-"]');
+        await expect(groupRows.first()).toBeVisible();
+
+        // Nothing is selected initially.
+        await expect(page.locator('.ag-row.ag-row-selected')).toHaveCount(0);
+
+        // Click the header select-all checkbox (selectAll: 'all').
+        const headerSelectAll = page.locator('.ag-header-select-all .ag-checkbox-input').first();
+        await headerSelectAll.click();
+
+        // The header checkbox reports the checked (fully selected) state.
+        await expect(page.locator('.ag-header-select-all .ag-checkbox-input-wrapper').first()).toHaveClass(
+            /ag-checked/
+        );
+
+        // Every visible group row becomes selected.
+        const total = await groupRows.count();
+        expect(total).toBeGreaterThan(0);
+        await expect(page.locator('.ag-row[row-id^="group-"].ag-row-selected')).toHaveCount(total);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-sorting/_examples/client-side-sorting/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-sorting/_examples/client-side-sorting/example.spec.ts
@@ -17,7 +17,7 @@ test.agExample(import.meta, () => {
         await expect(topGroup()).not.toContainText('United States');
 
         // Descending brings the highest gold total (United States) back to the top.
-        await page.waitForTimeout(400); // avoid the two clicks registering as a double-click
+        await page.waitForTimeout(600); // exceed the OS double-click threshold so the two clicks are separate sorts
         await goldHeader().click();
         await expect(topGroup()).toContainText('United States');
     });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-sorting/_examples/client-side-sorting/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-sorting/_examples/client-side-sorting/example.spec.ts
@@ -1,11 +1,24 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('serverSideEnableClientSideSort reorders loaded group rows on the client', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const topGroup = () =>
+            page.locator('.ag-row[row-index="0"] [col-id="ag-Grid-AutoColumn"] .ag-group-value').first();
+        const goldHeader = () => page.locator('.ag-header-cell[col-id="gold"]');
+
+        // Top level is grouped by Country; the server returns United States first.
+        await expect(topGroup()).toContainText('United States');
+
+        // Clicking the Gold header sorts the already-loaded group rows on the client (no server
+        // reload). Ascending pushes the highest medal-winner (United States) away from the top.
+        await goldHeader().click();
+        await expect(topGroup()).not.toContainText('United States');
+
+        // Descending brings the highest gold total (United States) back to the top.
+        await page.waitForTimeout(400); // avoid the two clicks registering as a double-click
+        await goldHeader().click();
+        await expect(topGroup()).toContainText('United States');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-sorting/_examples/server-side-sorting/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-sorting/_examples/server-side-sorting/example.spec.ts
@@ -17,7 +17,7 @@ test.agExample(import.meta, () => {
         await expect(topCountry()).toContainText('Afghanistan');
 
         // Clicking again requests a descending sort; the first row becomes the last country.
-        await page.waitForTimeout(400); // avoid the two clicks registering as a double-click
+        await page.waitForTimeout(600); // exceed the OS double-click threshold so the two clicks are separate sorts
         await countryHeader().click();
         await expect(topCountry()).toContainText('Zimbabwe');
     });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-sorting/_examples/server-side-sorting/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-sorting/_examples/server-side-sorting/example.spec.ts
@@ -1,11 +1,24 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Clicking a header sorts rows on the server and reloads them re-sorted', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const topCountry = () => page.locator('.ag-row[row-index="0"] [col-id="country"]').first();
+        const countryHeader = () => page.locator('.ag-header-cell[col-id="country"]');
+
+        // Default (unsorted) order: the server returns rows in their natural order, so the
+        // first row is Michael Phelps of the United States.
+        await expect(topCountry()).toContainText('United States');
+
+        // Clicking the Country header requests an ascending sort from the server; the block is
+        // reloaded re-sorted, so the first row becomes the alphabetically-first country.
+        await countryHeader().click();
+        await expect(topCountry()).toContainText('Afghanistan');
+
+        // Clicking again requests a descending sort; the first row becomes the last country.
+        await page.waitForTimeout(400); // avoid the two clicks registering as a double-click
+        await countryHeader().click();
+        await expect(topCountry()).toContainText('Zimbabwe');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-sorting/_examples/sort-all-levels/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-sorting/_examples/sort-all-levels/example.spec.ts
@@ -19,7 +19,7 @@ test.agExample(import.meta, () => {
             await expect(topGroup()).not.toContainText('United States');
 
             // Descending reloads with the highest gold total (United States) at the top.
-            await page.waitForTimeout(400); // avoid the two clicks registering as a double-click
+            await page.waitForTimeout(600); // exceed the OS double-click threshold so the two clicks are separate sorts
             await goldHeader().click();
             await expect(topGroup()).toContainText('United States');
         }

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-sorting/_examples/sort-all-levels/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-sorting/_examples/sort-all-levels/example.spec.ts
@@ -1,11 +1,27 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'serverSideSortAllLevels sorts grouped rows server-side and refreshes them',
+        async ({ page }) => {
+            await waitForGridContent(page);
+
+            const topGroup = () =>
+                page.locator('.ag-row[row-index="0"] [col-id="ag-Grid-AutoColumn"] .ag-group-value').first();
+            const goldHeader = () => page.locator('.ag-header-cell[col-id="gold"]');
+
+            // Top level is grouped by Country; the server returns United States first.
+            await expect(topGroup()).toContainText('United States');
+
+            // With serverSideSortAllLevels the Gold sort is applied server-side to the grouped data
+            // and the rows are reloaded. Ascending removes the top medal-winner from the first row.
+            await goldHeader().click();
+            await expect(topGroup()).not.toContainText('United States');
+
+            // Descending reloads with the highest gold total (United States) at the top.
+            await page.waitForTimeout(400); // avoid the two clicks registering as a double-click
+            await goldHeader().click();
+            await expect(topGroup()).toContainText('United States');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-tree-data/_examples/filtering-tree-data/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-tree-data/_examples/filtering-tree-data/example.spec.ts
@@ -1,11 +1,44 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
+
+const GROUP_COL = 'ag-Grid-AutoColumn';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Tree-list filter narrows the tree to matching branches', async ({ agIdFor, page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        // Kathryn Powers is open by default, so her level-1 reports are all visible up front.
+        await expect(groupRow('Kathryn Powers')).toBeVisible();
+        await expect(groupRow('Addie Meyer')).toBeVisible();
+        await expect(groupRow('Mabel Ward')).toBeVisible();
+
+        // Open the employeeName tree-list set filter and search for a single leaf employee.
+        await agIdFor.floatingFilterButton(GROUP_COL).click();
+        const setFilter = page.locator('.ag-set-filter');
+        await expect(setFilter).toBeVisible();
+
+        // Filter values load asynchronously — wait for the root node before searching.
+        await expect(setFilter.locator('.ag-set-filter-item').filter({ hasText: 'Kathryn Powers' })).toHaveCount(1);
+
+        const miniFilter = setFilter.locator('.ag-mini-filter input');
+        await miniFilter.pressSequentially('Joshua Matthews');
+        // The tree list is virtualised: the matched leaf is nested, so only its ancestor branch renders.
+        await expect(setFilter.locator('.ag-filter-no-matches')).toBeHidden();
+
+        // Excel mode applies the displayed (matching) values on Enter.
+        await miniFilter.focus();
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Escape');
+
+        // Only the matching branch (Kathryn Powers -> Addie Meyer -> Troy Walsh -> Joshua Matthews) survives:
+        // the ancestor Addie Meyer remains, while her non-matching sibling Mabel Ward is filtered out.
+        await expect(groupRow('Kathryn Powers')).toBeVisible();
+        await expect(groupRow('Addie Meyer')).toBeVisible();
+        await expect(groupRow('Mabel Ward')).toHaveCount(0);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-tree-data/_examples/purging-tree-data/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-tree-data/_examples/purging-tree-data/example.spec.ts
@@ -1,11 +1,30 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Refresh buttons purge and reload the tree cache', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        // Default-open path: Kathryn Powers -> Mabel Ward and Mabel Ward's loaded children.
+        await expect(groupRow('Kathryn Powers')).toBeVisible();
+        await expect(groupRow('Mabel Ward')).toBeVisible();
+        await expect(groupRow('Bryan Butler')).toBeVisible();
+
+        // Refreshing the whole tree purges every cache and reloads from the server.
+        await page.getByRole('button', { name: 'Refresh Everything' }).click();
+        await expect(page.locator('.ag-row-loading').first()).toBeVisible();
+        await expect(groupRow('Kathryn Powers')).toBeVisible();
+        await expect(groupRow('Mabel Ward')).toBeVisible();
+        await expect(groupRow('Bryan Butler')).toBeVisible();
+
+        // Refreshing a single node's cache purges just that route (Kathryn Powers -> Mabel Ward).
+        await page.getByRole('button', { name: "Refresh ['Kathryn Powers','Mabel Ward']" }).click();
+        await expect(page.locator('.ag-row-loading').first()).toBeVisible();
+        await expect(groupRow('Bryan Butler')).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-tree-data/_examples/selecting-tree-data/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-tree-data/_examples/selecting-tree-data/example.spec.ts
@@ -1,11 +1,30 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Group selection cascades to descendants and shows indeterminate state', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        // Default-open path exposes Mabel Ward (level 1) and her loaded children.
+        await expect(groupRow('Mabel Ward')).toBeVisible();
+        await expect(groupRow('Bryan Butler')).toBeVisible();
+
+        // Selecting the group cascades selection to all loaded descendants (groupSelects: 'descendants').
+        await groupRow('Mabel Ward').locator('.ag-selection-checkbox .ag-checkbox-input').click();
+        await expect(groupRow('Mabel Ward')).toHaveClass(/ag-row-selected/);
+        await expect(groupRow('Bryan Butler')).toHaveClass(/ag-row-selected/);
+        await expect(groupRow('Pauline Nash')).toHaveClass(/ag-row-selected/);
+
+        // Deselecting a single descendant makes the parent partially selected (indeterminate).
+        await groupRow('Bryan Butler').locator('.ag-selection-checkbox .ag-checkbox-input').click();
+        await expect(groupRow('Bryan Butler')).not.toHaveClass(/ag-row-selected/);
+        await expect(groupRow('Mabel Ward').locator('.ag-selection-checkbox .ag-checkbox-input-wrapper')).toHaveClass(
+            /ag-indeterminate/
+        );
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-tree-data/_examples/supplying-hierarchy/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-tree-data/_examples/supplying-hierarchy/example.spec.ts
@@ -1,11 +1,27 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Hierarchy supplied client-side expands without a server call', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        // Only roots are served by the datasource; the first two levels open by default.
+        await expect(groupRow('Kathryn Powers')).toBeVisible();
+        await expect(groupRow('Kathryn Powers').locator('[col-id="employmentType"]')).toContainText('Contract');
+        await expect(groupRow('Addie Meyer')).toBeVisible();
+        await expect(groupRow('Troy Walsh')).toBeVisible();
+
+        // Troy Walsh's children were pre-supplied via applyServerSideRowData, not yet displayed.
+        await expect(groupRow('Joshua Matthews')).toHaveCount(0);
+
+        // Expanding a deeper group shows the pre-supplied children without hitting the (failing) datasource.
+        await groupRow('Troy Walsh').locator('.ag-group-contracted').first().click();
+        await expect(groupRow('Joshua Matthews')).toBeVisible();
+        await expect(groupRow('Mitchell Wong')).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-tree-data/_examples/transactions-tree-data/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-tree-data/_examples/transactions-tree-data/example.spec.ts
@@ -1,11 +1,35 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Transactions add and delete tree children under the selected node', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        // Mabel Ward (level 1) is open by default, so her existing children load in and a child added
+        // under her renders straight away. Wait for her subtree to load before mutating it, otherwise
+        // an SSRM transaction routed to a not-yet-loaded store is a no-op.
+        await expect(groupRow('Mabel Ward')).toHaveCount(1);
+        await expect(groupRow('Bryan Butler')).toHaveCount(1);
+        await expect(groupRow('Bertrand Parker')).toHaveCount(0);
+
+        // Select Mabel Ward and add a child via an add transaction routed to her node. The button
+        // reads getSelectedNodes()[0], so wait until the row is actually selected before clicking it.
+        await groupRow('Mabel Ward').locator('.ag-selection-checkbox .ag-checkbox-input').click();
+        await expect(groupRow('Mabel Ward')).toHaveClass(/ag-row-selected/);
+        await page.getByRole('button', { name: 'Add Child to Selected' }).click();
+        await expect(groupRow('Bertrand Parker')).toHaveCount(1);
+        await expect(groupRow('Bertrand Parker').locator('[col-id="employmentType"]')).toContainText('Permanent');
+
+        // Select the new child and remove it via a delete transaction.
+        await groupRow('Bertrand Parker').locator('.ag-selection-checkbox .ag-checkbox-input').click();
+        await expect(groupRow('Bertrand Parker')).toHaveClass(/ag-row-selected/);
+        await page.getByRole('button', { name: 'Delete Selected' }).click();
+        await expect(groupRow('Bertrand Parker')).toHaveCount(0);
+        await expect(groupRow('Mabel Ward')).toHaveCount(1);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-tree-data/_examples/tree-data/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-tree-data/_examples/tree-data/example.spec.ts
@@ -1,11 +1,30 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Tree data lazy-loads children when a group is expanded', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Group rows are located by their displayed employeeName (the auto-group column's inner renderer).
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        // Top-level node loaded from the server, plus the first two levels which open by default.
+        await expect(groupRow('Erica Rogers')).toBeVisible();
+        await expect(groupRow('Erica Rogers').locator('[col-id="jobTitle"]')).toContainText('CEO');
+        await expect(groupRow('Malcolm Barrett')).toBeVisible();
+        await expect(groupRow('Esther Baker')).toBeVisible();
+
+        // Esther Baker's children are not loaded until the group is expanded.
+        await expect(groupRow('Brittany Hanson')).toHaveCount(0);
+        await expect(groupRow('Derek Paul')).toHaveCount(0);
+
+        // Expanding the level-2 group lazy-loads its children from the server.
+        await groupRow('Esther Baker').locator('.ag-group-contracted').first().click();
+        await expect(groupRow('Brittany Hanson')).toBeVisible();
+        await expect(groupRow('Derek Paul')).toBeVisible();
+        await expect(groupRow('Derek Paul').locator('[col-id="jobTitle"]')).toContainText('Inventory Control');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-refresh/_examples/refreshing-the-grid/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-refresh/_examples/refreshing-the-grid/example.spec.ts
@@ -1,11 +1,32 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Refresh Rows re-fetches data; Purge resets rows to loading first', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const topVersion = page.locator('.ag-row[row-index="0"] [col-id="version"]').first();
+        const serverVersion = page.locator('#version-indicator');
+
+        // Grid rows were fetched at server version 1.
+        await expect(topVersion).toContainText('1 - 1 - 1');
+
+        // The fake server bumps its version every 4s, but the grid keeps showing the
+        // version it last fetched — the displayed data lags the server.
+        await expect(serverVersion).not.toHaveText('1');
+        await expect(topVersion).toContainText('1 - 1 - 1');
+
+        // "Refresh Rows" re-fetches the current data, so the version cell catches up.
+        await page.getByRole('button', { name: 'Refresh Rows' }).click();
+        await expect(topVersion).not.toContainText('1 - 1 - 1');
+
+        // With Purge ticked, refreshing discards the cache first: rows briefly show the
+        // loading placeholder before the new data arrives (1s simulated server delay).
+        await page.locator('#purge').check();
+        await page.getByRole('button', { name: 'Refresh Rows' }).click();
+        await expect(page.locator('.ag-row-loading').first()).toBeVisible();
+
+        // The purged rows then reload from the server.
+        await expect(topVersion).not.toContainText('1 - 1 - 1');
+        await expect(page.locator('.ag-row-loading')).toHaveCount(0);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-refresh/_examples/refreshing-the-groups/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-refresh/_examples/refreshing-the-groups/example.spec.ts
@@ -1,11 +1,35 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Refreshing a group reloads its children while retaining expanded state', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        // Canada is open by default, and the 2002 group under it, so its leaf rows (with a version cell) are shown.
+        await expect(groupRow('Canada').locator('.ag-group-expanded')).toBeVisible();
+        await expect(groupRow('2002').locator('.ag-group-expanded')).toBeVisible();
+        const staleLeafVersions = page.locator('.ag-row:not(.ag-row-group) [col-id="version"]', {
+            hasText: '1 - 1 - 1',
+        });
+        await expect(staleLeafVersions.first()).toBeVisible();
+
+        // The fake server bumps its version every 4s; the loaded leaves still show the fetched version 1.
+        await expect(page.locator('#version-indicator')).not.toHaveText('1');
+        await expect(staleLeafVersions.first()).toBeVisible();
+
+        // Refresh only the ['Canada', '2002'] group's children (the leaf rows).
+        await page.getByRole('button', { name: "Refresh ['Canada', '2002'] Group" }).click();
+
+        // Both groups stay expanded (expanded state is retained across the refresh)...
+        await expect(groupRow('Canada').locator('.ag-group-expanded')).toBeVisible();
+        await expect(groupRow('2002').locator('.ag-group-expanded')).toBeVisible();
+
+        // ...and the leaf children reloaded, so no leaf still shows the stale version 1.
+        await expect(staleLeafVersions).toHaveCount(0);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-single-row/_examples/updating-all-rows/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-single-row/_examples/updating-all-rows/example.spec.ts
@@ -1,11 +1,22 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Set Rows and Update Rows both bump the version on every row', async ({ agIdFor, page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Rows are loaded from the fake server with the initial version counter (0).
+        const topVersion = agIdFor.cell('0', 'version');
+        await expect(topVersion).toContainText('0 - 0 - 0');
+
+        // "Set Rows" replaces the data on every node (setData, no flash) — version bumps to 1.
+        await page.getByRole('button', { name: 'Set Rows' }).click();
+        await expect(topVersion).toContainText('1 - 1 - 1');
+
+        // "Update Rows" applies a transaction on every node (updateData, flashes) — version bumps to 2.
+        await page.getByRole('button', { name: 'Update Rows' }).click();
+        await expect(topVersion).toContainText('2 - 2 - 2');
+
+        // The update is applied to every loaded row, not just the top one.
+        await expect(agIdFor.cell('3', 'version')).toContainText('2 - 2 - 2');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-single-row/_examples/updating-selected-row/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-single-row/_examples/updating-selected-row/example.spec.ts
@@ -1,11 +1,25 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Update Selected Rows bumps the version only on selected rows', async ({ agIdFor, page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // getRowId is `${athlete}-${date}`, so rows have stable, content-derived ids.
+        const selectedRowVersion = agIdFor.cell('Michael Phelps-24/08/2008', 'version');
+        const otherRowVersion = agIdFor.cell('Natalie Coughlin-24/08/2008', 'version');
+
+        // Every row starts on the initial server version.
+        await expect(selectedRowVersion).toContainText('0 - 0 - 0');
+        await expect(otherRowVersion).toContainText('0 - 0 - 0');
+
+        // Select the first row via its selection checkbox.
+        const row = page.locator('.ag-row[row-id="Michael Phelps-24/08/2008"]').first();
+        await row.locator('input.ag-checkbox-input').first().click();
+        await expect(row).toHaveClass(/ag-row-selected/);
+
+        // Updating selected rows bumps the version on the selected row only.
+        await page.getByRole('button', { name: 'Update Selected Rows' }).click();
+        await expect(selectedRowVersion).toContainText('1 - 1 - 1');
+        await expect(otherRowVersion).toContainText('0 - 0 - 0');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-single-row/_examples/updating-specific-rows/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-single-row/_examples/updating-specific-rows/example.spec.ts
@@ -1,11 +1,32 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'Update buttons bump the version only on rows matching the predicate',
+        async ({ agIdFor, page }) => {
+            await waitForGridContent(page);
+
+            // getRowId is `${athlete}-${date}`, so rows have stable, content-derived ids.
+            const phelps2008 = agIdFor.cell('Michael Phelps-24/08/2008', 'version');
+            const phelps2004 = agIdFor.cell('Michael Phelps-29/08/2004', 'version');
+            const nemov = agIdFor.cell('Aleksey Nemov-01/10/2000', 'version');
+
+            // Every loaded row starts on the initial server version.
+            await expect(phelps2008).toContainText('0 - 0 - 0');
+            await expect(phelps2004).toContainText('0 - 0 - 0');
+            await expect(nemov).toContainText('0 - 0 - 0');
+
+            // Update a single athlete+date pair — only that row's version changes.
+            await page.getByRole('button', { name: 'Update Michael Phelps, 29/08/2004' }).click();
+            await expect(phelps2004).toContainText('1 - 1 - 1');
+            await expect(phelps2008).toContainText('0 - 0 - 0');
+            await expect(nemov).toContainText('0 - 0 - 0');
+
+            // Update all rows for an athlete — every Michael Phelps row changes, others do not.
+            await page.getByRole('button', { name: 'Update All Michael Phelps Records' }).click();
+            await expect(phelps2008).toContainText('2 - 2 - 2');
+            await expect(phelps2004).toContainText('2 - 2 - 2');
+            await expect(nemov).toContainText('0 - 0 - 0');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-async/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-async/example.spec.ts
@@ -1,11 +1,30 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'applyServerSideTransactionAsync advances update counts under a live stream',
+        async ({ page }) => {
+            await waitForGridContent(page);
+
+            // Sum the 'updateCount' column across the currently rendered rows.
+            const updateCountCells = page.locator('.ag-cell[col-id="updateCount"]');
+            const sumUpdateCount = () =>
+                updateCountCells.evaluateAll((cells) =>
+                    cells.reduce((total, cell) => total + (parseInt(cell.textContent?.trim() || '0', 10) || 0), 0)
+                );
+
+            // Wait for the server-side data to load, then confirm all seeded rows start with updateCount 0.
+            await expect(updateCountCells.first()).toBeVisible();
+            expect(await sumUpdateCount()).toBe(0);
+
+            // Start the stream of async update/add/remove transactions.
+            await page.getByRole('button', { name: 'Start Updates' }).click();
+
+            // After batches of async transactions land, visible rows have been updated.
+            await page.waitForTimeout(1500);
+            expect(await sumUpdateCount()).toBeGreaterThan(0);
+
+            await page.getByRole('button', { name: 'Stop Updates' }).click();
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-async/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-async/example.spec.ts
@@ -20,8 +20,17 @@ test.agExample(import.meta, () => {
             // Start the stream of async update/add/remove transactions.
             await page.getByRole('button', { name: 'Start Updates' }).click();
 
-            // After batches of async transactions land, visible rows have been updated.
-            await page.waitForTimeout(1500);
+            // Poll (with a bounded timeout) until batched async transactions have landed and the
+            // summed updateCount becomes positive — no reliance on a fixed sleep matching the timers.
+            await page.waitForFunction(
+                () =>
+                    Array.from(document.querySelectorAll('.ag-cell[col-id="updateCount"]')).reduce(
+                        (total, cell) => total + (parseInt(cell.textContent?.trim() || '0', 10) || 0),
+                        0
+                    ) > 0,
+                undefined,
+                { timeout: 15000 }
+            );
             expect(await sumUpdateCount()).toBeGreaterThan(0);
 
             await page.getByRole('button', { name: 'Stop Updates' }).click();

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-grouping/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-grouping/example.spec.ts
@@ -18,7 +18,7 @@ test.agExample(import.meta, () => {
         await expect(page.locator('.ag-row[row-id="0"]')).toBeVisible();
 
         // "Add new 'Aggressive'" applies a routed add to the Aggressive group,
-        // creating leaf tradeId 11 (one past the 10 seeded rows) with book GL-1.
+        // creating leaf tradeId 11 (the server pre-increments its counter from the seed count of 10) with book GL-1.
         await page.getByRole('button', { name: "Add new 'Aggressive'" }).click();
         const newLeaf = page.locator('.ag-row[row-id="11"]');
         await expect(newLeaf).toBeVisible();

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-grouping/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-grouping/example.spec.ts
@@ -1,11 +1,36 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('routed transactions add, move and remove rows within groups', async ({ page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Group rows use getRowId === portfolio (level 0), leaf rows === tradeId.
+        const groupRow = (name: string) =>
+            page
+                .locator('.ag-row')
+                .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                .first();
+
+        // Top level is grouped by portfolio; Aggressive and Hybrid open by default.
+        await expect(groupRow('Aggressive')).toBeVisible();
+        await expect(groupRow('Hybrid')).toBeVisible();
+        // The first Aggressive leaf (tradeId 0) is lazy-loaded and visible under the open group.
+        await expect(page.locator('.ag-row[row-id="0"]')).toBeVisible();
+
+        // "Add new 'Aggressive'" applies a routed add to the Aggressive group,
+        // creating leaf tradeId 11 (one past the 10 seeded rows) with book GL-1.
+        await page.getByRole('button', { name: "Add new 'Aggressive'" }).click();
+        const newLeaf = page.locator('.ag-row[row-id="11"]');
+        await expect(newLeaf).toBeVisible();
+        await expect(newLeaf.locator('[col-id="book"]')).toContainText('GL-1');
+
+        // "Move all 'Aggressive' to 'Hybrid'" removes the Aggressive group entirely.
+        await page.getByRole('button', { name: "Move all 'Aggressive' to 'Hybrid'" }).click();
+        await expect(groupRow('Aggressive')).toHaveCount(0);
+        await expect(groupRow('Hybrid')).toBeVisible();
+
+        // "Remove all 'Hybrid'" removes the Hybrid group entirely.
+        await page.getByRole('button', { name: "Remove all 'Hybrid'" }).click();
+        await expect(groupRow('Hybrid')).toHaveCount(0);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-showcase/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-showcase/example.spec.ts
@@ -1,11 +1,39 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'async transactions keep grouping and aggregations in sync under a live stream',
+        async ({ page }) => {
+            await waitForGridContent(page);
+
+            const groupRow = (name: string) =>
+                page
+                    .locator('.ag-row')
+                    .filter({ has: page.locator('.ag-group-value', { hasText: name }) })
+                    .first();
+
+            // Data is grouped by product > portfolio > book with summed aggregations.
+            const woolGroup = groupRow('Wool');
+            await expect(woolGroup).toBeVisible();
+            // Group rows display a server-provided child count, e.g. "Wool (48)".
+            await expect(woolGroup.locator('.ag-group-child-count')).toContainText(/\(\d+\)/);
+            // Group rows carry an aggregated 'current' total.
+            await expect(woolGroup.locator('[col-id="current"]')).toContainText(/\d/);
+            // Wool is open by default, so its child portfolio groups are visible.
+            await expect(groupRow('Aggressive')).toBeVisible();
+
+            // Capture the rendered grid text, then start the transaction stream.
+            const gridText = () => page.locator('.ag-row').allInnerTexts();
+            const gridBefore = (await gridText()).join('|');
+            await page.getByRole('button', { name: 'Start Updates' }).click();
+
+            // The stream applies async update/add/remove transactions once per second;
+            // wait a few ticks and confirm the rendered values changed.
+            await page.waitForTimeout(3000);
+            const gridAfter = (await gridText()).join('|');
+            expect(gridAfter).not.toBe(gridBefore);
+
+            await page.getByRole('button', { name: 'Stop Updates' }).click();
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-showcase/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-showcase/example.spec.ts
@@ -23,15 +23,28 @@ test.agExample(import.meta, () => {
             await expect(groupRow('Aggressive')).toBeVisible();
 
             // Capture the rendered grid text, then start the transaction stream.
-            const gridText = () => page.locator('.ag-row').allInnerTexts();
-            const gridBefore = (await gridText()).join('|');
+            const snapshot = () =>
+                page.evaluate(() =>
+                    Array.from(document.querySelectorAll('.ag-row'))
+                        .map((r) => (r as HTMLElement).innerText)
+                        .join('|')
+                );
+            const gridBefore = await snapshot();
             await page.getByRole('button', { name: 'Start Updates' }).click();
 
-            // The stream applies async update/add/remove transactions once per second;
-            // wait a few ticks and confirm the rendered values changed.
-            await page.waitForTimeout(3000);
-            const gridAfter = (await gridText()).join('|');
-            expect(gridAfter).not.toBe(gridBefore);
+            // Poll (with a bounded timeout) until a streamed transaction has been processed and
+            // rendered — i.e. the grid text differs from the captured baseline — rather than
+            // assuming a fixed sleep is long enough for the timers to fire under a busy worker.
+            await page.waitForFunction(
+                (before) => {
+                    const now = Array.from(document.querySelectorAll('.ag-row'))
+                        .map((r) => (r as HTMLElement).innerText)
+                        .join('|');
+                    return now.length > 0 && now !== before;
+                },
+                gridBefore,
+                { timeout: 15000 }
+            );
 
             await page.getByRole('button', { name: 'Stop Updates' }).click();
         }

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-simple/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-updating-transactions/_examples/transactions-simple/example.spec.ts
@@ -1,11 +1,31 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('applyServerSideTransaction adds, updates and removes flat rows', async ({ agIdFor, page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // The first flat row has getRowId === tradeId === '0'.
+        const firstRow = page.locator('.ag-row[row-id="0"]');
+        await expect(agIdFor.cell('0', 'tradeId')).toContainText('0');
+
+        // Select the first row (via its selection checkbox) so the transaction buttons act on it.
+        await firstRow.locator('.ag-selection-checkbox .ag-checkbox-input').click();
+        await expect(firstRow).toHaveClass(/ag-row-selected/);
+
+        // "Update Selected" applies an update transaction that changes the 'current' value.
+        const currentCell = agIdFor.cell('0', 'current');
+        const before = (await currentCell.textContent())?.trim() ?? '';
+        await page.getByRole('button', { name: 'Update Selected' }).click();
+        await expect(currentCell).not.toHaveText(before);
+
+        // "Add Above Selected" inserts a new row (tradeId 219, one past the 218 seeded rows)
+        // at the selected index, i.e. at the top of the grid.
+        await page.getByRole('button', { name: 'Add Above Selected' }).click();
+        await expect(agIdFor.cell('219', 'tradeId')).toContainText('219');
+        await expect(page.locator('.ag-row[row-index="0"]')).toHaveAttribute('row-id', '219');
+
+        // "Remove Selected" removes the still-selected original first row (node id '0').
+        await page.getByRole('button', { name: 'Remove Selected' }).click();
+        await expect(page.locator('.ag-row[row-id="0"]')).toHaveCount(0);
     });
 });


### PR DESCRIPTION
## What

All 64 Server-Side Row Model (SSRM) documentation examples shipped an auto-generated placeholder `example.spec.ts` that only verified the grid mounted (`ensureGridReady` + `waitForGridContent` + `clickAllButtons`) and asserted nothing about the feature the example demonstrates.

This replaces every one with a real Playwright test that asserts the documented behaviour, grounded in each page's `index.mdoc` prose and the example source:

- **datasource / configuration** — on-demand block loading, cache block size/limits, block-load debounce, initial scroll position, `applyServerSideRowData`
- **sorting / filtering** — server-side sort reload, client-side sort, text/set/advanced filters, batched global apply
- **grouping** — lazy child loading, child counts, complex-object keys, grand totals, group footers, hide-open-parents, open-by-default, `ssrmExpandAllAffectsAllRows`, unbalanced groups
- **pivoting / pagination / selection / row height / retry / master-detail / tree data**
- **updating** — refresh (grid & group routes), single-row set/update, sync & async transactions

## Why

The placeholders gave the appearance of coverage while verifying none of the SSRM behaviour the examples exist to demonstrate; a regression in any of these features would not have failed a test.

## Testing

All 64 specs pass on chromium across **typescript, react, angular and vue3** (`FRAMEWORK=<fw> npx playwright test --project=chromium "server-side-model"`), verified with `retries=0`. Two specs (`resetting-row-height`, `transactions-tree-data`) and `expand-all-affects-all-rows` were hardened for cross-framework/timing determinism.