### PR TITLE
[AG-17857] Test(pivoting): behavioural coverage for example specs

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/column-group-definitions-example/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/column-group-definitions-example/example.spec.ts
@@ -1,11 +1,27 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'processPivotResultColGroupDef applies the pivot-gold class to every pivot group header cell',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
+
+            // Pivot on `sport`; the leftmost (alphabetical) group is `Alpine Skiing`.
+            const alpineGroup = agIdFor.headerGroupCell('pivotGroup_sport_Alpine Skiing_0');
+            await expect(alpineGroup).toBeVisible();
+            await expect(alpineGroup).toContainText('Alpine Skiing');
+
+            // The callback mutates the group colDef to add headerClass: 'pivot-gold'.
+            await expect(alpineGroup).toHaveClass(/pivot-gold/);
+
+            // Single aggregated value column (gold) forms the group's only child column.
+            await expect(agIdFor.headerCell('pivot_sport_Alpine Skiing_gold')).toContainText('Gold');
+
+            // The class is applied to all generated pivot groups, not just the first.
+            const goldGroups = page.locator('.ag-header-group-cell.pivot-gold');
+            await expect(goldGroups.first()).toBeVisible();
+            expect(await goldGroups.count()).toBeGreaterThan(1);
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/column-group-summary/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/column-group-summary/example.spec.ts
@@ -1,11 +1,21 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'Each unique sport generates a pivot column group holding one child column per aggregated value',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
+
+            // Pivot is on `sport`; groups appear in alphabetical order, so `Alpine Skiing` is leftmost.
+            const alpineGroup = agIdFor.headerGroupCell('pivotGroup_sport_Alpine Skiing_0');
+            await expect(alpineGroup).toBeVisible();
+            await expect(alpineGroup).toContainText('Alpine Skiing');
+
+            // The three aggregated value columns (gold, silver, bronze) become the group's child columns.
+            await expect(agIdFor.headerCell('pivot_sport_Alpine Skiing_gold')).toContainText('Gold');
+            await expect(agIdFor.headerCell('pivot_sport_Alpine Skiing_silver')).toContainText('Silver');
+            await expect(agIdFor.headerCell('pivot_sport_Alpine Skiing_bronze')).toContainText('Bronze');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/filter-pivoted-columns/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/filter-pivoted-columns/example.spec.ts
@@ -1,11 +1,30 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'Filtering a pivoted column removes its generated pivot column group rather than filtering rows',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
+
+            // Pivot on `sport`; the leftmost (alphabetical) group is `Biathlon`.
+            const biathlonGroup = agIdFor.headerGroupCell('pivotGroup_sport_Biathlon_0');
+            await expect(biathlonGroup).toBeVisible();
+            await expect(biathlonGroup).toContainText('Biathlon');
+
+            // The Sport set filter is expanded in the Filters Tool Panel (onGridReady). Deselect `Biathlon`.
+            const filterItem = agIdFor.setFilterInstanceItem(
+                { source: 'filter-toolpanel', colLabel: 'Sport' },
+                'Biathlon'
+            );
+            await expect(filterItem).toBeVisible();
+            await filterItem.click();
+
+            // Filtering the pivoted Sport column removes its pivot column group entirely.
+            await expect(biathlonGroup).toHaveCount(0);
+
+            // Other sport groups remain - the next alphabetical group is still present.
+            await expect(agIdFor.headerGroupCell('pivotGroup_sport_Cross Country Skiing_0')).toBeVisible();
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/fixed-pivot-column-groups/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/fixed-pivot-column-groups/example.spec.ts
@@ -1,11 +1,25 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'suppressExpandablePivotGroups shows all pivot columns with no expand/collapse controls',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
+
+            // Pivot columns are sport and year. The top-level `sport` group is present but NOT expandable.
+            const alpineGroup = agIdFor.headerGroupCell('pivotGroup_sport-year_Alpine Skiing_0');
+            await expect(alpineGroup).toBeVisible();
+            await expect(alpineGroup).toContainText('Alpine Skiing');
+            // No expand/collapse control is shown - both expand icons are hidden.
+            await expect(alpineGroup.locator('.ag-header-expand-icon-collapsed')).not.toBeVisible();
+            await expect(alpineGroup.locator('.ag-header-expand-icon-expanded')).not.toBeVisible();
+
+            // With no expandable groups, the nested year subgroups are always shown directly.
+            await expect(agIdFor.headerGroupCell('pivotGroup_sport-year_Alpine Skiing-2002_0')).toBeVisible();
+
+            // The leaf value column for a specific sport/year is rendered without any interaction.
+            await expect(agIdFor.headerCell('pivot_sport-year_Alpine Skiing-2002_gold')).toBeVisible();
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/hidden-single-value-column-header/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/hidden-single-value-column-header/example.spec.ts
@@ -1,11 +1,27 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'removePivotHeaderRowWhenSingleValueColumn skips the group row and labels the leaf column with the pivot key',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
+
+            const alpineLeaf = agIdFor.headerCell('pivot_sport_Alpine Skiing_gold');
+            const alpineGroup = agIdFor.headerGroupCell('pivotGroup_sport_Alpine Skiing_0');
+
+            // Checkbox starts checked: with a single value column the pivot group row is removed and the
+            // leaf column is instead labelled with the pivot key (`Alpine Skiing`) rather than `Gold`.
+            await expect(alpineLeaf).toBeVisible();
+            await expect(alpineLeaf).toContainText('Alpine Skiing');
+            await expect(alpineGroup).toHaveCount(0);
+
+            // Toggle the option off - the pivot group row reappears and the leaf reverts to the value name.
+            await page.locator('#removePivotHeaderRowWhenSingleValueColumn').click();
+
+            await expect(alpineGroup).toBeVisible();
+            await expect(alpineGroup).toContainText('Alpine Skiing');
+            await expect(alpineLeaf).toContainText('Gold');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/open-pivot-group-by-default/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/open-pivot-group-by-default/example.spec.ts
@@ -1,11 +1,22 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'pivotDefaultExpanded=1 expands the first pivot group level so the nested year groups are shown',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
+
+            // Pivot columns are sport, year, date. The top-level `sport` group is expanded by default.
+            const alpineGroup = agIdFor.headerGroupCell('pivotGroup_sport-year-date_Alpine Skiing_0');
+            await expect(alpineGroup).toBeVisible();
+            await expect(alpineGroup).toContainText('Alpine Skiing');
+
+            // Because it is expanded, its expand icon shows the expanded state (not collapsed).
+            await expect(alpineGroup.locator('.ag-header-expand-icon-expanded')).toBeVisible();
+
+            // The second pivot level (year) is revealed as nested groups under the expanded sport group.
+            await expect(agIdFor.headerGroupCell('pivotGroup_sport-year-date_Alpine Skiing-2002_0')).toBeVisible();
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/order-pivot-groups/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/order-pivot-groups/example.spec.ts
@@ -1,11 +1,24 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'pivotComparator reverses the default alphabetical order of the pivot groups',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
+
+            // The sport column supplies pivotComparator (b.localeCompare(a)) => reverse alphabetical order,
+            // so `Wrestling` (normally last) becomes the leftmost pivot group.
+            const wrestlingGroup = agIdFor.headerGroupCell('pivotGroup_sport_Wrestling_0');
+            await expect(wrestlingGroup).toBeVisible();
+            await expect(wrestlingGroup).toContainText('Wrestling');
+            await expect(agIdFor.headerCell('pivot_sport_Wrestling_gold')).toContainText('Gold');
+
+            // `Alpine Skiing` (first alphabetically) is now last, so it is scrolled off-screen and not rendered.
+            await expect(agIdFor.headerGroupCell('pivotGroup_sport_Alpine Skiing_0')).toHaveCount(0);
+
+            // The leftmost rendered pivot group is Wrestling, confirming the reversed order.
+            await expect(page.locator('.ag-header-group-cell').first()).toContainText('Wrestling');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/order-pivot-groups/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/order-pivot-groups/example.spec.ts
@@ -8,17 +8,33 @@ test.agExample(import.meta, () => {
             await waitForGridContent(page);
 
             // The sport column supplies pivotComparator (b.localeCompare(a)) => reverse alphabetical order,
-            // so `Wrestling` (normally last) becomes the leftmost pivot group.
+            // so `Wrestling` (alphabetically last) becomes the leftmost pivot group.
             const wrestlingGroup = agIdFor.headerGroupCell('pivotGroup_sport_Wrestling_0');
             await expect(wrestlingGroup).toBeVisible();
             await expect(wrestlingGroup).toContainText('Wrestling');
             await expect(agIdFor.headerCell('pivot_sport_Wrestling_gold')).toContainText('Gold');
 
-            // `Alpine Skiing` (first alphabetically) is now last, so it is scrolled off-screen and not rendered.
-            await expect(agIdFor.headerGroupCell('pivotGroup_sport_Alpine Skiing_0')).toHaveCount(0);
-
-            // The leftmost rendered pivot group is Wrestling, confirming the reversed order.
-            await expect(page.locator('.ag-header-group-cell').first()).toContainText('Wrestling');
+            // Header group cells are absolutely positioned, so determine visual order from their `left`
+            // offset rather than DOM order. The rendered sport groups must appear in descending
+            // (reverse-alphabetical) order with Wrestling leftmost, proving the pivotComparator was applied.
+            // This is robust to virtualisation: it asserts the ordering of whatever is rendered rather than
+            // relying on a specific group being scrolled off-screen.
+            const sportOrder = await page
+                .locator('.ag-header-group-cell[col-id^="pivotGroup_sport_"]')
+                .evaluateAll((els) =>
+                    els
+                        .map((e) => ({
+                            sport: e.getAttribute('col-id')!.replace(/^pivotGroup_sport_(.+)_0$/, '$1'),
+                            left: e.getBoundingClientRect().left,
+                        }))
+                        .sort((a, b) => a.left - b.left)
+                        .map((e) => e.sport)
+                );
+            expect(sportOrder.length).toBeGreaterThan(1);
+            expect(sportOrder[0]).toBe('Wrestling');
+            // Rendered left-to-right order equals reverse-alphabetical order of those same sports.
+            const reverseAlphabetical = [...sportOrder].sort((a, b) => b.localeCompare(a));
+            expect(sportOrder).toEqual(reverseAlphabetical);
         }
     );
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/sort-pivot-columns/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/sort-pivot-columns/example.spec.ts
@@ -1,11 +1,65 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
+
+// Header group cells are absolutely positioned, so visual order is determined by their `left` offset
+// rather than DOM order. Return the pivot year group col-ids ordered left-to-right.
+const yearGroupOrder = (page: import('@playwright/test').Page) =>
+    page.locator('.ag-header-group-cell[col-id^="pivotGroup_year_"]').evaluateAll((els) =>
+        els
+            .map((e) => ({ id: e.getAttribute('col-id')!, left: e.getBoundingClientRect().left }))
+            .sort((a, b) => a.left - b.left)
+            .map((e) => e.id)
+    );
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'Activating the Year pivot pill sorts the pivot column groups descending',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
+
+            // Pivot on `year`; pivot columns sort ascending by default, so 2000 is the leftmost group.
+            await expect(agIdFor.headerGroupCell('pivotGroup_year_2012_0')).toBeVisible();
+            expect(await yearGroupOrder(page)).toEqual([
+                'pivotGroup_year_2000_0',
+                'pivotGroup_year_2002_0',
+                'pivotGroup_year_2004_0',
+                'pivotGroup_year_2006_0',
+                'pivotGroup_year_2008_0',
+                'pivotGroup_year_2010_0',
+                'pivotGroup_year_2012_0',
+            ]);
+
+            // The Year pill in the pivot (Column Labels) panel starts ascending; activating it cycles to descending.
+            const yearPill = page.locator('.ag-column-drop-horizontal-cell', { hasText: 'Year' });
+            await expect(yearPill).toBeVisible();
+            await expect(yearPill.locator('.ag-sort-ascending-icon')).toBeVisible();
+            await yearPill.click();
+            await expect(yearPill.locator('.ag-sort-descending-icon')).toBeVisible();
+
+            // Wait for the group positions to settle (2012 becomes leftmost) before reading the full order.
+            await page.waitForFunction(() => {
+                const cells = Array.from(
+                    document.querySelectorAll('.ag-header-group-cell[col-id^="pivotGroup_year_"]')
+                );
+                if (!cells.length) {
+                    return false;
+                }
+                const leftmost = cells.sort(
+                    (a, b) => a.getBoundingClientRect().left - b.getBoundingClientRect().left
+                )[0];
+                return leftmost.getAttribute('col-id') === 'pivotGroup_year_2012_0';
+            });
+
+            // Descending pivotSort reverses the pivot column groups: 2012 is now leftmost, 2000 rightmost.
+            expect(await yearGroupOrder(page)).toEqual([
+                'pivotGroup_year_2012_0',
+                'pivotGroup_year_2010_0',
+                'pivotGroup_year_2008_0',
+                'pivotGroup_year_2006_0',
+                'pivotGroup_year_2004_0',
+                'pivotGroup_year_2002_0',
+                'pivotGroup_year_2000_0',
+            ]);
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/strict-column-order/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/strict-column-order/example.spec.ts
@@ -1,24 +1,53 @@
 import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
+    // Wait until pivot groups for both `before` and `after` values are rendered and `before` sits to the
+    // LEFT of `after`. Header group cells are absolutely positioned, so visual order is read from their
+    // `left` offset. Returns once the ordering holds; times out (failing the test) if it never does.
+    const waitForLeftToRightOrder = (page: import('@playwright/test').Page, before: number, after: number) =>
+        page.waitForFunction(
+            ([b, a]) => {
+                const parsed = Array.from(
+                    document.querySelectorAll('.ag-header-group-cell[col-id^="pivotGroup_pivotValue_"]')
+                )
+                    .map((e) => {
+                        const match = e.getAttribute('col-id')!.match(/^pivotGroup_pivotValue_(\d+)_0$/);
+                        return { value: match ? Number(match[1]) : NaN, left: e.getBoundingClientRect().left };
+                    })
+                    .filter((p) => !Number.isNaN(p.value));
+                const beforeEntry = parsed.find((p) => p.value === b);
+                const afterEntry = parsed.find((p) => p.value === a);
+                if (!beforeEntry || !afterEntry) {
+                    return false;
+                }
+                return beforeEntry.left < afterEntry.left;
+            },
+            [before, after] as [number, number],
+            { timeout: 15000 }
+        );
+
     test.eachFramework(
-        'Pivot groups are generated for the pivotValue column and enableStrictPivotColumnOrder can be toggled',
+        'enableStrictPivotColumnOrder re-sorts generated pivot columns instead of appending them',
         async ({ page }) => {
             await ensureGridReady(page);
             await waitForGridContent(page);
 
-            // The data set changes every second (rows are appended). Each unique pivotValue produces a
-            // pivot column group. At least one such group is present once data has loaded.
+            // The data set changes every second, appending rows in the source order 6,1,3,2,5,4. Each unique
+            // pivotValue produces a pivot column group.
             const pivotGroups = page.locator('.ag-header-group-cell[col-id^="pivotGroup_pivotValue_"]');
             await expect(pivotGroups.first()).toBeVisible();
 
-            // enableStrictPivotColumnOrder is toggled through the checkbox; enabling it re-sorts generated
-            // columns. Toggling it must not break rendering - pivot groups remain present afterwards.
+            // Default (enableStrictPivotColumnOrder = false): columns are APPENDED in first-appearance order,
+            // so value 6 (appended before value 1) renders to the left of value 1.
             const checkbox = page.locator('#enableStrictPivotColumnOrder');
             await expect(checkbox).not.toBeChecked();
+            await waitForLeftToRightOrder(page, 6, 1);
+
+            // Enabling the option re-sorts all generated columns alphanumerically, so value 1 now renders to
+            // the left of value 6 - the opposite of the append order, proving the re-sort actually happens.
             await checkbox.click();
             await expect(checkbox).toBeChecked();
-            await expect(pivotGroups.first()).toBeVisible();
+            await waitForLeftToRightOrder(page, 1, 6);
         }
     );
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/strict-column-order/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/_examples/strict-column-order/example.spec.ts
@@ -1,11 +1,24 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'Pivot groups are generated for the pivotValue column and enableStrictPivotColumnOrder can be toggled',
+        async ({ page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
+
+            // The data set changes every second (rows are appended). Each unique pivotValue produces a
+            // pivot column group. At least one such group is present once data has loaded.
+            const pivotGroups = page.locator('.ag-header-group-cell[col-id^="pivotGroup_pivotValue_"]');
+            await expect(pivotGroups.first()).toBeVisible();
+
+            // enableStrictPivotColumnOrder is toggled through the checkbox; enabling it re-sorts generated
+            // columns. Toggling it must not break rendering - pivot groups remain present afterwards.
+            const checkbox = page.locator('#enableStrictPivotColumnOrder');
+            await expect(checkbox).not.toBeChecked();
+            await checkbox.click();
+            await expect(checkbox).toBeChecked();
+            await expect(pivotGroups.first()).toBeVisible();
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting-result-columns/_examples/column-definitions-example/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-result-columns/_examples/column-definitions-example/example.spec.ts
@@ -1,11 +1,32 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
+
+// gold has cellStyle backgroundColor #f2e287 (rgb(242, 226, 135)); silver has an empty cellStyle object.
+// processPivotResultColDef mutates the (object) cellStyle to add color #2f73ff (rgb(47, 115, 255)).
+// Both properties are inherited by every generated pivot result column of that value field.
+const GOLD_BG = 'rgb(242, 226, 135)';
+const PIVOT_TEXT_COLOR = 'rgb(47, 115, 255)';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'Pivot result columns inherit and extend the value column cellStyle',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
+
+            // sport is the pivot field; generated result columns are pivot_sport_<sport>_<gold|silver>.
+            const goldCell = agIdFor.cell('row-group-country-United States', 'pivot_sport_Athletics_gold');
+            const silverCell = agIdFor.cell('row-group-country-United States', 'pivot_sport_Athletics_silver');
+
+            await expect(goldCell).toBeVisible();
+            await expect(silverCell).toBeVisible();
+
+            // gold pivot result cells inherit the gold background AND gain the processPivotResultColDef text colour.
+            await expect(goldCell).toHaveCSS('background-color', GOLD_BG);
+            await expect(goldCell).toHaveCSS('color', PIVOT_TEXT_COLOR);
+
+            // silver pivot result cells did not inherit a background, but still gain the text colour.
+            await expect(silverCell).not.toHaveCSS('background-color', GOLD_BG);
+            await expect(silverCell).toHaveCSS('color', PIVOT_TEXT_COLOR);
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting-result-columns/_examples/extreme-pivot/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-result-columns/_examples/extreme-pivot/example.spec.ts
@@ -1,11 +1,47 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
+const LIMIT_WARNING = 'limit of 1000 generated columns has been exceeded';
+
+// The example configures pivotMaxGeneratedColumns: 1000 with an onPivotMaxColumnsExceeded
+// handler that logs a warning. The `athlete` column has enablePivot, so pivoting by it
+// generates far more than 1000 pivot result columns, tripping the limit: the grid halts
+// column generation, clears the view, and fires onPivotMaxColumnsExceeded.
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'Pivoting by athlete exceeds the generated-column limit',
+        async ({ page, remoteGrid }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
+
+            const remoteApi = remoteGrid(page, '1');
+
+            // Baseline: no active pivot, so only the value columns are shown (no pivot result columns).
+            const initialCols = await page.locator('.ag-header-cell[col-id]').count();
+            expect(initialCols).toBeGreaterThan(0);
+            expect(await page.locator('.ag-header-cell[col-id^="pivot_"]').count()).toBe(0);
+
+            // Capture the warning emitted by onPivotMaxColumnsExceeded.
+            const warnings: string[] = [];
+            const handler = (msg: { type: () => string; text: () => string }) => {
+                if (msg.type() === 'warning' || msg.type() === 'error') {
+                    warnings.push(msg.text());
+                }
+            };
+            page.on('console', handler);
+
+            // Pivot by athlete: too many unique values -> exceeds pivotMaxGeneratedColumns (1000).
+            await remoteApi.setPivotColumns(['athlete']);
+
+            // The handler fires and logs the documented warning.
+            await expect(() => {
+                expect(warnings.some((w) => w.includes(LIMIT_WARNING))).toBe(true);
+            }).toPass();
+
+            // Column generation is halted and the pivot view is cleared - no pivot result columns rendered.
+            await expect(page.locator('.ag-header-cell[col-id^="pivot_"]')).toHaveCount(0);
+
+            page.off('console', handler);
+        },
+        { allowedConsoleMessages: [LIMIT_WARNING] }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting-result-columns/_examples/secondary-columns-filter/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-result-columns/_examples/secondary-columns-filter/example.spec.ts
@@ -1,11 +1,35 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
+
+// year is the pivot field; gold/silver/bronze value columns declare filter: 'agNumberColumnFilter'
+// and floatingFilter: true, so every generated pivot result column (pivot_year_<year>_<field>)
+// is filterable via a floating Number Filter. As the pivot values are aggregates, filtering
+// matches against the underlying leaf rows and does not re-aggregate the parent groups.
+const groupRows = (page: import('@playwright/test').Page) => page.locator('.ag-row[row-id^="row-group-country-"]');
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Pivot result columns can be filtered with a number floating filter', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Per the docs note, filter: 'agNumberColumnFilter' on the value column yields a Number Filter
+        // (backed by ag-number-field) with a floating filter on each generated pivot result column.
+        const floatingFilter = page.locator('.ag-floating-filter[col-id="pivot_year_2000_gold"]').first();
+        await expect(floatingFilter.locator('.ag-number-field')).toBeVisible();
+        const floatingInput = floatingFilter.locator('input').first();
+        await expect(floatingInput).toBeVisible();
+
+        const initialCount = await groupRows(page).count();
+        expect(initialCount).toBeGreaterThan(1);
+
+        // Filtering the pivot result column filters the underlying leaf rows (not the displayed
+        // aggregate). No individual leaf has a 2000 gold value of 7, so every group is filtered out.
+        await floatingInput.fill('7');
+        await floatingInput.press('Enter');
+        await expect(groupRows(page)).toHaveCount(0);
+
+        // Clearing the filter restores every group.
+        await floatingInput.fill('');
+        await floatingInput.press('Enter');
+        await expect(groupRows(page)).toHaveCount(initialCount);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting-totals/_examples/expandable-pivot-column-groups/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-totals/_examples/expandable-pivot-column-groups/example.spec.ts
@@ -1,11 +1,35 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'Collapsed pivot column groups show the group total, expanding reveals the per-year breakdown',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
+
+            const row = 'row-group-country-United States';
+            const athletics = agIdFor.headerGroupCell('pivotGroup_sport-year_Athletics_0');
+
+            // Collapsed: the Athletics group shows a single total column for the aggregation (gold),
+            // holding the sport's total across all years. US Athletics gold total = 69.
+            await expect(athletics).toBeVisible();
+            await expect(athletics.locator('.ag-header-expand-icon-collapsed')).toBeVisible();
+            await expect(agIdFor.cell(row, 'pivot_sport-year_Athletics_gold').first()).toContainText('69');
+
+            // Expand the group: the total column is hidden and the per-year breakdown columns appear.
+            await athletics.locator('.ag-header-expand-icon-collapsed').click();
+
+            const year2000 = agIdFor.cell(row, 'pivot_sport-year_Athletics-2000_gold');
+            await expect(year2000.first()).toBeVisible();
+
+            // The group total column is no longer rendered while expanded.
+            await expect(page.locator('.ag-header-cell[col-id="pivot_sport-year_Athletics_gold"]')).toHaveCount(0);
+
+            // Per-year gold values sum to the previously shown total (16 + 18 + 16 + 19 = 69).
+            await expect(agIdFor.cell(row, 'pivot_sport-year_Athletics-2000_gold').first()).toContainText('16');
+            await expect(agIdFor.cell(row, 'pivot_sport-year_Athletics-2004_gold').first()).toContainText('18');
+            await expect(agIdFor.cell(row, 'pivot_sport-year_Athletics-2008_gold').first()).toContainText('16');
+            await expect(agIdFor.cell(row, 'pivot_sport-year_Athletics-2012_gold').first()).toContainText('19');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting-totals/_examples/row-totals/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-totals/_examples/row-totals/example.spec.ts
@@ -11,14 +11,21 @@ test.agExample(import.meta, () => {
         await expect(agIdFor.headerGroupCell('PivotRowTotal__pivotGroup_silver_0')).toBeVisible();
         await expect(agIdFor.headerGroupCell('PivotRowTotal__pivotGroup_bronze_0')).toBeVisible();
 
-        // Verify the total columns come *before* the year pivot columns ('before' positioning).
-        const order = await page.evaluate(() =>
-            Array.from(document.querySelectorAll('.ag-header-cell[col-id]')).map((e) => e.getAttribute('col-id'))
-        );
-        const totalGoldIdx = order.indexOf('PivotRowTotal_pivot_year__gold');
-        const firstYearIdx = order.findIndex((id) => id?.startsWith('pivot_year_'));
-        expect(totalGoldIdx).toBeGreaterThanOrEqual(0);
-        expect(firstYearIdx).toBeGreaterThan(totalGoldIdx);
+        // Verify the total columns render visually *before* (to the LEFT of) the year pivot columns.
+        // Header cells are absolutely positioned, so compare their `left` offsets rather than DOM order.
+        const positions = await page.evaluate(() => {
+            const totalGoldEl = document.querySelector('.ag-header-cell[col-id="PivotRowTotal_pivot_year__gold"]');
+            const yearLefts = Array.from(document.querySelectorAll('.ag-header-cell[col-id^="pivot_year_"]')).map(
+                (e) => e.getBoundingClientRect().left
+            );
+            return {
+                totalGold: totalGoldEl ? totalGoldEl.getBoundingClientRect().left : null,
+                firstYear: yearLefts.length ? Math.min(...yearLefts) : null,
+            };
+        });
+        expect(positions.totalGold).not.toBeNull();
+        expect(positions.firstYear).not.toBeNull();
+        expect(positions.totalGold!).toBeLessThan(positions.firstYear!);
     });
 
     test.eachFramework('Row total columns show the aggregated total across all years', async ({ agIdFor, page }) => {

--- a/documentation/ag-grid-docs/src/content/docs/pivoting-totals/_examples/row-totals/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-totals/_examples/row-totals/example.spec.ts
@@ -1,11 +1,34 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Pivot row totals appear before the pivot columns', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // pivotRowTotals: 'before' inserts one total column per aggregation (gold/silver/bronze),
+        // grouped under a PivotRowTotal_ header group, positioned before the year pivot columns.
+        await expect(agIdFor.headerGroupCell('PivotRowTotal__pivotGroup_gold_0')).toBeVisible();
+        await expect(agIdFor.headerGroupCell('PivotRowTotal__pivotGroup_silver_0')).toBeVisible();
+        await expect(agIdFor.headerGroupCell('PivotRowTotal__pivotGroup_bronze_0')).toBeVisible();
+
+        // Verify the total columns come *before* the year pivot columns ('before' positioning).
+        const order = await page.evaluate(() =>
+            Array.from(document.querySelectorAll('.ag-header-cell[col-id]')).map((e) => e.getAttribute('col-id'))
+        );
+        const totalGoldIdx = order.indexOf('PivotRowTotal_pivot_year__gold');
+        const firstYearIdx = order.findIndex((id) => id?.startsWith('pivot_year_'));
+        expect(totalGoldIdx).toBeGreaterThanOrEqual(0);
+        expect(firstYearIdx).toBeGreaterThan(totalGoldIdx);
+    });
+
+    test.eachFramework('Row total columns show the aggregated total across all years', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        // United States row: the row-total columns hold the sum of that medal across every year.
+        const row = 'row-group-country-United States';
+        await expect(agIdFor.cell(row, 'PivotRowTotal_pivot_year__gold').first()).toContainText('552');
+        await expect(agIdFor.cell(row, 'PivotRowTotal_pivot_year__silver').first()).toContainText('440');
+        await expect(agIdFor.cell(row, 'PivotRowTotal_pivot_year__bronze').first()).toContainText('320');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting/_examples/pivot-mode/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting/_examples/pivot-mode/example.spec.ts
@@ -1,11 +1,43 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForRowAnimations } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // Country + Year row-grouped, gold/silver/bronze summed. Three buttons switch between:
+    // 1 - grouping only, 2 - grouping + pivot mode (no pivot), 3 - pivot mode + pivot active (year).
+    // Values from olympic-winners.json: United States total gold = 552; gold in 2000 = 130, 2004 = 118.
+
+    test.eachFramework('Grouping active: row groups expand to reveal nested year groups', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Aggregated (summed) total gold for the United States group.
+        await expect(agIdFor.cell('row-group-country-United States', 'gold')).toContainText('552');
+
+        // Row groups expand: expanding the country group reveals its nested year groups.
+        const usRow = page.locator('[row-id="row-group-country-United States"]').first();
+        await expect(usRow).toHaveAttribute('aria-expanded', 'false');
+        await agIdFor.groupContracted('row-group-country-United States', 'ag-Grid-AutoColumn').first().click();
+        await waitForRowAnimations(page);
+        await expect(usRow).toHaveAttribute('aria-expanded', 'true');
+        await expect(agIdFor.autoGroupCell('row-group-country-United States-year-2000')).toBeVisible();
     });
+
+    test.eachFramework(
+        'Pivot active: switching to mode 3 generates a gold column per year',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+
+            // Before pivot is active there are no pivot result columns for years.
+            await expect(agIdFor.headerGroupCell('pivotGroup_year_2000_0')).toHaveCount(0);
+
+            // Mode 3: pivot mode on with Year added to column labels (pivot active).
+            await page.getByRole('button', { name: '3 - Grouping Active with Pivot Mode and Pivot Active' }).click();
+            await waitForRowAnimations(page);
+
+            // Pivot result columns are grouped by the pivot field (year).
+            await expect(agIdFor.headerGroupCell('pivotGroup_year_2000_0')).toBeVisible();
+
+            // Aggregated gold per country per year.
+            await expect(agIdFor.cell('row-group-country-United States', 'pivot_year_2000_gold')).toContainText('130');
+            await expect(agIdFor.cell('row-group-country-United States', 'pivot_year_2004_gold')).toContainText('118');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting/_examples/pivot-overview/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting/_examples/pivot-overview/example.spec.ts
@@ -1,11 +1,39 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForRowAnimations } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    // Country row-grouped, gold summed, pivoted by Sport then Year, with the pivot panel always shown.
+    // Pivot result columns are grouped by sport; each sport group collapses to a gold total that
+    // expands into per-year gold columns.
+    // Values from olympic-winners.json (United States): Athletics gold total = 69; Athletics 2000 = 16.
+
+    test.eachFramework('Pivot panel shows the active pivot fields', async ({ agIdFor }) => {
+        const columnLabels = agIdFor.columnDropArea('toolbar', 'Column Labels');
+        await expect(columnLabels).toContainText('Sport');
+        await expect(columnLabels).toContainText('Year');
     });
+
+    test.eachFramework(
+        'Pivot result columns are grouped by sport and expand to yearly gold',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+
+            // Columns are grouped by the first pivot field (sport).
+            await expect(agIdFor.headerGroupCell('pivotGroup_sport-year_Alpine Skiing_0')).toBeVisible();
+
+            // Each sport group collapses to a summed gold total across all years.
+            await expect(
+                agIdFor.cell('row-group-country-United States', 'pivot_sport-year_Athletics_gold')
+            ).toContainText('69');
+
+            // Expanding the sport group reveals a gold column per year (the second pivot field).
+            await agIdFor
+                .headerGroupCell('pivotGroup_sport-year_Athletics_0')
+                .locator('.ag-header-expand-icon-collapsed')
+                .click();
+            await waitForRowAnimations(page);
+            await expect(
+                agIdFor.cell('row-group-country-United States', 'pivot_sport-year_Athletics-2000_gold')
+            ).toContainText('16');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting/_examples/pivot-panel/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting/_examples/pivot-panel/example.spec.ts
@@ -1,11 +1,50 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForRowAnimations } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    // Country row-grouped, gold summed, pivoted by Sport then Year. pivotPanelShow: 'onlyWhenPivoting'
+    // shows the pivot panel because a pivot is active, and the columns tool panel is configured with
+    // suppressPivots/suppressPivotMode to hide its pivoting section.
+    // Values from olympic-winners.json (United States): Athletics gold total = 69; Athletics 2000 = 16.
+
+    test.eachFramework(
+        'Pivot panel is shown while pivoting and the tool panel hides pivot controls',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+
+            // The panel bar is only rendered because a pivot is active (pivotPanelShow: 'onlyWhenPivoting').
+            await expect(agIdFor.columnDropArea('toolbar', 'Row Groups')).toBeVisible();
+
+            // Sport and Year are the active pivot (column label) fields.
+            const columnLabels = agIdFor.columnDropArea('panel', 'Column Labels');
+            await expect(columnLabels).toContainText('Sport');
+            await expect(columnLabels).toContainText('Year');
+
+            // The columns tool panel suppresses the pivot mode toggle.
+            await expect(agIdFor.pivotModeSelect()).toHaveCount(0);
+        }
+    );
+
+    test.eachFramework(
+        'Pivot result columns are grouped by sport and expand to yearly gold',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+
+            await expect(agIdFor.headerGroupCell('pivotGroup_sport-year_Alpine Skiing_0')).toBeVisible();
+
+            // Each sport group collapses to a summed gold total across all years.
+            await expect(
+                agIdFor.cell('row-group-country-United States', 'pivot_sport-year_Athletics_gold')
+            ).toContainText('69');
+
+            // Expanding the sport group reveals a gold column per year.
+            await agIdFor
+                .headerGroupCell('pivotGroup_sport-year_Athletics_0')
+                .locator('.ag-header-expand-icon-collapsed')
+                .click();
+            await waitForRowAnimations(page);
+            await expect(
+                agIdFor.cell('row-group-country-United States', 'pivot_sport-year_Athletics-2000_gold')
+            ).toContainText('16');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting/_examples/side-bar/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting/_examples/side-bar/example.spec.ts
@@ -1,11 +1,40 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { dragOverTo, ensureGridReady, expect, test, waitForRowAnimations } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // Country row-grouped, gold summed, pivotMode: true. Sport has enablePivot but is NOT pivoted
+    // initially, so pivot mode is on with no pivot active. The user can add Sport to the column
+    // labels via the side bar to make a pivot active.
+    // Values from olympic-winners.json (United States): total gold = 552; Alpine Skiing = 4, Athletics = 69.
+
+    test.eachFramework('Pivot mode on but no pivot active shows aggregated group totals', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // With no pivot active the grid shows the summed gold total per country group...
+        await expect(agIdFor.cell('row-group-country-United States', 'gold')).toContainText('552');
+        // ...and no pivot result columns exist yet.
+        await expect(agIdFor.headerGroupCell('pivotGroup_sport_Athletics_0')).toHaveCount(0);
     });
+
+    test.eachFramework(
+        'Adding Sport to Column Labels via the side bar creates pivot columns',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+
+            // Drag the Sport column into the Column Labels drop area to activate the pivot.
+            await dragOverTo(
+                agIdFor.columnSelectListItemDragHandle('Sport Column'),
+                agIdFor.columnDropArea('toolbar', 'Column Labels')
+            );
+            await waitForRowAnimations(page);
+
+            // Pivot result columns grouped by sport now appear, with aggregated gold values per country.
+            await expect(agIdFor.headerGroupCell('pivotGroup_sport_Alpine Skiing_0')).toBeVisible();
+            await expect(
+                agIdFor.cell('row-group-country-United States', 'pivot_sport_Alpine Skiing_gold')
+            ).toContainText('4');
+            await expect(agIdFor.cell('row-group-country-United States', 'pivot_sport_Athletics_gold')).toContainText(
+                '69'
+            );
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/pivoting/_examples/simple/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting/_examples/simple/example.spec.ts
@@ -1,11 +1,24 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // Pivot mode on: country row-grouped, gold summed, pivoted by sport.
+    // Pivot result columns are generated per sport value (id `pivot_sport_<Sport>_gold`).
+    // Values calculated from olympic-winners.json: United States gold in
+    // Alpine Skiing = 4, Athletics = 69.
+    test.eachFramework('Pivoting by sport generates a gold column per sport', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Pivot result columns are grouped by the pivot field (sport): the leaf
+        // column is the `sum(Gold)` measure nested under a `Alpine Skiing` header group.
+        const alpineGroup = agIdFor.headerGroupCell('pivotGroup_sport_Alpine Skiing_0');
+        await expect(alpineGroup).toBeVisible();
+        await expect(alpineGroup).toContainText('Alpine Skiing');
+        await expect(agIdFor.headerCell('pivot_sport_Alpine Skiing_gold')).toContainText('Gold');
+
+        // Aggregated (summed) gold values per country per sport.
+        await expect(agIdFor.cell('row-group-country-United States', 'pivot_sport_Alpine Skiing_gold')).toContainText(
+            '4'
+        );
+        await expect(agIdFor.cell('row-group-country-United States', 'pivot_sport_Athletics_gold')).toContainText('69');
     });
 });


### PR DESCRIPTION
## Summary

Part of the AG-17857 enterprise test-coverage effort. Converts **19 placeholder `example.spec.ts` files** across the Pivoting documentation pages into real Playwright tests. The audit found Pivoting at 2 real E2E example tests (19 placeholders).

### Pages covered (19 specs, 24 tests)
| Page | Specs |
|------|-------|
| pivoting | 5 |
| pivoting-column-groups | 9 |
| pivoting-result-columns | 3 |
| pivoting-totals | 2 |

### What the tests assert (examples)
- Pivot mode produces pivot result columns/header groups (`pivot_*` / `pivotGroup_*`) keyed by the pivot field, with **aggregated values computed from the source data** (e.g. US Alpine Skiing gold = 4, Athletics = 69, total gold = 552)
- Enabling pivot via API, tool-panel drag, and the pivot panel
- Pivot column-group ordering (`pivotComparator`), sorting, filtering pivoted columns, default-expanded groups, `suppressExpandablePivotGroups`, hidden single-value header
- Result-column `cellStyle` inheritance + `processPivotResultColDef`, `pivotMaxGeneratedColumns` / `onPivotMaxColumnsExceeded`, floating-filter on result columns
- Row totals (`pivotRowTotals: 'before'`) and expandable column-group totals, with breakdowns summing to the shown total

## Testing
Validated locally across ALL frameworks (typescript, vanilla, react, angular, vue3) with no FRAMEWORK env, plus prettier/lint clean. Any framework a given example does not support is guarded with an explicit `test.skip`.

## Notes
- **Test specs only** — no product source changed. No network shims.
