### PR TITLE
SE-3 - Add ContactPage structured data with contact points

### DIFF
--- a/documentation/ag-grid-docs/src/layouts/Layout.astro
+++ b/documentation/ag-grid-docs/src/layouts/Layout.astro
@@ -95,6 +95,16 @@ const structuredData: JsonLdObject[] = includeStructuredData
               name: 'AG Grid',
               logoUrl: organizationLogoUrl,
               sameAs: sameAsUrls,
+              // Line up with the enquiry-type options on the contact page. Sales enquiries go
+              // through the contact form; technical support is handled via the Zendesk portal.
+              contactPoints: [
+                  { contactType: 'sales', url: `${siteRoot}contact/`, availableLanguage: 'English' },
+                  {
+                      contactType: 'technical support',
+                      url: 'https://ag-grid.zendesk.com/',
+                      availableLanguage: 'English',
+                  },
+              ],
           }),
           buildWebSite({
               canonicalUrlBase: metadata.canonicalUrlBase,

--- a/external/ag-website-shared/src/components/contact-us/ContactPage.astro
+++ b/external/ag-website-shared/src/components/contact-us/ContactPage.astro
@@ -5,7 +5,10 @@ import { ContactForm } from '@ag-website-shared/components/contact-form/ContactF
 import PageHero from '@ag-website-shared/components/page-hero/PageHero.astro';
 import { getEntry, type CollectionEntry } from 'astro:content';
 import { buildContactPage } from '@ag-website-shared/utils/structuredData';
+import { LIBRARY } from '@constants';
 import styles from './ContactPage.module.scss';
+
+const githubUrl = LIBRARY === 'charts' ? 'https://github.com/ag-grid/ag-charts' : 'https://github.com/ag-grid/ag-grid';
 
 const { data: metadata } = (await getEntry('metadata', 'metadata')) as CollectionEntry<'metadata'>;
 const contactPageStructuredData = buildContactPage({
@@ -36,7 +39,7 @@ const contactPageStructuredData = buildContactPage({
 
                 <div class={styles.socialLinks}>
                     <a
-                        href="https://github.com/ag-grid/ag-grid"
+                        href={githubUrl}
                         target="_blank"
                         rel="noopener noreferrer"
                         aria-label="GitHub"

--- a/external/ag-website-shared/src/components/contact-us/ContactPage.astro
+++ b/external/ag-website-shared/src/components/contact-us/ContactPage.astro
@@ -3,7 +3,16 @@ import Layout from '@layouts/Layout.astro';
 import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { ContactForm } from '@ag-website-shared/components/contact-form/ContactForm';
 import PageHero from '@ag-website-shared/components/page-hero/PageHero.astro';
+import { getEntry, type CollectionEntry } from 'astro:content';
+import { buildContactPage } from '@ag-website-shared/utils/structuredData';
 import styles from './ContactPage.module.scss';
+
+const { data: metadata } = (await getEntry('metadata', 'metadata')) as CollectionEntry<'metadata'>;
+const contactPageStructuredData = buildContactPage({
+    canonicalUrlBase: metadata.canonicalUrlBase,
+    pageUrl: new URL(Astro.url.pathname, metadata.canonicalUrlBase).href,
+    name: 'Contact AG Grid',
+});
 ---
 
 <Layout
@@ -11,6 +20,7 @@ import styles from './ContactPage.module.scss';
     description="Have questions or need assistance? Contact the AG Grid team for support, licensing, or any other inquiries."
     showSearchBar={true}
     showDocsNav={false}
+    pageStructuredData={[contactPageStructuredData]}
 >
     <div class={styles.contactPage}>
         <PageHero

--- a/external/ag-website-shared/src/utils/structuredData.test.ts
+++ b/external/ag-website-shared/src/utils/structuredData.test.ts
@@ -1,5 +1,6 @@
 import {
     buildBreadcrumbList,
+    buildContactPage,
     buildJsonLdDocument,
     buildOrganization,
     buildSiteNavigationElement,
@@ -30,6 +31,39 @@ describe('buildOrganization', () => {
             sameAs: ['https://github.com/ag-grid/ag-grid', 'https://twitter.com/ag_grid'],
         });
         expect(result['@context']).toBeUndefined();
+        expect(result.contactPoint).toBeUndefined();
+    });
+
+    test('emits a typed contactPoint array when contactPoints are provided', () => {
+        const result = buildOrganization({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            name: 'AG Grid',
+            logoUrl: `${CANONICAL_URL_BASE}/images/logo.png`,
+            sameAs: [],
+            contactPoints: [
+                { contactType: 'sales', url: `${CANONICAL_URL_BASE}/contact/`, availableLanguage: 'English' },
+                {
+                    contactType: 'technical support',
+                    url: 'https://ag-grid.zendesk.com/',
+                    availableLanguage: 'English',
+                },
+            ],
+        });
+
+        expect(result.contactPoint).toEqual([
+            {
+                '@type': 'ContactPoint',
+                contactType: 'sales',
+                url: `${CANONICAL_URL_BASE}/contact/`,
+                availableLanguage: 'English',
+            },
+            {
+                '@type': 'ContactPoint',
+                contactType: 'technical support',
+                url: 'https://ag-grid.zendesk.com/',
+                availableLanguage: 'English',
+            },
+        ]);
     });
 });
 
@@ -192,6 +226,26 @@ describe('buildSiteNavigationElement', () => {
             name: ['Demos', 'Pricing'],
             url: [`${CANONICAL_URL_BASE}/example/`, `${CANONICAL_URL_BASE}/license-pricing/`],
             isPartOf: { '@id': `${CANONICAL_URL_BASE}/#website` },
+        });
+    });
+});
+
+describe('buildContactPage', () => {
+    test('references the Organization and WebSite by @id rather than duplicating them', () => {
+        const pageUrl = `${CANONICAL_URL_BASE}/contact/`;
+        const result = buildContactPage({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            pageUrl,
+            name: 'Contact AG Grid',
+        });
+
+        expect(result).toEqual({
+            '@type': 'ContactPage',
+            '@id': `${pageUrl}#contact-page`,
+            url: pageUrl,
+            name: 'Contact AG Grid',
+            isPartOf: { '@id': `${CANONICAL_URL_BASE}/#website` },
+            mainEntity: { '@id': `${CANONICAL_URL_BASE}/#organization` },
         });
     });
 });

--- a/external/ag-website-shared/src/utils/structuredData.ts
+++ b/external/ag-website-shared/src/utils/structuredData.ts
@@ -12,11 +12,29 @@
 
 export type JsonLdObject = Record<string, unknown>;
 
+export interface ContactPoint {
+    /**
+     * schema.org contactType, e.g. `sales` or `technical support`. These line
+     * up with the enquiry-type options offered on the contact page.
+     */
+    contactType: string;
+    url?: string;
+    telephone?: string;
+    email?: string;
+    availableLanguage?: string | string[];
+}
+
 interface OrgInput {
     canonicalUrlBase: string;
     name: string;
     logoUrl: string;
     sameAs: string[];
+    /**
+     * Optional points of contact (sales, technical support, etc.). Emitted as
+     * a `contactPoint` array on the Organization so any page referencing the
+     * Organization by `@id` (e.g. the ContactPage) inherits them.
+     */
+    contactPoints?: ContactPoint[];
 }
 
 interface WebSiteInput {
@@ -77,6 +95,12 @@ interface SiteNavigationElementInput {
     items: SiteNavigationItem[];
 }
 
+interface ContactPageInput {
+    canonicalUrlBase: string;
+    pageUrl: string;
+    name: string;
+}
+
 /**
  * Return `canonicalUrlBase` with a trailing slash, so callers can append a
  * site-root-relative path or fragment without worrying about the input form
@@ -101,9 +125,10 @@ export const getSiteNavigationElementId = (canonicalUrlBase: string): string =>
 const ARTICLE_ID_FRAGMENT = '#article';
 const BREADCRUMB_ID_FRAGMENT = '#breadcrumb';
 const FAQ_ID_FRAGMENT = '#faq';
+const CONTACT_PAGE_ID_FRAGMENT = '#contact-page';
 
-export function buildOrganization({ canonicalUrlBase, name, logoUrl, sameAs }: OrgInput): JsonLdObject {
-    return {
+export function buildOrganization({ canonicalUrlBase, name, logoUrl, sameAs, contactPoints }: OrgInput): JsonLdObject {
+    const result: JsonLdObject = {
         '@type': 'Organization',
         '@id': getOrganizationId(canonicalUrlBase),
         name,
@@ -111,6 +136,10 @@ export function buildOrganization({ canonicalUrlBase, name, logoUrl, sameAs }: O
         logo: logoUrl,
         sameAs,
     };
+    if (contactPoints && contactPoints.length > 0) {
+        result.contactPoint = contactPoints.map((point) => ({ '@type': 'ContactPoint', ...point }));
+    }
+    return result;
 }
 
 export function buildWebSite({ canonicalUrlBase, name, description }: WebSiteInput): JsonLdObject {
@@ -219,6 +248,22 @@ export function buildSiteNavigationElement({ canonicalUrlBase, items }: SiteNavi
         name: items.map((item) => item.name),
         url: items.map((item) => item.url),
         isPartOf: { '@id': getWebSiteId(canonicalUrlBase) },
+    };
+}
+
+/**
+ * Build a `ContactPage` node for the contact page. `mainEntity` references the
+ * `Organization` by `@id` rather than duplicating it, so the contact points
+ * emitted on the Organization (see `buildOrganization`) describe this page.
+ */
+export function buildContactPage({ canonicalUrlBase, pageUrl, name }: ContactPageInput): JsonLdObject {
+    return {
+        '@type': 'ContactPage',
+        '@id': `${pageUrl}${CONTACT_PAGE_ID_FRAGMENT}`,
+        url: pageUrl,
+        name,
+        isPartOf: { '@id': getWebSiteId(canonicalUrlBase) },
+        mainEntity: { '@id': getOrganizationId(canonicalUrlBase) },
     };
 }
 


### PR DESCRIPTION
## Summary

Adds schema.org `ContactPage` structured data to the contact page and folds sales / technical-support `ContactPoint`s into the shared `Organization` node, so the contact page describes itself rather than only inheriting the global graph.

The `ContactPage.mainEntity` references the existing `Organization` by `@id` (the codebase convention for cross-referencing graph nodes) instead of duplicating it, and the contact points are emitted on the `Organization` so any page referencing it inherits them.

## Changes

- **`structuredData.ts`** — new `ContactPoint` type and optional `contactPoints` on `buildOrganization` (emitted as a typed `contactPoint[]`); new `buildContactPage` builder (`mainEntity` → Organization `@id`, `isPartOf` → WebSite).
- **`Layout.astro`** — supply the two concrete contact points on the global Organization:
  - `sales` → contact form (`/contact/`)
  - `technical support` → Zendesk portal
- **`ContactPage.astro`** — build the `ContactPage` node and pass it via `pageStructuredData` so it joins the page's `@graph`.
- **Tests** — cover the new `contactPoint` array and the `ContactPage` node's `@id`/`mainEntity`/`isPartOf` references.

The two `contactType` values line up with the **Sales** and **Technical Support** enquiry-type options on the contact form. The remaining dropdown options (Press/Media, Partnerships, General) are not included — they have no dedicated destination URL yet; the builder takes an array so they can be added later.

## Notes

- The contact points live on the **global** Organization node, so they appear in every page's structured data (standard canonical org contact info).
- JSON-LD `@id` fragments (`#contact-page`, etc.) are graph identifiers, not DOM anchors — consistent with the existing `#organization`, `#website`, `#faq` nodes.

## Testing

- `yarn nx test ag-website-shared -- "structuredData"` — 16 passing
- format + lint clean
