### PR TITLE
AG-17790 Fix auto-size collapsing headers to min width on empty grid (#14362)

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/column-resizing/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-sizing/_examples/column-resizing/example.spec.ts
@@ -120,6 +120,40 @@ test.agExample(import.meta, () => {
         ).toBeGreaterThan(600);
     });
 
+    test.eachFramework(
+        'fitCellContents on an empty grid sizes headers to content',
+        async ({ page, remoteGrid, agIdFor }) => {
+            const remoteApi = remoteGrid(page, '1');
+            await remoteApi.setGridOption('columnDefs', [
+                { field: 'athlete', minWidth: 40 },
+                { field: 'age', headerName: 'Age of Athlete', minWidth: 40 },
+                { field: 'country', minWidth: 40 },
+                { field: 'year', minWidth: 40 },
+                { field: 'date', minWidth: 40 },
+            ]);
+
+            await waitForGridContent(page);
+
+            // the fetch that populates rowData only fires once on load, so clearing it leaves the grid
+            // empty for the rest of the test
+            await remoteApi.setGridOption('rowData', []);
+
+            await remoteApi.autoSizeAllColumns({});
+            await waitForAnimation(page);
+
+            const headers = getHeaders(agIdFor);
+            const widths = await getHeaderWidths(headers);
+
+            // when a column measures its width against the (display:none) row container it collapses to
+            // minWidth; every column would then share the same floor width. Sizing against the header
+            // content instead gives the longer "Age of Athlete" label a wider column than "Year".
+            expect(widths.age).toBeGreaterThan(widths.year);
+            expect(widths.year).toBeGreaterThan(40);
+            expect(widths.country).toBeGreaterThan(40);
+            expect(widths.date).toBeGreaterThan(40);
+        }
+    );
+
     test.describe('Example modifications', () => {
         test.use({ agModules: ['RowSelectionModule'] });
 

--- a/packages/ag-grid-community/src/rendering/autoWidthCalculator.ts
+++ b/packages/ag-grid-community/src/rendering/autoWidthCalculator.ts
@@ -56,16 +56,17 @@ export class AutoWidthCalculator extends BeanStub implements NamedBean {
         // position fixed, so it isn't restricted to the boundaries of the parent
         eDummyContainer.style.position = 'fixed';
 
-        // we put the dummy into the body container, so it will inherit all the
-        // css styles that the real cells are inheriting
-        const eBodyContainer = this.scrollingRowContainerCtrl.eContainer;
+        // we put the dummy into the body viewport, so it inherits all the css styles the real
+        // cells inherit. we use the viewport rather than the row container because the container
+        // is set to display:none while the grid has no rows, which would measure every clone at 0.
+        const eBodyViewport = this.scrollingRowContainerCtrl.eViewport;
 
         for (const el of elements) {
             this.cloneItemIntoDummy(el, eDummyContainer);
         }
 
         // only append the dummyContainer to the DOM after it contains all the necessary items
-        eBodyContainer.appendChild(eDummyContainer);
+        eBodyViewport.appendChild(eDummyContainer);
 
         // at this point, all the clones are lined up vertically with natural widths. the dummy
         // container will have a width wide enough just to fit the largest.


### PR DESCRIPTION
Column auto-size measured its dummy cells inside the scrolling row container, which is set to display:none while the grid has no rows. Every clone then measured offsetWidth 0 and clamped up to minWidth, collapsing headers. Measure into the always-visible body viewport instead.

Fix [AG-17790](https://ag-grid.atlassian.net/browse/AG-17790)