### PR TITLE
AG-17857 [Docs] Overlays (legacy): real example.spec.ts tests

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/overlays/_examples/custom-overlay-loading/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/overlays/_examples/custom-overlay-loading/example.spec.ts
@@ -1,10 +1,21 @@
-import { clickAllButtons, ensureGridReady, test } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Custom loading overlay renders custom markup', async ({ agIdFor, page }) => {
+        // custom loading overlay set via the legacy loadingOverlayComponent renders its own markup
+        const customOverlay = page.locator('.overlay-loading-center');
+
+        // loading starts true -> custom overlay shown with the custom message
+        await expect(customOverlay).toBeVisible();
+        await expect(customOverlay).toContainText('One moment please...');
+
+        // turning loading off reveals the row data
+        await page.getByRole('checkbox').uncheck();
+        await expect(customOverlay).toBeHidden();
+        await expect(agIdFor.cell('0', 'athlete')).toContainText('Michael Phelps');
+
+        // turning loading back on shows the custom overlay again
+        await page.getByRole('checkbox').check();
+        await expect(customOverlay).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/overlays/_examples/custom-overlay-no-rows/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/overlays/_examples/custom-overlay-no-rows/example.spec.ts
@@ -1,10 +1,21 @@
-import { clickAllButtons, ensureGridReady, test } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Custom no-rows overlay renders custom markup', async ({ agIdFor, page }) => {
+        // custom no-rows overlay set via the legacy noRowsOverlayComponent renders its own markup
+        const customOverlay = page.locator('.overlay-loading-center');
+
+        // rowData starts empty -> custom overlay shown with the dynamic message
+        await expect(customOverlay).toBeVisible();
+        await expect(customOverlay).toContainText('No rows found at:');
+
+        // setting row data hides the overlay and renders the row
+        await page.getByRole('button', { name: 'Set rowData' }).click();
+        await expect(agIdFor.cell('0', 'athlete')).toContainText('Michael Phelps');
+        await expect(customOverlay).toBeHidden();
+
+        // clearing row data shows the custom overlay again
+        await page.getByRole('button', { name: 'Clear rowData' }).click();
+        await expect(customOverlay).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/overlays/_examples/loading-overlay/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/overlays/_examples/loading-overlay/example.spec.ts
@@ -1,10 +1,21 @@
-import { clickAllButtons, ensureGridReady, test } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Loading overlay toggles with the loading option', async ({ agIdFor, page }) => {
+        const loadingOverlay = page.locator('.ag-overlay-loading-center');
+
+        // loading starts true, so the loading overlay is shown
+        await expect(loadingOverlay).toBeVisible();
+        await expect(loadingOverlay).toContainText('Loading...');
+
+        // provide data and turn loading off -> overlay hidden and row rendered
+        await page.getByRole('button', { name: 'Set rowData' }).click();
+        await page.getByRole('checkbox').uncheck();
+        await expect(loadingOverlay).toBeHidden();
+        await expect(agIdFor.cell('0', 'athlete')).toContainText('Michael Phelps');
+
+        // turning loading back on shows the overlay again
+        await page.getByRole('checkbox').check();
+        await expect(loadingOverlay).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/overlays/_examples/no-rows-overlay/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/overlays/_examples/no-rows-overlay/example.spec.ts
@@ -1,10 +1,20 @@
-import { clickAllButtons, ensureGridReady, test } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('No rows overlay toggles with row data', async ({ agIdFor, page }) => {
+        const noRowsOverlay = page.locator('.ag-overlay-no-rows-center');
+
+        // rowData starts empty, so the no-rows overlay is shown
+        await expect(noRowsOverlay).toBeVisible();
+        await expect(noRowsOverlay).toContainText('No Rows To Show');
+
+        // setting row data hides the overlay and renders the row
+        await page.getByRole('button', { name: 'Set rowData' }).click();
+        await expect(agIdFor.cell('0', 'athlete')).toContainText('Michael Phelps');
+        await expect(noRowsOverlay).toBeHidden();
+
+        // clearing row data shows the overlay again
+        await page.getByRole('button', { name: 'Clear rowData' }).click();
+        await expect(noRowsOverlay).toBeVisible();
     });
 });


### PR DESCRIPTION
Backfills real, assertion-bearing Playwright `example.spec.ts` tests for all 4 examples on the **Overlays (legacy)** docs page, replacing mount-only placeholders. Part of the AG-17857 docs example-spec coverage effort. All frameworks green locally (chromium).