### PR TITLE
Fix doc-tests report truncation and flaky row-numbers example specs

### DIFF
--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -273,17 +273,33 @@ jobs:
       - name: Normalise example test reports
         run: node documentation/ag-grid-docs/scripts/normalise-ctrf-reports.mjs combined-reports
 
+      # failed-folded-report is deliberately off: it embeds the full message/trace for every
+      # failed test with no cap, so a run with hundreds of failures produces a step summary
+      # over GitHub's 1MB per-job limit - at which point the summary is silently dropped
+      # entirely. "Summarise failed tests" below writes a fixed-size table instead, so the
+      # summary always renders.
       - name: Publish Combined Test Report
         id: ctrf
         uses: ctrf-io/github-test-reporter@bb6b54d6514e0952c3eea739be0c641143d1f06c # v1.0.17
         with:
           report-path: 'combined-reports/**/*.json'
           summary-report: true
-          failed-folded-report: true
           flaky-report: true
           skipped-report: false
           group-by: filePath
           write-ctrf-to-file: ${{ env.CTRF_FILE }}
+
+      - name: Summarise failed tests
+        if: always()
+        run: node documentation/ag-grid-docs/scripts/summarise-ctrf-failures.mjs ${{ env.CTRF_FILE }}
+
+      - name: Upload combined CTRF report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ctrf-report
+          path: ${{ env.CTRF_FILE }}
+          retention-days: ${{ env.DEFAULT_RETENTION_DAYS }}
 
       - name: Get previous run commit SHA
         id: prev-commit-sha

--- a/documentation/ag-grid-docs/scripts/summarise-ctrf-failures.mjs
+++ b/documentation/ag-grid-docs/scripts/summarise-ctrf-failures.mjs
@@ -31,7 +31,7 @@ const lines = ['## Failed tests', '', `${failed.length} test(s) failed.`, '', '|
 
 for (let i = 0, len = Math.min(failed.length, MAX_FAILURES); i < len; ++i) {
     const test = failed[i];
-    lines.push(`| ${escapeCell(test.name)} | ${escapeCell(truncate(firstLine(test.message)))} |`);
+    lines.push(`| ${escapeCell(truncate(firstLine(test.name)))} | ${escapeCell(truncate(firstLine(test.message)))} |`);
 }
 
 if (failed.length > MAX_FAILURES) {

--- a/documentation/ag-grid-docs/scripts/summarise-ctrf-failures.mjs
+++ b/documentation/ag-grid-docs/scripts/summarise-ctrf-failures.mjs
@@ -1,0 +1,59 @@
+// Appends a bounded, always-renderable failed-tests summary to $GITHUB_STEP_SUMMARY.
+//
+// ctrf-io/github-test-reporter's failed-folded-report includes the full message and trace for
+// every failed test with no cap, so a run with hundreds of failures can produce a step summary
+// well over GitHub's 1MB per-job limit - at which point the whole summary is silently dropped
+// rather than shrunk. This script reads the merged CTRF report and writes a small, fixed-size
+// table instead: it lists at most MAX_FAILURES tests with a single truncated line of error
+// detail each, so the summary always renders regardless of how many tests failed.
+import { appendFileSync, readFileSync } from 'node:fs';
+
+const MAX_FAILURES = 100;
+const MAX_MESSAGE_LENGTH = 200;
+
+const ctrfFile = process.argv[2];
+const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+if (!ctrfFile || !summaryFile) {
+    // eslint-disable-next-line no-console
+    console.error('Usage: GITHUB_STEP_SUMMARY=<path> node summarise-ctrf-failures.mjs <ctrf-report.json>');
+    process.exit(1);
+}
+
+const report = JSON.parse(readFileSync(ctrfFile, 'utf8'));
+const tests = report?.results?.tests ?? [];
+const failed = tests.filter((test) => test.status === 'failed');
+
+if (failed.length === 0) {
+    process.exit(0);
+}
+
+const lines = ['## Failed tests', '', `${failed.length} test(s) failed.`, '', '| Test | Error |', '| --- | --- |'];
+
+for (let i = 0, len = Math.min(failed.length, MAX_FAILURES); i < len; ++i) {
+    const test = failed[i];
+    lines.push(`| ${escapeCell(test.name)} | ${escapeCell(truncate(firstLine(test.message)))} |`);
+}
+
+if (failed.length > MAX_FAILURES) {
+    lines.push(
+        '',
+        `_...and ${failed.length - MAX_FAILURES} more failure(s) - see the \`ctrf-report\` artifact for the full report._`
+    );
+}
+
+appendFileSync(summaryFile, `${lines.join('\n')}\n`);
+
+function firstLine(message) {
+    if (typeof message !== 'string') {
+        return '';
+    }
+    return message.split('\n')[0];
+}
+
+function truncate(text) {
+    return text.length > MAX_MESSAGE_LENGTH ? `${text.slice(0, MAX_MESSAGE_LENGTH)}...` : text;
+}
+
+function escapeCell(text) {
+    return text.replaceAll('|', '\\|');
+}

--- a/documentation/ag-grid-docs/src/content/docs/row-numbers/_examples/row-numbers-default/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-numbers/_examples/row-numbers-default/example.spec.ts
@@ -1,30 +1,6 @@
 import { ensureGridReady, expect, test, waitForGridContent, waitForRowAnimations } from '@utils/grid/test-utils';
-import type { Page } from 'playwright/test';
 
 const ROW_NUMBERS_COL = 'ag-Grid-RowNumbersColumn';
-
-// Read the row-number column values in top-to-bottom display order (by row-index).
-async function rowNumberOrder(page: Page): Promise<string[]> {
-    const rows = await page.locator('.ag-row[row-index]').all();
-    const seen = new Map<number, string>();
-    for (let i = 0, len = rows.length; i < len; ++i) {
-        const row = rows[i];
-        const idxAttr = await row.getAttribute('row-index');
-        if (idxAttr == null) {
-            continue;
-        }
-        const idx = Number(idxAttr);
-        if (seen.has(idx)) {
-            continue;
-        }
-        const cell = row.locator(`[col-id="${ROW_NUMBERS_COL}"]`);
-        if ((await cell.count()) === 0) {
-            continue;
-        }
-        seen.set(idx, ((await cell.first().innerText()) ?? '').trim());
-    }
-    return [...seen.entries()].sort((a, b) => a[0] - b[0]).map(([, v]) => v);
-}
 
 test.agExample(import.meta, () => {
     test.eachFramework('Renders sequential row numbers', async ({ agIdFor, page }) => {
@@ -44,10 +20,15 @@ test.agExample(import.meta, () => {
         await waitForRowAnimations(page);
 
         // Row numbers track display position, not the data, so they remain 1, 2, 3, ... after a sort.
-        await expect(async () => {
-            const numbers = await rowNumberOrder(page);
-            expect(numbers.length).toBeGreaterThan(2);
-            expect(numbers.slice(0, 3)).toEqual(['1', '2', '3']);
-        }).toPass();
+        // A long-distance sort can briefly leave a zombie duplicate of a moved row sharing its
+        // row-index in the DOM (see waitForRowAnimations above) - scope to the scrolling
+        // container (as expectRowIdAtIndex does) and let each auto-retrying assertion ride out
+        // the transient, rather than hand-scraping every row with a one-shot `.all()`.
+        for (let index = 0; index < 3; ++index) {
+            const cell = page.locator(
+                `.ag-grid-scrolling-container .ag-row[row-index="${index}"] [col-id="${ROW_NUMBERS_COL}"]`
+            );
+            await expect(cell).toHaveText(String(index + 1));
+        }
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/row-numbers/_examples/row-numbers-export/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-numbers/_examples/row-numbers-export/example.spec.ts
@@ -23,11 +23,11 @@ test.agExample(import.meta, () => {
 
         const download = await downloadPromise;
         const csvPath = await download.path();
-        const csv = readFileSync(csvPath, 'utf8');
+        const lines = readFileSync(csvPath, 'utf8').split('\n');
 
         // The data column is still present, and each data row is prefixed with its row number.
-        expect(csv).toContain('Athlete');
-        expect(csv).toMatch(/\n1,/);
-        expect(csv).toMatch(/\n2,/);
+        expect(lines[0]).toContain('Athlete');
+        expect(lines[1]).toMatch(/^"1",/);
+        expect(lines[2]).toMatch(/^"2",/);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/row-numbers/_examples/row-numbers-row-resizer/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-numbers/_examples/row-numbers-row-resizer/example.spec.ts
@@ -31,7 +31,7 @@ test.agExample(import.meta, () => {
         await page.mouse.move(grabX, grabY + 40, { steps: 5 });
         await page.mouse.up();
 
-        const heightAfter = (await row.boundingBox())!.height;
-        expect(heightAfter).toBeGreaterThan(heightBefore);
+        // Poll: AG Grid re-renders the row at its new height on a later frame than mouseup.
+        await expect.poll(async () => (await row.boundingBox())!.height).toBeGreaterThan(heightBefore);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/row-numbers/_examples/row-numbers-row-resizer/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-numbers/_examples/row-numbers-row-resizer/example.spec.ts
@@ -18,18 +18,20 @@ test.agExample(import.meta, () => {
         const heightBefore = (await row.boundingBox())!.height;
 
         // The resizer handle sits inside the row-number cell; hover to reveal it, then drag down.
+        // It's positioned half outside the cell's box (bottom: -2px) and the cell clips overflow,
+        // so only its top edge is actually hit-testable - target that, not its vertical center.
         const numberCell = agIdFor.rowNumber('0');
-        await numberCell.hover();
         const resizer = numberCell.locator('.ag-row-numbers-resizer');
+        await numberCell.hover();
         const handle = (await resizer.boundingBox())!;
-        await page.mouse.move(handle.x + handle.width / 2, handle.y + handle.height / 2);
+        const grabX = handle.x + handle.width / 2;
+        const grabY = handle.y;
+        await page.mouse.move(grabX, grabY);
         await page.mouse.down();
-        await page.mouse.move(handle.x + handle.width / 2, handle.y + handle.height / 2 + 40, { steps: 5 });
+        await page.mouse.move(grabX, grabY + 40, { steps: 5 });
         await page.mouse.up();
 
-        await expect(async () => {
-            const heightAfter = (await row.boundingBox())!.height;
-            expect(heightAfter).toBeGreaterThan(heightBefore);
-        }).toPass();
+        const heightAfter = (await row.boundingBox())!.height;
+        expect(heightAfter).toBeGreaterThan(heightBefore);
     });
 });


### PR DESCRIPTION
No JIRA ticket for this work.

- Documentation Tests' publish-reports job silently drops the whole GitHub Actions job summary once the combined CTRF report exceeds GitHub's 1MB step-summary limit (seen at 8MB and 70MB with a few hundred failures). Disables the unbounded `failed-folded-report`, adds a bounded custom failed-tests summary (capped at 100 rows), and always uploads the raw `ctrf-report.json` as an artifact.
- Fixes three row-numbers doc example specs that were broken/flaky:
  - `row-numbers-export`: no longer dumps the entire CSV into the failure log on assertion failure.
  - `row-numbers-row-resizer`: the resizer's hit area is clipped by its parent cell's `overflow: hidden`, so the drag was targeting an untestable point and never starting.
  - `row-numbers-default`: replaces a hand-rolled DOM scrape racing AG Grid's sort-animation zombie-row window with per-position locator assertions, matching the existing `expectRowIdAtIndex` pattern.