### PR TITLE
AG-17857 [Docs] Tooltips: real example.spec.ts tests

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/blank-values/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/blank-values/example.spec.ts
@@ -9,7 +9,11 @@ test.agExample(import.meta, () => {
 
         // Row 0 has a missing (undefined) athlete value.
         // Column A uses tooltipField, so no tooltip is shown for the missing value.
+        // tooltipShowDelay is 500ms — wait past it before concluding no tooltip appears,
+        // otherwise a zero-count check immediately after hover would pass even if a
+        // tooltip surfaced after the delay.
         await agIdFor.cell('0', 'athlete').hover();
+        await page.waitForTimeout(900);
         await expect(tooltip).toHaveCount(0);
 
         // Column B (duplicate field) uses a tooltipValueGetter returning '- Missing -'.

--- a/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/blank-values/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/blank-values/example.spec.ts
@@ -1,11 +1,20 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('tooltipValueGetter shows a tooltip for missing values', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const tooltip = page.locator('.ag-tooltip');
+
+        // Row 0 has a missing (undefined) athlete value.
+        // Column A uses tooltipField, so no tooltip is shown for the missing value.
+        await agIdFor.cell('0', 'athlete').hover();
+        await expect(tooltip).toHaveCount(0);
+
+        // Column B (duplicate field) uses a tooltipValueGetter returning '- Missing -'.
+        await agIdFor.cell('0', 'athlete_1').hover();
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('- Missing -');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/custom-tooltip-component/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/custom-tooltip-component/example.spec.ts
@@ -1,11 +1,22 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Custom tooltip component renders on hover', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // A previous tooltip lingers (fading out) after moving hover targets, so target the
+        // most recently opened one with .last().
+        const latestTooltip = page.locator('.custom-tooltip').last();
+
+        // The Age column uses the default custom tooltip component (default background).
+        await agIdFor.cell('0', 'age').hover();
+        await expect(latestTooltip).toBeVisible();
+        await expect(latestTooltip).toContainText('Custom Tooltip');
+
+        // The Athlete column passes tooltipComponentParams { color: '#55AA77' }.
+        await agIdFor.cell('0', 'athlete').hover();
+        await expect(latestTooltip).toBeVisible();
+        await expect(latestTooltip).toHaveCSS('background-color', 'rgb(85, 170, 119)');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/custom-tooltip-interaction/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/custom-tooltip-interaction/example.spec.ts
@@ -1,11 +1,27 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Interactive custom tooltip updates the cell on submit', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const athleteCell = agIdFor.cell('0', 'athlete');
+        const originalValue = (await athleteCell.innerText()).trim();
+
+        const tooltip = page.locator('.custom-tooltip:not(.ag-tooltip-hiding)');
+
+        // Hover the Athlete cell to open the interactive custom tooltip form.
+        await athleteCell.hover();
+        await expect(tooltip).toBeVisible();
+
+        const input = tooltip.locator('input');
+        await expect(input).toHaveValue(originalValue);
+
+        // Edit the value and submit; the form calls node.setDataValue and hideTooltipCallback.
+        await input.fill('Edited Athlete');
+        await tooltip.locator('button[type="submit"]').click();
+
+        // The submitted value is written back to the Athlete cell.
+        await expect(athleteCell).toContainText('Edited Athlete');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/default-tooltip/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/default-tooltip/example.spec.ts
@@ -10,8 +10,10 @@ test.agExample(import.meta, () => {
         await expect(agIdFor.headerCell('age')).toHaveAttribute('title', 'Tooltip for Age Column Header');
         await expect(agIdFor.cell('0', 'age')).toHaveAttribute('title', /This is the Athlete/);
 
-        // No rich HTML tooltip element should be rendered on hover.
+        // No rich HTML tooltip element should be rendered on hover. Wait well past the
+        // default show delay so a rich tooltip that appeared late would still be caught.
         await agIdFor.cell('0', 'age').hover();
+        await page.waitForTimeout(2200);
         await expect(page.locator('.ag-tooltip')).toHaveCount(0);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/default-tooltip/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/default-tooltip/example.spec.ts
@@ -1,11 +1,17 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Browser tooltips use native title attributes', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // enableBrowserTooltips renders the tooltip text as a native `title` attribute
+        // rather than the grid's rich .ag-tooltip element.
+        await expect(agIdFor.headerCell('age')).toHaveAttribute('title', 'Tooltip for Age Column Header');
+        await expect(agIdFor.cell('0', 'age')).toHaveAttribute('title', /This is the Athlete/);
+
+        // No rich HTML tooltip element should be rendered on hover.
+        await agIdFor.cell('0', 'age').hover();
+        await expect(page.locator('.ag-tooltip')).toHaveCount(0);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/rowgroups-fullwidth-tooltip/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/rowgroups-fullwidth-tooltip/example.spec.ts
@@ -1,11 +1,17 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Full-width group rows inherit the grouped column tooltip', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // With groupDisplayType='groupRows', the full-width group row shows a tooltip
+        // inherited from the country colDef ('Country: <value>').
+        const firstGroupRow = page.locator('.ag-row-group').first();
+        await firstGroupRow.hover();
+
+        const tooltip = page.locator('.ag-tooltip');
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('Country:');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/rowgroups-header-tooltip/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/rowgroups-header-tooltip/example.spec.ts
@@ -1,11 +1,17 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Group column headers inherit headerTooltip', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // With groupDisplayType='multipleColumns', the generated Country group column header
+        // inherits headerTooltip 'Group by Country' from the country colDef.
+        const countryGroupHeader = page.locator('.ag-header-cell[col-id*="country"]').first();
+        await countryGroupHeader.hover();
+
+        const tooltip = page.locator('.ag-tooltip');
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('Group by Country');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/rowgroups-tooltip/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/rowgroups-tooltip/example.spec.ts
@@ -1,11 +1,16 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Group cells inherit the tooltip from the grouped column', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // The first group row (Country) shows a tooltip inherited from the country colDef.
+        const firstGroupCell = page.locator('.ag-row .ag-cell[col-id="ag-Grid-AutoColumn"]').first();
+        await firstGroupCell.hover();
+
+        const tooltip = page.locator('.ag-tooltip');
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('Country:');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/show-hide-delay/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/show-hide-delay/example.spec.ts
@@ -1,11 +1,14 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Tooltip shows immediately with a zero show delay', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // tooltipShowDelay is 0, so the tooltip appears as soon as the cell is hovered.
+        await agIdFor.cell('0', 'age').hover();
+        const tooltip = page.locator('.ag-tooltip');
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('This is the Athlete');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/show-hide-delay/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/show-hide-delay/example.spec.ts
@@ -6,9 +6,11 @@ test.agExample(import.meta, () => {
         await waitForGridContent(page);
 
         // tooltipShowDelay is 0, so the tooltip appears as soon as the cell is hovered.
+        // Assert visibility within a short timeout that would fail if the delay regressed
+        // to the default (2000ms) — the default retry timeout would mask such a regression.
         await agIdFor.cell('0', 'age').hover();
         const tooltip = page.locator('.ag-tooltip');
-        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toBeVisible({ timeout: 400 });
         await expect(tooltip).toContainText('This is the Athlete');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/tooltip-interaction/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/tooltip-interaction/example.spec.ts
@@ -1,11 +1,19 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Interactive tooltip stays visible while hovered', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        const tooltip = page.locator('.ag-tooltip');
+
+        await agIdFor.cell('0', 'age').hover();
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('This is the Athlete');
+
+        // With tooltipInteraction enabled, moving the cursor onto the tooltip keeps it open.
+        await tooltip.hover();
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('This is the Athlete');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/tooltip-mouse-tracking/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/tooltip-mouse-tracking/example.spec.ts
@@ -1,11 +1,14 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Tooltip shows on hover with mouse tracking enabled', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // tooltipMouseTrack is true; the tooltip still shows the column's tooltip content.
+        await agIdFor.cell('0', 'age').hover();
+        const tooltip = page.locator('.ag-tooltip');
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('This is the Athlete');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/tooltip-mouse-tracking/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/tooltip-mouse-tracking/example.spec.ts
@@ -1,14 +1,31 @@
 import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Tooltip shows on hover with mouse tracking enabled', async ({ agIdFor, page }) => {
+    test.eachFramework('Tooltip follows the pointer with mouse tracking enabled', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
 
-        // tooltipMouseTrack is true; the tooltip still shows the column's tooltip content.
-        await agIdFor.cell('0', 'age').hover();
+        const cell = agIdFor.cell('0', 'age');
+        const box = await cell.boundingBox();
+        if (!box) {
+            throw new Error('age cell not found');
+        }
+        const y = box.y + box.height / 2;
+
+        // Hover near the left edge of the cell — the tooltip appears near the pointer.
+        await page.mouse.move(box.x + 12, y);
         const tooltip = page.locator('.ag-tooltip');
         await expect(tooltip).toBeVisible();
         await expect(tooltip).toContainText('This is the Athlete');
+        const firstBox = await tooltip.boundingBox();
+
+        // Move the pointer to the right within the same cell. With tooltipMouseTrack the
+        // tooltip tracks the pointer, so its x position must increase. A grid that ignored
+        // tooltipMouseTrack would leave the tooltip anchored and fail this assertion.
+        await page.mouse.move(box.x + box.width - 12, y);
+        await page.waitForTimeout(200);
+        const secondBox = await tooltip.boundingBox();
+        expect(firstBox && secondBox).toBeTruthy();
+        expect(secondBox!.x).toBeGreaterThan(firstBox!.x);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/tooltip-show-mode/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/tooltip-show-mode/example.spec.ts
@@ -1,15 +1,42 @@
 import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Truncated header shows its tooltip', async ({ agIdFor, page }) => {
+    test.eachFramework('whenTruncated shows tooltips only for truncated content', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
 
-        // The Country column is only 100px wide, so its "Country of Athlete" header
-        // is truncated and a tooltip is shown even with tooltipShowMode='whenTruncated'.
-        await agIdFor.headerCell('country').hover();
         const tooltip = page.locator('.ag-tooltip');
+
+        // Positive: the Country column is only 100px wide, so its "Country of Athlete"
+        // header is truncated and a tooltip is shown under tooltipShowMode='whenTruncated'.
+        await agIdFor.headerCell('country').hover();
         await expect(tooltip).toBeVisible();
         await expect(tooltip).toContainText('Country of Athlete');
+
+        // Move away and let the tooltip hide before the negative case.
+        await page.mouse.move(0, 0);
+        await expect(tooltip).toHaveCount(0);
+
+        // Negative: whenTruncated must NOT show a tooltip when the content fits. Find a
+        // country cell whose text is not truncated (scrollWidth <= clientWidth) and assert
+        // no tooltip appears — an always-on grid would show one here and fail the test.
+        const countryCells = page.locator('.ag-cell[col-id="country"]');
+        const count = await countryCells.count();
+        let untruncatedIndex = -1;
+        for (let i = 0; i < count; i++) {
+            const isTruncated = await countryCells.nth(i).evaluate((el) => {
+                const value = (el.querySelector('.ag-cell-value') as HTMLElement) ?? (el as HTMLElement);
+                return value.scrollWidth > value.clientWidth + 1;
+            });
+            if (!isTruncated) {
+                untruncatedIndex = i;
+                break;
+            }
+        }
+        expect(untruncatedIndex).toBeGreaterThanOrEqual(0);
+
+        await countryCells.nth(untruncatedIndex).hover();
+        await page.waitForTimeout(900); // past tooltipShowDelay (500ms)
+        await expect(tooltip).toHaveCount(0);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/tooltip-show-mode/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/tooltip-show-mode/example.spec.ts
@@ -1,11 +1,15 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Truncated header shows its tooltip', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // The Country column is only 100px wide, so its "Country of Athlete" header
+        // is truncated and a tooltip is shown even with tooltipShowMode='whenTruncated'.
+        await agIdFor.headerCell('country').hover();
+        const tooltip = page.locator('.ag-tooltip');
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('Country of Athlete');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/tooltips/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/tooltips/_examples/tooltips/example.spec.ts
@@ -1,11 +1,25 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('Cell and header tooltips show on hover', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Exclude the previous, fading-out tooltip when moving between hover targets.
+        const tooltip = page.locator('.ag-tooltip:not(.ag-tooltip-hiding)');
+
+        // Age column uses a fixed-message tooltipValueGetter.
+        await agIdFor.cell('0', 'age').hover();
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('This is the Athlete');
+
+        // Year column uses a dynamic tooltip based on the cell value.
+        const yearValue = (await agIdFor.cell('0', 'year').innerText()).trim();
+        await agIdFor.cell('0', 'year').hover();
+        await expect(tooltip).toContainText(`dynamic tooltip using the value of ${yearValue}`);
+
+        // Header tooltip.
+        await agIdFor.headerCell('athlete').hover();
+        await expect(tooltip).toContainText('Tooltip for Athlete Column Header');
     });
 });


### PR DESCRIPTION
Backfills real, assertion-bearing Playwright `example.spec.ts` tests for all 12 examples on the **Tooltips** docs page, replacing mount-only placeholders. Part of the AG-17857 docs example-spec coverage effort. All frameworks green locally (chromium).