### PR TITLE
AG-17857 [Docs] Formula Editor Component: real example.spec.ts tests

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/formula-editor-component/_examples/formula-editor-component-disabled/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/formula-editor-component/_examples/formula-editor-component-disabled/example.spec.ts
@@ -1,10 +1,23 @@
-import { ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test } from '@utils/grid/test-utils';
 
+// The `total` column enables `allowFormula` but provides `cellEditor: 'agTextCellEditor'`, which opts
+// the column out of the Formula Cell Editor. Formulas still evaluate, but a plain text editor is used.
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'formulas evaluate but a plain text editor replaces the formula editor',
+        async ({ page, agIdFor }) => {
+            await ensureGridReady(page);
+
+            // Formulas still evaluate even though the formula editor is disabled.
+            await expect(agIdFor.cell('1', 'total')).toContainText('$ 4.80'); // 1.2 * 4
+            await expect(agIdFor.cell('3', 'total')).toContainText('$ 2.40'); // 0.8 * 3
+
+            const cell = agIdFor.cell('1', 'total');
+            await cell.dblclick();
+
+            // A standard text input is shown, and the Formula Cell Editor is NOT used.
+            await expect(page.locator('.ag-cell-inline-editing input.ag-input-field-input')).toBeVisible();
+            await expect(page.locator('.ag-cell-inline-editing .ag-formula-input-field')).toHaveCount(0);
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/formula-editor-component/_examples/formula-editor-component-validation/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/formula-editor-component/_examples/formula-editor-component-validation/example.spec.ts
@@ -1,10 +1,35 @@
-import { ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test } from '@utils/grid/test-utils';
 
+// The `total` column sets `cellEditorParams: { validateFormulas: true }`. Rows 2 (`=B2*`) and 5
+// (`=BADFUNC(1)`) hold invalid formulas that surface as error values (rendered starting with `#`);
+// valid rows compute normally. Editing an invalid formula surfaces the validation state on the cell.
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'invalid formulas surface as errors and validation surfaces while editing',
+        async ({ page, agIdFor }) => {
+            await ensureGridReady(page);
+
+            // Valid rows compute price * qty.
+            await expect(agIdFor.cell('1', 'total')).toContainText('$ 4.80'); // 1.2 * 4
+            await expect(agIdFor.cell('3', 'total')).toContainText('$ 2.40'); // 0.8 * 3
+
+            // Invalid formulas surface as error values (passed through by the value formatter, so they
+            // are rendered starting with '#').
+            await expect(agIdFor.cell('2', 'total')).toContainText('#'); // =B2*
+            await expect(agIdFor.cell('5', 'total')).toContainText('#'); // =BADFUNC(1)
+
+            // Editing an invalid formula surfaces the validation state on the editing cell.
+            const cell = agIdFor.cell('1', 'total');
+            await cell.dblclick();
+
+            const editable = page.locator('.ag-cell-inline-editing [contenteditable]').first();
+            await editable.click();
+            await page.keyboard.press('Control+a');
+            await page.keyboard.type('=1+');
+
+            await expect(cell).toHaveClass(/ag-cell-editing-error/);
+
+            await page.keyboard.press('Escape');
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/formula-editor-component/_examples/formula-editor-component/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/formula-editor-component/_examples/formula-editor-component/example.spec.ts
@@ -1,10 +1,30 @@
-import { ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test } from '@utils/grid/test-utils';
 
+// The `total` column enables `allowFormula` without a custom `cellEditor`, so the grid uses the
+// default Formula Cell Editor. Formulas multiply the row's price by its qty via REF/COLUMN/ROW.
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
+    test.eachFramework('formulas evaluate and the formula editor commits a new formula', async ({ page, agIdFor }) => {
         await ensureGridReady(page);
-        await waitForGridContent(page);
-        // END PLACEHOLDER
+
+        // Initial formulas evaluate: price * qty, formatted as currency.
+        await expect(agIdFor.cell('1', 'total')).toContainText('$ 4.80'); // 1.2 * 4
+        await expect(agIdFor.cell('2', 'total')).toContainText('$ 3.00'); // 0.5 * 6
+        await expect(agIdFor.cell('3', 'total')).toContainText('$ 2.40'); // 0.8 * 3
+
+        const cell = agIdFor.cell('1', 'total');
+        await cell.dblclick();
+
+        // The default editor for a formula column is the Formula Cell Editor (a contenteditable field),
+        // not a plain input.
+        const formulaEditor = page.locator('.ag-cell-inline-editing .ag-formula-input-field');
+        await expect(formulaEditor).toBeVisible();
+
+        const editable = page.locator('.ag-cell-inline-editing [contenteditable]').first();
+        await editable.click();
+        await page.keyboard.press('Control+a');
+        await page.keyboard.type('=3+4');
+        await page.keyboard.press('Enter');
+
+        await expect(cell).toContainText('$ 7.00');
     });
 });


### PR DESCRIPTION
Backfills real, assertion-bearing Playwright `example.spec.ts` tests for all 3 examples on the **Formula Editor Component** docs page, replacing mount-only placeholders. Part of the AG-17857 docs example-spec coverage effort. All frameworks green locally (chromium).