### PR TITLE
[AG-115] Size the edit column name dialog to its content

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_column-header-edit.scss
+++ b/community-modules/styles/src/internal/base/parts/_column-header-edit.scss
@@ -4,8 +4,8 @@
     .ag-column-header-edit-popup-content {
         display: flex;
         flex-direction: column;
-        gap: calc(var(--ag-spacing) * 2);
-        padding: calc(var(--ag-spacing) * 2);
+        gap: calc(var(--ag-grid-size) * 2);
+        padding: calc(var(--ag-grid-size) * 2);
         box-sizing: border-box;
         // The panel content wrapper lays out in a row, so grow to claim the dialog's full width.
         flex: 1 1 auto;

--- a/community-modules/styles/src/internal/base/parts/_column-header-edit.scss
+++ b/community-modules/styles/src/internal/base/parts/_column-header-edit.scss
@@ -4,10 +4,9 @@
     .ag-column-header-edit-popup-content {
         display: flex;
         flex-direction: column;
-        gap: var(--ag-widget-vertical-spacing);
-        padding: var(--ag-widget-container-vertical-padding) var(--ag-widget-container-horizontal-padding);
+        gap: calc(var(--ag-spacing) * 2);
+        padding: calc(var(--ag-spacing) * 2);
         box-sizing: border-box;
-        height: 100%;
         // The panel content wrapper lays out in a row, so grow to claim the dialog's full width.
         flex: 1 1 auto;
         min-width: 0;

--- a/packages/ag-grid-enterprise/src/columnHeaderEdit/columnHeaderEdit.css
+++ b/packages/ag-grid-enterprise/src/columnHeaderEdit/columnHeaderEdit.css
@@ -1,10 +1,9 @@
 .ag-column-header-edit-popup-content {
     display: flex;
     flex-direction: column;
-    gap: var(--ag-widget-vertical-spacing);
-    padding: var(--ag-widget-container-vertical-padding) var(--ag-widget-container-horizontal-padding);
+    gap: calc(var(--ag-spacing) * 2);
+    padding: calc(var(--ag-spacing) * 2);
     box-sizing: border-box;
-    height: 100%;
 
     /* The panel content wrapper lays out in a row, so grow to claim the dialog's full width. */
     flex: 1 1 auto;

--- a/packages/ag-grid-enterprise/src/columnHeaderEdit/columnHeaderEditPopup.ts
+++ b/packages/ag-grid-enterprise/src/columnHeaderEdit/columnHeaderEditPopup.ts
@@ -7,9 +7,6 @@ import { Dialog } from '../widgets/dialog';
 
 const WIDTH = 300;
 const MIN_WIDTH = 300;
-// Deferred mode adds the Apply/Cancel actions row, so the dialog needs more height.
-const LIVE_HEIGHT = 110;
-const DEFERRED_HEIGHT = 160;
 
 const ColumnHeaderEditContentElement: ElementParams = {
     tag: 'div',
@@ -120,13 +117,12 @@ export class ColumnHeaderEditPopup extends BeanStub {
         this.contentComp = contentComp;
 
         const translate = this.getLocaleTextFunc();
-        const height = liveApply ? LIVE_HEIGHT : DEFERRED_HEIGHT;
         const dialog = this.createManagedBean(
             new Dialog({
                 width: WIDTH,
                 minWidth: MIN_WIDTH,
-                height,
-                minHeight: height,
+                // Opt out of the default minimum so the dialog sizes to its content.
+                minHeight: 0,
                 title: translate('editColumnName', 'Edit Column Name'),
                 component: contentComp,
                 closable: true,


### PR DESCRIPTION
Removes the fixed height / min-height from the Edit Column Name dialog so it sizes to its content, and switches the content padding and gap to `calc(var(--ag-spacing) * 2)`.

Design-only; mirrored in the legacy theme SCSS.

fixes [AG-115](https://ag-grid.atlassian.net/browse/AG-115)

<img width="1346" height="773" alt="Screenshot-2026-07-31_14-57-37-162" src="https://github.com/user-attachments/assets/942c885d-72ad-4834-b7ea-185d7ea0d03f" />
<img width="1334" height="759" alt="Screenshot-2026-07-31_14-57-45-377" src="https://github.com/user-attachments/assets/2b6f76ae-f552-4c9c-8b76-2198a860d1dd" />
