### PR TITLE
cell-tooltip-perf-fix

### DIFF
--- a/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
@@ -153,10 +153,13 @@ export class CellCtrl extends BeanStub {
     private hasBeenFocused = false;
 
     private readonly editSvc?: EditService;
-    private readonly hasEdit: boolean = false;
 
     public tooltipFeature: TooltipFeature | undefined = undefined;
     public editorTooltipFeature: TooltipFeature | undefined = undefined;
+    /** Tooltip registered by the live cellRenderer via `params.setTooltip`, read lazily by the tooltip
+     * feature so registering or clearing it never rebuilds the bean. Cleared when that renderer goes. */
+    public rendererTooltipValue: string | undefined = undefined;
+    public rendererTooltipShouldDisplay: (() => boolean) | undefined = undefined;
 
     constructor(
         public readonly column: AgColumn,
@@ -168,7 +171,6 @@ export class CellCtrl extends BeanStub {
         this.beans = beans;
         this.gos = beans.gos;
         this.editSvc = beans.editSvc;
-        this.hasEdit = !!beans.editSvc;
 
         const { colId } = column;
         // unique id to this instance, including the column ID to help with debugging in React as it's used in 'key'
@@ -216,21 +218,26 @@ export class CellCtrl extends BeanStub {
         this.disableTooltipFeature();
     }
 
-    private enableTooltipFeature(value?: string, shouldDisplayTooltip?: () => boolean): void {
-        this.tooltipFeature = this.beans.tooltipSvc?.enableCellTooltipFeature(this, value, shouldDisplayTooltip);
+    private enableTooltipFeature(): void {
+        this.tooltipFeature = this.beans.tooltipSvc?.enableCellTooltipFeature(this);
     }
 
     private disableTooltipFeature() {
         this.tooltipFeature = this.beans.context.destroyBean(this.tooltipFeature);
+        this.rendererTooltipValue = undefined;
+        this.rendererTooltipShouldDisplay = undefined;
     }
 
+    /** Drops the outgoing renderer's tooltip so the column default applies again. */
     public resetCellRendererTooltip(): void {
-        if (!this.isAlive()) {
+        // Runs for every cell of every repaint, so exit before touching the feature.
+        if (this.rendererTooltipValue == null || !this.isAlive()) {
             return;
         }
 
-        this.disableTooltipFeature();
-        this.enableTooltipFeature();
+        this.rendererTooltipValue = undefined;
+        this.rendererTooltipShouldDisplay = undefined;
+
         this.tooltipFeature?.refreshTooltip();
     }
 
@@ -409,12 +416,9 @@ export class CellCtrl extends BeanStub {
             );
         }
 
-        if (
-            this.hasEdit &&
-            this.editSvc!.isBatchEditing() &&
-            this.editSvc!.isRowEditing(rowNode, { checkSiblings: true })
-        ) {
-            const result = this.editSvc!.prepDetailsDuringBatch(this, { compDetails, valueToDisplay });
+        const editSvc = this.editSvc;
+        if (editSvc?.isBatchEditing() && editSvc.isRowEditing(rowNode, { checkSiblings: true })) {
+            const result = editSvc.prepDetailsDuringBatch(this, { compDetails, valueToDisplay });
             if (result) {
                 if (result.compDetails) {
                     compDetails = result.compDetails;
@@ -552,10 +556,9 @@ export class CellCtrl extends BeanStub {
             ) => this.registerRowDragger(rowDraggerElement, dragStartPixels, suppressVisibilityChange),
             setTooltip: (value: string, shouldDisplayTooltip: () => boolean) => {
                 gos.assertModuleRegistered('Tooltip', 3);
-                if (this.tooltipFeature) {
-                    this.disableTooltipFeature();
-                }
-                this.enableTooltipFeature(value, shouldDisplayTooltip);
+                this.rendererTooltipValue = value;
+                this.rendererTooltipShouldDisplay = shouldDisplayTooltip;
+
                 this.tooltipFeature?.refreshTooltip();
             },
         });
@@ -577,12 +580,12 @@ export class CellCtrl extends BeanStub {
             this.refreshCell(params);
         }
 
-        if (this.hasEdit && this.editCompDetails) {
-            const { editSvc, comp } = this;
-
-            if (!comp?.getCellEditor() && editSvc!.isEditing(this, { withOpenEditor: true })) {
+        const editSvc = this.editSvc;
+        if (editSvc && this.editCompDetails) {
+            const comp = this.comp;
+            if (!comp?.getCellEditor() && editSvc.isEditing(this, { withOpenEditor: true })) {
                 // editor was cleaned up by virtualisation, needs to be re-created
-                editSvc!.startEditing(this, { startedEdit: false, source: 'api', silent: true });
+                editSvc.startEditing(this, { startedEdit: false, source: 'api', silent: true });
             }
         }
     }
@@ -1006,10 +1009,8 @@ export class CellCtrl extends BeanStub {
             return;
         }
 
-        this.disableTooltipFeature();
-        if (this.column.isTooltipEnabled()) {
-            this.enableTooltipFeature();
-        }
+        // the feature resolves the colDef on every read, so it never needs rebuilding for a new one
+        this.tooltipFeature?.refreshTooltip();
 
         this.setWrapText();
         this.setCalculatedColumnCss();

--- a/packages/ag-grid-community/src/tooltip/tooltipService.ts
+++ b/packages/ag-grid-community/src/tooltip/tooltipService.ts
@@ -25,12 +25,6 @@ type ResolvedCellTooltip = {
     shouldDisplay?: () => boolean;
 };
 
-type CellTooltipDisplayFunctions = {
-    shouldDisplayDefault: () => boolean;
-    shouldDisplayColumnTooltip: () => boolean;
-    shouldDisplayCustomTooltip: () => boolean;
-};
-
 type LocalisableError = Error & {
     getTranslatedMessage?: (translate: LocaleTextFunc) => string;
 };
@@ -96,15 +90,11 @@ const getCellTruncationCheck = (beans: BeanCollection, ctrl: CellCtrl): (() => b
     return _isElementOverflowingCallback(() => getCellValueOverflowTarget(ctrl));
 };
 
-const buildCellTooltipDisplayFunctions = (
-    beans: BeanCollection,
-    ctrl: CellCtrl,
-    shouldDisplayTooltip?: () => boolean
-): CellTooltipDisplayFunctions => {
+const buildShouldDisplayCellTooltip = (beans: BeanCollection, ctrl: CellCtrl): (() => boolean) => {
     const { editSvc } = beans;
     const { column } = ctrl;
 
-    const shouldDisplayCellTooltip = () => {
+    return () => {
         if (editSvc?.isEditing(ctrl, { withOpenEditor: true })) {
             return false;
         }
@@ -118,12 +108,6 @@ const buildCellTooltipDisplayFunctions = (
             return false;
         }
         return isCellTruncated();
-    };
-
-    return {
-        shouldDisplayDefault: shouldDisplayCellTooltip,
-        shouldDisplayColumnTooltip: shouldDisplayCellTooltip,
-        shouldDisplayCustomTooltip: shouldDisplayTooltip ?? shouldDisplayCellTooltip,
     };
 };
 
@@ -166,14 +150,12 @@ const usesGroupRowAggregatedValue = (beans: BeanCollection, ctrl: CellCtrl): boo
 const resolveCellTooltip = ({
     beans,
     ctrl,
-    value,
-    displayFunctions,
+    shouldDisplayCellTooltip,
     translate,
 }: {
     beans: BeanCollection;
     ctrl: CellCtrl;
-    value?: string;
-    displayFunctions: CellTooltipDisplayFunctions;
+    shouldDisplayCellTooltip: () => boolean;
     translate: LocaleTextFunc;
 }): ResolvedCellTooltip | null => {
     const { editSvc, formula, gos } = beans;
@@ -206,11 +188,14 @@ const resolveCellTooltip = ({
         }
     }
 
-    const { shouldDisplayCustomTooltip, shouldDisplayColumnTooltip } = displayFunctions;
-
     // 3) explicit value from cellRenderer params (setTooltip) wins over colDef tooltips.
-    if (value != null) {
-        return { value, location: 'cell', shouldDisplay: shouldDisplayCustomTooltip };
+    const rendererValue = ctrl.rendererTooltipValue;
+    if (rendererValue != null) {
+        return {
+            value: rendererValue,
+            location: 'cell',
+            shouldDisplay: ctrl.rendererTooltipShouldDisplay ?? shouldDisplayCellTooltip,
+        };
     }
 
     const data = rowNode.data;
@@ -228,14 +213,14 @@ const resolveCellTooltip = ({
                     transformValues: false,
                 }).value,
                 location: 'cell',
-                shouldDisplay: shouldDisplayColumnTooltip,
+                shouldDisplay: shouldDisplayCellTooltip,
             };
         }
         if (_exists(data)) {
             return {
                 value: resolveTooltipFieldValue(beans, column, rowNode, data, colDef.tooltipField),
                 location: 'cell',
-                shouldDisplay: shouldDisplayColumnTooltip,
+                shouldDisplay: shouldDisplayCellTooltip,
             };
         }
     }
@@ -257,7 +242,7 @@ const resolveCellTooltip = ({
                 })
             ),
             location: 'cell',
-            shouldDisplay: shouldDisplayColumnTooltip,
+            shouldDisplay: shouldDisplayCellTooltip,
         };
     }
 
@@ -387,14 +372,10 @@ export class TooltipService extends BeanStub implements NamedBean {
         return tooltipFeature ? ctrl.createBean(tooltipFeature) : tooltipFeature;
     }
 
-    public enableCellTooltipFeature(
-        ctrl: CellCtrl,
-        value?: string,
-        shouldDisplayTooltip?: () => boolean
-    ): TooltipFeature | undefined {
+    public enableCellTooltipFeature(ctrl: CellCtrl): TooltipFeature | undefined {
         const { beans } = this;
         const { column, rowNode } = ctrl;
-        const displayFunctions = buildCellTooltipDisplayFunctions(beans, ctrl, shouldDisplayTooltip);
+        const shouldDisplayCellTooltip = buildShouldDisplayCellTooltip(beans, ctrl);
         const translate = this.getLocaleTextFunc();
         let resolvedTooltip: ResolvedCellTooltip | null = null;
 
@@ -402,8 +383,7 @@ export class TooltipService extends BeanStub implements NamedBean {
             resolvedTooltip = resolveCellTooltip({
                 beans,
                 ctrl,
-                value,
-                displayFunctions,
+                shouldDisplayCellTooltip,
                 translate,
             });
             return resolvedTooltip;

--- a/packages/ag-stack/src/tooltip/agTooltipFeature.ts
+++ b/packages/ag-stack/src/tooltip/agTooltipFeature.ts
@@ -115,6 +115,14 @@ export class AgTooltipFeature<
 
     public refreshTooltip(clearWithEmptyString?: boolean): void {
         this.browserTooltips = this.beans.gos.get('enableBrowserTooltips')!;
+
+        // a tooltip on screen renders the value, component and params it was shown with; this refresh
+        // means any of them may have moved on, and none can be updated in place, so take it down
+        const tooltipManager = this.tooltipManager;
+        if (tooltipManager?.isShowing()) {
+            tooltipManager.hideTooltip(true);
+        }
+
         this.updateTooltipText();
 
         if (this.browserTooltips) {

--- a/packages/ag-stack/src/tooltip/baseTooltipStateManager.ts
+++ b/packages/ag-stack/src/tooltip/baseTooltipStateManager.ts
@@ -164,6 +164,11 @@ export abstract class BaseTooltipStateManager<
         return TooltipTrigger.FOCUS;
     }
 
+    /** True only once a tooltip is on screen — a show still waiting out its delay is not showing. */
+    public isShowing(): boolean {
+        return this.state === TooltipStates.SHOWING;
+    }
+
     public onMouseEnter(e: MouseEvent): void {
         // if `interactiveTooltipTimeoutId` is set, it means that this cell has a tooltip
         // and we are in the process of moving the cursor from the tooltip back to the cell

--- a/testing/behavioural/src/benchmarks/tooltip-repaint.bench.ts
+++ b/testing/behavioural/src/benchmarks/tooltip-repaint.bench.ts
@@ -1,0 +1,108 @@
+// Cell-repaint benchmark for the four cell-tooltip shapes. Each measured iteration forces a repaint of
+// every visible cell, so it captures the per-cell tooltip work a renderer teardown triggers — the cost
+// that differs between a cell whose renderer registers a tooltip, one that doesn't, and one with none.
+//
+// AllEnterpriseModule is registered so the per-cell cost reflects every feature being loaded.
+import { bench, suite } from 'vitest';
+
+import type { ColDef, GridApi, GridOptions, ICellRendererComp, ICellRendererParams } from 'ag-grid-community';
+import { AllEnterpriseModule } from 'ag-grid-enterprise';
+
+import { BenchGridsManager, benchDefaults } from './bench-utils';
+
+const modules = [AllEnterpriseModule];
+
+const ROW_COUNT = 2000;
+const COL_COUNT = 5;
+
+class SetTooltipRenderer implements ICellRendererComp {
+    private eGui!: HTMLElement;
+    public init(params: ICellRendererParams): void {
+        this.eGui = document.createElement('span');
+        this.eGui.textContent = String(params.value);
+        params.setTooltip(`Tip ${params.value}`, () => true);
+    }
+    public getGui(): HTMLElement {
+        return this.eGui;
+    }
+    public refresh(): boolean {
+        return false;
+    }
+}
+
+class PlainRenderer implements ICellRendererComp {
+    private eGui!: HTMLElement;
+    public init(params: ICellRendererParams): void {
+        this.eGui = document.createElement('span');
+        this.eGui.textContent = String(params.value);
+    }
+    public getGui(): HTMLElement {
+        return this.eGui;
+    }
+    public refresh(): boolean {
+        return false;
+    }
+}
+
+const buildCols = (cellRenderer: unknown, withColDefTooltip: boolean): ColDef[] => {
+    const cols: ColDef[] = [];
+    for (let i = 0; i < COL_COUNT; ++i) {
+        const col: ColDef = { colId: `c${i}`, field: `c${i}` };
+        if (cellRenderer) {
+            col.cellRenderer = cellRenderer;
+        }
+        if (withColDefTooltip) {
+            col.tooltipValueGetter = (params) => `Tip ${params.value}`;
+        }
+        cols.push(col);
+    }
+    return cols;
+};
+
+const buildData = (): any[] => {
+    const rows: any[] = [];
+    for (let r = 0; r < ROW_COUNT; ++r) {
+        const row: any = { id: `${r}` };
+        for (let c = 0; c < COL_COUNT; ++c) {
+            row[`c${c}`] = `r${r}c${c}`;
+        }
+        rows.push(row);
+    }
+    return rows;
+};
+
+suite('cell repaint — tooltip shapes', () => {
+    const gridsManager = new BenchGridsManager({ modules });
+    const data = buildData();
+    let gridId = 0;
+
+    const benchRepaint = (name: string, cellRenderer: unknown, withColDefTooltip: boolean) => {
+        const options: GridOptions = {
+            columnDefs: buildCols(cellRenderer, withColDefTooltip),
+            getRowId: (params) => String(params.data.id),
+            rowHeight: 20,
+        };
+        const id = `TR${++gridId}`;
+        let api!: GridApi;
+        bench(
+            name,
+            () => {
+                api.refreshCells({ force: true });
+                api.flushAllAnimationFrames();
+            },
+            {
+                ...benchDefaults({ noiseFactor: 3 }),
+                setup: async () => {
+                    await gridsManager.reset();
+                    api = gridsManager.createGrid(id, { ...options, rowData: data });
+                    api.flushAllAnimationFrames();
+                },
+            }
+        );
+    };
+
+    benchRepaint('repaint — renderer using setTooltip', SetTooltipRenderer, false);
+    benchRepaint('repaint — renderer without setTooltip, colDef tooltip', PlainRenderer, true);
+    benchRepaint('repaint — no renderer, colDef tooltip', undefined, true);
+    benchRepaint('repaint — no renderer, no tooltip', undefined, false);
+});

--- a/testing/behavioural/src/filters/advanced-filter-regression/af-builder-keyboard-nav.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-regression/af-builder-keyboard-nav.test.ts
@@ -1,3 +1,5 @@
+import { waitFor } from '@testing-library/dom';
+
 import type { AdvancedFilterModel, GridOptions } from 'ag-grid-community';
 import { ClientSideRowModelModule, NumberFilterModule, TextFilterModule, setupAgTestIds } from 'ag-grid-community';
 import { AdvancedFilterModule } from 'ag-grid-enterprise';
@@ -91,25 +93,23 @@ describe('Advanced Filter — builder keyboard navigation & reorder', () => {
 
         // Focusing the row highlights it.
         wrapper.focus();
-        await asyncSetTimeout(0);
-        expect(wrapper.classList.contains(HIGHLIGHT)).toBe(true);
+        await waitFor(() => expect(wrapper.classList.contains(HIGHLIGHT)).toBe(true));
 
         // Enter moves focus into the row's editable pills.
         wrapper.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
-        await asyncSetTimeout(0);
-        expect(document.activeElement).not.toBe(wrapper);
-        expect(condition.contains(document.activeElement)).toBe(true);
+        await waitFor(() => {
+            expect(document.activeElement).not.toBe(wrapper);
+            expect(condition.contains(document.activeElement)).toBe(true);
+        });
 
         // Escape returns focus to the row wrapper.
         document.activeElement!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
-        await asyncSetTimeout(0);
-        expect(document.activeElement).toBe(wrapper);
+        await waitFor(() => expect(document.activeElement).toBe(wrapper));
 
         // Moving focus away removes the highlight.
         wrapper.blur();
         wrapper.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
-        await asyncSetTimeout(0);
-        expect(wrapper.classList.contains(HIGHLIGHT)).toBe(false);
+        await waitFor(() => expect(wrapper.classList.contains(HIGHLIGHT)).toBe(false));
     });
 
     test('the Move Down button reorders sibling conditions (keyboard Enter)', async () => {
@@ -125,17 +125,18 @@ describe('Advanced Filter — builder keyboard navigation & reorder', () => {
         // Move the first (Athlete) condition down via the keyboard, then commit.
         await builder.moveWithKeyboard(conditions[0], 'down');
         await builder.apply();
-        await asyncSetTimeout(0);
 
         // Order flips in the persisted model; AND is commutative so the rows are unchanged.
-        expect(api.getAdvancedFilterModel()).toEqual({
-            filterType: 'join',
-            type: 'AND',
-            conditions: [
-                { filterType: 'number', colId: 'age', type: 'greaterThan', filter: 26 },
-                { filterType: 'text', colId: 'athlete', type: 'contains', filter: 'B' },
-            ],
-        });
+        await waitFor(() =>
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'join',
+                type: 'AND',
+                conditions: [
+                    { filterType: 'number', colId: 'age', type: 'greaterThan', filter: 26 },
+                    { filterType: 'text', colId: 'athlete', type: 'contains', filter: 'B' },
+                ],
+            })
+        );
         // contains 'B' AND age>26 ⇒ Bond only.
         await new GridRows(api, 'after keyboard move down').check(`
             ROOT id:ROOT_NODE_ID
@@ -154,16 +155,17 @@ describe('Advanced Filter — builder keyboard navigation & reorder', () => {
         // Move the second (Age) condition up above the first.
         await builder.move(conditions[1], 'up');
         await builder.apply();
-        await asyncSetTimeout(0);
 
-        expect(api.getAdvancedFilterModel()).toEqual({
-            filterType: 'join',
-            type: 'AND',
-            conditions: [
-                { filterType: 'number', colId: 'age', type: 'greaterThan', filter: 26 },
-                { filterType: 'text', colId: 'athlete', type: 'contains', filter: 'B' },
-            ],
-        });
+        await waitFor(() =>
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'join',
+                type: 'AND',
+                conditions: [
+                    { filterType: 'number', colId: 'age', type: 'greaterThan', filter: 26 },
+                    { filterType: 'text', colId: 'athlete', type: 'contains', filter: 'B' },
+                ],
+            })
+        );
         await new GridRows(api, 'after click move up').check(`
             ROOT id:ROOT_NODE_ID
             └── LEAF id:1 athlete:"Bond" age:40

--- a/testing/behavioural/src/tooltip/tooltip-react.test.tsx
+++ b/testing/behavioural/src/tooltip/tooltip-react.test.tsx
@@ -1,11 +1,11 @@
 import { getByTestId, waitFor } from '@testing-library/dom';
 import { act, cleanup, render } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import React, { useEffect } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle } from 'react';
 
 import { AllCommunityModule, ModuleRegistry, agTestIdFor, setupAgTestIds } from 'ag-grid-community';
 import type { CellRendererSelectorResult, ColDef, GridApi } from 'ag-grid-community';
-import { RowGroupingModule } from 'ag-grid-enterprise';
+import { FormulaModule, RowGroupingModule } from 'ag-grid-enterprise';
 import { AgGridReact } from 'ag-grid-react';
 import type { CustomCellRendererProps } from 'ag-grid-react';
 
@@ -13,7 +13,7 @@ import { asyncSetTimeout, ignoreConsoleLicenseKeyError, mockGridLayout } from '.
 
 describe('Tooltips (React)', () => {
     beforeAll(() => {
-        ModuleRegistry.registerModules([AllCommunityModule, RowGroupingModule]);
+        ModuleRegistry.registerModules([AllCommunityModule, RowGroupingModule, FormulaModule]);
         setupAgTestIds();
     });
     beforeEach(() => ignoreConsoleLicenseKeyError());
@@ -128,6 +128,118 @@ describe('Tooltips (React)', () => {
         expect(hasTooltipText('Cell renderer tooltip')).toBe(false);
         expect(getTooltips().length).toBeLessThanOrEqual(1);
         expect(getTooltips()[0]).toHaveTextContent('ColDef tooltip');
+    });
+
+    test('re-registers the renderer tooltip when refresh() returning false remounts the renderer (React)', async () => {
+        // React answers a refresh() of false by resetting the renderer tooltip and remounting under a new
+        // render key, so the tooltip registered by the outgoing renderer must be replaced, not duplicated.
+        const RefreshingTooltipRenderer = forwardRef<{ refresh: () => boolean }, CustomCellRendererProps>(
+            (props, ref) => {
+                useImperativeHandle(ref, () => ({ refresh: () => false }));
+                useEffect(() => {
+                    props.setTooltip(`Tip ${props.value}`, () => true);
+                }, []);
+                return <span>{String(props.value)}</span>;
+            }
+        );
+
+        let api: GridApi | undefined;
+
+        const rendered = render(
+            <div style={{ height: 400, width: 600 }}>
+                <AgGridReact
+                    columnDefs={[{ field: 'A', cellRenderer: RefreshingTooltipRenderer }]}
+                    rowData={[{ id: 'r1', A: 'a1' }]}
+                    getRowId={(params) => String(params.data.id)}
+                    tooltipShowDelay={200}
+                    onGridReady={(params) => {
+                        api = params.api;
+                    }}
+                />
+            </div>
+        );
+
+        const gridDiv = rendered.container;
+        const cell = await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r1', 'A')));
+
+        await userEvent.hover(cell);
+        await asyncSetTimeout(250);
+        await waitFor(() => expect(hasTooltipText('Tip a1')).toBe(true));
+
+        await userEvent.unhover(cell);
+        await asyncSetTimeout(250);
+        await waitFor(() => expect(getTooltips().length).toBe(0));
+
+        act(() => {
+            api!.setGridOption('rowData', [{ id: 'r1', A: 'a2' }]);
+        });
+        await waitFor(() => expect(getByTestId(gridDiv, agTestIdFor.cell('r1', 'A'))).toHaveTextContent('a2'));
+
+        await userEvent.hover(await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r1', 'A'))));
+        await asyncSetTimeout(250);
+        await waitFor(() => expect(hasTooltipText('Tip a2')).toBe(true));
+        expect(getTooltips()).toHaveLength(1);
+    });
+
+    test('keeps the formula error tooltip after a colDef change on a column with no tooltip config (React)', async () => {
+        // formula and validation error tooltips are not gated by the column's own tooltip config, so a
+        // colDef change must leave every cell with a tooltip feature, not just tooltip-enabled columns.
+        let api: GridApi | undefined;
+
+        const rendered = render(
+            <div style={{ height: 400, width: 600 }}>
+                <AgGridReact
+                    columnDefs={[{ field: 'A' }, { field: 'result' }]}
+                    defaultColDef={{ editable: true, allowFormula: true }}
+                    rowData={[
+                        { id: 'r1', A: 1 },
+                        { id: 'r2', A: 2, result: '=ERRORIFONE(REF(COLUMN("A"),ROW("r1"),COLUMN("A"),ROW("r2")))' },
+                    ]}
+                    getRowId={(params) => String(params.data.id)}
+                    formulaFuncs={{
+                        ERRORIFONE: {
+                            func: (params) => {
+                                for (const value of Array.from(params.values)) {
+                                    if (Number(value) === 1) {
+                                        throw new Error("Error, discovered a '1' in params");
+                                    }
+                                }
+                                return 'SUCCESS';
+                            },
+                        },
+                    }}
+                    tooltipShowDelay={200}
+                    onGridReady={(params) => {
+                        api = params.api;
+                    }}
+                />
+            </div>
+        );
+
+        const gridDiv = rendered.container;
+        const cell = await waitFor(() => {
+            const el = getByTestId(gridDiv, agTestIdFor.cell('r2', 'result'));
+            expect(el).toHaveTextContent('#ERROR!');
+            return el;
+        });
+
+        await userEvent.hover(cell);
+        await asyncSetTimeout(250);
+        await waitFor(() => expect(getTooltips()[0]?.classList.contains('ag-cell-formula-tooltip')).toBe(true));
+
+        await userEvent.unhover(cell);
+        await asyncSetTimeout(250);
+        await waitFor(() => expect(getTooltips().length).toBe(0));
+
+        act(() => {
+            api!.setGridOption('columnDefs', [{ field: 'A' }, { field: 'result', headerName: 'Renamed' }]);
+        });
+        await waitFor(() => expect(api!.getColumnDef('result')?.headerName).toBe('Renamed'));
+
+        const renamedCell = await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r2', 'result')));
+        await userEvent.hover(renamedCell);
+        await asyncSetTimeout(250);
+        await waitFor(() => expect(getTooltips()[0]?.classList.contains('ag-cell-formula-tooltip')).toBe(true));
     });
 
     test('AG-5004 aggregated group-row cell tooltips the aggregated value (React)', async () => {

--- a/testing/behavioural/src/tooltip/tooltip.test.ts
+++ b/testing/behavioural/src/tooltip/tooltip.test.ts
@@ -34,6 +34,11 @@ describe('Tooltips', () => {
     const getTooltips = () => Array.from(document.querySelectorAll<HTMLElement>('.ag-tooltip, .ag-tooltip-custom'));
     const waitForTooltips = async (count: number) =>
         await waitFor(() => expect(getTooltips().length).toBe(count), { timeout: 2000 });
+    /** Texts of tooltips that are on screen and not fading out. */
+    const visibleTooltipTexts = () =>
+        getTooltips()
+            .filter((tooltip) => !tooltip.classList.contains('ag-tooltip-hiding'))
+            .map((tooltip) => tooltip.textContent ?? '');
     const hasTooltipText = (text: string) => getTooltips().some((tooltip) => tooltip.textContent?.includes(text));
 
     test('shows tooltip when configured', async () => {
@@ -514,6 +519,446 @@ describe('Tooltips', () => {
         `);
     });
 
+    test('keeps the formula error tooltip after a colDef change on a column with no tooltip config', async () => {
+        // formula and validation error tooltips are not gated by the column's own tooltip config, so a
+        // colDef change must leave every cell with a tooltip feature, not just tooltip-enabled columns.
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'A' }, { field: 'result' }],
+            defaultColDef: {
+                editable: true,
+                allowFormula: true,
+            },
+            rowData: [
+                { id: 'r1', A: 1 },
+                { id: 'r2', A: 2, result: '=ERRORIFONE(REF(COLUMN("A"),ROW("r1"),COLUMN("A"),ROW("r2")))' },
+            ],
+            getRowId: (params) => params.data.id,
+            formulaFuncs: {
+                ERRORIFONE: {
+                    func: (params) => {
+                        for (const value of Array.from(params.values)) {
+                            if (Number(value) === 1) {
+                                throw new Error("Error, discovered a '1' in params");
+                            }
+                        }
+                        return 'SUCCESS';
+                    },
+                },
+            },
+            tooltipShowDelay: 200,
+        };
+
+        const api = await gridMgr.createGridAndWait('myGrid-tooltip-formula-colDefChanged', gridOptions);
+        await new GridRows(api, `formula error tooltip after colDef change setup`).check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:r1 row-number:"1" A:1
+            └── LEAF id:r2 row-number:"2" A:2 result:"#ERROR!"
+        `);
+        const gridDiv = getGridElement(api)! as HTMLElement;
+
+        await userEvent.hover(await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r2', 'result'))));
+        await asyncSetTimeout(250);
+        await waitForTooltips(1);
+        expect(getTooltips()[0].classList.contains('ag-cell-formula-tooltip')).toBe(true);
+
+        await userEvent.unhover(await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r2', 'result'))));
+        await asyncSetTimeout(250);
+        await waitForTooltips(0);
+
+        api.setGridOption('columnDefs', [{ field: 'A' }, { field: 'result', headerName: 'Renamed' }]);
+        await asyncSetTimeout(50);
+        await new GridColumns(api, `formula error tooltip after colDef change renamed`).checkColumns(`
+            LEFT
+            └── ag-Grid-RowNumbersColumn width:60 !resizable !sortable suppressMovable lockPosition:left
+            CENTER
+            ├── A width:200 editable
+            └── result "Renamed" width:200 editable
+        `);
+        await new GridRows(api, `formula error tooltip after colDef change renamed`).check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:r1 row-number:"1" A:1
+            └── LEAF id:r2 row-number:"2" A:2 result:"#ERROR!"
+        `);
+
+        await userEvent.hover(await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r2', 'result'))));
+        await asyncSetTimeout(250);
+        await waitForTooltips(1);
+        expect(getTooltips()[0].classList.contains('ag-cell-formula-tooltip')).toBe(true);
+    });
+
+    test('keeps the row validation error tooltip after a colDef change on a column with no tooltip config', async () => {
+        // row validation errors surface on every cell of the row, including one that is not editing and
+        // has no tooltip config of its own — the second source that ignores column.isTooltipEnabled().
+        const gridOptions: GridOptions = {
+            columnDefs: [
+                { field: 'A', editable: true },
+                { field: 'B', editable: false },
+            ],
+            rowData: [{ id: 'r1', A: 'a1', B: 'b1' }],
+            getRowId: (params) => String(params.data.id),
+            editType: 'fullRow',
+            getFullRowEditValidationErrors: ({ editorsState }) =>
+                editorsState.some((state) => String(state.newValue).includes('bad')) ? ['Row is not allowed'] : [],
+            tooltipShowDelay: 200,
+        };
+
+        const api = await gridMgr.createGridAndWait('myGrid-tooltip-row-validation-colDefChanged', gridOptions);
+        const gridDiv = getGridElement(api)! as HTMLElement;
+
+        await userEvent.dblClick(await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r1', 'A'))));
+        await asyncSetTimeout(1);
+        await userEvent.keyboard('bad');
+        await asyncSetTimeout(1);
+
+        // B is not editable, so it is not editing and resolves the row's validation error
+        await userEvent.hover(await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r1', 'B'))));
+        await asyncSetTimeout(250);
+        await waitForTooltips(1);
+        expect(hasTooltipText('Row is not allowed')).toBe(true);
+
+        await userEvent.unhover(await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r1', 'B'))));
+        await asyncSetTimeout(250);
+        await waitForTooltips(0);
+
+        api.setGridOption('columnDefs', [
+            { field: 'A', editable: true },
+            { field: 'B', editable: false, headerName: 'Renamed' },
+        ]);
+        await asyncSetTimeout(50);
+
+        await userEvent.hover(await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r1', 'B'))));
+        await asyncSetTimeout(250);
+        await waitForTooltips(1);
+        expect(hasTooltipText('Row is not allowed')).toBe(true);
+    });
+
+    test('does not leave an open colDef tooltip showing a stale value', async () => {
+        // a showing tooltip renders the value it was created with, so a cell repaint that changes the
+        // value has to take the tooltip down rather than leave the old text on screen.
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'A', tooltipValueGetter: (params) => `Tip ${params.value}` }],
+            rowData: [{ id: 'r1', A: 'a1' }],
+            getRowId: (params) => String(params.data.id),
+            tooltipShowDelay: 200,
+        };
+
+        const api = await gridMgr.createGridAndWait('myGrid-tooltip-stale-open', gridOptions);
+        const gridDiv = getGridElement(api)! as HTMLElement;
+
+        await userEvent.hover(await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r1', 'A'))));
+        await asyncSetTimeout(250);
+        await waitForTooltips(1);
+        expect(hasTooltipText('Tip a1')).toBe(true);
+
+        // the value changes while the tooltip is still open
+        api.getRowNode('r1')!.setDataValue('A', 'a2');
+        await new GridRows(api, `open tooltip stale value`).check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 A:"a2"
+        `);
+
+        await waitFor(() => expect(visibleTooltipTexts()).not.toContain('Tip a1'));
+    });
+
+    test('takes down an open custom tooltip when its params change behind the same text', async () => {
+        // a custom component renders data/node/valueFormatted, none of which the resolved text reflects.
+        class DataTooltip implements ITooltipComp {
+            private eGui!: HTMLElement;
+            public init(params: ITooltipParams): void {
+                this.eGui = document.createElement('div');
+                this.eGui.classList.add('ag-tooltip-custom');
+                this.eGui.textContent = `Data: ${params.data.A}`;
+            }
+            public getGui(): HTMLElement {
+                return this.eGui;
+            }
+        }
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'A', tooltipComponent: DataTooltip, tooltipValueGetter: () => 'constant' }],
+            rowData: [{ id: 'r1', A: 'a1' }],
+            getRowId: (params) => String(params.data.id),
+            tooltipShowDelay: 200,
+        };
+
+        const api = await gridMgr.createGridAndWait('myGrid-tooltip-stale-params', gridOptions);
+        const gridDiv = getGridElement(api)! as HTMLElement;
+
+        await userEvent.hover(await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r1', 'A'))));
+        await asyncSetTimeout(250);
+        await waitForTooltips(1);
+        expect(visibleTooltipTexts()).toEqual(['Data: a1']);
+
+        // the row data behind the component changes; the text the column resolves does not
+        api.setGridOption('rowData', [{ id: 'r1', A: 'a2' }]);
+
+        await waitFor(() => expect(visibleTooltipTexts()).not.toContain('Data: a1'));
+    });
+
+    test('never shows a tooltip whose source was cleared while the show delay was running', async () => {
+        class TooltipRenderer implements ICellRendererComp {
+            private eGui!: HTMLElement;
+            public init(params: ICellRendererParams): void {
+                this.eGui = document.createElement('span');
+                this.eGui.textContent = String(params.value);
+                params.setTooltip('Renderer tip', () => true);
+            }
+            public getGui(): HTMLElement {
+                return this.eGui;
+            }
+            public refresh(): boolean {
+                return false;
+            }
+        }
+
+        const gridOptions: GridOptions = {
+            columnDefs: [
+                {
+                    field: 'A',
+                    cellRendererSelector: (params) =>
+                        params.data?.showDetail ? { component: TooltipRenderer } : undefined,
+                },
+            ],
+            rowData: [{ id: 'r1', A: 'a1', showDetail: true }],
+            getRowId: (params) => String(params.data.id),
+            tooltipShowDelay: 500,
+        };
+
+        const api = await gridMgr.createGridAndWait('myGrid-tooltip-pending-cleared', gridOptions);
+        const gridDiv = getGridElement(api)! as HTMLElement;
+
+        // the renderer and its tooltip go while the show is still waiting out its delay
+        await userEvent.hover(await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r1', 'A'))));
+        api.setGridOption('rowData', [{ id: 'r1', A: 'a2', showDetail: false }]);
+
+        await asyncSetTimeout(700);
+        expect(getTooltips()).toHaveLength(0);
+    });
+
+    test('never shows a tooltip whose predicate turned false while the show delay was running', async () => {
+        class ReRegisteringRenderer implements ICellRendererComp {
+            private eGui!: HTMLElement;
+            public init(params: ICellRendererParams): void {
+                this.eGui = document.createElement('span');
+                this.eGui.textContent = String(params.value);
+                params.setTooltip('Same tooltip', () => !!params.data.showTip);
+            }
+            public getGui(): HTMLElement {
+                return this.eGui;
+            }
+            public refresh(params: ICellRendererParams): boolean {
+                this.eGui.textContent = String(params.value);
+                params.setTooltip('Same tooltip', () => !!params.data.showTip);
+                return true;
+            }
+        }
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'A', cellRenderer: ReRegisteringRenderer }],
+            rowData: [{ id: 'r1', A: 'a1', showTip: true }],
+            getRowId: (params) => String(params.data.id),
+            tooltipShowDelay: 500,
+        };
+
+        const api = await gridMgr.createGridAndWait('myGrid-tooltip-pending-predicate', gridOptions);
+        const gridDiv = getGridElement(api)! as HTMLElement;
+
+        await userEvent.hover(await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r1', 'A'))));
+        api.setGridOption('rowData', [{ id: 'r1', A: 'a2', showTip: false }]);
+
+        await asyncSetTimeout(700);
+        expect(getTooltips()).toHaveLength(0);
+    });
+
+    test('takes down an open tooltip when a renderer re-registers the same text behind a new predicate', async () => {
+        // a renderer can re-register from refresh() without being torn down: same text, new predicate.
+        class ReRegisteringRenderer implements ICellRendererComp {
+            private eGui!: HTMLElement;
+            public init(params: ICellRendererParams): void {
+                this.eGui = document.createElement('span');
+                this.eGui.textContent = String(params.value);
+                params.setTooltip('Same tooltip', () => !!params.data.showTip);
+            }
+            public getGui(): HTMLElement {
+                return this.eGui;
+            }
+            public refresh(params: ICellRendererParams): boolean {
+                this.eGui.textContent = String(params.value);
+                params.setTooltip('Same tooltip', () => !!params.data.showTip);
+                return true;
+            }
+        }
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'A', cellRenderer: ReRegisteringRenderer }],
+            rowData: [{ id: 'r1', A: 'a1', showTip: true }],
+            getRowId: (params) => String(params.data.id),
+            tooltipShowDelay: 200,
+        };
+
+        const api = await gridMgr.createGridAndWait('myGrid-tooltip-reregister-same-text', gridOptions);
+        const gridDiv = getGridElement(api)! as HTMLElement;
+
+        await userEvent.hover(await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r1', 'A'))));
+        await asyncSetTimeout(250);
+        await waitForTooltips(1);
+        expect(visibleTooltipTexts()).toEqual(['Same tooltip']);
+
+        // the renderer survives the update and re-registers the same text, now behind a false predicate
+        api.setGridOption('rowData', [{ id: 'r1', A: 'a2', showTip: false }]);
+
+        await waitFor(() => expect(visibleTooltipTexts()).toEqual([]));
+    });
+
+    test('takes down an open tooltip when a colDef change swaps the component behind the same text', async () => {
+        // the shown component is a snapshot: identical text does not mean the same component or params.
+        class TooltipA implements ITooltipComp {
+            private eGui!: HTMLElement;
+            public init(params: ITooltipParams): void {
+                this.eGui = document.createElement('div');
+                this.eGui.classList.add('ag-tooltip-custom');
+                this.eGui.textContent = `A: ${params.value}`;
+            }
+            public getGui(): HTMLElement {
+                return this.eGui;
+            }
+        }
+
+        class TooltipB implements ITooltipComp {
+            private eGui!: HTMLElement;
+            public init(params: ITooltipParams): void {
+                this.eGui = document.createElement('div');
+                this.eGui.classList.add('ag-tooltip-custom');
+                this.eGui.textContent = `B: ${params.value}`;
+            }
+            public getGui(): HTMLElement {
+                return this.eGui;
+            }
+        }
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'A', tooltipComponent: TooltipA, tooltipValueGetter: () => 'same' }],
+            rowData: [{ id: 'r1', A: 'a1' }],
+            getRowId: (params) => String(params.data.id),
+            tooltipShowDelay: 200,
+        };
+
+        const api = await gridMgr.createGridAndWait('myGrid-tooltip-comp-swap-same-text', gridOptions);
+        const gridDiv = getGridElement(api)! as HTMLElement;
+
+        await userEvent.hover(await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r1', 'A'))));
+        await asyncSetTimeout(250);
+        await waitForTooltips(1);
+        expect(visibleTooltipTexts()).toEqual(['A: same']);
+
+        // the component changes while the tooltip is open, the text it resolves does not
+        api.setGridOption('columnDefs', [{ field: 'A', tooltipComponent: TooltipB, tooltipValueGetter: () => 'same' }]);
+
+        await waitFor(() => expect(visibleTooltipTexts()).not.toContain('A: same'));
+    });
+
+    test('takes down an open renderer tooltip when its renderer goes and the column resolves the same text', async () => {
+        // the column fallback carries a different shouldDisplay, so an identical text must not stay up.
+        class TooltipRenderer implements ICellRendererComp {
+            private eGui!: HTMLElement;
+            public init(params: ICellRendererParams): void {
+                this.eGui = document.createElement('span');
+                this.eGui.textContent = String(params.value);
+                params.setTooltip('Same tooltip', () => true);
+            }
+            public getGui(): HTMLElement {
+                return this.eGui;
+            }
+            public refresh(): boolean {
+                return false;
+            }
+        }
+
+        const gridOptions: GridOptions = {
+            columnDefs: [
+                {
+                    field: 'A',
+                    tooltipValueGetter: () => 'Same tooltip',
+                    cellRendererSelector: (params) =>
+                        params.data?.showDetail ? { component: TooltipRenderer } : undefined,
+                },
+            ],
+            rowData: [{ id: 'r1', A: 'a1', showDetail: true }],
+            getRowId: (params) => String(params.data.id),
+            tooltipShowDelay: 200,
+        };
+
+        const api = await gridMgr.createGridAndWait('myGrid-tooltip-renderer-gone-same-text', gridOptions);
+        const gridDiv = getGridElement(api)! as HTMLElement;
+
+        await userEvent.hover(await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r1', 'A'))));
+        await asyncSetTimeout(250);
+        await waitForTooltips(1);
+        expect(visibleTooltipTexts()).toEqual(['Same tooltip']);
+
+        // the renderer goes while the tooltip is open; the column resolves the same text
+        api.setGridOption('rowData', [{ id: 'r1', A: 'a2', showDetail: false }]);
+
+        await waitFor(() => expect(visibleTooltipTexts()).toEqual([]));
+    });
+
+    test('a colDef change swaps the custom tooltip component and its value', async () => {
+        // the feature is no longer rebuilt on a colDef change, so the component and the params it
+        // receives must be resolved per hover rather than captured when the feature was created.
+        class TooltipA implements ITooltipComp {
+            private eGui!: HTMLElement;
+            public init(params: ITooltipParams): void {
+                this.eGui = document.createElement('div');
+                this.eGui.classList.add('ag-tooltip-custom');
+                this.eGui.textContent = `A: ${params.value}`;
+            }
+            public getGui(): HTMLElement {
+                return this.eGui;
+            }
+        }
+
+        class TooltipB implements ITooltipComp {
+            private eGui!: HTMLElement;
+            public init(params: ITooltipParams): void {
+                this.eGui = document.createElement('div');
+                this.eGui.classList.add('ag-tooltip-custom');
+                this.eGui.textContent = `B: ${params.value}`;
+            }
+            public getGui(): HTMLElement {
+                return this.eGui;
+            }
+        }
+
+        const gridOptions: GridOptions = {
+            columnDefs: [{ field: 'A', tooltipComponent: TooltipA, tooltipValueGetter: () => 'first' }],
+            rowData: [{ id: 'r1', A: 'a1' }],
+            getRowId: (params) => String(params.data.id),
+            tooltipShowDelay: 200,
+        };
+
+        const api = await gridMgr.createGridAndWait('myGrid-tooltip-custom-comp-colDefChanged', gridOptions);
+        const gridDiv = getGridElement(api)! as HTMLElement;
+
+        await userEvent.hover(await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r1', 'A'))));
+        await asyncSetTimeout(250);
+        await waitForTooltips(1);
+        expect(getTooltips()[0]).toHaveTextContent('A: first');
+
+        await userEvent.unhover(await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r1', 'A'))));
+        await asyncSetTimeout(250);
+        await waitForTooltips(0);
+
+        api.setGridOption('columnDefs', [
+            { field: 'A', tooltipComponent: TooltipB, tooltipValueGetter: () => 'second' },
+        ]);
+        await asyncSetTimeout(50);
+
+        await userEvent.hover(await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r1', 'A'))));
+        await asyncSetTimeout(250);
+        await waitForTooltips(1);
+        expect(getTooltips()[0]).toHaveTextContent('B: second');
+    });
+
     test('AG-17663 destroys cell renderer tooltip when the selector swaps to no renderer', async () => {
         class TooltipRenderer implements ICellRendererComp {
             private eGui!: HTMLElement;
@@ -567,6 +1012,71 @@ describe('Tooltips', () => {
         expect(hasTooltipText('Cell renderer tooltip')).toBe(false);
         expect(getTooltips().length).toBeLessThanOrEqual(1);
         expect(getTooltips()[0]).toHaveTextContent('ColDef tooltip');
+    });
+
+    test('keeps the colDef tooltip current when a renderer that never set one is recreated', async () => {
+        // refresh() returning false recreates the renderer on every update, tearing the old one down —
+        // the teardown path that reverts a renderer-registered tooltip must leave colDef tooltips alone.
+        class PlainRenderer implements ICellRendererComp {
+            private eGui!: HTMLElement;
+            public init(params: ICellRendererParams): void {
+                this.eGui = document.createElement('span');
+                this.eGui.textContent = String(params.value);
+            }
+            public getGui(): HTMLElement {
+                return this.eGui;
+            }
+            public refresh(): boolean {
+                return false;
+            }
+        }
+
+        const gridOptions: GridOptions = {
+            columnDefs: [
+                { field: 'A', cellRenderer: PlainRenderer, tooltipValueGetter: (params) => `Tip ${params.value}` },
+                { field: 'B', tooltipValueGetter: (params) => `Tip ${params.value}` },
+            ],
+            rowData: [{ id: 'r1', A: 'a1', B: 'b1' }],
+            getRowId: (params) => String(params.data.id),
+            tooltipShowDelay: 200,
+        };
+
+        const api = await gridMgr.createGridAndWait('myGrid-tooltip-renderer-without-setTooltip', gridOptions);
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        const cellA = await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r1', 'A')));
+        const cellB = await waitFor(() => getByTestId(gridDiv, agTestIdFor.cell('r1', 'B')));
+
+        await userEvent.hover(cellA);
+        await asyncSetTimeout(250);
+        await waitForTooltips(1);
+        expect(hasTooltipText('Tip a1')).toBe(true);
+
+        await userEvent.unhover(cellA);
+        await asyncSetTimeout(250);
+        await waitForTooltips(0);
+
+        api.setGridOption('rowData', [{ id: 'r1', A: 'a2', B: 'b2' }]);
+        await asyncSetTimeout(50);
+        await new GridRows(api, `colDef tooltip survives renderer recreation`).check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:r1 A:"a2" B:"b2"
+        `);
+
+        // the recreated renderer set no tooltip, so the colDef tooltip must show the updated value
+        await userEvent.hover(cellA);
+        await asyncSetTimeout(250);
+        await waitForTooltips(1);
+        expect(hasTooltipText('Tip a2')).toBe(true);
+
+        await userEvent.unhover(cellA);
+        await asyncSetTimeout(250);
+        await waitForTooltips(0);
+
+        // a plain cell with no renderer at all takes the same teardown path
+        await userEvent.hover(cellB);
+        await asyncSetTimeout(250);
+        await waitForTooltips(1);
+        expect(hasTooltipText('Tip b2')).toBe(true);
     });
 
     test('AG-17663 destroys cell renderer tooltip when cellRendererSelector swaps the renderer', async () => {


### PR DESCRIPTION
# Fix tooltips lost on a colDef change, and the cell-repaint tooltip regression

files: 4 changed
lines added: +57
lines removed: -63
net delta: -6

## Perf: the bean was rebuilt on every renderer teardown

PR #14289 (AG-17663, tooltip leak on renderer swap) made `CellComp.destroyRenderer` call `resetCellRendererTooltip()`, which destroyed and recreated the `TooltipFeature` bean — on every renderer teardown, including cells with no renderer and no tooltip, since `destroyRenderer` also runs when `compDetails` is null. It had to rebuild, because `params.setTooltip(value, shouldDisplay)` captured its arguments in closures. That is **418 bean rebuilds per live-preview keystroke flush, ~1.05 ms**.

The renderer's tooltip now lives on `CellCtrl` and is read lazily, as the truncation gate already was:

- `rendererTooltipValue` / `rendererTooltipShouldDisplay` — two scalar fields, no allocation.
- `setTooltip` assigns them; `resetCellRendererTooltip` clears them, returning early when nothing was registered. Neither touches the bean.
- `resolveCellTooltip` reads them at resolve time. `shouldDisplayCustomTooltip` and `shouldDisplayColumnTooltip` collapse into the one `shouldDisplayCellTooltip` they always aliased — two fewer closures per cell than before the regression.

The feature is built once per cell and never rebuilt. Two bugs the old rebuild was papering over had to be fixed for that.

## Bug: error tooltips die on a colDef change

`onColDefChanged` destroyed the feature and rebuilt it only when `column.isTooltipEnabled()` (`tooltipField`, `tooltipValueGetter` or `tooltipComponent`). Formula and edit-validation errors resolve ahead of that config and ignore it, so on any other column they went dark permanently after a colDef change. Nothing is captured at construction now, so a colDef change refreshes the feature the cell already has.

## Bug: an open tooltip could go stale

A tooltip on screen renders the value, component and params it was created with, and none of them can be updated in place — destroying the feature is what took it down. Without the rebuild it stayed up holding a stale snapshot: a changed value, a swapped `tooltipComponent`, a re-registered `shouldDisplayTooltip`, or changed `data` / `node` / `valueFormatted` behind identical text.

`AgTooltipFeature.refreshTooltip` now takes down a tooltip that is on screen, gated on the new `BaseTooltipStateManager.isShowing()` so a show still waiting out its delay isn't cancelled. Every source change already routes through a refresh, so one gate covers all of them.

## Behaviour

- AG-17663 unchanged: a renderer's tooltip is still dropped when its renderer is torn down. Forcing the reset guard to always skip fails those four tests.
- A colDef change no longer clears the renderer fields — a renderer that survives the refresh keeps its tooltip, one that is torn down still goes through `resetCellRendererTooltip`.
- No stale state on the next hover either: value, location, `shouldDisplay`, params and the user tooltip component all resolve then from the live `colDef`. The manager's construction-time reads (`tooltipTrigger`, `tooltipMouseTrack`, `tooltipInteraction`) are initial-only grid options.
- A show still inside `tooltipShowDelay` needs no invalidation: `showTooltip` re-reads the value and re-evaluates the predicate when the timer fires, so a source cleared or disabled in the meantime never reaches the screen. Two tests hold that.
- Header tooltips take the same path, and their `refresh()` only runs on colDef, header-name, agg-func and grid-option changes — not on sort or filter clicks.
- 75 tooltip tests pass (vanilla + React), full unit suite green (10012). Thirteen are new, six failing on the unfixed source: formula error after a colDef change (vanilla + React), row validation error on a non-editing cell, a value change, a component swapped and a predicate re-registered behind identical text, and changed component params behind identical text.

## Benchmarks

Real Chromium, 2 runs per side, interleaved. Deltas under 5.5% are reported as **same** — at or inside the margin of error.

Full-viewport repaint, 2000 rows × 5 cols, ops/s, via the new `tooltip-repaint.bench.ts`:

| Case                             | 36.0.2 | latest | this PR    | vs latest        | vs 36.0.2        |
| -------------------------------- | ------ | ------ | ---------- | ---------------- | ---------------- |
| renderer using `setTooltip`      | 154.3  | 593.1  | **2175.8** | **3.67x faster** | **14.1x faster** |
| renderer without, colDef tooltip | 2853.1 | 966.2  | **2830.0** | **2.93x faster** | same             |
| no renderer, colDef tooltip      | 3922.4 | 1116.7 | **3817.1** | **3.42x faster** | same             |
| no renderer, no tooltip          | 4110.1 | 1127.1 | **3914.9** | **3.47x faster** | same             |

Calculated-column live preview keystroke flush vs `latest`, ops/s:

| Benchmark                       | latest | this PR   | Result           |
| ------------------------------- | ------ | --------- | ---------------- |
| 10k rows, chained calc, no sort | 245.3  | **319.8** | **1.30x faster** |
| 10k rows, chained calc, SORTED  | 228.4  | **296.2** | **1.30x faster** |
| 1k rows, chained calc, no sort  | 115.6  | **131.8** | **1.14x faster** |
| 100k rows, chained calc, SORTED | 41.76  | **47.57** | **1.14x faster** |

Its other three cases are the same. Against 36.0.2 (separate paired run) every case is the same or better, so both benchmarks are back to baseline. `cell-editing-bulk` gains 1.17x on "paste 800 cells (non-batch control)", its other three the same.

## Also included

- **New benchmark** — `tooltip-repaint.bench.ts`, so this path stays measured.
- **Removed `CellCtrl.hasEdit`** — duplicated `editSvc != null`. Its two call sites cache `editSvc` in a local, dropping four non-null assertions.
- **Fixed a flaky test** — `af-builder-keyboard-nav.test.ts` asserted focus and reorder state after a fixed `asyncSetTimeout(0)`; now polls with `waitFor`.
