### PR TITLE
Delete a PR's Actions caches when it closes

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -35,3 +35,21 @@ jobs:
         with:
           pr_number: ${{ env.PR_NUMBER }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  cache_cleanup:
+    runs-on: ubuntu-latest
+    name: Remove PR Actions caches
+    # Same-repo PRs only (fork PRs can't hold the write token) — see pr-review.yml.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      # Deleting caches requires actions: write.
+      actions: write
+    env:
+      # merge-ref caches (node_modules + Nx) persist after merge and are never read
+      # again, so they only consume the repo's 10GB cache budget. See AG-17857 CI notes.
+      PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Delete this PR's caches
+        run: gh cache delete --all --ref "$PR_REF" --succeed-on-no-caches


### PR DESCRIPTION
## What

Adds a `cache_cleanup` job to `.github/workflows/pr-cleanup.yml` that deletes a PR's `refs/pull/N/merge` Actions caches (node_modules + Nx) when the PR closes.

## Why

The repo's Actions cache was sitting at the 10 GB per-repo limit. Merge-ref caches (~0.5 GB each) persist after a PR closes but are never read again — GitHub cache scoping is one-directional, so a PR's merge-ref cache is invisible to `latest` and to sibling PRs. Once over the limit, GitHub LRU-evicts caches faster than `latest`'s exact-hash `node_modules` caches can be reused, so every CI job restore-key-falls-back to a stale cache and runs a full `yarn install --ci` (with a node_modules wipe).

Cleaning up dead merge-ref caches on close frees the budget so `latest`'s exact-hash caches survive long enough to be hit.

## Notes

- Scoped `actions: write` on the new job only; the existing gh-pages cleanup job is unchanged.
- `--succeed-on-no-caches` makes it a clean no-op for PRs that never wrote a cache.
- Mirrors the existing job's same-repo `if:` guard (fork PRs can't hold a write token — and can't write caches to the base repo either, so nothing is left behind).