### PR TITLE
github-triage: wire the two Jira Manual Trigger buttons (Resume Analysis / Rebuild Repro Link)

### DIFF
--- a/.github/workflows/github-triage-pipeline.yml
+++ b/.github/workflows/github-triage-pipeline.yml
@@ -19,6 +19,21 @@ name: GitHub issue AI triage
 #       (from the single AITGH `→ In Progress` JIRA automation rule:
 #        POST /repos/ag-grid/ag-grid/dispatches
 #        {"event_type":"gh-triage-resume","client_payload":{"issue_key":"AITGH-XXX"}})
+#   repository_dispatch gh-triage-manual-resume → ALWAYS stage=resume, no routing
+#       (from a per-issue "Manual trigger" Jira Automation rule — a PM-facing
+#        button in the AITGH issue view's "..." menu, unrelated to the
+#        In Progress drag above. Explicit human intent, so it bypasses
+#        preflight/decide-resume-route entirely rather than going through the
+#        execute-vs-resume ambiguity that routing exists to resolve for the
+#        drag. POST /repos/ag-grid/ag-grid/dispatches
+#        {"event_type":"gh-triage-manual-resume","client_payload":{"issue_key":"AITGH-XXX"}})
+#   repository_dispatch gh-triage-manual-repro-rebuild → ALWAYS stage=repro-rebuild
+#       (same "Manual trigger" pattern, a second AITGH button. Independent of
+#        the browser-verify-chain/repro-rebuild-chain auto-chain below — this
+#        is the human-confirmed-reproduces path from github-triage-pipeline's
+#        rules.md, letting repro-rebuild run without ever needing browser-verify.
+#        POST /repos/ag-grid/ag-grid/dispatches
+#        {"event_type":"gh-triage-manual-repro-rebuild","client_payload":{"issue_key":"AITGH-XXX"}})
 #   workflow_dispatch                  → force a stage (dry-run / debugging)
 # ============================================================================
 
@@ -29,7 +44,7 @@ on:
     # issues:
     #     types: [opened, labeled]
     repository_dispatch:
-        types: [gh-triage-resume]
+        types: [gh-triage-resume, gh-triage-manual-resume, gh-triage-manual-repro-rebuild]
     workflow_dispatch:
         inputs:
             stage:
@@ -103,8 +118,12 @@ jobs:
                   jira_ai_bot_account_id: ${{ vars.JIRA_AI_BOT_ACCOUNT_ID }}
 
     # -------------------------------------------------- run
-    # The parameterised stage runner (triage / resume / execute). Runs on the
-    # issue event (triage), a forced dispatch, or a non-empty preflight route.
+    # The parameterised stage runner (triage / resume / execute / repro-rebuild).
+    # Runs on the issue event (triage), a forced dispatch, a non-empty preflight
+    # route, or one of the two manual-trigger button events (which — unlike
+    # gh-triage-resume — always resolve to ONE specific stage directly, no
+    # preflight/routing involved: the PM's button click IS the unambiguous
+    # intent signal).
     run:
         needs: [preflight]
         if: |
@@ -113,6 +132,8 @@ jobs:
               (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'triage') && github.event.issue.state == 'open')
               || github.event_name == 'workflow_dispatch'
               || (github.event_name == 'repository_dispatch' && needs.preflight.outputs.stage != '')
+              || (github.event_name == 'repository_dispatch' && github.event.action == 'gh-triage-manual-resume')
+              || (github.event_name == 'repository_dispatch' && github.event.action == 'gh-triage-manual-repro-rebuild')
             )
         runs-on: ubuntu-latest
         permissions:
@@ -136,7 +157,7 @@ jobs:
             - id: pipeline
               uses: ./.ag-dev-prompts/node_modules/@ag-grid/dev-prompts/.github/actions/github-triage-pipeline
               with:
-                  stage: ${{ needs.preflight.outputs.stage || inputs.stage || 'triage' }}
+                  stage: ${{ needs.preflight.outputs.stage || inputs.stage || (github.event.action == 'gh-triage-manual-resume' && 'resume') || (github.event.action == 'gh-triage-manual-repro-rebuild' && 'repro-rebuild') || 'triage' }}
                   product: grid
                   gh_issue: ${{ github.event.issue.number || github.event.client_payload.gh_issue || inputs.gh_issue }}
                   issue_key: ${{ needs.preflight.outputs.issue_key || github.event.client_payload.issue_key || inputs.issue_key }}

--- a/.github/workflows/github-triage-pipeline.yml
+++ b/.github/workflows/github-triage-pipeline.yml
@@ -27,8 +27,13 @@ name: GitHub issue AI triage
 #        execute-vs-resume ambiguity that routing exists to resolve for the
 #        drag. POST /repos/ag-grid/ag-grid/dispatches
 #        {"event_type":"gh-triage-manual-resume","client_payload":{"issue_key":"AITGH-XXX"}})
+#   repository_dispatch gh-triage-manual-browser-verify → ALWAYS stage=browser-verify
+#       (same "Manual trigger" pattern, a third AITGH button, wired ahead of a
+#        Jira button actually existing for it — see the workflow's own PR.
+#        POST /repos/ag-grid/ag-grid/dispatches
+#        {"event_type":"gh-triage-manual-browser-verify","client_payload":{"issue_key":"AITGH-XXX"}})
 #   repository_dispatch gh-triage-manual-repro-rebuild → ALWAYS stage=repro-rebuild
-#       (same "Manual trigger" pattern, a second AITGH button. Independent of
+#       (same "Manual trigger" pattern, a fourth AITGH button. Independent of
 #        the browser-verify-chain/repro-rebuild-chain auto-chain below — this
 #        is the human-confirmed-reproduces path from github-triage-pipeline's
 #        rules.md, letting repro-rebuild run without ever needing browser-verify.
@@ -44,7 +49,7 @@ on:
     # issues:
     #     types: [opened, labeled]
     repository_dispatch:
-        types: [gh-triage-resume, gh-triage-manual-resume, gh-triage-manual-repro-rebuild]
+        types: [gh-triage-resume, gh-triage-manual-resume, gh-triage-manual-browser-verify, gh-triage-manual-repro-rebuild]
     workflow_dispatch:
         inputs:
             stage:
@@ -118,12 +123,12 @@ jobs:
                   jira_ai_bot_account_id: ${{ vars.JIRA_AI_BOT_ACCOUNT_ID }}
 
     # -------------------------------------------------- run
-    # The parameterised stage runner (triage / resume / execute / repro-rebuild).
-    # Runs on the issue event (triage), a forced dispatch, a non-empty preflight
-    # route, or one of the two manual-trigger button events (which — unlike
-    # gh-triage-resume — always resolve to ONE specific stage directly, no
-    # preflight/routing involved: the PM's button click IS the unambiguous
-    # intent signal).
+    # The parameterised stage runner (triage / resume / execute / browser-verify /
+    # repro-rebuild). Runs on the issue event (triage), a forced dispatch, a
+    # non-empty preflight route, or one of the three manual-trigger button
+    # events (which — unlike gh-triage-resume — always resolve to ONE specific
+    # stage directly, no preflight/routing involved: the PM's button click IS
+    # the unambiguous intent signal).
     run:
         needs: [preflight]
         if: |
@@ -133,6 +138,7 @@ jobs:
               || github.event_name == 'workflow_dispatch'
               || (github.event_name == 'repository_dispatch' && needs.preflight.outputs.stage != '')
               || (github.event_name == 'repository_dispatch' && github.event.action == 'gh-triage-manual-resume')
+              || (github.event_name == 'repository_dispatch' && github.event.action == 'gh-triage-manual-browser-verify')
               || (github.event_name == 'repository_dispatch' && github.event.action == 'gh-triage-manual-repro-rebuild')
             )
         runs-on: ubuntu-latest
@@ -157,7 +163,18 @@ jobs:
             - id: pipeline
               uses: ./.ag-dev-prompts/node_modules/@ag-grid/dev-prompts/.github/actions/github-triage-pipeline
               with:
-                  stage: ${{ needs.preflight.outputs.stage || inputs.stage || (github.event.action == 'gh-triage-manual-resume' && 'resume') || (github.event.action == 'gh-triage-manual-repro-rebuild' && 'repro-rebuild') || 'triage' }}
+                  # Manual-dispatch action checks come FIRST, unconditionally,
+                  # BEFORE needs.preflight.outputs.stage (Codex — a real P1: the
+                  # previous order let a same-priority `||` chain trust
+                  # preflight's output ahead of the action-specific stage,
+                  # relying on preflight's OWN `if:` (which only ever matches
+                  # `gh-triage-resume`) to keep its output empty for these
+                  # events, rather than that invariant being enforced at the
+                  # POINT OF USE here too. Checking the manual action FIRST
+                  # makes it structurally impossible for anything
+                  # preflight-related to override or block a manual dispatch,
+                  # regardless of preflight's own behaviour.
+                  stage: ${{ (github.event.action == 'gh-triage-manual-resume' && 'resume') || (github.event.action == 'gh-triage-manual-browser-verify' && 'browser-verify') || (github.event.action == 'gh-triage-manual-repro-rebuild' && 'repro-rebuild') || needs.preflight.outputs.stage || inputs.stage || 'triage' }}
                   product: grid
                   gh_issue: ${{ github.event.issue.number || github.event.client_payload.gh_issue || inputs.gh_issue }}
                   issue_key: ${{ needs.preflight.outputs.issue_key || github.event.client_payload.issue_key || inputs.issue_key }}


### PR DESCRIPTION
## Summary

Adds three new `repository_dispatch` event types — `gh-triage-manual-resume`, `gh-triage-manual-browser-verify`, `gh-triage-manual-repro-rebuild` — routed directly to `stage=resume` / `stage=browser-verify` / `stage=repro-rebuild` in the existing `run` job. No new job, no `preflight`/`decide-resume-route` involved: a PM clicking a named button in the AITGH issue view IS the unambiguous intent signal that routing exists to *infer* for the ambiguous `→ In Progress` drag, so there's nothing to route.

Two of these fire from two new per-issue Jira Automation **"Manual trigger"** rules already built ("Resume Analysis" / "Rebuild Repro Link"), surfaced as named actions in the issue's `•••` menu — Jira-side config, not code. The third (`gh-triage-manual-browser-verify`) is wired ahead of its own Jira button existing, so the GHA side is ready whenever a "Verify Repro (Browser)" button is wanted, without a follow-up PR.

**Fixed a real Codex-caught bug (P1, 0.91 confidence) in the same pass:** the `stage:` resolution expression checked `needs.preflight.outputs.stage` *before* the manual-dispatch action checks — relying on `preflight`'s own `if:` (which only ever matches `gh-triage-resume`) to keep its output empty for the new manual events, rather than that invariant being enforced at the point of use here too. Reordered so the manual-action checks run first, unconditionally: it's now structurally impossible for anything preflight-related to override or block a manual dispatch, regardless of preflight's own behavior.

**Deliberately independent of the `browser-verify-chain`/`repro-rebuild-chain` auto-chain from #14599**: those jobs gate on `github.event_name == 'issues'` (or `workflow_dispatch stage=triage`) specifically, so a manual dispatch's `run` job produces `confirmed_bug`/`issue_key` outputs the chain jobs never consult — no accidental chaining in either direction. Full design + all the manual-vs-automatic scenarios: `ag-dev-prompts` → `docs/github-triage-pipeline.md` § "Dispatch contract" (companion PR: ag-grid/ag-dev-prompts#651).

## Test plan
- [x] `actionlint .github/workflows/github-triage-pipeline.yml` — clean.
- [x] Traced all three new dispatch types through the job graph by hand: `run` job's `if:`/`stage:` resolve correctly and can no longer be overridden by preflight; `browser-verify-chain`/`repro-rebuild-chain` correctly stay skipped (their own `if:` conditions don't match `repository_dispatch` events other than the ones they already check for).
- [ ] A real dispatch from each Jira Manual Trigger button (once the browser-verify one exists) on a real AITGH ticket — not yet run; recommend one controlled test per button before relying on them.
