### PR TITLE
AG-17910 Document provided/ variant upkeep and require meaningful example specs

### DIFF
--- a/.rulesync/rules/docs-example-specs.md
+++ b/.rulesync/rules/docs-example-specs.md
@@ -16,4 +16,4 @@ Do not leave the placeholder `example.spec.ts` in place. The placeholder only pr
 2. Write assertions that exercise that specific behaviour (not just that the grid loads).
 3. Validate across all frameworks, e.g. `./docs-e2e.sh "<example-name>"` and per-framework runs. Use the grid documentation framework strings for `--framework` (validated against `ALL_FRAMEWORKS` in `documentation/ag-grid-docs/src/utils/grid/test-utils.ts`): `typescript`, `vanilla`, `reactFunctionalTs`, `reactFunctionalTs_Dev`, `angular`, `vue3`.
 
-See [.rulesync/skills/docs-e2e-tests/SKILL.md](.rulesync/skills/docs-e2e-tests/SKILL.md) for the full procedure.
+See [docs-e2e-tests/SKILL.md](../skills/docs-e2e-tests/SKILL.md) for the full procedure.

--- a/.rulesync/rules/examples.md
+++ b/.rulesync/rules/examples.md
@@ -45,6 +45,47 @@ All public documentation examples MUST work across all frameworks:
 - Avoid complex DOM manipulation
 - No external library dependencies
 
+### Hand-authored `provided/` framework variants
+
+Examples are generated from `main.ts` by `generate-examples` — this is the default and strongly
+preferred path. A single `main.ts` yields all framework variants automatically, so there is
+nothing to keep in sync.
+
+Hand-authored `provided/` variants are a **last resort**, used only when an example cannot be
+generated cleanly (e.g. it needs framework-specific idioms the generator can't express). Do **not** add a
+`provided/` folder to work around a fixable generation issue — first try to make `main.ts`
+generate correctly. Prefer deleting a `provided/` variant and reverting to pure generation if a
+later change makes generation viable.
+
+```
+_examples/example-name/
+├── main.ts                              # vanilla source (generation input)
+└── provided/                            # last resort — only when generation can't express it
+    ├── reactFunctionalTs/index.tsx
+    ├── angular/app.component.ts
+    └── vue3/main.ts
+```
+
+When a `provided/` folder **does** exist, its files are **not** overwritten by
+`generate-examples` — they are the source of truth for their framework. So when you change
+`main.ts` (modules, `columnDefs`, grid options, handlers, or the HTML controls), you **must**
+make the equivalent change in every `provided/` variant so all frameworks stay consistent. Search
+for a `provided/` folder before considering an example edit complete. Watch for per-framework
+shape differences:
+
+- **React** — `columnDefs` is typed React state (e.g. `useState<(ColDef | ColGroupDef)[]>`); grid
+  options are JSX props; modules are passed via `AgGridProvider modules={...}` (no
+  `ModuleRegistry`).
+- **Angular** — `columnDefs` is a typed class field; grid options are template bindings
+  (`[option]="..."`); modules via `ModuleRegistry.registerModules`.
+- **Vue** — `columnDefs` is a typed `ref`; grid options are template bindings (`:option="..."`);
+  modules via `ModuleRegistry.registerModules`. Note comments inside the `template:` string are
+  in a template literal, but `setup()` body comments are ordinary code — don't escape backticks
+  there.
+
+After editing, run `yarn nx generate-examples ag-grid-docs` and `yarn nx format` to confirm every
+variant still typechecks and is formatted.
+
 ## Validation
 
 ```bash
@@ -108,27 +149,21 @@ The flexbox layout makes the controls sit at the top and the grid fills the rema
 
 ## Example Spec File (Required)
 
-Every example **must** have an `example.spec.ts` file. Without it, the build fails. At minimum, use this placeholder template:
+Every example **must** have an `example.spec.ts` file — without it, the build fails.
 
-```typescript
-import { clickAllButtons, ensureGridReady, test, waitForGridContent } from '@utils/grid/test-utils';
+When you **add a new example** or **create a new doc page** with examples, the example is not complete until its `example.spec.ts` contains **meaningful** assertions — not the placeholder template — and passes across every framework. A placeholder that only proves the grid mounts asserts nothing about the behaviour the example exists to demonstrate.
 
-test.agExample(import.meta, () => {
-    test.eachFramework('Example', async ({ page }) => {
-        // PLACEHOLDER - MINIMAL TEST TO ENSURE GRID LOADS WITHOUT ERRORS
-        await ensureGridReady(page);
-        await waitForGridContent(page);
-        await clickAllButtons(page);
-        // END PLACEHOLDER
-    });
-});
-```
+Follow these steps (the `docs-e2e-tests` skill walks through them):
 
-Replace the placeholder with meaningful assertions when the example demonstrates specific interactive behaviour.
+1. Read the page's `index.mdoc` and the example source to understand what the example demonstrates.
+2. Write assertions that exercise that specific behaviour (not just that the grid loads).
+3. Validate across all frameworks, e.g. `./docs-e2e.sh "<example-name>"`.
+
+See [.rulesync/skills/docs-e2e-tests/SKILL.md](.rulesync/skills/docs-e2e-tests/SKILL.md) for the full procedure.
 
 ## Best Practices
 
 1. Keep examples focused on a single feature
 2. Use realistic but minimal data
-3. Include comments explaining key concepts
+3. Keep comments to a minimum — only annotate code when the comment genuinely adds value (a non-obvious concept or gotcha); do not narrate what the code plainly does
 4. Test in dev server across all frameworks

--- a/.rulesync/rules/examples.md
+++ b/.rulesync/rules/examples.md
@@ -83,8 +83,9 @@ shape differences:
   in a template literal, but `setup()` body comments are ordinary code — don't escape backticks
   there.
 
-After editing, run `yarn nx generate-examples ag-grid-docs` and `yarn nx format` to confirm every
-variant still typechecks and is formatted.
+After editing, run `yarn nx generate-examples ag-grid-docs` and
+`yarn nx format --sort-root-tsconfig-paths=false` to confirm every variant still typechecks and is
+formatted.
 
 ## Validation
 
@@ -159,7 +160,7 @@ Follow these steps (the `docs-e2e-tests` skill walks through them):
 2. Write assertions that exercise that specific behaviour (not just that the grid loads).
 3. Validate across all frameworks, e.g. `./docs-e2e.sh "<example-name>"`.
 
-See [.rulesync/skills/docs-e2e-tests/SKILL.md](.rulesync/skills/docs-e2e-tests/SKILL.md) for the full procedure.
+See [docs-e2e-tests/SKILL.md](../skills/docs-e2e-tests/SKILL.md) for the full procedure.
 
 ## Best Practices
 

--- a/.rulesync/rules/framework-view-layers.md
+++ b/.rulesync/rules/framework-view-layers.md
@@ -33,7 +33,7 @@ React re-implements the **core grid scaffolding** — cells, rows, row container
 
 -   **Vanilla behavioural tests do not exercise React.** The behavioural suite defaults to the vanilla grid (which Angular and Vue share), so green vanilla tests say nothing about React's `reactUi` layer.
 -   **A shared-controller fix still needs a React test.** "It lives in the `*Ctrl`, so React is covered by construction" is a hypothesis, not a verification. The shared method runs under React's async mount and reconciliation, whose timing diverges from vanilla's synchronous render — a fix that holds for vanilla can still break under React. Confirm it; don't assert it.
--   **A React `.test.tsx` is the default for any lifecycle, teardown, or state-reset change to a twinned controller**, not an optional extra. Make it a real regression guard: confirm it fails without the fix and passes with it. See [Testing Guide](.rulesync/rules/testing.md) for the `render(<AgGridReact .../>)` pattern.
+-   **A React `.test.tsx` is the default for any lifecycle, teardown, or state-reset change to a twinned controller**, not an optional extra. Make it a real regression guard: confirm it fails without the fix and passes with it. See [Testing Guide](testing.md) for the `render(<AgGridReact .../>)` pattern.
 -   **Skip the React test only when it is genuinely infeasible** — for example, no way to drive the scenario through `AgGridReact`. Then trace the exact React call path that reaches your fix, state that trace, and flag the missing coverage to the reviewer. Never let a green vanilla suite stand in for React.
 
 ## Pre-PR checkpoint

--- a/documentation/ag-grid-docs/playwright.config.ts
+++ b/documentation/ag-grid-docs/playwright.config.ts
@@ -7,6 +7,21 @@ const PROD_URL = process.env['PUBLIC_SITE_URL'];
 const BASE_URL = process.env.BASE_URL;
 const baseURL = BASE_URL || PREV_URL || PROD_URL || 'https://localhost:4610';
 
+const LOCAL_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]'];
+
+function isLocalRun(url: string): boolean {
+    try {
+        return LOCAL_HOSTNAMES.includes(new URL(url).hostname);
+    } catch {
+        // A URL that does not parse is not one we can treat as local.
+        return false;
+    }
+}
+
+// A run against the local dev server gets no retry, so a flaky example fails fast rather than being
+// masked by a re-run. A run against a deployed site keeps one, since it can fail on the network alone.
+const localRetries = isLocalRun(baseURL) ? 0 : 1;
+
 // eslint-disable-next-line no-console
 console.log(`Using base URL: ${baseURL}`);
 if (process.env.FRAMEWORK) {
@@ -32,8 +47,7 @@ export default defineConfig({
     },
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
-    /* Retry on CI only */
-    retries: process.env.CI ? 2 : 1,
+    retries: process.env.CI ? 2 : localRetries,
     /* Limit parallel tests on CI. */
     workers: process.env.CI ? 4 : undefined,
     // Stop running tests if lots of errors as likely configuration issues


### PR DESCRIPTION
## Summary

Two documentation/tooling changes that came out of working on the grid-state examples, which have hand-authored `provided/` variants.

`generate-examples` does not overwrite a `provided/` folder, so editing `main.ts` silently leaves the framework variants stale. The examples guide now says so explicitly: `provided/` is a last resort, every variant must be updated in step with `main.ts`, and it lists the per-framework shape differences to watch for (React state vs Angular fields vs Vue refs, and how each passes modules).

It also replaces the "placeholder is acceptable" guidance for `example.spec.ts` with a requirement for meaningful assertions, pointing at the `docs-e2e-tests` skill for the procedure.

**Playwright retries now depend on what the run targets, not just on CI:**

| Run | Retries |
|---|---|
| CI | 2 (unchanged) |
| Local, against the dev server | 0 |
| Local, against a deployed site (`BASE_URL` / `PUBLIC_SITE_URL` / `PRE_34_VERSION`) | 1 |

Against a local dev server a retry only hides a flaky example and slows the feedback loop. But the same config is used locally to run against a deployed site, where a failure can come from the network alone — so that case keeps one retry. `isLocalRun` reads the already-resolved `baseURL`, and treats a URL it cannot parse as non-local, which is the conservative side (retry rather than fail).

## Position in Stack

PR 1 of 3.

**Next PR:** #14629 — the rendering fixes found by a grid-state round trip

## JIRA

Jira: [AG-17910](https://ag-grid.atlassian.net/browse/AG-17910)

## Test Plan

- [x] Effective `retries` verified through Playwright's own resolved config: default → 0, `BASE_URL=https://www.ag-grid.com` → 1, `BASE_URL=http://127.0.0.1:4610` → 0, `PUBLIC_SITE_URL=https://ag-grid.com` → 1, `CI=1` → 2
- [x] `npx eslint documentation/ag-grid-docs/playwright.config.ts` clean
- [x] `yarn nx format --sort-root-tsconfig-paths=false` clean