### PR TITLE
Test(docs-e2e): fix remaining nightly Documentation Tests failures

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/column-groups/_examples/group-changes/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/column-groups/_examples/group-changes/example.spec.ts
@@ -17,16 +17,18 @@ test.agExample(import.meta, () => {
         await ensureGridReady(page);
         await waitForGridContent(page);
 
+        // Anchored but whitespace-tolerant: the Angular and Vue generators reformat the longer
+        // button labels onto their own lines, so the element's text is padded with newlines.
         await page
             .locator('button')
-            .filter({ hasText: /^Medals in Group$/ })
+            .filter({ hasText: /^\s*Medals in Group\s*$/ })
             .click();
         await expect(page.locator('.ag-header-group-cell').filter({ hasText: 'Medals' })).toHaveCount(1);
         await expect(agIdFor.cell('0', 'gold')).toContainText('8');
 
         await page
             .locator('button')
-            .filter({ hasText: /^Participant in Group$/ })
+            .filter({ hasText: /^\s*Participant in Group\s*$/ })
             .click();
         await expect(page.locator('.ag-header-group-cell').filter({ hasText: 'Participant' })).toHaveCount(1);
         await expect(page.locator('.ag-header-group-cell').filter({ hasText: 'Medals' })).toHaveCount(0);
@@ -34,7 +36,7 @@ test.agExample(import.meta, () => {
 
         await page
             .locator('button')
-            .filter({ hasText: /^No Groups$/ })
+            .filter({ hasText: /^\s*No Groups\s*$/ })
             .click();
         await expect(page.locator('.ag-header-group-cell')).toHaveCount(0);
     });

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/example.spec.ts
@@ -1,4 +1,4 @@
-import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
+import { clickHeaderToSort, ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 // The grid records every state change (onStateUpdated) and, when recreated, seeds the new
 // grid from the previous grid's state so sort/filter/etc. are restored. State changes and
@@ -12,7 +12,7 @@ test.agExample(import.meta, () => {
         await ensureGridReady(page);
         await waitForGridContent(page);
 
-        await agIdFor.headerCell('age').click();
+        await clickHeaderToSort(agIdFor.headerCell('age'));
         await expect(agIdFor.headerCell('age')).toHaveAttribute('aria-sort', 'ascending');
 
         // onStateUpdated logs 'State updated' whenever the grid state changes.
@@ -43,7 +43,7 @@ test.agExample(import.meta, () => {
         await ensureGridReady(page);
         await waitForGridContent(page);
 
-        await agIdFor.headerCell('age').click();
+        await clickHeaderToSort(agIdFor.headerCell('age'));
         await expect(agIdFor.headerCell('age')).toHaveAttribute('aria-sort', 'ascending');
 
         // Recreate destroys the grid and seeds the new one from the previous state.

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/example.spec.ts
@@ -1,4 +1,4 @@
-import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
+import { clickHeaderToSort, ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 // Save State captures the current grid state, Recreate Grid with No State throws it away
 // (fresh grid), and Set State restores the saved state onto the existing grid via
@@ -15,7 +15,7 @@ test.agExample(import.meta, () => {
             await waitForGridContent(page);
 
             // Apply a sort so there is meaningful state to save.
-            await agIdFor.headerCell('age').click();
+            await clickHeaderToSort(agIdFor.headerCell('age'));
             await expect(agIdFor.headerCell('age')).toHaveAttribute('aria-sort', 'ascending');
 
             // Wait for the state-updated event so the captured state includes the sort.

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-page-setup/_examples/pdf-export-page-setup/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-page-setup/_examples/pdf-export-page-setup/main.ts
@@ -17,19 +17,22 @@ interface InventoryData {
     status: string;
 }
 
-const categories = ['Accessories', 'Displays', 'Networking', 'Storage'];
-const warehouses = ['London', 'Chicago', 'Singapore'];
-const rowData: InventoryData[] = [];
+// Build the rows in the declaration itself: the framework generators inline the `rowData` grid
+// option's initialiser and drop the declaration, so a separately-populated array (a top-level
+// `rowData.push(...)` loop) is left referencing a name that no longer exists.
+const rowData: InventoryData[] = Array.from({ length: 40 }, (_, index) => {
+    const categories = ['Accessories', 'Displays', 'Networking', 'Storage'];
+    const warehouses = ['London', 'Chicago', 'Singapore'];
+    const itemNumber = index + 1;
 
-for (let i = 1; i <= 40; i++) {
-    rowData.push({
-        item: `Item ${i}`,
-        category: categories[(i - 1) % categories.length],
-        warehouse: warehouses[(i - 1) % warehouses.length],
-        quantity: 20 + i * 3,
-        status: i % 4 === 0 ? 'Reorder' : 'Available',
-    });
-}
+    return {
+        item: `Item ${itemNumber}`,
+        category: categories[index % categories.length],
+        warehouse: warehouses[index % warehouses.length],
+        quantity: 20 + itemNumber * 3,
+        status: itemNumber % 4 === 0 ? 'Reorder' : 'Available',
+    };
+});
 
 let gridApi: GridApi<InventoryData>;
 

--- a/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/absolute-sorting/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/absolute-sorting/example.spec.ts
@@ -1,28 +1,11 @@
-import { ensureGridReady, expect, test, waitForGridContent, waitForRowAnimations } from '@utils/grid/test-utils';
-import type { Page } from 'playwright/test';
-
-// Read a column's rendered values in top-to-bottom display order (by row-index).
-async function orderedValues(page: Page, colId: string): Promise<string[]> {
-    const rows = await page.locator('.ag-row[row-index]').all();
-    const seen = new Map<number, string>();
-    for (let i = 0, len = rows.length; i < len; ++i) {
-        const row = rows[i];
-        const idxAttr = await row.getAttribute('row-index');
-        if (idxAttr == null) {
-            continue;
-        }
-        const idx = Number(idxAttr);
-        if (seen.has(idx)) {
-            continue;
-        }
-        const cell = row.locator(`[col-id="${colId}"]`);
-        if ((await cell.count()) === 0) {
-            continue;
-        }
-        seen.set(idx, ((await cell.first().innerText()) ?? '').trim());
-    }
-    return [...seen.entries()].sort((a, b) => a[0] - b[0]).map(([, v]) => v);
-}
+import {
+    ensureGridReady,
+    expect,
+    orderedValues,
+    test,
+    waitForGridContent,
+    waitForRowAnimations,
+} from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     test.eachFramework('Loads sorted by absolute value ascending', async ({ agIdFor, page }) => {

--- a/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/custom-sorting/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/custom-sorting/example.spec.ts
@@ -1,28 +1,11 @@
-import { ensureGridReady, expect, test, waitForGridContent, waitForRowAnimations } from '@utils/grid/test-utils';
-import type { Page } from 'playwright/test';
-
-// Read a column's rendered values in top-to-bottom display order (by row-index).
-async function orderedValues(page: Page, colId: string): Promise<string[]> {
-    const rows = await page.locator('.ag-row[row-index]').all();
-    const seen = new Map<number, string>();
-    for (let i = 0, len = rows.length; i < len; ++i) {
-        const row = rows[i];
-        const idxAttr = await row.getAttribute('row-index');
-        if (idxAttr == null) {
-            continue;
-        }
-        const idx = Number(idxAttr);
-        if (seen.has(idx)) {
-            continue;
-        }
-        const cell = row.locator(`[col-id="${colId}"]`);
-        if ((await cell.count()) === 0) {
-            continue;
-        }
-        seen.set(idx, ((await cell.first().innerText()) ?? '').trim());
-    }
-    return [...seen.entries()].sort((a, b) => a[0] - b[0]).map(([, v]) => v);
-}
+import {
+    ensureGridReady,
+    expect,
+    orderedValues,
+    test,
+    waitForGridContent,
+    waitForRowAnimations,
+} from '@utils/grid/test-utils';
 
 // dd/mm/yyyy -> comparable yyyymmdd number (mirrors the example's dateComparator).
 function toComparableDate(date: string): number {

--- a/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/multi-column/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/multi-column/example.spec.ts
@@ -1,31 +1,11 @@
-import { ensureGridReady, expect, test, waitForGridContent, waitForRowAnimations } from '@utils/grid/test-utils';
-import type { Page } from 'playwright/test';
-
-// Read a column's rendered values in top-to-bottom display order (by row-index). Read in a
-// single evaluate call: per-row awaits race virtualisation and hang on detached rows.
-async function orderedValues(page: Page, colId: string): Promise<string[]> {
-    return page.evaluate((colId) => {
-        const seen = new Map<number, string>();
-        const rows = document.querySelectorAll('.ag-row[row-index]');
-        for (let i = 0, len = rows.length; i < len; ++i) {
-            const row = rows[i];
-            const idxAttr = row.getAttribute('row-index');
-            if (idxAttr == null) {
-                continue;
-            }
-            const idx = Number(idxAttr);
-            if (seen.has(idx)) {
-                continue;
-            }
-            const cell = row.querySelector(`[col-id="${colId}"]`);
-            if (!cell) {
-                continue;
-            }
-            seen.set(idx, (cell.textContent ?? '').trim());
-        }
-        return [...seen.entries()].sort((a, b) => a[0] - b[0]).map(([, v]) => v);
-    }, colId);
-}
+import {
+    ensureGridReady,
+    expect,
+    orderedValues,
+    test,
+    waitForGridContent,
+    waitForRowAnimations,
+} from '@utils/grid/test-utils';
 
 function compare(a: string, b: string, isNumeric: boolean): number {
     return isNumeric ? Number(a) - Number(b) : a.localeCompare(b);

--- a/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/post-sort/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/post-sort/example.spec.ts
@@ -1,28 +1,11 @@
-import { ensureGridReady, expect, test, waitForGridContent, waitForRowAnimations } from '@utils/grid/test-utils';
-import type { Page } from 'playwright/test';
-
-// Read a column's rendered values in top-to-bottom display order (by row-index).
-async function orderedValues(page: Page, colId: string): Promise<string[]> {
-    const rows = await page.locator('.ag-row[row-index]').all();
-    const seen = new Map<number, string>();
-    for (let i = 0, len = rows.length; i < len; ++i) {
-        const row = rows[i];
-        const idxAttr = await row.getAttribute('row-index');
-        if (idxAttr == null) {
-            continue;
-        }
-        const idx = Number(idxAttr);
-        if (seen.has(idx)) {
-            continue;
-        }
-        const cell = row.locator(`[col-id="${colId}"]`);
-        if ((await cell.count()) === 0) {
-            continue;
-        }
-        seen.set(idx, ((await cell.first().innerText()) ?? '').trim());
-    }
-    return [...seen.entries()].sort((a, b) => a[0] - b[0]).map(([, v]) => v);
-}
+import {
+    ensureGridReady,
+    expect,
+    orderedValues,
+    test,
+    waitForGridContent,
+    waitForRowAnimations,
+} from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     test.eachFramework('Post-sort pins Ireland rows to the top', async ({ page }) => {

--- a/documentation/ag-grid-docs/src/content/docs/rtl/_examples/rtl-complex/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/rtl/_examples/rtl-complex/example.spec.ts
@@ -1,9 +1,11 @@
 import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 // 1x1 transparent PNG used to stub the external flag CDN, so the flag-image assertions do not depend
-// on network reachability of flags.fmcdn.net.
+// on network reachability of flags.fmcdn.net. Must be a byte-complete PNG (valid chunk CRCs, IEND
+// present): Firefox rejects a malformed one with a console "Image corrupt or truncated." error, which
+// fails the example's console-error check even though Chromium and WebKit decode it regardless.
 const TRANSPARENT_PNG = Buffer.from(
-    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgAAIAAAUAAXpeqz8AAAAASUVORK5CYII=',
     'base64'
 );
 

--- a/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
@@ -560,6 +560,17 @@ export async function expectRowIdAtIndex(page: Page, rowIndex: number, rowId: st
     }).toPass();
 }
 
+/**
+ * Click a column header's label to cycle its sort.
+ *
+ * Clicking the header cell itself targets the cell's centre. On a narrow column whose menu and
+ * filter buttons are always shown, those icons occupy the centre, so the click opens the menu
+ * instead of sorting. The label is always the sort target, whatever the remaining width.
+ */
+export async function clickHeaderToSort(headerCell: Locator) {
+    await headerCell.locator('.ag-header-cell-label').click();
+}
+
 export async function clickAllButtons(page: Page) {
     // Click all visible buttons in the grid example
     // Don't use buttons within the ag-root-wrapper as these are not part of the example
@@ -732,5 +743,6 @@ export async function expectConsistentFrameworkDom(page: Page, options?: Consist
 }
 
 export { ensureGridReady, waitForGridContent } from './test/remoteGridapi';
+export { orderedValues } from './test/orderedValues';
 export { repeat } from './test/repeat';
 export { scrollGridRelative } from './test/scrollGridRelative';

--- a/documentation/ag-grid-docs/src/utils/grid/test/orderedValues.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test/orderedValues.ts
@@ -1,0 +1,32 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Read a column's rendered values in top-to-bottom display order (by row-index).
+ *
+ * Read in a single evaluate call: per-row awaits race virtualisation, hang on rows detached
+ * mid-read, and cost one round-trip per cell, which alone can exhaust a test's budget when
+ * called from inside a retry loop.
+ */
+export function orderedValues(page: Page, colId: string): Promise<string[]> {
+    return page.evaluate((colId) => {
+        const seen = new Map<number, string>();
+        const rows = document.querySelectorAll('.ag-row[row-index]');
+        for (let i = 0, len = rows.length; i < len; ++i) {
+            const row = rows[i];
+            const idxAttr = row.getAttribute('row-index');
+            if (idxAttr == null) {
+                continue;
+            }
+            const idx = Number(idxAttr);
+            if (seen.has(idx)) {
+                continue;
+            }
+            const cell = row.querySelector(`[col-id="${colId}"]`);
+            if (!cell) {
+                continue;
+            }
+            seen.set(idx, (cell.textContent ?? '').trim());
+        }
+        return [...seen.entries()].sort((a, b) => a[0] - b[0]).map(([, v]) => v);
+    }, colId);
+}

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
@@ -305,6 +305,23 @@ export function tsNodeIsTopLevelFunction(node: any): boolean {
 }
 
 /**
+ * The names a declaration's binding name introduces into scope: the identifier itself, or every
+ * element of an object/array destructuring pattern.
+ */
+function boundNames(name: ts.BindingName): string[] {
+    if (ts.isObjectBindingPattern(name) || ts.isArrayBindingPattern(name)) {
+        const names: string[] = [];
+        name.elements.forEach((element) => {
+            if (ts.isBindingElement(element)) {
+                names.push(...boundNames(element.name));
+            }
+        });
+        return names;
+    }
+    return [name.getText()];
+}
+
+/**
  * Find all the variables defined in this node tree recursively
  */
 export function findAllVariables(node) {
@@ -313,12 +330,8 @@ export function findAllVariables(node) {
         allVariables.push(node.name.getText());
     }
     if (ts.isVariableDeclaration(node)) {
-        if (ts.isObjectBindingPattern(node.name)) {
-            // Code like this:  const { pageSetup, margins } = getSheetConfig();
-            node.name.elements.forEach((n) => allVariables.push(n.getText()));
-        } else {
-            allVariables.push(node.name.getText());
-        }
+        // Code like this:  const { pageSetup, margins } = getSheetConfig();
+        allVariables.push(...boundNames(node.name));
     }
     if (ts.isFunctionDeclaration(node)) {
         // catch locally defined functions within the main function body
@@ -329,8 +342,9 @@ export function findAllVariables(node) {
         // catch locally defined arrow functions with their params
         //  const colToNameFunc = (col: Column, index: number) => index + ' = ' + col.getId()
         //  const colNames = cols.map(colToNameFunc).join(', ')
-
-        allVariables.push(node.name.getText());
+        // Destructured params bind each element, not the pattern text: without unpacking them,
+        // `({ column }) => column.getColId()` reports `column` as an external dependency.
+        allVariables.push(...boundNames(node.name));
     }
     ts.forEachChild(node, (n) => {
         const variables = findAllVariables(n);


### PR DESCRIPTION
Accounts for all 93 failures in the nightly [Documentation Tests](https://github.com/ag-grid/ag-grid/actions/runs/30235437697) run, and fixes the 30 that were still outstanding.

That run's head SHA is `2a06528` (03:47); #14610 merged at 09:37, **after** it started, so 63 of the 93 were already fixed. I re-ran those against staging to confirm.

| Cause | Tests |
|---|---|
| Already fixed by #14610, which merged after this run started: `row-spanning-simple` (18), `status-bar` (9), `multi-column` (9), `suppress-click-selection` (9), `server-side` (9), `customising-menu-items` (9). Re-ran against staging, all green. | 63 |
| `grid-state` / `set-state`: `age` is 90px wide, so the always-shown menu/filter icons squeeze the sort label to 18px and a centre click hits the menu. Added `clickHeaderToSort`. | 9 |
| `post-sort` / `absolute-sorting`: per-row-await `orderedValues` copies blew the test budget inside `toPass()`. Promoted #14610's single-`evaluate` version to a shared helper and deduped all 4 copies. | 7 |
| `pdf-widths-autosizing` / `pdf-wrapping-grouping-pinning`: `findAllVariables` stored a destructured param as the pattern's source text, so `column` leaked into the generated `useCallback` deps where it is out of scope. | 6 |
| `pdf-export-page-setup`: the generators inline the `rowData` initialiser and drop the declaration, leaving a `rowData.push(...)` loop on a dead name. | 5 |
| `rtl-complex`: the 1x1 stub PNG has a bad IDAT CRC and no IEND chunk; Firefox rejects it. | 2 |
| `column-groups/group-changes`: Angular/Vue reformat long button labels onto their own lines, so the anchored regex never matched. | 1 |
| **Total** | **93** |

Regenerating all 1004 examples with the parser change diffs only those two examples (`}, [column])` -> `}, [])`).

The 95 flaky tests are not test defects: the console errors behind them are 404s, 502s and `MIME type ('text/html')` / Quirks-Mode warnings, i.e. staging serving error pages mid-redeploy. All 146 tests across the flaky-listed examples pass against healthy staging, and the six worst offenders pass at `--repeat-each 3`.