### PR TITLE
RTI-3419 Register TooltipModule in context menu example

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/context-menu/_examples/context-menu/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/context-menu/_examples/context-menu/main.ts
@@ -1,7 +1,13 @@
 import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
 
 import type { DefaultMenuItem, GetContextMenuItemsParams, GridApi, GridOptions, MenuItemDef } from 'ag-grid-community';
-import { ClientSideRowModelModule, ModuleRegistry, createGrid, enableDevValidations } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    ModuleRegistry,
+    TooltipModule,
+    createGrid,
+    enableDevValidations,
+} from 'ag-grid-community';
 import {
     CellSelectionModule,
     ClipboardModule,
@@ -23,6 +29,7 @@ ModuleRegistry.registerModules([
     ColumnMenuModule,
     ContextMenuModule,
     CellSelectionModule,
+    TooltipModule,
     IntegratedChartsModule.with(AgChartsEnterpriseModule),
 ]);
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/RTI-3419

Example was missing the TooltipModule. 

I have not added new validations now, because there would be some clashing with grid internal menu items that set tooltips and currently treat them as optional. 

Fix [RTI-3419](https://ag-grid.atlassian.net/browse/RTI-3419)