### PR TITLE
AG-17910 Calculated columns docs: select matching formatting via cell data types

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-advanced/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-advanced/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { ColDef, GridOptions, ValueFormatterLiteParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ModuleRegistry,
@@ -28,7 +28,7 @@ type SalesRow = {
     cost: number;
 };
 
-const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedString: string): string => {
+const formatter = (params: ValueFormatterLiteParams<SalesRow, number>, format: (value: number) => string): string => {
     const { value } = params;
     if (value == null) {
         return '';
@@ -38,42 +38,40 @@ const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedStri
         return String(value);
     }
 
-    return formattedString;
+    return format(value);
 };
 
-const currencyFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
-    formatter(params, `$${(params.value ?? '').toLocaleString()}`);
+const currencyFormatter = (params: ValueFormatterLiteParams<SalesRow, number>) =>
+    formatter(params, (value) => `$${value.toLocaleString()}`);
 
-const percentageFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
-    formatter(params, `${Math.round((params.value ?? 0) * 100)}%`);
+const percentageFormatter = (params: ValueFormatterLiteParams<SalesRow, number>) =>
+    formatter(params, (value) => `${Math.round(value * 100)}%`);
 
 const columnDefs: ColDef<SalesRow>[] = [
     { field: 'account', flex: 1.4 },
     {
         field: 'revenue',
-        valueFormatter: currencyFormatter,
+        cellDataType: 'currency',
     },
     {
         field: 'cost',
-        valueFormatter: currencyFormatter,
+        cellDataType: 'currency',
     },
     {
         colId: 'profit',
         headerName: 'Profit',
         calculatedExpression: '[revenue] - [cost]',
-        cellDataType: 'number',
+        cellDataType: 'currency',
         sortable: true,
         filter: 'agNumberColumnFilter',
-        valueFormatter: currencyFormatter,
     },
     {
         colId: 'margin',
         headerName: 'Margin',
         calculatedExpression: '[profit] / [revenue]',
-        cellDataType: 'number',
+        cellDataType: 'percentage',
         sortable: true,
         filter: 'agNumberColumnFilter',
-        valueFormatter: percentageFormatter,
     },
     {
         colId: 'status',
@@ -111,7 +109,21 @@ const rowData: SalesRow[] = [
 const gridOptions: GridOptions<SalesRow> = {
     columnDefs,
     rowData,
-    calculatedColumns: true,
+    dataTypeDefinitions: {
+        currency: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: currencyFormatter,
+        },
+        percentage: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: percentageFormatter,
+        },
+    },
+    calculatedColumns: {
+        dataTypes: ['currency', 'percentage', 'number', 'text', 'boolean'],
+    },
     defaultColDef: {
         flex: 1,
         minWidth: 130,

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-api/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-api/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridApi, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { ColDef, GridApi, GridOptions, ValueFormatterLiteParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ColumnApiModule,
@@ -27,30 +27,28 @@ type SalesRow = {
     cost: number;
 };
 
-const currencyFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
+const currencyFormatter = (params: ValueFormatterLiteParams<SalesRow, number>) =>
     params.value == null ? '' : `$${params.value.toLocaleString()}`;
 
-const percentFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
+const percentFormatter = (params: ValueFormatterLiteParams<SalesRow, number>) =>
     params.value == null ? '' : `${(params.value * 100).toFixed(1)}%`;
 
 const marginColumn: ColDef<SalesRow> = {
     colId: 'profitMargin',
     headerName: 'Profit Margin',
     calculatedExpression: '([revenue] - [cost]) / [revenue]',
-    cellDataType: 'number',
-    valueFormatter: percentFormatter,
+    cellDataType: 'percentage',
 };
 
 const columnDefs: ColDef<SalesRow>[] = [
     { field: 'product', flex: 1 },
-    { field: 'revenue', valueFormatter: currencyFormatter },
-    { field: 'cost', valueFormatter: currencyFormatter },
+    { field: 'revenue', cellDataType: 'currency' },
+    { field: 'cost', cellDataType: 'currency' },
     {
         colId: 'profit',
         headerName: 'Profit',
         calculatedExpression: '[revenue] - [cost]',
-        cellDataType: 'number',
-        valueFormatter: currencyFormatter,
+        cellDataType: 'currency',
     },
 ];
 
@@ -82,6 +80,18 @@ let gridApi: GridApi<SalesRow>;
 const gridOptions: GridOptions<SalesRow> = {
     columnDefs,
     rowData,
+    dataTypeDefinitions: {
+        currency: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: currencyFormatter,
+        },
+        percentage: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: percentFormatter,
+        },
+    },
     calculatedColumns: true,
     defaultColDef: {
         flex: 1,

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-apply-mode/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-apply-mode/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { ColDef, GridOptions, ValueFormatterLiteParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ModuleRegistry,
@@ -28,7 +28,7 @@ type SalesRow = {
     cost: number;
 };
 
-const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedString: string): string => {
+const currencyFormatter = (params: ValueFormatterLiteParams<SalesRow, number>): string => {
     const { value } = params;
     if (value == null) {
         return '';
@@ -38,32 +38,28 @@ const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedStri
         return String(value);
     }
 
-    return formattedString;
+    return `$${value.toLocaleString()}`;
 };
-
-const currencyFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
-    formatter(params, `$${(params.value ?? '').toLocaleString()}`);
 
 const columnDefs: ColDef<SalesRow>[] = [
     { field: 'product', flex: 1 },
     {
         field: 'revenue',
         editable: true,
-        valueFormatter: currencyFormatter,
+        cellDataType: 'currency',
     },
     {
         field: 'cost',
         editable: true,
-        valueFormatter: currencyFormatter,
+        cellDataType: 'currency',
     },
     {
         colId: 'profit',
         headerName: 'Profit',
         calculatedExpression: '[revenue] - [cost]',
-        cellDataType: 'number',
+        cellDataType: 'currency',
         sortable: true,
         filter: 'agNumberColumnFilter',
-        valueFormatter: currencyFormatter,
     },
 ];
 
@@ -93,8 +89,16 @@ const rowData: SalesRow[] = [
 const gridOptions: GridOptions<SalesRow> = {
     columnDefs,
     rowData,
+    dataTypeDefinitions: {
+        currency: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: currencyFormatter,
+        },
+    },
     calculatedColumns: {
         applyMode: 'deferred',
+        dataTypes: ['currency', 'number', 'text', 'boolean'],
     },
     defaultColDef: {
         flex: 1,

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-column-groups/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-column-groups/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, ColGroupDef, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { ColDef, ColGroupDef, GridOptions, ValueFormatterLiteParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ModuleRegistry,
@@ -34,7 +34,10 @@ type QuarterlyRevenueRow = {
 
 type QuarterField = Exclude<keyof QuarterlyRevenueRow, 'product'>;
 
-const formatter = (params: ValueFormatterParams<QuarterlyRevenueRow, number>, formattedString: string): string => {
+const formatter = (
+    params: ValueFormatterLiteParams<QuarterlyRevenueRow, number>,
+    format: (value: number) => string
+): string => {
     const { value } = params;
     if (value == null) {
         return '';
@@ -44,22 +47,21 @@ const formatter = (params: ValueFormatterParams<QuarterlyRevenueRow, number>, fo
         return String(value);
     }
 
-    return formattedString;
+    return format(value);
 };
 
-const currencyFormatter = (params: ValueFormatterParams<QuarterlyRevenueRow, number>) =>
-    formatter(params, `$${(params.value ?? '').toLocaleString()}`);
+const currencyFormatter = (params: ValueFormatterLiteParams<QuarterlyRevenueRow, number>) =>
+    formatter(params, (value) => `$${value.toLocaleString()}`);
 
-const percentageFormatter = (params: ValueFormatterParams<QuarterlyRevenueRow, number>) =>
-    formatter(params, `${(params.value ?? 0).toLocaleString(undefined, { maximumFractionDigits: 1 })}%`);
+const percentageFormatter = (params: ValueFormatterLiteParams<QuarterlyRevenueRow, number>) =>
+    formatter(params, (value) => `${(value * 100).toLocaleString(undefined, { maximumFractionDigits: 1 })}%`);
 
 const quarterColumn = (field: QuarterField): ColDef<QuarterlyRevenueRow, number> => ({
     field,
     colId: field,
     headerName: field.slice(0, 2).toUpperCase(),
     columnGroupShow: 'open',
-    cellDataType: 'number',
-    valueFormatter: currencyFormatter,
+    cellDataType: 'currency',
 });
 
 const columnDefs: (ColDef<QuarterlyRevenueRow> | ColGroupDef<QuarterlyRevenueRow>)[] = [
@@ -77,8 +79,7 @@ const columnDefs: (ColDef<QuarterlyRevenueRow> | ColGroupDef<QuarterlyRevenueRow
                 headerName: 'Total',
                 columnGroupShow: 'closed',
                 calculatedExpression: '[q1_2025] + [q2_2025] + [q3_2025] + [q4_2025]',
-                cellDataType: 'number',
-                valueFormatter: currencyFormatter,
+                cellDataType: 'currency',
             },
         ],
     },
@@ -95,8 +96,7 @@ const columnDefs: (ColDef<QuarterlyRevenueRow> | ColGroupDef<QuarterlyRevenueRow
                 headerName: 'Total',
                 columnGroupShow: 'closed',
                 calculatedExpression: '[q1_2026] + [q2_2026] + [q3_2026] + [q4_2026]',
-                cellDataType: 'number',
-                valueFormatter: currencyFormatter,
+                cellDataType: 'currency',
             },
         ],
     },
@@ -106,21 +106,19 @@ const columnDefs: (ColDef<QuarterlyRevenueRow> | ColGroupDef<QuarterlyRevenueRow
             {
                 colId: 'q4Change',
                 headerName: 'Q4 Change',
-                calculatedExpression: 'ROUND((([q4_2026] - [q4_2025]) / [q4_2025]) * 100, 1)',
-                cellDataType: 'number',
+                calculatedExpression: '([q4_2026] - [q4_2025]) / [q4_2025]',
+                cellDataType: 'percentage',
                 sortable: true,
                 filter: 'agNumberColumnFilter',
-                valueFormatter: percentageFormatter,
             },
             {
                 colId: 'yearChange',
                 headerName: 'Year Change',
                 calculatedExpression:
                     '([q1_2026] + [q2_2026] + [q3_2026] + [q4_2026]) - ([q1_2025] + [q2_2025] + [q3_2025] + [q4_2025])',
-                cellDataType: 'number',
+                cellDataType: 'currency',
                 sortable: true,
                 filter: 'agNumberColumnFilter',
-                valueFormatter: currencyFormatter,
             },
         ],
     },
@@ -352,7 +350,21 @@ const rowData: QuarterlyRevenueRow[] = [
 const gridOptions: GridOptions<QuarterlyRevenueRow> = {
     columnDefs,
     rowData,
-    calculatedColumns: true,
+    dataTypeDefinitions: {
+        currency: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: currencyFormatter,
+        },
+        percentage: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: percentageFormatter,
+        },
+    },
+    calculatedColumns: {
+        dataTypes: ['currency', 'percentage', 'number', 'text', 'boolean'],
+    },
     defaultColDef: {
         minWidth: 120,
         flex: 1,

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-dialog-data-types/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-dialog-data-types/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { ColDef, GridOptions, ValueFormatterLiteParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ModuleRegistry,
@@ -26,7 +26,7 @@ type SalesRow = {
     cost: number;
 };
 
-const currencyFormatter = (params: ValueFormatterParams<SalesRow, number>): string => {
+const currencyFormatter = (params: ValueFormatterLiteParams<SalesRow, number>): string => {
     const { value } = params;
     if (value == null) {
         return '';

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-dialog-helper-lists/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-dialog-helper-lists/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { ColDef, GridOptions, ValueFormatterLiteParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ModuleRegistry,
@@ -26,7 +26,7 @@ type SalesRow = {
     cost: number;
 };
 
-const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedString: string): string => {
+const currencyFormatter = (params: ValueFormatterLiteParams<SalesRow, number>): string => {
     const { value } = params;
     if (value == null) {
         return '';
@@ -36,23 +36,19 @@ const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedStri
         return String(value);
     }
 
-    return formattedString;
+    return `$${value.toLocaleString()}`;
 };
-
-const currencyFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
-    formatter(params, `$${(params.value ?? '').toLocaleString()}`);
 
 const columnDefs: ColDef<SalesRow>[] = [
     { field: 'product', flex: 1.3 },
-    { field: 'revenue', valueFormatter: currencyFormatter },
-    { field: 'cost', valueFormatter: currencyFormatter },
+    { field: 'revenue', cellDataType: 'currency' },
+    { field: 'cost', cellDataType: 'currency' },
     {
         colId: 'profit',
         headerName: 'Profit',
         calculatedExpression: '[revenue] - [cost]',
-        cellDataType: 'number',
+        cellDataType: 'currency',
         filter: 'agNumberColumnFilter',
-        valueFormatter: currencyFormatter,
     },
 ];
 
@@ -82,8 +78,16 @@ const rowData: SalesRow[] = [
 const gridOptions: GridOptions<SalesRow> = {
     columnDefs,
     rowData,
+    dataTypeDefinitions: {
+        currency: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: currencyFormatter,
+        },
+    },
     calculatedColumns: {
         expressionPickers: ['columns'],
+        dataTypes: ['currency', 'number', 'text', 'boolean'],
     },
     defaultColDef: {
         flex: 1,

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-dialog-highlighting/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-dialog-highlighting/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { ColDef, GridOptions, ValueFormatterLiteParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ModuleRegistry,
@@ -26,7 +26,7 @@ type SalesRow = {
     cost: number;
 };
 
-const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedString: string): string => {
+const currencyFormatter = (params: ValueFormatterLiteParams<SalesRow, number>): string => {
     const { value } = params;
     if (value == null) {
         return '';
@@ -36,23 +36,19 @@ const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedStri
         return String(value);
     }
 
-    return formattedString;
+    return `$${value.toLocaleString()}`;
 };
-
-const currencyFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
-    formatter(params, `$${(params.value ?? '').toLocaleString()}`);
 
 const columnDefs: ColDef<SalesRow>[] = [
     { field: 'product', flex: 1.3 },
-    { field: 'revenue', valueFormatter: currencyFormatter },
-    { field: 'cost', valueFormatter: currencyFormatter },
+    { field: 'revenue', cellDataType: 'currency' },
+    { field: 'cost', cellDataType: 'currency' },
     {
         colId: 'profit',
         headerName: 'Profit',
         calculatedExpression: '[revenue] - [cost]',
-        cellDataType: 'number',
+        cellDataType: 'currency',
         filter: 'agNumberColumnFilter',
-        valueFormatter: currencyFormatter,
     },
 ];
 
@@ -82,8 +78,16 @@ const rowData: SalesRow[] = [
 const gridOptions: GridOptions<SalesRow> = {
     columnDefs,
     rowData,
+    dataTypeDefinitions: {
+        currency: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: currencyFormatter,
+        },
+    },
     calculatedColumns: {
         suppressColumnHighlighting: true,
+        dataTypes: ['currency', 'number', 'text', 'boolean'],
     },
     defaultColDef: {
         flex: 1,

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-row-groups/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns-row-groups/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { ColDef, GridOptions, ValueFormatterLiteParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ModuleRegistry,
@@ -28,7 +28,7 @@ type SalesRow = {
     cost: number;
 };
 
-const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedString: string): string => {
+const formatter = (params: ValueFormatterLiteParams<SalesRow, number>, format: (value: number) => string): string => {
     const { value } = params;
     if (value == null) {
         return '';
@@ -38,14 +38,14 @@ const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedStri
         return String(value);
     }
 
-    return formattedString;
+    return format(value);
 };
 
-const currencyFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
-    formatter(params, `$${(params.value ?? '').toLocaleString()}`);
+const currencyFormatter = (params: ValueFormatterLiteParams<SalesRow, number>) =>
+    formatter(params, (value) => `$${value.toLocaleString()}`);
 
-const percentageFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
-    formatter(params, `${Math.round((params.value ?? 0) * 100)}%`);
+const percentageFormatter = (params: ValueFormatterLiteParams<SalesRow, number>) =>
+    formatter(params, (value) => `${Math.round(value * 100)}%`);
 
 const columnDefs: ColDef<SalesRow>[] = [
     { field: 'productType', rowGroup: true, hide: true },
@@ -53,12 +53,12 @@ const columnDefs: ColDef<SalesRow>[] = [
     {
         field: 'revenue',
         aggFunc: 'sum',
-        valueFormatter: currencyFormatter,
+        cellDataType: 'currency',
     },
     {
         field: 'cost',
         aggFunc: 'sum',
-        valueFormatter: currencyFormatter,
+        cellDataType: 'currency',
     },
     {
         colId: 'profit',
@@ -66,17 +66,15 @@ const columnDefs: ColDef<SalesRow>[] = [
         calculatedExpression: '[revenue] - [cost]',
         // aggFunc lets the calculated column aggregate its per-leaf results onto group rows.
         aggFunc: 'sum',
-        cellDataType: 'number',
+        cellDataType: 'currency',
         filter: 'agNumberColumnFilter',
-        valueFormatter: currencyFormatter,
     },
     {
         colId: 'margin',
         headerName: 'Margin',
         // No aggFunc: a ratio does not aggregate, so margin evaluates on leaf rows and is blank on groups.
         calculatedExpression: '[profit] / [revenue]',
-        cellDataType: 'number',
-        valueFormatter: percentageFormatter,
+        cellDataType: 'percentage',
     },
 ];
 
@@ -106,7 +104,21 @@ const rowData: SalesRow[] = [
 const gridOptions: GridOptions<SalesRow> = {
     columnDefs,
     rowData,
-    calculatedColumns: true,
+    dataTypeDefinitions: {
+        currency: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: currencyFormatter,
+        },
+        percentage: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: percentageFormatter,
+        },
+    },
+    calculatedColumns: {
+        dataTypes: ['currency', 'percentage', 'number', 'text', 'boolean'],
+    },
     defaultColDef: {
         flex: 1,
         minWidth: 130,

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/_examples/calculated-columns/main.ts
@@ -1,4 +1,4 @@
-import type { ColDef, GridOptions, ValueFormatterParams } from 'ag-grid-community';
+import type { ColDef, GridOptions, ValueFormatterLiteParams } from 'ag-grid-community';
 import {
     ClientSideRowModelModule,
     ModuleRegistry,
@@ -28,7 +28,7 @@ type SalesRow = {
     cost: number;
 };
 
-const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedString: string): string => {
+const currencyFormatter = (params: ValueFormatterLiteParams<SalesRow, number>): string => {
     const { value } = params;
     if (value == null) {
         return '';
@@ -38,32 +38,28 @@ const formatter = (params: ValueFormatterParams<SalesRow, number>, formattedStri
         return String(value);
     }
 
-    return formattedString;
+    return `$${value.toLocaleString()}`;
 };
-
-const currencyFormatter = (params: ValueFormatterParams<SalesRow, number>) =>
-    formatter(params, `$${(params.value ?? '').toLocaleString()}`);
 
 const columnDefs: ColDef<SalesRow>[] = [
     { field: 'product', flex: 1 },
     {
         field: 'revenue',
         editable: true,
-        valueFormatter: currencyFormatter,
+        cellDataType: 'currency',
     },
     {
         field: 'cost',
         editable: true,
-        valueFormatter: currencyFormatter,
+        cellDataType: 'currency',
     },
     {
         colId: 'profit',
         headerName: 'Profit',
         calculatedExpression: '[revenue] - [cost]',
-        cellDataType: 'number',
+        cellDataType: 'currency',
         sortable: true,
         filter: 'agNumberColumnFilter',
-        valueFormatter: currencyFormatter,
     },
 ];
 
@@ -93,7 +89,16 @@ const rowData: SalesRow[] = [
 const gridOptions: GridOptions<SalesRow> = {
     columnDefs,
     rowData,
-    calculatedColumns: true,
+    dataTypeDefinitions: {
+        currency: {
+            baseDataType: 'number',
+            extendsDataType: 'number',
+            valueFormatter: currencyFormatter,
+        },
+    },
+    calculatedColumns: {
+        dataTypes: ['currency', 'number', 'text', 'boolean'],
+    },
     defaultColDef: {
         flex: 1,
         minWidth: 130,

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/index.mdoc
@@ -95,6 +95,7 @@ const gridOptions = {
     },
     columnDefs: [
         { field: 'revenue', cellDataType: 'currency' },
+        { field: 'cost', cellDataType: 'currency' },
         {
             colId: 'profit',
             headerName: 'Profit',

--- a/documentation/ag-grid-docs/src/content/docs/calculated-columns/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/calculated-columns/index.mdoc
@@ -32,6 +32,8 @@ Application-declared calculated columns must define a `colId` explicitly.
 
 {% gridExampleRunner title="Calculated Columns" name="calculated-columns" /%}
 
+Register [Cell Data Types](./cell-data-types/) to give users formatting options to pick from when they create a column. The example above provides a `currency` type — see [dataTypes](#datatypes).
+
 Calculated expressions do not need a leading equals sign (`=`). The value inside brackets must match a column `colId`, which defaults to the `field` when no explicit `colId` is provided.
 
 Calculated Columns are supported with all row models. Same-row bracket references are reliable everywhere. Cross-row and range references depend on the referenced rows being loaded in the current row model.
@@ -91,8 +93,19 @@ const gridOptions = {
     calculatedColumns: {
         dataTypes: ['currency', 'number', 'boolean'],
     },
+    columnDefs: [
+        { field: 'revenue', cellDataType: 'currency' },
+        {
+            colId: 'profit',
+            headerName: 'Profit',
+            calculatedExpression: '[revenue] - [cost]',
+            cellDataType: 'currency',
+        },
+    ],
 };
 ```
+
+Applying the type to your own columns as well means a user who picks **Currency** in the dialog gets the same formatting as the columns you declared. A `valueFormatter` on a column definition cannot be selected in the dialog, so it is not available to users.
 
 Built-in types use the grid's locale text, while custom type names are converted to readable labels in the dialog. If a selected value does not match a registered [Cell Data Type](./cell-data-types/), the grid's normal `cellDataType` validation applies when the calculated column is created.
 
@@ -162,13 +175,12 @@ const gridOptions = {
         {
             colId: 'profit',
             calculatedExpression: '[revenue] - [cost]',
-            cellDataType: 'number',
+            cellDataType: 'currency',
         },
         {
             colId: 'margin',
             calculatedExpression: '[profit] / [revenue]',
-            cellDataType: 'number',
-            valueFormatter: params => `${Math.round(params.value * 100)}%`,
+            cellDataType: 'percentage',
         },
         {
             colId: 'status',
@@ -178,6 +190,8 @@ const gridOptions = {
     ],
 };
 ```
+
+The `currency` and `percentage` types are registered with `dataTypeDefinitions`, as shown in [dataTypes](#datatypes).
 
 {% gridExampleRunner title="Advanced Calculated Columns" name="calculated-columns-advanced" /%}
 

--- a/documentation/ag-grid-docs/src/content/docs/formulas/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/formulas/index.mdoc
@@ -134,8 +134,28 @@ If the formula store is mutated outside the grid (for example, syncing from a ba
 
 During a [CSV Export](./csv-export), the grid exports the evaluated values of any formulas. During an [Excel Export](./excel-export), the grid exports the formulas themselves so Excel can evaluate them.
 
+## Calculated Columns
+
+Formulas apply to individual cells: a user types an expression into one cell, and only that cell is affected.
+
+To derive a value for every row instead, use [Calculated Columns](./calculated-columns/). A calculated column defines one expression that evaluates against each row, referencing other columns by `colId`. Users can add their own calculated columns at runtime through the Column Menu.
+
+```{% frameworkTransform=true %}
+const gridOptions = {
+    calculatedColumns: true,
+    columnDefs: [
+        { field: 'revenue' },
+        { field: 'cost' },
+        { colId: 'profit', headerName: 'Profit', calculatedExpression: '[revenue] - [cost]' },
+    ],
+};
+```
+
+Use Formulas for ad-hoc, per-cell expressions; use [Calculated Columns](./calculated-columns/) for a derived value that applies to every row.
+
 ## See also
 
 - [Formula Editor Component](./formula-editor-component/) – The rich editing experience for formula cells, including autocomplete and range selection tools.
 - [Formula Reference](./formula-reference/) – Full reference for operators (+, -, \*, /, ^, &, comparisons), provided functions, and errors.
 - [Custom Functions](./formula-custom-functions/) – How to register and implement custom functions for formulas.
+- [Calculated Columns](./calculated-columns/) – Whole-column derived values, defined in code or added by users at runtime.

--- a/documentation/ag-grid-docs/src/content/docs/formulas/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/formulas/index.mdoc
@@ -158,4 +158,3 @@ Use Formulas for ad-hoc, per-cell expressions; use [Calculated Columns](./calcul
 - [Formula Editor Component](./formula-editor-component/) – The rich editing experience for formula cells, including autocomplete and range selection tools.
 - [Formula Reference](./formula-reference/) – Full reference for operators (+, -, \*, /, ^, &, comparisons), provided functions, and errors.
 - [Custom Functions](./formula-custom-functions/) – How to register and implement custom functions for formulas.
-- [Calculated Columns](./calculated-columns/) – Whole-column derived values, defined in code or added by users at runtime.


### PR DESCRIPTION
## Summary

Lands the documentation-only improvements from #14630 so they can ship independently of grid state support for calculated columns.

**Calculated Columns examples — formatting via cell data types**

Every example previously attached a `valueFormatter` directly to its columns. A `valueFormatter` on a column definition cannot be selected in the calculated-column dialog, so a user creating their own column had no way to get the same currency/percentage formatting as the declared columns. The examples now register `currency` / `percentage` [Cell Data Types](https://ag-grid.com/documentation/cell-data-types/) via `dataTypeDefinitions`, list them in `calculatedColumns.dataTypes`, and set `cellDataType` on the columns — so picking **Currency** in the dialog produces formatting identical to the columns declared in code.

Formatters move to `ValueFormatterLiteParams` as required by `dataTypeDefinitions`.

**Docs prose**

- `calculated-columns` page: notes that registering cell data types gives users formatting options, explains why a `valueFormatter` is not selectable, and adds the missing `headerName` to snippets.
- `formulas` page: new **Calculated Columns** section drawing the per-cell vs per-row distinction, plus a See-also entry.

## JIRA

Jira: [AG-17910](https://ag-grid.atlassian.net/browse/AG-17910)

## Test Plan

- [x] `./docs-e2e.sh "calculated-columns"` — 54 passed across all framework variants
- [x] `yarn nx format:check --sort-root-tsconfig-paths=false` clean

## Notes

Split out of #14630 (PR 3 of that stack). The one sentence in #14630 that cross-links Grid State from the calculated-columns page is deliberately **not** included here — it stays with the grid-state work.
