### PR TITLE
[AG-17928] ci: skip yarn on ro consumer jobs to end registry install storms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,11 @@ jobs:
         id: setup
         uses: ./.github/actions/setup-nx
         with:
+          # ro consumers restore the node_modules cache warmed by `init` (which already
+          # ran postinstall before saving), so no yarn execution is needed here. Skipping
+          # it removes every consumer's registry install on a cache miss — the fan-out that
+          # amplified transient registry errors into an install storm.
+          yarn_postinstall: no-install
           cache_mode: ro
 
       - name: nx test
@@ -290,6 +295,11 @@ jobs:
         id: setup
         uses: ./.github/actions/setup-nx
         with:
+          # ro consumers restore the node_modules cache warmed by `init` (which already
+          # ran postinstall before saving), so no yarn execution is needed here. Skipping
+          # it removes every consumer's registry install on a cache miss — the fan-out that
+          # amplified transient registry errors into an install storm.
+          yarn_postinstall: no-install
           cache_mode: ro
 
       - name: nx test:e2e
@@ -324,6 +334,11 @@ jobs:
         id: setup
         uses: ./.github/actions/setup-nx
         with:
+          # ro consumers restore the node_modules cache warmed by `init` (which already
+          # ran postinstall before saving), so no yarn execution is needed here. Skipping
+          # it removes every consumer's registry install on a cache miss — the fan-out that
+          # amplified transient registry errors into an install storm.
+          yarn_postinstall: no-install
           cache_mode: ro
 
       - name: nx format:check
@@ -360,6 +375,11 @@ jobs:
         id: setup
         uses: ./.github/actions/setup-nx
         with:
+          # ro consumers restore the node_modules cache warmed by `init` (which already
+          # ran postinstall before saving), so no yarn execution is needed here. Skipping
+          # it removes every consumer's registry install on a cache miss — the fan-out that
+          # amplified transient registry errors into an install storm.
+          yarn_postinstall: no-install
           cache_mode: ro
 
       - name: nx build
@@ -491,6 +511,11 @@ jobs:
         id: setup
         uses: ./.github/actions/setup-nx
         with:
+          # ro consumers restore the node_modules cache warmed by `init` (which already
+          # ran postinstall before saving), so no yarn execution is needed here. Skipping
+          # it removes every consumer's registry install on a cache miss — the fan-out that
+          # amplified transient registry errors into an install storm.
+          yarn_postinstall: no-install
           cache_mode: ro
 
       - name: update base url
@@ -558,6 +583,11 @@ jobs:
         if: matrix.framework != 'none'
         uses: ./.github/actions/setup-nx
         with:
+          # ro consumers restore the node_modules cache warmed by `init` (which already
+          # ran postinstall before saving), so no yarn execution is needed here. Skipping
+          # it removes every consumer's registry install on a cache miss — the fan-out that
+          # amplified transient registry errors into an install storm.
+          yarn_postinstall: no-install
           cache_mode: ro
 
       - name: nx package:test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,10 +229,11 @@ jobs:
         id: setup
         uses: ./.github/actions/setup-nx
         with:
-          # ro consumers restore the node_modules cache warmed by `init` (which already
-          # ran postinstall before saving), so no yarn execution is needed here. Skipping
-          # it removes every consumer's registry install on a cache miss — the fan-out that
-          # amplified transient registry errors into an install storm.
+          # ro consumers restore the node_modules cache warmed by `init` (which already ran
+          # postinstall before saving), so no yarn execution is needed. no-install skips it,
+          # removing the per-consumer registry install on a cache miss — the fan-out that
+          # amplified transient registry errors into an install storm. Applied to every ro
+          # consumer job below.
           yarn_postinstall: no-install
           cache_mode: ro
 
@@ -295,10 +296,6 @@ jobs:
         id: setup
         uses: ./.github/actions/setup-nx
         with:
-          # ro consumers restore the node_modules cache warmed by `init` (which already
-          # ran postinstall before saving), so no yarn execution is needed here. Skipping
-          # it removes every consumer's registry install on a cache miss — the fan-out that
-          # amplified transient registry errors into an install storm.
           yarn_postinstall: no-install
           cache_mode: ro
 
@@ -334,10 +331,6 @@ jobs:
         id: setup
         uses: ./.github/actions/setup-nx
         with:
-          # ro consumers restore the node_modules cache warmed by `init` (which already
-          # ran postinstall before saving), so no yarn execution is needed here. Skipping
-          # it removes every consumer's registry install on a cache miss — the fan-out that
-          # amplified transient registry errors into an install storm.
           yarn_postinstall: no-install
           cache_mode: ro
 
@@ -375,10 +368,6 @@ jobs:
         id: setup
         uses: ./.github/actions/setup-nx
         with:
-          # ro consumers restore the node_modules cache warmed by `init` (which already
-          # ran postinstall before saving), so no yarn execution is needed here. Skipping
-          # it removes every consumer's registry install on a cache miss — the fan-out that
-          # amplified transient registry errors into an install storm.
           yarn_postinstall: no-install
           cache_mode: ro
 
@@ -511,10 +500,6 @@ jobs:
         id: setup
         uses: ./.github/actions/setup-nx
         with:
-          # ro consumers restore the node_modules cache warmed by `init` (which already
-          # ran postinstall before saving), so no yarn execution is needed here. Skipping
-          # it removes every consumer's registry install on a cache miss — the fan-out that
-          # amplified transient registry errors into an install storm.
           yarn_postinstall: no-install
           cache_mode: ro
 
@@ -583,10 +568,6 @@ jobs:
         if: matrix.framework != 'none'
         uses: ./.github/actions/setup-nx
         with:
-          # ro consumers restore the node_modules cache warmed by `init` (which already
-          # ran postinstall before saving), so no yarn execution is needed here. Skipping
-          # it removes every consumer's registry install on a cache miss — the fan-out that
-          # amplified transient registry errors into an install storm.
           yarn_postinstall: no-install
           cache_mode: ro
 


### PR DESCRIPTION
[AG-17928](https://ag-grid.atlassian.net/browse/AG-17928) 

## What

Pass `yarn_postinstall: no-install` to the fanned-out consumer jobs (test shards, e2e, lint, build, docs, package tests). They already run `cache_mode: ro`; this makes them skip yarn execution entirely and rely solely on the `node_modules` cache warmed by `init`.

## Why

The registry-request storm's amplifier was the consumer fan-out. On a `ro` cache miss the consumers previously did `rm -rf node_modules && yarn install`, a genuine cold install against the registry. Sharding (#14371) multiplied the number of such consumers, so a single transient registry 504 fanned out into many full installs — a self-amplifying loop.

`init` runs `yarn install` (including postinstall) with `cache_mode: rw` and saves the resulting tree, so the restored cache is already complete. Consumers therefore don't need to run yarn at all — skipping it removes every consumer-side registry install.

This mirrors the pattern already in ag-charts ([ci.yml](https://github.com/ag-grid/ag-charts/blob/bf8afb58163c4afe5d017fc1be7bbeeaa25ac824/.github/workflows/ci.yml#L662C1-L669C95)) and is preferable to install retry loops, which carry their own traffic-amplification risk in failure cases.
 
## Testing

CI-only change; exercised by this PR's own pipeline.