### PR TITLE
AG-17864 second fix row grouping order and fix columns add/remove/move animations

### DIFF
--- a/packages/ag-grid-community/src/columnMove/columnAnimationService.ts
+++ b/packages/ag-grid-community/src/columnMove/columnAnimationService.ts
@@ -5,18 +5,21 @@ import type { GridBodyCtrl } from '../gridBodyComp/gridBodyCtrl';
 export class ColumnAnimationService extends BeanStub implements NamedBean {
     beanName = 'colAnimation' as const;
 
-    private gridBodyCtrl: GridBodyCtrl;
+    private gridBodyCtrl: GridBodyCtrl | undefined;
 
     private readonly executeNextFuncs: ((...args: any[]) => any)[] = [];
     private readonly executeLaterFuncs: ((...args: any[]) => any)[] = [];
 
     private active = false;
-    // activeNext starts with active but it is reset earlier after the nextFuncs are cleared
-    // to prevent calls made to executeNextVMTurn from queuing functions after executeNextFuncs has already been flushed,
+    /** Cleared a VM-turn earlier than {@link active} (once `executeNextFuncs` has flushed) so a late
+     *  {@link executeNextVMTurn} runs immediately instead of queuing behind an already-flushed batch. */
     private activeNext = false;
     private suppressAnimation = false;
 
     private animationThreadCount = 0;
+    /** Nesting depth: only the outermost {@link start}/{@link finish} pair drives the animation, so a wrapped
+     *  refresh (e.g. a role-col flush re-entering via pivot-sort) can't end it early. */
+    private startDepth = 0;
 
     public postConstruct(): void {
         this.beans.ctrlsSvc.whenReady(this, (p) => (this.gridBodyCtrl = p.gridBodyCtrl));
@@ -30,31 +33,33 @@ export class ColumnAnimationService extends BeanStub implements NamedBean {
         this.suppressAnimation = suppress;
     }
 
+    /** Open an animation window; nestable — only the outermost open actually starts the animation. */
     public start(): void {
+        this.startDepth++;
         if (this.active) {
             return;
         }
 
-        const { gos } = this;
-
-        if (gos.get('suppressColumnMoveAnimation')) {
+        const { gos, gridBodyCtrl } = this;
+        if (!gridBodyCtrl || gos.get('suppressColumnMoveAnimation')) {
             return;
         }
 
-        this.ensureAnimationCssClassPresent();
+        this.ensureAnimationCssClassPresent(gridBodyCtrl);
 
         this.active = true;
         this.activeNext = true;
     }
 
+    /** Close an animation window; the outermost close flushes the queued next/later funcs. */
     public finish(): void {
-        if (!this.active) {
+        // Only the outermost close (depth back to 0) flushes; nested closes and unbalanced calls no-op.
+        const depth = Math.max(0, this.startDepth - 1);
+        this.startDepth = depth;
+        if (depth > 0 || !this.active) {
             return;
         }
-        this.flush(
-            () => (this.activeNext = false),
-            () => (this.active = false)
-        );
+        this.flush();
     }
 
     public executeNextVMTurn(func: (...args: any[]) => any): void {
@@ -73,12 +78,11 @@ export class ColumnAnimationService extends BeanStub implements NamedBean {
         }
     }
 
-    private ensureAnimationCssClassPresent(): void {
+    private ensureAnimationCssClassPresent(gridBodyCtrl: GridBodyCtrl): void {
         // up the count, so we can tell if someone else has updated the count
         // by the time the 'wait' func executes
         this.animationThreadCount++;
         const animationThreadCountCopy = this.animationThreadCount;
-        const { gridBodyCtrl } = this;
         gridBodyCtrl.setColumnMovingCss(true);
 
         this.executeLaterFuncs.push(() => {
@@ -89,35 +93,34 @@ export class ColumnAnimationService extends BeanStub implements NamedBean {
         });
     }
 
-    private flush(callbackNext: () => void, callbackLater: () => void): void {
+    private flush(): void {
         const { executeNextFuncs, executeLaterFuncs } = this;
         if (executeNextFuncs.length === 0 && executeLaterFuncs.length === 0) {
-            callbackNext();
-            callbackLater();
+            this.activeNext = false;
+            this.active = false;
             return;
         }
 
-        const runFuncs = (queue: ((...args: any[]) => any)[]) => {
-            while (queue.length) {
-                const func = queue.pop();
-                if (func) {
-                    func();
-                }
-            }
-        };
-
         this.beans.frameworkOverrides.wrapIncoming(() => {
             window.setTimeout(() => {
-                callbackNext();
+                this.activeNext = false;
                 runFuncs(executeNextFuncs);
             }, 0);
             window.setTimeout(() => {
-                // run the callback before executeLaterFuncs
-                // because some functions being executed later
-                // check if this service is `active`.
-                callbackLater();
+                // Clear `active` before the later funcs run — some of them check it.
+                this.active = false;
                 runFuncs(executeLaterFuncs);
             }, 200);
         });
     }
 }
+
+/** Drain a queue, running each func (LIFO); captures nothing, so it's shared rather than re-allocated per flush. */
+const runFuncs = (queue: ((...args: any[]) => any)[]): void => {
+    while (queue.length) {
+        const func = queue.pop();
+        if (func) {
+            func();
+        }
+    }
+};

--- a/packages/ag-grid-community/src/columnMove/columnMoveService.ts
+++ b/packages/ag-grid-community/src/columnMove/columnMoveService.ts
@@ -47,30 +47,32 @@ export class ColumnMoveService extends BeanStub implements NamedBean {
         }
 
         colAnimation?.start();
-        // we want to pull all the columns out first and put them into an ordered list
-        const movedColumns: AgColumn[] = [];
-        for (let i = 0, len = columnsToMoveKeys.length; i < len; ++i) {
-            const col = colModel.getCol(columnsToMoveKeys[i]);
-            if (col) {
-                movedColumns.push(col);
+        try {
+            // we want to pull all the columns out first and put them into an ordered list
+            const movedColumns: AgColumn[] = [];
+            for (let i = 0, len = columnsToMoveKeys.length; i < len; ++i) {
+                const col = colModel.getCol(columnsToMoveKeys[i]);
+                if (col) {
+                    movedColumns.push(col);
+                }
             }
-        }
 
-        if (this.doesMovePassRules(movedColumns, toIndex)) {
-            _moveInArray(colModel.colsList, movedColumns, toIndex);
-            colModel.markColsListIndexDirty();
-            visibleCols.refresh(source, false);
-            this.eventSvc.dispatchEvent({
-                type: 'columnMoved',
-                columns: movedColumns,
-                column: movedColumns.length === 1 ? movedColumns[0] : null,
-                toIndex,
-                finished,
-                source,
-            });
+            if (this.doesMovePassRules(movedColumns, toIndex)) {
+                _moveInArray(colModel.colsList, movedColumns, toIndex);
+                colModel.markColsListIndexDirty();
+                visibleCols.refresh(source, false);
+                this.eventSvc.dispatchEvent({
+                    type: 'columnMoved',
+                    columns: movedColumns,
+                    column: movedColumns.length === 1 ? movedColumns[0] : null,
+                    toIndex,
+                    finished,
+                    source,
+                });
+            }
+        } finally {
+            colAnimation?.finish();
         }
-
-        colAnimation?.finish();
     }
 
     private doesMovePassRules(columnsToMove: AgColumn[], toIndex: number): boolean {

--- a/packages/ag-grid-community/src/columns/colsApplyPrevOrder.ts
+++ b/packages/ag-grid-community/src/columns/colsApplyPrevOrder.ts
@@ -28,17 +28,22 @@ export const applyPrevColumnsOrder = (
     const preservedOrder: AgColumn[] = [];
     const colPositionMap = new Map<AgColumn, number>();
     const groupHighestLeaf = new Map<AgProvidedColumnGroup, AgColumn>();
+    let hasPreservedAutoGroup = false;
     for (let i = 0; i < prevOrderLen; ++i) {
         const current = colsById[prevOrder[i]];
         if (current != null) {
             colPositionMap.set(current, preservedOrder.length);
             preservedOrder.push(current);
+            hasPreservedAutoGroup ||= current.colKind === 'auto-group';
             let g = current.originalParent;
             while (g != null) {
                 groupHighestLeaf.set(g, current);
                 g = g.originalParent;
             }
         }
+    }
+    if (hasPreservedAutoGroup) {
+        resnapAutoGroupCols(preservedOrder, colsList, colPositionMap);
     }
     if (preservedOrder.length === colsListLen) {
         return preservedOrder; // all preserved — order already correct
@@ -141,6 +146,30 @@ export const applyPrevColumnsOrder = (
         result[pos++] = endCalc[i];
     }
     return result;
+};
+
+/** Re-seat preserved auto-group cols into `colsList` (hierarchy) order without moving their slots: each
+ *  auto-col position in `preservedOrder` takes the next preserved auto col as `colsList` lists them. */
+const resnapAutoGroupCols = (
+    preservedOrder: AgColumn[],
+    colsList: AgColumn[],
+    colPositionMap: Map<AgColumn, number>
+): void => {
+    let autoIdx = 0;
+    const colsListLen = colsList.length;
+    for (let i = 0, len = preservedOrder.length; i < len; ++i) {
+        if (preservedOrder[i].colKind !== 'auto-group') {
+            continue;
+        }
+        while (autoIdx < colsListLen) {
+            const candidate = colsList[autoIdx++];
+            if (candidate.colKind === 'auto-group' && colPositionMap.has(candidate)) {
+                preservedOrder[i] = candidate;
+                colPositionMap.set(candidate, i); // keep the position map in step with the reordered slot
+                break;
+            }
+        }
+    }
 };
 
 /** True when any preserved col sits in a group with siblings — i.e. there are anchors to resolve. */

--- a/packages/ag-grid-community/src/columns/columnGroups/columnGroupState.ts
+++ b/packages/ag-grid-community/src/columns/columnGroups/columnGroupState.ts
@@ -38,27 +38,28 @@ export const _setColGroupState = (
     }
 
     colAnimation?.start();
-
-    let impactedGroups: AgProvidedColumnGroup[] | null = null;
-    for (let i = 0; i < stateLen; ++i) {
-        const stateItem = stateItems[i];
-        const group = groupsById.get(stateItem.groupId);
-        if (group?.setExpanded(stateItem.open)) {
-            impactedGroups ??= [];
-            impactedGroups.push(group);
+    try {
+        let impactedGroups: AgProvidedColumnGroup[] | null = null;
+        for (let i = 0; i < stateLen; ++i) {
+            const stateItem = stateItems[i];
+            const group = groupsById.get(stateItem.groupId);
+            if (group?.setExpanded(stateItem.open)) {
+                impactedGroups ??= [];
+                impactedGroups.push(group);
+            }
         }
-    }
 
-    if (impactedGroups) {
-        visibleCols.refresh(source, true);
-        eventSvc.dispatchEvent({
-            type: 'columnGroupOpened',
-            columnGroup: impactedGroups.length === 1 ? impactedGroups[0] : undefined,
-            columnGroups: impactedGroups,
-        });
+        if (impactedGroups) {
+            visibleCols.refresh(source, true);
+            eventSvc.dispatchEvent({
+                type: 'columnGroupOpened',
+                columnGroup: impactedGroups.length === 1 ? impactedGroups[0] : undefined,
+                columnGroups: impactedGroups,
+            });
+        }
+    } finally {
+        colAnimation?.finish();
     }
-
-    colAnimation?.finish();
 };
 
 export const _resetColGroupState = (beans: BeanCollection, source: ColumnEventType): void => {

--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -20,6 +20,12 @@ import { _convertColumnEventSourceType, _destroyColumnTreeAll, _destroyColumnTre
 //   colDefList / colDefTree  — PRIMARY cols (user-defined leaves + hierarchy virtuals).
 //   colsList   / colsTree    — DISPLAY cols: [serviceCols, ...colDefList] (or pivot result).
 
+/** What a {@link ColumnModel.flushColChanges} call must do:
+ *  - `'dispatch'`: dispatch staged service changes only, no rebuild (batch close, `setColumnAggFunc`).
+ *  - `'membership'`: a role add/remove/set — rebuild, raise the legacy `columnEverythingChanged`, animate the reflow.
+ *  - `'reorder'`: a same-set move — rebuild and animate, but keep the set so skip the legacy event. */
+type ColChangeKind = 'dispatch' | 'membership' | 'reorder';
+
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
 export class ColumnModel extends BeanStub implements NamedBean {
     beanName = 'colModel' as const;
@@ -37,6 +43,8 @@ export class ColumnModel extends BeanStub implements NamedBean {
     private pendingRefresh = false;
     /** A batched `buildFromColDefs` already raised `columnEverythingChanged`; stops the batch flush re-raising it. */
     private everythingChangedInBatch = false;
+    /** Accumulated across a batch: a change that must raise the legacy `columnEverythingChanged` (anything but a lone reorder). */
+    private pendingRaiseEverything = false;
     public colsList: AgColumn[] = [];
     public colsTree: (AgColumn | AgProvidedColumnGroup)[] = [];
     public colsTreeDepth = 0;
@@ -279,43 +287,59 @@ export class ColumnModel extends BeanStub implements NamedBean {
     /** Close a {@link beginColBatch}; the outermost close flushes once (one source for the whole action). */
     public endColBatch(source: ColumnEventType): void {
         this.colBatchDepth = Math.max(0, this.colBatchDepth - 1);
-        this.flushColChanges(source, false); // refresh only if a staged op accumulated one
+        this.flushColChanges(source, 'dispatch'); // flushes whatever the batch accumulated (refresh, animate, raise)
     }
 
     /** Refresh once (if needed) + dispatch each touched service. Fires immediately, or defers to {@link endColBatch}
-     *  when batched. `refresh` accumulates into {@link pendingRefresh}: membership passes `true`, order-only or a
-     *  func change on an already-active col (`moveColumn`, `setColumnAggFunc`) pass `false` to dispatch without a rebuild. */
-    public flushColChanges(source: ColumnEventType, refresh: boolean): void {
+     *  when batched. {@link ColChangeKind} selects the work: rebuild, legacy `columnEverythingChanged`, and/or a
+     *  move animation. */
+    public flushColChanges(source: ColumnEventType, kind: ColChangeKind): void {
+        const refresh = kind !== 'dispatch';
         if (refresh) {
             this.pendingRefresh = true;
+        }
+        // Accumulate the intent so a batched flush (endColBatch passes 'dispatch') still skips the legacy event
+        // for a batch of lone reorders, exactly as the unbatched path does.
+        if (refresh && kind !== 'reorder') {
+            this.pendingRaiseEverything = true;
         }
         if (this.colBatchDepth > 0) {
             return; // inside a batch: endColBatch will flush
         }
         const { rowGroupColsSvc, pivotColsSvc, valueColsSvc } = this.beans;
         const pendingRefresh = this.pendingRefresh;
+        const raiseEverything = this.pendingRaiseEverything;
         // A batched `buildFromColDefs` may already have raised it; consume the flag either way.
         const everythingAlreadyRaised = this.everythingChangedInBatch;
         this.everythingChangedInBatch = false;
+        this.pendingRaiseEverything = false;
         const nothingStaged =
             !rowGroupColsSvc?.pendingChanged && !pivotColsSvc?.pendingChanged && !valueColsSvc?.pendingChanged;
         if (nothingStaged && !pendingRefresh) {
             return; // no staged dispatch and no deferred refresh
         }
-        // Re-stamp active-col indexes once, before refresh/dispatch (and their listeners) read them.
-        rowGroupColsSvc?.flushReindex();
-        pivotColsSvc?.flushReindex();
-        valueColsSvc?.flushReindex();
-        if (pendingRefresh) {
-            this.performRefresh(source); // clears pendingRefresh
-            // Legacy compat: a role membership change (rowGroup/pivot/value add/remove/set) raised this.
-            if (!everythingAlreadyRaised) {
-                this.eventSvc.dispatchEvent({ type: 'columnEverythingChanged', source });
+        // A rebuild slides its reflow (snapshot the pre-rebuild layout so cols animate from their old spots); when
+        // nothing actually moves the animation is inert.
+        const colAnimation = pendingRefresh ? this.beans.colAnimation : undefined;
+        colAnimation?.start();
+        try {
+            // Re-stamp active-col indexes once, before refresh/dispatch (and their listeners) read them.
+            rowGroupColsSvc?.flushReindex();
+            pivotColsSvc?.flushReindex();
+            valueColsSvc?.flushReindex();
+            if (pendingRefresh) {
+                this.performRefresh(source); // clears pendingRefresh
+                // Legacy compat: a role membership change (add/remove/set) raised this; a lone reorder keeps the set, so skip it.
+                if (raiseEverything && !everythingAlreadyRaised) {
+                    this.eventSvc.dispatchEvent({ type: 'columnEverythingChanged', source });
+                }
             }
+            rowGroupColsSvc?.dispatchColChange(source);
+            pivotColsSvc?.dispatchColChange(source);
+            valueColsSvc?.dispatchColChange(source);
+        } finally {
+            colAnimation?.finish();
         }
-        rowGroupColsSvc?.dispatchColChange(source);
-        pivotColsSvc?.dispatchColChange(source);
-        valueColsSvc?.dispatchColChange(source);
     }
 
     public refreshCols(newColDefs: boolean, source: ColumnEventType): void {
@@ -329,141 +353,146 @@ export class ColumnModel extends BeanStub implements NamedBean {
         if (animatePivotSort) {
             beans.colAnimation?.start();
         }
-        const colDefList = this.colDefList;
-        const prevColTree = this.colsTree;
-        const prevWasPivot = this.showingPivotResult;
-        const resultColsSvc = this.pivotMode ? beans.pivotResultCols : null;
-        const pivotCols = resultColsSvc?.pivotCols ?? null;
-        const pivotResultCols = pivotCols != null ? resultColsSvc : null;
-        const showingPivotResult = !!pivotResultCols;
-        this.showingPivotResult = showingPivotResult;
-        const sourceList = pivotCols ?? colDefList;
-        const sourceTree = pivotResultCols ? pivotResultCols.pivotTree : this.colDefTree;
-        const sourceTreeDepth = pivotResultCols ? pivotResultCols.pivotTreeDepth : this.colDefTreeDepth;
-        this.colsTreeDepth = sourceTreeDepth;
-        this.hasMarryChildren = pivotResultCols ? pivotResultCols.pivotHasMarryChildren : this.colDefHasMarryChildren;
-        this.colsGroupsById = pivotResultCols ? pivotResultCols.pivotGroupsById : this.colDefGroupsById;
-        this.colsAllGroups = pivotResultCols ? pivotResultCols.pivotAllGroups : this.colDefAllGroups;
-        // Service refresh runs in dependency order; formulas operate on the primary cols (colDefList).
-        beans.formula?.setFormulasActive(colDefList);
-        const autoCols = beans.autoColSvc?.refreshCols(source);
-        const selectionCol = beans.selectionColSvc?.refreshCols();
-        const rowNumberCol = beans.rowNumbersSvc?.refreshCols();
-        // Snapshot prior colsList colIds into the mode's lastOrder so the next refresh restores user moves.
-        const oldColsList = this.colsList;
-        if (oldColsList.length > 0) {
-            if (prevWasPivot) {
-                // A strict pivot order (comparator/pivotSort) isn't a user arrangement to preserve - skip it so
-                // clearing pivotSort restores the prior non-strict order rather than the transient asc/desc one.
-                if (!this.prevPivotStrict) {
-                    this.lastPivotOrder = snapshotColIds(oldColsList, this.lastPivotOrder);
-                }
-            } else {
-                this.lastOrder = snapshotColIds(oldColsList, this.lastOrder);
-            }
-        }
-        this.prevPivotStrict = showingPivotResult && (beans.pivotColsSvc?.isStrictColumnOrder() ?? false);
-        // Emit in display order: rowNumbers → selection → autoGroup → user/pivot body cols.
-        const autoColsLen = autoCols?.length ?? 0;
-        const sourceListLen = sourceList.length;
-        const sourceTreeLen = sourceTree.length;
-        const serviceColsLen = (rowNumberCol ? 1 : 0) + (selectionCol ? 1 : 0) + autoColsLen;
-        // Pre-allocated at final size — the assemble loops below fill by index, not push.
-        const colsList = new Array<AgColumn>(serviceColsLen + sourceListLen);
-        const colsTree = new Array<AgColumn | AgProvidedColumnGroup>(serviceColsLen + sourceTreeLen);
-        const colsById: { [id: string]: AgColumn } = Object.create(null);
-        let colsIdx = 0;
-        if (rowNumberCol) {
-            colsList[colsIdx++] = rowNumberCol;
-        }
-        if (selectionCol) {
-            colsList[colsIdx++] = selectionCol;
-        }
-        for (let i = 0; i < autoColsLen; ++i) {
-            colsList[colsIdx++] = autoCols![i];
-        }
-        // At depth 0 the wrapper IS the col, so skip the wrap loop; still drop cached wrappers from
-        // a prior depth>0 build so service cols don't point at a stale wrapper.
-        const serviceWrapperCache = beans.colGroupSvc.wrapperCache;
-        if (sourceTreeDepth > 0) {
-            const buildToken = this.nextBuildToken();
-            for (let i = 0; i < serviceColsLen; ++i) {
-                const col = colsList[i];
-                colsById[col.colId] = col;
-                col.inColsList = true;
-                colsTree[i] = serviceWrapperCache.wrap(col, sourceTreeDepth, buildToken);
-            }
-            serviceWrapperCache.evict(buildToken);
-        } else {
-            serviceWrapperCache.destroy();
-            for (let i = 0; i < serviceColsLen; ++i) {
-                const col = colsList[i];
-                colsById[col.colId] = col;
-                col.inColsList = true;
-                col.originalParent = null;
-                colsTree[i] = col;
-            }
-        }
-
-        // In pivot mode, sourceList = pivotCols; primaries (colDefList) need colsById entries for lookups
-        // but are parked out of colsList (`inColsList = false`). Non-pivot covers them via the next loop.
-        if (pivotResultCols) {
-            // Entering pivot: freeze the current display order so `getColumnDefs` keeps reporting it.
-            if (!prevWasPivot) {
-                this.ensureColsListIndex();
-            }
-            // A col added while pivoting has no frozen index (-1); seat it after its left colDef neighbour so
-            // `getColumnDefs` reports it in colDef order (stable sort breaks the tie) without disturbing others.
-            let lastIndex = -1;
-            for (let i = 0, len = colDefList.length; i < len; ++i) {
-                const col = colDefList[i];
-                colsById[col.colId] = col;
-                col.inColsList = false;
-                if (col.colsListIndex < 0) {
-                    col.colsListIndex = lastIndex;
+        try {
+            const colDefList = this.colDefList;
+            const prevColTree = this.colsTree;
+            const prevWasPivot = this.showingPivotResult;
+            const resultColsSvc = this.pivotMode ? beans.pivotResultCols : null;
+            const pivotCols = resultColsSvc?.pivotCols ?? null;
+            const pivotResultCols = pivotCols != null ? resultColsSvc : null;
+            const showingPivotResult = !!pivotResultCols;
+            this.showingPivotResult = showingPivotResult;
+            const sourceList = pivotCols ?? colDefList;
+            const sourceTree = pivotResultCols ? pivotResultCols.pivotTree : this.colDefTree;
+            const sourceTreeDepth = pivotResultCols ? pivotResultCols.pivotTreeDepth : this.colDefTreeDepth;
+            this.colsTreeDepth = sourceTreeDepth;
+            this.hasMarryChildren = pivotResultCols
+                ? pivotResultCols.pivotHasMarryChildren
+                : this.colDefHasMarryChildren;
+            this.colsGroupsById = pivotResultCols ? pivotResultCols.pivotGroupsById : this.colDefGroupsById;
+            this.colsAllGroups = pivotResultCols ? pivotResultCols.pivotAllGroups : this.colDefAllGroups;
+            // Service refresh runs in dependency order; formulas operate on the primary cols (colDefList).
+            beans.formula?.setFormulasActive(colDefList);
+            const autoCols = beans.autoColSvc?.refreshCols(source);
+            const selectionCol = beans.selectionColSvc?.refreshCols();
+            const rowNumberCol = beans.rowNumbersSvc?.refreshCols();
+            // Snapshot prior colsList colIds into the mode's lastOrder so the next refresh restores user moves.
+            const oldColsList = this.colsList;
+            if (oldColsList.length > 0) {
+                if (prevWasPivot) {
+                    // A strict pivot order (comparator/pivotSort) isn't a user arrangement to preserve - skip it so
+                    // clearing pivotSort restores the prior non-strict order rather than the transient asc/desc one.
+                    if (!this.prevPivotStrict) {
+                        this.lastPivotOrder = snapshotColIds(oldColsList, this.lastPivotOrder);
+                    }
                 } else {
-                    lastIndex = col.colsListIndex;
+                    this.lastOrder = snapshotColIds(oldColsList, this.lastOrder);
                 }
             }
-        }
-        for (let i = 0; i < sourceListLen; ++i) {
-            const col = sourceList[i];
-            colsList[colsIdx++] = col;
-            colsById[col.colId] = col;
-            col.inColsList = true;
-        }
-        for (let i = 0; i < sourceTreeLen; ++i) {
-            colsTree[serviceColsLen + i] = sourceTree[i];
-        }
-        // An active interactive pivotSort forces strict pivot column order, overriding sticky-order preservation.
-        const restoreOrder = !newColDefs || _shouldMaintainColumnOrder(gos, showingPivotResult);
-        const lastOrder = showingPivotResult ? this.lastPivotOrder : this.lastOrder;
-        let prevOrder = restoreOrder ? lastOrder : null;
-        // pivotSort reorders the groups but keeps the user's within-group order and widths: re-rank the
-        // preserved order by the freshly-sorted group order rather than discarding it.
-        const pivotColsSvc = beans.pivotColsSvc;
-        if (prevOrder != null && showingPivotResult && !!pivotColsSvc?.hasInteractivePivotSort()) {
-            prevOrder = pivotColsSvc.reRankByPivotGroupOrder(colsList, prevOrder, colsById);
-        }
-        const ordered = prevOrder == null ? colsList : applyPrevColumnsOrder(colsList, colsById, prevOrder);
-        const finalColsList = placeLockedColumns(ordered, gos);
-        const colsListChanged = !_areEqual(finalColsList, oldColsList);
-        if (colsListChanged) {
-            this.colsListIndexDirty = true;
-        }
-        this.colsList = colsListChanged ? finalColsList : oldColsList;
-        this.colsTree = _areEqual(colsTree, prevColTree) ? prevColTree : colsTree;
-        this.colsById = colsById;
-        this.invalidateColsDerivedState();
-        this.refreshColsDerivedState();
-        if (colsListChanged) {
-            beans.rowSpanSvc?.refreshCols();
-        }
-        if (this.colsTree !== prevColTree) {
-            this.eventSvc.dispatchEvent({ type: 'gridColumnsChanged' });
-        }
-        if (animatePivotSort) {
-            beans.colAnimation?.finish();
+            this.prevPivotStrict = showingPivotResult && (beans.pivotColsSvc?.isStrictColumnOrder() ?? false);
+            // Emit in display order: rowNumbers → selection → autoGroup → user/pivot body cols.
+            const autoColsLen = autoCols?.length ?? 0;
+            const sourceListLen = sourceList.length;
+            const sourceTreeLen = sourceTree.length;
+            const serviceColsLen = (rowNumberCol ? 1 : 0) + (selectionCol ? 1 : 0) + autoColsLen;
+            // Pre-allocated at final size — the assemble loops below fill by index, not push.
+            const colsList = new Array<AgColumn>(serviceColsLen + sourceListLen);
+            const colsTree = new Array<AgColumn | AgProvidedColumnGroup>(serviceColsLen + sourceTreeLen);
+            const colsById: { [id: string]: AgColumn } = Object.create(null);
+            let colsIdx = 0;
+            if (rowNumberCol) {
+                colsList[colsIdx++] = rowNumberCol;
+            }
+            if (selectionCol) {
+                colsList[colsIdx++] = selectionCol;
+            }
+            for (let i = 0; i < autoColsLen; ++i) {
+                colsList[colsIdx++] = autoCols![i];
+            }
+            // At depth 0 the wrapper IS the col, so skip the wrap loop; still drop cached wrappers from
+            // a prior depth>0 build so service cols don't point at a stale wrapper.
+            const serviceWrapperCache = beans.colGroupSvc.wrapperCache;
+            if (sourceTreeDepth > 0) {
+                const buildToken = this.nextBuildToken();
+                for (let i = 0; i < serviceColsLen; ++i) {
+                    const col = colsList[i];
+                    colsById[col.colId] = col;
+                    col.inColsList = true;
+                    colsTree[i] = serviceWrapperCache.wrap(col, sourceTreeDepth, buildToken);
+                }
+                serviceWrapperCache.evict(buildToken);
+            } else {
+                serviceWrapperCache.destroy();
+                for (let i = 0; i < serviceColsLen; ++i) {
+                    const col = colsList[i];
+                    colsById[col.colId] = col;
+                    col.inColsList = true;
+                    col.originalParent = null;
+                    colsTree[i] = col;
+                }
+            }
+
+            // In pivot mode, sourceList = pivotCols; primaries (colDefList) need colsById entries for lookups
+            // but are parked out of colsList (`inColsList = false`). Non-pivot covers them via the next loop.
+            if (pivotResultCols) {
+                // Entering pivot: freeze the current display order so `getColumnDefs` keeps reporting it.
+                if (!prevWasPivot) {
+                    this.ensureColsListIndex();
+                }
+                // A col added while pivoting has no frozen index (-1); seat it after its left colDef neighbour so
+                // `getColumnDefs` reports it in colDef order (stable sort breaks the tie) without disturbing others.
+                let lastIndex = -1;
+                for (let i = 0, len = colDefList.length; i < len; ++i) {
+                    const col = colDefList[i];
+                    colsById[col.colId] = col;
+                    col.inColsList = false;
+                    if (col.colsListIndex < 0) {
+                        col.colsListIndex = lastIndex;
+                    } else {
+                        lastIndex = col.colsListIndex;
+                    }
+                }
+            }
+            for (let i = 0; i < sourceListLen; ++i) {
+                const col = sourceList[i];
+                colsList[colsIdx++] = col;
+                colsById[col.colId] = col;
+                col.inColsList = true;
+            }
+            for (let i = 0; i < sourceTreeLen; ++i) {
+                colsTree[serviceColsLen + i] = sourceTree[i];
+            }
+            // An active interactive pivotSort forces strict pivot column order, overriding sticky-order preservation.
+            const restoreOrder = !newColDefs || _shouldMaintainColumnOrder(gos, showingPivotResult);
+            const lastOrder = showingPivotResult ? this.lastPivotOrder : this.lastOrder;
+            let prevOrder = restoreOrder ? lastOrder : null;
+            // pivotSort reorders the groups but keeps the user's within-group order and widths: re-rank the
+            // preserved order by the freshly-sorted group order rather than discarding it.
+            const pivotColsSvc = beans.pivotColsSvc;
+            if (prevOrder != null && showingPivotResult && !!pivotColsSvc?.hasInteractivePivotSort()) {
+                prevOrder = pivotColsSvc.reRankByPivotGroupOrder(colsList, prevOrder, colsById);
+            }
+            const ordered = prevOrder == null ? colsList : applyPrevColumnsOrder(colsList, colsById, prevOrder);
+            const finalColsList = placeLockedColumns(ordered, gos);
+            const colsListChanged = !_areEqual(finalColsList, oldColsList);
+            if (colsListChanged) {
+                this.colsListIndexDirty = true;
+            }
+            this.colsList = colsListChanged ? finalColsList : oldColsList;
+            this.colsTree = _areEqual(colsTree, prevColTree) ? prevColTree : colsTree;
+            this.colsById = colsById;
+            this.invalidateColsDerivedState();
+            this.refreshColsDerivedState();
+            if (colsListChanged) {
+                beans.rowSpanSvc?.refreshCols();
+            }
+            if (this.colsTree !== prevColTree) {
+                this.eventSvc.dispatchEvent({ type: 'gridColumnsChanged' });
+            }
+        } finally {
+            if (animatePivotSort) {
+                beans.colAnimation?.finish();
+            }
         }
     }
 

--- a/packages/ag-grid-community/src/columns/columnStateUtils.ts
+++ b/packages/ag-grid-community/src/columns/columnStateUtils.ts
@@ -157,11 +157,14 @@ export function _setColsVisible(
     if (changed) {
         const { colAnimation, eventSvc } = beans;
         colAnimation?.start();
-        colModel.refreshColsDerivedState();
-        beans.visibleCols.refresh(source, false);
-        eventSvc.dispatchEvent({ type: 'columnEverythingChanged', source });
-        dispatchColumnVisibleEvent(eventSvc, changed, source);
-        colAnimation?.finish();
+        try {
+            colModel.refreshColsDerivedState();
+            beans.visibleCols.refresh(source, false);
+            eventSvc.dispatchEvent({ type: 'columnEverythingChanged', source });
+            dispatchColumnVisibleEvent(eventSvc, changed, source);
+        } finally {
+            colAnimation?.finish();
+        }
     }
 }
 
@@ -193,25 +196,26 @@ export function _applyColumnState(
     }
 
     colAnimation?.start();
+    try {
+        // Capture once, before any mutation: the single dispatch below diffs the whole operation.
+        const stateChanges = captureColumnStateChanges(beans);
 
-    // Capture once, before any mutation: the single dispatch below diffs the whole operation.
-    const stateChanges = captureColumnStateChanges(beans);
+        // Pass 1 — primary cols. Structural: `refreshCols` (re)creates auto/pivot-result/service cols.
+        let unmatched = applyStateToCols(beans, state ?? null, providedCols, params, source, true);
 
-    // Pass 1 — primary cols. Structural: `refreshCols` (re)creates auto/pivot-result/service cols.
-    let unmatched = applyStateToCols(beans, state ?? null, providedCols, params, source, true);
+        // Pass 2 — leftover states/defaults land on pass 1's pivot-result cols. Non-structural, no `refreshCols`.
+        if (unmatched !== null || params.defaultState) {
+            const pivotResultColsList = beans.pivotResultCols?.pivotCols;
+            unmatched = applyStateToCols(beans, unmatched, pivotResultColsList, params, source, false);
+        }
 
-    // Pass 2 — leftover states/defaults land on pass 1's pivot-result cols. Non-structural, no `refreshCols`.
-    if (unmatched !== null || params.defaultState) {
-        const pivotResultColsList = beans.pivotResultCols?.pivotCols;
-        unmatched = applyStateToCols(beans, unmatched, pivotResultColsList, params, source, false);
+        // Finalize once: re-order, single visible-cols refresh, single everything-changed + dispatch.
+        finalizeChange(beans, params, source, stateChanges);
+
+        return unmatched === null; // true ⇒ every provided state matched a column
+    } finally {
+        colAnimation?.finish();
     }
-
-    // Finalize once: re-order, single visible-cols refresh, single everything-changed + dispatch.
-    finalizeChange(beans, params, source, stateChanges);
-
-    colAnimation?.finish();
-
-    return unmatched === null; // true ⇒ every provided state matched a column
 }
 
 /** Apply `states` to `existingColumns` (by colId); the primary pass also runs the structural changes.
@@ -464,39 +468,42 @@ export function _resetColumnState(beans: BeanCollection, source: ColumnEventType
     }
 
     colAnimation?.start();
-    // Single capture before any mutation — the lone finalize dispatch diffs the whole reset.
-    const stateChanges = captureColumnStateChanges(beans);
+    try {
+        // Single capture before any mutation — the lone finalize dispatch diffs the whole reset.
+        const stateChanges = captureColumnStateChanges(beans);
 
-    // Apply field state; the structural pass (re)creates auto/service cols. No dispatch yet.
-    applyStateToCols(beans, columnStates, colModel.colDefList, {}, source, true);
+        // Apply field state; the structural pass (re)creates auto/service cols. No dispatch yet.
+        applyStateToCols(beans, columnStates, colModel.colDefList, {}, source, true);
 
-    // Force `pivotSort` back to its colDef default: `applyFieldState` skips an `undefined` target (so an
-    // omitted `pivotSort` in `applyColumnState` leaves it alone), but a reset must clear a user-applied sort.
-    const primaryCols = colModel.colDefList;
-    for (let i = 0, len = primaryCols.length; i < len; ++i) {
-        const col = primaryCols[i];
-        col.pivotSort = resolveInitialPivotSort(col.colDef);
+        // Force `pivotSort` back to its colDef default: `applyFieldState` skips an `undefined` target (so an
+        // omitted `pivotSort` in `applyColumnState` leaves it alone), but a reset must clear a user-applied sort.
+        const primaryCols = colModel.colDefList;
+        for (let i = 0, len = primaryCols.length; i < len; ++i) {
+            const col = primaryCols[i];
+            col.pivotSort = resolveInitialPivotSort(col.colDef);
+        }
+
+        // Order from the now-current service cols: auto cols may have been recreated above (their colIds change
+        // with the row-group set), so use the post-apply instances, not the pre-apply ids in `columnStates`.
+        const autoCols = autoColSvc?.columns;
+        const autoColsLen = autoCols?.length ?? 0;
+        const orderState = new Array<ColumnState>((selectionCol ? 1 : 0) + autoColsLen + colModel.colDefList.length);
+        let orderIdx = 0;
+        if (selectionCol) {
+            orderState[orderIdx++] = { colId: selectionCol.colId };
+        }
+        for (let i = 0; i < autoColsLen; ++i) {
+            orderState[orderIdx++] = { colId: autoCols![i].colId };
+        }
+        forEachColTreeLeaf(colModel.colDefTree, (col) => {
+            orderState[orderIdx++] = { colId: col.colId };
+        });
+
+        // Re-order + refresh + dispatch once, over the final (ordered) structure.
+        finalizeChange(beans, { state: orderState, applyOrder: true }, source, stateChanges);
+    } finally {
+        colAnimation?.finish();
     }
-
-    // Order from the now-current service cols: auto cols may have been recreated above (their colIds change
-    // with the row-group set), so use the post-apply instances, not the pre-apply ids in `columnStates`.
-    const autoCols = autoColSvc?.columns;
-    const autoColsLen = autoCols?.length ?? 0;
-    const orderState = new Array<ColumnState>((selectionCol ? 1 : 0) + autoColsLen + colModel.colDefList.length);
-    let orderIdx = 0;
-    if (selectionCol) {
-        orderState[orderIdx++] = { colId: selectionCol.colId };
-    }
-    for (let i = 0; i < autoColsLen; ++i) {
-        orderState[orderIdx++] = { colId: autoCols![i].colId };
-    }
-    forEachColTreeLeaf(colModel.colDefTree, (col) => {
-        orderState[orderIdx++] = { colId: col.colId };
-    });
-
-    // Re-order + refresh + dispatch once, over the final (ordered) structure.
-    finalizeChange(beans, { state: orderState, applyOrder: true }, source, stateChanges);
-    colAnimation?.finish();
 
     eventSvc.dispatchEvent(_addGridCommonParams<ColumnsResetEvent>(gos, { type: 'columnsReset', source }));
 }

--- a/packages/ag-grid-community/src/pinnedColumns/pinnedColumnService.ts
+++ b/packages/ag-grid-community/src/pinnedColumns/pinnedColumnService.ts
@@ -99,7 +99,7 @@ export class PinnedColumnService extends BeanStub implements NamedBean {
     }
 
     public setColsPinned(keys: ColKey[], pinned: ColumnPinnedType, source: ColumnEventType): void {
-        const { colModel, visibleCols, gos } = this.beans;
+        const { colModel, visibleCols, gos, colAnimation } = this.beans;
         if (!colModel.ready) {
             return;
         }
@@ -139,8 +139,14 @@ export class PinnedColumnService extends BeanStub implements NamedBean {
         }
 
         if (updatedCols.length) {
-            visibleCols.refresh(source, false);
-            dispatchColumnPinnedEvent(this.eventSvc, updatedCols, source);
+            // Slide the pinned/unpinned cols and the gap they leave, rather than jumping.
+            colAnimation?.start();
+            try {
+                visibleCols.refresh(source, false);
+                dispatchColumnPinnedEvent(this.eventSvc, updatedCols, source);
+            } finally {
+                colAnimation?.finish();
+            }
         }
     }
 

--- a/packages/ag-grid-enterprise/src/aggregation/valueColsSvc.ts
+++ b/packages/ag-grid-enterprise/src/aggregation/valueColsSvc.ts
@@ -120,7 +120,7 @@ export class ValueColsSvc extends BaseColsService implements NamedBean, IValueCo
         } else {
             this.recordColChange(column);
         }
-        this.colModel.flushColChanges(source, membershipChanged);
+        this.colModel.flushColChanges(source, membershipChanged ? 'membership' : 'dispatch');
     }
 
     public override syncColState(

--- a/packages/ag-grid-enterprise/src/columns/baseColsService.ts
+++ b/packages/ag-grid-enterprise/src/columns/baseColsService.ts
@@ -148,33 +148,38 @@ export abstract class BaseColsService extends BeanStub implements IColsService {
     /** React to a `this.columns` order/content change; `rowGroupColsSvc` stamps `rowGroupActiveIndex`. Default no-op. */
     protected onColumnsChanged(): void {}
 
-    /** Stage cols differing in membership or position between `before` and `after` (removed/moved/added) and
-     *  mark a reindex; returns whether any differed, so the caller can skip an unchanged apply. Records straight
-     *  into `pendingChanged` — no intermediate array — leaving it untouched (and null) when nothing changed. */
-    private stageChangedColsBetween(before: AgColumn[], after: AgColumn[]): boolean {
+    /** Diff `before`→`after`, staging every changed col straight into `pendingChanged` (no intermediate array,
+     *  left null when nothing changed): `'none'` identical, `'reorder'` same set moved, `'membership'` added/removed. */
+    private stageChangedColsBetween(before: AgColumn[], after: AgColumn[]): 'none' | 'membership' | 'reorder' {
         const afterIndex = _indexMap(after);
         const beforeSet = before.length > 0 ? new Set(before) : null;
         let pending: Set<AgColumn> | null = null;
+        let membership = false;
         for (let i = 0, len = before.length; i < len; ++i) {
             const col = before[i];
             const newIndex = afterIndex.get(col);
-            if (newIndex === undefined || newIndex !== i) {
-                pending ??= this.pendingColChangeSet(); // removed or moved
+            if (newIndex === undefined) {
+                membership = true; // removed
+                pending ??= this.pendingColChangeSet();
+                pending.add(col);
+            } else if (newIndex !== i) {
+                pending ??= this.pendingColChangeSet(); // moved
                 pending.add(col);
             }
         }
         for (let i = 0, len = after.length; i < len; ++i) {
             const col = after[i];
             if (!beforeSet?.has(col)) {
-                pending ??= this.pendingColChangeSet(); // added
+                membership = true; // added
+                pending ??= this.pendingColChangeSet();
                 pending.add(col);
             }
         }
         if (pending === null) {
-            return false;
+            return 'none';
         }
         this.reindexPending = true;
-        return true;
+        return membership ? 'membership' : 'reorder';
     }
 
     public setColumns(colKeys: ColKey[] | undefined, source: ColumnEventType): void {
@@ -197,11 +202,12 @@ export abstract class BaseColsService extends BeanStub implements IColsService {
         // Provided keys, hierarchy virtuals expanded before each source.
         const orderedSet = this.expandActiveCols(newCols);
         const orderedArr = Array.from(orderedSet);
-        if (!this.stageChangedColsBetween(before, orderedArr)) {
+        const change = this.stageChangedColsBetween(before, orderedArr);
+        if (change === 'none') {
             return; // identical membership + order — nothing to refresh or dispatch
         }
         this.applyActiveCols(before, orderedSet, orderedArr, source, true);
-        colModel.flushColChanges(source, true); // membership change → refresh; defers when batched
+        colModel.flushColChanges(source, change); // animated refresh; defers when batched
     }
 
     /** Seat a col into `res`; base adds just the col, `OrderedColsService` seats its virtuals first. */
@@ -313,7 +319,7 @@ export abstract class BaseColsService extends BeanStub implements IColsService {
         }
 
         this.stageColChanges(updatedCols);
-        colModel.flushColChanges(src, true); // membership change → refresh; defers when batched
+        colModel.flushColChanges(src, 'membership'); // add/remove → animated refresh; defers when batched
     }
 
     /** Bucket one primary col for the pass; no-op if not in this role. `colIsNew` ⇒ `initial*` props apply. */

--- a/packages/ag-grid-enterprise/src/rowGrouping/rowGroupColsSvc.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/rowGroupColsSvc.ts
@@ -27,9 +27,9 @@ export class RowGroupColsSvc extends OrderedColsService implements NamedBean, IR
         const reordered = columns.slice();
         reordered.splice(toIndex, 0, reordered.splice(fromIndex, 1)[0]);
         this.resetActiveCols(reordered);
-        // Reorder only (event-driven regroup): report the moved column.
+        // Reorder: multiple group cols must resnap to the new hierarchy order, sliding as they go.
         this.stageColChange(movedColumn);
-        this.colModel.flushColChanges(source, false);
+        this.colModel.flushColChanges(source, 'reorder');
     }
 
     protected override onColActiveChanged(column: AgColumn, active: boolean, source: ColumnEventType): void {

--- a/packages/ag-grid-enterprise/src/rowHierarchy/autoColService.ts
+++ b/packages/ag-grid-enterprise/src/rowHierarchy/autoColService.ts
@@ -83,23 +83,27 @@ export class AutoColService extends BeanStub implements NamedBean, IAutoColServi
             return null;
         }
 
-        // Cheap "same as before?" check — bench-critical: refreshCols runs on every pivot /
-        // grouping transaction. Matches colIds element-by-element with no allocation.
-        const doingMultiAutoColumn = !treeData && _isGroupMultiAutoColumn(gos);
-        if (autoColIdsMatch(currentCols, rowGroupCols, doingMultiAutoColumn)) {
+        const multiRequested = _isGroupMultiAutoColumn(gos);
+        const doingMultiAutoColumn = !treeData && multiRequested;
+        if (treeData && multiRequested) {
+            this.warn(182); // multipleColumns isn't supported with tree data — a single auto col is used
+        }
+
+        // Cheap "same as before?" check — bench-critical: refreshCols runs on every pivot / grouping
+        // transaction. Matches colIds element-by-element (no intermediate array); reuse the instances in place.
+        if (autoColsInOrder(currentCols, rowGroupCols, doingMultiAutoColumn)) {
             // Existing col instances stay; refresh their colDefs so options changes propagate.
             for (let i = 0, len = currentCols.length; i < len; ++i) {
                 const col = currentCols[i];
                 const rowGroupCol = doingMultiAutoColumn ? rowGroupCols![i] : undefined;
-                const colDef = this.createAutoColDef(col.colId, rowGroupCol, i);
-                col.setColDef(colDef, null, source);
+                col.setColDef(this.createAutoColDef(col.colId, rowGroupCol, i), null, source);
             }
             return currentCols;
         }
 
-        // Columns changed — destroy old, generate new.
-        this.destroyColumns();
-        const newCols = this.generateAutoCols(rowGroupCols);
+        // Set and/or order changed: reconcile — reuse surviving instances (so they keep their state and
+        // slide), creating only genuinely new cols and destroying only removed ones.
+        const newCols = this.reconcileAutoCols(currentCols, doingMultiAutoColumn ? rowGroupCols! : undefined, source);
         this.columns = newCols;
         if (!this.modelEverUpdated && _isClientSideRowModel(this.gos)) {
             // Mid-refreshCols: set visibility flags only; the enclosing refresh does the display refresh.
@@ -132,25 +136,52 @@ export class AutoColService extends BeanStub implements NamedBean, IAutoColServi
         }
     }
 
-    private generateAutoCols(rowGroupCols: AgColumn[] = []): AgColumn[] {
-        const autoCols: AgColumn[] = [];
-        const gos = this.gos;
-        const doingTreeData = gos.get('treeData');
-        let doingMultiAutoColumn = _isGroupMultiAutoColumn(gos);
-        if (doingTreeData && doingMultiAutoColumn) {
-            this.warn(182);
-            doingMultiAutoColumn = false;
+    /** Reconcile the auto-col set to `rowGroupCols` (undefined ⇒ the single shared auto col): reuse existing
+     *  instances by colId, create only genuinely new cols, and destroy only the ones no longer present. */
+    private reconcileAutoCols(
+        currentCols: AgColumn[],
+        rowGroupCols: readonly AgColumn[] | undefined,
+        source: ColumnEventType
+    ): AgColumn[] {
+        const survivors = new Map<string, AgColumn>();
+        for (let i = 0, len = currentCols.length; i < len; ++i) {
+            const col = currentCols[i];
+            survivors.set(col.colId, col);
         }
-
-        // if doing "multipleColumns", then we call the method multiple times, once for each column we are grouping by
-        if (doingMultiAutoColumn) {
-            for (let i = 0, len = rowGroupCols.length; i < len; ++i) {
-                autoCols.push(this.createOneAutoCol(rowGroupCols[i], i));
+        let result: AgColumn[];
+        if (rowGroupCols) {
+            const len = rowGroupCols.length;
+            result = new Array<AgColumn>(len);
+            for (let i = 0; i < len; ++i) {
+                result[i] = this.reuseOrCreateAutoCol(survivors, rowGroupCols[i], i, source);
             }
         } else {
-            autoCols.push(this.createOneAutoCol());
+            result = [this.reuseOrCreateAutoCol(survivors, undefined, undefined, source)];
         }
-        return autoCols;
+        // Whatever's left in `survivors` was removed from the grouping — destroy those instances.
+        for (const col of survivors.values()) {
+            if (col.isAlive()) {
+                col.destroy();
+            }
+        }
+        return result;
+    }
+
+    /** Reuse the existing auto col for `rowGroupCol` (refreshing its colDef + index) if present, else create it. */
+    private reuseOrCreateAutoCol(
+        survivors: Map<string, AgColumn>,
+        rowGroupCol: AgColumn | undefined,
+        index: number | undefined,
+        source: ColumnEventType
+    ): AgColumn {
+        const colId = autoColId(rowGroupCol);
+        const existing = survivors.get(colId);
+        if (existing !== undefined) {
+            survivors.delete(colId);
+            existing.setColDef(this.createAutoColDef(colId, rowGroupCol, index), null, source);
+            return existing;
+        }
+        return this.createOneAutoCol(colId, rowGroupCol, index);
     }
 
     private isSuppressAutoCol() {
@@ -164,14 +195,7 @@ export class AutoColService extends BeanStub implements NamedBean, IAutoColServi
     }
 
     // rowGroupCol and index are missing if groupDisplayType != "multipleColumns"
-    private createOneAutoCol(rowGroupCol?: AgColumn, index?: number): AgColumn {
-        // if doing multi, set the field
-        let colId: string;
-        if (rowGroupCol) {
-            colId = `${GROUP_AUTO_COLUMN_ID}-${rowGroupCol.colId}`;
-        } else {
-            colId = GROUP_AUTO_COLUMN_ID;
-        }
+    private createOneAutoCol(colId: string, rowGroupCol: AgColumn | undefined, index: number | undefined): AgColumn {
         const colDef = this.createAutoColDef(colId, rowGroupCol, index);
         const newCol = new AgColumn(colDef, null, colId, true, 'auto-group');
         this.beans.context.createBean(newCol);
@@ -426,9 +450,13 @@ export class AutoColService extends BeanStub implements NamedBean, IAutoColServi
     }
 }
 
-/** True when `currentCols` matches the colIds `generateAutoCols(rowGroupCols)` would produce for
- *  `doingMultiAutoColumn`, without allocating an intermediate string array. */
-const autoColIdsMatch = (
+/** Auto-col colId for a grouped col (or the shared single auto col when none). */
+const autoColId = (rowGroupCol?: AgColumn): string =>
+    rowGroupCol ? `${GROUP_AUTO_COLUMN_ID}-${rowGroupCol.colId}` : GROUP_AUTO_COLUMN_ID;
+
+/** True when `currentCols` already matches the colIds `rowGroupCols` implies, in order — the no-allocation
+ *  fast path skipping the reconcile. */
+const autoColsInOrder = (
     currentCols: readonly AgColumn[],
     rowGroupCols: readonly AgColumn[] | undefined,
     doingMultiAutoColumn: boolean
@@ -441,7 +469,7 @@ const autoColIdsMatch = (
         return false;
     }
     for (let i = 0; i < len; ++i) {
-        if (currentCols[i].colId !== `${GROUP_AUTO_COLUMN_ID}-${rowGroupCols[i].colId}`) {
+        if (currentCols[i].colId !== autoColId(rowGroupCols[i])) {
             return false;
         }
     }

--- a/testing/behavioural/src/columnToolPanel/deferred-suppress-sync-layout.test.ts
+++ b/testing/behavioural/src/columnToolPanel/deferred-suppress-sync-layout.test.ts
@@ -1,8 +1,8 @@
 import type { AgColumn, ColDef, GridApi, IColumnStateUpdateStrategy } from 'ag-grid-community';
-import { setupAgTestIds } from 'ag-grid-community';
+import { getGridElement, setupAgTestIds } from 'ag-grid-community';
 import { AllEnterpriseModule } from 'ag-grid-enterprise';
 
-import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+import { GridColumns, GridRows, TestGridsManager, asyncSetTimeout } from '../test-utils';
 
 describe('deferred column tool panel with suppressSyncLayoutWithGrid', () => {
     const gridMgr = new TestGridsManager({
@@ -443,6 +443,117 @@ describe('deferred column tool panel with suppressSyncLayoutWithGrid', () => {
             const { toolPanel } = await createGrid({ suppressSyncLayoutWithGrid: true });
 
             expect(getDisplayedPrimaryColumnOrder(toolPanel)).toEqual(['athlete', 'age', 'country', 'sport', 'gold']);
+        });
+    });
+
+    // A commit runs its role-column ops inside one beginColBatch/endColBatch. endColBatch flushes without the
+    // `change` kind, so the batch must still animate a reorder and skip the legacy event for a lone reorder.
+    describe('committing a batched role-column change', () => {
+        const createGroupedGrid = async (columnDefs: ColDef[]) => {
+            const gridApi = await gridMgr.createGridAndWait('myGrid', {
+                columnDefs,
+                rowData: [
+                    { country: 'US', sport: 'Swimming', athlete: 'Phelps' },
+                    { country: 'US', sport: 'Gymnastics', athlete: 'Biles' },
+                    { country: 'RO', sport: 'Gymnastics', athlete: 'Weber' },
+                ],
+                groupDisplayType: 'multipleColumns',
+                sideBar: {
+                    toolPanels: [
+                        {
+                            id: 'columns',
+                            labelDefault: 'Columns',
+                            labelKey: 'columns',
+                            iconKey: 'columns',
+                            toolPanel: 'agColumnsToolPanel',
+                        },
+                    ],
+                    defaultToolPanel: 'columns',
+                },
+            });
+            await asyncSetTimeout(50);
+            const strategy = getUpdateStrategy(gridApi.getToolPanelInstance('columns'));
+            return { gridApi, strategy };
+        };
+
+        test('a lone reorder skips columnEverythingChanged and animates the reflow', async () => {
+            const { gridApi, strategy } = await createGroupedGrid([
+                { colId: 'country', field: 'country', rowGroup: true },
+                { colId: 'sport', field: 'sport', rowGroup: true },
+                { colId: 'athlete', field: 'athlete' },
+            ]);
+            const gridEl = getGridElement(gridApi)! as HTMLElement;
+            expect(gridEl.querySelector('.ag-column-moving')).toBeNull();
+
+            const country = gridApi.getColumn('country')! as AgColumn;
+            const sport = gridApi.getColumn('sport')! as AgColumn;
+            const everything: any[] = [];
+            gridApi.addEventListener('columnEverythingChanged', (e) => everything.push(e));
+
+            strategy.setRowGroupColumns(true, [sport, country], 'toolPanelUi');
+            strategy.commit(true);
+
+            // colAnimation tags the body synchronously (the class is only removed a frame later).
+            expect(gridEl.querySelector('.ag-column-moving')).not.toBeNull();
+            await asyncSetTimeout(0);
+            expect(everything.length).toBe(0);
+            expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual(['sport', 'country']);
+            await new GridColumns(gridApi, 'batched reorder').checkColumns(`
+                CENTER
+                ├── ag-Grid-AutoColumn-sport "Sport" width:200
+                ├── ag-Grid-AutoColumn-country "Country" width:200
+                ├── country "Country" width:200 rowGroup
+                ├── sport "Sport" width:200 rowGroup
+                └── athlete "Athlete" width:200
+            `);
+            await new GridRows(gridApi, 'batched reorder').check(`
+                ROOT id:ROOT_NODE_ID ag-Grid-AutoColumn-sport:null ag-Grid-AutoColumn-country:null
+                ├─┬ filler collapsed id:row-group-sport-Swimming ag-Grid-AutoColumn-sport:"Swimming" ag-Grid-AutoColumn-country:null
+                │ └─┬ LEAF_GROUP collapsed hidden id:row-group-sport-Swimming-country-US ag-Grid-AutoColumn-country:"US"
+                │ · └── LEAF hidden id:0 country:"US" sport:"Swimming" athlete:"Phelps"
+                └─┬ filler collapsed id:row-group-sport-Gymnastics ag-Grid-AutoColumn-sport:"Gymnastics" ag-Grid-AutoColumn-country:null
+                · ├─┬ LEAF_GROUP collapsed hidden id:row-group-sport-Gymnastics-country-US ag-Grid-AutoColumn-country:"US"
+                · │ └── LEAF hidden id:1 country:"US" sport:"Gymnastics" athlete:"Biles"
+                · └─┬ LEAF_GROUP collapsed hidden id:row-group-sport-Gymnastics-country-RO ag-Grid-AutoColumn-country:"RO"
+                · · └── LEAF hidden id:2 country:"RO" sport:"Gymnastics" athlete:"Weber"
+            `);
+        });
+
+        test('adding a row group still raises columnEverythingChanged', async () => {
+            const { gridApi, strategy } = await createGroupedGrid([
+                { colId: 'country', field: 'country', rowGroup: true },
+                { colId: 'sport', field: 'sport' },
+                { colId: 'athlete', field: 'athlete' },
+            ]);
+            const country = gridApi.getColumn('country')! as AgColumn;
+            const sport = gridApi.getColumn('sport')! as AgColumn;
+            const everything: any[] = [];
+            gridApi.addEventListener('columnEverythingChanged', (e) => everything.push(e));
+
+            strategy.setRowGroupColumns(true, [country, sport], 'toolPanelUi');
+            strategy.commit(true);
+
+            await asyncSetTimeout(0);
+            expect(everything.length).toBe(1);
+            expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual(['country', 'sport']);
+            await new GridColumns(gridApi, 'batched add').checkColumns(`
+                CENTER
+                ├── ag-Grid-AutoColumn-country "Country" width:200
+                ├── ag-Grid-AutoColumn-sport "Sport" width:200
+                ├── country "Country" width:200 rowGroup
+                └── athlete "Athlete" width:200
+            `);
+            await new GridRows(gridApi, 'batched add').check(`
+                ROOT id:ROOT_NODE_ID ag-Grid-AutoColumn-country:null ag-Grid-AutoColumn-sport:null
+                ├─┬ filler collapsed id:row-group-country-US ag-Grid-AutoColumn-country:"US" ag-Grid-AutoColumn-sport:null
+                │ ├─┬ LEAF_GROUP collapsed hidden id:row-group-country-US-sport-Swimming ag-Grid-AutoColumn-sport:"Swimming"
+                │ │ └── LEAF hidden id:0 country:"US" sport:"Swimming" athlete:"Phelps"
+                │ └─┬ LEAF_GROUP collapsed hidden id:row-group-country-US-sport-Gymnastics ag-Grid-AutoColumn-sport:"Gymnastics"
+                │ · └── LEAF hidden id:1 country:"US" sport:"Gymnastics" athlete:"Biles"
+                └─┬ filler collapsed id:row-group-country-RO ag-Grid-AutoColumn-country:"RO" ag-Grid-AutoColumn-sport:null
+                · └─┬ LEAF_GROUP collapsed hidden id:row-group-country-RO-sport-Gymnastics ag-Grid-AutoColumn-sport:"Gymnastics"
+                · · └── LEAF hidden id:2 country:"RO" sport:"Gymnastics" athlete:"Weber"
+            `);
         });
     });
 });

--- a/testing/behavioural/src/columns/cols-service-events.test.ts
+++ b/testing/behavioural/src/columns/cols-service-events.test.ts
@@ -268,6 +268,7 @@ describe('Cols service events', () => {
 
             api.moveColumns(['d'], 0);
             api.moveRowGroupColumn(0, 1);
+            api.setRowGroupColumns(['a', 'b']); // pure reorder back — same set, no membership change
             api.setColumnWidths([{ key: 'd', newWidth: 123 }]);
             await asyncSetTimeout(0);
             expect(everything.length).toBe(0);

--- a/testing/behavioural/src/columns/column-api.test.ts
+++ b/testing/behavioural/src/columns/column-api.test.ts
@@ -700,6 +700,45 @@ describe('Column API', () => {
             expect(pinnedEvents[0].pinned).toBe('left');
             expect(pinnedEvents[1].pinned).toBe('right');
         });
+
+        test('animates the reflow when pinning a column', async () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [{ colId: 'a' }, { colId: 'b' }, { colId: 'c' }],
+            });
+            await asyncSetTimeout(0);
+            expect(document.querySelector('.ag-column-moving')).toBeNull();
+
+            api.setColumnsPinned(['c'], 'left');
+
+            // colAnimation tags the grid body while the pinned col and the gap it leaves slide.
+            expect(document.querySelector('.ag-column-moving')).not.toBeNull();
+            await new GridColumns(api, 'pin animation').checkColumns(`
+                LEFT
+                └── c width:200
+                CENTER
+                ├── a width:200
+                └── b width:200
+            `);
+        });
+
+        test('suppressColumnMoveAnimation skips the pinning animation', async () => {
+            const api = gridsManager.createGrid('myGrid', {
+                columnDefs: [{ colId: 'a' }, { colId: 'b' }, { colId: 'c' }],
+                suppressColumnMoveAnimation: true,
+            });
+            await asyncSetTimeout(0);
+
+            api.setColumnsPinned(['c'], 'left');
+
+            expect(document.querySelector('.ag-column-moving')).toBeNull();
+            await new GridColumns(api, 'pin without animation').checkColumns(`
+                LEFT
+                └── c width:200
+                CENTER
+                ├── a width:200
+                └── b width:200
+            `);
+        });
     });
 
     describe('column moving API', () => {

--- a/testing/behavioural/src/columns/order/auto-group-cols.test.ts
+++ b/testing/behavioural/src/columns/order/auto-group-cols.test.ts
@@ -842,6 +842,382 @@ describe('Auto Group Column Order', () => {
             expect(getColumnOrder(gridApi, 'left')).toEqual([`${GROUP_AUTO_COLUMN_ID}-a`, `${GROUP_AUTO_COLUMN_ID}-b`]);
         });
 
+        test('animates the column reflow when a row group is added at runtime', async () => {
+            const columnDefs: (ColDef | ColGroupDef)[] = [
+                { colId: 'a', rowGroup: true },
+                { colId: 'b' },
+                { colId: 'c' },
+            ];
+            const gridApi = gridsManager.createGrid('myGrid', { columnDefs, groupDisplayType });
+            const gridEl = getGridElement(gridApi)! as HTMLElement;
+            expect(gridEl.querySelector('.ag-column-moving')).toBeNull();
+
+            gridApi.addRowGroupColumns(['b']);
+
+            // colAnimation tags the grid body while the appended auto col slides in and the rest reflow.
+            expect(gridEl.querySelector('.ag-column-moving')).not.toBeNull();
+            await new GridColumns(gridApi, 'row group add animation').checkColumns(`
+                CENTER
+                ├── ag-Grid-AutoColumn-a width:200
+                ├── ag-Grid-AutoColumn-b width:200
+                ├── a width:200 rowGroup
+                └── c width:200
+            `);
+            await new GridRows(gridApi, 'row group add animation').check(`
+                ROOT id:ROOT_NODE_ID ag-Grid-AutoColumn-a:null ag-Grid-AutoColumn-b:null
+            `);
+        });
+
+        test('suppressColumnMoveAnimation skips the row group add animation', async () => {
+            const columnDefs: (ColDef | ColGroupDef)[] = [
+                { colId: 'a', rowGroup: true },
+                { colId: 'b' },
+                { colId: 'c' },
+            ];
+            const gridApi = gridsManager.createGrid('myGrid', {
+                columnDefs,
+                groupDisplayType,
+                suppressColumnMoveAnimation: true,
+            });
+            const gridEl = getGridElement(gridApi)! as HTMLElement;
+
+            gridApi.addRowGroupColumns(['b']);
+
+            expect(gridEl.querySelector('.ag-column-moving')).toBeNull();
+            await new GridColumns(gridApi, 'row group add without animation').checkColumns(`
+                CENTER
+                ├── ag-Grid-AutoColumn-a width:200
+                ├── ag-Grid-AutoColumn-b width:200
+                ├── a width:200 rowGroup
+                └── c width:200
+            `);
+            await new GridRows(gridApi, 'row group add without animation').check(`
+                ROOT id:ROOT_NODE_ID ag-Grid-AutoColumn-a:null ag-Grid-AutoColumn-b:null
+            `);
+        });
+
+        test('animates the column reflow when a row group is removed at runtime', async () => {
+            const columnDefs: (ColDef | ColGroupDef)[] = [
+                { colId: 'a', rowGroup: true },
+                { colId: 'b', rowGroup: true },
+                { colId: 'c' },
+            ];
+            const gridApi = gridsManager.createGrid('myGrid', { columnDefs, groupDisplayType });
+            const gridEl = getGridElement(gridApi)! as HTMLElement;
+            expect(gridEl.querySelector('.ag-column-moving')).toBeNull();
+
+            gridApi.removeRowGroupColumns(['b']);
+
+            // colAnimation tags the grid body while the removed auto col's gap closes and the rest reflow.
+            expect(gridEl.querySelector('.ag-column-moving')).not.toBeNull();
+            await new GridColumns(gridApi, 'row group remove animation').checkColumns(`
+                CENTER
+                ├── ag-Grid-AutoColumn-a width:200
+                ├── a width:200 rowGroup
+                ├── b width:200
+                └── c width:200
+            `);
+            await new GridRows(gridApi, 'row group remove animation').check(`
+                ROOT id:ROOT_NODE_ID ag-Grid-AutoColumn-a:null
+            `);
+        });
+
+        test('suppressColumnMoveAnimation skips the row group remove animation', async () => {
+            const columnDefs: (ColDef | ColGroupDef)[] = [
+                { colId: 'a', rowGroup: true },
+                { colId: 'b', rowGroup: true },
+                { colId: 'c' },
+            ];
+            const gridApi = gridsManager.createGrid('myGrid', {
+                columnDefs,
+                groupDisplayType,
+                suppressColumnMoveAnimation: true,
+            });
+            const gridEl = getGridElement(gridApi)! as HTMLElement;
+
+            gridApi.removeRowGroupColumns(['b']);
+
+            expect(gridEl.querySelector('.ag-column-moving')).toBeNull();
+            await new GridColumns(gridApi, 'row group remove without animation').checkColumns(`
+                CENTER
+                ├── ag-Grid-AutoColumn-a width:200
+                ├── a width:200 rowGroup
+                ├── b width:200
+                └── c width:200
+            `);
+            await new GridRows(gridApi, 'row group remove without animation').check(`
+                ROOT id:ROOT_NODE_ID ag-Grid-AutoColumn-a:null
+            `);
+        });
+
+        test('reuses auto group column instances when row groups are reordered', async () => {
+            const columnDefs: (ColDef | ColGroupDef)[] = [
+                { colId: 'a', rowGroup: true },
+                { colId: 'b', rowGroup: true },
+                { colId: 'c' },
+            ];
+            const gridApi = gridsManager.createGrid('myGrid', { columnDefs, groupDisplayType });
+            const autoA = gridApi.getColumn(`${GROUP_AUTO_COLUMN_ID}-a`);
+            const autoB = gridApi.getColumn(`${GROUP_AUTO_COLUMN_ID}-b`);
+            expect(autoA).toBeTruthy();
+            expect(autoB).toBeTruthy();
+
+            gridApi.moveRowGroupColumn(1, 0);
+
+            // a pure reorder must reuse the existing instances (keeping their state + sliding), not recreate them
+            expect(gridApi.getColumn(`${GROUP_AUTO_COLUMN_ID}-a`)).toBe(autoA);
+            expect(gridApi.getColumn(`${GROUP_AUTO_COLUMN_ID}-b`)).toBe(autoB);
+            await new GridColumns(gridApi, 'reuse instances on reorder').checkColumns(`
+                CENTER
+                ├── ag-Grid-AutoColumn-b width:200
+                ├── ag-Grid-AutoColumn-a width:200
+                ├── a width:200 rowGroup
+                ├── b width:200 rowGroup
+                └── c width:200
+            `);
+            await new GridRows(gridApi, 'reuse instances on reorder').check(`
+                ROOT id:ROOT_NODE_ID ag-Grid-AutoColumn-b:null ag-Grid-AutoColumn-a:null
+            `);
+        });
+
+        test('reuses surviving auto group column instances across add and remove', async () => {
+            const columnDefs: (ColDef | ColGroupDef)[] = [
+                { colId: 'a', rowGroup: true },
+                { colId: 'b' },
+                { colId: 'c' },
+            ];
+            const gridApi = gridsManager.createGrid('myGrid', { columnDefs, groupDisplayType });
+            const autoA = gridApi.getColumn(`${GROUP_AUTO_COLUMN_ID}-a`);
+            expect(autoA).toBeTruthy();
+
+            gridApi.addRowGroupColumns(['b']); // a survives the add
+
+            expect(gridApi.getColumn(`${GROUP_AUTO_COLUMN_ID}-a`)).toBe(autoA);
+            const autoB = gridApi.getColumn(`${GROUP_AUTO_COLUMN_ID}-b`);
+            expect(autoB).toBeTruthy();
+
+            gridApi.removeRowGroupColumns(['a']); // b survives the remove, a's auto col is destroyed
+
+            expect(gridApi.getColumn(`${GROUP_AUTO_COLUMN_ID}-b`)).toBe(autoB);
+            expect(gridApi.getColumn(`${GROUP_AUTO_COLUMN_ID}-a`)).toBeNull();
+            await new GridColumns(gridApi, 'reuse survivors across add/remove').checkColumns(`
+                CENTER
+                ├── ag-Grid-AutoColumn-b width:200
+                ├── a width:200
+                └── c width:200
+            `);
+            await new GridRows(gridApi, 'reuse survivors across add/remove').check(`
+                ROOT id:ROOT_NODE_ID ag-Grid-AutoColumn-b:null
+            `);
+        });
+
+        test('preserves a resized auto group column width across a runtime group add', async () => {
+            const columnDefs: (ColDef | ColGroupDef)[] = [
+                { colId: 'a', rowGroup: true },
+                { colId: 'b' },
+                { colId: 'c' },
+            ];
+            const gridApi = gridsManager.createGrid('myGrid', { columnDefs, groupDisplayType });
+            gridApi.setColumnWidths([{ key: `${GROUP_AUTO_COLUMN_ID}-a`, newWidth: 321 }]);
+            expect(gridApi.getColumn(`${GROUP_AUTO_COLUMN_ID}-a`)?.getActualWidth()).toBe(321);
+
+            gridApi.addRowGroupColumns(['b']);
+
+            // the surviving auto col keeps the user's width — the instance is reused, not recreated
+            expect(gridApi.getColumn(`${GROUP_AUTO_COLUMN_ID}-a`)?.getActualWidth()).toBe(321);
+            await new GridColumns(gridApi, 'width preserved across add').checkColumns(`
+                CENTER
+                ├── ag-Grid-AutoColumn-a width:321
+                ├── ag-Grid-AutoColumn-b width:200
+                ├── a width:200 rowGroup
+                └── c width:200
+            `);
+            await new GridRows(gridApi, 'width preserved across add').check(`
+                ROOT id:ROOT_NODE_ID ag-Grid-AutoColumn-a:null ag-Grid-AutoColumn-b:null
+            `);
+        });
+
+        test('resnaps a middle row group reordered to the front (3 groups)', async () => {
+            const columnDefs: (ColDef | ColGroupDef)[] = [
+                { colId: 'a', rowGroup: true },
+                { colId: 'b', rowGroup: true },
+                { colId: 'c', rowGroup: true },
+                { colId: 'd' },
+            ];
+            const gridApi = gridsManager.createGrid('myGrid', { columnDefs, groupDisplayType });
+            expect(getColumnOrder(gridApi, 'center')).toEqual([
+                `${GROUP_AUTO_COLUMN_ID}-a`,
+                `${GROUP_AUTO_COLUMN_ID}-b`,
+                `${GROUP_AUTO_COLUMN_ID}-c`,
+                'a',
+                'b',
+                'c',
+                'd',
+            ]);
+
+            gridApi.moveRowGroupColumn(2, 0); // c to the front → [c, a, b]
+
+            expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual(['c', 'a', 'b']);
+            expect(getColumnOrder(gridApi, 'center')).toEqual([
+                `${GROUP_AUTO_COLUMN_ID}-c`,
+                `${GROUP_AUTO_COLUMN_ID}-a`,
+                `${GROUP_AUTO_COLUMN_ID}-b`,
+                'a',
+                'b',
+                'c',
+                'd',
+            ]);
+            await new GridColumns(gridApi, '3-group middle reorder').checkColumns(`
+                CENTER
+                ├── ag-Grid-AutoColumn-c width:200
+                ├── ag-Grid-AutoColumn-a width:200
+                ├── ag-Grid-AutoColumn-b width:200
+                ├── a width:200 rowGroup
+                ├── b width:200 rowGroup
+                ├── c width:200 rowGroup
+                └── d width:200
+            `);
+            await new GridRows(gridApi, '3-group middle reorder').check(`
+                ROOT id:ROOT_NODE_ID ag-Grid-AutoColumn-c:null ag-Grid-AutoColumn-a:null ag-Grid-AutoColumn-b:null
+            `);
+        });
+
+        test('resnaps pinned auto group columns when row groups are reordered', async () => {
+            const columnDefs: (ColDef | ColGroupDef)[] = [
+                { colId: 'a', rowGroup: true },
+                { colId: 'b', rowGroup: true },
+                { colId: 'c' },
+            ];
+            const gridApi = gridsManager.createGrid('myGrid', {
+                columnDefs,
+                groupDisplayType,
+                autoGroupColumnDef: { pinned: 'left' },
+            });
+            expect(getColumnOrder(gridApi, 'left')).toEqual([`${GROUP_AUTO_COLUMN_ID}-a`, `${GROUP_AUTO_COLUMN_ID}-b`]);
+
+            gridApi.moveRowGroupColumn(1, 0);
+
+            expect(getColumnOrder(gridApi, 'left')).toEqual([`${GROUP_AUTO_COLUMN_ID}-b`, `${GROUP_AUTO_COLUMN_ID}-a`]);
+            await new GridColumns(gridApi, 'pinned reorder').checkColumns(`
+                LEFT
+                ├── ag-Grid-AutoColumn-b width:200
+                └── ag-Grid-AutoColumn-a width:200
+                CENTER
+                ├── a width:200 rowGroup
+                ├── b width:200 rowGroup
+                └── c width:200
+            `);
+            await new GridRows(gridApi, 'pinned reorder').check(`
+                ROOT id:ROOT_NODE_ID ag-Grid-AutoColumn-b:null ag-Grid-AutoColumn-a:null
+            `);
+        });
+
+        test.each([
+            ['setRowGroupColumns', (api: GridApi) => api.setRowGroupColumns(['b', 'a'])],
+            ['moveRowGroupColumn', (api: GridApi) => api.moveRowGroupColumn(1, 0)],
+        ] as const)(
+            'resnaps auto group columns when existing row groups are reordered via %s',
+            async (label, reorder) => {
+                const columnDefs: (ColDef | ColGroupDef)[] = [
+                    { colId: 'a', rowGroup: true },
+                    { colId: 'b', rowGroup: true },
+                    { colId: 'c' },
+                ];
+                const gridApi = gridsManager.createGrid('myGrid', { columnDefs, groupDisplayType });
+                const gridEl = getGridElement(gridApi)! as HTMLElement;
+                expect(getColumnOrder(gridApi, 'center')).toEqual([
+                    `${GROUP_AUTO_COLUMN_ID}-a`,
+                    `${GROUP_AUTO_COLUMN_ID}-b`,
+                    'a',
+                    'b',
+                    'c',
+                ]);
+
+                reorder(gridApi);
+
+                expect(gridEl.querySelector('.ag-column-moving')).not.toBeNull();
+                expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual(['b', 'a']);
+                expect(getColumnOrder(gridApi, 'center')).toEqual([
+                    `${GROUP_AUTO_COLUMN_ID}-b`,
+                    `${GROUP_AUTO_COLUMN_ID}-a`,
+                    'a',
+                    'b',
+                    'c',
+                ]);
+                await new GridColumns(gridApi, `resnaps auto group columns via ${label}`).checkColumns(`
+                    CENTER
+                    ├── ag-Grid-AutoColumn-b width:200
+                    ├── ag-Grid-AutoColumn-a width:200
+                    ├── a width:200 rowGroup
+                    ├── b width:200 rowGroup
+                    └── c width:200
+                `);
+                await new GridRows(gridApi, `resnaps auto group columns via ${label}`).check(`
+                    ROOT id:ROOT_NODE_ID ag-Grid-AutoColumn-b:null ag-Grid-AutoColumn-a:null
+                `);
+            }
+        );
+
+        test('resnaps a manually reordered auto group column back to hierarchy order on the next rebuild', async () => {
+            // Auto cols always follow row-group order: a manual move that breaks it sticks only until the next
+            // rebuild, which resnaps them back to hierarchy order. This matches v35.
+            const columnDefs: (ColDef | ColGroupDef)[] = [
+                { colId: 'a', field: 'a', rowGroup: true },
+                { colId: 'b', field: 'b', rowGroup: true },
+                { colId: 'c', field: 'c' },
+            ];
+            const rowData = [
+                { a: 'a1', b: 'b1', c: 'c1' },
+                { a: 'a1', b: 'b1', c: 'c2' },
+                { a: 'a1', b: 'b2', c: 'c1' },
+                { a: 'a2', b: 'b1', c: 'c1' },
+            ];
+            const gridApi = gridsManager.createGrid('myGrid', { columnDefs, rowData, groupDisplayType });
+
+            gridApi.moveColumns([`${GROUP_AUTO_COLUMN_ID}-a`], 1); // manual move, out of hierarchy order
+            expect(getColumnOrder(gridApi, 'center')).toEqual([
+                `${GROUP_AUTO_COLUMN_ID}-b`,
+                `${GROUP_AUTO_COLUMN_ID}-a`,
+                'a',
+                'b',
+                'c',
+            ]);
+
+            gridApi.addRowGroupColumns(['c']); // rebuild → resnaps every auto col to row-group order
+            expect(gridApi.getRowGroupColumns().map((col) => col.getColId())).toEqual(['a', 'b', 'c']);
+            expect(getColumnOrder(gridApi, 'center')).toEqual([
+                `${GROUP_AUTO_COLUMN_ID}-a`,
+                `${GROUP_AUTO_COLUMN_ID}-b`,
+                `${GROUP_AUTO_COLUMN_ID}-c`,
+                'a',
+                'b',
+            ]);
+            await new GridColumns(gridApi, 'resnap heals manual move on rebuild').checkColumns(`
+                CENTER
+                ├── ag-Grid-AutoColumn-a "A" width:200
+                ├── ag-Grid-AutoColumn-b "B" width:200
+                ├── ag-Grid-AutoColumn-c "C" width:200
+                ├── a "A" width:200 rowGroup
+                └── b "B" width:200 rowGroup
+            `);
+            await new GridRows(gridApi, 'resnap heals manual move on rebuild').check(`
+                ROOT id:ROOT_NODE_ID ag-Grid-AutoColumn-a:null ag-Grid-AutoColumn-b:null ag-Grid-AutoColumn-c:null
+                ├─┬ filler collapsed id:row-group-a-a1 ag-Grid-AutoColumn-a:"a1" ag-Grid-AutoColumn-b:null ag-Grid-AutoColumn-c:null
+                │ ├─┬ filler collapsed hidden id:row-group-a-a1-b-b1 ag-Grid-AutoColumn-b:"b1" ag-Grid-AutoColumn-c:null
+                │ │ ├─┬ LEAF_GROUP collapsed hidden id:row-group-a-a1-b-b1-c-c1 ag-Grid-AutoColumn-c:"c1"
+                │ │ │ └── LEAF hidden id:0 a:"a1" b:"b1" c:"c1"
+                │ │ └─┬ LEAF_GROUP collapsed hidden id:row-group-a-a1-b-b1-c-c2 ag-Grid-AutoColumn-c:"c2"
+                │ │ · └── LEAF hidden id:1 a:"a1" b:"b1" c:"c2"
+                │ └─┬ filler collapsed hidden id:row-group-a-a1-b-b2 ag-Grid-AutoColumn-b:"b2" ag-Grid-AutoColumn-c:null
+                │ · └─┬ LEAF_GROUP collapsed hidden id:row-group-a-a1-b-b2-c-c1 ag-Grid-AutoColumn-c:"c1"
+                │ · · └── LEAF hidden id:2 a:"a1" b:"b2" c:"c1"
+                └─┬ filler collapsed id:row-group-a-a2 ag-Grid-AutoColumn-a:"a2" ag-Grid-AutoColumn-b:null ag-Grid-AutoColumn-c:null
+                · └─┬ filler collapsed hidden id:row-group-a-a2-b-b1 ag-Grid-AutoColumn-b:"b1" ag-Grid-AutoColumn-c:null
+                · · └─┬ LEAF_GROUP collapsed hidden id:row-group-a-a2-b-b1-c-c1 ag-Grid-AutoColumn-c:"c1"
+                · · · └── LEAF hidden id:3 a:"a2" b:"b1" c:"c1"
+            `);
+        });
+
         test('orders row group column(s) by rowGroupIndex (lowest first) when enableRtl=true', async () => {
             const columnDefs: (ColDef | ColGroupDef)[] = [
                 { colId: 'a', rowGroupIndex: 1 },


### PR DESCRIPTION
# Row grouping: consistent reorder + animation for multiple group columns

FIX AG-17864 (follow-up to #14486)

With `groupDisplayType: 'multipleColumns'`, reordering row groups didn't reorder their auto group columns,
and group changes didn't animate the reflow. Now every row-group mutation (add / remove / move / set) keeps
the auto columns in hierarchy order and slides the reflow like `moveColumns`, pinning and `applyColumnState`.

## Cause

**New in v36 (regressed by #13973):**

- **Reorder** (`setRowGroupColumns`): sticky-order preservation restores the auto columns' _old_ positions, so
  the display stops matching `getRowGroupColumns()`. v35 reordered them correctly.
- **Animation** on add / remove: group mutations no longer wrap the reflow in the column-move animation. v35
  animated them.

**Pre-existing in v35:**

- **`moveRowGroupColumn`** never rebuilds the display, so a pill drag leaves the columns unmoved.
- **Reorder was never animated.**
- Auto columns are **destroyed + recreated** on every set/order change, losing state (e.g. width) and unable
  to slide.

## Fix

- `colsApplyPrevOrder` re-seat auto group columns into hierarchy order (in place) after sticky ordering.
- `autoColService` reconcile: reuse surviving instances, create only new, destroy only removed.
- `rowGroupColsSvc` a reorder now rebuilds + animates (was a no-rebuild dispatch).
- `pinnedColumnService` restore the pin/unpin animation (also regressed in v36).
- `columnModel.flushColChanges` one `ColChangeKind` (`'dispatch' | 'membership' | 'reorder'`) drives the
  rebuild, animation and legacy `columnEverythingChanged` gating. A batch accumulates the intent, so a batched
  lone reorder animates and stays silent (the batch close no longer misreports it as a membership change).
- `columnAnimationService` re-entrancy-safe `start` / `finish` (a nested refresh can't cut an animation
  short); every caller wraps the pair in `try / finally`.

## Behaviour (resnap / animate per operation)

| operation                      | v35   | latest (v36) | this PR |
| ------------------------------ | ----- | ------------ | ------- |
| `addRowGroupColumns`           | ✓ / ✓ | ✓ / ✗        | ✓ / ✓   |
| `removeRowGroupColumns`        | ✓ / ✓ | ✓ / ✗        | ✓ / ✓   |
| `setRowGroupColumns` (reorder) | ✓ / ✗ | ✗ / ✗        | ✓ / ✓   |
| `moveRowGroupColumn`           | ✗ / ✗ | ✗ / ✗        | ✓ / ✓   |

The documented model is _"one group column per grouping level"_, so `moveRowGroupColumn` leaving the display
different from the panel was a bug. Reorders keep the same set, so like `moveColumns` they don't raise the deprecated
`columnEverythingChanged`.

## Animation

Role-column mutations now slide their reflow through the shared column-move animation instead of jumping:

- **Add / remove** restores the animation dropped in v36.
- **Move / set (reorder)** newly animated; v35 never animated reorders.
- **Pinning** restores the pin / unpin animation, also dropped in v36.
- **Value columns** reflow like the other role columns (inert when nothing moves, visible in pivot).

`suppressColumnMoveAnimation` opts out of all of them.

## Notes

- Common refresh keeps its no-allocation fast paths; reconcile + resnap allocate only on a real group change.
- Auto columns always follow row-group order: a manual `moveColumns` on an auto column sticks only until the
  next rebuild, which resnaps them back to hierarchy order (verified identical in v35).
- Tests: reorder resnap (move + set, 2/3 groups, pinned), instance reuse across reorder/add/remove, width
  preserved across add, a manual auto-col move healed to hierarchy order on rebuild, animation +
  `suppressColumnMoveAnimation`, and reorder (direct + batched tool-panel commit) not raising
  `columnEverythingChanged`. GridColumns / GridRows snapshots included.
