### PR TITLE
AG-17996 - Consent field follow-ups: error clearing, Studio consent, a11y and sandbox IDs

### DIFF
--- a/external/ag-website-shared/src/components/consent-fields/ConsentCheckbox.tsx
+++ b/external/ag-website-shared/src/components/consent-fields/ConsentCheckbox.tsx
@@ -14,13 +14,27 @@ interface Props {
 }
 
 export const ConsentCheckbox: FunctionComponent<Props> = ({ id, label, error, nested, inputProps }: Props) => {
+    const errorId = `${id}-error`;
+
     return (
         <div className={classnames('input-field', { 'input-error': error }, { [styles.nested]: nested })}>
             <label className={styles.consentLabel} htmlFor={id}>
-                <input type="checkbox" id={id} {...inputProps} />
+                <input
+                    type="checkbox"
+                    id={id}
+                    aria-invalid={error ? true : undefined}
+                    aria-describedby={error ? errorId : undefined}
+                    {...inputProps}
+                />
                 <span>{label}</span>
             </label>
-            <div className={styles.errorContainer}>{error && <p className="error">{error}</p>}</div>
+            <div className={styles.errorContainer}>
+                {error && (
+                    <p className="error" id={errorId} role="alert">
+                        {error}
+                    </p>
+                )}
+            </div>
         </div>
     );
 };

--- a/external/ag-website-shared/src/components/contact-form/ContactForm.tsx
+++ b/external/ag-website-shared/src/components/contact-form/ContactForm.tsx
@@ -99,7 +99,10 @@ export const ContactForm: FunctionComponent<Props> = ({
         setValue,
         formState: { errors },
     } = useForm<FormValues>({
-        mode: 'onBlur',
+        // Validate on first blur, then re-validate on every change, so a message
+        // clears the moment the field is corrected. Plain 'onBlur' only re-validates
+        // on the next blur, which leaves a stale error next to a ticked checkbox.
+        mode: 'onTouched',
     });
 
     // Email tracking consent only applies to France and Italy, so hiding it must also

--- a/external/ag-website-shared/src/components/trial-licence-form/TrialLicenceForm.tsx
+++ b/external/ag-website-shared/src/components/trial-licence-form/TrialLicenceForm.tsx
@@ -254,6 +254,7 @@ function useTrialForm({ submitUrl }: Props) {
             }
         },
         [
+            submitUrl,
             validatedEmailError,
             validatedFirstNameError,
             validatedLastNameError,
@@ -292,7 +293,7 @@ function useTrialForm({ submitUrl }: Props) {
     };
 }
 
-export const TrialLicenceForm: FunctionComponent = ({ submitUrl }: Props) => {
+export const TrialLicenceForm: FunctionComponent<Props> = ({ submitUrl }: Props) => {
     const {
         formState,
         formError,

--- a/external/ag-website-shared/src/components/trial-licence-form/TrialLicenceFormStudio.tsx
+++ b/external/ag-website-shared/src/components/trial-licence-form/TrialLicenceFormStudio.tsx
@@ -1,3 +1,8 @@
+import { ConsentCheckbox } from '@ag-website-shared/components/consent-fields/ConsentCheckbox';
+import {
+    CONSENT_LABELS,
+    DATA_PROCESSING_CONSENT_REQUIRED,
+} from '@ag-website-shared/components/consent-fields/consentMessages';
 import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { TRIAL_LICENCE_FORM_URL, ZI_FORM_ID } from '@constants';
 import { trackTrialLicenseFormError, trackTrialLicenseFormSuccess } from '@utils/analytics';
@@ -90,22 +95,55 @@ function useRequiredValidation(initialValue: string = '') {
     };
 }
 
+function useCheckbox(initialValue: boolean = false) {
+    const [checked, setChecked] = useState<boolean>(initialValue);
+
+    const handleCheckedChange: ChangeEventHandler<HTMLInputElement> = useCallback((e) => {
+        setChecked(e.target.checked);
+    }, []);
+
+    return {
+        checked,
+        setChecked,
+        handleCheckedChange,
+    };
+}
+
 async function submitTrialLicenceFormData({
     submitUrl = TRIAL_LICENCE_FORM_URL,
     firstName,
     lastName,
     email,
     company,
+    dataProcessingConsent,
+    marketingEmailConsent,
+    emailTrackingConsent,
+    franceOrItaly,
 }: {
     submitUrl?: string;
     firstName: string;
     lastName: string;
     email: string;
     company: string;
+    dataProcessingConsent: boolean;
+    marketingEmailConsent: boolean;
+    emailTrackingConsent: boolean;
+    franceOrItaly: boolean;
 }) {
     const response = await fetch(submitUrl, {
         method: 'POST',
-        body: JSON.stringify({ data: { firstName, lastName, email, company } }),
+        body: JSON.stringify({
+            data: {
+                firstName,
+                lastName,
+                email,
+                company,
+                dataProcessingConsent,
+                marketingEmailConsent,
+                emailTrackingConsent,
+                franceOrItaly,
+            },
+        }),
         headers: {
             'Content-Type': 'application/json',
         },
@@ -136,12 +174,35 @@ function useTrialForm({ submitUrl }: Props) {
     } = useRequiredValidation();
     const lastNameError = wasValidated && validatedLastNameError ? validatedLastNameError : '';
 
+    const { checked: dataProcessingConsent, handleCheckedChange: handleDataProcessingConsentChange } = useCheckbox();
+    const dataProcessingConsentError = wasValidated && !dataProcessingConsent ? DATA_PROCESSING_CONSENT_REQUIRED : '';
+
+    const { checked: marketingEmailConsent, handleCheckedChange: handleMarketingEmailConsentChange } = useCheckbox();
+
+    const {
+        checked: emailTrackingConsent,
+        setChecked: setEmailTrackingConsent,
+        handleCheckedChange: handleEmailTrackingConsentChange,
+    } = useCheckbox();
+
+    const { checked: isFranceOrItaly, setChecked: setIsFranceOrItaly } = useCheckbox();
+
+    // Email tracking consent only applies to France and Italy, so hiding it must also
+    // withdraw it — never submit a consent the visitor can no longer see
+    const handleFranceOrItalyChange: ChangeEventHandler<HTMLInputElement> = useCallback((e) => {
+        const { checked } = e.target;
+        setIsFranceOrItaly(checked);
+        if (!checked) {
+            setEmailTrackingConsent(false);
+        }
+    }, []);
+
     const handleFormSubmit: FormEventHandler<HTMLFormElement> = useCallback(
         async (e) => {
             e.preventDefault();
             setWasValidated(true);
 
-            if (validatedEmailError || validatedFirstNameError || validatedLastNameError) {
+            if (validatedEmailError || validatedFirstNameError || validatedLastNameError || !dataProcessingConsent) {
                 setFormState('error');
                 return;
             }
@@ -153,7 +214,17 @@ function useTrialForm({ submitUrl }: Props) {
 
             try {
                 const company = (document.getElementById('company') as HTMLInputElement)?.value || '';
-                const response = await submitTrialLicenceFormData({ submitUrl, firstName, lastName, email, company });
+                const response = await submitTrialLicenceFormData({
+                    submitUrl,
+                    firstName,
+                    lastName,
+                    email,
+                    company,
+                    dataProcessingConsent,
+                    marketingEmailConsent,
+                    emailTrackingConsent,
+                    franceOrItaly: isFranceOrItaly,
+                });
 
                 if (response.error) {
                     setFormState('error');
@@ -182,7 +253,19 @@ function useTrialForm({ submitUrl }: Props) {
                 setFormState('error');
             }
         },
-        [validatedEmailError, validatedFirstNameError, validatedLastNameError, firstName, lastName, email]
+        [
+            submitUrl,
+            validatedEmailError,
+            validatedFirstNameError,
+            validatedLastNameError,
+            firstName,
+            lastName,
+            email,
+            dataProcessingConsent,
+            marketingEmailConsent,
+            emailTrackingConsent,
+            isFranceOrItaly,
+        ]
     );
 
     return {
@@ -197,11 +280,20 @@ function useTrialForm({ submitUrl }: Props) {
         lastName,
         lastNameError,
         handleLastNameChange,
+        dataProcessingConsent,
+        dataProcessingConsentError,
+        handleDataProcessingConsentChange,
+        marketingEmailConsent,
+        handleMarketingEmailConsentChange,
+        emailTrackingConsent,
+        handleEmailTrackingConsentChange,
+        isFranceOrItaly,
+        handleFranceOrItalyChange,
         handleFormSubmit,
     };
 }
 
-export const TrialLicenceFormStudio: FunctionComponent = ({ submitUrl }: Props) => {
+export const TrialLicenceFormStudio: FunctionComponent<Props> = ({ submitUrl }: Props) => {
     const {
         formState,
         formError,
@@ -214,9 +306,18 @@ export const TrialLicenceFormStudio: FunctionComponent = ({ submitUrl }: Props) 
         lastName,
         lastNameError,
         handleLastNameChange,
+        dataProcessingConsent,
+        dataProcessingConsentError,
+        handleDataProcessingConsentChange,
+        marketingEmailConsent,
+        handleMarketingEmailConsentChange,
+        emailTrackingConsent,
+        handleEmailTrackingConsentChange,
+        isFranceOrItaly,
+        handleFranceOrItalyChange,
         handleFormSubmit,
     } = useTrialForm({ submitUrl });
-    const hasFormError = Boolean(emailError || firstNameError || lastNameError);
+    const hasFormError = Boolean(emailError || firstNameError || lastNameError || dataProcessingConsentError);
 
     return (
         <form id={ZI_FORM_ID} noValidate className={styles.trialForm} onSubmit={handleFormSubmit}>
@@ -269,6 +370,53 @@ export const TrialLicenceFormStudio: FunctionComponent = ({ submitUrl }: Props) 
                     />
                 </span>
                 <p className="error">{emailError ? emailError : 'Email required'}</p>
+            </div>
+
+            <div className={styles.consents}>
+                <ConsentCheckbox
+                    id="data-processing-consent"
+                    label={CONSENT_LABELS.dataProcessing}
+                    error={dataProcessingConsentError}
+                    inputProps={{
+                        name: 'data-processing-consent',
+                        checked: dataProcessingConsent,
+                        onChange: handleDataProcessingConsentChange,
+                        required: true,
+                    }}
+                />
+
+                <ConsentCheckbox
+                    id="marketing-email-consent"
+                    label={CONSENT_LABELS.marketingEmail}
+                    inputProps={{
+                        name: 'marketing-email-consent',
+                        checked: marketingEmailConsent,
+                        onChange: handleMarketingEmailConsentChange,
+                    }}
+                />
+
+                <ConsentCheckbox
+                    id="france-or-italy"
+                    label={CONSENT_LABELS.franceOrItaly}
+                    inputProps={{
+                        name: 'france-or-italy',
+                        checked: isFranceOrItaly,
+                        onChange: handleFranceOrItalyChange,
+                    }}
+                />
+
+                {isFranceOrItaly && (
+                    <ConsentCheckbox
+                        id="email-tracking-consent"
+                        label={CONSENT_LABELS.emailTracking}
+                        nested
+                        inputProps={{
+                            name: 'email-tracking-consent',
+                            checked: emailTrackingConsent,
+                            onChange: handleEmailTrackingConsentChange,
+                        }}
+                    />
+                )}
             </div>
 
             <div className={classnames(styles.actions, 'trial-licence-actions')}>

--- a/external/ag-website-shared/src/constants.ts
+++ b/external/ag-website-shared/src/constants.ts
@@ -12,10 +12,10 @@ export const RECAPTCHA_URL = 'https://www.google.com/recaptcha/api.js';
  */
 export const CONSENT_FIELD_IDS = {
     default: {
-        dataProcessingConsentId: '00NQ500000IfxTS',
-        marketingEmailConsentId: '00NS900000KOnU0',
-        emailTrackingConsentId: '00NS900000KQ3GT',
-        franceOrItalyId: '00NS900000KYN3V',
+        dataProcessingConsentId: '00NS900000KbwBF',
+        marketingEmailConsentId: '00NS900000KbwBI',
+        emailTrackingConsentId: '00NS900000KbwBG',
+        franceOrItalyId: '00NS900000KbwBH',
     },
     production: {
         dataProcessingConsentId: '00NQ500000IfxTS',


### PR DESCRIPTION
Fixes QA **TC1** from AG-17996: tabbing past the unchecked data processing consent checkbox showed the required-consent error, and then ticking the box left the error on screen until focus moved away again.

## Cause

`ContactForm` uses react-hook-form with `mode: 'onBlur'`. That mode validates on blur but does **not** re-validate on change before the first submit, so the error state went stale as soon as the value changed — hence "the error goes away after tabbing".

## Fix

One line: `mode: 'onTouched'`. Same first-validation-on-blur behaviour, plus re-validation on change, so a message clears the moment the field is corrected.

## Verified

Reproduced TC1 with real keyboard events, not synthesised ones:

1. Click Message, type `aaa`, TAB TAB → error shown under the unchecked first checkbox (bug state reproduced)
2. SHIFT+TAB, SPACE → checkbox ticked, **error gone immediately** ✅

Checked for regressions, since `mode` affects every field on the form:

- Typing an invalid email **before** any blur still shows no error — errors do not fire while typing into an untouched field
- Blurring an invalid email shows "Enter a valid email"; correcting it now clears immediately rather than waiting for the next blur. This is the same class of bug as TC1, now also fixed for the text fields
- Submit still blocks on every required field, consent included

Format and lint pass.

The trial licence form is not affected — it derives its errors from live state on every render behind the `wasValidated` gate, so its consent error already cleared instantly.

One deviation from the ticket's steps worth noting: the second TAB lands on the "Privacy Policy" link inside the label rather than the second checkbox, because the link is in the tab order. The error state described in TC1 is reached either way.

---

## Also in this PR — review findings from #2225 / #7611

**Studio trial form had no privacy disclosure and no consent (P1).** `a8e0dc175a9` removed `By submitting this form you agree to our Privacy Policy.` from `TrialLicenceFormStudio.tsx` without giving it the consent controls that justified removing that line from the other forms — so it was collecting name and email with no disclosure at all. It now gets the same treatment as `TrialLicenceForm`: required data processing consent, optional marketing consent, and a France/Italy declaration revealing optional email tracking consent, all four sent in its JSON payload.

Note this form only renders on **ag-studio** (`PricingForm.tsx`); in ag-grid and ag-charts it is dead code, so the live regression was limited to the Studio site.

**Consent errors were invisible to assistive technology (P2).** The checkbox now gets `aria-invalid` and `aria-describedby` pointing at the message, which carries a matching `id` and `role="alert"`. Verified in the browser: both attributes appear on a failed submit, resolve to the real error element, and clear the instant the box is ticked.

**Two pre-existing issues also fixed (P2):**
- `submitUrl` was missing from the submit callback dependencies, so a changed prop would have kept posting to the previous endpoint
- both trial forms were typed `FunctionComponent` rather than `FunctionComponent<Props>`, so the exported type was `FunctionComponent<{}>` and consumers could not type-check `submitUrl`

**Sandbox consent field IDs updated** (`5df64433a81`) — the `default` block now uses a consistent `00NS900000Kbw*` set. Previously `dataProcessingConsentId` held a production `00NQ5*` ID, so data processing consent would not have landed in UAT.

### Not verified here
The Studio trial form is not rendered in this repo, so its consent flow could not be exercised in a browser. It mirrors `TrialLicenceForm` hook-for-hook and markup-for-markup, and the shared `ConsentCheckbox` behaviour was verified on the contact form, but the Studio form itself is best checked on ag-studio#2225.

---

## AG-17996 — related PRs

| Repo | Branch | PR |
| --- | --- | --- |
| ag-grid | `latest` | ag-grid/ag-grid#14646 (merged) |
| ag-grid | `latest` | ag-grid/ag-grid#14660 — QA TC1 fix |
| ag-grid | `b36.0.2` — production | ag-grid/ag-grid#14658 |
| ag-charts | `b14.0.2` — production | ag-grid/ag-charts#7610 |
| ag-charts | `b14.1.0` — next release | ag-grid/ag-charts#7611 (merged) |
| ag-charts | `b14.1.0` | ag-grid/ag-charts#7619 — QA TC1 fix |
| ag-studio | `latest` | ag-grid/ag-studio#2225 |
| ag-studio | `b2.0.1` — production | ag-grid/ag-studio#2226 |

The QA TC1 fix (contact form errors clearing as soon as a field is corrected) is included as an extra commit on the four still-open port branches — #14658, #7610, #2225 and #2226 — and as its own PR where the port had already merged: #7619 for `b14.1.0` and #14660 for `latest`.

The ag-charts changes are branched off the release branches directly and will reach `latest` after release.

