### PR TITLE
AG-17857 [Docs] Overlays Overview: real example.spec.ts tests

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/overlays-overview/_examples/loading-overlay/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/overlays-overview/_examples/loading-overlay/example.spec.ts
@@ -1,10 +1,10 @@
-import { clickAllButtons, ensureGridReady, test } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Loading overlay shown when loading is true', async ({ page }) => {
+        // grid is created with loading: true and no controls -> loading overlay is shown
+        const loadingOverlay = page.locator('.ag-overlay-loading-center');
+        await expect(loadingOverlay).toBeVisible();
+        await expect(loadingOverlay).toContainText('Loading...');
     });
 });


### PR DESCRIPTION
Backfills real, assertion-bearing Playwright `example.spec.ts` tests for all 1 examples on the **Overlays Overview** docs page, replacing mount-only placeholders. Part of the AG-17857 docs example-spec coverage effort. All frameworks green locally (chromium).