### PR TITLE
AG-16216-adv-filter-fix2

### DIFF
--- a/packages/ag-grid-enterprise/src/advancedFilter/autocomplete/agAutocomplete.ts
+++ b/packages/ag-grid-enterprise/src/advancedFilter/autocomplete/agAutocomplete.ts
@@ -1,5 +1,5 @@
 import type { AgComponentPopupPositionParams } from 'ag-stack';
-import { RefPlaceholder, _isNothingFocused, _makeNull } from 'ag-stack';
+import { RefPlaceholder, _makeNull } from 'ag-stack';
 
 import type {
     AgEvent,
@@ -225,8 +225,7 @@ export class AgAutocomplete extends Component<AgAutocompleteEvent> {
     }
 
     private setCaret(position: number, setFocus?: boolean): void {
-        if (setFocus || _isNothingFocused(this.beans)) {
-            // clicking on the list loses focus, so restore
+        if (setFocus) {
             this.eAutocompleteInput.getFocusableElement().focus();
         }
         const eInput = this.eAutocompleteInput.getInputElement();

--- a/testing/behavioural/src/filters/advanced-filter-header-dom.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-header-dom.test.ts
@@ -139,6 +139,11 @@ describe('Advanced Filter Header DOM', () => {
         { field: 'age', filter: true },
     ];
 
+    const athletes = [
+        { athlete: 'Michael Phelps', age: 23 },
+        { athlete: 'Usain Bolt', age: 25 },
+    ];
+
     test('input stays enabled while the grid is still waiting for row data', async () => {
         const api = gridsManager.createGrid('myGrid', {
             columnDefs: filterableColumnDefs,
@@ -252,5 +257,119 @@ describe('Advanced Filter Header DOM', () => {
             ROOT id:ROOT_NODE_ID
             └── LEAF id:0 athlete:"Michael Phelps" age:23
         `);
+    });
+
+    test('does not focus the input when the grid initialises without row data', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: filterableColumnDefs,
+            enableAdvancedFilter: true,
+        });
+        await asyncSetTimeout(0);
+
+        await new FilterDom(api, 'init without row data').checkFilterDom(`
+            ADVANCED FILTER
+            input: ""
+            valid: true
+            buttons: Apply ⊘ | Builder
+            model: null
+        `);
+        await new GridRows(api, 'init without row data').check(`
+            ROOT id:ROOT_NODE_ID
+        `);
+
+        expect(document.activeElement).toBe(document.body);
+    });
+
+    test('does not focus the input when the grid initialises with row data', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: filterableColumnDefs,
+            rowData: athletes,
+            enableAdvancedFilter: true,
+        });
+        await asyncSetTimeout(0);
+
+        await new FilterDom(api, 'init with row data').checkFilterDom(`
+            ADVANCED FILTER
+            input: ""
+            valid: true
+            buttons: Apply ⊘ | Builder
+            model: null
+        `);
+        await new GridRows(api, 'init with row data').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 athlete:"Michael Phelps" age:23
+            └── LEAF id:1 athlete:"Usain Bolt" age:25
+        `);
+
+        expect(document.activeElement).toBe(document.body);
+    });
+
+    test('does not focus the input when the model is set via the API', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: filterableColumnDefs,
+            rowData: athletes,
+            enableAdvancedFilter: true,
+        });
+        await asyncSetTimeout(0);
+
+        api.setAdvancedFilterModel({ filterType: 'text', colId: 'athlete', type: 'contains', filter: 'Bolt' });
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+
+        await new FilterDom(api, 'model set via API').checkFilterDom(`
+            ADVANCED FILTER
+            input: "[Athlete] contains "Bolt""
+            valid: true
+            buttons: Apply ⊘ | Builder
+            model:
+              filterType: "text"
+              colId: "athlete"
+              type: "contains"
+              filter: "Bolt"
+        `);
+        await new GridRows(api, 'model set via API').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:1 athlete:"Usain Bolt" age:25
+        `);
+
+        expect(document.activeElement).toBe(document.body);
+    });
+
+    test('restores focus to the input when cleared via the clear button', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: filterableColumnDefs,
+            rowData: athletes,
+            enableAdvancedFilter: true,
+            advancedFilterParams: { buttons: ['apply', 'clear'] },
+        });
+        await asyncSetTimeout(0);
+
+        const harness = AdvancedFilterHarness.get(api);
+        await harness.applyExpression('[Athlete] contains "Bolt"');
+        await asyncSetTimeout(0);
+
+        const eClear = document.querySelector<HTMLElement>('.ag-advanced-filter-buttons [data-ref=clearFilterButton]')!;
+        eClear.focus();
+        eClear.click();
+        await asyncSetTimeout(0);
+
+        // Clear only empties the editor - the applied model (and the filtered rows) stay until Apply.
+        await new FilterDom(api, 'cleared via clear button').checkFilterDom(`
+            ADVANCED FILTER
+            input: ""
+            valid: true
+            buttons: Apply | Clear | Builder
+            model:
+              filterType: "text"
+              colId: "athlete"
+              type: "contains"
+              filter: "Bolt"
+        `);
+        await new GridRows(api, 'cleared via clear button').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:1 athlete:"Usain Bolt" age:25
+        `);
+
+        expect(document.activeElement).toBe(harness.input);
     });
 });

--- a/testing/behavioural/src/filters/advanced-filter-regression/af-autocomplete.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-regression/af-autocomplete.test.ts
@@ -84,6 +84,33 @@ describe('Advanced Filter — autocomplete completion & editing', () => {
         expect(af.isAutocompleteOpen()).toBe(false);
     });
 
+    test('selecting an entry with the mouse completes it and leaves the caret in the input', async () => {
+        const api = await gridsManager.createGridAndWait('grid1', OPTS);
+        const af = AdvancedFilterHarness.get(api);
+
+        af.input.focus();
+        await af.type('[Ath');
+        expect(af.autocompleteEntries()).toEqual(['Athlete']);
+
+        const eRow = document.querySelector<HTMLElement>('.ag-autocomplete-list .ag-autocomplete-row')!;
+        const mousedown = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+        eRow.dispatchEvent(mousedown);
+        // The list must swallow the default action, otherwise the browser would blur the input and close the list.
+        expect(mousedown.defaultPrevented).toBe(true);
+        eRow.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await asyncSetTimeout(0);
+
+        expect(document.activeElement).toBe(af.input);
+        await new FilterDom(api, 'entry selected with the mouse').checkFilterDom(`
+            ADVANCED FILTER
+            input: "[Athlete] "
+            valid: false — Expression has an error. Option is missing at end of expression.
+            buttons: Apply ⊘ | Builder
+            model: null
+        `);
+        await new GridRows(api, 'entry selected with the mouse').check(UNFILTERED);
+    });
+
     test('an inherited property name in filterOptions is not offered as an operator', async () => {
         const api = await gridsManager.createGridAndWait('grid1', {
             columnDefs: [


### PR DESCRIPTION
# Advanced Filter: don't focus the input on a grid-driven refresh

FIX AG-16216

With `enableAdvancedFilter`, the filter input focused itself as soon as the grid initialised, so the page
loaded with a blinking caret in the Advanced Filter editor. Focus now stays where it was; only an explicit
user interaction moves it into the input.

## Cause

`AgAutocomplete.setCaret(position, setFocus)` focused the input when `setFocus` was requested **or** when
nothing on the page was focused:

```ts
if (setFocus || _isNothingFocused(this.beans)) { … focus() }
```

`AdvancedFilterComp.refresh()` runs `setCaret` without `setFocus` on every init and every `refreshComp()`, and
during init `document.activeElement` is `body` — so the passive refresh took focus.

`_isNothingFocused` was a _guard_ on an explicit restore request from the day it was added (AG-8951, v30):
"only restore if focus was actually lost". AG-10255 (#10769) flipped `&&` → `||` so the new Clear button could
restore focus — focus sits on the button there, not on `body`, so the guard blocked it — which turned the guard
into an independent trigger. The steal stayed invisible until #14555 stopped disabling the input while data
types were pending (`focus()` on a disabled input is a no-op).

## Fix

`setCaret` focuses only on explicit request.

## No risk to other usages

- Since `A || B` ignores `B` when `A` is true, the guard has been dead _as a guard_ since AG-10255. The only
  case it still affected is `setFocus` falsy — one call site, `AdvancedFilterComp.refresh()`, the bug itself.
- Every other path already passes `restoreFocus: true` and is untouched: option selected, self-correcting
  value while typing, Clear button, Escape closing the list.
- `AgAutocomplete` has a single consumer, `AdvancedFilterComp`, so nothing else in the grid can be reached.
- Selecting an entry with the mouse still leaves the caret in the editor: the list's `mousedown` calls
  `preventDefault()` (AG-8953), so the click never blurs the input, and `onOptionSelected` passes
  `restoreFocus: true` anyway. A new test covers it, and passes with the pre-fix condition restored.
- Reset / Cancel are unaffected on Chrome and Firefox (the clicked button keeps focus, so the guard was already
  false) and now match them on Safari, where a mouse click leaves `activeElement` on `body` and the caret used
  to jump into the editor. That matches the documented split: `clear` leaves the user mid-edit, while
  `apply` / `reset` / `cancel` are terminal — the column filters express the same rule by closing the popup for
  the terminal three and never for `clear`. Keyboard activation focuses the button in every browser, so there
  is no accessibility change.
- The remaining `focus()` calls can't close the autocomplete list: the popup is `anchorToElement`-anchored, so
  `popupSvc` repositions on scroll rather than hiding, and the Clear path focuses before the list reopens.

## Tests

`advanced-filter-header-dom.test.ts` — no focus taken on init without row data, on init with row data, or on
`setAdvancedFilterModel` (all three fail on the unfixed code), and the Clear button still restores it.

`af-autocomplete.test.ts` — selecting an entry with the mouse completes it and leaves the caret in the input.

FilterDom + GridRows snapshots throughout; FilterDom also covers the disabled state (`⊘`).
