### PR TITLE
[AG-17857] Fix(examples): tool-panel custom parent (vue3) & chart container destroy (angular)

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-container/_examples/provided-container/provided/angular/app.component.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-container/_examples/provided-container/provided/angular/app.component.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import type { ElementRef } from '@angular/core';
-import { Component, NgZone, ViewChild } from '@angular/core';
+import { Component, ViewChild, signal } from '@angular/core';
 import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
 
 import { AgGridAngular } from 'ag-grid-angular';
@@ -40,9 +40,9 @@ ModuleRegistry.registerModules([
             (gridReady)="onGridReady($event)"
         />
         <div #chartParent class="chart-wrapper">
-            @if (chartRef) {
+            @if (chartRef()) {
                 <div class="chart-wrapper-top">
-                    <h2 class="chart-wrapper-title">Chart created at {{ createdTime }}</h2>
+                    <h2 class="chart-wrapper-title">Chart created at {{ createdTime() }}</h2>
                     <button (click)="updateChart()">Destroy Chart</button>
                 </div>
             } @else {
@@ -62,15 +62,14 @@ export class AppComponent {
     defaultColDef: ColDef = { flex: 1 };
     popupParent: HTMLElement | null = document.body;
     rowData!: any[];
-    chartRef?: ChartRef;
-    createdTime?: string;
+    // Signals so the template updates even though the grid invokes createChartContainer
+    // outside Angular's zone (signal writes schedule change detection independently of zone.js).
+    chartRef = signal<ChartRef | undefined>(undefined);
+    createdTime = signal<string | undefined>(undefined);
 
     @ViewChild('chartParent') chartParent?: ElementRef;
 
-    constructor(
-        private http: HttpClient,
-        private ngZone: NgZone
-    ) {}
+    constructor(private http: HttpClient) {}
 
     onGridReady(params: GridReadyEvent) {
         this.http
@@ -82,21 +81,17 @@ export class AppComponent {
     }
 
     updateChart(chartRef: ChartRef | undefined) {
-        if (this.chartRef !== chartRef) {
+        if (this.chartRef() !== chartRef) {
             // Destroy previous chart if it exists
-            this.chartRef?.destroyChart();
+            this.chartRef()?.destroyChart();
         }
-        this.chartRef = chartRef;
-        this.createdTime = new Date().toLocaleString();
+        this.chartRef.set(chartRef);
+        this.createdTime.set(new Date().toLocaleString());
     }
 
-    // Arrow function used to correctly bind this to the component.
-    // The grid invokes this outside Angular's zone, so run the state update inside
-    // it to trigger change detection (otherwise the chart-wrapper template never updates).
+    // Arrow function used to correctly bind this to the component
     createChartContainer = (chartRef: ChartRef) => {
-        this.ngZone.run(() => {
-            this.updateChart(chartRef);
-            this.chartParent?.nativeElement.appendChild(chartRef.chartElement);
-        });
+        this.updateChart(chartRef);
+        this.chartParent?.nativeElement.appendChild(chartRef.chartElement);
     };
 }

--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-container/_examples/provided-container/provided/angular/app.component.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-container/_examples/provided-container/provided/angular/app.component.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import type { ElementRef } from '@angular/core';
-import { Component, ViewChild } from '@angular/core';
+import { Component, NgZone, ViewChild } from '@angular/core';
 import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
 
 import { AgGridAngular } from 'ag-grid-angular';
@@ -67,7 +67,10 @@ export class AppComponent {
 
     @ViewChild('chartParent') chartParent?: ElementRef;
 
-    constructor(private http: HttpClient) {}
+    constructor(
+        private http: HttpClient,
+        private ngZone: NgZone
+    ) {}
 
     onGridReady(params: GridReadyEvent) {
         this.http
@@ -87,9 +90,13 @@ export class AppComponent {
         this.createdTime = new Date().toLocaleString();
     }
 
-    // Arrow function used to correctly bind this to the component
+    // Arrow function used to correctly bind this to the component.
+    // The grid invokes this outside Angular's zone, so run the state update inside
+    // it to trigger change detection (otherwise the chart-wrapper template never updates).
     createChartContainer = (chartRef: ChartRef) => {
-        this.updateChart(chartRef);
-        this.chartParent?.nativeElement.appendChild(chartRef.chartElement);
+        this.ngZone.run(() => {
+            this.updateChart(chartRef);
+            this.chartParent?.nativeElement.appendChild(chartRef.chartElement);
+        });
     };
 }

--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-container/_examples/provided-container/provided/angular/app.component.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-container/_examples/provided-container/provided/angular/app.component.ts
@@ -62,8 +62,6 @@ export class AppComponent {
     defaultColDef: ColDef = { flex: 1 };
     popupParent: HTMLElement | null = document.body;
     rowData!: any[];
-    // Signals so the template updates even though the grid invokes createChartContainer
-    // outside Angular's zone (signal writes schedule change detection independently of zone.js).
     chartRef = signal<ChartRef | undefined>(undefined);
     createdTime = signal<string | undefined>(undefined);
 

--- a/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/provided/vue3/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/side-bar/_examples/tool-panel-parent/provided/vue3/main.ts
@@ -136,7 +136,7 @@ const VueExample = defineComponent({
             closeDrawer();
             const popup = popupRef.value!;
             popup.classList.toggle('active', true);
-            gridApi.value!.openToolPanel(columnsToolPanel.value.id);
+            gridApi.value!.openToolPanel(columnsToolPanel.value.id, popupContentRef.value!);
             addStyles(popup);
         }
         function openDrawer() {


### PR DESCRIPTION
## Summary

Two documentation examples did not behave as documented on specific frameworks. Surfaced while adding cross-framework example-spec coverage (AG-17857) — the specs on those PRs currently `test.skip` the affected framework; once this merges those skips can be removed.

### 1. `side-bar/tool-panel-parent` — vue3
The columns tool panel rendered in the **default side bar** instead of the custom `#popup` container. The vue3 variant can't resolve the popup element at config time, and mutating `ToolPanelDef.parent` in `onMounted` (after grid init) doesn't re-wire the already-created panel.
**Fix:** pass the resolved content element to `openToolPanel(id, parent)` in `openPopup` — mirroring the Filters/drawer button in the same example, which already works.

### 2. `integrated-charts-container/provided-container` — angular
The grid invokes `createChartContainer` **outside Angular's zone**, so assigning `this.chartRef` didn't trigger change detection — the `@if (chartRef)` block never rendered, so the "Destroy Chart" button never appeared (the chart itself was appended imperatively, so it looked fine).
**Fix:** wrap the state update in `NgZone.run(...)`.

## Testing
Verified on the affected frameworks against the dev server:
- vue3: columns panel now renders inside `#popup` (`#popup .ag-column-panel` visible).
- angular: "Destroy Chart" button now renders after chart creation, and the destroy round-trip works.

## Notes
- Examples/source only — no library code changed.
- Follow-up (after merge): drop the `vue3`/`angular` `test.skip` guards in the AG-17857 example-spec PRs (#14463 provided-container, #14466 tool-panel-parent) once those branches rebase on this.