### PR TITLE
[RTI-3423] Fix(docs): enable grouping in columns tool panel examples

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/theming-tool-panels/_examples/column-tool-panel/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/theming-tool-panels/_examples/column-tool-panel/main.ts
@@ -20,18 +20,27 @@ const gridOptions: GridOptions<IOlympicData> = {
         {
             headerName: 'Athlete',
             children: [
-                { field: 'athlete', minWidth: 170, rowGroup: true },
-                { field: 'age', rowGroup: true },
-                { field: 'country' },
+                { field: 'athlete', minWidth: 170, rowGroup: true, enableRowGroup: true, enablePivot: true },
+                { field: 'age', rowGroup: true, enableRowGroup: true, enablePivot: true },
+                { field: 'country', enableRowGroup: true, enablePivot: true },
             ],
         },
         {
             headerName: 'Event',
-            children: [{ field: 'year' }, { field: 'date' }, { field: 'sport' }],
+            children: [
+                { field: 'year', enableRowGroup: true, enablePivot: true },
+                { field: 'date' },
+                { field: 'sport', enableRowGroup: true, enablePivot: true },
+            ],
         },
         {
             headerName: 'Medals',
-            children: [{ field: 'gold' }, { field: 'silver' }, { field: 'bronze' }, { field: 'total' }],
+            children: [
+                { field: 'gold', enableValue: true },
+                { field: 'silver', enableValue: true },
+                { field: 'bronze', enableValue: true },
+                { field: 'total', enableValue: true },
+            ],
         },
     ],
     defaultColDef: {

--- a/documentation/ag-grid-docs/src/content/docs/theming-tool-panels/_examples/tool-panel-tabs/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/theming-tool-panels/_examples/tool-panel-tabs/main.ts
@@ -18,16 +18,16 @@ const myTheme = themeQuartz.withParams({
 });
 
 const columnDefs: ColDef[] = [
-    { field: 'athlete', minWidth: 170 },
-    { field: 'age' },
-    { field: 'country' },
-    { field: 'year' },
+    { field: 'athlete', minWidth: 170, enableRowGroup: true, enablePivot: true },
+    { field: 'age', enableRowGroup: true, enablePivot: true },
+    { field: 'country', enableRowGroup: true, enablePivot: true },
+    { field: 'year', enableRowGroup: true, enablePivot: true },
     { field: 'date' },
-    { field: 'sport' },
-    { field: 'gold' },
-    { field: 'silver' },
-    { field: 'bronze' },
-    { field: 'total' },
+    { field: 'sport', enableRowGroup: true, enablePivot: true },
+    { field: 'gold', enableValue: true },
+    { field: 'silver', enableValue: true },
+    { field: 'bronze', enableValue: true },
+    { field: 'total', enableValue: true },
 ];
 
 let gridApi: GridApi<IOlympicData>;
@@ -38,9 +38,6 @@ const gridOptions: GridOptions<IOlympicData> = {
     defaultColDef: {
         editable: true,
         filter: true,
-        enableRowGroup: true,
-        enablePivot: true,
-        enableValue: true,
     },
     sideBar: true,
 };

--- a/documentation/ag-grid-docs/src/content/docs/theming-v32-customisation-tool-panels/_examples/column-tool-panel/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/theming-v32-customisation-tool-panels/_examples/column-tool-panel/main.ts
@@ -44,18 +44,27 @@ const gridOptions: GridOptions<IOlympicData> = {
         {
             headerName: 'Athlete',
             children: [
-                { field: 'athlete', minWidth: 170, rowGroup: true },
-                { field: 'age', rowGroup: true },
-                { field: 'country' },
+                { field: 'athlete', minWidth: 170, rowGroup: true, enableRowGroup: true, enablePivot: true },
+                { field: 'age', rowGroup: true, enableRowGroup: true, enablePivot: true },
+                { field: 'country', enableRowGroup: true, enablePivot: true },
             ],
         },
         {
             headerName: 'Event',
-            children: [{ field: 'year' }, { field: 'date' }, { field: 'sport' }],
+            children: [
+                { field: 'year', enableRowGroup: true, enablePivot: true },
+                { field: 'date' },
+                { field: 'sport', enableRowGroup: true, enablePivot: true },
+            ],
         },
         {
             headerName: 'Medals',
-            children: [{ field: 'gold' }, { field: 'silver' }, { field: 'bronze' }, { field: 'total' }],
+            children: [
+                { field: 'gold', enableValue: true },
+                { field: 'silver', enableValue: true },
+                { field: 'bronze', enableValue: true },
+                { field: 'total', enableValue: true },
+            ],
         },
     ],
     defaultColDef: {


### PR DESCRIPTION
Examples showing the columns tool panel rendered the row group / pivot / values drop zones but no column could be dragged into them, because `enableRowGroup`/`enablePivot`/`enableValue` were not set.

Adds all three to `defaultColDef` in the reported example and its close siblings, matching the existing `tool-panel-tabs` example on the same page.

Fixes [RTI-3423](https://ag-grid.atlassian.net/browse/RTI-3423)