### PR TITLE
AG-17849 Add release content for 36.0.1 and 35.3.1

### DIFF
--- a/documentation/ag-grid-docs/public/changelog/changelog.json
+++ b/documentation/ag-grid-docs/public/changelog/changelog.json
@@ -1,10 +1,38 @@
 [
     {
+        "key": "AG-17849",
+        "issueType": "Bug",
+        "manualEntry": true,
+        "summary": "Placeholder for 36.0.1",
+        "versions": ["36.0.1"],
+        "status": "Done",
+        "resolution": "Done",
+        "features": null,
+        "moreInformation": null,
+        "deprecationNotes": null,
+        "breakingChangesNotes": null,
+        "documentationUrl": null
+    },
+    {
         "key": "AG-17593",
         "issueType": "Task",
         "manualEntry": true,
         "summary": "Placeholder for 36.0.0",
         "versions": ["36.0.0"],
+        "status": "Done",
+        "resolution": "Done",
+        "features": null,
+        "moreInformation": null,
+        "deprecationNotes": null,
+        "breakingChangesNotes": null,
+        "documentationUrl": null
+    },
+    {
+        "key": "AG-17849",
+        "issueType": "Bug",
+        "manualEntry": true,
+        "summary": "Placeholder for 35.3.1",
+        "versions": ["35.3.1"],
         "status": "Done",
         "resolution": "Done",
         "features": null,

--- a/documentation/ag-grid-docs/public/changelog/releaseVersionNotes.json
+++ b/documentation/ag-grid-docs/public/changelog/releaseVersionNotes.json
@@ -1,7 +1,15 @@
 [
     {
+        "release version": "36.0.1",
+        "markdown": "/releases/36_0_1.md"
+    },
+    {
         "release version": "36.0.0",
         "markdown": "/releases/36_0_0.md"
+    },
+    {
+        "release version": "35.3.1",
+        "markdown": "/releases/35_3_1.md"
     },
     {
         "release version": "35.3.0",

--- a/documentation/ag-grid-docs/public/changelog/releases/35_3_1.md
+++ b/documentation/ag-grid-docs/public/changelog/releases/35_3_1.md
@@ -1,0 +1,3 @@
+#### 2nd June 2026 - Grid v35.3.1 (Charts v13.3.1)
+
+See table below for changes included in this release.

--- a/documentation/ag-grid-docs/public/changelog/releases/36_0_1.md
+++ b/documentation/ag-grid-docs/public/changelog/releases/36_0_1.md
@@ -1,0 +1,3 @@
+#### 15th July 2026 - Grid v36.0.1 (Charts v14.0.1)
+
+See table below for changes included in this release.

--- a/documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json
+++ b/documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json
@@ -1,6 +1,7 @@
 [
     {
-        "version": "36.0.1"
+        "version": "36.0.1",
+        "date": "15th July 2026"
     },
     {
         "version": "36.0.0",
@@ -28,6 +29,10 @@
         ],
         "notesPath": "./upgrading-to-ag-grid-36",
         "hideBlogPostLink": false
+    },
+    {
+        "version": "35.3.1",
+        "date": "2nd June 2026"
     },
     {
         "version": "35.3.0",


### PR DESCRIPTION
Fixes AG-17849

Adds changelog, release notes, and version archive entries for v36.0.1 (15th July 2026) and v35.3.1 (2nd June 2026).