### PR TITLE
Add an Integrated Charts rule for effective AG Charts option values

### DIFF
--- a/.rulesync/.gitignore
+++ b/.rulesync/.gitignore
@@ -35,6 +35,7 @@ mcp.json
 !/rules/examples.md
 !/rules/framework-view-layers.md
 !/rules/grid-code-conventions.md
+!/rules/integrated-charts.md
 !/rules/testing.md
 # docs-review-testing.md ships as a sibling asset of the ag-prodeng docs-review
 # skill config (at skills/docs-review/ag-grid/), not as a top-level rule, so no

--- a/.rulesync/rules/integrated-charts.md
+++ b/.rulesync/rules/integrated-charts.md
@@ -1,0 +1,27 @@
+---
+targets: ['*']
+description: 'Integrated Charts: establishing effective AG Charts option values, and testing the format panel'
+globs: ['packages/ag-grid-enterprise/src/charts/**/*.ts', 'testing/behavioural/src/charts/**/*.ts']
+---
+
+# Integrated Charts
+
+The format panel binds each widget to an AG Charts option by **string expression**, resolved at runtime against the chart's processed options. Nothing in that path is type-checked, so an option AG Charts has renamed, moved, or left unset yields a control that silently reads the wrong value, writes nothing, or both.
+
+## Establishing what the chart actually renders
+
+An option's effective value is whatever the live chart resolves it to. The processed options are not that value: they carry only what the theme configures, so anything left at an AG Charts property default is absent from them.
+
+- Probe a **live chart** through the behavioural harness (`TestGridsManager` → `api.createRangeChart` → `await chartRef.chart.waitForUpdate()`) and read the value off the chart. In descending order of preference: the processed options, then `series[].properties`, then `properties.toJson()` for a value a series inherits from a sibling, then whichever subsystem owns it (`ctx.legendManager.getData()` for legend symbols).
+- **Do not read `node_modules/ag-charts-*/dist` to decide what a value is,** and do not infer it from a `??` default found there. Such a fallback fires only when the caller supplies nothing, which is the uncommon case — the value usually arrives from the series.
+- **Effective values are frequently per-series.** A chart-wide control can only honestly show a value every series agrees on: the agreed value, or blank when they differ. Verify across chart families (column, line, scatter, pie, polar, statistical), never from a single chart type.
+- Reads of AG Charts internals are declared on `AgChartActual` in `chartComp/utils/integration.ts` and used through it, never via an inline cast.
+
+## Masking to be aware of
+
+Several helpers substitute a plausible value for a missing read, which turns a broken binding into a control that merely looks correct: `getDefaultSliderParams` coerces with `?? 0`, `addEnableParams` with `?? false`, and `FontPanel` invents a font family, weight, and style. A control displaying one of these proves nothing about the binding behind it.
+
+## Testing the format panel
+
+- Widget values are **not queryable through `document`** in the jsdom behavioural environment. Assert them by instrumenting the `ChartMenuParamsFactory` factory methods and reading `params.value` once the panel has built — panels amend the params object after the factory returns, so the recorded object holds the final value.
+- `format-panel-options.test.ts` walks every binding on every chart type and is the gate for this class of drift.

--- a/.rulesync/rules/testing.md
+++ b/.rulesync/rules/testing.md
@@ -93,6 +93,10 @@ packages/ag-grid-community/src/
 
 > `./behave.sh` does not type-check (Vitest strips types via esbuild). Before committing, run `yarn nx run ag-behavioural-testing:build:test` to type-check.
 >
+> Invoke `./behave.sh` and `./benches.sh` by absolute path from the repo root — the shell working directory does not persist between commands, so a relative path fails after any `cd`.
+>
+> Some suites run past a two-minute command timeout; `testing/behavioural/src/charts/format-panel-options.test.ts` alone takes ~2.5 minutes. Run those in the background.
+>
 > The workspace membership and shared config live in `vitest.workspace.ts`, `vitest.config.ts`, and `vitest.shared.ts` at the repo root; each project keeps its own `vitest.config.ts`. Runner-global options (reporters, `onConsoleLog`, pool) must live in the **root** config — Vitest ignores them in a project config during a workspace run.
 
 ### Benchmarks

--- a/.rulesync/rules/testing.md
+++ b/.rulesync/rules/testing.md
@@ -93,9 +93,9 @@ packages/ag-grid-community/src/
 
 > `./behave.sh` does not type-check (Vitest strips types via esbuild). Before committing, run `yarn nx run ag-behavioural-testing:build:test` to type-check.
 >
-> Invoke `./behave.sh` and `./benches.sh` by absolute path from the repo root — the shell working directory does not persist between commands, so a relative path fails after any `cd`.
+> `./behave.sh` and `./benches.sh` resolve only from the repository root, so an agent whose shell has changed directory — earlier in the same command, or carried over from a previous one — will not find them. Prefix with `cd "$(git rev-parse --show-toplevel)" &&` rather than hardcoding a machine-specific path.
 >
-> Some suites run past a two-minute command timeout; `testing/behavioural/src/charts/format-panel-options.test.ts` alone takes ~2.5 minutes. Run those in the background.
+> Some suites take several minutes; `testing/behavioural/src/charts/format-panel-options.test.ts` alone runs ~2.5 minutes. Allow a timeout of at least five minutes, and wait for the run to finish and report its exit status — if the runner detaches the command, collect the result rather than treating silence as success.
 >
 > The workspace membership and shared config live in `vitest.workspace.ts`, `vitest.config.ts`, and `vitest.shared.ts` at the repo root; each project keeps its own `vitest.config.ts`. Runner-global options (reporters, `onConsoleLog`, pool) must live in the **root** config — Vitest ignores them in a project config during a workspace run.
 


### PR DESCRIPTION
Adds `.rulesync/rules/integrated-charts.md`, globbed to `packages/ag-grid-enterprise/src/charts/**/*.ts` and `testing/behavioural/src/charts/**/*.ts`:

- Where an option's effective value actually lives, and that the processed options are not it — anything left at an AG Charts property default is absent from them.
- That effective values are frequently per-series, so a chart-wide control can only show a value every series agrees on.
- The masking helpers (`?? 0` on sliders, `?? false` on enables, FontPanel's invented font values) that turn a broken binding into a control which merely looks right.
- That format panel widgets are not queryable through `document` under jsdom — instrument `ChartMenuParamsFactory` and read `params.value` instead.

Motivated by #14686: a marker stroke fallback was written from a `?? 1` default read out of the ag-charts bundle rather than probed on a live chart, and shipped showing `1` where a column chart renders `0`.

Two supporting lines in `.rulesync/rules/testing.md`: invoke `behave.sh` by absolute path from the repo root, and run the charts suites in the background since they exceed a two-minute timeout.

`.rulesync/.gitignore` gains the allowlist entry the new rule needs to be tracked. Generated outputs under `.claude/` are refreshed by `setup-prompts.sh` and are not part of this diff.