### PR TITLE
perf(csrm): identify displayed rows by slot instead of a Set of row ids

### DIFF
--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
@@ -52,6 +52,12 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
     /** Row nodes used for formula calculations when formula feature is active. */
     private formulaRows: RowNode[] = [];
 
+    /** Rows given a row top by the previous pass — the only rows that can hold a stale one. */
+    private positionedRows: RowNode[] = [];
+
+    /** Buffer the current pass fills, swapped into `positionedRows` once the stale tops are cleared. */
+    private positionedRowsNext: RowNode[] = [];
+
     /** The ordered list of row processing stages: group → filter → pivot → aggregate → filterAggregates → sort → flatten. */
     private stages: IRowNodeStage[] | null = null;
 
@@ -311,7 +317,7 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         return minIndex < stagesLen ? stages[minIndex].step : null;
     }
 
-    private setRowTopAndRowIndex(outputDisplayedRowsMapped?: Set<string>): void {
+    private setRowTopAndRowIndex(): void {
         const { beans, rowsToDisplay } = this;
         const defaultRowHeight = beans.environment.getDefaultRowHeight();
         let nextRowTop = 0;
@@ -320,13 +326,10 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         // with these two layouts.
         const allowEstimate = _isDomLayout(this.gos, 'normal');
 
-        for (let i = 0, len = rowsToDisplay.length; i < len; ++i) {
+        const len = rowsToDisplay.length;
+        const positioned = this.positionedRowsNext;
+        for (let i = 0; i < len; ++i) {
             const rowNode = rowsToDisplay[i];
-
-            const id = rowNode.id;
-            if (id != null) {
-                outputDisplayedRowsMapped?.add(id);
-            }
 
             if (rowNode.rowHeight == null) {
                 const rowHeight = _getRowHeightForNode(beans, rowNode, allowEstimate, defaultRowHeight);
@@ -336,9 +339,11 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
             rowNode.setRowTop(nextRowTop);
             rowNode.setRowIndex(i);
             nextRowTop += rowNode.rowHeight!;
+            positioned[i] = rowNode;
         }
+        positioned.length = len;
 
-        if (this.beans.formula?.isEvaluationActive()) {
+        if (beans.formula?.isEvaluationActive()) {
             const formulaRows = this.formulaRows;
             for (let i = 0, len = formulaRows.length; i < len; ++i) {
                 const rowNode = formulaRows[i];
@@ -347,39 +352,22 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         }
     }
 
-    private clearRowTopAndRowIndex(changedPath: ChangedPath | undefined, displayedRowsMapped: Set<string>): void {
-        const clearIfNotDisplayed = (rowNode?: RowNode) => {
-            if (rowNode?.id != null && !displayedRowsMapped.has(rowNode.id)) {
+    private clearRowTopAndRowIndex(): void {
+        const { rowsToDisplay, positionedRows } = this;
+
+        // Only a row positioned by the previous pass can hold a stale top, and `setRowTopAndRowIndex`
+        // has just given every currently-displayed row its slot, so a matching slot means still displayed.
+        for (let i = 0, len = positionedRows.length; i < len; ++i) {
+            const rowNode = positionedRows[i];
+            const rowIndex = rowNode.rowIndex;
+            if ((rowIndex == null || rowsToDisplay[rowIndex] !== rowNode) && !rowNode.destroyed) {
                 rowNode.clearRowTopAndRowIndex();
             }
-        };
-
-        const recurse = (rowNode: RowNode) => {
-            clearIfNotDisplayed(rowNode);
-            clearIfNotDisplayed(rowNode.detailNode);
-            clearIfNotDisplayed(rowNode.sibling);
-
-            const childrenAfterGroup = rowNode.childrenAfterGroup;
-            if (!rowNode.hasChildren() || !childrenAfterGroup) {
-                return;
-            }
-
-            // When changedPath is provided, we are here because of a transaction update or
-            // a change detection. Neither of these impacts the open/closed state of groups. So if
-            // a group is not open this time, it was not open last time. So we know all closed groups
-            // already have their top positions cleared — no need to traverse further.
-            if (changedPath && rowNode.level !== -1 && !rowNode.expanded) {
-                return;
-            }
-            for (let i = 0, len = childrenAfterGroup.length; i < len; ++i) {
-                recurse(childrenAfterGroup[i]);
-            }
-        };
-
-        const rootNode = this.rootNode;
-        if (rootNode) {
-            recurse(rootNode);
         }
+
+        this.positionedRows = this.positionedRowsNext;
+        positionedRows.length = 0;
+        this.positionedRowsNext = positionedRows;
     }
 
     public isLastRowIndexKnown(): boolean {
@@ -671,11 +659,9 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         }
         /* eslint-enable no-fallthrough */
 
-        // set all row tops to null, then set row tops on all visible rows. if we don't do this,
-        // then the algorithm below only sets row tops, old row tops from old rows will still lie around
-        const displayedNodesMapped = new Set<string>();
-        this.setRowTopAndRowIndex(displayedNodesMapped);
-        this.clearRowTopAndRowIndex(changedPath, displayedNodesMapped);
+        // Position the displayed rows first, then clear stale tops left on rows that dropped out.
+        this.setRowTopAndRowIndex();
+        this.clearRowTopAndRowIndex();
 
         this.updateRefreshParams(params); // Apply forced flags from any nested refresh calls
     }
@@ -1177,20 +1163,16 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         if (formula?.active) {
             const unfilteredRows = rootNode?.childrenAfterSort ?? [];
             this.formulaRows = unfilteredRows;
-            this.rowsToDisplay = unfilteredRows.filter((row) => !row.softFiltered);
-
-            for (const row of this.rowsToDisplay) {
-                row.setUiLevel(0);
-            }
+            this.rowsToDisplay = formulaRowsToDisplay(unfilteredRows);
             return;
         }
 
         if (flattenStage) {
             this.rowsToDisplay = flattenStage.execute();
         } else {
-            const rowsToDisplay = this.rootNode!.childrenAfterSort ?? [];
-            for (const row of rowsToDisplay) {
-                row.setUiLevel(0);
+            const rowsToDisplay = rootNode?.childrenAfterSort ?? [];
+            for (let i = 0, len = rowsToDisplay.length; i < len; ++i) {
+                rowsToDisplay[i].setUiLevel(0);
             }
             this.rowsToDisplay = rowsToDisplay;
         }
@@ -1257,6 +1239,8 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         this.started = false;
         this.rootNode = null;
         this.rowsToDisplay = [];
+        this.positionedRows.length = 0;
+        this.positionedRowsNext.length = 0;
         this.asyncTransactions = null;
         this.stages = null;
         this.stagesRefreshProps.clear();
@@ -1271,6 +1255,34 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         this.onRowHeightChanged_debounced();
     }
 }
+
+/**
+ * Displayed rows when formulas are active: every row except the soft-filtered ones.
+ * Soft filtering is the exception, so the scan returns `unfilteredRows` itself until one turns up.
+ */
+const formulaRowsToDisplay = (unfilteredRows: RowNode[]): RowNode[] => {
+    for (let i = 0, len = unfilteredRows.length; i < len; ++i) {
+        const row = unfilteredRows[i];
+        if (row.softFiltered) {
+            return collectNotSoftFiltered(unfilteredRows, i, len);
+        }
+        row.setUiLevel(0);
+    }
+    return unfilteredRows;
+};
+
+/** Everything before `from` is displayed and already levelled; `from` itself is soft-filtered. */
+const collectNotSoftFiltered = (unfilteredRows: RowNode[], from: number, len: number): RowNode[] => {
+    const displayed = unfilteredRows.slice(0, from);
+    for (let i = from + 1; i < len; ++i) {
+        const row = unfilteredRows[i];
+        if (!row.softFiltered) {
+            row.setUiLevel(0);
+            displayed.push(row);
+        }
+    }
+    return displayed;
+};
 
 const addAllLeafs = (result: RowNode[], node: RowNode): void => {
     const childrenAfterGroup = node.childrenAfterGroup;

--- a/testing/behavioural/src/benchmarks/map-stage.bench.ts
+++ b/testing/behavioural/src/benchmarks/map-stage.bench.ts
@@ -1,0 +1,86 @@
+// CSRM 'map' stage in isolation: flattening rows to display, then assigning/clearing row tops and
+// indexes. `refreshClientSideRowModel('map')` re-runs only that last pipeline step, so these measure
+// the row-positioning work without the grouping, aggregation or sorting stages ahead of it.
+// The three shapes differ in how many of the tree's nodes end up displayed: all of them (flat),
+// most of them (expanded groups), or almost none (collapsed groups).
+import { bench, suite } from 'vitest';
+
+import type { ColDef, GridApi } from 'ag-grid-community';
+import { ClientSideRowModelApiModule, ClientSideRowModelModule } from 'ag-grid-community';
+import { RowGroupingModule } from 'ag-grid-enterprise';
+
+import type { FlatRow, GroupedRow } from './bench-data';
+import { buildFlatData, buildGroupedData } from './bench-data';
+import { BenchGridsManager, benchDefaults } from './bench-utils';
+
+const ROW_COUNT = 20_000;
+
+suite(`map stage — flat (${ROW_COUNT} rows)`, () => {
+    const gridsManager = new BenchGridsManager({
+        modules: [ClientSideRowModelModule, ClientSideRowModelApiModule],
+    });
+    let api!: GridApi<FlatRow>;
+
+    const rowData = buildFlatData(ROW_COUNT);
+
+    bench(
+        `remap ${ROW_COUNT} displayed rows`,
+        () => {
+            api.refreshClientSideRowModel('map');
+        },
+        benchDefaults({
+            setup: () => {
+                api ??= gridsManager.createGrid('map-flat', {
+                    columnDefs: [{ field: 'name' }, { field: 'value' }],
+                    rowData,
+                    getRowId: ({ data }) => data.id,
+                });
+            },
+            teardown: async () => {
+                api = undefined!;
+                await gridsManager.reset();
+            },
+        })
+    );
+});
+
+// Both grouped benches share this shape; only `groupDefaultExpanded` differs, which is what decides
+// how much of the tree is displayed and therefore how much row positioning the stage has to do.
+const groupColumnDefs: ColDef[] = [
+    { field: 'group1', rowGroup: true, hide: true },
+    { field: 'group2', rowGroup: true, hide: true },
+    { field: 'group3', rowGroup: true, hide: true },
+    { field: 'value' },
+];
+
+suite(`map stage — grouped (3 levels, ${ROW_COUNT} rows)`, () => {
+    const gridsManager = new BenchGridsManager({
+        modules: [ClientSideRowModelModule, ClientSideRowModelApiModule, RowGroupingModule],
+    });
+    let api!: GridApi<GroupedRow>;
+
+    const rowData = buildGroupedData(ROW_COUNT);
+
+    for (const expanded of [true, false]) {
+        bench(
+            `remap with groups ${expanded ? 'expanded' : 'collapsed'}`,
+            () => {
+                api.refreshClientSideRowModel('map');
+            },
+            benchDefaults({
+                setup: () => {
+                    api ??= gridsManager.createGrid(`map-grouped-${expanded ? 'expanded' : 'collapsed'}`, {
+                        columnDefs: groupColumnDefs,
+                        rowData,
+                        groupDefaultExpanded: expanded ? -1 : 0,
+                        getRowId: ({ data }) => data.id,
+                    });
+                },
+                teardown: async () => {
+                    api = undefined!;
+                    await gridsManager.reset();
+                },
+            })
+        );
+    }
+});


### PR DESCRIPTION
# perf(csrm): clear stale row tops from the previously-positioned rows

## What

The `map` stage gives every displayed row a top and index, then clears the stale tops left on rows that
dropped out. Finding what to clear was the expensive half: a `Set<string>` of every displayed row id,
then a recursion over the whole node tree testing `Set.has(id)` per node.

**1. Identify displayed rows by slot, not by id.** `setRowTopAndRowIndex` has already given each
displayed row its index, so an array index and a pointer compare replace the set, the N string hashes
filling it, and a hash lookup per node:

```ts
if (rowIndex == null || rowsToDisplay[rowIndex] !== rowNode) {
    rowNode.clearRowTopAndRowIndex();
}
```

**2. Iterate the previously-positioned rows, not the tree.** `setRowTopAndRowIndex` records what it
positions into a buffer and the clear step walks that. O(all nodes) becomes O(previously-displayed), and
the recursion goes with its `changedPath` pruning, its per-node `hasChildren()` and its
`detailNode`/`sibling` probes. Two buffers swap, so nothing is reallocated per refresh.

**3. Stop allocating in the map path.** With formulas active, `doRowsToDisplay` called
`unfilteredRows.filter(...)` every refresh just to reproduce `unfilteredRows`. Soft-filtered rows are
the exception, so the scan now returns `unfilteredRows` itself until one turns up.

## Why it is safe

**The buffer holds exactly the rows that can carry a stale top.** `rowTop` is assigned only in
`RowNode.setRowTop` and `RowNode._destroy`; every other caller passing a non-null top belongs to another
row model (pinned, infinite, SSRM, viewport) or to `RowCtrl`. Within CSRM the sole caller is
`setRowTopAndRowIndex`. Nodes cleared elsewhere only make the buffer a superset.

**Detail rows and group footers are `rowsToDisplay` entries**, so they are recorded like any other row;
the old walk reached them via `detailNode`/`sibling`. Pinned clones hang off `pinnedSibling`, which
neither the old walk nor the buffer touches.

**Destroyed rows are skipped.** `clearRowTopAndRowIndex` leaves `oldRowTop` at the row's last top
(`setRowTop` assigns `oldRowTop = this.rowTop` before nulling) — the anchor `_destroy(fadeOut)` and
`RowCtrl.setAnimateFlags` use to slide the row out from where it was. A second call nulls that anchor.
The old walk never reached these nodes; the buffer holds them, hence the `!rowNode.destroyed` guard.

**The buffer is a copy, not a reference to `rowsToDisplay`.** `sortStage` reuses the previous
`childrenAfterSort` by reference and passes it to `postSortRows`, a user callback documented as mutating
it in place, and the community and formula map paths assign `childrenAfterSort` straight to
`rowsToDisplay`. A callback removing entries would silently leave stale tops. The spare is emptied on
handover so it doesn't pin the previous generation of rows, destroyed ones included.

Slot identity is also stricter than the id comparison it replaces: group ids are deterministic and
regenerated on rebuild, so a stale node could previously alias a displayed one and keep its top. Nodes
with `id == null`, unlookupable in an id-keyed set, were skipped entirely; they are now handled.

## Benchmarks

| Benchmark                                                    | base   | test    | Result      |
| ------------------------------------------------------------ | ------ | ------- | ----------- |
| map-stage › remap with groups collapsed                      | 726.2  | 207,601 | **285.87x** |
| map-stage › remap with groups expanded                       | 396.2  | 1133.8  | **2.86x**   |
| map-stage › remap 20000 displayed rows                       | 1846.7 | 4870.9  | **2.64x**   |
| pivot-transaction › transaction update                       | 3395.7 | 6361.9  | **1.87x**   |
| delta-sort-transaction › applyTransaction (deltaSort: true)  | 102.6  | 158.4   | **1.54x**   |
| grouping-pipelines › grouping from scratch 20k               | 69.27  | 94.41   | **1.36x**   |
| grouping-pipelines › sorting from scratch 15k (5 sorts)      | 31.59  | 40.65   | **1.29x**   |
| grouping-pipelines › update sorting rowData 15k (5 sorts)    | 64.96  | 79.49   | **1.22x**   |
| grouping-pipelines › update grouping rowData 20k             | 114.8  | 138.9   | **1.21x**   |
| calculated-live-preview › keystroke flush 10k, sorted        | 194.4  | 233.3   | **1.20x**   |
| flat-pipelines › immutable update with filter + sort 15k     | 72.24  | 86.42   | **1.20x**   |
| flat-pipelines › delta sort with 30% updates                 | 581.0  | 686.1   | **1.18x**   |
| flat-pipelines › full sort with 30% updates                  | 573.4  | 667.4   | **1.16x**   |
| flat-pipelines › filter + sort 15k                           | 26.76  | 30.82   | **1.15x**   |
| tree-data-parent-id › build from scratch 12k                 | 172.7  | 196.8   | **1.14x**   |
| pivot-aggregation › full refresh                             | 84.62  | 96.40   | **1.14x**   |
| pivot-aggregation › full refresh (pivotComparator)           | 83.24  | 94.24   | **1.13x**   |
| calculated-live-preview › keystroke flush 1k, chained calc   | 104.7  | 118.1   | **1.13x**   |
| grouping-pipelines › toggle text filter on/off 12k           | 91.55  | 103.0   | **1.13x**   |
| grouping-pipelines › immutable update with active filter 12k | 108.5  | 121.6   | **1.12x**   |
| flat-pipelines › immutable update with active filter 10k     | 133.6  | 148.2   | **1.11x**   |
| tree-data-path › build from scratch 21k                      | 14.33  | 15.65   | **1.09x**   |
| flat-pipelines › toggle text filter on/off 10k               | 126.3  | 137.8   | **1.09x**   |
| delta-sort-transaction › applyTransaction (deltaSort: false) | 14.86  | 16.18   | **1.09x**   |
| flat-pipelines › sort 8000 rows                              | 77.83  | 84.05   | **1.08x**   |
| tree-data-path › update rowData 21k                          | 11.54  | 12.34   | **1.07x**   |
| grouping-pipelines › 8 further agg/transaction benches       |        |         | 1.04–1.06x  |
