### PR TITLE
AG-17487: fix flaky inline-example render smoke test

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/page-verification.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/page-verification.spec.ts
@@ -202,12 +202,17 @@ test.describe('Page Verification', () => {
         await page.goto('/react-data-grid/row-sorting/');
         await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
 
-        // The iframe uses IntersectionObserver to lazy-load its src.
-        // scrollIntoViewIfNeeded() alone doesn't reliably trigger the observer in headless Chrome —
-        // mouse.wheel() simulates a real scroll event and fires it more reliably.
+        // The iframe lazy-loads its src only once an IntersectionObserver (threshold 0.2)
+        // reports it at least 20% visible. The example is 500px tall in a 720px viewport, so
+        // a minimal reveal (scrollIntoViewIfNeeded + a fixed 100px wheel) leaves its visible
+        // ratio sensitive to late layout shifts and scroll/observer timing — occasionally
+        // landing at ratio 0 (not intersecting), so the src is never set and the test times
+        // out. That intermittent miss was the source of this test's flakiness. Centring the
+        // iframe in the viewport (a deterministic native DOM scroll) makes it ~100% visible,
+        // comfortably clearing the threshold on every run.
         const iframeLocator = page.locator('iframe.exampleRunner').first();
         await iframeLocator.scrollIntoViewIfNeeded();
-        await page.mouse.wheel(0, 100);
+        await iframeLocator.evaluate((el) => el.scrollIntoView({ block: 'center' }));
         await expect(iframeLocator).toHaveAttribute('src', /example-runner/, { timeout: 30_000 });
 
         const exampleFrame = page.locator('iframe.exampleRunner').first().contentFrame();


### PR DESCRIPTION
## Summary

Fixes the persistently flaky `page-verification.spec.ts` test **"docs page with an inline example renders a grid"** that fails-then-passes in CI (the post-deploy verification job), generating repeated failure/pass noise.

## Root cause

The test waits for a lazy-loaded example iframe to populate its `src`. That iframe (`ExampleIFrame.tsx`) only loads once an `IntersectionObserver` with **threshold `0.2`** reports it **≥20% visible**. The first example on `/react-data-grid/row-sorting/` ("Custom Sorting") renders at the default **500px** height in the `Desktop Chrome` **720px** viewport.

The previous reveal — `scrollIntoViewIfNeeded()` + a single fixed `mouse.wheel(0, 100)` — left the iframe's visible ratio sensitive to late layout shifts (fonts/images above it) and scroll/observer callback timing. It usually lands the 500px iframe fully in view, but **intermittently yields intersection ratio ≈ 0**, so `isIntersecting` never fires, `src` is never set, and the `toHaveAttribute('src', …)` assertion times out. CI's `retries: 2` then re-runs and usually passes — the classic fail-then-pass churn.

## Fix

Reveal the iframe deterministically by centring it in the viewport with a native `scrollIntoView({ block: 'center' })`, making it ~100% visible and clearing the 0.2 threshold on every run. Test-only change; no product code touched.

## Verification (against the live deployed site, `BASE_URL=https://www.ag-grid.com`)

An instrumented probe measured the intersection ratio each approach produces:

| Approach | Measured intersection ratio |
|---|---|
| Current (`scrollIntoViewIfNeeded` + `wheel(0,100)`) | intermittently **0.0** (caught 1/6 in one batch) → not intersecting → timeout |
| Fixed (`scrollIntoView({block:'center'})`) | **1.0** on every run |

- Fixed test: **10/10 passes**, single worker, `--retries=0`, `--repeat-each=10` against the live site.

## Notes

The parallel post-deploy job saturating prod can still surface unrelated `page.goto`/actionability timeouts under extreme concurrent load, but those are distinct from the intersection-ratio flake this PR removes.
