### PR TITLE
AG-17910 Persist calculated columns added at runtime in grid state

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-advanced/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-advanced/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { ColDef, GridOptions, ValueFormatterLiteParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ModuleRegistry,
@@ -28,7 +28,7 @@ type SalesRow = {
     cost: number;
 };
 
-const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedString: string): string => {
+const formatter = (params: ValueFormatterLiteParams<SalesRow, number>, format: (value: number) => string): string => {
     const { value } = params;
     if (value == null) {
         return '';
@@ -38,42 +38,40 @@ const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedStri
         return String(value);
     }
 
-    return formattedString;
+    return format(value);
 };
 
-const currencyFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
-    formatter(params, `$${(params.value ?? '').toLocaleString()}`);
+const currencyFormatter = (params: ValueFormatterLiteParams<SalesRow, number>) =>
+    formatter(params, (value) => `$${value.toLocaleString()}`);
 
-const percentageFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
-    formatter(params, `${Math.round((params.value ?? 0) * 100)}%`);
+const percentageFormatter = (params: ValueFormatterLiteParams<SalesRow, number>) =>
+    formatter(params, (value) => `${Math.round(value * 100)}%`);
 
 const columnDefs: ColDef<SalesRow>[] = [
     { field: 'account', flex: 1.4 },
     {
         field: 'revenue',
-        valueFormatter: currencyFormatter,
+        cellDataType: 'currency',
     },
     {
         field: 'cost',
-        valueFormatter: currencyFormatter,
+        cellDataType: 'currency',
     },
     {
         colId: 'profit',
         headerName: 'Profit',
         calculatedExpression: '[revenue] - [cost]',
-        cellDataType: 'number',
+        cellDataType: 'currency',
         sortable: true,
         filter: 'agNumberColumnFilter',
-        valueFormatter: currencyFormatter,
     },
     {
         colId: 'margin',
         headerName: 'Margin',
         calculatedExpression: '[profit] / [revenue]',
-        cellDataType: 'number',
+        cellDataType: 'percentage',
         sortable: true,
         filter: 'agNumberColumnFilter',
-        valueFormatter: percentageFormatter,
     },
     {
         colId: 'status',
@@ -111,7 +109,21 @@ const rowData: SalesRow[] = [
 const gridOptions: GridOptions<SalesRow> = {
     columnDefs,
     rowData,
-    calculatedColumns: true,
+    dataTypeDefinitions: {
+        currency: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: currencyFormatter,
+        },
+        percentage: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: percentageFormatter,
+        },
+    },
+    calculatedColumns: {
+        dataTypes: ['currency', 'percentage', 'number', 'text', 'boolean'],
+    },
     defaultColDef: {
         flex: 1,
         minWidth: 130,

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-api/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-api/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridApi, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { ColDef, GridApi, GridOptions, ValueFormatterLiteParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ColumnApiModule,
@@ -27,30 +27,28 @@ type SalesRow = {
     cost: number;
 };
 
-const currencyFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
+const currencyFormatter = (params: ValueFormatterLiteParams<SalesRow, number>) =>
     params.value == null ? '' : `$${params.value.toLocaleString()}`;
 
-const percentFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
+const percentFormatter = (params: ValueFormatterLiteParams<SalesRow, number>) =>
     params.value == null ? '' : `${(params.value * 100).toFixed(1)}%`;
 
 const marginColumn: ColDef<SalesRow> = {
     colId: 'profitMargin',
     headerName: 'Profit Margin',
     calculatedExpression: '([revenue] - [cost]) / [revenue]',
-    cellDataType: 'number',
-    valueFormatter: percentFormatter,
+    cellDataType: 'percentage',
 };
 
 const columnDefs: ColDef<SalesRow>[] = [
     { field: 'product', flex: 1 },
-    { field: 'revenue', valueFormatter: currencyFormatter },
-    { field: 'cost', valueFormatter: currencyFormatter },
+    { field: 'revenue', cellDataType: 'currency' },
+    { field: 'cost', cellDataType: 'currency' },
     {
         colId: 'profit',
         headerName: 'Profit',
         calculatedExpression: '[revenue] - [cost]',
-        cellDataType: 'number',
-        valueFormatter: currencyFormatter,
+        cellDataType: 'currency',
     },
 ];
 
@@ -82,6 +80,18 @@ let gridApi: GridApi<SalesRow>;
 const gridOptions: GridOptions<SalesRow> = {
     columnDefs,
     rowData,
+    dataTypeDefinitions: {
+        currency: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: currencyFormatter,
+        },
+        percentage: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: percentFormatter,
+        },
+    },
     calculatedColumns: true,
     defaultColDef: {
         flex: 1,

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-apply-mode/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-apply-mode/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { ColDef, GridOptions, ValueFormatterLiteParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ModuleRegistry,
@@ -28,7 +28,7 @@ type SalesRow = {
     cost: number;
 };
 
-const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedString: string): string => {
+const currencyFormatter = (params: ValueFormatterLiteParams<SalesRow, number>): string => {
     const { value } = params;
     if (value == null) {
         return '';
@@ -38,32 +38,28 @@ const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedStri
         return String(value);
     }
 
-    return formattedString;
+    return `$${value.toLocaleString()}`;
 };
-
-const currencyFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
-    formatter(params, `$${(params.value ?? '').toLocaleString()}`);
 
 const columnDefs: ColDef<SalesRow>[] = [
     { field: 'product', flex: 1 },
     {
         field: 'revenue',
         editable: true,
-        valueFormatter: currencyFormatter,
+        cellDataType: 'currency',
     },
     {
         field: 'cost',
         editable: true,
-        valueFormatter: currencyFormatter,
+        cellDataType: 'currency',
     },
     {
         colId: 'profit',
         headerName: 'Profit',
         calculatedExpression: '[revenue] - [cost]',
-        cellDataType: 'number',
+        cellDataType: 'currency',
         sortable: true,
         filter: 'agNumberColumnFilter',
-        valueFormatter: currencyFormatter,
     },
 ];
 
@@ -93,8 +89,16 @@ const rowData: SalesRow[] = [
 const gridOptions: GridOptions<SalesRow> = {
     columnDefs,
     rowData,
+    dataTypeDefinitions: {
+        currency: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: currencyFormatter,
+        },
+    },
     calculatedColumns: {
         applyMode: 'deferred',
+        dataTypes: ['currency', 'number', 'text', 'boolean'],
     },
     defaultColDef: {
         flex: 1,

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-column-groups/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-column-groups/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, ColGroupDef, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { ColDef, ColGroupDef, GridOptions, ValueFormatterLiteParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ModuleRegistry,
@@ -34,7 +34,10 @@ type QuarterlyRevenueRow = {
 
 type QuarterField = Exclude<keyof QuarterlyRevenueRow, 'product'>;
 
-const formatter = (params: ValueFormatterParams<QuarterlyRevenueRow, number>, formattedString: string): string => {
+const formatter = (
+    params: ValueFormatterLiteParams<QuarterlyRevenueRow, number>,
+    format: (value: number) => string
+): string => {
     const { value } = params;
     if (value == null) {
         return '';
@@ -44,22 +47,21 @@ const formatter = (params: ValueFormatterParams<QuarterlyRevenueRow, number>, fo
         return String(value);
     }
 
-    return formattedString;
+    return format(value);
 };
 
-const currencyFormatter = (params: ValueFormatterParams<QuarterlyRevenueRow, number>) =>
-    formatter(params, `$${(params.value ?? '').toLocaleString()}`);
+const currencyFormatter = (params: ValueFormatterLiteParams<QuarterlyRevenueRow, number>) =>
+    formatter(params, (value) => `$${value.toLocaleString()}`);
 
-const percentageFormatter = (params: ValueFormatterParams<QuarterlyRevenueRow, number>) =>
-    formatter(params, `${(params.value ?? 0).toLocaleString(undefined, { maximumFractionDigits: 1 })}%`);
+const percentageFormatter = (params: ValueFormatterLiteParams<QuarterlyRevenueRow, number>) =>
+    formatter(params, (value) => `${(value * 100).toLocaleString(undefined, { maximumFractionDigits: 1 })}%`);
 
 const quarterColumn = (field: QuarterField): ColDef<QuarterlyRevenueRow, number> => ({
     field,
     colId: field,
     headerName: field.slice(0, 2).toUpperCase(),
     columnGroupShow: 'open',
-    cellDataType: 'number',
-    valueFormatter: currencyFormatter,
+    cellDataType: 'currency',
 });
 
 const columnDefs: (ColDef<QuarterlyRevenueRow> | ColGroupDef<QuarterlyRevenueRow>)[] = [
@@ -77,8 +79,7 @@ const columnDefs: (ColDef<QuarterlyRevenueRow> | ColGroupDef<QuarterlyRevenueRow
                 headerName: 'Total',
                 columnGroupShow: 'closed',
                 calculatedExpression: '[q1_2025] + [q2_2025] + [q3_2025] + [q4_2025]',
-                cellDataType: 'number',
-                valueFormatter: currencyFormatter,
+                cellDataType: 'currency',
             },
         ],
     },
@@ -95,8 +96,7 @@ const columnDefs: (ColDef<QuarterlyRevenueRow> | ColGroupDef<QuarterlyRevenueRow
                 headerName: 'Total',
                 columnGroupShow: 'closed',
                 calculatedExpression: '[q1_2026] + [q2_2026] + [q3_2026] + [q4_2026]',
-                cellDataType: 'number',
-                valueFormatter: currencyFormatter,
+                cellDataType: 'currency',
             },
         ],
     },
@@ -106,21 +106,19 @@ const columnDefs: (ColDef<QuarterlyRevenueRow> | ColGroupDef<QuarterlyRevenueRow
             {
                 colId: 'q4Change',
                 headerName: 'Q4 Change',
-                calculatedExpression: 'ROUND((([q4_2026] - [q4_2025]) / [q4_2025]) * 100, 1)',
-                cellDataType: 'number',
+                calculatedExpression: '([q4_2026] - [q4_2025]) / [q4_2025]',
+                cellDataType: 'percentage',
                 sortable: true,
                 filter: 'agNumberColumnFilter',
-                valueFormatter: percentageFormatter,
             },
             {
                 colId: 'yearChange',
                 headerName: 'Year Change',
                 calculatedExpression:
                     '([q1_2026] + [q2_2026] + [q3_2026] + [q4_2026]) - ([q1_2025] + [q2_2025] + [q3_2025] + [q4_2025])',
-                cellDataType: 'number',
+                cellDataType: 'currency',
                 sortable: true,
                 filter: 'agNumberColumnFilter',
-                valueFormatter: currencyFormatter,
             },
         ],
     },
@@ -352,7 +350,21 @@ const rowData: QuarterlyRevenueRow[] = [
 const gridOptions: GridOptions<QuarterlyRevenueRow> = {
     columnDefs,
     rowData,
-    calculatedColumns: true,
+    dataTypeDefinitions: {
+        currency: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: currencyFormatter,
+        },
+        percentage: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: percentageFormatter,
+        },
+    },
+    calculatedColumns: {
+        dataTypes: ['currency', 'percentage', 'number', 'text', 'boolean'],
+    },
     defaultColDef: {
         minWidth: 120,
         flex: 1,

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-dialog-data-types/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-dialog-data-types/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { ColDef, GridOptions, ValueFormatterLiteParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ModuleRegistry,
@@ -26,7 +26,7 @@ type SalesRow = {
     cost: number;
 };
 
-const currencyFormatter = (params: ValueFormatterParams<SalesRow, number>): string => {
+const currencyFormatter = (params: ValueFormatterLiteParams<SalesRow, number>): string => {
     const { value } = params;
     if (value == null) {
         return '';

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-dialog-helper-lists/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-dialog-helper-lists/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { ColDef, GridOptions, ValueFormatterLiteParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ModuleRegistry,
@@ -26,7 +26,7 @@ type SalesRow = {
     cost: number;
 };
 
-const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedString: string): string => {
+const currencyFormatter = (params: ValueFormatterLiteParams<SalesRow, number>): string => {
     const { value } = params;
     if (value == null) {
         return '';
@@ -36,23 +36,19 @@ const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedStri
         return String(value);
     }
 
-    return formattedString;
+    return `$${value.toLocaleString()}`;
 };
-
-const currencyFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
-    formatter(params, `$${(params.value ?? '').toLocaleString()}`);
 
 const columnDefs: ColDef<SalesRow>[] = [
     { field: 'product', flex: 1.3 },
-    { field: 'revenue', valueFormatter: currencyFormatter },
-    { field: 'cost', valueFormatter: currencyFormatter },
+    { field: 'revenue', cellDataType: 'currency' },
+    { field: 'cost', cellDataType: 'currency' },
     {
         colId: 'profit',
         headerName: 'Profit',
         calculatedExpression: '[revenue] - [cost]',
-        cellDataType: 'number',
+        cellDataType: 'currency',
         filter: 'agNumberColumnFilter',
-        valueFormatter: currencyFormatter,
     },
 ];
 
@@ -82,8 +78,16 @@ const rowData: SalesRow[] = [
 const gridOptions: GridOptions<SalesRow> = {
     columnDefs,
     rowData,
+    dataTypeDefinitions: {
+        currency: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: currencyFormatter,
+        },
+    },
     calculatedColumns: {
         expressionPickers: ['columns'],
+        dataTypes: ['currency', 'number', 'text', 'boolean'],
     },
     defaultColDef: {
         flex: 1,

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-dialog-highlighting/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-dialog-highlighting/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { ColDef, GridOptions, ValueFormatterLiteParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ModuleRegistry,
@@ -26,7 +26,7 @@ type SalesRow = {
     cost: number;
 };
 
-const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedString: string): string => {
+const currencyFormatter = (params: ValueFormatterLiteParams<SalesRow, number>): string => {
     const { value } = params;
     if (value == null) {
         return '';
@@ -36,23 +36,19 @@ const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedStri
         return String(value);
     }
 
-    return formattedString;
+    return `$${value.toLocaleString()}`;
 };
-
-const currencyFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
-    formatter(params, `$${(params.value ?? '').toLocaleString()}`);
 
 const columnDefs: ColDef<SalesRow>[] = [
     { field: 'product', flex: 1.3 },
-    { field: 'revenue', valueFormatter: currencyFormatter },
-    { field: 'cost', valueFormatter: currencyFormatter },
+    { field: 'revenue', cellDataType: 'currency' },
+    { field: 'cost', cellDataType: 'currency' },
     {
         colId: 'profit',
         headerName: 'Profit',
         calculatedExpression: '[revenue] - [cost]',
-        cellDataType: 'number',
+        cellDataType: 'currency',
         filter: 'agNumberColumnFilter',
-        valueFormatter: currencyFormatter,
     },
 ];
 
@@ -82,8 +78,16 @@ const rowData: SalesRow[] = [
 const gridOptions: GridOptions<SalesRow> = {
     columnDefs,
     rowData,
+    dataTypeDefinitions: {
+        currency: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: currencyFormatter,
+        },
+    },
     calculatedColumns: {
         suppressColumnHighlighting: true,
+        dataTypes: ['currency', 'number', 'text', 'boolean'],
     },
     defaultColDef: {
         flex: 1,

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-row-groups/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-row-groups/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { ColDef, GridOptions, ValueFormatterLiteParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ModuleRegistry,
@@ -28,7 +28,7 @@ type SalesRow = {
     cost: number;
 };
 
-const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedString: string): string => {
+const formatter = (params: ValueFormatterLiteParams<SalesRow, number>, format: (value: number) => string): string => {
     const { value } = params;
     if (value == null) {
         return '';
@@ -38,14 +38,14 @@ const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedStri
         return String(value);
     }
 
-    return formattedString;
+    return format(value);
 };
 
-const currencyFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
-    formatter(params, `$${(params.value ?? '').toLocaleString()}`);
+const currencyFormatter = (params: ValueFormatterLiteParams<SalesRow, number>) =>
+    formatter(params, (value) => `$${value.toLocaleString()}`);
 
-const percentageFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
-    formatter(params, `${Math.round((params.value ?? 0) * 100)}%`);
+const percentageFormatter = (params: ValueFormatterLiteParams<SalesRow, number>) =>
+    formatter(params, (value) => `${Math.round(value * 100)}%`);
 
 const columnDefs: ColDef<SalesRow>[] = [
     { field: 'productType', rowGroup: true, hide: true },
@@ -53,12 +53,12 @@ const columnDefs: ColDef<SalesRow>[] = [
     {
         field: 'revenue',
         aggFunc: 'sum',
-        valueFormatter: currencyFormatter,
+        cellDataType: 'currency',
     },
     {
         field: 'cost',
         aggFunc: 'sum',
-        valueFormatter: currencyFormatter,
+        cellDataType: 'currency',
     },
     {
         colId: 'profit',
@@ -66,17 +66,15 @@ const columnDefs: ColDef<SalesRow>[] = [
         calculatedExpression: '[revenue] - [cost]',
         // aggFunc lets the calculated column aggregate its per-leaf results onto group rows.
         aggFunc: 'sum',
-        cellDataType: 'number',
+        cellDataType: 'currency',
         filter: 'agNumberColumnFilter',
-        valueFormatter: currencyFormatter,
     },
     {
         colId: 'margin',
         headerName: 'Margin',
         // No aggFunc: a ratio does not aggregate, so margin evaluates on leaf rows and is blank on groups.
         calculatedExpression: '[profit] / [revenue]',
-        cellDataType: 'number',
-        valueFormatter: percentageFormatter,
+        cellDataType: 'percentage',
     },
 ];
 
@@ -106,7 +104,21 @@ const rowData: SalesRow[] = [
 const gridOptions: GridOptions<SalesRow> = {
     columnDefs,
     rowData,
-    calculatedColumns: true,
+    dataTypeDefinitions: {
+        currency: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: currencyFormatter,
+        },
+        percentage: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: percentageFormatter,
+        },
+    },
+    calculatedColumns: {
+        dataTypes: ['currency', 'percentage', 'number', 'text', 'boolean'],
+    },
     defaultColDef: {
         flex: 1,
         minWidth: 130,

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { ColDef, GridOptions, ValueFormatterLiteParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ModuleRegistry,
@@ -28,7 +28,7 @@ type SalesRow = {
     cost: number;
 };
 
-const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedString: string): string => {
+const currencyFormatter = (params: ValueFormatterLiteParams<SalesRow, number>): string => {
     const { value } = params;
     if (value == null) {
         return '';
@@ -38,32 +38,28 @@ const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedStri
         return String(value);
     }
 
-    return formattedString;
+    return `$${value.toLocaleString()}`;
 };
-
-const currencyFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
-    formatter(params, `$${(params.value ?? '').toLocaleString()}`);
 
 const columnDefs: ColDef<SalesRow>[] = [
     { field: 'product', flex: 1 },
     {
         field: 'revenue',
         editable: true,
-        valueFormatter: currencyFormatter,
+        cellDataType: 'currency',
     },
     {
         field: 'cost',
         editable: true,
-        valueFormatter: currencyFormatter,
+        cellDataType: 'currency',
     },
     {
         colId: 'profit',
         headerName: 'Profit',
         calculatedExpression: '[revenue] - [cost]',
-        cellDataType: 'number',
+        cellDataType: 'currency',
         sortable: true,
         filter: 'agNumberColumnFilter',
-        valueFormatter: currencyFormatter,
     },
 ];
 
@@ -93,7 +89,16 @@ const rowData: SalesRow[] = [
 const gridOptions: GridOptions<SalesRow> = {
     columnDefs,
     rowData,
-    calculatedColumns: true,
+    dataTypeDefinitions: {
+        currency: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: currencyFormatter,
+        },
+    },
+    calculatedColumns: {
+        dataTypes: ['currency', 'number', 'text', 'boolean'],
+    },
     defaultColDef: {
         flex: 1,
         minWidth: 130,

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/index.mdoc
@@ -33,6 +33,8 @@ Application-declared calculated columns must define a `colId` explicitly.
 
 {% gridExampleRunner title="Calculated Columns" name="calculated-columns" /%}
 
+Register [Cell Data Types](./cell-data-types/) to give users formatting options to pick from when they create a column. The example above provides a `currency` type — see [dataTypes](#datatypes).
+
 Calculated expressions do not need a leading equals sign (`=`). The value inside brackets must match a column `colId`, which defaults to the `field` when no explicit `colId` is provided.
 
 Calculated Columns are supported with all row models. Same-row bracket references are reliable everywhere. Cross-row and range references depend on the referenced rows being loaded in the current row model.
@@ -92,8 +94,19 @@ const gridOptions = {
     calculatedColumns: {
         dataTypes: ['currency', 'number', 'boolean'],
     },
+    columnDefs: [
+        { field: 'revenue', cellDataType: 'currency' },
+        {
+            colId: 'profit',
+            headerName: 'Profit',
+            calculatedExpression: '[revenue] - [cost]',
+            cellDataType: 'currency',
+        },
+    ],
 };
 ```
+
+Applying the type to your own columns as well means a user who picks **Currency** in the dialog gets the same formatting as the columns you declared. A `valueFormatter` on a column definition cannot be selected in the dialog, so it is not available to users.
 
 Built-in types use the grid's locale text, while custom type names are converted to readable labels in the dialog. If a selected value does not match a registered [Cell Data Type](./cell-data-types/), the grid's normal `cellDataType` validation applies when the calculated column is created.
 
@@ -164,14 +177,13 @@ const gridOptions = {
             colId: 'profit',
             headerName: 'Profit',
             calculatedExpression: '[revenue] - [cost]',
-            cellDataType: 'number',
+            cellDataType: 'currency',
         },
         {
             colId: 'margin',
             headerName: 'Margin',
             calculatedExpression: '[profit] / [revenue]',
-            cellDataType: 'number',
-            valueFormatter: params => `${Math.round(params.value * 100)}%`,
+            cellDataType: 'percentage',
         },
         {
             colId: 'status',
@@ -182,6 +194,8 @@ const gridOptions = {
     ],
 };
 ```
+
+The `currency` and `percentage` types are registered with `dataTypeDefinitions`, as shown in [dataTypes](#datatypes).
 
 {% gridExampleRunner title="Advanced Calculated Columns" name="calculated-columns-advanced" /%}
 

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/index.mdoc
@@ -17,6 +17,7 @@ const gridOptions = {
         { field: 'cost' },
         {
             colId: 'profit',
+            headerName: 'Profit',
             calculatedExpression: '[revenue] - [cost]',
             cellDataType: 'number',
             sortable: true,
@@ -161,17 +162,20 @@ const gridOptions = {
         { field: 'cost' },
         {
             colId: 'profit',
+            headerName: 'Profit',
             calculatedExpression: '[revenue] - [cost]',
             cellDataType: 'number',
         },
         {
             colId: 'margin',
+            headerName: 'Margin',
             calculatedExpression: '[profit] / [revenue]',
             cellDataType: 'number',
             valueFormatter: params => `${Math.round(params.value * 100)}%`,
         },
         {
             colId: 'status',
+            headerName: 'Status',
             calculatedExpression: 'IF([margin] >= 0.25, "Healthy", "Review")',
             cellDataType: 'text',
         },
@@ -189,7 +193,7 @@ A column added from the header menu appears after the column it was created from
 
 Manage calculated columns through column definitions, like other columns. Read the current definitions with `api.getColumnDefs()` and write them back with `api.setGridOption('columnDefs', ...)` to add, edit or remove a calculated column. To find the calculated columns in the grid, filter `api.getColumns()` by `calculatedExpression`.
 
-The dialog manages calculated columns inside the grid without mutating the `columnDefs` array supplied by the application. To persist user-created calculated columns, read the complete current definitions from `api.getColumnDefs()`.
+The dialog manages calculated columns inside the grid without mutating the `columnDefs` array supplied by the application. To persist user-created calculated columns, read the complete current definitions from `api.getColumnDefs()`, or use [Grid State](./grid-state/) which captures them and recreates them on restore.
 
 The following example adds, edits and removes a Profit Margin column through these APIs, and logs the calculated columns currently in the grid:
 

--- a/documentation/ag-grid-docs/src/content/docs/formulas/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/formulas/index.mdoc
@@ -134,8 +134,28 @@ If the formula store is mutated outside the grid (for example, syncing from a ba
 
 During a [CSV Export](./csv-export), the grid exports the evaluated values of any formulas. During an [Excel Export](./excel-export), the grid exports the formulas themselves so Excel can evaluate them.
 
+## Calculated Columns
+
+Formulas apply to individual cells: a user types an expression into one cell, and only that cell is affected.
+
+To derive a value for every row instead, use [Calculated Columns](./calculated-columns/). A calculated column defines one expression that evaluates against each row, referencing other columns by `colId`. Users can add their own calculated columns at runtime through the Column Menu.
+
+```{% frameworkTransform=true %}
+const gridOptions = {
+    calculatedColumns: true,
+    columnDefs: [
+        { field: 'revenue' },
+        { field: 'cost' },
+        { colId: 'profit', headerName: 'Profit', calculatedExpression: '[revenue] - [cost]' },
+    ],
+};
+```
+
+Use Formulas for ad-hoc, per-cell expressions; use [Calculated Columns](./calculated-columns/) for a derived value that applies to every row.
+
 ## See also
 
 - [Formula Editor Component](./formula-editor-component/) – The rich editing experience for formula cells, including autocomplete and range selection tools.
 - [Formula Reference](./formula-reference/) – Full reference for operators (+, -, \*, /, ^, &, comparisons), provided functions, and errors.
 - [Custom Functions](./formula-custom-functions/) – How to register and implement custom functions for formulas.
+- [Calculated Columns](./calculated-columns/) – Whole-column derived values, defined in code or added by users at runtime.

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/example.spec.ts
@@ -100,10 +100,51 @@ test.agExample(import.meta, () => {
         await expect(agIdFor.headerCell('age')).toHaveAttribute('aria-sort', 'ascending');
     });
 
+    test.eachFramework('Recreating the grid restores a runtime-added calculated column', async ({ agIdFor, page }) => {
+        await ensureGridReady(page, GRID_ID);
+        await waitForGridContent(page);
+
+        // Add a calculated column at runtime via the 'age' header menu.
+        const ageHeader = agIdFor.headerCell('age');
+        await ageHeader.hover();
+        await ageHeader.locator('.ag-header-cell-menu-button').click();
+        await page.locator('.ag-menu-option-text', { hasText: 'Add Calculated Column' }).click();
+
+        const form = page.locator('.ag-calculated-column-form');
+        await expect(form).toBeVisible();
+
+        // Live apply (the default) commits the column as the form is edited: set a title,
+        // a numeric type and an expression referencing the Age column.
+        await form.locator('.ag-input-field-input').first().fill('Age Plus Ten');
+        await form.locator('.ag-picker-field').click();
+        await page.locator('.ag-select-list .ag-list-item', { hasText: 'Number' }).click();
+        await form.locator('textarea').fill('[Age] + 10');
+
+        // Close the dialog; the runtime-added column remains.
+        await page.keyboard.press('Escape');
+        await expect(form).toBeHidden();
+
+        // The calculated column renders: Michael Phelps (age 23) => 33.
+        const calculatedHeader = () =>
+            page.locator('.ag-header-cell.ag-calculated-column').filter({ hasText: 'Age Plus Ten' });
+        await expect(calculatedHeader()).toBeVisible();
+        await expect(agIdFor.cell('0', 'age')).toContainText('23');
+        await expect(page.locator('.ag-row[row-id="0"] .ag-cell', { hasText: '33' }).first()).toBeVisible();
+
+        // Recreate destroys the grid and seeds the new one from the previous state.
+        await recreateButton(page).click();
+        await ensureGridReady(page, GRID_ID);
+        await waitForGridContent(page);
+
+        // The calculated column is recreated from the restored userColumns state.
+        await expect(calculatedHeader()).toBeVisible();
+        await expect(page.locator('.ag-row[row-id="0"] .ag-cell', { hasText: '33' }).first()).toBeVisible();
+    });
+
     // Drive the grid through as many state sections as can be applied purely through the UI —
-    // sort, row grouping + an expanded group, an opened column group, a pinned column, and an open
-    // side bar with a hidden column — then snapshot the rendered grid, recreate it from the
-    // captured state, and assert it renders identically.
+    // sort, row grouping + an expanded group, an opened column group, a pinned column, a
+    // runtime-added calculated column, and an open side bar with a hidden column — then snapshot
+    // the rendered grid, recreate it from the captured state, and assert it renders identically.
     test.eachFramework('Recreating the grid restores the whole rendered grid', async ({ agIdFor, page }) => {
         await ensureGridReady(page, GRID_ID);
         await waitForGridContent(page);
@@ -140,6 +181,22 @@ test.agExample(import.meta, () => {
         await page.locator('.ag-menu-option', { hasText: 'Pin Column' }).hover();
         await page.locator('.ag-menu-option-text', { hasText: 'Pin Left' }).click();
         await expect(agIdFor.headerCell('athlete')).toHaveClass(/ag-header-cell-last-left-pinned/);
+
+        // Add a runtime calculated column (userColumns state) via the age header menu.
+        await agIdFor.headerCell('age').hover();
+        await agIdFor.headerCell('age').locator('.ag-header-cell-menu-button').click();
+        await page.locator('.ag-menu-option-text', { hasText: 'Add Calculated Column' }).click();
+        const form = page.locator('.ag-calculated-column-form');
+        await expect(form).toBeVisible();
+        await form.locator('.ag-input-field-input').first().fill('Age Plus Ten');
+        await form.locator('.ag-picker-field').click();
+        await page.locator('.ag-select-list .ag-list-item', { hasText: 'Number' }).click();
+        await form.locator('textarea').fill('[Age] + 10');
+        await page.keyboard.press('Escape');
+        await expect(form).toBeHidden();
+        await expect(
+            page.locator('.ag-header-cell.ag-calculated-column').filter({ hasText: 'Age Plus Ten' })
+        ).toBeVisible();
 
         // Hide the date column (column state) via the Columns tool panel, which the open side bar
         // (side bar state) shows by default.

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/main.ts
@@ -55,6 +55,7 @@ const gridOptions: GridOptions<IOlympicData> = {
     pagination: true,
     rowSelection: { mode: 'multiRow' },
     cellSelection: true,
+    calculatedColumns: true,
     enableRowPinning: true,
     suppressColumnMoveAnimation: true,
     ensureDomOrder: true,

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/provided/angular/app.component.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/provided/angular/app.component.ts
@@ -50,6 +50,7 @@ ModuleRegistry.registerModules([AllEnterpriseModule]);
                     [pagination]="true"
                     [rowSelection]="rowSelection"
                     [cellSelection]="true"
+                    [calculatedColumns]="true"
                     [enableRowPinning]="true"
                     [suppressColumnMoveAnimation]="true"
                     [ensureDomOrder]="true"

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/provided/reactFunctionalTs/index.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/provided/reactFunctionalTs/index.tsx
@@ -124,6 +124,7 @@ const GridExample = () => {
                                 pagination={true}
                                 rowSelection={rowSelection}
                                 cellSelection={true}
+                                calculatedColumns={true}
                                 enableRowPinning={true}
                                 suppressColumnMoveAnimation={true}
                                 ensureDomOrder={true}

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/provided/vue3/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/provided/vue3/main.ts
@@ -45,6 +45,7 @@ const VueExample = defineComponent({
                     :pagination="true"
                     :rowSelection="rowSelection"
                     :cellSelection="true"
+                    :calculatedColumns="true"
                     :enableRowPinning="true"
                     :suppressColumnMoveAnimation="true"
                     :ensureDomOrder="true"

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/main.ts
@@ -55,6 +55,7 @@ const gridOptions: GridOptions<IOlympicData> = {
     pagination: true,
     rowSelection: { mode: 'multiRow' },
     cellSelection: true,
+    calculatedColumns: true,
     enableRowPinning: true,
     suppressColumnMoveAnimation: true,
     onGridPreDestroyed: onGridPreDestroyed,

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/provided/angular/app.component.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/provided/angular/app.component.ts
@@ -52,6 +52,7 @@ ModuleRegistry.registerModules([AllEnterpriseModule]);
                     [pagination]="true"
                     [rowSelection]="rowSelection"
                     [cellSelection]="true"
+                    [calculatedColumns]="true"
                     [enableRowPinning]="true"
                     [suppressColumnMoveAnimation]="true"
                     [rowData]="rowData"

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/provided/reactFunctionalTs/index.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/provided/reactFunctionalTs/index.tsx
@@ -142,6 +142,7 @@ const GridExample = () => {
                                 pagination={true}
                                 rowSelection={rowSelection}
                                 cellSelection={true}
+                                calculatedColumns={true}
                                 enableRowPinning={true}
                                 suppressColumnMoveAnimation={true}
                                 onGridReady={onGridReady}

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/provided/vue3/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/set-state/provided/vue3/main.ts
@@ -47,6 +47,7 @@ const VueExample = defineComponent({
                     :pagination="true"
                     :rowSelection="rowSelection"
                     :cellSelection="true"
+                    :calculatedColumns="true"
                     :enableRowPinning="true"
                     :suppressColumnMoveAnimation="true"
                     :rowData="rowData"

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/index.mdoc
@@ -62,6 +62,9 @@ The following is captured in the grid state:
 - [Show Values As](./aggregation-show-values-as/) (column state)
 - [Side Bar](./side-bar/)
 - [Sort](./row-sorting/) (column state)
+- [Calculated Columns](./calculated-columns/) added at runtime
+
+Most sections configure columns that already exist. Runtime-added columns such as [Calculated Columns](./calculated-columns/) are the exception: their definitions are captured so the grid can recreate the columns themselves when the state is restored, after which the other sections apply on top.
 
 {% note %}
 When restoring the current page using the [Server Side Row Model](./server-side-model/) or [Infinite Row Model](./infinite-scrolling/),

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/index.mdoc
@@ -64,8 +64,6 @@ The following is captured in the grid state:
 - [Sort](./row-sorting/) (column state)
 - [Calculated Columns](./calculated-columns/) added at runtime
 
-Most sections configure columns that already exist. Runtime-added columns such as [Calculated Columns](./calculated-columns/) are the exception: their definitions are captured so the grid can recreate the columns themselves when the state is restored, after which the other sections apply on top.
-
 {% note %}
 When restoring the current page using the [Server Side Row Model](./server-side-model/) or [Infinite Row Model](./infinite-scrolling/),
 additional configuration is required:

--- a/packages/ag-grid-community/src/columns/columnModel.ts
+++ b/packages/ag-grid-community/src/columns/columnModel.ts
@@ -591,7 +591,9 @@ export class ColumnModel extends BeanStub implements NamedBean {
     }
 
     public setColumnDefs(columnDefs: (ColDef | ColGroupDef)[], source: ColumnEventType) {
-        this.beans.calculatedColsSvc?.resetDynamicColumnDefs();
+        // The user's edits and deletions of declared calc cols survive: they are grid state, so a
+        // `columnDefs` change must not resurrect a column the user deleted. `resetColumnState` clears them.
+        this.beans.calculatedColsSvc?.resetDynamicColumnDefs({ preserveDeclaredColOverrides: true });
         this.colDefs = columnDefs;
         this.buildFromColDefs(source, true);
     }

--- a/packages/ag-grid-community/src/columns/columnStateUtils.ts
+++ b/packages/ag-grid-community/src/columns/columnStateUtils.ts
@@ -424,7 +424,7 @@ export function _resetColumnState(beans: BeanCollection, source: ColumnEventType
 
     // Park API/dialog-added calc cols and revert edits/removals of declared ones, so the reset below runs
     // against the original set — via the calc svc, so the rebuild emits no calc lifecycle/validation events.
-    if (calculatedColsSvc?.resetDynamicColumnDefs(true)) {
+    if (calculatedColsSvc?.resetDynamicColumnDefs({ preserveCreatedColumns: true })) {
         calculatedColsSvc.refreshDynamicColumns(source);
     }
 

--- a/packages/ag-grid-community/src/interfaces/gridState.ts
+++ b/packages/ag-grid-community/src/interfaces/gridState.ts
@@ -1,6 +1,9 @@
+import { ColDef } from 'ag-grid-community';
+
 import type { ShowValuesAs, ShowValuesAsType } from '../entities/colDef-showValuesAs';
 import type { CellRangeType } from './IRangeService';
 import type { AdvancedFilterModel } from './advancedFilterModel';
+import type { ColumnGroupShowType } from './iColumn';
 import type { RowGroupBulkExpansionState, RowGroupExpansionState } from './iExpansionService';
 import type { ColumnFilterState, FilterModel } from './iFilter';
 import type { RowPosition } from './iRowPosition';
@@ -189,6 +192,12 @@ export interface ColumnHeaderNameColumnState {
     headerName: string;
 }
 
+export interface ColumnPropertyColumnState<T extends keyof ColDef> {
+    colId: string;
+    propertyName: T;
+    value: ColDef[T];
+}
+
 export interface ColumnHeaderNameState {
     /** User-edited column header names, keyed by column id. */
     columnHeaderNames: ColumnHeaderNameColumnState[];
@@ -204,6 +213,9 @@ export interface UserColumnStateBase {
     /** Leaf `colId` whose column group this column joins; group membership is inherited from that sibling
      *  leaf. `null` when the column sits at the top level (no group). */
     groupAnchorColId: string | null;
+    /** `columnGroupShow` the column was created with (taken from the anchor leaf at creation time).
+     *  Serialised explicitly so restore does not depend on the anchor's current configuration. */
+    columnGroupShow?: ColumnGroupShowType;
 }
 
 export interface CalculatedUserColumnState extends UserColumnStateBase {
@@ -213,8 +225,23 @@ export interface CalculatedUserColumnState extends UserColumnStateBase {
     headerName?: string;
 }
 
-/** Discriminated union of runtime-added columns; grows one member per column kind. */
-export type UserColumnState = CalculatedUserColumnState;
+/** A user change to a calculated column that IS declared in `columnDefs`. The column itself is created by
+ *  `columnDefs`; this only carries what the user changed about it, so that state stays authoritative:
+ *  a listed entry re-applies the change, and an absent one reverts the column to its `columnDefs`
+ *  definition. Position and layout stay owned by `columnDefs` and the other column sections. */
+export interface CalculatedOverrideUserColumnState {
+    kind: 'calculatedOverride';
+    colId: string;
+    /** `true` when the user deleted the column; restore removes it again rather than re-applying a
+     *  definition. Mutually exclusive with the definition properties below. */
+    removed?: boolean;
+    calculatedExpression?: string;
+    cellDataType?: string;
+    headerName?: string;
+}
+
+/** Discriminated union of runtime column additions and overrides; grows one member per column kind. */
+export type UserColumnState = CalculatedUserColumnState | CalculatedOverrideUserColumnState;
 
 export interface RowPinningState {
     /** Row IDs of rows pinned to the top container */
@@ -232,9 +259,10 @@ export interface GridState {
     columnGroup?: ColumnGroupState;
     /** Includes column ordering (column state) */
     columnOrder?: ColumnOrderState;
-    /** Columns added at runtime that are not present in `columnDefs` (e.g. calculated columns).
-     *  Unlike the other column sections (which configure existing columns), this recreates the columns
-     *  themselves when the state is applied. */
+    /** Runtime changes to the set of columns themselves (e.g. calculated columns): columns added by the
+     *  user that are not present in `columnDefs`, plus edits and deletions the user made to `columnDefs`
+     *  ones. Unlike the other column sections (which configure existing columns), applying this creates
+     *  and removes columns. */
     userColumns?: UserColumnState[];
     /** Includes left/right pinned columns (column state) */
     columnPinning?: ColumnPinningState;

--- a/packages/ag-grid-community/src/interfaces/gridState.ts
+++ b/packages/ag-grid-community/src/interfaces/gridState.ts
@@ -194,6 +194,28 @@ export interface ColumnHeaderNameState {
     columnHeaderNames: ColumnHeaderNameColumnState[];
 }
 
+/** Shared shape for a column added at runtime that is not present in `columnDefs`. `kind` routes the
+ *  descriptor to the service that owns that column type and selects the strict payload below. Layout and
+ *  config (width, hide, pinned, sort, …) are intentionally absent here — they are owned by the
+ *  `columnSizing` / `columnVisibility` / `columnPinning` / `sort` sections. */
+export interface UserColumnStateBase {
+    kind: string;
+    colId: string;
+    /** Leaf `colId` whose column group this column joins; group membership is inherited from that sibling
+     *  leaf. `null` when the column sits at the top level (no group). */
+    groupAnchorColId: string | null;
+}
+
+export interface CalculatedUserColumnState extends UserColumnStateBase {
+    kind: 'calculated';
+    calculatedExpression: string;
+    cellDataType?: string;
+    headerName?: string;
+}
+
+/** Discriminated union of runtime-added columns; grows one member per column kind. */
+export type UserColumnState = CalculatedUserColumnState;
+
 export interface RowPinningState {
     /** Row IDs of rows pinned to the top container */
     top: string[];
@@ -210,6 +232,10 @@ export interface GridState {
     columnGroup?: ColumnGroupState;
     /** Includes column ordering (column state) */
     columnOrder?: ColumnOrderState;
+    /** Columns added at runtime that are not present in `columnDefs` (e.g. calculated columns).
+     *  Unlike the other column sections (which configure existing columns), this recreates the columns
+     *  themselves when the state is applied. */
+    userColumns?: UserColumnState[];
     /** Includes left/right pinned columns (column state) */
     columnPinning?: ColumnPinningState;
     /** Includes column width/flex (column state) */

--- a/packages/ag-grid-community/src/interfaces/iCalculatedColumns.ts
+++ b/packages/ag-grid-community/src/interfaces/iCalculatedColumns.ts
@@ -4,6 +4,7 @@ import type { Bean } from '../context/bean';
 import type { AgColumn } from '../entities/agColumn';
 import type { ColDef } from '../entities/colDef';
 import type { ColumnEventType } from '../events';
+import type { CalculatedUserColumnState } from './gridState';
 import type { HeaderPosition } from './iHeaderPosition';
 
 export type CalculatedColumnExpressionPicker = 'columns' | 'functions' | 'operators';
@@ -66,6 +67,11 @@ export interface ICalculatedColumnsService extends Bean {
     resetDynamicColumnDefs(preserveCreatedColumns?: boolean): boolean;
     /** Re-add parked dynamic cols referenced by `state` and return whether any were restored (caller rebuilds). */
     restoreDynamicColumnDefs(state: ColumnState[]): boolean;
+    /** Serialise dynamic (API/dialog-added) calc cols to grid state, in creation order. `undefined` when none. */
+    getUserColumnState(): CalculatedUserColumnState[] | undefined;
+    /** Reconcile dynamic calc cols against authoritative grid state: recreate listed cols, drop any not
+     *  listed. Rebuilds once. */
+    reconcileUserColumns(state: CalculatedUserColumnState[]): void;
     /** Run a suppressed rebuild after calc-col mutation so column-state ops avoid spurious calc lifecycle events. */
     refreshDynamicColumns(source: ColumnEventType): void;
     isEnabled(): boolean;

--- a/packages/ag-grid-community/src/interfaces/iCalculatedColumns.ts
+++ b/packages/ag-grid-community/src/interfaces/iCalculatedColumns.ts
@@ -4,7 +4,7 @@ import type { Bean } from '../context/bean';
 import type { AgColumn } from '../entities/agColumn';
 import type { ColDef } from '../entities/colDef';
 import type { ColumnEventType } from '../events';
-import type { CalculatedUserColumnState } from './gridState';
+import type { CalculatedOverrideUserColumnState, CalculatedUserColumnState } from './gridState';
 import type { HeaderPosition } from './iHeaderPosition';
 
 export type CalculatedColumnExpressionPicker = 'columns' | 'functions' | 'operators';
@@ -47,6 +47,17 @@ export type CalculatedColumnUpdate<TData = any, TValue = any> = Partial<ColDef<T
     calculatedExpression?: string;
 };
 
+export interface CalculatedColumnsResetOptions {
+    /** Park API/dialog-added cols for a later `restoreDynamicColumnDefs` instead of dropping them. */
+    preserveCreatedColumns?: boolean;
+    /** Keep the user's edits and deletions of `columnDefs`-declared calc cols. Set when `columnDefs`
+     *  changes, so a column the user deleted is not resurrected by an unrelated developer change. */
+    preserveDeclaredColOverrides?: boolean;
+}
+
+/** The `GridState.userColumns` members owned by the calculated-columns service. */
+export type CalculatedColumnsUserState = CalculatedUserColumnState | CalculatedOverrideUserColumnState;
+
 export interface ICalculatedColumnsService extends Bean {
     removeCalculatedColumn(column: AgColumn | null | undefined): void;
     openCalculatedColumnDialog(
@@ -63,15 +74,16 @@ export interface ICalculatedColumnsService extends Bean {
     overrideFor(colDef: ColDef): ColDef | null | undefined;
     /** Build-time dynamic calc-col hook: keep owned AgColumns alive and splice them at anchors (`overrideFor` handles static cols). */
     contributeTo(build: ColumnTreeBuild): void;
-    /** Clear dynamic calc-col state; with `preserveCreatedColumns`, park added cols for `restoreDynamicColumnDefs`, and return whether caller must rebuild. */
-    resetDynamicColumnDefs(preserveCreatedColumns?: boolean): boolean;
+    /** Clear dynamic calc-col state and return whether the caller must rebuild. See {@link CalculatedColumnsResetOptions}. */
+    resetDynamicColumnDefs(options?: CalculatedColumnsResetOptions): boolean;
     /** Re-add parked dynamic cols referenced by `state` and return whether any were restored (caller rebuilds). */
     restoreDynamicColumnDefs(state: ColumnState[]): boolean;
-    /** Serialise dynamic (API/dialog-added) calc cols to grid state, in creation order. `undefined` when none. */
-    getUserColumnState(): CalculatedUserColumnState[] | undefined;
-    /** Reconcile dynamic calc cols against authoritative grid state: recreate listed cols, drop any not
-     *  listed. Rebuilds once. */
-    reconcileUserColumns(state: CalculatedUserColumnState[]): void;
+    /** Serialise dynamic (API/dialog-added) calc cols to grid state in creation order, followed by the
+     *  user's edits and deletions of `columnDefs`-declared ones. `undefined` when there are none. */
+    getUserColumnState(): CalculatedColumnsUserState[] | undefined;
+    /** Reconcile calc cols against authoritative grid state: recreate listed dynamic cols and drop any
+     *  not listed, re-apply listed overrides of `columnDefs` cols and revert any not listed. Rebuilds once. */
+    reconcileUserColumns(state: CalculatedColumnsUserState[]): void;
     /** Run a suppressed rebuild after calc-col mutation so column-state ops avoid spurious calc lifecycle events. */
     refreshDynamicColumns(source: ColumnEventType): void;
     isEnabled(): boolean;

--- a/packages/ag-grid-community/src/main.ts
+++ b/packages/ag-grid-community/src/main.ts
@@ -615,6 +615,7 @@ export type { GridOptionsService, PropertyChangedEvent, PropertyValueChangedEven
 export type {
     AggregationColumnState,
     AggregationState,
+    CalculatedUserColumnState,
     CellSelectionCellState,
     CellSelectionState,
     ColumnGroupHeaderNameState,
@@ -647,6 +648,8 @@ export type {
     ShowValuesAsState,
     SideBarState,
     SortState,
+    UserColumnState,
+    UserColumnStateBase,
 } from './interfaces/gridState';
 export type { RowGroupBulkExpansionState, RowGroupExpansionState } from './interfaces/iExpansionService';
 export type { ServerSideRowGroupSelectionState, ServerSideRowSelectionState } from './interfaces/selectionState';

--- a/packages/ag-grid-community/src/main.ts
+++ b/packages/ag-grid-community/src/main.ts
@@ -246,6 +246,8 @@ export type {
     CalculatedColumnExpressionPicker,
     CalculatedColumnsGridOption,
     CalculatedColumnsOptions,
+    CalculatedColumnsResetOptions,
+    CalculatedColumnsUserState,
     CalculatedColumnUpdate,
     ICalculatedColumnsService,
 } from './interfaces/iCalculatedColumns';
@@ -615,6 +617,7 @@ export type { GridOptionsService, PropertyChangedEvent, PropertyValueChangedEven
 export type {
     AggregationColumnState,
     AggregationState,
+    CalculatedOverrideUserColumnState,
     CalculatedUserColumnState,
     CellSelectionCellState,
     CellSelectionState,

--- a/packages/ag-grid-community/src/misc/state/stateService.ts
+++ b/packages/ag-grid-community/src/misc/state/stateService.ts
@@ -11,7 +11,6 @@ import { _isCellSelectionEnabled, _isClientSideRowModel } from '../../gridOption
 import type { CellRange } from '../../interfaces/IRangeService';
 import type {
     AggregationState,
-    CalculatedUserColumnState,
     CellSelectionState,
     ColumnGroupState,
     ColumnHeaderNameState,
@@ -32,6 +31,7 @@ import type {
     SideBarState,
     SortState,
 } from '../../interfaces/gridState';
+import type { CalculatedColumnsUserState } from '../../interfaces/iCalculatedColumns';
 import type { RowGroupBulkExpansionState, RowGroupExpansionState } from '../../interfaces/iExpansionService';
 import type { FilterModel } from '../../interfaces/iFilter';
 import type { ServerSideRowGroupSelectionState, ServerSideRowSelectionState } from '../../interfaces/selectionState';
@@ -229,13 +229,15 @@ export class StateService extends BeanStub implements NamedBean {
             return;
         }
         // The incoming state is authoritative: recreate the calc cols it lists and drop any it omits.
-        // An absent/empty section therefore removes every runtime-added calc col.
+        // An absent/empty section therefore removes every runtime-added calc col and reverts every
+        // `columnDefs`-declared one to its declared definition.
         const userColumns = state.userColumns;
-        const calculatedCols: CalculatedUserColumnState[] = [];
+        const calculatedCols: CalculatedColumnsUserState[] = [];
         if (userColumns) {
             for (let i = 0, len = userColumns.length; i < len; ++i) {
                 const userColumn = userColumns[i];
-                if (userColumn.kind === 'calculated') {
+                const kind = userColumn.kind;
+                if (kind === 'calculated' || kind === 'calculatedOverride') {
                     calculatedCols.push(userColumn);
                 }
             }

--- a/packages/ag-grid-community/src/misc/state/stateService.ts
+++ b/packages/ag-grid-community/src/misc/state/stateService.ts
@@ -11,6 +11,7 @@ import { _isCellSelectionEnabled, _isClientSideRowModel } from '../../gridOption
 import type { CellRange } from '../../interfaces/IRangeService';
 import type {
     AggregationState,
+    CalculatedUserColumnState,
     CellSelectionState,
     ColumnGroupState,
     ColumnHeaderNameState,
@@ -194,6 +195,12 @@ export class StateService extends BeanStub implements NamedBean {
             'sort',
         ]);
         this.updateCachedState('columnGroup', this.getColumnGroupState());
+        // Only reflect user columns when the feature is active. When it is disabled (or the module is
+        // absent), leave any provided `userColumns` untouched in the cache so a later re-save is not lossy.
+        const calculatedColsSvc = this.beans.calculatedColsSvc;
+        if (calculatedColsSvc?.isEnabled()) {
+            this.updateCachedState('userColumns', calculatedColsSvc.getUserColumnState());
+        }
     }
 
     private setColumnsInitialisedState(
@@ -202,10 +209,38 @@ export class StateService extends BeanStub implements NamedBean {
         partialColumnState: boolean,
         ignoreSet?: Set<GridStateKey>
     ): void {
+        // Recreate runtime-added columns BEFORE applying column state, so their colIds exist when
+        // columnOrder / columnSizing / sort / etc. are applied on top of them.
+        this.reconcileUserColumns(state, ignoreSet);
         this.applyColumnGridState(state, source, partialColumnState, ignoreSet);
         this.setColumnGroupState(state, source, ignoreSet);
 
         this.updateColumnAndGroupState();
+    }
+
+    private reconcileUserColumns(state: GridState, ignoreSet?: Set<GridStateKey>): void {
+        if (ignoreSet?.has('userColumns')) {
+            return;
+        }
+        // When the feature is disabled (or the module is absent), leave any provided `userColumns`
+        // untouched so a later re-save into a calc-enabled grid is not lossy.
+        const calculatedColsSvc = this.beans.calculatedColsSvc;
+        if (!calculatedColsSvc?.isEnabled()) {
+            return;
+        }
+        // The incoming state is authoritative: recreate the calc cols it lists and drop any it omits.
+        // An absent/empty section therefore removes every runtime-added calc col.
+        const userColumns = state.userColumns;
+        const calculatedCols: CalculatedUserColumnState[] = [];
+        if (userColumns) {
+            for (let i = 0, len = userColumns.length; i < len; ++i) {
+                const userColumn = userColumns[i];
+                if (userColumn.kind === 'calculated') {
+                    calculatedCols.push(userColumn);
+                }
+            }
+        }
+        calculatedColsSvc.reconcileUserColumns(calculatedCols);
     }
 
     private setupStateOnColumnsInitialised(initialState: GridState, partialColumnState: boolean): void {

--- a/packages/ag-grid-enterprise/src/calculatedColumns/calculatedColumnUtils.ts
+++ b/packages/ag-grid-enterprise/src/calculatedColumns/calculatedColumnUtils.ts
@@ -27,6 +27,20 @@ export function clearStaleDataTypeProperties(colDef: ColDef, userColDef: ColDef 
 }
 
 /**
+ * Whether two calculated-column colDefs differ in any property carried by `GridState.userColumns`.
+ * Only these properties are restorable from state, so an identical result means re-applying the
+ * persisted definition would be a no-op and the grid does not need rebuilding.
+ */
+export function persistedColDefDiffers(colDef: ColDef, nextColDef: ColDef): boolean {
+    return (
+        colDef.calculatedExpression !== nextColDef.calculatedExpression ||
+        colDef.cellDataType !== nextColDef.cellDataType ||
+        colDef.headerName !== nextColDef.headerName ||
+        colDef.columnGroupShow !== nextColDef.columnGroupShow
+    );
+}
+
+/**
  * Visits every `[ref]` bracket reference in a calculated-column expression and produces a new
  * expression with each reference replaced by the callback's return value. String-literal
  * boundaries (`"..."`) are respected, including the SQL-style `""` escape — brackets inside a

--- a/packages/ag-grid-enterprise/src/calculatedColumns/calculatedColumnsService.ts
+++ b/packages/ag-grid-enterprise/src/calculatedColumns/calculatedColumnsService.ts
@@ -54,7 +54,11 @@ import {
     createCalculatedColumnReferenceMapper,
     translateCalculatedColumnReferenceError,
 } from './calculatedColumnReferenceMapper';
-import { clearStaleDataTypeProperties, replaceBracketReferences } from './calculatedColumnUtils';
+import {
+    clearStaleDataTypeProperties,
+    persistedColDefDiffers,
+    replaceBracketReferences,
+} from './calculatedColumnUtils';
 
 type ValidationState = 'valid' | CalculatedColumnValidationReason;
 
@@ -578,15 +582,29 @@ export class CalculatedColumnsService extends BeanStub implements NamedBean, ICa
             }
             this.closeCalculatedColumnDialog(colId);
             dynamicColumns.delete(colId);
-            inactive.delete(colId);
             changed = true;
         }
+        // Parked cols are dropped too, so a later `applyColumnState` cannot resurrect one the state omits.
+        for (const colId of inactive.keys()) {
+            if (!wanted.has(colId)) {
+                inactive.delete(colId);
+            }
+        }
 
-        // Addition: recreate any listed col not already present.
+        // Addition / update: recreate any listed col not already present, and re-apply the persisted
+        // definition over any live edits made to one that is.
         for (let i = 0, len = state.length; i < len; ++i) {
             const userCol = state[i];
             const colId = userCol.colId;
-            if (dynamicColumns.has(colId)) {
+            const colDef = this.toRestoredColDef(userCol);
+            const anchorColId = userCol.groupAnchorColId;
+            const existing = dynamicColumns.get(colId);
+            if (existing !== undefined) {
+                if (existing.anchorColId !== anchorColId || persistedColDefDiffers(existing.colDef, colDef)) {
+                    existing.colDef = colDef;
+                    existing.anchorColId = anchorColId;
+                    changed = true;
+                }
                 continue;
             }
             // Honour the serialised colId, but never clobber a real columnDefs column of the same id.
@@ -596,8 +614,8 @@ export class CalculatedColumnsService extends BeanStub implements NamedBean, ICa
             }
             inactive.delete(colId);
             dynamicColumns.set(colId, {
-                colDef: this.toRestoredColDef(userCol),
-                anchorColId: userCol.groupAnchorColId,
+                colDef,
+                anchorColId,
                 instance: null,
             });
             changed = true;

--- a/packages/ag-grid-enterprise/src/calculatedColumns/calculatedColumnsService.ts
+++ b/packages/ag-grid-enterprise/src/calculatedColumns/calculatedColumnsService.ts
@@ -14,6 +14,9 @@ import type {
     CalculatedColumnUpdate,
     CalculatedColumnValidationReason,
     CalculatedColumnsOptions,
+    CalculatedColumnsResetOptions,
+    CalculatedColumnsUserState,
+    CalculatedOverrideUserColumnState,
     CalculatedUserColumnState,
     ColDef,
     ColKey,
@@ -479,11 +482,14 @@ export class CalculatedColumnsService extends BeanStub implements NamedBean, ICa
         });
     }
 
-    public resetDynamicColumnDefs(preserveCreatedColumns = false): boolean {
+    public resetDynamicColumnDefs(options?: CalculatedColumnsResetOptions): boolean {
+        const { preserveCreatedColumns, preserveDeclaredColOverrides } = options ?? {};
         if (!preserveCreatedColumns) {
             this.inactiveDynamicColumns.clear();
         }
-        if (!this.dynamicColumns.size && !this.staticColOverrides.size) {
+        const staticColOverrides = this.staticColOverrides;
+        const clearOverrides = !preserveDeclaredColOverrides && staticColOverrides.size > 0;
+        if (!this.dynamicColumns.size && !clearOverrides) {
             return false;
         }
         // Owned AgColumns are destroyed by the rebuild that always follows (colModel owns tree lifetime).
@@ -495,7 +501,9 @@ export class CalculatedColumnsService extends BeanStub implements NamedBean, ICa
             });
         }
         this.dynamicColumns.clear();
-        this.staticColOverrides.clear();
+        if (clearOverrides) {
+            staticColOverrides.clear();
+        }
         return true;
     }
 
@@ -523,13 +531,13 @@ export class CalculatedColumnsService extends BeanStub implements NamedBean, ICa
         return restored;
     }
 
-    public getUserColumnState(): CalculatedUserColumnState[] | undefined {
-        if (!this.isEnabled() || this.dynamicColumns.size === 0) {
+    public getUserColumnState(): CalculatedColumnsUserState[] | undefined {
+        if (!this.isEnabled() || (this.dynamicColumns.size === 0 && this.staticColOverrides.size === 0)) {
             return undefined;
         }
-        const res: CalculatedUserColumnState[] = [];
+        const res: CalculatedColumnsUserState[] = [];
         this.dynamicColumns.forEach((dc, colId) => {
-            const { calculatedExpression, cellDataType, headerName } = dc.colDef;
+            const { calculatedExpression, cellDataType, headerName, columnGroupShow } = dc.colDef;
             const state: CalculatedUserColumnState = {
                 kind: 'calculated',
                 colId,
@@ -544,6 +552,30 @@ export class CalculatedColumnsService extends BeanStub implements NamedBean, ICa
             }
             if (headerName != null) {
                 state.headerName = headerName;
+            }
+            if (columnGroupShow != null) {
+                state.columnGroupShow = columnGroupShow;
+            }
+            res.push(state);
+        });
+        // Edits and deletions of `columnDefs`-declared calc cols. Only the user's change is serialised —
+        // the column itself is still created by `columnDefs` on restore.
+        this.staticColOverrides.forEach((colDef, colId) => {
+            if (colDef === null) {
+                res.push({ kind: 'calculatedOverride', colId, removed: true });
+                return;
+            }
+            const state: CalculatedOverrideUserColumnState = {
+                kind: 'calculatedOverride',
+                colId,
+                calculatedExpression: colDef.calculatedExpression ?? '',
+            };
+            const cellDataType = colDef.cellDataType;
+            if (typeof cellDataType === 'string') {
+                state.cellDataType = cellDataType;
+            }
+            if (colDef.headerName != null) {
+                state.headerName = colDef.headerName;
             }
             res.push(state);
         });
@@ -562,10 +594,66 @@ export class CalculatedColumnsService extends BeanStub implements NamedBean, ICa
         return anchor;
     }
 
-    public reconcileUserColumns(state: CalculatedUserColumnState[]): void {
+    public reconcileUserColumns(state: CalculatedColumnsUserState[]): void {
         if (!this.isEnabled()) {
             return;
         }
+        const added: CalculatedUserColumnState[] = [];
+        const overrides: CalculatedOverrideUserColumnState[] = [];
+        for (let i = 0, len = state.length; i < len; ++i) {
+            const userCol = state[i];
+            if (userCol.kind === 'calculated') {
+                added.push(userCol);
+            } else {
+                overrides.push(userCol);
+            }
+        }
+        // Both passes must run before the rebuild, so a single build materialises the whole target state.
+        const addedChanged = this.reconcileDynamicColumns(added);
+        const overridesChanged = this.reconcileStaticColOverrides(overrides);
+        if (addedChanged || overridesChanged) {
+            this.refreshDynamicColumns('calculatedColumn');
+        }
+    }
+
+    /** Re-apply the user's edits and deletions of `columnDefs`-declared calc cols. State is authoritative,
+     *  so an override the state does not list is dropped, reverting that column to its declared definition. */
+    private reconcileStaticColOverrides(state: CalculatedOverrideUserColumnState[]): boolean {
+        const { colModel } = this.beans;
+        const staticColOverrides = this.staticColOverrides;
+        // Cleared up front so a listed override merges onto the `columnDefs` definition rather than onto
+        // a live edit, and so an unlisted one reverts.
+        let changed = staticColOverrides.size > 0;
+        staticColOverrides.clear();
+        for (let i = 0, len = state.length; i < len; ++i) {
+            const userCol = state[i];
+            const colId = userCol.colId;
+            if (userCol.removed) {
+                this.closeCalculatedColumnDialog(colId);
+                staticColOverrides.set(colId, null);
+                changed = true;
+                continue;
+            }
+            // Nothing to override once `columnDefs` no longer declares the column as a calc col; the
+            // developer owns that, so the entry is simply dropped rather than reinstating an expression.
+            const column = colModel.getCol(colId);
+            if (!column?.isCalculatedCol) {
+                continue;
+            }
+            staticColOverrides.set(
+                colId,
+                this.getUpdatedCalculatedColDef(column, {
+                    calculatedExpression: userCol.calculatedExpression,
+                    cellDataType: userCol.cellDataType,
+                    headerName: userCol.headerName,
+                })
+            );
+            changed = true;
+        }
+        return changed;
+    }
+
+    private reconcileDynamicColumns(state: CalculatedUserColumnState[]): boolean {
         const { colModel } = this.beans;
         const dynamicColumns = this.dynamicColumns;
         const inactive = this.inactiveDynamicColumns;
@@ -620,22 +708,15 @@ export class CalculatedColumnsService extends BeanStub implements NamedBean, ICa
             });
             changed = true;
         }
-        if (changed) {
-            this.refreshDynamicColumns('calculatedColumn');
-        }
+        return changed;
     }
 
     // The stored expression is already in internal colId form, so it is used verbatim (no reference re-mapping).
     private toRestoredColDef(state: CalculatedUserColumnState): ColDef {
         const colDef = this.baseCalculatedColDef(state);
-        const anchorColId = state.groupAnchorColId;
-        if (anchorColId != null) {
-            // The anchor is always serialised as a stable (columnDefs-declared) leaf, so it is already
-            // in the col model here — inherit its group membership.
-            const columnGroupShow = this.beans.colModel.getCol(anchorColId)?.colDef.columnGroupShow;
-            if (columnGroupShow != null) {
-                colDef.columnGroupShow = columnGroupShow;
-            }
+        const columnGroupShow = state.columnGroupShow;
+        if (columnGroupShow != null) {
+            colDef.columnGroupShow = columnGroupShow;
         }
         return colDef;
     }
@@ -1082,16 +1163,21 @@ export class CalculatedColumnsService extends BeanStub implements NamedBean, ICa
             }
         }
 
-        if (shouldDispatch) {
-            previousColumns.forEach((previousColumn, colId) => {
-                if (!nextColumns.has(colId)) {
-                    this.dispatchCreatedOrRemovedEvent(
-                        'calculatedColumnRemoved',
-                        this.getEventCommonParams(previousColumn.column, previousColumn.expression, source)
-                    );
-                }
-            });
-        }
+        previousColumns.forEach((previousColumn, colId) => {
+            if (nextColumns.has(colId)) {
+                return;
+            }
+            // The column the dialog edits no longer exists — a `columnDefs` change can drop one the user
+            // has open. Removal through the menu or grid state closes it before rebuilding, so this is a
+            // no-op there.
+            this.closeCalculatedColumnDialog(colId);
+            if (shouldDispatch) {
+                this.dispatchCreatedOrRemovedEvent(
+                    'calculatedColumnRemoved',
+                    this.getEventCommonParams(previousColumn.column, previousColumn.expression, source)
+                );
+            }
+        });
 
         this.knownCalculatedColumns = nextColumns;
         this.lifecycleInitialised = true;

--- a/packages/ag-grid-enterprise/src/calculatedColumns/calculatedColumnsService.ts
+++ b/packages/ag-grid-enterprise/src/calculatedColumns/calculatedColumnsService.ts
@@ -14,6 +14,7 @@ import type {
     CalculatedColumnUpdate,
     CalculatedColumnValidationReason,
     CalculatedColumnsOptions,
+    CalculatedUserColumnState,
     ColDef,
     ColKey,
     ColumnEventType,
@@ -518,6 +519,109 @@ export class CalculatedColumnsService extends BeanStub implements NamedBean, ICa
         return restored;
     }
 
+    public getUserColumnState(): CalculatedUserColumnState[] | undefined {
+        if (!this.isEnabled() || this.dynamicColumns.size === 0) {
+            return undefined;
+        }
+        const res: CalculatedUserColumnState[] = [];
+        this.dynamicColumns.forEach((dc, colId) => {
+            const { calculatedExpression, cellDataType, headerName } = dc.colDef;
+            const state: CalculatedUserColumnState = {
+                kind: 'calculated',
+                colId,
+                // The anchor only identifies the group the col joins (order is owned by `columnOrder`),
+                // so serialise a stable leaf: collapse any chain through other runtime-added cols, which
+                // may not exist when this state is restored into a fresh grid.
+                groupAnchorColId: this.resolveLeafAnchor(dc.anchorColId),
+                calculatedExpression: calculatedExpression ?? '',
+            };
+            if (typeof cellDataType === 'string') {
+                state.cellDataType = cellDataType;
+            }
+            if (headerName != null) {
+                state.headerName = headerName;
+            }
+            res.push(state);
+        });
+        return res;
+    }
+
+    /** Walk an anchor chain through runtime-added cols down to the first stable (non-dynamic) column —
+     *  the leaf whose group the calc col ultimately joins. Returns null for a top-level col. */
+    private resolveLeafAnchor(anchorColId: string | null): string | null {
+        const seen = new Set<string>();
+        let anchor = anchorColId;
+        while (anchor != null && this.dynamicColumns.has(anchor) && !seen.has(anchor)) {
+            seen.add(anchor);
+            anchor = this.dynamicColumns.get(anchor)!.anchorColId;
+        }
+        return anchor;
+    }
+
+    public reconcileUserColumns(state: CalculatedUserColumnState[]): void {
+        if (!this.isEnabled()) {
+            return;
+        }
+        const { colModel } = this.beans;
+        const dynamicColumns = this.dynamicColumns;
+        const inactive = this.inactiveDynamicColumns;
+        const wanted = new Set<string>();
+        for (let i = 0, len = state.length; i < len; ++i) {
+            wanted.add(state[i].colId);
+        }
+        let changed = false;
+
+        // Removal: the incoming state is authoritative, so any dynamic col it does not list is dropped.
+        for (const colId of dynamicColumns.keys()) {
+            if (wanted.has(colId)) {
+                continue;
+            }
+            this.closeCalculatedColumnDialog(colId);
+            dynamicColumns.delete(colId);
+            inactive.delete(colId);
+            changed = true;
+        }
+
+        // Addition: recreate any listed col not already present.
+        for (let i = 0, len = state.length; i < len; ++i) {
+            const userCol = state[i];
+            const colId = userCol.colId;
+            if (dynamicColumns.has(colId)) {
+                continue;
+            }
+            // Honour the serialised colId, but never clobber a real columnDefs column of the same id.
+            if (colModel.getCol(colId) != null) {
+                _warnOnce(`reconcileUserColumns: colId '${colId}' already exists; skipping.`);
+                continue;
+            }
+            inactive.delete(colId);
+            dynamicColumns.set(colId, {
+                colDef: this.toRestoredColDef(userCol),
+                anchorColId: userCol.groupAnchorColId,
+                instance: null,
+            });
+            changed = true;
+        }
+        if (changed) {
+            this.refreshDynamicColumns('calculatedColumn');
+        }
+    }
+
+    // The stored expression is already in internal colId form, so it is used verbatim (no reference re-mapping).
+    private toRestoredColDef(state: CalculatedUserColumnState): ColDef {
+        const colDef = this.baseCalculatedColDef(state);
+        const anchorColId = state.groupAnchorColId;
+        if (anchorColId != null) {
+            // The anchor is always serialised as a stable (columnDefs-declared) leaf, so it is already
+            // in the col model here — inherit its group membership.
+            const columnGroupShow = this.beans.colModel.getCol(anchorColId)?.colDef.columnGroupShow;
+            if (columnGroupShow != null) {
+                colDef.columnGroupShow = columnGroupShow;
+            }
+        }
+        return colDef;
+    }
+
     private getOrCreateColumn(
         dc: DynamicCalculatedColumn,
         colId: string,
@@ -873,11 +977,25 @@ export class CalculatedColumnsService extends BeanStub implements NamedBean, ICa
     }
 
     private toColDef(draft: CalculatedColumnDraft): ColDef {
-        return {
-            colId: draft.colId,
-            headerName: draft.headerName,
+        return this.baseCalculatedColDef({
+            ...draft,
             calculatedExpression: _normaliseCalculatedExpression(draft.calculatedExpression) ?? '',
-            cellDataType: draft.cellDataType,
+        });
+    }
+
+    /** Base colDef shared by every calc-col builder: the data fields plus the calc-col invariants
+     *  (`editable: false`, `suppressPaste: true`), which the grid also enforces centrally via `isCalculatedCol`. */
+    private baseCalculatedColDef(source: {
+        colId: string;
+        headerName?: string;
+        cellDataType?: string;
+        calculatedExpression: string;
+    }): ColDef {
+        return {
+            colId: source.colId,
+            headerName: source.headerName,
+            calculatedExpression: source.calculatedExpression,
+            cellDataType: source.cellDataType,
             editable: false,
             suppressPaste: true,
         };

--- a/testing/behavioural/src/formulas/calculated-columns-ordering.test.ts
+++ b/testing/behavioural/src/formulas/calculated-columns-ordering.test.ts
@@ -45,16 +45,12 @@ describe('calculated columns - display ordering', () => {
         ] as Module[],
     });
 
-    let restoreOffsetParent: (() => void) | undefined;
-
     beforeEach(() => {
         gridsManager.reset();
     });
 
     afterEach(() => {
         gridsManager.reset();
-        restoreOffsetParent?.();
-        restoreOffsetParent = undefined;
     });
 
     function createGrid(id: string, opts: Partial<GridOptions>): GridApi {
@@ -91,26 +87,6 @@ describe('calculated columns - display ordering', () => {
     }
 
     // --- dialog plumbing (the only public surface that sets an anchor) ---------------------------
-
-    function enableOffsetParentPolyfill(): void {
-        if (restoreOffsetParent) {
-            return;
-        }
-        const original = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetParent');
-        Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
-            configurable: true,
-            get(this: HTMLElement) {
-                return this.parentElement;
-            },
-        });
-        restoreOffsetParent = () => {
-            if (original) {
-                Object.defineProperty(HTMLElement.prototype, 'offsetParent', original);
-            } else {
-                delete (HTMLElement.prototype as any).offsetParent;
-            }
-        };
-    }
 
     async function clickColumnMenuItem(name: string): Promise<void> {
         const menuItem = await waitFor(() => {
@@ -161,7 +137,6 @@ describe('calculated columns - display ordering', () => {
      *  Returns the auto-generated colId of the new column, discovered by diffing the column set. */
     async function addViaDialog(api: GridApi, anchorColId: string, expression: string): Promise<string> {
         const before = new Set(order(api));
-        enableOffsetParentPolyfill();
         api.showColumnMenu(anchorColId);
         await asyncSetTimeout(10);
         await clickColumnMenuItem('Add Calculated Column');
@@ -179,7 +154,6 @@ describe('calculated columns - display ordering', () => {
     /** Removes a dynamic (dialog-added) calc col through its header menu — dynamic calc cols are not in
      *  `columnDefs`, so they can only be removed via the menu's "Remove Calculated Column" action. */
     async function removeViaMenu(api: GridApi, colId: string): Promise<void> {
-        enableOffsetParentPolyfill();
         api.showColumnMenu(colId);
         await asyncSetTimeout(10);
         await clickColumnMenuItem('Remove Calculated Column');
@@ -404,7 +378,6 @@ describe('calculated columns - display ordering', () => {
         });
         const before = new Set(order(api));
 
-        enableOffsetParentPolyfill();
         api.showColumnMenu('age');
         await asyncSetTimeout(10);
         await clickColumnMenuItem('Add Calculated Column');
@@ -443,7 +416,6 @@ describe('calculated columns - display ordering', () => {
             columnDefs: [{ field: 'age' }],
         });
 
-        enableOffsetParentPolyfill();
         api.showColumnMenu('age');
         await asyncSetTimeout(10);
         await clickColumnMenuItem('Add Calculated Column');

--- a/testing/behavioural/src/formulas/calculated-columns-state.test.ts
+++ b/testing/behavioural/src/formulas/calculated-columns-state.test.ts
@@ -396,6 +396,48 @@ describe('calculated columns - grid state persistence', () => {
         expect(api.getState().userColumns).toEqual(userColumns);
     });
 
+    // === columnGroupShow is persisted, not re-derived from the anchor on restore =================
+
+    test('a calc col keeps its columnGroupShow when the anchor leaf no longer declares one', async () => {
+        // The col inherits `columnGroupShow` from its anchor leaf when created, but the value is
+        // serialised on the descriptor — restore must not re-read it from whatever the anchor happens
+        // to declare in the target grid's columnDefs.
+        const group = (revenueGroupShow?: 'open') => [
+            {
+                groupId: 'money',
+                headerName: 'Money',
+                openByDefault: true,
+                children: [
+                    { field: 'revenue', headerName: 'Revenue', columnGroupShow: revenueGroupShow },
+                    // `closed` keeps the group expandable in both grids, so the assertions below turn
+                    // only on the calc col's own columnGroupShow.
+                    { field: 'cost', headerName: 'Cost', columnGroupShow: 'closed' as const },
+                ],
+            },
+        ];
+        const rowData = [{ id: 'r1', revenue: 10, cost: 3 }];
+
+        const source = createGrid('state-group-show-source', { rowData, columnDefs: group('open') });
+        const calcId = await addViaDialog(source, 'revenue', '[Revenue] - [Cost]');
+        expect(source.getColumn(calcId)!.getColDef().columnGroupShow).toBe('open');
+
+        // Target declares `revenue` with no columnGroupShow, so an anchor lookup would yield nothing.
+        const target = createGrid('state-group-show-target', {
+            rowData,
+            columnDefs: group(),
+            initialState: source.getState(),
+        });
+        await waitFor(() => expect(order(target)).toContain(calcId));
+        expect(target.getColumn(calcId)!.getColDef().columnGroupShow).toBe('open');
+        await new GridColumns(target, 'calc col keeps persisted columnGroupShow').checkColumns(`
+            CENTER
+            └─┬ "Money" GROUP open
+              ├── revenue "Revenue" width:200
+              ├── ${calcId} "Untitled" width:200 ƒ columnGroupShow:open
+              └── cost "Cost" width:200 columnGroupShow:closed hidden
+        `);
+    });
+
     // === plural case: two calc cols, one anchored to the other, round-trip in order ==============
 
     test('two dynamic calc cols, one anchored to the other, round-trip in serialised order with group inheritance', async () => {
@@ -422,11 +464,6 @@ describe('calculated columns - grid state persistence', () => {
         expect(order(api)).toEqual(['revenue', calcId1, calcId2, 'cost']);
 
         const savedState = api.getState();
-        expect(savedState.userColumns?.map(({ colId, groupAnchorColId }) => ({ colId, groupAnchorColId }))).toEqual([
-            { colId: calcId1, groupAnchorColId: 'revenue' },
-            { colId: calcId2, groupAnchorColId: 'revenue' },
-        ]);
-
         const api2 = createGrid('state-plural-target', {
             rowData: [{ id: 'r1', revenue: 10, cost: 3 }],
             columnDefs,
@@ -474,12 +511,6 @@ describe('calculated columns - grid state persistence', () => {
         expect(order(source)).toEqual(['athlete', 'gold', calcId1, calcId2, 'silver']);
 
         const savedState = source.getState();
-        // Both calc cols anchor to the leaf `gold` — the chain through calcId1 is collapsed on save.
-        expect(savedState.userColumns?.map(({ colId, groupAnchorColId }) => ({ colId, groupAnchorColId }))).toEqual([
-            { colId: calcId1, groupAnchorColId: 'gold' },
-            { colId: calcId2, groupAnchorColId: 'gold' },
-        ]);
-
         // Restore the saved state and a variant with userColumns reversed: the two must be identical,
         // including group membership (the part columnOrder does not carry).
         const reversedState: GridState = {
@@ -1055,6 +1086,277 @@ describe('calculated columns - grid state persistence', () => {
         });
         await waitFor(() => expect(api.getColumn(calcId)!.getColDef().calculatedExpression).toBe('[a] * 3'));
         expect(api.getColumn(calcId)!.getColDef()).not.toBe(colDefBefore);
+    });
+
+    // === columnDefs-declared calc cols: user edits and deletions are the state's to keep ==========
+
+    // These calc cols are created by `columnDefs`, so `userColumns` carries only what the user changed
+    // about them (`kind: 'calculatedOverride'`) — never the column itself. State stays authoritative:
+    // a listed entry re-applies the change, an absent one reverts to the declared definition.
+    const STATIC_ROW_DATA = [{ id: 'r1', a: 10, b: 3 }];
+    const staticColumnDefs = (): GridOptions['columnDefs'] => [
+        { field: 'a' },
+        { field: 'b' },
+        { colId: 'declared', headerName: 'Declared', calculatedExpression: '[a] + [b]' },
+    ];
+    function cellValue(api: GridApi, colKey: string): unknown {
+        return api.getCellValue({ colKey, rowNode: api.getRowNode('r1')! });
+    }
+
+    test('an untouched columnDefs-declared calc col is not reported in userColumns', async () => {
+        const api = createGrid('state-declared-untouched', {
+            rowData: STATIC_ROW_DATA,
+            columnDefs: staticColumnDefs(),
+        });
+        await waitFor(() => expect(cellValue(api, 'declared')).toBe(13));
+        // Nothing user-changed, so nothing to persist: the column is the developer's to declare, and a
+        // state entry would let saved state resurrect or suppress it behind their back.
+        expect(api.getState().userColumns).toBeUndefined();
+    });
+
+    test('an edit to a columnDefs-declared calc col is persisted and re-applied on restore', async () => {
+        const source = createGrid('state-declared-edit-source', {
+            rowData: STATIC_ROW_DATA,
+            columnDefs: staticColumnDefs(),
+        });
+        await waitFor(() => expect(cellValue(source, 'declared')).toBe(13));
+        await editViaDialog(source, 'declared', { expression: '[a] * [b]' });
+        expect(cellValue(source, 'declared')).toBe(30);
+
+        const savedState = source.getState();
+        expect(savedState.userColumns).toEqual([
+            expect.objectContaining({
+                kind: 'calculatedOverride',
+                colId: 'declared',
+                calculatedExpression: '[a] * [b]',
+            }),
+        ]);
+
+        const target = createGrid('state-declared-edit-target', {
+            rowData: STATIC_ROW_DATA,
+            columnDefs: staticColumnDefs(),
+            initialState: savedState,
+        });
+        await waitFor(() => expect(cellValue(target, 'declared')).toBe(30));
+        // The override merges over the declared colDef, so untouched properties survive.
+        expect(target.getColumn('declared')!.getColDef().headerName).toBe('Declared');
+        expect(target.getState().userColumns).toEqual(savedState.userColumns);
+    });
+
+    test('a columnDefs-declared calc col deleted by the user stays deleted after a state round-trip', async () => {
+        const source = createGrid('state-declared-remove-source', {
+            rowData: STATIC_ROW_DATA,
+            columnDefs: staticColumnDefs(),
+        });
+        await waitFor(() => expect(order(source)).toEqual(['a', 'b', 'declared']));
+        await removeViaMenu(source, 'declared');
+        await waitFor(() => expect(order(source)).toEqual(['a', 'b']));
+
+        const savedState = source.getState();
+        expect(savedState.userColumns).toEqual([{ kind: 'calculatedOverride', colId: 'declared', removed: true }]);
+
+        const target = createGrid('state-declared-remove-target', {
+            rowData: STATIC_ROW_DATA,
+            columnDefs: staticColumnDefs(),
+            initialState: savedState,
+        });
+        await asyncSetTimeout(0);
+        expect(order(target)).toEqual(['a', 'b']);
+        // The tombstone survives a re-save, so the deletion is not lost on the next reload.
+        expect(target.getState().userColumns).toEqual(savedState.userColumns);
+    });
+
+    test('applying a state that lists no override reverts a live edit to the declared definition', async () => {
+        const clean = createGrid('state-declared-revert-clean', {
+            rowData: STATIC_ROW_DATA,
+            columnDefs: staticColumnDefs(),
+        });
+        await waitFor(() => expect(cellValue(clean, 'declared')).toBe(13));
+        const cleanState = clean.getState();
+
+        const api = createGrid('state-declared-revert', {
+            rowData: STATIC_ROW_DATA,
+            columnDefs: staticColumnDefs(),
+        });
+        await waitFor(() => expect(cellValue(api, 'declared')).toBe(13));
+        await editViaDialog(api, 'declared', { expression: '[a] * [b]' });
+        expect(cellValue(api, 'declared')).toBe(30);
+
+        api.setState(cleanState);
+        await waitFor(() => expect(cellValue(api, 'declared')).toBe(13));
+        expect(api.getState().userColumns).toBeUndefined();
+    });
+
+    test('a persisted override is dropped when columnDefs no longer declares the calc col', async () => {
+        const source = createGrid('state-declared-gone-source', {
+            rowData: STATIC_ROW_DATA,
+            columnDefs: staticColumnDefs(),
+        });
+        await waitFor(() => expect(cellValue(source, 'declared')).toBe(13));
+        await editViaDialog(source, 'declared', { expression: '[a] * [b]' });
+
+        // The developer owns the column's existence, so dropping it from columnDefs drops the override
+        // with it — the state cannot reinstate a column the developer no longer declares.
+        const target = createGrid('state-declared-gone-target', {
+            rowData: STATIC_ROW_DATA,
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+            initialState: source.getState(),
+        });
+        await asyncSetTimeout(0);
+        expect(order(target)).toEqual(['a', 'b']);
+        expect(target.getState().userColumns).toBeUndefined();
+    });
+
+    test('applying a state that deletes a columnDefs-declared calc col closes its open dialog', async () => {
+        const source = createGrid('state-declared-tombstone-dialog-source', {
+            rowData: STATIC_ROW_DATA,
+            columnDefs: staticColumnDefs(),
+        });
+        await waitFor(() => expect(order(source)).toEqual(['a', 'b', 'declared']));
+        await removeViaMenu(source, 'declared');
+        const tombstoneState = source.getState();
+
+        const api = createGrid('state-declared-tombstone-dialog', {
+            rowData: STATIC_ROW_DATA,
+            columnDefs: staticColumnDefs(),
+        });
+        await waitFor(() => expect(order(api)).toEqual(['a', 'b', 'declared']));
+        api.showColumnMenu('declared');
+        await asyncSetTimeout(10);
+        await clickColumnMenuItem('Edit Calculated Column');
+        await asyncSetTimeout(1);
+        expect(document.querySelectorAll('.ag-calculated-column-form')).toHaveLength(1);
+
+        // The dialog edits a column the state has just deleted, so it cannot be left open — same
+        // contract as removing the column through its header menu.
+        api.setState(tombstoneState);
+        await waitFor(() => expect(order(api)).toEqual(['a', 'b']));
+        expect(document.querySelectorAll('.ag-calculated-column-form')).toHaveLength(0);
+    });
+
+    test('a restored override whose expression references a missing column shows an error value', async () => {
+        const source = createGrid('state-declared-badref-source', {
+            rowData: STATIC_ROW_DATA,
+            columnDefs: staticColumnDefs(),
+        });
+        await waitFor(() => expect(cellValue(source, 'declared')).toBe(13));
+        await editViaDialog(source, 'declared', { expression: '[a] * [b]' });
+
+        // `b` is gone from the target grid, so the persisted expression cannot resolve. The override
+        // still applies — the column reports the error rather than silently keeping its declared value.
+        const target = createGrid('state-declared-badref-target', {
+            rowData: [{ id: 'r1', a: 10 }],
+            columnDefs: [{ field: 'a' }, { colId: 'declared', headerName: 'Declared', calculatedExpression: '[a]' }],
+            initialState: source.getState(),
+        });
+        await waitFor(() => expect(cellValue(target, 'declared')).toBe('#PARSE!'));
+    });
+
+    // A `columnDefs` change is the developer reasserting which columns exist — it does not speak for the
+    // user's calc-col edits and deletions, which are state. They therefore survive `columnDefs` churn and
+    // re-apply if the column comes back. Only `resetColumnState` clears them.
+    test('a user deletion of a columnDefs-declared calc col survives the developer dropping and re-declaring it', async () => {
+        const api = createGrid('state-declared-live-redeclare', {
+            rowData: STATIC_ROW_DATA,
+            columnDefs: staticColumnDefs(),
+        });
+        await waitFor(() => expect(order(api)).toEqual(['a', 'b', 'declared']));
+        await removeViaMenu(api, 'declared');
+        await waitFor(() => expect(order(api)).toEqual(['a', 'b']));
+
+        api.setGridOption('columnDefs', [{ field: 'a' }, { field: 'b' }]);
+        await asyncSetTimeout(0);
+        api.setGridOption('columnDefs', staticColumnDefs());
+        await asyncSetTimeout(0);
+        // Still deleted: the developer re-declaring the column does not undo the user's deletion.
+        expect(order(api)).toEqual(['a', 'b']);
+        expect(api.getState().userColumns).toEqual([{ kind: 'calculatedOverride', colId: 'declared', removed: true }]);
+    });
+
+    test('a live edit of a columnDefs-declared calc col survives the developer dropping and re-declaring it', async () => {
+        const api = createGrid('state-declared-live-drop', {
+            rowData: STATIC_ROW_DATA,
+            columnDefs: staticColumnDefs(),
+        });
+        await waitFor(() => expect(cellValue(api, 'declared')).toBe(13));
+        await editViaDialog(api, 'declared', { expression: '[a] * [b]' });
+        expect(cellValue(api, 'declared')).toBe(30);
+
+        api.setGridOption('columnDefs', [{ field: 'a' }, { field: 'b' }]);
+        await waitFor(() => expect(order(api)).toEqual(['a', 'b']));
+        // The edit is still the user's, so it stays saveable while the column is away.
+        expect(api.getState().userColumns).toEqual([
+            expect.objectContaining({ kind: 'calculatedOverride', colId: 'declared' }),
+        ]);
+
+        api.setGridOption('columnDefs', staticColumnDefs());
+        await waitFor(() => expect(order(api)).toEqual(['a', 'b', 'declared']));
+        expect(cellValue(api, 'declared')).toBe(30);
+    });
+
+    test('resetColumnState clears a user edit of a columnDefs-declared calc col', async () => {
+        const api = createGrid('state-declared-reset', {
+            rowData: STATIC_ROW_DATA,
+            columnDefs: staticColumnDefs(),
+        });
+        await waitFor(() => expect(cellValue(api, 'declared')).toBe(13));
+        await editViaDialog(api, 'declared', { expression: '[a] * [b]' });
+        expect(cellValue(api, 'declared')).toBe(30);
+
+        // An explicit reset does speak for the user's edits — unlike a `columnDefs` change.
+        api.resetColumnState();
+        await waitFor(() => expect(cellValue(api, 'declared')).toBe(13));
+        expect(api.getState().userColumns).toBeUndefined();
+    });
+
+    test('dropping the group that contains an edited calc col keeps the override for when it returns', async () => {
+        const groupedColumnDefs = (): GridOptions['columnDefs'] => [
+            { field: 'a' },
+            {
+                groupId: 'derived',
+                headerName: 'Derived',
+                children: [{ field: 'b' }, { colId: 'declared', calculatedExpression: '[a] + [b]' }],
+            },
+        ];
+        const api = createGrid('state-declared-group-drop', {
+            rowData: STATIC_ROW_DATA,
+            columnDefs: groupedColumnDefs(),
+        });
+        await waitFor(() => expect(cellValue(api, 'declared')).toBe(13));
+        await editViaDialog(api, 'declared', { expression: '[a] * [b]' });
+        expect(cellValue(api, 'declared')).toBe(30);
+
+        api.setGridOption('columnDefs', [{ field: 'a' }]);
+        await waitFor(() => expect(order(api)).toEqual(['a']));
+        expect(api.getState().userColumns).toHaveLength(1);
+
+        api.setGridOption('columnDefs', groupedColumnDefs());
+        await waitFor(() => expect(order(api)).toEqual(['a', 'b', 'declared']));
+        expect(cellValue(api, 'declared')).toBe(30);
+        expect(api.getColumn('declared')!.getParent()!.getGroupId()).toBe('derived');
+    });
+
+    test('a user edit of a columnDefs-declared calc col wins over a later columnDefs expression change', async () => {
+        const api = createGrid('state-declared-vs-coldef', {
+            rowData: STATIC_ROW_DATA,
+            columnDefs: staticColumnDefs(),
+        });
+        await waitFor(() => expect(cellValue(api, 'declared')).toBe(13));
+        await editViaDialog(api, 'declared', { expression: '[a] * [b]' });
+        expect(cellValue(api, 'declared')).toBe(30);
+
+        // The user's edit is authoritative until state says otherwise, so re-declaring the column with a
+        // different expression does NOT take effect. `resetColumnState` is how the developer reclaims it.
+        api.setGridOption('columnDefs', [
+            { field: 'a' },
+            { field: 'b' },
+            { colId: 'declared', headerName: 'Declared', calculatedExpression: '[a] - [b]' },
+        ]);
+        await asyncSetTimeout(0);
+        expect(cellValue(api, 'declared')).toBe(30);
+
+        api.resetColumnState();
+        await waitFor(() => expect(cellValue(api, 'declared')).toBe(7));
     });
 
     // === parked columns: resetColumnState / applyColumnState ======================================

--- a/testing/behavioural/src/formulas/calculated-columns-state.test.ts
+++ b/testing/behavioural/src/formulas/calculated-columns-state.test.ts
@@ -146,6 +146,27 @@ describe('calculated columns - grid state persistence', () => {
         return added[0];
     }
 
+    /** Edits an existing calc col through its header menu, under the default 'live' apply mode. */
+    async function editViaDialog(
+        api: GridApi,
+        colId: string,
+        edits: { expression?: string; title?: string }
+    ): Promise<void> {
+        enableOffsetParentPolyfill();
+        api.showColumnMenu(colId);
+        await asyncSetTimeout(10);
+        await clickColumnMenuItem('Edit Calculated Column');
+        await asyncSetTimeout(1);
+        if (edits.title !== undefined) {
+            setTitle(edits.title);
+        }
+        if (edits.expression !== undefined) {
+            setExpression(edits.expression);
+        }
+        clickDialogButton('Apply');
+        await asyncSetTimeout(40);
+    }
+
     // === core repro: initialState round-trip =====================================================
 
     test('a dynamic calc col added via the dialog is saved in getState().userColumns and recreated via initialState on a fresh grid', async () => {
@@ -266,6 +287,58 @@ describe('calculated columns - grid state persistence', () => {
             ROOT id:ROOT_NODE_ID
             └── LEAF id:r1 a:5 ${calcId1}:10 b:2
         `);
+    });
+
+    test('api.setState restores the persisted definition of a calc col that has since been edited', async () => {
+        const api = createGrid('state-update-existing', {
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+        });
+        const calcId = await addViaDialog(api, 'a', '[A] * 2');
+        const savedState = api.getState();
+        expect(savedState.userColumns).toMatchObject([{ colId: calcId, calculatedExpression: '[a] * 2' }]);
+
+        // Edit the live column so its definition no longer matches the snapshot.
+        await editViaDialog(api, calcId, { expression: '[A] * 3', title: 'Triple A' });
+        expect(api.getColumn(calcId)!.getColDef().calculatedExpression).toBe('[a] * 3');
+        expect(api.getColumn(calcId)!.getColDef().headerName).toBe('Triple A');
+
+        // The incoming state is authoritative: the surviving column must be reverted to its persisted
+        // definition, not left on the edited one just because a col of that colId already exists.
+        api.setState(savedState);
+        await waitFor(() => expect(api.getColumn(calcId)!.getColDef().calculatedExpression).toBe('[a] * 2'));
+        expect(api.getColumn(calcId)!.getColDef().headerName).not.toBe('Triple A');
+        expect(api.getState().userColumns).toEqual(savedState.userColumns);
+        await new GridRows(api, 'calc col definition restored via setState - rows').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 a:5 ${calcId}:10 b:2
+        `);
+    });
+
+    test('api.setState drops a calc col parked by resetColumnState, so a later applyColumnState cannot resurrect it', async () => {
+        const api = createGrid('state-parked-removal', {
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+        });
+        const stateWithoutCalc = api.getState();
+        const calcId = await addViaDialog(api, 'a', '[A] * 2');
+        const columnStateWithCalc = api.getColumnState();
+
+        // resetColumnState parks the runtime-added col so a later applyColumnState can bring it back.
+        api.resetColumnState();
+        await waitFor(() => expect(order(api)).toEqual(['a', 'b']));
+
+        // Applying a state that does not list the calc col must also discard the parked copy.
+        api.setState(stateWithoutCalc);
+        await asyncSetTimeout(0);
+        expect(order(api)).toEqual(['a', 'b']);
+
+        // The parked copy is gone, so the old column state can no longer resurrect the removed column.
+        api.applyColumnState({ state: columnStateWithCalc, applyOrder: true });
+        await asyncSetTimeout(0);
+        expect(order(api)).toEqual(['a', 'b']);
+        expect(api.getColumn(calcId)).toBeNull();
+        expect(api.getState().userColumns).toBeUndefined();
     });
 
     // === save-side freshness: getState reflects the current expression, not a stale snapshot =====

--- a/testing/behavioural/src/formulas/calculated-columns-state.test.ts
+++ b/testing/behavioural/src/formulas/calculated-columns-state.test.ts
@@ -5,7 +5,9 @@ import {
     ClientSideRowModelModule,
     GridStateModule,
     NumberEditorModule,
+    NumberFilterModule,
     TextEditorModule,
+    TextFilterModule,
     ValidationModule,
 } from 'ag-grid-community';
 import {
@@ -37,11 +39,11 @@ describe('calculated columns - grid state persistence', () => {
             RowNumbersModule,
             TextEditorModule,
             NumberEditorModule,
+            TextFilterModule,
+            NumberFilterModule,
             ValidationModule,
         ] as Module[],
     });
-
-    let restoreOffsetParent: (() => void) | undefined;
 
     beforeEach(() => {
         gridsManager.reset();
@@ -49,8 +51,6 @@ describe('calculated columns - grid state persistence', () => {
 
     afterEach(() => {
         gridsManager.reset();
-        restoreOffsetParent?.();
-        restoreOffsetParent = undefined;
     });
 
     function createGrid(id: string, opts: Partial<GridOptions>): GridApi {
@@ -66,26 +66,6 @@ describe('calculated columns - grid state persistence', () => {
     }
 
     // --- dialog plumbing (the only public surface that sets an anchor) ---------------------------
-
-    function enableOffsetParentPolyfill(): void {
-        if (restoreOffsetParent) {
-            return;
-        }
-        const original = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetParent');
-        Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
-            configurable: true,
-            get(this: HTMLElement) {
-                return this.parentElement;
-            },
-        });
-        restoreOffsetParent = () => {
-            if (original) {
-                Object.defineProperty(HTMLElement.prototype, 'offsetParent', original);
-            } else {
-                delete (HTMLElement.prototype as any).offsetParent;
-            }
-        };
-    }
 
     async function clickColumnMenuItem(name: string): Promise<void> {
         const menuItem = await waitFor(() => {
@@ -119,6 +99,18 @@ describe('calculated columns - grid state persistence', () => {
         input!.dispatchEvent(new Event('input', { bubbles: true }));
     }
 
+    async function selectDataType(label: string): Promise<void> {
+        getDialog()
+            .querySelector<HTMLElement>('.ag-select .ag-picker-field-wrapper')!
+            .dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+        await asyncSetTimeout(1);
+        const option = Array.from(document.querySelectorAll<HTMLElement>('.ag-list-item')).find(
+            (element) => element.textContent?.trim() === label
+        );
+        expect(option).toBeTruthy();
+        option!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    }
+
     function clickDialogButton(label: string): void {
         const button = Array.from(getDialog().querySelectorAll<HTMLButtonElement>('button')).find(
             (element) => element.textContent?.trim() === label
@@ -131,7 +123,6 @@ describe('calculated columns - grid state persistence', () => {
      *  Returns the auto-generated colId of the new column, discovered by diffing the column set. */
     async function addViaDialog(api: GridApi, anchorColId: string, expression: string): Promise<string> {
         const before = new Set(order(api));
-        enableOffsetParentPolyfill();
         api.showColumnMenu(anchorColId);
         await asyncSetTimeout(10);
         await clickColumnMenuItem('Add Calculated Column');
@@ -152,7 +143,6 @@ describe('calculated columns - grid state persistence', () => {
         colId: string,
         edits: { expression?: string; title?: string }
     ): Promise<void> {
-        enableOffsetParentPolyfill();
         api.showColumnMenu(colId);
         await asyncSetTimeout(10);
         await clickColumnMenuItem('Edit Calculated Column');
@@ -165,6 +155,15 @@ describe('calculated columns - grid state persistence', () => {
         }
         clickDialogButton('Apply');
         await asyncSetTimeout(40);
+    }
+
+    /** Removes a dynamic calc col through its header menu — dynamic calc cols are not in `columnDefs`,
+     *  so the menu's "Remove Calculated Column" action is the only way a user can drop one. */
+    async function removeViaMenu(api: GridApi, colId: string): Promise<void> {
+        api.showColumnMenu(colId);
+        await asyncSetTimeout(10);
+        await clickColumnMenuItem('Remove Calculated Column');
+        await asyncSetTimeout(1);
     }
 
     // === core repro: initialState round-trip =====================================================
@@ -356,7 +355,6 @@ describe('calculated columns - grid state persistence', () => {
         });
 
         // Reopen the column menu and edit the expression live (default apply mode).
-        enableOffsetParentPolyfill();
         api.showColumnMenu(calcId);
         await asyncSetTimeout(10);
         await clickColumnMenuItem('Edit Calculated Column');
@@ -574,5 +572,552 @@ describe('calculated columns - grid state persistence', () => {
             ROOT id:ROOT_NODE_ID
             └── LEAF id:r1 revenue:10 ${calcId}:7 cost:3
         `);
+    });
+
+    // === layout sections apply to the recreated col ==============================================
+    // Recreation runs BEFORE the column-state sections precisely so their colIds exist by then. These
+    // tests pin that contract: everything a user can configure on a calc col must come back with it.
+
+    test('width, sort, pinning and filter configured on a dynamic calc col are all restored alongside it', async () => {
+        const rowData = [
+            { id: 'r1', a: 5, b: 2 },
+            { id: 'r2', a: 3, b: 7 },
+        ];
+        const columnDefs = [{ field: 'a' }, { field: 'b' }];
+        const defaultColDef = { filter: true };
+        const api = createGrid('state-layout-source', { rowData, columnDefs, defaultColDef });
+        const calcId = await addViaDialog(api, 'a', '[A] + [B]');
+
+        const filterModel = { filterType: 'text', type: 'notEqual', filter: '99' };
+        api.setColumnWidths([{ key: calcId, newWidth: 320 }]);
+        api.setColumnsPinned([calcId], 'left');
+        api.applyColumnState({ state: [{ colId: calcId, sort: 'desc' }] });
+        await api.setColumnFilterModel(calcId, filterModel);
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+        expect(api.getColumnFilterModel(calcId)).toEqual(filterModel);
+
+        const savedState = api.getState();
+        expect(savedState.sort).toMatchObject({ sortModel: [{ colId: calcId, sort: 'desc' }] });
+        expect(savedState.filter).toMatchObject({ filterModel: { [calcId]: filterModel } });
+
+        const api2 = createGrid('state-layout-target', {
+            rowData,
+            columnDefs,
+            defaultColDef,
+            initialState: savedState,
+        });
+        await waitFor(() => expect(order(api2)).toContain(calcId));
+        const restored = api2.getColumn(calcId)!;
+        expect(restored.getActualWidth()).toBe(320);
+        expect(restored.getPinned()).toBe('left');
+        expect(restored.getSort()).toBe('desc');
+        expect(api2.getColumnFilterModel(calcId)).toEqual(filterModel);
+        await new GridColumns(api2, 'calc col restored with its layout state').checkColumns(`
+            LEFT
+            └── ${calcId} "Untitled" width:320 sort:desc sortIndex:0 ƒ filter
+            CENTER
+            ├── a "A" width:200
+            └── b "B" width:200
+        `);
+        // Sort applies to the restored col, so the higher total (a+b) leads.
+        await new GridRows(api2, 'calc col restored with its layout state - rows').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:r2 a:3 ${calcId}:10 b:7
+            └── LEAF id:r1 a:5 ${calcId}:7 b:2
+        `);
+    });
+
+    test('a hidden dynamic calc col is restored still hidden', async () => {
+        const rowData = [{ id: 'r1', a: 5, b: 2 }];
+        const columnDefs = [{ field: 'a' }, { field: 'b' }];
+        const api = createGrid('state-hidden-source', { rowData, columnDefs });
+        const calcId = await addViaDialog(api, 'a', '[A] * 2');
+        api.setColumnsVisible([calcId], false);
+        await asyncSetTimeout(0);
+
+        const savedState = api.getState();
+        expect(savedState.columnVisibility).toEqual({ hiddenColIds: [calcId] });
+
+        const api2 = createGrid('state-hidden-target', { rowData, columnDefs, initialState: savedState });
+        await waitFor(() => expect(api2.getColumn(calcId)).not.toBeNull());
+        // The column exists (so unhiding it in the tool panel brings back a working calc col) but is
+        // not displayed.
+        expect(api2.getColumn(calcId)!.isVisible()).toBe(false);
+        expect(api2.getAllDisplayedColumns().map((col) => col.getColId())).toEqual(['a', 'b']);
+    });
+
+    test('a header name override on a dynamic calc col is restored, and layered over the persisted colDef title', async () => {
+        const rowData = [{ id: 'r1', a: 5, b: 2 }];
+        const columnDefs = [{ field: 'a' }, { field: 'b' }];
+        const api = createGrid('state-headername-source', { rowData, columnDefs });
+        const calcId = await addViaDialog(api, 'a', '[A] * 2');
+        setTitle('Double A');
+        await waitFor(() => expect(api.getColumn(calcId)!.getColDef().headerName).toBe('Double A'));
+        api.applyColumnState({ state: [{ colId: calcId, headerName: 'Renamed' }] });
+        await asyncSetTimeout(0);
+
+        const savedState = api.getState();
+        // The dialog title lives in `userColumns` (it is part of the column's definition); the override
+        // lives in `columnHeaderName`. Both must survive, since either can be reverted independently.
+        expect(savedState.userColumns).toMatchObject([{ colId: calcId, headerName: 'Double A' }]);
+        expect(savedState.columnHeaderName).toEqual({ columnHeaderNames: [{ colId: calcId, headerName: 'Renamed' }] });
+
+        const api2 = createGrid('state-headername-target', { rowData, columnDefs, initialState: savedState });
+        await waitFor(() => expect(api2.getColumn(calcId)).not.toBeNull());
+        const restored = api2.getColumn(calcId)!;
+        expect(restored.getColDef().headerName).toBe('Double A');
+        expect(api2.getDisplayNameForColumn(restored, 'header')).toBe('Renamed');
+        // Clearing the override falls back to the persisted dialog title, not to 'Untitled'.
+        api2.applyColumnState({ state: [{ colId: calcId, headerName: null }] });
+        await asyncSetTimeout(0);
+        expect(api2.getDisplayNameForColumn(restored, 'header')).toBe('Double A');
+    });
+
+    // === display order is owned by columnOrder, not by the anchor ================================
+
+    test('a dynamic calc col moved away from its anchor is restored at the moved position, not next to the anchor', async () => {
+        const rowData = [{ id: 'r1', a: 5, b: 2, c: 1 }];
+        const columnDefs = [{ field: 'a' }, { field: 'b' }, { field: 'c' }];
+        const api = createGrid('state-order-moved-source', { rowData, columnDefs });
+        const calcId = await addViaDialog(api, 'a', '[A] * 2');
+        expect(order(api)).toEqual(['a', calcId, 'b', 'c']);
+
+        // Drag the calc col to the front, away from its anchor `a`.
+        api.moveColumns([calcId], 0);
+        await asyncSetTimeout(0);
+        expect(order(api)).toEqual([calcId, 'a', 'b', 'c']);
+
+        const savedState = api.getState();
+        expect(savedState.columnOrder).toEqual({ orderedColIds: [calcId, 'a', 'b', 'c'] });
+
+        const api2 = createGrid('state-order-moved-target', { rowData, columnDefs, initialState: savedState });
+        await waitFor(() => expect(order(api2)).toContain(calcId));
+        // The anchor only decides group membership; `columnOrder` decides the position, so the col must
+        // come back at the front rather than back beside `a`.
+        expect(order(api2)).toEqual([calcId, 'a', 'b', 'c']);
+        await new GridRows(api2, 'moved calc col restored at its moved position - rows').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 ${calcId}:10 a:5 b:2 c:1
+        `);
+    });
+
+    test('a dynamic calc col dragged out of its anchor group round-trips to the same layout it had before the save', async () => {
+        const rowData = [{ id: 'r1', athlete: 'A', gold: 3, silver: 1 }];
+        const columnDefs: GridOptions['columnDefs'] = [
+            { field: 'athlete' },
+            { headerName: 'Medals', groupId: 'medals', children: [{ field: 'gold' }, { field: 'silver' }] },
+        ];
+        const api = createGrid('state-order-outofgroup-source', { rowData, columnDefs });
+        const calcId = await addViaDialog(api, 'gold', '[gold] * 2');
+        expect(api.getColumn(calcId)!.getParent()!.getGroupId()).toBe('medals');
+
+        // Dragging the col to the front keeps its Medals group membership, so the group renders split
+        // across two instances. Whatever that layout is, the round-trip must reproduce it exactly —
+        // the anchor carries group membership and `columnOrder` carries the position, independently.
+        api.moveColumns([calcId], 0);
+        await asyncSetTimeout(0);
+        expect(order(api)).toEqual([calcId, 'athlete', 'gold', 'silver']);
+        const splitGroupLayout = `
+            CENTER
+            ├─┬ "Medals" GROUP
+            │ └── ${calcId} "Untitled" width:200 ƒ
+            ├── athlete "Athlete" width:200
+            └─┬ "Medals" GROUP
+              ├── gold "Gold" width:200
+              └── silver "Silver" width:200
+        `;
+        await new GridColumns(api, 'calc col dragged out of its anchor group - before save').checkColumns(
+            splitGroupLayout
+        );
+
+        const savedState = api.getState();
+        const api2 = createGrid('state-order-outofgroup-target', { rowData, columnDefs, initialState: savedState });
+        await waitFor(() => expect(order(api2)).toContain(calcId));
+        expect(order(api2)).toEqual([calcId, 'athlete', 'gold', 'silver']);
+        await new GridColumns(api2, 'calc col dragged out of its anchor group - after restore').checkColumns(
+            splitGroupLayout
+        );
+    });
+
+    // === non-leaf anchors: generated columns can be anchors but are not columnDefs leaves ========
+
+    test('a calc col anchored on the auto-group column round-trips and comes back beside it', async () => {
+        const rowData = [
+            { id: 'r1', region: 'EMEA', revenue: 10, cost: 3 },
+            { id: 'r2', region: 'APAC', revenue: 20, cost: 8 },
+        ];
+        const columnDefs: GridOptions['columnDefs'] = [
+            { field: 'region', rowGroup: true, hide: true },
+            { field: 'revenue', headerName: 'Revenue', aggFunc: 'sum' },
+            { field: 'cost', headerName: 'Cost', aggFunc: 'sum' },
+        ];
+        const api = createGrid('state-autogroup-source', { rowData, columnDefs });
+        await waitFor(() => expect(order(api)).toContain('ag-Grid-AutoColumn'));
+        const calcId = await addViaDialog(api, 'ag-Grid-AutoColumn', '[Revenue] - [Cost]');
+        expect(order(api)).toEqual(['ag-Grid-AutoColumn', calcId, 'region', 'revenue', 'cost']);
+
+        // The auto-group col is generated, not a columnDefs leaf, but it is still the serialised anchor:
+        // it exists again in the target grid because `region` carries `rowGroup: true` in columnDefs.
+        const savedState = api.getState();
+        expect(savedState.userColumns).toMatchObject([{ colId: calcId, groupAnchorColId: 'ag-Grid-AutoColumn' }]);
+
+        const api2 = createGrid('state-autogroup-target', { rowData, columnDefs, initialState: savedState });
+        await waitFor(() => expect(order(api2)).toContain(calcId));
+        expect(order(api2)).toEqual(['ag-Grid-AutoColumn', calcId, 'region', 'revenue', 'cost']);
+        await new GridColumns(api2, 'calc col anchored on the auto-group column restored').checkColumns(`
+            CENTER
+            ├── ag-Grid-AutoColumn "Group" width:200
+            ├── ${calcId} "Untitled" width:200 ƒ
+            ├── revenue "Revenue" width:200 aggFunc:sum
+            └── cost "Cost" width:200 aggFunc:sum
+        `);
+    });
+
+    test('a calc col anchored on the auto-group column is restored top-level when the target grid is not grouped', async () => {
+        const rowData = [{ id: 'r1', region: 'EMEA', revenue: 10, cost: 3 }];
+        const groupedColumnDefs: GridOptions['columnDefs'] = [
+            { field: 'region', rowGroup: true, hide: true },
+            { field: 'revenue', headerName: 'Revenue', aggFunc: 'sum' },
+            { field: 'cost', headerName: 'Cost', aggFunc: 'sum' },
+        ];
+        const api = createGrid('state-autogroup-missing-source', { rowData, columnDefs: groupedColumnDefs });
+        await waitFor(() => expect(order(api)).toContain('ag-Grid-AutoColumn'));
+        const calcId = await addViaDialog(api, 'ag-Grid-AutoColumn', '[Revenue] - [Cost]');
+        const savedState = api.getState();
+
+        // Restoring into a grid whose columnDefs do not group means the anchor never exists. The calc
+        // col must still be recreated (with its expression working) rather than dropped.
+        const api2 = createGrid('state-autogroup-missing-target', {
+            rowData,
+            columnDefs: [
+                { field: 'region' },
+                { field: 'revenue', headerName: 'Revenue' },
+                { field: 'cost', headerName: 'Cost' },
+            ],
+            initialState: { ...savedState, rowGroup: undefined },
+        });
+        await waitFor(() => expect(order(api2)).toContain(calcId));
+        expect(api2.getColumn(calcId)!.getParent()).toBeNull();
+        // `columnOrder` still seats it where it was saved, ahead of the columns that followed the
+        // now-absent auto-group anchor.
+        expect(order(api2)).toEqual([calcId, 'region', 'revenue', 'cost']);
+        await new GridRows(api2, 'calc col with a missing anchor restored top-level - rows').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 ${calcId}:7 region:"EMEA" revenue:10 cost:3
+        `);
+    });
+
+    // === restoring into a grid whose columnDefs have since changed ================================
+    // A saved state outlives the app's columnDefs, so restore must degrade predictably rather than
+    // throw or silently drop the user's column.
+
+    test('a calc col whose anchor leaf no longer exists is still recreated, at the top level', async () => {
+        const rowData = [{ id: 'r1', athlete: 'A', gold: 3, silver: 1 }];
+        const api = createGrid('state-anchor-gone-source', {
+            rowData,
+            columnDefs: [
+                { field: 'athlete' },
+                { headerName: 'Medals', groupId: 'medals', children: [{ field: 'gold' }, { field: 'silver' }] },
+            ],
+        });
+        const calcId = await addViaDialog(api, 'gold', '34');
+        const savedState = api.getState();
+        expect(savedState.userColumns).toMatchObject([{ colId: calcId, groupAnchorColId: 'gold' }]);
+
+        // The target grid has dropped the `gold` column (and with it the Medals group's first child).
+        const api2 = createGrid('state-anchor-gone-target', {
+            rowData,
+            columnDefs: [
+                { field: 'athlete' },
+                { headerName: 'Medals', groupId: 'medals', children: [{ field: 'silver' }] },
+            ],
+            initialState: savedState,
+        });
+        await waitFor(() => expect(order(api2)).toContain(calcId));
+        // No anchor to inherit from, so it lands at the top level. Its saved neighbour is gone too, so
+        // the order restoration cannot seat it after `athlete` and it falls to the front.
+        expect(api2.getColumn(calcId)!.getParent()).toBeNull();
+        await new GridColumns(api2, 'calc col with a removed anchor leaf restored top-level').checkColumns(`
+            CENTER
+            ├── ${calcId} "Untitled" width:200 ƒ
+            ├── athlete "Athlete" width:200
+            └─┬ "Medals" GROUP
+              └── silver "Silver" width:200
+        `);
+    });
+
+    test('a calc col whose expression references a column missing from the target grid is restored showing an error value', async () => {
+        const api = createGrid('state-missing-ref-source', {
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+        });
+        const calcId = await addViaDialog(api, 'a', '[A] + [B]');
+        const savedState = api.getState();
+        expect(savedState.userColumns).toMatchObject([{ calculatedExpression: '[a] + [b]' }]);
+
+        // `b` is gone in the target grid, so the persisted expression cannot resolve. The column must
+        // still come back — the user can then edit the expression to fix it.
+        const api2 = createGrid('state-missing-ref-target', {
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }],
+            initialState: savedState,
+        });
+        await waitFor(() => expect(order(api2)).toContain(calcId));
+        expect(api2.getColumn(calcId)!.getColDef().calculatedExpression).toBe('[a] + [b]');
+        expect(api2.getCellValue({ rowNode: api2.getDisplayedRowAtIndex(0)!, colKey: calcId })).toBe('#PARSE!');
+    });
+
+    test('a calc col whose colId is now taken by a columnDefs column is skipped with a warning', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const rowData = [{ id: 'r1', a: 5, b: 2, calculated_1: 'taken' }];
+        const api = createGrid('state-collision-source', {
+            rowData,
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+        });
+        const calcId = await addViaDialog(api, 'a', '[A] * 2');
+        expect(calcId).toBe('calculated_1');
+        const savedState = api.getState();
+
+        // The target grid declares a real column on that colId, so recreating would clobber it.
+        const api2 = createGrid('state-collision-target', {
+            rowData,
+            columnDefs: [{ field: 'a' }, { field: 'b' }, { field: 'calculated_1' }],
+            initialState: savedState,
+        });
+        await asyncSetTimeout(0);
+        // `columnOrder` still seats the colId where the calc col used to be, but the column itself is
+        // the declared one, not a calculated column.
+        expect(order(api2)).toEqual(['a', 'calculated_1', 'b']);
+        expect(api2.getColumn('calculated_1')!.getColDef().calculatedExpression).toBeUndefined();
+        expect(warn).toHaveBeenCalledWith(
+            expect.stringContaining(`reconcileUserColumns: colId 'calculated_1' already exists; skipping.`)
+        );
+        await new GridRows(api2, 'calc col colId collision skipped - rows').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 a:5 calculated_1:"taken" b:2
+        `);
+        warn.mockRestore();
+    });
+
+    // === deferred apply mode: only committed columns reach the state ==============================
+
+    test('under deferred apply mode a calc col reaches getState only once Apply is clicked', async () => {
+        const api = createGrid('state-deferred-apply', {
+            calculatedColumns: { applyMode: 'deferred' },
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+        });
+
+        api.showColumnMenu('a');
+        await asyncSetTimeout(10);
+        await clickColumnMenuItem('Add Calculated Column');
+        await asyncSetTimeout(1);
+        setExpression('[A] * 2');
+        // Typing does not commit under deferred mode, so nothing is persisted yet.
+        expect(order(api)).toEqual(['a', 'b']);
+        expect(api.getState().userColumns).toBeUndefined();
+
+        clickDialogButton('Apply');
+        await asyncSetTimeout(1);
+        expect(api.getState().userColumns).toMatchObject([{ colId: 'calculated_1', calculatedExpression: '[a] * 2' }]);
+    });
+
+    test('under deferred apply mode a cancelled dialog leaves the state untouched', async () => {
+        const api = createGrid('state-deferred-cancel', {
+            calculatedColumns: { applyMode: 'deferred' },
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+        });
+
+        api.showColumnMenu('a');
+        await asyncSetTimeout(10);
+        await clickColumnMenuItem('Add Calculated Column');
+        await asyncSetTimeout(1);
+        setExpression('[A] * 2');
+        clickDialogButton('Cancel');
+        await asyncSetTimeout(1);
+
+        expect(order(api)).toEqual(['a', 'b']);
+        expect(api.getState().userColumns).toBeUndefined();
+    });
+
+    test('under deferred apply mode a cancelled edit keeps the previously applied definition in the state', async () => {
+        const api = createGrid('state-deferred-cancel-edit', {
+            calculatedColumns: { applyMode: 'deferred' },
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+        });
+
+        api.showColumnMenu('a');
+        await asyncSetTimeout(10);
+        await clickColumnMenuItem('Add Calculated Column');
+        await asyncSetTimeout(1);
+        setExpression('[A] * 2');
+        clickDialogButton('Apply');
+        await asyncSetTimeout(1);
+
+        api.showColumnMenu('calculated_1');
+        await asyncSetTimeout(10);
+        await clickColumnMenuItem('Edit Calculated Column');
+        await asyncSetTimeout(1);
+        setExpression('[A] * 3');
+        clickDialogButton('Cancel');
+        await asyncSetTimeout(1);
+
+        expect(api.getState().userColumns).toMatchObject([{ colId: 'calculated_1', calculatedExpression: '[a] * 2' }]);
+    });
+
+    // === removal through the dialog: the user's own way of dropping a calc col ====================
+
+    test('removing a dynamic calc col through its header menu drops it from getState', async () => {
+        const api = createGrid('state-remove-via-menu', {
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+        });
+        const calcId = await addViaDialog(api, 'a', '[A] * 2');
+        const calcId2 = await addViaDialog(api, 'b', '[B] * 3');
+        expect(api.getState().userColumns).toHaveLength(2);
+
+        await removeViaMenu(api, calcId);
+        expect(api.getColumn(calcId)).toBeNull();
+        // Only the removed descriptor goes; the other calc col is untouched.
+        expect(api.getState().userColumns).toMatchObject([{ colId: calcId2 }]);
+
+        await removeViaMenu(api, calcId2);
+        expect(api.getState().userColumns).toBeUndefined();
+        await new GridRows(api, 'calc cols removed via header menu - rows').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 a:5 b:2
+        `);
+    });
+
+    // === cellDataType chosen in the dialog survives the round-trip ================================
+
+    test('a calc col typed as Number in the dialog is restored as a number column, not as text', async () => {
+        const rowData = [{ id: 'r1', a: 5, b: 2 }];
+        const columnDefs = [{ field: 'a' }, { field: 'b' }];
+        const api = createGrid('state-datatype-source', { rowData, columnDefs });
+        const calcId = await addViaDialog(api, 'a', '[A] + [B]');
+        await editViaDialog(api, calcId, {});
+        await selectDataType('Number');
+        clickDialogButton('Apply');
+        await waitFor(() => expect(api.getColumn(calcId)!.getColDef().cellDataType).toBe('number'));
+
+        const savedState = api.getState();
+        expect(savedState.userColumns).toMatchObject([{ colId: calcId, cellDataType: 'number' }]);
+
+        const api2 = createGrid('state-datatype-target', { rowData, columnDefs, initialState: savedState });
+        await waitFor(() => expect(order(api2)).toContain(calcId));
+        expect(api2.getColumn(calcId)!.getColDef().cellDataType).toBe('number');
+        // A number-typed column produces a numeric value, so the restored type is not merely cosmetic.
+        expect(api2.getCellValue({ rowNode: api2.getDisplayedRowAtIndex(0)!, colKey: calcId })).toBe(7);
+    });
+
+    // === empty and no-op state applications =======================================================
+
+    test('an empty userColumns array removes existing calc cols, exactly as an absent section does', async () => {
+        const api = createGrid('state-empty-array', {
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+        });
+        const calcId = await addViaDialog(api, 'a', '[A] * 2');
+        const savedState = api.getState();
+
+        api.setState({ ...savedState, userColumns: [] });
+        await waitFor(() => expect(api.getColumn(calcId)).toBeNull());
+        expect(order(api)).toEqual(['a', 'b']);
+        expect(api.getState().userColumns).toBeUndefined();
+    });
+
+    test('re-applying an unchanged state leaves the calc col colDef untouched, but a changed definition re-applies it', async () => {
+        const api = createGrid('state-idempotent', {
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+        });
+        const calcId = await addViaDialog(api, 'a', '[A] * 2');
+        const savedState = api.getState();
+        const colDefBefore = api.getColumn(calcId)!.getColDef();
+
+        api.setState(savedState);
+        await asyncSetTimeout(0);
+        api.setState(savedState);
+        await asyncSetTimeout(0);
+        // The persisted definition matched what is already there, so the colDef was never re-applied.
+        expect(api.getColumn(calcId)!.getColDef()).toBe(colDefBefore);
+        expect(order(api)).toEqual(['a', calcId, 'b']);
+        expect(api.getState().userColumns).toEqual(savedState.userColumns);
+
+        // A changed expression must re-apply, otherwise the guard would be swallowing real updates.
+        api.setState({
+            ...savedState,
+            userColumns: [{ ...savedState.userColumns![0], calculatedExpression: '[a] * 3' }],
+        });
+        await waitFor(() => expect(api.getColumn(calcId)!.getColDef().calculatedExpression).toBe('[a] * 3'));
+        expect(api.getColumn(calcId)!.getColDef()).not.toBe(colDefBefore);
+    });
+
+    // === parked columns: resetColumnState / applyColumnState ======================================
+
+    test('resetColumnState drops the calc col from getState, and applyColumnState brings it back', async () => {
+        const api = createGrid('state-parked-roundtrip', {
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+        });
+        const calcId = await addViaDialog(api, 'a', '[A] * 2');
+        const savedState = api.getState();
+        const columnStateWithCalc = api.getColumnState();
+
+        // Parked columns are not part of the grid, so they must not be reported as user columns.
+        api.resetColumnState();
+        await waitFor(() => expect(order(api)).toEqual(['a', 'b']));
+        expect(api.getState().userColumns).toBeUndefined();
+
+        // Restoring the column state resurrects the parked col, and the state reports it again.
+        api.applyColumnState({ state: columnStateWithCalc, applyOrder: true });
+        await waitFor(() => expect(order(api)).toEqual(['a', calcId, 'b']));
+        expect(api.getState().userColumns).toEqual(savedState.userColumns);
+        await new GridRows(api, 'parked calc col resurrected by applyColumnState - rows').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 a:5 ${calcId}:10 b:2
+        `);
+    });
+});
+
+// The calculated-columns module being absent is a different grid setup, so it needs its own manager.
+describe('calculated columns - grid state persistence without the calculated columns module', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, GridStateModule, ValidationModule] as Module[],
+    });
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    test('userColumns in initialState are preserved by getState when the module is not registered', () => {
+        const userColumns: GridState['userColumns'] = [
+            {
+                kind: 'calculated',
+                colId: 'calc_1',
+                groupAnchorColId: 'a',
+                calculatedExpression: '[a] * 2',
+                cellDataType: 'text',
+                headerName: 'Double A',
+            },
+        ];
+        const api = gridsManager.createGrid('state-no-module', {
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+            initialState: { userColumns },
+        });
+
+        // No calc col is created, but the descriptors must survive a re-save untouched so the state can
+        // later be restored into a grid that does register the module.
+        expect(api.getAllGridColumns().map((col) => col.getColId())).toEqual(['a', 'b']);
+        expect(api.getState().userColumns).toEqual(userColumns);
     });
 });

--- a/testing/behavioural/src/formulas/calculated-columns-state.test.ts
+++ b/testing/behavioural/src/formulas/calculated-columns-state.test.ts
@@ -1,0 +1,505 @@
+import { waitFor } from '@testing-library/dom';
+
+import type { GridApi, GridOptions, GridState, Module } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    GridStateModule,
+    NumberEditorModule,
+    TextEditorModule,
+    ValidationModule,
+} from 'ag-grid-community';
+import {
+    CalculatedColumnsModule,
+    ColumnMenuModule,
+    ContextMenuModule,
+    FormulaModule,
+    RowGroupingModule,
+    RowNumbersModule,
+} from 'ag-grid-enterprise';
+
+import { GridColumns, GridRows, TestGridsManager, asyncSetTimeout } from '../test-utils';
+
+// Behavioural spec for PERSISTING runtime-added (dynamic) calculated columns in grid state.
+// A dynamic calc col is added via the header-menu dialog, so it is not present in `columnDefs`.
+// The `GridState.userColumns` section is responsible for recreating it when state is restored
+// (via `initialState` or `api.setState`) into a grid whose `columnDefs` do NOT declare the calc col.
+
+describe('calculated columns - grid state persistence', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [
+            ClientSideRowModelModule,
+            GridStateModule,
+            CalculatedColumnsModule,
+            FormulaModule,
+            ColumnMenuModule,
+            ContextMenuModule,
+            RowGroupingModule,
+            RowNumbersModule,
+            TextEditorModule,
+            NumberEditorModule,
+            ValidationModule,
+        ] as Module[],
+    });
+
+    let restoreOffsetParent: (() => void) | undefined;
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+        restoreOffsetParent?.();
+        restoreOffsetParent = undefined;
+    });
+
+    function createGrid(id: string, opts: Partial<GridOptions>): GridApi {
+        return gridsManager.createGrid(id, {
+            getRowId: (params) => params.data?.id,
+            calculatedColumns: true,
+            ...opts,
+        });
+    }
+
+    function order(api: GridApi): string[] {
+        return api.getAllGridColumns()!.map((col) => col.getColId());
+    }
+
+    // --- dialog plumbing (the only public surface that sets an anchor) ---------------------------
+
+    function enableOffsetParentPolyfill(): void {
+        if (restoreOffsetParent) {
+            return;
+        }
+        const original = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetParent');
+        Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+            configurable: true,
+            get(this: HTMLElement) {
+                return this.parentElement;
+            },
+        });
+        restoreOffsetParent = () => {
+            if (original) {
+                Object.defineProperty(HTMLElement.prototype, 'offsetParent', original);
+            } else {
+                delete (HTMLElement.prototype as any).offsetParent;
+            }
+        };
+    }
+
+    async function clickColumnMenuItem(name: string): Promise<void> {
+        const menuItem = await waitFor(() => {
+            const text = Array.from(document.querySelectorAll<HTMLElement>('.ag-menu-option-text')).find(
+                (element) => element.textContent?.trim() === name
+            );
+            const element = text?.closest<HTMLElement>('.ag-menu-option');
+            expect(element).toBeTruthy();
+            return element!;
+        });
+        menuItem.click();
+    }
+
+    function getDialog(): HTMLElement {
+        // Live-apply dialogs stay open after Apply, so target the most recently opened one.
+        const dialogs = document.querySelectorAll<HTMLElement>('.ag-calculated-column-form');
+        expect(dialogs.length).toBeGreaterThan(0);
+        return dialogs[dialogs.length - 1];
+    }
+
+    function setExpression(expression: string): void {
+        const input = getDialog().querySelector<HTMLTextAreaElement>('textarea')!;
+        input.value = expression;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+
+    function setTitle(title: string): void {
+        const input = getDialog().querySelector<HTMLInputElement>('input');
+        expect(input).toBeTruthy();
+        input!.value = title;
+        input!.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+
+    function clickDialogButton(label: string): void {
+        const button = Array.from(getDialog().querySelectorAll<HTMLButtonElement>('button')).find(
+            (element) => element.textContent?.trim() === label
+        );
+        expect(button).toBeTruthy();
+        button!.click();
+    }
+
+    /** Adds a calc col through the header menu of {@link anchorColId} (the documented "anchor").
+     *  Returns the auto-generated colId of the new column, discovered by diffing the column set. */
+    async function addViaDialog(api: GridApi, anchorColId: string, expression: string): Promise<string> {
+        const before = new Set(order(api));
+        enableOffsetParentPolyfill();
+        api.showColumnMenu(anchorColId);
+        await asyncSetTimeout(10);
+        await clickColumnMenuItem('Add Calculated Column');
+        await asyncSetTimeout(1);
+        setExpression(expression);
+        clickDialogButton('Apply');
+        // Wait past the live-apply animation frame so no expression flush is in flight when the
+        // caller starts toggling columns (under the default 'live' mode Apply is a no-op).
+        await asyncSetTimeout(40);
+        const added = order(api).filter((id) => !before.has(id));
+        expect(added).toHaveLength(1);
+        return added[0];
+    }
+
+    // === core repro: initialState round-trip =====================================================
+
+    test('a dynamic calc col added via the dialog is saved in getState().userColumns and recreated via initialState on a fresh grid', async () => {
+        const api = createGrid('state-initial-source', {
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+        });
+        const calcId = await addViaDialog(api, 'a', '[A] * 2');
+        setTitle('Double A');
+        await waitFor(() => expect(api.getColumn(calcId)!.getColDef().headerName).toBe('Double A'));
+
+        const savedState = api.getState();
+        expect(savedState.userColumns).toEqual([
+            {
+                kind: 'calculated',
+                colId: calcId,
+                groupAnchorColId: 'a',
+                calculatedExpression: '[a] * 2',
+                cellDataType: 'text',
+                headerName: 'Double A',
+            },
+        ]);
+
+        // Restore into a brand new grid: same columnDefs, but WITHOUT the calc col declared anywhere.
+        const api2 = createGrid('state-initial-target', {
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+            initialState: savedState,
+        });
+        await waitFor(() => expect(order(api2)).toContain(calcId));
+        expect(order(api2)).toEqual(['a', calcId, 'b']);
+        await new GridColumns(api2, 'dynamic calc col recreated via initialState').checkColumns(`
+            CENTER
+            ├── a "A" width:200
+            ├── ${calcId} "Double A" width:200 ƒ
+            └── b "B" width:200
+        `);
+        await new GridRows(api2, 'dynamic calc col recreated via initialState - rows').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 a:5 ${calcId}:10 b:2
+        `);
+    });
+
+    // === api.setState round-trip: exercises the setState re-entrancy path ========================
+
+    test('a dynamic calc col is recreated via api.setState on a fresh grid, and cachedState round-trips afterwards', async () => {
+        const api = createGrid('state-setstate-source', {
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+        });
+        const calcId = await addViaDialog(api, 'a', '[A] * 2');
+        const savedState = api.getState();
+        expect(savedState.userColumns).toHaveLength(1);
+
+        const api2 = createGrid('state-setstate-target', {
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+        });
+        expect(order(api2)).toEqual(['a', 'b']);
+
+        api2.setState(savedState);
+        await waitFor(() => expect(order(api2)).toContain(calcId));
+        expect(order(api2)).toEqual(['a', calcId, 'b']);
+        await new GridRows(api2, 'dynamic calc col recreated via api.setState - rows').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 a:5 ${calcId}:10 b:2
+        `);
+
+        // cachedState must not be corrupted by the setState re-entrancy: a subsequent getState() still
+        // reports the recreated calc col's descriptor.
+        const roundTripped = api2.getState();
+        expect(roundTripped.userColumns).toEqual(savedState.userColumns);
+    });
+
+    // === removal: setState is authoritative — a calc col absent from the new state is removed ======
+
+    test('api.setState with a state that omits an existing calc col removes it from the grid', async () => {
+        const api = createGrid('state-remove', {
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+        });
+        // Snapshot the pre-calc state (no userColumns), then add a calc col on top of it.
+        const stateWithoutCalc = api.getState();
+        expect(stateWithoutCalc.userColumns).toBeUndefined();
+        const calcId = await addViaDialog(api, 'a', '[A] * 2');
+        expect(order(api)).toEqual(['a', calcId, 'b']);
+
+        // Re-applying the pre-calc state must drop the runtime-added calc col — the state does not list it.
+        api.setState(stateWithoutCalc);
+        await waitFor(() => expect(order(api)).toEqual(['a', 'b']));
+        expect(api.getColumn(calcId)).toBeNull();
+        expect(api.getState().userColumns).toBeUndefined();
+        await new GridRows(api, 'calc col removed via setState - rows').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 a:5 b:2
+        `);
+    });
+
+    test('api.setState reconciles the calc-col set — cols not in the new state are removed, listed ones kept', async () => {
+        const api = createGrid('state-reconcile', {
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+        });
+        const calcId1 = await addViaDialog(api, 'a', '[A] * 2');
+        // Snapshot with only the first calc col present, then add a second on top.
+        const stateWithOneCalc = api.getState();
+        expect(stateWithOneCalc.userColumns).toHaveLength(1);
+        const calcId2 = await addViaDialog(api, 'b', '[B] * 3');
+        expect(order(api)).toEqual(['a', calcId1, 'b', calcId2]);
+
+        // Applying the one-calc state must keep calcId1 and drop calcId2.
+        api.setState(stateWithOneCalc);
+        await waitFor(() => expect(api.getColumn(calcId2)).toBeNull());
+        expect(order(api)).toEqual(['a', calcId1, 'b']);
+        expect(api.getColumn(calcId1)).not.toBeNull();
+        expect(api.getState().userColumns).toEqual(stateWithOneCalc.userColumns);
+        await new GridRows(api, 'calc col reconciled via setState - rows').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 a:5 ${calcId1}:10 b:2
+        `);
+    });
+
+    // === save-side freshness: getState reflects the current expression, not a stale snapshot =====
+
+    test('getState reflects the current expression and cellDataType after a live edit through the dialog', async () => {
+        const api = createGrid('state-freshness', {
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+        });
+        const calcId = await addViaDialog(api, 'a', '[A] * 2');
+        expect((api.getState().userColumns as GridState['userColumns'])?.[0]).toMatchObject({
+            colId: calcId,
+            calculatedExpression: '[a] * 2',
+            cellDataType: 'text',
+        });
+
+        // Reopen the column menu and edit the expression live (default apply mode).
+        enableOffsetParentPolyfill();
+        api.showColumnMenu(calcId);
+        await asyncSetTimeout(10);
+        await clickColumnMenuItem('Edit Calculated Column');
+        await asyncSetTimeout(1);
+        setExpression('[A] * 3');
+        await waitFor(() => expect(api.getColumn(calcId)!.getColDef().calculatedExpression).toBe('[a] * 3'));
+        clickDialogButton('Apply');
+        await asyncSetTimeout(40);
+
+        expect((api.getState().userColumns as GridState['userColumns'])?.[0]).toMatchObject({
+            colId: calcId,
+            calculatedExpression: '[a] * 3',
+        });
+    });
+
+    // === non-lossy when the feature is disabled: provided userColumns survive a re-save ==========
+
+    test('userColumns in initialState are preserved by getState when calculated columns are disabled', async () => {
+        const userColumns: GridState['userColumns'] = [
+            {
+                kind: 'calculated',
+                colId: 'calc_1',
+                groupAnchorColId: 'a',
+                calculatedExpression: '[a] * 2',
+                cellDataType: 'text',
+                headerName: 'Double A',
+            },
+        ];
+        const api = createGrid('state-disabled-non-lossy', {
+            rowData: [{ id: 'r1', a: 5, b: 2 }],
+            columnDefs: [{ field: 'a' }, { field: 'b' }],
+            calculatedColumns: false,
+            initialState: { userColumns },
+        });
+        // The column is not recreated (feature disabled), but the descriptors must survive a re-save
+        // untouched so restoring the state later into a calc-enabled grid is not lossy.
+        await asyncSetTimeout(0);
+        expect(order(api)).toEqual(['a', 'b']);
+        expect(api.getState().userColumns).toEqual(userColumns);
+    });
+
+    // === plural case: two calc cols, one anchored to the other, round-trip in order ==============
+
+    test('two dynamic calc cols, one anchored to the other, round-trip in serialised order with group inheritance', async () => {
+        const columnDefs = [
+            {
+                groupId: 'money',
+                headerName: 'Money',
+                openByDefault: true,
+                children: [
+                    { field: 'revenue', headerName: 'Revenue', columnGroupShow: 'open' as const },
+                    { field: 'cost', headerName: 'Cost' },
+                ],
+            },
+        ];
+        const api = createGrid('state-plural-source', {
+            rowData: [{ id: 'r1', revenue: 10, cost: 3 }],
+            columnDefs,
+        });
+        const calcId1 = await addViaDialog(api, 'revenue', '[Revenue] - [Cost]');
+        // The second col is added against the first calc col, but the anchor is a group-membership
+        // pointer: it serialises the stable leaf (`revenue`), collapsing the runtime-added chain so
+        // restore never depends on another runtime-added col existing first.
+        const calcId2 = await addViaDialog(api, calcId1, '[Revenue] * 2');
+        expect(order(api)).toEqual(['revenue', calcId1, calcId2, 'cost']);
+
+        const savedState = api.getState();
+        expect(savedState.userColumns?.map(({ colId, groupAnchorColId }) => ({ colId, groupAnchorColId }))).toEqual([
+            { colId: calcId1, groupAnchorColId: 'revenue' },
+            { colId: calcId2, groupAnchorColId: 'revenue' },
+        ]);
+
+        const api2 = createGrid('state-plural-target', {
+            rowData: [{ id: 'r1', revenue: 10, cost: 3 }],
+            columnDefs,
+            initialState: savedState,
+        });
+        await waitFor(() => expect(order(api2)).toContain(calcId2));
+        expect(order(api2)).toEqual(['revenue', calcId1, calcId2, 'cost']);
+        // Both calc cols sit inside the group, inheriting columnGroupShow from the shared leaf anchor.
+        expect(api2.getColumn(calcId1)!.getColDef().columnGroupShow).toBe('open');
+        expect(api2.getColumn(calcId2)!.getColDef().columnGroupShow).toBe('open');
+        await new GridColumns(api2, 'two chained dynamic calc cols restored').checkColumns(`
+            CENTER
+            └─┬ "Money" GROUP open
+              ├── revenue "Revenue" width:200 columnGroupShow:open
+              ├── ${calcId1} "Untitled" width:200 ƒ columnGroupShow:open
+              ├── ${calcId2} "Untitled" width:200 ƒ columnGroupShow:open
+              └── cost "Cost" width:200
+        `);
+        await new GridRows(api2, 'two chained dynamic calc cols restored - rows').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 revenue:10 ${calcId1}:7 ${calcId2}:20 cost:3
+        `);
+    });
+
+    // === order-independence: a chained calc col anchors to a stable leaf, so userColumns order is free =
+
+    test('a calc col added against another calc col anchors to the shared leaf, so userColumns order does not affect restore', async () => {
+        // calculated_2 is added against calculated_1, which is itself anchored to the `gold` leaf. The
+        // anchor is a group-membership pointer (display order is owned by columnOrder), so it must
+        // serialise the stable leaf `gold` — never the runtime-added calculated_1, which may not exist
+        // yet on restore. That makes the userColumns order irrelevant: reversing it restores identically.
+        const columnDefs: GridOptions['columnDefs'] = [
+            { field: 'athlete' },
+            {
+                headerName: 'Medals',
+                groupId: 'medals',
+                children: [{ field: 'gold' }, { field: 'silver' }],
+            },
+        ];
+        const rowData = [{ id: 'r1', athlete: 'A', gold: 3, silver: 1 }];
+
+        const source = createGrid('state-order-source', { rowData, columnDefs });
+        const calcId1 = await addViaDialog(source, 'gold', '[gold]*2');
+        const calcId2 = await addViaDialog(source, calcId1, '34');
+        expect(order(source)).toEqual(['athlete', 'gold', calcId1, calcId2, 'silver']);
+
+        const savedState = source.getState();
+        // Both calc cols anchor to the leaf `gold` — the chain through calcId1 is collapsed on save.
+        expect(savedState.userColumns?.map(({ colId, groupAnchorColId }) => ({ colId, groupAnchorColId }))).toEqual([
+            { colId: calcId1, groupAnchorColId: 'gold' },
+            { colId: calcId2, groupAnchorColId: 'gold' },
+        ]);
+
+        // Restore the saved state and a variant with userColumns reversed: the two must be identical,
+        // including group membership (the part columnOrder does not carry).
+        const reversedState: GridState = {
+            ...savedState,
+            userColumns: [savedState.userColumns![1], savedState.userColumns![0]],
+        };
+        const apiNatural = createGrid('state-order-natural', { rowData, columnDefs, initialState: savedState });
+        const apiReversed = createGrid('state-order-reversed', { rowData, columnDefs, initialState: reversedState });
+
+        await waitFor(() => expect(order(apiReversed)).toContain(calcId2));
+        const expectedOrder = ['athlete', 'gold', calcId1, calcId2, 'silver'];
+        expect(order(apiNatural)).toEqual(expectedOrder);
+        expect(order(apiReversed)).toEqual(expectedOrder);
+
+        // Both calc cols land inside the Medals group regardless of userColumns order.
+        for (const api of [apiNatural, apiReversed]) {
+            expect(api.getColumn(calcId1)!.getParent()!.getGroupId()).toBe('medals');
+            expect(api.getColumn(calcId2)!.getParent()!.getGroupId()).toBe('medals');
+        }
+        await new GridColumns(apiReversed, 'chained calc cols restored from reversed userColumns').checkColumns(`
+            CENTER
+            ├── athlete "Athlete" width:200
+            └─┬ "Medals" GROUP
+              ├── gold "Gold" width:200
+              ├── ${calcId1} "Untitled" width:200 ƒ
+              ├── ${calcId2} "Untitled" width:200 ƒ
+              └── silver "Silver" width:200
+        `);
+        await new GridRows(apiReversed, 'chained calc cols restored from reversed userColumns - rows').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 athlete:"A" gold:3 ${calcId1}:6 ${calcId2}:34 silver:1
+        `);
+    });
+
+    // === grouped anchor: the calc col comes back inside the same column group ====================
+
+    test('a dynamic calc col anchored inside a column group is restored into that group after a state round-trip', async () => {
+        const api = createGrid('state-group-source', {
+            rowData: [{ id: 'r1', revenue: 10, cost: 3 }],
+            columnDefs: [
+                {
+                    groupId: 'money',
+                    headerName: 'Money',
+                    children: [
+                        { field: 'revenue', headerName: 'Revenue' },
+                        { field: 'cost', headerName: 'Cost' },
+                    ],
+                },
+            ],
+        });
+        const calcId = await addViaDialog(api, 'revenue', '[Revenue] - [Cost]');
+        expect(order(api)).toEqual(['revenue', calcId, 'cost']);
+
+        const savedState = api.getState();
+        expect(savedState.userColumns).toEqual([
+            {
+                kind: 'calculated',
+                colId: calcId,
+                groupAnchorColId: 'revenue',
+                calculatedExpression: '[revenue] - [cost]',
+                cellDataType: 'text',
+                headerName: 'Untitled',
+            },
+        ]);
+
+        const api2 = createGrid('state-group-target', {
+            rowData: [{ id: 'r1', revenue: 10, cost: 3 }],
+            columnDefs: [
+                {
+                    groupId: 'money',
+                    headerName: 'Money',
+                    children: [
+                        { field: 'revenue', headerName: 'Revenue' },
+                        { field: 'cost', headerName: 'Cost' },
+                    ],
+                },
+            ],
+            initialState: savedState,
+        });
+        await waitFor(() => expect(order(api2)).toContain(calcId));
+        expect(order(api2)).toEqual(['revenue', calcId, 'cost']);
+        await new GridColumns(api2, 'grouped dynamic calc col restored into its group').checkColumns(`
+            CENTER
+            └─┬ "Money" GROUP
+              ├── revenue "Revenue" width:200
+              ├── ${calcId} "Untitled" width:200 ƒ
+              └── cost "Cost" width:200
+        `);
+        await new GridRows(api2, 'grouped dynamic calc col restored into its group - rows').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 revenue:10 ${calcId}:7 cost:3
+        `);
+    });
+});

--- a/testing/behavioural/src/formulas/calculated-columns.test.ts
+++ b/testing/behavioural/src/formulas/calculated-columns.test.ts
@@ -3680,6 +3680,29 @@ describe('ag-grid calculated columns', () => {
         expect(document.querySelectorAll('.ag-calculated-column-form')).toHaveLength(0);
     });
 
+    test('dropping a calculated column from columnDefs closes its open dialog', async () => {
+        const api = createGrid('calculated-column-coldef-drop-open-dialog', {
+            rowData: [{ id: 'r1', revenue: 10, cost: 3 }],
+            columnDefs: [
+                { field: 'revenue' },
+                { field: 'cost' },
+                { colId: 'profit', headerName: 'Profit', calculatedExpression: '[revenue] - [cost]' },
+            ],
+        });
+        await asyncSetTimeout(1);
+
+        await openEditDialogViaMenu(api, 'profit');
+        expect(document.querySelectorAll('.ag-calculated-column-form')).toHaveLength(1);
+
+        // The developer removing the column destroys it, so the dialog editing it cannot stay open —
+        // same contract as removing it through the header menu.
+        removeColumnDef(api, 'profit');
+        await asyncSetTimeout(1);
+
+        expect(api.getColumn('profit')).toBeNull();
+        expect(document.querySelectorAll('.ag-calculated-column-form')).toHaveLength(0);
+    });
+
     test('unknown references, invalid syntax and cycles surface formula errors', async () => {
         const api = createGrid('calculated-errors', {
             rowData: [{ id: 'r1', revenue: 10, cost: 3 }],


### PR DESCRIPTION
## Summary

Calculated columns created at runtime — through the header-menu dialog or the API — live only in `CalculatedColumnsService`'s `dynamicColumns` map and were never serialised. Saving a grid's state and restoring it into a fresh grid lost them, and because the column was gone, the other column sections had no `colId` to configure.

**The `userColumns` section**

`GridState` gains a `userColumns` section for columns that are *added* at runtime rather than declared in `columnDefs`. This widens grid state from "configure existing columns" to "configure + create", so it is applied **before** `applyColumnGridState` — from both `initialState` and `api.setState` — and the existing sections then apply on top.

Layout and config (width, hide, pinned, sort) are deliberately **absent** from the descriptor. Those stay owned by `columnSizing` / `columnVisibility` / `columnPinning` / `sort`, so there is exactly one section responsible for each.

**Why a discriminated union, not a `ColDef`**

The descriptor is keyed by `kind`, which routes it to the service owning that column type and constrains it to the fields that service can actually rebuild from. `CalculatedUserColumnState` is the first member; the union grows one member per column kind rather than becoming a dumping ground for arbitrary `ColDef` fields (which would not survive serialisation anyway — functions, renderers).

**Group membership**

Carried as `groupAnchorColId`: a leaf `colId` whose column group the calculated column joins (`null` for top level). Anchor chains through *other* runtime-added columns are collapsed down to the first `columnDefs`-declared leaf, since an intermediate dynamic column may not exist yet at the point the state is restored. Ordering is left entirely to `columnOrder`.

**Restore semantics**

The incoming state is authoritative: listed columns are recreated, unlisted dynamic columns are dropped, and the whole reconciliation triggers a single rebuild. Two guards worth calling out:

- A serialised `colId` that collides with a real `columnDefs` column is skipped with a warning rather than clobbering it.
- Recreated columns are cleared from `inactiveDynamicColumns` rather than parked there, so this path does not add to that map's growth.

When calculated columns are disabled or the module is absent, a provided `userColumns` section is left untouched in the cached state, so a later re-save into a calc-enabled grid is not lossy.

## Position in Stack

PR 3 of 3, and the last. PRs 1 (#14628) and 2 (#14629) have merged, so this is now rebased directly onto `latest` and stands alone.

## JIRA

Jira: [AG-17910](https://ag-grid.atlassian.net/browse/AG-17910)

## Test Plan

- [x] `./behave.sh` — full unit suite, 9803 passed / 25 skipped (re-run after the rebase onto `latest`)
- [x] `calculated-columns-state.test.ts` — 9 behavioural tests covering save/restore via `initialState` and `api.setState`, removal, group anchoring, colId collision, and the calc-module-absent case
- [x] `./docs-e2e.sh "grid-state/_examples"` — 48 passed across all 6 framework variants, including recreating a runtime-added calculated column and the whole-rendered-grid round trip
- [x] `yarn nx build:types ag-grid-enterprise`
- [x] `yarn nx lint` ag-grid-community, ag-grid-enterprise
- [x] `yarn nx format --sort-root-tsconfig-paths=false` clean
