### PR TITLE
AG-15954-react-memory-leak-test

### DIFF
--- a/testing/behavioural/src/rows/row-data-churn-retention-react.test.tsx
+++ b/testing/behavioural/src/rows/row-data-churn-retention-react.test.tsx
@@ -1,0 +1,271 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import React, { useEffect, useState } from 'react';
+
+import type { ColDef, GridApi } from 'ag-grid-community';
+import { ClientSideRowModelModule, ModuleRegistry, RowApiModule, ScrollApiModule } from 'ag-grid-community';
+import { AgGridReact } from 'ag-grid-react';
+
+import { asyncSetTimeout, collectWeakRefsUntilStable, ignoreConsoleLicenseKeyError } from '../test-utils';
+import { mockGridLayout } from '../test-utils/polyfills/mockGridLayout';
+
+/**
+ * Guards against unbounded retention in the React view layer: replacing `rowData` without
+ * `getRowId` destroys and rebuilds every RowCtrl/CellCtrl, so anything holding on to a torn-down
+ * controller (or its detached element) accumulates linearly with update count.
+ */
+
+const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+const CHURNS = 60;
+const MOUNTS = 30;
+/** React and test-local closures keep a short trailing window of roots reachable; only older ones must be collected. */
+const TRAILING_WINDOW = 5;
+
+const colDefs: ColDef[] = [
+    { colId: 'ID', field: 'id', width: 90 },
+    ...LETTERS.map((letter) => ({ colId: `C_${letter}`, field: letter, width: 50 })),
+];
+
+const makeRowData = (tick: number) => {
+    const rows: Record<string, unknown>[] = [];
+    for (let i = 0; i < 100; i++) {
+        const row: Record<string, unknown> = { id: `row-${i}` };
+        for (let j = 0, len = LETTERS.length; j < len; ++j) {
+            row[LETTERS[j]] = tick;
+        }
+        rows.push(row);
+    }
+    return rows;
+};
+
+/** Inside act(): the settle window lets queued animation-frame tasks drive their React state updates. */
+const collectUntilStable = (refs: WeakRef<object>[]) =>
+    collectWeakRefsUntilStable(refs, () => act(async () => void (await asyncSetTimeout(10))));
+
+describe('row data churn retention (React)', () => {
+    beforeAll(() => {
+        mockGridLayout.init();
+        ModuleRegistry.registerModules([ClientSideRowModelModule, RowApiModule, ScrollApiModule]);
+        ignoreConsoleLicenseKeyError();
+    });
+
+    afterEach(async () => {
+        await act(async () => {
+            await asyncSetTimeout(0);
+            cleanup();
+        });
+    });
+
+    test('LEAK: repeatedly replacing rowData retains no torn-down row or cell ctrls', async () => {
+        let api: GridApi | undefined;
+        let setTick: ((tick: number) => void) | undefined;
+
+        const Harness = () => {
+            const [tick, tickState] = useState(0);
+            const [rowData, setRowData] = useState(() => makeRowData(0));
+            setTick = tickState;
+            useEffect(() => {
+                setRowData(makeRowData(tick));
+            }, [tick]);
+            return (
+                <div style={{ height: 400, width: 600 }}>
+                    <AgGridReact
+                        columnDefs={colDefs}
+                        rowData={rowData}
+                        onGridReady={(params) => {
+                            api = params.api;
+                        }}
+                    />
+                </div>
+            );
+        };
+
+        const rendered = render(<Harness />);
+        await waitFor(() => expect(rendered.container.querySelectorAll('[row-id]').length).toBeGreaterThan(0));
+
+        // Internal access is unavoidable: retention of destroyed controllers has no public API or DOM
+        // footprint, so we census every controller ever mounted by spying their prototype setComp.
+        const rowRenderer = (api!.getDisplayedRowAtIndex(0) as any).beans.rowRenderer;
+        await waitFor(() => expect(rowRenderer.getAllRowCtrls()[0]?.getAllCellCtrls()?.length).toBeGreaterThan(0));
+
+        const cellRefs: WeakRef<any>[] = [];
+        const rowRefs: WeakRef<any>[] = [];
+        const cellCtrlProto = Object.getPrototypeOf(rowRenderer.getAllRowCtrls()[0].getAllCellCtrls()[0]);
+        const rowCtrlProto = Object.getPrototypeOf(rowRenderer.getAllRowCtrls()[0]);
+        const origCellSetComp = cellCtrlProto.setComp;
+        const origRowSetComp = rowCtrlProto.setComp;
+        cellCtrlProto.setComp = function (...args: any[]) {
+            cellRefs.push(new WeakRef(this));
+            return origCellSetComp.apply(this, args);
+        };
+        rowCtrlProto.setComp = function (...args: any[]) {
+            rowRefs.push(new WeakRef(this));
+            return origRowSetComp.apply(this, args);
+        };
+
+        let liveCellsAfterFirstThird = 0;
+        let liveRowsAfterFirstThird = 0;
+        try {
+            for (let tick = 1; tick <= CHURNS; tick++) {
+                await act(async () => {
+                    setTick!(tick);
+                    await asyncSetTimeout(0);
+                });
+
+                if (tick === CHURNS / 3) {
+                    liveCellsAfterFirstThird = await collectUntilStable(cellRefs);
+                    liveRowsAfterFirstThird = await collectUntilStable(rowRefs);
+                }
+            }
+        } finally {
+            cellCtrlProto.setComp = origCellSetComp;
+            rowCtrlProto.setComp = origRowSetComp;
+        }
+
+        const liveCells = await collectUntilStable(cellRefs);
+        const liveRows = await collectUntilStable(rowRefs);
+
+        // Every controller mounted was torn down and rebuilt, so the census must be far larger than
+        // what stays alive — otherwise the churn never happened and the test proves nothing.
+        expect(cellRefs.length).toBeGreaterThan(liveCells * 10);
+
+        // Retention must be bounded by the viewport, not by the number of updates.
+        expect(liveCells).toBeLessThanOrEqual(liveCellsAfterFirstThird);
+        expect(liveRows).toBeLessThanOrEqual(liveRowsAfterFirstThird);
+
+        const reachableCells = new Set<unknown>();
+        for (const rowCtrl of rowRenderer.getAllRowCtrls()) {
+            for (const cellCtrl of rowCtrl.getAllCellCtrls()) {
+                reachableCells.add(cellCtrl);
+            }
+        }
+        expect(liveCells).toBe(reachableCells.size);
+
+        const liveWithDetachedGui = cellRefs.filter((ref) => {
+            const gui = ref.deref()?.eGui;
+            return gui && !gui.isConnected;
+        });
+        expect(liveWithDetachedGui).toEqual([]);
+    });
+
+    test('LEAK: repeatedly mounting and unmounting a grid retains no grid api or beans', async () => {
+        const apiRefs: WeakRef<object>[] = [];
+        const beanRefs: WeakRef<object>[] = [];
+
+        for (let i = 0; i < MOUNTS; i++) {
+            let api: GridApi | undefined;
+            render(
+                <div style={{ height: 400, width: 600 }}>
+                    <AgGridReact
+                        columnDefs={colDefs}
+                        rowData={makeRowData(i)}
+                        onGridReady={(params) => {
+                            api = params.api;
+                        }}
+                    />
+                </div>
+            );
+            await waitFor(() => expect(api).toBeDefined());
+
+            apiRefs.push(new WeakRef(api!));
+            beanRefs.push(new WeakRef((api!.getDisplayedRowAtIndex(0) as any).beans));
+            api = undefined;
+
+            await act(async () => {
+                await asyncSetTimeout(0);
+                cleanup();
+            });
+        }
+
+        await collectUntilStable(apiRefs);
+        await collectUntilStable(beanRefs);
+
+        const survivingApis = apiRefs.map((ref, index) => (ref.deref() ? index : -1)).filter((index) => index >= 0);
+        const survivingBeans = beanRefs.map((ref, index) => (ref.deref() ? index : -1)).filter((index) => index >= 0);
+
+        expect(survivingApis.every((index) => index >= MOUNTS - TRAILING_WINDOW)).toBe(true);
+        expect(survivingBeans.every((index) => index >= MOUNTS - TRAILING_WINDOW)).toBe(true);
+    });
+
+    test('LEAK: scrolling back and forth retains no row or cell ctrls from previous viewports', async () => {
+        let api: GridApi | undefined;
+
+        const rowData: Record<string, unknown>[] = [];
+        for (let i = 0; i < 2000; i++) {
+            const row: Record<string, unknown> = { id: `row-${i}` };
+            for (let j = 0, len = LETTERS.length; j < len; ++j) {
+                row[LETTERS[j]] = i;
+            }
+            rowData.push(row);
+        }
+
+        const rendered = render(
+            <div style={{ height: 400, width: 600 }}>
+                <AgGridReact
+                    columnDefs={colDefs}
+                    rowData={rowData}
+                    getRowId={(params) => params.data.id as string}
+                    onGridReady={(params) => {
+                        api = params.api;
+                    }}
+                />
+            </div>
+        );
+        await waitFor(() => expect(rendered.container.querySelectorAll('[row-id]').length).toBeGreaterThan(0));
+
+        const rowRenderer = (api!.getDisplayedRowAtIndex(0) as any).beans.rowRenderer;
+        await waitFor(() => expect(rowRenderer.getAllRowCtrls()[0]?.getAllCellCtrls()?.length).toBeGreaterThan(0));
+
+        const cellRefs: WeakRef<any>[] = [];
+        const rowRefs: WeakRef<any>[] = [];
+        const cellCtrlProto = Object.getPrototypeOf(rowRenderer.getAllRowCtrls()[0].getAllCellCtrls()[0]);
+        const rowCtrlProto = Object.getPrototypeOf(rowRenderer.getAllRowCtrls()[0]);
+        const origCellSetComp = cellCtrlProto.setComp;
+        const origRowSetComp = rowCtrlProto.setComp;
+        cellCtrlProto.setComp = function (...args: any[]) {
+            cellRefs.push(new WeakRef(this));
+            return origCellSetComp.apply(this, args);
+        };
+        rowCtrlProto.setComp = function (...args: any[]) {
+            rowRefs.push(new WeakRef(this));
+            return origRowSetComp.apply(this, args);
+        };
+
+        let liveCellsAfterFirstSweep = 0;
+        let liveRowsAfterFirstSweep = 0;
+        try {
+            for (let sweep = 0; sweep < 4; sweep++) {
+                for (let index = 0; index < 2000; index += 250) {
+                    await act(async () => {
+                        api!.ensureIndexVisible(index);
+                        await asyncSetTimeout(0);
+                    });
+                }
+                await act(async () => {
+                    api!.ensureIndexVisible(0);
+                    await asyncSetTimeout(0);
+                });
+
+                if (sweep === 0) {
+                    liveCellsAfterFirstSweep = await collectUntilStable(cellRefs);
+                    liveRowsAfterFirstSweep = await collectUntilStable(rowRefs);
+                }
+            }
+        } finally {
+            cellCtrlProto.setComp = origCellSetComp;
+            rowCtrlProto.setComp = origRowSetComp;
+        }
+
+        const liveCells = await collectUntilStable(cellRefs);
+        const liveRows = await collectUntilStable(rowRefs);
+
+        expect(cellRefs.length).toBeGreaterThan(liveCells * 10);
+        expect(liveCells).toBeLessThanOrEqual(liveCellsAfterFirstSweep);
+        expect(liveRows).toBeLessThanOrEqual(liveRowsAfterFirstSweep);
+
+        const liveWithDetachedGui = cellRefs.filter((ref) => {
+            const gui = ref.deref()?.eGui;
+            return gui && !gui.isConnected;
+        });
+        expect(liveWithDetachedGui).toEqual([]);
+    });
+});

--- a/testing/behavioural/src/test-utils/gc-utils.ts
+++ b/testing/behavioural/src/test-utils/gc-utils.ts
@@ -1,0 +1,61 @@
+import v8 from 'node:v8';
+import vm from 'node:vm';
+
+let gcFn: (() => void) | null = null;
+
+/**
+ * `--expose-gc` is a per-isolate V8 flag, so each Vitest worker must enable it for itself. The flag is
+ * restored straight after grabbing the function, otherwise every other test file sharing this worker
+ * would run with a different GC configuration.
+ */
+const acquireGc = (): (() => void) => {
+    const existing = (globalThis as { gc?: () => void }).gc;
+    if (typeof existing === 'function') {
+        return existing;
+    }
+
+    v8.setFlagsFromString('--expose-gc');
+    try {
+        const exposed = vm.runInNewContext('gc');
+        if (typeof exposed !== 'function') {
+            throw new Error('gc is not a function');
+        }
+        return exposed;
+    } catch (e) {
+        throw new Error('Could not expose V8 gc, which retention tests require. Run node with --expose-gc.', {
+            cause: e,
+        });
+    } finally {
+        v8.setFlagsFromString('--no-expose-gc');
+    }
+};
+
+/** Runs a full major GC. Only meaningful for retention tests; never use it to paper over timing. */
+export const forceGc = (): void => {
+    gcFn ??= acquireGc();
+    gcFn();
+};
+
+const countLive = (refs: WeakRef<object>[]): number => refs.filter((ref) => ref.deref() !== undefined).length;
+
+/**
+ * Number of `refs` still reachable once collection has settled. `settle` must yield to the event loop —
+ * a WeakRef target survives the job that created it — and should flush any pending framework work.
+ */
+export const collectWeakRefsUntilStable = async (
+    refs: WeakRef<object>[],
+    settle: () => Promise<void>,
+    maxPasses = 5
+): Promise<number> => {
+    let live = countLive(refs);
+    for (let pass = 0; pass < maxPasses; pass++) {
+        await settle();
+        forceGc();
+        const next = countLive(refs);
+        if (next === live) {
+            return next;
+        }
+        live = next;
+    }
+    return live;
+};

--- a/testing/behavioural/src/test-utils/index.ts
+++ b/testing/behavioural/src/test-utils/index.ts
@@ -17,6 +17,7 @@ export * from './gridColumns/gridColumnsOptions';
 export * from './gridColumns/columns-validation/gridColumnErrors';
 export * from './gridColumns/columns-validation/gridColumnsErrors';
 export * from './utils';
+export * from './gc-utils';
 export * from './node-utils';
 export * from './string-utils';
 export * from './cachedJSONObjects';


### PR DESCRIPTION
# React grid retention — verification

FIX AG-15954

## Result

No unbounded retention in the React view layer on `latest`. Row and cell controllers, the elements they
hold, and whole grid instances are all collectable; heap is flat across sustained churn.

## Why the `{pending, lanes, dispatch, lastRenderedReducer, lastRenderedState}` heap row grows

That object is React's internal `UpdateQueue`, one per live `useState`/`useReducer` hook. The React view
layer has ~8 `useState` per cell and ~12 per row, so a wide grid has thousands of them by design, and
`lastRenderedState` legitimately references `renderDetails` / `CellCtrl[]` — which is why expanding the
row shows gridcells.

Its retained size in the Summary view is an aggregate DevTools sums per object, and `dispatch` is
`dispatchSetState.bind(null, fiber, queue)`, so the group sits next to the fiber graph and its
attribution shifts as the dominator tree changes, with no change in allocation. The leak-bearing signals
are **object count** and **total heap after a forced GC**.

## Measurements

100 rows × 27 columns, new row objects pushed in via the `rowData` prop, no `getRowId`, weak-referencing
every controller mounted via `CellCtrl.setComp` / `RowCtrl.setComp`, forcing GC at checkpoints:

| tick | cells mounted | live cells | live rows | live cells w/ detached eGui | heap    |
| ---- | ------------- | ---------- | --------- | --------------------------- | ------- |
| 20   | 5,280         | 264        | 11        | 0                           | 109.0MB |
| 40   | 10,560        | 264        | 11        | 0                           | 109.4MB |
| 60   | 15,840        | 264        | 11        | 0                           | 109.8MB |

Live controllers stay pinned at the visible viewport regardless of update count.

- **Mount/unmount:** after 10/20/30 mounts the surviving `GridApi`s are `[8,9,10]`, `[18,19,20]`,
  `[28,29,30]` — a fixed trailing window, everything older collected.
- **Scroll:** repeated sweeps across 2000 rows retain nothing beyond the current viewport.
- **`getRowId`:** takes cells mounted from 15,840 to **0** — controllers are reused rather than destroyed
  and rebuilt on every update.

## Bounded retention that is by design

- `zombieRowCtrls` — rows held for the removal animation, drained after `ROW_ANIMATION_TIMEOUT` (400 ms).
- `RowCtrlCache` — only when `keepDetailRows` is set, capped at `keepDetailRowsCount` (default 3).
- `getNextValueIfDifferent` merges previous and next ctrl arrays to keep DOM order stable, but keeps only
  entries still present in `next`, so nothing carries across scroll positions.

## Regression guard

`testing/behavioural/src/rows/row-data-churn-retention-react.test.tsx` — rowData churn, mount/unmount and
scroll churn. All three go red against a one-line injected retention bug in `cellComp`.

## Retention fixes since the 32.3 branch point

| Ticket   | PR     | Shipped | What it fixed                                                                           |
| -------- | ------ | ------- | --------------------------------------------------------------------------------------- |
| AG-13189 | #9025  | v33     | Broad memory-leak pass + CSRM deallocation (root/node-manager, state svc, scroll comps) |
| AG-15167 | #10849 | v34     | Memory consumption of average/count aggregations                                        |
| AG-16089 | #12237 | v35     | Theming perf regression in detached grids                                               |
| AG-17663 | #14289 | v36     | Cell-renderer tooltip leak on renderer swap — tooltips accumulated in the DOM           |
| AG-17702 | #14273 | v36     | ARIA description container growth; measurement container not removed on destroy         |
| AG-17720 | #14283 | v36     | `CellFlashService.animateCell` crash on unmounted cells                                 |
| AG-17053 | #13496 | v36     | Column Chooser popup not cleaned up on grid destroy                                     |
| AG-17741 | #14313 | v36     | Viewport row model stale index / orphaned RowCtrl leak                                  |

Most relevant to a long-running React grid with cell renderers: **AG-13189** (destroy-path deallocation)
and **AG-17663** (DOM accumulation on renderer swap).
