### PR TITLE
Check each version's archive directly for noDocs

### DIFF
--- a/documentation/ag-grid-docs/scripts/versions-data/updateVersionsData.ts
+++ b/documentation/ag-grid-docs/scripts/versions-data/updateVersionsData.ts
@@ -4,7 +4,18 @@ import * as fs from 'fs/promises';
 
 // Absolute path from the root directory
 const VERSIONS_DATA_PATH = 'documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json';
-const WEBSITE_ARCHIVE_URL = 'https://www.ag-grid.com/archive';
+// Mirrors `getArchiveUrl` in external/ag-website-shared/src/utils/getArchiveUrl.ts, which
+// is what the site itself uses to link to archived docs. Kept as a local copy because this
+// script runs as a bare `tsx` entry point with no path-alias resolution.
+const ARCHIVE_BASE_URL = 'https://www.ag-grid.com/archive';
+
+// The site rejects non-browser clients with a 403, so identify as one. Without this every
+// probe fails, and a failed probe must never be mistaken for a missing archive.
+const BROWSER_USER_AGENT =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
+
+// One request per version, so keep them spaced out to avoid being rate limited.
+const PROBE_DELAY_MS = 250;
 
 function sortByVersionAsc(a: string, b: string) {
     const aParts = a.split('.').map(Number);
@@ -21,23 +32,47 @@ function sortByVersionDesc(a: string, b: string) {
     return sortByVersionAsc(b, a);
 }
 
-function extractVersionsFromHref(html: string) {
-    const hrefRegex = /<a\s+href="(\d+\.\d+\.\d+)\/">/g;
-
-    const versions = [];
-    let match;
-    while ((match = hrefRegex.exec(html)) !== null) {
-        versions.push(match[1]);
-    }
-
-    return [...new Set(versions)].sort(sortByVersionAsc);
+function delay(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function getWebsiteVersions() {
-    const response = await fetch(WEBSITE_ARCHIVE_URL);
-    const html = await response.text();
+/**
+ * Whether archived docs are published for a version.
+ *
+ * Asks the server directly rather than reading the /documentation-archive/ page: that page
+ * is generated from this very file, so using it here would be circular - a version missing
+ * from the file could never appear on the page, which would flag it `noDocs` and then keep
+ * it flagged forever.
+ */
+async function hasArchivedDocs(version: string) {
+    // Request the trailing-slash form, which is the canonical one, so a published version
+    // answers 200 in a single request.
+    const url = `${ARCHIVE_BASE_URL}/${version}/`;
+    // Redirects must not be followed: an unpublished version is soft-404'd to a 404 page
+    // that itself answers 200, which would be indistinguishable from a real archive.
+    const response = await fetch(url, {
+        method: 'HEAD',
+        redirect: 'manual',
+        headers: { 'User-Agent': BROWSER_USER_AGENT },
+    });
 
-    return extractVersionsFromHref(html);
+    if (response.status === 200) {
+        return true;
+    }
+
+    if (response.status === 404) {
+        return false;
+    }
+
+    if (response.status >= 300 && response.status < 400) {
+        // A redirect that stays within this version's archive path is a genuine relocation;
+        // anything else is the soft-404 described above.
+        return (response.headers.get('location') ?? '').includes(`/archive/${version}`);
+    }
+
+    // Typically a 403 (blocked) or 429 (rate limited). Treating either as "not archived"
+    // would silently drop the version from the selector, so stop instead of guessing.
+    throw new Error(`Unexpected ${response.status} ${response.statusText} for ${url}`);
 }
 
 function getDaySuffix(day: number) {
@@ -73,54 +108,68 @@ function getNpmLibraryVersions(library: string) {
     return JSON.parse(results.toString());
 }
 
-function logInitialReport({ versionsDataFile, agVersions, npmVersions, missingNpmVersions, websiteVersions }) {
+function logInitialReport({ versionsDataFile, agVersions, npmVersions, missingNpmVersions, versionsToProbe }) {
     console.log(`${agVersions.length} versions in '${versionsDataFile}'`);
     console.log(`${npmVersions.length} npm versions`);
-    console.log(`${websiteVersions.length} website versions`);
+    console.log(`${versionsToProbe.size} versions to probe for archived docs`);
     console.log(`${missingNpmVersions.length} missing npm versions${missingNpmVersions.length ? ':' : ''}`);
     if (missingNpmVersions.length) {
         console.log(missingNpmVersions);
     }
 }
 
-function logFinalReport({ versionsDataFile, allVersions, noDocsUpdated }) {
+function logFinalReport({ versionsDataFile, allVersions, noDocsUpdated, probeCount }) {
     console.log(`Wrote changes to '${versionsDataFile}'`);
+    console.log(`${probeCount} versions probed`);
     console.log(`${noDocsUpdated} noDocs values updated`);
     console.log(`${allVersions.length} versions written`);
 }
 
-function updateNoDocs({ versions, websiteVersions }) {
+async function updateNoDocs({ versions, versionsToProbe }) {
     let num = 0;
-    // Check website to see if version has docs
-    const updatedVersions = versions.map((versionData) => {
-        const noDocs = !websiteVersions.includes(versionData.version);
+    let probeCount = 0;
+    const updatedVersions = [];
+
+    for (const versionData of versions) {
+        // Each probe is a network request, so only spend one where the answer is not already
+        // recorded. Pass --recheck-all to re-probe everything.
+        if (!versionsToProbe.has(versionData.version)) {
+            updatedVersions.push(versionData);
+            continue;
+        }
+
+        if (probeCount > 0) {
+            await delay(PROBE_DELAY_MS);
+        }
+        probeCount++;
 
         const newData = { ...versionData };
 
-        if (noDocs) {
-            newData.noDocs = true;
-
-            if (!versionData.noDocs) {
-                num++;
-            }
-        } else {
+        if (await hasArchivedDocs(versionData.version)) {
             delete newData.noDocs;
 
             if (versionData.noDocs) {
                 num++;
             }
+        } else {
+            newData.noDocs = true;
+
+            if (!versionData.noDocs) {
+                num++;
+            }
         }
 
-        return newData;
-    });
+        updatedVersions.push(newData);
+    }
 
     return {
         num,
+        probeCount,
         versions: updatedVersions,
     };
 }
 
-async function updateVersionsData({ isVerbose }: { isVerbose: boolean }) {
+async function updateVersionsData({ isVerbose, recheckAll }: { isVerbose: boolean; recheckAll: boolean }) {
     const versionsDataFile = VERSIONS_DATA_PATH;
     const agVersions = JSON.parse((await fs.readFile(VERSIONS_DATA_PATH)).toString());
     const allNpmVersionMap = getNpmLibraryVersions('ag-grid-community');
@@ -135,20 +184,30 @@ async function updateVersionsData({ isVerbose }: { isVerbose: boolean }) {
         .filter(({ version }) => {
             return version.match(/^\d+\.\d+\.\d+$/);
         });
-    const websiteVersions = await getWebsiteVersions();
     const missingNpmVersions = npmVersions.filter(({ version }) => {
         const hasVersion = agVersions.some((agVersion) => version === agVersion.version);
         return !hasVersion;
     });
 
-    if (isVerbose) {
-        logInitialReport({ versionsDataFile, agVersions, npmVersions, missingNpmVersions, websiteVersions });
-    }
-
     const combinedVersions = [...agVersions, ...missingNpmVersions].sort((a, b) => {
         return sortByVersionDesc(a.version, b.version);
     });
-    const { versions: allVersions, num: noDocsUpdated } = updateNoDocs({ versions: combinedVersions, websiteVersions });
+
+    // Versions already in the file have had their `noDocs` flag determined by an earlier run,
+    // so by default only the newly discovered ones need a probe.
+    const versionsToProbe = new Set(
+        recheckAll ? combinedVersions.map(({ version }) => version) : missingNpmVersions.map(({ version }) => version)
+    );
+
+    if (isVerbose) {
+        logInitialReport({ versionsDataFile, agVersions, npmVersions, missingNpmVersions, versionsToProbe });
+    }
+
+    const {
+        versions: allVersions,
+        num: noDocsUpdated,
+        probeCount,
+    } = await updateNoDocs({ versions: combinedVersions, versionsToProbe });
 
     if (missingNpmVersions.length || noDocsUpdated > 0) {
         const updatedVersions = JSON.stringify(allVersions, null, 4) + '\n';
@@ -157,7 +216,7 @@ async function updateVersionsData({ isVerbose }: { isVerbose: boolean }) {
         await fs.writeFile(VERSIONS_DATA_PATH, updatedVersions);
 
         if (isVerbose) {
-            logFinalReport({ versionsDataFile, allVersions, noDocsUpdated });
+            logFinalReport({ versionsDataFile, allVersions, noDocsUpdated, probeCount });
         }
     } else if (isVerbose) {
         console.log('No changes needed');
@@ -165,5 +224,6 @@ async function updateVersionsData({ isVerbose }: { isVerbose: boolean }) {
 }
 
 const isVerbose = process.argv.includes('--verbose');
+const recheckAll = process.argv.includes('--recheck-all');
 
-updateVersionsData({ isVerbose });
+updateVersionsData({ isVerbose, recheckAll });

--- a/documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json
+++ b/documentation/ag-grid-docs/src/content/versions/ag-grid-versions.json
@@ -27,6 +27,14 @@
         "hideBlogPostLink": false
     },
     {
+        "version": "36.0.2",
+        "date": "July 22nd, 2026"
+    },
+    {
+        "version": "36.0.1",
+        "date": "July 15th, 2026"
+    },
+    {
         "version": "36.0.0",
         "date": "June 24th 2026",
         "landingPageHighlight": "Calculated Columns, Show Values As, Automatic Column Generation, Accessibility Improvements, Theming Improvements",
@@ -52,6 +60,10 @@
         ],
         "notesPath": "./upgrading-to-ag-grid-36",
         "hideBlogPostLink": false
+    },
+    {
+        "version": "35.3.1",
+        "date": "June 2nd, 2026"
     },
     {
         "version": "35.3.0",
@@ -461,6 +473,14 @@
         ],
         "notesPath": "./upgrading-to-ag-grid-33",
         "hideBlogPostLink": false
+    },
+    {
+        "version": "32.3.9",
+        "date": "August 13th, 2025"
+    },
+    {
+        "version": "32.3.8",
+        "date": "June 10th, 2025"
     },
     {
         "version": "32.3.7",


### PR DESCRIPTION
Replaces #14700, which fixed how the archive page was fetched but kept the underlying
mistake: `/documentation-archive/` is **generated from the very file this script
writes**. `MajorTable` renders `versionsData.filter((entry) => … && !entry.noDocs)`
(`external/ag-website-shared/src/markdoc/buildMajorTable.ts`), so deriving `noDocs`
from it is circular, and self-reinforcing:

- a version missing from the JSON can never appear on the page, so it is flagged
- once flagged it is filtered off the page, so the next run re-flags it

A flag could therefore never be cleared, and every newly added version acquired one
permanently. #14700 made that ratchet work reliably rather than removing it - it
wrongly flagged 18.1.0, 32.3.8 and 32.3.9, all of which are archived. `/archive` is
also no longer a listing; it redirects to the generated page.

Ask the server instead - `HEAD …/archive/<version>/`, **without following redirects**:

| Response | Meaning |
|---|---|
| 200 | archived |
| 404 | not archived |
| 3xx | archived only if `location` stays within `/archive/<version>` |
| anything else (403 bot filter, 429) | unknown -> throw |

The last row is the point: a blocked or rate-limited request must never be recorded as
"no archived docs", because that is what silently strips versions from
`VersionsSelector` and the archive table. The redirect row guards a soft-404 pattern
seen on the charts site, where an unpublished version 301s to a 404 page that itself
answers 200; grid does not currently do this, but the three scripts are kept
consistent.

**Request volume.** Only versions whose flag is not already recorded get probed, so a
normal run makes zero archive requests. `--recheck-all` re-probes everything,
sequentially and spaced by `PROBE_DELAY_MS`.

**Second commit: data.** A full re-probe of all 141 versions changed **no** `noDocs`
flags, so the existing 24 are all correct - it only surfaced five released versions
that were never added (36.0.2, 36.0.1, 35.3.1, 32.3.9, 32.3.8), all archived.
Spot-checked independently with `curl -I`, in both directions: 32.3.9, 36.0.2 and
18.1.0 return 200 and carry no flag; 33.0.1, 31.2.1 and 31.1.1 return 404 and keep
theirs.

Same fix in ag-charts (#7674) and ag-studio (#2292), which share this script.
