### PR TITLE
AG-17878 flatten ag-react-wrapper wrapper for toolbar only

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_root.scss
+++ b/community-modules/styles/src/internal/base/parts/_root.scss
@@ -13,7 +13,8 @@
         display: contents;
     }
 
-    .ag-react-container:not(.ag-react-wrapper-block) {
+    // TODO scoped to ag-toolbar for minor release, should make global in v37.0
+    .ag-toolbar .ag-react-container:not(.ag-react-wrapper-block) {
         display: contents;
     }
 

--- a/community-modules/styles/src/internal/base/parts/_root.scss
+++ b/community-modules/styles/src/internal/base/parts/_root.scss
@@ -13,6 +13,10 @@
         display: contents;
     }
 
+    .ag-react-container:not(.ag-react-wrapper-block) {
+        display: contents;
+    }
+
     [class*='ag-theme-'] {
         -webkit-font-smoothing: antialiased;
         font-family: var(--ag-font-family);

--- a/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/toolbar-custom/customToolbarItem_typescript.ts
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/toolbar-custom/customToolbarItem_typescript.ts
@@ -16,17 +16,15 @@ export class WinnersToggle implements IToolbarItemComp {
         this.params = params;
 
         this.eGui = document.createElement('div');
-        this.eGui.className = 'ag-toolbar-item';
-        this.eGui.style.cssText = 'display: flex; gap: 12px; padding: 8px;';
+        this.eGui.className = 'ag-toolbar-item winners-toggle';
 
         for (const { column, label } of COLUMNS) {
             const eLabel = document.createElement('label');
-            eLabel.style.cssText = 'display: inline-flex; align-items: center; gap: 4px; padding: 0 4px;';
+            eLabel.className = 'winners-toggle-item';
 
             const eInput = document.createElement('input');
             eInput.type = 'checkbox';
             eInput.dataset.column = column;
-            eInput.style.margin = '0';
 
             eLabel.appendChild(eInput);
             eLabel.appendChild(document.createTextNode(label));

--- a/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/toolbar-custom/provided/reactFunctionalTs/customToolbarItem.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/toolbar-custom/provided/reactFunctionalTs/customToolbarItem.tsx
@@ -30,14 +30,13 @@ export const WinnersToggle = (props: IToolbarItemParams) => {
     };
 
     return (
-        <div className="ag-toolbar-item" style={{ display: 'flex', gap: 12, padding: 8 }}>
+        <div className="ag-toolbar-item winners-toggle">
             {COLUMNS.map(({ column, label }) => (
-                <label key={column} style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '0 4px' }}>
+                <label key={column} className="winners-toggle-item">
                     <input
                         type="checkbox"
                         checked={checked[column] ?? false}
                         onChange={(event) => onChange(column, event)}
-                        style={{ margin: 0 }}
                     />
                     {label}
                 </label>

--- a/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/toolbar-custom/styles.css
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/toolbar-custom/styles.css
@@ -1,0 +1,19 @@
+.winners-toggle {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px;
+    height: 100%;
+    background-color: #2244cc44;
+}
+
+.winners-toggle-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 0 4px;
+}
+
+.winners-toggle-item input {
+    margin: 0;
+}

--- a/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/toolbar-custom/winners-toggle.component_angular.ts
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/toolbar-custom/winners-toggle.component_angular.ts
@@ -11,20 +11,14 @@ const COLUMNS = [
 @Component({
     standalone: true,
     changeDetection: ChangeDetectionStrategy.OnPush,
+    host: { class: 'ag-toolbar-item winners-toggle' },
     template: `
-        <div class="ag-toolbar-item" style="display: flex; gap: 12px; padding: 8px;">
-            @for (option of options; track option.column) {
-                <label style="display: inline-flex; align-items: center; gap: 4px; padding: 0 4px;">
-                    <input
-                        type="checkbox"
-                        [checked]="checked[option.column]"
-                        (change)="onChange(option.column, $event)"
-                        style="margin: 0;"
-                    />
-                    {{ option.label }}
-                </label>
-            }
-        </div>
+        @for (option of options; track option.column) {
+            <label class="winners-toggle-item">
+                <input type="checkbox" [checked]="checked[option.column]" (change)="onChange(option.column, $event)" />
+                {{ option.label }}
+            </label>
+        }
     `,
 })
 export class WinnersToggle implements IToolbarItemAngularComp, OnDestroy {

--- a/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/toolbar-custom/winnersToggle_vue3.ts
+++ b/documentation/ag-grid-docs/src/content/docs/toolbar/_examples/toolbar-custom/winnersToggle_vue3.ts
@@ -5,13 +5,12 @@ const COLUMNS = [
 
 export default {
     template: `
-        <div class="ag-toolbar-item" style="display: flex; gap: 12px; padding: 8px;">
-            <label v-for="option in options" :key="option.column" style="display: inline-flex; align-items: center; gap: 4px; padding: 0 4px;">
+        <div class="ag-toolbar-item winners-toggle">
+            <label v-for="option in options" :key="option.column" class="winners-toggle-item">
                 <input
                     type="checkbox"
                     :checked="checked[option.column]"
                     @change="onChange(option.column, $event)"
-                    style="margin: 0;"
                 />
                 {{ option.label }}
             </label>

--- a/packages/ag-grid-community/src/components/framework/userCompUtils.ts
+++ b/packages/ag-grid-community/src/components/framework/userCompUtils.ts
@@ -38,6 +38,7 @@ const DateComponent: ComponentType<IDateComp> = {
 const DragAndDropImageComponent: ComponentType<IDragAndDropImageComponent> = {
     name: 'dragAndDropImageComponent',
     mandatoryMethods: ['setIcon', 'setLabel'],
+    requiresBlockWrapper: true,
 };
 
 const HeaderComponent: ComponentType = { name: 'headerComponent', optionalMethods: ['refresh'] };
@@ -82,7 +83,7 @@ const CellEditorComponent: ComponentType<ICellEditorComp> = {
     ],
 };
 
-const TooltipComponent: ComponentType = { name: 'tooltipComponent' };
+const TooltipComponent: ComponentType = { name: 'tooltipComponent', requiresBlockWrapper: true };
 
 const FilterComponent: ComponentType<ISimpleFilter> = {
     name: 'filter',

--- a/packages/ag-grid-community/src/interfaces/iUserCompDetails.ts
+++ b/packages/ag-grid-community/src/interfaces/iUserCompDetails.ts
@@ -17,4 +17,12 @@ export interface ComponentType<TComp = any> {
     cellRenderer?: boolean;
     mandatoryMethods?: (keyof TComp & string)[];
     optionalMethods?: (keyof TComp & string)[];
+    /**
+     * Set to true to force display:block on the .ag-react-wrapper element around custom react components
+     *
+     * By default the .ag-react-wrapper element around react custom components is display:contents so as not to break
+     * flex child behaviour. But when the grid positions or measures the React wrapper element itself (e.g.
+     * absolutely-positioned tooltips and drag images), the wrapper must be display:block.
+     */
+    requiresBlockWrapper?: boolean;
 }

--- a/packages/ag-grid-react/src/shared/reactComponent.ts
+++ b/packages/ag-grid-react/src/shared/reactComponent.ts
@@ -75,6 +75,10 @@ export class ReactComponent implements IComponent<any>, WrappableInterface {
 
         (eParentElement as HTMLElement).classList.add('ag-react-container');
 
+        if (this.componentType.requiresBlockWrapper) {
+            (eParentElement as HTMLElement).classList.add('ag-react-wrapper-block');
+        }
+
         /** @deprecated v21.2 */
         params.reactContainer = eParentElement;
 

--- a/packages/ag-stack/src/theming/shared/css/_root.css
+++ b/packages/ag-stack/src/theming/shared/css/_root.css
@@ -12,3 +12,7 @@
 
     --ag-indentation-level: 0;
 }
+
+.ag-react-container:not(.ag-react-wrapper-block) {
+    display: contents;
+}

--- a/packages/ag-stack/src/theming/shared/css/_root.css
+++ b/packages/ag-stack/src/theming/shared/css/_root.css
@@ -13,6 +13,7 @@
     --ag-indentation-level: 0;
 }
 
-.ag-react-container:not(.ag-react-wrapper-block) {
+/* TODO scoped to ag-toolbar for minor release, should make global in v37.0 */
+:where(.ag-toolbar) .ag-react-container:where(:not(.ag-react-wrapper-block)) {
     display: contents;
 }


### PR DESCRIPTION
Fix [AG-17878](https://ag-grid.atlassian.net/browse/AG-17878)

React components get a wrapper element that other framework custom components don't get.

- Add `display: contents` to `.ag-react-container` by default
- Add `requiresBlockWrapper` flag to `ComponentType` to provide an opt-out for components that need to be absolutely positioned (absolute position doesn't work on `display:contents` elements
- Update the toolbar custom example across React/Angular/Vue/Vanilla to show a full-height custom component

