### PR TITLE
github-triage: auto-chain browser-verify + repro-rebuild after a fresh confirmed bug

### DIFF
--- a/.github/workflows/github-triage-pipeline.yml
+++ b/.github/workflows/github-triage-pipeline.yml
@@ -119,6 +119,99 @@ jobs:
             contents: read
             issues: write
             packages: read
+        outputs:
+            # NEW — downstream chain jobs need the mapping-ticket key and the
+            # fresh-confirmed-bug signal. See github-triage-pipeline action's own
+            # CLAUDE.md § "Auto-chaining browser-verify / repro-rebuild".
+            issue_key: ${{ steps.pipeline.outputs.issue_key }}
+            confirmed_bug: ${{ steps.pipeline.outputs.confirmed_bug }}
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 1
+            - name: Install @ag-grid/dev-prompts
+              uses: ./external/ag-shared/github/actions/install-ag-dev-prompts
+              with:
+                  channel: ${{ env.DEV_PROMPTS_CHANNEL }}
+            - id: pipeline
+              uses: ./.ag-dev-prompts/node_modules/@ag-grid/dev-prompts/.github/actions/github-triage-pipeline
+              with:
+                  stage: ${{ needs.preflight.outputs.stage || inputs.stage || 'triage' }}
+                  product: grid
+                  gh_issue: ${{ github.event.issue.number || github.event.client_payload.gh_issue || inputs.gh_issue }}
+                  issue_key: ${{ needs.preflight.outputs.issue_key || github.event.client_payload.issue_key || inputs.issue_key }}
+                  anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  jira_email: ${{ secrets.JIRA_AI_BOT_EMAIL }}
+                  jira_api_token: ${{ secrets.JIRA_AI_BOT_API_TOKEN }}
+                  jira_site_url: ${{ vars.JIRA_SITE_URL }}
+                  jira_ai_bot_account_id: ${{ vars.JIRA_AI_BOT_ACCOUNT_ID }}
+
+    # -------------------------------------------------- browser-verify-chain (NEW)
+    # Auto-fires ONLY after a FRESH triage (issues event, or an explicit
+    # workflow_dispatch stage=triage) just recorded a genuine triage-confirmed-bug
+    # — never after a resume/execute run, and never on a stale/failed run (the
+    # confirmed_bug output is itself gated on that — see the action's CLAUDE.md).
+    # Deliberately NOT gated on a resume also confirming a bug for this first
+    # increment — extending that is a small, separate follow-on if wanted.
+    #
+    # SECURITY NOTE: this reuses the SAME job permissions as `run` (no dedicated
+    # minimal-permission job split / persist-credentials:false / harden-runner
+    # block yet) — that hardening is a deliberately separate, not-yet-landed
+    # follow-up (see github-triage-pipeline action's CLAUDE.md § "Browser-verify
+    # (B2) — security posture"). Do not treat this job as hardened.
+    browser-verify-chain:
+        needs: [run]
+        if: |
+            !cancelled() &&
+            needs.run.outputs.confirmed_bug == 'true' &&
+            (
+              github.event_name == 'issues'
+              || (github.event_name == 'workflow_dispatch' && inputs.stage == 'triage')
+            )
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            issues: write
+            packages: read
+        outputs:
+            reproduces: ${{ steps.pipeline.outputs.reproduces }}
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 1
+            - name: Install @ag-grid/dev-prompts
+              uses: ./external/ag-shared/github/actions/install-ag-dev-prompts
+              with:
+                  channel: ${{ env.DEV_PROMPTS_CHANNEL }}
+            - id: pipeline
+              uses: ./.ag-dev-prompts/node_modules/@ag-grid/dev-prompts/.github/actions/github-triage-pipeline
+              with:
+                  stage: browser-verify
+                  product: grid
+                  issue_key: ${{ needs.run.outputs.issue_key }}
+                  anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  jira_email: ${{ secrets.JIRA_AI_BOT_EMAIL }}
+                  jira_api_token: ${{ secrets.JIRA_AI_BOT_API_TOKEN }}
+                  jira_site_url: ${{ vars.JIRA_SITE_URL }}
+                  jira_ai_bot_account_id: ${{ vars.JIRA_AI_BOT_ACCOUNT_ID }}
+
+    # -------------------------------------------------- repro-rebuild-chain (NEW)
+    # Auto-fires ONLY after browser-verify-chain recorded a genuine, fresh
+    # `reproduces` verdict. needs BOTH prior jobs (not just browser-verify-chain)
+    # because its own step below reads needs.run.outputs.issue_key — a job can
+    # only reference needs.<job>.outputs for jobs actually listed in its own
+    # `needs:`. Same security note as browser-verify-chain above.
+    repro-rebuild-chain:
+        needs: [run, browser-verify-chain]
+        if: |
+            !cancelled() && needs.browser-verify-chain.outputs.reproduces == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            issues: write
+            packages: read
         steps:
             - uses: actions/checkout@v4
               with:
@@ -129,10 +222,9 @@ jobs:
                   channel: ${{ env.DEV_PROMPTS_CHANNEL }}
             - uses: ./.ag-dev-prompts/node_modules/@ag-grid/dev-prompts/.github/actions/github-triage-pipeline
               with:
-                  stage: ${{ needs.preflight.outputs.stage || inputs.stage || 'triage' }}
+                  stage: repro-rebuild
                   product: grid
-                  gh_issue: ${{ github.event.issue.number || github.event.client_payload.gh_issue || inputs.gh_issue }}
-                  issue_key: ${{ needs.preflight.outputs.issue_key || github.event.client_payload.issue_key || inputs.issue_key }}
+                  issue_key: ${{ needs.run.outputs.issue_key }}
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   jira_email: ${{ secrets.JIRA_AI_BOT_EMAIL }}


### PR DESCRIPTION
## Summary

**Draft — not for merge without Hesam's explicit review/approval.**

Adds two new jobs to `.github/workflows/github-triage-pipeline.yml` so `browser-verify` and `repro-rebuild` fire automatically instead of needing a separate manual `workflow_dispatch` per stage:

- **`browser-verify-chain`** — fires only after a FRESH `triage` (a real `issues` event, or an explicit `workflow_dispatch stage=triage`) records a genuine `triage-confirmed-bug` outcome. Never fires after `resume`/`execute`, and never on a stale or failed run — the `confirmed_bug` output it reads is itself gated on that (see `ag-grid/ag-dev-prompts` [PR #636](https://github.com/ag-grid/ag-dev-prompts/pull/636) / [PR #637](https://github.com/ag-grid/ag-dev-prompts/pull/637), both merged to `canary`).
- **`repro-rebuild-chain`** — fires only after `browser-verify-chain` records a genuine, fresh `reproduces` verdict.

Both re-invoke the SAME composite action with a different `stage` input, via GHA job-graph `needs:` chaining — not a new `repository_dispatch` event type (simpler: no new cross-repo write scope needed, reuses outputs already threaded through the same workflow run).

## ⚠️ Security note — please read before approving

Both new jobs reuse the **same job permissions** as the existing `run` job (`contents: read`, `issues: write`, `packages: read`) — there is **no dedicated minimal-permission job split, no `persist-credentials: false`, no harden-runner block mode** yet. That hardening is deliberately separate, not-yet-landed follow-up work (documented in the action's own `CLAUDE.md`, § "Browser-verify (B2) — security posture"). The threat model: during these stages the agent keeps full Bash/Read/Write tools live (not just the browser), and the job's `GITHUB_TOKEN` + Jira credentials sit in the same process — a prompt-injected repro page could in principle try to exfiltrate them. This is accepted as bounded for manual, human-chosen dispatch (which is all that's happened to date); auto-firing on every confirmed pick with no per-instance human screening is exactly the scenario the deferred hardening is meant to close before this runs at real volume. Landing the chain first, unhardened, was an explicit call this session — flagging it here so it's a genuine decision at review time, not an oversight.

## Test plan
- [x] `actionlint .github/workflows/github-triage-pipeline.yml` — clean.
- [x] Sanity-checked actionlint actually catches the class of bug it's meant to (a `needs.<job>` reference to a job not listed in the job's own `needs:` — the exact mistake caught in the upstream ag-dev-prompts PR's own review).
- [ ] A real dispatch exercising the full chain (triage → browser-verify → repro-rebuild) on a real issue — not yet run; recommend a single controlled test before wider use.