### PR TITLE
AG-17661 Fix combo chart series theme-override type assignment

### DIFF
--- a/packages/ag-grid-enterprise/src/charts/chartComp/chartProxies/combo/comboChartProxy.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/chartProxies/combo/comboChartProxy.ts
@@ -100,7 +100,10 @@ export class ComboChartProxy extends CartesianChartProxy<'line' | 'bar' | 'area'
             chartTypes.add(seriesChartType.chartType);
         }
         for (const chartType of chartTypes) {
-            overrides[getSeriesType(chartType) as 'line' | 'bar' | 'area'] = seriesOverrides;
+            const seriesType = getSeriesType(chartType) as 'line' | 'bar' | 'area';
+            // The per-series theme-override types are not mutually assignable (line/area vs bar have
+            // divergent label.placement domains); widen to a record so the union-keyed write compiles.
+            (overrides as Record<'line' | 'bar' | 'area', typeof seriesOverrides>)[seriesType] = seriesOverrides;
         }
     }
 }


### PR DESCRIPTION
The cartesian series theme-override types (line/area vs bar) are no longer mutually assignable: ag-charts gave line/area a `label.placement` domain (directional) distinct from bar's (`inside-*`/`outside-*`). The union-keyed write in `setSeriesChartThemeDefaults` (comboChartProxy) targets the intersection of the three override types, which no longer type-checks (TS2322) and breaks the ag-charts integration build.

Widen the assignment target to a record so the write is type-safe regardless of how the per-series override types diverge. Runtime behaviour is unchanged.

Verified by building `ag-grid-enterprise` against the ag-charts branch's types: reproduced the TS2322 before, clean after.