### PR TITLE
AG-17857 [Docs] Provided Overlays: real example.spec.ts tests

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/overlays-provided/_examples/custom-component-map/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/overlays-provided/_examples/custom-component-map/example.spec.ts
@@ -1,10 +1,21 @@
-import { clickAllButtons, ensureGridReady, test } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Custom no-rows overlay component renders custom markup', async ({ agIdFor, page }) => {
+        // custom no-rows overlay registered via noRowsOverlayComponent renders its own markup
+        const customOverlay = page.locator('.overlay-loading-center');
+
+        // rowData starts empty -> custom overlay shown with the dynamic message
+        await expect(customOverlay).toBeVisible();
+        await expect(customOverlay).toContainText('No rows found at:');
+
+        // setting row data hides the overlay and renders the row
+        await page.getByRole('button', { name: 'Set rowData' }).click();
+        await expect(agIdFor.cell('0', 'athlete')).toContainText('Michael Phelps');
+        await expect(customOverlay).toBeHidden();
+
+        // clearing row data shows the custom overlay again
+        await page.getByRole('button', { name: 'Clear rowData' }).click();
+        await expect(customOverlay).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/overlays-provided/_examples/custom-overlay-component/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/overlays-provided/_examples/custom-overlay-component/example.spec.ts
@@ -1,10 +1,17 @@
-import { clickAllButtons, ensureGridReady, test } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Single overlay component renders per overlay type', async ({ page }) => {
+        // one custom overlayComponent covers all overlay types, switching text by overlayType
+        const customOverlay = page.locator('.overlay-center');
+
+        // loading starts true -> loading message
+        await expect(customOverlay).toBeVisible();
+        await expect(customOverlay).toContainText('Custom loading message');
+
+        // turning loading off with empty rowData -> no-rows message from the same component
+        await page.getByRole('checkbox').uncheck();
+        await expect(customOverlay).toBeVisible();
+        await expect(customOverlay).toContainText('Custom no rows message');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/overlays-provided/_examples/custom-overlay-selector/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/overlays-provided/_examples/custom-overlay-selector/example.spec.ts
@@ -1,10 +1,16 @@
-import { clickAllButtons, ensureGridReady, test } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Selector overrides loading overlay only', async ({ page }) => {
+        // selector returns a custom component for the loading overlay
+        const customLoadingOverlay = page.locator('.overlay-loading-center');
+        await expect(customLoadingOverlay).toBeVisible();
+        await expect(customLoadingOverlay).toContainText('Please wait while data is loading...');
+
+        // no-rows falls back to the provided overlay (selector returns undefined)
+        await page.getByRole('checkbox').uncheck();
+        const noRowsOverlay = page.locator('.ag-overlay-no-rows-center');
+        await expect(noRowsOverlay).toBeVisible();
+        await expect(noRowsOverlay).toContainText('No Rows To Show');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/overlays-provided/_examples/loading-overlay/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/overlays-provided/_examples/loading-overlay/example.spec.ts
@@ -1,10 +1,21 @@
-import { clickAllButtons, ensureGridReady, test } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Loading overlay toggles with the loading option', async ({ agIdFor, page }) => {
+        const loadingOverlay = page.locator('.ag-overlay-loading-center');
+
+        // loading starts true, so the loading overlay is shown
+        await expect(loadingOverlay).toBeVisible();
+        await expect(loadingOverlay).toContainText('Loading...');
+
+        // provide data and turn loading off -> overlay hidden and row rendered
+        await page.getByRole('button', { name: 'Set rowData' }).click();
+        await page.getByRole('checkbox').uncheck();
+        await expect(loadingOverlay).toBeHidden();
+        await expect(agIdFor.cell('0', 'athlete')).toContainText('Michael Phelps');
+
+        // turning loading back on shows the overlay again
+        await page.getByRole('checkbox').check();
+        await expect(loadingOverlay).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/overlays-provided/_examples/no-rows-overlay/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/overlays-provided/_examples/no-rows-overlay/example.spec.ts
@@ -1,10 +1,20 @@
-import { clickAllButtons, ensureGridReady, test } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('No rows overlay toggles with row data', async ({ agIdFor, page }) => {
+        const noRowsOverlay = page.locator('.ag-overlay-no-rows-center');
+
+        // rowData starts empty, so the no-rows overlay is shown
+        await expect(noRowsOverlay).toBeVisible();
+        await expect(noRowsOverlay).toContainText('No Rows To Show');
+
+        // setting row data hides the overlay and renders the row
+        await page.getByRole('button', { name: 'Set rowData' }).click();
+        await expect(agIdFor.cell('0', 'athlete')).toContainText('Michael Phelps');
+        await expect(noRowsOverlay).toBeHidden();
+
+        // clearing row data shows the overlay again
+        await page.getByRole('button', { name: 'Clear rowData' }).click();
+        await expect(noRowsOverlay).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/overlays-provided/_examples/provided-overlays-text/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/overlays-provided/_examples/provided-overlays-text/example.spec.ts
@@ -1,10 +1,24 @@
-import { clickAllButtons, ensureGridReady, test } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Provided overlays show customised text per state', async ({ page }) => {
+        // loading starts true -> customised loading text
+        const loadingOverlay = page.locator('.ag-overlay-loading-center');
+        await expect(loadingOverlay).toBeVisible();
+        await expect(loadingOverlay).toContainText('Please wait while your data is loading...');
+
+        // turn loading off, then apply a non-matching filter -> customised no-matching-rows text
+        await page.getByRole('checkbox').uncheck();
+        await page.getByRole('button', { name: 'Set Non Matching Filter' }).click();
+        const noMatchingOverlay = page.locator('.ag-overlay-no-matching-rows-center');
+        await expect(noMatchingOverlay).toBeVisible();
+        await expect(noMatchingOverlay).toContainText('Current Filter Matches No Rows');
+
+        // clear the filter and the row data -> customised no-rows text
+        await page.getByRole('button', { name: 'Clear Filter' }).click();
+        await page.getByRole('button', { name: 'Clear Row Data' }).click();
+        const noRowsOverlay = page.locator('.ag-overlay-no-rows-center');
+        await expect(noRowsOverlay).toBeVisible();
+        await expect(noRowsOverlay).toContainText('This grid has no data!');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/overlays-provided/_examples/provided-overlays/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/overlays-provided/_examples/provided-overlays/example.spec.ts
@@ -1,10 +1,24 @@
-import { clickAllButtons, ensureGridReady, test } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Provided overlays follow grid state', async ({ page }) => {
+        // loading starts true -> loading overlay
+        const loadingOverlay = page.locator('.ag-overlay-loading-center');
+        await expect(loadingOverlay).toBeVisible();
+        await expect(loadingOverlay).toContainText('Loading...');
+
+        // turn loading off then apply a non-matching filter -> no-matching-rows overlay
+        await page.getByRole('checkbox').uncheck();
+        await page.getByRole('button', { name: 'Set Non Matching Filter' }).click();
+        const noMatchingOverlay = page.locator('.ag-overlay-no-matching-rows-center');
+        await expect(noMatchingOverlay).toBeVisible();
+        await expect(noMatchingOverlay).toContainText('No Matching Rows');
+
+        // clear the filter and row data -> no-rows overlay
+        await page.getByRole('button', { name: 'Clear Filter' }).click();
+        await page.getByRole('button', { name: 'Clear Row Data' }).click();
+        const noRowsOverlay = page.locator('.ag-overlay-no-rows-center');
+        await expect(noRowsOverlay).toBeVisible();
+        await expect(noRowsOverlay).toContainText('No Rows To Show');
     });
 });


### PR DESCRIPTION
Backfills real, assertion-bearing Playwright `example.spec.ts` tests for all 7 examples on the **Provided Overlays** docs page, replacing mount-only placeholders. Part of the AG-17857 docs example-spec coverage effort. All frameworks green locally (chromium).