### PR TITLE
[AG-17857] Test(enterprise): behavioural coverage for rich select and status bar

### DIFF
--- a/testing/behavioural/src/cell-editing/rich-select/rich-select-editor.test.ts
+++ b/testing/behavioural/src/cell-editing/rich-select/rich-select-editor.test.ts
@@ -51,7 +51,6 @@ async function commitByClick(popup: HTMLElement, label: string): Promise<void> {
     const rowHeight = target.getBoundingClientRect().height || 20;
     const clientY = rowHeight * index + rowHeight / 2;
     fireEvent(target, new MouseEvent('click', { bubbles: true, clientY }));
-    await userEvent.click(target);
     await asyncSetTimeout(1);
 }
 
@@ -151,6 +150,8 @@ describe('Rich Select cell editor', () => {
         await asyncSetTimeout(1);
 
         expect(getAllRows(api)[0].data.a).toBe('Alpha');
+        expect(gridDiv.querySelector('.ag-rich-select-list')).toBeNull();
+        expect(gridDiv.querySelector('.ag-popup')).toBeNull();
     });
 
     // 3. allowTyping: true filters via the typed text using formatValue.
@@ -361,12 +362,16 @@ describe('Rich Select cell editor', () => {
         await openEditor(api, gridDiv, 0, 'a');
         expect(gridDiv.querySelector('.ag-rich-select-list')).not.toBeNull();
 
-        // Focus leaving the picker to an outside element collapses it.
-        const wrapper = gridDiv.querySelector<HTMLElement>('.ag-picker-field-wrapper')!;
-        fireEvent.focusOut(wrapper, { relatedTarget: document.body });
-        await asyncSetTimeout(1);
-
-        await waitFor(() => expect(gridDiv.querySelector('.ag-rich-select-list')).toBeNull());
+        // A real click on an element outside the picker collapses it.
+        const outside = document.createElement('button');
+        document.body.appendChild(outside);
+        try {
+            await userEvent.click(outside);
+            await asyncSetTimeout(1);
+            await waitFor(() => expect(gridDiv.querySelector('.ag-rich-select-list')).toBeNull());
+        } finally {
+            outside.remove();
+        }
     });
 
     // 12. Empty/null initial value opens with no highlight; committing from empty works.

--- a/testing/behavioural/src/cell-editing/rich-select/rich-select-editor.test.ts
+++ b/testing/behavioural/src/cell-editing/rich-select/rich-select-editor.test.ts
@@ -232,10 +232,14 @@ describe('Rich Select cell editor', () => {
     // 6. Paged/lazy loading: valuesPage loads the initial page and renders its rows.
     test('paged values load the initial page and render its rows', async () => {
         const dataset = Array.from({ length: 30 }, (_, i) => `Item-${i}`);
-        const valuesPage = ({ startRow, endRow }: { startRow: number; endRow: number }) => ({
-            values: dataset.slice(startRow, endRow),
-            lastRow: dataset.length,
-        });
+        const pageRequests: { startRow: number; endRow: number }[] = [];
+        const valuesPage = ({ startRow, endRow }: { startRow: number; endRow: number }) => {
+            pageRequests.push({ startRow, endRow });
+            return {
+                values: dataset.slice(startRow, endRow),
+                lastRow: dataset.length,
+            };
+        };
         const api = await createGrid({
             columnDefs: [
                 {
@@ -252,7 +256,13 @@ describe('Rich Select cell editor', () => {
         const popup = await openEditor(api, gridDiv, 0, 'a');
 
         await waitFor(() => expect(getRows(popup).length).toBeGreaterThan(0));
-        expect(getRowLabels(popup)[0]).toBe('Item-0');
+
+        // The initial page requests the first block (startRow 0) sized to valuesPageSize.
+        expect(pageRequests[0]).toEqual({ startRow: 0, endRow: 10 });
+        // Rendered rows are the leading, in-order slice of the loaded first page.
+        const rendered = getRowLabels(popup);
+        expect(rendered).toEqual(dataset.slice(0, rendered.length));
+        expect(rendered[0]).toBe('Item-0');
 
         await commitByClick(popup, 'Item-0');
         expect(getAllRows(api)[0].data.a).toBe('Item-0');
@@ -283,7 +293,7 @@ describe('Rich Select cell editor', () => {
         await asyncSetTimeout(1);
 
         const committed = getAllRows(api)[0].data.a as string[];
-        expect(committed).toEqual(expect.arrayContaining(['Beta', 'Gamma']));
+        expect([...committed].sort()).toEqual(['Alpha', 'Beta', 'Gamma']);
     });
 
     // 8. filterList + searchType 'match' filters on a leading-substring match.
@@ -319,8 +329,10 @@ describe('Rich Select cell editor', () => {
         const gridDiv = getGridElement(api)! as HTMLElement;
         const popup = await openEditor(api, gridDiv, 0, 'a');
 
-        const input = gridDiv.querySelector<HTMLInputElement>('.ag-rich-select-field-input input');
-        expect(input?.offsetParent === null || input === null || (input && !input.offsetHeight)).toBeTruthy();
+        // With allowTyping:false the editor hides the text input via `setDisplayed(false)`,
+        // which adds `ag-hidden` to the input field element (jsdom has no layout to assert on).
+        const inputField = gridDiv.querySelector<HTMLElement>('.ag-rich-select-field-input');
+        expect(inputField?.classList.contains('ag-hidden')).toBe(true);
 
         await commitByClick(popup, 'Beta');
         expect(getAllRows(api)[0].data.a).toBe('Beta');

--- a/testing/behavioural/src/cell-editing/rich-select/rich-select-editor.test.ts
+++ b/testing/behavioural/src/cell-editing/rich-select/rich-select-editor.test.ts
@@ -1,0 +1,411 @@
+import { fireEvent, waitFor } from '@testing-library/dom';
+import { userEvent } from '@testing-library/user-event';
+
+import { getGridElement } from 'ag-grid-community';
+import type { GridApi, GridOptions } from 'ag-grid-community';
+import { RichSelectModule } from 'ag-grid-enterprise';
+
+import {
+    GridRows,
+    TestGridsManager,
+    asyncSetTimeout,
+    fakeElementAttribute,
+    getAllRows,
+    waitForPopup,
+} from '../../test-utils';
+
+/**
+ * End-to-end behavioural coverage for the Rich Select cell editor (`agRichSelectCellEditor`).
+ *
+ * These tests drive the real open -> render list -> search / keyboard-navigate -> commit path
+ * through the public GridApi, verifying committed cell values and the rendered popup DOM.
+ *
+ * jsdom has no layout, so the VirtualList only renders rows once a non-zero `offsetHeight` is
+ * faked on its viewport (see `fakeElementAttribute`). Row clicks resolve the target from the
+ * pointer `clientY` (not the event target), hence the `clientY` maths when committing by click.
+ */
+
+async function openEditor(api: GridApi, gridDiv: HTMLElement, rowIndex: number, colKey: string): Promise<HTMLElement> {
+    api.startEditingCell({ rowIndex, colKey });
+    await asyncSetTimeout(1);
+    return waitForPopup(gridDiv);
+}
+
+function getRows(popup: HTMLElement): HTMLElement[] {
+    return Array.from(popup.querySelectorAll<HTMLElement>('.ag-rich-select-row'));
+}
+
+function getRowLabels(popup: HTMLElement): string[] {
+    return getRows(popup).map((row) => row.textContent?.trim() ?? '');
+}
+
+/** Commits a Rich Select row by clicking it. The editor reads the row from `clientY`, so a plain
+ * click always lands on row 0 — we compute a `clientY` inside the target row's band. */
+async function commitByClick(popup: HTMLElement, label: string): Promise<void> {
+    const rows = getRows(popup);
+    const index = rows.findIndex((row) => row.textContent?.trim() === label);
+    if (index < 0) {
+        throw new Error(`Rich Select row "${label}" not found. Available: ${getRowLabels(popup).join(', ')}`);
+    }
+    const target = rows[index];
+    const rowHeight = target.getBoundingClientRect().height || 20;
+    const clientY = rowHeight * index + rowHeight / 2;
+    fireEvent(target, new MouseEvent('click', { bubbles: true, clientY }));
+    await userEvent.click(target);
+    await asyncSetTimeout(1);
+}
+
+/** Fires a keydown on the picker aria/wrapper element (the element the editor listens on). */
+function pressKey(gridDiv: HTMLElement, key: string): void {
+    const wrapper = gridDiv.querySelector<HTMLElement>('.ag-picker-field-wrapper')!;
+    fireEvent.keyDown(wrapper, { key });
+}
+
+function getHighlightedRow(popup: HTMLElement): HTMLElement | undefined {
+    return getRows(popup).find((row) => row.classList.contains('ag-rich-select-row-highlighted'));
+}
+
+describe('Rich Select cell editor', () => {
+    const gridMgr = new TestGridsManager({
+        includeDefaultModules: true,
+        modules: [RichSelectModule],
+    });
+
+    beforeEach(() => {
+        // VirtualList skips rendering rows when the viewport height is 0 (no layout in jsdom).
+        fakeElementAttribute('offsetHeight', 100, '.ag-virtual-list-viewport');
+    });
+
+    afterEach(() => gridMgr.reset());
+
+    const createGrid = (options: GridOptions): Promise<GridApi> => gridMgr.createGridAndWait('grid', options);
+
+    const baseColDef = (params: object = {}) => ({
+        field: 'a',
+        editable: true,
+        cellEditor: 'agRichSelectCellEditor',
+        cellEditorParams: { values: ['Alpha', 'Beta', 'Gamma'], ...params },
+    });
+
+    // 1. Opening the editor renders the values list; clicking an item commits it and closes the popup.
+    test('opening renders the values list, clicking an item commits and closes the popup', async () => {
+        const api = await createGrid({
+            columnDefs: [baseColDef()],
+            rowData: [{ id: '0', a: 'Alpha' }],
+            getRowId: (p) => p.data.id,
+        });
+        const gridDiv = getGridElement(api)! as HTMLElement;
+
+        const popup = await openEditor(api, gridDiv, 0, 'a');
+        expect(getRowLabels(popup)).toEqual(['Alpha', 'Beta', 'Gamma']);
+
+        await commitByClick(popup, 'Gamma');
+
+        expect(getAllRows(api)[0].data.a).toBe('Gamma');
+        expect(gridDiv.querySelector('.ag-popup')).toBeNull();
+        await new GridRows(api, 'after commit Gamma').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:0 a:"Gamma"
+        `);
+    });
+
+    // 2. Keyboard flow: type-to-filter narrows the list, arrows move highlight, Enter commits.
+    test('keyboard: type-to-filter narrows the list, arrows move highlight, Enter commits', async () => {
+        const api = await createGrid({
+            columnDefs: [baseColDef({ values: ['Alpha', 'Beta', 'Gamma', 'Gadget'], filterList: true })],
+            rowData: [{ id: '0', a: 'Alpha' }],
+            getRowId: (p) => p.data.id,
+        });
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const popup = await openEditor(api, gridDiv, 0, 'a');
+
+        pressKey(gridDiv, 'G');
+        await asyncSetTimeout(1);
+        expect(getRowLabels(popup)).toEqual(['Gamma', 'Gadget']);
+
+        // ArrowDown moves the highlight down the filtered list; commit whichever row it lands on.
+        pressKey(gridDiv, 'ArrowDown');
+        await asyncSetTimeout(1);
+        const highlighted = getHighlightedRow(popup)?.textContent?.trim();
+        expect(['Gamma', 'Gadget']).toContain(highlighted);
+
+        pressKey(gridDiv, 'Enter');
+        await asyncSetTimeout(1);
+        expect(getAllRows(api)[0].data.a).toBe(highlighted);
+        expect(gridDiv.querySelector('.ag-popup')).toBeNull();
+    });
+
+    // 2b. Escape cancels without committing.
+    test('keyboard: Escape closes the picker without committing', async () => {
+        const api = await createGrid({
+            columnDefs: [baseColDef()],
+            rowData: [{ id: '0', a: 'Alpha' }],
+            getRowId: (p) => p.data.id,
+        });
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        await openEditor(api, gridDiv, 0, 'a');
+
+        pressKey(gridDiv, 'ArrowDown');
+        await asyncSetTimeout(1);
+        pressKey(gridDiv, 'Escape');
+        await asyncSetTimeout(1);
+
+        expect(getAllRows(api)[0].data.a).toBe('Alpha');
+    });
+
+    // 3. allowTyping: true filters via the typed text using formatValue.
+    test('allowTyping filters the list via the typed text', async () => {
+        const api = await createGrid({
+            columnDefs: [baseColDef({ values: ['Alpha', 'Beta', 'Gamma'], allowTyping: true, filterList: true })],
+            rowData: [{ id: '0', a: 'Alpha' }],
+            getRowId: (p) => p.data.id,
+        });
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const popup = await openEditor(api, gridDiv, 0, 'a');
+
+        const input = gridDiv.querySelector<HTMLInputElement>('.ag-rich-select-field-input input')!;
+        expect(input).toBeTruthy();
+        input.focus();
+        await userEvent.clear(input);
+        await userEvent.type(input, 'Be');
+
+        await waitFor(() => expect(getRowLabels(popup)).toEqual(['Beta']), { timeout: 2000 });
+    });
+
+    // 4. Object values with keyCreator + formatValue: display text and committed value are correct.
+    test('object values with keyCreator + formatValue commit the object and display formatted text', async () => {
+        type Country = { code: string; name: string };
+        const values: Country[] = [
+            { code: 'IE', name: 'Ireland' },
+            { code: 'FR', name: 'France' },
+            { code: 'DE', name: 'Germany' },
+        ];
+        const api = await createGrid({
+            columnDefs: [
+                {
+                    field: 'a',
+                    editable: true,
+                    cellDataType: false,
+                    cellEditor: 'agRichSelectCellEditor',
+                    keyCreator: (p: { value: Country }) => p.value.code,
+                    cellEditorParams: {
+                        values,
+                        formatValue: (value: Country) => value?.name ?? '',
+                    },
+                    valueFormatter: (p: { value?: Country }) => p.value?.name ?? '',
+                },
+            ],
+            rowData: [{ id: '0', a: values[0] }],
+            getRowId: (p) => p.data.id,
+        });
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const popup = await openEditor(api, gridDiv, 0, 'a');
+
+        expect(getRowLabels(popup)).toEqual(['Ireland', 'France', 'Germany']);
+
+        await commitByClick(popup, 'France');
+        expect(getAllRows(api)[0].data.a).toEqual({ code: 'FR', name: 'France' });
+    });
+
+    // 5. Async values promise populates the list.
+    test('async values promise populates the list once resolved', async () => {
+        const api = await createGrid({
+            columnDefs: [
+                baseColDef({
+                    values: () =>
+                        new Promise<string[]>((resolve) => setTimeout(() => resolve(['One', 'Two', 'Three']), 10)),
+                }),
+            ],
+            rowData: [{ id: '0', a: 'One' }],
+            getRowId: (p) => p.data.id,
+        });
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const popup = await openEditor(api, gridDiv, 0, 'a');
+
+        await waitFor(() => expect(getRowLabels(popup)).toEqual(['One', 'Two', 'Three']));
+
+        await commitByClick(popup, 'Two');
+        expect(getAllRows(api)[0].data.a).toBe('Two');
+    });
+
+    // 6. Paged/lazy loading: valuesPage loads the initial page and renders its rows.
+    test('paged values load the initial page and render its rows', async () => {
+        const dataset = Array.from({ length: 30 }, (_, i) => `Item-${i}`);
+        const valuesPage = ({ startRow, endRow }: { startRow: number; endRow: number }) => ({
+            values: dataset.slice(startRow, endRow),
+            lastRow: dataset.length,
+        });
+        const api = await createGrid({
+            columnDefs: [
+                {
+                    field: 'a',
+                    editable: true,
+                    cellEditor: 'agRichSelectCellEditor',
+                    cellEditorParams: { valuesPage, valuesPageSize: 10 },
+                },
+            ],
+            rowData: [{ id: '0', a: 'Item-0' }],
+            getRowId: (p) => p.data.id,
+        });
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const popup = await openEditor(api, gridDiv, 0, 'a');
+
+        await waitFor(() => expect(getRows(popup).length).toBeGreaterThan(0));
+        expect(getRowLabels(popup)[0]).toBe('Item-0');
+
+        await commitByClick(popup, 'Item-0');
+        expect(getAllRows(api)[0].data.a).toBe('Item-0');
+    });
+
+    // 7. multiSelect: true selects several values; committed cell value is the expected collection.
+    test('multiSelect commits the selected collection', async () => {
+        const api = await createGrid({
+            columnDefs: [
+                {
+                    field: 'a',
+                    editable: true,
+                    cellDataType: false,
+                    cellEditor: 'agRichSelectCellEditor',
+                    cellEditorParams: { values: ['Alpha', 'Beta', 'Gamma'], multiSelect: true },
+                },
+            ],
+            rowData: [{ id: '0', a: ['Alpha'] }],
+            getRowId: (p) => p.data.id,
+        });
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const popup = await openEditor(api, gridDiv, 0, 'a');
+
+        await commitByClick(popup, 'Beta');
+        await commitByClick(popup, 'Gamma');
+
+        api.stopEditing();
+        await asyncSetTimeout(1);
+
+        const committed = getAllRows(api)[0].data.a as string[];
+        expect(committed).toEqual(expect.arrayContaining(['Beta', 'Gamma']));
+    });
+
+    // 8. filterList + searchType 'match' filters on a leading-substring match.
+    test('searchType "match" filters rows whose text contains the search string', async () => {
+        const api = await createGrid({
+            columnDefs: [
+                baseColDef({
+                    values: ['Apple', 'Apricot', 'Banana'],
+                    filterList: true,
+                    searchType: 'match',
+                }),
+            ],
+            rowData: [{ id: '0', a: 'Apple' }],
+            getRowId: (p) => p.data.id,
+        });
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const popup = await openEditor(api, gridDiv, 0, 'a');
+
+        pressKey(gridDiv, 'A');
+        pressKey(gridDiv, 'p');
+        await asyncSetTimeout(1);
+
+        expect(getRowLabels(popup)).toEqual(['Apple', 'Apricot']);
+    });
+
+    // 9. allowTyping: false blocks free-text entry; there is no typing input, selection is list-only.
+    test('allowTyping false renders no text input and commits only from the list', async () => {
+        const api = await createGrid({
+            columnDefs: [baseColDef({ allowTyping: false })],
+            rowData: [{ id: '0', a: 'Alpha' }],
+            getRowId: (p) => p.data.id,
+        });
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const popup = await openEditor(api, gridDiv, 0, 'a');
+
+        const input = gridDiv.querySelector<HTMLInputElement>('.ag-rich-select-field-input input');
+        expect(input?.offsetParent === null || input === null || (input && !input.offsetHeight)).toBeTruthy();
+
+        await commitByClick(popup, 'Beta');
+        expect(getAllRows(api)[0].data.a).toBe('Beta');
+    });
+
+    // 10. highlightMatch marks matched substrings in filtered results.
+    test('highlightMatch wraps the matched substring in the rendered rows', async () => {
+        const api = await createGrid({
+            columnDefs: [
+                baseColDef({
+                    values: ['Apple', 'Apricot', 'Banana'],
+                    filterList: true,
+                    searchType: 'match',
+                    highlightMatch: true,
+                }),
+            ],
+            rowData: [{ id: '0', a: 'Apple' }],
+            getRowId: (p) => p.data.id,
+        });
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const popup = await openEditor(api, gridDiv, 0, 'a');
+
+        pressKey(gridDiv, 'A');
+        pressKey(gridDiv, 'p');
+        await asyncSetTimeout(1);
+
+        const highlight = popup.querySelector('.ag-rich-select-row-text-highlight');
+        expect(highlight?.textContent).toBe('Ap');
+    });
+
+    // 11. Clicking outside the picker closes it.
+    test('clicking outside the picker closes it', async () => {
+        const api = await createGrid({
+            columnDefs: [baseColDef()],
+            rowData: [{ id: '0', a: 'Alpha' }],
+            getRowId: (p) => p.data.id,
+        });
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        await openEditor(api, gridDiv, 0, 'a');
+        expect(gridDiv.querySelector('.ag-rich-select-list')).not.toBeNull();
+
+        // Focus leaving the picker to an outside element collapses it.
+        const wrapper = gridDiv.querySelector<HTMLElement>('.ag-picker-field-wrapper')!;
+        fireEvent.focusOut(wrapper, { relatedTarget: document.body });
+        await asyncSetTimeout(1);
+
+        await waitFor(() => expect(gridDiv.querySelector('.ag-rich-select-list')).toBeNull());
+    });
+
+    // 12. Empty/null initial value opens with no highlight; committing from empty works.
+    test('null initial value opens with no highlighted row and commits from empty', async () => {
+        const api = await createGrid({
+            columnDefs: [baseColDef()],
+            rowData: [{ id: '0', a: null }],
+            getRowId: (p) => p.data.id,
+        });
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const popup = await openEditor(api, gridDiv, 0, 'a');
+
+        expect(getRows(popup).some((row) => row.classList.contains('ag-rich-select-row-selected'))).toBe(false);
+
+        await commitByClick(popup, 'Alpha');
+        expect(getAllRows(api)[0].data.a).toBe('Alpha');
+    });
+
+    // 13. Navigation keys while the picker is open drive the list, not grid cell navigation.
+    test('arrow keys navigate the picker list and do not move the focused grid cell', async () => {
+        const api = await createGrid({
+            columnDefs: [baseColDef({ values: ['Alpha', 'Beta', 'Gamma'], filterList: true })],
+            rowData: [
+                { id: '0', a: 'Alpha' },
+                { id: '1', a: 'Beta' },
+            ],
+            getRowId: (p) => p.data.id,
+        });
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const popup = await openEditor(api, gridDiv, 0, 'a');
+
+        pressKey(gridDiv, 'ArrowDown');
+        pressKey(gridDiv, 'ArrowDown');
+        await asyncSetTimeout(1);
+
+        // Highlight moved within the list; the editing cell is still row 0 (grid did not navigate).
+        expect(getHighlightedRow(popup)).toBeTruthy();
+        const editingCells = api.getEditingCells();
+        expect(editingCells).toHaveLength(1);
+        expect(editingCells[0].rowIndex).toBe(0);
+    });
+});

--- a/testing/behavioural/src/status-bar/status-bar-panels.test.ts
+++ b/testing/behavioural/src/status-bar/status-bar-panels.test.ts
@@ -1,0 +1,362 @@
+import type { AggregationStatusPanelAggFunc, GridApi, IStatusPanel } from 'ag-grid-community';
+import { ClientSideRowModelModule, LocaleModule, NumberFilterModule, RowSelectionModule } from 'ag-grid-community';
+import { CellSelectionModule, StatusBarModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, waitForEvent } from '../test-utils';
+
+// Reads the rendered value of a name/value status item (total/filtered/selected panels, and the
+// individual aggregation entries) identified by its label text.
+function getStatusBarValue(gridDiv: HTMLElement, label: string): string | null {
+    const items = Array.from(gridDiv.querySelectorAll<HTMLElement>('.ag-status-name-value'));
+    for (let i = 0, len = items.length; i < len; ++i) {
+        const item = items[i];
+        const labelSpan = item.querySelector('span');
+        if (labelSpan?.textContent === label) {
+            return item.querySelector<HTMLElement>('.ag-status-name-value-value')?.textContent ?? null;
+        }
+    }
+    return null;
+}
+
+// A name/value item is only meaningful to the user when it is displayed; the grid hides items via
+// the `ag-hidden` class rather than removing them from the DOM.
+function isStatusItemDisplayed(gridDiv: HTMLElement, label: string): boolean {
+    const items = Array.from(gridDiv.querySelectorAll<HTMLElement>('.ag-status-name-value'));
+    for (let i = 0, len = items.length; i < len; ++i) {
+        const item = items[i];
+        const labelSpan = item.querySelector('span');
+        if (labelSpan?.textContent === label) {
+            return !item.classList.contains('ag-hidden');
+        }
+    }
+    return false;
+}
+
+function getPanel(gridDiv: HTMLElement, panelClass: string): HTMLElement | null {
+    return gridDiv.querySelector<HTMLElement>(`.${panelClass}`);
+}
+
+function panelClassesInSlot(gridDiv: HTMLElement, slotClass: string): string[] {
+    const slot = gridDiv.querySelector<HTMLElement>(`.${slotClass}`);
+    const panels = slot?.querySelectorAll<HTMLElement>('.ag-status-panel') ?? [];
+    const classes: string[] = [];
+    for (let i = 0, len = panels.length; i < len; ++i) {
+        const panel = panels[i];
+        for (let j = 0, jlen = panel.classList.length; j < jlen; ++j) {
+            const cls = panel.classList[j];
+            if (cls !== 'ag-status-panel') {
+                classes.push(cls);
+            }
+        }
+    }
+    return classes;
+}
+
+async function selectCellRange(
+    api: GridApi,
+    rowStartIndex: number,
+    rowEndIndex: number,
+    columns: string[]
+): Promise<void> {
+    const selectionChanged = waitForEvent('cellSelectionChanged', api);
+    api.addCellRange({ rowStartIndex, rowEndIndex, columns });
+    await selectionChanged;
+}
+
+describe('Status bar panels', () => {
+    const gridMgr = new TestGridsManager({
+        modules: [
+            ClientSideRowModelModule,
+            StatusBarModule,
+            CellSelectionModule,
+            RowSelectionModule,
+            NumberFilterModule,
+            LocaleModule,
+        ],
+    });
+
+    const rowData = [
+        { id: 'r1', name: 'alpha', value: 10 },
+        { id: 'r2', name: 'beta', value: 20 },
+        { id: 'r3', name: 'gamma', value: 30 },
+        { id: 'r4', name: 'delta', value: 40 },
+    ];
+
+    afterEach(() => {
+        gridMgr.reset();
+    });
+
+    test('each configured panel renders in its aligned slot', async () => {
+        const api = await gridMgr.createGridAndWait('status-bar-alignment', {
+            columnDefs: [{ field: 'name' }, { field: 'value' }],
+            rowData,
+            getRowId: (params) => params.data?.id,
+            statusBar: {
+                statusPanels: [
+                    { statusPanel: 'agTotalRowCountComponent', align: 'left' },
+                    { statusPanel: 'agFilteredRowCountComponent', align: 'center' },
+                    { statusPanel: 'agAggregationComponent', align: 'right' },
+                ],
+            },
+        });
+
+        const gridDiv = TestGridsManager.getHTMLElement(api)!;
+        expect(panelClassesInSlot(gridDiv, 'ag-status-bar-left')).toContain('ag-status-panel-total-row-count');
+        expect(panelClassesInSlot(gridDiv, 'ag-status-bar-center')).toContain('ag-status-panel-filtered-row-count');
+        expect(panelClassesInSlot(gridDiv, 'ag-status-bar-right')).toContain('ag-status-panel-aggregations');
+    });
+
+    test('agTotalRowCountComponent shows total and updates on setGridOption rowData', async () => {
+        const api = await gridMgr.createGridAndWait('status-bar-total', {
+            columnDefs: [{ field: 'value' }],
+            rowData,
+            getRowId: (params) => params.data?.id,
+            statusBar: { statusPanels: [{ statusPanel: 'agTotalRowCountComponent' }] },
+        });
+
+        const gridDiv = TestGridsManager.getHTMLElement(api)!;
+        expect(getStatusBarValue(gridDiv, 'Total Rows')).toBe('4');
+
+        const modelUpdated = waitForEvent('modelUpdated', api);
+        api.setGridOption('rowData', [...rowData, { id: 'r5', name: 'epsilon', value: 50 }]);
+        await modelUpdated;
+
+        expect(getStatusBarValue(gridDiv, 'Total Rows')).toBe('5');
+    });
+
+    test('agFilteredRowCountComponent shows filtered count, updates on filter apply/clear', async () => {
+        const api = await gridMgr.createGridAndWait('status-bar-filtered', {
+            columnDefs: [{ field: 'value', filter: 'agNumberColumnFilter' }],
+            rowData,
+            getRowId: (params) => params.data?.id,
+            statusBar: { statusPanels: [{ statusPanel: 'agFilteredRowCountComponent' }] },
+        });
+
+        const gridDiv = TestGridsManager.getHTMLElement(api)!;
+        // No filter active => nothing filtered out => panel hidden.
+        expect(isStatusItemDisplayed(gridDiv, 'Filtered')).toBe(false);
+
+        const filterApplied = waitForEvent('filterChanged', api);
+        api.setFilterModel({ value: { filterType: 'number', type: 'lessThan', filter: 25 } });
+        await filterApplied;
+
+        expect(isStatusItemDisplayed(gridDiv, 'Filtered')).toBe(true);
+        expect(getStatusBarValue(gridDiv, 'Filtered')).toBe('2');
+
+        const filterCleared = waitForEvent('filterChanged', api);
+        api.setFilterModel(null);
+        await filterCleared;
+
+        expect(isStatusItemDisplayed(gridDiv, 'Filtered')).toBe(false);
+    });
+
+    test('agTotalAndFilteredRowCountComponent shows both, hides filtered part when no filter active', async () => {
+        const api = await gridMgr.createGridAndWait('status-bar-total-and-filtered', {
+            columnDefs: [{ field: 'value', filter: 'agNumberColumnFilter' }],
+            rowData,
+            getRowId: (params) => params.data?.id,
+            statusBar: { statusPanels: [{ statusPanel: 'agTotalAndFilteredRowCountComponent' }] },
+        });
+
+        const gridDiv = TestGridsManager.getHTMLElement(api)!;
+        // No filter: just the total, no "x of y".
+        expect(getStatusBarValue(gridDiv, 'Rows')).toBe('4');
+
+        const filterApplied = waitForEvent('filterChanged', api);
+        api.setFilterModel({ value: { filterType: 'number', type: 'lessThan', filter: 25 } });
+        await filterApplied;
+
+        expect(getStatusBarValue(gridDiv, 'Rows')).toBe('2 of 4');
+    });
+
+    test('agSelectedRowCountComponent updates on single, multi, select-all and deselect', async () => {
+        const api = await gridMgr.createGridAndWait('status-bar-selected', {
+            columnDefs: [{ field: 'value' }],
+            rowData,
+            getRowId: (params) => params.data?.id,
+            rowSelection: { mode: 'multiRow' },
+            statusBar: { statusPanels: [{ statusPanel: 'agSelectedRowCountComponent' }] },
+        });
+
+        const gridDiv = TestGridsManager.getHTMLElement(api)!;
+        // Nothing selected => panel hidden.
+        expect(isStatusItemDisplayed(gridDiv, 'Selected')).toBe(false);
+
+        const singleSelected = waitForEvent('selectionChanged', api);
+        api.getRowNode('r1')!.setSelected(true);
+        await singleSelected;
+        expect(isStatusItemDisplayed(gridDiv, 'Selected')).toBe(true);
+        expect(getStatusBarValue(gridDiv, 'Selected')).toBe('1');
+
+        const multiSelected = waitForEvent('selectionChanged', api);
+        api.getRowNode('r2')!.setSelected(true);
+        await multiSelected;
+        expect(getStatusBarValue(gridDiv, 'Selected')).toBe('2');
+
+        const allSelected = waitForEvent('selectionChanged', api);
+        api.selectAll();
+        await allSelected;
+        expect(getStatusBarValue(gridDiv, 'Selected')).toBe('4');
+
+        const allDeselected = waitForEvent('selectionChanged', api);
+        api.deselectAll();
+        await allDeselected;
+        expect(isStatusItemDisplayed(gridDiv, 'Selected')).toBe(false);
+    });
+
+    test('agAggregationComponent shows sum/avg/min/max/count for numeric ranges', async () => {
+        const api = await gridMgr.createGridAndWait('status-bar-agg-numeric', {
+            columnDefs: [{ field: 'value' }],
+            rowData,
+            getRowId: (params) => params.data?.id,
+            cellSelection: true,
+            statusBar: { statusPanels: [{ statusPanel: 'agAggregationComponent' }] },
+        });
+
+        const gridDiv = TestGridsManager.getHTMLElement(api)!;
+        await selectCellRange(api, 0, 3, ['value']);
+
+        expect(getStatusBarValue(gridDiv, 'Count')).toBe('4');
+        expect(getStatusBarValue(gridDiv, 'Sum')).toBe('100');
+        expect(getStatusBarValue(gridDiv, 'Min')).toBe('10');
+        expect(getStatusBarValue(gridDiv, 'Max')).toBe('40');
+        expect(getStatusBarValue(gridDiv, 'Average')).toBe('25');
+    });
+
+    test('agAggregationComponent shows only count for non-numeric ranges', async () => {
+        const api = await gridMgr.createGridAndWait('status-bar-agg-nonnumeric', {
+            columnDefs: [{ field: 'name' }],
+            rowData,
+            getRowId: (params) => params.data?.id,
+            cellSelection: true,
+            statusBar: { statusPanels: [{ statusPanel: 'agAggregationComponent' }] },
+        });
+
+        const gridDiv = TestGridsManager.getHTMLElement(api)!;
+        await selectCellRange(api, 0, 3, ['name']);
+
+        expect(isStatusItemDisplayed(gridDiv, 'Count')).toBe(true);
+        expect(getStatusBarValue(gridDiv, 'Count')).toBe('4');
+        expect(isStatusItemDisplayed(gridDiv, 'Sum')).toBe(false);
+        expect(isStatusItemDisplayed(gridDiv, 'Min')).toBe(false);
+        expect(isStatusItemDisplayed(gridDiv, 'Max')).toBe(false);
+        expect(isStatusItemDisplayed(gridDiv, 'Average')).toBe(false);
+    });
+
+    test('aggregation panel aggFuncs config restricts which aggregations display', async () => {
+        const aggFuncs: AggregationStatusPanelAggFunc[] = ['sum', 'count'];
+        const api = await gridMgr.createGridAndWait('status-bar-agg-funcs', {
+            columnDefs: [{ field: 'value' }],
+            rowData,
+            getRowId: (params) => params.data?.id,
+            cellSelection: true,
+            statusBar: {
+                statusPanels: [{ statusPanel: 'agAggregationComponent', statusPanelParams: { aggFuncs } }],
+            },
+        });
+
+        const gridDiv = TestGridsManager.getHTMLElement(api)!;
+        await selectCellRange(api, 0, 3, ['value']);
+
+        expect(isStatusItemDisplayed(gridDiv, 'Sum')).toBe(true);
+        expect(isStatusItemDisplayed(gridDiv, 'Count')).toBe(true);
+        expect(isStatusItemDisplayed(gridDiv, 'Min')).toBe(false);
+        expect(isStatusItemDisplayed(gridDiv, 'Max')).toBe(false);
+        expect(isStatusItemDisplayed(gridDiv, 'Average')).toBe(false);
+    });
+
+    test('aggregation panel recomputes when the cell range changes', async () => {
+        const api = await gridMgr.createGridAndWait('status-bar-agg-recompute', {
+            columnDefs: [{ field: 'value' }],
+            rowData,
+            getRowId: (params) => params.data?.id,
+            cellSelection: true,
+            statusBar: { statusPanels: [{ statusPanel: 'agAggregationComponent' }] },
+        });
+
+        const gridDiv = TestGridsManager.getHTMLElement(api)!;
+        await selectCellRange(api, 0, 1, ['value']);
+        expect(getStatusBarValue(gridDiv, 'Sum')).toBe('30');
+
+        api.clearCellSelection();
+        await selectCellRange(api, 2, 3, ['value']);
+        expect(getStatusBarValue(gridDiv, 'Sum')).toBe('70');
+    });
+
+    test('getStatusPanel returns the instance and undefined for unknown keys', async () => {
+        const api = await gridMgr.createGridAndWait('status-bar-get-panel', {
+            columnDefs: [{ field: 'value' }],
+            rowData,
+            getRowId: (params) => params.data?.id,
+            statusBar: {
+                statusPanels: [
+                    { statusPanel: 'agTotalRowCountComponent' },
+                    { statusPanel: 'agAggregationComponent', key: 'myAgg' },
+                ],
+            },
+        });
+
+        expect(api.getStatusPanel<IStatusPanel>('agTotalRowCountComponent')).toBeDefined();
+        // custom key is used in preference to the component name
+        expect(api.getStatusPanel<IStatusPanel>('myAgg')).toBeDefined();
+        expect(api.getStatusPanel<IStatusPanel>('agAggregationComponent')).toBeUndefined();
+        expect(api.getStatusPanel<IStatusPanel>('doesNotExist')).toBeUndefined();
+    });
+
+    test('aggregation over a range excludes rows hidden by a filter', async () => {
+        const api = await gridMgr.createGridAndWait('status-bar-agg-hidden-rows', {
+            columnDefs: [{ field: 'value', filter: 'agNumberColumnFilter' }],
+            rowData,
+            getRowId: (params) => params.data?.id,
+            cellSelection: true,
+            statusBar: { statusPanels: [{ statusPanel: 'agAggregationComponent' }] },
+        });
+
+        const gridDiv = TestGridsManager.getHTMLElement(api)!;
+
+        const filterApplied = waitForEvent('filterChanged', api);
+        api.setFilterModel({ value: { filterType: 'number', type: 'lessThan', filter: 25 } });
+        await filterApplied;
+
+        // Only rows r1 (10) and r2 (20) remain displayed; the range spans both displayed rows.
+        await selectCellRange(api, 0, 1, ['value']);
+        expect(getStatusBarValue(gridDiv, 'Count')).toBe('2');
+        expect(getStatusBarValue(gridDiv, 'Sum')).toBe('30');
+    });
+
+    test('status bar is hidden entirely when statusBar removed via setGridOption', async () => {
+        const api = await gridMgr.createGridAndWait('status-bar-removed', {
+            columnDefs: [{ field: 'value' }],
+            rowData,
+            getRowId: (params) => params.data?.id,
+            statusBar: { statusPanels: [{ statusPanel: 'agTotalRowCountComponent' }] },
+        });
+
+        const gridDiv = TestGridsManager.getHTMLElement(api)!;
+        const statusBar = getPanel(gridDiv, 'ag-status-bar')!;
+        expect(statusBar.classList.contains('ag-hidden')).toBe(false);
+
+        api.setGridOption('statusBar', undefined);
+
+        expect(statusBar.classList.contains('ag-hidden')).toBe(true);
+    });
+
+    test('panel labels use provided localeText keys', async () => {
+        const api = await gridMgr.createGridAndWait('status-bar-locale', {
+            columnDefs: [{ field: 'value' }],
+            rowData,
+            getRowId: (params) => params.data?.id,
+            localeText: { totalRows: 'Grand Total', sum: 'Somme' },
+            cellSelection: true,
+            statusBar: {
+                statusPanels: [{ statusPanel: 'agTotalRowCountComponent' }, { statusPanel: 'agAggregationComponent' }],
+            },
+        });
+
+        const gridDiv = TestGridsManager.getHTMLElement(api)!;
+        expect(getStatusBarValue(gridDiv, 'Grand Total')).toBe('4');
+
+        await selectCellRange(api, 0, 3, ['value']);
+        expect(getStatusBarValue(gridDiv, 'Somme')).toBe('100');
+    });
+});


### PR DESCRIPTION
Adds behavioural tests for two enterprise features flagged as under-covered in the AG-17857 coverage audit.

- **Rich Select** — 14 cases (open/commit, keyboard nav, allowTyping, object values, async/paged values, multiSelect, search, highlightMatch).
- **Status Bar** — 13 cases (all panels, alignment slots, `getStatusPanel`, aggregation, row visibility, removal, localeText).

Behavioural suite only; no runtime changes.