### PR TITLE
AG-17871 pasting cells performance

### DIFF
--- a/packages/ag-grid-community/src/edit/editApi.ts
+++ b/packages/ag-grid-community/src/edit/editApi.ts
@@ -1,5 +1,6 @@
 import { ensureColumnVisible, ensureIndexVisible } from '../api/scrollApi';
 import type { BeanCollection } from '../context/context';
+import type { AgColumn } from '../entities/agColumn';
 import { _getRowNode } from '../entities/positionUtils';
 import type { RowNode } from '../entities/rowNode';
 import type {
@@ -21,40 +22,32 @@ export function redoCellEditing(beans: BeanCollection): void {
 }
 
 export function getEditRowValues(beans: BeanCollection, rowNode: IRowNode): Record<string, any> | undefined {
-    return beans.editModelSvc?.getEditRowDataValue(rowNode, { checkSiblings: true });
+    return beans.editModelSvc?.getEditRowDataValue(rowNode);
 }
 
 export function getEditingCells(beans: BeanCollection): EditingCellPosition[] {
     const edits = beans.editModelSvc?.getEditMap();
     const positions: EditingCellPosition[] = [];
-    edits?.forEach((editRow, rowNode) => {
-        const { rowIndex, rowPinned } = rowNode as RowNode;
-        editRow.forEach((editValue, column) => {
-            const { editorValue, pendingValue, sourceValue: oldValue, state } = editValue;
-            const diff = _sourceAndPendingDiffer(editValue);
-
-            let newValue = editorValue ?? pendingValue;
-
-            if (newValue === UNEDITED) {
-                newValue = undefined;
-            }
-
-            const edit: EditingCellPosition = {
-                newValue,
-                oldValue,
-                state,
-                column,
-                colId: column.getColId(),
-                colKey: column.getColId(),
-                rowIndex: rowIndex!,
-                rowPinned,
-            };
-
-            const editing = state === 'editing';
-            const changed = !editing && diff;
-
+    edits?.forEach((editRow, rowNode: RowNode) => {
+        editRow.forEach((editValue, column: AgColumn) => {
+            const editing = editValue.state === 'editing';
+            const changed = !editing && _sourceAndPendingDiffer(editValue);
             if (editing || changed) {
-                positions.push(edit);
+                const colId = column.colId;
+                let newValue = editValue.editorValue ?? editValue.pendingValue;
+                if (newValue === UNEDITED) {
+                    newValue = undefined;
+                }
+                positions.push({
+                    newValue,
+                    oldValue: editValue.sourceValue,
+                    state: editValue.state,
+                    column,
+                    colId,
+                    colKey: colId,
+                    rowIndex: rowNode.rowIndex!,
+                    rowPinned: rowNode.rowPinned,
+                });
             }
         });
     });

--- a/packages/ag-grid-community/src/edit/editModelService.test.ts
+++ b/packages/ag-grid-community/src/edit/editModelService.test.ts
@@ -62,14 +62,25 @@ describe('EditModelService', () => {
 
     describe('getEditMap', () => {
         it('when empty', () => {
-            const editMap = editModelService.getEditMap();
+            expect(editModelService.getEditMap()).toEqual(new Map());
+        });
+
+        it('returns the live map by reference (no copy)', () => {
+            editModelService.setEdit(position1, { editorValue: 'value1' });
+            expect(editModelService.getEditMap()).toBe(editModelService.getEditMap());
+        });
+    });
+
+    describe('getEditMapCopy', () => {
+        it('when empty', () => {
+            const editMap = editModelService.getEditMapCopy();
             expect(editMap).toEqual(new Map());
         });
 
         it('when it has positions', () => {
             editModelService.setEdit(position1, { editorValue: 'value1' });
             editModelService.setEdit(position2, { editorValue: 'value2' });
-            const editMap = editModelService.getEditMap();
+            const editMap = editModelService.getEditMapCopy();
             expect(editMap).toEqual(
                 createExpectedMap([
                     [position1, { editorValue: 'value1' }],
@@ -82,7 +93,7 @@ describe('EditModelService', () => {
             editModelService.setEdit(position1, { editorValue: 'value1' });
             editModelService.setEdit(position2, { editorValue: 'value2' });
             editModelService.removeEdits(position1);
-            const editMap = editModelService.getEditMap();
+            const editMap = editModelService.getEditMapCopy();
             const expected = createExpectedMap([[position1, { editorValue: 'value2' }]]);
             expect(editMap).toEqual(expected);
         });
@@ -90,12 +101,126 @@ describe('EditModelService', () => {
         it('creates an actual copy of the deepest object', () => {
             editModelService.setEdit(position1, { editorValue: 'value1' });
             editModelService.setEdit(position2, { editorValue: 'value2' });
-            const editMap = editModelService.getEditMap();
-            const copy = editModelService.getEditMap();
+            const editMap = editModelService.getEditMapCopy();
+            const copy = editModelService.getEditMapCopy();
             expect(copy).toEqual(editMap);
             expect(copy).not.toBe(editMap);
             expect(copy.get(rowNode1)).not.toBe(editMap.get(rowNode1));
             expect(copy.get(rowNode1)!.get(column1)).not.toBe(editMap.get(rowNode1)!.get(column1));
+        });
+    });
+
+    // hasOpenEditors is backed by a live `editingCount` maintained at every mutation site; these
+    // pin that the count stays in sync with the `state` field (its source of truth) across each path.
+    describe('hasOpenEditors', () => {
+        it('is false when empty', () => {
+            expect(editModelService.hasOpenEditors()).toBe(false);
+        });
+
+        it('tracks setEdit transitions into and out of the editing state', () => {
+            editModelService.setEdit(position1, { state: 'changed' });
+            expect(editModelService.hasOpenEditors()).toBe(false);
+
+            editModelService.setEdit(position1, { state: 'editing' });
+            expect(editModelService.hasOpenEditors()).toBe(true);
+
+            // Re-writing an already-editing cell must not double-count.
+            editModelService.setEdit(position1, { editorValue: 'typing' });
+            expect(editModelService.hasOpenEditors()).toBe(true);
+
+            editModelService.setEdit(position1, { state: 'changed' });
+            expect(editModelService.hasOpenEditors()).toBe(false);
+        });
+
+        it('stays open until the last editing cell leaves the editing state', () => {
+            editModelService.setEdit(position1, { state: 'editing' });
+            editModelService.setEdit(position2, { state: 'editing' });
+            expect(editModelService.hasOpenEditors()).toBe(true);
+
+            editModelService.setEdit(position1, { state: 'changed' });
+            expect(editModelService.hasOpenEditors()).toBe(true);
+
+            editModelService.setEdit(position2, { state: 'changed' });
+            expect(editModelService.hasOpenEditors()).toBe(false);
+        });
+
+        it('decrements when an editing cell is removed by column', () => {
+            editModelService.setEdit(position1, { state: 'editing' });
+            editModelService.removeEdits(position1);
+            expect(editModelService.hasOpenEditors()).toBe(false);
+        });
+
+        it('decrements every editing cell when a whole row is removed', () => {
+            const positionSameRow: Required<EditPosition> = { rowNode: rowNode1, column: column2 };
+            editModelService.setEdit(position1, { state: 'editing' });
+            editModelService.setEdit(positionSameRow, { state: 'editing' });
+            editModelService.removeEdits({ rowNode: rowNode1 });
+            expect(editModelService.hasOpenEditors()).toBe(false);
+        });
+
+        it('decrements when clearEditValue reverts an editing cell to changed', () => {
+            editModelService.setEdit(position1, { state: 'editing' });
+            editModelService.clearEditValue(position1);
+            expect(editModelService.hasOpenEditors()).toBe(false);
+        });
+
+        it('recomputes the count from scratch on setEditMap', () => {
+            const map = new Map([
+                [rowNode1, new Map([[column1, { state: 'editing' } as any]])],
+                [rowNode2, new Map([[column2, { state: 'changed' } as any]])],
+            ]);
+            editModelService.setEditMap(map);
+            expect(editModelService.hasOpenEditors()).toBe(true);
+
+            editModelService.setEditMap(new Map());
+            expect(editModelService.hasOpenEditors()).toBe(false);
+        });
+
+        it('resets the count on clear', () => {
+            editModelService.setEdit(position1, { state: 'editing' });
+            editModelService.clear();
+            expect(editModelService.hasOpenEditors()).toBe(false);
+        });
+    });
+
+    describe('setEditMap', () => {
+        // getEditMap returns the live map, so setEditMap(getEditMap()) aliases its own source.
+        it('preserves edits (and editingCount) when passed the live map from getEditMap', () => {
+            editModelService.setEdit(position1, { editorValue: 'value1', state: 'editing' });
+            editModelService.setEdit(position2, { editorValue: 'value2', state: 'changed' });
+
+            editModelService.setEditMap(editModelService.getEditMap()!);
+
+            expect(editModelService.getEditMapCopy()).toEqual(
+                createExpectedMap([
+                    [position1, { editorValue: 'value1', state: 'editing' } as any],
+                    [position2, { editorValue: 'value2', state: 'changed' } as any],
+                ])
+            );
+            expect(editModelService.hasOpenEditors()).toBe(true);
+        });
+    });
+
+    describe('start', () => {
+        // findNextCellToFocusOn suspends the model while it may initialise editors (see singleCellEditStrategy),
+        // so start() can run for a row that already has editing entries while suspended.
+        it('keeps existing editing entries and editingCount in sync when suspended', () => {
+            editModelService['beans'] = { valueSvc: { getValueFromData: () => 'src' } } as any;
+
+            editModelService.setEdit(position1, { state: 'editing' }); // rowNode1 / column1
+            editModelService.suspend(true);
+            editModelService.start({ rowNode: rowNode1, column: column2 }); // same row, new editing cell
+            editModelService.suspend(false);
+
+            const row = editModelService.getEditMapCopy().get(rowNode1)!;
+            expect(row.has(column1)).toBe(true); // pre-existing editing entry not dropped
+            expect(row.has(column2)).toBe(true);
+
+            // editingCount tracks both, so removing them both returns hasOpenEditors to false (no stuck count).
+            editModelService.removeEdits({ rowNode: rowNode1, column: column1 });
+            expect(editModelService.hasOpenEditors()).toBe(true);
+            editModelService.removeEdits({ rowNode: rowNode1, column: column2 });
+            expect(editModelService.hasOpenEditors()).toBe(false);
         });
     });
 });

--- a/packages/ag-grid-community/src/edit/editModelService.ts
+++ b/packages/ag-grid-community/src/edit/editModelService.ts
@@ -13,6 +13,7 @@ import type {
     EditValidationMap,
     EditValue,
     GetEditsParams,
+    ReadonlyEditMap,
 } from '../interfaces/iEditModelService';
 import type { EditPosition, EditRowPosition } from '../interfaces/iEditService';
 import type { IRowNode } from '../interfaces/iRowNode';
@@ -22,6 +23,8 @@ export class EditModelService extends BeanStub implements NamedBean {
     public beanName = 'editModelSvc' as const;
 
     private readonly edits: EditMap = new Map();
+    // O(1) count of 'editing'-state edits so hasOpenEditors avoids scanning the map (`state` is the truth).
+    private editingCount = 0;
     private cellValidations: EditCellValidationModel = new EditCellValidationModel();
     private rowValidations: EditRowValidationModel = new EditRowValidationModel();
 
@@ -32,6 +35,10 @@ export class EditModelService extends BeanStub implements NamedBean {
         this.suspendEdits = suspend;
     }
 
+    public hasOpenEditors(): boolean {
+        return this.editingCount > 0;
+    }
+
     public removeEdits({ rowNode, column }: EditPosition): void {
         if (!this.hasEdits({ rowNode }) || !rowNode) {
             return;
@@ -40,8 +47,16 @@ export class EditModelService extends BeanStub implements NamedBean {
         const editRow = this.getEditRow(rowNode)!;
 
         if (column) {
+            if (editRow.get(column)?.state === 'editing') {
+                this.editingCount--;
+            }
             editRow.delete(column);
         } else {
+            editRow.forEach((edit) => {
+                if (edit.state === 'editing') {
+                    this.editingCount--;
+                }
+            });
             editRow.clear();
         }
 
@@ -50,7 +65,7 @@ export class EditModelService extends BeanStub implements NamedBean {
         }
     }
 
-    public getEditRow(rowNode: IRowNode, params: GetEditsParams = {}): EditRow | undefined {
+    public getEditRow(rowNode: IRowNode, checkSiblings?: boolean): EditRow | undefined {
         if (this.suspendEdits) {
             return undefined;
         }
@@ -65,7 +80,7 @@ export class EditModelService extends BeanStub implements NamedBean {
             return edits;
         }
 
-        if (params.checkSiblings) {
+        if (checkSiblings) {
             const pinnedSibling = (rowNode as RowNode).pinnedSibling;
             if (pinnedSibling) {
                 return this.getEditRow(pinnedSibling);
@@ -75,79 +90,67 @@ export class EditModelService extends BeanStub implements NamedBean {
         return undefined;
     }
 
-    public getEditRowDataValue(rowNode: IRowNode, { checkSiblings }: GetEditsParams = {}): any {
+    public getEditRowDataValue(rowNode: IRowNode): any {
         if (!rowNode || this.edits.size === 0) {
             return undefined;
         }
 
-        // don't check siblings via getEditRow parameter, as we want to combine edits from the row and its siblings
+        // Merge the row AND its pinned sibling, so we can't use getEditRow's checkSiblings (returns one or the other).
         const editRow = this.getEditRow(rowNode);
         const pinnedSibling = (rowNode as RowNode).pinnedSibling;
-        const siblingRow = checkSiblings && pinnedSibling && this.getEditRow(pinnedSibling);
+        const siblingRow = pinnedSibling ? this.getEditRow(pinnedSibling) : undefined;
 
         if (!editRow && !siblingRow) {
             return undefined;
         }
 
         const data: any = { ...rowNode.data };
-
-        const applyEdits = (edits: EditRow, data: any) =>
-            edits.forEach(({ editorValue, pendingValue }, column) => {
-                const value = editorValue === undefined ? pendingValue : editorValue;
-                if (value !== UNEDITED) {
-                    data[column.getColId()] = value;
-                }
-            });
-
         if (editRow) {
-            applyEdits(editRow, data);
+            applyEditsToData(editRow, data);
         }
-
         if (siblingRow) {
-            applyEdits(siblingRow, data);
+            applyEditsToData(siblingRow, data);
         }
 
         return data;
     }
 
-    public getEdit(position: EditPosition = {}, params?: GetEditsParams): EditValue | undefined {
-        const { rowNode, column } = position;
-        const edits = this.edits;
-        if (this.suspendEdits || edits.size === 0 || !rowNode || !column) {
-            return undefined; // no edits or incomplete position
-        }
-
-        // Check the row's edits first
-        const edit = edits.get(rowNode)?.get(column);
-        if (edit) {
-            return edit; // found edit for the cell
-        }
-
-        // If checkSiblings, also check the pinned sibling for the column
-        if (params?.checkSiblings) {
-            const pinnedSibling = (rowNode as RowNode).pinnedSibling;
-            if (pinnedSibling) {
-                return edits.get(pinnedSibling)?.get(column); // return edit from pinned sibling if found
-            }
-        }
-
-        return undefined;
+    public getEdit(position: EditPosition = {}): EditValue | undefined {
+        return this.getCellEdit(position.rowNode, position.column);
     }
 
-    public getEditMap(copy = true): EditMap {
-        if (this.suspendEdits || this.edits.size === 0) {
-            return new Map();
+    /** Direct single-cell lookup — allocation-free, no pinned-sibling fallback (see {@link getCellEditWithSibling}). */
+    public getCellEdit(rowNode: IRowNode | null | undefined, column: Column | null | undefined): EditValue | undefined {
+        const edits = this.edits;
+        if (edits.size === 0 || this.suspendEdits || !rowNode || !column) {
+            return undefined; // no edits or incomplete position
         }
+        return edits.get(rowNode)?.get(column);
+    }
 
-        if (!copy) {
-            return this.edits;
+    /** Single-cell lookup that falls back to the pinned sibling, since pinned rows mirror their sibling's edits. */
+    public getCellEditWithSibling(
+        rowNode: IRowNode | null | undefined,
+        column: Column | null | undefined
+    ): EditValue | undefined {
+        return this.getCellEdit(rowNode, column) ?? this.getCellEdit((rowNode as RowNode)?.pinnedSibling, column);
+    }
+
+    /** The live edit map, or null while edits are suspended. Read-only: mutating it would break editingCount. */
+    public getEditMap(): ReadonlyEditMap | null {
+        return this.suspendEdits ? null : this.edits;
+    }
+
+    /** A deep copy of the edit map — a mutable snapshot, safe to hold and mutate across model changes. */
+    public getEditMapCopy(): EditMap {
+        const map: EditMap = new Map();
+        if (this.suspendEdits) {
+            return map;
         }
-
-        const map = new Map<IRowNode, Map<Column, EditValue>>();
         this.edits.forEach((editRow, rowNode) => {
             const newEditRow = new Map<Column, EditValue>();
             editRow.forEach(({ editorState: _, ...cellData }, column) =>
-                // Ensure we copy the cell data to avoid reference issues
+                // Copy the cell data so the snapshot is decoupled from the live model.
                 newEditRow.set(column, { ...cellData } as EditValue)
             );
             map.set(rowNode, newEditRow);
@@ -155,25 +158,39 @@ export class EditModelService extends BeanStub implements NamedBean {
         return map;
     }
 
-    public setEditMap(newEdits: EditMap): void {
-        this.edits.clear();
+    public setEditMap(newEdits: ReadonlyEditMap): void {
+        // newEdits may alias this.edits (getEditMap returns it), so build the copy before clearing.
+        const rebuilt = new Map<IRowNode, Map<Column, EditValue>>();
+        let editingCount = 0;
         newEdits.forEach((editRow, rowNode) => {
             const newRow = new Map<Column, EditValue>();
-            editRow.forEach((cellData, column) =>
-                // Ensure we copy the cell data to avoid reference issues
-                newRow.set(column, { ...cellData })
-            );
-            this.edits.set(rowNode, newRow);
+            editRow.forEach((cellData, column) => {
+                if (cellData.state === 'editing') {
+                    editingCount++;
+                }
+                newRow.set(column, { ...cellData });
+            });
+            rebuilt.set(rowNode, newRow);
         });
+
+        const edits = this.edits;
+        edits.clear();
+        rebuilt.forEach((row, rowNode) => edits.set(rowNode, row));
+        this.editingCount = editingCount;
     }
 
     public setEdit(position: Required<EditPosition>, edit: Partial<EditValue>): Readonly<EditValue> {
+        const { rowNode, column } = position;
         const edits = this.edits;
-        if (edits.size === 0 || !edits.has(position.rowNode)) {
-            edits.set(position.rowNode, new Map());
+        let editRow = edits.get(rowNode);
+        if (!editRow) {
+            editRow = new Map<Column, EditValue>();
+            edits.set(rowNode, editRow);
         }
 
-        const currentEdit = this.getEdit(position);
+        // Matches getEdit's suspend semantics: while suspended there is no current edit to merge onto.
+        const existing = editRow.get(column);
+        const currentEdit = this.suspendEdits ? undefined : existing;
 
         const updatedEdit: EditValue = {
             editorState: {
@@ -184,7 +201,14 @@ export class EditModelService extends BeanStub implements NamedBean {
             ...edit,
         } as EditValue;
 
-        this.getEditRow(position.rowNode)!.set(position.column, updatedEdit);
+        // Track the 'editing' population from the actual stored state before/after the write.
+        const wasEditing = existing?.state === 'editing';
+        const nowEditing = updatedEdit.state === 'editing';
+        if (wasEditing !== nowEditing) {
+            this.editingCount += nowEditing ? 1 : -1;
+        }
+
+        editRow.set(column, updatedEdit);
 
         return updatedEdit;
     }
@@ -196,6 +220,9 @@ export class EditModelService extends BeanStub implements NamedBean {
         }
 
         const update = (edit: EditValue) => {
+            if (edit.state === 'editing') {
+                this.editingCount--;
+            }
             edit.editorValue = undefined;
             edit.pendingValue = edit.sourceValue;
             // Reverting to sourceValue is always 'changed' (i.e. "no longer editing").
@@ -242,7 +269,7 @@ export class EditModelService extends BeanStub implements NamedBean {
         return positions;
     }
 
-    public hasRowEdits(rowNode: IRowNode, params?: GetEditsParams): boolean {
+    public hasRowEdits(rowNode: IRowNode, checkSiblings?: boolean): boolean {
         if (this.suspendEdits) {
             return false;
         }
@@ -251,7 +278,7 @@ export class EditModelService extends BeanStub implements NamedBean {
             return false;
         }
 
-        const rowEdits = this.getEditRow(rowNode, params);
+        const rowEdits = this.getEditRow(rowNode, checkSiblings);
         return !!rowEdits;
     }
 
@@ -267,7 +294,7 @@ export class EditModelService extends BeanStub implements NamedBean {
         const { rowNode, column } = position;
         const { withOpenEditor } = params;
         if (rowNode) {
-            const rowEdits = this.getEditRow(rowNode, params);
+            const rowEdits = this.getEditRow(rowNode, params.checkSiblings);
             if (!rowEdits) {
                 return false;
             }
@@ -290,15 +317,21 @@ export class EditModelService extends BeanStub implements NamedBean {
         }
 
         if (withOpenEditor) {
-            return this.getEditPositions().some(({ state }: any) => state === 'editing');
+            return this.hasOpenEditors();
         }
 
         return this.edits.size > 0;
     }
 
     public start(position: Required<EditPosition>): void {
-        const map = this.getEditRow(position.rowNode) ?? new Map<Column, EditValue>();
         const { rowNode, column } = position;
+        // Read the live row directly (not via getEditRow, which returns undefined while suspended):
+        // replacing an existing row here would drop its editing entries without adjusting editingCount.
+        let map = this.edits.get(rowNode);
+        if (!map) {
+            map = new Map<Column, EditValue>();
+            this.edits.set(rowNode, map);
+        }
         if (column && !map.has(column)) {
             map.set(column, {
                 editorValue: undefined,
@@ -310,8 +343,8 @@ export class EditModelService extends BeanStub implements NamedBean {
                     isCancelBeforeStart: undefined,
                 },
             });
+            this.editingCount++;
         }
-        this.edits.set(rowNode, map);
     }
 
     public stop(position: Required<EditPosition>, preserveBatch: boolean, cancel: boolean): void {
@@ -343,6 +376,7 @@ export class EditModelService extends BeanStub implements NamedBean {
             pendingRowEdits.clear();
         }
         this.edits.clear();
+        this.editingCount = 0;
     }
 
     public getCellValidationModel(): EditCellValidationModel {
@@ -440,3 +474,13 @@ export class EditRowValidationModel {
         this.rowValidations.clear();
     }
 }
+
+/** Merges a row's pending/editor values into a plain data object, skipping UNEDITED cells. */
+const applyEditsToData = (edits: EditRow, data: any): void => {
+    edits.forEach(({ editorValue, pendingValue }, column) => {
+        const value = editorValue === undefined ? pendingValue : editorValue;
+        if (value !== UNEDITED) {
+            data[column.getColId()] = value;
+        }
+    });
+};

--- a/packages/ag-grid-community/src/edit/editService.ts
+++ b/packages/ag-grid-community/src/edit/editService.ts
@@ -2,6 +2,7 @@ import { KeyCode } from 'ag-stack';
 
 import type { NamedBean } from '../context/bean';
 import { BeanStub } from '../context/beanStub';
+import type { BeanCollection } from '../context/context';
 import type { AgColumn } from '../entities/agColumn';
 import { _getRowNode } from '../entities/positionUtils';
 import type { RowNode } from '../entities/rowNode';
@@ -49,6 +50,7 @@ import {
     _destroyEditors,
     _filterChangedEdits,
     _populateModelValidationErrors,
+    _purgeUnchangedEdit,
     _purgeUnchangedEdits,
     _refreshEditorOnColDefChanged,
     _setupEditor,
@@ -112,6 +114,7 @@ export class EditService extends BeanStub implements NamedBean {
 
     public committing = false;
 
+    private csrm = false;
     private batch: boolean = false;
     private batchStartDispatched: boolean = false;
     private model: EditModelService;
@@ -121,11 +124,16 @@ export class EditService extends BeanStub implements NamedBean {
     private stopping = false;
     private rangeSelectionWhileEditing = 0;
 
+    // Nonzero while a bulk write coalesces per-cell cleanup/refresh (see beginBulkWrite).
+    private bulkWriteDepth = 0;
+    private bulkWriteTouched: Required<EditPosition>[] = [];
+
     public postConstruct(): void {
         const { beans } = this;
         this.model = beans.editModelSvc!;
         this.valueSvc = beans.valueSvc;
         this.rangeSvc = beans.rangeSvc!;
+        this.csrm = _isClientSideRowModel(this.gos, beans.rowModel);
 
         this.addManagedPropertyListener('editType', ({ currentValue }: any) => {
             this.stopEditing(undefined, CANCEL_PARAMS);
@@ -269,7 +277,7 @@ export class EditService extends BeanStub implements NamedBean {
     }
 
     public isRowEditing(rowNode?: IRowNode, params?: IsEditingParams): boolean {
-        return !!rowNode && this.model.hasRowEdits(rowNode, params);
+        return !!rowNode && this.model.hasRowEdits(rowNode, params?.checkSiblings);
     }
 
     public enableRangeSelectionWhileEditing(): void {
@@ -403,7 +411,7 @@ export class EditService extends BeanStub implements NamedBean {
         return {
             cancel,
             cellCtrl,
-            edits: this.model.getEditMap(true),
+            edits: this.model.getEditMapCopy(),
             event: event ?? null,
             forceCancel,
             forceStop,
@@ -436,7 +444,7 @@ export class EditService extends BeanStub implements NamedBean {
             this.strategy?.cleanupEditors(position);
         }
 
-        return { res: false, edits: this.model.getEditMap() };
+        return { res: false, edits: this.model.getEditMapCopy() };
     }
 
     private handleStopOrCancel(context: StopContext): StopOutcome {
@@ -448,7 +456,7 @@ export class EditService extends BeanStub implements NamedBean {
         const persist = !this.batch || !willCancel;
         _syncFromEditors(beans, { persist, isCancelling: willCancel || cancel, isStopping: willStop });
 
-        const freshEdits = model.getEditMap();
+        const freshEdits = model.getEditMapCopy();
         const shouldCommit = !willCancel && (!this.batch || commit);
         const editsToDelete = shouldCommit ? this.processEdits(freshEdits, source) : [];
 
@@ -527,7 +535,7 @@ export class EditService extends BeanStub implements NamedBean {
 
             this.bulkRefreshMap(edits, { suppressFlash: true });
 
-            return model.getEditMap();
+            return model.getEditMapCopy();
         }
 
         return edits;
@@ -737,7 +745,7 @@ export class EditService extends BeanStub implements NamedBean {
                 // Reading from valueSvc.getValue('data') can return stale aggData for group nodes when
                 // aggregation is deferred (e.g. inside a changeDetectionSvc batch), causing the edit
                 // to appear as pending (⏳) even after undo/redo restores the original value.
-                this.beans.editModelSvc?.setEdit(position, { sourceValue: edit.pendingValue });
+                this.model.setEdit(position, { sourceValue: edit.pendingValue });
             } else {
                 this.model.clearEditValue(position);
             }
@@ -751,28 +759,30 @@ export class EditService extends BeanStub implements NamedBean {
         this.bulkRefreshMap(edits);
 
         // force refresh of all row cells as custom renderers may depend on multiple cell values
-        let refreshParams = FORCE_REFRESH;
+        let refreshParams: RefreshCellsParams = FORCE_REFRESH;
         if (params?.forceRefreshOfEditCellsOnly) {
-            // Only refresh the cells for the current edits
-            refreshParams = {
-                ...getRowColumnsFromMap(edits),
-                ...FORCE_REFRESH,
-            };
+            // Only refresh the current edit cells: gather row keys + deduped columns in one pass.
+            const rowNodes: IRowNode[] = [];
+            const columns = new Set<Column>();
+            edits.forEach((editRow, rowNode) => {
+                rowNodes.push(rowNode);
+                for (const column of editRow.keys()) {
+                    columns.add(column);
+                }
+            });
+            refreshParams = { rowNodes, columns: Array.from(columns), ...FORCE_REFRESH };
         }
         this.beans.rowRenderer.refreshCells(refreshParams);
     }
 
     private dispatchEditValuesChanged(
-        { rowNode, column }: EditPosition,
+        rowNode: IRowNode,
+        column: Column,
         edit: Partial<Pick<EditValue, 'pendingValue' | 'sourceValue'>> = {}
     ): void {
-        if (!rowNode || !column || !edit) {
-            return;
-        }
-
         const { pendingValue, sourceValue } = edit;
         const { rowIndex, rowPinned, data } = rowNode;
-        this.beans.eventSvc.dispatchEvent({
+        this.eventSvc.dispatchEvent({
             type: 'cellEditValuesChanged',
             node: rowNode,
             rowIndex,
@@ -787,71 +797,109 @@ export class EditService extends BeanStub implements NamedBean {
         });
     }
 
+    // A bulk write (paste/fill/range-delete/undo) stages many cells via setDataValue. Between
+    // beginBulkWrite/endBulkWrite the per-cell editor cleanup and refresh are deferred, then applied
+    // once on the outermost endBulkWrite — turning O(N^2) per-cell work into O(N). Callers own try/finally.
+    public beginBulkWrite(): void {
+        this.bulkWriteDepth++;
+    }
+
+    public endBulkWrite(): void {
+        if (--this.bulkWriteDepth === 0) {
+            this.flushBulkWrite();
+        }
+    }
+
+    private flushBulkWrite(): void {
+        const touched = this.bulkWriteTouched;
+        this.bulkWriteTouched = [];
+        if (!this.batch || touched.length === 0) {
+            return;
+        }
+
+        // A pre-existing open editor (rare during a bulk write) is torn down once here; the common
+        // no-editor case skips it in O(1). Staged cells were already scope-purged per cell.
+        if (this.model.hasOpenEditors()) {
+            this.cleanupEditors();
+        }
+
+        // refCell drives CSRM-only ancestor/group refresh, matching bulkRefreshCell/bulkRefreshMap.
+        if (!this.csrm) {
+            return;
+        }
+
+        // Refresh each cell once (a cell can be staged more than once per bulk write), and dedup shared
+        // ancestor (group/total) refreshes across cells too.
+        const seenCells = new Map<IRowNode, Set<Column>>();
+        const seenAncestors = new Map<IRowNode, Set<Column>>();
+        for (let i = 0, len = touched.length; i < len; ++i) {
+            const position = touched[i];
+            const { rowNode, column } = position;
+            if (markSeen(seenCells, rowNode, column)) {
+                this.refCell(rowNode, column, this.model.getCellEdit(rowNode, column), undefined, seenAncestors);
+            }
+        }
+    }
+
     private bulkRefreshCell(position: Required<EditPosition>, params?: RefreshCellsParams): void {
-        if (_isClientSideRowModel(this.gos, this.beans.rowModel)) {
-            this.refCell(position, this.model.getEdit(position), params);
+        if (this.csrm) {
+            const { rowNode, column } = position;
+            this.refCell(rowNode, column, this.model.getCellEdit(rowNode, column), params);
         }
     }
 
     private bulkRefreshMap(editMap: EditMap, params?: RefreshCellsParams): void {
-        if (_isClientSideRowModel(this.gos, this.beans.rowModel)) {
+        if (this.csrm) {
             editMap.forEach((editRow, rowNode) => {
                 for (const column of editRow.keys()) {
-                    this.refCell({ rowNode, column }, editRow.get(column), params);
+                    this.refCell(rowNode, column, editRow.get(column), params);
                 }
             });
         }
     }
 
     private refCell(
-        { rowNode, column }: Required<EditPosition>,
-        edit?: EditValue,
-        params: RefreshCellsParams = {}
+        rowNode: IRowNode,
+        column: Column,
+        edit: EditValue | undefined,
+        params: RefreshCellsParams = {},
+        seenAncestors?: Map<IRowNode, Set<Column>>
     ): void {
         const { beans, gos } = this;
-
-        const updatedNodes: Set<IRowNode> = new Set([rowNode]);
-        const refreshNodes: Set<IRowNode> = new Set();
-
         const pinnedSibling = (rowNode as RowNode).pinnedSibling;
+
+        // Primary cell(s): the row and its pinned sibling (always distinct). Dispatch both, then refresh both.
+        this.dispatchEditValuesChanged(rowNode, column, edit);
         if (pinnedSibling) {
-            updatedNodes.add(pinnedSibling);
+            this.dispatchEditValuesChanged(pinnedSibling, column, edit);
+        }
+        _getCellCtrl(beans, { rowNode, column })?.refreshCell(params);
+        if (pinnedSibling) {
+            _getCellCtrl(beans, { rowNode: pinnedSibling, column })?.refreshCell(params);
         }
 
+        // Ancestor cells whose displayed value depends on this cell (sibling/group/total rows).
+        const batch = this.batch;
         const sibling = rowNode.sibling;
         if (sibling) {
-            refreshNodes.add(sibling);
+            refreshAncestorCell(beans, sibling, column, params, batch, seenAncestors);
         }
 
         let parent = rowNode.parent;
+        if (!parent) {
+            return; // no parent (e.g. pinned rows) — no ancestor cells to refresh
+        }
+        const groupTotalRow = gos.get('groupTotalRow');
+        const grandTotalRow = gos.get('grandTotalRow');
         while (parent) {
-            if (parent.sibling?.footer && gos.get('groupTotalRow')) {
-                refreshNodes.add(parent.sibling);
-            } else if (!parent.parent && parent.sibling && gos.get('grandTotalRow')) {
-                refreshNodes.add(parent.sibling);
-            } else {
-                refreshNodes.add(parent);
-            }
+            const parentSibling = parent.sibling;
+            // Group/grand-total footer rows mirror the aggregated cell; otherwise refresh the parent itself.
+            const target =
+                parentSibling && ((parentSibling.footer && groupTotalRow) || (!parent.parent && grandTotalRow))
+                    ? parentSibling
+                    : parent;
+            refreshAncestorCell(beans, target, column, params, batch, seenAncestors);
             parent = parent.parent;
-        }
-
-        for (const node of updatedNodes) {
-            this.dispatchEditValuesChanged({ rowNode: node, column }, edit);
-        }
-        for (const node of updatedNodes) {
-            _getCellCtrl(beans, { rowNode: node, column })?.refreshCell(params);
-        }
-        for (const node of refreshNodes) {
-            const cellCtrl = _getCellCtrl(beans, { rowNode: node, column });
-            if (cellCtrl) {
-                cellCtrl.refreshCell(params);
-                // During batch, parent/group/grand-total rows need their batch edit CSS
-                // updated even when their aggregated value hasn't changed (dataNeedsUpdating
-                // is false, so refreshCell alone won't run _applyCellEditStyles).
-                if (!params.force && this.batch) {
-                    _applyCellEditStyles(beans, cellCtrl);
-                }
-            }
         }
     }
 
@@ -1019,17 +1067,18 @@ export class EditService extends BeanStub implements NamedBean {
      */
     public getPendingEditValue(rowNode: IRowNode, column: Column, from: Exclude<CellValueResolveFrom, 'data'>): any {
         // Caller (ValueService.getValue) has already resolved any pivot result column.
-        if (from === 'batch' && !this.batch) {
+        const batch = this.batch;
+        if (from === 'batch' && !batch) {
             return undefined; // 'batch' mode: only return edit values when batch editing is active
         }
 
-        const edit = this.model.getEdit({ rowNode, column }, CHECK_SIBLING);
+        const edit = this.model.getCellEditWithSibling(rowNode, column);
         if (!edit) {
             return undefined;
         }
 
         // Skip during stopEditing when value was already committed (non-batch, no editor opened)
-        if (this.stopping && !this.batch && !edit.editorState?.cellStartedEditing) {
+        if (this.stopping && !batch && !edit.editorState?.cellStartedEditing) {
             return undefined;
         }
 
@@ -1049,7 +1098,7 @@ export class EditService extends BeanStub implements NamedBean {
     }
 
     public getCellDataValue(position: Required<EditPosition>): any {
-        const edit = this.model.getEdit(position, CHECK_SIBLING);
+        const edit = this.model.getCellEditWithSibling(position.rowNode, position.column);
         if (edit) {
             const newValue = edit.pendingValue;
             if (newValue !== UNEDITED) {
@@ -1091,8 +1140,8 @@ export class EditService extends BeanStub implements NamedBean {
             return false; // don't toggle-back if currently being edited
         }
 
-        this.dispatchEditValuesChanged(position, { ...existing, pendingValue: sourceValue });
-        this.beans.editModelSvc?.removeEdits(position);
+        this.dispatchEditValuesChanged(position.rowNode, position.column, { ...existing, pendingValue: sourceValue });
+        this.model.removeEdits(position);
         _getCellCtrl(this.beans, position)?.refreshCell(FORCE_REFRESH);
         return true; // toggled back to source value
     }
@@ -1196,10 +1245,10 @@ export class EditService extends BeanStub implements NamedBean {
         }
 
         // sourceValue === newValue: setting back to original value removes the edit entirely.
-        this.beans.editModelSvc?.removeEdits(position);
+        this.model.removeEdits(position);
         this.ensureBatchStarted();
 
-        this.dispatchEditValuesChanged(position, {
+        this.dispatchEditValuesChanged(position.rowNode, position.column, {
             ...existing,
             pendingValue: newValue,
         });
@@ -1262,6 +1311,7 @@ export class EditService extends BeanStub implements NamedBean {
         const beans = this.beans;
 
         if (this.batch) {
+            const bulkWrite = this.bulkWriteDepth > 0;
             if (eventSource === 'batch' && _getCellCtrl(beans, position)?.comp?.getCellEditor()) {
                 // 'batch' source with an open editor: write ONLY to pendingValue,
                 // leaving editorValue untouched so the editor keeps showing what
@@ -1281,19 +1331,26 @@ export class EditService extends BeanStub implements NamedBean {
 
                 // 'batch' source (no open editor) stages a pending value without disrupting display;
                 // other sources close the editor, symmetrically with how default setDataValue works.
-                if (eventSource !== 'batch') {
+                // Within a bulk write this cleanup is coalesced into a single flush pass.
+                if (eventSource !== 'batch' && !bulkWrite) {
                     this.cleanupEditors();
                 }
             }
 
-            _purgeUnchangedEdits(beans);
+            // Only the cell just staged can have become unchanged; a full-map rescan here is O(N^2)
+            // across a bulk paste/fill (each staged cell would rescan every pending edit).
+            _purgeUnchangedEdit(beans, position);
 
             // Lazily dispatch batchEditingStarted for direct API writes during batch.
             this.ensureBatchStarted();
 
-            // Refresh the changed cell and dispatch cellEditValuesChanged so consumers
-            // (e.g. find service) react to the pending value update.
-            this.bulkRefreshCell(position);
+            if (bulkWrite) {
+                this.bulkWriteTouched.push(position);
+            } else {
+                // Refresh the changed cell and dispatch cellEditValuesChanged so consumers
+                // (e.g. find service) react to the pending value update.
+                this.bulkRefreshCell(position);
+            }
             return true;
         }
 
@@ -1305,8 +1362,8 @@ export class EditService extends BeanStub implements NamedBean {
         this.syncEditAfterCommit(position, success);
 
         // After undo/redo or direct data writes, the edit's pendingValue may now match sourceValue.
-        // Purge such entries so they don't show as batch-pending (⏳) when the value was restored.
-        _purgeUnchangedEdits(beans);
+        // Only this cell changed, so a scoped purge suffices (a full rescan here would be O(N^2) in bulk).
+        _purgeUnchangedEdit(beans, position);
 
         // Re-fetch: change detection during setDataValue may have recreated the CellCtrl.
         // Only allow flash when the value was actually committed; suppress when setDataValue
@@ -1334,7 +1391,7 @@ export class EditService extends BeanStub implements NamedBean {
             return;
         }
 
-        const hasEdits = model.hasRowEdits(position.rowNode, CHECK_SIBLING);
+        const hasEdits = model.hasRowEdits(position.rowNode, true);
 
         if (!hasEdits) {
             return;
@@ -1345,7 +1402,7 @@ export class EditService extends BeanStub implements NamedBean {
 
         if (compDetails) {
             const { params } = compDetails;
-            params.data = model.getEditRowDataValue(rowNode, CHECK_SIBLING);
+            params.data = model.getEditRowDataValue(rowNode);
             return { compDetails };
         }
 
@@ -1402,7 +1459,7 @@ export class EditService extends BeanStub implements NamedBean {
 
         _syncFromEditors(beans, { persist: true });
 
-        const edits: EditMap = this.model.getEditMap(true);
+        const edits: EditMap = this.model.getEditMapCopy();
         let editValue = edits.get(rowNode)?.get(column)?.pendingValue;
 
         let bulkStartDispatched = false;
@@ -1588,15 +1645,43 @@ export class EditService extends BeanStub implements NamedBean {
     }
 }
 
-function getRowColumnsFromMap(edits: EditMap): { rowNodes: IRowNode[] | undefined; columns: Column[] | undefined } {
-    return {
-        rowNodes: edits ? Array.from(edits.keys()) : undefined,
-        columns: edits
-            ? [...new Set(Array.from(edits.values()).flatMap((er: EditRow) => Array.from(er.keys())))]
-            : undefined,
-    };
-}
-
 function getEditType(gos: GridOptionsService, editType?: EditStrategyType) {
     return editType ?? gos.get('editType') ?? 'singleCell';
 }
+
+/** Records a (node, column) pair; returns false if it was already recorded (a duplicate). */
+const markSeen = (seen: Map<IRowNode, Set<Column>>, node: IRowNode, column: Column): boolean => {
+    let cols = seen.get(node);
+    if (!cols) {
+        cols = new Set();
+        seen.set(node, cols);
+    }
+    if (cols.has(column)) {
+        return false;
+    }
+    cols.add(column);
+    return true;
+};
+
+/** Refreshes one ancestor (group/total/sibling) cell, deduping across a bulk-write flush via `seenAncestors`. */
+const refreshAncestorCell = (
+    beans: BeanCollection,
+    node: IRowNode,
+    column: Column,
+    params: RefreshCellsParams,
+    batch: boolean,
+    seenAncestors: Map<IRowNode, Set<Column>> | undefined
+): void => {
+    if (seenAncestors && !markSeen(seenAncestors, node, column)) {
+        return; // already refreshed this ancestor cell earlier in the bulk-write flush
+    }
+    const cellCtrl = _getCellCtrl(beans, { rowNode: node, column });
+    if (cellCtrl) {
+        cellCtrl.refreshCell(params);
+        // During batch, parent/group/grand-total rows need their batch edit CSS updated even when their
+        // aggregated value is unchanged (dataNeedsUpdating is false, so refreshCell alone won't run it).
+        if (!params.force && batch) {
+            _applyCellEditStyles(beans, cellCtrl);
+        }
+    }
+};

--- a/packages/ag-grid-community/src/edit/strategy/baseEditStrategy.ts
+++ b/packages/ag-grid-community/src/edit/strategy/baseEditStrategy.ts
@@ -6,7 +6,7 @@ import type { AgColumn } from '../../entities/agColumn';
 import { _getRowNode } from '../../entities/positionUtils';
 import type { AgEventType } from '../../eventTypes';
 import type { CellFocusClearedEvent, CellFocusedEvent, CommonCellFocusParams } from '../../events';
-import type { EditMap, EditValue } from '../../interfaces/iEditModelService';
+import type { EditMap, EditValue, ReadonlyEditMap, ReadonlyEditRow } from '../../interfaces/iEditModelService';
 import type {
     EditInputEvents,
     EditPosition,
@@ -15,6 +15,7 @@ import type {
     StartEditWithPositionParams,
     _SetEditingCellsParams,
 } from '../../interfaces/iEditService';
+import type { IRowNode } from '../../interfaces/iRowNode';
 import type { CellCtrl } from '../../rendering/cell/cellCtrl';
 import type { EditModelService } from '../editModelService';
 import type { EditService } from '../editService';
@@ -320,11 +321,20 @@ export abstract class BaseEditStrategy extends BeanStub {
             });
         });
 
+        let newEdits: ReadonlyEditMap = edits;
         if (params?.update) {
-            edits = new Map([...this.model.getEditMap(), ...edits]);
+            // Merge existing rows under the new ones (new rows win). setEditMap deep-copies, so the
+            // read-only rows from the live map can be aliased here without mutating it.
+            const merged = new Map<IRowNode, ReadonlyEditRow>(edits);
+            this.model.getEditMap()?.forEach((row, rowNode) => {
+                if (!merged.has(rowNode)) {
+                    merged.set(rowNode, row);
+                }
+            });
+            newEdits = merged;
         }
 
-        this.model?.setEditMap(edits);
+        this.model?.setEditMap(newEdits);
 
         if (cells.length > 0) {
             const position = cells.at(-1)!;

--- a/packages/ag-grid-community/src/edit/strategy/fullRowEditStrategy.ts
+++ b/packages/ag-grid-community/src/edit/strategy/fullRowEditStrategy.ts
@@ -141,7 +141,7 @@ export class FullRowEditStrategy extends BaseEditStrategy {
         }
 
         const changedRows: IRowNode[] = [];
-        model.getEditMap().forEach((rowEdits, rowNode) => {
+        model.getEditMap()?.forEach((rowEdits, rowNode) => {
             if (!rowEdits || rowEdits.size === 0) {
                 return;
             }
@@ -340,7 +340,7 @@ export class FullRowEditStrategy extends BaseEditStrategy {
         const { beans, model } = this;
         // check all cells that should have an editor have one - in the case of small viewports,
         // editors might have been destroyed along with their corresponding cellCtrl
-        model.getEditMap().forEach((rowEdits, rowNode) =>
+        model.getEditMap()?.forEach((rowEdits, rowNode) =>
             rowEdits.forEach(({ state }, column) => {
                 if (state !== 'editing') {
                     return;

--- a/packages/ag-grid-community/src/edit/styles/style-utils.ts
+++ b/packages/ag-grid-community/src/edit/styles/style-utils.ts
@@ -30,8 +30,8 @@ const nodeHasLeafEdit = (
         const child = children[i];
         if (child.data) {
             const highlight =
-                editHighlightFn(editModelSvc?.getEdit({ rowNode: child, column })) ||
-                editHighlightFn(editModelSvc?.getEdit({ rowNode: child.pinnedSibling, column }));
+                editHighlightFn(editModelSvc?.getCellEdit(child, column)) ||
+                editHighlightFn(editModelSvc?.getCellEdit(child.pinnedSibling, column));
             if (highlight) {
                 return true;
             }
@@ -58,10 +58,5 @@ export function _hasPinnedEdits(beans: BeanCollection, { rowNode, column }: Edit
     if (!rowNode) {
         return;
     }
-    return editHighlightFn(
-        beans.editModelSvc?.getEdit({
-            rowNode,
-            column,
-        })
-    );
+    return editHighlightFn(beans.editModelSvc?.getCellEdit(rowNode, column));
 }

--- a/packages/ag-grid-community/src/edit/utils/editors.ts
+++ b/packages/ag-grid-community/src/edit/utils/editors.ts
@@ -17,6 +17,7 @@ import type {
 import type { Column } from '../../interfaces/iColumn';
 import type { EditMap, EditState, EditValue } from '../../interfaces/iEditModelService';
 import type { EditPosition } from '../../interfaces/iEditService';
+import type { IRowNode } from '../../interfaces/iRowNode';
 import type { CellCtrl } from '../../rendering/cell/cellCtrl';
 import type { RowCtrl } from '../../rendering/row/rowCtrl';
 import { EditCellValidationModel, EditRowValidationModel } from '../editModelService';
@@ -307,20 +308,49 @@ function _createEditorParams(
     });
 }
 
+function purgeEditIfUnchanged(
+    editModelSvc: NonNullable<BeanCollection['editModelSvc']>,
+    rowNode: IRowNode,
+    column: Column,
+    edit: EditValue,
+    includeEditing?: boolean
+): void {
+    if (!includeEditing && (edit.state === 'editing' || edit.pendingValue === UNEDITED)) {
+        return;
+    }
+
+    // remove edits where the pending is equal to the old value
+    if (!_sourceAndPendingDiffer(edit)) {
+        editModelSvc.removeEdits({ rowNode, column });
+    }
+}
+
 export function _purgeUnchangedEdits(beans: BeanCollection, includeEditing?: boolean): void {
     const { editModelSvc } = beans;
-    editModelSvc?.getEditMap().forEach((editRow, rowNode) => {
-        editRow.forEach((edit, column) => {
-            if (!includeEditing && (edit.state === 'editing' || edit.pendingValue === UNEDITED)) {
-                return;
-            }
-
-            if (!_sourceAndPendingDiffer(edit) && (edit.state !== 'editing' || includeEditing)) {
-                // remove edits where the pending is equal to the old value
-                editModelSvc?.removeEdits({ rowNode, column });
-            }
-        });
+    // Read-only iteration (removeEdits only deletes the current entry) — no need for a map copy.
+    editModelSvc?.getEditMap()?.forEach((editRow, rowNode) => {
+        editRow.forEach((edit, column) => purgeEditIfUnchanged(editModelSvc, rowNode, column, edit, includeEditing));
     });
+}
+
+/**
+ * Scoped purge for a single staged cell — O(1) instead of rescanning the whole edit map.
+ * Staging one cell can only make that cell match its source, so bulk operations (paste/fill)
+ * must purge per-cell here rather than calling {@link _purgeUnchangedEdits} per staged cell (O(N^2)).
+ */
+export function _purgeUnchangedEdit(
+    beans: BeanCollection,
+    position: Required<EditPosition>,
+    includeEditing?: boolean
+): void {
+    const { editModelSvc } = beans;
+    if (!editModelSvc) {
+        return;
+    }
+    const edit = editModelSvc.getEdit(position);
+    if (edit) {
+        purgeEditIfUnchanged(editModelSvc, position.rowNode, position.column, edit, includeEditing);
+    }
 }
 
 export function _refreshEditorOnColDefChanged(beans: BeanCollection, cellCtrl: CellCtrl): void {
@@ -750,7 +780,7 @@ export function _populateModelValidationErrors(beans: BeanCollection, force?: bo
 const _generateRowValidationErrors = (beans: BeanCollection): EditRowValidationModel => {
     const rowValidationModel = new EditRowValidationModel();
     const getFullRowEditValidationErrors = beans.gos.get('getFullRowEditValidationErrors');
-    // populate row-level errors
+    // populate row-level errors (read-only iteration — no map copy needed)
     const editMap = beans.editModelSvc?.getEditMap();
 
     if (!editMap) {

--- a/packages/ag-grid-community/src/edit/utils/refresh.ts
+++ b/packages/ag-grid-community/src/edit/utils/refresh.ts
@@ -31,8 +31,8 @@ const purgeCells = ({ editModelSvc }: BeanCollection, rowNodes: Set<IRowNode>, c
 
 export const _refreshEditCells = (beans: BeanCollection) => () => {
     const columns = new Set<Column>(beans.colModel.getCols());
-    const updates = beans.editModelSvc!.getEditMap(true);
-    const rowNodes = new Set(updates.keys());
+    // Only the row keys are read here — no need to deep-copy the whole edit map.
+    const rowNodes = new Set(beans.editModelSvc!.getEditMap()?.keys());
 
     purgeCells(beans, purgeRows(beans, rowNodes), columns);
 };

--- a/packages/ag-grid-community/src/interfaces/iEditModelService.ts
+++ b/packages/ag-grid-community/src/interfaces/iEditModelService.ts
@@ -32,11 +32,14 @@ export type EditPositionValue = Required<EditPosition> & EditValue;
 export type EditRow<C = Column, V = EditValue> = Map<C, V>;
 export type EditMap = Map<IRowNode, Map<Column, EditValue>>;
 
+/** Read-only view of the live edit map from getEditMap; mutating it would break editingCount bookkeeping. */
+export type ReadonlyEditRow = ReadonlyMap<Column, Readonly<EditValue>>;
+export type ReadonlyEditMap = ReadonlyMap<IRowNode, ReadonlyEditRow>;
+
 export type EditValidationMap = Map<IRowNode, Map<Column, EditValidation>>;
 export type EditRowValidationMap = Map<IRowNode, EditValidation>;
 
 export type GetEditsParams = {
     checkSiblings?: boolean;
-    includeParents?: boolean;
     withOpenEditor?: boolean;
 };

--- a/packages/ag-grid-community/src/undoRedo/undoRedoService.ts
+++ b/packages/ag-grid-community/src/undoRedo/undoRedoService.ts
@@ -180,9 +180,10 @@ export class UndoRedoService extends BeanStub implements NamedBean {
         valueExtractor: (cellValueChange: CellValueChange) => any,
         source: string
     ) {
-        const { changeDetectionSvc } = this.beans;
-        changeDetectionSvc?.beginDeferred();
+        const { changeDetectionSvc, editSvc } = this.beans;
+        editSvc?.beginBulkWrite();
         try {
+            changeDetectionSvc?.beginDeferred();
             for (const cellValueChange of action.cellValueChanges) {
                 const { rowIndex, rowPinned, columnId } = cellValueChange;
                 const rowPosition: RowPosition = { rowIndex, rowPinned };
@@ -198,6 +199,7 @@ export class UndoRedoService extends BeanStub implements NamedBean {
             }
         } finally {
             changeDetectionSvc?.endDeferred();
+            editSvc?.endBulkWrite();
         }
     }
 

--- a/packages/ag-grid-enterprise/src/clipboard/clipboardService.ts
+++ b/packages/ag-grid-enterprise/src/clipboard/clipboardService.ts
@@ -278,7 +278,7 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
     ): void {
         const source = 'clipboard';
 
-        const { eventSvc, focusSvc, rowRenderer, gos } = this.beans;
+        const { eventSvc, focusSvc, rowRenderer, gos, editSvc } = this.beans;
 
         eventSvc.dispatchEvent({
             type: 'pasteStart',
@@ -293,7 +293,12 @@ export class ClipboardService extends BeanStub implements NamedBean, IClipboardS
         const updatedRowNodes: RowNode[] = [];
         const focusedCell = focusSvc.getFocusedCell();
 
-        pasteOperationFunc(cellsToFlash, updatedRowNodes, focusedCell, changedPath);
+        editSvc?.beginBulkWrite();
+        try {
+            pasteOperationFunc(cellsToFlash, updatedRowNodes, focusedCell, changedPath);
+        } finally {
+            editSvc?.endBulkWrite();
+        }
 
         const nodesToRefresh: RowNode[] = updatedRowNodes.slice();
         if (changedPath) {

--- a/packages/ag-grid-enterprise/src/rangeSelection/agFillHandle.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/agFillHandle.ts
@@ -423,9 +423,10 @@ export class AgFillHandle extends AbstractSelectionHandle {
             }
         };
 
-        const { changeDetectionSvc } = this.beans;
-        changeDetectionSvc?.beginDeferred();
+        const { changeDetectionSvc, editSvc } = this.beans;
+        editSvc?.beginBulkWrite();
         try {
+            changeDetectionSvc?.beginDeferred();
             if (isVertical) {
                 initialRange.columns.forEach((col: AgColumn) => {
                     iterateAcrossCells(col);
@@ -436,9 +437,10 @@ export class AgFillHandle extends AbstractSelectionHandle {
             }
             // Stop the editor inside the deferred block so the commit (if any) is included
             // in the same doAggregate pass as the fill writes.
-            this.beans.editSvc?.stopEditing(undefined, { source: 'fillHandle' });
+            editSvc?.stopEditing(undefined, { source: 'fillHandle' });
         } finally {
             changeDetectionSvc?.endDeferred();
+            editSvc?.endBulkWrite();
         }
     }
 

--- a/packages/ag-grid-enterprise/src/rangeSelection/rangeService.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/rangeService.ts
@@ -927,8 +927,9 @@ export class RangeService extends BeanStub implements NamedBean, IRangeService, 
         const batch = !!editSvc?.isBatchEditing();
 
         const { changeDetectionSvc } = beans;
-        changeDetectionSvc?.beginDeferred();
+        editSvc?.beginBulkWrite();
         try {
+            changeDetectionSvc?.beginDeferred();
             this.forEachEditableCellInRanges(cellRanges, (rowNode, column) => {
                 if (restoreSourceInBatch && batch) {
                     editSvc?.batchResetToSourceValue({ rowNode, column });
@@ -939,6 +940,7 @@ export class RangeService extends BeanStub implements NamedBean, IRangeService, 
             });
         } finally {
             changeDetectionSvc?.endDeferred();
+            editSvc?.endBulkWrite();
         }
 
         if (dispatchWrapperEvents) {

--- a/testing/behavioural/src/benchmarks/cell-editing-bulk.bench.ts
+++ b/testing/behavioural/src/benchmarks/cell-editing-bulk.bench.ts
@@ -1,0 +1,133 @@
+import { bench, suite } from 'vitest';
+
+import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
+import { ClientSideRowModelModule, EventApiModule, TextEditorModule } from 'ag-grid-community';
+import { BatchEditModule, CellSelectionModule, ClipboardModule } from 'ag-grid-enterprise';
+
+import { clipboardUtils } from '../test-utils/polyfills/clipboard';
+import { BenchGridsManager, benchDefaults } from './bench-utils';
+
+const modules = [
+    ClientSideRowModelModule,
+    EventApiModule,
+    TextEditorModule,
+    ClipboardModule,
+    CellSelectionModule,
+    BatchEditModule,
+];
+
+const COLS = 10;
+const GRID_ROWS = 300;
+// Pre-staged edits (for the "already pending" bench) live below the pasted rows so they never overlap.
+const PRELOAD_START_ROW = 100;
+const PRELOAD_ROWS = 200;
+
+const colIds: string[] = [];
+const columnDefs: ColDef[] = [];
+for (let c = 0; c < COLS; ++c) {
+    const colId = `c${c}`;
+    colIds.push(colId);
+    columnDefs.push({ colId, field: colId, editable: true });
+}
+
+const gridOptions: GridOptions = {
+    columnDefs,
+    cellSelection: true,
+    getRowId: ({ data }) => data.id,
+};
+
+const buildRowData = (): Record<string, string>[] => {
+    const rows = new Array<Record<string, string>>(GRID_ROWS);
+    for (let r = 0; r < GRID_ROWS; ++r) {
+        const row: Record<string, string> = { id: `r${r}` };
+        for (let c = 0; c < COLS; ++c) {
+            row[colIds[c]] = `init${r}_${c}`;
+        }
+        rows[r] = row;
+    }
+    return rows;
+};
+
+// A tab/newline block of `rows`×COLS values, tagged so consecutive pastes differ (no no-op skips).
+const buildBlock = (rows: number, tag: string): string => {
+    const lines = new Array<string>(rows);
+    for (let r = 0; r < rows; ++r) {
+        const cells = new Array<string>(COLS);
+        for (let c = 0; c < COLS; ++c) {
+            cells[c] = `${tag}${r}_${c}`;
+        }
+        lines[r] = cells.join('\t');
+    }
+    return lines.join('\n');
+};
+
+// Local, dependency-free pasteEnd wait: the shared waitForEvent pulls in node-only test utils that
+// aren't available in the real-browser bench environment.
+const waitPasteEnd = (api: GridApi): Promise<void> =>
+    new Promise((resolve) => {
+        const listener = () => {
+            api.removeEventListener('pasteEnd', listener);
+            resolve();
+        };
+        api.addEventListener('pasteEnd', listener);
+    });
+
+const pasteBlock = async (api: GridApi, block: string, startRow: number): Promise<void> => {
+    clipboardUtils.setText(block);
+    api.setFocusedCell(startRow, colIds[0]);
+    const done = waitPasteEnd(api);
+    api.pasteFromClipboard();
+    await done;
+    // Flush the deferred (rAF) render so each iteration captures its own paste + render synchronously,
+    // instead of leaking it into the next iteration as an outlier spike.
+    api.flushAllAnimationFrames();
+};
+
+let gridSeq = 0;
+
+suite(`cell editing — batch paste (${GRID_ROWS} rows × ${COLS} cols)`, () => {
+    // `preloadRows > 0` pre-stages preloadRows×COLS pending edits before measuring, exercising the
+    // session-degradation case (on `latest`, per-cell cost scales with total pending edits).
+    const benchPaste = (name: string, blockRows: number, batch: boolean, preloadRows = 0): void => {
+        const id = `EP${++gridSeq}`;
+        const gridsManager = new BenchGridsManager({ modules });
+        const blockA = buildBlock(blockRows, 'A');
+        const blockB = buildBlock(blockRows, 'B');
+        const preload = preloadRows > 0 ? buildBlock(preloadRows, 'P') : null;
+        let api!: GridApi;
+        let toggle = false;
+
+        bench(
+            name,
+            async () => {
+                toggle = !toggle;
+                await pasteBlock(api, toggle ? blockA : blockB, 0);
+            },
+            {
+                ...benchDefaults({ noiseFactor: 2 }),
+                setup: async () => {
+                    await gridsManager.reset();
+                    clipboardUtils.init();
+                    api = gridsManager.createGrid(id, { ...gridOptions, rowData: buildRowData() });
+                    if (batch) {
+                        api.startBatchEdit();
+                    }
+                    if (preload) {
+                        await pasteBlock(api, preload, PRELOAD_START_ROW);
+                    }
+                    toggle = false;
+                },
+            }
+        );
+    };
+
+    // Single paste, empty session — 20×10 vs 80×10 (4× cells) reads the per-paste scaling.
+    benchPaste('batch paste 200 cells', 20, true);
+    benchPaste('batch paste 800 cells', 80, true);
+
+    // Same 200-cell paste, but 2000 edits are already staged — the session-degradation case.
+    benchPaste('batch paste 200 cells (2000 already pending)', 20, true, PRELOAD_ROWS);
+
+    // Non-batch paste writes straight to row data (no pending session): a baseline control.
+    benchPaste('paste 800 cells (non-batch control)', 80, false);
+});

--- a/testing/behavioural/src/cell-editing/clipboard/clipboard-paste.test.ts
+++ b/testing/behavioural/src/cell-editing/clipboard/clipboard-paste.test.ts
@@ -512,4 +512,139 @@ describe('Clipboard Paste Behaviour: paste flows', () => {
 
         expect(editRequests).toEqual(['ROW_1:field:Top Value']);
     });
+
+    test('batch paste stages every cell once (coalesced), then commit applies them all', async () => {
+        const api = await gridMgr.createGridAndWait('bulkCoalesce', {
+            columnDefs: [
+                { colId: 'a', field: 'a', editable: true },
+                { colId: 'b', field: 'b', editable: true },
+            ],
+            rowData: [
+                { id: 'r0', a: 'a0', b: 'b0' },
+                { id: 'r1', a: 'a1', b: 'b1' },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        await new GridRows(api, 'before batch paste').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:r0 a:"a0" b:"b0"
+            └── LEAF id:r1 a:"a1" b:"b1"
+        `);
+
+        api.startBatchEdit();
+
+        clipboardUtils.setText('X0\tY0\nX1\tY1');
+        api.setFocusedCell(0, 'a');
+        const pasted = waitForEvent('pasteEnd', api);
+        api.pasteFromClipboard();
+        await pasted;
+
+        expect(api.getEditingCells()).toHaveLength(4);
+
+        await new GridRows(api, 'staged, pre-commit').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF ⏳ id:r0 a:⏳"X0" "a0" b:⏳"Y0" "b0"
+            └── LEAF ⏳ id:r1 a:⏳"X1" "a1" b:⏳"Y1" "b1"
+        `);
+
+        api.commitBatchEdit();
+
+        await new GridRows(api, 'after commit').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:r0 a:"X0" b:"Y0"
+            └── LEAF id:r1 a:"X1" b:"Y1"
+        `);
+        expect(api.getEditingCells()).toHaveLength(0);
+    });
+
+    test('batch paste scoped purge drops only the cell whose pasted value matches its source', async () => {
+        const api = await gridMgr.createGridAndWait('bulkPurge', {
+            columnDefs: [
+                { colId: 'a', field: 'a', editable: true },
+                { colId: 'b', field: 'b', editable: true },
+            ],
+            rowData: [
+                { id: 'r0', a: 'a0', b: 'b0' },
+                { id: 'r1', a: 'a1', b: 'b1' },
+            ],
+            getRowId: (params) => params.data.id,
+        });
+
+        await new GridRows(api, 'purge: before').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:r0 a:"a0" b:"b0"
+            └── LEAF id:r1 a:"a1" b:"b1"
+        `);
+
+        api.startBatchEdit();
+
+        // Pre-stage an unrelated pending edit that the scoped purge must NOT remove.
+        clipboardUtils.setText('KEEP');
+        api.setFocusedCell(0, 'a');
+        const preStaged = waitForEvent('pasteEnd', api);
+        api.pasteFromClipboard();
+        await preStaged;
+
+        await new GridRows(api, 'purge: after pre-stage r0/a').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF ⏳ id:r0 a:⏳"KEEP" "a0" b:"b0"
+            └── LEAF id:r1 a:"a1" b:"b1"
+        `);
+
+        // Paste a 2×1 block into b: r0/b receives its own source value 'b0' (→ purged), r1/b changes (→ kept).
+        clipboardUtils.setText('b0\nZ1');
+        api.setFocusedCell(0, 'b');
+        const pasted = waitForEvent('pasteEnd', api);
+        api.pasteFromClipboard();
+        await pasted;
+
+        // r0/b purged (no ⏳), r1/b kept, and the pre-staged r0/a survived the scoped purge.
+        await new GridRows(api, 'purge: after paste into b').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF ⏳ id:r0 a:⏳"KEEP" "a0" b:"b0"
+            └── LEAF ⏳ id:r1 a:"a1" b:⏳"Z1" "b1"
+        `);
+        expect(
+            api
+                .getEditingCells()
+                .map((c: { rowIndex: number | null; colId: string }) => `${c.rowIndex}:${c.colId}`)
+                .sort()
+        ).toEqual(['0:a', '1:b']);
+    });
+
+    test('batch full-row paste keeps pasted values for non-focused open editors, not their stale values', async () => {
+        const api = await gridMgr.createGridAndWait('bulkFullRowOpenEditor', {
+            editType: 'fullRow',
+            cellSelection: true,
+            columnDefs: [
+                { colId: 'a', field: 'a', editable: true },
+                { colId: 'b', field: 'b', editable: true },
+            ],
+            rowData: [{ id: 'r0', a: 'a0', b: 'b0' }],
+            getRowId: (params) => params.data.id,
+        });
+
+        api.startBatchEdit();
+
+        // Full-row editing opens an editor on EVERY cell of the row; only 'a' is focused, so 'b' stays
+        // stale (showing 'b0') while the paste stages 'Y0' into it.
+        api.setFocusedCell(0, 'a');
+        api.startEditingCell({ rowIndex: 0, colKey: 'a' });
+        await waitFor(() => expect(api.getEditingCells().length).toBe(2));
+
+        clipboardUtils.setText('X0\tY0');
+        api.setFocusedCell(0, 'a');
+        const pasteEnd = waitForEvent('pasteEnd', api);
+        api.pasteFromClipboard();
+        await pasteEnd;
+
+        api.commitBatchEdit();
+        await asyncSetTimeout(0);
+
+        await new GridRows(api, 'after commit').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r0 a:"X0" b:"Y0"
+        `);
+    });
 });


### PR DESCRIPTION
FIX AG-17871

Pasting, filling, range-deleting and undo/redoing large cell ranges scaled O(N*N): each staged cell re-scanned every pending edit and ran its own editor-cleanup and refresh pass. This makes that per-cell work O(1) so a bulk write is O(N) overall. Public API and grid behaviour are unchanged.

## Benchmark

Real headless-Chromium runs (`./benches.sh cell-editing-bulk`), latest vs this branch. The branch column stays flat at ~4.7 ms regardless of paste size or existing pending edits — the O(N) win.

| Flow                                          |  latest | this branch | speedup |
| --------------------------------------------- | ------: | ----------: | ------: |
| batch paste 200 cells                         | 40.6 ms |     4.64 ms |    8.8× |
| batch paste 800 cells                         |  914 ms |     4.67 ms |    196× |
| batch paste 200 cells (2000 already pending)  | 1074 ms |     4.79 ms |    224× |

Non-batch paste (control) and all the other benches unchanged — the fix targets the batch-pending path.

## Changes in grid core

files:         0 added, 0 removed, 13 changed (13 total)
lines added:   +380
lines removed: -209
net delta:     +171

**Bulk-write coalescing** — `editService.ts`, and callers `clipboardService`, `agFillHandle`, `rangeService`, `undoRedoService`

- New `beginBulkWrite()` / `endBulkWrite()` bracket a bulk operation. Between them the per-cell editor cleanup and cell refresh are deferred and applied once on the outermost `endBulkWrite` (`flushBulkWrite`), deduping repeated cells and shared group/total ancestor refreshes. The four callers wrap their write loops in `try/finally`.
- Per staged cell, the full-map rescan `_purgeUnchangedEdits` is replaced by a scoped `_purgeUnchangedEdit` — only the cell just written can have become unchanged.

**O(1) open-editor count** — `editModelService.ts`

- An `editingCount`, kept in sync at every mutation site, backs a new `hasOpenEditors()`. It replaces the `getEditPositions().some(state === 'editing')` full scan behind `hasEdits({ withOpenEditor })`.

**Edit-map access** — `editModelService.ts` and callers

- `getEditMap()` returns the live map instead of always deep-copying — typed as a read-only `ReadonlyEditMap` (or `null` while suspended) so callers can't mutate the model and desync its bookkeeping. `getEditMapCopy()` covers the callers that need a mutable snapshot. Read-only callers (`_purgeUnchangedEdits`, validation, refresh, edit strategies, `getEditingCells`) read the live map directly.
- Single-cell reads use new allocation-free `getCellEdit` / `getCellEditWithSibling` in place of `getEdit(position, params)`. `GetEditsParams` plumbing collapses to a `checkSiblings` boolean and the unused `includeParents` is removed.

**Cell refresh** — `editService.ts`

- `refCell` takes `(rowNode, column, edit)` and refreshes the cell plus its pinned sibling, then walks ancestor/total cells via `refreshAncestorCell`, deduped across a flush. `groupTotalRow` / `grandTotalRow` reads are hoisted out of the walk and parentless rows return early.
- `csrm` (row-model type) is resolved once in `postConstruct`; `getEditingCells` builds a result object only for the cells it emits; the per-cell edit-changed dispatch reads cached `eventSvc` / `model` fields rather than `this.beans` each time.
