### PR TITLE
AG-16216 advanced filter apply enabled with no rows

### DIFF
--- a/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterService.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/advancedFilterService.ts
@@ -10,7 +10,6 @@ import type {
     IAdvancedFilterService,
     IRowNode,
     NamedBean,
-    NewColumnsLoadedEvent,
     ValueService,
 } from 'ag-grid-community';
 import { BeanStub, _isClientSideRowModel, _isServerSideRowModel } from 'ag-grid-community';
@@ -68,15 +67,18 @@ export class AdvancedFilterService extends BeanStub implements NamedBean, IAdvan
         };
 
         this.addManagedPropertyListener('enableAdvancedFilter', (event) => this.setEnabled(!!event.currentValue));
+        this.addManagedPropertyListener('includeHiddenColumnsInAdvancedFilter', () => this.revalidateAndApply());
+        // Until data types are inferred, columns default to text, so a number/date expression built while
+        // waiting for row data parses as invalid - re-parse it once real types are known.
         this.addManagedEventListeners({
-            newColumnsLoaded: (event) => this.onNewColumnsLoaded(event),
+            dataTypesInferred: () => this.revalidateAndApply(),
         });
-        this.addManagedPropertyListener('includeHiddenColumnsInAdvancedFilter', () => {
-            const updatedValidity = this.updateValidity();
-            if (updatedValidity) {
-                this.filterManager?.onFilterChanged({ source: 'advancedFilter' });
-            }
-        });
+    }
+
+    private revalidateAndApply(): void {
+        if (this.updateValidity()) {
+            this.filterManager?.onFilterChanged({ source: 'advancedFilter' });
+        }
     }
 
     public isEnabled(): boolean {
@@ -217,19 +219,5 @@ export class AdvancedFilterService extends BeanStub implements NamedBean, IAdvan
         this.ctrl.refreshComp();
         this.ctrl.refreshBuilderComp();
         return updatedValidity;
-    }
-
-    private onNewColumnsLoaded(event: NewColumnsLoadedEvent): void {
-        if (event.source !== 'gridInitializing' || !this.dataTypeSvc?.isPendingInference) {
-            return;
-        }
-
-        this.ctrl.setInputDisabled(true);
-        const [destroyFunc] = this.addManagedEventListeners({
-            dataTypesInferred: () => {
-                destroyFunc?.();
-                this.ctrl.setInputDisabled(false);
-            },
-        });
     }
 }

--- a/testing/behavioural/src/filters/advanced-filter-header-dom.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-header-dom.test.ts
@@ -1,13 +1,26 @@
 import { waitFor } from '@testing-library/dom';
 
-import { ClientSideRowModelModule, PinnedRowModule } from 'ag-grid-community';
+import { ClientSideRowModelModule, NumberFilterModule, PinnedRowModule, TextFilterModule } from 'ag-grid-community';
 import { AdvancedFilterModule } from 'ag-grid-enterprise';
 
-import { GridColumns, GridRows, TestGridsManager } from '../test-utils';
+import {
+    AdvancedFilterHarness,
+    FilterDom,
+    GridColumns,
+    GridRows,
+    TestGridsManager,
+    asyncSetTimeout,
+} from '../test-utils';
 
 describe('Advanced Filter Header DOM', () => {
     const gridsManager = new TestGridsManager({
-        modules: [ClientSideRowModelModule, PinnedRowModule, AdvancedFilterModule],
+        modules: [
+            ClientSideRowModelModule,
+            PinnedRowModule,
+            TextFilterModule,
+            NumberFilterModule,
+            AdvancedFilterModule,
+        ],
     });
 
     const columnDefs = [{ field: 'athlete' }, { field: 'age' }];
@@ -119,5 +132,125 @@ describe('Advanced Filter Header DOM', () => {
 
         // Pinned top rows must start at or below the advanced filter row.
         expect(pinnedTopRowTop).toBeGreaterThanOrEqual(advancedFilterBottom - 1);
+    });
+
+    const filterableColumnDefs = [
+        { field: 'athlete', filter: true },
+        { field: 'age', filter: true },
+    ];
+
+    test('input stays enabled while the grid is still waiting for row data', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: filterableColumnDefs,
+            enableAdvancedFilter: true,
+        });
+        await asyncSetTimeout(0);
+
+        await new FilterDom(api, 'no row data yet').checkFilterDom(`
+            ADVANCED FILTER
+            input: ""
+            valid: true
+            buttons: Apply ⊘ | Builder
+            model: null
+        `);
+    });
+
+    test('input stays enabled after row data is set to an empty array', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: filterableColumnDefs,
+            enableAdvancedFilter: true,
+        });
+        await asyncSetTimeout(0);
+        api.setGridOption('rowData', []);
+        await asyncSetTimeout(0);
+
+        await new FilterDom(api, 'empty row data').checkFilterDom(`
+            ADVANCED FILTER
+            input: ""
+            valid: true
+            buttons: Apply ⊘ | Builder
+            model: null
+        `);
+    });
+
+    test('a filter set before data loads is applied once data arrives', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: filterableColumnDefs,
+            enableAdvancedFilter: true,
+        });
+        await asyncSetTimeout(0);
+        api.setGridOption('rowData', []);
+        await asyncSetTimeout(0);
+
+        await AdvancedFilterHarness.get(api).applyExpression('[Athlete] contains "Bolt"');
+        await asyncSetTimeout(0);
+
+        await new FilterDom(api, 'filter built with no data').checkFilterDom(`
+            ADVANCED FILTER
+            input: "[Athlete] contains "Bolt""
+            valid: true
+            buttons: Apply ⊘ | Builder
+            model:
+              filterType: "text"
+              colId: "athlete"
+              type: "contains"
+              filter: "Bolt"
+        `);
+
+        api.setGridOption('rowData', [
+            { athlete: 'Michael Phelps', age: 23 },
+            { athlete: 'Usain Bolt', age: 25 },
+        ]);
+        await asyncSetTimeout(0);
+
+        await new GridRows(api, 'filter applied once data arrives').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:1 athlete:"Usain Bolt" age:25
+        `);
+    });
+
+    test('a number filter built before data loads self-corrects and filters once data arrives', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: filterableColumnDefs,
+            enableAdvancedFilter: true,
+        });
+        await asyncSetTimeout(0);
+
+        // With no row data yet, Age's data type is not inferred (defaults to text), so a number
+        // expression cannot be validated and shows as invalid.
+        await AdvancedFilterHarness.get(api).applyExpression('[Age] > 20');
+        await asyncSetTimeout(0);
+
+        await new FilterDom(api, 'number filter before data').checkFilterDom(`
+            ADVANCED FILTER
+            input: "[Age] > 20"
+            valid: false — Expression has an error. Option not found - > 20.
+            buttons: Apply ⊘ | Builder
+            model: null
+        `);
+
+        api.setGridOption('rowData', [
+            { athlete: 'Michael Phelps', age: 23 },
+            { athlete: 'Usain Bolt', age: 15 },
+        ]);
+        await asyncSetTimeout(0);
+
+        // Once data arrives Age is inferred as a number, the expression re-parses and becomes valid.
+        await new FilterDom(api, 'number filter after data').checkFilterDom(`
+            ADVANCED FILTER
+            input: "[Age] > 20"
+            valid: true
+            buttons: Apply ⊘ | Builder
+            model:
+              filterType: "number"
+              colId: "age"
+              type: "greaterThan"
+              filter: 20
+        `);
+
+        await new GridRows(api, 'number filter applied once data arrives').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:0 athlete:"Michael Phelps" age:23
+        `);
     });
 });

--- a/testing/behavioural/src/test-utils/filters/filterDomSerialize.ts
+++ b/testing/behavioural/src/test-utils/filters/filterDomSerialize.ts
@@ -232,7 +232,11 @@ export function serializeAdvancedFilter(root: ParentNode): string {
     }
 
     const message = input.validationMessage;
-    const lines = ['ADVANCED FILTER', `input: "${input.value}"`, message ? `valid: false — ${message}` : 'valid: true'];
+    const lines = [
+        'ADVANCED FILTER',
+        `input: "${input.value}"${input.disabled ? ' ⊘' : ''}`,
+        message ? `valid: false — ${message}` : 'valid: true',
+    ];
 
     const buttons = Array.from(wrapper.querySelectorAll<HTMLButtonElement>('.ag-advanced-filter-buttons button'));
     const builderButton = wrapper.querySelector<HTMLButtonElement>('.ag-advanced-filter-builder-button');


### PR DESCRIPTION
# Advanced Filter: input no longer stuck disabled while waiting for data

FIX AG-16216

## Problem

The Advanced Filter disabled its input during column data-type inference and re-enabled it only on `dataTypesInferred`. That event fires only when the first **non-empty** row data arrives, so with no data (or an empty array) the input stayed disabled forever.

## Fix

- Stop disabling the input during inference — it stays enabled while the grid waits for data.
- On `dataTypesInferred`, re-validate and re-apply the current expression, so a filter built before data (parsed against the default `text` type) self-corrects once real column types are known.

## Behaviour

- Input stays enabled with no row data / empty row data.
- A filter built before data applies once data arrives.
- A number/date expression built before inference shows a transient "invalid" state (types unknown), then becomes valid and filters once data loads.

## Tests

Added behavioural tests in `advanced-filter-header-dom.test.ts` covering the enabled input, a text filter built before data, and a number filter self-correcting after data arrives.
