### PR TITLE
AG-17779 Fix React pinned rows not rendering on state update (#14337)

### DIFF
--- a/packages/ag-grid-community/src/rendering/rowRenderer.ts
+++ b/packages/ag-grid-community/src/rendering/rowRenderer.ts
@@ -509,9 +509,9 @@ export class RowRenderer extends BeanStub implements NamedBean {
     }
 
     private refreshPinnedRowComps(recycleRows = true): void {
-        this.refreshPinnedRows(this.topRowCtrls, 'top', recycleRows);
+        this.topRowCtrls = this.refreshPinnedRows(this.topRowCtrls, 'top', recycleRows);
 
-        this.refreshPinnedRows(this.bottomRowCtrls, 'bottom', recycleRows);
+        this.bottomRowCtrls = this.refreshPinnedRows(this.bottomRowCtrls, 'bottom', recycleRows);
     }
 
     /**
@@ -527,9 +527,17 @@ export class RowRenderer extends BeanStub implements NamedBean {
      * @param rowCtrls The list of existing row controllers
      * @param rowNodes The canonical list of row nodes that should have associated controllers
      */
-    private refreshPinnedRows(rowCtrls: RowCtrl[], pinned: NonNullable<RowPinnedType>, recycleRows: boolean): void {
+    private refreshPinnedRows(
+        rowCtrls: RowCtrl[],
+        pinned: NonNullable<RowPinnedType>,
+        recycleRows: boolean
+    ): RowCtrl[] {
         const { pinnedRowModel, beans, printLayout } = this;
         const rowCtrlMap = Object.fromEntries(rowCtrls.map((ctrl) => [ctrl.rowNode.id!, ctrl]));
+
+        // Build a fresh array rather than mutating in place: the React view layer detects changes by
+        // array reference, so recycling the same instance would suppress re-renders (e.g. added pinned rows).
+        const newRowCtrls: RowCtrl[] = [];
 
         pinnedRowModel?.forEachPinnedRow(pinned, (node, i) => {
             const rowCtrl = rowCtrls[i];
@@ -544,11 +552,11 @@ export class RowRenderer extends BeanStub implements NamedBean {
 
             if (node.id! in rowCtrlMap && recycleRows) {
                 // ctrl exists already, re-use it
-                rowCtrls[i] = rowCtrlMap[node.id!];
+                newRowCtrls[i] = rowCtrlMap[node.id!];
                 delete rowCtrlMap[node.id!];
             } else {
                 // ctrl doesn't exist, create it
-                rowCtrls[i] = new RowCtrl(node, beans, false, false, printLayout);
+                newRowCtrls[i] = new RowCtrl(node, beans, false, false, printLayout);
             }
         });
 
@@ -556,8 +564,10 @@ export class RowRenderer extends BeanStub implements NamedBean {
             (pinned === 'top' ? pinnedRowModel?.getPinnedTopRowCount() : pinnedRowModel?.getPinnedBottomRowCount()) ??
             0;
 
-        // Truncate array if rowCtrls is longer than rowNodes
-        rowCtrls.length = rowNodeCount;
+        // Truncate array if newRowCtrls is longer than rowNodes
+        newRowCtrls.length = rowNodeCount;
+
+        return newRowCtrls;
     }
 
     private onPinnedRowDataChanged(): void {

--- a/testing/behavioural/src/row-data/pinned-row-data-react.test.tsx
+++ b/testing/behavioural/src/row-data/pinned-row-data-react.test.tsx
@@ -1,0 +1,84 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import type { ColDef } from 'ag-grid-community';
+import { ClientSideRowModelModule, ModuleRegistry, PinnedRowModule } from 'ag-grid-community';
+import { AgGridReact } from 'ag-grid-react';
+
+import { asyncSetTimeout, ignoreConsoleLicenseKeyError } from '../test-utils';
+
+const PINNED_TOP_SELECTOR = '.ag-grid-pinned-top-rows [row-id]';
+const PINNED_BOTTOM_SELECTOR = '.ag-grid-pinned-bottom-rows [row-id]';
+
+// Regression: driving pinnedTopRowData / pinnedBottomRowData via React state used to grow the
+// pinned section's height but never render the rows, because the row renderer mutated its
+// topRowCtrls/bottomRowCtrls arrays in place and the React container skips re-rendering when the
+// array reference is unchanged.
+describe('React-driven pinned row data', () => {
+    beforeAll(() => {
+        ModuleRegistry.registerModules([ClientSideRowModelModule, PinnedRowModule]);
+        ignoreConsoleLicenseKeyError();
+    });
+
+    afterEach(async () => {
+        await act(async () => {
+            await asyncSetTimeout(0);
+            cleanup();
+        });
+    });
+
+    type Datum = { make: string };
+    const columnDefs: ColDef[] = [{ field: 'make' }];
+    const rowData: Datum[] = [{ make: 'Toyota' }, { make: 'Ford' }];
+
+    let drivePinnedTop: React.Dispatch<React.SetStateAction<Datum[]>> | undefined;
+    let drivePinnedBottom: React.Dispatch<React.SetStateAction<Datum[]>> | undefined;
+
+    function Wrapper() {
+        const [pinnedTop, setPinnedTop] = React.useState<Datum[]>([]);
+        const [pinnedBottom, setPinnedBottom] = React.useState<Datum[]>([]);
+        drivePinnedTop = setPinnedTop;
+        drivePinnedBottom = setPinnedBottom;
+        return (
+            <div style={{ height: 400, width: 600 }}>
+                <AgGridReact
+                    rowData={rowData}
+                    columnDefs={columnDefs}
+                    pinnedTopRowData={pinnedTop}
+                    pinnedBottomRowData={pinnedBottom}
+                />
+            </div>
+        );
+    }
+
+    test('adding pinned top rows via state renders them in the DOM', async () => {
+        const rendered = render(<Wrapper />);
+        await waitFor(() => expect(rendered.container.querySelectorAll('[row-id]').length).toBeGreaterThan(0));
+
+        expect(rendered.container.querySelectorAll(PINNED_TOP_SELECTOR).length).toBe(0);
+
+        act(() => drivePinnedTop!([{ make: 'Pinned A' }]));
+        await waitFor(() => expect(rendered.container.querySelectorAll(PINNED_TOP_SELECTOR).length).toBe(1));
+        expect(rendered.container.textContent).toContain('Pinned A');
+
+        // Adding a second pinned row must also render (in-place mutation kept the same array reference).
+        act(() => drivePinnedTop!([{ make: 'Pinned A' }, { make: 'Pinned B' }]));
+        await waitFor(() => expect(rendered.container.querySelectorAll(PINNED_TOP_SELECTOR).length).toBe(2));
+        expect(rendered.container.textContent).toContain('Pinned B');
+    });
+
+    test('adding pinned bottom rows via state renders them in the DOM', async () => {
+        const rendered = render(<Wrapper />);
+        await waitFor(() => expect(rendered.container.querySelectorAll('[row-id]').length).toBeGreaterThan(0));
+
+        expect(rendered.container.querySelectorAll(PINNED_BOTTOM_SELECTOR).length).toBe(0);
+
+        act(() => drivePinnedBottom!([{ make: 'Bottom A' }]));
+        await waitFor(() => expect(rendered.container.querySelectorAll(PINNED_BOTTOM_SELECTOR).length).toBe(1));
+        expect(rendered.container.textContent).toContain('Bottom A');
+
+        act(() => drivePinnedBottom!([{ make: 'Bottom A' }, { make: 'Bottom B' }]));
+        await waitFor(() => expect(rendered.container.querySelectorAll(PINNED_BOTTOM_SELECTOR).length).toBe(2));
+        expect(rendered.container.textContent).toContain('Bottom B');
+    });
+});


### PR DESCRIPTION
refreshPinnedRows mutated topRowCtrls/bottomRowCtrls in place. Since the single-container refactor, the React row container receives that array reference directly and skips re-rendering when the reference is unchanged, so pinned rows added via pinnedTopRowData/pinnedBottomRowData state never appeared. Return a fresh array instead, matching how allRowCtrls behaves.

Fixes [AG-17779](https://ag-grid.atlassian.net/browse/AG-17779)