### PR TITLE
[AG-17857] Test(master-detail): behavioural coverage for master/detail example specs

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/master-detail-custom-detail/_examples/custom-detail-keyboard-navigation/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-custom-detail/_examples/custom-detail-keyboard-navigation/example.spec.ts
@@ -1,11 +1,27 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Custom detail keyboard navigation', async ({ agIdFor, page }) => {
+        // Master row '1' (Mila Smith) is expanded on first data rendered.
+        await expect(agIdFor.cell('1', 'name')).toContainText('Mila Smith');
+
+        // The custom detail renders a form populated from the master row's first call record
+        // (callId 579, number "(02) 47485405", direction "Out").
+        const detail = page.locator('.ag-full-width-row');
+        const inputs = detail.locator('input');
+        await expect(inputs).toHaveCount(3);
+        await expect(inputs.nth(0)).toHaveValue('579');
+        await expect(inputs.nth(1)).toHaveValue('(02) 47485405');
+        await expect(inputs.nth(2)).toHaveValue('Out');
+
+        // Focusing a cell in the master row then Tabbing forward moves focus into the custom
+        // detail panel, landing on the first input (per the focus handler in the cell renderer).
+        await agIdFor.cell('1', 'minutes').click();
+        await page.keyboard.press('Tab');
+
+        const activeValue = await page.evaluate(
+            () => (document.activeElement as HTMLInputElement | null)?.value ?? null
+        );
+        expect(activeValue).toBe('579');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-custom-detail/_examples/custom-detail-with-form/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-custom-detail/_examples/custom-detail-with-form/example.spec.ts
@@ -1,11 +1,21 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Custom detail cell renderer with form', async ({ agIdFor, page }) => {
+        // Master row '1' (Mila Smith) is expanded on first data rendered.
+        await expect(agIdFor.cell('1', 'name')).toContainText('Mila Smith');
+
+        // The custom detail renders a form (not a grid) populated from the master
+        // row's first call record (callId 579, number "(02) 47485405", direction "Out").
+        const detail = page.locator('.ag-full-width-row');
+        await expect(detail).toContainText('Call Id:');
+        await expect(detail).toContainText('Number:');
+        await expect(detail).toContainText('Direction:');
+
+        const inputs = detail.locator('input');
+        await expect(inputs).toHaveCount(3);
+        await expect(inputs.nth(0)).toHaveValue('579');
+        await expect(inputs.nth(1)).toHaveValue('(02) 47485405');
+        await expect(inputs.nth(2)).toHaveValue('Out');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-custom-detail/_examples/custom-detail-with-form/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-custom-detail/_examples/custom-detail-with-form/example.spec.ts
@@ -7,7 +7,9 @@ test.agExample(import.meta, () => {
 
         // The custom detail renders a form (not a grid) populated from the master
         // row's first call record (callId 579, number "(02) 47485405", direction "Out").
-        const detail = page.locator('.ag-full-width-row');
+        // Some frameworks pre-render every detail row (all but the expanded one are hidden),
+        // so scope to the expanded master row '1' detail row explicitly.
+        const detail = page.getByTestId('ag-row:row-id=detail_1');
         await expect(detail).toContainText('Call Id:');
         await expect(detail).toContainText('Number:');
         await expect(detail).toContainText('Direction:');

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-custom-detail/_examples/custom-detail-with-grid/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-custom-detail/_examples/custom-detail-with-grid/example.spec.ts
@@ -1,11 +1,25 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Custom detail cell renderer with grid', async ({ agIdFor, page }) => {
+        // Master row at display index 1 (Mila Smith) is expanded on first data rendered.
+        await expect(agIdFor.cell('1', 'name')).toContainText('Mila Smith');
+
+        // The custom detail renders master row info plus a nested detail grid.
+        const detail = page.locator('.ag-full-width-row');
+        await expect(detail).toContainText('Name:');
+        await expect(detail).toContainText('Mila Smith');
+        await expect(detail).toContainText('Account:');
+        await expect(detail).toContainText('177001');
+
+        // The nested detail grid renders its five configured columns.
+        const detailGrid = detail.locator('.ag-root-wrapper');
+        await expect(detailGrid).toBeVisible();
+        for (const colId of ['callId', 'direction', 'number', 'duration', 'switchCode']) {
+            await expect(detailGrid.locator(`.ag-header-cell[col-id="${colId}"]`)).toBeVisible();
+        }
+
+        // The nested grid is populated from the master row's call records (first callId 579).
+        await expect(detailGrid.locator('.ag-cell[col-id="callId"]').first()).toContainText('579');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-custom-detail/_examples/custom-detail-with-refresh/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-custom-detail/_examples/custom-detail-with-refresh/example.spec.ts
@@ -1,11 +1,24 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Custom detail with refresh', async ({ agIdFor, page }) => {
+        // All master rows are expanded (groupDefaultExpanded: 1). The first row (Nora Thomas)
+        // is the one whose data is updated on an interval; its detail row id is "detail_0".
+        await expect(agIdFor.cell('0', 'name')).toContainText('Nora Thomas');
+
+        const detail = page.locator('[row-id="detail_0"]');
+        await expect(detail).toContainText('Calls:');
+        await expect(detail).toContainText('Last Updated:');
+
+        // The example applies a transaction update to the first row every 2s, which triggers
+        // refresh() on its detail cell renderer (returning true so the component updates in place
+        // rather than being destroyed and recreated). The rendered call count increases over time.
+        const callsInput = detail.locator('input').first();
+        const before = Number(await callsInput.inputValue());
+        expect(before).toBeGreaterThanOrEqual(24);
+
+        await page.waitForTimeout(2500);
+        const after = Number(await callsInput.inputValue());
+        expect(after).toBeGreaterThan(before);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-custom-detail/_examples/simple-custom-detail/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-custom-detail/_examples/simple-custom-detail/example.spec.ts
@@ -1,11 +1,21 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Simple custom detail cell renderer', async ({ agIdFor, page }) => {
+        // Master row '1' (Mila Smith) is expanded on first data rendered.
+        await expect(agIdFor.cell('1', 'name')).toContainText('Mila Smith');
+
+        // The custom detail cell renderer shows the "My Custom Detail" message
+        // where the default detail grid would normally appear.
+        const detail = page.locator('.ag-full-width-row');
+        await expect(detail).toContainText('My Custom Detail');
+
+        // Collapsing the master row removes the custom detail.
+        await agIdFor.groupExpanded('1', 'name').click();
+        await expect(detail).toHaveCount(0);
+
+        // Re-expanding renders the custom detail again.
+        await agIdFor.groupContracted('1', 'name').click();
+        await expect(page.locator('.ag-full-width-row')).toContainText('My Custom Detail');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/detail-grid-api/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/detail-grid-api/example.spec.ts
@@ -1,11 +1,26 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('All master rows are expanded and flash buttons flash detail cells', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // onFirstDataRendered expands every master row, so a detail grid renders for each of the 5 accounts.
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(5);
+
+        // 'Flash Mila Smith' uses getDetailGridInfo('detail_177001') to flash only Mila's detail grid.
+        // getRowId uses the account attribute, and Mila (account 177001) is the row at index 1.
+        const milaDetail = detailRows.nth(1);
+        await page.getByRole('button', { name: 'Flash Mila Smith' }).click();
+        await expect(milaDetail.locator('.ag-cell-data-changed').first()).toBeVisible();
+
+        // Only Mila's detail grid flashed - the first account's detail grid has no flashed cells.
+        await expect(detailRows.nth(0).locator('.ag-cell-data-changed')).toHaveCount(0);
+
+        // 'Flash All' uses forEachDetailGridInfo to flash every detail grid.
+        await page.getByRole('button', { name: 'Flash All' }).click();
+        await expect(detailRows.nth(0).locator('.ag-cell-data-changed').first()).toBeVisible();
+        await expect(detailRows.nth(4).locator('.ag-cell-data-changed').first()).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/dynamic-params/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/dynamic-params/example.spec.ts
@@ -1,11 +1,27 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Detail grids get different columns based on the master row', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // onFirstDataRendered expands rows at index 1 (Mila Smith) and index 2 (Evelyn Taylor).
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(2);
+
+        // Mila Smith matches the name check, so her detail grid only has the {Call Id, Number} columns.
+        const milaDetail = detailRows.nth(0);
+        await expect(milaDetail.locator('.ag-header-cell-text')).toContainText(['Call Id', 'Number']);
+        await expect(milaDetail.locator('.ag-header-cell-text')).toHaveCount(2);
+
+        // Evelyn Taylor does not match, so her detail grid has the full column set.
+        const evelynDetail = detailRows.nth(1);
+        await expect(evelynDetail.locator('.ag-header-cell-text')).toContainText([
+            'Call Id',
+            'Direction',
+            'Duration',
+            'Switch Code',
+        ]);
+        await expect(evelynDetail.locator('.ag-header-cell-text')).toHaveCount(4);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/grid-options/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/grid-options/example.spec.ts
@@ -1,11 +1,35 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Detail grid renders configured columns with pagination and selection', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // onFirstDataRendered expands the row at index 1 (Mila Smith), so one detail grid renders on load.
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(1);
+        const detail = detailRows.first();
+        await expect(detail).toBeVisible();
+
+        // Detail grid exposes the call-record columns defined in detailGridOptions.
+        await expect(detail.locator('.ag-header-cell-text')).toContainText([
+            'Call Id',
+            'Direction',
+            'Number',
+            'Duration',
+            'Switch Code',
+        ]);
+
+        // pagination=true means the detail grid shows a paging panel.
+        await expect(detail.locator('.ag-paging-panel')).toBeVisible();
+
+        // rowSelection mode 'multiRow' adds per-row selection checkboxes to the detail grid.
+        await expect(detail.locator('.ag-selection-checkbox').first()).toBeVisible();
+
+        // headerCheckbox=false means the detail grid header has no select-all checkbox.
+        await expect(detail.locator('.ag-header-select-all')).toHaveCount(0);
+
+        // duration values are formatted with an 's' suffix by the detail grid's valueFormatter.
+        await expect(detail).toContainText('s');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/keep-detail-rows/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/keep-detail-rows/example.spec.ts
@@ -1,11 +1,33 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Detail row state is retained when the master row is re-opened', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // onFirstDataRendered expands the row at index 1, so one detail grid renders on load.
+        const detailRow = page.locator('.ag-details-row').first();
+        await expect(detailRow).toBeVisible();
+
+        const ascendingIcon = () =>
+            detailRow
+                .locator('.ag-header-cell', { has: page.locator('.ag-header-cell-text', { hasText: 'Call Id' }) })
+                .locator('.ag-sort-indicator-icon.ag-sort-ascending-icon');
+
+        // Sort the detail grid by the 'Call Id' column by clicking its header.
+        await detailRow
+            .locator('.ag-header-cell', { has: page.locator('.ag-header-cell-text', { hasText: 'Call Id' }) })
+            .click();
+        await expect(ascendingIcon()).toBeVisible();
+
+        // Collapse the master row. With keepDetailRows=true the detail grid is cached (kept in the DOM
+        // but hidden) rather than destroyed, so its sort state survives.
+        await agIdFor.groupExpanded('1', 'name').click();
+        await expect(detailRow).not.toBeVisible();
+
+        // Re-open the master row: the cached detail grid returns with its ascending sort still applied.
+        await agIdFor.groupContracted('1', 'name').click();
+        await expect(detailRow).toBeVisible();
+        await expect(ascendingIcon()).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/lazy-load-rows/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/lazy-load-rows/example.spec.ts
@@ -1,11 +1,30 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Detail rows are supplied asynchronously via getDetailRowData', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // No master row is auto-expanded, so no detail grid is present initially.
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(0);
+
+        // Expand the first master row (Nora Thomas).
+        await agIdFor.groupContracted('0', 'name').click();
+
+        // The detail grid appears immediately with its column headers...
+        await expect(detailRows).toHaveCount(1);
+        await expect(detailRows.first().locator('.ag-header-cell-text')).toContainText([
+            'Call Id',
+            'Direction',
+            'Number',
+            'Duration',
+            'Switch Code',
+        ]);
+
+        // ...but the row data is supplied after a 1s setTimeout, so it eventually renders call records.
+        // Nora Thomas's first call record has callId 555, and durations are formatted with an 's' suffix.
+        await expect(detailRows.first()).toContainText('555');
+        await expect(detailRows.first()).toContainText('s');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/row-selection/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/row-selection/example.spec.ts
@@ -1,11 +1,32 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Selecting a master row selects all rows in its detail grid', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // onFirstDataRendered expands the row at index 1 (Mila Smith), so one detail grid renders on load.
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(1);
+        const detail = detailRows.first();
+
+        // The master and detail grids both have a row with row-id=1. The master row is a level-0 group row
+        // rendered before its detail grid in the DOM, so .first() disambiguates it from the detail row.
+        const masterRow1 = page.locator('.ag-row[row-id="1"]').first();
+
+        // Select the master row via its selection checkbox.
+        await masterRow1.locator('.ag-selection-checkbox .ag-checkbox-input').click();
+
+        // masterSelects='detail' means selecting the master row selects every row in the detail grid.
+        await expect(masterRow1).toHaveClass(/ag-row-selected/);
+        const detailDataRows = detail.locator('.ag-row');
+        const detailSelected = detail.locator('.ag-row.ag-row-selected');
+        await expect(detailSelected).toHaveCount(await detailDataRows.count());
+
+        // Deselecting a single detail row puts the master row into the indeterminate state.
+        await detail.locator('.ag-row').first().locator('.ag-selection-checkbox .ag-checkbox-input').click();
+        await expect(masterRow1.locator('.ag-selection-checkbox .ag-checkbox-input-wrapper')).toHaveClass(
+            /ag-indeterminate/
+        );
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/string-template-customisation/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/string-template-customisation/example.spec.ts
@@ -1,12 +1,26 @@
-import { clickAllButtons, ensureGridReady, test } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ agFramework, page }) => {
-        test.skip(agFramework.includes('react'), 'Example not for React.');
-
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Detail rows use a static string template with a fixed title', async ({ page }) => {
         await ensureGridReady(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+        await waitForGridContent(page);
+
+        // The custom string template replaces the default detail wrapper, so locate the detail grid by its
+        // eDetailGrid host. onFirstDataRendered expands the row at index 1, so one detail grid renders on load.
+        const detail = page.locator('[data-ref="eDetailGrid"]');
+        await expect(detail).toHaveCount(1);
+        await expect(detail).toBeVisible();
+
+        // The custom string template wraps the detail grid with a fixed 'Call Details' title.
+        await expect(page.locator('.ag-full-width-row')).toContainText('Call Details');
+
+        // The eDetailGrid ref still hosts a fully functional detail grid with the call-record columns.
+        await expect(detail.locator('.ag-header-cell-text')).toContainText([
+            'Call Id',
+            'Direction',
+            'Number',
+            'Duration',
+            'Switch Code',
+        ]);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/string-template-customisation/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/string-template-customisation/example.spec.ts
@@ -1,7 +1,9 @@
 import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Detail rows use a static string template with a fixed title', async ({ page }) => {
+    test.eachFramework('Detail rows use a static string template with a fixed title', async ({ agFramework, page }) => {
+        test.skip(agFramework.includes('react'), 'Example not for React.');
+
         await ensureGridReady(page);
         await waitForGridContent(page);
 

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/template-callback-customisation/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/template-callback-customisation/example.spec.ts
@@ -1,12 +1,21 @@
-import { clickAllButtons, ensureGridReady, test } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ agFramework, page }) => {
-        test.skip(agFramework.includes('react'), 'Example not for React.');
-
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Detail rows use a dynamic template showing the master row name', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+        await waitForGridContent(page);
+
+        // The custom function template replaces the default detail wrapper. onFirstDataRendered expands the
+        // row at index 1 (Mila Smith), so one detail grid renders on load.
+        const detailHosts = page.locator('[data-ref="eDetailGrid"]');
+        await expect(detailHosts).toHaveCount(1);
+
+        // The function template builds a title from the master row's data, e.g. 'Name: Mila Smith'.
+        await expect(page.locator('.ag-full-width-row', { hasText: 'Name: Mila Smith' })).toBeVisible();
+
+        // Expanding a different master row produces a template titled with that row's name.
+        await agIdFor.groupContracted('3', 'name').click();
+        await expect(detailHosts).toHaveCount(2);
+        await expect(page.locator('.ag-full-width-row', { hasText: 'Name: Harper Johnson' })).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/template-callback-customisation/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/template-callback-customisation/example.spec.ts
@@ -1,27 +1,26 @@
 import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Detail rows use a dynamic template showing the master row name', async ({
-        agIdFor,
-        agFramework,
-        page,
-    }) => {
-        test.skip(agFramework.includes('react'), 'Example not for React.');
+    test.eachFramework(
+        'Detail rows use a dynamic template showing the master row name',
+        async ({ agIdFor, agFramework, page }) => {
+            test.skip(agFramework.includes('react'), 'Example not for React.');
 
-        await ensureGridReady(page);
-        await waitForGridContent(page);
+            await ensureGridReady(page);
+            await waitForGridContent(page);
 
-        // The custom function template replaces the default detail wrapper. onFirstDataRendered expands the
-        // row at index 1 (Mila Smith), so one detail grid renders on load.
-        const detailHosts = page.locator('[data-ref="eDetailGrid"]');
-        await expect(detailHosts).toHaveCount(1);
+            // The custom function template replaces the default detail wrapper. onFirstDataRendered expands the
+            // row at index 1 (Mila Smith), so one detail grid renders on load.
+            const detailHosts = page.locator('[data-ref="eDetailGrid"]');
+            await expect(detailHosts).toHaveCount(1);
 
-        // The function template builds a title from the master row's data, e.g. 'Name: Mila Smith'.
-        await expect(page.locator('.ag-full-width-row', { hasText: 'Name: Mila Smith' })).toBeVisible();
+            // The function template builds a title from the master row's data, e.g. 'Name: Mila Smith'.
+            await expect(page.locator('.ag-full-width-row', { hasText: 'Name: Mila Smith' })).toBeVisible();
 
-        // Expanding a different master row produces a template titled with that row's name.
-        await agIdFor.groupContracted('3', 'name').click();
-        await expect(detailHosts).toHaveCount(2);
-        await expect(page.locator('.ag-full-width-row', { hasText: 'Name: Harper Johnson' })).toBeVisible();
-    });
+            // Expanding a different master row produces a template titled with that row's name.
+            await agIdFor.groupContracted('3', 'name').click();
+            await expect(detailHosts).toHaveCount(2);
+            await expect(page.locator('.ag-full-width-row', { hasText: 'Name: Harper Johnson' })).toBeVisible();
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/template-callback-customisation/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-grids/_examples/template-callback-customisation/example.spec.ts
@@ -1,7 +1,13 @@
 import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Detail rows use a dynamic template showing the master row name', async ({ agIdFor, page }) => {
+    test.eachFramework('Detail rows use a dynamic template showing the master row name', async ({
+        agIdFor,
+        agFramework,
+        page,
+    }) => {
+        test.skip(agFramework.includes('react'), 'Example not for React.');
+
         await ensureGridReady(page);
         await waitForGridContent(page);
 

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-height/_examples/auto-height/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-height/_examples/auto-height/example.spec.ts
@@ -1,11 +1,29 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('detailRowAutoHeight sizes the detail row to fit all its call records', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // onFirstDataRendered auto-expands the master row at index 1 (Mila Smith, 24 call records).
+        const detail = page.locator('.ag-details-row').first();
+        await expect(detail).toBeVisible();
+
+        // The detail grid exposes the call-record columns defined in detailGridOptions.
+        await expect(detail.locator('.ag-header-cell-text')).toContainText([
+            'Call Id',
+            'Direction',
+            'Number',
+            'Duration',
+            'Switch Code',
+        ]);
+
+        // With detailRowAutoHeight all 24 records render (no row virtualisation) and the
+        // detail row auto-sizes to fit them, so it grows well beyond the default 300px.
+        await expect(detail.locator('.ag-row')).toHaveCount(24);
+
+        const box = await detail.boundingBox();
+        expect(box).not.toBeNull();
+        expect(box!.height).toBeGreaterThan(400);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-height/_examples/custom-detail-auto-height/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-height/_examples/custom-detail-auto-height/example.spec.ts
@@ -1,11 +1,30 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('custom detail renderer auto-sizes its row as content is toggled', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // onFirstDataRendered auto-expands the master row at index 1. The custom Detail Cell Renderer
+        // (not a detail grid) renders inside a full-width row.
+        const detail = page.locator('.ag-full-width-row').first();
+        await expect(detail).toBeVisible();
+
+        // The custom renderer shows a toggle button.
+        const toggle = detail.getByRole('button', { name: 'Show Optional Element' });
+        await expect(toggle).toBeVisible();
+
+        // Measure the detail row height before revealing the optional 100px panel.
+        const boxBefore = await detail.boundingBox();
+        expect(boxBefore).not.toBeNull();
+
+        // Revealing the optional element adds a 100px panel; detailRowAutoHeight regrows the row to fit it.
+        await toggle.click();
+        await expect(detail.getByRole('button', { name: 'Hide Optional Element' })).toBeVisible();
+        await expect(detail).toContainText('Optional element content');
+
+        const boxAfter = await detail.boundingBox();
+        expect(boxAfter).not.toBeNull();
+        expect(boxAfter!.height).toBeGreaterThan(boxBefore!.height + 80);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-height/_examples/dynamic-detail-row-height/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-height/_examples/dynamic-detail-row-height/example.spec.ts
@@ -1,11 +1,41 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'getRowHeight sizes each detail row by its number of call records',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
+
+            // onFirstDataRendered auto-expands the master row at index 1 (Mila Smith, 10 call records).
+            // Expand the first master row too (Nora Thomas, 5 call records).
+            await agIdFor.groupContracted('0', 'name').click();
+
+            // Detail grids use domLayout autoHeight, so every record renders. Distinguish the two
+            // detail grids by their first call id: row 0 -> 555, row 1 -> 579.
+            const detailShort = page
+                .locator('.ag-details-row')
+                .filter({ has: page.locator('[col-id="callId"]', { hasText: '555' }) })
+                .first();
+            const detailTall = page
+                .locator('.ag-details-row')
+                .filter({ has: page.locator('[col-id="callId"]', { hasText: '579' }) })
+                .first();
+
+            await expect(detailShort).toBeVisible();
+            await expect(detailTall).toBeVisible();
+
+            // 5 records vs 10 records rendered in each detail grid.
+            await expect(detailShort.locator('.ag-row')).toHaveCount(5);
+            await expect(detailTall.locator('.ag-row')).toHaveCount(10);
+
+            // getRowHeight scales the detail row height by callRecords.length, so the 10-record
+            // detail is measurably taller than the 5-record detail.
+            const boxShort = await detailShort.boundingBox();
+            const boxTall = await detailTall.boundingBox();
+            expect(boxShort).not.toBeNull();
+            expect(boxTall).not.toBeNull();
+            expect(boxTall!.height).toBeGreaterThan(boxShort!.height + 100);
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-height/_examples/fixed-detail-row-height/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-height/_examples/fixed-detail-row-height/example.spec.ts
@@ -1,11 +1,29 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('detailRowHeight fixes the detail row height at 200px', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // onFirstDataRendered auto-expands the master row at index 1, so exactly one detail grid renders on load.
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(1);
+        await expect(detailRows.first()).toBeVisible();
+
+        // The detail grid exposes the call-record columns defined in detailGridOptions.
+        await expect(detailRows.first().locator('.ag-header-cell-text')).toContainText([
+            'Call Id',
+            'Direction',
+            'Number',
+            'Duration',
+            'Switch Code',
+        ]);
+
+        // detailRowHeight: 200 fixes the detail row height at 200px regardless of how many
+        // call records exist, so it is shorter than the default 300px fixed height.
+        const box = await detailRows.first().boundingBox();
+        expect(box).not.toBeNull();
+        expect(box!.height).toBeGreaterThan(180);
+        expect(box!.height).toBeLessThan(220);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-master-rows/_examples/changing-dynamic-1/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-master-rows/_examples/changing-dynamic-1/example.spec.ts
@@ -1,11 +1,40 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // getRowId uses the account, so row ids are the account numbers.
+    const NORA = '177000';
+    const MILA = '177001';
+
+    test.eachFramework('Row with no call records is not a master row', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Nora Thomas has no detail records, so isRowMaster returns false: the cell is not expandable.
+        await expect(agIdFor.cell(NORA, 'name')).toContainText('Nora Thomas');
+        await expect(agIdFor.cell(NORA, 'name').locator('.ag-cell-expandable')).toHaveCount(0);
+
+        // Mila Smith has detail records, so it is a master row (auto-expanded by onFirstDataRendered).
+        await expect(agIdFor.cell(MILA, 'name')).toContainText('Mila Smith');
+        await expect(agIdFor.cell(MILA, 'name').locator('.ag-cell-expandable')).toBeVisible();
+        await expect(agIdFor.groupExpanded(MILA, 'name')).toBeVisible();
+        await expect(page.locator('.ag-details-row')).toHaveCount(1);
+    });
+
+    test.eachFramework('Clearing calls via transaction makes the row non-expandable', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        // Mila starts expandable with a detail grid open.
+        await expect(agIdFor.cell(MILA, 'name').locator('.ag-cell-expandable')).toBeVisible();
+        await expect(page.locator('.ag-details-row')).toHaveCount(1);
+
+        // Clearing Mila's calls updates the row; isRowMaster is re-called and now returns false.
+        await page.getByRole('button', { name: 'Clear Mila Calls' }).click();
+        await expect(agIdFor.cell(MILA, 'name').locator('.ag-cell-expandable')).toHaveCount(0);
+        await expect(page.locator('.ag-details-row')).toHaveCount(0);
+
+        // Setting Mila's calls again makes the row a master row once more.
+        await page.getByRole('button', { name: 'Set Mila Calls' }).click();
+        await expect(agIdFor.cell(MILA, 'name').locator('.ag-cell-expandable')).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-master-rows/_examples/changing-dynamic-2/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-master-rows/_examples/changing-dynamic-2/example.spec.ts
@@ -1,11 +1,48 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // getRowId uses the account, so row ids are the account numbers.
+    const NORA = '177000';
+    const MILA = '177001';
+
+    test.eachFramework('Adding a call row makes a non-master row an expanded master', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Nora Thomas has no calls, so is not a master row initially.
+        await expect(agIdFor.cell(NORA, 'name')).toContainText('Nora Thomas');
+        await expect(agIdFor.cell(NORA, 'name').locator('.ag-cell-expandable')).toHaveCount(0);
+
+        // Only Mila's auto-expanded detail grid is present on load.
+        await expect(page.locator('.ag-details-row')).toHaveCount(1);
+
+        // Clicking '+' in Nora's calls cell adds a detail row, makes the row expandable, and expands it.
+        await agIdFor.cell(NORA, 'calls').getByRole('button', { name: '+' }).click();
+        await expect(agIdFor.cell(NORA, 'name').locator('.ag-cell-expandable')).toBeVisible();
+        await expect(agIdFor.groupExpanded(NORA, 'name')).toBeVisible();
+        await expect(page.locator('.ag-details-row')).toHaveCount(2);
+    });
+
+    test.eachFramework('Removing all calls makes a master row non-expandable', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        // Mila Smith is a master row (auto-expanded) with call records.
+        await expect(agIdFor.cell(MILA, 'name')).toContainText('Mila Smith');
+        await expect(agIdFor.cell(MILA, 'name').locator('.ag-cell-expandable')).toBeVisible();
+
+        // Read Mila's current call count from the calls cell.
+        const callsText = await agIdFor.cell(MILA, 'calls').innerText();
+        const callCount = parseInt(callsText.replace(/[^0-9]/g, ''), 10);
+        expect(callCount).toBeGreaterThan(0);
+
+        const removeButton = agIdFor.cell(MILA, 'calls').getByRole('button', { name: '-' });
+        for (let i = 0; i < callCount; ++i) {
+            await removeButton.click();
+        }
+
+        // With no call records left, isRowMaster returns false: the row is no longer expandable.
+        await expect(agIdFor.cell(MILA, 'name').locator('.ag-cell-expandable')).toHaveCount(0);
+        await expect(page.locator('.ag-details-row')).toHaveCount(0);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-master-rows/_examples/dynamic/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-master-rows/_examples/dynamic/example.spec.ts
@@ -1,11 +1,38 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('isRowMaster only makes rows with call records expandable', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Row '0' (Nora Thomas) has no call records, so isRowMaster returns false: the cell is not
+        // expandable and neither expand control is shown.
+        await expect(agIdFor.cell('0', 'name')).toContainText('Nora Thomas');
+        await expect(agIdFor.cell('0', 'name').locator('.ag-cell-expandable')).toHaveCount(0);
+        await expect(agIdFor.groupContracted('0', 'name')).not.toBeVisible();
+        await expect(agIdFor.groupExpanded('0', 'name')).not.toBeVisible();
+
+        // Row '1' has call records, so it is a master row: the cell is expandable.
+        // onFirstDataRendered expands the row at index 1, so its expanded control is shown.
+        await expect(agIdFor.cell('1', 'name').locator('.ag-cell-expandable')).toBeVisible();
+        await expect(agIdFor.groupExpanded('1', 'name')).toBeVisible();
+
+        // Row '2' is also a master row but collapsed, so its contracted control is shown.
+        await expect(agIdFor.cell('2', 'name').locator('.ag-cell-expandable')).toBeVisible();
+        await expect(agIdFor.groupContracted('2', 'name')).toBeVisible();
+    });
+
+    test.eachFramework('Auto-expanded master row renders its detail grid with call columns', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        // Exactly one detail grid on load (the auto-expanded master row).
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(1);
+        await expect(detailRows.first()).toBeVisible();
+
+        // Detail grid exposes the call-record columns from detailGridOptions.
+        const detailHeader = detailRows.first().locator('.ag-header-cell-text');
+        await expect(detailHeader).toContainText(['Call Id', 'Direction', 'Number', 'Duration', 'Switch Code']);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-nesting/_examples/nesting-autoheight/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-nesting/_examples/nesting-autoheight/example.spec.ts
@@ -1,11 +1,48 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Nested master / detail renders with auto detail row height', async ({ agIdFor, page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Level 1 (master grid) shows its own columns.
+        await expect(agIdFor.cell('0', 'a1')).toContainText('level 1 - 111');
+        await expect(agIdFor.cell('0', 'b1')).toContainText('level 1 - 222');
+
+        // groupDefaultExpanded=1 auto-expands the master row, so the Level 2 detail grid is shown.
+        const level2 = page
+            .locator('.ag-details-row')
+            .filter({ has: page.locator('[col-id="a2"]', { hasText: 'level 2 - 333' }) })
+            .first();
+        await expect(level2).toBeVisible();
+        await expect(level2.locator('.ag-root-wrapper').first()).toBeVisible();
+        await expect(level2.locator('[col-id="b2"]', { hasText: 'level 2 - 444' }).first()).toBeVisible();
+
+        // The Level 2 detail grid is itself a master grid; its row auto-expands to reveal the Level 3 detail grid.
+        const level3 = page
+            .locator('.ag-details-row')
+            .filter({ has: page.locator('[col-id="a3"]', { hasText: 'level 3 - 5551' }) })
+            .first();
+        await expect(level3).toBeVisible();
+        await expect(level3.locator('.ag-root-wrapper').first()).toBeVisible();
+
+        // With detailRowAutoHeight=true the Level 3 grid grows to fit all its rows, so every one of the
+        // six Level 3 rows is visible without needing to scroll the detail grid.
+        for (let i = 1; i <= 6; i++) {
+            await expect(level3.locator('[col-id="a3"]', { hasText: `level 3 - 555${i}` }).first()).toBeVisible();
+            await expect(level3.locator('[col-id="b3"]', { hasText: `level 3 - 666${i}` }).first()).toBeVisible();
+        }
+
+        // Both master rows are expanded, so there are four detail rows in total:
+        // one Level 2 detail grid per master row, each containing one nested Level 3 detail grid.
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(4);
+
+        // Collapsing the first master row removes its whole nested structure (its Level 2 grid and the Level 3 child).
+        await agIdFor.groupExpanded('0', 'a1').click();
+        await expect(detailRows).toHaveCount(2);
+
+        // Re-expanding the master row brings its nested detail grids back.
+        await agIdFor.groupContracted('0', 'a1').click();
+        await expect(detailRows).toHaveCount(4);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-nesting/_examples/nesting/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-nesting/_examples/nesting/example.spec.ts
@@ -1,11 +1,42 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
+    test.eachFramework('Two levels of nested master / detail render', async ({ agIdFor, page }) => {
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Level 1 (master grid) shows its own columns.
+        await expect(agIdFor.cell('0', 'a1')).toContainText('level 1 - 111');
+        await expect(agIdFor.cell('0', 'b1')).toContainText('level 1 - 222');
+
+        // groupDefaultExpanded=1 auto-expands the master row, so the Level 2 detail grid is shown.
+        const level2 = page
+            .locator('.ag-details-row')
+            .filter({ has: page.locator('[col-id="a2"]', { hasText: 'level 2 - 333' }) })
+            .first();
+        await expect(level2).toBeVisible();
+        await expect(level2.locator('.ag-root-wrapper').first()).toBeVisible();
+        await expect(level2.locator('[col-id="b2"]', { hasText: 'level 2 - 444' }).first()).toBeVisible();
+
+        // The Level 2 detail grid is itself a master grid; its row auto-expands to reveal the Level 3 detail grid.
+        const level3 = page
+            .locator('.ag-details-row')
+            .filter({ has: page.locator('[col-id="a3"]', { hasText: 'level 3 - 5551' }) })
+            .first();
+        await expect(level3).toBeVisible();
+        await expect(level3.locator('.ag-root-wrapper').first()).toBeVisible();
+        await expect(level3.locator('[col-id="b3"]', { hasText: 'level 3 - 6661' }).first()).toBeVisible();
+
+        // Both master rows are expanded, so there are four detail rows in total:
+        // one Level 2 detail grid per master row, each containing one nested Level 3 detail grid.
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(4);
+
+        // Collapsing the first master row removes its whole nested structure (its Level 2 grid and the Level 3 child).
+        await agIdFor.groupExpanded('0', 'a1').click();
+        await expect(detailRows).toHaveCount(2);
+
+        // Re-expanding the master row brings its nested detail grids back.
+        await agIdFor.groupContracted('0', 'a1').click();
+        await expect(detailRows).toHaveCount(4);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-other/_examples/detail-scrolls-with-master/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-other/_examples/detail-scrolls-with-master/example.spec.ts
@@ -1,11 +1,48 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Second master row is auto-expanded showing its detail grid', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // onFirstDataRendered expands the row at index 1. Because embedFullWidthRows=true, the
+        // detail panel is embedded once per scrollable section (pinned left, centre, pinned right),
+        // so three detail-row copies are rendered for the single expanded master row.
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(3);
+
+        // The populated detail grid lives in the centre (scrolling) section and exposes the
+        // call-record columns defined in detailGridOptions.
+        const scrollingDetail = page.locator('.ag-grid-scrolling-cells > .ag-details-row').first();
+        const detailHeader = scrollingDetail.locator('.ag-header-cell-text');
+        await expect(detailHeader).toContainText(['Call Id', 'Direction', 'Number', 'Duration', 'Switch Code']);
+
+        // Duration values are formatted with an "s" suffix by the detail grid's valueFormatter.
+        await expect(scrollingDetail).toContainText('s');
+    });
+
+    test.eachFramework('Detail grid is embedded within the scrolling cells section', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        // embedFullWidthRows=true lays the detail panel out with the other rows: exactly one copy
+        // sits inside the horizontally-scrollable centre section (.ag-grid-scrolling-cells), which
+        // is the mechanism that makes it move with the master grid's horizontal scroll (rather than
+        // the default overlay full-width container that ignores horizontal scrolling).
+        const scrollingDetail = page.locator('.ag-grid-scrolling-cells > .ag-details-row');
+        await expect(scrollingDetail).toHaveCount(1);
+        await expect(scrollingDetail.first()).toBeVisible();
+    });
+
+    test.eachFramework('Expanding another master row reveals a second detail grid', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(3);
+
+        // Expanding the first master row adds another embedded detail panel per section (3 -> 6).
+        await agIdFor.groupContracted('0', 'name').click();
+        await expect(detailRows).toHaveCount(6);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-other/_examples/embed-custom-detail/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-other/_examples/embed-custom-detail/example.spec.ts
@@ -1,11 +1,18 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Custom detail panel renders once per pinned section', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // onFirstDataRendered expands the row with id '1'. Because embedFullWidthRows is combined
+        // with a custom Detail Panel, the panel is rendered three times, once for each scrollable
+        // section: pinned left, centre and pinned right.
+        const customDetails = page.locator('.custom-detail');
+        await expect(customDetails).toHaveCount(3);
+
+        // The custom renderer prints its params.pinned value ('left'/'right') or 'center'.
+        const texts = await customDetails.allInnerTexts();
+        expect(texts.map((t) => t.trim()).sort()).toEqual(['center', 'left', 'right']);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-other/_examples/filtering-with-sort/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-other/_examples/filtering-with-sort/example.spec.ts
@@ -1,11 +1,47 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Master and detail grids each render with their own columns', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // The auto-expanded row (index 1) shows exactly one detail grid on load.
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(1);
+
+        // Detail grid exposes its own call-record columns, independent of the master columns.
+        const detailHeader = detailRows.first().locator('.ag-header-cell-text');
+        await expect(detailHeader).toContainText(['Call Id', 'Direction', 'Number', 'Duration', 'Switch Code']);
+    });
+
+    test.eachFramework('Sorting the master grid is applied independently', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        // Clicking a master header sorts that grid; the header advertises its sort state.
+        const callsHeader = agIdFor.headerCell('calls');
+        await callsHeader.click();
+        await expect(callsHeader).toHaveAttribute('aria-sort', 'ascending');
+
+        // Clicking again toggles to descending, confirming the master grid sorts independently.
+        await callsHeader.click();
+        await expect(callsHeader).toHaveAttribute('aria-sort', 'descending');
+    });
+
+    test.eachFramework('Detail grid headers are independently sortable', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(1);
+
+        // Sorting a detail column only affects the detail grid, not the master grid.
+        const detailDurationHeader = detailRows
+            .first()
+            .locator('.ag-header-cell')
+            .filter({ hasText: 'Duration' })
+            .first();
+        await detailDurationHeader.click();
+        await expect(detailDurationHeader).toHaveAttribute('aria-sort', 'ascending');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-other/_examples/grouping-master-detail/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-other/_examples/grouping-master-detail/example.spec.ts
@@ -1,11 +1,46 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Rows are grouped by region with an auto group column', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // The data is grouped by region; the North group is auto-expanded on load.
+        await expect(agIdFor.autoGroupCell('row-group-region-North')).toContainText('North', { useInnerText: true });
+    });
+
+    test.eachFramework('A leaf master row inside a group shows its detail grid', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        // onFirstDataRendered expands the North group and the Alice Smith master row (id '1'),
+        // so its detail grid is rendered on load.
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(1);
+        await expect(detailRows.first()).toBeVisible();
+
+        // The detail grid exposes the call-record columns configured for grouped master detail.
+        const detailHeader = detailRows.first().locator('.ag-header-cell-text');
+        await expect(detailHeader).toContainText(['Call Id', 'Number', 'Duration']);
+
+        // Alice's two call records are rendered with duration formatted with an "s" suffix.
+        await expect(detailRows.first()).toContainText('555-1234');
+        await expect(detailRows.first()).toContainText('s');
+    });
+
+    test.eachFramework('Only leaf rows with call records are masters', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        // Alice Smith (id '1') has call records, so isRowMaster returns true and she has a
+        // visible expand/collapse control (currently expanded).
+        await expect(
+            agIdFor.autoGroupCell('1').locator('.ag-group-expanded:visible, .ag-group-contracted:visible')
+        ).toHaveCount(1);
+
+        // Bob Johnson (id '2') has no call records, so he is not a master and has no control.
+        await expect(
+            agIdFor.autoGroupCell('2').locator('.ag-group-expanded:visible, .ag-group-contracted:visible')
+        ).toHaveCount(0);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-other/_examples/tree-data-master-detail/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-other/_examples/tree-data-master-detail/example.spec.ts
@@ -1,11 +1,59 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Tree data renders with the category auto group column', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Auto group column ('Category') plus the 'Origin' column are shown.
+        const headers = page.locator('.ag-header-cell-text');
+        await expect(headers).toContainText(['Category', 'Origin']);
+
+        // groupDefaultExpanded=1 expands the top-level groups, revealing their children.
+        await expect(page.getByText('Root Vegetables', { exact: true })).toBeVisible();
+        await expect(page.getByText('Carrot', { exact: true })).toBeVisible();
+    });
+
+    test.eachFramework('Group tree nodes with facts are masters and show detail before children', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        // Leafy Greens and Cruciferous are level-0 groups that also have facts, so they are master
+        // rows. Master/detail shows detail grids for every eligible row by default, so with the top
+        // level expanded (groupDefaultExpanded=1) both group detail grids are rendered on load.
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(2);
+
+        // The Leafy Greens group detail contains its facts.
+        const leafyDetail = detailRows.filter({ hasText: 'Edible leaves' });
+        await expect(leafyDetail).toHaveCount(1);
+        await expect(leafyDetail.first().locator('.ag-header-cell-text')).toContainText(['Description', 'Importance']);
+
+        // The group's detail grid is shown before (above) its child rows (e.g. Spinach).
+        const detailBox = await leafyDetail.first().boundingBox();
+        const spinachBox = await page.getByText('Spinach', { exact: true }).first().boundingBox();
+        expect(detailBox).not.toBeNull();
+        expect(spinachBox).not.toBeNull();
+        expect(detailBox!.y).toBeLessThan(spinachBox!.y);
+    });
+
+    test.eachFramework('A leaf tree node with facts is also a master row', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        // Two group detail grids are shown on load; Carrot (a collapsed leaf) has none yet.
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(2);
+
+        // Carrot is a leaf with facts, so isRowMaster returns true and it has a detail expand control.
+        const carrotCell = page
+            .locator("[data-testid^='ag-cell'][data-testid$='ag-Grid-AutoColumn']")
+            .filter({ hasText: 'Carrot' })
+            .first();
+        await carrotCell.locator('.ag-group-contracted:visible').click();
+
+        // Expanding Carrot adds its detail grid with the fact 'Orange color'.
+        await expect(detailRows).toHaveCount(3);
+        await expect(detailRows.filter({ hasText: 'Orange color' })).toHaveCount(1);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-everything/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-everything/example.spec.ts
@@ -2,11 +2,12 @@ import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/t
 
 test.agExample(import.meta, () => {
     // Refresh Strategy 'everything' destroys and recreates the Detail Panel on each master
-    // refresh, so getDetailRowData runs again, the row data updates, and the custom template
-    // (title) is rebuilt with the new call count.
+    // refresh, so getDetailRowData runs again and the detail grid data updates. The non-React
+    // variants also wrap the detail grid in a custom template whose title shows the call count,
+    // which is rebuilt on recreation.
     test.eachFramework(
-        'Refresh Everything recreates the detail panel and updates the title',
-        async ({ agIdFor, page }) => {
+        'Refresh Everything recreates the detail panel and updates the data',
+        async ({ agIdFor, agFramework, page }) => {
             await ensureGridReady(page);
             await waitForGridContent(page);
 
@@ -22,16 +23,31 @@ test.agExample(import.meta, () => {
                 'Switch Code',
             ]);
 
-            // Title is 'Nora Thomas 24 calls' on load.
-            await expect(detailRow).toContainText('Nora Thomas 24 calls');
+            // Only the non-React variants use the custom string template that renders a title.
+            const usesTemplate = !agFramework.includes('react');
+            if (usesTemplate) {
+                // Title is 'Nora Thomas 24 calls' on load.
+                await expect(detailRow).toContainText('Nora Thomas 24 calls');
+            }
+
+            // Capture an odd detail row's duration; the master refresh increments odd rows' duration.
+            const durationCell = detailRow.locator('.ag-cell[col-id="duration"]').nth(1);
+            const durationBefore = (await durationCell.textContent())?.trim();
 
             // Wait for at least one master refresh to occur (calls increments past the initial 24).
             const masterCalls = agIdFor.cell('177000', 'calls');
             await expect(masterCalls).not.toHaveText('24');
 
-            // The template is rebuilt on recreation, so the title no longer shows the initial count.
-            await expect(page.locator('.ag-details-row').first()).not.toContainText('Nora Thomas 24 calls');
-            await expect(page.locator('.ag-details-row').first()).toContainText('calls');
+            // The panel is recreated and getDetailRowData re-runs, so the detail data reflects the update.
+            await expect(
+                page.locator('.ag-details-row').first().locator('.ag-cell[col-id="duration"]').nth(1)
+            ).not.toHaveText(durationBefore ?? '');
+
+            if (usesTemplate) {
+                // The template is rebuilt on recreation, so the title no longer shows the initial count.
+                await expect(page.locator('.ag-details-row').first()).not.toContainText('Nora Thomas 24 calls');
+                await expect(page.locator('.ag-details-row').first()).toContainText('calls');
+            }
         }
     );
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-everything/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-everything/example.spec.ts
@@ -1,11 +1,37 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    // Refresh Strategy 'everything' destroys and recreates the Detail Panel on each master
+    // refresh, so getDetailRowData runs again, the row data updates, and the custom template
+    // (title) is rebuilt with the new call count.
+    test.eachFramework(
+        'Refresh Everything recreates the detail panel and updates the title',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
+
+            const detailRow = page.locator('.ag-details-row').first();
+            await expect(detailRow).toBeVisible();
+
+            // Detail Grid renders the call-record columns from detailGridOptions.
+            await expect(detailRow.locator('.ag-header-cell-text')).toContainText([
+                'Call Id',
+                'Direction',
+                'Number',
+                'Duration',
+                'Switch Code',
+            ]);
+
+            // Title is 'Nora Thomas 24 calls' on load.
+            await expect(detailRow).toContainText('Nora Thomas 24 calls');
+
+            // Wait for at least one master refresh to occur (calls increments past the initial 24).
+            const masterCalls = agIdFor.cell('177000', 'calls');
+            await expect(masterCalls).not.toHaveText('24');
+
+            // The template is rebuilt on recreation, so the title no longer shows the initial count.
+            await expect(page.locator('.ag-details-row').first()).not.toContainText('Nora Thomas 24 calls');
+            await expect(page.locator('.ag-details-row').first()).toContainText('calls');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-nothing/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-nothing/example.spec.ts
@@ -1,11 +1,42 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    // Refresh Strategy 'nothing' performs no detail refresh: getDetailRowData is never called
+    // again, so the Detail Grid keeps its old data and the title is unchanged, even though the
+    // Master Grid row (calls count) still updates every two seconds.
+    test.eachFramework(
+        'Refresh Nothing leaves the detail grid unchanged while the master updates',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
+
+            const detailRow = page.locator('.ag-details-row').first();
+            await expect(detailRow).toBeVisible();
+
+            // Detail Grid renders the call-record columns from detailGridOptions.
+            await expect(detailRow.locator('.ag-header-cell-text')).toContainText([
+                'Call Id',
+                'Direction',
+                'Number',
+                'Duration',
+                'Switch Code',
+            ]);
+
+            // Title is 'Nora Thomas 24 calls' on load.
+            await expect(detailRow).toContainText('Nora Thomas 24 calls');
+
+            // Capture the second detail row's duration (the master refresh would change odd rows).
+            const durationCell = detailRow.locator('.ag-cell[col-id="duration"]').nth(1);
+            const durationBefore = (await durationCell.textContent())?.trim();
+
+            // Wait for at least one master refresh to occur (calls increments past the initial 24).
+            const masterCalls = agIdFor.cell('177000', 'calls');
+            await expect(masterCalls).not.toHaveText('24');
+
+            // No detail refresh happened: title still shows the initial count and the data is untouched.
+            await expect(detailRow).toContainText('Nora Thomas 24 calls');
+            const durationAfter = (await durationCell.textContent())?.trim();
+            expect(durationAfter).toBe(durationBefore);
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-nothing/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-nothing/example.spec.ts
@@ -6,7 +6,7 @@ test.agExample(import.meta, () => {
     // Master Grid row (calls count) still updates every two seconds.
     test.eachFramework(
         'Refresh Nothing leaves the detail grid unchanged while the master updates',
-        async ({ agIdFor, page }) => {
+        async ({ agIdFor, agFramework, page }) => {
             await ensureGridReady(page);
             await waitForGridContent(page);
 
@@ -22,8 +22,12 @@ test.agExample(import.meta, () => {
                 'Switch Code',
             ]);
 
-            // Title is 'Nora Thomas 24 calls' on load.
-            await expect(detailRow).toContainText('Nora Thomas 24 calls');
+            // Only the non-React variants use the custom string template that renders a title.
+            const usesTemplate = !agFramework.includes('react');
+            if (usesTemplate) {
+                // Title is 'Nora Thomas 24 calls' on load.
+                await expect(detailRow).toContainText('Nora Thomas 24 calls');
+            }
 
             // Capture the second detail row's duration (the master refresh would change odd rows).
             const durationCell = detailRow.locator('.ag-cell[col-id="duration"]').nth(1);
@@ -34,7 +38,9 @@ test.agExample(import.meta, () => {
             await expect(masterCalls).not.toHaveText('24');
 
             // No detail refresh happened: title still shows the initial count and the data is untouched.
-            await expect(detailRow).toContainText('Nora Thomas 24 calls');
+            if (usesTemplate) {
+                await expect(detailRow).toContainText('Nora Thomas 24 calls');
+            }
             const durationAfter = (await durationCell.textContent())?.trim();
             expect(durationAfter).toBe(durationBefore);
         }

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-rows/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-rows/example.spec.ts
@@ -5,38 +5,47 @@ test.agExample(import.meta, () => {
     // data is refreshed every two seconds: calls++ and half of the detail durations change.
     // Refresh Strategy 'rows' keeps the same Detail Grid instance: getDetailRowData is called
     // again and setRowData updates the rows, but the custom template (title) is set only once.
-    test.eachFramework('Refresh Rows updates detail row data while keeping the title', async ({ agIdFor, page }) => {
-        await ensureGridReady(page);
-        await waitForGridContent(page);
+    // Only the non-React variants use the custom string template that renders the title.
+    test.eachFramework(
+        'Refresh Rows updates detail row data while keeping the title',
+        async ({ agIdFor, agFramework, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
 
-        const detailRow = page.locator('.ag-details-row').first();
-        await expect(detailRow).toBeVisible();
+            const detailRow = page.locator('.ag-details-row').first();
+            await expect(detailRow).toBeVisible();
 
-        // Detail Grid renders the call-record columns from detailGridOptions.
-        await expect(detailRow.locator('.ag-header-cell-text')).toContainText([
-            'Call Id',
-            'Direction',
-            'Number',
-            'Duration',
-            'Switch Code',
-        ]);
+            // Detail Grid renders the call-record columns from detailGridOptions.
+            await expect(detailRow.locator('.ag-header-cell-text')).toContainText([
+                'Call Id',
+                'Direction',
+                'Number',
+                'Duration',
+                'Switch Code',
+            ]);
 
-        // Title is 'Nora Thomas 24 calls' on load.
-        await expect(detailRow).toContainText('Nora Thomas 24 calls');
+            const usesTemplate = !agFramework.includes('react');
+            if (usesTemplate) {
+                // Title is 'Nora Thomas 24 calls' on load.
+                await expect(detailRow).toContainText('Nora Thomas 24 calls');
+            }
 
-        // The second detail row (odd index) has its duration incremented on every refresh.
-        const durationCell = detailRow.locator('.ag-cell[col-id="duration"]').nth(1);
-        const durationBefore = (await durationCell.textContent())?.trim();
+            // The second detail row (odd index) has its duration incremented on every refresh.
+            const durationCell = detailRow.locator('.ag-cell[col-id="duration"]').nth(1);
+            const durationBefore = (await durationCell.textContent())?.trim();
 
-        // Wait for at least one master refresh to occur (calls increments past the initial 24).
-        const masterCalls = agIdFor.cell('177000', 'calls');
-        await expect(masterCalls).not.toHaveText('24');
+            // Wait for at least one master refresh to occur (calls increments past the initial 24).
+            const masterCalls = agIdFor.cell('177000', 'calls');
+            await expect(masterCalls).not.toHaveText('24');
 
-        // Refresh Rows keeps the Detail Grid instance, so the once-set template title stays at 24.
-        await expect(detailRow).toContainText('Nora Thomas 24 calls');
+            if (usesTemplate) {
+                // Refresh Rows keeps the Detail Grid instance, so the once-set template title stays at 24.
+                await expect(detailRow).toContainText('Nora Thomas 24 calls');
+            }
 
-        // But the row data was refreshed in place, so the duration value changed.
-        const durationAfter = (await durationCell.textContent())?.trim();
-        expect(durationAfter).not.toBe(durationBefore);
-    });
+            // But the row data was refreshed in place, so the duration value changed.
+            const durationAfter = (await durationCell.textContent())?.trim();
+            expect(durationAfter).not.toBe(durationBefore);
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-rows/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail-refresh/_examples/refresh-rows/example.spec.ts
@@ -1,11 +1,42 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // The first master row (Nora Thomas, account 177000) is auto-expanded and its master
+    // data is refreshed every two seconds: calls++ and half of the detail durations change.
+    // Refresh Strategy 'rows' keeps the same Detail Grid instance: getDetailRowData is called
+    // again and setRowData updates the rows, but the custom template (title) is set only once.
+    test.eachFramework('Refresh Rows updates detail row data while keeping the title', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const detailRow = page.locator('.ag-details-row').first();
+        await expect(detailRow).toBeVisible();
+
+        // Detail Grid renders the call-record columns from detailGridOptions.
+        await expect(detailRow.locator('.ag-header-cell-text')).toContainText([
+            'Call Id',
+            'Direction',
+            'Number',
+            'Duration',
+            'Switch Code',
+        ]);
+
+        // Title is 'Nora Thomas 24 calls' on load.
+        await expect(detailRow).toContainText('Nora Thomas 24 calls');
+
+        // The second detail row (odd index) has its duration incremented on every refresh.
+        const durationCell = detailRow.locator('.ag-cell[col-id="duration"]').nth(1);
+        const durationBefore = (await durationCell.textContent())?.trim();
+
+        // Wait for at least one master refresh to occur (calls increments past the initial 24).
+        const masterCalls = agIdFor.cell('177000', 'calls');
+        await expect(masterCalls).not.toHaveText('24');
+
+        // Refresh Rows keeps the Detail Grid instance, so the once-set template title stays at 24.
+        await expect(detailRow).toContainText('Nora Thomas 24 calls');
+
+        // But the row data was refreshed in place, so the duration value changed.
+        const durationAfter = (await durationCell.textContent())?.trim();
+        expect(durationAfter).not.toBe(durationBefore);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/master-detail/_examples/simple/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/master-detail/_examples/simple/example.spec.ts
@@ -1,11 +1,46 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Master rows render account data with formatted minutes', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // First master row: Nora Thomas, account 177000, 24 calls, minutes formatted with an "m" suffix.
+        await expect(agIdFor.cell('0', 'name')).toContainText('Nora Thomas');
+        await expect(agIdFor.cell('0', 'account')).toContainText('177000');
+        await expect(agIdFor.cell('0', 'calls')).toContainText('24');
+        await expect(agIdFor.cell('0', 'minutes')).toContainText('m');
+    });
+
+    test.eachFramework('Second master row is auto-expanded showing its detail grid', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        // onFirstDataRendered expands the row at index 1, so exactly one detail grid renders on load.
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(1);
+        await expect(detailRows.first()).toBeVisible();
+
+        // The detail grid exposes the call-record columns defined in detailGridOptions.
+        const detailHeaderText = detailRows.first().locator('.ag-header-cell-text');
+        await expect(detailHeaderText).toContainText(['Call Id', 'Direction', 'Number', 'Duration', 'Switch Code']);
+
+        // Duration values are formatted with an "s" suffix by the detail grid's valueFormatter.
+        await expect(detailRows.first().locator('.ag-cell').first()).toBeVisible();
+        await expect(detailRows.first()).toContainText('s');
+    });
+
+    test.eachFramework('Expanding another master row reveals a second detail grid', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const detailRows = page.locator('.ag-details-row');
+
+        // Only the auto-expanded row's detail grid is present initially.
+        await expect(detailRows).toHaveCount(1);
+
+        // Expanding the first master row adds its own detail grid.
+        await agIdFor.groupContracted('0', 'name').click();
+        await expect(detailRows).toHaveCount(2);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/theming-master-detail/_examples/custom-properties-fixed/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/theming-master-detail/_examples/custom-properties-fixed/example.spec.ts
@@ -1,11 +1,47 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
+
+// styles.css sets --ag-background-color: IndianRed on the body, and on .ag-details-grid explicitly sets the
+// lower-level variables (--ag-data-background-color / --ag-odd-row-background-color to MediumSeaGreen).
+// The docs explain that, unlike the custom-properties example, this DOES turn the detail rows green because
+// the low-level variables are set directly rather than relying on the (already-inherited) high-level default.
+const INDIAN_RED = 'rgb(205, 92, 92)';
+const MEDIUM_SEA_GREEN = 'rgb(60, 179, 113)';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Auto-expanded detail grid renders call-record columns', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(1);
+        await expect(detailRows.first()).toBeVisible();
+
+        const detailHeader = detailRows.first().locator('.ag-header-cell-text');
+        await expect(detailHeader).toContainText(['Call Id', 'Direction', 'Number', 'Duration', 'Switch Code']);
+    });
+
+    test.eachFramework(
+        'Master rows use the IndianRed background from --ag-background-color',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
+
+            const masterRowBg = await agIdFor
+                .cell('0', 'name')
+                .evaluate((el) => getComputedStyle(el.closest('.ag-row') as HTMLElement).backgroundColor);
+            expect(masterRowBg).toBe(INDIAN_RED);
+        }
+    );
+
+    test.eachFramework('Detail grid rows turn MediumSeaGreen when low-level variables are set', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        // Setting the low-level variables explicitly overrides the inherited red, so the detail rows are green.
+        const detailRowBg = await page
+            .locator('.ag-details-grid .ag-row')
+            .first()
+            .evaluate((el) => getComputedStyle(el).backgroundColor);
+        expect(detailRowBg).toBe(MEDIUM_SEA_GREEN);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/theming-master-detail/_examples/custom-properties/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/theming-master-detail/_examples/custom-properties/example.spec.ts
@@ -1,11 +1,46 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
+
+// styles.css sets --ag-background-color: IndianRed on the body and MediumSeaGreen on .ag-details-grid.
+// The docs explain that setting the high-level --ag-background-color on the detail grid has NO effect,
+// because the lower-level row-background variables have already inherited the red value from the master.
+const INDIAN_RED = 'rgb(205, 92, 92)';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Auto-expanded detail grid renders call-record columns', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(1);
+        await expect(detailRows.first()).toBeVisible();
+
+        const detailHeader = detailRows.first().locator('.ag-header-cell-text');
+        await expect(detailHeader).toContainText(['Call Id', 'Direction', 'Number', 'Duration', 'Switch Code']);
+    });
+
+    test.eachFramework(
+        'Master rows use the IndianRed background from --ag-background-color',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
+
+            const masterRowBg = await agIdFor
+                .cell('0', 'name')
+                .evaluate((el) => getComputedStyle(el.closest('.ag-row') as HTMLElement).backgroundColor);
+            expect(masterRowBg).toBe(INDIAN_RED);
+        }
+    );
+
+    test.eachFramework('Detail grid rows stay IndianRed - the green override has no effect', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        // Demonstrates the documented limitation: --ag-background-color: MediumSeaGreen on the detail grid
+        // cannot override the already-defined red row background inherited from the master grid.
+        const detailRowBg = await page
+            .locator('.ag-details-grid .ag-row')
+            .first()
+            .evaluate((el) => getComputedStyle(el).backgroundColor);
+        expect(detailRowBg).toBe(INDIAN_RED);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/theming-master-detail/_examples/detail-styling/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/theming-master-detail/_examples/detail-styling/example.spec.ts
@@ -1,11 +1,39 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Auto-expanded detail grid renders call-record columns', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // onFirstDataRendered expands the row at index 1, so exactly one detail grid renders on load.
+        const detailRows = page.locator('.ag-details-row');
+        await expect(detailRows).toHaveCount(1);
+        await expect(detailRows.first()).toBeVisible();
+
+        const detailHeader = detailRows.first().locator('.ag-header-cell-text');
+        await expect(detailHeader).toContainText(['Call Id', 'Direction', 'Number', 'Duration', 'Switch Code']);
+    });
+
+    test.eachFramework('.ag-details-row receives the documented background and padding', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const detailRow = page.locator('.ag-details-row').first();
+        await expect(detailRow).toBeVisible();
+
+        // styles.css: background: #f442 (rgba(255, 68, 68, 0.133...)) and padding: 5px 5px 5px 40px.
+        await expect(detailRow).toHaveCSS('background-color', 'rgba(255, 68, 68, 0.133)');
+        await expect(detailRow).toHaveCSS('padding', '5px 5px 5px 40px');
+    });
+
+    test.eachFramework('.ag-details-grid header cells are styled orange and bold', async ({ page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        // styles.css: .ag-details-grid .ag-header-cell { color: #f80; font-weight: bold; }
+        const detailHeaderCell = page.locator('.ag-details-grid .ag-header-cell').first();
+        await expect(detailHeaderCell).toBeVisible();
+        await expect(detailHeaderCell).toHaveCSS('color', 'rgb(255, 136, 0)');
+        await expect(detailHeaderCell).toHaveCSS('font-weight', '700');
     });
 });


### PR DESCRIPTION
## Summary

Part of the AG-17857 enterprise test-coverage effort. Converts **34 placeholder `example.spec.ts` files** across the Master/Detail documentation pages into real Playwright tests with meaningful, behaviour-level assertions.

The audit found Master/Detail at **0 real E2E** example tests (31 placeholders) — these placeholders only verified the grid rendered without throwing. This PR replaces them with tests that assert the documented behaviour of each example.

### Pages covered (34 specs, 62 tests)
| Page | Specs |
|------|-------|
| master-detail | 1 |
| master-detail-custom-detail | 5 |
| master-detail-grids | 8 |
| master-detail-height | 4 |
| master-detail-master-rows | 3 |
| master-detail-nesting | 2 |
| master-detail-other | 5 |
| master-detail-refresh | 3 |
| theming-master-detail | 3 |

### What the tests assert (examples)
- Master rows render account data; detail grids appear on expand with the expected columns/rows
- `detailGridOptions` vs custom `detailCellRenderer` rendering paths
- Detail height modes (`detailRowHeight`, `detailRowAutoHeight`, per-row `getRowHeight`)
- `isRowMaster` (static and dynamically changing), lazy-loaded detail rows
- Detail-grid API (flash), `keepDetailRows`, `masterSelects: 'detail'` selection propagation
- Refresh strategies (`rows` / `everything` / `nothing`) produce distinct observable outcomes
- Multi-level nesting, `embedFullWidthRows`, independent filter/sort, grouping + tree-data master rows
- Theming: detail-row background/padding, header styling, custom-property inheritance limitation + fix

## Testing
All green on `FRAMEWORK=typescript` chromium (single-worker):
```
62 passed
```

## Notes
- **Test specs only** — no product source changed.
- Follows the existing `docs-e2e-tests` conventions (`agIdFor`, `test.eachFramework`); no network shims — examples fetch their data as all other docs examples do.
