### PR TITLE
[AG-9664] Fix(pivoting): apply pivotSort from colDef on column creation

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/_examples/creating_pivot_result_columns/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/_examples/creating_pivot_result_columns/main.ts
@@ -35,11 +35,12 @@ ModuleRegistry.registerModules([
 let gridApi: GridApi<IOlympicData>;
 const gridOptions: GridOptions<IOlympicData> = {
     columnDefs: [
-        { field: 'country', rowGroup: true },
-        { field: 'year', pivot: true }, // pivot on 'year'
-        { field: 'gold', aggFunc: 'sum' },
-        { field: 'silver', aggFunc: 'sum' },
-        { field: 'bronze', aggFunc: 'sum' },
+        { field: 'country', rowGroup: true, enableRowGroup: true },
+        { field: 'sport', enableRowGroup: true },
+        { field: 'year', pivot: true, enablePivot: true }, // pivot on 'year'
+        { field: 'gold', aggFunc: 'sum', enableValue: true },
+        { field: 'silver', aggFunc: 'sum', enableValue: true },
+        { field: 'bronze', aggFunc: 'sum', enableValue: true },
     ],
     defaultColDef: {
         flex: 1,

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/_examples/creating_pivot_result_columns/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/_examples/creating_pivot_result_columns/main.ts
@@ -12,6 +12,7 @@ import {
     ColumnsToolPanelModule,
     ContextMenuModule,
     RowGroupingModule,
+    RowGroupingPanelModule,
     ServerSideRowModelModule,
 } from 'ag-grid-enterprise';
 
@@ -27,6 +28,7 @@ ModuleRegistry.registerModules([
     ColumnMenuModule,
     ContextMenuModule,
     RowGroupingModule,
+    RowGroupingPanelModule,
     ServerSideRowModelModule,
 ]);
 
@@ -52,6 +54,12 @@ const gridOptions: GridOptions<IOlympicData> = {
 
     // enable pivoting
     pivotMode: true,
+
+    sideBar: {
+        toolPanels: ['columns'],
+    },
+    rowGroupPanelShow: 'always',
+    pivotPanelShow: 'always',
 };
 
 // setup the grid after the page has finished loading

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/_examples/supplying_pivot_result_fields/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/_examples/supplying_pivot_result_fields/main.ts
@@ -28,11 +28,12 @@ ModuleRegistry.registerModules([
 let gridApi: GridApi<IOlympicData>;
 const gridOptions: GridOptions<IOlympicData> = {
     columnDefs: [
-        { field: 'country', rowGroup: true },
-        { field: 'year', pivot: true }, // pivot on 'year'
-        { field: 'gold', aggFunc: 'sum' },
-        { field: 'silver', aggFunc: 'sum' },
-        { field: 'bronze', aggFunc: 'sum' },
+        { field: 'country', rowGroup: true, enableRowGroup: true },
+        { field: 'sport', enableRowGroup: true },
+        { field: 'year', pivot: true, enablePivot: true }, // pivot on 'year'
+        { field: 'gold', aggFunc: 'sum', enableValue: true },
+        { field: 'silver', aggFunc: 'sum', enableValue: true },
+        { field: 'bronze', aggFunc: 'sum', enableValue: true },
     ],
     defaultColDef: {
         flex: 1,

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/_examples/supplying_pivot_result_fields/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/_examples/supplying_pivot_result_fields/main.ts
@@ -5,6 +5,7 @@ import {
     ColumnsToolPanelModule,
     ContextMenuModule,
     RowGroupingModule,
+    RowGroupingPanelModule,
     ServerSideRowModelModule,
 } from 'ag-grid-enterprise';
 
@@ -20,6 +21,7 @@ ModuleRegistry.registerModules([
     ColumnMenuModule,
     ContextMenuModule,
     RowGroupingModule,
+    RowGroupingPanelModule,
     ServerSideRowModelModule,
 ]);
 
@@ -45,6 +47,12 @@ const gridOptions: GridOptions<IOlympicData> = {
 
     // enable pivoting
     pivotMode: true,
+
+    sideBar: {
+        toolPanels: ['columns'],
+    },
+    rowGroupPanelShow: 'always',
+    pivotPanelShow: 'always',
 
     // specify the field separator, e.g. '2000_gold' should be '_' which is the default
     serverSidePivotResultFieldSeparator: '_',

--- a/packages/ag-grid-community/src/columns/columnStateUtils.ts
+++ b/packages/ag-grid-community/src/columns/columnStateUtils.ts
@@ -5,6 +5,7 @@ import type { BeanCollection } from '../context/context';
 import type { AgColumn } from '../entities/agColumn';
 import {
     _normalizeSortType,
+    _resolvePivotSortFromColDef,
     getSortDefFromInput,
     isSortDirectionValid,
     isSortTypeValid,
@@ -487,7 +488,7 @@ export function _resetColumnState(beans: BeanCollection, source: ColumnEventType
         const primaryCols = colModel.colDefList;
         for (let i = 0, len = primaryCols.length; i < len; ++i) {
             const col = primaryCols[i];
-            col.pivotSort = resolveInitialPivotSort(col.colDef);
+            col.pivotSort = _resolvePivotSortFromColDef(col.colDef);
         }
 
         // Order from the now-current service cols: auto cols may have been recreated above (their colIds change
@@ -832,12 +833,6 @@ export const _getColumnState = (beans: BeanCollection): ColumnState[] => {
     return res;
 };
 
-// Unset (`undefined`) is left as-is so it resolves to ascending; an explicit `null` ("no sort") is preserved.
-function resolveInitialPivotSort(colDef: AgColumn['colDef']): SortDirection | undefined {
-    const pivotSortLike = colDef.pivotSort !== undefined ? colDef.pivotSort : colDef.initialPivotSort;
-    return pivotSortLike === undefined ? undefined : normalizeSortDirection(pivotSortLike);
-}
-
 export function getColumnStateFromColDef(beans: BeanCollection, column: AgColumn): ColumnState {
     const colDef = column.colDef;
     const sortDef = getSortDefFromInput(colDef.sort ?? colDef.initialSort ?? null);
@@ -864,7 +859,7 @@ export function getColumnStateFromColDef(beans: BeanCollection, column: AgColumn
         rowGroupIndex,
         pivot,
         pivotIndex,
-        pivotSort: resolveInitialPivotSort(colDef),
+        pivotSort: _resolvePivotSortFromColDef(colDef),
         aggFunc: colDef.aggFunc ?? colDef.initialAggFunc ?? null,
         showValuesAs: beans.showValuesAsSvc?.colDefSelection(colDef) ?? null,
         headerName: null,

--- a/packages/ag-grid-community/src/entities/agColumn.ts
+++ b/packages/ag-grid-community/src/entities/agColumn.ts
@@ -247,6 +247,8 @@ export class AgColumn<TValue = any>
         const hide = colDef.hide;
         this.visible = hide !== undefined ? !hide : !colDef.initialHide;
 
+        this.pivotSort = _resolvePivotSortFromColDef(colDef);
+
         pinnedCols?.initCol(this);
 
         colFlex?.initCol(this);
@@ -959,6 +961,14 @@ export const _isSortDefValid = (maybeSortDef: unknown): maybeSortDef is SortDef 
     }
     const maybeSortDefT = maybeSortDef as { type?: unknown; direction?: unknown };
     return isSortTypeValid(maybeSortDefT.type) && isSortDirectionValid(maybeSortDefT.direction);
+};
+
+/** Resolves a colDef's pivot sort. Unset (`undefined`) is left as-is so it resolves to ascending;
+ *  an explicit `null` ("no sort") is preserved.
+ *  @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
+export const _resolvePivotSortFromColDef = (colDef: ColDef): SortDirection | undefined => {
+    const pivotSortLike = colDef.pivotSort !== undefined ? colDef.pivotSort : colDef.initialPivotSort;
+    return pivotSortLike === undefined ? undefined : normalizeSortDirection(pivotSortLike);
 };
 
 export const normalizeSortDirection = (sortDirectionLike?: unknown): SortDirection =>

--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -737,6 +737,7 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
     /**
      * Sort direction applied to this column's pivot result columns when this column is used to pivot on.
      * Independent of `sort` - pivot sorting does not flow to or from the column's own sort.
+     * @default 'asc'
      * @agModule `PivotModule`
      */
     pivotSort?: SortDirection;

--- a/testing/behavioural/src/sorting/pivot-column-sort.test.ts
+++ b/testing/behavioural/src/sorting/pivot-column-sort.test.ts
@@ -1,4 +1,4 @@
-import type { GridApi, GridOptions } from 'ag-grid-community';
+import type { ColDef, GridApi, GridOptions } from 'ag-grid-community';
 import { ClientSideRowModelModule } from 'ag-grid-community';
 import { PivotModule, RowGroupingModule, RowGroupingPanelModule } from 'ag-grid-enterprise';
 
@@ -13,11 +13,11 @@ describe('pivot: interactive pivot column sorting (pivotSort)', () => {
     beforeEach(() => gridsManager.reset());
     afterEach(() => gridsManager.reset());
 
-    function createPivotGrid(): GridApi {
+    function createPivotGrid(yearColDef?: Partial<ColDef>): GridApi {
         const gridOptions: GridOptions = {
             columnDefs: [
                 { field: 'country', rowGroup: true, hide: true },
-                { field: 'year', pivot: true, hide: true },
+                { field: 'year', pivot: true, hide: true, ...yearColDef },
                 { field: 'sales', aggFunc: 'sum', hide: true },
             ],
             pivotMode: true,
@@ -43,6 +43,18 @@ describe('pivot: interactive pivot column sorting (pivotSort)', () => {
             'pivot_year_2021_sales',
             'pivot_year_2022_sales',
         ]);
+    });
+
+    test.each(['pivotSort', 'initialPivotSort'] as const)('colDef.%s is applied on initialisation', async (prop) => {
+        const api = createPivotGrid({ [prop]: 'desc' });
+        await asyncSetTimeout(10);
+
+        expect(getColumnOrder(api, 'all').filter((id) => id.startsWith('pivot_'))).toEqual([
+            'pivot_year_2022_sales',
+            'pivot_year_2021_sales',
+            'pivot_year_2020_sales',
+        ]);
+        expect(api.getColumnState().find((s) => s.colId === 'year')!.pivotSort).toBe('desc');
     });
 
     test('pivotSort desc reverses the pivot column order; asc/none restore it', async () => {


### PR DESCRIPTION
Fixes [AG-9664](https://ag-grid.atlassian.net/browse/AG-9664)

- `colDef.pivotSort` / `initialPivotSort` are now seeded onto the column at creation, so they take effect on initialisation 
- `pivotSort` API docs now show `default: 'asc'` 
- The two SSRM pivoting examples show the pivot / row group panels so the sorting is discoverable 