### PR TITLE
AG-18000-grand-total-row-refresh-fix

### DIFF
--- a/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyCache.ts
+++ b/packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyCache.ts
@@ -903,7 +903,7 @@ export class LazyCache extends BeanStub {
                 grandTotalData = response.grandTotalData;
             }
             if (grandTotalData !== undefined) {
-                this.store.grandTotalData = grandTotalData;
+                this.setGrandTotalData(grandTotalData);
             }
         }
 
@@ -1074,6 +1074,21 @@ export class LazyCache extends BeanStub {
         });
     }
 
+    /**
+     * Caches the grand total data on the store and applies it to the rendered node straight away.
+     * Deferring to `setDisplayIndexes` only works for creation, so an existing node would go stale.
+     * Returns the updated node, if there is one.
+     */
+    private setGrandTotalData(data: any): RowNode | undefined {
+        const store = this.store;
+        store.grandTotalData = data;
+        // `null` clears the grand total — `setDisplayIndexes` destroys the node
+        if (data == null || !store.getGrandTotalNode()) {
+            return undefined;
+        }
+        return this.createOrUpdateGrandTotalNode(data);
+    }
+
     /** Creates the grand total row node, or applies new data to the existing one. */
     public createOrUpdateGrandTotalNode(data: any): RowNode {
         const existingNode = this.store.getGrandTotalNode();
@@ -1134,14 +1149,12 @@ export class LazyCache extends BeanStub {
      */
     public updateRowNodes(updates: any[]): RowNode[] {
         const updatedNodes: RowNode[] = [];
-        const { store, blockUtils, nodeMap } = this;
+        const { blockUtils, nodeMap } = this;
         for (const data of updates) {
             const id = this.getRowId(data);
             if (id === GRAND_TOTAL_ROW_ID) {
-                store.grandTotalData = data;
-                const grandTotalNode = store.getGrandTotalNode();
+                const grandTotalNode = this.setGrandTotalData(data);
                 if (grandTotalNode) {
-                    grandTotalNode._updateDataNoSibling(data);
                     updatedNodes.push(grandTotalNode);
                 }
                 continue;
@@ -1174,7 +1187,7 @@ export class LazyCache extends BeanStub {
             // Grand total is not a regular store row — store the data and let
             // setDisplayIndexes create the footer node on next render.
             if (dataId === GRAND_TOTAL_ROW_ID) {
-                this.store.grandTotalData = data;
+                this.setGrandTotalData(data);
                 return;
             }
             if (dataId && this.isNodeInCache(dataId)) {
@@ -1223,7 +1236,7 @@ export class LazyCache extends BeanStub {
         // grand total as part of an async refresh without triggering another request per block.
         const idsToRemoveSet = new Set(idsToRemove);
         if (idsToRemoveSet.delete(GRAND_TOTAL_ROW_ID)) {
-            this.store.grandTotalData = null;
+            this.setGrandTotalData(null);
         }
 
         // track how many nodes have been deleted, as when we pass other nodes we need to shift them up

--- a/testing/behavioural/src/cell-editing/group-edit/group-edit-test-utils.ts
+++ b/testing/behavioural/src/cell-editing/group-edit/group-edit-test-utils.ts
@@ -1,6 +1,6 @@
 import { userEvent } from '@testing-library/user-event';
 
-import type { ColDef, GridApi, IRowNode } from 'ag-grid-community';
+import type { CellEditingStoppedEvent, ColDef, GridApi, IRowNode } from 'ag-grid-community';
 import { AllCommunityModule, ClientSideRowModelModule, UndoRedoEditModule } from 'ag-grid-community';
 import { RowGroupingEditModule, RowGroupingModule, SetFilterModule, TreeDataModule } from 'ag-grid-enterprise';
 
@@ -26,24 +26,22 @@ export type GroupRowValueSetterCallback = Extract<NonNullable<ColDef['groupRowVa
 export type ValueSetterCallback = Extract<NonNullable<ColDef['valueSetter']>, (...args: any[]) => any>;
 export type ValueParserCallback = Extract<NonNullable<ColDef['valueParser']>, (...args: any[]) => any>;
 
-function locateCellElements(api: GridApi, rowNode: IRowNode, colId: string) {
+/**
+ * The cell element of `rowNode`/`colId`, or `null` while a redraw has it detached.
+ *
+ * Matched on `row-id` only: an `aria-rowindex` lookup is offset by the header rows and pinned lanes,
+ * so it silently resolves to a neighbouring row.
+ */
+function locateCell(api: GridApi, rowNode: IRowNode, colId: string) {
     const gridDiv = TestGridsManager.getHTMLElement(api);
     expect(gridDiv).not.toBeNull();
-
-    const rowId = rowNode.id;
-    expect(rowId).toBeDefined();
 
     const rowIndex = rowNode.rowIndex;
     expect(rowIndex).not.toBeNull();
 
-    let cell = gridDiv!.querySelector<HTMLElement>(`[row-id="${rowId}"] [col-id="${colId}"]`);
-    if (!cell && rowIndex != null) {
-        const rowElement = gridDiv!.querySelector<HTMLElement>(`.ag-row[aria-rowindex="${rowIndex + 1}"]`);
-        cell = rowElement?.querySelector<HTMLElement>(`[col-id="${colId}"]`) ?? null;
-    }
-    expect(cell).not.toBeNull();
+    const cell = gridDiv!.querySelector<HTMLElement>(`[row-id="${rowNode.id}"] [col-id="${colId}"]`);
 
-    return { gridDiv: gridDiv!, cell: cell!, rowIndex: rowIndex! };
+    return { gridDiv: gridDiv!, cell, rowIndex: rowIndex! };
 }
 
 /**
@@ -56,12 +54,14 @@ async function typeIntoEditor(api: GridApi, rowNode: IRowNode, colId: string, ne
     for (let attempt = 0; attempt < TYPE_ATTEMPTS; ++attempt) {
         // Re-queried per attempt and cell-scoped: a previous editor's input can linger in the DOM
         // long enough for a grid-wide lookup to find it instead of the one just opened.
-        const { gridDiv, cell } = locateCellElements(api, rowNode, colId);
-        const input = await waitForInput(gridDiv, cell);
-        await userEvent.clear(input);
-        await userEvent.type(input, newValue);
-        if (input.isConnected && input.value === newValue) {
-            return input;
+        const { gridDiv, cell } = locateCell(api, rowNode, colId);
+        if (cell) {
+            const input = await waitForInput(gridDiv, cell);
+            await userEvent.clear(input);
+            await userEvent.type(input, newValue);
+            if (input.isConnected && input.value === newValue) {
+                return input;
+            }
         }
         await asyncSetTimeout(0);
     }
@@ -74,19 +74,21 @@ export async function editCell(api: GridApi, rowNode: IRowNode, colId: string, n
     // A redraw still pending from a previous edit would detach this editor's input mid-typing.
     await asyncSetTimeout(0);
 
-    // Enter dispatched into a detached input commits nothing yet still leaves the grid not editing,
-    // so the stop event is the only proof the keystroke landed; without it, re-open and retype.
+    // A stop event is the only proof the Enter keystroke landed, but a redraw tearing the editor down
+    // also stops it — as a cancel that commits nothing — so require this cell and an editor value.
     for (let attempt = 0; attempt < TYPE_ATTEMPTS; ++attempt) {
-        const { rowIndex } = locateCellElements(api, rowNode, colId);
+        const { rowIndex } = locateCell(api, rowNode, colId);
         api.setFocusedCell(rowIndex, colId, rowNode.rowPinned ?? undefined);
         api.startEditingCell({ rowIndex, rowPinned: rowNode.rowPinned, colKey: colId });
         await asyncSetTimeout(0);
 
         const input = await typeIntoEditor(api, rowNode, colId, newValue);
 
-        let stopped = false;
-        const onStopped = () => {
-            stopped = true;
+        let committed = false;
+        const onStopped = ({ node, column, valueChanged, newValue: editorValue }: CellEditingStoppedEvent) => {
+            if (node === rowNode && column.getColId() === colId && (valueChanged || editorValue !== undefined)) {
+                committed = true;
+            }
         };
         api.addEventListener('cellEditingStopped', onStopped);
         if (input.isConnected) {
@@ -95,13 +97,13 @@ export async function editCell(api: GridApi, rowNode: IRowNode, colId: string, n
         }
         api.removeEventListener('cellEditingStopped', onStopped);
 
-        if (stopped) {
+        if (committed) {
             expect(api.getEditingCells()).toEqual([]);
             return;
         }
         await asyncSetTimeout(attempt * 2);
     }
-    throw new Error(`Enter never reached the editor of "${colId}": its input kept being replaced`);
+    throw new Error(`The edit of "${colId}" never committed: its editor kept being replaced`);
 }
 
 /**

--- a/testing/behavioural/src/cell-editing/group-edit/group-edit-test-utils.ts
+++ b/testing/behavioural/src/cell-editing/group-edit/group-edit-test-utils.ts
@@ -119,8 +119,8 @@ export async function performEdit(
         await editCell(api, node, colId, `${value}`);
     } else {
         node.setDataValue(colId, typeof value === 'string' ? Number(value) : value, 'ui');
-        await asyncSetTimeout(0);
     }
+    await asyncSetTimeout(0);
 }
 
 export function getGroupColumnDisplayValue(rowNode: IRowNode): string | undefined {

--- a/testing/behavioural/src/grouping-data/ssrm/ssrm-grand-total.test.ts
+++ b/testing/behavioural/src/grouping-data/ssrm/ssrm-grand-total.test.ts
@@ -1500,6 +1500,228 @@ describe('SSRM grand total row', () => {
         `);
     });
 
+    // --- Soft refresh (purge: false) ---
+
+    test('grand total updates on soft refresh via grandTotalData field', async () => {
+        let total = 60;
+        let loadCount = 0;
+        const api = gridManager.createGrid(null, {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            getRowId: (params: GetRowIdParams<RowData>) => params.data.id,
+            grandTotalRow: 'bottom',
+            serverSideDatasource: {
+                getRows(params: IServerSideGetRowsParams) {
+                    setTimeout(() => {
+                        params.success({
+                            rowData: [...flatRows],
+                            rowCount: flatRows.length,
+                            grandTotalData: { id: GRAND_TOTAL_ID, value: total },
+                        });
+                        loadCount++;
+                    }, 0);
+                },
+            },
+        });
+
+        await new GridRows(api, 'soft refresh via grandTotalData field before load').check(`
+            ROOT id:<no-id>
+            └── filler id:rowIndex:0
+        `);
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+        expect(api.getRowNode(GRAND_TOTAL_ID)?.data?.value).toBe(60);
+        await new GridRows(api, 'soft refresh via grandTotalData field after first load').check(unindentText`
+            ROOT id:<no-id>
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            ├── LEAF id:3 id:"3" value:30
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:60
+        `);
+
+        const originalNodeId = api.getRowNode(GRAND_TOTAL_ID)?.id;
+        total = 999;
+        const loadsBeforeRefresh = loadCount;
+        api.refreshServerSide({ purge: false });
+        while (loadCount === loadsBeforeRefresh) {
+            await asyncSetTimeout(1);
+        }
+
+        // The existing node is updated in place, no purge required
+        expect(api.getRowNode(GRAND_TOTAL_ID)?.id).toBe(originalNodeId);
+        expect(api.getRowNode(GRAND_TOTAL_ID)?.data?.value).toBe(999);
+        await new GridRows(api, 'after soft refresh via grandTotalData field').check(unindentText`
+            ROOT id:<no-id>
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            ├── LEAF id:3 id:"3" value:30
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:999
+        `);
+    });
+
+    test('grand total updates on soft refresh via id in rowData', async () => {
+        let total = 60;
+        let loadCount = 0;
+        const api = gridManager.createGrid(null, {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            getRowId: (params: GetRowIdParams<RowData>) => params.data.id,
+            grandTotalRow: 'bottom',
+            serverSideDatasource: {
+                getRows(params: IServerSideGetRowsParams) {
+                    setTimeout(() => {
+                        params.success({
+                            rowData: [...flatRows, { id: GRAND_TOTAL_ID, value: total }],
+                            rowCount: flatRows.length,
+                        });
+                        loadCount++;
+                    }, 0);
+                },
+            },
+        });
+
+        await new GridRows(api, 'soft refresh via id in rowData before load').check(`
+            ROOT id:<no-id>
+            └── filler id:rowIndex:0
+        `);
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+        expect(api.getRowNode(GRAND_TOTAL_ID)?.data?.value).toBe(60);
+        await new GridRows(api, 'soft refresh via id in rowData after first load').check(unindentText`
+            ROOT id:<no-id>
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            ├── LEAF id:3 id:"3" value:30
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:60
+        `);
+
+        total = 111;
+        const loadsBeforeRefresh = loadCount;
+        api.refreshServerSide({ purge: false });
+        while (loadCount === loadsBeforeRefresh) {
+            await asyncSetTimeout(1);
+        }
+
+        await new GridRows(api, 'after soft refresh via id in rowData').check(unindentText`
+            ROOT id:<no-id>
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            ├── LEAF id:3 id:"3" value:30
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:111
+        `);
+    });
+
+    test('pinnedBottom grand total updates on soft refresh', async () => {
+        let total = 60;
+        let loadCount = 0;
+        const api = gridManager.createGrid(null, {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            getRowId: (params: GetRowIdParams<RowData>) => params.data.id,
+            grandTotalRow: 'pinnedBottom',
+            serverSideDatasource: {
+                getRows(params: IServerSideGetRowsParams) {
+                    setTimeout(() => {
+                        params.success({
+                            rowData: [...flatRows],
+                            rowCount: flatRows.length,
+                            grandTotalData: { id: GRAND_TOTAL_ID, value: total },
+                        });
+                        loadCount++;
+                    }, 0);
+                },
+            },
+        });
+
+        await new GridRows(api, 'pinnedBottom soft refresh before load').check(`
+            ROOT id:<no-id>
+            └── filler id:rowIndex:0
+        `);
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+        expect(api.getPinnedBottomRow(0)?.data?.value).toBe(60);
+        await new GridRows(api, 'pinnedBottom soft refresh after first load').check(unindentText`
+            ROOT id:<no-id>
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            └── LEAF id:3 id:"3" value:30
+            PINNED_BOTTOM id:b-bottom-rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:60
+        `);
+
+        total = 777;
+        const loadsBeforeRefresh = loadCount;
+        api.refreshServerSide({ purge: false });
+        while (loadCount === loadsBeforeRefresh) {
+            await asyncSetTimeout(1);
+        }
+
+        expect(api.getPinnedBottomRowCount()).toBe(1);
+        expect(api.getPinnedBottomRow(0)?.data?.value).toBe(777);
+        await new GridRows(api, 'after pinnedBottom soft refresh').check(unindentText`
+            ROOT id:<no-id>
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            └── LEAF id:3 id:"3" value:30
+            PINNED_BOTTOM id:b-bottom-rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:777
+        `);
+    });
+
+    test('grandTotalData: null on soft refresh removes existing grand total', async () => {
+        let loadCount = 0;
+        const api = gridManager.createGrid(null, {
+            columnDefs: [{ field: 'id' }, { field: 'value' }],
+            rowModelType: 'serverSide',
+            getRowId: (params: GetRowIdParams<RowData>) => params.data.id,
+            grandTotalRow: 'bottom',
+            serverSideDatasource: {
+                getRows(params: IServerSideGetRowsParams) {
+                    const isFirstLoad = loadCount === 0;
+                    setTimeout(() => {
+                        params.success({
+                            rowData: [...flatRows],
+                            rowCount: flatRows.length,
+                            grandTotalData: isFirstLoad ? { id: GRAND_TOTAL_ID, value: 60 } : null,
+                        });
+                        loadCount++;
+                    }, 0);
+                },
+            },
+        });
+
+        await new GridRows(api, 'null grandTotalData soft refresh before load').check(`
+            ROOT id:<no-id>
+            └── filler id:rowIndex:0
+        `);
+
+        await waitForEvent('firstDataRendered', api);
+        await waitForNoLoadingRows(api);
+        expect(api.getRowNode(GRAND_TOTAL_ID)).toBeDefined();
+        await new GridRows(api, 'null grandTotalData soft refresh after first load').check(unindentText`
+            ROOT id:<no-id>
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            ├── LEAF id:3 id:"3" value:30
+            └─ footer id:rowGroupFooter_ROOT_NODE_ID id:"rowGroupFooter_ROOT_NODE_ID" value:60
+        `);
+
+        const loadsBeforeRefresh = loadCount;
+        api.refreshServerSide({ purge: false });
+        while (loadCount === loadsBeforeRefresh) {
+            await asyncSetTimeout(1);
+        }
+
+        expect(api.getRowNode(GRAND_TOTAL_ID)).toBeUndefined();
+        await new GridRows(api, 'after soft refresh with null grandTotalData').check(unindentText`
+            ROOT id:<no-id>
+            ├── LEAF id:1 id:"1" value:10
+            ├── LEAF id:2 id:"2" value:20
+            └── LEAF id:3 id:"3" value:30
+        `);
+    });
+
     // --- Dynamic option toggle ---
 
     test('dynamically enabling grandTotalRow uses cached data', async () => {


### PR DESCRIPTION
# AG-18000 SSRM grand total row not refreshed by a soft refresh

FIX AG-18000

files: 1 changed
lines added:   +20
lines removed: -7
net delta:     +13

## Problem

With `rowModelType: 'serverSide'` and a grand total row, fresh grand total data returned from `success()` was ignored once the grand total node existed. A soft refresh (`refreshServerSide({ purge: false })`, filter/crossfilter change) left the rendered total stale indefinitely — it only updated on first load or after a purging refresh, contradicting the documented `needsGrandTotal` / `grandTotalData` contract.

`LazyCache.onLoadSuccess()` wrote `store.grandTotalData` as a plain field, and `LazyStore.setDisplayIndexes()` — the only consumer — created the node solely when it didn't already exist. The update branch of `createOrUpdateGrandTotalNode()` was reachable only from `applyServerSideTransaction()`.

## Fix

`packages/ag-grid-enterprise/src/serverSideRowModel/stores/lazy/lazyCache.ts`

Added `setGrandTotalData()`, which caches the data on the store _and_ applies it to the existing node immediately (`null` still defers destruction to `setDisplayIndexes`). Every write site now goes through it: `onLoadSuccess`, `updateRowNodes`, `insertRowNodes`, `removeRowNodes`. Creation stays where it was, in `setDisplayIndexes`.

## Tests

`testing/behavioural/src/grouping-data/ssrm/ssrm-grand-total.test.ts` — four soft-refresh regression tests (each with before-load, after-first-load and after-refresh snapshots):

- inline `bottom` total updates via the `grandTotalData` field
- inline `bottom` total updates via `GRAND_TOTAL_ROW_ID` in `rowData`
- `pinnedBottom` total updates
- `grandTotalData: null` removes the total (already passing; guards the `null` branch)

The first three failed before the fix.

Fix also the flakey editCell test util that might cause other unrelated tests to rarely fail