### PR TITLE
github-triage stub: accept browser-verify / repro-rebuild / open-investigation dispatch stages

### DIFF
--- a/.github/workflows/github-triage-pipeline.yml
+++ b/.github/workflows/github-triage-pipeline.yml
@@ -36,7 +36,7 @@ on:
                 description: 'Pipeline stage'
                 type: choice
                 default: triage
-                options: [triage, resume, execute]
+                options: [triage, resume, browser-verify, repro-rebuild, execute, open-investigation]
             gh_issue:
                 description: 'GitHub issue number (triage)'
                 type: string


### PR DESCRIPTION
Adds the three missing stages to the `workflow_dispatch` `stage` choice in the github-triage consumer stub, so the dispatch-only stages can be exercised via **Run workflow** on `canary` for pre-promotion dry-runs:

- **`browser-verify`** (B2 — advisory headless repro verification)
- **`repro-rebuild`** (C — golden-ticket repro rebuild)
- **`open-investigation`** (Type-2 opening move)

The `channel` input already exists, so this is the **only** stub change needed to dry-run them. **Inert** — it adds manual-dispatch options only; the `issues:` auto-trigger stays commented out and no routing changes. These stages resolve to the action on the `canary` dist-tag (where they exist pre-promotion); dispatch with `channel=canary`.

Design + runbook: ag-dev-prompts → `docs/github-triage-pipeline.md`.