### PR TITLE
ci(github-triage): pass jira_ai_bot_account_id to both triage actions

### DIFF
--- a/.github/workflows/github-triage-pipeline.yml
+++ b/.github/workflows/github-triage-pipeline.yml
@@ -100,6 +100,7 @@ jobs:
                   jira_email: ${{ secrets.JIRA_AI_BOT_EMAIL }}
                   jira_api_token: ${{ secrets.JIRA_AI_BOT_API_TOKEN }}
                   jira_site_url: ${{ vars.JIRA_SITE_URL }}
+                  jira_ai_bot_account_id: ${{ vars.JIRA_AI_BOT_ACCOUNT_ID }}
 
     # -------------------------------------------------- run
     # The parameterised stage runner (triage / resume / execute). Runs on the
@@ -137,3 +138,4 @@ jobs:
                   jira_email: ${{ secrets.JIRA_AI_BOT_EMAIL }}
                   jira_api_token: ${{ secrets.JIRA_AI_BOT_API_TOKEN }}
                   jira_site_url: ${{ vars.JIRA_SITE_URL }}
+                  jira_ai_bot_account_id: ${{ vars.JIRA_AI_BOT_ACCOUNT_ID }}


### PR DESCRIPTION
## What

Threads the new optional `jira_ai_bot_account_id` input through **both** steps of the github-triage stub (preflight + run), sourced from the repo var `JIRA_AI_BOT_ACCOUNT_ID`.

## Why

The github-triage pipeline resolves the bot's own Atlassian accountId via `GET /rest/api/3/myself`. The scoped `JIRA_AI_BOT_API_TOKEN` does every other call (search / issue PUT / comment) but **401s on `/myself`** (missing the user/`read:me` scope). The resume-preflight's execute gate needs the bot's accountId to recognise its own handback — without it, `gather()` throws and the preflight fails open to `resume`, so a confirmed-bug drag never reaches `execute`. Rotating the token needs infra, so the action now accepts a configured accountId instead ([ag-grid/dev-prompts#597](https://github.com/ag-grid/ag-dev-prompts/pull/597)).

## How

Passes `jira_ai_bot_account_id: ${{ vars.JIRA_AI_BOT_ACCOUNT_ID }}` to the `github-triage-resume-preflight` and `github-triage-pipeline` actions.

**Requires** the repo var `JIRA_AI_BOT_ACCOUNT_ID` to be set (jira-ai-bot's accountId). **Inert until then** — an empty var makes the actions fall back to the live `/myself` lookup (current behaviour), so this is safe to merge before/after setting the var.

## Notes
- Pairs with the canary action change; the action treats the input as optional (`required: false`).
- No behavioural change to the triage/resume flows themselves.