### PR TITLE
AG-18028 Add v36.1.0 release content to what's new, migration and changelog

### DIFF
--- a/documentation/ag-grid-docs/public/changelog/changelog.json
+++ b/documentation/ag-grid-docs/public/changelog/changelog.json
@@ -1,5 +1,19 @@
 [
     {
+        "key": "AG-18028",
+        "issueType": "Task",
+        "manualEntry": true,
+        "summary": "Placeholder for 36.1.0",
+        "versions": ["36.1.0"],
+        "status": "Done",
+        "resolution": "Done",
+        "features": null,
+        "moreInformation": null,
+        "deprecationNotes": null,
+        "breakingChangesNotes": null,
+        "documentationUrl": null
+    },
+    {
         "key": "AG-17593",
         "issueType": "Task",
         "manualEntry": true,

--- a/documentation/ag-grid-docs/public/changelog/releaseVersionNotes.json
+++ b/documentation/ag-grid-docs/public/changelog/releaseVersionNotes.json
@@ -1,5 +1,9 @@
 [
     {
+        "release version": "36.1.0",
+        "markdown": "/releases/36_1_0.md"
+    },
+    {
         "release version": "36.0.0",
         "markdown": "/releases/36_0_0.md"
     },

--- a/documentation/ag-grid-docs/public/changelog/releases/36_1_0.md
+++ b/documentation/ag-grid-docs/public/changelog/releases/36_1_0.md
@@ -1,0 +1,5 @@
+#### August 5th 2026 - Grid v36.1.0 (Charts v14.1.0)
+
+See table below for changes included in this release.
+
+For more details see [v36.1 release post](https://blog.ag-grid.com/whats-new-in-ag-grid-36-1/).

--- a/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-36-1/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/upgrading-to-ag-grid-36-1/index.mdoc
@@ -1,0 +1,37 @@
+---
+title: "Upgrading to AG Grid 36.1"
+description: "See what's new in AG Grid, view a full list of changes and migrate your $framework Data Grid to version v36.1."
+migrationVersion: "36.1.0"
+---
+
+Column Header Edit, Custom Context Menu Items, AI Coding Skill, Documentation in markdown format, Quality Improvements
+
+## What's New
+
+AG Grid {% migrationVersion() %} adds important new features - [Column Header Edit](./column-headers/#editable-header-name), [Custom Context Menu Items in Columns Tool Panel](./tool-panel-columns/#custom-menu-items), [AI Coding Skill](./skills/#ag-dev), Documentation in markdown format, Quality Improvements.
+These improvements involve no breaking changes as listed below.
+
+<!--
+Documentation to the highest patch release of the major/minor
+NOTE: This will not show if the current library version is the same as the migration version
+-->
+
+{% documentationArchiveSection version=migrationVersionPatch() /%}
+
+## Breaking Changes
+
+There are no breaking changes in AG Grid version {% migrationVersion() %}.
+
+## Behaviour Changes
+
+There are no behaviour changes in AG Grid version {% migrationVersion() %}.
+
+## Removal of Deprecated APIs
+
+There are no deprecated API removals in AG Grid version {% migrationVersion() %}.
+
+## Deprecations
+
+There are no deprecations in AG Grid version {% migrationVersion() %}.
+
+{% changelogSection version=$migrationVersion /%}

--- a/documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json
+++ b/documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json
@@ -1,5 +1,32 @@
 [
     {
+        "version": "36.1.0",
+        "date": "August 5th 2026",
+        "landingPageHighlight": "Column Header Edit, Custom Context Menu Items in Columns Tool Panel, AI Coding Skill, Documentation in markdown format, Quality Improvements",
+        "highlights": [
+            {
+                "text": "Column Header Edit",
+                "path": "./column-headers/#editable-header-name"
+            },
+            {
+                "text": "Custom Context Menu Items in Columns Tool Panel",
+                "path": "./tool-panel-columns/#custom-menu-items"
+            },
+            {
+                "text": "AI Coding Skill",
+                "path": "./skills/#ag-dev"
+            },
+            {
+                "text": "Documentation in markdown format"
+            },
+            {
+                "text": "Quality Improvements"
+            }
+        ],
+        "notesPath": "./upgrading-to-ag-grid-36-1",
+        "hideBlogPostLink": false
+    },
+    {
         "version": "36.0.0",
         "date": "June 24th 2026",
         "landingPageHighlight": "Calculated Columns, Show Values As, Automatic Column Generation, Accessibility Improvements, Theming Improvements",


### PR DESCRIPTION
## Summary
- Adds a What's New tile for AG Grid v36.1.0 (`ag-grid-versions.json`), with feature highlights linking to Column Header Edit, Custom Context Menu Items in Columns Tool Panel, and the AI Coding Skill docs.
- Adds the v36.1.0 migration guide page (`upgrading-to-ag-grid-36-1/index.mdoc`) — no breaking changes, no behaviour changes, no deprecations/removals for this release.
- Adds the v36.1.0 changelog dropdown entry and release note.

Clones the AG-17289 (v35.3.0) pattern exactly — all 5 files mirror that precedent's structure with content substituted for this release.

Two intentional wording deviations from the ticket's literal text, matching every prior release's established pattern (confirmed with the requester):
- Migration guide keeps the `{% changelogSection %}` markdoc tag (renders an actual filtered changes table) rather than a hand-written "see full changelog" sentence.
- Changelog release note uses the established markdown-link phrasing ("For more details see [v36.1 release post](url).") rather than the ticket's literal plain-URL text.

Confirmed via `Version.tsx` that the tile's "See release notes" and "See all changes" buttons are derived automatically from `notesPath`/`version` — no extra fields needed.

## Test plan
- [x] All edited/created JSON files validated (`json.load`)
- [x] `yarn nx lint ag-grid-docs` — pass
- [x] `yarn nx format:check` — pass
- [x] New migration guide / release note diffed structurally against the exact v35.3.0 precedent files — only content differs, all markdoc tags/boilerplate identical
- [ ] Visual check on deployed preview: What's New tile, migration guide page, and changelog page/dropdown render correctly for v36.1.0

Jira: https://ag-grid.atlassian.net/browse/AG-18028