### PR TITLE
test(docs-e2e): fix filtering/find/value-getters example specs

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/filtering/_examples/provided-filters/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/filtering/_examples/provided-filters/example.spec.ts
@@ -17,8 +17,25 @@ const EXPECTED = {
 
 // Reads the visible text of every rendered cell in a column.
 async function visibleColumnValues(page: any, colId: string): Promise<string[]> {
-    const texts = await page.locator(`.ag-center-cols-container .ag-cell[col-id="${colId}"]`).allInnerTexts();
+    const texts = await page.locator(`.ag-grid-scrolling-container .ag-cell[col-id="${colId}"]`).allInnerTexts();
     return texts.map((t: string) => t.trim()).filter((t: string) => t.length > 0);
+}
+
+// The displayed row count (grid API) settles before the viewport finishes repainting the filtered
+// rows, so a one-shot DOM read can catch an empty viewport. Poll the read and its assertions until
+// the rendered cells have caught up.
+async function expectVisibleColumnValues(
+    page: any,
+    colId: string,
+    assertValue: (value: string) => void
+): Promise<void> {
+    await expect(async () => {
+        const values = await visibleColumnValues(page, colId);
+        expect(values.length).toBeGreaterThan(0);
+        for (const value of values) {
+            assertValue(value);
+        }
+    }).toPass();
 }
 
 test.agExample(import.meta, () => {
@@ -44,11 +61,7 @@ test.agExample(import.meta, () => {
 
             // Michael Phelps (row-id 0) no longer passes the filter and every visible athlete matches.
             await expect(agIdFor.cell('0', 'athlete')).toHaveCount(0);
-            const values = await visibleColumnValues(page, 'athlete');
-            expect(values.length).toBeGreaterThan(0);
-            for (const value of values) {
-                expect(value).toContain('Fischer');
-            }
+            await expectVisibleColumnValues(page, 'athlete', (value) => expect(value).toContain('Fischer'));
         }
     );
 
@@ -72,11 +85,7 @@ test.agExample(import.meta, () => {
 
             // Michael Phelps is 23, so row-id 0 is filtered out; every visible age is above 40.
             await expect(agIdFor.cell('0', 'age')).toHaveCount(0);
-            const values = await visibleColumnValues(page, 'age');
-            expect(values.length).toBeGreaterThan(0);
-            for (const value of values) {
-                expect(Number(value)).toBeGreaterThan(40);
-            }
+            await expectVisibleColumnValues(page, 'age', (value) => expect(Number(value)).toBeGreaterThan(40));
         }
     );
 
@@ -109,11 +118,7 @@ test.agExample(import.meta, () => {
             }).toPass();
 
             // Every rendered country is United States.
-            const values = await visibleColumnValues(page, 'country');
-            expect(values.length).toBeGreaterThan(0);
-            for (const value of values) {
-                expect(value).toBe('United States');
-            }
+            await expectVisibleColumnValues(page, 'country', (value) => expect(value).toBe('United States'));
         }
     );
 
@@ -136,11 +141,7 @@ test.agExample(import.meta, () => {
                 expect(await remoteGrid(page).getDisplayedRowCount()).toBe(EXPECTED.sportContainsSwimming);
             }).toPass();
 
-            const values = await visibleColumnValues(page, 'sport');
-            expect(values.length).toBeGreaterThan(0);
-            for (const value of values) {
-                expect(value).toContain('Swimming');
-            }
+            await expectVisibleColumnValues(page, 'sport', (value) => expect(value).toContain('Swimming'));
         }
     );
 });

--- a/documentation/ag-grid-docs/src/content/docs/filtering/_examples/provided-filters/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/filtering/_examples/provided-filters/main.ts
@@ -4,6 +4,7 @@ import {
     DateFilterModule,
     ModuleRegistry,
     NumberFilterModule,
+    RowApiModule,
     TextFilterModule,
     createGrid,
     enableDevValidations,
@@ -24,6 +25,7 @@ ModuleRegistry.registerModules([
     TextFilterModule,
     NumberFilterModule,
     DateFilterModule,
+    RowApiModule,
 ]);
 
 const filterParams: IDateFilterParams = {

--- a/documentation/ag-grid-docs/src/content/docs/find/_examples/customising-find/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/find/_examples/customising-find/example.spec.ts
@@ -8,6 +8,11 @@ test.agExample(import.meta, () => {
     const findInput = (page: any) => page.locator('.ag-toolbar-find input');
     const matchCount = (page: any) => page.locator('.ag-toolbar-find-match-count');
 
+    // The Vue example transform drops the `id` from the control checkboxes, so target them by their
+    // label text instead — this resolves consistently across every framework.
+    const optionCheckbox = (page: any, label: string) =>
+        page.locator('label', { hasText: label }).locator('input[type="checkbox"]');
+
     test.eachFramework('caseSensitive controls whether casing must match', async ({ page }) => {
         await ensureGridReady(page);
 
@@ -21,7 +26,7 @@ test.agExample(import.meta, () => {
         await expect(page.locator('mark.ag-find-match')).toHaveCount(0);
 
         // Turning off case sensitivity makes the same term match again.
-        await page.locator('#caseSensitive').uncheck();
+        await optionCheckbox(page, 'caseSensitive').uncheck();
         await expect(page.locator('mark.ag-find-match').first()).toBeVisible();
     });
 
@@ -39,7 +44,7 @@ test.agExample(import.meta, () => {
         }).toPass();
 
         // Turning it off searches every page, yielding strictly more matches.
-        await page.locator('#currentPageOnly').uncheck();
+        await optionCheckbox(page, 'currentPageOnly').uncheck();
         await expect(async () => {
             const [, total] = (await matchCount(page).innerText()).split('/');
             expect(Number(total)).toBeGreaterThan(pageOnlyTotal);

--- a/documentation/ag-grid-docs/src/content/docs/find/_examples/find/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/find/_examples/find/example.spec.ts
@@ -1,13 +1,18 @@
 import { ensureGridReady, expect, test } from '@utils/grid/test-utils';
 
-// Find is driven via grid options / API here. External controls: #find-text-box updates
-// findSearchValue, Previous/Next buttons call findPrevious()/findNext(), #activeMatchNum shows
+// Find is driven via grid options / API here. External controls: a text box updates
+// findSearchValue, Previous/Next buttons call findPrevious()/findNext(), a span shows
 // "current/total", and the Go To input + button call findGoTo(matchNumber).
 // Matched text is wrapped in <mark class="ag-find-match">; active match adds ag-find-active-match.
+//
+// The control `id`s are dropped by the framework example transforms, so target the controls by
+// structure (their position within .example-controls) so the selectors hold across every framework.
 
 test.agExample(import.meta, () => {
-    const findInput = (page: any) => page.locator('#find-text-box');
-    const activeMatchNum = (page: any) => page.locator('#activeMatchNum');
+    const findInput = (page: any) => page.locator('.example-controls input[type="text"]');
+    const gotoInput = (page: any) => page.locator('.example-controls input[type="number"]');
+    // The match counter is the trailing span of the first controls row (after the "Find:" label).
+    const activeMatchNum = (page: any) => page.locator('.example-controls').first().locator('span').last();
 
     test.eachFramework('Typing highlights matches and reports the total', async ({ page }) => {
         await ensureGridReady(page);
@@ -43,7 +48,7 @@ test.agExample(import.meta, () => {
         await findInput(page).fill('Swimming');
         await expect(page.locator('mark.ag-find-match').first()).toBeVisible();
 
-        await page.locator('#find-goto').fill('3');
+        await gotoInput(page).fill('3');
         await page.getByRole('button', { name: 'Go To', exact: true }).click();
 
         await expect(activeMatchNum(page)).toHaveText(/^\s*3\/\d+\s*$/);

--- a/documentation/ag-grid-docs/src/content/docs/value-getters/_examples/value-getters/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-getters/_examples/value-getters/example.spec.ts
@@ -2,7 +2,7 @@ import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/t
 
 test.agExample(import.meta, () => {
     // rowData: a = i % 4, b = i % 7 for i in 0..99.
-    // colIds: 'ID #' (anonymous) -> '0', 'a', 'b', 'A + B' -> 'a&b',
+    // colIds: 'ID #' (anonymous) -> '0', 'a', 'b', 'A + B' -> 'aPlusB',
     //         'A * 1000' -> '1', 'B * 137' -> '2', 'Chain' -> '3', 'Const' -> '4'.
 
     test.eachFramework('ID # valueGetter prints the row node id', async ({ agIdFor, page }) => {
@@ -21,7 +21,7 @@ test.agExample(import.meta, () => {
         // Row 5: a = 5 % 4 = 1, b = 5 % 7 = 5.
         await expect(agIdFor.cell('5', 'a')).toContainText('1');
         await expect(agIdFor.cell('5', 'b')).toContainText('5');
-        await expect(agIdFor.cell('5', 'a&b')).toContainText('6'); // a + b
+        await expect(agIdFor.cell('5', 'aPlusB')).toContainText('6'); // a + b
         await expect(agIdFor.cell('5', '1')).toContainText('1000'); // a * 1000
         await expect(agIdFor.cell('5', '2')).toContainText('685'); // b * 137
         await expect(agIdFor.cell('5', '3')).toContainText('6000'); // chain: (a + b) * 1000

--- a/documentation/ag-grid-docs/src/content/docs/value-getters/_examples/value-getters/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/value-getters/_examples/value-getters/main.ts
@@ -23,7 +23,7 @@ function b137ValueGetter(params: ValueGetterParams) {
     return params.data.b * 137;
 }
 function chainValueGetter(params: ValueGetterParams) {
-    return params.getValue('a&b') * 1000;
+    return params.getValue('aPlusB') * 1000;
 }
 function constValueGetter() {
     return 99999;
@@ -40,7 +40,7 @@ const gridOptions: GridOptions = {
         { field: 'b' },
         {
             headerName: 'A + B',
-            colId: 'a&b',
+            colId: 'aPlusB',
             valueGetter: abValueGetter,
         },
         {


### PR DESCRIPTION
## What

Fixes the docs-e2e example specs that turned the nightly **Documentation Tests** run red ([run 29889128675](https://github.com/ag-grid/ag-grid/actions/runs/29889128675)). These specs were introduced in my earlier PRs (#14509, #14510) and broke due to **recent grid-internal changes** plus framework example-transform behaviour — the assertions themselves were correct when written.

> Note: that nightly run also had a large, unrelated failure spike (~250 vs ~11 the previous night, run ~1.5× slower, `Test timeout of 60000ms exceeded` across many unrelated examples) that looks like staging/environment degradation. This PR only addresses the genuinely, consistently reproducible failures — confirmed by re-running the specs against `grid-staging.ag-grid.com`.

## Root causes & fixes

**`value-getters/value-getters`** (failed all frameworks, both nights)
The `A + B` column used `colId: 'a&b'`. The `&` is HTML-entity-encoded in the DOM (verified live: `col-id="a&amp;b"`), so the generated cell test-id never matched. Renamed the colId to `aPlusB` (invisible to users — the header stays `A + B`).

**`filtering/provided-filters`** (failed all frameworks)
- The row container class was renamed `ag-center-cols-container` → `ag-grid-scrolling-container`, so the visible-value reader matched nothing. Updated the selector and made the read poll (`toPass`) for robustness.
- `getDisplayedRowCount()` now requires `RowApiModule` (surfaced as `error #200`, which the harness treats as a failure). Registered it in the example.

**`find/find` & `find/customising-find`** (failed on the frameworks whose transform drops control ids)
The framework example transforms strip `id`s from the external control elements (`#find-text-box`, `#activeMatchNum`, `#find-goto`, `#caseSensitive`, `#currentPageOnly`), so they were absent on some frameworks. Target the controls by structure/label instead, which resolves across every framework.

## Validation

Re-ran each spec against `--url https://grid-staging.ag-grid.com` (same target as the nightly), all frameworks:
- `find/find`, `find/customising-find` — pass on vanilla, typescript, angular, reactFunctionalTs, vue3.
- `filtering/provided-filters` — pass on vanilla & vue3; angular/react/typescript were blocked only by the `error #200` above (fixed via `RowApiModule`; can't be verified against staging until the example redeploys, but the fix is the remedy named in the error itself).
- `value-getters` root cause confirmed via live DOM inspection; both changed examples regenerate and typecheck cleanly.

## Follow-up (out of scope)
The `ag-center-cols-container` → `ag-grid-scrolling-container` rename affects several other specs (e.g. `infinite-scrolling/block-larger-page`, `viewport/pagination-viewport`, `view-refresh/refresh-cells`, some `row-selection-*`) and the v36 upgrade guide. Worth a sweep in a separate PR.