### PR TITLE
ci: disable git auto-gc to stop shallow-fetch race in job setup

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -22,6 +22,15 @@ on:
 #    - cron: '0 0 * * *' # Run daily at midnight UTC
 
 env:
+  # Disable git's post-fetch background gc/maintenance for every git invocation in this
+  # workflow (via git's GIT_CONFIG_* protocol); otherwise it rewrites .git/shallow
+  # concurrently with the next chained `git fetch --depth 1`, intermittently failing job
+  # setup with "fatal: shallow file has changed since we read it". Fixed in git >= 2.55.
+  GIT_CONFIG_COUNT: 2
+  GIT_CONFIG_KEY_0: gc.auto
+  GIT_CONFIG_VALUE_0: '0'
+  GIT_CONFIG_KEY_1: maintenance.auto
+  GIT_CONFIG_VALUE_1: 'false'
   NX_NO_CLOUD: true
   NX_BRANCH: ${{ github.ref }}
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,15 @@ on:
           - 'affected'
           - 'run-many'
 env:
+  # Disable git's post-fetch background gc/maintenance for every git invocation in this
+  # workflow (via git's GIT_CONFIG_* protocol); otherwise it rewrites .git/shallow
+  # concurrently with the next chained `git fetch --depth 1`, intermittently failing job
+  # setup with "fatal: shallow file has changed since we read it". Fixed in git >= 2.55.
+  GIT_CONFIG_COUNT: 2
+  GIT_CONFIG_KEY_0: gc.auto
+  GIT_CONFIG_VALUE_0: '0'
+  GIT_CONFIG_KEY_1: maintenance.auto
+  GIT_CONFIG_VALUE_1: 'false'
   NX_NO_CLOUD: true
   IBM_TELEMETRY_DISABLED: true
   NX_BRANCH: ${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,17 @@ on:
         branches: ['latest', 'b[0-9][0-9].[0-9].[0-9]', 'lts']
         types: [opened, synchronize, reopened, ready_for_review]
 
+env:
+    # Disable git's post-fetch background gc/maintenance for every git invocation in this
+    # workflow (via git's GIT_CONFIG_* protocol); otherwise it rewrites .git/shallow
+    # concurrently with the next chained `git fetch --depth 1`, intermittently failing job
+    # setup with "fatal: shallow file has changed since we read it". Fixed in git >= 2.55.
+    GIT_CONFIG_COUNT: 2
+    GIT_CONFIG_KEY_0: gc.auto
+    GIT_CONFIG_VALUE_0: '0'
+    GIT_CONFIG_KEY_1: maintenance.auto
+    GIT_CONFIG_VALUE_1: 'false'
+
 # Least-privilege default; the analyze job overrides this with its own block.
 permissions:
     contents: read

--- a/.github/workflows/csp.yml
+++ b/.github/workflows/csp.yml
@@ -2,6 +2,15 @@ name: Content Security Policy (CSP)
 description: Content Security Policy Testing
 
 env:
+    # Disable git's post-fetch background gc/maintenance for every git invocation in this
+    # workflow (via git's GIT_CONFIG_* protocol); otherwise it rewrites .git/shallow
+    # concurrently with the next chained `git fetch --depth 1`, intermittently failing job
+    # setup with "fatal: shallow file has changed since we read it". Fixed in git >= 2.55.
+    GIT_CONFIG_COUNT: 2
+    GIT_CONFIG_KEY_0: gc.auto
+    GIT_CONFIG_VALUE_0: '0'
+    GIT_CONFIG_KEY_1: maintenance.auto
+    GIT_CONFIG_VALUE_1: 'false'
     NX_NO_CLOUD: true
     CI: true
     DEFAULT_RETENTION_DAYS: 30

--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -2,6 +2,15 @@ name: Documentation Tests
 description: Run tests for the documentation examples
 
 env:
+  # Disable git's post-fetch background gc/maintenance for every git invocation in this
+  # workflow (via git's GIT_CONFIG_* protocol); otherwise it rewrites .git/shallow
+  # concurrently with the next chained `git fetch --depth 1`, intermittently failing job
+  # setup with "fatal: shallow file has changed since we read it". Fixed in git >= 2.55.
+  GIT_CONFIG_COUNT: 2
+  GIT_CONFIG_KEY_0: gc.auto
+  GIT_CONFIG_VALUE_0: '0'
+  GIT_CONFIG_KEY_1: maintenance.auto
+  GIT_CONFIG_VALUE_1: 'false'
   NX_NO_CLOUD: true
   CI: true
   DEFAULT_RETENTION_DAYS: 30

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -152,6 +152,15 @@ concurrency:
     cancel-in-progress: false
 
 env:
+    # Disable git's post-fetch background gc/maintenance for every git invocation in this
+    # workflow (via git's GIT_CONFIG_* protocol); otherwise it rewrites .git/shallow
+    # concurrently with the next chained `git fetch --depth 1`, intermittently failing job
+    # setup with "fatal: shallow file has changed since we read it". Fixed in git >= 2.55.
+    GIT_CONFIG_COUNT: 2
+    GIT_CONFIG_KEY_0: gc.auto
+    GIT_CONFIG_VALUE_0: '0'
+    GIT_CONFIG_KEY_1: maintenance.auto
+    GIT_CONFIG_VALUE_1: 'false'
     ISSUE_KEY: ${{ github.event.client_payload.issue_key || inputs.issue_key }}
     DEV_PROMPTS_CHANNEL: latest
 

--- a/.github/workflows/module-size-comparison.yml
+++ b/.github/workflows/module-size-comparison.yml
@@ -14,6 +14,15 @@ on:
         required: true
 
 env:
+  # Disable git's post-fetch background gc/maintenance for every git invocation in this
+  # workflow (via git's GIT_CONFIG_* protocol); otherwise it rewrites .git/shallow
+  # concurrently with the next chained `git fetch --depth 1`, intermittently failing job
+  # setup with "fatal: shallow file has changed since we read it". Fixed in git >= 2.55.
+  GIT_CONFIG_COUNT: 2
+  GIT_CONFIG_KEY_0: gc.auto
+  GIT_CONFIG_VALUE_0: '0'
+  GIT_CONFIG_KEY_1: maintenance.auto
+  GIT_CONFIG_VALUE_1: 'false'
   NX_NO_CLOUD: true
   NX_BRANCH: ${{ github.ref }}
   SHARP_IGNORE_GLOBAL_LIBVIPS: true

--- a/.github/workflows/module-size-vs-release.yml
+++ b/.github/workflows/module-size-vs-release.yml
@@ -32,6 +32,15 @@ on:
         required: false
 
 env:
+  # Disable git's post-fetch background gc/maintenance for every git invocation in this
+  # workflow (via git's GIT_CONFIG_* protocol); otherwise it rewrites .git/shallow
+  # concurrently with the next chained `git fetch --depth 1`, intermittently failing job
+  # setup with "fatal: shallow file has changed since we read it". Fixed in git >= 2.55.
+  GIT_CONFIG_COUNT: 2
+  GIT_CONFIG_KEY_0: gc.auto
+  GIT_CONFIG_VALUE_0: '0'
+  GIT_CONFIG_KEY_1: maintenance.auto
+  GIT_CONFIG_VALUE_1: 'false'
   NX_NO_CLOUD: true
   NX_BRANCH: ${{ github.ref }}
   SHARP_IGNORE_GLOBAL_LIBVIPS: true

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -27,6 +27,15 @@ on:
     - cron: '0 0 * * *' # Run daily at midnight UTC
 
 env:
+  # Disable git's post-fetch background gc/maintenance for every git invocation in this
+  # workflow (via git's GIT_CONFIG_* protocol); otherwise it rewrites .git/shallow
+  # concurrently with the next chained `git fetch --depth 1`, intermittently failing job
+  # setup with "fatal: shallow file has changed since we read it". Fixed in git >= 2.55.
+  GIT_CONFIG_COUNT: 2
+  GIT_CONFIG_KEY_0: gc.auto
+  GIT_CONFIG_VALUE_0: '0'
+  GIT_CONFIG_KEY_1: maintenance.auto
+  GIT_CONFIG_VALUE_1: 'false'
   NX_NO_CLOUD: true
   NX_BRANCH: ${{ github.ref }}
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -7,6 +7,15 @@ on:
       - 'release-*'
 
 env:
+  # Disable git's post-fetch background gc/maintenance for every git invocation in this
+  # workflow (via git's GIT_CONFIG_* protocol); otherwise it rewrites .git/shallow
+  # concurrently with the next chained `git fetch --depth 1`, intermittently failing job
+  # setup with "fatal: shallow file has changed since we read it". Fixed in git >= 2.55.
+  GIT_CONFIG_COUNT: 2
+  GIT_CONFIG_KEY_0: gc.auto
+  GIT_CONFIG_VALUE_0: '0'
+  GIT_CONFIG_KEY_1: maintenance.auto
+  GIT_CONFIG_VALUE_1: 'false'
   CI: true
   IBM_TELEMETRY_DISABLED: true
   DEPLOYMENT_APP_ID: 957224


### PR DESCRIPTION
## Summary

Fixes the intermittent `fatal: shallow file has changed since we read it` failures during CI job setup (e.g. module-size, ci, accessibility).

### Root cause

Every CI job does a shallow `actions/checkout` (`fetch-depth: 1`), then chained `git fetch --depth 1 …` calls (the inline "Fetch Refs" step plus more inside the `setup-nx` composite action). On completion `git fetch` spawns a **detached, background** `git maintenance run --auto`, which on a shallow repo rewrites `.git/shallow`. The *next* chained fetch reads `.git/shallow`, and when it goes to commit its own update it detects the file changed underneath it and aborts:

```
fatal: shallow file has changed since we read it
```

It's intermittent because it depends on the detached maintenance process from the *previous* fetch overlapping the *next* one. This is a **git 2.54.0 regression**, fixed in **git >= 2.55**; the hosted runners still ship 2.54.x.

### Fix

Inject `gc.auto=0` and `maintenance.auto=false` into **every** git invocation via git's `GIT_CONFIG_*` env protocol, added at the **workflow `env:` level** so it's in effect from `checkout` onward across every git process (including the `setup-nx` composite action). No fetch spawns background maintenance, so the race window disappears entirely.

This replaces the earlier per-fetch retry-wrapper approach: the env approach eliminates the race at the source (it also covers `actions/checkout`'s own internal fetch, which per-fetch wrapping could not) and requires no change to the shared `setup-nx-core` action. Mirrors the fix already merged in ag-charts (#6969).

### Scope

Applied to the workflows exposed to the race (a "Fetch Refs" step and/or a `setup-nx` invocation): `ci`, `accessibility`, `performance`, `prod-release`, `doc-tests`, `csp`, `codeql`, `jira-agent-pipeline`, `module-size-comparison`, `module-size-vs-release`.

### Test plan

- Only takes effect in CI. Confirmed all 10 workflow YAMLs parse and each carries the `GIT_CONFIG_*` env at the top level.
- CI on this PR exercises the same shallow-fetch setup path that was failing.

### Follow-up

Removable once the runner images ship git >= 2.55.
