### PR TITLE
Restore public-recipes nested workspace to node_modules cache paths

### DIFF
--- a/.github/actions/setup-nx/action.yml
+++ b/.github/actions/setup-nx/action.yml
@@ -85,5 +85,5 @@ runs:
                   testing/public-recipes/*/node_modules/
                   documentation/*/node_modules/
                   external/*/node_modules/
-              node_modules_hash: ${{ hashFiles('yarn.lock','patches/*.patch', 'packages/*/package.json', 'plugins/*/package.json', 'community-modules/*/package.json', 'documentation/*/package.json', 'testing/*/package.json', 'external/*/package.json') }}
+              node_modules_hash: ${{ hashFiles('yarn.lock','patches/*.patch', 'packages/*/package.json', 'plugins/*/package.json', 'community-modules/*/package.json', 'documentation/*/package.json', 'testing/*/package.json', 'testing/public-recipes/*/package.json', 'external/*/package.json') }}
               nx_cache_hash: ${{ hashFiles('yarn.lock','patches/*.patch', 'packages/*/package.json', 'plugins/*/package.json', 'documentation/*/package.json', 'testing/*/package.json', 'community-modules/*/package.json') }}

--- a/.github/actions/setup-nx/action.yml
+++ b/.github/actions/setup-nx/action.yml
@@ -82,6 +82,7 @@ runs:
                   plugins/*/node_modules/
                   community-modules/*/node_modules/
                   testing/*/node_modules/
+                  testing/public-recipes/*/node_modules/
                   documentation/*/node_modules/
                   external/*/node_modules/
               node_modules_hash: ${{ hashFiles('yarn.lock','patches/*.patch', 'packages/*/package.json', 'plugins/*/package.json', 'community-modules/*/package.json', 'documentation/*/package.json', 'testing/*/package.json', 'external/*/package.json') }}

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Publish Combined Test Report
         id: ctrf
-        uses: ctrf-io/github-test-reporter@v1.0.17
+        uses: ctrf-io/github-test-reporter@bb6b54d6514e0952c3eea739be0c641143d1f06c # v1.0.17
         with:
           report-path: '${{ env.REPORTS_PATH }}/**/*.json'
           summary-report: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Detect file changes (PR only)
         id: filter
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         with:
           filters: |
             code:
@@ -454,7 +454,7 @@ jobs:
 
       - name: Post sticky PR comment
         if: steps.stage.outputs.publish == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: pr-preview-umd
           message: |
@@ -642,7 +642,7 @@ jobs:
           done)
 
       - name: Test Report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@3eeb9fc888e82e8be2fb356bbeec2750231672bc # v1
         if: needs.test.result == 'success' || needs.test.result == 'failure' ||
           needs.e2e.result == 'success' || needs.e2e.result == 'failure'
         id: testReport
@@ -703,7 +703,7 @@ jobs:
       - name: Tag Latest Successful Commit
         if: success() && github.ref == 'refs/heads/latest' &&
           steps.lastJobStatus.outputs.workflowStatus != 'failure'
-        uses: EndBug/latest-tag@latest
+        uses: EndBug/latest-tag@8fcae8848c1e23fd8212258f69a9619bc62cad67 # v1.6.3
         with:
           ref: latest-success
           description: Latest commit to pass GitHub Actions workflow on latest branch.
@@ -711,7 +711,7 @@ jobs:
       - name: Find matching workflow
         if: always() && job.status != 'cancelled' && github.ref == 'refs/heads/latest'
         id: find_latest_sha
-        uses: SamhammerAG/last-successful-build-action@v4
+        uses: SamhammerAG/last-successful-build-action@1c368a27a90596574a71ac0ede422a897d0e8e84 # v4
         with:
           branch: "latest"
           workflow: "ci"

--- a/.github/workflows/csp.yml
+++ b/.github/workflows/csp.yml
@@ -45,7 +45,7 @@ jobs:
                 path: reports/
                 retention-days: ${{env.DEFAULT_RETENTION_DAYS}}
             - name: Publish CSP Report
-              uses: ctrf-io/github-test-reporter@v1
+              uses: ctrf-io/github-test-reporter@e500b992f936420eb633c91644cf10d4d71df700 # v1.1.0
               if: always()
               with:
                 report-path: './reports/*.json'

--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -266,7 +266,7 @@ jobs:
 
       - name: Publish Combined Test Report
         id: ctrf
-        uses: ctrf-io/github-test-reporter@v1.0.17
+        uses: ctrf-io/github-test-reporter@bb6b54d6514e0952c3eea739be0c641143d1f06c # v1.0.17
         with:
           report-path: 'combined-reports/**/*.json'
           summary-report: true

--- a/.github/workflows/module-size-comparison.yml
+++ b/.github/workflows/module-size-comparison.yml
@@ -6,6 +6,23 @@ on:
       - 'latest'
       - 'b[0-9][0-9]?.[0-9][0-9]?.[0-9][0-9]?'
     types: [opened, synchronize, reopened, ready_for_review]
+    # Only run when a change could actually move bundle sizes: grid source, its build
+    # config, dependency manifests, or the module-size measurement infra itself. Skips
+    # CI/config/docs-only PRs. NOTE: if this workflow is made a required status check,
+    # a paths filter causes it to be reported as skipped (not run) — see the
+    # "required check with path filtering" pattern before relying on it as a gate.
+    paths:
+      - 'packages/**'
+      - 'community-modules/**'
+      - 'yarn.lock'
+      - 'nx.json'
+      - 'tsconfig.*.json'
+      # module-size measurement infrastructure
+      - 'testing/module-size/**'
+      - 'testing/module-size-angular/**'
+      - '.github/workflows/module-size-comparison.yml'
+      - '.github/actions/module-size-test/**'
+      - 'scripts/ci/*module-size*'
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/module-size-comparison.yml
+++ b/.github/workflows/module-size-comparison.yml
@@ -6,23 +6,6 @@ on:
       - 'latest'
       - 'b[0-9][0-9]?.[0-9][0-9]?.[0-9][0-9]?'
     types: [opened, synchronize, reopened, ready_for_review]
-    # Only run when a change could actually move bundle sizes: grid source, its build
-    # config, dependency manifests, or the module-size measurement infra itself. Skips
-    # CI/config/docs-only PRs. NOTE: if this workflow is made a required status check,
-    # a paths filter causes it to be reported as skipped (not run) — see the
-    # "required check with path filtering" pattern before relying on it as a gate.
-    paths:
-      - 'packages/**'
-      - 'community-modules/**'
-      - 'yarn.lock'
-      - 'nx.json'
-      - 'tsconfig.*.json'
-      # module-size measurement infrastructure
-      - 'testing/module-size/**'
-      - 'testing/module-size-angular/**'
-      - '.github/workflows/module-size-comparison.yml'
-      - '.github/actions/module-size-test/**'
-      - 'scripts/ci/*module-size*'
   workflow_dispatch:
     inputs:
       pr_number:
@@ -101,12 +84,47 @@ jobs:
             core.setOutput('is-draft', pr.draft ? 'true' : 'false');
             core.setOutput('base-ref', pr.base.ref);
 
+  # Gate the heavy measurement jobs on whether any change could actually move bundle
+  # sizes. This is a per-job gate (not a workflow-level `paths:` filter) on purpose: the
+  # `status` job below is the required branch-protection check, and a path-filtered
+  # workflow would leave that check stuck "Expected" and block merges. Instead the heavy
+  # jobs skip and `status` treats skipped inputs as a pass.
+  detect-changes:
+    name: Detect Size-Relevant Changes
+    runs-on: ubuntu-latest
+    needs: prepare
+    if: needs.prepare.outputs.is-draft != 'true'
+    outputs:
+      relevant: ${{ steps.filter.outputs.size }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Detect file changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            size:
+              - 'packages/**'
+              - 'community-modules/**'
+              - 'yarn.lock'
+              - 'nx.json'
+              - 'tsconfig.*.json'
+              # module-size measurement infrastructure
+              - 'testing/module-size/**'
+              - 'testing/module-size-angular/**'
+              - '.github/workflows/module-size-comparison.yml'
+              - '.github/actions/module-size-test/**'
+              - 'scripts/ci/*module-size*'
+
   # Check for cached base results
   check-base-cache:
     name: Check Base Cache
     runs-on: ubuntu-latest
-    needs: prepare
-    if: needs.prepare.outputs.is-draft != 'true'
+    needs: [prepare, detect-changes]
+    if: needs.prepare.outputs.is-draft != 'true' && needs.detect-changes.outputs.relevant == 'true'
     outputs:
       cache-hit: ${{ steps.cache-check.outputs.cache-hit }}
       base-sha: ${{ steps.get-merge-base.outputs.sha }}
@@ -146,8 +164,8 @@ jobs:
   module-size-pr:
     name: Module Size PR (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
-    needs: prepare
-    if: needs.prepare.outputs.is-draft != 'true'
+    needs: [prepare, detect-changes]
+    if: needs.prepare.outputs.is-draft != 'true' && needs.detect-changes.outputs.relevant == 'true'
     strategy:
       matrix:
         shard: ${{ fromJSON(needs.prepare.outputs.shard-matrix) }}
@@ -172,8 +190,8 @@ jobs:
   module-size-base:
     name: Module Size Base (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
-    needs: [prepare, check-base-cache]
-    if: needs.prepare.outputs.is-draft != 'true' && needs.check-base-cache.outputs.cache-hit != 'true'
+    needs: [prepare, detect-changes, check-base-cache]
+    if: needs.prepare.outputs.is-draft != 'true' && needs.detect-changes.outputs.relevant == 'true' && needs.check-base-cache.outputs.cache-hit != 'true'
     strategy:
       matrix:
         shard: ${{ fromJSON(needs.prepare.outputs.shard-matrix) }}
@@ -364,13 +382,14 @@ jobs:
   status:
     name: Module Size Status
     runs-on: ubuntu-latest
-    needs: [prepare, check-base-cache, module-size-pr, module-size-base, compare-and-report]
+    needs: [prepare, detect-changes, check-base-cache, module-size-pr, module-size-base, compare-and-report]
     if: always() && needs.prepare.outputs.is-draft != 'true'
     steps:
       - name: Check job results
         run: |
           echo "Checking job results..."
           echo "prepare: ${{ needs.prepare.result }}"
+          echo "detect-changes: ${{ needs.detect-changes.result }} (relevant=${{ needs.detect-changes.outputs.relevant }})"
           echo "check-base-cache: ${{ needs.check-base-cache.result }}"
           echo "module-size-pr: ${{ needs.module-size-pr.result }}"
           echo "module-size-base: ${{ needs.module-size-base.result }}"
@@ -380,6 +399,17 @@ jobs:
           if [[ "${{ needs.prepare.result }}" != "success" ]]; then
             echo "::error::prepare job failed"
             exit 1
+          fi
+
+          # No size-relevant changes: the heavy jobs are intentionally skipped and this
+          # required check passes without a comparison. detect-changes must have run.
+          if [[ "${{ needs.detect-changes.result }}" != "success" ]]; then
+            echo "::error::detect-changes job failed"
+            exit 1
+          fi
+          if [[ "${{ needs.detect-changes.outputs.relevant }}" != "true" ]]; then
+            echo "No size-relevant changes detected — skipping module size comparison."
+            exit 0
           fi
 
           # check-base-cache must succeed

--- a/.github/workflows/module-size-comparison.yml
+++ b/.github/workflows/module-size-comparison.yml
@@ -103,7 +103,7 @@ jobs:
           fetch-depth: 1
       - name: Detect file changes
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         with:
           filters: |
             size:

--- a/.github/workflows/module-size-vs-release.yml
+++ b/.github/workflows/module-size-vs-release.yml
@@ -5,6 +5,21 @@ on:
     branches:
       - 'latest'
       - 'b[0-9][0-9]?.[0-9][0-9]?.[0-9][0-9]?'
+    # Only re-measure vs the release baseline when a change could actually move bundle
+    # sizes: grid source, its build config, dependency manifests, or the module-size
+    # measurement infra. Skips config/docs-only merges. workflow_dispatch is unaffected.
+    paths:
+      - 'packages/**'
+      - 'community-modules/**'
+      - 'yarn.lock'
+      - 'nx.json'
+      - 'tsconfig.*.json'
+      # module-size measurement infrastructure
+      - 'testing/module-size/**'
+      - 'testing/module-size-angular/**'
+      - '.github/workflows/module-size-vs-release.yml'
+      - '.github/actions/module-size-test/**'
+      - 'scripts/ci/*module-size*'
   workflow_dispatch:
     inputs:
       release_tag:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -213,7 +213,7 @@ jobs:
 
       - name: Test Reporter
         id: ctrf
-        uses: ctrf-io/github-test-reporter@v1.0.17
+        uses: ctrf-io/github-test-reporter@bb6b54d6514e0952c3eea739be0c641143d1f06c # v1.0.17
         with:
           report-path: ${{ env.PW_REPORT_PATH }}
           summary-report: true

--- a/.github/workflows/post-deploy-verification.yml
+++ b/.github/workflows/post-deploy-verification.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Publish CTRF Report
         if: always()
-        uses: ctrf-io/github-test-reporter@v1
+        uses: ctrf-io/github-test-reporter@e500b992f936420eb633c91644cf10d4d71df700 # v1.1.0
         with:
           report-path: 'reports/ag-grid-examples-interactive-default.json'
 

--- a/.github/workflows/post-scorecard-check.yml
+++ b/.github/workflows/post-scorecard-check.yml
@@ -82,7 +82,7 @@ jobs:
             path: ${{ env.SCORECARD_FILE }}
 
       - name: Publish CTRF Report
-        uses: ctrf-io/github-test-reporter@v1
+        uses: ctrf-io/github-test-reporter@e500b992f936420eb633c91644cf10d4d71df700 # v1.1.0
         if: always()
         with:
           report-path: '${{ env.REPORT_FILE }}'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -102,7 +102,7 @@ jobs:
                   snyk_file: ${{ env.SNYK_FILE }}
 
             - name: Publish CTRF Report
-              uses: ctrf-io/github-test-reporter@v1
+              uses: ctrf-io/github-test-reporter@e500b992f936420eb633c91644cf10d4d71df700 # v1.1.0
               if: always()
               with:
                 report-path: '${{ env.OUTPUT_DIR }}${{ env.REPORT_FILE }}'


### PR DESCRIPTION
Follow-up to #14519. That PR's fix restored the node_modules cache save, which unmasked a second regression from #14378: the setup-nx rewrite dropped `testing/public-recipes/*/node_modules/` from the cache path list (originally added by #14369). `testing/*/node_modules/` does not match the nested workspace, so an exact-hit restore was missing those folders — `yarn check --integrity` correctly rejected the cache ("Some module folders are missing") and jobs fell back to a full reinstall, as seen in the Docs job of run 29819696925.

Restores the one missing path line, matching the pre-#14378 list.

After merge, ro jobs with `EXACT_CACHE_HIT: true` should pass `yarn check --integrity` and skip the reinstall entirely.