### PR TITLE
RTI-340

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_common-structural.scss
+++ b/community-modules/styles/src/internal/base/parts/_common-structural.scss
@@ -241,6 +241,10 @@
         display: block;
         min-height: 100%;
         width: 100%;
+
+        // contain the row and cell-lane z-indexes below, so scrolling rows can never paint over the
+        // header or the pinned top/bottom bands.
+        isolation: isolate;
     }
 
     .ag-body-horizontal-scroll-viewport {
@@ -878,6 +882,12 @@
     .ag-row-inline-editing {
         // inline row editors must float above standard rows.
         z-index: 1;
+    }
+
+    .ag-row-dragging {
+        // dragged rows overlap their neighbours mid-animation, so they must sit above every cell lane:
+        // centre 0, centre spans 1, pinned 2, pinned spans 3.
+        z-index: 4;
     }
 
     .ag-stub-cell {

--- a/packages/ag-grid-community/src/theming/core/css/_general.css
+++ b/packages/ag-grid-community/src/theming/core/css/_general.css
@@ -79,6 +79,10 @@
     display: block;
     min-height: 100%;
     width: 100%;
+
+    /* contain the row and cell-lane z-indexes below, so scrolling rows can never paint over the
+       header or the pinned top/bottom bands. */
+    isolation: isolate;
 }
 
 .ag-body-horizontal-scroll-viewport {
@@ -378,6 +382,12 @@
 .ag-row-inline-editing {
     /* inline row editors must float above standard rows. */
     z-index: 1;
+}
+
+.ag-row-dragging {
+    /* dragged rows overlap their neighbours mid-animation, so they must sit above every cell lane:
+       centre 0, centre spans 1, pinned 2, pinned spans 3. */
+    z-index: 4;
 }
 
 .ag-stub-cell {


### PR DESCRIPTION
# Fix: dragged row paints behind the rows it is dragged over

FIX RTI-3408

## Cause

[#14512](https://github.com/ag-grid/ag-grid/pull/14512) (AG-17818, a `focusCell` refactor) deleted
`.ag-row-dragging { z-index: 2 }` from both stylesheets. The rule dates back to 34.0.0.

It is load-bearing because rows overlap for real while they animate (`transform`/`top`, 0.4s), and row DOM
order is creation order, not visual order — the dragged row keeps its original DOM slot while moving, so at
`z-index: auto` the tree-order tie goes to the row it slides over.

## Fix

Restoring `z-index: 2` is not enough: rows are stacking contexts only because of the positioning
`transform`, and `suppressRowTransform`/`enableCellSpan` switch rows to `top` positioning
([rowCtrl.ts:167](../packages/ag-grid-community/src/rendering/row/rowCtrl.ts#L167)), letting per-row lane
z-indexes escape — a neighbour's pinned lane (2) or spanned pinned lane (3) then beats the dragged row.

So, in both the Theming API CSS and the Legacy Themes SCSS:

1. `.ag-row-dragging { z-index: 4 }` — above every cell lane (centre 0, centre spans 1, pinned 2, pinned
   spans 3).
2. `.ag-grid-scrolling-container { isolation: isolate }` — contains those z-indexes in the scrolling band,
   so no row outranks the header or the sticky pinned bands. Also fixes a pre-existing bleed of scrolling
   rows over the pinned-top band.
