### PR TITLE
Fix(behavioural): stop UI group edits silently dropping when the editor is redrawn

### DIFF
--- a/testing/behavioural/src/cell-editing/group-edit/group-edit-test-utils.ts
+++ b/testing/behavioural/src/cell-editing/group-edit/group-edit-test-utils.ts
@@ -46,23 +46,51 @@ function locateCellElements(api: GridApi, rowNode: IRowNode, colId: string) {
     return { gridDiv: gridDiv!, cell: cell!, rowIndex: rowIndex! };
 }
 
-export async function editCell(api: GridApi, rowNode: IRowNode, colId: string, newValue: string) {
-    const { gridDiv, rowIndex } = locateCellElements(api, rowNode, colId);
+const TYPE_ATTEMPTS = 3;
 
+/**
+ * Types `newValue` into the open editor of a cell and returns the input it was typed into.
+ *
+ * A redraw landing part-way through typing replaces the editor input, discarding the keystrokes
+ * already dispatched into the now-detached element. Re-query the cell and retry on that, rather
+ * than committing a half-typed (or empty) editor and silently dropping the edit.
+ */
+async function typeIntoEditor(api: GridApi, rowNode: IRowNode, colId: string, newValue: string) {
+    for (let attempt = 0; attempt < TYPE_ATTEMPTS; ++attempt) {
+        // Re-query the cell each attempt — in jsdom, `ensureIndexVisible` and aggregation-driven
+        // redraws replace cell DOM elements, making an earlier reference stale. Scope the input
+        // lookup to this cell rather than the whole grid: when edits happen in sequence a previous
+        // editor's input can briefly linger in the DOM, and a grid-wide lookup would grab that
+        // stale input instead of the one just opened.
+        const { gridDiv, cell } = locateCellElements(api, rowNode, colId);
+        const input = await waitForInput(gridDiv, cell);
+        await userEvent.clear(input);
+        await userEvent.type(input, newValue);
+        if (input.isConnected && input.value === newValue) {
+            return input;
+        }
+        await asyncSetTimeout(0);
+    }
+    throw new Error(`Could not type "${newValue}" into the editor of "${colId}": the input kept being replaced`);
+}
+
+export async function editCell(api: GridApi, rowNode: IRowNode, colId: string, newValue: string) {
+    // Let a redraw still pending from a previous edit settle before opening this editor, so it
+    // cannot detach this editor's input part-way through typing.
+    await asyncSetTimeout(0);
+
+    const { rowIndex } = locateCellElements(api, rowNode, colId);
     api.setFocusedCell(rowIndex, colId, rowNode.rowPinned ?? undefined);
     api.startEditingCell({ rowIndex, rowPinned: rowNode.rowPinned, colKey: colId });
     await asyncSetTimeout(0);
 
-    // Re-query the cell after startEditingCell — in jsdom, `ensureIndexVisible` can
-    // trigger a row redraw that replaces cell DOM elements, making the original reference stale.
-    // Scope the input lookup to this cell rather than the whole grid: when edits happen in
-    // sequence a previous editor's input can briefly linger in the DOM, and a grid-wide lookup
-    // would grab that stale input instead of the one just opened, silently dropping the edit.
-    const { cell } = locateCellElements(api, rowNode, colId);
-    const input = await waitForInput(gridDiv, cell);
-    await userEvent.clear(input);
-    await userEvent.type(input, `${newValue}{Enter}`);
+    const input = await typeIntoEditor(api, rowNode, colId, newValue);
+    await userEvent.type(input, '{Enter}');
     await asyncSetTimeout(0);
+
+    // Enter dispatched into an input the grid has already discarded commits nothing. Fail here
+    // rather than leaving the test to report a confusing stale value several assertions later.
+    expect(api.getEditingCells(), `edit of "${colId}" was not committed`).toEqual([]);
 }
 
 /**

--- a/testing/behavioural/src/cell-editing/group-edit/group-edit-test-utils.ts
+++ b/testing/behavioural/src/cell-editing/group-edit/group-edit-test-utils.ts
@@ -90,7 +90,7 @@ export async function editCell(api: GridApi, rowNode: IRowNode, colId: string, n
 
     // Enter dispatched into an input the grid has already discarded commits nothing. Fail here
     // rather than leaving the test to report a confusing stale value several assertions later.
-    expect(api.getEditingCells(), `edit of "${colId}" was not committed`).toEqual([]);
+    expect(api.getEditingCells()).toEqual([]);
 }
 
 /**


### PR DESCRIPTION
Fixes the `latest` CI failure in [run 30348150585](https://github.com/ag-grid/ag-grid/actions/runs/30348150585).

Sequential `ui`-mode edits in the group-edit suite intermittently lost the typed value, so assertions saw pre-edit values — `distribute-default.test.ts > editing different groups in sequence (ui)` in that run, and `distribute-modes.test.ts > percentage mode (ui)` in run 30262022274. Only the `ui` variants fail; the `setDataValue` variants of the same scenarios pass, so the cause is the `editCell` helper, not the distribution logic: a redraw pending from the previous edit replaces the editor input part-way through typing, sending the remaining keystrokes and Enter to a detached element.

`editCell` now settles before opening the editor, re-queries and retypes if the input is replaced, and asserts the edit committed so a dropped edit fails at the helper.

Not run locally — relying on CI.