### PR TITLE
AG-17857 [Docs] Key Features: real example.spec.ts tests

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/key-features/_examples/cell-row-style/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/key-features/_examples/cell-row-style/example.spec.ts
@@ -1,11 +1,21 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
+    test.eachFramework(
+        'Applies cellClassRules to electric cells and rowClassRules to Ford rows',
+        async ({ agIdFor, page }) => {
+            // cellClassRules: electric === true (Tesla, row 0) gets the rag-green class
+            await expect(agIdFor.cell('0', 'electric').locator('input[type="checkbox"]')).toBeChecked();
+            await expect(agIdFor.cell('0', 'electric')).toHaveClass(/rag-green/);
+            // electric === false (Ford, row 1) does not get rag-green
+            await expect(agIdFor.cell('1', 'electric').locator('input[type="checkbox"]')).not.toBeChecked();
+            await expect(agIdFor.cell('1', 'electric')).not.toHaveClass(/rag-green/);
+
+            // rowClassRules: Ford rows get the rag-red class (row index 1 is Ford F-Series)
+            await expect(agIdFor.cell('1', 'make')).toContainText('Ford');
+            await expect(agIdFor.rowNode('1')).toHaveClass(/rag-red/);
+            // Non-Ford row (Tesla, index 0) is not red
+            await expect(agIdFor.rowNode('0')).not.toHaveClass(/rag-red/);
+        }
+    );
 });

--- a/documentation/ag-grid-docs/src/content/docs/key-features/_examples/custom-quartz-theme/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/key-features/_examples/custom-quartz-theme/example.spec.ts
@@ -1,11 +1,18 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Loads Olympic data and applies the customised Quartz theme', async ({ agIdFor, page }) => {
+        // data is fetched asynchronously — wait for the first athlete cell to populate
+        await expect(agIdFor.cell('0', 'athlete')).not.toBeEmpty();
+        await expect(agIdFor.headerCell('athlete')).toBeVisible();
+        await expect(agIdFor.headerCell('gold')).toBeVisible();
+
+        // the customised theme sets a light-blue background via the Theming API,
+        // exposed as the --ag-background-color custom property on the grid wrapper
+        const backgroundColor = await page
+            .locator('.ag-root-wrapper')
+            .first()
+            .evaluate((el) => getComputedStyle(el).getPropertyValue('--ag-background-color').trim());
+        expect(backgroundColor).toBe('rgb(241, 247, 255)');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/key-features/_examples/enterprise-features-example/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/key-features/_examples/enterprise-features-example/example.spec.ts
@@ -1,11 +1,18 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Shows row grouping, a side bar and an integrated chart', async ({ agIdFor, page }) => {
+        // rowGroup on make produces group rows in the auto (single) group column
+        const groupRows = page.locator('.ag-row-group');
+        await expect(groupRows.first()).toBeVisible();
+        // group cells are expandable
+        await expect(page.locator('.ag-row-group .ag-cell-expandable').first()).toBeVisible();
+
+        // side bar (columns + filters tool panels) is present
+        await expect(page.locator('.ag-side-bar')).toBeVisible();
+        await expect(page.getByRole('tab', { name: 'Columns' })).toBeVisible();
+
+        // integrated chart created onFirstDataRendered renders a chart canvas
+        await expect(page.locator('.ag-charts-canvas canvas').first()).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/key-features/_examples/showing-data-example/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/key-features/_examples/showing-data-example/example.spec.ts
@@ -1,11 +1,19 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Renders car data with formatted price and custom button', async ({ agIdFor, page }) => {
+        // valueGetter combines make + model
+        await expect(page.locator('.ag-cell').filter({ hasText: 'Tesla Model Y' }).first()).toBeVisible();
+
+        // price column is formatted with a £ prefix and thousands separator
+        await expect(agIdFor.cell('0', 'price')).toContainText('£64,950');
+        await expect(agIdFor.cell('1', 'price')).toContainText('£33,850');
+
+        // electric boolean value rendered as a checkbox reflecting the value
+        await expect(agIdFor.cell('0', 'electric').locator('input[type="checkbox"]')).toBeChecked();
+        await expect(agIdFor.cell('1', 'electric').locator('input[type="checkbox"]')).not.toBeChecked();
+
+        // custom cell renderer supplies a "Push Me!" button in every row
+        await expect(agIdFor.cell('0', 'button').getByRole('button', { name: 'Push Me!' })).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/key-features/_examples/working-with-data-example/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/key-features/_examples/working-with-data-example/example.spec.ts
@@ -1,11 +1,21 @@
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
+    test.eachFramework('Supports pagination, sorting and row selection', async ({ agIdFor, page }) => {
+        // pagination is enabled with a page size of 10
+        const pagingPanel = page.locator('.ag-paging-panel');
+        await expect(pagingPanel).toBeVisible();
+        await expect(
+            page.locator('.ag-center-cols-container .ag-row, .ag-grid-scrolling-container .ag-row')
+        ).toHaveCount(10);
+
+        // sort by price ascending — the cheapest car (Fiat Panda, 13724) moves to the top
+        await agIdFor.headerCell('price').click();
+        await expect(agIdFor.cell('10', 'price')).toContainText('13724');
+        await expect(agIdFor.cell('10', 'make')).toContainText('Fiat');
+
+        // multiRow selection — clicking a row checkbox selects the row
+        await agIdFor.rowNode('10').locator('.ag-selection-checkbox').click();
+        await expect(agIdFor.rowNode('10')).toHaveClass(/ag-row-selected/);
     });
 });


### PR DESCRIPTION
Backfills real, assertion-bearing Playwright `example.spec.ts` tests for all 5 examples on the **Key Features** docs page, replacing mount-only placeholders. Part of the AG-17857 docs example-spec coverage effort. All frameworks green locally (chromium).