### PR TITLE
aiw: opt into the CI-flake re-run (AG-17967)

### DIFF
--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -187,12 +187,6 @@ jobs:
             contents: read
             pull-requests: read
             packages: read
-            # AG-17967: lets the preflight re-run a first-attempt CI failure's
-            # failed jobs (see `run_attempt` on the cifail step below).
-            # `permissions:` REPLACES rather than merges, so the two reads above
-            # must stay — without `pull-requests: read` the preflight's PR
-            # lookup finds nothing and the whole CI-failure path goes silently
-            # ineligible, not just the flake re-run.
             actions: write
         outputs:
             stage: ${{ steps.resume.outputs.stage }}
@@ -233,11 +227,6 @@ jobs:
                   head_branch: ${{ github.event.workflow_run.head_branch }}
                   head_sha: ${{ github.event.workflow_run.head_sha }}
                   run_url: ${{ github.event.workflow_run.html_url }}
-                  # AG-17967: on attempt 1 the preflight re-runs the failed jobs
-                  # instead of dispatching an agent, so a flake costs runner
-                  # minutes rather than an agent round + a unit of RECOVERY_CAP.
-                  # Fails safe: without `actions: write` the rerun 403s, the
-                  # preflight warns, and it dispatches the agent as before.
                   run_attempt: ${{ github.event.workflow_run.run_attempt }}
                   jira_email: ${{ secrets.JIRA_AI_BOT_EMAIL }}
                   jira_api_token: ${{ secrets.JIRA_AI_BOT_API_TOKEN }}

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -187,6 +187,13 @@ jobs:
             contents: read
             pull-requests: read
             packages: read
+            # AG-17967: lets the preflight re-run a first-attempt CI failure's
+            # failed jobs (see `run_attempt` on the cifail step below).
+            # `permissions:` REPLACES rather than merges, so the two reads above
+            # must stay — without `pull-requests: read` the preflight's PR
+            # lookup finds nothing and the whole CI-failure path goes silently
+            # ineligible, not just the flake re-run.
+            actions: write
         outputs:
             stage: ${{ steps.resume.outputs.stage }}
             prior_pr_outcome: ${{ steps.resume.outputs.prior_pr_outcome }}
@@ -226,6 +233,12 @@ jobs:
                   head_branch: ${{ github.event.workflow_run.head_branch }}
                   head_sha: ${{ github.event.workflow_run.head_sha }}
                   run_url: ${{ github.event.workflow_run.html_url }}
+                  # AG-17967: on attempt 1 the preflight re-runs the failed jobs
+                  # instead of dispatching an agent, so a flake costs runner
+                  # minutes rather than an agent round + a unit of RECOVERY_CAP.
+                  # Fails safe: without `actions: write` the rerun 403s, the
+                  # preflight warns, and it dispatches the agent as before.
+                  run_attempt: ${{ github.event.workflow_run.run_attempt }}
                   jira_email: ${{ secrets.JIRA_AI_BOT_EMAIL }}
                   jira_api_token: ${{ secrets.JIRA_AI_BOT_API_TOKEN }}
                   jira_site_url: ${{ vars.JIRA_SITE_URL }}


### PR DESCRIPTION
Consumer-side opt-in for the CI-flake re-run shipped in `@ag-grid/dev-prompts` 1.6.185 (ag-dev-prompts#667).

## Why

On [AG-17967](https://ag-grid.atlassian.net/browse/AG-17967) the AI Workflow gave up on a ticket whose CI ended up **green**. Two defects compounded; both are fixed in the shared action. This PR enables the half that needs a consumer change.

The relevant one: `RECOVERY_CAP` (3) is charged **at dispatch**, before the agent runs. So a CI *flake* spent a whole attempt. On AG-17967, run `30459957173` attempt 1 was `failure` and attempt 2 was `success` **with no new commits** — a full agent round plus a third of the ticket's budget, burned on nothing.

## What changes

Two lines in the `workflow_run · failure` preflight job:

- pass `run_attempt` to `jira-ci-failure-preflight`
- add `actions: write` to that job's `permissions:`

With both present, a **first-attempt** CI failure re-runs its own failed jobs (`gh run rerun --failed`) instead of dispatching an agent. A flake then costs runner minutes rather than an agent round and a unit of `RECOVERY_CAP`. Attempt ≥ 2 dispatches the agent exactly as it does today, so a genuinely red CI is not delayed beyond one re-run.

## ⚠️ `permissions:` replaces, it does not merge

The existing `contents: read` and `pull-requests: read` are deliberately kept in the block. Reducing it to a bare `actions: write` would strip the PR read, the preflight's `gh pr list --head` lookup would find nothing, `evaluateGate` would return ineligible — and that would **silently disable the entire CI-failure path**, not just the flake re-run.

## Fail-safe on both sides

| Situation | Behaviour |
|---|---|
| `run_attempt` omitted | Re-run never fires; today's behaviour |
| `run_attempt` passed, no `actions: write` | Re-run API call 403s → preflight logs a `::warning` → dispatches the agent as before |
| Run not eligible (human branch, wrong author, wrong status) | Never re-runs — the pipeline won't touch CI it doesn't own |

## Verification

- Decider unit tests cover all four cells including the ineligible-run guard (`decide-preflight.test.ts`); 831 tests green in the shared repo.
- The re-entry assumption — that a re-run fires a fresh `workflow_run` event — is verified against real AG-17967 data, not assumed: pipeline run `30467775634` (`event=workflow_run`) fired 9 s after attempt 2 completed and invoked `ci-success-handler` with `run_url=…/30459957173`.
- Not yet exercised end-to-end in a live consumer run — the first real red CI on an agent branch is the proof. Watch the preflight log for the `ci_flake_rerun=true` notice.

Design + rationale: [`docs/ai-workflow.md` → Wiring step 6](https://github.com/ag-grid/ag-dev-prompts/blob/latest/docs/ai-workflow.md).
