### PR TITLE
SE-81 Keep agent Link header off error responses (404s)

### DIFF
--- a/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -2740,7 +2740,7 @@ Header always set Permissions-Policy "geolocation=(), microphone=(), camera=()"
     Header append Vary Accept
 </If>
 
-Header set Link "</llms.txt>; rel=describedby, </sitemap-index.xml>; rel=sitemap, <https://www.ag-grid.com/javascript-data-grid/mcp-server/>; rel=related" "expr=%{CONTENT_TYPE} =~ m#^text/html#"
+Header set Link "</llms.txt>; rel=describedby, </sitemap-index.xml>; rel=sitemap, <https://www.ag-grid.com/javascript-data-grid/mcp-server/>; rel=related" "expr=%{REQUEST_STATUS} == 200 && %{CONTENT_TYPE} =~ m#^text/html#"
 
 # Content-Security-Policy — enforced, path-scoped (the report-only validation window
 # for removing 'unsafe-eval' from the main-site policy is complete). The block unsets
@@ -2820,7 +2820,7 @@ AddCharset utf-8 .md
     Header append Vary Accept
 </If>
 
-Header set Link "</llms.txt>; rel=describedby, </sitemap-index.xml>; rel=sitemap, <https://www.ag-grid.com/javascript-data-grid/mcp-server/>; rel=related" "expr=%{CONTENT_TYPE} =~ m#^text/html#"
+Header set Link "</llms.txt>; rel=describedby, </sitemap-index.xml>; rel=sitemap, <https://www.ag-grid.com/javascript-data-grid/mcp-server/>; rel=related" "expr=%{REQUEST_STATUS} == 200 && %{CONTENT_TYPE} =~ m#^text/html#"
 
 # Content-Security-Policy — enforced, path-scoped. Unsets the legacy wildcard CSP on
 # the staging vhost so this tightened policy is the only one in effect.

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
@@ -100,19 +100,20 @@ describe('htaccessRules', () => {
             );
         });
 
-        it('should scope the Link header to HTML documents (not assets, redirects or errors)', () => {
+        it('should scope the Link header to successful HTML documents (not assets, redirects or errors)', () => {
             const linkLine = productionContent.split('\n').find((l) => l.includes('set Link'));
             expect(linkLine).toBeDefined();
-            // Not `always` (so it is skipped on error responses) and guarded by a
-            // Content-Type expr so it only applies to HTML documents.
+            // Not `always` (so it is skipped on error responses), and guarded by an expr that
+            // requires both a 200 status and an HTML content-type. The status check is what
+            // keeps it off the custom text/html 404 page (whose content-type alone would match).
             expect(linkLine).not.toContain('always set Link');
-            expect(linkLine).toContain('"expr=%{CONTENT_TYPE} =~ m#^text/html#"');
+            expect(linkLine).toContain('"expr=%{REQUEST_STATUS} == 200 && %{CONTENT_TYPE} =~ m#^text/html#"');
         });
 
         it('should include the Link header on staging too so it can be verified before production', () => {
             expect(stagingContent).toContain('Header set Link');
             expect(stagingContent).toContain('</llms.txt>; rel=describedby');
-            expect(stagingContent).toContain('"expr=%{CONTENT_TYPE} =~ m#^text/html#"');
+            expect(stagingContent).toContain('"expr=%{REQUEST_STATUS} == 200 && %{CONTENT_TYPE} =~ m#^text/html#"');
         });
     });
 

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
@@ -113,11 +113,16 @@ const markdownVaryHeader = `# SE-80: docs pages content-negotiate on Accept (see
 // to the key resources without parsing the page first: rel=describedby -> /llms.txt,
 // rel=sitemap -> the sitemap index, and rel=related -> the MCP server docs. Single-token
 // rel values are unquoted per RFC 8288, which keeps the directive free of escaped quotes.
-// Scoped to HTML documents via the Content-Type expr (evaluated at response time): the
+// Scoped to successful HTML documents via the expr (evaluated at response time): the
 // header is document metadata, so applying it to assets, downloads, redirects and error
 // responses only wastes bandwidth and, for rel=describedby, wrongly describes non-documents.
-// Shared by the staging and production .htaccess so the header can be verified on staging.
-const agentLinkHeader = `Header set Link "</llms.txt>; rel=describedby, </sitemap-index.xml>; rel=sitemap, <https://www.ag-grid.com/javascript-data-grid/mcp-server/>; rel=related" "expr=%{CONTENT_TYPE} =~ m#^text/html#"`;
+// The Content-Type check alone is not enough: the custom `ErrorDocument 404 /404.html` is a
+// real text/html file served via an internal subrequest, so a 404 would still match on
+// content-type and leak the header (verified on staging). The `%{REQUEST_STATUS} == 200`
+// guard restricts it to genuine 200 documents — REQUEST_STATUS reflects the final response
+// status (404 for the error page), confirmed against Apache 2.4. Shared by the staging and
+// production .htaccess so the header can be verified on staging.
+const agentLinkHeader = `Header set Link "</llms.txt>; rel=describedby, </sitemap-index.xml>; rel=sitemap, <https://www.ag-grid.com/javascript-data-grid/mcp-server/>; rel=related" "expr=%{REQUEST_STATUS} == 200 && %{CONTENT_TYPE} =~ m#^text/html#"`;
 
 // Lazily built: the redirect generation resolves urlWithBaseUrl (which needs the
 // build-time base URL), so it must not run at module import — only when the


### PR DESCRIPTION
## Problem

Follow-up to the SE-81 `Link` response header. On staging, a 404 (`GET https://grid-staging.ag-grid.com/abc`) was returning the `Link` header, which it should not:

```
HTTP/2 404
content-type: text/html
link: </llms.txt>; rel=describedby, </sitemap-index.xml>; rel=sitemap, <https://www.ag-grid.com/javascript-data-grid/mcp-server/>; rel=related
```

## Cause

The header was scoped with `Header set Link … "expr=%{CONTENT_TYPE} =~ m#^text/html#"`. Using `Header set` (not `always`) was meant to keep it off error responses, but the custom `ErrorDocument 404 /404.html` is a **real `text/html` file served via an internal subrequest that succeeds (200)** — so the content-type check matched and the header leaked onto the final 404. This affected both staging and production (shared `agentLinkHeader`).

## Fix

Add a status guard to the expr:

```
"expr=%{REQUEST_STATUS} == 200 && %{CONTENT_TYPE} =~ m#^text/html#"
```

`%{REQUEST_STATUS}` reflects the *final* response status (404 for the error page), so the header now applies only to genuine 200 HTML documents.

## Verification

Reproduced and validated against a real local Apache 2.4 (with `mod_headers` + `ErrorDocument 404 /404.html`):

| Response | Before | After |
|---|---|---|
| 200 HTML document | Link present | **Link present** |
| 404 (custom error doc) | Link present (bug) | **Link absent** |
| static asset | Link absent | Link absent |

Tests updated (production + staging assertions) and snapshot regenerated; 100 htaccess tests pass. Format + lint clean.