### PR TITLE
[AG-115] Fix(column-header): stretch the edit column name dialog content to full width

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_column-header-edit.scss
+++ b/community-modules/styles/src/internal/base/parts/_column-header-edit.scss
@@ -8,6 +8,9 @@
         padding: var(--ag-widget-container-vertical-padding) var(--ag-widget-container-horizontal-padding);
         box-sizing: border-box;
         height: 100%;
+        /* The panel content wrapper lays out in a row, so grow to claim the dialog's full width. */
+        flex: 1 1 auto;
+        min-width: 0;
     }
 
     .ag-column-header-edit-popup-editor {

--- a/community-modules/styles/src/internal/base/parts/_column-header-edit.scss
+++ b/community-modules/styles/src/internal/base/parts/_column-header-edit.scss
@@ -8,7 +8,7 @@
         padding: var(--ag-widget-container-vertical-padding) var(--ag-widget-container-horizontal-padding);
         box-sizing: border-box;
         height: 100%;
-        /* The panel content wrapper lays out in a row, so grow to claim the dialog's full width. */
+        // The panel content wrapper lays out in a row, so grow to claim the dialog's full width.
         flex: 1 1 auto;
         min-width: 0;
     }

--- a/packages/ag-grid-enterprise/src/columnHeaderEdit/columnHeaderEdit.css
+++ b/packages/ag-grid-enterprise/src/columnHeaderEdit/columnHeaderEdit.css
@@ -5,6 +5,10 @@
     padding: var(--ag-widget-container-vertical-padding) var(--ag-widget-container-horizontal-padding);
     box-sizing: border-box;
     height: 100%;
+
+    /* The panel content wrapper lays out in a row, so grow to claim the dialog's full width. */
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
 .ag-column-header-edit-popup-editor {

--- a/packages/ag-grid-enterprise/src/columnHeaderEdit/columnHeaderEditPopup.ts
+++ b/packages/ag-grid-enterprise/src/columnHeaderEdit/columnHeaderEditPopup.ts
@@ -8,8 +8,8 @@ import { Dialog } from '../widgets/dialog';
 const WIDTH = 300;
 const MIN_WIDTH = 300;
 // Deferred mode adds the Apply/Cancel actions row, so the dialog needs more height.
-const LIVE_HEIGHT = 130;
-const DEFERRED_HEIGHT = 190;
+const LIVE_HEIGHT = 110;
+const DEFERRED_HEIGHT = 160;
 
 const ColumnHeaderEditContentElement: ElementParams = {
     tag: 'div',


### PR DESCRIPTION
Follow-up to #14669 (merged) — the dialog got wider there, but the content inside did not stretch.

`.ag-panel-content-wrapper` is a **row** flex container, so the popup content sized to its own content and left-aligned; the extra dialog width was unused. Fixed with `flex: 1 1 auto` + `min-width: 0` on the content, matching how the calculated-column panel's form claims its width.

Measured on the docs example: content was 201px inside the 210px dialog, and 208px after the fix.

Also reverts the height bump from #14669 — the editor is `flex: 1 1 auto` in a column container, so the extra height only made the input taller. Width is what makes the dialog noticeable.

<img width="1626" height="755" alt="image" src="https://github.com/user-attachments/assets/25feb4af-1bb3-423a-88f5-c91c3553edb5" />
