### PR TITLE
Only attribute reviewer/merger to the JIRA ticket a PR actually fixes

### DIFF
--- a/.github/workflows/update-jira-ticket.yml
+++ b/.github/workflows/update-jira-ticket.yml
@@ -141,7 +141,7 @@ jobs:
                     
                     // blocks section
                     const content = [];
-                    if (pull_number) {
+                    if (pull_number && moveOrMention === 'move') {
                         const {reviewers, mergedBy} = await getReviewers(pr);
                         
                         const samePerson = reviewers.length === 1 && reviewers[0] === mergedBy;


### PR DESCRIPTION
## Summary
- `update-jira-ticket.yml` posts a "Reviewed by X. Merged by Y." comment to **every** JIRA ticket key found in a merged PR's body, whether that ticket is the one actually being fixed (`moveOrMention === 'move'`) or merely mentioned for context (`'mention'`).
- Example: PR #14665 fixes AG-17967 but its description mentions AG-13278 as background ("the shortcut was deliberately removed in AG-13278..."). AG-13278 still received a "Reviewed by ... Merged by ..." comment, wrongly implying it was resolved by that PR — see [AG-13278 comment](https://ag-grid.atlassian.net/browse/AG-13278?focusedCommentId=128536).
- Scopes the reviewer/merged-by attribution block to only the ticket classified as `'move'` (the actual fix ticket), leaving the "mentioned in PR" comment for merely-referenced tickets unchanged.

## Test plan
- [ ] Re-run the workflow via `workflow_dispatch` with `debug_pr_id: 14665` and `debug_skip_merge_check: true` against a scratch ticket to confirm only the fix ticket gets reviewer/merged-by attribution and mentioned tickets get only the "mentioned in PR" comment.