### PR TITLE
Add SONARCLOUD_ENABLED guard to commented-out SonarQube steps

### DIFF
--- a/.github/workflows/full-clean-build.yml
+++ b/.github/workflows/full-clean-build.yml
@@ -179,7 +179,8 @@ jobs:
 #
 #      - name: SonarQube Analysis Community
 #        uses: SonarSource/sonarqube-scan-action@v5.2.0
-#        if: ${{ !inputs.fast_build }}
+#        # Set org-scoped GHA variable SONARCLOUD_ENABLED=false to skip when re-enabled.
+#        if: ${{ !inputs.fast_build && vars.SONARCLOUD_ENABLED != 'false' }}
 #        env:
 #          SONAR_HOST_URL: https://sonarcloud.io
 #          SONAR_TOKEN: ${{ secrets.SONAR_COMMUNITY_LOGIN }}
@@ -197,7 +198,8 @@ jobs:
 #
 #      - name: SonarQube Analysis Enterprise
 #        uses: SonarSource/sonarqube-scan-action@v5.2.0
-#        if: ${{ !inputs.fast_build }}
+#        # Set org-scoped GHA variable SONARCLOUD_ENABLED=false to skip when re-enabled.
+#        if: ${{ !inputs.fast_build && vars.SONARCLOUD_ENABLED != 'false' }}
 #        env:
 #          SONAR_TOKEN: ${{ secrets.SONAR_ENTERPRISE_LOGIN }}
 #          SONAR_HOST_URL: https://sonarcloud.io


### PR DESCRIPTION
Bakes the org-scoped GitHub Actions variable kill-switch (`SONARCLOUD_ENABLED`, introduced in ag-charts) into the `if:` conditions of the commented-out SonarQube Analysis steps in `full-clean-build.yml`, combined with the existing `!inputs.fast_build` guard:

```
if: ${{ !inputs.fast_build && vars.SONARCLOUD_ENABLED != 'false' }}
```

**No runtime effect:** these steps have been commented out since 2025-07-29, so nothing changes in active CI. This only ensures that whenever the block is re-enabled it honours the same central kill-switch as ag-charts and ag-studio.

Note: ag-grid's currently-failing SonarCloud checks are **not** produced by this workflow — they come from SonarCloud's Automatic Analysis (the SonarCloud GitHub App), which is toggled in SonarCloud project settings (Administration → Analysis Method), not via a GHA variable. This PR does not affect those.