### PR TITLE
[RTI-3409] Fix(docs): split column state examples into subsections

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/column-updating-definitions/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/column-updating-definitions/index.mdoc
@@ -85,6 +85,8 @@ const gridOptions = {
 }
 ```
 
+### Initial Attributes
+
 The example below shows Column Definitions using **initial attributes**. Note the following:
 
 - The `initialWidth`, `initialSort` and `initialPinned` are applied only when the columns are created.
@@ -92,6 +94,8 @@ The example below shows Column Definitions using **initial attributes**. Note th
 - Removing the columns first and then setting them again will use the initial values again.
 
 {% gridExampleRunner title="Updating Column Initial Attributes" name="changing-default" /%}
+
+### Stateful Attributes
 
 The following example shows Column Definitions using **stateful attributes**. Note the following:
 


### PR DESCRIPTION
Adds `Initial Attributes` and `Stateful Attributes` subsections under *Changing Column State* on the Updating Column Definitions page.

Fixes [RTI-3409](https://ag-grid.atlassian.net/browse/RTI-3409)