### PR TITLE
AG-17385 optimize column model reindex

### DIFF
--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -174,7 +174,6 @@ export class ColumnModel extends BeanStub implements NamedBean {
             eventSvc,
             groupHierarchyColSvc,
             calculatedColsSvc,
-            sortSvc,
         } = beans;
 
         // only dispatch before/after events when updating an existing column model, not on first set.
@@ -224,10 +223,7 @@ export class ColumnModel extends BeanStub implements NamedBean {
             _destroyColumnTreeUnused(oldCols, oldAllGroups, builder.buildToken);
         }
 
-        this.cachedColsByDef = null;
-        this.cachedAllCols = null;
-        this.cachedColsInStateOrder = null;
-        sortSvc?.invalidate();
+        this.invalidateColsDerivedState();
 
         // Single shared scan: each service classifies independently, bucketing lazily until commit.
         const oldProvidedSet = oldCols.length > 0 ? new Set(oldCols) : null;
@@ -274,14 +270,15 @@ export class ColumnModel extends BeanStub implements NamedBean {
         }
     }
 
-    /** Open a column-change batch; mutations until the {@link endColBatch} share one flush. */
+    /** Open a column-change batch; mutations until the {@link endColBatch} share one flush. Active-col indexes
+     *  (`*ActiveIndex`) are re-stamped only at the flush, so they read stale inside an open batch. */
     public beginColBatch(): void {
         this.colBatchDepth++;
     }
 
     /** Close a {@link beginColBatch}; the outermost close flushes once (one source for the whole action). */
     public endColBatch(source: ColumnEventType): void {
-        this.colBatchDepth--;
+        this.colBatchDepth = Math.max(0, this.colBatchDepth - 1);
         this.flushColChanges(source, false); // refresh only if a staged op accumulated one
     }
 
@@ -305,6 +302,10 @@ export class ColumnModel extends BeanStub implements NamedBean {
         if (nothingStaged && !pendingRefresh) {
             return; // no staged dispatch and no deferred refresh
         }
+        // Re-stamp active-col indexes once, before refresh/dispatch (and their listeners) read them.
+        rowGroupColsSvc?.flushReindex();
+        pivotColsSvc?.flushReindex();
+        valueColsSvc?.flushReindex();
         if (pendingRefresh) {
             this.performRefresh(source); // clears pendingRefresh
             // Legacy compat: a role membership change (rowGroup/pivot/value add/remove/set) raised this.
@@ -453,10 +454,7 @@ export class ColumnModel extends BeanStub implements NamedBean {
         this.colsList = colsListChanged ? finalColsList : oldColsList;
         this.colsTree = _areEqual(colsTree, prevColTree) ? prevColTree : colsTree;
         this.colsById = colsById;
-        this.cachedColsByDef = null;
-        this.cachedAllCols = null;
-        this.cachedColsInStateOrder = null;
-        beans.sortSvc?.invalidate();
+        this.invalidateColsDerivedState();
         this.refreshColsDerivedState();
         if (colsListChanged) {
             beans.rowSpanSvc?.refreshCols();
@@ -575,7 +573,18 @@ export class ColumnModel extends BeanStub implements NamedBean {
      *  (`moveColumns`, `applyColumnState` with `applyOrder`); next `ensureColsListIndex` re-stamps. */
     public markColsListIndexDirty(): void {
         this.colsListIndexDirty = true;
+        // Both order-derived views snapshot `colsList` order while pivoting (parked-primary concat) — drop both.
         this.cachedColsInStateOrder = null;
+        this.cachedAllCols = null;
+    }
+
+    /** Drop all col-set/order-derived state after a structural (`colsList`) rebuild — this model's caches plus
+     *  the sort service's column-derived cache. (An order-only move uses {@link markColsListIndexDirty} instead.) */
+    private invalidateColsDerivedState(): void {
+        this.cachedColsByDef = null;
+        this.cachedAllCols = null;
+        this.cachedColsInStateOrder = null;
+        this.beans.sortSvc?.invalidate();
     }
 
     /** Lazily stamp each col's index in `colsList` onto `AgColumn.colsListIndex`, once per order change.

--- a/packages/ag-grid-community/src/interfaces/iColsService.ts
+++ b/packages/ag-grid-community/src/interfaces/iColsService.ts
@@ -16,6 +16,9 @@ export interface IColsService {
     /** Dispatch this service's staged change (if any); called by {@link ColumnModel.flushColChanges}. */
     dispatchColChange(source: ColumnEventType): void;
 
+    /** Re-stamp active-col indexes once if a staged change moved the set; called by {@link ColumnModel.flushColChanges}. */
+    flushReindex(): void;
+
     setColumns(colKeys: ColKey[] | undefined, source: ColumnEventType): void;
     addColumns(keys: (ColKey | null | undefined)[] | undefined, source: ColumnEventType): void;
     removeColumns(keys: (ColKey | null | undefined)[] | undefined, source: ColumnEventType): void;

--- a/packages/ag-grid-enterprise/src/aggregation/valueColsSvc.ts
+++ b/packages/ag-grid-enterprise/src/aggregation/valueColsSvc.ts
@@ -13,6 +13,22 @@ import type {
 
 import { BaseColsService } from '../columns/baseColsService';
 
+/** {@link ValueColsSvc.applyAggFunc} outcome: nothing moved / func changed on an active col / (de)activated. */
+const AGG_UNCHANGED = 0;
+const AGG_FUNC_ONLY = 1;
+const AGG_MEMBERSHIP = 2;
+type AggFuncChange = typeof AGG_UNCHANGED | typeof AGG_FUNC_ONLY | typeof AGG_MEMBERSHIP;
+
+/** Write `aggFunc` onto `column` (dispatching the state event); returns whether it changed. */
+const writeAggFunc = (column: AgColumn, aggFunc: ColAggFunc): boolean => {
+    if (column.aggFunc === aggFunc) {
+        return false;
+    }
+    column.aggFunc = aggFunc;
+    column.dispatchStateUpdatedEvent('aggFunc');
+    return true;
+};
+
 export class ValueColsSvc extends BaseColsService implements NamedBean, IValueColsService {
     beanName = 'valueColsSvc' as const;
     protected override eventName = 'columnValueChanged' as const;
@@ -45,16 +61,16 @@ export class ValueColsSvc extends BaseColsService implements NamedBean, IValueCo
             if (modeAggFunc) {
                 this.bucketCol(col, colIsNew);
                 if (!col.aggFunc) {
-                    this.writeAggFunc(col, modeAggFunc);
+                    writeAggFunc(col, modeAggFunc);
                 }
             }
             return;
         }
         this.bucketCol(col, colIsNew);
         if (aggFunc != null && aggFunc !== '') {
-            this.writeAggFunc(col, aggFunc);
+            writeAggFunc(col, aggFunc);
         } else if (!col.aggFunc) {
-            this.writeAggFunc(col, colDef.initialAggFunc);
+            writeAggFunc(col, colDef.initialAggFunc);
         }
     }
 
@@ -63,11 +79,7 @@ export class ValueColsSvc extends BaseColsService implements NamedBean, IValueCo
     private bucketCol(col: AgColumn, colIsNew: boolean): void {
         const colDef = col.colDef;
         const key = colDef.valueIndex ?? (colIsNew ? colDef.initialValueIndex : null);
-        if (key != null) {
-            this.extractAddColWithIndex(col, key);
-        } else {
-            this.extractAddColWithValue(col);
-        }
+        this.bucketByKey(col, key);
     }
 
     // Imperative-only (the base gates on `runSideEffects`); the state/agg-func paths set the func explicitly.
@@ -75,7 +87,7 @@ export class ValueColsSvc extends BaseColsService implements NamedBean, IValueCo
         // A newly-active col with no agg-func picks up the default for its cell-data type.
         const aggFuncSvc = this.aggFuncSvc;
         if (active && aggFuncSvc && !column.aggFunc) {
-            this.writeAggFunc(column, aggFuncSvc.getDefaultAggFunc(column));
+            writeAggFunc(column, aggFuncSvc.getDefaultAggFunc(column));
         }
     }
 
@@ -89,23 +101,27 @@ export class ValueColsSvc extends BaseColsService implements NamedBean, IValueCo
     }
 
     public setColumnAggFunc(key: ColKey | undefined, aggFunc: ColAggFunc, source: ColumnEventType): void {
-        if (key) {
-            const column = this.colModel.getNonPivotCol(key);
-            if (column) {
-                const { changed, membershipChanged } = this.applyAggFunc(column, aggFunc, source);
-                if (changed) {
-                    // Membership changes ((de)activation) alter the value-column set, so pivot result columns must
-                    // rebuild; a func-only change on an already-active col re-aggregates event-driven, no refresh.
-                    this.stageColChange([column]);
-                    this.colModel.flushColChanges(source, membershipChanged);
-                }
-            }
+        if (!key) {
+            return;
         }
+        const column = this.colModel.getNonPivotCol(key);
+        if (!column) {
+            return;
+        }
+        const change = this.applyAggFunc(column, aggFunc, source);
+        if (change === AGG_UNCHANGED) {
+            return;
+        }
+        const membershipChanged = change === AGG_MEMBERSHIP;
+        // (De)activation moves the value-column set → reindex + rebuild pivot result cols; a func-only change
+        // keeps positions and re-aggregates event-driven, so just record it for dispatch (no reindex/rebuild).
+        if (membershipChanged) {
+            this.stageColChange(column);
+        } else {
+            this.recordColChange(column);
+        }
+        this.colModel.flushColChanges(source, membershipChanged);
     }
-
-    /** `valueIndex` per active col from the current state-apply pass; consumed by {@link sortByPendingState}.
-     *  Non-null signals a pending re-sort. */
-    private pendingStateOrder: Map<AgColumn, number> | null = null;
 
     public override syncColState(
         column: AgColumn,
@@ -133,42 +149,9 @@ export class ValueColsSvc extends BaseColsService implements NamedBean, IValueCo
             this.setColActive(column, true, source, true);
         }
         if (typeof valueIndex === 'number' && column.aggregationActive) {
-            let idxMap = this.pendingStateOrder;
-            if (idxMap === null) {
-                idxMap = new Map();
-                this.pendingStateOrder = idxMap;
-            }
-            idxMap.set(column, valueIndex);
+            this.recordPendingStateOrder(column, valueIndex);
         }
     }
-
-    /** Re-order active value cols by the `valueIndex` recorded during the last `syncColState` pass; else keep
-     *  insertion order. Runs before `refreshCols` so pivot result columns pick up the new value-col order. */
-    public sortByPendingState(): void {
-        if (!this.pendingStateOrder) {
-            return;
-        }
-        const cols = this.columns;
-        if (cols.length > 0) {
-            cols.sort(this.compareByStateIndex);
-            this.resetActiveCols(cols);
-        }
-        this.onColumnsChanged();
-        this.pendingStateOrder = null;
-    }
-
-    private readonly compareByStateIndex = (a: AgColumn, b: AgColumn): number => {
-        const indexes = this.pendingStateOrder;
-        if (!indexes) {
-            return 0;
-        }
-        const aIdx = indexes.get(a);
-        const bIdx = indexes.get(b);
-        if (aIdx != null) {
-            return bIdx != null ? aIdx - bIdx : -1;
-        }
-        return bIdx != null ? 1 : 0;
-    };
 
     /** Stamps each active col's position as its value-column order (`aggregationActiveIndex`, valid only when active). */
     protected override onColumnsChanged(): void {
@@ -178,28 +161,18 @@ export class ValueColsSvc extends BaseColsService implements NamedBean, IValueCo
         }
     }
 
-    /** `changed`: any state moved (dispatch a change). `membershipChanged`: the col was (de)activated, so the
-     *  value-column set changed and callers must refresh dependent (pivot result) columns. */
-    private applyAggFunc(
-        column: AgColumn,
-        aggFunc: ColAggFunc,
-        source: ColumnEventType
-    ): { changed: boolean; membershipChanged: boolean } {
+    /** Apply `aggFunc` to `column` and report what moved: {@link AGG_MEMBERSHIP} ((de)activation — the
+     *  value-column set changed, so dependent pivot result columns must rebuild), {@link AGG_FUNC_ONLY} (func
+     *  changed on an already-active col — re-aggregates event-driven), or {@link AGG_UNCHANGED}. */
+    private applyAggFunc(column: AgColumn, aggFunc: ColAggFunc, source: ColumnEventType): AggFuncChange {
         if (aggFunc != null && aggFunc !== '') {
-            const aggFuncChanged = this.writeAggFunc(column, aggFunc);
+            const aggFuncChanged = writeAggFunc(column, aggFunc);
             const activeChanged = this.setColActive(column, true, source);
-            return { changed: aggFuncChanged || activeChanged, membershipChanged: activeChanged };
+            if (activeChanged) {
+                return AGG_MEMBERSHIP;
+            }
+            return aggFuncChanged ? AGG_FUNC_ONLY : AGG_UNCHANGED;
         }
-        const activeChanged = this.setColActive(column, false, source);
-        return { changed: activeChanged, membershipChanged: activeChanged };
-    }
-
-    private writeAggFunc(column: AgColumn, aggFunc: ColAggFunc): boolean {
-        if (column.aggFunc === aggFunc) {
-            return false;
-        }
-        column.aggFunc = aggFunc;
-        column.dispatchStateUpdatedEvent('aggFunc');
-        return true;
+        return this.setColActive(column, false, source) ? AGG_MEMBERSHIP : AGG_UNCHANGED;
     }
 }

--- a/packages/ag-grid-enterprise/src/columns/baseColsService.ts
+++ b/packages/ag-grid-enterprise/src/columns/baseColsService.ts
@@ -31,6 +31,18 @@ export abstract class BaseColsService extends BeanStub implements IColsService {
     private extractColsWithIndex: { col: AgColumn; key: number }[] | null = null;
     private extractColsWithValue: Set<AgColumn> | null = null;
 
+    /** Cols changed since the last flush; non-null = dirty. Dispatched once by {@link dispatchColChange}. */
+    public pendingChanged: Set<AgColumn> | null = null;
+
+    /** A staged change moved the active set/order → re-stamp indexes once at flush ({@link flushReindex}). */
+    private reindexPending = false;
+
+    /** Order index recorded per active col during the current state-apply pass; consumed by {@link sortByPendingState}. */
+    protected pendingStateOrder: Map<AgColumn, number> | null = null;
+
+    /** Set when the current state-apply pass changed membership/order → re-sort + re-stamp at {@link sortByPendingState}. */
+    protected pendingStateChanged = false;
+
     /** Bucket an indexed col, opening {@link extractColsWithIndex} lazily. */
     protected extractAddColWithIndex(col: AgColumn, key: number): void {
         let bucket = this.extractColsWithIndex;
@@ -51,8 +63,14 @@ export abstract class BaseColsService extends BeanStub implements IColsService {
         bucket.add(col);
     }
 
-    /** Cols changed since the last flush; non-null = dirty. Dispatched once by {@link dispatchColChange}. */
-    public pendingChanged: Set<AgColumn> | null = null;
+    /** Bucket `col` by its resolved order `key`: indexed (non-null) cols sort in `commitExtract`, the rest keep order. */
+    protected bucketByKey(col: AgColumn, key: number | null | undefined): void {
+        if (key != null) {
+            this.extractAddColWithIndex(col, key);
+        } else {
+            this.extractAddColWithValue(col);
+        }
+    }
 
     /** Active columns, in order. Ref-stable until the next edit. */
     public get columns(): AgColumn[] {
@@ -130,25 +148,33 @@ export abstract class BaseColsService extends BeanStub implements IColsService {
     /** React to a `this.columns` order/content change; `rowGroupColsSvc` stamps `rowGroupActiveIndex`. Default no-op. */
     protected onColumnsChanged(): void {}
 
-    /** Cols differing in membership or position between `before` and `after` (the change-event payload). */
-    private changedColsBetween(before: AgColumn[], after: AgColumn[]): AgColumn[] {
+    /** Stage cols differing in membership or position between `before` and `after` (removed/moved/added) and
+     *  mark a reindex; returns whether any differed, so the caller can skip an unchanged apply. Records straight
+     *  into `pendingChanged` — no intermediate array — leaving it untouched (and null) when nothing changed. */
+    private stageChangedColsBetween(before: AgColumn[], after: AgColumn[]): boolean {
         const afterIndex = _indexMap(after);
-        const changed: AgColumn[] = [];
+        const beforeSet = before.length > 0 ? new Set(before) : null;
+        let pending: Set<AgColumn> | null = null;
         for (let i = 0, len = before.length; i < len; ++i) {
             const col = before[i];
             const newIndex = afterIndex.get(col);
             if (newIndex === undefined || newIndex !== i) {
-                changed.push(col); // removed or moved
+                pending ??= this.pendingColChangeSet(); // removed or moved
+                pending.add(col);
             }
         }
-        const beforeSet = before.length > 0 ? new Set(before) : null;
         for (let i = 0, len = after.length; i < len; ++i) {
             const col = after[i];
             if (!beforeSet?.has(col)) {
-                changed.push(col); // added
+                pending ??= this.pendingColChangeSet(); // added
+                pending.add(col);
             }
         }
-        return changed;
+        if (pending === null) {
+            return false;
+        }
+        this.reindexPending = true;
+        return true;
     }
 
     public setColumns(colKeys: ColKey[] | undefined, source: ColumnEventType): void {
@@ -171,12 +197,10 @@ export abstract class BaseColsService extends BeanStub implements IColsService {
         // Provided keys, hierarchy virtuals expanded before each source.
         const orderedSet = this.expandActiveCols(newCols);
         const orderedArr = Array.from(orderedSet);
-        const changed = this.changedColsBetween(before, orderedArr);
-        if (changed.length === 0) {
+        if (!this.stageChangedColsBetween(before, orderedArr)) {
             return; // identical membership + order — nothing to refresh or dispatch
         }
         this.applyActiveCols(before, orderedSet, orderedArr, source, true);
-        this.stageColChange(changed);
         colModel.flushColChanges(source, true); // membership change → refresh; defers when batched
     }
 
@@ -194,16 +218,42 @@ export abstract class BaseColsService extends BeanStub implements IColsService {
         return res;
     }
 
-    /** Record changed cols for the next {@link ColumnModel.flushColChanges}; a `Set` dedupes the payload. */
-    protected stageColChange(changedCols: AgColumn[]): void {
-        this.onColumnsChanged();
+    /** Stage a membership/order change of one col: mark the set for re-index at flush + record for dispatch. */
+    protected stageColChange(col: AgColumn): void {
+        this.reindexPending = true;
+        this.pendingColChangeSet().add(col);
+    }
+
+    /** {@link stageColChange} for several cols at once. */
+    protected stageColChanges(changedCols: Iterable<AgColumn>): void {
+        this.reindexPending = true;
+        const pending = this.pendingColChangeSet();
+        for (const col of changedCols) {
+            pending.add(col);
+        }
+    }
+
+    /** Record a col for the next {@link dispatchColChange} WITHOUT a re-index — for value-only changes that
+     *  keep the active set/order unchanged (a `Set` dedupes the payload). */
+    protected recordColChange(col: AgColumn): void {
+        this.pendingColChangeSet().add(col);
+    }
+
+    private pendingColChangeSet(): Set<AgColumn> {
         let pending = this.pendingChanged;
         if (pending === null) {
             pending = new Set();
             this.pendingChanged = pending;
         }
-        for (let i = 0, len = changedCols.length; i < len; ++i) {
-            pending.add(changedCols[i]);
+        return pending;
+    }
+
+    /** Re-stamp active-col indexes once if a staged change moved the set; called by
+     *  {@link ColumnModel.flushColChanges} before refresh/dispatch read the stamped positions. */
+    public flushReindex(): void {
+        if (this.reindexPending) {
+            this.reindexPending = false;
+            this.onColumnsChanged();
         }
     }
 
@@ -262,7 +312,7 @@ export abstract class BaseColsService extends BeanStub implements IColsService {
             return;
         }
 
-        this.stageColChange(Array.from(updatedCols));
+        this.stageColChanges(updatedCols);
         colModel.flushColChanges(src, true); // membership change → refresh; defers when batched
     }
 
@@ -271,7 +321,7 @@ export abstract class BaseColsService extends BeanStub implements IColsService {
 
     /** Finalise the pass: order the buckets, diff vs the previous active cols (flagging changes), re-seat,
      *  then release the buckets. */
-    public commitExtract(source: ColumnEventType): AgColumn[] {
+    public commitExtract(source: ColumnEventType): void {
         const extractColsWithIndex = this.extractColsWithIndex;
         const extractColsWithValue = this.extractColsWithValue;
         const activeColSet = this.activeColSet;
@@ -309,8 +359,53 @@ export abstract class BaseColsService extends BeanStub implements IColsService {
         this.onColumnsChanged();
         this.extractColsWithIndex = null;
         this.extractColsWithValue = null;
-        return this.columns;
     }
+
+    /** Record a col's target order index for {@link sortByPendingState} and mark the pass dirty. */
+    protected recordPendingStateOrder(col: AgColumn, index: number): void {
+        let idxMap = this.pendingStateOrder;
+        if (idxMap === null) {
+            idxMap = new Map();
+            this.pendingStateOrder = idxMap;
+        }
+        idxMap.set(col, index);
+        this.pendingStateChanged = true;
+    }
+
+    /** Re-order + re-stamp active cols when this apply changed membership/order; else keep insertion order. */
+    public sortByPendingState(): void {
+        if (!this.pendingStateChanged) {
+            return;
+        }
+        this.pendingStateChanged = false;
+        const cols = this.columns;
+        if (cols.length > 0 && this.sortPendingCols(cols)) {
+            this.resetActiveCols(cols);
+        }
+        this.onColumnsChanged();
+        this.pendingStateOrder = null;
+    }
+
+    protected sortPendingCols(cols: AgColumn[]): boolean {
+        if (this.pendingStateOrder) {
+            cols.sort(this.compareByStateIndex);
+            return true;
+        }
+        return false;
+    }
+
+    protected readonly compareByStateIndex = (a: AgColumn, b: AgColumn): number => {
+        const indexes = this.pendingStateOrder;
+        if (!indexes) {
+            return 0;
+        }
+        const aIdx = indexes.get(a);
+        const bIdx = indexes.get(b);
+        if (aIdx == null) {
+            return bIdx == null ? 0 : 1;
+        }
+        return bIdx == null ? -1 : aIdx - bIdx;
+    };
 
     /** Apply one `ColumnState` entry to this service; ordered services share the impl, `valueColsSvc` overrides. */
     public abstract syncColState(

--- a/packages/ag-grid-enterprise/src/columns/orderedColsService.ts
+++ b/packages/ag-grid-enterprise/src/columns/orderedColsService.ts
@@ -61,11 +61,7 @@ export abstract class OrderedColsService extends BaseColsService implements IOrd
             return;
         }
         const key = colDef[indexProp] ?? (colIsNew ? colDef[initialIndexProp] : null);
-        if (key != null) {
-            this.extractAddColWithIndex(col, key);
-        } else {
-            this.extractAddColWithValue(col);
-        }
+        this.bucketByKey(col, key);
     }
 
     /** This col's hierarchy virtuals (date-part group levels) to seat immediately before it; undefined if none. */
@@ -105,9 +101,6 @@ export abstract class OrderedColsService extends BaseColsService implements IOrd
         return super.setColActive(col, active, source, runSideEffects);
     }
 
-    private pendingStateOrder: Map<AgColumn, number> | null = null;
-    private pendingStateChanged = false;
-
     public override syncColState(
         column: AgColumn,
         stateItem: ColumnState | null,
@@ -131,51 +124,21 @@ export abstract class OrderedColsService extends BaseColsService implements IOrd
         if (typeof idx === 'number') {
             // An explicit index can reorder an already-active col, so flag regardless of whether it flipped.
             this.setColActive(column, true, source);
-            let idxMap = this.pendingStateOrder;
-            if (idxMap === null) {
-                idxMap = new Map();
-                this.pendingStateOrder = idxMap;
-            }
-            idxMap.set(column, idx);
-            this.pendingStateChanged = true;
+            this.recordPendingStateOrder(column, idx);
         } else if (this.setColActive(column, !!enable, source)) {
             this.pendingStateChanged = true;
         }
     }
 
-    /** Re-order + re-stamp active cols when this apply changed membership; else keep insertion order. */
-    public sortByPendingState(): void {
-        if (!this.pendingStateChanged) {
-            return;
+    /** Fold hierarchy ordering in front of the state-index sort; else fall back to the base index sort. */
+    protected override sortPendingCols(cols: AgColumn[]): boolean {
+        const hierarchy = this.getActiveHierarchyCols();
+        if (hierarchy) {
+            cols.sort((a, b) => hierarchy.compareVirtualColumns(a, b) ?? this.compareByStateIndex(a, b));
+            return true;
         }
-        this.pendingStateChanged = false;
-        const cols = this.columns;
-        if (cols.length > 0) {
-            const hierarchy = this.getActiveHierarchyCols();
-            if (hierarchy) {
-                cols.sort((a, b) => hierarchy.compareVirtualColumns(a, b) ?? this.compareByStateIndex(a, b));
-                this.resetActiveCols(cols);
-            } else if (this.pendingStateOrder) {
-                cols.sort(this.compareByStateIndex);
-                this.resetActiveCols(cols);
-            }
-        }
-        this.onColumnsChanged();
-        this.pendingStateOrder = null;
+        return super.sortPendingCols(cols);
     }
-
-    private readonly compareByStateIndex = (a: AgColumn, b: AgColumn): number => {
-        const indexes = this.pendingStateOrder;
-        if (!indexes) {
-            return 0;
-        }
-        const aIdx = indexes.get(a);
-        const bIdx = indexes.get(b);
-        if (aIdx != null) {
-            return bIdx != null ? aIdx - bIdx : -1;
-        }
-        return bIdx != null ? 1 : 0;
-    };
 
     /** Stamps synthetic `indexProp` onto `incoming`/`accumulator` so a `cellDataType`-inferred rowGroup/pivot
      *  flip keeps the original primary-col order (new cols slot in at their col-def position). */

--- a/packages/ag-grid-enterprise/src/rowGrouping/rowGroupColsSvc.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/rowGroupColsSvc.ts
@@ -28,7 +28,7 @@ export class RowGroupColsSvc extends OrderedColsService implements NamedBean, IR
         reordered.splice(toIndex, 0, reordered.splice(fromIndex, 1)[0]);
         this.resetActiveCols(reordered);
         // Reorder only (event-driven regroup): report the moved column.
-        this.stageColChange([movedColumn]);
+        this.stageColChange(movedColumn);
         this.colModel.flushColChanges(source, false);
     }
 

--- a/testing/behavioural/src/grid-state/value-column-order.test.ts
+++ b/testing/behavioural/src/grid-state/value-column-order.test.ts
@@ -132,3 +132,75 @@ describe('Value Column Order (valueIndex)', () => {
         ]);
     });
 });
+
+// rowGroupIndex/pivotIndex in column state derive from the active-col index re-stamped at flush. An
+// imperative reorder must re-stamp so the saved state reflects the new order — the rowGroup/pivot
+// counterpart of the valueIndex coverage above (both fail if the flush-time re-index is skipped).
+describe('Role Column Order (rowGroupIndex / pivotIndex)', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [AllEnterpriseModule],
+    });
+
+    const rowData = [{ a: 'x', b: 'y', c: 'z' }];
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    const orderFromState = (state: ColumnState[], key: 'rowGroupIndex' | 'pivotIndex'): string[] =>
+        state
+            .filter((s) => s[key] != null)
+            .sort((a, b) => (a[key] as number) - (b[key] as number))
+            .map((s) => s.colId!);
+
+    test('row-group column order is captured in and restored from column state', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'a' }, { field: 'b' }, { field: 'c' }],
+            rowData,
+        });
+
+        api.setRowGroupColumns(['a', 'b']);
+        await asyncSetTimeout(1);
+        expect(orderFromState(api.getColumnState(), 'rowGroupIndex')).toEqual(['a', 'b']);
+
+        // Reorder imperatively — the saved state must follow the new order, not the original.
+        api.setRowGroupColumns(['b', 'a']);
+        await asyncSetTimeout(1);
+        const savedState = api.getColumnState();
+        expect(orderFromState(savedState, 'rowGroupIndex')).toEqual(['b', 'a']);
+
+        // Reorder away, then restore the saved order.
+        api.setRowGroupColumns(['a', 'b']);
+        await asyncSetTimeout(1);
+        expect(orderFromState(api.getColumnState(), 'rowGroupIndex')).toEqual(['a', 'b']);
+
+        api.applyColumnState({ state: savedState, applyOrder: true });
+        await asyncSetTimeout(1);
+        expect(orderFromState(api.getColumnState(), 'rowGroupIndex')).toEqual(['b', 'a']);
+    });
+
+    test('pivot column order is captured in and restored from column state', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'a' }, { field: 'b' }, { field: 'c' }],
+            pivotMode: true,
+            rowData,
+        });
+
+        api.setPivotColumns(['a', 'b']);
+        await asyncSetTimeout(1);
+        expect(orderFromState(api.getColumnState(), 'pivotIndex')).toEqual(['a', 'b']);
+
+        api.setPivotColumns(['b', 'a']);
+        await asyncSetTimeout(1);
+        const savedState = api.getColumnState();
+        expect(orderFromState(savedState, 'pivotIndex')).toEqual(['b', 'a']);
+
+        api.setPivotColumns(['a', 'b']);
+        await asyncSetTimeout(1);
+        expect(orderFromState(api.getColumnState(), 'pivotIndex')).toEqual(['a', 'b']);
+
+        api.applyColumnState({ state: savedState, applyOrder: true });
+        await asyncSetTimeout(1);
+        expect(orderFromState(api.getColumnState(), 'pivotIndex')).toEqual(['b', 'a']);
+    });
+});


### PR DESCRIPTION
# AG-17385 — Column-model flush optimisations

Follow-up to the `setColumnAggFunc` refresh fix (AG-17385, already on `latest`). Re-stamps
active-column indexes once per action instead of once per staged change, and skips redundant work
when only an aggFunc value changes. Behaviour-preserving.

Net source delta vs `latest`: +199 / −156 across 6 files, plus 72 lines of tests.

## Changes (vs `latest`)

**Deferred re-index** — `stageColChange` no longer calls `onColumnsChanged()` eagerly; it sets a
`reindexPending` flag and `ColumnModel.flushColChanges` calls the new `flushReindex()` on each
service once, just before refresh/dispatch. A multi-column action (or batch) now re-stamps
`rowGroup/pivot/aggregation ActiveIndex` once instead of N times. These indexes read stale inside an
open batch — documented on `beginColBatch`; verified safe, as every reader runs after the flush.

**Func-only aggFunc edit skips the re-index** — new `recordColChange` records a column for dispatch
_without_ a reindex. `setColumnAggFunc` records (not stages) when the func changes on an
already-active column, and only stages + refreshes dependent pivot result columns on (de)activation.
Equivalent output, less work on the common re-aggregate path.

**Cleanup / dedup**

- Hoisted `sortByPendingState` / `sortPendingCols` / `compareByStateIndex` / `pendingStateOrder` and
  `writeAggFunc` out of the subclasses into shared code (`BaseColsService` / module scope);
  `valueColsSvc` now shares them, overriding only for hierarchy ordering.
- Extracted `bucketByKey` and `invalidateColsDerivedState` (the latter deduped two rebuild sites).
- `applyAggFunc` returns an outcome enum; `commitExtract` returns `void` (result was unused).
- `markColsListIndexDirty` also drops `cachedAllCols` so it stays in lockstep with the other
  order-derived cache (defensive — current `getAllCols()` callers read it as a set, so not
  user-observable, but keeps the two caches consistent under the deferred-flush timing).
- `endColBatch` clamps the depth counter at 0 (defensive against an unbalanced begin/end).

## Tests

Added rowGroupIndex / pivotIndex round-trip cases to `grid-state/value-column-order.test.ts`: saved
column state must follow an imperative reorder. These cover the deferred re-index for the rowGroup
and pivot roles (the value role was already covered there) and fail if `flushReindex` is skipped.
