### PR TITLE
[RTI-3416] Fix(menu): suppress focus ring on menu item activated with no document focus

### DIFF
--- a/community-modules/styles/src/internal/base/parts/_menu.scss
+++ b/community-modules/styles/src/internal/base/parts/_menu.scss
@@ -33,6 +33,10 @@
     }
     @include ag.keyboard-focus((ag-menu-option), 1px);
 
+    :where(.ag-menu-list-no-focus-ring) .ag-menu-option:focus-visible::after {
+        content: none;
+    }
+
     .ag-menu-option-active,
     .ag-compact-menu-option-active {
         background-color: var(--ag-row-hover-color);

--- a/community-modules/styles/src/internal/base/parts/_menu.scss
+++ b/community-modules/styles/src/internal/base/parts/_menu.scss
@@ -33,7 +33,7 @@
     }
     @include ag.keyboard-focus((ag-menu-option), 1px);
 
-    :where(.ag-menu-list-no-focus-ring) .ag-menu-option:focus-visible::after {
+    .ag-menu-list-no-focus-ring .ag-menu-option:focus-visible::after {
         content: none;
     }
 

--- a/packages/ag-grid-enterprise/src/agStack/agMenuItemComponent.ts
+++ b/packages/ag-grid-enterprise/src/agStack/agMenuItemComponent.ts
@@ -10,14 +10,7 @@ import type {
     TooltipCtrl,
     WithoutCommon,
 } from 'ag-stack';
-import {
-    AgBeanStub,
-    _isNothingFocused,
-    _setAriaDisabled,
-    _setAriaExpanded,
-    _setAriaHasPopup,
-    _setAriaRole,
-} from 'ag-stack';
+import { AgBeanStub, _setAriaDisabled, _setAriaExpanded, _setAriaHasPopup, _setAriaRole } from 'ag-stack';
 
 import type { AgEvent, AgPromise, IComponent, IMenuConfigParams, IMenuItem, TapEvent } from 'ag-grid-community';
 import { KeyCode, TouchListener, _createElement } from 'ag-grid-community';
@@ -419,9 +412,6 @@ export class AgMenuItemComponent<
         this.isActive = true;
         if (!this.suppressRootStyles) {
             this.eGui.classList.add(`${this.cssClassPrefix}-active`);
-            // Chrome treats a programmatic focus taken while the document has no focused element as
-            // keyboard-driven, so :focus-visible would draw a focus ring on a mouse-opened menu.
-            this.eGui.classList.toggle(`${this.cssClassPrefix}-no-focus-ring`, _isNothingFocused(this.beans));
         }
         this.menuItemComp.setActive?.(true);
         if (!this.suppressFocus) {
@@ -442,7 +432,7 @@ export class AgMenuItemComponent<
     public deactivate() {
         this.cancelDeactivate();
         if (!this.suppressRootStyles) {
-            this.eGui.classList.remove(`${this.cssClassPrefix}-active`, `${this.cssClassPrefix}-no-focus-ring`);
+            this.eGui.classList.remove(`${this.cssClassPrefix}-active`);
         }
         this.menuItemComp.setActive?.(false);
         this.isActive = false;

--- a/packages/ag-grid-enterprise/src/agStack/agMenuItemComponent.ts
+++ b/packages/ag-grid-enterprise/src/agStack/agMenuItemComponent.ts
@@ -10,7 +10,14 @@ import type {
     TooltipCtrl,
     WithoutCommon,
 } from 'ag-stack';
-import { AgBeanStub, _setAriaDisabled, _setAriaExpanded, _setAriaHasPopup, _setAriaRole } from 'ag-stack';
+import {
+    AgBeanStub,
+    _isNothingFocused,
+    _setAriaDisabled,
+    _setAriaExpanded,
+    _setAriaHasPopup,
+    _setAriaRole,
+} from 'ag-stack';
 
 import type { AgEvent, AgPromise, IComponent, IMenuConfigParams, IMenuItem, TapEvent } from 'ag-grid-community';
 import { KeyCode, TouchListener, _createElement } from 'ag-grid-community';
@@ -412,6 +419,9 @@ export class AgMenuItemComponent<
         this.isActive = true;
         if (!this.suppressRootStyles) {
             this.eGui.classList.add(`${this.cssClassPrefix}-active`);
+            // Chrome treats a programmatic focus taken while the document has no focused element as
+            // keyboard-driven, so :focus-visible would draw a focus ring on a mouse-opened menu.
+            this.eGui.classList.toggle(`${this.cssClassPrefix}-no-focus-ring`, _isNothingFocused(this.beans));
         }
         this.menuItemComp.setActive?.(true);
         if (!this.suppressFocus) {
@@ -432,7 +442,7 @@ export class AgMenuItemComponent<
     public deactivate() {
         this.cancelDeactivate();
         if (!this.suppressRootStyles) {
-            this.eGui.classList.remove(`${this.cssClassPrefix}-active`);
+            this.eGui.classList.remove(`${this.cssClassPrefix}-active`, `${this.cssClassPrefix}-no-focus-ring`);
         }
         this.menuItemComp.setActive?.(false);
         this.isActive = false;

--- a/packages/ag-grid-enterprise/src/agStack/agMenuList.ts
+++ b/packages/ag-grid-enterprise/src/agStack/agMenuList.ts
@@ -6,7 +6,7 @@ import type {
     IPropertiesService,
     WithoutCommon,
 } from 'ag-stack';
-import { AgTabGuardComp, _createAgElement, _focusInto, _getActiveDomElement, _last } from 'ag-stack';
+import { AgTabGuardComp, _createAgElement, _focusInto, _getActiveDomElement, _isNothingFocused, _last } from 'ag-stack';
 
 import { AgPromise, KeyCode } from 'ag-grid-community';
 
@@ -250,13 +250,13 @@ export class AgMenuList<
     public focusInto(): boolean {
         const focused = _focusInto(this.getGui());
         // Framework menu items render asynchronously and may be absent now; retry once they land,
-        // unless focus has since moved to an item or away from the menu entirely. Activating while
-        // nothing is focused would draw a focus ring on a mouse-opened menu.
+        // unless focus has since moved to an item or away from the menu entirely.
         this.itemsReady?.then(() => {
             if (!this.isAlive() || this.activeMenuItem) {
                 return;
             }
-            if (this.getGui().contains(_getActiveDomElement(this.beans))) {
+            const activeElement = _getActiveDomElement(this.beans);
+            if (_isNothingFocused(this.beans) || this.getGui().contains(activeElement)) {
                 this.activateFirstItem();
             }
         });

--- a/packages/ag-grid-enterprise/src/agStack/agMenuList.ts
+++ b/packages/ag-grid-enterprise/src/agStack/agMenuList.ts
@@ -94,6 +94,7 @@ export class AgMenuList<
             case KeyCode.DOWN:
             case KeyCode.LEFT:
                 e.preventDefault();
+                this.getGui().classList.remove('ag-menu-list-no-focus-ring');
                 this.handleNavKey(e.key);
                 break;
             case KeyCode.ESCAPE:
@@ -248,6 +249,9 @@ export class AgMenuList<
     }
 
     public focusInto(): boolean {
+        // Chrome reports a programmatic focus taken while the document has no focused element as
+        // :focus-visible, which would draw a keyboard focus ring on a mouse-opened menu.
+        this.getGui().classList.toggle('ag-menu-list-no-focus-ring', _isNothingFocused(this.beans));
         const focused = _focusInto(this.getGui());
         // Framework menu items render asynchronously and may be absent now; retry once they land,
         // unless focus has since moved to an item or away from the menu entirely.

--- a/packages/ag-grid-enterprise/src/agStack/agMenuList.ts
+++ b/packages/ag-grid-enterprise/src/agStack/agMenuList.ts
@@ -21,6 +21,8 @@ import { AgMenuItemComponent } from './agMenuItemComponent';
 
 type AgMenuListEvent = AgMenuItemComponentEvent;
 
+const NO_FOCUS_RING_CLASS = 'ag-menu-list-no-focus-ring';
+
 export class AgMenuList<
     TBeanCollection extends AgCoreBeanCollection<TProperties, TGlobalEvents, TCommon, TPropertiesService>,
     TProperties extends BaseProperties,
@@ -94,7 +96,8 @@ export class AgMenuList<
             case KeyCode.DOWN:
             case KeyCode.LEFT:
                 e.preventDefault();
-                this.getGui().classList.remove('ag-menu-list-no-focus-ring');
+                // ancestors too: Left returns focus to the parent menu, which must show its ring again.
+                this.clearNoFocusRing();
                 this.handleNavKey(e.key);
                 break;
             case KeyCode.ESCAPE:
@@ -251,7 +254,7 @@ export class AgMenuList<
     public focusInto(): boolean {
         // Chrome reports a programmatic focus taken while the document has no focused element as
         // :focus-visible, which would draw a keyboard focus ring on a mouse-opened menu.
-        this.getGui().classList.toggle('ag-menu-list-no-focus-ring', _isNothingFocused(this.beans));
+        this.getGui().classList.toggle(NO_FOCUS_RING_CLASS, _isNothingFocused(this.beans));
         const focused = _focusInto(this.getGui());
         // Framework menu items render asynchronously and may be absent now; retry once they land,
         // unless focus has since moved to an item or away from the menu entirely.
@@ -309,6 +312,17 @@ export class AgMenuList<
             this.closeIfIsChild();
         } else {
             this.openChild();
+        }
+    }
+
+    private clearNoFocusRing(): void {
+        this.getGui().classList.remove(NO_FOCUS_RING_CLASS);
+        const parentItem = this.getParentComponent();
+        if (parentItem instanceof AgMenuItemComponent) {
+            const parentList = parentItem.getParentComponent();
+            if (parentList instanceof AgMenuList) {
+                parentList.clearNoFocusRing();
+            }
         }
     }
 

--- a/packages/ag-grid-enterprise/src/agStack/agMenuList.ts
+++ b/packages/ag-grid-enterprise/src/agStack/agMenuList.ts
@@ -6,7 +6,7 @@ import type {
     IPropertiesService,
     WithoutCommon,
 } from 'ag-stack';
-import { AgTabGuardComp, _createAgElement, _focusInto, _getActiveDomElement, _isNothingFocused, _last } from 'ag-stack';
+import { AgTabGuardComp, _createAgElement, _focusInto, _getActiveDomElement, _last } from 'ag-stack';
 
 import { AgPromise, KeyCode } from 'ag-grid-community';
 
@@ -250,13 +250,13 @@ export class AgMenuList<
     public focusInto(): boolean {
         const focused = _focusInto(this.getGui());
         // Framework menu items render asynchronously and may be absent now; retry once they land,
-        // unless focus has since moved to an item or away from the menu entirely.
+        // unless focus has since moved to an item or away from the menu entirely. Activating while
+        // nothing is focused would draw a focus ring on a mouse-opened menu.
         this.itemsReady?.then(() => {
             if (!this.isAlive() || this.activeMenuItem) {
                 return;
             }
-            const activeElement = _getActiveDomElement(this.beans);
-            if (_isNothingFocused(this.beans) || this.getGui().contains(activeElement)) {
+            if (this.getGui().contains(_getActiveDomElement(this.beans))) {
                 this.activateFirstItem();
             }
         });

--- a/packages/ag-grid-enterprise/src/widgets/menu.css
+++ b/packages/ag-grid-enterprise/src/widgets/menu.css
@@ -59,8 +59,8 @@
     background-color: var(--ag-row-hover-color);
 }
 
-.ag-menu-option-no-focus-ring:focus-visible,
-.ag-compact-menu-option-no-focus-ring:focus-visible {
+.ag-menu-list-no-focus-ring .ag-menu-option:focus-visible,
+.ag-menu-list-no-focus-ring .ag-compact-menu-option:focus-visible {
     box-shadow: none;
 }
 

--- a/packages/ag-grid-enterprise/src/widgets/menu.css
+++ b/packages/ag-grid-enterprise/src/widgets/menu.css
@@ -59,8 +59,8 @@
     background-color: var(--ag-row-hover-color);
 }
 
-.ag-menu-list-no-focus-ring .ag-menu-option:focus-visible,
-.ag-menu-list-no-focus-ring .ag-compact-menu-option:focus-visible {
+:where(.ag-menu-list-no-focus-ring) .ag-menu-option:focus-visible,
+:where(.ag-menu-list-no-focus-ring) .ag-compact-menu-option:focus-visible {
     box-shadow: none;
 }
 

--- a/packages/ag-grid-enterprise/src/widgets/menu.css
+++ b/packages/ag-grid-enterprise/src/widgets/menu.css
@@ -59,6 +59,11 @@
     background-color: var(--ag-row-hover-color);
 }
 
+.ag-menu-option-no-focus-ring:focus-visible,
+.ag-compact-menu-option-no-focus-ring:focus-visible {
+    box-shadow: none;
+}
+
 .ag-menu-option-part,
 .ag-compact-menu-option-part {
     line-height: var(--ag-icon-size);


### PR DESCRIPTION
Fixes [RTI-3416](https://ag-grid.atlassian.net/browse/RTI-3416).

The first menu item is focused programmatically while the document has no focused element, which Chrome treats as keyboard-driven, so `:focus-visible` drew a focus ring on a mouse-opened menu. Activation in that state now suppresses the ring; keyboard navigation is unaffected.