### PR TITLE
AG-17857 [Docs] Active Overlay: real example.spec.ts tests

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/overlays-active/_examples/active-overlay-component/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/overlays-active/_examples/active-overlay-component/example.spec.ts
@@ -1,8 +1,25 @@
-import { clickAllButtons, ensureGridReady, test } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        await ensureGridReady(page);
-        await clickAllButtons(page);
+    test.eachFramework('Custom active overlay reflects its params', async ({ agIdFor, page }) => {
+        const customOverlay = page.locator('.my-custom-overlay');
+
+        // activeOverlay is set from the start with count 1
+        await expect(customOverlay).toBeVisible();
+        await expect(customOverlay).toContainText('Custom Overlay: 1');
+
+        // incrementing the param refreshes the overlay content
+        await page.getByRole('button', { name: 'Increment Param' }).click();
+        await expect(customOverlay).toContainText('Custom Overlay: 2');
+
+        // hiding clears the overlay and reveals the rows
+        await page.getByRole('button', { name: 'Hide custom overlay' }).click();
+        await expect(customOverlay).toBeHidden();
+        await expect(agIdFor.cell('0', 'athlete')).toContainText('Michael Phelps');
+
+        // showing it again brings back the overlay with the current param
+        await page.getByRole('button', { name: 'Show custom overlay' }).click();
+        await expect(customOverlay).toBeVisible();
+        await expect(customOverlay).toContainText('Custom Overlay: 2');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/overlays-active/_examples/active-overlay-switcher/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/overlays-active/_examples/active-overlay-switcher/example.spec.ts
@@ -1,8 +1,29 @@
-import { clickAllButtons, ensureGridReady, test } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        await ensureGridReady(page);
-        await clickAllButtons(page);
+    test.eachFramework('Active overlay can be switched on demand', async ({ agIdFor, page }) => {
+        const noRowsOverlay = page.locator('.ag-overlay-no-rows-center');
+        const statusOverlay = page.locator('.status-overlay');
+
+        // grid has rows and no active overlay initially
+        await expect(agIdFor.cell('0', 'athlete')).toContainText('Michael Phelps');
+        await expect(noRowsOverlay).toBeHidden();
+        await expect(statusOverlay).toBeHidden();
+
+        // provided no-rows overlay can be shown even though the grid has rows
+        await page.getByRole('button', { name: 'activeOverlay = agNoRowsOverlay' }).click();
+        await expect(noRowsOverlay).toBeVisible();
+
+        // switch to the custom status overlay registered in the components map
+        // (its rendered text differs per framework, so just assert it takes over)
+        await page.getByRole('button', { name: 'activeOverlay = CustomOverlay' }).click();
+        await expect(statusOverlay).toBeVisible();
+        await expect(statusOverlay).toContainText(/ustom/);
+        await expect(noRowsOverlay).toBeHidden();
+
+        // hide the active overlay
+        await page.getByRole('button', { name: 'Hide activeOverlay' }).click();
+        await expect(statusOverlay).toBeHidden();
+        await expect(agIdFor.cell('0', 'athlete')).toContainText('Michael Phelps');
     });
 });


### PR DESCRIPTION
Backfills real, assertion-bearing Playwright `example.spec.ts` tests for all 2 examples on the **Active Overlay** docs page, replacing mount-only placeholders. Part of the AG-17857 docs example-spec coverage effort. All frameworks green locally (chromium).