### PR TITLE
AG-17857 [Docs] Row Spanning: real example.spec.ts tests

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/row-spanning/_examples/row-spanning-auto-height/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-spanning/_examples/row-spanning-auto-height/example.spec.ts
@@ -1,11 +1,30 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('spanned lorem column uses auto height for wrapped text', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // The lorem column spans equal contiguous values (every non-third row shares the
+        // same long lorem string) and is configured with wrapText + autoHeight.
+        const loremSpans = page.locator('.ag-spanned-cell[col-id="lorem"]');
+        await expect(loremSpans.first()).toBeVisible();
+
+        const firstLorem = loremSpans.first();
+        await expect(firstLorem).toContainText('Lorem ipsum');
+        // Adjacent equal lorem values are merged, so the span covers at least 2 rows.
+        expect(Number(await firstLorem.getAttribute('aria-rowspan'))).toBeGreaterThanOrEqual(2);
+
+        // Auto height: the wrapped text makes the spanned cell much taller than a normal
+        // single-row cell in a non-spanning column (athlete).
+        const normalCell = page.locator('.ag-cell[col-id="athlete"]').first();
+        const normalBox = await normalCell.boundingBox();
+        const loremBox = await firstLorem.boundingBox();
+        expect(normalBox).not.toBeNull();
+        expect(loremBox).not.toBeNull();
+        expect(loremBox!.height).toBeGreaterThan(normalBox!.height * 2);
+
+        // A non-spanning column (athlete) never produces spanned cells.
+        await expect(page.locator('.ag-spanned-cell[col-id="athlete"]')).toHaveCount(0);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/row-spanning/_examples/row-spanning-custom/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-spanning/_examples/row-spanning-custom/example.spec.ts
@@ -1,11 +1,32 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('custom spanRows callback excludes Algeria from spanning', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Data is sorted country asc. Afghanistan (2 rows) then Algeria (8 rows) sit at the top.
+        const countrySpans = page.locator('.ag-spanned-cell[col-id="country"]');
+        await expect(countrySpans.first()).toBeVisible();
+
+        // Countries other than Algeria still span normally: Afghanistan spans its 2 rows.
+        const afghanistan = countrySpans.filter({ hasText: 'Afghanistan' });
+        await expect(afghanistan).toHaveCount(1);
+        await expect(afghanistan).toHaveAttribute('aria-rowspan', '2');
+
+        // The custom callback returns false for Algeria, so it is NEVER merged into a spanned cell.
+        await expect(countrySpans.filter({ hasText: 'Algeria' })).toHaveCount(0);
+
+        // Instead, each Algeria leaf row renders its own normal country cell.
+        const normalAlgeria = page
+            .locator('.ag-cell[col-id="country"]:not(.ag-spanned-cell)')
+            .filter({ hasText: 'Algeria' });
+        await expect(normalAlgeria.first()).toBeVisible();
+        // Several Algeria rows are within the initial viewport (8 rows total).
+        expect(await normalAlgeria.count()).toBeGreaterThan(1);
+
+        // year and sport columns are unaffected and continue to span.
+        await expect(page.locator('.ag-spanned-cell[col-id="year"]').first()).toBeVisible();
+        await expect(page.locator('.ag-spanned-cell[col-id="sport"]').first()).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/row-spanning/_examples/row-spanning-simple/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-spanning/_examples/row-spanning-simple/example.spec.ts
@@ -1,11 +1,46 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('spanRows merges equal contiguous values into a single spanned cell', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+
+        // Data is sorted country/year/sport asc. Alphabetically the top group is
+        // Afghanistan (2 rows) followed by Algeria (8 rows).
+        const countrySpans = page.locator('.ag-spanned-cell[col-id="country"]');
+        await expect(countrySpans.first()).toBeVisible();
+
+        // Afghanistan appears twice contiguously -> a single cell spanning 2 rows.
+        const afghanistan = countrySpans.filter({ hasText: 'Afghanistan' });
+        await expect(afghanistan).toHaveCount(1);
+        await expect(afghanistan).toHaveAttribute('aria-rowspan', '2');
+
+        // Algeria appears 8 times contiguously -> a single cell spanning 8 rows.
+        const algeria = countrySpans.filter({ hasText: 'Algeria' });
+        await expect(algeria).toHaveCount(1);
+        await expect(algeria).toHaveAttribute('aria-rowspan', '8');
+
+        // The spanned cell physically covers multiple row heights: it is far taller
+        // than a normal single-row cell in a non-spanning column (athlete).
+        const normalCell = page.locator('.ag-cell[col-id="athlete"]').first();
+        const normalBox = await normalCell.boundingBox();
+        const algeriaBox = await algeria.boundingBox();
+        expect(normalBox).not.toBeNull();
+        expect(algeriaBox).not.toBeNull();
+        // 8 spanned rows -> at least ~6x a single row height (allow slack).
+        expect(algeriaBox!.height).toBeGreaterThan(normalBox!.height * 6);
+
+        // Covered leaf rows must NOT render a duplicate normal country cell.
+        const normalAlgeria = page
+            .locator('.ag-cell[col-id="country"]:not(.ag-spanned-cell)')
+            .filter({ hasText: 'Algeria' });
+        await expect(normalAlgeria).toHaveCount(0);
+
+        // A non-spanning column (athlete) never produces spanned cells.
+        await expect(page.locator('.ag-spanned-cell[col-id="athlete"]')).toHaveCount(0);
+
+        // year and sport are also configured to span.
+        await expect(page.locator('.ag-spanned-cell[col-id="year"]').first()).toBeVisible();
+        await expect(page.locator('.ag-spanned-cell[col-id="sport"]').first()).toBeVisible();
     });
 });


### PR DESCRIPTION
Backfills real, assertion-bearing Playwright `example.spec.ts` tests for all 3 examples on the **Row Spanning** docs page, replacing mount-only placeholders. Part of the AG-17857 docs example-spec coverage effort. All frameworks green locally (chromium).