### PR TITLE
test(docs): remove React fixme for menu initial focus (AG-17934)

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/component-menu-item/_examples/custom-menu-item/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/component-menu-item/_examples/custom-menu-item/example.spec.ts
@@ -1,13 +1,7 @@
 import { expect, test } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('opening the menu moves keyboard focus into it', async ({ agIdFor, page, agFramework }) => {
-        // React does not focus a menu containing custom framework items, breaking keyboard nav — see AG-17785.
-        test.fixme(
-            agFramework.startsWith('reactFunctionalTs'),
-            'AG-17785: React menu with custom items does not receive initial focus'
-        );
-
+    test.eachFramework('opening the menu moves keyboard focus into it', async ({ agIdFor, page }) => {
         await agIdFor.headerCell('athlete').hover();
         await agIdFor.headerCellMenuButton('athlete').click();
         await expect(agIdFor.menu()).toBeVisible();


### PR DESCRIPTION
## Summary

AG-17934 (React menu with custom items never receiving initial keyboard focus) is fixed by `6f61d00fd0a` ("retry menu initial focus after async framework items render"). This removes the now-obsolete `test.fixme` React skip on the **"opening the menu moves keyboard focus into it"** test in the `custom-menu-item` docs example.

The skip was tagged under the umbrella ticket AG-17785, but the behaviour it guarded is precisely the AG-17934 bug.

## Testing

`./docs-e2e.sh "custom-menu-item" --grep "opening the menu moves keyboard focus into it"` — **6 passed** across all frameworks (typescript, vanilla, reactFunctionalTs, reactFunctionalTs_Dev, angular, vue3).

Other AG-17785 fixmes (floating-filter emits, group-total expansion) are unrelated and left in place.