### PR TITLE
AG-17572 ssrm last page fetch bug

### DIFF
--- a/packages/ag-grid-community/src/pagination/paginationService.ts
+++ b/packages/ag-grid-community/src/pagination/paginationService.ts
@@ -152,9 +152,7 @@ export class PaginationService extends BeanStub implements NamedBean {
     }
 
     public goToLastPage(): void {
-        const rowCount = this.beans.rowModel.getRowCount();
-        const lastPage = Math.floor(rowCount / this.pageSize);
-        this.goToPage(lastPage);
+        this.goToPage(Math.max(0, this.totalPages - 1));
     }
 
     public getPageSize(): number {
@@ -347,12 +345,13 @@ export class PaginationService extends BeanStub implements NamedBean {
             return;
         }
 
-        const { pageSize, currentPage } = this;
+        const pageSize = this.pageSize;
         const maxRowIndex = masterRowCount - 1;
         this.totalPages = Math.floor(maxRowIndex / pageSize) + 1;
 
         this.adjustCurrentPageIfInvalid();
 
+        const currentPage = this.currentPage;
         this.topDisplayedRowIndex = pageSize * currentPage;
         this.bottomDisplayedRowIndex = pageSize * (currentPage + 1) - 1;
 

--- a/testing/behavioural/src/pagination/pagination-events.test.ts
+++ b/testing/behavioural/src/pagination/pagination-events.test.ts
@@ -652,6 +652,25 @@ describe('Pagination Events', () => {
             `);
         });
 
+        test('goToLastPage on the last page fires no redundant event', async () => {
+            const api = createGrid(gridsManager);
+
+            api.paginationGoToLastPage();
+            await asyncSetTimeout(0);
+            expect(api.paginationGetCurrentPage()).toBe(4);
+
+            const events: PaginationChangedEvent[] = [];
+            api.addEventListener('paginationChanged', (e) => events.push(e));
+
+            // 50 rows / pageSize 10 is an exact multiple: targeting the last page from the row
+            // count asks for out-of-range page 5 and re-fires; totalPages-1 keeps it a no-op.
+            api.paginationGoToLastPage();
+            await asyncSetTimeout(0);
+
+            expect(events).toHaveLength(0);
+            expect(api.paginationGetCurrentPage()).toBe(4);
+        });
+
         test('goToPage with same page does not fire event', async () => {
             const api = createGrid(gridsManager);
             await new GridColumns(api, `goToPage with same page does not fire event setup`).checkColumns(`

--- a/testing/behavioural/src/row-data/ssrm-block-loading.test.ts
+++ b/testing/behavioural/src/row-data/ssrm-block-loading.test.ts
@@ -1,5 +1,7 @@
+import { waitFor } from '@testing-library/dom';
+
 import type { GridOptions, IServerSideGetRowsRequest } from 'ag-grid-community';
-import { ScrollApiModule } from 'ag-grid-community';
+import { PaginationModule, ScrollApiModule } from 'ag-grid-community';
 import { ServerSideRowModelApiModule, ServerSideRowModelModule } from 'ag-grid-enterprise';
 
 import { GridRows, TestGridsManager, waitForEvent } from '../test-utils';
@@ -22,7 +24,7 @@ import { GridRows, TestGridsManager, waitForEvent } from '../test-utils';
  */
 describe('SSRM block loading', () => {
     const gridsManager = new TestGridsManager({
-        modules: [ServerSideRowModelApiModule, ScrollApiModule, ServerSideRowModelModule],
+        modules: [ServerSideRowModelApiModule, ScrollApiModule, ServerSideRowModelModule, PaginationModule],
     });
 
     afterEach(() => {
@@ -186,5 +188,45 @@ describe('SSRM block loading', () => {
             ├── LEAF id:1 id:1 value:"Row 1"
             └── LEAF id:2 id:2 value:"Row 2"
         `);
+    });
+
+    // Regression (v33.0.0): with pagination + paginateChildRows, jumping to the last page
+    // computed the page bounds from the pre-clamp page index, leaving the viewport stuck at
+    // the top so lazyBlockLoadingService never requested the final (unloaded) block.
+    test('jumping to the last page fetches the final block with paginateChildRows', async () => {
+        const totalRows = 3500;
+        const rowData = Array.from({ length: totalRows }, (_, i) => ({ id: i, value: `Row ${i}` }));
+        const requests: number[] = [];
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            pagination: true,
+            paginationPageSize: 100,
+            cacheBlockSize: 500,
+            paginateChildRows: true,
+            getRowId: (params) => String(params.data.id),
+            serverSideDatasource: {
+                getRows: (params) => {
+                    requests.push(params.request.startRow!);
+                    const slice = rowData.slice(params.request.startRow, params.request.endRow);
+                    params.success({ rowData: slice, rowCount: totalRows });
+                },
+            },
+        };
+
+        const api = gridsManager.createGrid(null, gridOptions);
+        await waitForEvent('firstDataRendered', api);
+
+        api.paginationGoToLastPage();
+
+        // 3500 rows / 100 per page => 35 pages (0..34). The last page shows rows 3400..3499.
+        // The page index and the displayed viewport must both land on the last page; the bug
+        // clamped the index to 34 but computed the bounds from the unclamped index (35).
+        expect(api.paginationGetCurrentPage()).toBe(34);
+        expect(api.getFirstDisplayedRowIndex()).toBe(3400);
+
+        // With the viewport on the last page, its block (start 3000, cacheBlockSize 500) is requested.
+        await waitFor(() => expect(requests).toContain(3000));
     });
 });


### PR DESCRIPTION
# SSRM last page fetch bug

FIX AG-17572

## Problem

With SSRM pagination and `paginateChildRows: true`, jumping to the last page did not fetch the
final block. The page index updated to the last page, but the grid body never scrolled onto it,
no `getRows` call fired, and the last page showed no data. `paginateChildRows: false` (the default)
was unaffected.

## Root cause

`PaginationService.calculatePagesAllRows()` read `currentPage` into a local **before**
`adjustCurrentPageIfInvalid()` clamped it:

```ts
const { pageSize, currentPage } = this; // currentPage still out of range
this.adjustCurrentPageIfInvalid(); // clamps this.currentPage, not the local
this.topDisplayedRowIndex = pageSize * currentPage; // uses stale value
```

`paginationGoToLastPage()` navigates to `floor(rowCount / pageSize)`, which is one past the last
page when `rowCount` is a multiple of `pageSize` (3500/100 → page 35, valid range 0–34). The clamp
corrected `this.currentPage` to 34, but the bounds were computed from the stale 35, giving
`topDisplayedRowIndex = 3500` (out of range). `getRowBounds` returned null → pixel offset 0 → the
viewport stayed at the top → `lazyBlockLoadingService` never saw a stub in view → the final block
was never requested. `calculatePagesMasterRowsOnly()` reads `this.currentPage` after the clamp,
which is why the non-child-rows path worked.

## Fix

- `calculatePagesAllRows()` now reads `currentPage` after `adjustCurrentPageIfInvalid()`, matching
  `calculatePagesMasterRowsOnly()`.
- `goToLastPage()` now targets `totalPages - 1` (the last page the UI recognises) instead of
  deriving it from the row count, which over-counts child rows and off-by-ones on exact page-size
  multiples. It previously relied on the clamp to correct an out-of-range index.

## Regression

Introduced in **v33.0.0** by #9269 (AG-12847, "optimise more community"): a field-access caching
optimisation destructured `currentPage` into a local, inadvertently capturing it before the clamp.

## Testing

- `ssrm-block-loading.test.ts`: after `paginationGoToLastPage()`, `getFirstDisplayedRowIndex()`
  lands on the last page and the final block is requested from the datasource.
- `pagination-events.test.ts`: `goToLastPage()` on the last page fires no redundant event (guards
  the `totalPages - 1` change; fails with the old row-count derivation).
- Verified in a real browser (Chromium) against the reported repro: without the fix the datasource
  is asked only for block `[0]`; with the fix it is asked for `[0, 3000]` and the last page renders.
