### PR TITLE
CRT-1175 - Show the example loading logo when reloading in another language

### DIFF
--- a/documentation/ag-grid-docs/src/components/example-runner/components/ExampleIFrame.tsx
+++ b/documentation/ag-grid-docs/src/components/example-runner/components/ExampleIFrame.tsx
@@ -1,3 +1,4 @@
+import { EXAMPLE_RELOADING_MESSAGE_TYPE } from '@ag-website-shared/components/loading-logo/messages';
 import { useIntersectionObserver } from '@ag-website-shared/utils/hooks/useIntersectionObserver';
 import { useDarkmode } from '@utils/hooks/useDarkmode';
 import classnames from 'classnames';
@@ -59,8 +60,15 @@ export const ExampleIFrame: FunctionComponent<Props> = ({
         if (!isIntersecting || !url || !iFrameRef.current || (currentSrc as URL)?.pathname === url || isScrolling) {
             return;
         }
+
+        if (currentSrc) {
+            // Post before navigating, otherwise the stale example stays visible until the loading
+            // logo island handles the message
+            window.postMessage({ type: EXAMPLE_RELOADING_MESSAGE_TYPE, loadingIFrameId });
+        }
+
         iFrameRef.current.src = url;
-    }, [isIntersecting, url, isScrolling]);
+    }, [isIntersecting, url, isScrolling, loadingIFrameId]);
 
     // when dark mode is changed, applies it to the iframe.
     useEffect(() => {

--- a/external/ag-website-shared/src/components/loading-logo/LoadingLogo.tsx
+++ b/external/ag-website-shared/src/components/loading-logo/LoadingLogo.tsx
@@ -1,4 +1,5 @@
 import { getLoadingIFrameId } from '@ag-website-shared/components/loading-logo/getElementId';
+import { EXAMPLE_RELOADING_MESSAGE_TYPE } from '@ag-website-shared/components/loading-logo/messages';
 import AgLoadingLogo from '@ag-website-shared/images/inline-svgs/ag-grid-logomark-not-loading.svg?react';
 import {
     type UseIntersectionObserverParams,
@@ -11,6 +12,12 @@ interface Props {
     pageName: string;
     exampleName: string;
 }
+
+/**
+ * An example only becomes visible once it reports back with an `init` message, so one that never
+ * sends it must not leave its iFrame hidden indefinitely.
+ */
+const REVEAL_FALLBACK_TIMEOUT_MS = 15_000;
 
 export const LoadingLogo: FunctionComponent<Props> = ({ pageName, exampleName }) => {
     const loadingLogoRef = useRef<HTMLDivElement>(null);
@@ -39,21 +46,56 @@ export const LoadingLogo: FunctionComponent<Props> = ({ pageName, exampleName })
     });
 
     useEffect(() => {
-        window.addEventListener('message', ({ data }) => {
+        let revealFallbackTimeout: ReturnType<typeof setTimeout> | undefined;
+
+        const eachIFrame = (callback: (iframe: HTMLIFrameElement) => void) => {
+            document.querySelectorAll<HTMLIFrameElement>('#' + loadingIFrameId).forEach(callback);
+        };
+
+        const showExample = () => {
+            clearTimeout(revealFallbackTimeout);
+            setHide(true);
+
+            eachIFrame((iframe) => {
+                iframe.style.visibility = 'visible';
+                if (document.documentElement.dataset['darkMode'] === 'true' && iframe.contentDocument) {
+                    iframe.contentDocument.documentElement.dataset['darkMode'] = 'true';
+                }
+            });
+        };
+
+        const showLoadingLogo = () => {
+            clearTimeout(revealFallbackTimeout);
+            setHide(false);
+            eachIFrame((iframe) => {
+                iframe.style.visibility = 'hidden';
+            });
+
+            revealFallbackTimeout = setTimeout(showExample, REVEAL_FALLBACK_TIMEOUT_MS);
+        };
+
+        const onMessage = ({ data }: MessageEvent) => {
+            if (data?.type === EXAMPLE_RELOADING_MESSAGE_TYPE) {
+                if (data.loadingIFrameId === loadingIFrameId) {
+                    showLoadingLogo();
+                }
+                return;
+            }
+
             const isExample = pageName === data?.pageName && exampleName === data?.exampleName;
             if (!isExample) return;
 
             if (data?.type === 'init') {
-                setHide(true);
-
-                document.querySelectorAll('#' + loadingIFrameId).forEach((iframe) => {
-                    iframe.style.visibility = 'visible';
-                    if (document.documentElement.dataset['darkMode'] === 'true') {
-                        iframe.contentDocument.documentElement.dataset.darkMode = true;
-                    }
-                });
+                showExample();
             }
-        });
+        };
+
+        window.addEventListener('message', onMessage);
+
+        return () => {
+            window.removeEventListener('message', onMessage);
+            clearTimeout(revealFallbackTimeout);
+        };
     }, []);
 
     return (

--- a/external/ag-website-shared/src/components/loading-logo/messages.ts
+++ b/external/ag-website-shared/src/components/loading-logo/messages.ts
@@ -1,0 +1,6 @@
+/**
+ * Posted on `window` by the example runner island before an example iFrame navigates, so the
+ * separate loading logo island can show itself again. Must carry the `loadingIFrameId` from
+ * `getLoadingIFrameId`, as pages contain one loading logo per example.
+ */
+export const EXAMPLE_RELOADING_MESSAGE_TYPE = 'exampleReloading';


### PR DESCRIPTION
Mirror of ag-grid/ag-charts#7644, keeping `external/ag-website-shared` byte-identical across repos.

## Problem

Toggling an example's language (JavaScript/TypeScript) and pressing **Preview** shows the old example briefly, then a blank gap for the duration of the load with no progress indicator, then the new example.

Two pieces of state are never reset when an example reloads in place:

- `LoadingLogo`'s `hide` flag is one-shot — `setHide(true)` on `init` is never undone, so the logo never returns.
- The iFrame's `visibility` is flipped to `visible` imperatively from outside React, so React never re-applies its JSX `hidden` on the next render.

`LoadingLogo` and the example-runner live in sibling Astro islands with only a one-way `init` message between them, so there was no "reloading" signal the loader could react to.

## Change

Additive, and symmetric with the existing `init` handshake:

- `loading-logo/messages.ts` (new) — the shared `exampleReloading` message type.
- `ExampleIFrame` posts that message before reassigning `src`, and only when the iFrame already had one, so initial loads are untouched.
- `LoadingLogo` handles it by re-hiding the iFrame and showing the logo again.

Revealing the iFrame is the only code path that makes an example visible, and `PostInitMessageScript`'s timeout only `console.warn`s. Re-hiding it is therefore paired with a 15s parent-side fallback that reveals it anyway if `init` never arrives — otherwise a failing example would become permanently blank, which is worse than the bug being fixed. A parent-side timer also covers an iFrame that fails to load at all.

## Verification

The shared `LoadingLogo.tsx` and `messages.ts` are **byte-identical** to the ag-charts versions, which were verified end to end in a browser there: iFrame → hidden, logo shown, `init` → iFrame revealed, logo removed; and an example that never sends `init` revealed at ~15s instead of staying blank. ag-charts also has a new e2e regression test confirmed to fail without the fix.

Verified in this repo:

- `external/ag-website-shared/.../LoadingLogo.tsx` on `latest` was byte-identical to the ag-charts pre-fix version, so the mirrors were in sync before this change and remain so after.
- The `ExampleIFrame` hunk is identical to the ag-studio one; both differ from ag-charts only in the pre-existing `isScrolling` guard and dep.
- `prettier --check` and `eslint` clean on all three changed files; `tsc` reports no new errors (the three in `ExampleIFrame.tsx` are pre-existing `useDarkmode`/`.module.scss` ones, confirmed present at the same pre-shift line numbers on `latest`).

Not run here: the docs dev server, so the behaviour itself is verified only in ag-charts. Happy to run it through a local grid docs server if you'd rather see it before merge.

## Notes

- No AG- ticket exists for this, so the CRT key driving the change is used. Rename if you'd prefer a grid-side ticket.
- The e2e test was not ported: grid's specs are content-colocated and run across chromium/firefox/webkit, and I could not execute one here — an unrun cross-browser spec seemed more likely to break CI than to help. Can add one on request.
- Gallery, hero and interactive-demo style runners pass a fixed example name and framework, so their URL never changes and their behaviour is unaffected.
