### PR TITLE
test(docs-e2e): give slow timing specs CI headroom

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/column-groups/_examples/group-changes/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-groups/_examples/group-changes/example.spec.ts
@@ -11,6 +11,9 @@ test.agExample(import.meta, () => {
     });
 
     test.eachFramework('Buttons add and remove column groups while preserving columns', async ({ agIdFor, page }) => {
+        // Rebuilding the column groups re-renders the whole header several times; under a loaded
+        // CI machine this can eat into the default budget, so allow extra time.
+        test.slow();
         await ensureGridReady(page);
         await waitForGridContent(page);
 

--- a/documentation/ag-grid-docs/src/content/docs/data-update-high-frequency/_examples/async-transaction/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/data-update-high-frequency/_examples/async-transaction/example.spec.ts
@@ -23,18 +23,24 @@ test.agExample(import.meta, () => {
     });
 
     test.eachFramework('Normal update applies transactions and reports timing', async ({ page }) => {
+        // The example fires 5,000 individual transactions, each re-aggregating the grouped
+        // data, so completion is legitimately slow under a loaded CI machine. Give it headroom.
+        test.slow();
         await ensureGridReady(page);
         await waitForGridContent(page);
 
         await page.getByRole('button', { name: 'Normal Update' }).click();
-        await expect(page.locator('#eMessage')).toContainText('Transaction took', { timeout: 30000 });
+        await expect(page.locator('#eMessage')).toContainText('Transaction took', { timeout: 60000 });
     });
 
     test.eachFramework('Async update batches transactions and reports timing', async ({ page }) => {
+        // 5,000 async transactions are batched by the grid but still take a while to drain
+        // under load; give the timing message extra time before asserting.
+        test.slow();
         await ensureGridReady(page);
         await waitForGridContent(page);
 
         await page.getByRole('button', { name: 'Async Update' }).click();
-        await expect(page.locator('#eMessage')).toContainText('Async took', { timeout: 30000 });
+        await expect(page.locator('#eMessage')).toContainText('Async took', { timeout: 60000 });
     });
 });


### PR DESCRIPTION
## Why

The scheduled **Documentation Tests** workflow fails every day. Investigating [run 29715418393](https://github.com/ag-grid/ag-grid/actions/runs/29715418393), each shard reported `1 failed` amid several `flaky` (passed-on-retry) tests. The suite runs Playwright against deployed `grid-staging.ag-grid.com`.

Two failures **recur day-to-day** and both sit right at the Playwright timeout boundary on loaded CI shards:

- `data-update-high-frequency/async-transaction` – *Normal update reports timing* (vanilla/firefox): `#eMessage` still read "Running Transaction" (never "Transaction took") within the 30s assertion. The example fires **5,000 individual re-aggregating transactions** — legitimately slow under load.
- `column-groups/group-changes` – *Buttons add and remove column groups* (angular/chromium): 60s test-timeout consumed before a button click resolved.

Both **pass locally against `latest`** (async ~13s across all 3 browsers; column-groups ~11s), so these are timing flakes on the staging-targeted scheduled suite, not code regressions.

## What

- `async-transaction/example.spec.ts` — `test.slow()` on both timing tests + raise the timing-message assertion timeout 30s → 60s.
- `column-groups/group-changes/example.spec.ts` — `test.slow()` on the header-rebuild test.

## Testing

- `./docs-e2e.sh "async-transaction" --framework vanilla --all-browsers` → 9 passed
- `./docs-e2e.sh "group-changes" --framework angular` → 4 passed

## Out of scope

This won't turn the scheduled suite fully green — it's broadly flaky against staging (`502 Bad Gateway`, `.playwright-network-cache` ENOENT misses, webkit chart timing). Those need an infra look rather than per-test patches; a follow-up ticket is warranted.