### PR TITLE
RTI-3427-textarea-does-not-have-aria-expanded

### DIFF
--- a/packages/ag-grid-enterprise/src/calculatedColumns/calculatedColumnForm.ts
+++ b/packages/ag-grid-enterprise/src/calculatedColumns/calculatedColumnForm.ts
@@ -225,7 +225,6 @@ export class CalculatedColumnForm extends Component {
         const input = this.eExpression.getInputElement();
         _setAriaAutoComplete(input, 'list');
         _setAriaHasPopup(input, 'listbox');
-        _setAriaExpanded(input, false);
 
         const pickerButtons = [this.eColumns, this.eFunctions, this.eOperators];
         for (const button of pickerButtons) {
@@ -508,7 +507,6 @@ export class CalculatedColumnForm extends Component {
         const renderedActiveOptionId =
             activeOptionId && _getDocument(this.beans).getElementById(activeOptionId) ? activeOptionId : null;
 
-        _setAriaExpanded(expressionInputEl, isInline);
         _setAriaControls(expressionInputEl, isInline ? listId : null);
         _setAriaActiveDescendant(expressionInputEl, renderedActiveOptionId);
 
@@ -521,7 +519,6 @@ export class CalculatedColumnForm extends Component {
 
     private clearAriaForSuggestions(): void {
         const expressionInputEl = this.eExpression.getInputElement();
-        _setAriaExpanded(expressionInputEl, false);
         _setAriaControls(expressionInputEl, null);
         _setAriaActiveDescendant(expressionInputEl, null);
 

--- a/testing/behavioural/src/formulas/calculated-columns.test.ts
+++ b/testing/behavioural/src/formulas/calculated-columns.test.ts
@@ -2150,7 +2150,8 @@ describe('ag-grid calculated columns', () => {
         const input = getExpressionInput();
         expect(input).toHaveAttribute('aria-autocomplete', 'list');
         expect(input).toHaveAttribute('aria-haspopup', 'listbox');
-        expect(input).toHaveAttribute('aria-expanded', 'false');
+        // role textbox does not support aria-expanded, and textarea cannot take role combobox
+        expect(input).not.toHaveAttribute('aria-expanded');
 
         input.value = '[Revenue';
         input.setSelectionRange(input.value.length, input.value.length);
@@ -2165,7 +2166,7 @@ describe('ag-grid calculated columns', () => {
         });
         const popup = document.querySelector<HTMLElement>('.ag-autocomplete-list-popup')!;
 
-        expect(input).toHaveAttribute('aria-expanded', 'true');
+        expect(input).not.toHaveAttribute('aria-expanded');
         expect(controlledList).toHaveAttribute('role', 'listbox');
         expect(controlledList).not.toBe(popup);
 
@@ -2194,7 +2195,7 @@ describe('ag-grid calculated columns', () => {
 
         input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
 
-        expect(input).toHaveAttribute('aria-expanded', 'false');
+        expect(input).not.toHaveAttribute('aria-expanded');
         expect(input).not.toHaveAttribute('aria-controls');
         expect(input).not.toHaveAttribute('aria-activedescendant');
     });


### PR DESCRIPTION
# RTI-3427 Fix `aria-expanded` not allowed on the Calculated Column expression editor

FIX RTI-3427

## Problem

axe DevTools reported one violation on the Calculated Column dialog — `aria-allowed-attr`, "ARIA attribute is not allowed: `aria-expanded="false"`" — on the expression `<textarea>`. A textarea's implicit role is `textbox`, and `aria-expanded` stopped being a global attribute in ARIA 1.2.

## Fix

`calculatedColumnForm.ts` — stopped setting `aria-expanded` on the expression textarea (`setupAria`, `refreshAriaForSuggestions`, `clearAriaForSuggestions`).

`role="combobox"` isn't an alternative: ARIA in HTML permits no role override on `textarea`, so it would just trade this violation for an `aria-allowed-role` one.

Nothing is lost — `aria-expanded` on an unsupporting role is ignored by AT anyway, and the attributes carrying the actual information are all valid on `textbox`: `aria-autocomplete` and `aria-activedescendant` (allowed on the role), `aria-haspopup` and `aria-controls` (global).

## Scope

The picker buttons keep their `aria-expanded` (`role=button` supports it). No other element changes — this was the only place in the grid putting `aria-expanded` on an input-like element; `agSelect`/`agRichSelect` set `role="combobox"` on the same element, so they were already valid.

## Tests

`calculated-columns.test.ts` — the existing "dialog expression suggestions control the virtual list aria state" test now asserts `aria-expanded` is absent throughout instead of present and toggling. Its other aria assertions are unchanged.

`./behave.sh "calculated-column"` (239 tests), `build:types` and `lint` on `ag-grid-enterprise` all pass.
