### PR TITLE
AG-17866: align example runner code viewer scrollbar to container bottom

### DIFF
--- a/external/ag-website-shared/src/components/code/CodeHighlight.module.scss
+++ b/external/ag-website-shared/src/components/code/CodeHighlight.module.scss
@@ -17,6 +17,13 @@
 }
 
 .lineNumbers .shikiCode {
+    // Stretch the code element to fill a height-constrained container (e.g. the example
+    // runner code viewer) so its horizontal scrollbar sits at the container's bottom edge
+    // rather than directly under the last line of code. This restores the behaviour the
+    // Prism-era global `.line-numbers > code { height: 100%; overflow: auto }` rule used to
+    // provide, which no longer matches now that Shiki emits a hashed CSS-module class.
+    height: 100%;
+    overflow: auto;
     padding-left: 3.8em;
     padding-top: 1.5em;
     padding-bottom: 1.5em;


### PR DESCRIPTION
## Summary

Fixes the example runner code viewer showing the horizontal scrollbar directly under the last line of code instead of at the bottom edge of the container.

**Cause:** the Prism→Shiki migration changed the line-numbers marker from a global `.line-numbers` class to a hashed CSS-module class, so the leftover Prism-era global rule `pre.code.line-numbers > code { height: 100%; overflow: auto }` no longer matched. The `<code>` element then only kept `width: 100%; overflow-x: auto` at content height, making it the horizontal scroll container while shrink-wrapped to its content.

**Fix:** give `.lineNumbers .shikiCode` `height: 100%` and `overflow: auto` so the code fills a height-constrained container (the example runner), pinning its scrollbar to the bottom edge. Content-height snippets are unaffected (percentage height resolves to `auto`).

Verified short and tall files: scrollbar sits at the container bottom edge and vertical scrolling still works.

Fix AG-17866