### PR TITLE
ci(jira-agent-pipeline): pass ANTHROPIC_API_KEY to the ci-success handler

### DIFF
--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -336,6 +336,10 @@ jobs:
                   jira_email: ${{ secrets.JIRA_AI_BOT_EMAIL }}
                   jira_api_token: ${{ secrets.JIRA_AI_BOT_API_TOKEN }}
                   jira_site_url: ${{ vars.JIRA_SITE_URL }}
+                  # Counterfactual effort-estimate (completed phase) write on the
+                  # green-CI promotion — the dominant RoI write path. Empty ⇒ the
+                  # estimate is silently skipped (best-effort), never a failure.
+                  anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   # Live-test snippet — the ci.yml `pr_preview` job publishes
                   # per-PR UMD bundles to gh-pages, so the reviewer can paste
                   # these two <script> tags into a vanilla-JS Plunker to


### PR DESCRIPTION
Pass `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}` to the `jira-ci-success-handler` step.

The green-CI promotion is the dominant AI-completed terminal and the primary `completed`-phase effort-estimate write (`maybeWriteEffortEstimate`). Without the key the estimate is silently skipped, so the AI Workflow Report RoI tab never gets completed-ticket counterfactual bands on this path. Fix depends on ag-dev-prompts PR #596 (adds the `anthropic_api_key` input to the action).

**Do not merge until** the action change has reached this repo`s dev-prompts channel:
- ag-charts (channel `canary`): after #596 lands on canary + republishes.
- ag-grid (channel `latest`): after #596 is promoted to `latest`.