### PR TITLE
SE-71 Add Wikidata link, founder and description to Organization structured data

### DIFF
--- a/documentation/ag-grid-docs/src/layouts/Layout.astro
+++ b/documentation/ag-grid-docs/src/layouts/Layout.astro
@@ -113,6 +113,16 @@ const organizationFounder = {
     name: 'Niall Crosby',
     sameAs: ['https://www.wikidata.org/wiki/Q114758691'],
 };
+const organizationLegalName = 'AG Grid Ltd.';
+// ISO 8601 (YYYY-MM-DD) for schema.org — the company was founded on 19 July 2010.
+const organizationFoundingDate = '2010-07-19';
+const organizationAddress = {
+    streetAddress: '70 Wilson St',
+    addressLocality: 'London',
+    postalCode: 'EC2A 2DB',
+    // ISO 3166-1 alpha-2 country code, the form Google expects for addressCountry.
+    addressCountry: 'GB',
+};
 const structuredData: JsonLdObject[] = includeStructuredData
     ? [
           buildOrganization({
@@ -121,6 +131,9 @@ const structuredData: JsonLdObject[] = includeStructuredData
               logoUrl: organizationLogoUrl,
               sameAs: organizationSameAs,
               description: organizationDescription,
+              legalName: organizationLegalName,
+              foundingDate: organizationFoundingDate,
+              address: organizationAddress,
               founder: organizationFounder,
               // Line up with the enquiry-type options on the contact page. Sales enquiries go
               // through the contact form; technical support is handled via the Zendesk portal.

--- a/documentation/ag-grid-docs/src/layouts/Layout.astro
+++ b/documentation/ag-grid-docs/src/layouts/Layout.astro
@@ -104,13 +104,24 @@ const sameAsUrls = includeStructuredData
     : [];
 const organizationLogoUrl = `${siteRoot}images/ag-logos/png-logos/AG-Grid-Logo_Light-Theme_476_140.png`;
 const licensePricingUrl = `${siteRoot}license-pricing/`;
+// AG Grid's Wikidata item, appended to the footer-derived social profiles so Google can tie
+// the site, the Wikidata entry and the Knowledge Graph panel to the same entity.
+const organizationSameAs = [...sameAsUrls, 'https://www.wikidata.org/wiki/Q128283374'];
+const organizationDescription =
+    'AG Grid is the maker of the industry-leading JavaScript Data Grid, offering high-performance, feature-rich data grid components for React, Angular, Vue and JavaScript, available as a free open-source Community edition and a commercial Enterprise edition.';
+const organizationFounder = {
+    name: 'Niall Crosby',
+    sameAs: ['https://www.wikidata.org/wiki/Q114758691'],
+};
 const structuredData: JsonLdObject[] = includeStructuredData
     ? [
           buildOrganization({
               canonicalUrlBase: metadata.canonicalUrlBase,
               name: 'AG Grid',
               logoUrl: organizationLogoUrl,
-              sameAs: sameAsUrls,
+              sameAs: organizationSameAs,
+              description: organizationDescription,
+              founder: organizationFounder,
               // Line up with the enquiry-type options on the contact page. Sales enquiries go
               // through the contact form; technical support is handled via the Zendesk portal.
               contactPoints: [

--- a/external/ag-website-shared/src/utils/structuredData.test.ts
+++ b/external/ag-website-shared/src/utils/structuredData.test.ts
@@ -65,6 +65,47 @@ describe('buildOrganization', () => {
             },
         ]);
     });
+
+    test('emits description and a nested founder Person when provided', () => {
+        const result = buildOrganization({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            name: 'AG Grid',
+            logoUrl: `${CANONICAL_URL_BASE}/images/logo.png`,
+            sameAs: ['https://www.wikidata.org/wiki/Q128283374'],
+            description: 'AG Grid is the industry-leading JavaScript Data Grid.',
+            founder: {
+                name: 'Niall Crosby',
+                sameAs: ['https://www.wikidata.org/wiki/Q114758691'],
+            },
+        });
+
+        expect(result.description).toBe('AG Grid is the industry-leading JavaScript Data Grid.');
+        expect(result.founder).toEqual({
+            '@type': 'Person',
+            name: 'Niall Crosby',
+            sameAs: ['https://www.wikidata.org/wiki/Q114758691'],
+        });
+    });
+
+    test('omits description and founder when not provided, and a founder without sameAs has no sameAs key', () => {
+        const withoutOptionals = buildOrganization({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            name: 'AG Grid',
+            logoUrl: `${CANONICAL_URL_BASE}/images/logo.png`,
+            sameAs: [],
+        });
+        expect(withoutOptionals.description).toBeUndefined();
+        expect(withoutOptionals.founder).toBeUndefined();
+
+        const bareFounder = buildOrganization({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            name: 'AG Grid',
+            logoUrl: `${CANONICAL_URL_BASE}/images/logo.png`,
+            sameAs: [],
+            founder: { name: 'Niall Crosby' },
+        });
+        expect(bareFounder.founder).toEqual({ '@type': 'Person', name: 'Niall Crosby' });
+    });
 });
 
 describe('buildWebSite', () => {

--- a/external/ag-website-shared/src/utils/structuredData.test.ts
+++ b/external/ag-website-shared/src/utils/structuredData.test.ts
@@ -87,6 +87,33 @@ describe('buildOrganization', () => {
         });
     });
 
+    test('emits legalName, foundingDate and a nested PostalAddress when provided', () => {
+        const result = buildOrganization({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            name: 'AG Grid',
+            logoUrl: `${CANONICAL_URL_BASE}/images/logo.png`,
+            sameAs: [],
+            legalName: 'AG Grid Ltd.',
+            foundingDate: '2010-07-19',
+            address: {
+                streetAddress: '70 Wilson St',
+                addressLocality: 'London',
+                postalCode: 'EC2A 2DB',
+                addressCountry: 'GB',
+            },
+        });
+
+        expect(result.legalName).toBe('AG Grid Ltd.');
+        expect(result.foundingDate).toBe('2010-07-19');
+        expect(result.address).toEqual({
+            '@type': 'PostalAddress',
+            streetAddress: '70 Wilson St',
+            addressLocality: 'London',
+            postalCode: 'EC2A 2DB',
+            addressCountry: 'GB',
+        });
+    });
+
     test('omits description and founder when not provided, and a founder without sameAs has no sameAs key', () => {
         const withoutOptionals = buildOrganization({
             canonicalUrlBase: CANONICAL_URL_BASE,
@@ -96,6 +123,9 @@ describe('buildOrganization', () => {
         });
         expect(withoutOptionals.description).toBeUndefined();
         expect(withoutOptionals.founder).toBeUndefined();
+        expect(withoutOptionals.legalName).toBeUndefined();
+        expect(withoutOptionals.foundingDate).toBeUndefined();
+        expect(withoutOptionals.address).toBeUndefined();
 
         const bareFounder = buildOrganization({
             canonicalUrlBase: CANONICAL_URL_BASE,

--- a/external/ag-website-shared/src/utils/structuredData.ts
+++ b/external/ag-website-shared/src/utils/structuredData.ts
@@ -34,6 +34,15 @@ export interface OrganizationFounder {
     url?: string;
 }
 
+export interface OrganizationAddress {
+    streetAddress: string;
+    addressLocality: string;
+    postalCode: string;
+    /** ISO 3166-1 alpha-2 country code (e.g. `GB`) — the form Google expects. */
+    addressCountry: string;
+    addressRegion?: string;
+}
+
 interface OrgInput {
     canonicalUrlBase: string;
     name: string;
@@ -41,6 +50,12 @@ interface OrgInput {
     sameAs: string[];
     /** Optional short company description, emitted as the Organization `description`. */
     description?: string;
+    /** Optional registered legal name, emitted as the Organization `legalName`. */
+    legalName?: string;
+    /** Optional founding date in ISO 8601 (`YYYY-MM-DD`), emitted as `foundingDate`. */
+    foundingDate?: string;
+    /** Optional registered address, emitted as a nested schema.org `PostalAddress`. */
+    address?: OrganizationAddress;
     /** Optional founder, emitted as a nested schema.org `Person`. */
     founder?: OrganizationFounder;
     /**
@@ -147,6 +162,9 @@ export function buildOrganization({
     logoUrl,
     sameAs,
     description,
+    legalName,
+    foundingDate,
+    address,
     founder,
     contactPoints,
 }: OrgInput): JsonLdObject {
@@ -160,6 +178,15 @@ export function buildOrganization({
     };
     if (description) {
         result.description = description;
+    }
+    if (legalName) {
+        result.legalName = legalName;
+    }
+    if (foundingDate) {
+        result.foundingDate = foundingDate;
+    }
+    if (address) {
+        result.address = { '@type': 'PostalAddress', ...address };
     }
     if (founder) {
         const founderNode: JsonLdObject = { '@type': 'Person', name: founder.name };

--- a/external/ag-website-shared/src/utils/structuredData.ts
+++ b/external/ag-website-shared/src/utils/structuredData.ts
@@ -24,11 +24,25 @@ export interface ContactPoint {
     availableLanguage?: string | string[];
 }
 
+export interface OrganizationFounder {
+    name: string;
+    /**
+     * Authoritative entries for the person (e.g. their Wikidata item), so the
+     * emitted `Person` node can be tied to the same entity across sources.
+     */
+    sameAs?: string[];
+    url?: string;
+}
+
 interface OrgInput {
     canonicalUrlBase: string;
     name: string;
     logoUrl: string;
     sameAs: string[];
+    /** Optional short company description, emitted as the Organization `description`. */
+    description?: string;
+    /** Optional founder, emitted as a nested schema.org `Person`. */
+    founder?: OrganizationFounder;
     /**
      * Optional points of contact (sales, technical support, etc.). Emitted as
      * a `contactPoint` array on the Organization so any page referencing the
@@ -127,7 +141,15 @@ const BREADCRUMB_ID_FRAGMENT = '#breadcrumb';
 const FAQ_ID_FRAGMENT = '#faq';
 const CONTACT_PAGE_ID_FRAGMENT = '#contact-page';
 
-export function buildOrganization({ canonicalUrlBase, name, logoUrl, sameAs, contactPoints }: OrgInput): JsonLdObject {
+export function buildOrganization({
+    canonicalUrlBase,
+    name,
+    logoUrl,
+    sameAs,
+    description,
+    founder,
+    contactPoints,
+}: OrgInput): JsonLdObject {
     const result: JsonLdObject = {
         '@type': 'Organization',
         '@id': getOrganizationId(canonicalUrlBase),
@@ -136,6 +158,19 @@ export function buildOrganization({ canonicalUrlBase, name, logoUrl, sameAs, con
         logo: logoUrl,
         sameAs,
     };
+    if (description) {
+        result.description = description;
+    }
+    if (founder) {
+        const founderNode: JsonLdObject = { '@type': 'Person', name: founder.name };
+        if (founder.url) {
+            founderNode.url = founder.url;
+        }
+        if (founder.sameAs && founder.sameAs.length > 0) {
+            founderNode.sameAs = founder.sameAs;
+        }
+        result.founder = founderNode;
+    }
     if (contactPoints && contactPoints.length > 0) {
         result.contactPoint = contactPoints.map((point) => ({ '@type': 'ContactPoint', ...point }));
     }


### PR DESCRIPTION
## What

Enriches the **Organization** JSON-LD structured data emitted site-wide so Google can tie the website, the Wikidata item and the Knowledge Graph panel to the same entity.

Implements [SE-71](https://ag-grid.atlassian.net/browse/SE-71) — part 1 (the "add now" items). 