### PR TITLE
AG-17882 preserve mid-edit floating filter keystroke during interleaving filter-changed cycle

### DIFF
--- a/packages/ag-grid-community/src/filter/floating/provided/floatingFilterTextInputService.ts
+++ b/packages/ag-grid-community/src/filter/floating/provided/floatingFilterTextInputService.ts
@@ -1,4 +1,4 @@
-import { RefPlaceholder } from 'ag-stack';
+import { RefPlaceholder, _getActiveDomElement } from 'ag-stack';
 
 import type { AgInputTextFieldParams } from '../../../agWidgets/agInputTextField';
 import { AgInputTextField } from '../../../agWidgets/agInputTextField';
@@ -31,6 +31,10 @@ export class FloatingFilterTextInputService extends BeanStub implements Floating
 
     public setEditable(editable: boolean): void {
         this.eInput.setDisabled(!editable);
+    }
+
+    public isFocused(): boolean {
+        return _getActiveDomElement(this.beans) === this.eInput.getInputElement();
     }
 
     public getValue(): string | null | undefined {

--- a/packages/ag-grid-community/src/filter/floating/provided/iFloatingFilterInputService.ts
+++ b/packages/ag-grid-community/src/filter/floating/provided/iFloatingFilterInputService.ts
@@ -3,6 +3,7 @@ import type { Bean } from '../../../context/bean';
 export interface FloatingFilterInputService extends Bean {
     setupGui(parentElement: HTMLElement): void;
     setEditable(editable: boolean): void;
+    isFocused(): boolean;
     getValue(): string | null | undefined;
     setValue(value: string | null | undefined, silent?: boolean): void;
     setValueChangedListener(listener: (e: KeyboardEvent) => void): void;

--- a/packages/ag-grid-community/src/filter/floating/provided/textInputFloatingFilter.ts
+++ b/packages/ag-grid-community/src/filter/floating/provided/textInputFloatingFilter.ts
@@ -33,6 +33,7 @@ export abstract class TextInputFloatingFilter<
     private inputSvc: FloatingFilterInputService;
 
     private applyActive: boolean;
+    private pendingEdit = false;
 
     protected abstract createFloatingFilterInputService(params: TParams): FloatingFilterInputService;
 
@@ -42,9 +43,17 @@ export abstract class TextInputFloatingFilter<
     protected override defaultDebounceMs: number = 500;
 
     protected onModelUpdated(model: M): void {
+        const { inputSvc } = this;
         this.setLastTypeFromModel(model);
         this.setEditable(this.canWeEditAfterModelFromParentFilter(model));
-        this.inputSvc.setValue(this.filterModelFormatter.getModelAsString(model));
+
+        // Don't clobber a keystroke the user is mid-typing: an interleaving non-floating
+        // filter-changed cycle can deliver a stale model while the input is focused.
+        if (inputSvc.isFocused() && this.pendingEdit) {
+            return;
+        }
+        inputSvc.setValue(this.filterModelFormatter.getModelAsString(model));
+        this.pendingEdit = false;
     }
 
     protected override setParams(params: TParams): void {
@@ -79,7 +88,11 @@ export abstract class TextInputFloatingFilter<
 
         if (!readOnly) {
             const debounceMs = getDebounceMs(filterParams as TextFilterParams, defaultDebounceMs);
-            inputSvc.setValueChangedListener(_debounce(this, this.syncUpWithParentFilter.bind(this), debounceMs));
+            const debouncedSync = _debounce(this, this.syncUpWithParentFilter.bind(this), debounceMs);
+            inputSvc.setValueChangedListener((e) => {
+                this.pendingEdit = true;
+                debouncedSync(e);
+            });
         }
     }
 
@@ -109,6 +122,7 @@ export abstract class TextInputFloatingFilter<
         if (this.applyActive && !isEnterKey) {
             return;
         }
+        this.pendingEdit = false;
 
         const { inputSvc, params, lastType } = this;
         let value = inputSvc.getValue();

--- a/packages/ag-grid-community/src/filter/provided/number/numberFloatingFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/number/numberFloatingFilter.ts
@@ -1,3 +1,5 @@
+import { _getActiveDomElement } from 'ag-stack';
+
 import { AgInputNumberField } from '../../../agWidgets/agInputNumberField';
 import { AgInputTextField } from '../../../agWidgets/agInputTextField';
 import { BeanStub } from '../../../context/beanStub';
@@ -42,6 +44,10 @@ class FloatingFilterNumberInputService extends BeanStub implements FloatingFilte
     public setAutoComplete(autoComplete: boolean | string): void {
         this.eNumberInput.setAutoComplete(autoComplete);
         this.eTextInput.setAutoComplete(autoComplete);
+    }
+
+    public isFocused(): boolean {
+        return _getActiveDomElement(this.beans) === this.getActiveInputElement().getInputElement();
     }
 
     public getValue(): string | null | undefined {

--- a/testing/behavioural/src/filters/multi-filter-floating-filter.test.ts
+++ b/testing/behavioural/src/filters/multi-filter-floating-filter.test.ts
@@ -1,0 +1,210 @@
+import { findByTestId } from '@testing-library/dom';
+
+import type { GridApi, GridOptions } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    EventApiModule,
+    NumberFilterModule,
+    TextFilterModule,
+    agTestIdFor,
+    getGridElement,
+    setupAgTestIds,
+} from 'ag-grid-community';
+import { ColumnMenuModule, MultiFilterModule, SetFilterModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+
+interface Row {
+    name?: string;
+    age?: number;
+}
+
+const ROW_DATA: Row[] = [{ name: 'michael' }, { name: 'michelle' }, { name: 'bob' }, { name: 'alice' }];
+const NUMBER_ROW_DATA: Row[] = [{ age: 5 }, { age: 58 }, { age: 100 }];
+
+describe('Multi Filter floating filter keystroke race', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [
+            ClientSideRowModelModule,
+            EventApiModule,
+            MultiFilterModule,
+            NumberFilterModule,
+            SetFilterModule,
+            TextFilterModule,
+            ColumnMenuModule,
+        ],
+    });
+
+    beforeAll(() => setupAgTestIds());
+    afterEach(() => gridsManager.reset());
+
+    async function createGrid(overrides?: Partial<GridOptions<Row>>): Promise<GridApi<Row>> {
+        return gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'name',
+                    filter: 'agMultiColumnFilter',
+                    filterParams: {
+                        filters: [
+                            { filter: 'agTextColumnFilter', filterParams: { debounceMs: 1 } },
+                            { filter: 'agSetColumnFilter', filterParams: { debounceMs: 1 } },
+                        ],
+                    },
+                    floatingFilter: true,
+                },
+            ],
+            rowData: ROW_DATA,
+            ...overrides,
+        });
+    }
+
+    async function getFloatingFilterInput(api: GridApi<Row>): Promise<HTMLInputElement> {
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        return findByTestId<HTMLInputElement>(
+            gridDiv,
+            agTestIdFor.textFilterInstanceInput({ source: 'floating-filter', colId: 'name', index: 0 })
+        );
+    }
+
+    async function getTextFloatingFilterInput(api: GridApi<Row>, colId: string): Promise<HTMLInputElement> {
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        return findByTestId<HTMLInputElement>(
+            gridDiv,
+            agTestIdFor.textFilterInstanceInput({ source: 'floating-filter', colId })
+        );
+    }
+
+    async function getNumberFloatingFilterInput(api: GridApi<Row>, colId: string): Promise<HTMLInputElement> {
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        return findByTestId<HTMLInputElement>(
+            gridDiv,
+            agTestIdFor.numberFilterInstanceInput({ source: 'floating-filter', colId })
+        );
+    }
+
+    describe.each([false, true])('enableFilterHandlers: %s', (enableFilterHandlers) => {
+        test('typed character is not clobbered by an interleaving non-floating filter-changed cycle', async () => {
+            const api = await createGrid({ enableFilterHandlers });
+            const input = await getFloatingFilterInput(api);
+
+            // Type and apply `u` so the parent filter model becomes `u`.
+            input.focus();
+            input.value = 'u';
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+            await asyncSetTimeout(2);
+            expect(api.getDisplayedRowCount()).toBe(0);
+
+            // User continues typing: the live input is now `u8` while still focused, but the new
+            // keystroke has not yet flushed through the debounce into the filter model.
+            input.value = 'u8';
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+
+            // An interleaving, non-floating filter-changed cycle re-runs the model writeback over the
+            // focused input with the still-stale `u` model — the keystroke-clobber trigger.
+            api.onFilterChanged();
+            await asyncSetTimeout(2);
+
+            // The live keystroke must survive: the input must still read `u8`, not revert to `u`.
+            expect(input.value).toBe('u8');
+
+            // ...and the applied filter model must converge on the live keystroke, not the stale `u`.
+            const model = api.getColumnFilterModel<{ filterModels: ({ filter?: string } | null)[] }>('name');
+            expect(model?.filterModels?.[0]?.filter).toBe('u8');
+        });
+
+        test('external model writeback still updates the input when it is not focused', async () => {
+            const api = await createGrid({ enableFilterHandlers });
+            const input = await getFloatingFilterInput(api);
+
+            input.blur();
+
+            await api.setColumnFilterModel('name', {
+                filterType: 'multi',
+                filterModels: [{ filterType: 'text', type: 'contains', filter: 'bob' }, null],
+            });
+            await api.onFilterChanged();
+            await asyncSetTimeout(2);
+
+            expect(input.value).toBe('bob');
+        });
+
+        test('external model writeback updates a focused input when no keystroke is pending', async () => {
+            const api = await createGrid({ enableFilterHandlers });
+            const input = await getFloatingFilterInput(api);
+
+            // Input is focused but the user has not typed anything, so there is no pending edit to protect.
+            input.focus();
+
+            await api.setColumnFilterModel('name', {
+                filterType: 'multi',
+                filterModels: [{ filterType: 'text', type: 'contains', filter: 'bob' }, null],
+            });
+            await api.onFilterChanged();
+            await asyncSetTimeout(2);
+
+            expect(input.value).toBe('bob');
+        });
+
+        test('number floating filter keystroke is not clobbered by an interleaving filter-changed cycle', async () => {
+            const api = await createGrid({
+                enableFilterHandlers,
+                columnDefs: [
+                    {
+                        field: 'age',
+                        filter: 'agNumberColumnFilter',
+                        filterParams: { debounceMs: 1 },
+                        floatingFilter: true,
+                    },
+                ],
+                rowData: NUMBER_ROW_DATA,
+            });
+            const input = await getNumberFloatingFilterInput(api, 'age');
+
+            // Type and apply `5` so the parent filter model becomes `5`.
+            input.focus();
+            input.value = '5';
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+            await asyncSetTimeout(2);
+
+            // Continue typing `58` while focused, before the keystroke flushes into the model.
+            input.value = '58';
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+
+            api.onFilterChanged();
+            await asyncSetTimeout(2);
+
+            expect(input.value).toBe('58');
+            const model = api.getColumnFilterModel<{ filter?: number }>('age');
+            expect(model?.filter).toBe(58);
+        });
+
+        test('typed character survives an interleaving cycle when an apply button is configured', async () => {
+            const api = await createGrid({
+                enableFilterHandlers,
+                columnDefs: [
+                    {
+                        field: 'name',
+                        filter: 'agTextColumnFilter',
+                        filterParams: { buttons: ['apply'] },
+                        floatingFilter: true,
+                    },
+                ],
+                rowData: ROW_DATA,
+            });
+            const input = await getTextFloatingFilterInput(api, 'name');
+
+            input.focus();
+            input.value = 'mich';
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+            await asyncSetTimeout(2);
+
+            // With an apply button the keystroke is held until applied, so `pendingEdit` stays set.
+            api.onFilterChanged();
+            await asyncSetTimeout(2);
+
+            expect(input.value).toBe('mich');
+            // Nothing was applied: the apply button still gates the model.
+            expect(api.getColumnFilterModel('name')).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
Backport of #14216 to the 36.0.2 release branch.

The Multi Filter floating filter dropped the last-typed character when an async, non-floating filter-changed cycle interleaved with typing (e.g. a set filter inside a multi filter). The floating filter's `onModelUpdated` wrote the stale applied model back over the focused input. This is guarded by a `pendingEdit` flag so the writeback is skipped only during a genuine mid-edit race, while a focused-but-idle external change still writes through.

Fix [AG-17882](https://ag-grid.atlassian.net/browse/AG-17882)