### PR TITLE
AG-17995 - Add opt out success page

### DIFF
--- a/documentation/ag-grid-docs/src/pages-styles/your-choice.module.scss
+++ b/documentation/ag-grid-docs/src/pages-styles/your-choice.module.scss
@@ -1,0 +1,10 @@
+@use 'design-system' as *;
+
+.optOutRequestPage {
+    display: flex;
+    flex-direction: column;
+    max-width: 600px;
+    margin: 0 auto;
+    padding-top: $spacing-size-20;
+    padding-bottom: $spacing-size-20;
+}

--- a/documentation/ag-grid-docs/src/pages/privacy/your-choice.astro
+++ b/documentation/ag-grid-docs/src/pages/privacy/your-choice.astro
@@ -1,0 +1,28 @@
+---
+import Layout from '@layouts/Layout.astro';
+import styles from '@pages-styles/your-choice.module.scss';
+---
+
+<Layout
+    title={`Opt Out Request Received`}
+    description="We've noted your request to opt out and will remove your details from our records within 5 working days"
+    showSearchBar={true}
+    showDocsNav={false}
+>
+    <div class:list={styles.optOutRequestPage}>
+        <div class="layout-max-width-small columns-1-4">
+            <h1>Your request has been received</h1>
+
+            <p>
+                Thank you. We've noted your request to opt out and will remove your details from our records within 5
+                working days. You'll receive a confirmation email once this is done.
+            </p>
+
+            <p>
+                If you have any questions in the meantime, please contact <br /><a href="mailto:privacy@ag-grid.com"
+                    >privacy@ag-grid.com</a
+                >.
+            </p>
+        </div>
+    </div>
+</Layout>

--- a/documentation/ag-grid-docs/src/utils/sitemapPages.ts
+++ b/documentation/ag-grid-docs/src/utils/sitemapPages.ts
@@ -20,6 +20,9 @@ export async function getSitemapIgnorePaths() {
 
         // Release note stubs — minimal content, crawl waste
         urlWithBaseUrl('/changelog/releases'),
+
+        // Opt out success page
+        urlWithBaseUrl('/privacy/your-choice'),
     ];
     const folderPaths = ignorePaths.map(addTrailingSlash);
 


### PR DESCRIPTION
Port from https://github.com/ag-grid/ag-grid/pull/14622

Adds a `/privacy/your-choice` page shown after a user submits a privacy opt-out request, confirming the request was received and that details will be removed within 5 working days.

- New page `documentation/ag-grid-docs/src/pages/privacy/your-choice.astro` with accompanying `your-choice.module.scss`
- Excluded from the sitemap (`sitemapPages.ts`), consistent with other non-crawlable stub pages