### PR TITLE
[AG-17572] docs(pagination): explain post-adjust currentPage read

### DIFF
--- a/packages/ag-grid-community/src/pagination/paginationService.ts
+++ b/packages/ag-grid-community/src/pagination/paginationService.ts
@@ -310,6 +310,9 @@ export class PaginationService extends BeanStub implements NamedBean {
 
         this.adjustCurrentPageIfInvalid();
 
+        // Read `currentPage` only after `adjustCurrentPageIfInvalid()`, as it may clamp the current
+        // page (e.g. when jumping to the last page). Using the pre-clamp value here computes the
+        // wrong row bounds and can leave the viewport stuck, so keep this read below the adjust call.
         const currentPage = this.currentPage;
 
         const masterPageStartIndex = pageSize * currentPage;
@@ -351,6 +354,9 @@ export class PaginationService extends BeanStub implements NamedBean {
 
         this.adjustCurrentPageIfInvalid();
 
+        // Read `currentPage` only after `adjustCurrentPageIfInvalid()`, as it may clamp the current
+        // page (e.g. when jumping to the last page). Using the pre-clamp value here computes the
+        // wrong row bounds and can leave the viewport stuck, so keep this read below the adjust call.
         const currentPage = this.currentPage;
         this.topDisplayedRowIndex = pageSize * currentPage;
         this.bottomDisplayedRowIndex = pageSize * (currentPage + 1) - 1;


### PR DESCRIPTION
Follow-up to #14495 (merged) addressing review feedback: adds an explanatory comment so the ordering of the `currentPage` read is not accidentally regressed in future.

## Changes
- Documents why `const currentPage = this.currentPage` must be read **after** `adjustCurrentPageIfInvalid()` — that call can clamp the current page (e.g. jumping to the last page), and reading the pre-clamp value computes wrong row bounds and can leave the viewport stuck.
- Added to both `calculatePagesAllRows()` and `calculatePagesMasterRowsOnly()` (the `paginateChildRows` path), which share the same load-bearing ordering.

No behavioural change; the regression test added in #14495 already guards the runtime behaviour.