### PR TITLE
RTI-3421: keep the framework name in the docs page h1, version out

### DIFF
--- a/documentation/ag-grid-docs/src/components/docs/components/Header.module.scss
+++ b/documentation/ag-grid-docs/src/components/docs/components/Header.module.scss
@@ -16,45 +16,49 @@
     }
 }
 
-// Narrow screens stack the title block, then the controls. From the docs-search
-// breakpoint up, the controls move to the top right, level with the eyebrow line
-// inside the title rather than pushing the title down.
+// The eyebrow line pairs the framework name, which has to sit inside the h1 for SEO,
+// with the version, which has to sit outside it so it does not read as part of the
+// heading. They can still share a line because the h1 is `display: contents` (see
+// .pageTitle), which makes its children items of this grid alongside the version and
+// the controls. Narrow screens stack eyebrow, controls, then title; from the
+// docs-search breakpoint up the controls move to the top right, level with the eyebrow.
 .pageTitleContainer {
     display: grid;
     width: 100%;
-    grid-template-columns: 1fr;
+    grid-template-columns: auto 1fr;
     grid-template-areas:
-        'title'
-        'actions';
+        'meta version'
+        'actions actions'
+        'title title';
     row-gap: $spacing-size-3;
+    column-gap: $spacing-size-3;
 
     @media screen and (min-width: $breakpoint-docs-search-medium) {
-        grid-template-columns: 1fr auto;
-        grid-template-areas: 'title actions';
-        column-gap: $spacing-size-4;
+        grid-template-columns: auto 1fr auto;
+        grid-template-areas:
+            'meta version actions'
+            'title title actions';
     }
 }
 
-// Eyebrow line above the page title, holding the framework name and grid version.
-// Inside the h1, so it carries its own spacing and opts out of heading line-height.
-.titleMeta {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    gap: $spacing-size-3;
-    margin-bottom: $spacing-size-3;
-    line-height: var(--text-lh-base);
-}
-
+// Framework name, inside the h1, so it opts back out of the heading type it inherits.
 .headerFramework {
+    grid-area: meta;
+    align-self: baseline;
     font-size: var(--text-fs-base);
     font-weight: var(--text-semibold);
+    line-height: var(--text-lh-base);
     color: var(--color-text-brand-primary);
 }
 
+// Sibling of the h1, deliberately — see Header.tsx.
 .version {
+    grid-area: version;
+    align-self: baseline;
+    justify-self: start;
     font-size: var(--text-fs-sm);
     font-weight: var(--text-regular);
+    line-height: var(--text-lh-base);
     color: var(--color-text-tertiary);
 }
 
@@ -84,12 +88,21 @@
     }
 }
 
-// Spacing below the heading is the grid's row gap; the global heading margin
-// would stack on top of it.
+// `display: contents` drops the h1's box so its children — the framework name and the
+// title — are placed in .pageTitleContainer's grid directly, which is what lets the
+// version sit on the eyebrow line without being inside the heading. Inherited styles
+// still reach the children; the box's own margin goes with it, so the grid's row gap
+// alone spaces the header.
 .pageTitle {
-    grid-area: title;
-    margin-bottom: 0;
+    display: contents;
     color: var(--color-fg-primary);
+}
+
+// Carries the heading type the h1's dropped box would have applied. A real element
+// rather than a bare text node so it can be placed in the grid — and so it can span
+// the full width instead of being trapped in the eyebrow's column.
+.titleText {
+    grid-area: title;
 }
 
 .enterpriseLabel {

--- a/documentation/ag-grid-docs/src/components/docs/components/Header.module.scss
+++ b/documentation/ag-grid-docs/src/components/docs/components/Header.module.scss
@@ -16,35 +16,34 @@
     }
 }
 
-// Narrow screens stack the metadata, then the controls, then the title. From the
-// docs-search breakpoint up, the controls move to the top right: they span both
-// rows so they sit level with the metadata without pushing the title down.
+// Narrow screens stack the title block, then the controls. From the docs-search
+// breakpoint up, the controls move to the top right, level with the eyebrow line
+// inside the title rather than pushing the title down.
 .pageTitleContainer {
     display: grid;
     width: 100%;
     grid-template-columns: 1fr;
     grid-template-areas:
-        'meta'
-        'actions'
-        'title';
+        'title'
+        'actions';
     row-gap: $spacing-size-3;
 
     @media screen and (min-width: $breakpoint-docs-search-medium) {
         grid-template-columns: 1fr auto;
-        grid-template-areas:
-            'meta actions'
-            'title actions';
+        grid-template-areas: 'title actions';
         column-gap: $spacing-size-4;
     }
 }
 
 // Eyebrow line above the page title, holding the framework name and grid version.
+// Inside the h1, so it carries its own spacing and opts out of heading line-height.
 .titleMeta {
-    grid-area: meta;
     display: flex;
     flex-wrap: wrap;
     align-items: baseline;
     gap: $spacing-size-3;
+    margin-bottom: $spacing-size-3;
+    line-height: var(--text-lh-base);
 }
 
 .headerFramework {
@@ -85,8 +84,11 @@
     }
 }
 
+// Spacing below the heading is the grid's row gap; the global heading margin
+// would stack on top of it.
 .pageTitle {
     grid-area: title;
+    margin-bottom: 0;
     color: var(--color-fg-primary);
 }
 

--- a/documentation/ag-grid-docs/src/components/docs/components/Header.test.tsx
+++ b/documentation/ag-grid-docs/src/components/docs/components/Header.test.tsx
@@ -1,0 +1,43 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { Header } from './Header';
+
+type HeaderProps = Parameters<typeof Header>[0];
+
+const defaultProps: HeaderProps = {
+    title: 'Getting Started',
+    framework: 'react',
+    path: '/react-data-grid/getting-started/',
+    menuItems: [],
+};
+
+function getHeadingHtml(props: Partial<HeaderProps> = {}) {
+    const html = renderToStaticMarkup(<Header {...defaultProps} {...props} />);
+    const heading = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/);
+    if (!heading) {
+        throw new Error(`No <h1> rendered in:\n${html}`);
+    }
+    return heading[1];
+}
+
+describe('Header', () => {
+    it('renders the framework name inside the h1, as search engines index the heading', () => {
+        expect(getHeadingHtml()).toContain('React Data Grid');
+    });
+
+    it('renders the version inside the h1 when one is given', () => {
+        expect(getHeadingHtml({ version: '36.1.0' })).toContain('Version 36.1.0');
+    });
+
+    it('omits the framework name from the h1 when it is suppressed', () => {
+        const headingHtml = getHeadingHtml({ suppressFrameworkHeader: true });
+
+        expect(headingHtml).not.toContain('React Data Grid');
+        expect(headingHtml).toContain('Getting Started');
+    });
+
+    it('keeps the page title as a direct text node of the h1, as the Algolia indexer reads only those', () => {
+        expect(getHeadingHtml({ version: '36.1.0' })).toMatch(/<\/span>Getting Started$/);
+    });
+});

--- a/documentation/ag-grid-docs/src/components/docs/components/Header.test.tsx
+++ b/documentation/ag-grid-docs/src/components/docs/components/Header.test.tsx
@@ -12,8 +12,12 @@ const defaultProps: HeaderProps = {
     menuItems: [],
 };
 
+function renderHeader(props: Partial<HeaderProps> = {}) {
+    return renderToStaticMarkup(<Header {...defaultProps} {...props} />);
+}
+
 function getHeadingHtml(props: Partial<HeaderProps> = {}) {
-    const html = renderToStaticMarkup(<Header {...defaultProps} {...props} />);
+    const html = renderHeader(props);
     const heading = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/);
     if (!heading) {
         throw new Error(`No <h1> rendered in:\n${html}`);
@@ -26,10 +30,6 @@ describe('Header', () => {
         expect(getHeadingHtml()).toContain('React Data Grid');
     });
 
-    it('renders the version inside the h1 when one is given', () => {
-        expect(getHeadingHtml({ version: '36.1.0' })).toContain('Version 36.1.0');
-    });
-
     it('omits the framework name from the h1 when it is suppressed', () => {
         const headingHtml = getHeadingHtml({ suppressFrameworkHeader: true });
 
@@ -37,7 +37,14 @@ describe('Header', () => {
         expect(headingHtml).toContain('Getting Started');
     });
 
-    it('keeps the page title as a direct text node of the h1, as the Algolia indexer reads only those', () => {
-        expect(getHeadingHtml({ version: '36.1.0' })).toMatch(/<\/span>Getting Started$/);
+    it('renders the version outside the h1, so it does not read as part of the heading', () => {
+        const html = renderHeader({ version: '36.1.0' });
+
+        expect(html).toContain('Version 36.1.0');
+        expect(getHeadingHtml({ version: '36.1.0' })).not.toContain('Version 36.1.0');
+    });
+
+    it('marks the page title within the h1, as that is how the Algolia indexer finds it', () => {
+        expect(getHeadingHtml()).toMatch(/<span[^>]*data-page-title[^>]*>Getting Started<\/span>/);
     });
 });

--- a/documentation/ag-grid-docs/src/components/docs/components/Header.tsx
+++ b/documentation/ag-grid-docs/src/components/docs/components/Header.tsx
@@ -37,21 +37,23 @@ export const Header: FunctionComponent<Props> = ({
         <header className={styles.docsPageHeader}>
             <div id="top" className={styles.docsPageTitle}>
                 <div className={styles.pageTitleContainer}>
-                    {/* The framework name must stay inside the h1 to count towards it for SEO, and `title`
-                        must stay a direct text node — the Algolia indexer reads only the h1's text nodes. */}
+                    {/* The framework name must stay inside the h1 to count towards it for SEO. The version
+                        must stay outside it, or it would read as part of the heading too — it only sits
+                        beside the framework name because the h1 is `display: contents`, which lets the two
+                        be laid out together from different parents. `data-page-title` is how the Algolia
+                        indexer finds the page title within the heading. */}
                     <h1 className={styles.pageTitle}>
-                        {(!suppressFrameworkHeader || version) && (
-                            <span className={styles.titleMeta}>
-                                {!suppressFrameworkHeader && (
-                                    <span className={styles.headerFramework}>
-                                        {`${getFrameworkDisplayText(framework)} Data Grid`}
-                                    </span>
-                                )}
-                                {version && <span className={styles.version}>{`Version ${version}`}</span>}
+                        {!suppressFrameworkHeader && (
+                            <span className={styles.headerFramework}>
+                                {`${getFrameworkDisplayText(framework)} Data Grid`}
                             </span>
                         )}
-                        {title}
+                        <span className={styles.titleText} data-page-title>
+                            {title}
+                        </span>
                     </h1>
+
+                    {version && <span className={styles.version}>{`Version ${version}`}</span>}
 
                     <div className={styles.headerActions}>
                         {markdownHref && <MarkdownActions markdownHref={markdownHref} />}

--- a/documentation/ag-grid-docs/src/components/docs/components/Header.tsx
+++ b/documentation/ag-grid-docs/src/components/docs/components/Header.tsx
@@ -37,14 +37,21 @@ export const Header: FunctionComponent<Props> = ({
         <header className={styles.docsPageHeader}>
             <div id="top" className={styles.docsPageTitle}>
                 <div className={styles.pageTitleContainer}>
-                    <div className={styles.titleMeta}>
-                        {!suppressFrameworkHeader && (
-                            <span className={styles.headerFramework}>
-                                {`${getFrameworkDisplayText(framework)} Data Grid`}
+                    {/* The framework name must stay inside the h1 to count towards it for SEO, and `title`
+                        must stay a direct text node — the Algolia indexer reads only the h1's text nodes. */}
+                    <h1 className={styles.pageTitle}>
+                        {(!suppressFrameworkHeader || version) && (
+                            <span className={styles.titleMeta}>
+                                {!suppressFrameworkHeader && (
+                                    <span className={styles.headerFramework}>
+                                        {`${getFrameworkDisplayText(framework)} Data Grid`}
+                                    </span>
+                                )}
+                                {version && <span className={styles.version}>{`Version ${version}`}</span>}
                             </span>
                         )}
-                        {version && <span className={styles.version}>{`Version ${version}`}</span>}
-                    </div>
+                        {title}
+                    </h1>
 
                     <div className={styles.headerActions}>
                         {markdownHref && <MarkdownActions markdownHref={markdownHref} />}
@@ -56,8 +63,6 @@ export const Header: FunctionComponent<Props> = ({
                             />
                         </div>
                     </div>
-
-                    <h1 className={styles.pageTitle}>{title}</h1>
                 </div>
 
                 {isEnterprise && (

--- a/documentation/update-algolia-indices/src/generators/docs-pages.ts
+++ b/documentation/update-algolia-indices/src/generators/docs-pages.ts
@@ -327,6 +327,14 @@ const cleanContents = (contents: string): string => {
 };
 
 const extractTitle = ({ dom, titleTag }: { dom: JSDOM; titleTag: HTMLElement | null }) => {
+    // The h1 also holds the framework name ('React Data Grid'), which is part of the
+    // heading for SEO but not part of the page title, so the title is marked up
+    // explicitly. Fall back to the h1's own text nodes for headings without the marker.
+    const pageTitle = titleTag?.querySelector('[data-page-title]');
+    if (pageTitle) {
+        return pageTitle.textContent?.trim() ?? '';
+    }
+
     let extractedText = '';
 
     // Only extract text node


### PR DESCRIPTION
Restores the framework name to the docs page `<h1>`, which AG-17860 moved out into a sibling `div` when it restructured the header into a CSS grid. Search engines only index the heading, so the framework name had stopped counting towards it.

The framework name now sits inside the `<h1>`; `Version X.Y.Z` stays outside it, so it doesn't read as part of the heading. They still share the eyebrow line because the `<h1>` is `display: contents`, which places its children in the header grid directly. The page title is now a marked-up element (`data-page-title`) rather than a bare text node, so it can be given a grid area — the Algolia indexer reads that marker, falling back to the h1's text nodes.

Header layout is unchanged from AG-17860 at every breakpoint, including the controls sitting between the eyebrow and the title on narrow screens.

RTI-3421