### PR TITLE
Add grid source conventions and regression-test-path rules

### DIFF
--- a/.rulesync/.gitignore
+++ b/.rulesync/.gitignore
@@ -34,6 +34,7 @@ mcp.json
 !/rules/docs-pages.md
 !/rules/examples.md
 !/rules/framework-view-layers.md
+!/rules/grid-code-conventions.md
 !/rules/testing.md
 # docs-review-testing.md ships as a sibling asset of the ag-prodeng docs-review
 # skill config (at skills/docs-review/ag-grid/), not as a top-level rule, so no

--- a/.rulesync/rules/grid-code-conventions.md
+++ b/.rulesync/rules/grid-code-conventions.md
@@ -6,7 +6,7 @@ globs: ['packages/*/src/**/*.ts', 'community-modules/*/src/**/*.ts', 'enterprise
 
 # AG Grid Source Conventions
 
-Grid-specific rules for runtime source, layered on top of the shared [Code Quality Guide](.rulesync/rules/code-quality.md). Scoped to `src` so it loads only when editing grid source, not into the always-on project context.
+Grid-specific rules for runtime source, layered on top of the shared [Code Quality Guide](code-quality.md). Scoped to `src` so it loads only when editing grid source, not into the always-on project context.
 
 ## Prefer inline null checks over `_exists` / `_missing`
 

--- a/.rulesync/rules/grid-code-conventions.md
+++ b/.rulesync/rules/grid-code-conventions.md
@@ -1,0 +1,27 @@
+---
+targets: ['*']
+description: 'AG Grid-specific source code conventions (layered on the shared code-quality guide)'
+globs: ['packages/*/src/**/*.ts', 'community-modules/*/src/**/*.ts', 'enterprise-modules/*/src/**/*.ts']
+---
+
+# AG Grid Source Conventions
+
+Grid-specific rules for runtime source, layered on top of the shared [Code Quality Guide](.rulesync/rules/code-quality.md). Scoped to `src` so it loads only when editing grid source, not into the always-on project context.
+
+## Prefer inline null checks over `_exists` / `_missing`
+
+Do not use `_exists` / `_missing` in new code. They wrap a cheap null check in a function call and add a `!== ''` empty-string test that is usually unwanted:
+
+```ts
+export function _exists(value: any): boolean {
+    return value != null && value !== '';
+}
+```
+
+Inline the check instead:
+
+- `value != null` — the common case (the `_exists` intent).
+- `value == null` — the `_missing` intent.
+- Add `&& value !== ''` only when an empty string genuinely must be excluded.
+
+Leave existing call sites alone unless you're already changing that code — this is a rule for new code, not a repo-wide sweep.

--- a/.rulesync/rules/testing.md
+++ b/.rulesync/rules/testing.md
@@ -28,6 +28,18 @@ Search `testing/behavioural` for an existing harness before assuming a behaviour
 
 Behavioural tests are a separate nx project — `yarn nx test <package>` does **not** run them. Use `./behave.sh` or the affected gate (`yarn nx affected -t test`).
 
+## Regression Tests: Cover Every Reproduction Path
+
+A bug rarely has one trigger. The same broken behaviour is usually reachable through several entry points — a programmatic API call, `applyColumnState`, a panel drag, a tool-panel drop — that run **different code paths** to the same end state. A fix that only patches the path in the ticket's first repro step can leave the others broken.
+
+When writing regression tests for a bug fix:
+
+- **Enumerate the reproduction paths named in the ticket, and add a test for each.** If the ticket says the bug reproduces via `addRowGroupColumns`, the Row Group Panel, and the Columns tool-panel drop zone, that is three tests, not one. Interactive entry points count — drive them with the real harness (`DragEventDispatcher` for header/panel drags) rather than skipping them because they're awkward to set up.
+- **Test the plural case, not just N=1.** If the fix reorders, inserts, or buckets a *list* of things, cover adding two or three, not only one. Single-item cases often pass by coincidence (no reordering needed) while the multi-item case is where the logic actually bites.
+- **Assert the observable end state for every path**, e.g. `getColumnOrder(...)`, not just that the operation didn't throw.
+
+Before finishing, re-read the ticket's "Steps to reproduce" and confirm each distinct trigger has a corresponding test. A fix verified through only one of several documented triggers is not fully verified.
+
 ## Test Structure
 
 ### Directory Layout


### PR DESCRIPTION
Local rulesync updates:

- New `grid-code-conventions` rule: prefer inline null checks over `_exists`/`_missing` in new grid source (scoped to `src`).
- `testing.md`: require a regression test for every reproduction path named in a ticket, cover the plural case, and assert observable end state.