### PR TITLE
[RTI-3426] Fix(docs): expand first master row in SSRM infinite scrolling example

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-master-detail/_examples/infinite-scrolling/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-master-detail/_examples/infinite-scrolling/example.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
-    test.eachFramework('Master row expands to a nested detail grid of call records', async ({ page }) => {
+    test.eachFramework('First master row is expanded by default into a nested detail grid', async ({ page }) => {
         await waitForGridContent(page);
 
         // Master rows are individual accounts loaded lazily by the server-side row model.
@@ -13,9 +13,7 @@ test.agExample(import.meta, () => {
 
         // First account in the fake server dataset.
         await expect(masterRow('Liam Padberg')).toBeVisible();
-
-        // Expand the master row via the group cell renderer icon on the accountId column.
-        await masterRow('Liam Padberg').locator('.ag-group-contracted').first().click();
+        await expect(masterRow('Liam Padberg').locator('.ag-group-expanded').first()).toBeVisible();
 
         // The detail grid renders as a nested grid inside the details row, showing the
         // account's call records (first record for Liam Padberg has callId 2000, direction IN).
@@ -27,5 +25,20 @@ test.agExample(import.meta, () => {
         await expect(detail.locator('.ag-root-wrapper')).toBeVisible();
         await expect(detail.locator('.ag-row').first()).toBeVisible();
         await expect(detail.locator('.ag-cell[col-id="direction"]').first()).toContainText('IN');
+    });
+
+    test.eachFramework('Master row collapses when the expanded icon is clicked', async ({ page }) => {
+        await waitForGridContent(page);
+
+        const masterRow = page
+            .locator('.ag-row')
+            .filter({ has: page.locator('[col-id="name"]', { hasText: 'Liam Padberg' }) })
+            .first();
+
+        await expect(masterRow.locator('.ag-group-expanded').first()).toBeVisible();
+        await masterRow.locator('.ag-group-expanded').first().click();
+
+        await expect(masterRow.locator('.ag-group-contracted').first()).toBeVisible();
+        await expect(page.locator('.ag-details-row')).toHaveCount(0);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-master-detail/_examples/infinite-scrolling/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-master-detail/_examples/infinite-scrolling/main.ts
@@ -8,7 +8,6 @@ import type {
 import {
     ClientSideRowModelModule,
     ModuleRegistry,
-    RowApiModule,
     createGrid,
     enableDevValidations,
 } from 'ag-grid-community';
@@ -26,7 +25,6 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 ModuleRegistry.registerModules([
-    RowApiModule,
     ClientSideRowModelModule,
     ColumnsToolPanelModule,
     MasterDetailModule,
@@ -75,15 +73,8 @@ const gridOptions: GridOptions = {
             params.successCallback(params.data.callRecords);
         },
     } as IDetailCellRendererParams<IAccount, ICallRecord>,
-    onGridReady: (params) => {
-        setTimeout(() => {
-            // expand some master row
-            const someRow = params.api.getRowNode('1');
-            if (someRow) {
-                someRow.setExpanded(true);
-            }
-        }, 1000);
-    },
+    // expand the first master row once the server has returned it
+    isServerSideGroupOpenByDefault: (params) => params.rowNode.id === '0',
 };
 
 function getServerSideDatasource(server: any): IServerSideDatasource {

--- a/documentation/ag-grid-docs/src/content/docs/server-side-model-master-detail/_examples/infinite-scrolling/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/server-side-model-master-detail/_examples/infinite-scrolling/main.ts
@@ -5,12 +5,7 @@ import type {
     IServerSideDatasource,
     IServerSideGetRowsRequest,
 } from 'ag-grid-community';
-import {
-    ClientSideRowModelModule,
-    ModuleRegistry,
-    createGrid,
-    enableDevValidations,
-} from 'ag-grid-community';
+import { ClientSideRowModelModule, ModuleRegistry, createGrid, enableDevValidations } from 'ag-grid-community';
 import {
     ColumnMenuModule,
     ColumnsToolPanelModule,


### PR DESCRIPTION
Fixes [RTI-3426](https://ag-grid.atlassian.net/browse/RTI-3426)

The example relied on a 1s `setTimeout` in `onGridReady` calling `getRowNode('1')` — the fetch plus the 500ms fake-server delay often exceeded it, so no row was expanded on load. Replaced with `isServerSideGroupOpenByDefault`, which the lazy cache applies as each row arrives.