### PR TITLE
[AG-9664] Fix(pivoting): supplied pivot result columns default to no pivot sort

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/index.mdoc
@@ -91,9 +91,10 @@ the same way row group columns are sorted from their pills.
 
 `pivotSort` is independent of `sort`: it controls the order of a pivoted column's result columns only, and neither
 direction flows to or from the column's own sort. Pivot columns the grid generates are sorted ascending by default,
-while pivot result columns supplied via [SSRM Pivoting](./server-side-model-pivoting/) default to no sort so their
-supplied order is kept. Clicking a pill cycles through ascending, descending and no sort, where no sort keeps the
-order the columns were generated or supplied in.
+while pivot result columns supplied through
+[`setPivotResultColumns`](./server-side-model-pivoting/#creating-pivot-result-columns-advanced) default to no sort so
+their supplied order is kept. Clicking a pill cycles through ascending, descending and no sort, where no sort keeps
+the order the columns were generated or supplied in.
 When a `pivotComparator` is supplied, ascending uses that comparator's order and descending reverses it.
 
 {% gridExampleRunner title="Sorting Pivot Columns" name="sort-pivot-columns" /%}

--- a/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/pivoting-column-groups/index.mdoc
@@ -90,8 +90,10 @@ the same way row group columns are sorted from their pills.
 {% apiDocumentation source="column-properties/properties.json" section="pivoting" names=["pivotSort"] /%}
 
 `pivotSort` is independent of `sort`: it controls the order of a pivoted column's result columns only, and neither
-direction flows to or from the column's own sort. Pivot columns are sorted ascending by default. Clicking a pill
-cycles through ascending, descending and no sort, where no sort keeps the order the columns were generated in.
+direction flows to or from the column's own sort. Pivot columns the grid generates are sorted ascending by default,
+while pivot result columns supplied via [SSRM Pivoting](./server-side-model-pivoting/) default to no sort so their
+supplied order is kept. Clicking a pill cycles through ascending, descending and no sort, where no sort keeps the
+order the columns were generated or supplied in.
 When a `pivotComparator` is supplied, ascending uses that comparator's order and descending reverses it.
 
 {% gridExampleRunner title="Sorting Pivot Columns" name="sort-pivot-columns" /%}

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/index.mdoc
@@ -174,11 +174,11 @@ more complex implementation that creates column groups. Note the following:
 
 {% note %}
 You can control the order of the pivot result columns by sorting the `pivotColDefs` array before passing it to
-`api.setPivotResultColumns(pivotColDefs)`. That supplied order is the natural order, used when
-[Pivot Column Sorting](./pivoting-column-groups/#sorting-pivot-columns) is set to no sort (`pivotSort: null`).
-Any other `pivotSort` - including the ascending default - orders the supplied column groups by header name
-instead, so sorting from a pivot column's pill reorders them without the grid asking the server for the columns
-again.
+`api.setPivotResultColumns(pivotColDefs)`. That supplied order is the natural order, and it is what the grid shows
+until [Pivot Column Sorting](./pivoting-column-groups/#sorting-pivot-columns) is applied - so unlike generated pivot
+result columns, supplied ones default to no sort rather than ascending. An explicit `pivotSort` of `'asc'` or
+`'desc'` orders the supplied column groups by header name instead, so sorting from a pivot column's pill reorders
+them without the grid asking the server for the columns again.
 {% /note %}
 
 ## Example: Pivot Column Groups

--- a/packages/ag-grid-community/src/columns/columnStateUtils.ts
+++ b/packages/ag-grid-community/src/columns/columnStateUtils.ts
@@ -4,6 +4,7 @@ import { doesMovePassMarryChildren, placeLockedColumns } from '../columnMove/col
 import type { BeanCollection } from '../context/context';
 import type { AgColumn } from '../entities/agColumn';
 import {
+    _defaultPivotSort,
     _normalizeSortType,
     _resolvePivotSortFromColDef,
     getSortDefFromInput,
@@ -803,6 +804,7 @@ export const _getColumnState = (beans: BeanCollection): ColumnState[] => {
         return [];
     }
     const cols = colModel.getColsInStateOrder();
+    const defaultPivotSort = _defaultPivotSort(beans);
     const res = new Array<ColumnState>(cols.length);
     for (let i = 0, len = cols.length; i < len; ++i) {
         const column = cols[i];
@@ -824,7 +826,7 @@ export const _getColumnState = (beans: BeanCollection): ColumnState[] => {
             rowGroupIndex: rowGroupActive ? column.rowGroupActiveIndex : null,
             pivot: pivotActive,
             pivotIndex: pivotActive ? column.pivotActiveIndex : null,
-            pivotSort: column.pivotSort === undefined ? 'asc' : column.pivotSort,
+            pivotSort: column.pivotSort === undefined ? defaultPivotSort : column.pivotSort,
             flex: column.flex ?? null,
             showValuesAs: beans.showValuesAsSvc?.toColState(column) ?? null,
             headerName: column.headerNameOverride,

--- a/packages/ag-grid-community/src/entities/agColumn.ts
+++ b/packages/ag-grid-community/src/entities/agColumn.ts
@@ -977,6 +977,19 @@ export const _resolvePivotSortFromColDef = (colDef: ColDef): SortDirection | und
     return pivotSortLike === undefined ? undefined : normalizeSortDirection(pivotSortLike);
 };
 
+/** Direction an unset (`undefined`) `pivotSort` resolves to. The grid's own pivot columns are generated
+ *  ascending, so ascending is what the chip and the ordering must report. Application-supplied pivot result
+ *  columns instead arrive in an order the application chose, which the grid must leave alone until the user
+ *  sorts - so there the default is "no sort".
+ *  @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
+export const _defaultPivotSort = (beans: BeanCollection): SortDirection =>
+    beans.pivotResultCols?.suppliedColDefs != null ? null : 'asc';
+
+/** A column's pivot sort with the unset default resolved via {@link _defaultPivotSort}.
+ *  @internal AG_GRID_INTERNAL - Not for public use. Can change / be removed at any time. */
+export const _resolvePivotSort = (beans: BeanCollection, pivotSort: SortDirection | undefined): SortDirection =>
+    pivotSort === undefined ? _defaultPivotSort(beans) : pivotSort;
+
 export const normalizeSortDirection = (sortDirectionLike?: unknown): SortDirection =>
     isSortDirectionValid(sortDirectionLike) ? sortDirectionLike : null;
 

--- a/packages/ag-grid-community/src/entities/colDef.ts
+++ b/packages/ag-grid-community/src/entities/colDef.ts
@@ -738,6 +738,10 @@ export interface ColDef<TData = any, TValue = any> extends AbstractColDef<TData,
     /**
      * Sort direction applied to this column's pivot result columns when this column is used to pivot on.
      * Independent of `sort` - pivot sorting does not flow to or from the column's own sort.
+     *
+     * Defaults to `'asc'` for the pivot result columns the grid generates. When the pivot result columns are
+     * supplied by the application via `setPivotResultColumns`, it defaults to `null` so the supplied order is kept
+     * until a sort is applied.
      * @default 'asc'
      * @agModule `PivotModule`
      */

--- a/packages/ag-grid-community/src/main-internal.ts
+++ b/packages/ag-grid-community/src/main-internal.ts
@@ -88,10 +88,12 @@ export type { RowDragComp } from './dragAndDrop/rowDragComp';
 export type { RowDragService } from './dragAndDrop/rowDragService';
 export type { RowsDrop as _RowsDrop } from './dragAndDrop/rowDragTypes';
 export {
+    _defaultPivotSort,
     _getAvailableSortTypes,
     _getDisplaySortForColumn,
     _normalizeSortType,
     _resolvePivotColumnForRow,
+    _resolvePivotSort,
     AgColumn,
 } from './entities/agColumn';
 export type { ColKind } from './entities/agColumn';

--- a/packages/ag-grid-enterprise/src/columnToolPanel/updates/columnStateUpdateExecutionStrategy.ts
+++ b/packages/ag-grid-enterprise/src/columnToolPanel/updates/columnStateUpdateExecutionStrategy.ts
@@ -14,6 +14,7 @@ import {
     BeanStub,
     _applyColumnState,
     _dispatchColumnChangedEvent,
+    _resolvePivotSort,
     _setColsVisible,
     isColumnGroupAutoCol,
     isSpecialCol,
@@ -29,8 +30,9 @@ import type {
 const noop = () => {};
 type StrategyBeans = BeanCollection;
 
-/** Cycle: ascending default (`undefined`/`'asc'`) -> descending -> `null` (no sort, natural order) -> ascending. */
-function getNextPivotSort(current: SortDirection | undefined): SortDirection {
+/** Cycle: ascending -> descending -> `null` (no sort, natural order) -> ascending. `current` must already have
+ *  the unset default resolved, so the first click moves away from what the pill actually shows. */
+function getNextPivotSort(current: SortDirection): SortDirection {
     if (current === 'desc') {
         return null;
     }
@@ -256,7 +258,7 @@ class SynchronousColumnStateUpdateStrategy implements ColumnStateConcreteUpdateS
     }
 
     public progressPivotSortFromEvent(column: AgColumn): void {
-        column.pivotSort = getNextPivotSort(column.pivotSort);
+        column.pivotSort = getNextPivotSort(_resolvePivotSort(this.beans, column.pivotSort));
         // Pivot membership is unchanged, so applyColumnState wouldn't fire this - dispatch it to trigger
         // the pivot refresh (columnPivotChanged → refreshModel step 'pivot') that re-derives column order.
         _dispatchColumnChangedEvent(this.beans.eventSvc, 'columnPivotChanged', [column], 'uiColumnSorted');
@@ -722,7 +724,7 @@ class DeferredColumnStateUpdateStrategy implements ColumnStateConcreteUpdateStra
     }
 
     public progressPivotSortFromEvent(column: AgColumn): void {
-        const next = getNextPivotSort(this.getPivotSort(column));
+        const next = getNextPivotSort(_resolvePivotSort(this.beans, this.getPivotSort(column)));
         mergeColumnStatePatch(this.state, { colId: column.colId, pivotSort: next });
         const columnState = ensureColumnStateDraft(this.state);
         columnState.seq = nextSeq(this.sequence);

--- a/packages/ag-grid-enterprise/src/pivot/pivotColDefService.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotColDefService.ts
@@ -10,7 +10,7 @@ import type {
     IValueColsService,
     NamedBean,
 } from 'ag-grid-community';
-import { BeanStub } from 'ag-grid-community';
+import { BeanStub, _resolvePivotSort } from 'ag-grid-community';
 
 const PIVOT_ROW_TOTAL_PREFIX = 'PivotRowTotal_';
 
@@ -588,12 +588,12 @@ export class PivotColDefService extends BeanStub implements NamedBean, IPivotCol
     }
 
     /** Comparator ordering a pivot column's groups. `pivotSort` is isolated from `colDef.sort`:
-     *  `null` keeps the natural (generated) order, `'desc'` reverses, and the unset default (`undefined`)
-     *  and `'asc'` both sort ascending by the custom `pivotComparator` or header name. */
+     *  `null` keeps the natural (supplied or generated) order, `'desc'` reverses, and `'asc'` sorts ascending by
+     *  the custom `pivotComparator` or header name. The unset default resolves via {@link _resolvePivotSort}. */
     private getPivotGroupComparator(
         primaryColumn: AgColumn
     ): (a: ColGroupDef | ColDef, b: ColGroupDef | ColDef) => number {
-        const pivotSort = primaryColumn.pivotSort;
+        const pivotSort = _resolvePivotSort(this.beans, primaryColumn.pivotSort);
         if (pivotSort === null) {
             return naturalOrderComparator;
         }

--- a/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
+++ b/packages/ag-grid-enterprise/src/pivot/pivotStage.ts
@@ -9,9 +9,10 @@ import type {
     IPivotResultColsService,
     NamedBean,
     RowNode,
+    SortDirection,
     _IRowNodePivotStage,
 } from 'ag-grid-community';
-import { BeanStub, _forEachChangedGroupDepthFirst } from 'ag-grid-community';
+import { BeanStub, _defaultPivotSort, _forEachChangedGroupDepthFirst } from 'ag-grid-community';
 
 import type { PivotColDefService } from './pivotColDefService';
 
@@ -123,7 +124,9 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
 
         const pivotColumns = pivotColsSvc?.columns ?? [];
         const shouldTrackPivotOrder = pivotColsSvc?.isStrictColumnOrder() ?? false;
-        const pivotOrder = shouldTrackPivotOrder ? computePivotOrder(this.uniqueValues, pivotColumns, 0) : [];
+        const pivotOrder = shouldTrackPivotOrder
+            ? computePivotOrder(this.uniqueValues, pivotColumns, 0, _defaultPivotSort(this.beans))
+            : [];
         const pivotOrderChanged = !_areEqual(pivotOrder, this.pivotOrderLastTime);
         this.pivotOrderLastTime = pivotOrder;
 
@@ -268,13 +271,19 @@ export class PivotStage extends BeanStub implements NamedBean, _IRowNodePivotSta
  * order changes (e.g. a sort toggle or comparator closure mutation) without relying on function reference or
  * source equality.
  */
-function computePivotOrder(values: Map<string, any>, pivotColumns: AgColumn[], depth: number): string[] {
+function computePivotOrder(
+    values: Map<string, any>,
+    pivotColumns: AgColumn[],
+    depth: number,
+    defaultPivotSort: SortDirection
+): string[] {
     const pivotColumn = pivotColumns[depth];
     const keys = [...values.keys()];
     // Mirror pivotColDefService's ordering so the snapshot tracks the rendered order and a toggle is detected as
-    // an order change: `null` keeps the natural (insertion) key order, `'desc'` reverses, and the unset default
-    // and `'asc'` sort ascending by the custom comparator or string order.
-    const pivotSort = pivotColumn?.pivotSort;
+    // an order change: `null` keeps the natural (insertion) key order, `'desc'` reverses, and `'asc'` sorts
+    // ascending by the custom comparator or string order.
+    const rawPivotSort = pivotColumn?.pivotSort;
+    const pivotSort = rawPivotSort === undefined ? defaultPivotSort : rawPivotSort;
     if (pivotSort !== null) {
         const comparator = pivotColumn?.colDef.pivotComparator;
         if (comparator) {
@@ -296,7 +305,7 @@ function computePivotOrder(values: Map<string, any>, pivotColumns: AgColumn[], d
         const child = values.get(key);
         // child is a nested Map at non-leaf levels; if absent (sparse map), skip its subtree.
         if (child instanceof Map) {
-            const childKeys = computePivotOrder(child, pivotColumns, depth + 1);
+            const childKeys = computePivotOrder(child, pivotColumns, depth + 1, defaultPivotSort);
             for (let j = 0; j < childKeys.length; j++) {
                 result.push(childKeys[j]);
             }

--- a/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/dropZoneColumnComp.ts
+++ b/packages/ag-grid-enterprise/src/rowGrouping/columnDropZones/dropZoneColumnComp.ts
@@ -10,7 +10,7 @@ import type {
     SortDirection,
     SortIndicatorComp,
 } from 'ag-grid-community';
-import { Component, DragSourceType, KeyCode, _createElement } from 'ag-grid-community';
+import { Component, DragSourceType, KeyCode, _createElement, _resolvePivotSort } from 'ag-grid-community';
 
 import { isDeferredMode, refreshDeferredToolPanelUi } from '../../columnToolPanel/toolPanelDeferredUiUtils';
 import type { ColumnStateUpdateParams } from '../../columnToolPanel/updates/columnStateUpdateTypes';
@@ -200,6 +200,14 @@ export class DropZoneColumnComp extends PillDragComp<AgColumn> {
         this.bindSort(this.getPivotSortDefOverride.bind(this), (column) =>
             this.beans.columnStateUpdateStrategy.progressPivotSortFromEvent(this.deferApply, column)
         );
+        // What an unset pivotSort displays depends on whether the pivot result columns are application-supplied,
+        // which `setPivotResultColumns` can change while this pill lives.
+        this.addManagedEventListeners({
+            gridColumnsChanged: () => {
+                this.eSortIndicator.refresh();
+                this.setupAria();
+            },
+        });
     }
 
     private bindSort(
@@ -241,14 +249,18 @@ export class DropZoneColumnComp extends PillDragComp<AgColumn> {
         return this.beans.columnStateUpdateStrategy.getSortDef(this.deferApply, this.column);
     }
 
-    // Pivot sort is isolated from the column's own sort. The unset default (`undefined`) and `'asc'` both
-    // show ascending; `null` is an explicit "no sort" and shows no icon. Never falls back to the column's sort.
+    // Pivot sort is isolated from the column's own sort: `null` is an explicit "no sort" and shows no icon,
+    // and the unset default resolves via `_resolvePivotSort`. Never falls back to the column's sort.
     private getPivotSortDefOverride(): SortDef | null {
-        const direction = this.beans.columnStateUpdateStrategy.getPivotSort(this.deferApply, this.column);
+        const beans = this.beans;
+        const direction = _resolvePivotSort(
+            beans,
+            beans.columnStateUpdateStrategy.getPivotSort(this.deferApply, this.column)
+        );
         if (direction === null) {
             return null;
         }
-        return { type: 'default', direction: direction ?? 'asc' };
+        return { type: 'default', direction };
     }
 
     protected override getDefaultIconName(): DragAndDropIcon {

--- a/testing/behavioural/src/sorting/pivot-column-sort-ssrm.test.ts
+++ b/testing/behavioural/src/sorting/pivot-column-sort-ssrm.test.ts
@@ -1,6 +1,7 @@
 import { waitFor } from '@testing-library/dom';
 
 import type { ColDef, GridApi, IServerSideDatasource } from 'ag-grid-community';
+import { getGridElement } from 'ag-grid-community';
 import { AllEnterpriseModule } from 'ag-grid-enterprise';
 
 import { createFakeServer, createServerSideDatasource } from '../columnToolPanel/deferredPivotModeFakeServer';
@@ -135,9 +136,9 @@ describe('SSRM: interactive pivot column sorting (pivotSort)', () => {
 
         const pivots = () => pivotsOf(api);
         const supplied = ['2004_gold', '2000_gold', '2008_gold'];
-        // Supplying the columns leaves pivotSort alone, so its ascending default orders them by header name.
-        await waitFor(() => expect(pivots()).toEqual(['2000_gold', '2004_gold', '2008_gold']));
-        expect(api.getColumnState().find((s) => s.colId === 'year')!.pivotSort).toBe('asc');
+        // The application chose this order, so an unset pivotSort leaves it alone and reports no sort.
+        await waitFor(() => expect(pivots()).toEqual(supplied));
+        expect(api.getColumnState().find((s) => s.colId === 'year')!.pivotSort).toBeNull();
 
         api.applyColumnState({ state: [{ colId: 'year', pivotSort: 'desc' }] });
         await waitFor(() => expect(pivots()).toEqual(['2008_gold', '2004_gold', '2000_gold']));
@@ -154,6 +155,83 @@ describe('SSRM: interactive pivot column sorting (pivotSort)', () => {
         await waitFor(() => expect(pivots()).toEqual(['2008_gold', '2004_gold', '2000_gold']));
         api.applyColumnState({ state: [{ colId: 'year', pivotSort: null }] });
         await waitFor(() => expect(pivots()).toEqual(supplied));
+    });
+
+    test('supplied pivot result columns start unsorted and the first pill click sorts them ascending', async () => {
+        const datasource: IServerSideDatasource = {
+            getRows: (params) => setTimeout(() => params.success({ rowData: rowData as any, rowCount: 3 }), 0),
+        };
+        const api = await createPivotGrid(datasource);
+
+        // Supplied in an order that is neither ascending nor descending, so "no sort" is distinguishable.
+        const supplied = ['2004_gold', '2000_gold', '2008_gold'];
+        api.setPivotResultColumns([
+            { groupId: '2004', headerName: '2004', children: [{ colId: '2004_gold', field: '2004_gold' }] },
+            { groupId: '2000', headerName: '2000', children: [{ colId: '2000_gold', field: '2000_gold' }] },
+            { groupId: '2008', headerName: '2008', children: [{ colId: '2008_gold', field: '2008_gold' }] },
+        ]);
+
+        const pivots = () => pivotsOf(api);
+        await waitFor(() => expect(pivots()).toEqual(supplied));
+
+        const yearCol = api.getColumn('year') as any;
+        const strategy = yearCol.beans.columnStateUpdateStrategy;
+        expect(strategy.getPivotSort(false, yearCol)).toBeUndefined();
+
+        strategy.progressPivotSortFromEvent(false, yearCol);
+        await waitFor(() => {
+            expect(strategy.getPivotSort(false, yearCol)).toBe('asc');
+            expect(pivots()).toEqual(['2000_gold', '2004_gold', '2008_gold']);
+        });
+
+        strategy.progressPivotSortFromEvent(false, yearCol);
+        await waitFor(() => {
+            expect(strategy.getPivotSort(false, yearCol)).toBe('desc');
+            expect(pivots()).toEqual(['2008_gold', '2004_gold', '2000_gold']);
+        });
+
+        strategy.progressPivotSortFromEvent(false, yearCol);
+        await waitFor(() => {
+            expect(strategy.getPivotSort(false, yearCol)).toBeNull();
+            expect(pivots()).toEqual(supplied);
+        });
+    });
+
+    test('the pivot pill shows no sort indicator while supplied pivot result columns are unsorted', async () => {
+        const api = await gridsManager.createGridAndWait('ssrmPill', {
+            columnDefs: [
+                { field: 'country', rowGroup: true, hide: true },
+                { field: 'year', pivot: true, hide: true },
+                { field: 'gold', aggFunc: 'sum', hide: true },
+            ],
+            pivotMode: true,
+            pivotPanelShow: 'always',
+            rowModelType: 'serverSide',
+            serverSideDatasource: {
+                getRows: (params) => setTimeout(() => params.success({ rowData: rowData as any, rowCount: 3 }), 0),
+            },
+        });
+        await waitForNoLoadingRows(api);
+
+        api.setPivotResultColumns([
+            { groupId: '2004', headerName: '2004', children: [{ colId: '2004_gold', field: '2004_gold' }] },
+            { groupId: '2000', headerName: '2000', children: [{ colId: '2000_gold', field: '2000_gold' }] },
+        ]);
+        await waitFor(() => expect(pivotsOf(api)).toEqual(['2004_gold', '2000_gold']));
+
+        const pill = getGridElement(api)!.querySelector('.ag-column-drop-horizontal-pivot .ag-column-drop-cell')!;
+        const shown = (selector: string) => {
+            const icon = pill.querySelector(selector);
+            return !!icon && !icon.classList.contains('ag-hidden');
+        };
+        expect(shown('.ag-sort-ascending-icon')).toBe(false);
+        expect(shown('.ag-sort-descending-icon')).toBe(false);
+
+        pill.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+        await waitFor(() => {
+            expect(shown('.ag-sort-ascending-icon')).toBe(true);
+            expect(pivotsOf(api)).toEqual(['2000_gold', '2004_gold']);
+        });
     });
 
     test('sorting supplied pivot result columns does not mutate the application-owned arrays', async () => {
@@ -190,10 +268,10 @@ describe('SSRM: interactive pivot column sorting (pivotSort)', () => {
             { groupId: 'sup_2004', headerName: '2004', children: [{ colId: 'sup_2004_gold', field: '2004_gold' }] },
             { groupId: 'sup_2000', headerName: '2000', children: [{ colId: 'sup_2000_gold', field: '2000_gold' }] },
         ]);
-        await waitFor(() => expect(pivots()).toEqual(['sup_2000_gold', 'sup_2004_gold']));
-
-        api.applyColumnState({ state: [{ colId: 'year', pivotSort: 'desc' }] });
         await waitFor(() => expect(pivots()).toEqual(['sup_2004_gold', 'sup_2000_gold']));
+
+        api.applyColumnState({ state: [{ colId: 'year', pivotSort: 'asc' }] });
+        await waitFor(() => expect(pivots()).toEqual(['sup_2000_gold', 'sup_2004_gold']));
     });
 
     test('a server refresh does not replace application-supplied pivot result columns', async () => {
@@ -209,12 +287,12 @@ describe('SSRM: interactive pivot column sorting (pivotSort)', () => {
             { groupId: 'sup_2004', headerName: '2004', children: [{ colId: 'sup_2004_gold', field: '2004_gold' }] },
             { groupId: 'sup_2000', headerName: '2000', children: [{ colId: 'sup_2000_gold', field: '2000_gold' }] },
         ]);
-        await waitFor(() => expect(pivots()).toEqual(['sup_2000_gold', 'sup_2004_gold']));
+        await waitFor(() => expect(pivots()).toEqual(['sup_2004_gold', 'sup_2000_gold']));
 
         api.refreshServerSide({ purge: true });
         await waitForNoLoadingRows(api);
         await waitFor(() => expect(api.getDisplayedRowCount()).toBeGreaterThan(0));
-        expect(pivots()).toEqual(['sup_2000_gold', 'sup_2004_gold']);
+        expect(pivots()).toEqual(['sup_2004_gold', 'sup_2000_gold']);
 
         // ...and the application keeps the order until it hands the columns back.
         api.setPivotResultColumns(null);
@@ -260,11 +338,11 @@ describe('SSRM: interactive pivot column sorting (pivotSort)', () => {
         ]);
 
         const pivots = () => pivotsOf(api, /^\d{4}_/);
-        // Groups ordered by the ascending default; Silver still precedes Gold inside each.
-        await waitFor(() => expect(pivots()).toEqual(['2000_silver', '2000_gold', '2004_silver', '2004_gold']));
-
-        api.applyColumnState({ state: [{ colId: 'year', pivotSort: 'desc' }] });
+        // Groups keep the supplied order while unsorted; Silver still precedes Gold inside each.
         await waitFor(() => expect(pivots()).toEqual(['2004_silver', '2004_gold', '2000_silver', '2000_gold']));
+
+        api.applyColumnState({ state: [{ colId: 'year', pivotSort: 'asc' }] });
+        await waitFor(() => expect(pivots()).toEqual(['2000_silver', '2000_gold', '2004_silver', '2004_gold']));
     });
 
     test('pivotKeys mark supplied leaves as a flattened inner pivot level', async () => {
@@ -303,10 +381,10 @@ describe('SSRM: interactive pivot column sorting (pivotSort)', () => {
         ]);
 
         const pivots = () => pivotsOf(api, /^\d{4}_/);
-        await waitFor(() => expect(pivots()).toEqual(['2000_Diving', '2000_Swimming']));
-
-        api.applyColumnState({ state: [{ colId: 'sport', pivotSort: 'desc' }] });
         await waitFor(() => expect(pivots()).toEqual(['2000_Swimming', '2000_Diving']));
+
+        api.applyColumnState({ state: [{ colId: 'sport', pivotSort: 'asc' }] });
+        await waitFor(() => expect(pivots()).toEqual(['2000_Diving', '2000_Swimming']));
     });
 
     test('pivotSort orders flat supplied pivot columns when pivoting on two columns', async () => {
@@ -334,10 +412,10 @@ describe('SSRM: interactive pivot column sorting (pivotSort)', () => {
         ]);
 
         const pivots = () => pivotsOf(api, /^\d{4}_/);
-        await waitFor(() => expect(pivots()).toEqual(['2000_gold', '2004_gold']));
-
-        api.applyColumnState({ state: [{ colId: 'year', pivotSort: 'desc' }] });
         await waitFor(() => expect(pivots()).toEqual(['2004_gold', '2000_gold']));
+
+        api.applyColumnState({ state: [{ colId: 'year', pivotSort: 'asc' }] });
+        await waitFor(() => expect(pivots()).toEqual(['2000_gold', '2004_gold']));
     });
 
     test('pivotSort pins a supplied non-group column while the groups beside it reorder', async () => {
@@ -355,10 +433,10 @@ describe('SSRM: interactive pivot column sorting (pivotSort)', () => {
         ]);
 
         const pivots = () => pivotsOf(api);
-        await waitFor(() => expect(pivots()).toEqual(['2000_gold', '2004_gold', 'total_gold']));
-
-        api.applyColumnState({ state: [{ colId: 'year', pivotSort: 'desc' }] });
         await waitFor(() => expect(pivots()).toEqual(['2004_gold', '2000_gold', 'total_gold']));
+
+        api.applyColumnState({ state: [{ colId: 'year', pivotSort: 'asc' }] });
+        await waitFor(() => expect(pivots()).toEqual(['2000_gold', '2004_gold', 'total_gold']));
     });
 
     test('a supplied total marked with empty pivotKeys is pinned in a flat level', async () => {
@@ -376,10 +454,10 @@ describe('SSRM: interactive pivot column sorting (pivotSort)', () => {
         ]);
 
         const pivots = () => pivotsOf(api);
-        await waitFor(() => expect(pivots()).toEqual(['total_gold', '2000_gold', '2004_gold']));
-
-        api.applyColumnState({ state: [{ colId: 'year', pivotSort: 'desc' }] });
         await waitFor(() => expect(pivots()).toEqual(['total_gold', '2004_gold', '2000_gold']));
+
+        api.applyColumnState({ state: [{ colId: 'year', pivotSort: 'asc' }] });
+        await waitFor(() => expect(pivots()).toEqual(['total_gold', '2000_gold', '2004_gold']));
     });
 
     test('changing the pivot columns still refetches from the server', async () => {


### PR DESCRIPTION
TC13: an unset `pivotSort` resolved to ascending for every pivot column, so application-supplied pivot result columns (`setPivotResultColumns`) were reordered by header name and their pill showed an ascending indicator instead of keeping the supplied order.

An unset `pivotSort` now resolves to `null` (no sort) while the pivot result columns are application-supplied, and to `'asc'` for the columns the grid generates. The pill cycle, the column state and the docs follow the same default.

Behavioural tests added/updated in `pivot-column-sort-ssrm.test.ts`.