### PR TITLE
RTI-3411 locking group column drag icons disabled

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/grouping-group-panel/_examples/prevent-group-order-changes/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grouping-group-panel/_examples/prevent-group-order-changes/example.spec.ts
@@ -10,17 +10,22 @@ test.agExample(import.meta, () => {
         await expect(rowGroupsArea.getByText('Country', { exact: true })).toBeVisible();
         await expect(rowGroupsArea.getByText('Year', { exact: true })).toBeVisible();
 
-        // `groupLockGroupColumns: -1` locks every pill — the remove (X) button must not
-        // be shown, and the drag handle carries the readonly class so the pill cannot be
-        // dragged out of the panel.
+        // `groupLockGroupColumns: -1` locks every pill, so the remove (X) button is not shown.
         const removeButtons = pills.locator('.ag-column-drop-cell-button');
         const count = await removeButtons.count();
         for (let i = 0; i < count; i++) {
             await expect(removeButtons.nth(i)).toBeHidden();
         }
 
+        // The drag handles carry the readonly class so the pills cannot be dragged out of the
+        // panel, and are dimmed to show as disabled even though no tool panel is loaded.
         const dragHandles = pills.locator('.ag-column-drop-cell-drag-handle');
-        await expect(dragHandles.first()).toHaveClass(/ag-column-select-column-readonly/);
-        await expect(dragHandles.last()).toHaveClass(/ag-column-select-column-readonly/);
+        const handleCount = await dragHandles.count();
+        for (let i = 0; i < handleCount; i++) {
+            const handle = dragHandles.nth(i);
+            await expect(handle).toHaveClass(/ag-column-select-column-readonly/);
+            await expect(handle).toHaveCSS('opacity', '0.5');
+            await expect(handle.locator('.ag-icon')).toHaveCSS('opacity', '0.35');
+        }
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/grouping-group-panel/_examples/prevent-group-order-changes/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/grouping-group-panel/_examples/prevent-group-order-changes/example.spec.ts
@@ -20,8 +20,8 @@ test.agExample(import.meta, () => {
         // The drag handles carry the readonly class so the pills cannot be dragged out of the
         // panel, and are dimmed to show as disabled even though no tool panel is loaded.
         const dragHandles = pills.locator('.ag-column-drop-cell-drag-handle');
-        const handleCount = await dragHandles.count();
-        for (let i = 0; i < handleCount; i++) {
+        await expect(dragHandles).toHaveCount(2);
+        for (let i = 0; i < 2; i++) {
             const handle = dragHandles.nth(i);
             await expect(handle).toHaveClass(/ag-column-select-column-readonly/);
             await expect(handle).toHaveCSS('opacity', '0.5');

--- a/packages/ag-grid-enterprise/src/widgets/pillDropZonePanel.css
+++ b/packages/ag-grid-enterprise/src/widgets/pillDropZonePanel.css
@@ -85,6 +85,15 @@
     margin-left: calc(var(--ag-spacing) / 4);
 }
 
+.ag-column-drop-cell-drag-handle.ag-column-select-column-readonly {
+    opacity: 0.5;
+    pointer-events: none;
+
+    :where(.ag-icon) {
+        opacity: 0.35;
+    }
+}
+
 .ag-column-drop-wrapper {
     display: flex;
 }


### PR DESCRIPTION
# RTI-3411 Locked row group pills show enabled drag icons without the Columns Tool Panel

FIX RTI-3411

## Problem

With `groupLockGroupColumns` set, the Row Group Panel pills are correctly non-draggable but their grip
icons render at full opacity, so they look enabled. Adding `sideBar` makes them appear disabled again.

## Cause

`PillDragComp` marks a locked pill's drag handle with `ag-column-select-column-readonly`, but that class
is only styled in `agPrimaryCols.css` — CSS registered by the `AgPrimaryCols` component, so it is
injected only once the Columns Tool Panel is instantiated. Without it the class lands on the handle with
no styling attached.

Worked in 34.1 because the same rules also lived in the always-injected core stylesheet
(`theming/core/css/_icons.css`); `db2ecb73118` (AG-15429 — split themes) dropped them from core, leaving
the tool-panel copy as the only one.

## Fix

Added the readonly styling for the pill drag handle to `pillDropZonePanel.css`, registered by
`PillDropZonePanel` — the only creator of pills (row group / pivot / aggregation zones and the charts
pill select). Values match what `agPrimaryCols.css` produces today, so the appearance is identical
whether or not the tool panel is loaded and the duplicate declarations cannot conflict.

## Legacy Themes

No Legacy Themes change is needed. Legacy ships one stylesheet rather than per-module CSS, so the rule
is never conditional on the tool panel:

- `base/parts/_widgets.scss` gives `.ag-column-select-column-readonly` the disabled foreground colour
  and `pointer-events: none`, and `base/_index.scss` includes that part unconditionally.
- Alpine, Balham and Quartz each set `.ag-column-select-column-readonly .ag-icon-grip` to `opacity: 0.35`
  — the same value as the Theming API fix. The pill's icon carries `ag-icon-grip` because
  `agGridEnterpriseModule` maps the `columnDrag` icon to `grip`.

## Tests

`prevent-group-order-changes/example.spec.ts` previously asserted only that the readonly class was
present, which passed while the bug was live. It now asserts computed opacity on the handle and its
icon, and asserts a handle count first so the loop cannot pass vacuously if the handles disappear. The
opacity assertions fail against the unfixed build (`Expected "0.5", Received "1"`) and pass after.
`./docs-e2e.sh "grouping-group-panel"` green across all 30 framework runs.
