### PR TITLE
[AG-9664] Fix(pivoting): reset pivotSort to colDef default on resetColumnState

### DIFF
--- a/packages/ag-grid-community/src/columns/columnStateUtils.ts
+++ b/packages/ag-grid-community/src/columns/columnStateUtils.ts
@@ -470,6 +470,14 @@ export function _resetColumnState(beans: BeanCollection, source: ColumnEventType
     // Apply field state; the structural pass (re)creates auto/service cols. No dispatch yet.
     applyStateToCols(beans, columnStates, colModel.colDefList, {}, source, true);
 
+    // Force `pivotSort` back to its colDef default: `applyFieldState` skips an `undefined` target (so an
+    // omitted `pivotSort` in `applyColumnState` leaves it alone), but a reset must clear a user-applied sort.
+    const primaryCols = colModel.colDefList;
+    for (let i = 0, len = primaryCols.length; i < len; ++i) {
+        const col = primaryCols[i];
+        col.pivotSort = resolveInitialPivotSort(col.colDef);
+    }
+
     // Order from the now-current service cols: auto cols may have been recreated above (their colIds change
     // with the row-group set), so use the post-apply instances, not the pre-apply ids in `columnStates`.
     const autoCols = autoColSvc?.columns;

--- a/testing/behavioural/src/sorting/pivot-column-sort.test.ts
+++ b/testing/behavioural/src/sorting/pivot-column-sort.test.ts
@@ -100,6 +100,29 @@ describe('pivot: interactive pivot column sorting (pivotSort)', () => {
         expect(api.getColumnState().find((s) => s.colId === 'year')!.pivotSort).toBeNull();
     });
 
+    test('resetColumnState restores pivotSort to the colDef default', async () => {
+        const api = createPivotGrid();
+        await asyncSetTimeout(10);
+
+        api.applyColumnState({ state: [{ colId: 'year', pivotSort: 'desc' }] });
+        await asyncSetTimeout(10);
+        expect(api.getColumnState().find((s) => s.colId === 'year')!.pivotSort).toBe('desc');
+        expect(getColumnOrder(api, 'all').filter((id) => id.startsWith('pivot_'))).toEqual([
+            'pivot_year_2022_sales',
+            'pivot_year_2021_sales',
+            'pivot_year_2020_sales',
+        ]);
+
+        api.resetColumnState();
+        await asyncSetTimeout(10);
+        expect(api.getColumnState().find((s) => s.colId === 'year')!.pivotSort).toBe('asc');
+        expect(getColumnOrder(api, 'all').filter((id) => id.startsWith('pivot_'))).toEqual([
+            'pivot_year_2020_sales',
+            'pivot_year_2021_sales',
+            'pivot_year_2022_sales',
+        ]);
+    });
+
     test('desc reverses correctly when data insertion order differs from sorted order', async () => {
         const gridOptions: GridOptions = {
             columnDefs: [


### PR DESCRIPTION
TC6: `resetColumnState()` did not reset `pivotSort` to colDef defaults (restore worked, reset didn't).

`getColumnStateFromColDef` emits `pivotSort: undefined` for the ascending default, but `applyFieldState` skips `undefined` targets (so an omitted `pivotSort` in `applyColumnState` is left alone). Reset therefore left a user-applied `pivotSort` in place. Fix forces `pivotSort` back to its colDef default in `_resetColumnState`.

Fix [AG-9664](https://ag-grid.atlassian.net/browse/AG-9664)