### PR TITLE
SE-81 Emit agent Link header on staging too (pre-prod verification)

### DIFF
--- a/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -2740,13 +2740,6 @@ Header always set Permissions-Policy "geolocation=(), microphone=(), camera=()"
     Header append Vary Accept
 </If>
 
-# SE-81: agent-useful Link response header. Gives AI agents a machine-readable pointer
-# to the key resources without parsing the page first: rel=describedby -> /llms.txt,
-# rel=sitemap -> the sitemap index, and rel=related -> the MCP server docs. Single-token
-# rel values are unquoted per RFC 8288, which keeps the directive free of escaped quotes.
-# Scoped to HTML documents via the Content-Type expr (evaluated at response time): the
-# header is document metadata, so applying it to assets, downloads, redirects and error
-# responses only wastes bandwidth and, for rel=describedby, wrongly describes non-documents.
 Header set Link "</llms.txt>; rel=describedby, </sitemap-index.xml>; rel=sitemap, <https://www.ag-grid.com/javascript-data-grid/mcp-server/>; rel=related" "expr=%{CONTENT_TYPE} =~ m#^text/html#"
 
 # Content-Security-Policy — enforced, path-scoped (the report-only validation window
@@ -2826,6 +2819,8 @@ AddCharset utf-8 .md
 <If "%{REQUEST_URI} =~ m#^/((react|angular|vue|javascript)-data-grid/|(license-pricing|changelog|pipeline)/?$)#">
     Header append Vary Accept
 </If>
+
+Header set Link "</llms.txt>; rel=describedby, </sitemap-index.xml>; rel=sitemap, <https://www.ag-grid.com/javascript-data-grid/mcp-server/>; rel=related" "expr=%{CONTENT_TYPE} =~ m#^text/html#"
 
 # Content-Security-Policy — enforced, path-scoped. Unsets the legacy wildcard CSP on
 # the staging vhost so this tightened policy is the only one in effect.

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
@@ -108,6 +108,12 @@ describe('htaccessRules', () => {
             expect(linkLine).not.toContain('always set Link');
             expect(linkLine).toContain('"expr=%{CONTENT_TYPE} =~ m#^text/html#"');
         });
+
+        it('should include the Link header on staging too so it can be verified before production', () => {
+            expect(stagingContent).toContain('Header set Link');
+            expect(stagingContent).toContain('</llms.txt>; rel=describedby');
+            expect(stagingContent).toContain('"expr=%{CONTENT_TYPE} =~ m#^text/html#"');
+        });
     });
 
     describe('AG-17152: /charts/ framework overview redirects', () => {

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
@@ -109,6 +109,16 @@ const markdownVaryHeader = `# SE-80: docs pages content-negotiate on Accept (see
     Header append Vary Accept
 </If>`;
 
+// SE-81: agent-useful Link response header. Gives AI agents a machine-readable pointer
+// to the key resources without parsing the page first: rel=describedby -> /llms.txt,
+// rel=sitemap -> the sitemap index, and rel=related -> the MCP server docs. Single-token
+// rel values are unquoted per RFC 8288, which keeps the directive free of escaped quotes.
+// Scoped to HTML documents via the Content-Type expr (evaluated at response time): the
+// header is document metadata, so applying it to assets, downloads, redirects and error
+// responses only wastes bandwidth and, for rel=describedby, wrongly describes non-documents.
+// Shared by the staging and production .htaccess so the header can be verified on staging.
+const agentLinkHeader = `Header set Link "</llms.txt>; rel=describedby, </sitemap-index.xml>; rel=sitemap, <https://www.ag-grid.com/javascript-data-grid/mcp-server/>; rel=related" "expr=%{CONTENT_TYPE} =~ m#^text/html#"`;
+
 // Lazily built: the redirect generation resolves urlWithBaseUrl (which needs the
 // build-time base URL), so it must not run at module import — only when the
 // production .htaccess is actually generated.
@@ -266,6 +276,8 @@ ${markdownNegotiationBlock}
 
 ${markdownVaryHeader}
 
+${agentLinkHeader}
+
 # Content-Security-Policy — enforced, path-scoped. Unsets the legacy wildcard CSP on
 # the staging vhost so this tightened policy is the only one in effect.
 ${getScopedCspHtaccessBlock({ env: 'staging' }, 'enforce')}
@@ -290,14 +302,7 @@ Header always set Permissions-Policy "geolocation=(), microphone=(), camera=()"
 
 ${markdownVaryHeader}
 
-# SE-81: agent-useful Link response header. Gives AI agents a machine-readable pointer
-# to the key resources without parsing the page first: rel=describedby -> /llms.txt,
-# rel=sitemap -> the sitemap index, and rel=related -> the MCP server docs. Single-token
-# rel values are unquoted per RFC 8288, which keeps the directive free of escaped quotes.
-# Scoped to HTML documents via the Content-Type expr (evaluated at response time): the
-# header is document metadata, so applying it to assets, downloads, redirects and error
-# responses only wastes bandwidth and, for rel=describedby, wrongly describes non-documents.
-Header set Link "</llms.txt>; rel=describedby, </sitemap-index.xml>; rel=sitemap, <https://www.ag-grid.com/javascript-data-grid/mcp-server/>; rel=related" "expr=%{CONTENT_TYPE} =~ m#^text/html#"
+${agentLinkHeader}
 
 ${getProductionCspContent()}
 


### PR DESCRIPTION
## What

Follow-up to #14516. That PR added the agent-useful `Link` response header (AR5) but placed it only in the **production** `.htaccess`, alongside the other security headers, so the header never appeared on `grid-staging.ag-grid.com` and couldn't be verified before release.

