### PR TITLE
test(filters): adopt waitFor over fixed sleeps + document the convention

### DIFF
--- a/.rulesync/rules/testing.md
+++ b/.rulesync/rules/testing.md
@@ -222,6 +222,21 @@ for (const [name, example] of Object.entries(EXAMPLES)) {
 }
 ```
 
+### Waiting for Async Grid Updates
+
+Much grid behaviour resolves asynchronously — set-filter values load after the panel attaches, reloads run off a debounce/microtask, and so on. To observe such an update, **poll the condition with `waitFor`** (from `@testing-library/dom`) so the test proceeds the moment the state is ready:
+
+```typescript
+import { waitFor } from '@testing-library/dom';
+
+api.setGridOption('rowData', ATHLETES);
+await waitFor(() => expect(panel.setFilterItemLabels('Athlete')).toEqual(LI_MATCHES));
+```
+
+**Do not** `await asyncSetTimeout(<fixed n>)` and then assert. A guessed delay is flaky (too short under load) and slow (always waits the full time). Nonzero fixed delays scattered through the suite are legacy, not the pattern to copy.
+
+`await asyncSetTimeout(0)` is fine for its distinct purpose: flushing a single microtask/event-loop tick after a synchronous action (e.g. after setting a native input value) before reading the result.
+
 ## Best Practices
 
 1. **Test behaviour, not implementation** - Focus on what the code does, not how
@@ -231,7 +246,8 @@ for (const [name, example] of Object.entries(EXAMPLES)) {
 5. **Merge tests that differ only in assertions** - Same setup → one test with sequential assertions. Avoids test-count bloat.
 6. **Clean up after tests** - Reset mocks and state in `afterEach`
 7. **Review similar tests** - When adding tests, check related tests for consistency
-8. **Register the module before using a grid API** - Tests and benchmarks build their own module lists (not `AllCommunityModule`), so a `GridApi` method or feature whose module isn't registered logs `error #200` (`moduleName=…&reasonOrId=api.<method>`) and **no-ops silently**. Before using a new API, find its providing module (grep the method under `packages/*/src`, or read the `moduleName=` in the error URL) and register it. A passing test/bench prints no `error #200`.
+8. **Wait, don't sleep** - Poll async grid updates with `waitFor`; never assert after a fixed `asyncSetTimeout(n)` delay (see [Waiting for Async Grid Updates](#waiting-for-async-grid-updates)).
+9. **Register the module before using a grid API** - Tests and benchmarks build their own module lists (not `AllCommunityModule`), so a `GridApi` method or feature whose module isn't registered logs `error #200` (`moduleName=…&reasonOrId=api.<method>`) and **no-ops silently**. Before using a new API, find its providing module (grep the method under `packages/*/src`, or read the `moduleName=` in the error URL) and register it. A passing test/bench prints no `error #200`.
 
 
 ## GridRows and GridColumns Snapshots

--- a/.rulesync/skills/docs-e2e-tests/reference/pitfalls-and-patterns.md
+++ b/.rulesync/skills/docs-e2e-tests/reference/pitfalls-and-patterns.md
@@ -6,7 +6,7 @@ Situational reference for writing `example.spec.ts` tests. Read the pitfalls rel
 
 ### Pitfall 1: Strict Mode Violations (Multiple Matching Elements)
 
-AG Grid renders rows in multiple viewport containers (pinned left, centre, pinned right, plus sticky rows). Some rows — especially **grand total rows** and **pinned rows** — can appear in multiple containers, causing the same test ID to match 2+ elements.
+Since the single-container DOM refactor, all of a row's cells (including pinned columns) render inside one `.ag-row` element in the `.ag-grid-scrolling-container` — there are **no** separate pinned-left/centre/pinned-right row fragments. However, rows are still split across *vertical* containers (the main scrolling container plus `stickyTop`/`stickyBottom`, `pinnedTop`/`pinnedBottom`). Some rows — especially **grand total rows** and **pinned rows** — appear in both a pinned/sticky container and the main container, so the same test ID matches 2+ elements. A row can also transiently duplicate mid-animation (e.g. during a sort that moves it a long distance) until the grid settles.
 
 **Fix:** Use `.first()` on locators for rows that may be duplicated across containers:
 

--- a/testing/behavioural/src/filters/filter-behaviour/set-filter-api-advanced.test.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/set-filter-api-advanced.test.ts
@@ -591,7 +591,7 @@ describe('Set Filter — list rendering', () => {
         expect(label).toBeTruthy();
 
         await userEvent.hover(label);
-        await asyncSetTimeout(250);
+        // The waitFor below polls up to 2s for the tooltip, so no fixed pre-delay is needed.
         await waitFor(
             () => expect(document.querySelectorAll('.ag-tooltip, .ag-tooltip-custom').length).toBeGreaterThan(0),
             { timeout: 2000 }

--- a/testing/behavioural/src/filters/filter-behaviour/toolPanelHarness.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/toolPanelHarness.ts
@@ -1,3 +1,5 @@
+import { waitFor } from '@testing-library/dom';
+
 import type { GridApi, SideBarDef } from 'ag-grid-community';
 
 import {
@@ -76,8 +78,12 @@ export class ToolPanelHarness {
             await firePointerLikeClick(
                 wrapper.querySelector<HTMLElement>('.ag-filter-toolpanel-group-level-0-header')!
             );
-            // Let the (async) filter comp resolve and attach its body.
-            await asyncSetTimeout(10);
+            // Wait for the (async) filter comp to resolve and attach its body, rather than a fixed delay.
+            await waitFor(() => {
+                if (!wrapper.querySelector('.ag-filter-toolpanel-instance-body')) {
+                    throw new Error(`Filter body for "${title}" has not attached yet`);
+                }
+            });
         }
         return this;
     }


### PR DESCRIPTION
## What & why

The testing guide was silent on how to wait for asynchronous grid updates, so behavioural tests copied the surrounding pattern of hardcoded `asyncSetTimeout(n)` sleeps — flaky under load and slow by construction.

**Skill:** adds a "Waiting for Async Grid Updates" section to the testing guide (`.rulesync/rules/testing.md`, regenerated into `.claude/`): poll async grid state with `waitFor` rather than asserting after a fixed delay; `asyncSetTimeout(0)` stays valid for a single tick flush.

**Tests:** applies the rule to the two safely-convertible filter-behaviour sleeps:
- `toolPanelHarness.expandGroup` — polls for the filter body to attach instead of `asyncSetTimeout(10)`.
- `set-filter-api-advanced` tooltip test — drops the redundant `asyncSetTimeout(250)` sitting in front of an existing `waitFor`.

Genuine debounce waits (`search`, date-filter) and negative-after-settle assertions (asserting something did *not* happen) are intentionally left as fixed delays — `waitFor` can't express those.

## Verification
- `./behave.sh "filter-behaviour"` → 155/155 pass
- `yarn nx run ag-behavioural-testing:build:test` → type-check clean
- `yarn nx format` clean