### PR TITLE
AG-18016 React grid hides first row when advanced filter is enabled

### DIFF
--- a/packages/ag-grid-community/src/gridBodyComp/gridBodyCtrl.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/gridBodyCtrl.ts
@@ -112,16 +112,17 @@ export class GridBodyCtrl extends BeanStub {
         this.setGridRole();
         this.onGridColumnsChanged();
         this.addBodyViewportListener();
+        // Mount before setPinnedRowsHeights: the top section has to reserve vertical space for the
+        // advanced filter bar, so its height must be known by the time the section is measured.
+        this.filterManager?.mountAdvFilterTopSectionComp({
+            mountComp: (eGui) => eTopExtraRows.appendChild(eGui),
+            unmountComp: (eGui) => eGui.remove(),
+        });
         this.setPinnedRowsHeights();
         this.disableBrowserDragging();
         this.addStopEditingWhenGridLosesFocus();
         this.updatePinnedColumnStickyOffsets();
         this.updateScrollingClasses();
-
-        this.filterManager?.mountAdvFilterTopSectionComp({
-            mountComp: (eGui) => eTopExtraRows.appendChild(eGui),
-            unmountComp: (eGui) => eGui.remove(),
-        });
 
         this.ctrlsSvc.register('gridBodyCtrl', this);
     }

--- a/testing/behavioural/src/filters/advanced-filter-row-position.test.tsx
+++ b/testing/behavioural/src/filters/advanced-filter-row-position.test.tsx
@@ -1,0 +1,85 @@
+import { waitFor } from '@testing-library/dom';
+import { cleanup, render } from '@testing-library/react';
+import React from 'react';
+
+import type { ColDef } from 'ag-grid-community';
+import { ClientSideRowModelModule, ModuleRegistry, TextFilterModule } from 'ag-grid-community';
+import { AdvancedFilterModule } from 'ag-grid-enterprise';
+import { AgGridReact } from 'ag-grid-react';
+
+import { TestGridsManager } from '../test-utils';
+import { mockGridLayout } from '../test-utils/polyfills/mockGridLayout';
+
+const modules = [ClientSideRowModelModule, TextFilterModule, AdvancedFilterModule];
+
+interface Athlete {
+    athlete: string;
+    age: number;
+}
+
+const columnDefs: ColDef<Athlete>[] = [{ field: 'athlete' }, { field: 'age' }];
+const rowData: Athlete[] = [
+    { athlete: 'Michael Phelps', age: 23 },
+    { athlete: 'Usain Bolt', age: 25 },
+];
+
+/**
+ * The advanced filter bar is absolutely positioned inside the top section (`.ag-grid-pinned-top-rows`),
+ * so the only thing stopping the first row rendering behind it is the height the top section reserves
+ * for it (`--ag-top-rows-height`). If that stays 0 the bar overlaps the first row.
+ */
+const expectTopSectionToReserveAdvancedFilterHeight = async () => {
+    // The bar and the header cells are both mounted by the time the grid's layout has settled.
+    await waitFor(() => {
+        expect(document.querySelector('.ag-advanced-filter-header')).not.toBeNull();
+        expect(document.querySelectorAll('.ag-header-cell').length).toBe(columnDefs.length);
+    });
+
+    const advancedFilterBar = document.querySelector<HTMLElement>('.ag-advanced-filter-header')!;
+    const topSection = document.querySelector<HTMLElement>('.ag-grid-pinned-top-rows')!;
+
+    const advancedFilterHeight = Number.parseFloat(advancedFilterBar.style.height);
+    const reservedHeight = Number.parseFloat(topSection.style.getPropertyValue('--ag-top-rows-height'));
+
+    expect(advancedFilterHeight).toBeGreaterThan(0);
+    expect(reservedHeight).toBe(advancedFilterHeight);
+};
+
+describe('Advanced Filter row position', () => {
+    beforeAll(() => {
+        mockGridLayout.init();
+        ModuleRegistry.registerModules(modules);
+    });
+
+    const gridsManager = new TestGridsManager({ modules });
+
+    afterEach(() => {
+        gridsManager.reset();
+        cleanup();
+    });
+
+    // Row data arriving after mount is the common shape (the docs examples fetch it), and it is the
+    // case where nothing else re-runs the top section layout, so a missed measurement sticks.
+    test('vanilla reserves space for the advanced filter bar when row data arrives after mount', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs,
+            enableAdvancedFilter: true,
+        });
+
+        await expectTopSectionToReserveAdvancedFilterHeight();
+
+        api.setGridOption('rowData', rowData);
+
+        await expectTopSectionToReserveAdvancedFilterHeight();
+    });
+
+    test('React reserves space for the advanced filter bar when row data arrives after mount', async () => {
+        const rendered = render(<AgGridReact columnDefs={columnDefs} enableAdvancedFilter={true} />);
+
+        await expectTopSectionToReserveAdvancedFilterHeight();
+
+        rendered.rerender(<AgGridReact columnDefs={columnDefs} rowData={rowData} enableAdvancedFilter={true} />);
+
+        await expectTopSectionToReserveAdvancedFilterHeight();
+    });
+});


### PR DESCRIPTION
## Issue

[AG-18016](https://ag-grid.atlassian.net/browse/AG-18016) — regression from 35.3.1. With `enableAdvancedFilter`, React renders the first row behind the advanced filter bar; vanilla is correct.

## Root cause

The top section (`.ag-grid-pinned-top-rows`) reserves vertical space for the advanced filter bar via `--ag-top-rows-height`, computed in `refreshTopSection`. `GridBodyCtrl.setComp` mounted the bar *after* `setPinnedRowsHeights()` had already measured the section, so the bar's height was still 0 on the first pass.

## Fix

Mount the bar before the section is measured, so the height is correct on the first layout pass and vanilla no longer depends on construction order. Six-line reorder in `GridBodyCtrl.setComp`; no new events.
