### PR TITLE
fix(docs-e2e): skip PDF Export examples while the release is delayed

### DIFF
--- a/documentation/ag-grid-docs/playwright.config.ts
+++ b/documentation/ag-grid-docs/playwright.config.ts
@@ -20,6 +20,8 @@ if (process.env.FRAMEWORK) {
 export default defineConfig({
     snapshotPathTemplate: '{testDir}/{testFileDir}/{testFileName}-snapshots/{arg}{ext}',
     testDir: './src/content/docs/',
+    /* PDF Export is not part of the public API yet (release delayed), so its examples cannot load the module. */
+    testIgnore: '**/pdf-export*/**',
     /* Run tests in files in parallel */
     fullyParallel: true,
     timeout: process.env.CI ? 60_000 : 20_000,


### PR DESCRIPTION
Nightly [Documentation Tests run 30326526120](https://github.com/ag-grid/ag-grid/actions/runs/30326526120) failed on `latest` across every framework: all `pdf-export*` examples error with `TypeError: Cannot read properties of undefined (reading 'version')` in `runVersionChecks`.

Root cause: #14633 (PDF Export - Delay Release) removed `PdfExportModule` from the `ag-grid-enterprise` public exports and hid the docs pages from nav/sitemap, but the examples and their `example.spec.ts` files remain, so Playwright still runs them and `registerModules([undefined])` throws.

Adds `testIgnore: '**/pdf-export*/**'` to the docs Playwright config, mirroring the sitemap exclusion already added in that PR. Revert when PDF Export ships.
 