### PR TITLE
[AG-9664] Fix(docs-e2e): correct SSRM pivot spec and skip broken pdf-export specs

### DIFF
--- a/documentation/ag-grid-docs/playwright.config.ts
+++ b/documentation/ag-grid-docs/playwright.config.ts
@@ -9,6 +9,15 @@ const baseURL = BASE_URL || PREV_URL || PROD_URL || 'https://localhost:4610';
 
 const LOCAL_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]'];
 
+const IGNORED_TESTS = ['**/pdf-export*/**'];
+
+const BROWSER_IGNORED_TESTS = [
+    ...IGNORED_TESTS,
+    '**/async-test/provided/angular/app.component.spec.ts',
+    // page-verification.spec.ts runs in its own dedicated CI job.
+    '**/page-verification.spec.ts',
+];
+
 function isLocalRun(url: string): boolean {
     try {
         return LOCAL_HOSTNAMES.includes(new URL(url).hostname);
@@ -35,8 +44,12 @@ if (process.env.FRAMEWORK) {
 export default defineConfig({
     snapshotPathTemplate: '{testDir}/{testFileDir}/{testFileName}-snapshots/{arg}{ext}',
     testDir: './src/content/docs/',
-    /* PDF Export is not part of the public API yet (release delayed), so its examples cannot load the module. */
-    testIgnore: '**/pdf-export*/**',
+    /**
+     * PDF Export is not part of the public API yet (release delayed), so its examples cannot load the module.
+     * Project-level `testIgnore` replaces this value rather than merging with it, so every project below that
+     * declares its own `testIgnore` must also spread in IGNORED_TESTS.
+     */
+    testIgnore: IGNORED_TESTS,
     /* Run tests in files in parallel */
     fullyParallel: true,
     timeout: process.env.CI ? 60_000 : 20_000,
@@ -86,29 +99,17 @@ export default defineConfig({
         {
             name: 'chromium',
             use: { ...devices['Desktop Chrome'] },
-            testIgnore: [
-                '**/async-test/provided/angular/app.component.spec.ts',
-                // page-verification.spec.ts runs in its own dedicated CI job.
-                '**/page-verification.spec.ts',
-            ],
+            testIgnore: BROWSER_IGNORED_TESTS,
         },
         {
             name: 'firefox',
             use: { ...devices['Desktop Firefox'] },
-            testIgnore: [
-                '**/async-test/provided/angular/app.component.spec.ts',
-                // page-verification.spec.ts runs in its own dedicated CI job.
-                '**/page-verification.spec.ts',
-            ],
+            testIgnore: BROWSER_IGNORED_TESTS,
         },
         {
             name: 'webkit',
             use: { ...devices['Desktop Safari'] },
-            testIgnore: [
-                '**/async-test/provided/angular/app.component.spec.ts',
-                // page-verification.spec.ts runs in its own dedicated CI job.
-                '**/page-verification.spec.ts',
-            ],
+            testIgnore: BROWSER_IGNORED_TESTS,
         },
         {
             // Dedicated project for post-deploy verification — run via post-deploy-verification.yml.

--- a/documentation/ag-grid-docs/playwright.config.ts
+++ b/documentation/ag-grid-docs/playwright.config.ts
@@ -9,6 +9,7 @@ const baseURL = BASE_URL || PREV_URL || PROD_URL || 'https://localhost:4610';
 
 const LOCAL_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]'];
 
+/* PDF Export is not part of the public API yet (release delayed), so its examples cannot load the module. */
 const IGNORED_TESTS = ['**/pdf-export*/**'];
 
 const BROWSER_IGNORED_TESTS = [
@@ -44,12 +45,6 @@ if (process.env.FRAMEWORK) {
 export default defineConfig({
     snapshotPathTemplate: '{testDir}/{testFileDir}/{testFileName}-snapshots/{arg}{ext}',
     testDir: './src/content/docs/',
-    /**
-     * PDF Export is not part of the public API yet (release delayed), so its examples cannot load the module.
-     * Project-level `testIgnore` replaces this value rather than merging with it, so every project below that
-     * declares its own `testIgnore` must also spread in IGNORED_TESTS.
-     */
-    testIgnore: IGNORED_TESTS,
     /* Run tests in files in parallel */
     fullyParallel: true,
     timeout: process.env.CI ? 60_000 : 20_000,

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/_examples/creating_pivot_result_columns/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-pivoting/_examples/creating_pivot_result_columns/example.spec.ts
@@ -23,14 +23,15 @@ const waitForYears = (page: Page, mode: 'asc' | 'desc') =>
     expect(async () => {
         const years = await yearGroupOrder(page);
         expect(years.length).toBeGreaterThan(1);
-        const ascending = years.slice().sort();
-        expect(years).toEqual(mode === 'asc' ? ascending : ascending.reverse());
+        const sorted = years.slice().sort();
+        expect(years).toEqual(mode === 'asc' ? sorted : sorted.reverse());
     }).toPass();
 
 test.agExample(import.meta, () => {
     test.eachFramework(
         'App-built pivot result columns (setPivotResultColumns) render nested year -> medal groups',
         async ({ page }) => {
+            await ensureGridReady(page);
             await waitForGridContent(page);
 
             const groupRow = (name: string) =>
@@ -42,6 +43,13 @@ test.agExample(import.meta, () => {
             // Grid is grouped by Country on the server side.
             await expect(groupRow('United States')).toBeVisible();
             await expect(groupRow('Russia')).toBeVisible();
+
+            // The example supplies the year groups shuffled, so which of them fall inside the rendered header
+            // window varies per load. Sort ascending from the Year pill first so 2000 is leftmost and rendered.
+            const yearPill = yearPillFor(page);
+            await expect(yearPill).toBeVisible();
+            await yearPill.click();
+            await waitForYears(page, 'asc');
 
             // createPivotResultColumns() builds a year column group per distinct year,
             // each nesting gold/silver/bronze value children.
@@ -64,40 +72,34 @@ test.agExample(import.meta, () => {
             await ensureGridReady(page);
             await waitForGridContent(page);
 
-            // createPivotResultColumns() supplies the years in a scrambled order, but pivotSort defaults to
-            // ascending, so the grid orders the supplied columns rather than displaying them as supplied.
-            await waitForYears(page, 'asc');
-
+            // Unlike grid-generated pivot result columns, supplied ones default to no sort, so the grid shows them
+            // in the order createPivotResultColumns() supplied. That order is shuffled, so capture it rather than
+            // pinning a permutation.
             const yearPill = yearPillFor(page);
             await expect(yearPill).toBeVisible();
-            await expect(yearPill.locator('.ag-sort-ascending-icon')).toBeVisible();
+            await expect(yearPill.locator('.ag-sort-ascending-icon')).toBeHidden();
+            await expect(yearPill.locator('.ag-sort-descending-icon')).toBeHidden();
 
-            // Activating the pill reorders the supplied columns, even though the grid did not generate them.
+            const suppliedOrder = await yearGroupOrder(page);
+            expect(suppliedOrder.length).toBeGreaterThan(1);
+
+            // Activating the pill orders the supplied columns by header name, even though the grid did not
+            // generate them, and does so without asking the server for the columns again.
+            await yearPill.click();
+            await expect(yearPill.locator('.ag-sort-ascending-icon')).toBeVisible();
+            await waitForYears(page, 'asc');
+
             await yearPill.click();
             await expect(yearPill.locator('.ag-sort-descending-icon')).toBeVisible();
             await waitForYears(page, 'desc');
 
-            // Cycling on to no sort falls back to the order the columns were supplied in. The example shuffles that
-            // order with the docs' seeded generator, so rather than pin the exact permutation to the seed, assert
-            // what the example actually claims: the same years, in neither ascending nor descending order.
-            const descendingYears = await yearGroupOrder(page);
-            const ascendingYears = descendingYears.slice().reverse();
-            const sortedYears = descendingYears.slice().sort();
+            // Cycling on to no sort falls back to the order the columns were supplied in.
             await yearPill.click();
-            await expect(yearPill.locator('.ag-sort-descending-icon')).toBeHidden();
             await expect(yearPill.locator('.ag-sort-ascending-icon')).toBeHidden();
+            await expect(yearPill.locator('.ag-sort-descending-icon')).toBeHidden();
             await expect(async () => {
-                const suppliedOrder = await yearGroupOrder(page);
-                expect(suppliedOrder.length).toBeGreaterThan(1);
-                expect(suppliedOrder.slice().sort()).toEqual(sortedYears);
-                expect(suppliedOrder).not.toEqual(ascendingYears);
-                expect(suppliedOrder).not.toEqual(descendingYears);
+                expect(await yearGroupOrder(page)).toEqual(suppliedOrder);
             }).toPass();
-
-            // And back round to ascending.
-            await yearPill.click();
-            await expect(yearPill.locator('.ag-sort-ascending-icon')).toBeVisible();
-            await waitForYears(page, 'asc');
         }
     );
 });


### PR DESCRIPTION
Nightly Documentation Tests have been red since 2026-07-28, in two clusters.

**`creating_pivot_result_columns` (10 failures).** #14645 changed supplied pivot result columns to default to no sort but left this spec asserting ascending. Reworked against the documented behaviour: supplied order and unsorted pill first, then asc → desc → supplied. The first test sorts ascending before its DOM assertions because the example shuffles the year groups and 2000 is otherwise outside the rendered header window.

**`pdf-export*` (64 failures).** These examples throw `(SystemJS) Cannot read properties of undefined (reading 'version')` on grid-staging, so the grid never renders. The config already ignored `**/pdf-export*/**`, but project-level `testIgnore` *replaces* the config-level value rather than merging with it, so chromium/firefox/webkit discarded it. Both lists now share one constant.

Targets `b36.1.0` due to the code freeze on `latest`.