### PR TITLE
RTI-3413 cannot resize chart range

### DIFF
--- a/packages/ag-grid-enterprise/src/rangeSelection/abstractSelectionHandle.ts
+++ b/packages/ag-grid-enterprise/src/rangeSelection/abstractSelectionHandle.ts
@@ -177,7 +177,7 @@ export abstract class AbstractSelectionHandle extends Component {
             return;
         }
         const { id, type } = this.cellRange;
-        if (!id || id !== event.id) {
+        if (!id || (event.id != null && id !== event.id)) {
             return;
         }
 

--- a/testing/behavioural/src/charts/chart-range-handle.test.ts
+++ b/testing/behavioural/src/charts/chart-range-handle.test.ts
@@ -1,0 +1,80 @@
+import { getByTestId } from '@testing-library/dom';
+import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
+
+import { ClientSideRowModelModule, agTestIdFor, getGridElement, setupAgTestIds } from 'ag-grid-community';
+import { CellSelectionModule, IntegratedChartsModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout, canvasPolyfill } from '../test-utils';
+
+describe('chart range handle', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, CellSelectionModule, IntegratedChartsModule.with(AgChartsEnterpriseModule)],
+    });
+
+    const rowData = [
+        { id: 'ROW_0', month: 'Jan', sunshine: 1 },
+        { id: 'ROW_1', month: 'Feb', sunshine: 2 },
+        { id: 'ROW_2', month: 'Mar', sunshine: 3 },
+        { id: 'ROW_3', month: 'Apr', sunshine: 4 },
+        { id: 'ROW_4', month: 'May', sunshine: 5 },
+    ];
+
+    beforeAll(async () => {
+        setupAgTestIds();
+        await canvasPolyfill.init();
+    });
+    afterAll(() => canvasPolyfill.reset());
+    afterEach(() => gridsManager.reset());
+
+    // The chart replaces its cell range objects on every range change, so a drag spanning more than
+    // one row only reaches the final row if the handle keeps up with those new objects.
+    test.each([
+        ['grows', 1, [2, 3, 4], 4],
+        ['shrinks', 4, [3, 2, 1], 1],
+    ] as const)(
+        'dragging the handle across several rows %s the chart range to the last row',
+        async (_action, initialEndRow, hoveredRows, expectedEndRow) => {
+            const api = await gridsManager.createGridAndWait('chartRangeHandleGrid', {
+                cellSelection: true,
+                columnDefs: [
+                    { field: 'month', chartDataType: 'category' },
+                    { field: 'sunshine', chartDataType: 'series' },
+                ],
+                rowData,
+                getRowId: ({ data }) => data.id,
+            });
+
+            api.createRangeChart({
+                cellRange: { rowStartIndex: 0, rowEndIndex: initialEndRow, columns: ['month', 'sunshine'] },
+                chartType: 'groupedColumn',
+            });
+            await asyncSetTimeout(1);
+
+            const gridDiv = getGridElement(api)! as HTMLElement;
+            const cellOfRow = (rowIndex: number) =>
+                getByTestId(gridDiv, agTestIdFor.cell(`ROW_${rowIndex}`, 'sunshine'));
+
+            gridDiv
+                .querySelector('.ag-range-handle')!
+                .dispatchEvent(new MouseEvent('mousedown', { bubbles: true, clientX: 0, clientY: 0 }));
+            for (let i = 0, len = hoveredRows.length; i < len; ++i) {
+                cellOfRow(hoveredRows[i]).dispatchEvent(
+                    new MouseEvent('mousemove', { bubbles: true, clientX: 0, clientY: 1 })
+                );
+                await asyncSetTimeout(1);
+            }
+            cellOfRow(expectedEndRow).dispatchEvent(
+                new MouseEvent('mouseup', { bubbles: true, clientX: 0, clientY: 1 })
+            );
+            await asyncSetTimeout(1);
+
+            const [chartModel] = api.getChartModels()!;
+            expect(chartModel.cellRange.rowEndIndex).toBe(expectedEndRow);
+            // the dimension range must follow the value range that carries the handle
+            expect(api.getCellRanges()!.map((r) => [r.startRow!.rowIndex, r.endRow!.rowIndex])).toEqual([
+                [0, expectedEndRow],
+                [0, expectedEndRow],
+            ]);
+        }
+    );
+});


### PR DESCRIPTION
# RTI-3413 Fix(charts): resize the chart range by more than one row

FIX RTI-3413

Dragging the bottom of an integrated-chart range moved it by a single row, however far the cursor went. `chartRangeSelectionChanged` still fired for every row crossed, so the drag looked live while the range stayed put.

## Cause

`AgRangeHandle` drags against a cached `CellRange` object. Chart ranges are the one case where those objects are swapped mid-drag: the first mouse-move mutates the range, which triggers `ChartController.updateForRangeChange` → `setChartRange()` → `rangeSvc.setCellRanges()`, installing ranges freshly built by `chartDataModel.createCellRange`. The handle's re-sync listener only re-resolved when `event.id` matched its range, but `setCellRanges` dispatches `cellSelectionChanged` with no id — so every later mouse-move mutated an orphaned object.

## Fix

`abstractSelectionHandle.ts` — an id-less `cellSelectionChanged` means all ranges were replaced, so re-resolve by id and type; skip only when the event names a different range.

## Tests

New `testing/behavioural/src/charts/chart-range-handle.test.ts` drives a real handle drag (mousedown, three mousemoves, mouseup) in both directions from the ticket: grow rows 0–1 to 0–4, shrink rows 0–4 to 0–1. Asserts the chart model's range and that the dimension range follows the value range. Both fail without the fix with the one-row-only symptom (`expected 2 to be 4`, `expected 3 to be 1`).

No docs example change: the `integrated-charts-events` example's `updateChart` call was not the trigger, any integrated-chart handle drag was affected.
