### PR TITLE
SE-79 - include .well-known directory in docs deploy zip

### DIFF
--- a/scripts/deployments/createAndDeployDocsToTC.sh
+++ b/scripts/deployments/createAndDeployDocsToTC.sh
@@ -15,6 +15,15 @@ cd documentation/ag-grid-docs/dist
 FILENAME=release_"$ZIP_PREFIX"_v"$ZIP_PREFIX".zip
 echo "Creating $FILENAME"
 zip -qr ../../../$FILENAME *
+# The glob above skips dot-prefixed entries, so add them explicitly:
+# - the generated .htaccess (present on staging/production builds)
+# - the .well-known directory (e.g. the MCP discovery card, SE-79)
+if [ -f .htaccess ]; then
+  zip -q ../../../$FILENAME .htaccess
+fi
+if [ -d .well-known ]; then
+  zip -qr ../../../$FILENAME .well-known
+fi
 
 cd ../../../
 

--- a/scripts/deployments/createAndDeployDocsToTCGH.sh
+++ b/scripts/deployments/createAndDeployDocsToTCGH.sh
@@ -24,9 +24,14 @@ cd documentation/ag-grid-docs/dist
 FILENAME=release_"$ZIP_PREFIX"_v"$ZIP_PREFIX".zip
 echo "Creating $FILENAME"
 zip -qr ../../../$FILENAME *
-# The glob above skips dotfiles, so add the generated .htaccess explicitly (present on staging/production builds)
+# The glob above skips dot-prefixed entries, so add them explicitly:
+# - the generated .htaccess (present on staging/production builds)
+# - the .well-known directory (e.g. the MCP discovery card, SE-79)
 if [ -f .htaccess ]; then
   zip -q ../../../$FILENAME .htaccess
+fi
+if [ -d .well-known ]; then
+  zip -qr ../../../$FILENAME .well-known
 fi
 
 cd ../../../


### PR DESCRIPTION
## What

The MCP discovery card (SE-79) at `/.well-known/mcp/server-card.json` 404s on staging even though the endpoint is built correctly. Root cause is the docs **deploy packaging**, not the build.

The deploy zips `dist` with the shell glob `zip -qr $FILENAME *`, and `*` does not match dot-prefixed entries. `.htaccess` was already re-added explicitly, but the `.well-known/` directory was not — so `dist/.well-known/mcp/server-card.json` never reached the server. This is why *every* `.well-known/*` path 404s on staging, not just the card.

Astro's build is fine (Astro 6.1.9 explicitly special-cases `.well-known` in its route scanner and emits the file), and the generated `.htaccess` does not block `.well-known/mcp`.

## Change

Add explicit `.well-known` handling alongside the existing `.htaccess` block in both zip-based deploy scripts:

- `scripts/deployments/createAndDeployDocsToTCGH.sh` — the **active** staging deploy (unblocks QA).
- `scripts/deployments/createAndDeployDocsToTC.sh` — legacy TeamCity script; had the same glob bug and wasn't re-adding `.htaccess` either, now brought in line.

`branchDeploy/createAndDeployDocsToS3.sh` is **not** affected — `aws s3 cp --recursive` walks the filesystem and already includes dot-directories.

## Verification

Sandbox simulation of the zip logic:

- Before: `zip * ` produces `normal/` only — `.htaccess` and `.well-known/` both dropped.
- After: zip contains `.htaccess`, `.well-known/mcp/server-card.json`, and the normal files.

## Post-merge QA (SE-79)

After this deploys to staging, re-check `https://grid-staging.ag-grid.com/.well-known/mcp/server-card.json` → expect HTTP 200 + `application/json` and validate the card body. The other three discovery checks (llms.txt, AGENTS.md, `Link: rel=related` header) already pass on staging.
