### PR TITLE
Fix update-versions-data silently mislabelling every version

### DIFF
--- a/documentation/ag-grid-docs/scripts/versions-data/updateVersionsData.ts
+++ b/documentation/ag-grid-docs/scripts/versions-data/updateVersionsData.ts
@@ -4,7 +4,13 @@ import * as fs from 'fs/promises';
 
 // Absolute path from the root directory
 const VERSIONS_DATA_PATH = 'documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json';
-const WEBSITE_ARCHIVE_URL = 'https://www.ag-grid.com/archive';
+const WEBSITE_ARCHIVE_URL = 'https://www.ag-grid.com/documentation-archive/';
+
+// The archive page is served behind a filter that rejects non-browser clients with
+// a 403, so identify as one. Without this every request fails and the script would
+// conclude that no version has archived docs.
+const BROWSER_USER_AGENT =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
 
 function sortByVersionAsc(a: string, b: string) {
     const aParts = a.split('.').map(Number);
@@ -22,7 +28,7 @@ function sortByVersionDesc(a: string, b: string) {
 }
 
 function extractVersionsFromHref(html: string) {
-    const hrefRegex = /<a\s+href="(\d+\.\d+\.\d+)\/">/g;
+    const hrefRegex = /href="[^"]*\/archive\/(\d+\.\d+\.\d+)(?:\/|")/g;
 
     const versions = [];
     let match;
@@ -34,10 +40,23 @@ function extractVersionsFromHref(html: string) {
 }
 
 async function getWebsiteVersions() {
-    const response = await fetch(WEBSITE_ARCHIVE_URL);
-    const html = await response.text();
+    const response = await fetch(WEBSITE_ARCHIVE_URL, { headers: { 'User-Agent': BROWSER_USER_AGENT } });
 
-    return extractVersionsFromHref(html);
+    if (!response.ok) {
+        throw new Error(`Could not read ${WEBSITE_ARCHIVE_URL}: ${response.status} ${response.statusText}`);
+    }
+
+    const html = await response.text();
+    const versions = extractVersionsFromHref(html);
+
+    // Every version is compared against this list to decide its `noDocs` flag, so an
+    // empty result is never legitimate: it would mark the entire file as having no
+    // archived docs. Treat it as a broken URL or changed page markup instead.
+    if (versions.length === 0) {
+        throw new Error(`Found no archived versions at ${WEBSITE_ARCHIVE_URL}; the URL or its markup has changed`);
+    }
+
+    return versions;
 }
 
 function getDaySuffix(day: number) {
@@ -91,9 +110,12 @@ function logFinalReport({ versionsDataFile, allVersions, noDocsUpdated }) {
 
 function updateNoDocs({ versions, websiteVersions }) {
     let num = 0;
-    // Check website to see if version has docs
-    const updatedVersions = versions.map((versionData) => {
-        const noDocs = !websiteVersions.includes(versionData.version);
+    // Check website to see if version has docs. `versions` is sorted newest-first, and
+    // the newest entry is the live release, whose docs are served from the main site
+    // rather than the archive - so it is never in `websiteVersions`. Exempt it, or it
+    // would be flagged `noDocs` and dropped from the version selector.
+    const updatedVersions = versions.map((versionData, index) => {
+        const noDocs = index > 0 && !websiteVersions.includes(versionData.version);
 
         const newData = { ...versionData };
 

--- a/documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json
+++ b/documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json
@@ -27,6 +27,14 @@
         "hideBlogPostLink": false
     },
     {
+        "version": "36.0.2",
+        "date": "July 22nd, 2026"
+    },
+    {
+        "version": "36.0.1",
+        "date": "July 15th, 2026"
+    },
+    {
         "version": "36.0.0",
         "date": "June 24th 2026",
         "landingPageHighlight": "Calculated Columns, Show Values As, Automatic Column Generation, Accessibility Improvements, Theming Improvements",
@@ -52,6 +60,10 @@
         ],
         "notesPath": "./upgrading-to-ag-grid-36",
         "hideBlogPostLink": false
+    },
+    {
+        "version": "35.3.1",
+        "date": "June 2nd, 2026"
     },
     {
         "version": "35.3.0",
@@ -461,6 +473,16 @@
         ],
         "notesPath": "./upgrading-to-ag-grid-33",
         "hideBlogPostLink": false
+    },
+    {
+        "version": "32.3.9",
+        "date": "August 13th, 2025",
+        "noDocs": true
+    },
+    {
+        "version": "32.3.8",
+        "date": "June 10th, 2025",
+        "noDocs": true
     },
     {
         "version": "32.3.7",
@@ -1153,7 +1175,8 @@
     },
     {
         "version": "18.1.0",
-        "date": "4th July 2018"
+        "date": "4th July 2018",
+        "noDocs": true
     },
     {
         "version": "17.1.1",


### PR DESCRIPTION
`nx update-versions-data ag-grid-docs` is currently destructive. `/archive` was
removed and now redirects to `/documentation-archive/`, and the site rejects
non-browser clients with a 403 regardless of path.

Both failures were swallowed. `getWebsiteVersions()` returned an empty list, and
because `noDocs` is derived from "version absent from the archive", every entry
got `noDocs: true` - which filters it out of `VersionsSelector` and the archive
`MajorTable`. Running the target on `b36.1.0` today empties both.

- Read `/documentation-archive/` and match the absolute hrefs it actually serves
  (`href="https://www.ag-grid.com/archive/14.0.0"`); the old regex expected an
  Apache directory listing that no longer serves.
- Send a browser `User-Agent` so the request is not rejected.
- Throw on a non-OK response or an empty version list rather than writing a file
  derived from nothing.
- Exempt the newest entry from the `noDocs` check: the live release is served
  from the main docs site, so it is never in the archive and must not be flagged.
  Without this, `36.1.0` itself would be dropped from the selector.

The second commit is the resulting data refresh, adding the five released
versions missing from the list. Every flag was cross-checked against the live
archive: 36.0.2, 36.0.1 and 35.3.1 are archived (no `noDocs`); 32.3.9, 32.3.8 and
18.1.0 are not (flagged). Nothing lost a flag it should have kept, and `36.1.0`
is untouched.

Same fix as ag-charts and ag-studio, which have the identical script.