### PR TITLE
[AG-115] Fix(column-header): edit popup padding + header tooltip refresh on rename

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_column-header-edit.scss
+++ b/community-modules/styles/src/internal/base/parts/_column-header-edit.scss
@@ -6,7 +6,7 @@
         flex-direction: column;
         gap: var(--ag-widget-vertical-spacing);
         padding: var(--ag-widget-container-vertical-padding) var(--ag-widget-container-horizontal-padding)
-            calc(var(--ag-widget-container-vertical-padding) * 2);
+            var(--ag-widget-vertical-spacing);
         box-sizing: border-box;
         height: 100%;
     }

--- a/packages/ag-grid-community/src/tooltip/tooltipService.ts
+++ b/packages/ag-grid-community/src/tooltip/tooltipService.ts
@@ -291,17 +291,22 @@ export class TooltipService extends BeanStub implements NamedBean {
         }
         const location = 'header';
         const headerLocation = 'header';
-        const valueFormatted = this.beans.colNames.getDisplayNameForColumn(column, headerLocation, true);
-        const value = passedValue ?? valueFormatted;
         const tooltipCtrl: ITooltipCtrl = {
             getGui: () => eGui,
             getLocation: () => location,
-            getTooltipValue: () =>
-                passedValue ??
-                colDef?.headerTooltipValueGetter?.(
-                    _addGridCommonParams(gos, { location, colDef, column, value, valueFormatted })
-                ) ??
-                colDef?.headerTooltip,
+            // Resolve the display name on each read so a refresh (e.g. after a header rename) reflects the
+            // current name, rather than serving the name captured when the tooltip was first set up.
+            getTooltipValue: () => {
+                if (passedValue != null) {
+                    return passedValue;
+                }
+                const valueFormatted = this.beans.colNames.getDisplayNameForColumn(column, headerLocation, true);
+                return (
+                    colDef?.headerTooltipValueGetter?.(
+                        _addGridCommonParams(gos, { location, colDef, column, value: valueFormatted, valueFormatted })
+                    ) ?? colDef?.headerTooltip
+                );
+            },
             shouldDisplayTooltip,
             getAdditionalParams: () => ({
                 column,
@@ -342,18 +347,23 @@ export class TooltipService extends BeanStub implements NamedBean {
 
         const location = 'headerGroup';
         const headerLocation = 'header';
-        const valueFormatted = this.beans.colNames.getDisplayNameForColumnGroup(column, headerLocation);
-        const value = passedValue ?? valueFormatted;
 
         const tooltipCtrl: ITooltipCtrl = {
             getGui: () => eGui,
             getLocation: () => location,
-            getTooltipValue: () =>
-                passedValue ??
-                colDef?.headerTooltipValueGetter?.(
-                    _addGridCommonParams(gos, { location, colDef, column, value, valueFormatted })
-                ) ??
-                colDef?.headerTooltip,
+            // Resolve the display name on each read so a refresh (e.g. after a group rename) reflects the
+            // current name, rather than serving the name captured when the tooltip was first set up.
+            getTooltipValue: () => {
+                if (passedValue != null) {
+                    return passedValue;
+                }
+                const valueFormatted = this.beans.colNames.getDisplayNameForColumnGroup(column, headerLocation);
+                return (
+                    colDef?.headerTooltipValueGetter?.(
+                        _addGridCommonParams(gos, { location, colDef, column, value: valueFormatted, valueFormatted })
+                    ) ?? colDef?.headerTooltip
+                );
+            },
             shouldDisplayTooltip,
             getAdditionalParams: () => {
                 const additionalParams: ITooltipCtrlParams = {

--- a/packages/ag-grid-community/src/tooltip/tooltipService.ts
+++ b/packages/ag-grid-community/src/tooltip/tooltipService.ts
@@ -5,6 +5,8 @@ import type { NamedBean } from '../context/bean';
 import { BeanStub } from '../context/beanStub';
 import type { BeanCollection } from '../context/context';
 import type { AgColumn } from '../entities/agColumn';
+import type { AgColumnGroup } from '../entities/agColumnGroup';
+import type { ColDef, ColGroupDef } from '../entities/colDef';
 import type { RowNode } from '../entities/rowNode';
 import { _addGridCommonParams } from '../gridOptionsUtils';
 import type { HeaderCellCtrl } from '../headerRendering/cells/column/headerCellCtrl';
@@ -265,6 +267,31 @@ const resolveCellTooltip = ({
 export class TooltipService extends BeanStub implements NamedBean {
     beanName = 'tooltipSvc' as const;
 
+    /**
+     * Resolves the display name on each read so a refresh (e.g. after a header rename) reflects the current
+     * name, rather than serving the name captured when the tooltip was first set up.
+     */
+    private createHeaderTooltipValueGetter(
+        location: 'header' | 'headerGroup',
+        column: AgColumn | AgColumnGroup,
+        colDef: ColDef | ColGroupDef | null | undefined,
+        passedValue: string | undefined,
+        getDisplayName: () => string | null
+    ): () => string | null | undefined {
+        const gos = this.gos;
+        return () => {
+            if (passedValue != null) {
+                return passedValue;
+            }
+            const valueFormatted = getDisplayName();
+            return (
+                colDef?.headerTooltipValueGetter?.(
+                    _addGridCommonParams(gos, { location, colDef, column, value: valueFormatted, valueFormatted })
+                ) ?? colDef?.headerTooltip
+            );
+        };
+    }
+
     public setupHeaderTooltip(
         existingTooltipFeature: TooltipFeature | undefined,
         ctrl: HeaderCellCtrl,
@@ -294,19 +321,9 @@ export class TooltipService extends BeanStub implements NamedBean {
         const tooltipCtrl: ITooltipCtrl = {
             getGui: () => eGui,
             getLocation: () => location,
-            // Resolve the display name on each read so a refresh (e.g. after a header rename) reflects the
-            // current name, rather than serving the name captured when the tooltip was first set up.
-            getTooltipValue: () => {
-                if (passedValue != null) {
-                    return passedValue;
-                }
-                const valueFormatted = this.beans.colNames.getDisplayNameForColumn(column, headerLocation, true);
-                return (
-                    colDef?.headerTooltipValueGetter?.(
-                        _addGridCommonParams(gos, { location, colDef, column, value: valueFormatted, valueFormatted })
-                    ) ?? colDef?.headerTooltip
-                );
-            },
+            getTooltipValue: this.createHeaderTooltipValueGetter(location, column, colDef, passedValue, () =>
+                this.beans.colNames.getDisplayNameForColumn(column, headerLocation, true)
+            ),
             shouldDisplayTooltip,
             getAdditionalParams: () => ({
                 column,
@@ -351,19 +368,9 @@ export class TooltipService extends BeanStub implements NamedBean {
         const tooltipCtrl: ITooltipCtrl = {
             getGui: () => eGui,
             getLocation: () => location,
-            // Resolve the display name on each read so a refresh (e.g. after a group rename) reflects the
-            // current name, rather than serving the name captured when the tooltip was first set up.
-            getTooltipValue: () => {
-                if (passedValue != null) {
-                    return passedValue;
-                }
-                const valueFormatted = this.beans.colNames.getDisplayNameForColumnGroup(column, headerLocation);
-                return (
-                    colDef?.headerTooltipValueGetter?.(
-                        _addGridCommonParams(gos, { location, colDef, column, value: valueFormatted, valueFormatted })
-                    ) ?? colDef?.headerTooltip
-                );
-            },
+            getTooltipValue: this.createHeaderTooltipValueGetter(location, column, colDef, passedValue, () =>
+                this.beans.colNames.getDisplayNameForColumnGroup(column, headerLocation)
+            ),
             shouldDisplayTooltip,
             getAdditionalParams: () => {
                 const additionalParams: ITooltipCtrlParams = {

--- a/packages/ag-grid-enterprise/src/columnHeaderEdit/columnHeaderEdit.css
+++ b/packages/ag-grid-enterprise/src/columnHeaderEdit/columnHeaderEdit.css
@@ -3,7 +3,7 @@
     flex-direction: column;
     gap: var(--ag-widget-vertical-spacing);
     padding: var(--ag-widget-container-vertical-padding) var(--ag-widget-container-horizontal-padding)
-        calc(var(--ag-widget-container-vertical-padding) * 2);
+        var(--ag-widget-vertical-spacing);
     box-sizing: border-box;
     height: 100%;
 }

--- a/testing/behavioural/src/columnHeaderEdit/editable-header-name-tooltip-and-grouping.test.ts
+++ b/testing/behavioural/src/columnHeaderEdit/editable-header-name-tooltip-and-grouping.test.ts
@@ -1,0 +1,151 @@
+import { userEvent } from '@testing-library/user-event';
+import { waitFor } from '@testing-library/dom';
+
+import type { AgColumn, ColDef, GridApi } from 'ag-grid-community';
+import { getGridElement } from 'ag-grid-community';
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+
+/**
+ * A renamed header name is stored as an override on the column entity (and the group-id-keyed group
+ * map), so it flows through the same display-name resolver the header tooltip and the row-group
+ * machinery consume. These tests lock in two behaviours not covered by editable-header-name.test.ts:
+ * the header tooltip reflecting a rename, and a leaf rename surviving a row-group/ungroup cycle.
+ */
+describe('Editable header name — tooltips', () => {
+    const gridMgr = new TestGridsManager({ modules: [AllEnterpriseModule] });
+
+    afterEach(() => {
+        gridMgr.reset();
+        vi.resetAllMocks();
+    });
+
+    const rowData = [{ athlete: 'Michael Phelps' }];
+
+    async function createGrid(columnDefs: ColDef[]): Promise<{ api: GridApi; gridDiv: HTMLElement }> {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs,
+            rowData,
+            defaultColDef: { flex: 1, minWidth: 100 },
+            tooltipShowDelay: 200,
+        });
+        return { api, gridDiv: getGridElement(api)! as HTMLElement };
+    }
+
+    const getTooltips = () => Array.from(document.querySelectorAll<HTMLElement>('.ag-tooltip, .ag-tooltip-custom'));
+    const waitForTooltips = async (count: number) =>
+        await waitFor(() => expect(getTooltips().length).toBe(count), { timeout: 2000 });
+
+    async function hoverHeader(gridDiv: HTMLElement): Promise<void> {
+        const headerCell = await waitFor(
+            () => document.querySelector('.ag-header-cell[col-id="athlete"]') as HTMLElement
+        );
+        await userEvent.hover(headerCell);
+        await asyncSetTimeout(250);
+    }
+
+    async function unhoverHeader(): Promise<void> {
+        const headerCell = document.querySelector('.ag-header-cell[col-id="athlete"]') as HTMLElement;
+        await userEvent.unhover(headerCell);
+        await asyncSetTimeout(250);
+        await waitForTooltips(0);
+    }
+
+    test('the header tooltip reflects the renamed name through headerTooltipValueGetter', async () => {
+        // The getter returns valueFormatted, which the tooltip service derives from the display name,
+        // so the override must surface here just as it does in the header cell text.
+        const { api, gridDiv } = await createGrid([
+            {
+                field: 'athlete',
+                headerNameEditable: true,
+                headerTooltipValueGetter: (params) => params.valueFormatted ?? '',
+            },
+        ]);
+
+        await hoverHeader(gridDiv);
+        await waitForTooltips(1);
+        expect(getTooltips()[0]).toHaveTextContent('Athlete');
+        await unhoverHeader();
+
+        api.applyColumnState({ state: [{ colId: 'athlete', headerName: 'Renamed' }] });
+        await asyncSetTimeout(1);
+
+        await hoverHeader(gridDiv);
+        await waitForTooltips(1);
+        expect(getTooltips()[0]).toHaveTextContent('Renamed');
+    });
+
+    test('a static headerTooltip string is unaffected by a rename', async () => {
+        // headerTooltip is a fixed string independent of the display name, so a rename does not touch it.
+        const { api, gridDiv } = await createGrid([
+            { field: 'athlete', headerNameEditable: true, headerTooltip: 'Static tip' },
+        ]);
+
+        api.applyColumnState({ state: [{ colId: 'athlete', headerName: 'Renamed' }] });
+        await asyncSetTimeout(1);
+        const column = api.getColumn('athlete') as unknown as AgColumn;
+        expect(api.getDisplayNameForColumn(column, 'header')).toBe('Renamed');
+
+        await hoverHeader(gridDiv);
+        await waitForTooltips(1);
+        expect(getTooltips()[0]).toHaveTextContent('Static tip');
+    });
+});
+
+describe('Editable header name — row grouping', () => {
+    const gridMgr = new TestGridsManager({ modules: [AllEnterpriseModule] });
+
+    afterEach(() => {
+        gridMgr.reset();
+        vi.resetAllMocks();
+    });
+
+    const rowData = [
+        { athlete: 'Michael Phelps', country: 'United States' },
+        { athlete: 'Ian Thorpe', country: 'Australia' },
+    ];
+
+    async function createGrid(): Promise<GridApi> {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [{ field: 'athlete', headerNameEditable: true }, { field: 'country' }],
+            rowData,
+            defaultColDef: { flex: 1, minWidth: 100 },
+        });
+        await asyncSetTimeout(1);
+        return api;
+    }
+
+    test('a renamed leaf column keeps its edited name through a row-group and ungroup cycle', async () => {
+        // The override lives on the persistent AgColumn, not on a colDef that grouping regenerates,
+        // so grouping by the column and ungrouping again must both preserve the edited name.
+        const api = await createGrid();
+        const column = api.getColumn('athlete') as unknown as AgColumn;
+
+        api.applyColumnState({ state: [{ colId: 'athlete', headerName: 'Renamed' }] });
+        await asyncSetTimeout(1);
+        expect(api.getDisplayNameForColumn(column, 'header')).toBe('Renamed');
+
+        api.addRowGroupColumn('athlete');
+        await asyncSetTimeout(1);
+        expect(api.getRowGroupColumns().map((c) => c.getColId())).toEqual(['athlete']);
+        expect(api.getDisplayNameForColumn(column, 'header')).toBe('Renamed');
+
+        api.removeRowGroupColumn('athlete');
+        await asyncSetTimeout(1);
+        expect(api.getRowGroupColumns()).toEqual([]);
+        expect(api.getDisplayNameForColumn(column, 'header')).toBe('Renamed');
+    });
+
+    test('a renamed leaf column that is row-grouped still exports its edited name to grid state', async () => {
+        const api = await createGrid();
+
+        api.applyColumnState({ state: [{ colId: 'athlete', headerName: 'Renamed' }] });
+        api.addRowGroupColumn('athlete');
+        await asyncSetTimeout(1);
+
+        expect(api.getState().columnHeaderName?.columnHeaderNames).toEqual([
+            { colId: 'athlete', headerName: 'Renamed' },
+        ]);
+    });
+});

--- a/testing/behavioural/src/columnHeaderEdit/editable-header-name-tooltip-and-grouping.test.ts
+++ b/testing/behavioural/src/columnHeaderEdit/editable-header-name-tooltip-and-grouping.test.ts
@@ -1,7 +1,7 @@
 import { waitFor } from '@testing-library/dom';
 import { userEvent } from '@testing-library/user-event';
 
-import type { AgColumn, ColDef, GridApi } from 'ag-grid-community';
+import type { AgColumn, ColDef, GridApi, HeaderLocation } from 'ag-grid-community';
 import { getGridElement } from 'ag-grid-community';
 import { AllEnterpriseModule } from 'ag-grid-enterprise';
 
@@ -82,9 +82,7 @@ describe('Editable header name — tooltips', () => {
 
     test('a static headerTooltip string is unaffected by a rename', async () => {
         // headerTooltip is a fixed string independent of the display name, so a rename does not touch it.
-        const { api } = await createGrid([
-            { field: 'athlete', headerNameEditable: true, headerTooltip: 'Static tip' },
-        ]);
+        const { api } = await createGrid([{ field: 'athlete', headerNameEditable: true, headerTooltip: 'Static tip' }]);
 
         api.applyColumnState({ state: [{ colId: 'athlete', headerName: 'Renamed' }] });
         await asyncSetTimeout(1);
@@ -94,6 +92,43 @@ describe('Editable header name — tooltips', () => {
         await hoverHeader();
         await waitForTooltips(1);
         expect(getTooltips()[0]).toHaveTextContent('Static tip');
+    });
+});
+
+describe('Editable header name — header locations', () => {
+    const gridMgr = new TestGridsManager({ modules: [AllEnterpriseModule] });
+
+    afterEach(() => {
+        gridMgr.reset();
+        vi.resetAllMocks();
+    });
+
+    // The override is resolved in getHeaderName ahead of the headerValueGetter, independent of the
+    // location passed in, so the edited name must be returned for every consumer location.
+    const locations: Exclude<HeaderLocation, null>[] = [
+        'header',
+        'columnDrop',
+        'columnToolPanel',
+        'csv',
+        'filterToolPanel',
+        'groupFilter',
+        'model',
+        'advancedFilter',
+        'chart',
+    ];
+
+    test.each(locations)('an edited header name is returned for the "%s" location', async (location) => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [{ field: 'athlete', headerNameEditable: true, headerValueGetter: () => 'From Getter' }],
+            rowData: [{ athlete: 'Michael Phelps' }],
+            initialState: {
+                columnHeaderName: { columnHeaderNames: [{ colId: 'athlete', headerName: 'Renamed' }] },
+            },
+        });
+        await asyncSetTimeout(1);
+
+        const column = api.getColumn('athlete') as unknown as AgColumn;
+        expect(api.getDisplayNameForColumn(column, location)).toBe('Renamed');
     });
 });
 

--- a/testing/behavioural/src/columnHeaderEdit/editable-header-name-tooltip-and-grouping.test.ts
+++ b/testing/behavioural/src/columnHeaderEdit/editable-header-name-tooltip-and-grouping.test.ts
@@ -1,5 +1,5 @@
-import { userEvent } from '@testing-library/user-event';
 import { waitFor } from '@testing-library/dom';
+import { userEvent } from '@testing-library/user-event';
 
 import type { AgColumn, ColDef, GridApi } from 'ag-grid-community';
 import { getGridElement } from 'ag-grid-community';
@@ -23,12 +23,16 @@ describe('Editable header name — tooltips', () => {
 
     const rowData = [{ athlete: 'Michael Phelps' }];
 
-    async function createGrid(columnDefs: ColDef[]): Promise<{ api: GridApi; gridDiv: HTMLElement }> {
+    async function createGrid(
+        columnDefs: ColDef[],
+        extraOptions?: Record<string, any>
+    ): Promise<{ api: GridApi; gridDiv: HTMLElement }> {
         const api = await gridMgr.createGridAndWait('myGrid', {
             columnDefs,
             rowData,
             defaultColDef: { flex: 1, minWidth: 100 },
             tooltipShowDelay: 200,
+            ...extraOptions,
         });
         return { api, gridDiv: getGridElement(api)! as HTMLElement };
     }
@@ -37,7 +41,7 @@ describe('Editable header name — tooltips', () => {
     const waitForTooltips = async (count: number) =>
         await waitFor(() => expect(getTooltips().length).toBe(count), { timeout: 2000 });
 
-    async function hoverHeader(gridDiv: HTMLElement): Promise<void> {
+    async function hoverHeader(): Promise<void> {
         const headerCell = await waitFor(
             () => document.querySelector('.ag-header-cell[col-id="athlete"]') as HTMLElement
         );
@@ -52,10 +56,10 @@ describe('Editable header name — tooltips', () => {
         await waitForTooltips(0);
     }
 
-    test('the header tooltip reflects the renamed name through headerTooltipValueGetter', async () => {
-        // The getter returns valueFormatted, which the tooltip service derives from the display name,
-        // so the override must surface here just as it does in the header cell text.
-        const { api, gridDiv } = await createGrid([
+    test('the header tooltip reflects the edited name after a rename', async () => {
+        // headerTooltipValueGetter reads valueFormatted, which the tooltip service resolves from the
+        // display name on each read, so a rename underneath the header must surface in the tooltip.
+        const { api } = await createGrid([
             {
                 field: 'athlete',
                 headerNameEditable: true,
@@ -63,7 +67,7 @@ describe('Editable header name — tooltips', () => {
             },
         ]);
 
-        await hoverHeader(gridDiv);
+        await hoverHeader();
         await waitForTooltips(1);
         expect(getTooltips()[0]).toHaveTextContent('Athlete');
         await unhoverHeader();
@@ -71,14 +75,14 @@ describe('Editable header name — tooltips', () => {
         api.applyColumnState({ state: [{ colId: 'athlete', headerName: 'Renamed' }] });
         await asyncSetTimeout(1);
 
-        await hoverHeader(gridDiv);
+        await hoverHeader();
         await waitForTooltips(1);
         expect(getTooltips()[0]).toHaveTextContent('Renamed');
     });
 
     test('a static headerTooltip string is unaffected by a rename', async () => {
         // headerTooltip is a fixed string independent of the display name, so a rename does not touch it.
-        const { api, gridDiv } = await createGrid([
+        const { api } = await createGrid([
             { field: 'athlete', headerNameEditable: true, headerTooltip: 'Static tip' },
         ]);
 
@@ -87,7 +91,7 @@ describe('Editable header name — tooltips', () => {
         const column = api.getColumn('athlete') as unknown as AgColumn;
         expect(api.getDisplayNameForColumn(column, 'header')).toBe('Renamed');
 
-        await hoverHeader(gridDiv);
+        await hoverHeader();
         await waitForTooltips(1);
         expect(getTooltips()[0]).toHaveTextContent('Static tip');
     });
@@ -126,12 +130,12 @@ describe('Editable header name — row grouping', () => {
         await asyncSetTimeout(1);
         expect(api.getDisplayNameForColumn(column, 'header')).toBe('Renamed');
 
-        api.addRowGroupColumn('athlete');
+        api.addRowGroupColumns(['athlete']);
         await asyncSetTimeout(1);
         expect(api.getRowGroupColumns().map((c) => c.getColId())).toEqual(['athlete']);
         expect(api.getDisplayNameForColumn(column, 'header')).toBe('Renamed');
 
-        api.removeRowGroupColumn('athlete');
+        api.removeRowGroupColumns(['athlete']);
         await asyncSetTimeout(1);
         expect(api.getRowGroupColumns()).toEqual([]);
         expect(api.getDisplayNameForColumn(column, 'header')).toBe('Renamed');
@@ -141,7 +145,7 @@ describe('Editable header name — row grouping', () => {
         const api = await createGrid();
 
         api.applyColumnState({ state: [{ colId: 'athlete', headerName: 'Renamed' }] });
-        api.addRowGroupColumn('athlete');
+        api.addRowGroupColumns(['athlete']);
         await asyncSetTimeout(1);
 
         expect(api.getState().columnHeaderName?.columnHeaderNames).toEqual([

--- a/testing/behavioural/src/columnHeaderEdit/editable-header-name-tooltip-and-grouping.test.ts
+++ b/testing/behavioural/src/columnHeaderEdit/editable-header-name-tooltip-and-grouping.test.ts
@@ -1,11 +1,12 @@
 import { waitFor } from '@testing-library/dom';
 import { userEvent } from '@testing-library/user-event';
+import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
 
-import type { AgColumn, ColDef, GridApi, HeaderLocation } from 'ag-grid-community';
+import type { AgColumn, ColDef, GridApi } from 'ag-grid-community';
 import { getGridElement } from 'ag-grid-community';
 import { AllEnterpriseModule } from 'ag-grid-enterprise';
 
-import { TestGridsManager, asyncSetTimeout } from '../test-utils';
+import { TestGridsManager, asyncSetTimeout, canvasPolyfill } from '../test-utils';
 
 /**
  * A renamed header name is stored as an override on the column entity (and the group-id-keyed group
@@ -95,7 +96,14 @@ describe('Editable header name — tooltips', () => {
     });
 });
 
-describe('Editable header name — header locations', () => {
+/**
+ * Each HeaderLocation surface resolves the name through the same getHeaderName override short-circuit,
+ * so an edited name must appear wherever the column is rendered — not just in the header cell. Each test
+ * renders the surface and asserts the edited name in its real output. `headerValueGetter` is present so
+ * the assertions also prove the override wins over it. The 'chart' location is covered separately (it
+ * needs the AG Charts module and canvas polyfill); 'model' is SSRM-internal metadata and not rendered.
+ */
+describe('Editable header name — rendered header locations', () => {
     const gridMgr = new TestGridsManager({ modules: [AllEnterpriseModule] });
 
     afterEach(() => {
@@ -103,32 +111,162 @@ describe('Editable header name — header locations', () => {
         vi.resetAllMocks();
     });
 
-    // The override is resolved in getHeaderName ahead of the headerValueGetter, independent of the
-    // location passed in, so the edited name must be returned for every consumer location.
-    const locations: Exclude<HeaderLocation, null>[] = [
-        'header',
-        'columnDrop',
-        'columnToolPanel',
-        'csv',
-        'filterToolPanel',
-        'groupFilter',
-        'model',
-        'advancedFilter',
-        'chart',
+    const rowData = [
+        { athlete: 'Michael Phelps', country: 'United States', age: 23 },
+        { athlete: 'Ian Thorpe', country: 'Australia', age: 24 },
     ];
 
-    test.each(locations)('an edited header name is returned for the "%s" location', async (location) => {
+    const RENAMED = 'Renamed';
+    const editedAthlete = (extra: Partial<ColDef> = {}): ColDef => ({
+        field: 'athlete',
+        headerNameEditable: true,
+        headerValueGetter: () => 'From Getter',
+        ...extra,
+    });
+    const initialRename = {
+        columnHeaderName: { columnHeaderNames: [{ colId: 'athlete', headerName: RENAMED }] },
+    };
+
+    const panelText = (selector: string): string =>
+        Array.from(document.querySelectorAll(selector))
+            .map((el) => el.textContent ?? '')
+            .join(' | ');
+
+    test('header: the edited name renders as the header cell text', async () => {
+        await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [editedAthlete(), { field: 'country' }],
+            rowData,
+            initialState: initialRename,
+        });
+        await waitFor(() =>
+            expect(document.querySelector('.ag-header-cell[col-id="athlete"] .ag-header-cell-text')?.textContent).toBe(
+                RENAMED
+            )
+        );
+    });
+
+    test('csv: the edited name is used in the exported header row', async () => {
         const api = await gridMgr.createGridAndWait('myGrid', {
-            columnDefs: [{ field: 'athlete', headerNameEditable: true, headerValueGetter: () => 'From Getter' }],
-            rowData: [{ athlete: 'Michael Phelps' }],
-            initialState: {
-                columnHeaderName: { columnHeaderNames: [{ colId: 'athlete', headerName: 'Renamed' }] },
-            },
+            columnDefs: [editedAthlete(), { field: 'country' }],
+            rowData,
+            initialState: initialRename,
         });
         await asyncSetTimeout(1);
 
-        const column = api.getColumn('athlete') as unknown as AgColumn;
-        expect(api.getDisplayNameForColumn(column, location)).toBe('Renamed');
+        const headerRow = api.getDataAsCsv()!.split('\n')[0];
+        expect(headerRow).toContain(RENAMED);
+        expect(headerRow).not.toContain('From Getter');
+    });
+
+    test('columnToolPanel: the edited name renders as the tool-panel column label', async () => {
+        await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [editedAthlete(), { field: 'country' }],
+            rowData,
+            initialState: initialRename,
+            sideBar: { toolPanels: ['columns'], defaultToolPanel: 'columns' },
+        });
+        await waitFor(() => expect(panelText('.ag-column-select-column-label')).toContain(RENAMED));
+    });
+
+    test('columnDrop: the edited name renders in the row-group panel pill', async () => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [editedAthlete(), { field: 'country' }, { field: 'age' }],
+            rowData,
+            initialState: initialRename,
+            rowGroupPanelShow: 'always',
+        });
+        api.addRowGroupColumns(['athlete']);
+        await waitFor(() => expect(panelText('.ag-column-drop-cell-text')).toContain(RENAMED));
+    });
+
+    test('filterToolPanel: the edited name renders as the filters tool-panel group title', async () => {
+        await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [editedAthlete({ filter: true }), { field: 'country', filter: true }],
+            rowData,
+            initialState: initialRename,
+            sideBar: { toolPanels: ['filters'], defaultToolPanel: 'filters' },
+        });
+        await waitFor(() => expect(panelText('.ag-filter-toolpanel-header')).toContain(RENAMED));
+    });
+
+    test('advancedFilter: the edited name renders in the column autocomplete', async () => {
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [editedAthlete({ filter: true }), { field: 'country', filter: true }],
+            rowData,
+            initialState: initialRename,
+            enableAdvancedFilter: true,
+        });
+        await asyncSetTimeout(0);
+
+        const input = getGridElement(api)!.querySelector('.ag-advanced-filter input[type=text]') as HTMLInputElement;
+        input.value = '[';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        await asyncSetTimeout(0);
+
+        await waitFor(() => expect(panelText('.ag-autocomplete-list-popup')).toContain(RENAMED));
+    });
+
+    test('groupFilter: the edited name renders in the group filter field select', async () => {
+        // Two row-grouped columns make the group filter render its column field-select, whose options
+        // are labelled by display name; the first (athlete) is selected, so its edited name shows.
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [editedAthlete({ filter: true }), { field: 'country', filter: true }, { field: 'age' }],
+            rowData,
+            initialState: initialRename,
+            groupDisplayType: 'singleColumn',
+            autoGroupColumnDef: { filter: 'agGroupColumnFilter' },
+        });
+        api.addRowGroupColumns(['athlete', 'country']);
+        await waitFor(() => expect(api.getRowGroupColumns().length).toBe(2));
+
+        const autoCol = document.querySelector('.ag-header-cell[col-id^="ag-Grid-AutoColumn"]')?.getAttribute('col-id');
+        expect(autoCol).toBeTruthy();
+        api.showColumnFilter(autoCol!);
+        await waitFor(() => expect(panelText('.ag-group-filter-field-select-wrapper')).toContain(RENAMED));
+    });
+});
+
+describe('Editable header name — integrated charts location', () => {
+    const gridMgr = new TestGridsManager({
+        modules: [AllEnterpriseModule.with(AgChartsEnterpriseModule)],
+    });
+
+    beforeAll(async () => {
+        await canvasPolyfill.init();
+    });
+    afterAll(() => canvasPolyfill.reset());
+    afterEach(() => {
+        gridMgr.reset();
+        vi.resetAllMocks();
+    });
+
+    test('chart: the edited name renders in the chart data tool panel', async () => {
+        // The chart resolves each column name via the 'chart' location; the data tool panel renders those
+        // names, so an edited value-column name must appear there. Rename the charted value column 'gold'.
+        const api = await gridMgr.createGridAndWait('myGrid', {
+            columnDefs: [
+                { field: 'country' },
+                { field: 'gold', headerNameEditable: true, headerValueGetter: () => 'From Getter' },
+            ],
+            rowData: [
+                { country: 'United States', gold: 3 },
+                { country: 'Australia', gold: 2 },
+            ],
+            initialState: { columnHeaderName: { columnHeaderNames: [{ colId: 'gold', headerName: 'Renamed' }] } },
+        });
+
+        const chartRef = api.createRangeChart({
+            cellRange: { columns: ['country', 'gold'] },
+            chartType: 'groupedColumn',
+        })!;
+        expect(chartRef).toBeTruthy();
+
+        api.openChartToolPanel({ chartId: chartRef.chartId, panel: 'data' });
+        await waitFor(() => expect(document.querySelector('.ag-chart-data-wrapper')?.textContent).toContain('Renamed'));
+
+        // The settings panel schedules an unguarded 250ms scroll-into-view; let it run while the chart is
+        // still mounted so it does not fire against a torn-down component after this test completes.
+        await asyncSetTimeout(300);
     });
 });
 


### PR DESCRIPTION
Fixes [AG-115](https://ag-grid.atlassian.net/browse/AG-115) QA follow-up  

## Fixes
- **Edit popup padding** — in the deferred column header edit popup the editor grows to fill the fixed-height dialog, so the space above the action buttons was the flex `gap` while the space below was double the container vertical padding. Set `padding-bottom` to match the gap (Theming API CSS + Legacy SCSS).
- **Header tooltip stale after rename** — `tooltipService` captured the header/group display name once at setup, so renaming a header refreshed the header text but not the tooltip. Resolve the name lazily inside `getTooltipValue` so the `columnHeaderNameChanged` refresh surfaces the edited name.
 