### PR TITLE
RTI-3414-click-while-collapse-animation-loses-focus

### DIFF
--- a/packages/ag-grid-community/src/gridBodyComp/rowContainer/rowContainerEventsFeature.ts
+++ b/packages/ag-grid-community/src/gridBodyComp/rowContainer/rowContainerEventsFeature.ts
@@ -20,6 +20,13 @@ import { _isStopPropagationForAgGrid } from '../../utils/gridEvent';
 import { _isUserSuppressingKeyboardEvent } from '../../utils/keyboardEvent';
 import { _selectAllCells } from '../../utils/selection';
 
+interface EventTargetCtrls {
+    cellCtrl: CellCtrl | null;
+    rowCtrl: RowCtrl | null;
+    /** True when the event came from a row animating out and was moved onto the row now owning its slot. */
+    retargeted?: boolean;
+}
+
 export class RowContainerEventsFeature extends BeanStub {
     private editSvc?: EditService;
 
@@ -60,7 +67,7 @@ export class RowContainerEventsFeature extends BeanStub {
             return;
         }
 
-        const { cellCtrl, rowCtrl } = this.getControlsForEventTarget(mouseEvent.target);
+        const { cellCtrl, rowCtrl, retargeted } = this.getControlsForEventTarget(mouseEvent.target);
 
         if (eventName === 'contextmenu') {
             if (!cellCtrl && !rowCtrl) {
@@ -72,22 +79,47 @@ export class RowContainerEventsFeature extends BeanStub {
             this.beans.contextMenuSvc?.handleContextMenuMouseEvent(mouseEvent, undefined, rowCtrl, cellCtrl);
         } else {
             if (cellCtrl) {
-                cellCtrl.onMouseEvent(eventName, mouseEvent);
+                cellCtrl.onMouseEvent(eventName, mouseEvent, retargeted);
             }
             if (rowCtrl) {
-                rowCtrl.onMouseEvent(eventName, mouseEvent);
+                rowCtrl.onMouseEvent(eventName, mouseEvent, retargeted);
             }
         }
     }
 
-    public getControlsForEventTarget(target: EventTarget | null): {
-        cellCtrl: CellCtrl | null;
-        rowCtrl: RowCtrl | null;
-    } {
+    public getControlsForEventTarget(target: EventTarget | null): EventTargetCtrls {
         const { gos } = this;
+        const cellCtrl = _getCellCtrlForEventTarget(gos, target);
+        const rowCtrl = _getRowCtrlForEventTarget(gos, target);
+
+        // A row animating out keeps its destroyed ctrls (and dom) until the animation ends, but its node has
+        // already lost its position, so acting on them would focus a cell that is about to be removed.
+        // The row's own dom data goes on destroy, so a stale row is only reachable through its cells.
+        const ownerRowCtrl = cellCtrl?.rowCtrl ?? rowCtrl;
+        if (ownerRowCtrl?.destroyed) {
+            return this.getCtrlsForVacatedSlot(ownerRowCtrl, cellCtrl?.column);
+        }
+
+        return { cellCtrl, rowCtrl };
+    }
+
+    /** The live ctrls for the display slot the given animating-out row is vacating, if it is still rendered. */
+    private getCtrlsForVacatedSlot(staleRowCtrl: RowCtrl, column: AgColumn | undefined): EventTargetCtrls {
+        const { rowModel, rowRenderer } = this.beans;
+        const { oldRowTop, rowPinned } = staleRowCtrl.rowNode;
+
+        // a pinned row's top is in its own model's coordinates, so it cannot be looked up against the body
+        if (oldRowTop == null || rowPinned) {
+            return { cellCtrl: null, rowCtrl: null, retargeted: true };
+        }
+
+        const rowIndex = rowModel.getRowIndexAtPixel(oldRowTop);
+        const rowCtrl = rowRenderer.getRowByPosition({ rowIndex, rowPinned: null });
+
         return {
-            cellCtrl: _getCellCtrlForEventTarget(gos, target),
-            rowCtrl: _getRowCtrlForEventTarget(gos, target),
+            cellCtrl: column && rowCtrl ? rowCtrl.getCellCtrl(column) : null,
+            rowCtrl,
+            retargeted: true,
         };
     }
 

--- a/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellCtrl.ts
@@ -752,8 +752,8 @@ export class CellCtrl extends BeanStub {
         _onCellKeyDown(this.beans, this, event);
     }
 
-    public onMouseEvent(eventName: string, mouseEvent: MouseEvent): void {
-        _onCellMouseEvent(this.beans, this, eventName, mouseEvent);
+    public onMouseEvent(eventName: string, mouseEvent: MouseEvent, retargeted?: boolean): void {
+        _onCellMouseEvent(this.beans, this, eventName, mouseEvent, retargeted);
     }
 
     public getColSpanningList(): AgColumn[] {

--- a/packages/ag-grid-community/src/rendering/cell/cellMouseListenerFeature.ts
+++ b/packages/ag-grid-community/src/rendering/cell/cellMouseListenerFeature.ts
@@ -12,7 +12,8 @@ export function _onCellMouseEvent(
     beans: BeanCollection,
     cellCtrl: CellCtrl,
     eventName: string,
-    mouseEvent: MouseEvent
+    mouseEvent: MouseEvent,
+    retargeted?: boolean
 ): void {
     if (_isStopPropagationForAgGrid(mouseEvent)) {
         return;
@@ -25,16 +26,16 @@ export function _onCellMouseEvent(
         case 'pointerdown':
         case 'mousedown':
         case 'touchstart':
-            onMouseDown(beans, cellCtrl, mouseEvent);
+            onMouseDown(beans, cellCtrl, mouseEvent, retargeted);
             break;
         case 'dblclick':
             _onCellDoubleClicked(beans, cellCtrl, mouseEvent);
             break;
         case 'mouseout':
-            onMouseOut(beans, cellCtrl, mouseEvent);
+            onMouseOut(beans, cellCtrl, mouseEvent, retargeted);
             break;
         case 'mouseover':
-            onMouseOver(beans, cellCtrl, mouseEvent);
+            onMouseOver(beans, cellCtrl, mouseEvent, retargeted);
             break;
     }
 }
@@ -146,7 +147,12 @@ export function _onCellDoubleClicked(beans: BeanCollection, cellCtrl: CellCtrl, 
     }
 }
 
-function onMouseDown(beans: BeanCollection, cellCtrl: CellCtrl, mouseEvent: MouseEvent): void {
+function onMouseDown(beans: BeanCollection, cellCtrl: CellCtrl, mouseEvent: MouseEvent, retargeted?: boolean): void {
+    if (retargeted) {
+        // the event came from a row animating out, so stop the browser focusing that doomed element
+        mouseEvent.preventDefault();
+    }
+
     const { shiftKey } = mouseEvent;
     const target = mouseEvent.target as HTMLElement;
     const { eventSvc, rangeSvc, rowNumbersSvc, focusSvc, gos, editSvc } = beans;
@@ -172,7 +178,8 @@ function onMouseDown(beans: BeanCollection, cellCtrl: CellCtrl, mouseEvent: Mous
     }
 
     const hasRanges = rangeSvc && !rangeSvc.isEmpty();
-    const containsWidget = cellContainsWidget(target);
+    // a retargeted event's target is the dying row, so any widget under it is not this cell's
+    const containsWidget = !retargeted && cellContainsWidget(target);
 
     const isRowNumberColumn = isRowNumberCol(column);
 
@@ -190,8 +197,11 @@ function onMouseDown(beans: BeanCollection, cellCtrl: CellCtrl, mouseEvent: Mous
         // however, this should never be true if the mousedown was triggered
         // due to a click on a cell editor for example, otherwise cell selection within
         // an editor would be blocked.
+        // A retargeted event says nothing about this cell (its target is the dying row), and the browser
+        // focus we suppressed above has to be replaced.
         const forceBrowserFocus =
-            (_isBrowserSafari() || shouldFocus) && !editing && !_isFocusableFormField(target) && !containsWidget;
+            !editing &&
+            (retargeted || ((_isBrowserSafari() || shouldFocus) && !_isFocusableFormField(target) && !containsWidget));
 
         cellCtrl.focusCell({ forceBrowserFocus, sourceEvent: mouseEvent });
     }
@@ -259,8 +269,8 @@ function cellContainsWidget(target: HTMLElement): boolean {
     );
 }
 
-function onMouseOut(beans: BeanCollection, cellCtrl: CellCtrl, mouseEvent: MouseEvent): void {
-    if (mouseStayingInsideCell(cellCtrl, mouseEvent)) {
+function onMouseOut(beans: BeanCollection, cellCtrl: CellCtrl, mouseEvent: MouseEvent, retargeted?: boolean): void {
+    if (mouseStayingInsideCell(cellCtrl, mouseEvent, retargeted)) {
         return;
     }
     const { eventSvc, colHover } = beans;
@@ -268,8 +278,8 @@ function onMouseOut(beans: BeanCollection, cellCtrl: CellCtrl, mouseEvent: Mouse
     colHover?.clearMouseOver();
 }
 
-function onMouseOver(beans: BeanCollection, cellCtrl: CellCtrl, mouseEvent: MouseEvent): void {
-    if (mouseStayingInsideCell(cellCtrl, mouseEvent)) {
+function onMouseOver(beans: BeanCollection, cellCtrl: CellCtrl, mouseEvent: MouseEvent, retargeted?: boolean): void {
+    if (mouseStayingInsideCell(cellCtrl, mouseEvent, retargeted)) {
         return;
     }
     const { eventSvc, colHover } = beans;
@@ -277,11 +287,15 @@ function onMouseOver(beans: BeanCollection, cellCtrl: CellCtrl, mouseEvent: Mous
     colHover?.setMouseOver([cellCtrl.column]);
 }
 
-function mouseStayingInsideCell(cellCtrl: CellCtrl, e: MouseEvent): boolean {
+function mouseStayingInsideCell(cellCtrl: CellCtrl, e: MouseEvent, retargeted?: boolean): boolean {
     if (!e.target || !e.relatedTarget) {
         return false;
     }
-    const eCell = cellCtrl.eGui;
+    // a retargeted event's target sits in the dying row, so the pointer's own cell is what we compare against
+    const eCell = retargeted ? (e.target as HTMLElement).closest('.ag-cell') : cellCtrl.eGui;
+    if (!eCell) {
+        return false;
+    }
     const cellContainsTarget = eCell.contains(e.target as Node);
     const cellContainsRelatedTarget = eCell.contains(e.relatedTarget as Node);
     return cellContainsTarget && cellContainsRelatedTarget;

--- a/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
+++ b/packages/ag-grid-community/src/rendering/row/rowCtrl.ts
@@ -792,7 +792,7 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         this.rowModeFeature.recreateCell(cellCtrl);
     }
 
-    public onMouseEvent(eventName: string, mouseEvent: MouseEvent): void {
+    public onMouseEvent(eventName: string, mouseEvent: MouseEvent, retargeted?: boolean): void {
         switch (eventName) {
             case 'dblclick':
                 this.onRowDblClick(mouseEvent);
@@ -803,7 +803,7 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
             case 'pointerdown':
             case 'touchstart':
             case 'mousedown':
-                this.onRowMouseDown(mouseEvent);
+                this.onRowMouseDown(mouseEvent, retargeted);
                 break;
         }
     }
@@ -854,8 +854,10 @@ export class RowCtrl extends BeanStub<RowCtrlEvent> {
         return this.rowModeFeature.getTarget?.(element);
     }
 
-    private onRowMouseDown(mouseEvent: MouseEvent) {
-        this.lastMouseDownOnDragger = _isElementChildOfClass(mouseEvent.target as HTMLElement, 'ag-row-drag', 3);
+    private onRowMouseDown(mouseEvent: MouseEvent, retargeted?: boolean) {
+        // a retargeted event's target is the dying row, so any dragger under it is not this row's
+        this.lastMouseDownOnDragger =
+            !retargeted && _isElementChildOfClass(mouseEvent.target as HTMLElement, 'ag-row-drag', 3);
         this.rowModeFeature.onRowMouseDown?.(mouseEvent);
     }
 

--- a/testing/behavioural/src/rows/interaction-during-row-animation-react.test.tsx
+++ b/testing/behavioural/src/rows/interaction-during-row-animation-react.test.tsx
@@ -1,0 +1,116 @@
+import { act, cleanup, render } from '@testing-library/react';
+import React from 'react';
+
+import type { ColDef, GridApi } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    GROUP_AUTO_COLUMN_ID,
+    KeyCode,
+    ModuleRegistry,
+    RenderApiModule,
+    ValidationModule,
+} from 'ag-grid-community';
+import { RowGroupingModule } from 'ag-grid-enterprise';
+import { AgGridReact } from 'ag-grid-react';
+
+import { asyncSetTimeout, ignoreConsoleLicenseKeyError } from '../test-utils';
+
+interface RowData {
+    category: string;
+    value: string;
+}
+
+const columnDefs: ColDef<RowData>[] = [
+    { field: 'category', rowGroup: true, hide: true },
+    { field: 'value', colId: 'value' },
+];
+
+// Expanded layout (groupDefaultExpanded: -1):
+//   row 0: group A
+//   row 1: leaf { category:'A', value:'v1' }
+//   row 2: leaf { category:'A', value:'v2' }
+//   row 3: group B
+//   row 4: leaf { category:'B', value:'v3' }
+const rowData: RowData[] = [
+    { category: 'A', value: 'v1' },
+    { category: 'A', value: 'v2' },
+    { category: 'B', value: 'v3' },
+];
+
+function getCell(rowId: string, colId: string): HTMLElement {
+    const cell = document.querySelector(`[row-id="${rowId}"] [col-id="${colId}"]`);
+    if (!cell) {
+        throw new Error(`No cell for row ${rowId} / column ${colId}`);
+    }
+    return cell as HTMLElement;
+}
+
+describe('Interactions while rows animate out (React)', () => {
+    beforeAll(() => {
+        ModuleRegistry.registerModules([
+            ClientSideRowModelModule,
+            RowGroupingModule,
+            RenderApiModule,
+            ValidationModule,
+        ]);
+        ignoreConsoleLicenseKeyError();
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    test('clicking a row that is animating out focuses the row now occupying that slot', async () => {
+        let resolveReady!: (api: GridApi) => void;
+        const readyPromise = new Promise<GridApi>((resolve) => {
+            resolveReady = resolve;
+        });
+
+        act(() => {
+            render(
+                <AgGridReact
+                    rowData={rowData}
+                    columnDefs={columnDefs}
+                    groupDefaultExpanded={-1}
+                    suppressRowVirtualisation
+                    suppressColumnVirtualisation
+                    animateRows
+                    onGridReady={(e) => resolveReady(e.api)}
+                />
+            );
+        });
+
+        const api = await readyPromise;
+        await asyncSetTimeout(0); // allow React to complete the initial cell render pass
+
+        act(() => api.setFocusedCell(0, GROUP_AUTO_COLUMN_ID));
+
+        // collapse group A; its two leaves stay in the dom, fading out, until the animation completes
+        act(() => {
+            getCell('row-group-category-A', GROUP_AUTO_COLUMN_ID).dispatchEvent(
+                new KeyboardEvent('keydown', { key: KeyCode.ENTER, bubbles: true, cancelable: true })
+            );
+            api.flushAllAnimationFrames();
+        });
+        await act(() => asyncSetTimeout(0));
+
+        // the leaf that was at row index 1 is still rendered, covering the slot group B now owns.
+        // jsdom reports no pointer/mouse support, so the grid listens for touchstart as its mouse down event
+        act(() => {
+            getCell('0', GROUP_AUTO_COLUMN_ID).dispatchEvent(
+                new MouseEvent('touchstart', { bubbles: true, cancelable: true })
+            );
+        });
+
+        expect(api.getFocusedCell()?.rowIndex).toBe(1);
+        expect(api.getFocusedCell()?.column.getColId()).toBe(GROUP_AUTO_COLUMN_ID);
+        expect(document.activeElement).toBe(getCell('row-group-category-B', GROUP_AUTO_COLUMN_ID));
+
+        act(() => {
+            (document.activeElement as HTMLElement).dispatchEvent(
+                new KeyboardEvent('keydown', { key: KeyCode.DOWN, bubbles: true, cancelable: true })
+            );
+        });
+        expect(api.getFocusedCell()?.rowIndex).toBe(2);
+    });
+});

--- a/testing/behavioural/src/rows/interaction-during-row-animation.test.ts
+++ b/testing/behavioural/src/rows/interaction-during-row-animation.test.ts
@@ -1,0 +1,158 @@
+import type { CellMouseDownEvent, CellMouseOverEvent, ColDef, GridApi, GridOptions } from 'ag-grid-community';
+import {
+    ClientSideRowModelModule,
+    EventApiModule,
+    GROUP_AUTO_COLUMN_ID,
+    KeyCode,
+    RenderApiModule,
+    RowDragModule,
+} from 'ag-grid-community';
+import { RowGroupingModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout, initPointerEventPolyfill } from '../test-utils';
+
+interface RowData {
+    category: string;
+    value: string;
+}
+
+// Expanded layout (groupDefaultExpanded: -1):
+//   row 0: group A
+//   row 1: leaf { category:'A', value:'v1' }   <- fades out on collapse, covering the slot group B takes
+//   row 2: leaf { category:'A', value:'v2' }
+//   row 3: group B
+//   row 4: leaf { category:'B', value:'v3' }
+const rowData: RowData[] = [
+    { category: 'A', value: 'v1' },
+    { category: 'A', value: 'v2' },
+    { category: 'B', value: 'v3' },
+];
+
+const FADING_LEAF = '0';
+const GROUP_B = 'row-group-category-B';
+
+function getCell(rowId: string, colId: string): HTMLElement {
+    const cell = document.querySelector(`[row-id="${rowId}"] [col-id="${colId}"]`);
+    if (!cell) {
+        throw new Error(`No cell for row ${rowId} / column ${colId}`);
+    }
+    return cell as HTMLElement;
+}
+
+function dispatchPointerDown(element: HTMLElement): void {
+    element.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true }));
+}
+
+describe('Interactions while rows animate out', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, RowGroupingModule, RenderApiModule, RowDragModule, EventApiModule],
+    });
+
+    beforeAll(() => {
+        // without it jsdom reports no pointer support and the grid falls back to touchstart, which the
+        // row drag handle then rejects for having no touches
+        initPointerEventPolyfill();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    /** Collapses group A and leaves its leaves in the dom, mid fade-out, as they are when the user clicks one. */
+    function createGridWithCollapsingGroup(columnDefs: ColDef<RowData>[]): GridApi<RowData> {
+        const api: GridApi<RowData> = gridsManager.createGrid('myGrid', {
+            columnDefs,
+            rowData,
+            groupDefaultExpanded: -1,
+            animateRows: true,
+            // animation is suppressed while the grid enforces dom order
+            ensureDomOrder: false,
+        } as GridOptions<RowData>);
+
+        api.flushAllAnimationFrames();
+        api.setFocusedCell(0, GROUP_AUTO_COLUMN_ID);
+        getCell('row-group-category-A', GROUP_AUTO_COLUMN_ID).dispatchEvent(
+            new KeyboardEvent('keydown', { key: KeyCode.ENTER, bubbles: true, cancelable: true })
+        );
+        api.flushAllAnimationFrames();
+
+        return api;
+    }
+
+    test('clicking a row that is animating out focuses the row now occupying that slot', () => {
+        const api = createGridWithCollapsingGroup([
+            { field: 'category', rowGroup: true, hide: true },
+            { field: 'value', colId: 'value' },
+        ]);
+
+        dispatchPointerDown(getCell(FADING_LEAF, GROUP_AUTO_COLUMN_ID));
+
+        expect(api.getFocusedCell()?.rowIndex).toBe(1);
+        expect(api.getFocusedCell()?.column.getColId()).toBe(GROUP_AUTO_COLUMN_ID);
+        expect(document.activeElement).toBe(getCell(GROUP_B, GROUP_AUTO_COLUMN_ID));
+
+        (document.activeElement as HTMLElement).dispatchEvent(
+            new KeyboardEvent('keydown', { key: KeyCode.DOWN, bubbles: true, cancelable: true })
+        );
+        expect(api.getFocusedCell()?.rowIndex).toBe(2);
+    });
+
+    test('a widget on the row animating out does not suppress cell handling for the row taking its slot', async () => {
+        const api = createGridWithCollapsingGroup([
+            { field: 'category', rowGroup: true, hide: true },
+            { field: 'value', colId: 'value', rowDrag: true },
+        ]);
+
+        const mouseDownEvents: CellMouseDownEvent<RowData>[] = [];
+        api.addEventListener('cellMouseDown', (e) => mouseDownEvents.push(e));
+
+        const dragger = getCell(FADING_LEAF, 'value').querySelector('.ag-row-drag') as HTMLElement;
+        expect(dragger).toBeTruthy();
+        dispatchPointerDown(dragger);
+        await asyncSetTimeout(0);
+
+        // the drag handle belongs to the dying row, so this counts as a plain click on the live cell
+        expect(mouseDownEvents).toHaveLength(1);
+        expect(mouseDownEvents[0].node.id).toBe(GROUP_B);
+        expect(api.getFocusedCell()?.rowIndex).toBe(1);
+    });
+
+    test('a drag handle on the row animating out does not suppress rowClicked for the row taking its slot', async () => {
+        const api = createGridWithCollapsingGroup([
+            { field: 'category', rowGroup: true, hide: true },
+            { field: 'value', colId: 'value', rowDrag: true },
+        ]);
+
+        const rowClickedIds: (string | undefined)[] = [];
+        api.addEventListener('rowClicked', (e) => rowClickedIds.push(e.node.id));
+
+        const dragger = getCell(FADING_LEAF, 'value').querySelector('.ag-row-drag') as HTMLElement;
+        dispatchPointerDown(dragger);
+        dragger.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+        await asyncSetTimeout(0);
+
+        expect(rowClickedIds).toEqual([GROUP_B]);
+    });
+
+    test('moving within a cell of the row animating out reports the hover once', async () => {
+        const api = createGridWithCollapsingGroup([
+            { field: 'category', rowGroup: true, hide: true },
+            { field: 'value', colId: 'value' },
+        ]);
+
+        const mouseOverEvents: CellMouseOverEvent<RowData>[] = [];
+        api.addEventListener('cellMouseOver', (e) => mouseOverEvents.push(e));
+
+        const fadingCell = getCell(FADING_LEAF, GROUP_AUTO_COLUMN_ID);
+        const inner = fadingCell.firstElementChild as HTMLElement;
+        expect(inner).toBeTruthy();
+
+        fadingCell.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+        // the pointer moves into a child of the same cell, so it is the same hover and must not be reported again
+        inner.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, relatedTarget: fadingCell }));
+        await asyncSetTimeout(0);
+
+        expect(mouseOverEvents).toHaveLength(1);
+        expect(mouseOverEvents[0].node.id).toBe(GROUP_B);
+    });
+});


### PR DESCRIPTION
# fix(focus): clicking a row that is animating out no longer loses focus

FIX RTI-3414

## Problem

Collapse a group with `animateRows` on, then click a row while it animates. Focus is lost, and arrow
keys scroll the viewport instead of moving the focused cell.

Removed rows are destroyed in a first pass only: their `CellCtrl`s and DOM linger for 400ms to fade out,
but their `RowNode`s have already lost `rowTop` and `rowIndex`. A click in that window is handled by a
stale cell, so the grid records `{ rowIndex: null }` and the browser focuses a doomed element.

## Solution

`getControlsForEventTarget` retargets such an event to the row now owning that display slot, resolved
with `getRowIndexAtPixel(oldRowTop)`. A stale row is only reachable through its cells, since the row's
own dom data goes on destroy. `onMouseDown` then calls `preventDefault()` so the browser cannot focus
the dying element, and focuses the live cell instead. Clicks, context menus, cell selection and the
keyboard path follow, as they share that lookup.

That leaves the ctrl live while `mouseEvent.target` still points into the dying row, so three decisions
taken from `target` are skipped when retargeted: `containsWidget` and `lastMouseDownOnDragger`, which
would let a stale checkbox or drag handle suppress the live cell's `cellMouseDown` and its row's
`rowClicked`, and `mouseStayingInsideCell`, whose hover de-dup never matches across two elements.

## Notes

The whole mousedown runs against the retargeted cell, so a cell range starts there too.
`getRowIndexAtPixel` clamps, so clicking below the new end of the grid focuses the last row.

## Tests

`rows/interaction-during-row-animation.test.ts` collapses a group and interacts with a fading row,
covering the retarget and each of the three guards; all four fail without the fix. The React twin covers
the focus path, since `CellCtrl.onMouseEvent` is a twinned controller.
