### PR TITLE
AG-17862 Port charts markdown fixes and improve API reference tables

### DIFF
--- a/documentation/ag-grid-docs/src/components/license-setup/components/LicenseSetup.tsx
+++ b/documentation/ag-grid-docs/src/components/license-setup/components/LicenseSetup.tsx
@@ -97,19 +97,6 @@ export const LicenseSetup: FunctionComponent<Props> = ({ library, framework, pat
 
     return (
         <>
-            <h2 id="request-trial-licence">
-                Request a Trial Licence
-                <LinkIcon href="#request-trial-licence" />
-            </h2>
-            <Note>
-                You can test AG Grid Enterprise locally without a licence. To test in production, access support and
-                remove the watermark & console warnings,{' '}
-                <a href="../community-vs-enterprise/#request-a-30-day-enterprise-bundle-trial-licence">
-                    request a trial licence
-                </a>
-                .
-            </Note>
-
             <form className={styles.form}>
                 <h2 id="validate-your-license">
                     Validate Your Licence

--- a/documentation/ag-grid-docs/src/content/docs/license-install/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/license-install/index.mdoc
@@ -32,6 +32,12 @@ headings:
 
 Validate your licence key and configure your application. See sample code and example projects to learn how to install your AG Grid Enterprise products.
 
+## Request a Trial Licence {% #request-trial-licence %}
+
+{% note %}
+You can test AG Grid Enterprise locally without a licence. To test in production, access support and remove the watermark & console warnings, [request a trial licence](./community-vs-enterprise/#request-a-30-day-enterprise-bundle-trial-licence).
+{% /note %}
+
 {% licenseSetup /%}
 
 {% if isFramework("react") %}

--- a/documentation/ag-grid-docs/src/pages/[framework]-data-grid/[pageName].md.ts
+++ b/documentation/ag-grid-docs/src/pages/[framework]-data-grid/[pageName].md.ts
@@ -38,7 +38,11 @@ export async function GET({
         body: page.body ?? '',
         framework,
         pageName,
-        frontmatter: { title: page.data.title, description: page.data.description },
+        frontmatter: {
+            title: page.data.title,
+            description: page.data.description,
+            enterprise: page.data.enterprise,
+        },
         // Release version only — drop the beta/build suffix (e.g. 36.0.0-beta.2026… → 36.0.0).
         version: agGridVersion.split('-')[0],
         // Per-page Markdoc variables the site injects via <Content> props, so tags like

--- a/documentation/ag-grid-docs/src/pages/community/beyond-the-prompt.astro
+++ b/documentation/ag-grid-docs/src/pages/community/beyond-the-prompt.astro
@@ -6,7 +6,10 @@ import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 import { DISABLE_MARKDOWN_DOCS } from '@constants';
 import {
+    PAGE_CONTENT,
     SESSIONS,
+    SPEAKERS,
+    headSlug,
     sessionDurationMins,
     sessionSlug,
     sessionThumbSlug,
@@ -16,141 +19,6 @@ import CommunityMenu from '@ag-website-shared/components/community/components/Co
 import communityMenu from '@ag-website-shared/content/community/community-menu.json';
 
 const SOCIAL_IMAGE_URL = 'images/campaigns/beyond-the-prompt/social-card.png';
-
-type Speaker = {
-    name: string;
-    title: string;
-    bio: string;
-    image: string;
-    // Re-shaded variant designed for orange backgrounds. The ditherpattern
-    // and knockout values are tuned for #F43800; we crossfade to it on
-    // card hover (Speakers grid) and use it directly in the agenda hover
-    // overlay, where the row turns orange behind the portrait.
-    imageOrange?: string;
-    // Some speaker SVGs are exported as full-figure portraits with very tall,
-    // narrow aspect ratios (e.g. Mats 193×352, John 232×388). Using the
-    // default `object-fit: cover` on a 4:5 box clips ~140px off the bottom.
-    // Setting `imageFit: 'contain'` switches just those cards to fit-the-whole
-    // SVG while staying anchored to the bottom of the frame.
-    imageFit?: 'contain';
-};
-
-const SPEAKERS: Speaker[] = [
-    {
-        name: 'Matt Webb',
-        title: 'Co-founder, Inanimate',
-        bio: "Matt is co-founder of Inanimate, consumer hardware bringing agents into the real world. Previously he has consulted with Google's AI research group, run startup accelerators with R/GA Ventures, and was CEO and co-founder of the design studio BERG which invented some of the world’s first internet-connected consumer products like Little Printer (and has work in the New York MoMA). He is co-author of Mind Hacks (O’Reilly, 2004). Since 2000 Matt has blogged at interconnected.org. He writes weekly+ on computing, design, and speculative futures. He lives in London.",
-        image: 'images/campaigns/beyond-the-prompt/svg/mat-web.svg',
-        imageOrange: 'images/campaigns/beyond-the-prompt/svg/mat-web-orange-bg.svg',
-    },
-    {
-        name: 'Stephen Cooper',
-        title: 'Team Lead, AG Grid',
-        bio: `Stephen is the Team Lead for AG Grid and loves sharing practical, experience-based tips, tricks, and case studies from years in the codebase. He's gone deep into grid performance and framework integrations, and has spent more time than he'd like profiling render cycles. Outside of work, life revolves around family, four kids and two dogs, and he's happiest when the whole crew is out together exploring in the park.`,
-        image: 'images/campaigns/beyond-the-prompt/svg/stephen.svg',
-        imageOrange: 'images/campaigns/beyond-the-prompt/svg/stephen-orange-bg.svg',
-    },
-    {
-        name: 'Maggie Appleton',
-        title: 'Staff Research Engineer, GitHub',
-        bio: `Maggie is a Staff Research Engineer at GitHub, where she works on tools for thinking, writing, and building with code. With a background in anthropology, she’s known for her visual essays that explore how developers understand systems, languages, and ideas. She’s a strong advocate for “digital gardens” over traditional publishing, and spends her time mapping out how knowledge grows on the web. Outside of work, she’s usually sketching concepts, writing, or connecting dots between code and culture.`,
-        image: 'images/campaigns/beyond-the-prompt/svg/maggie.svg',
-        imageOrange: 'images/campaigns/beyond-the-prompt/svg/maggie-orange-bg.svg',
-    },
-    {
-        name: 'Sophie Koonin',
-        title: 'Web Discipline Lead, Monzo',
-        bio: `Sophie leads a team within the Operations collective at Monzo, building the software that powers the bank's award-winning customer experience. She's also Monzo's Web Discipline Lead, advocating for web and empowering others to lead web platform improvements throughout the company. Outside of work, Sophie loves arranging pop songs for her choir Mixtape, playing video games, cooking, and gardening.`,
-        image: 'images/campaigns/beyond-the-prompt/svg/sophie.svg',
-        imageOrange: 'images/campaigns/beyond-the-prompt/svg/sophie-orange-bg.svg',
-    },
-    {
-        name: 'David Khourshid',
-        title: 'Founder, Stately.ai',
-        bio: `David is the founder of Stately.ai and creator of XState, the most popular open-source state machine & statecharts library. He's a longtime advocate for event-driven modeling and visual diagramming as the foundation for reliable UIs and, increasingly, AI agents. When he's not at a computer keyboard, he's at a piano keyboard.`,
-        image: 'images/campaigns/beyond-the-prompt/svg/david-kourshid.svg',
-        imageOrange: 'images/campaigns/beyond-the-prompt/svg/david-kourshid-orange-bg.svg',
-    },
-    {
-        name: 'Mats Bryntse',
-        title: 'Founder & CEO, Bryntum',
-        bio: `Mats is the founder and CEO of Bryntum, where he and his team build advanced scheduling and project planning tools for modern web apps. For the past 15 years, he has obsessed over JavaScript performance, developer experience, and making complex UIs feel simple. He used to enjoy chess, badminton, and independent thought, until Claude entered his life and optimized those away.`,
-        image: 'images/campaigns/beyond-the-prompt/svg/mats.svg',
-        imageOrange: 'images/campaigns/beyond-the-prompt/svg/mats-orange-bg.svg',
-        imageFit: 'contain',
-    },
-    {
-        name: 'Steve Ruiz',
-        title: 'CEO, tldraw',
-        bio: `A developer, designer, and now startup founder in London. With a background in visual art, Steve works primarily in creative tools for the web. He is known for tldraw, and demos of perfect arrows.`,
-        image: 'images/campaigns/beyond-the-prompt/svg/steve-ruiz.svg',
-        imageOrange: 'images/campaigns/beyond-the-prompt/svg/steve-ruiz-bg.svg',
-    },
-    {
-        name: 'Matt Pocock',
-        title: 'Senior Developer Educator, AI Hero',
-        bio: `Matt is a senior developer educator at AI Hero, a TypeScript author, and an educator passionate about bringing real software engineering rigour to the age of AI. He co-organizes the AI Coding for Real Engineers cohort, a community for experienced developers who want to build with AI tools without throwing away everything they already know. Outside of the keyboard, Matt enjoys long runs through the Oxfordshire countryside, loudly supporting Arsenal, and experimenting with new ways to make complex ideas click for developers everywhere.`,
-        image: 'images/campaigns/beyond-the-prompt/svg/matt-pocock.svg',
-        imageOrange: 'images/campaigns/beyond-the-prompt/svg/matt-pocock-orange-bg.svg',
-    },
-    {
-        name: 'Bernie Sumption',
-        title: 'Engineer, AG Grid',
-        bio: `Bernie is an engineer at AG Grid specialising in theming. "The other engineers make it work fast and well, I make it look pretty" he likes to say. Outside work he goes hiking, plays with his kids, and once made a tweeting cat flap that has 10x more social media followers than he does.`,
-        image: 'images/campaigns/beyond-the-prompt/svg/bernie.svg',
-        imageOrange: 'images/campaigns/beyond-the-prompt/svg/bernie-orange-bg.svg',
-    },
-    {
-        name: 'Josh Hobson',
-        title: 'Developer, AG Grid',
-        bio: `Josh is a developer at AG Grid, where he's been building AG Studio, a new dashboard library with multi-agent AI baked in. He's a mathematician by training and a maker by instinct, with a particular love for developer tooling, type systems, and intelligent interfaces. Outside of work, Josh can be found tinkering with 3D printers, ski touring in the Alps, or out on long walks with his dog.`,
-        image: 'images/campaigns/beyond-the-prompt/svg/josh.svg',
-        imageOrange: 'images/campaigns/beyond-the-prompt/svg/josh-orange-bg.svg',
-    },
-    {
-        name: 'Adam Wang',
-        title: 'AG Studio Product Lead, AG Grid',
-        bio: `Adam is the AG Studio Product Lead at AG Grid, with around 10 years of experience in product management across various disciplines. He previously worked on AG Grid Integrated Charts before focusing on AG Studio. He enjoys the creative process of product management and is keen to solve problems by truly understanding user needs. Outside of work, he's a spin instructor who loves to put together a fire playlist. He also collects coloured vinyl.`,
-        image: 'images/campaigns/beyond-the-prompt/svg/adam.svg',
-        imageOrange: 'images/campaigns/beyond-the-prompt/svg/adam-orange-bg.svg',
-    },
-    {
-        name: 'Patrick Rau',
-        title: 'Senior Developer, TCS',
-        bio: `Patrick builds and maintains core parts of Team Centric Software's fleetplan platform, specializing in UI integration and complex components like AG Grid, Bryntum's Scheduler Pro, and modules for audit tracking and safety reporting. He's driven by a passion for creating software that makes a real difference for the people who use it. When he's not solving problems at work, you'll find him exploring new technologies through personal projects, gaming, or planning his next trip.`,
-        image: 'images/campaigns/beyond-the-prompt/svg/patrick-rau.svg',
-        imageOrange: 'images/campaigns/beyond-the-prompt/svg/patrick-rau-bg.svg',
-    },
-    {
-        name: 'Johan Isaksson',
-        title: 'Head of Engineering, Bryntum',
-        bio: `Johan is responsible for architecture, gate keeping, performance and styling across all Bryntum products. When not checking pull requests, recording performance profiles or tweaking CSS he enjoys watching hockey and playing floorball.`,
-        image: 'images/campaigns/beyond-the-prompt/svg/johan.svg',
-        imageOrange: 'images/campaigns/beyond-the-prompt/svg/johan-orange-bg.svg',
-    },
-    {
-        name: 'John Masterson',
-        title: 'CEO, AG Grid',
-        bio: `John is the CEO of AG Grid, which he first joined in 2016 as employee number two. After a detour as CTO of a London health-tech startup, he returned in 2020 and stepped into the CEO role in 2024. He's spent fifteen years building software and leading engineering teams, and is determined to keep AG Grid the first choice for JavaScript developers. Outside of work, John can be found on his bike, in his headphones listening to a podcast, or picking up a guitar.`,
-        image: 'images/campaigns/beyond-the-prompt/svg/john.svg',
-        imageOrange: 'images/campaigns/beyond-the-prompt/svg/john-orange-bg.svg',
-        imageFit: 'contain',
-    },
-    {
-        name: 'Phil Hawksworth',
-        title: 'Event MC',
-        bio: `With a passion for browser technologies, and the empowering properties of the web, Phil loves seeking out ingenuity and simplicity, especially in places where over-engineering is common. After 25 years of building web applications for companies such as Google, Apple, Nike, R/GA, and The London Stock Exchange, he has worked to challenge traditional technical architectures in favour of simplicity and effectiveness, working in Developer Experience at Netlify and Deno.`,
-        image: 'images/campaigns/beyond-the-prompt/svg/phil.svg',
-        imageOrange: 'images/campaigns/beyond-the-prompt/svg/phil-orange-bg.svg',
-    },
-];
-
-// Slug for the speaker-head PNGs, e.g. "John Masterson" -> "john-masterson".
-const headSlug = (name: string): string =>
-    name
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-+|-+$/g, '');
 
 // Featured faces for the hero (use the SVG illustrations).
 // Order is intentional: the middle slot drops down in the layout to create a
@@ -326,23 +194,10 @@ const markdownUrl = DISABLE_MARKDOWN_DOCS ? undefined : urlWithBaseUrl('/communi
                 <div class={styles.introGrid}>
                     <div class={styles.introText}>
                         <div class={styles.sectionHeader}>
-                            <h2 class={styles.sectionTitle}>
-                                Getting to a prototype with AI is easy. Production is not.
-                            </h2>
+                            <h2 class={styles.sectionTitle}>{PAGE_CONTENT.intro.heading}</h2>
                         </div>
                         <div class={styles.introBody}>
-                            <p>
-                                Beyond the Prompt is a series of events exploring the tension between how easy it is to
-                                prototype with AI and how hard it is to make that work hold up in production.
-                                Performance degrades, edge cases multiply, and the application you built is not the one
-                                you need. That is the point where AI helps less, and where the real engineering begins.
-                            </p>
-                            <p>
-                                London was the first stop. The day brought together engineers and experts to talk
-                                honestly about what it takes to build applications that hold up in production, with time
-                                to connect with our teams over lunch, coffee, and drinks. The series continues later
-                                this year in New York.
-                            </p>
+                            {PAGE_CONTENT.intro.body.map((paragraph) => <p>{paragraph}</p>)}
                         </div>
                     </div>
                     <img
@@ -357,7 +212,7 @@ const markdownUrl = DISABLE_MARKDOWN_DOCS ? undefined : urlWithBaseUrl('/communi
 
         <section id="programme" class={styles.programmeSection}>
             <div class={styles.sectionRule}>
-                <p class={styles.programmeLocation}>London, May 2026</p>
+                <p class={styles.programmeLocation}>{PAGE_CONTENT.programme.location}</p>
                 <div class={styles.programmeTabs} role="tablist" aria-label="Programme">
                     <button
                         type="button"
@@ -386,10 +241,7 @@ const markdownUrl = DISABLE_MARKDOWN_DOCS ? undefined : urlWithBaseUrl('/communi
 
             <div id="panel-speakers" role="tabpanel" aria-labelledby="tab-speakers" data-panel="speakers" hidden>
                 <div class={styles.container}>
-                    <p class={styles.sectionLead}>
-                        Engineers and experts from AG Grid, Bryntum, and beyond who spoke about what it takes to build
-                        applications that hold up in production.
-                    </p>
+                    <p class={styles.sectionLead}>{PAGE_CONTENT.programme.speakersLead}</p>
 
                     <div class={styles.speakerGrid}>
                         {
@@ -592,13 +444,10 @@ const markdownUrl = DISABLE_MARKDOWN_DOCS ? undefined : urlWithBaseUrl('/communi
                     <div class={styles.sectionHeader}>
                         <p class={styles.eyebrowAccent}>
                             <Icon name="mapPin" />
-                            New York · October 2026
+                            {PAGE_CONTENT.notify.location}
                         </p>
-                        <h2 class={styles.sectionTitle}>Get notified</h2>
-                        <p class={styles.notifyLead}>
-                            The series continues in New York this October. Leave your email and we'll let you know as
-                            soon as registration opens.
-                        </p>
+                        <h2 class={styles.sectionTitle}>{PAGE_CONTENT.notify.heading}</h2>
+                        <p class={styles.notifyLead}>{PAGE_CONTENT.notify.lead}</p>
                     </div>
 
                     <div id="mc_embed_signup">

--- a/documentation/ag-grid-docs/src/utils/beyondThePromptSessions.ts
+++ b/documentation/ag-grid-docs/src/utils/beyondThePromptSessions.ts
@@ -1,6 +1,28 @@
-// Shared session data for the Beyond the Prompt page and its /session/<slug>
-// recording pages. Kept here (rather than inline in the page) so the dynamic
-// route can build a real, crawlable page per recorded session.
+// Shared content for the Beyond the Prompt page, its markdown twin and its
+// /session/<slug> recording pages. Kept here (rather than inline in the page) so
+// the dynamic route can build a real, crawlable page per recorded session and the
+// markdown twin renders the same prose as the page.
+
+// Prose the page and its markdown twin both render.
+export const PAGE_CONTENT = {
+    intro: {
+        heading: 'Getting to a prototype with AI is easy. Production is not.',
+        body: [
+            'Beyond the Prompt is a series of events exploring the tension between how easy it is to prototype with AI and how hard it is to make that work hold up in production. Performance degrades, edge cases multiply, and the application you built is not the one you need. That is the point where AI helps less, and where the real engineering begins.',
+            'London was the first stop. The day brought together engineers and experts to talk honestly about what it takes to build applications that hold up in production, with time to connect with our teams over lunch, coffee, and drinks. The series continues later this year in New York.',
+        ],
+    },
+    programme: {
+        location: 'London, May 2026',
+        speakersLead:
+            'Engineers and experts from AG Grid, Bryntum, and beyond who spoke about what it takes to build applications that hold up in production.',
+    },
+    notify: {
+        location: 'New York · October 2026',
+        heading: 'Get notified',
+        lead: "The series continues in New York this October. Leave your email and we'll let you know as soon as registration opens.",
+    },
+};
 
 export type SessionSpeaker = {
     name: string;
@@ -102,6 +124,134 @@ export const SESSIONS: Session[] = [
         description:
             'Matt showed his vibe coding experiments, from his AI clock to an app that points to the centre of the galaxy, and shared some learnings from building hardware at his startup, Inanimate. Then we asked: what are the limits of vibing and agentic coding? And how might we create libraries that agents love?',
         youtubeUrl: 'https://youtu.be/mcHscAcv288',
+    },
+];
+
+export type Speaker = {
+    name: string;
+    title: string;
+    bio: string;
+    image: string;
+    // Re-shaded variant designed for orange backgrounds. The ditherpattern
+    // and knockout values are tuned for #F43800; we crossfade to it on
+    // card hover (Speakers grid) and use it directly in the agenda hover
+    // overlay, where the row turns orange behind the portrait.
+    imageOrange?: string;
+    // Some speaker SVGs are exported as full-figure portraits with very tall,
+    // narrow aspect ratios (e.g. Mats 193×352, John 232×388). Using the
+    // default `object-fit: cover` on a 4:5 box clips ~140px off the bottom.
+    // Setting `imageFit: 'contain'` switches just those cards to fit-the-whole
+    // SVG while staying anchored to the bottom of the frame.
+    imageFit?: 'contain';
+};
+
+export const SPEAKERS: Speaker[] = [
+    {
+        name: 'Matt Webb',
+        title: 'Co-founder, Inanimate',
+        bio: "Matt is co-founder of Inanimate, consumer hardware bringing agents into the real world. Previously he has consulted with Google's AI research group, run startup accelerators with R/GA Ventures, and was CEO and co-founder of the design studio BERG which invented some of the world’s first internet-connected consumer products like Little Printer (and has work in the New York MoMA). He is co-author of Mind Hacks (O’Reilly, 2004). Since 2000 Matt has blogged at interconnected.org. He writes weekly+ on computing, design, and speculative futures. He lives in London.",
+        image: 'images/campaigns/beyond-the-prompt/svg/mat-web.svg',
+        imageOrange: 'images/campaigns/beyond-the-prompt/svg/mat-web-orange-bg.svg',
+    },
+    {
+        name: 'Stephen Cooper',
+        title: 'Team Lead, AG Grid',
+        bio: `Stephen is the Team Lead for AG Grid and loves sharing practical, experience-based tips, tricks, and case studies from years in the codebase. He's gone deep into grid performance and framework integrations, and has spent more time than he'd like profiling render cycles. Outside of work, life revolves around family, four kids and two dogs, and he's happiest when the whole crew is out together exploring in the park.`,
+        image: 'images/campaigns/beyond-the-prompt/svg/stephen.svg',
+        imageOrange: 'images/campaigns/beyond-the-prompt/svg/stephen-orange-bg.svg',
+    },
+    {
+        name: 'Maggie Appleton',
+        title: 'Staff Research Engineer, GitHub',
+        bio: `Maggie is a Staff Research Engineer at GitHub, where she works on tools for thinking, writing, and building with code. With a background in anthropology, she’s known for her visual essays that explore how developers understand systems, languages, and ideas. She’s a strong advocate for “digital gardens” over traditional publishing, and spends her time mapping out how knowledge grows on the web. Outside of work, she’s usually sketching concepts, writing, or connecting dots between code and culture.`,
+        image: 'images/campaigns/beyond-the-prompt/svg/maggie.svg',
+        imageOrange: 'images/campaigns/beyond-the-prompt/svg/maggie-orange-bg.svg',
+    },
+    {
+        name: 'Sophie Koonin',
+        title: 'Web Discipline Lead, Monzo',
+        bio: `Sophie leads a team within the Operations collective at Monzo, building the software that powers the bank's award-winning customer experience. She's also Monzo's Web Discipline Lead, advocating for web and empowering others to lead web platform improvements throughout the company. Outside of work, Sophie loves arranging pop songs for her choir Mixtape, playing video games, cooking, and gardening.`,
+        image: 'images/campaigns/beyond-the-prompt/svg/sophie.svg',
+        imageOrange: 'images/campaigns/beyond-the-prompt/svg/sophie-orange-bg.svg',
+    },
+    {
+        name: 'David Khourshid',
+        title: 'Founder, Stately.ai',
+        bio: `David is the founder of Stately.ai and creator of XState, the most popular open-source state machine & statecharts library. He's a longtime advocate for event-driven modeling and visual diagramming as the foundation for reliable UIs and, increasingly, AI agents. When he's not at a computer keyboard, he's at a piano keyboard.`,
+        image: 'images/campaigns/beyond-the-prompt/svg/david-kourshid.svg',
+        imageOrange: 'images/campaigns/beyond-the-prompt/svg/david-kourshid-orange-bg.svg',
+    },
+    {
+        name: 'Mats Bryntse',
+        title: 'Founder & CEO, Bryntum',
+        bio: `Mats is the founder and CEO of Bryntum, where he and his team build advanced scheduling and project planning tools for modern web apps. For the past 15 years, he has obsessed over JavaScript performance, developer experience, and making complex UIs feel simple. He used to enjoy chess, badminton, and independent thought, until Claude entered his life and optimized those away.`,
+        image: 'images/campaigns/beyond-the-prompt/svg/mats.svg',
+        imageOrange: 'images/campaigns/beyond-the-prompt/svg/mats-orange-bg.svg',
+        imageFit: 'contain',
+    },
+    {
+        name: 'Steve Ruiz',
+        title: 'CEO, tldraw',
+        bio: `A developer, designer, and now startup founder in London. With a background in visual art, Steve works primarily in creative tools for the web. He is known for tldraw, and demos of perfect arrows.`,
+        image: 'images/campaigns/beyond-the-prompt/svg/steve-ruiz.svg',
+        imageOrange: 'images/campaigns/beyond-the-prompt/svg/steve-ruiz-bg.svg',
+    },
+    {
+        name: 'Matt Pocock',
+        title: 'Senior Developer Educator, AI Hero',
+        bio: `Matt is a senior developer educator at AI Hero, a TypeScript author, and an educator passionate about bringing real software engineering rigour to the age of AI. He co-organizes the AI Coding for Real Engineers cohort, a community for experienced developers who want to build with AI tools without throwing away everything they already know. Outside of the keyboard, Matt enjoys long runs through the Oxfordshire countryside, loudly supporting Arsenal, and experimenting with new ways to make complex ideas click for developers everywhere.`,
+        image: 'images/campaigns/beyond-the-prompt/svg/matt-pocock.svg',
+        imageOrange: 'images/campaigns/beyond-the-prompt/svg/matt-pocock-orange-bg.svg',
+    },
+    {
+        name: 'Bernie Sumption',
+        title: 'Engineer, AG Grid',
+        bio: `Bernie is an engineer at AG Grid specialising in theming. "The other engineers make it work fast and well, I make it look pretty" he likes to say. Outside work he goes hiking, plays with his kids, and once made a tweeting cat flap that has 10x more social media followers than he does.`,
+        image: 'images/campaigns/beyond-the-prompt/svg/bernie.svg',
+        imageOrange: 'images/campaigns/beyond-the-prompt/svg/bernie-orange-bg.svg',
+    },
+    {
+        name: 'Josh Hobson',
+        title: 'Developer, AG Grid',
+        bio: `Josh is a developer at AG Grid, where he's been building AG Studio, a new dashboard library with multi-agent AI baked in. He's a mathematician by training and a maker by instinct, with a particular love for developer tooling, type systems, and intelligent interfaces. Outside of work, Josh can be found tinkering with 3D printers, ski touring in the Alps, or out on long walks with his dog.`,
+        image: 'images/campaigns/beyond-the-prompt/svg/josh.svg',
+        imageOrange: 'images/campaigns/beyond-the-prompt/svg/josh-orange-bg.svg',
+    },
+    {
+        name: 'Adam Wang',
+        title: 'AG Studio Product Lead, AG Grid',
+        bio: `Adam is the AG Studio Product Lead at AG Grid, with around 10 years of experience in product management across various disciplines. He previously worked on AG Grid Integrated Charts before focusing on AG Studio. He enjoys the creative process of product management and is keen to solve problems by truly understanding user needs. Outside of work, he's a spin instructor who loves to put together a fire playlist. He also collects coloured vinyl.`,
+        image: 'images/campaigns/beyond-the-prompt/svg/adam.svg',
+        imageOrange: 'images/campaigns/beyond-the-prompt/svg/adam-orange-bg.svg',
+    },
+    {
+        name: 'Patrick Rau',
+        title: 'Senior Developer, TCS',
+        bio: `Patrick builds and maintains core parts of Team Centric Software's fleetplan platform, specializing in UI integration and complex components like AG Grid, Bryntum's Scheduler Pro, and modules for audit tracking and safety reporting. He's driven by a passion for creating software that makes a real difference for the people who use it. When he's not solving problems at work, you'll find him exploring new technologies through personal projects, gaming, or planning his next trip.`,
+        image: 'images/campaigns/beyond-the-prompt/svg/patrick-rau.svg',
+        imageOrange: 'images/campaigns/beyond-the-prompt/svg/patrick-rau-bg.svg',
+    },
+    {
+        name: 'Johan Isaksson',
+        title: 'Head of Engineering, Bryntum',
+        bio: `Johan is responsible for architecture, gate keeping, performance and styling across all Bryntum products. When not checking pull requests, recording performance profiles or tweaking CSS he enjoys watching hockey and playing floorball.`,
+        image: 'images/campaigns/beyond-the-prompt/svg/johan.svg',
+        imageOrange: 'images/campaigns/beyond-the-prompt/svg/johan-orange-bg.svg',
+    },
+    {
+        name: 'John Masterson',
+        title: 'CEO, AG Grid',
+        bio: `John is the CEO of AG Grid, which he first joined in 2016 as employee number two. After a detour as CTO of a London health-tech startup, he returned in 2020 and stepped into the CEO role in 2024. He's spent fifteen years building software and leading engineering teams, and is determined to keep AG Grid the first choice for JavaScript developers. Outside of work, John can be found on his bike, in his headphones listening to a podcast, or picking up a guitar.`,
+        image: 'images/campaigns/beyond-the-prompt/svg/john.svg',
+        imageOrange: 'images/campaigns/beyond-the-prompt/svg/john-orange-bg.svg',
+        imageFit: 'contain',
+    },
+    {
+        name: 'Phil Hawksworth',
+        title: 'Event MC',
+        bio: `With a passion for browser technologies, and the empowering properties of the web, Phil loves seeking out ingenuity and simplicity, especially in places where over-engineering is common. After 25 years of building web applications for companies such as Google, Apple, Nike, R/GA, and The London Stock Exchange, he has worked to challenge traditional technical architectures in favour of simplicity and effectiveness, working in Developer Experience at Netlify and Deno.`,
+        image: 'images/campaigns/beyond-the-prompt/svg/phil.svg',
+        imageOrange: 'images/campaigns/beyond-the-prompt/svg/phil-orange-bg.svg',
     },
 ];
 

--- a/documentation/ag-grid-docs/src/utils/getErrorText.test.ts
+++ b/documentation/ag-grid-docs/src/utils/getErrorText.test.ts
@@ -1,4 +1,12 @@
+import { BASE_URL } from '../../../../packages/ag-grid-community/src/baseUrl';
 import { getErrorText } from './getErrorText';
+
+// `BASE_URL` is rewritten at release time — localhost while developing, the archive URL on a
+// `b<major>.<minor>.<patch>` branch — so normalise it out before snapshotting. The docs path is
+// what an error message has to get right; the origin it is served from is not this test's business.
+function withStableBaseUrl(text: string): string {
+    return text.replaceAll(BASE_URL, '<base-url>');
+}
 
 // Params reach the error page as strings from the URL; arrays/objects are JSON-encoded by
 // `stringifyValue` in the grid's logging util. These assert the full reconstructed message so a
@@ -89,7 +97,7 @@ describe('getErrorText param reconstruction', () => {
             },
         });
 
-        expect(text).toMatchInlineSnapshot(`
+        expect(withStableBaseUrl(text)).toMatchInlineSnapshot(`
           "Unable to use \`rowSelection\` as \`RowSelectionModule\` is not registered.
           Unable to use \`enableValue\` as \`RowGroupingModule\` is not registered.
           Check if you have registered the modules:
@@ -99,7 +107,7 @@ describe('getErrorText param reconstruction', () => {
 
           ModuleRegistry.registerModules([ RowSelectionModule, RowGroupingModule ]);
 
-          For more info see: https://localhost:4610/javascript-data-grid/modules/"
+          For more info see: <base-url>/javascript-data-grid/modules/"
         `);
     });
 

--- a/documentation/ag-grid-docs/src/utils/markdoc/buildApiReferenceTable.test.ts
+++ b/documentation/ag-grid-docs/src/utils/markdoc/buildApiReferenceTable.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildApiReferenceSection } from './buildApiReferenceTable';
+
+const links = { framework: 'javascript' as const, siteRoot: 'https://www.ag-grid.com/' };
+
+function bodyRows(output: string): string[][] {
+    return output
+        .split('\n')
+        .filter((line) => line.startsWith('|'))
+        .slice(2)
+        .map((line) =>
+            line
+                .split('|')
+                .slice(1, -1)
+                .map((cell) => cell.trim())
+        );
+}
+
+describe('buildApiReferenceSection', () => {
+    const properties = {
+        cellRange: {
+            definition: {
+                isRequired: true,
+                description:
+                    'Defines the range of cells to be charted. See [Add Cell Range](./cell-selection-api-reference/#reference-selection-addCellRange) for more information.',
+            },
+            propertyType: 'ChartParamsCellRange',
+        },
+        suppressChartRanges: {
+            definition: { default: false, description: 'Set `suppressChartRanges=true` to suppress this behaviour.' },
+            propertyType: 'boolean',
+        },
+        switchCategorySeries: {
+            definition: { description: 'Switch Category / Series.' },
+            propertyType: 'boolean',
+        },
+    };
+
+    it('marks required properties and gives defaults their own column', () => {
+        const output = buildApiReferenceSection({ config: {}, properties }, links);
+
+        expect(output).toContain('| Property | Type | Required | Default | Description |');
+        const [cellRange, suppressChartRanges, switchCategorySeries] = bodyRows(output);
+        expect(cellRange.slice(0, 4)).toEqual(['`cellRange`', '`ChartParamsCellRange`', 'Yes', '']);
+        expect(suppressChartRanges.slice(0, 4)).toEqual(['`suppressChartRanges`', '`boolean`', '', '`false`']);
+        expect(switchCategorySeries.slice(0, 4)).toEqual(['`switchCategorySeries`', '`boolean`', '', '']);
+    });
+
+    it('reads the default from the @default JSDoc tag when the docs config has none', () => {
+        const output = buildApiReferenceSection(
+            {
+                config: {},
+                properties: {
+                    rowHeight: {
+                        definition: {},
+                        propertyType: 'number',
+                        gridOpProp: { meta: { comment: 'Row height.', tags: [{ name: 'default', comment: '25' }] } },
+                    },
+                },
+            },
+            links
+        );
+
+        expect(bodyRows(output)[0].slice(0, 4)).toEqual(['`rowHeight`', '`number`', '', '`25`']);
+    });
+
+    it('keeps inline links in descriptions, resolved to absolute doc URLs', () => {
+        const output = buildApiReferenceSection({ config: {}, properties }, links);
+
+        expect(bodyRows(output)[0][4]).toContain(
+            '[Add Cell Range](https://www.ag-grid.com/javascript-data-grid/cell-selection-api-reference/#reference-selection-addCellRange)'
+        );
+    });
+
+    it('keeps the @agModule badge as a link to the module registry', () => {
+        const output = buildApiReferenceSection(
+            {
+                config: {},
+                properties: {
+                    createRangeChart: {
+                        definition: {},
+                        propertyType: 'Function',
+                        gridOpProp: {
+                            meta: {
+                                comment: 'Used to programmatically create charts from a range.',
+                                tags: [
+                                    {
+                                        name: 'agModule',
+                                        comment: '`IntegratedChartsModule`',
+                                        modules: [{ name: 'IntegratedChartsModule', isEnterprise: true }],
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+            links
+        );
+
+        expect(bodyRows(output)[0][4]).toBe(
+            'Used to programmatically create charts from a range. Module: [`IntegratedChartsModule`](https://www.ag-grid.com/javascript-data-grid/modules/).'
+        );
+    });
+
+    it('lists every module when a property is available in more than one', () => {
+        const output = buildApiReferenceSection(
+            {
+                config: {},
+                properties: {
+                    getRowId: {
+                        definition: { description: 'Row id callback.' },
+                        propertyType: 'Function',
+                        gridOpProp: {
+                            meta: { tags: [{ name: 'agModule', comment: '`RowApiModule` / `RowSelectionModule`' }] },
+                        },
+                    },
+                },
+            },
+            links
+        );
+
+        expect(bodyRows(output)[0][4]).toContain('Modules (any of): [`RowApiModule`]');
+        expect(bodyRows(output)[0][4]).toContain('[`RowSelectionModule`]');
+    });
+
+    it('leads with the section copy the page shows, not a fabricated heading', () => {
+        const output = buildApiReferenceSection(
+            {
+                title: 'CreateRangeChartParams',
+                meta: {
+                    displayName: 'createRangeChart params',
+                    description: 'Properties available on the `CreateRangeChartParams` interface.',
+                },
+                // interfaceDocumentation hides the header by default, as the page does.
+                config: { hideHeader: true },
+                properties,
+            },
+            links
+        );
+
+        expect(output.startsWith('Properties available on the `CreateRangeChartParams` interface.')).toBe(true);
+        expect(output).not.toContain('### createRangeChart params');
+    });
+
+    it('emits the heading and description for a section the page shows a header for', () => {
+        const output = buildApiReferenceSection(
+            {
+                title: 'rowGrouping',
+                meta: {
+                    displayName: 'Row Grouping',
+                    description: 'Grouping options.',
+                    page: { name: 'Row Grouping', url: './grouping/' },
+                },
+                config: {},
+                properties,
+            },
+            links
+        );
+
+        expect(output).toContain('### Row Grouping');
+        expect(output).toContain('Grouping options.');
+        expect(output).toContain('See [Row Grouping](https://www.ag-grid.com/javascript-data-grid/grouping/)');
+    });
+
+    it('omits the header entirely for a subset of a larger reference', () => {
+        const output = buildApiReferenceSection(
+            { title: 'charts', meta: { displayName: 'Charts' }, config: { isSubset: true }, properties },
+            links
+        );
+
+        expect(output.startsWith('| Property |')).toBe(true);
+    });
+
+    it('degrades to an empty string when the section has no properties', () => {
+        expect(buildApiReferenceSection({ config: {}, properties: {} }, links)).toBe('');
+    });
+});

--- a/documentation/ag-grid-docs/src/utils/markdoc/buildApiReferenceTable.ts
+++ b/documentation/ag-grid-docs/src/utils/markdoc/buildApiReferenceTable.ts
@@ -1,0 +1,194 @@
+import type { Framework } from '@ag-grid-types';
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+import { AG_MODULE_TAG_NAME } from '@components/reference-documentation/constants';
+import { getInterfaceName } from '@components/reference-documentation/utils/interface-helpers';
+import { urlWithPrefix } from '@utils/urlWithPrefix';
+
+/** One section of a reference model — the same shape the site's `Section` component renders. */
+export interface ApiReferenceSection {
+    title?: string;
+    meta?: Record<string, any>;
+    config: Record<string, any>;
+    properties: Record<string, any>;
+}
+
+/** Framework/site context needed to resolve the doc links embedded in reference prose. */
+export interface LinkContext {
+    framework: Framework;
+    siteRoot?: string;
+}
+
+interface PropertyRow {
+    name: string;
+    type: string;
+    isRequired: boolean;
+    defaultValue: string;
+    description: string;
+}
+
+/** Docs page listing every module — where the on-page `@agModule` badges link to. */
+const MODULES_URL = './modules';
+
+/**
+ * Render one reference section as the section copy the page leads with followed by a
+ * GFM table (`Property | Type | Required | Default | Description`). Pure (no
+ * `astro:content`) so it is unit-testable; renderApiReferenceTable loads the model
+ * and calls this.
+ */
+export function buildApiReferenceSection(
+    { title, meta, config, properties }: ApiReferenceSection,
+    links: LinkContext
+): string {
+    const rows = buildRows(properties, links);
+    if (rows.length === 0) {
+        return '';
+    }
+    return [buildSectionHeader({ title, meta, config }, links), buildTable(rows)].filter(Boolean).join('\n\n');
+}
+
+/**
+ * Reproduce the copy the page leads the table with: the heading (only when the page
+ * shows one), the section description and the "see also" page link. Mirrors
+ * Section/SectionHeader so the markdown does not invent headings the reader cannot
+ * find on the HTML page.
+ */
+function buildSectionHeader({ title, meta, config }: Omit<ApiReferenceSection, 'properties'>, links: LinkContext) {
+    if (config.isSubset) {
+        return '';
+    }
+
+    const parts: string[] = [];
+    if (!config.hideHeader) {
+        parts.push(`### ${meta?.displayName || title}`);
+    }
+    if (meta?.description) {
+        parts.push(resolveMarkdownLinks(String(meta.description).trim(), links));
+    }
+    if (meta?.page?.url) {
+        parts.push(`See [${meta.page.name}](${resolveDocUrl(meta.page.url, links)}) for more information.`);
+    }
+    return parts.join('\n\n');
+}
+
+function buildRows(properties: Record<string, any>, links: LinkContext): PropertyRow[] {
+    const rows: PropertyRow[] = [];
+    const names = Object.keys(properties ?? {});
+    for (let i = 0, len = names.length; i < len; ++i) {
+        const name = names[i];
+        const prop = properties[name];
+        if (!prop || typeof prop !== 'object') {
+            continue;
+        }
+        const definition = prop.definition ?? {};
+        const definitionType = typeof definition.type === 'string' ? definition.type : undefined;
+        const type = prop.propertyType || definitionType || getInterfaceName(name);
+        // Mirror the site's getDescription fallback: explicit description, then the
+        // resolved code comment, then the parent object's meta description.
+        const rawDescription = definition.description || prop.gridOpProp?.meta?.comment || definition.meta?.description;
+        const tags = prop.gridOpProp?.meta?.tags ?? definition.tags ?? [];
+        // The property's modules are badges in the page's description column, so keep
+        // them with the description rather than giving them a column of their own.
+        const modules = buildModuleLinks(tags, links);
+        rows.push({
+            name,
+            type: String(type ?? ''),
+            isRequired: Boolean(definition.isRequired),
+            defaultValue: buildDefaultValue(definition, tags),
+            description: [toCellText(rawDescription, links), modules].filter(Boolean).join(' '),
+        });
+    }
+    return rows;
+}
+
+/** Mirrors Property's getTagsData: an explicit default wins over the `@default` JSDoc tag. */
+function buildDefaultValue(definition: Record<string, any>, tags: { name: string; comment?: string }[]): string {
+    const jsdocDefault = tags.find((tag) => tag.name === 'default');
+    const defaultValue = definition.default ?? jsdocDefault?.comment;
+    if (defaultValue == null) {
+        return '';
+    }
+    const formatted = Array.isArray(defaultValue)
+        ? `[${defaultValue.map((value) => `"${value}"`).join(', ')}]`
+        : String(defaultValue);
+    return `\`${escapeCell(formatted)}\``;
+}
+
+/**
+ * The `@agModule` tag as a link to the module registry, matching the PropertyModules
+ * badges on the page. `modules` is resolved by getApiDocumentationModel; the interface
+ * path has no such enrichment, so fall back to the raw tag comment.
+ */
+function buildModuleLinks(tags: Record<string, any>[], links: LinkContext): string {
+    const tag = tags.find((entry) => entry.name === AG_MODULE_TAG_NAME);
+    if (!tag) {
+        return '';
+    }
+    const names: string[] = tag.modules
+        ? tag.modules.map((module: { name: string }) => module.name)
+        : String(tag.comment ?? '')
+              .split('/')
+              .map((name) => name.trim().replace(/`/g, ''));
+    const present = names.filter(Boolean);
+    if (present.length === 0) {
+        return '';
+    }
+    const url = resolveDocUrl(MODULES_URL, links);
+    const moduleLinks = present.map((name) => `[\`${name}\`](${url})`).join(', ');
+    return present.length > 1 ? `Modules (any of): ${moduleLinks}.` : `Module: ${moduleLinks}.`;
+}
+
+function buildTable(rows: PropertyRow[]): string {
+    const lines = ['| Property | Type | Required | Default | Description |', '| --- | --- | --- | --- | --- |'];
+    for (let i = 0, len = rows.length; i < len; ++i) {
+        const { name, type, isRequired, defaultValue, description } = rows[i];
+        lines.push(
+            `| \`${name}\` | \`${escapeCell(type)}\` | ${isRequired ? 'Yes' : ''} | ${defaultValue} | ${description} |`
+        );
+    }
+    return lines.join('\n');
+}
+
+function toCellText(raw: unknown, links: LinkContext): string {
+    if (!raw) {
+        return '';
+    }
+    const text = String(raw)
+        // {@link Target | Display} → Display (or Target)
+        .replace(/\{@link(?:code|plain)?\s+([^}|]+?)(?:\s*\|\s*([^}]+))?\}/g, (_match, target, display) =>
+            (display || target).trim()
+        )
+        // The default has its own column, so drop the JSDoc tag from the prose,
+        // matching the page's removeDefaultValue.
+        .replace(/@default .*\n/g, '')
+        // Strip any embedded HTML so the cell stays plain markdown.
+        .replace(/<[^>]+>/g, '')
+        .replace(/\r?\n/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .replace(/\|/g, '\\|');
+    return resolveMarkdownLinks(text, links);
+}
+
+/**
+ * Make the doc links inside reference prose absolute, so a `.md` read out of context
+ * resolves them — the page does the equivalent via convertMarkdown/urlWithPrefix.
+ */
+function resolveMarkdownLinks(text: string, links: LinkContext): string {
+    return text.replace(
+        /\[([^\]]+)\]\(([^)]+)\)/g,
+        (_match, label, href) => `[${label}](${resolveDocUrl(href, links)})`
+    );
+}
+
+function resolveDocUrl(href: string, { framework, siteRoot }: LinkContext): string {
+    try {
+        return toAbsoluteUrl(urlWithPrefix({ url: href, framework }), siteRoot);
+    } catch {
+        // Not a doc-relative URL (e.g. a bare relative path) — leave it untouched.
+        return href;
+    }
+}
+
+function escapeCell(text: string): string {
+    return text.replace(/\r?\n/g, ' ').replace(/\|/g, '\\|');
+}

--- a/documentation/ag-grid-docs/src/utils/markdoc/renderApiReferenceTable.ts
+++ b/documentation/ag-grid-docs/src/utils/markdoc/renderApiReferenceTable.ts
@@ -4,39 +4,37 @@ import { getApiDocumentationModel } from '@components/reference-documentation/ut
 import { getInterfaceDocumentationModel } from '@components/reference-documentation/utils/getInterfaceDocumentationModel';
 import { getOverrides } from '@components/reference-documentation/utils/getOverrides';
 import { getPropertiesFromSource } from '@components/reference-documentation/utils/getPropertiesFromSource';
-import { getInterfaceName } from '@components/reference-documentation/utils/interface-helpers';
 import { getJsonFile } from '@utils/pages';
 import { type CollectionEntry, getEntry } from 'astro:content';
+
+import { type LinkContext, buildApiReferenceSection } from './buildApiReferenceTable';
 
 interface RenderApiReferenceTableParams {
     attributes: Record<string, any>;
     framework: Framework;
     kind: 'api' | 'interface';
-}
-
-interface PropertyRow {
-    name: string;
-    type: string;
-    description: string;
+    siteRoot?: string;
 }
 
 /**
- * Render an `apiDocumentation` / `interfaceDocumentation` Markdoc tag as a
- * Markdown table (`Property | Type | Description`), reusing the same reference
- * model the site's React components consume. Runs inside the Astro endpoint, so
- * it can use `astro:content` and `getJsonFile` exactly as the `.astro`
- * components do. Never throws — reference issues degrade to empty output rather
- * than failing the build.
+ * Render an `apiDocumentation` / `interfaceDocumentation` Markdoc tag as Markdown,
+ * reusing the same reference model the site's React components consume. Runs inside
+ * the Astro endpoint, so it can use `astro:content` and `getJsonFile` exactly as the
+ * `.astro` components do; the model is handed to buildApiReferenceSection for the
+ * actual serialization. Never throws — reference issues degrade to empty output
+ * rather than failing the build.
  */
 export async function renderApiReferenceTable({
     attributes,
     framework,
     kind,
+    siteRoot,
 }: RenderApiReferenceTableParams): Promise<string> {
     try {
+        const links: LinkContext = { framework, siteRoot };
         return kind === 'interface'
-            ? await renderInterfaceTable(attributes, framework)
-            : await renderApiTable(attributes, framework);
+            ? await renderInterfaceTable(attributes, framework, links)
+            : await renderApiTable(attributes, framework, links);
     } catch (error) {
         // The .md is a supplementary artifact, so one bad reference tag must not
         // fail the whole build — but the failure is reported with context so a
@@ -51,7 +49,11 @@ export async function renderApiReferenceTable({
     }
 }
 
-async function renderApiTable(attributes: Record<string, any>, framework: Framework): Promise<string> {
+async function renderApiTable(
+    attributes: Record<string, any>,
+    framework: Framework,
+    links: LinkContext
+): Promise<string> {
     const { source, sources: sourcesProp, section, names, config } = attributes;
 
     const interfaceLookup = getJsonFile('reference/interfaces.AUTO.json');
@@ -81,18 +83,32 @@ async function renderApiTable(attributes: Record<string, any>, framework: Framew
     }
 
     if (model.type === 'single') {
-        return renderSection(model.title ?? model.meta?.displayName, model.properties);
+        // Mirrors ApiDocumentation.tsx: a named section is a subset of a larger
+        // reference, and the page renders it without a header or description.
+        return buildApiReferenceSection(
+            { title: model.title, config: { ...model.config, isSubset: true }, properties: model.properties },
+            links
+        );
     }
 
     const parts: string[] = [];
     for (let i = 0, len = model.entries.length; i < len; ++i) {
         const [name, entry] = model.entries[i];
-        parts.push(renderSection(entry.meta?.displayName ?? name, entry.properties));
+        parts.push(
+            buildApiReferenceSection(
+                { title: name, meta: entry.meta, config: model.config ?? {}, properties: entry.properties },
+                links
+            )
+        );
     }
     return parts.filter(Boolean).join('\n\n');
 }
 
-async function renderInterfaceTable(attributes: Record<string, any>, framework: Framework): Promise<string> {
+async function renderInterfaceTable(
+    attributes: Record<string, any>,
+    framework: Framework,
+    links: LinkContext
+): Promise<string> {
     const { interfaceName, overrideSrc, names, exclude, config } = attributes;
 
     const overrides = await getOverrides(overrideSrc);
@@ -115,70 +131,11 @@ async function renderInterfaceTable(attributes: Record<string, any>, framework: 
     }
 
     const group = (model.properties as Record<string, any>)[interfaceName] ?? {};
-    return renderSection(model.meta?.displayName ?? interfaceName, group as Record<string, any>);
-}
-
-function renderSection(title: string | undefined, properties: Record<string, any>): string {
-    const rows = buildRows(properties);
-    if (rows.length === 0) {
-        return '';
-    }
-    const heading = title ? `### ${title}\n\n` : '';
-    return heading + renderTable(rows);
-}
-
-function buildRows(properties: Record<string, any>): PropertyRow[] {
-    const rows: PropertyRow[] = [];
-    const names = Object.keys(properties ?? {});
-    for (let i = 0, len = names.length; i < len; ++i) {
-        const name = names[i];
-        const prop = properties[name];
-        if (!prop || typeof prop !== 'object') {
-            continue;
-        }
-        const definition = prop.definition ?? {};
-        const definitionType = typeof definition.type === 'string' ? definition.type : undefined;
-        const type = prop.propertyType || definitionType || getInterfaceName(name);
-        // Mirror the site's getDescription fallback: explicit description, then the
-        // resolved code comment, then the parent object's meta description.
-        const rawDescription = definition.description || prop.gridOpProp?.meta?.comment || definition.meta?.description;
-        rows.push({
-            name,
-            type: String(type ?? ''),
-            description: toCellText(rawDescription),
-        });
-    }
-    return rows;
-}
-
-function renderTable(rows: PropertyRow[]): string {
-    const lines = ['| Property | Type | Description |', '| --- | --- | --- |'];
-    for (let i = 0, len = rows.length; i < len; ++i) {
-        const { name, type, description } = rows[i];
-        lines.push(`| \`${name}\` | \`${escapeCell(type)}\` | ${description} |`);
-    }
-    return lines.join('\n');
-}
-
-function toCellText(raw: unknown): string {
-    if (!raw) {
-        return '';
-    }
-    return (
-        String(raw)
-            // {@link Target | Display} → Display (or Target)
-            .replace(/\{@link(?:code|plain)?\s+([^}|]+?)(?:\s*\|\s*([^}]+))?\}/g, (_match, target, display) =>
-                (display || target).trim()
-            )
-            // Strip any embedded HTML so the cell stays plain markdown.
-            .replace(/<[^>]+>/g, '')
-            .replace(/\r?\n/g, ' ')
-            .replace(/\s+/g, ' ')
-            .trim()
-            .replace(/\|/g, '\\|')
+    // Mirrors InterfaceDocumentation.astro, which hides the header unless the tag
+    // asks for it — the page leads with the interface description instead.
+    const sectionConfig = { ...config, hideHeader: config?.hideHeader ?? true };
+    return buildApiReferenceSection(
+        { title: interfaceName, meta: model.meta, config: sectionConfig, properties: group },
+        links
     );
-}
-
-function escapeCell(text: string): string {
-    return text.replace(/\r?\n/g, ' ').replace(/\|/g, '\\|');
 }

--- a/documentation/ag-grid-docs/src/utils/markdoc/renderMarkdocResolvers.ts
+++ b/documentation/ag-grid-docs/src/utils/markdoc/renderMarkdocResolvers.ts
@@ -91,7 +91,7 @@ export function createGridMarkdownResolvers({ siteRoot }: { siteRoot?: string } 
         },
 
         renderApiTable: ({ attributes, framework, kind }) =>
-            renderApiReferenceTable({ attributes, framework: framework as Framework, kind }),
+            renderApiReferenceTable({ attributes, framework: framework as Framework, kind, siteRoot }),
 
         renderTag: ({ tag, attributes, framework, pageName }) =>
             renderMarkdocTag({ tag, attributes, framework, pageName, siteRoot }),

--- a/documentation/ag-grid-docs/src/utils/markdoc/renderMarkdocTables.test.ts
+++ b/documentation/ag-grid-docs/src/utils/markdoc/renderMarkdocTables.test.ts
@@ -71,4 +71,18 @@ describe('buildModuleMappingsTable', () => {
         const output = buildModuleMappingsTable(groups, 'react', 'https://www.ag-grid.com/');
         expect(output).toContain('(https://www.ag-grid.com/');
     });
+
+    it('leads with a link to the module selector on the HTML page', () => {
+        const output = buildModuleMappingsTable(groups, 'react', 'https://www.ag-grid.com/');
+
+        expect(output.split('\n')[0]).toContain(
+            '[Select modules interactively](https://www.ag-grid.com/react-data-grid/modules/#selecting-modules)'
+        );
+    });
+
+    it('degrades to an empty string when every module is hidden', () => {
+        expect(
+            buildModuleMappingsTable([{ name: 'Hidden', moduleName: 'HiddenModule', hideFromSelection: true }], 'react')
+        ).toBe('');
+    });
 });

--- a/documentation/ag-grid-docs/src/utils/markdoc/renderModuleMappings.ts
+++ b/documentation/ag-grid-docs/src/utils/markdoc/renderModuleMappings.ts
@@ -13,20 +13,33 @@ export interface ModuleNode {
     children?: ModuleNode[];
 }
 
+interface ModuleLeaf {
+    name: string;
+    moduleName: string;
+    path?: string;
+    isEnterprise: boolean;
+}
+
+const MODULE_SELECTOR_URL = './modules/#selecting-modules';
+
 /**
  * Build the `moduleMappings` tag as a flat GFM table of every module (leaf nodes of
  * the module tree): the feature name (linked to its docs when a `path` is set), the
  * module name, and whether it is an Enterprise module. Pure (no `astro:content`) so
- * it is unit-testable; the dispatcher loads the tree and calls this. Interactive
- * selection state from the on-page tree is irrelevant to a static reference.
+ * it is unit-testable; the dispatcher loads the tree and calls this. The table is
+ * preceded by a link to the interactive selector on the HTML page, which generates
+ * the registration code for a chosen set of features.
  */
 export function buildModuleMappingsTable(
     groups: ModuleNode[],
     framework: MarkdownFramework,
     siteRoot?: string
 ): string {
-    const leaves: { name: string; moduleName: string; path?: string; isEnterprise: boolean }[] = [];
+    const leaves: ModuleLeaf[] = [];
     collectLeaves(groups ?? [], false, leaves);
+    if (leaves.length === 0) {
+        return '';
+    }
 
     const rows = leaves.map((leaf) => {
         // Module `path` values are bare (e.g. `grouping`); the on-page renderer prepends
@@ -38,14 +51,16 @@ export function buildModuleMappingsTable(
         return [feature, `\`${leaf.moduleName}\``, leaf.isEnterprise ? 'Enterprise' : ''];
     });
 
-    return markdownTable(['Feature', 'Module', 'Enterprise'], rows);
+    const selectorUrl = toAbsoluteUrl(
+        urlWithPrefix({ url: MODULE_SELECTOR_URL, framework: framework as Framework }),
+        siteRoot
+    );
+    const lead = `[Select modules interactively](${selectorUrl}) to generate the registration code, or work from the full module list below.`;
+
+    return [lead, markdownTable(['Feature', 'Module', 'Enterprise'], rows)].join('\n\n');
 }
 
-function collectLeaves(
-    nodes: ModuleNode[],
-    inheritedEnterprise: boolean,
-    out: { name: string; moduleName: string; path?: string; isEnterprise: boolean }[]
-): void {
+function collectLeaves(nodes: ModuleNode[], inheritedEnterprise: boolean, out: ModuleLeaf[]): void {
     for (let i = 0, len = nodes.length; i < len; ++i) {
         const node = nodes[i];
         if (node.hideFromSelection) {

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/buildCommunityBeyondThePromptMarkdown.test.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/buildCommunityBeyondThePromptMarkdown.test.ts
@@ -11,11 +11,30 @@ describe('buildCommunityBeyondThePromptMarkdown', () => {
         expect(output).toContain('\n# Beyond the Prompt');
     });
 
-    it('renders the programme with speakers and recording links', () => {
+    it('renders the intro the page leads with', () => {
+        expect(output).toContain('## Getting to a prototype with AI is easy. Production is not.');
+        expect(output).toContain('Beyond the Prompt is a series of events exploring the tension');
+        expect(output).toContain('London was the first stop.');
+    });
+
+    it('renders the programme with its location, speakers and recording links', () => {
         expect(output).toContain('## Programme');
+        expect(output).toContain('London, May 2026');
         expect(output).toContain('**Opening Keynote**');
         expect(output).toContain('John Masterson (CEO, AG Grid)');
         expect(output).toContain('([recording](https://youtu.be/');
+    });
+
+    it('renders each speaker with their title and bio', () => {
+        expect(output).toContain('## Speakers');
+        expect(output).toContain('### Maggie Appleton — Staff Research Engineer, GitHub');
+        expect(output).toContain('Maggie is a Staff Research Engineer at GitHub');
+    });
+
+    it('links to the signup section rather than reproducing the form', () => {
+        expect(output).toContain('## Get notified');
+        expect(output).toContain('New York · October 2026');
+        expect(output).toContain('[Sign up for updates](https://www.ag-grid.com/community/beyond-the-prompt/#notify)');
     });
 
     it('ends with a single trailing newline', () => {

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/buildCommunityBeyondThePromptMarkdown.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/buildCommunityBeyondThePromptMarkdown.ts
@@ -1,12 +1,14 @@
-import { SESSIONS } from '@utils/beyondThePromptSessions';
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+import { PAGE_CONTENT, SESSIONS, SPEAKERS } from '@utils/beyondThePromptSessions';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 
 /**
  * Build the markdown twin of /community/beyond-the-prompt: the AG Grid × Bryntum conference on
- * building AI-assisted applications that hold up in production. The programme is read from the
- * shared SESSIONS data (also used by the page and the per-session recording routes), so the
- * agenda cannot drift; each session lists its speakers and links to its recording.
+ * building AI-assisted applications that hold up in production. The prose, programme and speakers
+ * are read from the shared content the page renders (also used by the per-session recording
+ * routes), so the twin cannot drift; each session lists its speakers and links to its recording.
  */
-export function buildCommunityBeyondThePromptMarkdown(_options: { siteRoot?: string } = {}): string {
+export function buildCommunityBeyondThePromptMarkdown({ siteRoot }: { siteRoot?: string } = {}): string {
     const frontmatter = [
         '---',
         'title: "Beyond the Prompt: AG Grid & Bryntum Conference"',
@@ -14,7 +16,9 @@ export function buildCommunityBeyondThePromptMarkdown(_options: { siteRoot?: str
         '---',
     ].join('\n');
 
-    const programme = SESSIONS.map((session) => {
+    const { intro, programme, notify } = PAGE_CONTENT;
+
+    const sessions = SESSIONS.map((session) => {
         const speakers = (session.speakers ?? []).map((speaker) => `${speaker.name} (${speaker.role})`).join(', ');
         const who = speakers ? ` — ${speakers}` : '';
         const description = session.description ? `: ${session.description}` : '';
@@ -22,11 +26,19 @@ export function buildCommunityBeyondThePromptMarkdown(_options: { siteRoot?: str
         return `- **${session.title}**${who}${description}${recording}`;
     }).join('\n');
 
+    const speakers = SPEAKERS.map((speaker) => `### ${speaker.name} — ${speaker.title}\n\n${speaker.bio}`).join('\n\n');
+
+    // The signup form is a Mailchimp embed; link to the section that hosts it instead.
+    const signupUrl = toAbsoluteUrl(urlWithBaseUrl('/community/beyond-the-prompt/#notify'), siteRoot);
+
     const document = [
         frontmatter,
         '# Beyond the Prompt',
-        'A one-day conference on building applications that hold up in production, hosted by AG Grid and Bryntum. Beyond the Prompt explores the tension between how easy it is to prototype with AI and how hard it is to make that work hold up in production.',
-        `## Programme\n\n${programme}`,
+        `## ${intro.heading}`,
+        ...intro.body,
+        `## Programme\n\n${programme.location}\n\n${sessions}`,
+        `## Speakers\n\n${programme.speakersLead}\n\n${speakers}`,
+        `## ${notify.heading}\n\n${notify.location}\n\n${notify.lead}\n\n[Sign up for updates](${signupUrl})`,
     ].join('\n\n');
 
     return `${document.trimEnd()}\n`;

--- a/external/ag-website-shared/src/markdoc/renderMarkdocToMarkdown.test.ts
+++ b/external/ag-website-shared/src/markdoc/renderMarkdocToMarkdown.test.ts
@@ -59,6 +59,20 @@ describe('renderMarkdocToMarkdown', () => {
         expect(output).not.toContain('How to edit cells.');
     });
 
+    it('flags an Enterprise-only page in the frontmatter', async () => {
+        const output = await render('Body paragraph.', {
+            frontmatter: { title: 'Context Menu', enterprise: true },
+        });
+
+        expect(output).toContain('enterprise: true');
+    });
+
+    it('omits the Enterprise flag for a Community page', async () => {
+        const output = await render('Body paragraph.', { frontmatter: { title: 'Row Sorting' } });
+
+        expect(output).not.toContain('enterprise:');
+    });
+
     it('passes through standard markdown (headings, emphasis, links, lists, tables)', async () => {
         const body = [
             '## Heading Two',

--- a/external/ag-website-shared/src/markdoc/renderMarkdocToMarkdown.ts
+++ b/external/ag-website-shared/src/markdoc/renderMarkdocToMarkdown.ts
@@ -87,7 +87,7 @@ export interface RenderMarkdocToMarkdownOptions {
     framework: MarkdownFramework;
     pageName: string;
     /** Pulled from `page.data`; `page.body` does not include frontmatter. */
-    frontmatter?: { title?: string; description?: string };
+    frontmatter?: { title?: string; description?: string; enterprise?: boolean };
     /** Current product version, emitted in the frontmatter so it is machine-readable. */
     version?: string;
     /**
@@ -133,7 +133,12 @@ export async function renderMarkdocToMarkdown(opts: RenderMarkdocToMarkdownOptio
     await prefetchImageSrcs(ast.children, ctx);
     const bodyMarkdown = await renderBlocks(ast.children, ctx);
 
-    const frontmatterBlock = buildFrontmatter({ title: frontmatter.title, framework, version });
+    const frontmatterBlock = buildFrontmatter({
+        title: frontmatter.title,
+        enterprise: frontmatter.enterprise,
+        framework,
+        version,
+    });
     // Just the H1 — the description is intentionally omitted; the page body is the content.
     const opener = frontmatter.title ? `# ${frontmatter.title}` : '';
 
@@ -144,16 +149,22 @@ export async function renderMarkdocToMarkdown(opts: RenderMarkdocToMarkdownOptio
 
 function buildFrontmatter({
     title,
+    enterprise,
     framework,
     version,
 }: {
     title?: string;
+    enterprise?: boolean;
     framework: MarkdownFramework;
     version?: string;
 }): string {
     const lines = ['---'];
     if (title) {
         lines.push(`title: ${JSON.stringify(title)}`);
+    }
+    // Only emitted when the page is Enterprise-only, matching the source frontmatter.
+    if (enterprise) {
+        lines.push('enterprise: true');
     }
     lines.push(`framework: ${framework}`);
     if (version) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17862

Ports the relevant markdown fixes from [ag-charts#7660](https://github.com/ag-grid/ag-charts/pull/7660), and fixes TC1–TC3 from [this QA comment](https://ag-grid.atlassian.net/browse/AG-17862?focusedCommentId=128885) (TC4–TC6 are covered by the port).

### Ported from ag-charts#7660

| Charts change | Grid equivalent | QA case |
| --- | --- | --- |
| `enterprise` in the markdown frontmatter | Same edit to the shared serializer, plus `[pageName].md.ts` passing `page.data.enterprise` | TC6 |
| Trial-licence note moved out of the React component | `LicenseSetup.tsx` → `license-install/index.mdoc` as a `{% note %}` | TC5 |
| `moduleMappings` leads with a link to the interactive selector | `renderModuleMappings.ts`, pointing at grid's `./modules/#selecting-modules` | TC4 |
| Beyond the Prompt prose/speakers extracted to shared data | `beyondThePromptSessions.ts` holds `PAGE_CONTENT` + `SPEAKERS`; the `.astro` page and the markdown twin both read it | — |

Two grid-specific deviations:

- The `## Request a Trial Licence` heading had to move into the mdoc as well (charts has no such heading). Its id is pinned with `{% #request-trial-licence %}` so the public anchor does not change to `#request-a-trial-licence`.
- The two new `buildModuleMappingsTable` cases went into the existing `renderMarkdocTables.test.ts` rather than a separate test file, since grid already covers that function there.

### TC1–TC3 — API reference tables

The serialization moves into `buildApiReferenceTable.ts` so it can be unit tested (`renderApiReferenceTable.ts` keeps the `astro:content` coupling), matching the `build*`/`render*` split already used for the other tags.

- **TC1** — `Required` and `Default` columns, read from `definition.isRequired` and `definition.default ?? @default`, mirroring `Property.tsx`'s `getTagsData`.
- **TC2** — headings now follow the page. They are suppressed for an `apiDocumentation` subset (`section=`) and for `interfaceDocumentation`'s default hidden header, with `meta.description` and the "see also" page link rendered instead. Multi-section references such as `column-events.md` keep their `###` headings, as the page shows them.
- **TC3** — the `@agModule` badge is preserved as a link to the module registry, and links inside descriptions are resolved to absolute doc URLs instead of staying as raw `./page/#anchor`.

Before / after on `integrated-charts-api-range-chart.md`:

```diff
-### charts
+(no heading — the page shows none for a section subset)

-| Property | Type | Description |
-| `createRangeChart` | `Function` | Used to programmatically create charts from a range. |
+| Property | Type | Required | Default | Description |
+| `createRangeChart` | `Function` |  |  | Used to programmatically create charts from a range. Module: [`IntegratedChartsModule`](https://www.ag-grid.com/javascript-data-grid/modules/). |

-### createRangeChart params
+Properties available on the `CreateRangeChartParams` interface.

-| `cellRange` | `ChartParamsCellRange` | … See [Add Cell Range](./cell-selection-api-reference/#reference-selection-addCellRange) for more information. |
-| `suppressChartRanges` | `boolean` | By default, when a chart is displayed… |
+| `cellRange` | `ChartParamsCellRange` | Yes |  | … See [Add Cell Range](https://www.ag-grid.com/javascript-data-grid/cell-selection-api-reference/#reference-selection-addCellRange) for more information. |
+| `suppressChartRanges` | `boolean` |  | `false` | By default, when a chart is displayed… |
```

### Testing

`yarn nx format`, `yarn nx lint ag-grid-docs`, and the `ag-grid-docs` (552) and `ag-website-shared` (152) unit suites all pass. Nine new tests cover the API reference serialization.

Verified against a local dev server: `integrated-charts-api-range-chart.md`, `column-events.md`, `license-install.md` and its HTML page, `modules.md`, `beyond-the-prompt.md` and its HTML page, and `row-sorting.md` (no stray `enterprise:` on community pages).

I did not run the full `yarn nx e2e ag-grid-docs` suite — it is entirely example-driven and no examples changed, and `page-verification.spec.ts` only runs post-deploy against a deployed site.

### Unrelated issue found

`grid-options.md` is currently empty on `latest`, and it is not caused by this PR (confirmed by stashing these changes). `onColumnHeaderNameChanged` exists in the API but has no entry in `grid-options/properties.json`, so the reference model throws and the section degrades to `''` — introduced by bd387269a61 (AG-115). Worth a separate ticket, since it silently drops the entire Grid Options reference from the markdown twin.
