### PR TITLE
test(docs-e2e): fix nightly Documentation Tests failures

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/column-menu/_examples/customising-menu-items/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-menu/_examples/customising-menu-items/example.spec.ts
@@ -1,8 +1,11 @@
-import { expect, test } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     test.eachFramework('age column appends custom items to the default menu', async ({ agIdFor, page }) => {
-        await expect(agIdFor.cell('0', 'age')).toContainText('23');
+        // `sport` is row-grouped, so the top displayed rows are group rows without leaf cells;
+        // just wait for the grid to render rather than asserting a specific leaf cell.
+        await ensureGridReady(page);
+        await waitForGridContent(page);
 
         await agIdFor.headerCell('age').hover();
         await agIdFor.headerCellMenuButton('age').click();

--- a/documentation/ag-grid-docs/src/content/docs/infinite-scrolling/_examples/server-side/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/infinite-scrolling/_examples/server-side/example.spec.ts
@@ -23,9 +23,15 @@ test.agExample(import.meta, () => {
         await agIdFor.headerCell('athlete').click();
         await waitForRowAnimations(page);
 
-        // Ascending by athlete name: 'Michael Phelps' is no longer the first row.
-        await expect(dataRow(0).locator('[col-id="athlete"]')).not.toContainText('Michael Phelps');
-        await expect(dataRow(0).locator('[col-id="athlete"]')).not.toBeEmpty();
+        // The sort purges the cache and re-fetches; row 0 is briefly a loading placeholder
+        // (a spinner image in the ID column). This demo dataset has blank-athlete records
+        // that sort to the top ascending, so assert the block has finished loading (no
+        // spinner) and that the re-order moved 'Michael Phelps' off the first row — rather
+        // than assuming row 0's athlete is non-empty.
+        await expect(async () => {
+            await expect(dataRow(0).locator('img')).toHaveCount(0);
+            await expect(dataRow(0).locator('[col-id="athlete"]')).not.toContainText('Michael Phelps');
+        }).toPass();
     });
 
     test.eachFramework('selecting a row applies the selected state', async ({ page }) => {

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-rows/_examples/pdf-export-rows/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-rows/_examples/pdf-export-rows/main.ts
@@ -3,6 +3,7 @@ import {
     ClientSideRowModelModule,
     ModuleRegistry,
     PinnedRowModule,
+    RowApiModule,
     RowSelectionModule,
     TextFilterModule,
     createGrid,
@@ -18,6 +19,7 @@ if (process.env.NODE_ENV !== 'production') {
 ModuleRegistry.registerModules([
     ClientSideRowModelModule,
     PinnedRowModule,
+    RowApiModule,
     RowSelectionModule,
     TextFilterModule,
     PdfExportModule,

--- a/documentation/ag-grid-docs/src/content/docs/row-selection-single-row/_examples/suppress-click-selection/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-selection-single-row/_examples/suppress-click-selection/example.spec.ts
@@ -1,15 +1,16 @@
 import { ensureGridReady, expect, test, waitForRowAnimations } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('enableClickSelection true selects and deselects on click', async ({ agIdFor, page }) => {
+    test.eachFramework('enableClickSelection true moves selection on click', async ({ agIdFor, page }) => {
         await ensureGridReady(page);
 
         // Default control value is 'true' — clicking a row selects it.
         await agIdFor.cell('0', 'athlete').first().click();
         await expect(agIdFor.rowNode('0')).toHaveClass(/ag-row-selected/);
 
-        // Clicking the selected row again deselects it.
-        await agIdFor.cell('0', 'athlete').first().click();
+        // In single-row mode, clicking another row moves the selection to it.
+        await agIdFor.cell('1', 'athlete').first().click();
+        await expect(agIdFor.rowNode('1')).toHaveClass(/ag-row-selected/);
         await expect(agIdFor.rowNode('0')).not.toHaveClass(/ag-row-selected/);
     });
 

--- a/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/multi-column/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/multi-column/example.spec.ts
@@ -1,27 +1,30 @@
 import { ensureGridReady, expect, test, waitForGridContent, waitForRowAnimations } from '@utils/grid/test-utils';
 import type { Page } from 'playwright/test';
 
-// Read a column's rendered values in top-to-bottom display order (by row-index).
+// Read a column's rendered values in top-to-bottom display order (by row-index). Read in a
+// single evaluate call: per-row awaits race virtualisation and hang on detached rows.
 async function orderedValues(page: Page, colId: string): Promise<string[]> {
-    const rows = await page.locator('.ag-row[row-index]').all();
-    const seen = new Map<number, string>();
-    for (let i = 0, len = rows.length; i < len; ++i) {
-        const row = rows[i];
-        const idxAttr = await row.getAttribute('row-index');
-        if (idxAttr == null) {
-            continue;
+    return page.evaluate((colId) => {
+        const seen = new Map<number, string>();
+        const rows = document.querySelectorAll('.ag-row[row-index]');
+        for (let i = 0, len = rows.length; i < len; ++i) {
+            const row = rows[i];
+            const idxAttr = row.getAttribute('row-index');
+            if (idxAttr == null) {
+                continue;
+            }
+            const idx = Number(idxAttr);
+            if (seen.has(idx)) {
+                continue;
+            }
+            const cell = row.querySelector(`[col-id="${colId}"]`);
+            if (!cell) {
+                continue;
+            }
+            seen.set(idx, (cell.textContent ?? '').trim());
         }
-        const idx = Number(idxAttr);
-        if (seen.has(idx)) {
-            continue;
-        }
-        const cell = row.locator(`[col-id="${colId}"]`);
-        if ((await cell.count()) === 0) {
-            continue;
-        }
-        seen.set(idx, ((await cell.first().innerText()) ?? '').trim());
-    }
-    return [...seen.entries()].sort((a, b) => a[0] - b[0]).map(([, v]) => v);
+        return [...seen.entries()].sort((a, b) => a[0] - b[0]).map(([, v]) => v);
+    }, colId);
 }
 
 function compare(a: string, b: string, isNumeric: boolean): number {

--- a/documentation/ag-grid-docs/src/content/docs/row-spanning/_examples/row-spanning-simple/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-spanning/_examples/row-spanning-simple/example.spec.ts
@@ -22,11 +22,18 @@ async function expectCellOwnsItsCentre(page: Page, selector: string, minimumHeig
 }
 
 async function scrollHorizontally(page: Page): Promise<void> {
-    const viewport = page.locator('.ag-grid-viewport');
-    await viewport.evaluate((element) => {
-        element.scrollLeft = 300;
+    // The grid drives horizontal scroll from the dedicated scrollbar viewport; assigning
+    // scrollLeft on the display viewport is reset by the grid, so scroll the scrollbar one.
+    // Retry via waitForFunction until the grid is wide enough for the scroll to take effect.
+    await page.waitForFunction(() => {
+        const scrollbar = document.querySelector<HTMLElement>('.ag-body-horizontal-scroll-viewport');
+        if (!scrollbar) {
+            return false;
+        }
+        scrollbar.scrollLeft = 300;
+        scrollbar.dispatchEvent(new Event('scroll'));
+        return scrollbar.scrollLeft > 0;
     });
-    await expect.poll(() => viewport.evaluate((element) => element.scrollLeft)).toBeGreaterThan(0);
 }
 
 test.agExample(import.meta, () => {

--- a/documentation/ag-grid-docs/src/content/docs/row-spanning/_examples/row-spanning-simple/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-spanning/_examples/row-spanning-simple/main.ts
@@ -2,6 +2,7 @@ import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
 import {
     CellSpanModule,
     ClientSideRowModelModule,
+    ColumnApiModule,
     ModuleRegistry,
     createGrid,
     enableDevValidations,
@@ -12,7 +13,7 @@ if (process.env.NODE_ENV !== 'production') {
     enableDevValidations();
 }
 
-ModuleRegistry.registerModules([CellSpanModule, ClientSideRowModelModule]);
+ModuleRegistry.registerModules([CellSpanModule, ClientSideRowModelModule, ColumnApiModule]);
 
 const columnDefs: ColDef[] = [
     { field: 'country', spanRows: true, sort: 'asc' },

--- a/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/status-bar/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/status-bar/_examples/status-bar/example.spec.ts
@@ -19,9 +19,12 @@ test.agExample(import.meta, () => {
         await expect(aggregations.locator('.ag-status-name-value').filter({ hasText: 'Average' })).toContainText('6');
         await expect(aggregations.locator('.ag-status-name-value').filter({ hasText: 'Sum' })).toContainText('18');
 
-        // Count, Min and Max are not configured, so they must not be shown.
-        await expect(aggregations).not.toContainText('Count');
-        await expect(aggregations).not.toContainText('Min');
-        await expect(aggregations).not.toContainText('Max');
+        // Count, Min and Max are not configured. Their label elements stay in the DOM but are
+        // hidden (display:none), so assert visibility rather than text absence — `toContainText`
+        // matches textContent, which includes hidden nodes.
+        const named = (label: string) => aggregations.locator('.ag-status-name-value').filter({ hasText: label });
+        await expect(named('Count')).toBeHidden();
+        await expect(named('Min')).toBeHidden();
+        await expect(named('Max')).toBeHidden();
     });
 });


### PR DESCRIPTION
Fixes the 8 deterministic failures in the nightly **Documentation Tests** job (docs-e2e run against grid-staging).

- **pdf-export-rows**, **row-spanning-simple**: register `RowApiModule` / `ColumnApiModule` — the staging production build only has explicitly-registered modules.
- **row-spanning-simple**: fix the horizontal-scroll helper (scroll the scrollbar viewport; `expect.poll` isn't available on the wrapped `expect`).
- **column-menu**, **row-selection**, **status-bar**, **row-sorting**, **infinite-scrolling**: correct wrong spec assertions (row-grouped leaf cell, single-row re-click, hidden aggregation labels, virtualization-hang in `orderedValues`, blank-athlete sort order).