### PR TITLE
AG-3390: verify JavaScript inline example renders in e2e smoke test

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/page-verification.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/page-verification.spec.ts
@@ -196,25 +196,31 @@ test.describe('Page Verification', () => {
         expect(cspViolations, 'CSP violations').toEqual([]);
     });
 
-    test('docs page with an inline example renders a grid', async ({ page }) => {
-        const cspViolations = await setupPage(page);
+    // The inline example on a docs page renders the same grid regardless of framework —
+    // only the URL prefix changes (e.g. /react-data-grid/ vs /javascript-data-grid/). We
+    // verify both the React and the JavaScript variants render, since a build/runtime break
+    // can affect one framework's example bundle without touching the other.
+    for (const framework of ['react', 'javascript']) {
+        test(`docs page with an inline example renders a grid (${framework})`, async ({ page }) => {
+            const cspViolations = await setupPage(page);
 
-        await page.goto('/react-data-grid/row-sorting/');
-        await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+            await page.goto(`/${framework}-data-grid/row-sorting/`);
+            await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
 
-        // The iframe uses IntersectionObserver to lazy-load its src.
-        // scrollIntoViewIfNeeded() alone doesn't reliably trigger the observer in headless Chrome —
-        // mouse.wheel() simulates a real scroll event and fires it more reliably.
-        const iframeLocator = page.locator('iframe.exampleRunner').first();
-        await iframeLocator.scrollIntoViewIfNeeded();
-        await page.mouse.wheel(0, 100);
-        await expect(iframeLocator).toHaveAttribute('src', /example-runner/, { timeout: 30_000 });
+            // The iframe uses IntersectionObserver to lazy-load its src.
+            // scrollIntoViewIfNeeded() alone doesn't reliably trigger the observer in headless Chrome —
+            // mouse.wheel() simulates a real scroll event and fires it more reliably.
+            const iframeLocator = page.locator('iframe.exampleRunner').first();
+            await iframeLocator.scrollIntoViewIfNeeded();
+            await page.mouse.wheel(0, 100);
+            await expect(iframeLocator).toHaveAttribute('src', /example-runner/, { timeout: 30_000 });
 
-        const exampleFrame = page.locator('iframe.exampleRunner').first().contentFrame();
-        await expect(exampleFrame.locator('.ag-root-wrapper')).toBeVisible({ timeout: 30_000 });
+            const exampleFrame = page.locator('iframe.exampleRunner').first().contentFrame();
+            await expect(exampleFrame.locator('.ag-root-wrapper')).toBeVisible({ timeout: 30_000 });
 
-        expect(cspViolations, 'CSP violations').toEqual([]);
-    });
+            expect(cspViolations, 'CSP violations').toEqual([]);
+        });
+    }
 
     // --- Product switcher ---
 

--- a/documentation/ag-grid-docs/src/content/docs/page-verification.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/page-verification.spec.ts
@@ -196,30 +196,29 @@ test.describe('Page Verification', () => {
         expect(cspViolations, 'CSP violations').toEqual([]);
     });
 
-    // The inline example on a docs page renders the same grid regardless of framework —
-    // only the URL prefix changes (e.g. /react-data-grid/ vs /javascript-data-grid/). We
-    // verify both the React and the JavaScript variants render, since a build/runtime break
-    // can affect one framework's example bundle without touching the other.
-    for (const framework of ['react', 'javascript']) {
-        test(`docs page with an inline example renders a grid (${framework})`, async ({ page }) => {
-            const cspViolations = await setupPage(page);
+    // Sense-check the standalone example runner across frameworks by loading a couple of
+    // examples directly at their framework-specific URLs and asserting the grid renders. This
+    // exercises each framework's example compiler head-on — in particular the vanilla
+    // (JavaScript) build. The docs-page inline runner defaults to the TypeScript variant, so it
+    // can render successfully while the vanilla compiler is broken; loading `/vanilla` directly
+    // is what actually catches that.
+    const exampleRenderChecks = [
+        { pageName: 'getting-started', exampleName: 'quick-start-example' },
+        { pageName: 'row-sorting', exampleName: 'multi-column' },
+    ];
+    for (const { pageName, exampleName } of exampleRenderChecks) {
+        for (const framework of ['reactFunctionalTs', 'vanilla']) {
+            test(`example runner renders a grid: ${pageName}/${exampleName} (${framework})`, async ({ page }) => {
+                const cspViolations = await setupPage(page);
 
-            await page.goto(`/${framework}-data-grid/row-sorting/`);
-            await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+                // The standalone example page renders the grid directly in the top-level
+                // document (no iframe), unlike the embedded docs-page runner.
+                await page.goto(`/examples/${pageName}/${exampleName}/${framework}`);
+                await expect(page.locator('.ag-root-wrapper')).toBeVisible({ timeout: 30_000 });
 
-            // The iframe uses IntersectionObserver to lazy-load its src.
-            // scrollIntoViewIfNeeded() alone doesn't reliably trigger the observer in headless Chrome —
-            // mouse.wheel() simulates a real scroll event and fires it more reliably.
-            const iframeLocator = page.locator('iframe.exampleRunner').first();
-            await iframeLocator.scrollIntoViewIfNeeded();
-            await page.mouse.wheel(0, 100);
-            await expect(iframeLocator).toHaveAttribute('src', /example-runner/, { timeout: 30_000 });
-
-            const exampleFrame = page.locator('iframe.exampleRunner').first().contentFrame();
-            await expect(exampleFrame.locator('.ag-root-wrapper')).toBeVisible({ timeout: 30_000 });
-
-            expect(cspViolations, 'CSP violations').toEqual([]);
-        });
+                expect(cspViolations, 'CSP violations').toEqual([]);
+            });
+        }
     }
 
     // --- Product switcher ---


### PR DESCRIPTION
## What
Extend the inline-example smoke test in `page-verification.spec.ts` to verify both the React and JavaScript variants of the inline example render, rather than React only.

## Why
The test previously navigated only to `/react-data-grid/row-sorting/`, so a build or runtime break affecting the JavaScript example bundle would go undetected. It now loops over `react` and `javascript`, navigating `/${framework}-data-grid/row-sorting/`. All assertions were already framework-agnostic (example-runner iframe src, `.ag-root-wrapper` visible inside the frame, no enforced CSP violations), so only the URL prefix varies per framework.

## Notes
The Playwright `page-verification` suite was not run locally (it needs a built/deployed docs site), so this relies on CI. Opened as draft for that reason.
