### PR TITLE
AG-17910 Fix rendering state that a grid-state round trip failed to reproduce

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/example.spec.ts
@@ -16,12 +16,10 @@ const GRID_ID = 'gridState';
 // state itself: the aria live region holds the most recent screen-reader announcement, and the
 // hidden overlay keeps the class of whichever overlay was last shown — only the frameworks that
 // drive a `loading` flag put up a loading overlay while fetching, and only on the first fetch.
-function stripHistory(dom: string | null): string | null {
-    return (
-        dom
-            ?.replace(/(class="ag-aria-description-container">).*?(<\/div>)/g, '$1$2')
-            .replace(/ag-overlay-loading-wrapper /g, '') ?? null
-    );
+function stripHistory(dom: string): string {
+    return dom
+        .replace(/(class="ag-aria-description-container">).*?(<\/div>)/g, '$1$2')
+        .replace(/ag-overlay-loading-wrapper /g, '');
 }
 
 type Page = Parameters<typeof serializeGridDom>[0];

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/example.spec.ts
@@ -1,4 +1,51 @@
-import { clickHeaderToSort, ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
+import {
+    clickHeaderToSort,
+    ensureGridReady,
+    expect,
+    serializeGridDom,
+    test,
+    waitForGridContent,
+    waitForRowAnimations,
+} from '@utils/grid/test-utils';
+
+// The example sets an explicit `gridId`, so `grid-id` and the root `data-testid` survive a
+// destroy/recreate cycle unchanged.
+const GRID_ID = 'gridState';
+
+// Normalise the parts of the serialised grid that record how a state was reached rather than the
+// state itself: the aria live region holds the most recent screen-reader announcement, and the
+// hidden overlay keeps the class of whichever overlay was last shown — only the frameworks that
+// drive a `loading` flag put up a loading overlay while fetching, and only on the first fetch.
+function stripHistory(dom: string | null): string | null {
+    return (
+        dom
+            ?.replace(/(class="ag-aria-description-container">).*?(<\/div>)/g, '$1$2')
+            .replace(/ag-overlay-loading-wrapper /g, '') ?? null
+    );
+}
+
+type Page = Parameters<typeof serializeGridDom>[0];
+
+const recreateButton = (page: Page) =>
+    page.getByRole('button', { name: 'Recreate Grid with Current State', exact: true });
+
+// Serialise the rendered grid once it has settled: loading is complete, scrolling has stopped
+// (`ag-scrollbar-scrolling` is transient mid-settle), and rows are not mid-animation. A freshly
+// created grid also applies measured scrollbar sizing and header classes over subsequent frames, so
+// poll until two consecutive serialisations agree rather than capturing part-way through settling.
+async function captureSettledGrid(page: Page) {
+    await expect(page.locator('.ag-overlay-loading-center')).toHaveCount(0);
+    await waitForRowAnimations(page);
+    await expect(page.locator('.ag-scrollbar-scrolling')).toHaveCount(0);
+    let previous: string | null = null;
+    let current: string | null = null;
+    await expect(async () => {
+        previous = current;
+        current = stripHistory(await serializeGridDom(page));
+        expect(current).toBe(previous);
+    }).toPass();
+    return current;
+}
 
 // The grid records every state change (onStateUpdated) and, when recreated, seeds the new
 // grid from the previous grid's state so sort/filter/etc. are restored. State changes and
@@ -9,7 +56,7 @@ test.agExample(import.meta, () => {
         const handler = (msg: { text: () => string }) => logs.push(msg.text());
         page.on('console', handler);
 
-        await ensureGridReady(page);
+        await ensureGridReady(page, GRID_ID);
         await waitForGridContent(page);
 
         await clickHeaderToSort(agIdFor.headerCell('age'));
@@ -28,7 +75,7 @@ test.agExample(import.meta, () => {
         const handler = (msg: { text: () => string }) => logs.push(msg.text());
         page.on('console', handler);
 
-        await ensureGridReady(page);
+        await ensureGridReady(page, GRID_ID);
         await waitForGridContent(page);
 
         await page.getByRole('button', { name: 'Print State', exact: true }).click();
@@ -40,17 +87,108 @@ test.agExample(import.meta, () => {
     });
 
     test.eachFramework('Recreating the grid restores the applied sort', async ({ agIdFor, page }) => {
-        await ensureGridReady(page);
+        await ensureGridReady(page, GRID_ID);
         await waitForGridContent(page);
 
         await clickHeaderToSort(agIdFor.headerCell('age'));
         await expect(agIdFor.headerCell('age')).toHaveAttribute('aria-sort', 'ascending');
 
         // Recreate destroys the grid and seeds the new one from the previous state.
-        await page.getByRole('button', { name: 'Recreate Grid with Current State', exact: true }).click();
+        await recreateButton(page).click();
+        await ensureGridReady(page, GRID_ID);
         await waitForGridContent(page);
 
         // The ascending sort on 'age' survives the destroy/recreate cycle via the restored state.
         await expect(agIdFor.headerCell('age')).toHaveAttribute('aria-sort', 'ascending');
+    });
+
+    // Drive the grid through as many state sections as can be applied purely through the UI —
+    // sort, row grouping + an expanded group, an opened column group, a pinned column, and an open
+    // side bar with a hidden column — then snapshot the rendered grid, recreate it from the
+    // captured state, and assert it renders identically.
+    test.eachFramework('Recreating the grid restores the whole rendered grid', async ({ agIdFor, page }) => {
+        await ensureGridReady(page, GRID_ID);
+        await waitForGridContent(page);
+
+        // Sort (column state).
+        await clickHeaderToSort(agIdFor.headerCell('age'));
+        await expect(agIdFor.headerCell('age')).toHaveAttribute('aria-sort', 'ascending');
+        await waitForRowAnimations(page);
+
+        // Row group by country (column state) via the column menu.
+        const countryHeader = agIdFor.headerCell('country');
+        await countryHeader.hover();
+        await countryHeader.locator('.ag-header-cell-menu-button').click();
+        await page.locator('.ag-menu-option-text', { hasText: 'Group by Country' }).click();
+        await expect(agIdFor.headerCell('ag-Grid-AutoColumn')).toBeVisible();
+        await waitForRowAnimations(page);
+
+        // Expand the first group row (expanded row groups).
+        await page.locator('.ag-group-contracted').first().click();
+        await waitForRowAnimations(page);
+
+        // Open the Medals column group (opened column groups) — the only group with columnGroupShow children.
+        await page
+            .locator('.ag-header-group-cell', { hasText: 'Medals' })
+            .locator('.ag-header-expand-icon-collapsed')
+            .click();
+        await expect(agIdFor.headerCell('silver')).toBeVisible();
+
+        // Pin the athlete column left (column state) via the column menu.
+        const athleteHeader = agIdFor.headerCell('athlete');
+        await athleteHeader.hover();
+        await athleteHeader.locator('.ag-header-cell-menu-button').click();
+        // 'Pin Column' opens a submenu on hover; the pin options live inside it.
+        await page.locator('.ag-menu-option', { hasText: 'Pin Column' }).hover();
+        await page.locator('.ag-menu-option-text', { hasText: 'Pin Left' }).click();
+        await expect(agIdFor.headerCell('athlete')).toHaveClass(/ag-header-cell-last-left-pinned/);
+
+        // Hide the date column (column state) via the Columns tool panel, which the open side bar
+        // (side bar state) shows by default.
+        await expect(agIdFor.columnToolPanel()).toBeVisible();
+        await agIdFor.columnSelectListItemCheckbox('Date Column').click();
+        await expect(agIdFor.headerCell('date')).toBeHidden();
+
+        // Tab guards only sit in the tab order while focus is outside the grid, and recreating leaves
+        // focus on the Recreate button, so both snapshots are taken with that button focused.
+        await recreateButton(page).focus();
+
+        // Snapshot the rendered grid, then recreate from the captured state.
+        const before = await captureSettledGrid(page);
+        expect(before).not.toBeNull();
+
+        await recreateButton(page).click();
+        await ensureGridReady(page, GRID_ID);
+        await waitForGridContent(page);
+        await expect(agIdFor.headerCell('ag-Grid-AutoColumn')).toBeVisible();
+
+        // The recreated grid renders identically to the pre-recreate snapshot.
+        expect(await captureSettledGrid(page)).toBe(before);
+    });
+
+    test.eachFramework('Recreating the grid restores the current page', async ({ page }) => {
+        await ensureGridReady(page, GRID_ID);
+        await waitForGridContent(page);
+
+        // Move to the second page (pagination state). Page size is 100, so the second page starts at
+        // row-index 100 — a recreated grid renders page one first and moves to the restored page a
+        // moment later, so this is the anchor for both captures being of the same page.
+        await page.locator('[aria-label="Next Page"]').click();
+        const firstRowOfSecondPage = page.locator('.ag-grid-scrolling-container .ag-row[row-index="100"]');
+        await expect(firstRowOfSecondPage).toBeVisible();
+
+        // Clicking Next Page left focus inside the grid, which takes the tab guards out of the tab
+        // order — park focus where recreating leaves it so both snapshots agree.
+        await recreateButton(page).focus();
+
+        const before = await captureSettledGrid(page);
+        expect(before).not.toBeNull();
+
+        await recreateButton(page).click();
+        await ensureGridReady(page, GRID_ID);
+        await waitForGridContent(page);
+        await expect(firstRowOfSecondPage).toBeVisible();
+
+        expect(await captureSettledGrid(page)).toBe(before);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/main.ts
@@ -1,43 +1,18 @@
 import type { GridApi, GridOptions, GridPreDestroyedEvent, StateUpdatedEvent } from 'ag-grid-community';
-import {
-    ClientSideRowModelModule,
-    GridStateModule,
-    ModuleRegistry,
-    NumberFilterModule,
-    PaginationModule,
-    RowSelectionModule,
-    createGrid,
-    enableDevValidations,
-} from 'ag-grid-community';
-import {
-    CellSelectionModule,
-    ColumnsToolPanelModule,
-    FiltersToolPanelModule,
-    PivotModule,
-    SetFilterModule,
-} from 'ag-grid-enterprise';
+import { ModuleRegistry, createGrid, enableDevValidations } from 'ag-grid-community';
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
 
 // Enable extended validations only for development
 if (process.env.NODE_ENV !== 'production') {
     enableDevValidations();
 }
 
-ModuleRegistry.registerModules([
-    NumberFilterModule,
-    GridStateModule,
-    PaginationModule,
-    ClientSideRowModelModule,
-    ColumnsToolPanelModule,
-    FiltersToolPanelModule,
-    RowSelectionModule,
-    CellSelectionModule,
-    SetFilterModule,
-    PivotModule,
-]);
+ModuleRegistry.registerModules([AllEnterpriseModule]);
 
 let gridApi: GridApi<IOlympicData>;
 
 const gridOptions: GridOptions<IOlympicData> = {
+    gridId: 'gridState',
     columnDefs: [
         {
             field: 'athlete',
@@ -45,13 +20,25 @@ const gridOptions: GridOptions<IOlympicData> = {
         },
         { field: 'age', maxWidth: 90 },
         { field: 'country', minWidth: 150 },
-        { field: 'year', maxWidth: 90 },
-        { field: 'date', minWidth: 150 },
-        { field: 'sport', minWidth: 150 },
-        { field: 'gold' },
-        { field: 'silver' },
-        { field: 'bronze' },
-        { field: 'total' },
+        {
+            headerName: 'Competition',
+            groupId: 'competition',
+            children: [
+                { field: 'year', maxWidth: 90 },
+                { field: 'date', minWidth: 150 },
+                { field: 'sport', minWidth: 150 },
+            ],
+        },
+        {
+            headerName: 'Medals',
+            groupId: 'medals',
+            children: [
+                { field: 'gold' },
+                { field: 'silver', columnGroupShow: 'open' },
+                { field: 'bronze', columnGroupShow: 'open' },
+                { field: 'total', columnGroupShow: 'closed' },
+            ],
+        },
     ],
     defaultColDef: {
         flex: 1,
@@ -67,7 +54,10 @@ const gridOptions: GridOptions<IOlympicData> = {
     sideBar: true,
     pagination: true,
     rowSelection: { mode: 'multiRow' },
+    cellSelection: true,
+    enableRowPinning: true,
     suppressColumnMoveAnimation: true,
+    ensureDomOrder: true,
     onGridPreDestroyed: onGridPreDestroyed,
     onStateUpdated: onStateUpdated,
 };

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/provided/angular/app.component.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/provided/angular/app.component.ts
@@ -5,6 +5,7 @@ import { AgGridAngular } from 'ag-grid-angular';
 import type {
     AutoGroupColumnDef,
     ColDef,
+    ColGroupDef,
     GridApi,
     GridOptions,
     GridPreDestroyedEvent,
@@ -13,22 +14,8 @@ import type {
     RowSelectionOptions,
     StateUpdatedEvent,
 } from 'ag-grid-community';
-import {
-    ClientSideRowModelModule,
-    GridStateModule,
-    ModuleRegistry,
-    NumberFilterModule,
-    PaginationModule,
-    RowSelectionModule,
-    enableDevValidations,
-} from 'ag-grid-community';
-import {
-    CellSelectionModule,
-    ColumnsToolPanelModule,
-    FiltersToolPanelModule,
-    PivotModule,
-    SetFilterModule,
-} from 'ag-grid-enterprise';
+import { ModuleRegistry, enableDevValidations } from 'ag-grid-community';
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
 
 import type { IOlympicData } from './interfaces';
 import './styles.css';
@@ -38,18 +25,7 @@ if (process.env.NODE_ENV !== 'production') {
     enableDevValidations();
 }
 
-ModuleRegistry.registerModules([
-    NumberFilterModule,
-    GridStateModule,
-    PaginationModule,
-    ClientSideRowModelModule,
-    ColumnsToolPanelModule,
-    FiltersToolPanelModule,
-    RowSelectionModule,
-    CellSelectionModule,
-    SetFilterModule,
-    PivotModule,
-]);
+ModuleRegistry.registerModules([AllEnterpriseModule]);
 
 @Component({
     standalone: true,
@@ -66,13 +42,17 @@ ModuleRegistry.registerModules([
             @if (gridVisible()) {
                 <ag-grid-angular
                     style="width: 100%; height: 100%;"
+                    gridId="gridState"
                     [columnDefs]="columnDefs"
                     [defaultColDef]="defaultColDef"
                     [autoGroupColumnDef]="autoGroupColumnDef"
                     [sideBar]="true"
                     [pagination]="true"
                     [rowSelection]="rowSelection"
+                    [cellSelection]="true"
+                    [enableRowPinning]="true"
                     [suppressColumnMoveAnimation]="true"
+                    [ensureDomOrder]="true"
                     [rowData]="rowData"
                     [initialState]="initialState"
                     [gridOptions]="gridOptions"
@@ -86,17 +66,29 @@ ModuleRegistry.registerModules([
 export class AppComponent {
     private gridApi!: GridApi<IOlympicData>;
 
-    public columnDefs: ColDef[] = [
+    public columnDefs: (ColDef | ColGroupDef)[] = [
         { field: 'athlete', minWidth: 150 },
         { field: 'age', maxWidth: 90 },
         { field: 'country', minWidth: 150 },
-        { field: 'year', maxWidth: 90 },
-        { field: 'date', minWidth: 150 },
-        { field: 'sport', minWidth: 150 },
-        { field: 'gold' },
-        { field: 'silver' },
-        { field: 'bronze' },
-        { field: 'total' },
+        {
+            headerName: 'Competition',
+            groupId: 'competition',
+            children: [
+                { field: 'year', maxWidth: 90 },
+                { field: 'date', minWidth: 150 },
+                { field: 'sport', minWidth: 150 },
+            ],
+        },
+        {
+            headerName: 'Medals',
+            groupId: 'medals',
+            children: [
+                { field: 'gold' },
+                { field: 'silver', columnGroupShow: 'open' },
+                { field: 'bronze', columnGroupShow: 'open' },
+                { field: 'total', columnGroupShow: 'closed' },
+            ],
+        },
     ];
     public defaultColDef: ColDef = {
         flex: 1,

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/provided/reactFunctionalTs/index.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/provided/reactFunctionalTs/index.tsx
@@ -4,26 +4,14 @@ import { createRoot } from 'react-dom/client';
 import type {
     AutoGroupColumnDef,
     ColDef,
+    ColGroupDef,
     GridPreDestroyedEvent,
     GridState,
     RowSelectionOptions,
     StateUpdatedEvent,
 } from 'ag-grid-community';
-import {
-    ClientSideRowModelModule,
-    GridStateModule,
-    NumberFilterModule,
-    PaginationModule,
-    RowSelectionModule,
-    enableDevValidations,
-} from 'ag-grid-community';
-import {
-    CellSelectionModule,
-    ColumnsToolPanelModule,
-    FiltersToolPanelModule,
-    PivotModule,
-    SetFilterModule,
-} from 'ag-grid-enterprise';
+import { enableDevValidations } from 'ag-grid-community';
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
 import { AgGridProvider, AgGridReact } from 'ag-grid-react';
 
 import type { IOlympicData } from './interfaces';
@@ -35,34 +23,35 @@ if (process.env.NODE_ENV !== 'production') {
     enableDevValidations();
 }
 
-const modules = [
-    NumberFilterModule,
-    RowSelectionModule,
-    GridStateModule,
-    PaginationModule,
-    ClientSideRowModelModule,
-    ColumnsToolPanelModule,
-    FiltersToolPanelModule,
-    SetFilterModule,
-    CellSelectionModule,
-    PivotModule,
-];
+const modules = [AllEnterpriseModule];
 
 const GridExample = () => {
     const gridRef = useRef<AgGridReact<IOlympicData>>(null);
     const containerStyle = useMemo(() => ({ width: '100%', height: '100%' }), []);
     const gridStyle = useMemo(() => ({ height: '100%', width: '100%' }), []);
-    const [columnDefs, setColumnDefs] = useState<ColDef[]>([
+    const [columnDefs, setColumnDefs] = useState<(ColDef | ColGroupDef)[]>([
         { field: 'athlete', minWidth: 150 },
         { field: 'age', maxWidth: 90 },
         { field: 'country', minWidth: 150 },
-        { field: 'year', maxWidth: 90 },
-        { field: 'date', minWidth: 150 },
-        { field: 'sport', minWidth: 150 },
-        { field: 'gold' },
-        { field: 'silver' },
-        { field: 'bronze' },
-        { field: 'total' },
+        {
+            headerName: 'Competition',
+            groupId: 'competition',
+            children: [
+                { field: 'year', maxWidth: 90 },
+                { field: 'date', minWidth: 150 },
+                { field: 'sport', minWidth: 150 },
+            ],
+        },
+        {
+            headerName: 'Medals',
+            groupId: 'medals',
+            children: [
+                { field: 'gold' },
+                { field: 'silver', columnGroupShow: 'open' },
+                { field: 'bronze', columnGroupShow: 'open' },
+                { field: 'total', columnGroupShow: 'closed' },
+            ],
+        },
     ]);
     const defaultColDef = useMemo<ColDef>(() => {
         return {
@@ -125,6 +114,7 @@ const GridExample = () => {
                         {gridVisible && (
                             <AgGridReact<IOlympicData>
                                 ref={gridRef}
+                                gridId="gridState"
                                 rowData={data}
                                 loading={loading}
                                 columnDefs={columnDefs}
@@ -133,7 +123,10 @@ const GridExample = () => {
                                 sideBar={true}
                                 pagination={true}
                                 rowSelection={rowSelection}
+                                cellSelection={true}
+                                enableRowPinning={true}
                                 suppressColumnMoveAnimation={true}
+                                ensureDomOrder={true}
                                 initialState={initialState}
                                 onGridPreDestroyed={onGridPreDestroyed}
                                 onStateUpdated={onStateUpdated}

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/provided/vue3/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/provided/vue3/main.ts
@@ -2,6 +2,7 @@ import { createApp, defineComponent, ref, shallowRef } from 'vue';
 
 import type {
     ColDef,
+    ColGroupDef,
     GridApi,
     GridPreDestroyedEvent,
     GridReadyEvent,
@@ -9,22 +10,8 @@ import type {
     RowSelectionOptions,
     StateUpdatedEvent,
 } from 'ag-grid-community';
-import {
-    ClientSideRowModelModule,
-    GridStateModule,
-    ModuleRegistry,
-    NumberFilterModule,
-    PaginationModule,
-    RowSelectionModule,
-    enableDevValidations,
-} from 'ag-grid-community';
-import {
-    CellSelectionModule,
-    ColumnsToolPanelModule,
-    FiltersToolPanelModule,
-    PivotModule,
-    SetFilterModule,
-} from 'ag-grid-enterprise';
+import { ModuleRegistry, enableDevValidations } from 'ag-grid-community';
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
 import { AgGridVue } from 'ag-grid-vue3';
 
 import './styles.css';
@@ -34,18 +21,7 @@ if (process.env.NODE_ENV !== 'production') {
     enableDevValidations();
 }
 
-ModuleRegistry.registerModules([
-    ClientSideRowModelModule,
-    NumberFilterModule,
-    RowSelectionModule,
-    PaginationModule,
-    GridStateModule,
-    ColumnsToolPanelModule,
-    FiltersToolPanelModule,
-    SetFilterModule,
-    CellSelectionModule,
-    PivotModule,
-]);
+ModuleRegistry.registerModules([AllEnterpriseModule]);
 
 const VueExample = defineComponent({
     template: `
@@ -60,6 +36,7 @@ const VueExample = defineComponent({
                 <ag-grid-vue
                     v-if="gridVisible"
                     style="width: 100%; height: 100%;"
+                    gridId="gridState"
                     :columnDefs="columnDefs"
                     @grid-ready="onGridReady"
                     :defaultColDef="defaultColDef"
@@ -67,7 +44,10 @@ const VueExample = defineComponent({
                     :sideBar="true"
                     :pagination="true"
                     :rowSelection="rowSelection"
+                    :cellSelection="true"
+                    :enableRowPinning="true"
                     :suppressColumnMoveAnimation="true"
+                    :ensureDomOrder="true"
                     :rowData="rowData"
                     :initialState="initialState"
                     @grid-pre-destroyed="onGridPreDestroyed"
@@ -80,17 +60,30 @@ const VueExample = defineComponent({
         'ag-grid-vue': AgGridVue,
     },
     setup(props) {
-        const columnDefs = ref<ColDef[]>([
+        const columnDefs = ref<(ColDef | ColGroupDef)[]>([
             { field: 'athlete', minWidth: 150 },
             { field: 'age', maxWidth: 90 },
             { field: 'country', minWidth: 150 },
-            { field: 'year', maxWidth: 90 },
-            { field: 'date', minWidth: 150 },
-            { field: 'sport', minWidth: 150 },
-            { field: 'gold' },
-            { field: 'silver' },
-            { field: 'bronze' },
-            { field: 'total' },
+            {
+                headerName: 'Competition',
+                groupId: 'competition',
+                children: [
+                    { field: 'year', maxWidth: 90 },
+                    { field: 'date', minWidth: 150 },
+                    { field: 'sport', minWidth: 150 },
+                ],
+            },
+            {
+                // Collapsible group with a stable groupId so open/closed columnGroup state can round-trip.
+                headerName: 'Medals',
+                groupId: 'medals',
+                children: [
+                    { field: 'gold' },
+                    { field: 'silver', columnGroupShow: 'open' },
+                    { field: 'bronze', columnGroupShow: 'open' },
+                    { field: 'total', columnGroupShow: 'closed' },
+                ],
+            },
         ]);
         const gridApi = shallowRef<GridApi | null>(null);
         const defaultColDef = ref<ColDef>({
@@ -105,26 +98,28 @@ const VueExample = defineComponent({
         const rowSelection = ref<RowSelectionOptions>({
             mode: 'multiRow',
         });
-        const rowData = ref<any[]>(null);
+        const rowData = ref<any[] | undefined>(undefined);
         const gridVisible = ref(true);
-        const initialState = ref(undefined);
+        const initialState = ref<GridState | undefined>(undefined);
 
         const reloadGrid = () => {
-            const state = gridApi.value.getState();
-            gridVisible.value = false;
-            setTimeout(() => {
-                initialState.value = state;
-                rowData.value = undefined;
-                gridVisible.value = true;
-            });
+            if (gridApi.value) {
+                const state = gridApi.value.getState();
+                gridVisible.value = false;
+                setTimeout(() => {
+                    initialState.value = state;
+                    rowData.value = undefined;
+                    gridVisible.value = true;
+                });
+            }
         };
         const printState = () => {
-            console.log('Grid state', gridApi.value.getState());
+            console.log('Grid state', gridApi.value!.getState());
         };
         const onGridReady = (params: GridReadyEvent) => {
             gridApi.value = params.api;
 
-            const updateData = (data) => (rowData.value = data);
+            const updateData = (data: any[]) => (rowData.value = data);
 
             fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
                 .then((resp) => resp.json())

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/example.spec.ts
@@ -1,5 +1,9 @@
 import { clickHeaderToSort, ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
+// The example sets an explicit `gridId`, so the same selector resolves the grid before and after
+// it is recreated.
+const GRID_ID = 'setState';
+
 // Save State captures the current grid state, Recreate Grid with No State throws it away
 // (fresh grid), and Set State restores the saved state onto the existing grid via
 // api.setState(). We drive that round-trip with a sort so the restore is observable.
@@ -11,7 +15,7 @@ test.agExample(import.meta, () => {
             const handler = (msg: { text: () => string }) => logs.push(msg.text());
             page.on('console', handler);
 
-            await ensureGridReady(page);
+            await ensureGridReady(page, GRID_ID);
             await waitForGridContent(page);
 
             // Apply a sort so there is meaningful state to save.
@@ -30,6 +34,7 @@ test.agExample(import.meta, () => {
 
             // Recreate with no state: the fresh grid has no sort.
             await page.getByRole('button', { name: 'Recreate Grid with No State', exact: true }).click();
+            await ensureGridReady(page, GRID_ID);
             await waitForGridContent(page);
             await expect(agIdFor.headerCell('age')).toHaveAttribute('aria-sort', 'none');
 
@@ -49,7 +54,7 @@ test.agExample(import.meta, () => {
         const handler = (msg: { text: () => string }) => logs.push(msg.text());
         page.on('console', handler);
 
-        await ensureGridReady(page);
+        await ensureGridReady(page, GRID_ID);
         await waitForGridContent(page);
 
         await page.getByRole('button', { name: 'Print State', exact: true }).click();

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/main.ts
@@ -1,43 +1,18 @@
 import type { GridApi, GridOptions, GridPreDestroyedEvent, GridState, StateUpdatedEvent } from 'ag-grid-community';
-import {
-    ClientSideRowModelModule,
-    GridStateModule,
-    ModuleRegistry,
-    NumberFilterModule,
-    PaginationModule,
-    RowSelectionModule,
-    createGrid,
-    enableDevValidations,
-} from 'ag-grid-community';
-import {
-    CellSelectionModule,
-    ColumnsToolPanelModule,
-    FiltersToolPanelModule,
-    PivotModule,
-    SetFilterModule,
-} from 'ag-grid-enterprise';
+import { ModuleRegistry, createGrid, enableDevValidations } from 'ag-grid-community';
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
 
 // Enable extended validations only for development
 if (process.env.NODE_ENV !== 'production') {
     enableDevValidations();
 }
 
-ModuleRegistry.registerModules([
-    NumberFilterModule,
-    GridStateModule,
-    PaginationModule,
-    ClientSideRowModelModule,
-    ColumnsToolPanelModule,
-    FiltersToolPanelModule,
-    RowSelectionModule,
-    CellSelectionModule,
-    SetFilterModule,
-    PivotModule,
-]);
+ModuleRegistry.registerModules([AllEnterpriseModule]);
 
 let gridApi: GridApi<IOlympicData>;
 
 const gridOptions: GridOptions<IOlympicData> = {
+    gridId: 'setState',
     columnDefs: [
         {
             field: 'athlete',
@@ -45,13 +20,25 @@ const gridOptions: GridOptions<IOlympicData> = {
         },
         { field: 'age', maxWidth: 90 },
         { field: 'country', minWidth: 150 },
-        { field: 'year', maxWidth: 90 },
-        { field: 'date', minWidth: 150 },
-        { field: 'sport', minWidth: 150 },
-        { field: 'gold' },
-        { field: 'silver' },
-        { field: 'bronze' },
-        { field: 'total' },
+        {
+            headerName: 'Competition',
+            groupId: 'competition',
+            children: [
+                { field: 'year', maxWidth: 90 },
+                { field: 'date', minWidth: 150 },
+                { field: 'sport', minWidth: 150 },
+            ],
+        },
+        {
+            headerName: 'Medals',
+            groupId: 'medals',
+            children: [
+                { field: 'gold' },
+                { field: 'silver', columnGroupShow: 'open' },
+                { field: 'bronze', columnGroupShow: 'open' },
+                { field: 'total', columnGroupShow: 'closed' },
+            ],
+        },
     ],
     defaultColDef: {
         flex: 1,
@@ -67,6 +54,8 @@ const gridOptions: GridOptions<IOlympicData> = {
     sideBar: true,
     pagination: true,
     rowSelection: { mode: 'multiRow' },
+    cellSelection: true,
+    enableRowPinning: true,
     suppressColumnMoveAnimation: true,
     onGridPreDestroyed: onGridPreDestroyed,
     onStateUpdated: onStateUpdated,

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/provided/angular/app.component.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/provided/angular/app.component.ts
@@ -5,6 +5,7 @@ import { AgGridAngular } from 'ag-grid-angular';
 import type {
     AutoGroupColumnDef,
     ColDef,
+    ColGroupDef,
     GridApi,
     GridOptions,
     GridPreDestroyedEvent,
@@ -13,22 +14,8 @@ import type {
     RowSelectionOptions,
     StateUpdatedEvent,
 } from 'ag-grid-community';
-import {
-    ClientSideRowModelModule,
-    GridStateModule,
-    ModuleRegistry,
-    NumberFilterModule,
-    PaginationModule,
-    RowSelectionModule,
-    enableDevValidations,
-} from 'ag-grid-community';
-import {
-    CellSelectionModule,
-    ColumnsToolPanelModule,
-    FiltersToolPanelModule,
-    PivotModule,
-    SetFilterModule,
-} from 'ag-grid-enterprise';
+import { ModuleRegistry, enableDevValidations } from 'ag-grid-community';
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
 
 import type { IOlympicData } from './interfaces';
 import './styles.css';
@@ -38,18 +25,7 @@ if (process.env.NODE_ENV !== 'production') {
     enableDevValidations();
 }
 
-ModuleRegistry.registerModules([
-    NumberFilterModule,
-    GridStateModule,
-    PaginationModule,
-    ClientSideRowModelModule,
-    ColumnsToolPanelModule,
-    FiltersToolPanelModule,
-    RowSelectionModule,
-    CellSelectionModule,
-    SetFilterModule,
-    PivotModule,
-]);
+ModuleRegistry.registerModules([AllEnterpriseModule]);
 
 @Component({
     standalone: true,
@@ -68,12 +44,15 @@ ModuleRegistry.registerModules([
             @if (gridVisible()) {
                 <ag-grid-angular
                     style="width: 100%; height: 100%;"
+                    gridId="setState"
                     [columnDefs]="columnDefs"
                     [defaultColDef]="defaultColDef"
                     [autoGroupColumnDef]="autoGroupColumnDef"
                     [sideBar]="true"
                     [pagination]="true"
                     [rowSelection]="rowSelection"
+                    [cellSelection]="true"
+                    [enableRowPinning]="true"
                     [suppressColumnMoveAnimation]="true"
                     [rowData]="rowData"
                     [gridOptions]="gridOptions"
@@ -87,17 +66,29 @@ ModuleRegistry.registerModules([
 export class AppComponent {
     private gridApi!: GridApi<IOlympicData>;
 
-    public columnDefs: ColDef[] = [
+    public columnDefs: (ColDef | ColGroupDef)[] = [
         { field: 'athlete', minWidth: 150 },
         { field: 'age', maxWidth: 90 },
         { field: 'country', minWidth: 150 },
-        { field: 'year', maxWidth: 90 },
-        { field: 'date', minWidth: 150 },
-        { field: 'sport', minWidth: 150 },
-        { field: 'gold' },
-        { field: 'silver' },
-        { field: 'bronze' },
-        { field: 'total' },
+        {
+            headerName: 'Competition',
+            groupId: 'competition',
+            children: [
+                { field: 'year', maxWidth: 90 },
+                { field: 'date', minWidth: 150 },
+                { field: 'sport', minWidth: 150 },
+            ],
+        },
+        {
+            headerName: 'Medals',
+            groupId: 'medals',
+            children: [
+                { field: 'gold' },
+                { field: 'silver', columnGroupShow: 'open' },
+                { field: 'bronze', columnGroupShow: 'open' },
+                { field: 'total', columnGroupShow: 'closed' },
+            ],
+        },
     ];
     public defaultColDef: ColDef = {
         flex: 1,

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/provided/reactFunctionalTs/index.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/provided/reactFunctionalTs/index.tsx
@@ -4,27 +4,15 @@ import { createRoot } from 'react-dom/client';
 import type {
     AutoGroupColumnDef,
     ColDef,
+    ColGroupDef,
     GridPreDestroyedEvent,
     GridReadyEvent,
     GridState,
     RowSelectionOptions,
     StateUpdatedEvent,
 } from 'ag-grid-community';
-import {
-    ClientSideRowModelModule,
-    GridStateModule,
-    NumberFilterModule,
-    PaginationModule,
-    RowSelectionModule,
-    enableDevValidations,
-} from 'ag-grid-community';
-import {
-    CellSelectionModule,
-    ColumnsToolPanelModule,
-    FiltersToolPanelModule,
-    PivotModule,
-    SetFilterModule,
-} from 'ag-grid-enterprise';
+import { enableDevValidations } from 'ag-grid-community';
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
 import { AgGridProvider, AgGridReact } from 'ag-grid-react';
 
 import type { IOlympicData } from './interfaces';
@@ -35,35 +23,36 @@ if (process.env.NODE_ENV !== 'production') {
     enableDevValidations();
 }
 
-const modules = [
-    NumberFilterModule,
-    RowSelectionModule,
-    GridStateModule,
-    PaginationModule,
-    ClientSideRowModelModule,
-    ColumnsToolPanelModule,
-    FiltersToolPanelModule,
-    SetFilterModule,
-    CellSelectionModule,
-    PivotModule,
-];
+const modules = [AllEnterpriseModule];
 
 const GridExample = () => {
     const gridRef = useRef<AgGridReact<IOlympicData>>(null);
     const containerStyle = useMemo(() => ({ width: '100%', height: '100%' }), []);
     const gridStyle = useMemo(() => ({ height: '100%', width: '100%' }), []);
     const [rowData, setRowData] = useState<IOlympicData[]>();
-    const [columnDefs, setColumnDefs] = useState<ColDef[]>([
+    const [columnDefs, setColumnDefs] = useState<(ColDef | ColGroupDef)[]>([
         { field: 'athlete', minWidth: 150 },
         { field: 'age', maxWidth: 90 },
         { field: 'country', minWidth: 150 },
-        { field: 'year', maxWidth: 90 },
-        { field: 'date', minWidth: 150 },
-        { field: 'sport', minWidth: 150 },
-        { field: 'gold' },
-        { field: 'silver' },
-        { field: 'bronze' },
-        { field: 'total' },
+        {
+            headerName: 'Competition',
+            groupId: 'competition',
+            children: [
+                { field: 'year', maxWidth: 90 },
+                { field: 'date', minWidth: 150 },
+                { field: 'sport', minWidth: 150 },
+            ],
+        },
+        {
+            headerName: 'Medals',
+            groupId: 'medals',
+            children: [
+                { field: 'gold' },
+                { field: 'silver', columnGroupShow: 'open' },
+                { field: 'bronze', columnGroupShow: 'open' },
+                { field: 'total', columnGroupShow: 'closed' },
+            ],
+        },
     ]);
     const defaultColDef = useMemo<ColDef>(() => {
         return {
@@ -144,6 +133,7 @@ const GridExample = () => {
                         {gridVisible && (
                             <AgGridReact<IOlympicData>
                                 ref={gridRef}
+                                gridId="setState"
                                 rowData={rowData}
                                 columnDefs={columnDefs}
                                 defaultColDef={defaultColDef}
@@ -151,6 +141,8 @@ const GridExample = () => {
                                 sideBar={true}
                                 pagination={true}
                                 rowSelection={rowSelection}
+                                cellSelection={true}
+                                enableRowPinning={true}
                                 suppressColumnMoveAnimation={true}
                                 onGridReady={onGridReady}
                                 onGridPreDestroyed={onGridPreDestroyed}

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/provided/vue3/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/provided/vue3/main.ts
@@ -2,6 +2,7 @@ import { createApp, defineComponent, ref, shallowRef } from 'vue';
 
 import type {
     ColDef,
+    ColGroupDef,
     GridApi,
     GridPreDestroyedEvent,
     GridReadyEvent,
@@ -9,22 +10,8 @@ import type {
     RowSelectionOptions,
     StateUpdatedEvent,
 } from 'ag-grid-community';
-import {
-    ClientSideRowModelModule,
-    GridStateModule,
-    ModuleRegistry,
-    NumberFilterModule,
-    PaginationModule,
-    RowSelectionModule,
-    enableDevValidations,
-} from 'ag-grid-community';
-import {
-    CellSelectionModule,
-    ColumnsToolPanelModule,
-    FiltersToolPanelModule,
-    PivotModule,
-    SetFilterModule,
-} from 'ag-grid-enterprise';
+import { ModuleRegistry, enableDevValidations } from 'ag-grid-community';
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
 import { AgGridVue } from 'ag-grid-vue3';
 
 import './styles.css';
@@ -34,18 +21,7 @@ if (process.env.NODE_ENV !== 'production') {
     enableDevValidations();
 }
 
-ModuleRegistry.registerModules([
-    ClientSideRowModelModule,
-    NumberFilterModule,
-    RowSelectionModule,
-    PaginationModule,
-    GridStateModule,
-    ColumnsToolPanelModule,
-    FiltersToolPanelModule,
-    SetFilterModule,
-    CellSelectionModule,
-    PivotModule,
-]);
+ModuleRegistry.registerModules([AllEnterpriseModule]);
 
 const VueExample = defineComponent({
     template: `
@@ -62,6 +38,7 @@ const VueExample = defineComponent({
                 <ag-grid-vue
                     v-if="gridVisible"
                     style="width: 100%; height: 100%;"
+                    gridId="setState"
                     :columnDefs="columnDefs"
                     @grid-ready="onGridReady"
                     :defaultColDef="defaultColDef"
@@ -69,6 +46,8 @@ const VueExample = defineComponent({
                     :sideBar="true"
                     :pagination="true"
                     :rowSelection="rowSelection"
+                    :cellSelection="true"
+                    :enableRowPinning="true"
                     :suppressColumnMoveAnimation="true"
                     :rowData="rowData"
                     @grid-pre-destroyed="onGridPreDestroyed"
@@ -81,17 +60,29 @@ const VueExample = defineComponent({
         'ag-grid-vue': AgGridVue,
     },
     setup(props) {
-        const columnDefs = ref<ColDef[]>([
+        const columnDefs = ref<(ColDef | ColGroupDef)[]>([
             { field: 'athlete', minWidth: 150 },
             { field: 'age', maxWidth: 90 },
             { field: 'country', minWidth: 150 },
-            { field: 'year', maxWidth: 90 },
-            { field: 'date', minWidth: 150 },
-            { field: 'sport', minWidth: 150 },
-            { field: 'gold' },
-            { field: 'silver' },
-            { field: 'bronze' },
-            { field: 'total' },
+            {
+                headerName: 'Competition',
+                groupId: 'competition',
+                children: [
+                    { field: 'year', maxWidth: 90 },
+                    { field: 'date', minWidth: 150 },
+                    { field: 'sport', minWidth: 150 },
+                ],
+            },
+            {
+                headerName: 'Medals',
+                groupId: 'medals',
+                children: [
+                    { field: 'gold' },
+                    { field: 'silver', columnGroupShow: 'open' },
+                    { field: 'bronze', columnGroupShow: 'open' },
+                    { field: 'total', columnGroupShow: 'closed' },
+                ],
+            },
         ]);
         const gridApi = shallowRef<GridApi | null>(null);
         const defaultColDef = ref<ColDef>({
@@ -106,7 +97,7 @@ const VueExample = defineComponent({
         const rowSelection = ref<RowSelectionOptions>({
             mode: 'multiRow',
         });
-        const rowData = ref<any[]>(null);
+        const rowData = ref<any[] | undefined>(undefined);
         const gridVisible = ref(true);
         const savedState = ref<GridState>();
 
@@ -134,7 +125,7 @@ const VueExample = defineComponent({
         const onGridReady = (params: GridReadyEvent) => {
             gridApi.value = params.api;
 
-            const updateData = (data) => (rowData.value = data);
+            const updateData = (data: any[]) => (rowData.value = data);
 
             fetch('https://www.ag-grid.com/example-assets/olympic-winners.json')
                 .then((resp) => resp.json())

--- a/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
@@ -591,6 +591,13 @@ export type ConsistentDomOptions = {
     includeText?: boolean;
     /** Extra attribute names to drop before comparing (in addition to the volatile defaults). */
     ignoreAttributes?: string[];
+    /**
+     * Collapse measured pixel values and virtualisation transforms in `style` attributes. Defaults to
+     * `false`, so widths, offsets and scroll positions are compared as their real values. Set to
+     * `true` when comparing across frameworks or browsers, where measured layout legitimately differs
+     * ({@link expectConsistentFrameworkDom} does this).
+     */
+    normalisePixels?: boolean;
 };
 
 // Attributes dropped before comparing:
@@ -625,7 +632,8 @@ const DEFAULT_VOLATILE_ATTRIBUTES = [
  * React provider div, vanilla `#myGrid`) legitimately differs and is excluded.
  *
  * The serialised markup is normalised to remove non-structural noise: measured pixel values and
- * transforms are collapsed, generated ids are dropped, and class lists are sorted.
+ * transforms are collapsed (frameworks and browsers measure layout differently), generated ids are
+ * dropped, and class lists are sorted.
  *
  * The first framework to run writes the shared baseline snapshot (`<spec>-snapshots/grid-dom.html`);
  * commit it alongside the spec. On the initial run Playwright reports the baseline-writing test as
@@ -660,29 +668,63 @@ const DEFAULT_VOLATILE_ATTRIBUTES = [
  * });
  */
 export async function expectConsistentFrameworkDom(page: Page, options?: ConsistentDomOptions) {
-    const rootSelector = options?.rootSelector ?? '.ag-root-wrapper';
     const snapshotName = options?.snapshotName ?? 'grid-dom.html';
+
+    // One baseline is shared by every framework and browser, where measured layout legitimately differs.
+    const serialised = await serializeGridDom(page, { normalisePixels: true, ...options });
+
+    playwrightExpect(
+        serialised,
+        `No element matching '${options?.rootSelector ?? '.ag-root-wrapper'}' found to compare across frameworks`
+    ).not.toBeNull();
+    playwrightExpect(serialised).toMatchSnapshot(snapshotName);
+}
+
+/**
+ * Serialise the rendered grid DOM to a normalised, comparable string.
+ *
+ * This is the primitive behind {@link expectConsistentFrameworkDom}. Use it directly to compare
+ * the rendered grid at two points in the same test — for example capturing the grid before and
+ * after a destroy/recreate cycle to assert that restored state renders identically:
+ *
+ * @example
+ * const before = await serializeGridDom(page);
+ * await recreateGrid();
+ * await waitForGridContent(page);
+ * expect(await serializeGridDom(page)).toBe(before);
+ *
+ * Only the subtree rooted at `rootSelector` (default `.ag-root-wrapper`, the grid core's output) is
+ * serialised, so the differing framework host element is excluded. Generated ids / `comp-id`s are
+ * dropped and class lists are sorted, while measured pixel values are compared as-is unless
+ * `normalisePixels` is set.
+ *
+ * Returns `null` when no element matches `rootSelector`.
+ */
+export async function serializeGridDom(page: Page, options?: ConsistentDomOptions): Promise<string | null> {
+    const rootSelector = options?.rootSelector ?? '.ag-root-wrapper';
     const includeText = options?.includeText ?? true;
     const volatileAttributes = [...DEFAULT_VOLATILE_ATTRIBUTES, ...(options?.ignoreAttributes ?? [])];
+    const normalisePixels = options?.normalisePixels ?? false;
 
     // Wait for the grid to render before serialising — the raw page.evaluate does not auto-wait like a locator.
     await page.locator(rootSelector).first().waitFor({ state: 'attached' });
 
-    const serialised = await page.evaluate(
-        ({ rootSelector, includeText, volatileAttributes }) => {
+    return await page.evaluate(
+        ({ rootSelector, includeText, volatileAttributes, normalisePixels }) => {
             const root = document.querySelector(rootSelector);
             if (!root) {
                 return null;
             }
 
             const normaliseStyle = (value: string): string => {
-                const collapsed = value
-                    // Collapse measured pixel values (widths, offsets) that depend on runtime layout.
-                    .replace(/-?\d+(\.\d+)?px/g, 'Npx')
-                    // Collapse virtualisation transforms.
-                    .replace(/translate[XY3d]*\([^)]*\)/g, 'translate(_)')
-                    .replace(/\s+/g, ' ')
-                    .trim();
+                const measured = normalisePixels
+                    ? value
+                          // Collapse measured pixel values (widths, offsets) that depend on runtime layout.
+                          .replace(/-?\d+(\.\d+)?px/g, 'Npx')
+                          // Collapse virtualisation transforms.
+                          .replace(/translate[XY3d]*\([^)]*\)/g, 'translate(_)')
+                    : value;
+                const collapsed = measured.replace(/\s+/g, ' ').trim();
                 // Sort declarations — property order is not structurally significant and varies by framework.
                 return collapsed
                     .split(';')
@@ -732,14 +774,8 @@ export async function expectConsistentFrameworkDom(page: Page, options?: Consist
             walk(root, 0);
             return lines.join('\n');
         },
-        { rootSelector, includeText, volatileAttributes }
+        { rootSelector, includeText, volatileAttributes, normalisePixels }
     );
-
-    playwrightExpect(
-        serialised,
-        `No element matching '${rootSelector}' found to compare across frameworks`
-    ).not.toBeNull();
-    playwrightExpect(serialised).toMatchSnapshot(snapshotName);
 }
 
 export { ensureGridReady, waitForGridContent } from './test/remoteGridapi';

--- a/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
@@ -673,10 +673,6 @@ export async function expectConsistentFrameworkDom(page: Page, options?: Consist
     // One baseline is shared by every framework and browser, where measured layout legitimately differs.
     const serialised = await serializeGridDom(page, { normalisePixels: true, ...options });
 
-    playwrightExpect(
-        serialised,
-        `No element matching '${options?.rootSelector ?? '.ag-root-wrapper'}' found to compare across frameworks`
-    ).not.toBeNull();
     playwrightExpect(serialised).toMatchSnapshot(snapshotName);
 }
 
@@ -697,10 +693,8 @@ export async function expectConsistentFrameworkDom(page: Page, options?: Consist
  * serialised, so the differing framework host element is excluded. Generated ids / `comp-id`s are
  * dropped and class lists are sorted, while measured pixel values are compared as-is unless
  * `normalisePixels` is set.
- *
- * Returns `null` when no element matches `rootSelector`.
  */
-export async function serializeGridDom(page: Page, options?: ConsistentDomOptions): Promise<string | null> {
+export async function serializeGridDom(page: Page, options?: ConsistentDomOptions): Promise<string> {
     const rootSelector = options?.rootSelector ?? '.ag-root-wrapper';
     const includeText = options?.includeText ?? true;
     const volatileAttributes = [...DEFAULT_VOLATILE_ATTRIBUTES, ...(options?.ignoreAttributes ?? [])];
@@ -709,7 +703,7 @@ export async function serializeGridDom(page: Page, options?: ConsistentDomOption
     // Wait for the grid to render before serialising — the raw page.evaluate does not auto-wait like a locator.
     await page.locator(rootSelector).first().waitFor({ state: 'attached' });
 
-    return await page.evaluate(
+    const serialised = await page.evaluate(
         ({ rootSelector, includeText, volatileAttributes, normalisePixels }) => {
             const root = document.querySelector(rootSelector);
             if (!root) {
@@ -776,6 +770,12 @@ export async function serializeGridDom(page: Page, options?: ConsistentDomOption
         },
         { rootSelector, includeText, volatileAttributes, normalisePixels }
     );
+
+    if (serialised === null) {
+        throw new Error(`Element matching '${rootSelector}' was detached before it could be serialised`);
+    }
+
+    return serialised;
 }
 
 export { ensureGridReady, waitForGridContent } from './test/remoteGridapi';

--- a/packages/ag-grid-community/src/gridBodyComp/abstractFakeScrollComp.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/abstractFakeScrollComp.ts
@@ -13,6 +13,12 @@ import type { ElementParams } from '../utils/element';
 import { Component } from '../widgets/component';
 import type { ScrollPartner } from './gridBodyScrollFeature';
 
+/**
+ * Size given to a fake scrollbar when the platform reports a zero-width scrollbar (overlay
+ * scrollbars, e.g. macOS): the fake scrollbar is always drawn, so it still occupies space.
+ */
+export const INVISIBLE_SCROLLBAR_SIZE = 16;
+
 export abstract class AbstractFakeScrollComp extends Component implements ScrollPartner {
     public readonly eViewport: HTMLElement = RefPlaceholder;
     protected readonly eContainer: HTMLElement = RefPlaceholder;

--- a/packages/ag-grid-community/src/gridBodyComp/fakeHScrollComp.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/fakeHScrollComp.ts
@@ -4,7 +4,7 @@ import type { VisibleColsService } from '../columns/visibleColsService';
 import type { BeanCollection } from '../context/context';
 import type { ElementParams } from '../utils/element';
 import type { ComponentSelector } from '../widgets/component';
-import { AbstractFakeScrollComp } from './abstractFakeScrollComp';
+import { AbstractFakeScrollComp, INVISIBLE_SCROLLBAR_SIZE } from './abstractFakeScrollComp';
 import type { ScrollVisibleService } from './scrollVisibleService';
 
 const FakeHScrollElement: ElementParams = {
@@ -103,7 +103,8 @@ export class FakeHScrollComp extends AbstractFakeScrollComp {
         const invisibleScrollbar = this.invisibleScrollbar;
         const isSuppressHorizontalScroll = this.gos.get('suppressHorizontalScroll');
         const scrollbarWidth = hScrollShowing ? this.scrollVisibleSvc.getScrollbarWidth() || 0 : 0;
-        const adjustedScrollbarWidth = scrollbarWidth === 0 && invisibleScrollbar ? 16 : scrollbarWidth;
+        const adjustedScrollbarWidth =
+            scrollbarWidth === 0 && invisibleScrollbar ? INVISIBLE_SCROLLBAR_SIZE : scrollbarWidth;
         const scrollContainerSize = !isSuppressHorizontalScroll ? adjustedScrollbarWidth : 0;
 
         // Avoid scrollbars flickering on as we resize the grid. Before showing

--- a/packages/ag-grid-community/src/gridBodyComp/fakeVScrollComp.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/fakeVScrollComp.ts
@@ -3,7 +3,7 @@ import { RefPlaceholder, _isVisible, _requestAnimationFrame, _setFixedWidth } fr
 import type { CtrlsService } from '../ctrlsService';
 import type { ElementParams } from '../utils/element';
 import type { ComponentSelector } from '../widgets/component';
-import { AbstractFakeScrollComp } from './abstractFakeScrollComp';
+import { AbstractFakeScrollComp, INVISIBLE_SCROLLBAR_SIZE } from './abstractFakeScrollComp';
 
 const FakeVScrollElement: ElementParams = {
     tag: 'div',
@@ -64,7 +64,8 @@ export class FakeVScrollComp extends AbstractFakeScrollComp {
         const scrollbarWidth = vScrollShowing
             ? (gridBodyCtrl?.getVerticalScrollbarWidth() ?? fallbackScrollbarWidth)
             : 0;
-        const adjustedScrollbarWidth = scrollbarWidth === 0 && invisibleScrollbar ? 16 : scrollbarWidth;
+        const adjustedScrollbarWidth =
+            scrollbarWidth === 0 && invisibleScrollbar ? INVISIBLE_SCROLLBAR_SIZE : scrollbarWidth;
         const horizontalScrollHeight = gridBodyCtrl?.getHorizontalScrollbarHeight() ?? 0;
         const headerRowsOffset = gridBodyCtrl?.getHeaderRowsOffset() ?? 0;
 

--- a/packages/ag-grid-community/src/gridBodyComp/gridBodyCtrl.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/gridBodyCtrl.ts
@@ -1,4 +1,10 @@
-import { _getInnerWidth, _getScrollLeft, _isElementChildOfClass, _setScrollLeft } from 'ag-stack';
+import {
+    _getInnerWidth,
+    _getScrollLeft,
+    _isElementChildOfClass,
+    _isInvisibleScrollbar,
+    _setScrollLeft,
+} from 'ag-stack';
 
 import type { ColumnModel } from '../columns/columnModel';
 import { BeanStub } from '../context/beanStub';
@@ -14,6 +20,7 @@ import type { IPinnedRowModel } from '../interfaces/iPinnedRowModel';
 import type { LayoutView } from '../styling/layoutFeature';
 import { LayoutFeature } from '../styling/layoutFeature';
 import type { PopupService } from '../widgets/popupService';
+import { INVISIBLE_SCROLLBAR_SIZE } from './abstractFakeScrollComp';
 import { GridBodyScrollFeature } from './gridBodyScrollFeature';
 import type { ScrollVisibleService } from './scrollVisibleService';
 
@@ -619,7 +626,12 @@ export class GridBodyCtrl extends BeanStub {
             return fakeScrollbarHeight;
         }
 
+        // Showing the horizontal scrollbar is debounced, so it can still measure zero here while it is
+        // about to take up space. Fall back to the size the scroll comps themselves will apply.
         const scrollbarWidth = this.scrollVisibleSvc.getScrollbarWidth() || 0;
+        if (scrollbarWidth === 0 && _isInvisibleScrollbar()) {
+            return INVISIBLE_SCROLLBAR_SIZE;
+        }
         return scrollbarWidth;
     }
 }

--- a/packages/ag-grid-community/src/headerRendering/row/headerRowComp.ts
+++ b/packages/ag-grid-community/src/headerRendering/row/headerRowComp.ts
@@ -1,7 +1,6 @@
-import { _setAriaRowIndex, _setDomChildOrder } from 'ag-stack';
+import { _addOrRemoveAttribute, _setAriaRowIndex, _setDomChildOrder } from 'ag-stack';
 
 import { _createElement } from '../../utils/element';
-import { _isHeaderFocusSuppressed } from '../../utils/gridFocus';
 import { Component } from '../../widgets/component';
 import type { AbstractHeaderCellComp } from '../cells/abstractCell/abstractHeaderCellComp';
 import type { AbstractHeaderCellCtrl, HeaderCellCtrlInstanceId } from '../cells/abstractCell/abstractHeaderCellCtrl';
@@ -67,16 +66,6 @@ export class HeaderRowComp extends Component {
     }
 
     public postConstruct(): void {
-        const eGui = this.getGui();
-        const updateTabIndex = () => {
-            if (_isHeaderFocusSuppressed(this.beans)) {
-                eGui.removeAttribute('tabindex');
-            } else {
-                eGui.setAttribute('tabindex', String(this.gos.get('tabIndex')));
-            }
-        };
-        updateTabIndex();
-        this.addManagedPropertyListeners(['suppressHeaderFocus'], updateTabIndex);
         this.setRowIndex(this.ctrl.getAriaRowIndex());
 
         const compProxy: IHeaderRowComp = {
@@ -86,6 +75,7 @@ export class HeaderRowComp extends Component {
             refreshPinnedCellGroupWidths: () => this.updatePinnedCellGroupWidths(),
             setWidth: (width) => (this.getGui().style.width = width),
             setRowIndex: (rowIndex) => this.setRowIndex(rowIndex),
+            setTabIndex: (tabIndex) => _addOrRemoveAttribute(this.getGui(), 'tabindex', tabIndex),
         };
 
         this.ctrl.setComp(compProxy, undefined);

--- a/packages/ag-grid-community/src/headerRendering/row/headerRowCtrl.ts
+++ b/packages/ag-grid-community/src/headerRendering/row/headerRowCtrl.ts
@@ -5,6 +5,7 @@ import type { AgColumnGroup } from '../../entities/agColumnGroup';
 import { _isDomLayout } from '../../gridOptionsUtils';
 import type { BrandedType } from '../../interfaces/brandedType';
 import type { HeaderColumnId } from '../../interfaces/iColumn';
+import { _isHeaderFocusSuppressed } from '../../utils/gridFocus';
 import type { AbstractHeaderCellCtrl } from '../cells/abstractCell/abstractHeaderCellCtrl';
 import { HeaderCellCtrl } from '../cells/column/headerCellCtrl';
 import type { HeaderGroupCellCtrl } from '../cells/columnGroup/headerGroupCellCtrl';
@@ -25,6 +26,7 @@ export interface IHeaderRowComp {
     refreshPinnedCellGroupWidths(): void;
     setWidth(width: string): void;
     setRowIndex(rowIndex: number): void;
+    setTabIndex(tabIndex: number | undefined): void;
 }
 
 let instanceIdSequence = 0;
@@ -97,6 +99,12 @@ export class HeaderRowCtrl extends BeanStub {
         this.setWidth();
 
         this.addEventListeners(compBean);
+        this.refreshTabIndex();
+    }
+
+    private refreshTabIndex(): void {
+        const { beans, gos } = this;
+        this.comp?.setTabIndex(_isHeaderFocusSuppressed(beans) ? undefined : gos.get('tabIndex'));
     }
 
     public getAriaRowIndex(): number {
@@ -106,6 +114,7 @@ export class HeaderRowCtrl extends BeanStub {
     private addEventListeners(compBean: BeanStub): void {
         const onHeightChanged = this.onRowHeightChanged.bind(this);
         const onDisplayedColumnsChanged = this.onDisplayedColumnsChanged.bind(this);
+        const refreshTabIndex = this.refreshTabIndex.bind(this);
         compBean.addManagedEventListeners({
             columnResized: this.setWidth.bind(this),
             leftPinnedWidthChanged: this.refreshPinnedCellGroupWidths.bind(this),
@@ -117,7 +126,10 @@ export class HeaderRowCtrl extends BeanStub {
             columnHeaderHeightChanged: onHeightChanged,
             stylesChanged: onHeightChanged,
             advancedFilterEnabledChanged: onHeightChanged,
+            overlayExclusiveChanged: refreshTabIndex,
         });
+
+        compBean.addManagedPropertyListeners(['suppressHeaderFocus'], refreshTabIndex);
 
         // when print layout changes, it changes what columns are in what section
         compBean.addManagedPropertyListener('domLayout', onDisplayedColumnsChanged);

--- a/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
@@ -277,6 +277,9 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         for (const name of initialRowClasses) {
             rowComp.toggleCss(name, true);
         }
+        // Cells apply their own edit styles on creation; rows otherwise only pick theirs up from
+        // postProcessCss, which never runs for a row that renders once and never changes index.
+        this.beans.editSvc?.applyRowEditStyles(this);
         this.executeSlideAndFadeAnimations();
 
         if (this.rowNode.group) {

--- a/packages/ag-grid-community/src/sort/sortService.ts
+++ b/packages/ag-grid-community/src/sort/sortService.ts
@@ -315,6 +315,9 @@ export class SortService extends BeanStub implements NamedBean {
             columnRowGroupChanged: refreshStyles,
             displayedColumnsChanged: refreshStyles,
         });
+
+        // A column already sorted when its header is created (e.g. from initialState) must have correct styles
+        refreshStyles();
     }
 
     public initCol(column: AgColumn): void {

--- a/packages/ag-grid-react/src/reactUi/header/headerRowComp.tsx
+++ b/packages/ag-grid-react/src/reactUi/header/headerRowComp.tsx
@@ -58,6 +58,9 @@ const HeaderRowComp = ({
     const sectionSignatureRef = useRef<string>('');
     const domOrderRef = useRef<boolean>(false);
     const [cellCtrls, setCellCtrls] = useState<AbstractHeaderCellCtrl[]>([]);
+    const [tabIndex, setTabIndex] = useState<number | undefined>(() =>
+        _isHeaderFocusSuppressed(beans) ? undefined : gos.get('tabIndex')
+    );
 
     const pinnedWidthsCache = useRef<PinnedSectionWidthsCache>({
         pinnedLeftWidth: undefined,
@@ -132,6 +135,7 @@ const HeaderRowComp = ({
                         eGui.current.classList.toggle('ag-header-row-not-first', rowIndex !== 1);
                     }
                 },
+                setTabIndex,
             };
 
             ctrl.setComp(compProxy, compBean.current);
@@ -164,8 +168,6 @@ const HeaderRowComp = ({
         },
         [ctrl.type]
     );
-
-    const tabIndex = _isHeaderFocusSuppressed(beans) ? undefined : gos.get('tabIndex');
 
     return (
         <div ref={setRef} className={ctrl.headerRowClass} role="row" tabIndex={tabIndex}>

--- a/testing/behavioural/src/navigation/header-row-tab-index-overlay-react.test.tsx
+++ b/testing/behavioural/src/navigation/header-row-tab-index-overlay-react.test.tsx
@@ -1,0 +1,30 @@
+import { cleanup, render, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import type { ColDef } from 'ag-grid-community';
+import { ClientSideRowModelModule, ModuleRegistry } from 'ag-grid-community';
+import { AgGridReact } from 'ag-grid-react';
+
+const columnDefs: ColDef[] = [{ field: 'athlete' }, { field: 'age' }];
+
+function headerRowTabIndexes(): (string | null)[] {
+    return Array.from(document.querySelectorAll('.ag-header-row')).map((el) => el.getAttribute('tabindex'));
+}
+
+describe('header row tabindex and exclusive overlays (react)', () => {
+    beforeAll(() => {
+        ModuleRegistry.registerModules([ClientSideRowModelModule]);
+    });
+
+    beforeEach(() => {
+        cleanup();
+    });
+
+    test('header rows rejoin the tab order once an exclusive overlay is hidden', async () => {
+        const { rerender } = render(<AgGridReact columnDefs={columnDefs} rowData={[]} loading />);
+        await waitFor(() => expect(headerRowTabIndexes()).toEqual([null]));
+
+        rerender(<AgGridReact columnDefs={columnDefs} rowData={[]} loading={false} />);
+        await waitFor(() => expect(headerRowTabIndexes()).toEqual(['0']));
+    });
+});

--- a/testing/behavioural/src/navigation/header-row-tab-index-overlay.test.ts
+++ b/testing/behavioural/src/navigation/header-row-tab-index-overlay.test.ts
@@ -1,0 +1,52 @@
+import type { ColDef } from 'ag-grid-community';
+import { ClientSideRowModelModule } from 'ag-grid-community';
+
+import { TestGridsManager } from '../test-utils';
+
+const columnDefs: ColDef[] = [{ field: 'athlete' }, { field: 'age' }];
+
+function headerRowTabIndexes(): (string | null)[] {
+    return Array.from(document.querySelectorAll('.ag-header-row')).map((el) => el.getAttribute('tabindex'));
+}
+
+describe('header row tabindex and exclusive overlays', () => {
+    const gridsManager = new TestGridsManager({ modules: [ClientSideRowModelModule] });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    test('header rows rejoin the tab order once an exclusive overlay is hidden', () => {
+        const api = gridsManager.createGrid('myGrid', { columnDefs, loading: true });
+
+        expect(headerRowTabIndexes()).toEqual([null]);
+
+        api.setGridOption('loading', false);
+
+        expect(headerRowTabIndexes()).toEqual(['0']);
+    });
+
+    test('header rows leave the tab order while an exclusive overlay is shown', () => {
+        const api = gridsManager.createGrid('myGrid', { columnDefs, rowData: [{ athlete: 'a', age: 1 }] });
+
+        expect(headerRowTabIndexes()).toEqual(['0']);
+
+        api.setGridOption('loading', true);
+
+        expect(headerRowTabIndexes()).toEqual([null]);
+    });
+
+    test('suppressHeaderFocus keeps header rows out of the tab order', () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs,
+            rowData: [{ athlete: 'a', age: 1 }],
+            suppressHeaderFocus: true,
+        });
+
+        expect(headerRowTabIndexes()).toEqual([null]);
+
+        api.setGridOption('suppressHeaderFocus', false);
+
+        expect(headerRowTabIndexes()).toEqual(['0']);
+    });
+});


### PR DESCRIPTION
## Summary

A grid restored from its own saved state should render identically to the grid the state was captured from. Asserting that — serialise the rendered DOM, recreate the grid from the captured state, compare — turned up four places where a freshly created grid renders differently from one the user drove into the same state.

**The fixes**

- **Sort styles** (`sortService.ts`) — styles were only refreshed on subsequent sort events, so a column already sorted when its header is created (as from `initialState`) rendered without its sort styling. Now refreshed once on init.
- **Header row tabindex** (`headerRowCtrl.ts`, `headerRowComp.ts`, react `headerRowComp.tsx`) — the tabindex was set once in `HeaderRowComp.postConstruct` and only refreshed for `suppressHeaderFocus`. Header rows created while an exclusive overlay was up therefore never rejoined the tab order when it was hidden. Ownership moves to `HeaderRowCtrl`, which refreshes on `overlayExclusiveChanged`, and the React header row follows through the same comp proxy — so this is fixed for both renderers rather than one.
- **Overlay scrollbar height** (`gridBodyCtrl.ts`, `abstractFakeScrollComp.ts`, `fakeH/VScrollComp.ts`) — `getHorizontalScrollbarHeight` measured zero for a platform overlay scrollbar (macOS), while the fake scroll comps reserve 16px for it. Showing the horizontal scrollbar is debounced, so it can measure zero while about to take up space. The magic `16` becomes a shared `INVISIBLE_SCROLLBAR_SIZE` and the measurement falls back to it.
- **Row edit styles** (`rowCtrl.ts`) — cells apply their own edit styles on creation, but rows only picked theirs up from `postProcessCss`, which never runs for a row that renders once and never changes index.

**Supporting test work**

`serializeGridDom` is extracted from `expectConsistentFrameworkDom` so a test can capture the grid at two points in a single run. Pixel normalisation becomes opt-in: it is needed when comparing *across* frameworks (where measured layout legitimately differs), but within one run the measured widths and offsets are exactly what must match — normalising them would hide the scrollbar bug above.

`serializeGridDom` returns a plain `string`. It waits for the root selector to attach and throws on timeout, so the nullable result it originally advertised was unreachable; callers no longer carry dead null handling for it.

The grid-state examples gain the state sections that make the round trip worth asserting on: column groups with `columnGroupShow` children, cell selection, row pinning, an explicit `gridId` so the grid resolves across a recreate, and `ensureDomOrder` for stable serialisation.

## Position in Stack

PR 2 of 3. Rebased onto `latest` now that PR 1 (#14628) has merged.

**Next PR:** #14630 — persist calculated columns added at runtime in grid state

Fix [AG-17910](https://ag-grid.atlassian.net/browse/AG-17910)


