### PR TITLE
test(docs-e2e): meaningful example specs for value handling

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/reference-data/_examples/ref-data-property/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/reference-data/_examples/ref-data-property/example.spec.ts
@@ -1,11 +1,68 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // colIds: 'make', 'exteriorColour', 'interiorColour', 'retailPrice' (colId),
+    //         'Retail Price (incl Taxes)' (anonymous) -> '0'.
+    // Row 0 data: make 'tyt', exteriorColour 'fg', interiorColour 'bw', price 35000.
+    // refData maps: tyt->Toyota, fg->Forest Green, bw->Burlywood.
+
+    test.eachFramework('refData maps stored codes to display values', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        await expect(agIdFor.cell('0', 'make')).toContainText('Toyota');
+        await expect(agIdFor.cell('0', 'exteriorColour')).toContainText('Forest Green');
+        await expect(agIdFor.cell('0', 'interiorColour')).toContainText('Burlywood');
+    });
+
+    test.eachFramework('price valueGetter/formatter and the chained taxes getter compute values', async ({
+        agIdFor,
+        page,
+    }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        // Retail Price = price formatted as currency; taxes column = retailPrice * 1.2.
+        await expect(agIdFor.cell('0', 'retailPrice')).toContainText('£35,000');
+        await expect(agIdFor.cell('0', '0')).toContainText('£42,000');
+    });
+
+    test.eachFramework('retail price valueSetter round-trips and re-drives the chained getter', async ({
+        agIdFor,
+        page,
+    }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const priceCell = agIdFor.cell('0', 'retailPrice');
+        await priceCell.dblclick();
+        const editor = priceCell.locator('input');
+        await expect(editor).toBeVisible();
+        await editor.fill('50000');
+        await page.keyboard.press('Enter');
+        await expect(editor).toHaveCount(0);
+
+        // valueSetter stores 50000; taxes = 50000 * 1.2 = 60000.
+        await expect(priceCell).toContainText('£50,000');
+        await expect(agIdFor.cell('0', '0')).toContainText('£60,000');
+    });
+
+    test.eachFramework('editing a refData cell stores the entered code and displays the mapped value', async ({
+        agIdFor,
+        page,
+    }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const interiorCell = agIdFor.cell('0', 'interiorColour');
+        await interiorCell.dblclick();
+        const editor = interiorCell.locator('input');
+        await expect(editor).toBeVisible();
+        // With refData + a text editor the raw code must be entered; 'fg' maps to Forest Green.
+        await editor.fill('fg');
+        await page.keyboard.press('Enter');
+        await expect(editor).toHaveCount(0);
+
+        await expect(interiorCell).toContainText('Forest Green');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/reference-data/_examples/ref-data-property/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/reference-data/_examples/ref-data-property/example.spec.ts
@@ -15,54 +15,54 @@ test.agExample(import.meta, () => {
         await expect(agIdFor.cell('0', 'interiorColour')).toContainText('Burlywood');
     });
 
-    test.eachFramework('price valueGetter/formatter and the chained taxes getter compute values', async ({
-        agIdFor,
-        page,
-    }) => {
-        await ensureGridReady(page);
-        await waitForGridContent(page);
+    test.eachFramework(
+        'price valueGetter/formatter and the chained taxes getter compute values',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
 
-        // Retail Price = price formatted as currency; taxes column = retailPrice * 1.2.
-        await expect(agIdFor.cell('0', 'retailPrice')).toContainText('£35,000');
-        await expect(agIdFor.cell('0', '0')).toContainText('£42,000');
-    });
+            // Retail Price = price formatted as currency; taxes column = retailPrice * 1.2.
+            await expect(agIdFor.cell('0', 'retailPrice')).toContainText('£35,000');
+            await expect(agIdFor.cell('0', '0')).toContainText('£42,000');
+        }
+    );
 
-    test.eachFramework('retail price valueSetter round-trips and re-drives the chained getter', async ({
-        agIdFor,
-        page,
-    }) => {
-        await ensureGridReady(page);
-        await waitForGridContent(page);
+    test.eachFramework(
+        'retail price valueSetter round-trips and re-drives the chained getter',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
 
-        const priceCell = agIdFor.cell('0', 'retailPrice');
-        await priceCell.dblclick();
-        const editor = priceCell.locator('input');
-        await expect(editor).toBeVisible();
-        await editor.fill('50000');
-        await page.keyboard.press('Enter');
-        await expect(editor).toHaveCount(0);
+            const priceCell = agIdFor.cell('0', 'retailPrice');
+            await priceCell.dblclick();
+            const editor = priceCell.locator('input');
+            await expect(editor).toBeVisible();
+            await editor.fill('50000');
+            await page.keyboard.press('Enter');
+            await expect(editor).toHaveCount(0);
 
-        // valueSetter stores 50000; taxes = 50000 * 1.2 = 60000.
-        await expect(priceCell).toContainText('£50,000');
-        await expect(agIdFor.cell('0', '0')).toContainText('£60,000');
-    });
+            // valueSetter stores 50000; taxes = 50000 * 1.2 = 60000.
+            await expect(priceCell).toContainText('£50,000');
+            await expect(agIdFor.cell('0', '0')).toContainText('£60,000');
+        }
+    );
 
-    test.eachFramework('editing a refData cell stores the entered code and displays the mapped value', async ({
-        agIdFor,
-        page,
-    }) => {
-        await ensureGridReady(page);
-        await waitForGridContent(page);
+    test.eachFramework(
+        'editing a refData cell stores the entered code and displays the mapped value',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
 
-        const interiorCell = agIdFor.cell('0', 'interiorColour');
-        await interiorCell.dblclick();
-        const editor = interiorCell.locator('input');
-        await expect(editor).toBeVisible();
-        // With refData + a text editor the raw code must be entered; 'fg' maps to Forest Green.
-        await editor.fill('fg');
-        await page.keyboard.press('Enter');
-        await expect(editor).toHaveCount(0);
+            const interiorCell = agIdFor.cell('0', 'interiorColour');
+            await interiorCell.dblclick();
+            const editor = interiorCell.locator('input');
+            await expect(editor).toBeVisible();
+            // With refData + a text editor the raw code must be entered; 'fg' maps to Forest Green.
+            await editor.fill('fg');
+            await page.keyboard.press('Enter');
+            await expect(editor).toHaveCount(0);
 
-        await expect(interiorCell).toContainText('Forest Green');
-    });
+            await expect(interiorCell).toContainText('Forest Green');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/reference-data/_examples/ref-data-property/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/reference-data/_examples/ref-data-property/example.spec.ts
@@ -2,7 +2,7 @@ import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/t
 
 test.agExample(import.meta, () => {
     // colIds: 'make', 'exteriorColour', 'interiorColour', 'retailPrice' (colId),
-    //         'Retail Price (incl Taxes)' (anonymous) -> '0'.
+    //         'Retail Price (incl Taxes)' (anonymous) -> '0' .
     // Row 0 data: make 'tyt', exteriorColour 'fg', interiorColour 'bw', price 35000.
     // refData maps: tyt->Toyota, fg->Forest Green, bw->Burlywood.
 

--- a/documentation/ag-grid-docs/src/content/docs/reference-data/_examples/ref-data-value-handler/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/reference-data/_examples/ref-data-value-handler/example.spec.ts
@@ -1,11 +1,66 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // colIds: 'make', 'exteriorColour', 'interiorColour', 'retailPrice' (colId),
+    //         'Retail Price (incl Taxes)' (anonymous) -> '0'.
+    // Row 0 data: make 'tyt', exteriorColour 'fg', interiorColour 'bw', price 35000.
+    // valueFormatters map codes to names: tyt->Toyota, fg->Forest Green, bw->Burlywood.
+
+    test.eachFramework('valueFormatters map stored codes to display values', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        await expect(agIdFor.cell('0', 'make')).toContainText('Toyota');
+        await expect(agIdFor.cell('0', 'exteriorColour')).toContainText('Forest Green');
+        await expect(agIdFor.cell('0', 'interiorColour')).toContainText('Burlywood');
+    });
+
+    test.eachFramework('price valueGetter/formatter and the chained taxes getter compute values', async ({
+        agIdFor,
+        page,
+    }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        await expect(agIdFor.cell('0', 'retailPrice')).toContainText('£35,000');
+        await expect(agIdFor.cell('0', '0')).toContainText('£42,000');
+    });
+
+    test.eachFramework('retail price valueSetter round-trips and re-drives the chained getter', async ({
+        agIdFor,
+        page,
+    }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const priceCell = agIdFor.cell('0', 'retailPrice');
+        await priceCell.dblclick();
+        const editor = priceCell.locator('input');
+        await expect(editor).toBeVisible();
+        await editor.fill('50000');
+        await page.keyboard.press('Enter');
+        await expect(editor).toHaveCount(0);
+
+        await expect(priceCell).toContainText('£50,000');
+        await expect(agIdFor.cell('0', '0')).toContainText('£60,000');
+    });
+
+    test.eachFramework('text editor with useFormatter edits by name and the valueParser stores the code', async ({
+        agIdFor,
+        page,
+    }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const interiorCell = agIdFor.cell('0', 'interiorColour');
+        await interiorCell.dblclick();
+        const editor = interiorCell.locator('input');
+        await expect(editor).toBeVisible();
+        // useFormatter shows the name for editing; entering the name 'Cadet Blue' is parsed to 'cb'.
+        await editor.fill('Cadet Blue');
+        await page.keyboard.press('Enter');
+        await expect(editor).toHaveCount(0);
+
+        await expect(interiorCell).toContainText('Cadet Blue');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/reference-data/_examples/ref-data-value-handler/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/reference-data/_examples/ref-data-value-handler/example.spec.ts
@@ -15,52 +15,52 @@ test.agExample(import.meta, () => {
         await expect(agIdFor.cell('0', 'interiorColour')).toContainText('Burlywood');
     });
 
-    test.eachFramework('price valueGetter/formatter and the chained taxes getter compute values', async ({
-        agIdFor,
-        page,
-    }) => {
-        await ensureGridReady(page);
-        await waitForGridContent(page);
+    test.eachFramework(
+        'price valueGetter/formatter and the chained taxes getter compute values',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
 
-        await expect(agIdFor.cell('0', 'retailPrice')).toContainText('£35,000');
-        await expect(agIdFor.cell('0', '0')).toContainText('£42,000');
-    });
+            await expect(agIdFor.cell('0', 'retailPrice')).toContainText('£35,000');
+            await expect(agIdFor.cell('0', '0')).toContainText('£42,000');
+        }
+    );
 
-    test.eachFramework('retail price valueSetter round-trips and re-drives the chained getter', async ({
-        agIdFor,
-        page,
-    }) => {
-        await ensureGridReady(page);
-        await waitForGridContent(page);
+    test.eachFramework(
+        'retail price valueSetter round-trips and re-drives the chained getter',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
 
-        const priceCell = agIdFor.cell('0', 'retailPrice');
-        await priceCell.dblclick();
-        const editor = priceCell.locator('input');
-        await expect(editor).toBeVisible();
-        await editor.fill('50000');
-        await page.keyboard.press('Enter');
-        await expect(editor).toHaveCount(0);
+            const priceCell = agIdFor.cell('0', 'retailPrice');
+            await priceCell.dblclick();
+            const editor = priceCell.locator('input');
+            await expect(editor).toBeVisible();
+            await editor.fill('50000');
+            await page.keyboard.press('Enter');
+            await expect(editor).toHaveCount(0);
 
-        await expect(priceCell).toContainText('£50,000');
-        await expect(agIdFor.cell('0', '0')).toContainText('£60,000');
-    });
+            await expect(priceCell).toContainText('£50,000');
+            await expect(agIdFor.cell('0', '0')).toContainText('£60,000');
+        }
+    );
 
-    test.eachFramework('text editor with useFormatter edits by name and the valueParser stores the code', async ({
-        agIdFor,
-        page,
-    }) => {
-        await ensureGridReady(page);
-        await waitForGridContent(page);
+    test.eachFramework(
+        'text editor with useFormatter edits by name and the valueParser stores the code',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
 
-        const interiorCell = agIdFor.cell('0', 'interiorColour');
-        await interiorCell.dblclick();
-        const editor = interiorCell.locator('input');
-        await expect(editor).toBeVisible();
-        // useFormatter shows the name for editing; entering the name 'Cadet Blue' is parsed to 'cb'.
-        await editor.fill('Cadet Blue');
-        await page.keyboard.press('Enter');
-        await expect(editor).toHaveCount(0);
+            const interiorCell = agIdFor.cell('0', 'interiorColour');
+            await interiorCell.dblclick();
+            const editor = interiorCell.locator('input');
+            await expect(editor).toBeVisible();
+            // useFormatter shows the name for editing; entering the name 'Cadet Blue' is parsed to 'cb'.
+            await editor.fill('Cadet Blue');
+            await page.keyboard.press('Enter');
+            await expect(editor).toHaveCount(0);
 
-        await expect(interiorCell).toContainText('Cadet Blue');
-    });
+            await expect(interiorCell).toContainText('Cadet Blue');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/value-cache/_examples/expiring-through-editing/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-cache/_examples/expiring-through-editing/example.spec.ts
@@ -1,11 +1,56 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent, waitForRowAnimations } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // 10 rows, valueCache: true, editable quarter columns, groupDefaultExpanded: 1.
+    // colIds: q1..q4, 'Total' -> 'total', 'Total x 10' (anonymous) -> '0'.
+    // Leaf row '0' (i=0): q1=6912, q2=1200, q3=0, q4=0 -> total 8112 ('8,112'), x10 81120 ('81,120').
+
+    test.eachFramework('renders the total and total x 10 leaf values', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        await expect(agIdFor.cell('0', 'total')).toContainText('8,112');
+        await expect(agIdFor.cell('0', '0')).toContainText('81,120');
+    });
+
+    test.eachFramework('editing a value expires the cache so the total recomputes', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const q1Cell = agIdFor.cell('0', 'q1');
+        await q1Cell.dblclick();
+        const editor = q1Cell.locator('input');
+        await expect(editor).toBeVisible();
+        await editor.fill('1000');
+        await page.keyboard.press('Enter');
+        await expect(editor).toHaveCount(0);
+
+        // Editing clears the value cache; total = 1000 + 1200 + 0 + 0 = 2200, x10 = 22000.
+        await expect(agIdFor.cell('0', 'total')).toContainText('2,200');
+        await expect(agIdFor.cell('0', '0')).toContainText('22,000');
+    });
+
+    test.eachFramework('refresh alone keeps the cache; invalidating first re-runs the value getter', async ({
+        page,
+    }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const logs: string[] = [];
+        const handler = (msg: { text: () => string }) => logs.push(msg.text());
+        page.on('console', handler);
+
+        // Refresh Cells alone uses the cache: the value getter is not executed again.
+        await page.getByRole('button', { name: 'Refresh Cells' }).click();
+        await waitForRowAnimations(page);
+        expect(logs.some((l) => l.includes('Total Value Getter'))).toBe(false);
+
+        // Invalidate the cache, then refresh: now the value getter must run again.
+        await page.getByRole('button', { name: 'Invalidate Value Cache' }).click();
+        await page.getByRole('button', { name: 'Refresh Cells' }).click();
+        await expect(() => {
+            expect(logs.some((l) => l.includes('Total Value Getter'))).toBe(true);
+        }).toPass();
+        page.off('console', handler);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/value-cache/_examples/expiring-through-editing/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-cache/_examples/expiring-through-editing/example.spec.ts
@@ -30,27 +30,28 @@ test.agExample(import.meta, () => {
         await expect(agIdFor.cell('0', '0')).toContainText('22,000');
     });
 
-    test.eachFramework('refresh alone keeps the cache; invalidating first re-runs the value getter', async ({
-        page,
-    }) => {
-        await ensureGridReady(page);
-        await waitForGridContent(page);
+    test.eachFramework(
+        'refresh alone keeps the cache; invalidating first re-runs the value getter',
+        async ({ page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
 
-        const logs: string[] = [];
-        const handler = (msg: { text: () => string }) => logs.push(msg.text());
-        page.on('console', handler);
+            const logs: string[] = [];
+            const handler = (msg: { text: () => string }) => logs.push(msg.text());
+            page.on('console', handler);
 
-        // Refresh Cells alone uses the cache: the value getter is not executed again.
-        await page.getByRole('button', { name: 'Refresh Cells' }).click();
-        await waitForRowAnimations(page);
-        expect(logs.some((l) => l.includes('Total Value Getter'))).toBe(false);
+            // Refresh Cells alone uses the cache: the value getter is not executed again.
+            await page.getByRole('button', { name: 'Refresh Cells' }).click();
+            await waitForRowAnimations(page);
+            expect(logs.some((l) => l.includes('Total Value Getter'))).toBe(false);
 
-        // Invalidate the cache, then refresh: now the value getter must run again.
-        await page.getByRole('button', { name: 'Invalidate Value Cache' }).click();
-        await page.getByRole('button', { name: 'Refresh Cells' }).click();
-        await expect(() => {
-            expect(logs.some((l) => l.includes('Total Value Getter'))).toBe(true);
-        }).toPass();
-        page.off('console', handler);
-    });
+            // Invalidate the cache, then refresh: now the value getter must run again.
+            await page.getByRole('button', { name: 'Invalidate Value Cache' }).click();
+            await page.getByRole('button', { name: 'Refresh Cells' }).click();
+            await expect(() => {
+                expect(logs.some((l) => l.includes('Total Value Getter'))).toBe(true);
+            }).toPass();
+            page.off('console', handler);
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/value-cache/_examples/never-expire/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-cache/_examples/never-expire/example.spec.ts
@@ -13,30 +13,30 @@ test.agExample(import.meta, () => {
         await expect(agIdFor.cell('0', '0')).toContainText('81,120');
     });
 
-    test.eachFramework('edits leave the total stale until the cache is expired and refreshed', async ({
-        agIdFor,
-        page,
-    }) => {
-        await ensureGridReady(page);
-        await waitForGridContent(page);
+    test.eachFramework(
+        'edits leave the total stale until the cache is expired and refreshed',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
 
-        const q1Cell = agIdFor.cell('0', 'q1');
-        await q1Cell.dblclick();
-        const editor = q1Cell.locator('input');
-        await expect(editor).toBeVisible();
-        await editor.fill('1000');
-        await page.keyboard.press('Enter');
-        await expect(editor).toHaveCount(0);
+            const q1Cell = agIdFor.cell('0', 'q1');
+            await q1Cell.dblclick();
+            const editor = q1Cell.locator('input');
+            await expect(editor).toBeVisible();
+            await editor.fill('1000');
+            await page.keyboard.press('Enter');
+            await expect(editor).toHaveCount(0);
 
-        // q1 now shows the new value, but the cache never expires so Total stays stale at 8,112.
-        await expect(q1Cell).toContainText('1,000');
-        await expect(agIdFor.cell('0', 'total')).toContainText('8,112');
+            // q1 now shows the new value, but the cache never expires so Total stays stale at 8,112.
+            await expect(q1Cell).toContainText('1,000');
+            await expect(agIdFor.cell('0', 'total')).toContainText('8,112');
 
-        // Expire the cache, then aggregate + refresh: Total recomputes to 1000 + 1200 = 2200.
-        await page.getByRole('button', { name: 'Expire Value Cache' }).click();
-        await page.getByRole('button', { name: 'Aggregate Data & Refresh Cells' }).click();
+            // Expire the cache, then aggregate + refresh: Total recomputes to 1000 + 1200 = 2200.
+            await page.getByRole('button', { name: 'Expire Value Cache' }).click();
+            await page.getByRole('button', { name: 'Aggregate Data & Refresh Cells' }).click();
 
-        await expect(agIdFor.cell('0', 'total')).toContainText('2,200');
-        await expect(agIdFor.cell('0', '0')).toContainText('22,000');
-    });
+            await expect(agIdFor.cell('0', 'total')).toContainText('2,200');
+            await expect(agIdFor.cell('0', '0')).toContainText('22,000');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/value-cache/_examples/never-expire/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-cache/_examples/never-expire/example.spec.ts
@@ -1,11 +1,42 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // valueCache: true, valueCacheNeverExpires: true. 10 rows, groupDefaultExpanded: 1.
+    // colIds: q1..q4, 'Total' -> 'total', 'Total x 10' (anonymous) -> '0'.
+    // Leaf row '0' (i=0): total 8112 ('8,112'), x10 81120 ('81,120').
+
+    test.eachFramework('renders the initial total from the value cache', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        await expect(agIdFor.cell('0', 'total')).toContainText('8,112');
+        await expect(agIdFor.cell('0', '0')).toContainText('81,120');
+    });
+
+    test.eachFramework('edits leave the total stale until the cache is expired and refreshed', async ({
+        agIdFor,
+        page,
+    }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const q1Cell = agIdFor.cell('0', 'q1');
+        await q1Cell.dblclick();
+        const editor = q1Cell.locator('input');
+        await expect(editor).toBeVisible();
+        await editor.fill('1000');
+        await page.keyboard.press('Enter');
+        await expect(editor).toHaveCount(0);
+
+        // q1 now shows the new value, but the cache never expires so Total stays stale at 8,112.
+        await expect(q1Cell).toContainText('1,000');
+        await expect(agIdFor.cell('0', 'total')).toContainText('8,112');
+
+        // Expire the cache, then aggregate + refresh: Total recomputes to 1000 + 1200 = 2200.
+        await page.getByRole('button', { name: 'Expire Value Cache' }).click();
+        await page.getByRole('button', { name: 'Aggregate Data & Refresh Cells' }).click();
+
+        await expect(agIdFor.cell('0', 'total')).toContainText('2,200');
+        await expect(agIdFor.cell('0', '0')).toContainText('22,000');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/value-cache/_examples/value-cache/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-cache/_examples/value-cache/example.spec.ts
@@ -1,10 +1,61 @@
-import { clickAllButtons, ensureGridReady, test } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent, waitForRowAnimations } from '@utils/grid/test-utils';
+
+// typescriptOnly example. Grouped by year (2015/2016), groupDefaultExpanded: 1.
+// The 'Total' column valueGetter sums q1..q4 and logs a 'Total Value Getter' message on every call.
+// Leaf row id '0' (i=0): q1=6912, q2=1200, q3=0, q4=0 -> total 8112 -> displayed '8,112'.
 
 test.agExample(import.meta, () => {
-    test.typescript('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.typescript('value getter computes the leaf and re-runs on expand when the cache is off', async ({
+        agIdFor,
+        page,
+    }) => {
         await ensureGridReady(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+        await waitForGridContent(page);
+
+        await expect(agIdFor.cell('0', 'total')).toContainText('8,112');
+
+        // With the value cache OFF (default), collapsing then re-expanding a group forces the DOM
+        // to be recreated, so the value getter is executed again.
+        const logs: string[] = [];
+        const handler = (msg: { text: () => string }) => logs.push(msg.text());
+        page.on('console', handler);
+
+        await agIdFor.autoGroupExpanded('row-group-year-2015').click();
+        await waitForRowAnimations(page);
+        await agIdFor.autoGroupContracted('row-group-year-2015').click();
+
+        await expect(() => {
+            expect(logs.some((l) => l.includes('Total Value Getter'))).toBe(true);
+        }).toPass();
+        page.off('console', handler);
+    });
+
+    test.typescript('turning the cache on keeps values correct and stops re-execution on expand', async ({
+        agIdFor,
+        page,
+    }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        // Turn the value cache ON (first radio); the grid is destroyed and recreated.
+        await page.locator('input[name="valueCache"]').first().click();
+
+        // Values are still correct when served from the cache.
+        await expect(agIdFor.cell('0', 'total')).toContainText('8,112');
+        await waitForRowAnimations(page);
+
+        // Start listening only after initialisation has settled, then collapse/expand a group.
+        const logs: string[] = [];
+        const handler = (msg: { text: () => string }) => logs.push(msg.text());
+        page.on('console', handler);
+
+        await agIdFor.autoGroupExpanded('row-group-year-2015').click();
+        await waitForRowAnimations(page);
+        await agIdFor.autoGroupContracted('row-group-year-2015').click();
+        await waitForRowAnimations(page);
+
+        // With the cache ON, expand/collapse does not re-execute the value getter.
+        expect(logs.some((l) => l.includes('Total Value Getter'))).toBe(false);
+        page.off('console', handler);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/value-cache/_examples/value-cache/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-cache/_examples/value-cache/example.spec.ts
@@ -5,57 +5,57 @@ import { ensureGridReady, expect, test, waitForGridContent, waitForRowAnimations
 // Leaf row id '0' (i=0): q1=6912, q2=1200, q3=0, q4=0 -> total 8112 -> displayed '8,112'.
 
 test.agExample(import.meta, () => {
-    test.typescript('value getter computes the leaf and re-runs on expand when the cache is off', async ({
-        agIdFor,
-        page,
-    }) => {
-        await ensureGridReady(page);
-        await waitForGridContent(page);
+    test.typescript(
+        'value getter computes the leaf and re-runs on expand when the cache is off',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
 
-        await expect(agIdFor.cell('0', 'total')).toContainText('8,112');
+            await expect(agIdFor.cell('0', 'total')).toContainText('8,112');
 
-        // With the value cache OFF (default), collapsing then re-expanding a group forces the DOM
-        // to be recreated, so the value getter is executed again.
-        const logs: string[] = [];
-        const handler = (msg: { text: () => string }) => logs.push(msg.text());
-        page.on('console', handler);
+            // With the value cache OFF (default), collapsing then re-expanding a group forces the DOM
+            // to be recreated, so the value getter is executed again.
+            const logs: string[] = [];
+            const handler = (msg: { text: () => string }) => logs.push(msg.text());
+            page.on('console', handler);
 
-        await agIdFor.autoGroupExpanded('row-group-year-2015').click();
-        await waitForRowAnimations(page);
-        await agIdFor.autoGroupContracted('row-group-year-2015').click();
+            await agIdFor.autoGroupExpanded('row-group-year-2015').click();
+            await waitForRowAnimations(page);
+            await agIdFor.autoGroupContracted('row-group-year-2015').click();
 
-        await expect(() => {
-            expect(logs.some((l) => l.includes('Total Value Getter'))).toBe(true);
-        }).toPass();
-        page.off('console', handler);
-    });
+            await expect(() => {
+                expect(logs.some((l) => l.includes('Total Value Getter'))).toBe(true);
+            }).toPass();
+            page.off('console', handler);
+        }
+    );
 
-    test.typescript('turning the cache on keeps values correct and stops re-execution on expand', async ({
-        agIdFor,
-        page,
-    }) => {
-        await ensureGridReady(page);
-        await waitForGridContent(page);
+    test.typescript(
+        'turning the cache on keeps values correct and stops re-execution on expand',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
 
-        // Turn the value cache ON (first radio); the grid is destroyed and recreated.
-        await page.locator('input[name="valueCache"]').first().click();
+            // Turn the value cache ON (first radio); the grid is destroyed and recreated.
+            await page.locator('input[name="valueCache"]').first().click();
 
-        // Values are still correct when served from the cache.
-        await expect(agIdFor.cell('0', 'total')).toContainText('8,112');
-        await waitForRowAnimations(page);
+            // Values are still correct when served from the cache.
+            await expect(agIdFor.cell('0', 'total')).toContainText('8,112');
+            await waitForRowAnimations(page);
 
-        // Start listening only after initialisation has settled, then collapse/expand a group.
-        const logs: string[] = [];
-        const handler = (msg: { text: () => string }) => logs.push(msg.text());
-        page.on('console', handler);
+            // Start listening only after initialisation has settled, then collapse/expand a group.
+            const logs: string[] = [];
+            const handler = (msg: { text: () => string }) => logs.push(msg.text());
+            page.on('console', handler);
 
-        await agIdFor.autoGroupExpanded('row-group-year-2015').click();
-        await waitForRowAnimations(page);
-        await agIdFor.autoGroupContracted('row-group-year-2015').click();
-        await waitForRowAnimations(page);
+            await agIdFor.autoGroupExpanded('row-group-year-2015').click();
+            await waitForRowAnimations(page);
+            await agIdFor.autoGroupContracted('row-group-year-2015').click();
+            await waitForRowAnimations(page);
 
-        // With the cache ON, expand/collapse does not re-execute the value getter.
-        expect(logs.some((l) => l.includes('Total Value Getter'))).toBe(false);
-        page.off('console', handler);
-    });
+            // With the cache ON, expand/collapse does not re-execute the value getter.
+            expect(logs.some((l) => l.includes('Total Value Getter'))).toBe(false);
+            page.off('console', handler);
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/value-formatters/_examples/use-value-formatter-for-export/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-formatters/_examples/use-value-formatter-for-export/example.spec.ts
@@ -1,11 +1,47 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { dragFillHandleOverTo, ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // fields 'a' and 'b'. Formatter: '£' + value (no digit grouping). Parser strips a leading '£'.
+    // a = Math.floor(((i + 2) * 173456) % 10000): row 0 -> 6912, row 1 -> 368.
+    // b = Math.floor(((i + 7) * 373456) % 10000): row 0 -> 4192.
+
+    test.eachFramework('valueFormatter renders values with a pound prefix', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        await expect(agIdFor.cell('0', 'a')).toContainText('£6912');
+        await expect(agIdFor.cell('0', 'b')).toContainText('£4192');
+        await expect(agIdFor.cell('1', 'a')).toContainText('£368');
+    });
+
+    test.eachFramework('editing round-trips through the parser and formatter', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const cell = agIdFor.cell('0', 'a');
+        await cell.dblclick();
+        const editor = cell.locator('input');
+        await expect(editor).toBeVisible();
+        // Type with the pound sign; the parser strips it and stores the number 999.
+        await editor.fill('£999');
+        await page.keyboard.press('Enter');
+
+        await expect(editor).toHaveCount(0);
+        await expect(cell).toContainText('£999');
+    });
+
+    test.eachFramework('fill handle uses the formatter for export and parser for import', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const source = agIdFor.cell('0', 'a'); // £6912
+        const target = agIdFor.cell('1', 'a');
+
+        await source.click();
+        await dragFillHandleOverTo(agIdFor.fillHandle(), target);
+
+        // The source value is exported via the formatter and re-imported via the parser,
+        // so the filled cell displays the same formatted value.
+        await expect(target).toContainText('£6912');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/value-formatters/_examples/value-formatters/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-formatters/_examples/value-formatters/example.spec.ts
@@ -1,11 +1,35 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // All three columns bind field 'a'; duplicate fields are suffixed, so colIds are
+    // 'a' (Raw Value), 'a_1' (Currency), 'a_2' (Bracketed).
+    // a = Math.floor(((i + 2) * 173456) % 10000): row 0 -> 6912, row 1 -> 368, row 2 -> 3824.
+
+    test.eachFramework('raw column shows the unformatted value', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        await expect(agIdFor.cell('0', 'a')).toContainText('6912');
+        await expect(agIdFor.cell('1', 'a')).toContainText('368');
+    });
+
+    test.eachFramework('currency valueFormatter prefixes with a pound sign and groups digits', async ({
+        agIdFor,
+        page,
+    }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        await expect(agIdFor.cell('0', 'a_1')).toContainText('£6,912');
+        await expect(agIdFor.cell('1', 'a_1')).toContainText('£368');
+        await expect(agIdFor.cell('2', 'a_1')).toContainText('£3,824');
+    });
+
+    test.eachFramework('brackets valueFormatter wraps the value in parentheses', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        await expect(agIdFor.cell('0', 'a_2')).toContainText('(6912)');
+        await expect(agIdFor.cell('1', 'a_2')).toContainText('(368)');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/value-formatters/_examples/value-formatters/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-formatters/_examples/value-formatters/example.spec.ts
@@ -13,17 +13,17 @@ test.agExample(import.meta, () => {
         await expect(agIdFor.cell('1', 'a')).toContainText('368');
     });
 
-    test.eachFramework('currency valueFormatter prefixes with a pound sign and groups digits', async ({
-        agIdFor,
-        page,
-    }) => {
-        await ensureGridReady(page);
-        await waitForGridContent(page);
+    test.eachFramework(
+        'currency valueFormatter prefixes with a pound sign and groups digits',
+        async ({ agIdFor, page }) => {
+            await ensureGridReady(page);
+            await waitForGridContent(page);
 
-        await expect(agIdFor.cell('0', 'a_1')).toContainText('£6,912');
-        await expect(agIdFor.cell('1', 'a_1')).toContainText('£368');
-        await expect(agIdFor.cell('2', 'a_1')).toContainText('£3,824');
-    });
+            await expect(agIdFor.cell('0', 'a_1')).toContainText('£6,912');
+            await expect(agIdFor.cell('1', 'a_1')).toContainText('£368');
+            await expect(agIdFor.cell('2', 'a_1')).toContainText('£3,824');
+        }
+    );
 
     test.eachFramework('brackets valueFormatter wraps the value in parentheses', async ({ agIdFor, page }) => {
         await ensureGridReady(page);

--- a/documentation/ag-grid-docs/src/content/docs/value-getters/_examples/column-fields/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-getters/_examples/column-fields/example.spec.ts
@@ -1,11 +1,29 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // Columns: 'name' (field), 'person.country' (field + dot notation), and an anonymous
+    // valueGetter column (Total Medals = gold + silver + bronze) which is assigned colId '0'.
+    test.eachFramework('field and dot-notation field map the row data', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Row 0: { name: 'Michael Phelps', person: { country: 'United States' }, medals: 8/0/0 }
+        await expect(agIdFor.cell('0', 'name')).toContainText('Michael Phelps');
+        await expect(agIdFor.cell('0', 'person.country')).toContainText('United States');
+
+        // Row 4: dot notation resolves a different nested country.
+        await expect(agIdFor.cell('4', 'person.country')).toContainText('Russia');
+    });
+
+    test.eachFramework('valueGetter sums the three medal totals', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        // Row 0: 8 + 0 + 0 = 8
+        await expect(agIdFor.cell('0', '0')).toContainText('8');
+        // Row 3: Natalie Coughlin 1 + 2 + 3 = 6
+        await expect(agIdFor.cell('3', '0')).toContainText('6');
+        // Row 4: Aleksey Nemov 2 + 1 + 3 = 6
+        await expect(agIdFor.cell('4', '0')).toContainText('6');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/value-getters/_examples/value-getters/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-getters/_examples/value-getters/example.spec.ts
@@ -1,11 +1,37 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // rowData: a = i % 4, b = i % 7 for i in 0..99.
+    // colIds: 'ID #' (anonymous) -> '0', 'a', 'b', 'A + B' -> 'a&b',
+    //         'A * 1000' -> '1', 'B * 137' -> '2', 'Chain' -> '3', 'Const' -> '4'.
+
+    test.eachFramework('ID # valueGetter prints the row node id', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // hashValueGetter returns Number(node.id); default node ids are the row index.
+        await expect(agIdFor.cell('0', '0')).toContainText('0');
+        await expect(agIdFor.cell('5', '0')).toContainText('5');
+    });
+
+    test.eachFramework('arithmetic and chained valueGetters compute derived values', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        // Row 5: a = 5 % 4 = 1, b = 5 % 7 = 5.
+        await expect(agIdFor.cell('5', 'a')).toContainText('1');
+        await expect(agIdFor.cell('5', 'b')).toContainText('5');
+        await expect(agIdFor.cell('5', 'a&b')).toContainText('6'); // a + b
+        await expect(agIdFor.cell('5', '1')).toContainText('1000'); // a * 1000
+        await expect(agIdFor.cell('5', '2')).toContainText('685'); // b * 137
+        await expect(agIdFor.cell('5', '3')).toContainText('6000'); // chain: (a + b) * 1000
+    });
+
+    test.eachFramework('constant valueGetter returns the same value for every row', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        await expect(agIdFor.cell('0', '4')).toContainText('99999');
+        await expect(agIdFor.cell('5', '4')).toContainText('99999');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/value-parsers/_examples/example-parsers/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-parsers/_examples/example-parsers/example.spec.ts
@@ -1,11 +1,46 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // fields 'simple', 'numberBad', 'numberGood' (numberGood has a Number() valueParser). All editable.
+    // Row 0: simple 'One', numberBad 6912, numberGood 2642.
+
+    test.eachFramework('renders the source values', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        await expect(agIdFor.cell('0', 'simple')).toContainText('One');
+        await expect(agIdFor.cell('0', 'numberBad')).toContainText('6912');
+        await expect(agIdFor.cell('0', 'numberGood')).toContainText('2642');
+    });
+
+    test.eachFramework('editing the string column writes the new text back', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const cell = agIdFor.cell('0', 'simple');
+        await cell.dblclick();
+        const editor = cell.locator('input');
+        await expect(editor).toBeVisible();
+        await editor.fill('Grid');
+        await page.keyboard.press('Enter');
+
+        await expect(editor).toHaveCount(0);
+        await expect(cell).toContainText('Grid');
+    });
+
+    test.eachFramework('editing the parsed number column round-trips the value', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const cell = agIdFor.cell('0', 'numberGood');
+        await cell.dblclick();
+        const editor = cell.locator('input');
+        await expect(editor).toBeVisible();
+        // valueParser converts the typed string '1234' to the number 1234.
+        await editor.fill('1234');
+        await page.keyboard.press('Enter');
+
+        await expect(editor).toHaveCount(0);
+        await expect(cell).toContainText('1234');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/value-parsers/_examples/use-value-parser-for-import/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-parsers/_examples/use-value-parser-for-import/example.spec.ts
@@ -1,11 +1,44 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { dragFillHandleOverTo, ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // fields 'a' and 'b'. Formatter: '£' + value. Parser strips a leading '£' then parseFloat.
+    // a = Math.floor(((i + 2) * 173456) % 10000): row 0 -> 6912, row 1 -> 368.
+
+    test.eachFramework('valueFormatter renders values with a pound prefix', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        await expect(agIdFor.cell('0', 'a')).toContainText('£6912');
+        await expect(agIdFor.cell('1', 'a')).toContainText('£368');
+    });
+
+    test.eachFramework('editing parses a formatted string back into a number', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const cell = agIdFor.cell('0', 'a');
+        await cell.dblclick();
+        const editor = cell.locator('input');
+        await expect(editor).toBeVisible();
+        await editor.fill('£1500');
+        await page.keyboard.press('Enter');
+
+        // The parser strips '£' and stores 1500; the formatter renders it back with the prefix.
+        await expect(editor).toHaveCount(0);
+        await expect(cell).toContainText('£1500');
+    });
+
+    test.eachFramework('fill handle imports the value via the parser', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const source = agIdFor.cell('0', 'a'); // £6912
+        const target = agIdFor.cell('1', 'a');
+
+        await source.click();
+        await dragFillHandleOverTo(agIdFor.fillHandle(), target);
+
+        // The formatted source is re-imported through the parser, so the target matches the source.
+        await expect(target).toContainText('£6912');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/value-setters/_examples/example-setters/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-setters/_examples/example-setters/example.spec.ts
@@ -1,11 +1,61 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // colIds: 'Name' (anonymous) -> '0', 'A' -> 'a', 'B' (anonymous) -> '1',
+    //         'C.X' (anonymous) -> '2', 'C.Y' (anonymous) -> '3'. All columns editable.
+    // Row 0 firstName/lastName are deterministic: 'Niall' / 'Pink'.
+
+    test.eachFramework('Name valueGetter combines firstName and lastName', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        await expect(agIdFor.cell('0', '0')).toContainText('Niall Pink');
+    });
+
+    test.eachFramework('Name valueSetter splits the edited value back into two fields', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const nameCell = agIdFor.cell('0', '0');
+        await nameCell.dblclick();
+        const editor = nameCell.locator('input');
+        await expect(editor).toBeVisible();
+        await editor.fill('John Black');
+        await page.keyboard.press('Enter');
+
+        // The setter writes firstName='John' and lastName='Black'; the getter re-derives the display.
+        await expect(editor).toHaveCount(0);
+        await expect(nameCell).toContainText('John Black');
+    });
+
+    test.eachFramework('B valueSetter writes the edited number back to the data', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const bCell = agIdFor.cell('0', '1');
+        await bCell.dblclick();
+        const editor = bCell.locator('input');
+        await expect(editor).toBeVisible();
+        await editor.fill('55');
+        await page.keyboard.press('Enter');
+
+        await expect(editor).toHaveCount(0);
+        await expect(bCell).toContainText('55');
+    });
+
+    test.eachFramework('C.X valueSetter writes into the embedded object', async ({ agIdFor, page }) => {
+        await ensureGridReady(page);
+        await waitForGridContent(page);
+
+        const cxCell = agIdFor.cell('0', '2');
+        await cxCell.dblclick();
+        const editor = cxCell.locator('input');
+        await expect(editor).toBeVisible();
+        await editor.fill('77');
+        await page.keyboard.press('Enter');
+
+        // The setter creates data.c if missing and stores x=77; the getter reads it back.
+        await expect(editor).toHaveCount(0);
+        await expect(cxCell).toContainText('77');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/value-setters/_examples/read-only-row-data/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-setters/_examples/read-only-row-data/example.spec.ts
@@ -1,11 +1,24 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // readOnlyEdit: true, but the app listens for cellEditRequest and sets new rowData
+    // (immutable store + getRowId), so the edit is applied. Row 0: athlete 'Michael Phelps'.
+
+    test.eachFramework('editing a cell persists once the app updates rowData', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const athleteCell = agIdFor.cell('0', 'athlete');
+        await expect(athleteCell).toContainText('Michael Phelps');
+
+        await athleteCell.dblclick();
+        const editor = athleteCell.locator('input');
+        await expect(editor).toBeVisible();
+        await editor.fill('Fred');
+        await page.keyboard.press('Enter');
+
+        // cellEditRequest handler rebuilds the immutable store and calls setGridOption('rowData').
+        await expect(editor).toHaveCount(0);
+        await expect(athleteCell).toContainText('Fred');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/value-setters/_examples/read-only-transactions/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-setters/_examples/read-only-transactions/example.spec.ts
@@ -1,11 +1,24 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // readOnlyEdit: true; the app listens for cellEditRequest and applies an update transaction
+    // (applyTransaction with getRowId), so the edit is applied. Row 0: athlete 'Michael Phelps'.
+
+    test.eachFramework('editing a cell persists via an update transaction', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const athleteCell = agIdFor.cell('0', 'athlete');
+        await expect(athleteCell).toContainText('Michael Phelps');
+
+        await athleteCell.dblclick();
+        const editor = athleteCell.locator('input');
+        await expect(editor).toBeVisible();
+        await editor.fill('Fred');
+        await page.keyboard.press('Enter');
+
+        // cellEditRequest handler builds a new row object and calls api.applyTransaction({ update }).
+        await expect(editor).toHaveCount(0);
+        await expect(athleteCell).toContainText('Fred');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/value-setters/_examples/read-only/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-setters/_examples/read-only/example.spec.ts
@@ -1,11 +1,25 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    // readOnlyEdit: true. Editing fires cellEditRequest but the grid never updates the data,
+    // so the cell keeps its original value. Row 0: athlete 'Michael Phelps'.
+
+    test.eachFramework('editing a cell does not change the value (read only edit)', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const athleteCell = agIdFor.cell('0', 'athlete');
+        await expect(athleteCell).toContainText('Michael Phelps');
+
+        await athleteCell.dblclick();
+        const editor = athleteCell.locator('input');
+        await expect(editor).toBeVisible();
+        await editor.fill('Fred');
+        await page.keyboard.press('Enter');
+
+        // The grid discards the edit because readOnlyEdit stops it updating the data.
+        await expect(editor).toHaveCount(0);
+        await expect(athleteCell).toContainText('Michael Phelps');
+        await expect(athleteCell).not.toContainText('Fred');
     });
 });


### PR DESCRIPTION
## What

Replaces the placeholder Playwright `example.spec.ts` tests (grid-loads-only, no assertions) with real assertion-bearing tests for the **Value Handling** docs feature.

All 15 examples across 6 pages were placeholders; every one now has meaningful assertions.

### Pages & examples covered

- **value-getters**
  - `column-fields` — `field`, dot-notation `field`, and a summing `valueGetter`
  - `value-getters` — node-id getter, arithmetic/chained getters, constant getter
- **value-setters**
  - `example-setters` — Name getter/setter split, `field` setter, embedded-object setter (edit round-trips)
  - `read-only` — `readOnlyEdit` discards the edit (value unchanged)
  - `read-only-row-data` — edit persists via `setGridOption('rowData')`
  - `read-only-transactions` — edit persists via `applyTransaction`
- **value-formatters**
  - `value-formatters` — raw / currency (grouped) / bracketed formatters
  - `use-value-formatter-for-export` — formatted display, edit round-trip, fill-handle import via parser
- **value-parsers**
  - `example-parsers` — string edit + parsed-number edit round-trips
  - `use-value-parser-for-import` — formatted display, edit round-trip, fill-handle import
- **value-cache**
  - `value-cache` — leaf total value; getter re-runs on expand with cache off, not with cache on (console-observed)
  - `expiring-through-editing` — total/×10 values; edit expires cache; refresh keeps cache, invalidate+refresh re-runs getter
  - `never-expire` — edits leave total stale until `expireValueCache()` + aggregate/refresh
- **reference-data**
  - `ref-data-property` — `refData` mapping, price getter/formatter + chained taxes getter, price setter round-trip, refData text-edit by code
  - `ref-data-value-handler` — `valueFormatter` mapping, price getter/setter, text editor `useFormatter` edit-by-name (parser stores code)

## Notes

- Expected cell values and colIds were computed from each example's source (`main.ts`/`data.ts`) and, for the olympic examples, the `example-assets/olympic-winners.json` fixture.
- Anonymous (no `field`/`colId`) columns are addressed by their generated numeric colIds (`'0'`, `'1'`, …) per the grid's deterministic colId allocation.
- Assertions were authored from source analysis; they are verified by the central docs e2e run (no local run in this worktree).
- Deliberately not asserted: the string-vs-number distinction in `example-parsers` (identical DOM text — round-trips are asserted instead), and driving the `agSelectCellEditor` / `agRichSelectCellEditor` dropdowns in the reference-data examples (fragile; the reliable text-editor and price round-trips cover the same code/name mapping behaviour).
