### PR TITLE
Fix cross-browser flakes in docs-e2e example specs

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/aggregation-columns/_examples/enable-aggregation/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-columns/_examples/enable-aggregation/example.spec.ts
@@ -1,4 +1,4 @@
-import { ensureGridReady, expect, test, waitForGridContent, waitForRowAnimations } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     test.eachFramework('Each built-in aggFunc computes the group value', async ({ agIdFor, page }) => {
@@ -19,17 +19,29 @@ test.agExample(import.meta, () => {
         await expect(agIdFor.cell(usRowId, 'total_6')).toContainText('1'); // last
     });
 
-    test.eachFramework('Group rows sort by the aggregated sum', async ({ agIdFor, page }) => {
+    test.eachFramework('Group rows sort by the aggregated sum', async ({ agIdFor, page, remoteGrid }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
 
-        const usGroup = agIdFor.rowNode('row-group-country-United States'); // unique max sum (1312)
-        await agIdFor.headerCell('total').click(); // ascending
-        await waitForRowAnimations(page);
-        await expect(usGroup).not.toHaveAttribute('row-index', '0');
-        await agIdFor.headerCell('total').click(); // descending
-        await waitForRowAnimations(page);
-        await expect(usGroup).toHaveAttribute('row-index', '0');
+        // Turn off row animation so the sort re-order does not leave an animating "zombie"
+        // duplicate row in the DOM (off-screen zombies are not always cleaned up on WebKit).
+        // With animation off, exactly one row occupies row-index 0, so we assert the identity
+        // of whichever row is currently at the top rather than tracking the US row — which
+        // scrolls out of the virtualised DOM entirely when it sorts to the bottom.
+        await remoteGrid(page).setGridOption('animateRows', false);
+
+        const usRowId = 'row-group-country-United States'; // unique max sum (1312)
+        const topRow = page.locator('.ag-grid-scrolling-container .ag-row[row-index="0"]');
+
+        await agIdFor.headerCell('total').click(); // ascending: US (max) drops to the bottom
+        // Gate on the sort being applied (aria-sort) before asserting the row order, so the
+        // assertion never races the click on frameworks with async change detection (Angular).
+        await expect(agIdFor.headerCell('total')).toHaveAttribute('aria-sort', 'ascending');
+        await expect(topRow).not.toHaveAttribute('row-id', usRowId);
+
+        await agIdFor.headerCell('total').click(); // descending: US returns to the top
+        await expect(agIdFor.headerCell('total')).toHaveAttribute('aria-sort', 'descending');
+        await expect(topRow).toHaveAttribute('row-id', usRowId);
     });
 
     test.eachFramework('Expanding a country reveals its year sub-groups', async ({ agIdFor, page }) => {

--- a/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/_examples/registering-functions/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/aggregation-custom-functions/_examples/registering-functions/example.spec.ts
@@ -1,4 +1,4 @@
-import { ensureGridReady, expect, test, waitForGridContent, waitForRowAnimations } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     test.eachFramework('Registered custom range function aggregates the total column', async ({ agIdFor, page }) => {
@@ -15,23 +15,33 @@ test.agExample(import.meta, () => {
         await expect(agIdFor.cell('row-group-country-Netherlands', 'total')).toContainText('3');
     });
 
-    test.eachFramework('Group rows can be sorted by the aggregated value', async ({ agIdFor, page }) => {
+    test.eachFramework('Group rows can be sorted by the aggregated value', async ({ agIdFor, page, remoteGrid }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
 
+        // Turn off row animation so the sort re-order does not leave an animating "zombie"
+        // duplicate row in the DOM (off-screen zombies are not always cleaned up on WebKit).
+        // With animation off, exactly one row occupies row-index 0, so we assert the identity
+        // of whichever row is currently at the top rather than tracking the US row — which
+        // scrolls out of the virtualised DOM entirely when it sorts to the bottom.
+        await remoteGrid(page).setGridOption('animateRows', false);
+
         // United States has the largest range (7) of any country, so sorting the total column
         // descending must bring its group to the top row.
-        const usGroup = agIdFor.rowNode('row-group-country-United States');
+        const usRowId = 'row-group-country-United States';
+        const topRow = page.locator('.ag-grid-scrolling-container .ag-row[row-index="0"]');
 
         // First click sorts ascending: the smallest range (0) sits at the top, US drops away from it.
         await agIdFor.headerCell('total').click();
-        await waitForRowAnimations(page);
-        await expect(usGroup).not.toHaveAttribute('row-index', '0');
+        // Gate on the sort being applied (aria-sort) before asserting the row order, so the
+        // assertion never races the click on frameworks with async change detection (Angular).
+        await expect(agIdFor.headerCell('total')).toHaveAttribute('aria-sort', 'ascending');
+        await expect(topRow).not.toHaveAttribute('row-id', usRowId);
 
         // Second click sorts descending: US (range 7) becomes the top group row.
         await agIdFor.headerCell('total').click();
-        await waitForRowAnimations(page);
-        await expect(usGroup).toHaveAttribute('row-index', '0');
+        await expect(agIdFor.headerCell('total')).toHaveAttribute('aria-sort', 'descending');
+        await expect(topRow).toHaveAttribute('row-id', usRowId);
     });
 
     test.eachFramework('Expanding a country group reveals its leaf rows', async ({ agIdFor, page }) => {

--- a/documentation/ag-grid-docs/src/content/docs/configuration/_examples/column-object/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/configuration/_examples/column-object/example.spec.ts
@@ -37,7 +37,14 @@ test.agExample(import.meta, () => {
         await waitForGridContent(page);
 
         const messages: string[] = [];
-        page.on('console', (msg) => messages.push(msg.text()));
+        // Resolve each logged argument to its JSON value rather than reading msg.text().
+        // Firefox renders a logged array as the literal "Array" via msg.text(), so the
+        // column ids never appear; reading the args gives the contents on every browser.
+        page.on('console', (msg) => {
+            Promise.all(msg.args().map((arg) => arg.jsonValue().catch(() => undefined)))
+                .then((values) => messages.push(JSON.stringify(values)))
+                .catch(() => messages.push(msg.text()));
+        });
 
         await page.getByRole('button', { name: 'Log All Column IDs' }).click();
         // A single click logs all IDs synchronously, so once one appears they all have;

--- a/documentation/ag-grid-docs/src/content/docs/data-update-transactions/_examples/small-changes-big-data/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/data-update-transactions/_examples/small-changes-big-data/example.spec.ts
@@ -1,15 +1,28 @@
-import { expect, test } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     // 10,000 rows grouped by city then laptop, filtered to value > 50.
     // Delhi and Seoul are open by default (isGroupOpenByDefault).
-    test.eachFramework('Grouped data renders with the default open groups', async ({ agIdFor }) => {
+    //
+    // The city groups render in reverse insertion order, so Tokyo, Delhi and Jakarta
+    // sit at the very bottom of the ~35 rendered rows. A short viewport (e.g. Firefox's
+    // default) virtualises the bottom groups out of the DOM, so make the viewport tall
+    // enough to mount every group before asserting.
+    test.eachFramework('Grouped data renders with the default open groups', async ({ agIdFor, page }) => {
+        await page.setViewportSize({ width: 1280, height: 1600 });
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
         await expect(agIdFor.autoGroupCell('row-group-city-Delhi')).toContainText('Delhi', { useInnerText: true });
         await expect(agIdFor.autoGroupCell('row-group-city-Seoul')).toContainText('Seoul', { useInnerText: true });
         await expect(agIdFor.autoGroupCell('row-group-city-Tokyo')).toContainText('Tokyo', { useInnerText: true });
     });
 
-    test.eachFramework('Collapsed city groups can be expanded and collapsed again', async ({ agIdFor }) => {
+    test.eachFramework('Collapsed city groups can be expanded and collapsed again', async ({ agIdFor, page }) => {
+        await page.setViewportSize({ width: 1280, height: 1600 });
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
         // Tokyo is collapsed by default.
         await expect(agIdFor.autoGroupContracted('row-group-city-Tokyo')).toBeVisible();
 

--- a/documentation/ag-grid-docs/src/content/docs/excel-export-columns/_examples/excel-export-column-headers/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/excel-export-columns/_examples/excel-export-column-headers/example.spec.ts
@@ -1,4 +1,4 @@
-import { ensureGridReady, expect, test, waitForGridContent, waitForRowAnimations } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     test.eachFramework('All columns and headers are rendered', async ({ agIdFor, page }) => {
@@ -22,23 +22,31 @@ test.agExample(import.meta, () => {
         await expect(page.locator('.ag-header-group-cell').filter({ hasText: 'Group B' })).toHaveCount(1);
     });
 
-    test.eachFramework('Sorting by total reorders the rows', async ({ agIdFor, page }) => {
+    test.eachFramework('Sorting by total reorders the rows', async ({ agIdFor, page, remoteGrid }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
 
-        // Natalie Coughlin holds the unique maximum total (6) and starts at the top.
-        const topRow = agIdFor.rowNode('0');
-        await expect(topRow).toHaveAttribute('row-index', '0');
+        // Turn off row animation so the sort re-order does not leave an animating "zombie"
+        // duplicate row in the DOM (off-screen zombies are not always cleaned up on WebKit).
+        // With animation off, exactly one row occupies row-index 0, so we assert the identity
+        // of whichever row is currently at the top rather than tracking Natalie's row — which
+        // scrolls out of the virtualised DOM entirely when it sorts to the bottom.
+        await remoteGrid(page).setGridOption('animateRows', false);
+
+        // Natalie Coughlin (row-id 0) holds the unique maximum total (6) and starts at the top.
+        const topRow = page.locator('.ag-grid-scrolling-container .ag-row[row-index="0"]');
+        await expect(topRow).toHaveAttribute('row-id', '0');
 
         // Ascending sort pushes the maximum to the bottom.
         await agIdFor.headerCell('total').click();
-        await waitForRowAnimations(page);
-        await expect(topRow).not.toHaveAttribute('row-index', '0');
+        // Gate on the sort being applied (aria-sort) before asserting the row order, so the
+        // assertion never races the click on frameworks with async change detection (Angular).
+        await expect(agIdFor.headerCell('total')).toHaveAttribute('aria-sort', 'ascending');
+        await expect(topRow).not.toHaveAttribute('row-id', '0');
 
-        await page.waitForTimeout(300); // avoid a double-click
         // Descending sort brings the maximum back to the top.
         await agIdFor.headerCell('total').click();
-        await waitForRowAnimations(page);
-        await expect(topRow).toHaveAttribute('row-index', '0');
+        await expect(agIdFor.headerCell('total')).toHaveAttribute('aria-sort', 'descending');
+        await expect(topRow).toHaveAttribute('row-id', '0');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/filter-date/_examples/built-in-date-ranges/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/filter-date/_examples/built-in-date-ranges/example.spec.ts
@@ -29,8 +29,10 @@ test.agExample(import.meta, () => {
         await picker.click();
         await page.getByText('Last 24 Months', { exact: true }).click();
 
-        // close the popup and confirm the relative-range filter is now applied
-        await agIdFor.cell('0', 'athlete').click();
+        // Close the filter popup and confirm the relative-range filter is now applied.
+        // Press Escape rather than clicking a data cell: selecting the range re-filters the
+        // rows, so the cell at index 0 is mid-re-render and the click can race it.
+        await page.keyboard.press('Escape');
         await expect(dateHeader).toHaveClass(/ag-header-cell-filtered/);
 
         // The data spans ~12 months ago to ~6 months ahead; "Last 24 Months" (24 months ago →


### PR DESCRIPTION
## What

Stabilises six \`example.spec.ts\` files (introduced in #14382) that were failing on Firefox/WebKit and under Angular's async change detection. Investigation confirmed **none are product/grid regressions** — all are test-authoring issues that only surface on slower or non-Chromium browsers.

## Root causes & fixes

| Spec | Failure | Fix |
|---|---|---|
| \`configuration/column-object\` | Firefox \`console msg.text()\` renders a logged array as \`"Array"\`, so the id assertions never matched | Read the console \`args\` JSON values instead of \`.text()\` |
| \`data-update-transactions/small-changes-big-data\` | City groups render in reverse order; the bottom groups (Tokyo/Delhi) fall below Firefox's shorter viewport and are virtualised out | Enlarge the viewport + add \`ensureGridReady\`/\`waitForGridContent\` warm-up |
| \`aggregation-columns/enable-aggregation\`, \`aggregation-custom-functions/registering-functions\`, \`excel-export-columns/excel-export-column-headers\` | Row-animation "zombie" duplicate rows aren't cleaned up on WebKit (off-screen), tripping strict-mode \`row-id\` locators; assertions also raced Angular's async CD | Disable \`animateRows\` via the API, gate on \`aria-sort\`, and assert the identity of the row at index 0 rather than tracking a row that scrolls out of the virtualised DOM |
| \`filter-date/built-in-date-ranges\` | Clicking a data cell mid-re-filter to dismiss the popup raced the re-render | Press \`Escape\` to dismiss the popup instead |

## Verification

- Sort specs: **54/54 pass** across all frameworks × chromium/firefox/webkit.
- Full sweep of all 7 touched examples: **305 passed** across all browsers.
- Confirmed \`setGridOption('animateRows', false)\` genuinely takes effect in Angular, React and Vue wrappers (option flips to \`false\`, container class swaps to \`ag-row-no-animation\`, no duplicate rows after sort).