### PR TITLE
AG-17865 fix React floating-filter horizontal scroll snap-back (#14477)

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/floating-filters/_examples/floating-filter/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/floating-filters/_examples/floating-filter/example.spec.ts
@@ -1,6 +1,36 @@
-import { expect, test } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
+    // React-only: with a floating filter focused, horizontal scrolling must not be hijacked. If the
+    // reconcile moves the focused input's DOM node, refocus-on-remount runs scrollIntoView and snaps the
+    // viewport back to the first column. Focus retention differs by framework, so this guard is React-specific.
+    test.reactFunctionalTs('Floating filter focus does not hijack horizontal scroll', async ({ page, agIdFor }) => {
+        // Narrow viewport so columns virtualise and the first column scrolls out of view.
+        await page.setViewportSize({ width: 800, height: 600 });
+        await ensureGridReady(page);
+
+        const athleteFilterInput = agIdFor.floatingFilter('athlete').locator('input');
+        await athleteFilterInput.click();
+        await expect(athleteFilterInput).toBeFocused();
+
+        const hScroll = page.locator('.ag-body-horizontal-scroll-viewport');
+
+        // Scroll the focused column out of view.
+        await hScroll.evaluate((el) => {
+            el.scrollLeft = 600;
+            el.dispatchEvent(new Event('scroll'));
+        });
+
+        // The scroll must stick — pre-fix, the focus-on-remount scrollIntoView snapped it back to 0.
+        await expect(async () => {
+            const left = await hScroll.evaluate((el) => el.scrollLeft);
+            expect(left).toBeGreaterThan(100);
+        }).toPass();
+
+        // The floating filter keeps focus (cell kept alive, not remounted/refocused).
+        await expect(athleteFilterInput).toBeFocused();
+    });
+
     test.eachFramework('Example Tab Focus', async ({ page, agIdFor }) => {
         // force the viewport width to be 800px so that columns are virtualised
         await page.setViewportSize({ width: 800, height: 600 });

--- a/packages/ag-grid-community/src/headerRendering/headerUtils.ts
+++ b/packages/ag-grid-community/src/headerRendering/headerUtils.ts
@@ -3,6 +3,7 @@ import type { VisibleColsService } from '../columns/visibleColsService';
 import type { BeanCollection } from '../context/context';
 import type { ColumnPinnedType } from '../interfaces/iColumn';
 import type { HeaderPosition } from '../interfaces/iHeaderPosition';
+import type { AbstractHeaderCellCtrl } from './cells/abstractCell/abstractHeaderCellCtrl';
 import type { HeaderRowCtrl } from './row/headerRowCtrl';
 
 // + gridPanel -> for resizing the body and setting top margin
@@ -174,6 +175,18 @@ export interface PinnedSections<T> {
     left: T[];
     center: T[];
     right: T[];
+}
+
+export function compareCtrlsByLeft(a: AbstractHeaderCellCtrl, b: AbstractHeaderCellCtrl): number {
+    return (a.column.getLeft() ?? 0) - (b.column.getLeft() ?? 0);
+}
+
+export function sortCtrlsByPinnedThenLeft(ctrls: AbstractHeaderCellCtrl[]): AbstractHeaderCellCtrl[] {
+    const { left, center, right } = partitionByPinned(ctrls, (c) => c.column.getPinned());
+    left.sort(compareCtrlsByLeft);
+    center.sort(compareCtrlsByLeft);
+    right.sort(compareCtrlsByLeft);
+    return [...left, ...center, ...right];
 }
 
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */

--- a/packages/ag-grid-community/src/headerRendering/row/headerRowComp.ts
+++ b/packages/ag-grid-community/src/headerRendering/row/headerRowComp.ts
@@ -12,7 +12,7 @@ import type { HeaderGroupCellCtrl } from '../cells/columnGroup/headerGroupCellCt
 import { HeaderFilterCellComp } from '../cells/floatingFilter/headerFilterCellComp';
 import type { HeaderFilterCellCtrl } from '../cells/floatingFilter/headerFilterCellCtrl';
 import type { PinnedSectionWidthsCache } from '../headerUtils';
-import { partitionByPinned, updatePinnedSectionWidths } from '../headerUtils';
+import { compareCtrlsByLeft, partitionByPinned, updatePinnedSectionWidths } from '../headerUtils';
 import type { HeaderRowCtrl, IHeaderRowComp } from './headerRowCtrl';
 
 export type HeaderRowType = 'group' | 'column' | 'filter';
@@ -129,7 +129,7 @@ export class HeaderRowComp extends Component {
             const sortByLeft = (
                 a: AbstractHeaderCellComp<AbstractHeaderCellCtrl>,
                 b: AbstractHeaderCellComp<AbstractHeaderCellCtrl>
-            ) => a.getCtrl().column.getLeft()! - b.getCtrl().column.getLeft()!;
+            ) => compareCtrlsByLeft(a.getCtrl(), b.getCtrl());
 
             if (this.gos.get('domLayout') === 'print') {
                 const comps = Object.values(this.headerComps).sort(sortByLeft);

--- a/packages/ag-grid-community/src/headerRendering/row/headerRowCtrl.ts
+++ b/packages/ag-grid-community/src/headerRendering/row/headerRowCtrl.ts
@@ -9,7 +9,12 @@ import type { AbstractHeaderCellCtrl } from '../cells/abstractCell/abstractHeade
 import { HeaderCellCtrl } from '../cells/column/headerCellCtrl';
 import type { HeaderGroupCellCtrl } from '../cells/columnGroup/headerGroupCellCtrl';
 import type { HeaderFilterCellCtrl } from '../cells/floatingFilter/headerFilterCellCtrl';
-import { getColumnHeaderRowHeight, getFloatingFiltersHeight, getGroupRowsHeight } from '../headerUtils';
+import {
+    getColumnHeaderRowHeight,
+    getFloatingFiltersHeight,
+    getGroupRowsHeight,
+    sortCtrlsByPinnedThenLeft,
+} from '../headerUtils';
 import type { HeaderRowType } from './headerRowComp';
 
 /** @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
@@ -219,11 +224,13 @@ export class HeaderRowCtrl extends BeanStub {
             return ctrl.column.displayed && this.beans.focusSvc.isHeaderWrapperFocused(ctrl);
         };
 
+        let keptCtrlOutOfOrder = false;
         if (oldCtrls) {
             for (const [id, oldCtrl] of oldCtrls) {
                 const keepCtrl = isFocusedAndDisplayed(oldCtrl as HeaderCellCtrl);
                 if (keepCtrl) {
                     this.ctrlsById.set(id, oldCtrl);
+                    keptCtrlOutOfOrder = true;
                 } else {
                     this.destroyBean(oldCtrl);
                 }
@@ -231,6 +238,11 @@ export class HeaderRowCtrl extends BeanStub {
         }
 
         this.allCtrls = Array.from(this.ctrlsById.values());
+        if (keptCtrlOutOfOrder) {
+            // a kept-alive focused ctrl was appended after the in-order viewport ctrls; restore column
+            // order so consumers (e.g. React, which derives DOM order from this array) can rely on it.
+            this.allCtrls = sortCtrlsByPinnedThenLeft(this.allCtrls);
+        }
         return this.allCtrls;
     }
 

--- a/testing/behavioural/src/columns/headers/floating-filter-scroll-focus-react.test.tsx
+++ b/testing/behavioural/src/columns/headers/floating-filter-scroll-focus-react.test.tsx
@@ -1,0 +1,139 @@
+import { cleanup, render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import type { ColDef, GridApi, GridReadyEvent } from 'ag-grid-community';
+import { AllCommunityModule } from 'ag-grid-community';
+import { AgGridReact } from 'ag-grid-react';
+
+import { asyncSetTimeout } from '../../test-utils';
+import { mockGridLayout } from '../../test-utils/polyfills/mockGridLayout';
+
+const COL_COUNT = 20;
+
+function makeColumnDefs(pinned: boolean): ColDef[] {
+    return Array.from({ length: COL_COUNT }, (_, i) => ({
+        colId: `c${i}`,
+        field: `c${i}`,
+        width: 150,
+        filter: 'agTextColumnFilter',
+        floatingFilter: true,
+        pinned: pinned && i === 0 ? 'left' : pinned && i === COL_COUNT - 1 ? 'right' : null,
+    }));
+}
+
+// col indices of the rendered floating-filter cells within a header section, in DOM order.
+function floatingFilterColIndices(container: HTMLElement, sectionClass: string): number[] {
+    const row = container.querySelector('.ag-header-row-filter');
+    const section = row?.querySelector(`.${sectionClass}`);
+    return Array.from(section?.querySelectorAll('[col-id]') ?? []).map((el) =>
+        Number(el.getAttribute('col-id')!.slice(1))
+    );
+}
+
+interface ScrollOptions {
+    ensureDomOrder: boolean;
+    pinned: boolean;
+}
+
+// Drives the regression scenario: render, focus the first centre floating-filter input (engages
+// keep-alive; pinned columns never virtualise out, so only centre cells can hit that path), then scroll
+// the focused column out of view so virtualisation retains its kept-alive ctrl. Resolves once
+// virtualisation has engaged, returning the rendered floating-filter col indices per header section.
+async function scrollFocusedColumnOutOfView({ ensureDomOrder, pinned }: ScrollOptions) {
+    const columnDefs = makeColumnDefs(pinned);
+    const rowData = [Object.fromEntries(columnDefs.map((c) => [c.field!, 1]))];
+    const apiRef: { current?: GridApi } = {};
+    const { container } = render(
+        <div style={{ height: 400, width: 600 }}>
+            <AgGridReact
+                rowData={rowData}
+                columnDefs={columnDefs}
+                modules={[AllCommunityModule]}
+                ensureDomOrder={ensureDomOrder}
+                onGridReady={(e: GridReadyEvent) => {
+                    apiRef.current = e.api;
+                }}
+            />
+        </div>
+    );
+
+    const centerIndices = () => floatingFilterColIndices(container, 'ag-grid-scrolling-cells');
+
+    await waitFor(() => expect(apiRef.current).toBeDefined());
+    await waitFor(() => expect(centerIndices().length).toBeGreaterThan(0));
+
+    // Focus the first centre floating-filter input — registers the focused header and engages keep-alive.
+    const focusedColId = pinned ? 'c1' : 'c0';
+    const focusedIndex = pinned ? 1 : 0;
+    const input = container.querySelector<HTMLInputElement>(
+        `.ag-header-row-filter .ag-grid-scrolling-cells [col-id="${focusedColId}"] input`
+    );
+    expect(input).not.toBeNull();
+    input!.focus();
+    await asyncSetTimeout(0);
+
+    // Scroll horizontally until the focused column leaves the viewport. The first scroll also
+    // measures the viewport (jsdom fires no initial resize), so virtualisation engages here.
+    const lastCenterCol = pinned ? `c${COL_COUNT - 2}` : `c${COL_COUNT - 1}`;
+    apiRef.current!.ensureColumnVisible(lastCenterCol);
+
+    // Guard: wait until virtualisation has engaged (fewer than all centre columns rendered), otherwise
+    // the scenario is not exercised. The focused cell stays rendered (kept alive for keyboard nav).
+    const centerColCount = pinned ? COL_COUNT - 2 : COL_COUNT;
+    await waitFor(() => expect(centerIndices().length).toBeLessThan(centerColCount));
+
+    return {
+        focusedIndex,
+        left: floatingFilterColIndices(container, 'ag-grid-pinned-left-cells'),
+        center: centerIndices(),
+        right: floatingFilterColIndices(container, 'ag-grid-pinned-right-cells'),
+    };
+}
+
+describe('React floating filter: horizontal scroll does not snap back to the focused column', () => {
+    beforeAll(() => {
+        mockGridLayout.init();
+        mockGridLayout.useRealOffsetDimensions = true;
+    });
+    afterAll(() => {
+        mockGridLayout.useRealOffsetDimensions = false;
+    });
+    afterEach(() => cleanup());
+
+    // A focused floating-filter cell is kept alive for keyboard nav, so virtualisation retains its ctrl
+    // after it scrolls out of view. The header ctrl must keep the ctrl array in column order: if the
+    // kept-alive ctrl is appended last, React moves the focused cell's DOM node to the end, dropping focus
+    // and triggering a scrollIntoView that snaps the viewport to column 1. Guard the centre cell order.
+    it.each([false, true])(
+        'keeps centre floating-filter cells in column order after scrolling the focused column out of view (ensureDomOrder: %s)',
+        async (ensureDomOrder) => {
+            const { focusedIndex, center } = await scrollFocusedColumnOutOfView({ ensureDomOrder, pinned: false });
+
+            // The focused (now scrolled-out) cell must not be appended last.
+            expect(center.at(-1)).not.toBe(focusedIndex);
+            // Rendered centre cells stay in ascending column order.
+            expect(center).toEqual([...center].sort((a, b) => a - b));
+        }
+    );
+
+    // With pinned columns, all sections share one ctrl array with per-section left values; the restore of
+    // column order must not interleave sections or displace the pinned cells.
+    it.each([false, true])(
+        'keeps pinned sections intact and centre cells in column order (ensureDomOrder: %s)',
+        async (ensureDomOrder) => {
+            const { focusedIndex, left, center, right } = await scrollFocusedColumnOutOfView({
+                ensureDomOrder,
+                pinned: true,
+            });
+
+            expect(left).toEqual([0]);
+            expect(right).toEqual([COL_COUNT - 1]);
+            expect(center.at(-1)).not.toBe(focusedIndex);
+            expect(center).toEqual([...center].sort((a, b) => a - b));
+            // Centre section contains only centre columns.
+            expect(center).not.toContain(0);
+            expect(center).not.toContain(COL_COUNT - 1);
+        }
+    );
+});


### PR DESCRIPTION
Cherry-pick of #14477 (5c6751c) into the `b36.0.2` release branch.

## What & why

When a floating filter is focused, virtualisation keeps its header cell alive but appends it last in the ctrl array. On scroll-driven section changes the focused cell's DOM node was moved to the end, dropping focus and triggering a `scrollIntoView` that snapped the viewport back to the first column.

`getUpdatedHeaderCtrls` now restores column order (per pinned section, by left) when a kept-alive focused ctrl is re-added out of order, so every consumer of the ctrl array receives it in column order. The sort only runs in that rare case; the general rendering path is unchanged.

## Testing

Includes a regression test across ensureDomOrder × pinned/unpinned, plus updated floating-filter e2e spec.