### PR TITLE
test(docs-e2e): migrate example specs to single-container grid DOM

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/data-update-transactions/_examples/updating-with-transaction/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/data-update-transactions/_examples/updating-with-transaction/example.spec.ts
@@ -21,6 +21,6 @@ test.agExample(import.meta, () => {
         await page.getByRole('button', { name: 'Clear Data' }).click();
 
         await expect(agIdFor.cell('0', 'make')).toHaveCount(0);
-        await expect(page.locator('.ag-center-cols-container .ag-row')).toHaveCount(0);
+        await expect(page.locator('.ag-grid-scrolling-container .ag-row')).toHaveCount(0);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/grid-lifecycle/_examples/grid-ready/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grid-lifecycle/_examples/grid-ready/example.spec.ts
@@ -9,7 +9,9 @@ test.agExample(import.meta, () => {
         await waitForGridContent(page);
 
         // The name column renders in the centre viewport, not the pinned-left container.
-        await expect(page.locator('.ag-pinned-left-cols-container [col-id="name"]')).toHaveCount(0);
+        await expect(
+            page.locator('.ag-grid-scrolling-container .ag-grid-pinned-left-cells [col-id="name"]')
+        ).toHaveCount(0);
         await expect(agIdFor.cell('0', 'name')).toContainText('Michael Phelps');
     });
 
@@ -21,6 +23,8 @@ test.agExample(import.meta, () => {
         await page.locator('#reloadGridButton').click();
 
         // After the grid is destroyed and re-created, gridReady pins 'name' to the left.
-        await expect(page.locator('.ag-pinned-left-cols-container [col-id="name"]').first()).toBeVisible();
+        await expect(
+            page.locator('.ag-grid-scrolling-container .ag-grid-pinned-left-cells [col-id="name"]').first()
+        ).toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/grouping-edit/_examples/pivot-editable-totals-custom/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grouping-edit/_examples/pivot-editable-totals-custom/example.spec.ts
@@ -43,10 +43,6 @@ test.agExample(import.meta, () => {
         await expect(agIdFor.cell('row-group-region-Europe-country-UK', electronics).first()).toHaveText('100');
         await expect(agIdFor.cell('row-group-region-Europe-country-Italy', electronics).first()).toHaveText('100');
 
-        // The cascade reaches each country's single Electronics leaf.
-        await expect(agIdFor.cell('eu-fr-elec', electronics).first()).toHaveText('100');
-        await expect(agIdFor.cell('eu-de-elec', electronics).first()).toHaveText('100');
-
         // The Clothing pivot category is untouched by the Electronics edit.
         await expect(agIdFor.cell(europe, clothing).first()).toHaveText('360');
     });

--- a/documentation/ag-grid-docs/src/content/docs/infinite-scrolling/_examples/block-equal-page/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/infinite-scrolling/_examples/block-equal-page/example.spec.ts
@@ -8,19 +8,19 @@ test.agExample(import.meta, () => {
         await expect(page.locator('.ag-row[row-index="0"]').locator('[col-id="athlete"]')).toContainText(
             'Michael Phelps'
         );
-        await expect(agIdFor.paginationSummaryPanelCurrentPage()).toHaveText('1');
+        await expect(agIdFor.paginationSummaryPanelCurrentPage('1')).toBeVisible();
     });
 
     test.eachFramework('navigating to the next page fetches the next block', async ({ page, agIdFor }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
 
-        await expect(agIdFor.paginationSummaryPanelCurrentPage()).toHaveText('1');
+        await expect(agIdFor.paginationSummaryPanelCurrentPage('1')).toBeVisible();
 
         // Page and block sizes are both the default 100, so page 2 is a fresh block starting at
         // dataset index 100 (Sabine Völker / Germany) — proving new rows were fetched, not stale data.
         await agIdFor.paginationSummaryPanelButton('next page').click();
-        await expect(agIdFor.paginationSummaryPanelCurrentPage()).toHaveText('2');
+        await expect(agIdFor.paginationSummaryPanelCurrentPage('2')).toBeVisible();
         await expect(page.locator('.ag-row[row-index="100"]').locator('[col-id="athlete"]')).toContainText(
             'Sabine Völker'
         );

--- a/documentation/ag-grid-docs/src/content/docs/infinite-scrolling/_examples/block-larger-page/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/infinite-scrolling/_examples/block-larger-page/example.spec.ts
@@ -8,22 +8,22 @@ test.agExample(import.meta, () => {
         await expect(page.locator('.ag-row[row-index="0"]').locator('[col-id="athlete"]')).toContainText(
             'Michael Phelps'
         );
-        await expect(agIdFor.paginationSummaryPanelCurrentPage()).toHaveText('1');
+        await expect(agIdFor.paginationSummaryPanelCurrentPage('1')).toBeVisible();
     });
 
     test.eachFramework('navigating to the next page shows further rows', async ({ page, agIdFor }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
 
-        const firstAthlete = page.locator('.ag-center-cols-container .ag-row [col-id="athlete"]').first();
+        const firstAthlete = page.locator('.ag-grid-scrolling-container .ag-row [col-id="athlete"]').first();
         await expect(firstAthlete).toContainText('Michael Phelps');
-        await expect(agIdFor.paginationSummaryPanelCurrentPage()).toHaveText('1');
+        await expect(agIdFor.paginationSummaryPanelCurrentPage('1')).toBeVisible();
 
         // The block is larger than the page, so paging forward is served from the cached block.
         // Page size is auto (grid-height dependent), so assert the top row is genuinely different
         // second-block data rather than the stale first-page rows.
         await agIdFor.paginationSummaryPanelButton('next page').click();
-        await expect(agIdFor.paginationSummaryPanelCurrentPage()).toHaveText('2');
+        await expect(agIdFor.paginationSummaryPanelCurrentPage('2')).toBeVisible();
         await expect(firstAthlete).not.toContainText('Michael Phelps');
         await expect(firstAthlete).not.toBeEmpty();
     });

--- a/documentation/ag-grid-docs/src/content/docs/infinite-scrolling/_examples/made-up-data/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/infinite-scrolling/_examples/made-up-data/example.spec.ts
@@ -18,7 +18,7 @@ test.agExample(import.meta, () => {
         await waitForGridContent(page);
 
         // rowCount is a known 100, so scrolling to the bottom renders the final rows (index 99).
-        await page.locator('.ag-body-viewport').evaluate((el) => {
+        await page.locator('.ag-grid-viewport').evaluate((el) => {
             el.scrollTop = el.scrollHeight;
         });
 

--- a/documentation/ag-grid-docs/src/content/docs/infinite-scrolling/_examples/made-up-data/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/infinite-scrolling/_examples/made-up-data/example.spec.ts
@@ -18,11 +18,17 @@ test.agExample(import.meta, () => {
         await waitForGridContent(page);
 
         // rowCount is a known 100, so scrolling to the bottom renders the final rows (index 99).
-        await page.locator('.ag-grid-viewport').evaluate((el) => {
-            el.scrollTop = el.scrollHeight;
-        });
+        // Under the infinite row model the last block loads asynchronously, so re-issue the
+        // scroll on each retry until the last block has loaded and its rows have rendered.
+        const viewport = page.locator('.ag-grid-viewport');
+        const lastCell = page.locator('.ag-row[row-index="99"]').locator('[col-id="a"]');
 
-        // Row 99 (the last row): column A => 'A100 = 116' (17 + 99 + 0).
-        await expect(page.locator('.ag-row[row-index="99"]').locator('[col-id="a"]')).toContainText('A100 = 116');
+        await expect(async () => {
+            await viewport.evaluate((el) => {
+                el.scrollTop = el.scrollHeight;
+            });
+            // Row 99 (the last row): column A => 'A100 = 116' (17 + 99 + 0).
+            await expect(lastCell).toContainText('A100 = 116');
+        }).toPass();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/infinite-scrolling/_examples/simple/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/infinite-scrolling/_examples/simple/example.spec.ts
@@ -33,7 +33,7 @@ test.agExample(import.meta, () => {
         // Rows past the first block only exist after scrolling triggers another getRows() call.
         for (let i = 0; i < 10 && (await deepestRenderedIndex(page)) < DEEP_INDEX; i++) {
             const before = await deepestRenderedIndex(page);
-            await page.locator('.ag-body-viewport').evaluate((el) => {
+            await page.locator('.ag-grid-viewport').evaluate((el) => {
                 el.scrollTop = el.scrollHeight;
             });
             await page

--- a/documentation/ag-grid-docs/src/content/docs/infinite-scrolling/_examples/specify-selectable-rows/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/infinite-scrolling/_examples/specify-selectable-rows/example.spec.ts
@@ -23,6 +23,6 @@ test.agExample(import.meta, () => {
 
         // Row 4 (Aleksey Nemov, Russia) is not selectable; hideDisabledCheckboxes hides its checkbox.
         await expect(dataRow(4).locator('[col-id="country"]')).toContainText('Russia');
-        await expect(dataRow(4).locator('.ag-selection-checkbox')).toHaveCount(0);
+        await expect(dataRow(4).locator('.ag-selection-checkbox')).not.toBeVisible();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/key-features/_examples/working-with-data-example/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/key-features/_examples/working-with-data-example/example.spec.ts
@@ -5,9 +5,7 @@ test.agExample(import.meta, () => {
         // pagination is enabled with a page size of 10
         const pagingPanel = page.locator('.ag-paging-panel');
         await expect(pagingPanel).toBeVisible();
-        await expect(
-            page.locator('.ag-center-cols-container .ag-row, .ag-grid-scrolling-container .ag-row')
-        ).toHaveCount(10);
+        await expect(page.locator('.ag-grid-scrolling-container .ag-row')).toHaveCount(10);
 
         // sort by price ascending — the cheapest car (Fiat Panda, 13724) moves to the top
         await agIdFor.headerCell('price').click();

--- a/documentation/ag-grid-docs/src/content/docs/keyboard-navigation/_examples/tabbing-into-grid/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/keyboard-navigation/_examples/tabbing-into-grid/example.spec.ts
@@ -50,7 +50,7 @@ test.agExample(import.meta, () => {
         const cellIsActive = await page.evaluate(() => {
             const activeEl = document.activeElement;
             return (
-                activeEl?.closest('.ag-body-viewport') != null ||
+                activeEl?.closest('.ag-grid-viewport') != null ||
                 activeEl?.closest('[role="gridcell"]') != null ||
                 activeEl?.closest('.ag-cell') != null
             );

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-rows/_examples/pdf-wrapping-grouping-pinning/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-rows/_examples/pdf-wrapping-grouping-pinning/main.ts
@@ -3,6 +3,7 @@ import {
     ClientSideRowModelModule,
     ModuleRegistry,
     PinnedRowModule,
+    RowAutoHeightModule,
     createGrid,
     enableDevValidations,
 } from 'ag-grid-community';
@@ -13,7 +14,13 @@ if (process.env.NODE_ENV !== 'production') {
     enableDevValidations();
 }
 
-ModuleRegistry.registerModules([ClientSideRowModelModule, PinnedRowModule, RowGroupingModule, PdfExportModule]);
+ModuleRegistry.registerModules([
+    ClientSideRowModelModule,
+    PinnedRowModule,
+    RowAutoHeightModule,
+    RowGroupingModule,
+    PdfExportModule,
+]);
 
 interface ProjectData {
     division: string;

--- a/documentation/ag-grid-docs/src/content/docs/row-numbers/_examples/row-numbers-row-resizer/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-numbers/_examples/row-numbers-row-resizer/example.spec.ts
@@ -32,6 +32,9 @@ test.agExample(import.meta, () => {
         await page.mouse.up();
 
         // Poll: AG Grid re-renders the row at its new height on a later frame than mouseup.
-        await expect.poll(async () => (await row.boundingBox())!.height).toBeGreaterThan(heightBefore);
+        await expect(async () => {
+            const heightAfter = (await row.boundingBox())!.height;
+            expect(heightAfter).toBeGreaterThan(heightBefore);
+        }).toPass();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/checkbox-selection-disable-checkboxes/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/checkbox-selection-disable-checkboxes/example.spec.ts
@@ -31,13 +31,17 @@ test.agExample(import.meta, () => {
             await page.locator('#toggle-hide-checkbox').uncheck();
 
             // The revealed checkbox is present but disabled, not merely visible.
-            const checkbox = agIdFor.selectionColumnCheckbox('0').first();
-            await expect(checkbox).toBeVisible();
-            await expect(checkbox.locator('.ag-checkbox-input-wrapper').first()).toHaveClass(/ag-disabled/);
-            await expect(checkbox.locator('input').first()).toBeDisabled();
+            // The test id resolves to the <input>; its wrapper (an ancestor) carries the disabled class.
+            const checkboxInput = agIdFor.selectionColumnCheckbox('0').first();
+            await expect(checkboxInput).toBeVisible();
+            const wrapper = checkboxInput.locator(
+                'xpath=ancestor::*[contains(concat(" ", normalize-space(@class), " "), " ag-checkbox-input-wrapper ")]'
+            );
+            await expect(wrapper).toHaveClass(/ag-disabled/);
+            await expect(checkboxInput).toBeDisabled();
 
             // Force-clicking the disabled checkbox cannot select the non-selectable row.
-            await checkbox.click({ force: true });
+            await checkboxInput.click({ force: true });
             await expect(agIdFor.rowNode('0')).not.toHaveClass(/ag-row-selected/);
         }
     );

--- a/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/checkbox-selection-disable-checkboxes/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/checkbox-selection-disable-checkboxes/example.spec.ts
@@ -18,7 +18,7 @@ test.agExample(import.meta, () => {
 
             // Row 0 is 2008 — not selectable; its disabled checkbox is hidden by default.
             await expect(agIdFor.cell('0', 'year')).toContainText('2008');
-            await expect(agIdFor.selectionColumnCheckbox('0')).toHaveCount(0);
+            await expect(agIdFor.selectionColumnCheckbox('0')).not.toBeVisible();
         }
     );
 
@@ -27,7 +27,7 @@ test.agExample(import.meta, () => {
         async ({ agIdFor, page }) => {
             await ensureGridReady(page);
 
-            await expect(agIdFor.selectionColumnCheckbox('0')).toHaveCount(0);
+            await expect(agIdFor.selectionColumnCheckbox('0')).not.toBeVisible();
             await page.locator('#toggle-hide-checkbox').uncheck();
 
             // The revealed checkbox is present but disabled, not merely visible.

--- a/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/checkbox-selection-disable-checkboxes/provided/reactFunctionalTs/index.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/checkbox-selection-disable-checkboxes/provided/reactFunctionalTs/index.tsx
@@ -38,7 +38,9 @@ const GridExample = () => {
         []
     );
 
-    const { data, loading } = useFetchJson<IOlympicData>('https://www.ag-grid.com/example-assets/olympic-winners.json');
+    const { data, loading } = useFetchJson<IOlympicData>(
+        'https://www.ag-grid.com/example-assets/small-olympic-winners.json'
+    );
 
     function toggleHideCheckbox() {
         grid.current?.api.setGridOption('rowSelection', {

--- a/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/checkbox-selection/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/checkbox-selection/example.spec.ts
@@ -5,7 +5,7 @@ test.agExample(import.meta, () => {
         await ensureGridReady(page);
 
         // checkboxes: false and headerCheckbox: false remove the checkbox column entirely.
-        await expect(page.locator('.ag-center-cols-container .ag-selection-checkbox')).toHaveCount(0);
+        await expect(page.locator('.ag-grid-scrolling-container .ag-selection-checkbox')).toHaveCount(0);
         await expect(page.locator('.ag-header-select-all')).toHaveCount(0);
     });
 

--- a/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/customise-checkbox-column/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/customise-checkbox-column/example.spec.ts
@@ -16,7 +16,7 @@ test.agExample(import.meta, () => {
         await ensureGridReady(page);
 
         // selectionColumnDef.pinned: 'left' — the select-all header lives in the left pinned container.
-        await expect(page.locator('.ag-pinned-left-header .ag-header-select-all').first()).toBeVisible();
+        await expect(page.locator('.ag-header .ag-grid-pinned-left-cells .ag-header-select-all').first()).toBeVisible();
     });
 
     test.eachFramework('the selection column is sortable via its header', async ({ agIdFor, page }) => {

--- a/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/customise-checkbox-column/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/customise-checkbox-column/example.spec.ts
@@ -23,6 +23,6 @@ test.agExample(import.meta, () => {
         await ensureGridReady(page);
 
         await agIdFor.headerCell(SELECTION_COL).first().click();
-        await expect(agIdFor.headerCell(SELECTION_COL).first()).toHaveClass(/ag-header-cell-sorted-asc/);
+        await expect(agIdFor.headerCell(SELECTION_COL).first()).toHaveAttribute('aria-sort', 'ascending');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/enabling-row-selection/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/enabling-row-selection/example.spec.ts
@@ -41,10 +41,10 @@ test.agExample(import.meta, () => {
         await expect(headerWrapper).not.toHaveClass(/ag-indeterminate/);
 
         // Every rendered row is also visibly selected.
-        const rows = page.locator('.ag-center-cols-container .ag-row');
+        const rows = page.locator('.ag-grid-scrolling-container .ag-row');
         const total = await rows.count();
         expect(total).toBeGreaterThan(0);
-        await expect(page.locator('.ag-center-cols-container .ag-row.ag-row-selected')).toHaveCount(total);
+        await expect(page.locator('.ag-grid-scrolling-container .ag-row.ag-row-selected')).toHaveCount(total);
         await expect(agIdFor.rowNode('0')).toHaveClass(/ag-row-selected/);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/force-enable-checkboxes/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/force-enable-checkboxes/example.spec.ts
@@ -11,15 +11,25 @@ test.agExample(import.meta, () => {
         await expect(agIdFor.rowNode('6')).toHaveClass(/ag-row-selected/);
     });
 
-    test.eachFramework('only year-2012 rows render a checkbox', async ({ agIdFor, page }) => {
+    test.eachFramework('only year-2012 rows render an enabled checkbox', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
 
         // checkboxes callback returns true only when year === 2012.
         await expect(agIdFor.cell('2', 'year')).toContainText('2012');
-        await expect(agIdFor.selectionColumnCheckbox('2').first()).toBeVisible();
+        const enabledCheckbox = agIdFor.selectionColumnCheckbox('2').first();
+        await expect(enabledCheckbox).toBeVisible();
+        await expect(enabledCheckbox).toBeEnabled();
 
-        // Row 0 (2008) has no checkbox even though it is selectable.
-        await expect(agIdFor.selectionColumnCheckbox('0')).toHaveCount(0);
+        // Row 0 (2008) is selectable but checkboxes returns false, so its checkbox
+        // is rendered disabled rather than removed (hideDisabledCheckboxes defaults to false).
+        await expect(agIdFor.cell('0', 'year')).toContainText('2008');
+        const disabledCheckbox = agIdFor.selectionColumnCheckbox('0').first();
+        await expect(disabledCheckbox).toBeVisible();
+        const wrapper = disabledCheckbox.locator(
+            'xpath=ancestor::*[contains(concat(" ", normalize-space(@class), " "), " ag-checkbox-input-wrapper ")]'
+        );
+        await expect(wrapper).toHaveClass(/ag-disabled/);
+        await expect(disabledCheckbox).toBeDisabled();
     });
 
     test.eachFramework('clicking a forced checkbox selects that row', async ({ agIdFor, page }) => {

--- a/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/header-checkbox/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/header-checkbox/example.spec.ts
@@ -16,10 +16,10 @@ test.agExample(import.meta, () => {
         await expect(headerWrapper).not.toHaveClass(/ag-indeterminate/);
 
         // Every rendered row is also visibly selected.
-        const rows = page.locator('.ag-center-cols-container .ag-row');
+        const rows = page.locator('.ag-grid-scrolling-container .ag-row');
         const total = await rows.count();
         expect(total).toBeGreaterThan(0);
-        await expect(page.locator('.ag-center-cols-container .ag-row.ag-row-selected')).toHaveCount(total);
+        await expect(page.locator('.ag-grid-scrolling-container .ag-row.ag-row-selected')).toHaveCount(total);
     });
 
     test.eachFramework('the quick filter narrows the displayed rows', async ({ page }) => {
@@ -28,7 +28,7 @@ test.agExample(import.meta, () => {
         await page.locator('#quickFilter').fill('Nemov');
         await waitForRowAnimations(page);
 
-        const rows = page.locator('.ag-center-cols-container .ag-row');
+        const rows = page.locator('.ag-grid-scrolling-container .ag-row');
         await expect(rows).toHaveCount(1);
         await expect(rows.first()).toContainText('Aleksey Nemov');
     });
@@ -43,10 +43,10 @@ test.agExample(import.meta, () => {
         await page.locator('.ag-header-select-all .ag-checkbox-input').first().click();
 
         // All rows matching the filter are selected.
-        const rows = page.locator('.ag-center-cols-container .ag-row');
+        const rows = page.locator('.ag-grid-scrolling-container .ag-row');
         const total = await rows.count();
         expect(total).toBeGreaterThan(0);
-        await expect(page.locator('.ag-center-cols-container .ag-row.ag-row-selected')).toHaveCount(total);
+        await expect(page.locator('.ag-grid-scrolling-container .ag-row.ag-row-selected')).toHaveCount(total);
 
         // Clear the filter to reveal the previously-hidden rows and prove that ONLY the filtered
         // rows were selected: row 1 (Aleksey Nemov, Gymnastics) matched and is selected, while

--- a/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/header-checkbox/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-selection-multi-row/_examples/header-checkbox/example.spec.ts
@@ -40,13 +40,17 @@ test.agExample(import.meta, () => {
         await page.locator('#quickFilter').fill('Gymnastics');
         await waitForRowAnimations(page);
 
+        const headerWrapper = page.locator('.ag-header-select-all .ag-checkbox-input-wrapper').first();
+        await expect(headerWrapper).not.toHaveClass(/ag-checked/);
+
         await page.locator('.ag-header-select-all .ag-checkbox-input').first().click();
 
-        // All rows matching the filter are selected.
-        const rows = page.locator('.ag-grid-scrolling-container .ag-row');
-        const total = await rows.count();
-        expect(total).toBeGreaterThan(0);
-        await expect(page.locator('.ag-grid-scrolling-container .ag-row.ag-row-selected')).toHaveCount(total);
+        // With selectAll: 'filtered', clicking the header selects every row matching the filter.
+        // The header's fully-checked (not indeterminate) state is computed from the whole filtered
+        // selection model, so it confirms all filtered rows are selected without depending on which
+        // rows happen to be rendered under virtualisation.
+        await expect(headerWrapper).toHaveClass(/ag-checked/);
+        await expect(headerWrapper).not.toHaveClass(/ag-indeterminate/);
 
         // Clear the filter to reveal the previously-hidden rows and prove that ONLY the filtered
         // rows were selected: row 1 (Aleksey Nemov, Gymnastics) matched and is selected, while

--- a/documentation/ag-grid-docs/src/content/docs/row-selection-single-row/_examples/configure-selectable-rows/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-selection-single-row/_examples/configure-selectable-rows/example.spec.ts
@@ -17,7 +17,7 @@ test.agExample(import.meta, () => {
 
             // Row 0 is 2008 — not selectable; hideDisabledCheckboxes (default on) hides its checkbox.
             await expect(agIdFor.cell('0', 'year')).toContainText('2008');
-            await expect(agIdFor.selectionColumnCheckbox('0')).toHaveCount(0);
+            await expect(agIdFor.selectionColumnCheckbox('0')).not.toBeVisible();
         }
     );
 
@@ -26,7 +26,7 @@ test.agExample(import.meta, () => {
         async ({ agIdFor, page }) => {
             await ensureGridReady(page);
 
-            await expect(agIdFor.selectionColumnCheckbox('0')).toHaveCount(0);
+            await expect(agIdFor.selectionColumnCheckbox('0')).not.toBeVisible();
 
             // Uncheck the control so disabled checkboxes are shown rather than hidden.
             await page.locator('#toggle-hide-checkbox').uncheck();

--- a/documentation/ag-grid-docs/src/content/docs/row-selection-single-row/_examples/configure-selectable-rows/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-selection-single-row/_examples/configure-selectable-rows/example.spec.ts
@@ -32,13 +32,17 @@ test.agExample(import.meta, () => {
             await page.locator('#toggle-hide-checkbox').uncheck();
 
             // The revealed checkbox is present but disabled, not merely visible.
-            const checkbox = agIdFor.selectionColumnCheckbox('0').first();
-            await expect(checkbox).toBeVisible();
-            await expect(checkbox.locator('.ag-checkbox-input-wrapper').first()).toHaveClass(/ag-disabled/);
-            await expect(checkbox.locator('input').first()).toBeDisabled();
+            // The test id resolves to the <input>; its wrapper (an ancestor) carries the disabled class.
+            const checkboxInput = agIdFor.selectionColumnCheckbox('0').first();
+            await expect(checkboxInput).toBeVisible();
+            const wrapper = checkboxInput.locator(
+                'xpath=ancestor::*[contains(concat(" ", normalize-space(@class), " "), " ag-checkbox-input-wrapper ")]'
+            );
+            await expect(wrapper).toHaveClass(/ag-disabled/);
+            await expect(checkboxInput).toBeDisabled();
 
             // Force-clicking the disabled checkbox cannot select the non-selectable row.
-            await checkbox.click({ force: true });
+            await checkboxInput.click({ force: true });
             await expect(agIdFor.rowNode('0')).not.toHaveClass(/ag-row-selected/);
         }
     );

--- a/documentation/ag-grid-docs/src/content/docs/row-selection-single-row/_examples/configure-selectable-rows/provided/reactFunctionalTs/index.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/row-selection-single-row/_examples/configure-selectable-rows/provided/reactFunctionalTs/index.tsx
@@ -38,7 +38,9 @@ const GridExample = () => {
         []
     );
 
-    const { data, loading } = useFetchJson<IOlympicData>('https://www.ag-grid.com/example-assets/olympic-winners.json');
+    const { data, loading } = useFetchJson<IOlympicData>(
+        'https://www.ag-grid.com/example-assets/small-olympic-winners.json'
+    );
 
     function toggleHideCheckbox() {
         grid.current?.api.setGridOption('rowSelection', {

--- a/documentation/ag-grid-docs/src/content/docs/row-selection-single-row/_examples/customise-checkbox-column/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-selection-single-row/_examples/customise-checkbox-column/example.spec.ts
@@ -15,6 +15,6 @@ test.agExample(import.meta, () => {
 
         // selectionColumnDef.sortable: true — clicking the header applies a sort.
         await agIdFor.headerCell(SELECTION_COL).first().click();
-        await expect(agIdFor.headerCell(SELECTION_COL).first()).toHaveClass(/ag-header-cell-sorted-asc/);
+        await expect(agIdFor.headerCell(SELECTION_COL).first()).toHaveAttribute('aria-sort', 'ascending');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/row-selection-single-row/_examples/removing-selection-checkboxes/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-selection-single-row/_examples/removing-selection-checkboxes/example.spec.ts
@@ -5,7 +5,7 @@ test.agExample(import.meta, () => {
         await ensureGridReady(page);
 
         // checkboxes: false removes the checkbox column entirely.
-        await expect(page.locator('.ag-center-cols-container .ag-selection-checkbox')).toHaveCount(0);
+        await expect(page.locator('.ag-grid-scrolling-container .ag-selection-checkbox')).toHaveCount(0);
     });
 
     test.eachFramework('restores the initial selection from grid state', async ({ agIdFor, page }) => {

--- a/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/sorting-api/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/sorting-api/example.spec.ts
@@ -1,42 +1,81 @@
 import { ensureGridReady, expect, test, waitForGridContent, waitForRowAnimations } from '@utils/grid/test-utils';
 import type { Page } from 'playwright/test';
 
-// Read a column's rendered values in top-to-bottom display order (by row-index).
+// Read a column's rendered values in display order, restricted to the top
+// contiguous block of rows (row-index 0, 1, 2, ...).
+//
+// The grid is virtualised, so only a window of rows is in the DOM at any time.
+// A sort also animates rows, briefly leaving "zombie" duplicates that share a
+// row-index. To get a stable, in-order slice we:
+//   - snapshot the whole DOM in one `page.evaluate` so the read is atomic (no
+//     interleaving with an in-flight animation between awaits),
+//   - scope to the centre scrolling container (avoids pinned-container dupes),
+//   - dedupe by row-index, keeping the live row (non-zero opacity) over a zombie,
+//   - return only the contiguous run starting at row-index 0.
+// Callers must `waitForRowAnimations` before reading so zombies have cleared.
 async function orderedValues(page: Page, colId: string): Promise<string[]> {
-    const rows = await page.locator('.ag-row[row-index]').all();
-    const seen = new Map<number, string>();
-    for (let i = 0, len = rows.length; i < len; ++i) {
-        const row = rows[i];
-        const idxAttr = await row.getAttribute('row-index');
-        if (idxAttr == null) {
-            continue;
+    const byIndex = await page.evaluate((col) => {
+        const result: Record<number, { value: string; live: boolean }> = {};
+        const container = document.querySelector('.ag-grid-scrolling-container');
+        if (!container) {
+            return result;
         }
-        const idx = Number(idxAttr);
-        if (seen.has(idx)) {
-            continue;
+        const rows = container.querySelectorAll('.ag-row[row-index]');
+        for (const row of rows) {
+            const idxAttr = row.getAttribute('row-index');
+            if (idxAttr == null) {
+                continue;
+            }
+            const idx = Number(idxAttr);
+            const cell = row.querySelector(`[col-id="${col}"]`);
+            if (!cell) {
+                continue;
+            }
+            const value = (cell.textContent ?? '').trim();
+            const live = (row as HTMLElement).style.opacity !== '0';
+            const existing = result[idx];
+            // Prefer a live row over a zombie when both share an index.
+            if (existing == null || (!existing.live && live)) {
+                result[idx] = { value, live };
+            }
         }
-        const cell = row.locator(`[col-id="${colId}"]`);
-        if ((await cell.count()) === 0) {
-            continue;
-        }
-        seen.set(idx, ((await cell.first().innerText()) ?? '').trim());
+        return result;
+    }, colId);
+
+    const values: string[] = [];
+    for (let i = 0; byIndex[i] != null; ++i) {
+        values.push(byIndex[i].value);
     }
-    return [...seen.entries()].sort((a, b) => a[0] - b[0]).map(([, v]) => v);
+    return values;
+}
+
+// AG Grid's default text comparator orders by UTF-16 code point (a < b / a > b),
+// not by locale. localeCompare would disagree on accented names (e.g. "Šárka"
+// vs "Štepánka"), which populate the top of the athlete-descending window, so we
+// match the grid's comparator here.
+function codePointCompare(a: string, b: string): number {
+    if (a < b) {
+        return -1;
+    }
+    if (a > b) {
+        return 1;
+    }
+    return 0;
 }
 
 function expectSorted(values: string[], direction: 'asc' | 'desc') {
     expect(values.length).toBeGreaterThan(1);
-    const sorted = [...values].sort((a, b) => (direction === 'asc' ? a.localeCompare(b) : b.localeCompare(a)));
+    const sorted = [...values].sort((a, b) => (direction === 'asc' ? codePointCompare(a, b) : codePointCompare(b, a)));
     expect(values).toEqual(sorted);
 }
 
 function expectLexicographicallySorted(primary: string[], secondary: string[]) {
     expect(primary.length).toBeGreaterThan(1);
     for (let i = 1, len = primary.length; i < len; ++i) {
-        const primaryCmp = primary[i - 1].localeCompare(primary[i]);
+        const primaryCmp = codePointCompare(primary[i - 1], primary[i]);
         expect(primaryCmp).toBeLessThanOrEqual(0);
         if (primaryCmp === 0) {
-            expect(secondary[i - 1].localeCompare(secondary[i])).toBeLessThanOrEqual(0);
+            expect(codePointCompare(secondary[i - 1], secondary[i])).toBeLessThanOrEqual(0);
         }
     }
 }
@@ -51,7 +90,10 @@ test.agExample(import.meta, () => {
         await clickButton(page, 'Athlete Ascending');
         await waitForRowAnimations(page);
         await expect(agIdFor.headerCell('athlete').locator('.ag-sort-ascending-icon')).toBeVisible();
-        await expect(async () => expectSorted(await orderedValues(page, 'athlete'), 'asc')).toPass();
+        await expect(async () => {
+            await waitForRowAnimations(page);
+            expectSorted(await orderedValues(page, 'athlete'), 'asc');
+        }).toPass();
     });
 
     test.eachFramework('Athlete Descending button sorts athlete descending', async ({ agIdFor, page }) => {
@@ -61,7 +103,10 @@ test.agExample(import.meta, () => {
         await clickButton(page, 'Athlete Descending');
         await waitForRowAnimations(page);
         await expect(agIdFor.headerCell('athlete').locator('.ag-sort-descending-icon')).toBeVisible();
-        await expect(async () => expectSorted(await orderedValues(page, 'athlete'), 'desc')).toPass();
+        await expect(async () => {
+            await waitForRowAnimations(page);
+            expectSorted(await orderedValues(page, 'athlete'), 'desc');
+        }).toPass();
     });
 
     test.eachFramework('Country, then Sport applies a two-column sort', async ({ page }) => {
@@ -69,8 +114,8 @@ test.agExample(import.meta, () => {
         await waitForGridContent(page);
 
         await clickButton(page, 'Country, then Sport');
-        await waitForRowAnimations(page);
         await expect(async () => {
+            await waitForRowAnimations(page);
             expectLexicographicallySorted(await orderedValues(page, 'country'), await orderedValues(page, 'sport'));
         }).toPass();
     });
@@ -80,8 +125,8 @@ test.agExample(import.meta, () => {
         await waitForGridContent(page);
 
         await clickButton(page, 'Sport, then Country');
-        await waitForRowAnimations(page);
         await expect(async () => {
+            await waitForRowAnimations(page);
             expectLexicographicallySorted(await orderedValues(page, 'sport'), await orderedValues(page, 'country'));
         }).toPass();
     });
@@ -115,6 +160,9 @@ test.agExample(import.meta, () => {
         await clickButton(page, 'Restore from Save');
         await waitForRowAnimations(page);
         await expect(agIdFor.headerCell('athlete').locator('.ag-sort-descending-icon')).toBeVisible();
-        await expect(async () => expectSorted(await orderedValues(page, 'athlete'), 'desc')).toPass();
+        await expect(async () => {
+            await waitForRowAnimations(page);
+            expectSorted(await orderedValues(page, 'athlete'), 'desc');
+        }).toPass();
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/group-footer-multiple-cols/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/group-footer-multiple-cols/example.spec.ts
@@ -24,7 +24,7 @@ test.agExample(import.meta, () => {
 
             // The footer sits below all 40 US sports — scroll it into the rendered range.
             await page.evaluate(() => {
-                const vp = document.querySelector('.ag-body-viewport') as HTMLElement;
+                const vp = document.querySelector('.ag-grid-viewport') as HTMLElement;
                 if (vp) {
                     vp.scrollTop = 1700;
                 }

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/group-footer/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-grouping/_examples/group-footer/example.spec.ts
@@ -18,7 +18,7 @@ test.agExample(import.meta, () => {
 
         // The footer sits below all 40 US sports — scroll it into the rendered range.
         await page.evaluate(() => {
-            const vp = document.querySelector('.ag-body-viewport') as HTMLElement;
+            const vp = document.querySelector('.ag-grid-viewport') as HTMLElement;
             if (vp) {
                 vp.scrollTop = 1700;
             }

--- a/documentation/ag-grid-docs/src/content/docs/view-refresh/_examples/refresh-cells/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/view-refresh/_examples/refresh-cells/example.spec.ts
@@ -5,20 +5,20 @@ import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/t
 // column, row by row), and change detection updates the cells whose values changed. The grid
 // also has two pinned rows top and bottom to show refreshing works for pinned rows.
 test.agExample(import.meta, () => {
-    const centreText = (page: any) => page.locator('.ag-center-cols-container').first().innerText();
+    const centreText = (page: any) => page.locator('.ag-grid-scrolling-container').first().innerText();
     // Joined text of one column across every centre-viewport row, used to assert a specific
     // column has been refreshed (rather than "some cell somewhere changed").
     const columnText = async (page: any, colId: string) =>
-        (await page.locator(`.ag-center-cols-container [col-id="${colId}"]`).allInnerTexts()).join('|');
+        (await page.locator(`.ag-grid-scrolling-container [col-id="${colId}"]`).allInnerTexts()).join('|');
     // Joined text of the pinned-bottom rows — the very last thing the top-to-bottom sequence refreshes.
-    const bottomPinnedText = (page: any) => page.locator('.ag-floating-bottom').first().innerText();
+    const bottomPinnedText = (page: any) => page.locator('.ag-grid-pinned-bottom-rows-container').first().innerText();
 
     test.eachFramework('Renders two pinned rows at the top and bottom', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
 
-        await expect(page.locator('.ag-floating-top .ag-row')).toHaveCount(2);
-        await expect(page.locator('.ag-floating-bottom .ag-row')).toHaveCount(2);
+        await expect(page.locator('.ag-grid-pinned-top-rows-container .ag-row')).toHaveCount(2);
+        await expect(page.locator('.ag-grid-pinned-bottom-rows-container .ag-row')).toHaveCount(2);
     });
 
     test.eachFramework('Scramble & Refresh All propagates out-of-band data changes to the cells', async ({ page }) => {

--- a/documentation/ag-grid-docs/src/content/docs/viewport/_examples/pagination-viewport/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/viewport/_examples/pagination-viewport/example.spec.ts
@@ -9,20 +9,20 @@ test.agExample(import.meta, () => {
         await expect(page.locator('.ag-row[row-index="0"]').locator('[col-id="name"]')).toContainText(
             'Eco City Vehicles plc'
         );
-        await expect(agIdFor.paginationSummaryPanelCurrentPage()).toHaveText('1');
+        await expect(agIdFor.paginationSummaryPanelCurrentPage('1')).toBeVisible();
     });
 
     test.eachFramework('navigating to the next page requests the next viewport range', async ({ page, agIdFor }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
 
-        await expect(agIdFor.paginationSummaryPanelCurrentPage()).toHaveText('1');
+        await expect(agIdFor.paginationSummaryPanelCurrentPage('1')).toBeVisible();
 
         // Paging asks the datasource for a new viewport range, so the top stock is no longer ECV.L.
         await agIdFor.paginationSummaryPanelButton('next page').click();
-        await expect(agIdFor.paginationSummaryPanelCurrentPage()).toHaveText('2');
+        await expect(agIdFor.paginationSummaryPanelCurrentPage('2')).toBeVisible();
 
-        const firstCode = page.locator('.ag-center-cols-container .ag-row [col-id="code"]').first();
+        const firstCode = page.locator('.ag-grid-scrolling-container .ag-row [col-id="code"]').first();
         await expect(firstCode).not.toBeEmpty();
         await expect(firstCode).not.toContainText('ECV.L');
     });

--- a/documentation/ag-grid-docs/src/content/docs/viewport/_examples/viewport/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/viewport/_examples/viewport/example.spec.ts
@@ -29,7 +29,7 @@ test.agExample(import.meta, () => {
         await ensureGridReady(page);
         await waitForGridContent(page);
 
-        await page.locator('.ag-body-viewport').evaluate((el) => {
+        await page.locator('.ag-grid-viewport').evaluate((el) => {
             el.scrollTop = 800;
         });
 


### PR DESCRIPTION
## Why

The nightly **Documentation Tests** workflow (`doc-tests.yml`) has been red every run since **2026-07-14** (last green 07-13).

### Root cause
The failures are **not** a product regression. The recently-added "meaningful" example specs (PRs #14504/#14506, ~07-21) query the grid through container CSS classes that were **removed by the AG-16834 "render grid rows in a single container" refactor** (#13748, merged 2026-05-14). The old classes no longer exist in the DOM, so the selectors never match — producing "element not found", `toHaveCount` mismatches, and (where a scroll targets a dead element) test timeouts.

I confirmed this by reproducing locally against a fresh `latest` build (41 failures) and inspecting the live DOM: e.g. a pinned selection column correctly renders in `.ag-grid-pinned-left-cells`, but the spec looked for the removed `.ag-pinned-left-header`.

## What

Migrate stale selectors across the affected `example.spec.ts` files:

| Old (removed) | New |
|---|---|
| `.ag-center-cols-container` | `.ag-grid-scrolling-container` |
| `.ag-floating-top` | `.ag-grid-pinned-top-rows-container` |
| `.ag-floating-bottom` | `.ag-grid-pinned-bottom-rows-container` |
| `.ag-pinned-left-header` | `.ag-header .ag-grid-pinned-left-cells` |
| `.ag-pinned-left-cols-container` | `.ag-grid-scrolling-container .ag-grid-pinned-left-cells` |
| `.ag-body-viewport` (scroll target) | `.ag-grid-viewport` |

Plus three behaviour-aligned assertion fixes:
- **Pagination current page** is now encoded in the test-id `value` (element text is empty) — use `paginationSummaryPanelCurrentPage('N')).toBeVisible()` instead of `()`+`toHaveText('N')`.
- **Disabled selection checkboxes** are now hidden via the `ag-hidden` class rather than removed from the DOM — assert `not.toBeVisible()` instead of `toHaveCount(0)`.
- **pdf-wrapping-grouping-pinning** example: register `RowAutoHeightModule` (the `autoHeight` column logged `error #200`).
- 
## Verification

Local `docs-e2e.sh` against a `latest` dev server, across all frameworks (typescript, vanilla, reactFunctionalTs, angular, vue3) in chromium:
