### PR TITLE
map-stage-row-top-clear-perf-follow-up

### DIFF
--- a/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
+++ b/packages/ag-grid-community/src/clientSideRowModel/clientSideRowModel.ts
@@ -55,8 +55,11 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
     /** Rows given a row top by the previous pass — the only rows that can hold a stale one. */
     private positionedRows: RowNode[] = [];
 
-    /** Buffer the current pass fills, swapped into `positionedRows` once the stale tops are cleared. */
+    /** Buffer the current pass fills. Handed over to `positionedRows` before the first row is positioned. */
     private positionedRowsNext: RowNode[] = [];
+
+    /** Positioning requests in flight: above 1 when the row events a pass dispatches re-entered the model. */
+    private positioningRows: number = 0;
 
     /** The ordered list of row processing stages: group → filter → pivot → aggregate → filterAggregates → sort → flatten. */
     private stages: IRowNodeStage[] | null = null;
@@ -317,7 +320,60 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         return minIndex < stagesLen ? stages[minIndex].step : null;
     }
 
+    /**
+     * Gives every displayed row its top and index, then clears the tops left stale on the rows that
+     * dropped out of display — only a row `positionedRows` tracks can be holding one.
+     */
     private setRowTopAndRowIndex(): void {
+        if (this.positioningRows) {
+            ++this.positioningRows;
+            return; // Re-entrant, so the buffers are mid-handover and the heights it wants applied must wait.
+        }
+
+        this.positioningRows = 1;
+        try {
+            this.positionAndClearRows();
+            if (this.positioningRows > 1) {
+                // Applies the heights a re-entrant call recalculated. Once only: it can re-enter again.
+                this.positionAndClearRows();
+            }
+        } finally {
+            this.positioningRows = 0;
+        }
+    }
+
+    private positionAndClearRows(): void {
+        const stale = this.positionedRows;
+        const positioned = this.positionedRowsNext;
+        // Own the buffer before positioning anything, so a `getRowHeight` or row event handler that
+        // throws mid-pass leaves the rows positioned so far tracked rather than stuck with their top.
+        this.positionedRows = positioned;
+        this.positionedRowsNext = stale;
+        positioned.length = 0;
+
+        try {
+            this.positionRows(positioned);
+            this.updateFormulaRowIndexes();
+            this.clearStaleRowTops(stale);
+        } catch (e) {
+            // A throw leaves rows holding a top the pass never got to check, and a later pass only
+            // looks at the rows it tracks.
+            this.retainStaleRows(stale);
+            throw e;
+        }
+    }
+
+    /** Runs before the stale tops are cleared, as clearing dispatches row events that read these. */
+    private updateFormulaRowIndexes(): void {
+        if (this.beans.formula?.isEvaluationActive()) {
+            const formulaRows = this.formulaRows;
+            for (let i = 0, len = formulaRows.length; i < len; ++i) {
+                formulaRows[i].formulaRowIndex = i;
+            }
+        }
+    }
+
+    private positionRows(positioned: RowNode[]): void {
         const { beans, rowsToDisplay } = this;
         const defaultRowHeight = beans.environment.getDefaultRowHeight();
         let nextRowTop = 0;
@@ -326,10 +382,9 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         // with these two layouts.
         const allowEstimate = _isDomLayout(this.gos, 'normal');
 
-        const len = rowsToDisplay.length;
-        const positioned = this.positionedRowsNext;
-        for (let i = 0; i < len; ++i) {
+        for (let i = 0, len = rowsToDisplay.length; i < len; ++i) {
             const rowNode = rowsToDisplay[i];
+            positioned[i] = rowNode;
 
             if (rowNode.rowHeight == null) {
                 const rowHeight = _getRowHeightForNode(beans, rowNode, allowEstimate, defaultRowHeight);
@@ -339,35 +394,35 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
             rowNode.setRowTop(nextRowTop);
             rowNode.setRowIndex(i);
             nextRowTop += rowNode.rowHeight!;
-            positioned[i] = rowNode;
-        }
-        positioned.length = len;
-
-        if (beans.formula?.isEvaluationActive()) {
-            const formulaRows = this.formulaRows;
-            for (let i = 0, len = formulaRows.length; i < len; ++i) {
-                const rowNode = formulaRows[i];
-                rowNode.formulaRowIndex = i;
-            }
         }
     }
 
-    private clearRowTopAndRowIndex(): void {
-        const { rowsToDisplay, positionedRows } = this;
-
-        // Only a row positioned by the previous pass can hold a stale top, and `setRowTopAndRowIndex`
-        // has just given every currently-displayed row its slot, so a matching slot means still displayed.
-        for (let i = 0, len = positionedRows.length; i < len; ++i) {
-            const rowNode = positionedRows[i];
+    /** Clears the tops of `stale` rows that are no longer displayed, then empties it. */
+    private clearStaleRowTops(stale: RowNode[]): void {
+        const rowsToDisplay = this.rowsToDisplay;
+        // Every displayed row holds its slot by now, so a row whose slot no longer holds it dropped out.
+        for (let i = 0, len = stale.length; i < len; ++i) {
+            const rowNode = stale[i];
             const rowIndex = rowNode.rowIndex;
             if ((rowIndex == null || rowsToDisplay[rowIndex] !== rowNode) && !rowNode.destroyed) {
                 rowNode.clearRowTopAndRowIndex();
             }
         }
+        stale.length = 0;
+    }
 
-        this.positionedRows = this.positionedRowsNext;
-        positionedRows.length = 0;
-        this.positionedRowsNext = positionedRows;
+    /** Hands the rows an interrupted pass left in `stale` over to the buffer it now tracks, and empties it. */
+    private retainStaleRows(stale: RowNode[]): void {
+        const { rowsToDisplay, positionedRows } = this;
+        const reached = positionedRows.length; // How far `positionRows` got before the throw.
+        for (let i = 0, len = stale.length; i < len; ++i) {
+            const rowNode = stale[i];
+            const rowIndex = rowNode.rowIndex;
+            if (rowIndex == null || rowIndex >= reached || rowsToDisplay[rowIndex] !== rowNode) {
+                positionedRows.push(rowNode);
+            }
+        }
+        stale.length = 0;
     }
 
     public isLastRowIndexKnown(): boolean {
@@ -659,9 +714,7 @@ export class ClientSideRowModel extends BeanStub implements IClientSideRowModel,
         }
         /* eslint-enable no-fallthrough */
 
-        // Position the displayed rows first, then clear stale tops left on rows that dropped out.
         this.setRowTopAndRowIndex();
-        this.clearRowTopAndRowIndex();
 
         this.updateRefreshParams(params); // Apply forced flags from any nested refresh calls
     }

--- a/testing/behavioural/src/row-data/row-data.test.ts
+++ b/testing/behavioural/src/row-data/row-data.test.ts
@@ -1,6 +1,14 @@
 import type { MockInstance } from 'vitest';
 
-import { ClientSideRowModelModule, NumberFilterModule, RowApiModule, TextFilterModule } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    ExternalFilterModule,
+    NumberFilterModule,
+    RenderApiModule,
+    RowApiModule,
+    ScrollApiModule,
+    TextFilterModule,
+} from 'ag-grid-community';
 import type { GridOptions, IRowNode, ModelUpdatedEvent } from 'ag-grid-community';
 
 import {
@@ -16,7 +24,15 @@ import {
 
 describe('ag-grid row data', () => {
     const gridsManager = new TestGridsManager({
-        modules: [TextFilterModule, NumberFilterModule, ClientSideRowModelModule, RowApiModule],
+        modules: [
+            TextFilterModule,
+            NumberFilterModule,
+            ExternalFilterModule,
+            ClientSideRowModelModule,
+            RowApiModule,
+            RenderApiModule,
+            ScrollApiModule,
+        ],
     });
     let consoleWarnSpy: MockInstance | undefined;
     let consoleErrorSpy: MockInstance | undefined;
@@ -468,6 +484,190 @@ describe('ag-grid row data', () => {
         expect(topChangedCount).toBe(0);
         expect(rowIndexChangedCount).toBe(0);
         expect(displayedChangedCount).toBe(0);
+    });
+
+    // The row model tracks the rows it positions to know whose top to clear next time. A row event
+    // listener throwing mid-pass must not orphan that tracking, or the row keeps its top for good.
+    test('a row positioned by a pass that throws does not keep its top', async () => {
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'id', filter: 'agTextColumnFilter' }],
+            rowData: [{ id: 'a' }, { id: 'b' }],
+            getRowId: ({ data }) => data.id,
+        });
+        await asyncSetTimeout(1);
+
+        let failOnTopChanged = false;
+        api.getRowNode('b')!.addEventListener('topChanged', () => {
+            if (failOnTopChanged) {
+                failOnTopChanged = false;
+                throw new Error('topChanged listener failed');
+            }
+        });
+
+        // Adding at the top moves `b` down, so the pass positions `n` before it throws on `b`.
+        failOnTopChanged = true;
+        expect(() => api.applyTransaction({ addIndex: 0, add: [{ id: 'n' }] })).toThrow('topChanged listener failed');
+
+        const n = api.getRowNode('n')!;
+        expect(n.rowTop).not.toBeNull();
+
+        // `n` is filtered out, so the next pass has to recognise it as no longer displayed.
+        api.setFilterModel({ id: { filterType: 'text', type: 'notEqual', filter: 'n' } });
+        await asyncSetTimeout(1);
+
+        expect(n.rowTop).toBeNull();
+        expect(n.rowIndex).toBeNull();
+        expect(n.displayed).toBe(false);
+    });
+
+    // Mirror of the above: the rows a throwing pass never reached still hold the top the previous pass gave
+    // them, so dropping them from the tracking is just as lossy as dropping the ones it did position.
+    test('a row a throwing pass never reached does not keep its top', async () => {
+        let hideAllButA = false;
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'id' }],
+            rowData: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+            getRowId: ({ data }) => data.id,
+            isExternalFilterPresent: () => hideAllButA,
+            doesExternalFilterPass: ({ data }) => data.id === 'a',
+        });
+        await asyncSetTimeout(1);
+
+        let failOnTopChanged = false;
+        api.getRowNode('b')!.addEventListener('topChanged', () => {
+            if (failOnTopChanged) {
+                failOnTopChanged = false;
+                throw new Error('topChanged listener failed');
+            }
+        });
+
+        // Growing `a` shifts the tops below it without moving any row, so the pass throws on `b` and leaves
+        // `c` with the top of the previous pass.
+        api.getRowNode('a')!.setRowHeight(100);
+        failOnTopChanged = true;
+        expect(() => api.onRowHeightChanged()).toThrow('topChanged listener failed');
+
+        const c = api.getRowNode('c')!;
+        expect(c.rowTop).not.toBeNull();
+
+        hideAllButA = true;
+        api.onFilterChanged();
+
+        expect(c.rowTop).toBeNull();
+        expect(c.rowIndex).toBeNull();
+        expect(c.displayed).toBe(false);
+    });
+
+    // Clearing a stale top runs row event listeners too, so the clear step can be interrupted the same way.
+    test('a row a throwing clear never reached does not keep its top', async () => {
+        let hideAllButA = false;
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'id' }],
+            rowData: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+            getRowId: ({ data }) => data.id,
+            isExternalFilterPresent: () => hideAllButA,
+            doesExternalFilterPass: ({ data }) => data.id === 'a',
+        });
+        await asyncSetTimeout(1);
+
+        let failOnTopChanged = false;
+        api.getRowNode('b')!.addEventListener('topChanged', () => {
+            if (failOnTopChanged) {
+                failOnTopChanged = false;
+                throw new Error('topChanged listener failed');
+            }
+        });
+
+        // `b` and `c` both drop out of display, and clearing `b` throws before `c` is looked at.
+        hideAllButA = true;
+        failOnTopChanged = true;
+        expect(() => api.onFilterChanged()).toThrow('topChanged listener failed');
+
+        const c = api.getRowNode('c')!;
+        expect(c.rowTop).not.toBeNull();
+
+        // Any later pass has to finish the clearing the failed one gave up on.
+        api.onRowHeightChanged();
+
+        expect(c.rowTop).toBeNull();
+        expect(c.rowIndex).toBeNull();
+        expect(c.displayed).toBe(false);
+    });
+
+    // The row being positioned is the one that throws, and it was not displayed before, so neither buffer
+    // holds it unless the pass tracks a row before giving it a top.
+    test('a row that throws while being positioned does not keep its top', async () => {
+        let hideC = true;
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'id' }],
+            rowData: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+            getRowId: ({ data }) => data.id,
+            isExternalFilterPresent: () => hideC,
+            doesExternalFilterPass: ({ data }) => data.id !== 'c',
+        });
+        await asyncSetTimeout(1);
+
+        const c = api.getRowNode('c')!;
+        expect(c.rowTop).toBeNull();
+
+        let failOnTopChanged = false;
+        c.addEventListener('topChanged', () => {
+            if (failOnTopChanged) {
+                failOnTopChanged = false;
+                throw new Error('topChanged listener failed');
+            }
+        });
+
+        // `c` comes back into display, and throws as it is given its top.
+        hideC = false;
+        failOnTopChanged = true;
+        expect(() => api.onFilterChanged()).toThrow('topChanged listener failed');
+        expect(c.rowTop).not.toBeNull();
+
+        hideC = true;
+        api.onFilterChanged();
+
+        expect(c.rowTop).toBeNull();
+        expect(c.rowIndex).toBeNull();
+        expect(c.displayed).toBe(false);
+    });
+
+    // Scrolling or redrawing from a row event listener re-enters the model through `ensureRowHeightsValid`,
+    // so a pass can start while another is midway through positioning.
+    test('a pass re-entered from a row listener keeps tracking its rows', async () => {
+        let hideTen = false;
+        const api = gridsManager.createGrid('myGrid', {
+            columnDefs: [{ field: 'id' }],
+            rowData: Array.from({ length: 30 }, (_, i) => ({ id: String(i) })),
+            getRowId: ({ data }) => data.id,
+            getRowHeight: () => 30, // Heights are then estimated, so `ensureRowHeightsValid` has work to do.
+            isExternalFilterPresent: () => hideTen,
+            doesExternalFilterPass: ({ data }) => data.id !== '10',
+        });
+        await asyncSetTimeout(1);
+
+        let reenter = false;
+        api.getRowNode('5')!.addEventListener('topChanged', () => {
+            if (reenter) {
+                reenter = false;
+                api.ensureIndexVisible(20);
+                api.redrawRows();
+            }
+        });
+
+        // Adding at the top moves every row, so `5` fires its listener partway through the pass.
+        reenter = true;
+        api.applyTransaction({ addIndex: 0, add: [{ id: 'new' }] });
+        await asyncSetTimeout(1);
+
+        hideTen = true;
+        api.onFilterChanged();
+        await asyncSetTimeout(1);
+
+        const ten = api.getRowNode('10')!;
+        expect(ten.rowTop).toBeNull();
+        expect(ten.rowIndex).toBeNull();
+        expect(ten.displayed).toBe(false);
     });
 
     describe('onModelUpdated event flags', () => {


### PR DESCRIPTION
# fix(csrm): don't lose track of positioned rows when a pass throws

apply a healing fix if map stage throws - if a throw happened during a map stage the grid would have been in a unrecoverable broken state.
This is really a extreme edge case, but, better to cover it.

Follow-up to #14668.

## The edge case

Positioning rows runs user code: `getRowHeight`, and the `topChanged` / `rowIndexChanged` listeners that
reach cell renderers and value getters. A throw from any of them skipped the buffer swap at the end of
`clearRowTopAndRowIndex`, leaving the ledger of positioned rows a pass behind. A row positioned by the
failed pass and no longer displayed then kept its `rowTop` and `rowIndex` for good — `displayed` while
hidden, with `getDisplayedRowAtIndex` disagreeing with `node.rowIndex`. The recursive walk #14668 replaced
rebuilt the set every refresh, so it self-healed.

Fix: the buffers change hands before the first row is positioned, and a pass that doesn't run to completion
hands the rows it was still tracking back to the new buffer. Half-updated indices can't tell a dropped-out
row from a displayed one, so a failed pass clears nothing and the next one clears whatever ended up out of
display. Whether the throw lands while positioning or while clearing, no row holding a top goes untracked.

## Tests

`row-data.test.ts`

## Benchmarks

Identical, no regression.
