### PR TITLE
SE-67 - Remove link tag from localhost links

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/server-side-operations-graphql/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-operations-graphql/index.mdoc
@@ -65,7 +65,7 @@ To run the application execute the following from the command line:
 yarn start
 ```
 
-Then point your browser to <http://localhost:4000/>
+Then point your browser to `http://localhost:4000/`
 
 ## Defining the GraphQL schema
 
@@ -166,7 +166,7 @@ app.listen(4000, () => {
 });
 ```
 
-Notice that we have supplied the option: `graphiql: true` to enable the GraphiQL client, which is a useful tool for testing queries during development, and is available at: [http://localhost:4000/graphql](http://localhost:4000/graphql/).
+Notice that we have supplied the option: `graphiql: true` to enable the GraphiQL client, which is a useful tool for testing queries during development, and is available at: `http://localhost:4000/graphql`.
 
 {% imageCaption imagePath="resources/graphiql.png" alt="GraphQL" constrained=true /%}
 

--- a/documentation/ag-grid-docs/src/content/docs/server-side-operations-nodejs/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-operations-nodejs/index.mdoc
@@ -66,7 +66,7 @@ To run the application execute the following from the command line:
 yarn start
 ```
 
-Then point your browser to <http://localhost:4000/>
+Then point your browser to `http://localhost:4000/`
 
 ## Client Configuration
 

--- a/documentation/ag-grid-docs/src/content/docs/server-side-operations-oracle/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-operations-oracle/index.mdoc
@@ -156,7 +156,7 @@ If successful you should see something like this:
 
 {% imageCaption imagePath="resources/tomcat-started.png" alt="TomCat Started" constrained=true enableDarkModeFilter=true /%}
 
-To test the application point your browser to <http://localhost:9090>
+To test the application point your browser to `http://localhost:9090`
 
 ## Server-Side Row Model Interfaces
 

--- a/documentation/ag-grid-docs/src/content/docs/server-side-operations-spark/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-operations-spark/index.mdoc
@@ -130,7 +130,7 @@ If successful you should see something like this:
 
 {% imageCaption imagePath="resources/tomcat-started.png" alt="Tomcat" constrained=true enableDarkModeFilter=true /%}
 
-To test the application point your browser to <http://localhost:9090>
+To test the application point your browser to `http://localhost:9090`
 
 ## Server-Side Get Rows Request
 


### PR DESCRIPTION
For better SEO, as localhost links don't go anywhere for crawlers.