### PR TITLE
SE-79 - Add machine-readable MCP server discovery card

### DIFF
--- a/documentation/ag-grid-docs/src/pages/.well-known/mcp/server-card.json.ts
+++ b/documentation/ag-grid-docs/src/pages/.well-known/mcp/server-card.json.ts
@@ -1,0 +1,24 @@
+import { siteRootUrl } from '@ag-website-shared/utils/structuredData';
+import { getFrameworkPath } from '@components/docs/utils/urlPaths';
+import { buildMcpServerCard } from '@utils/mcpServerCard';
+import { type CollectionEntry, getEntry } from 'astro:content';
+
+// Served at /.well-known/mcp/server-card.json. A machine-readable discovery card
+// so an agent that probes the well-known location finds the ag-mcp server without
+// prior knowledge (SE-79). Generated from the canonical base URL so the docs link
+// cannot drift from the shipped site.
+export async function GET() {
+    const { data: metadata } = (await getEntry('metadata', 'metadata')) as CollectionEntry<'metadata'>;
+
+    const output = buildMcpServerCard({
+        siteRoot: siteRootUrl(metadata.canonicalUrlBase),
+        gridDocsPrefix: getFrameworkPath('javascript'),
+    });
+
+    return new Response(output, {
+        status: 200,
+        headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+        },
+    });
+}

--- a/documentation/ag-grid-docs/src/utils/mcpServerCard.test.ts
+++ b/documentation/ag-grid-docs/src/utils/mcpServerCard.test.ts
@@ -1,0 +1,55 @@
+import { buildMcpServerCard } from './mcpServerCard';
+
+const INPUT = {
+    siteRoot: 'https://www.ag-grid.com/',
+    gridDocsPrefix: 'javascript-data-grid',
+};
+
+describe('buildMcpServerCard', () => {
+    const json = buildMcpServerCard(INPUT);
+    const card = JSON.parse(json);
+
+    test('is valid JSON ending in a trailing newline', () => {
+        expect(json.endsWith('\n')).toBe(true);
+        expect(typeof card).toBe('object');
+    });
+
+    test('names the ag-mcp server', () => {
+        expect(card.name).toBe('ag-mcp');
+        expect(card.title).toBe('AG Grid MCP Server');
+    });
+
+    test('points documentation at the canonical MCP server docs page', () => {
+        expect(card.documentation).toBe('https://www.ag-grid.com/javascript-data-grid/mcp-server/');
+        expect(card.homepage).toBe('https://www.ag-grid.com/javascript-data-grid/mcp-server/');
+    });
+
+    test('links the ag-mcp repository', () => {
+        expect(card.repository.url).toBe('https://github.com/ag-grid/ag-mcp');
+    });
+
+    test('names the npm package and the stdio launch command (acceptance criteria)', () => {
+        expect(card.packages).toHaveLength(1);
+        const pkg = card.packages[0];
+        expect(pkg.registry).toBe('npm');
+        expect(pkg.name).toBe('ag-mcp');
+        expect(pkg.command).toBe('npx');
+        expect(pkg.args).toEqual(['ag-mcp']);
+        expect(pkg.transport).toBe('stdio');
+    });
+
+    test('provides an mcpServers block a client can use directly', () => {
+        expect(card.mcpServers['ag-mcp']).toEqual({
+            command: 'npx',
+            args: ['ag-mcp'],
+            type: 'stdio',
+        });
+    });
+
+    test('derives the docs link from the canonical base (no other host)', () => {
+        const urls = json.match(/https?:\/\/[^"]+/g) ?? [];
+        const agGridUrls = urls.filter((u) => u.includes('ag-grid.com'));
+        expect(agGridUrls.length).toBeGreaterThan(0);
+        expect(agGridUrls.every((u) => u.startsWith('https://www.ag-grid.com/'))).toBe(true);
+    });
+});

--- a/documentation/ag-grid-docs/src/utils/mcpServerCard.ts
+++ b/documentation/ag-grid-docs/src/utils/mcpServerCard.ts
@@ -1,0 +1,65 @@
+/**
+ * Builder for the machine-readable MCP discovery card served at
+ * `/.well-known/mcp/server-card.json` (SE-79). An autonomous agent that probes
+ * the well-known location learns the ag-mcp server exists without prior
+ * knowledge, and gets the exact launch command to configure it.
+ *
+ * Like the agent-readiness files (see agentReadinessFiles.ts, SE-77), the card
+ * is generated from the canonical base URL, so the documentation link cannot
+ * drift from the shipped site. The human-facing docs page stays the canonical
+ * reference; this card just points at it and names the entry point.
+ */
+
+interface McpServerCardInput {
+    /** Canonical site root with a trailing slash, e.g. `https://www.ag-grid.com/`. */
+    siteRoot: string;
+    /**
+     * Framework segment used for the grid doc links, e.g. `javascript-data-grid`.
+     * JavaScript is the framework-agnostic core, so it is the natural canonical
+     * entry point.
+     */
+    gridDocsPrefix: string;
+}
+
+/**
+ * Build the `/.well-known/mcp/server-card.json` body: a description of the
+ * ag-mcp server, its npm package and stdio launch command, plus an
+ * `mcpServers` block a client can drop straight into its MCP config.
+ */
+export function buildMcpServerCard({ siteRoot, gridDocsPrefix }: McpServerCardInput): string {
+    const docsUrl = `${siteRoot}${gridDocsPrefix}/mcp-server/`;
+
+    const card = {
+        name: 'ag-mcp',
+        title: 'AG Grid MCP Server',
+        description:
+            'Version-aware AG Grid documentation, examples and API reference for AI coding assistants, returned as condensed markdown. Detects the AG Grid version and framework in your project so generated code targets the correct API.',
+        homepage: docsUrl,
+        documentation: docsUrl,
+        repository: {
+            url: 'https://github.com/ag-grid/ag-mcp',
+            source: 'github',
+        },
+        // The ag-mcp server installs and runs locally over stdio; there is no
+        // hosted remote endpoint. This is the current entry point.
+        packages: [
+            {
+                registry: 'npm',
+                name: 'ag-mcp',
+                command: 'npx',
+                args: ['ag-mcp'],
+                transport: 'stdio',
+            },
+        ],
+        // Ready to drop into an MCP client config (the shape every client consumes).
+        mcpServers: {
+            'ag-mcp': {
+                command: 'npx',
+                args: ['ag-mcp'],
+                type: 'stdio',
+            },
+        },
+    };
+
+    return `${JSON.stringify(card, null, 2)}\n`;
+}


### PR DESCRIPTION
Serve /.well-known/mcp/server-card.json so an agent probing the well-known location discovers the ag-mcp server (npx ag-mcp, stdio)

Generated from the canonical base URL like the llms.txt / AGENTS.md endpoints, with unit tests.