### PR TITLE
fix(github-triage): honor client_payload.channel on the resume dispatch

### DIFF
--- a/.github/workflows/github-triage-pipeline.yml
+++ b/.github/workflows/github-triage-pipeline.yml
@@ -63,11 +63,12 @@ concurrency:
     cancel-in-progress: false
 
 env:
-    # Defaults to `latest` (inputs is empty on issues / repository_dispatch).
-    # During rollout/dogfood, test unpromoted action changes by manually
-    # dispatching with channel=canary — the github-triage-pipeline action lands
-    # on the canary dist-tag first and reaches `latest` only on promotion.
-    DEV_PROMPTS_CHANNEL: ${{ inputs.channel || 'latest' }}
+    # Defaults to `latest`. A repository_dispatch (the JIRA `→ In Progress` drag)
+    # overrides via client_payload.channel; a workflow_dispatch via inputs.channel.
+    # During rollout/dogfood the JIRA rule sends "channel":"canary" so the drag runs
+    # the unpromoted action (canary dist-tag → `latest` only on promotion); drop the
+    # payload channel at activation so production drags run the promoted `latest`.
+    DEV_PROMPTS_CHANNEL: ${{ github.event.client_payload.channel || inputs.channel || 'latest' }}
 
 jobs:
     # -------------------------------------------------- preflight


### PR DESCRIPTION
## What

The GitHub-issue triage workflow's `DEV_PROMPTS_CHANNEL` read only `inputs.channel`, which is **empty on a `repository_dispatch`** (the JIRA `→ In Progress` drag). So even when the JIRA automation sends `"channel":"canary"` in `client_payload`, it was **silently dropped** and the drag ran the promoted `latest` action instead of the intended `canary` one.

## Fix (one line)

```yaml
DEV_PROMPTS_CHANNEL: ${{ github.event.client_payload.channel || inputs.channel || 'latest' }}
```

- `repository_dispatch` (drag) → honors `client_payload.channel` (e.g. `canary` during calibration/dogfood).
- `workflow_dispatch` → honors `inputs.channel`.
- Everything else → `latest`.

**Production-safe:** once the JIRA rule drops the `canary` payload channel at activation, drags default to the promoted `latest` again. No behavior change for the `issues:`/default path.

## Context

Surfaced while validating the confirmed-bug → execute path: a drag was routing on `latest` despite the JIRA rule sending `canary`. (Separately, the execute path was blocked by a preflight `GET /myself` 401 — a `JIRA_AI_BOT_API_TOKEN` scope issue, fixed on the operator side.)