### PR TITLE
RTI-3410 combo charts show as custom

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-chart-types/_examples/combo/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-chart-types/_examples/combo/example.spec.ts
@@ -12,17 +12,14 @@ test.agExample(import.meta, () => {
 
         const gridApi = remoteGrid(page);
 
-        // Reads the per-series chart types from the grid's chart model as a colId -> chartType map.
-        // This is the framework-independent signal for a combination chart: the top-level chartType
-        // label of a combo varies by framework (columnLineCombo vs customCombo), but the per-series
-        // composition is identical everywhere.
-        const seriesTypes = async (): Promise<Record<string, string>> => {
+        // Reads the chart's combination type and its per-series chart types as a colId -> chartType map.
+        const comboState = async (): Promise<{ chartType: string; seriesTypes: Record<string, string> }> => {
             const model = (await gridApi.getChartModels())![0] as any;
-            const map: Record<string, string> = {};
+            const seriesTypes: Record<string, string> = {};
             for (let i = 0, types = model.seriesChartTypes, len = types.length; i < len; ++i) {
-                map[types[i].colId] = types[i].chartType;
+                seriesTypes[types[i].colId] = types[i].chartType;
             }
-            return map;
+            return { chartType: model.chartType, seriesTypes };
         };
 
         // Grid renders the documented category + series columns.
@@ -37,20 +34,27 @@ test.agExample(import.meta, () => {
 
         // The chart is initially the Column & Line combination: recurring drawn as columns, individual
         // drawn as a line.
+        const columnLineState = {
+            chartType: 'columnLineCombo',
+            seriesTypes: { recurring: 'groupedColumn', individual: 'line' },
+        };
         await expect(async () => {
-            expect(await seriesTypes()).toEqual({ recurring: 'groupedColumn', individual: 'line' });
+            expect(await comboState()).toEqual(columnLineState);
         }).toPass({ timeout: 5000 });
 
         // The Area Column Combo button recomposes the series: recurring becomes an area, individual a column.
         await switchChartType(page, 'Area Column Combo');
         await expect(async () => {
-            expect(await seriesTypes()).toEqual({ recurring: 'stackedArea', individual: 'groupedColumn' });
+            expect(await comboState()).toEqual({
+                chartType: 'areaColumnCombo',
+                seriesTypes: { recurring: 'stackedArea', individual: 'groupedColumn' },
+            });
         }).toPass({ timeout: 5000 });
 
         // The Column Line Combo button restores the column + line composition.
         await switchChartType(page, 'Column Line Combo');
         await expect(async () => {
-            expect(await seriesTypes()).toEqual({ recurring: 'groupedColumn', individual: 'line' });
+            expect(await comboState()).toEqual(columnLineState);
         }).toPass({ timeout: 5000 });
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-customisation/_examples/label-formatting/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-customisation/_examples/label-formatting/main.ts
@@ -109,7 +109,7 @@ function onFirstDataRendered(params: FirstDataRenderedEvent) {
             { colId: 'surplus', chartType: 'groupedColumn', secondaryAxis: false },
             { colId: 'efficiency', chartType: 'line', secondaryAxis: true },
         ],
-        chartType: 'columnLineCombo',
+        chartType: 'customCombo',
         chartContainer: document.querySelector('#myChart') as any,
         aggFunc: 'sum',
     });

--- a/packages/ag-grid-enterprise/src/charts/chartComp/menu/data/seriesChartTypePanel.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/menu/data/seriesChartTypePanel.ts
@@ -148,8 +148,10 @@ export class SeriesChartTypePanel extends Component {
             const chartTypeComp = this.chartTypeComps.get(colId);
             const secondaryAxisComp = this.secondaryAxisComps.get(colId);
 
-            chartTypeComp?.setValue(seriesChartType.chartType);
-            secondaryAxisComp?.setValue(!!seriesChartType.secondaryAxis);
+            // silent: these comps are reflecting model state, so firing their change handlers would
+            // report the refresh back as a user edit and convert a built-in combo to a custom one
+            chartTypeComp?.setValue(seriesChartType.chartType, true);
+            secondaryAxisComp?.setValue(!!seriesChartType.secondaryAxis, true);
             secondaryAxisComp?.setDisabled(this.isSecondaryAxisDisabled(seriesChartType.chartType));
         }
     }

--- a/packages/ag-grid-enterprise/src/charts/chartComp/model/comboChartModel.ts
+++ b/packages/ag-grid-enterprise/src/charts/chartComp/model/comboChartModel.ts
@@ -20,24 +20,26 @@ export class ComboChartModel extends BeanStub {
     }
 
     public postConstruct(): void {
-        this.initComboCharts();
+        this.initComboCharts(this.seriesChartTypes.length > 0);
     }
 
     public update(seriesChartTypes?: SeriesChartType[]): void {
+        // built-in combos derive their own `seriesChartTypes`, so only types supplied by this update
+        // identify a custom combo
+        const suppliedSeriesChartTypes = seriesChartTypes != null && seriesChartTypes.length > 0;
         this.seriesChartTypes = seriesChartTypes ?? this.seriesChartTypes;
-        this.initComboCharts();
+        this.initComboCharts(suppliedSeriesChartTypes);
         this.updateSeriesChartTypes();
     }
 
-    private initComboCharts() {
-        const seriesChartTypesExist = this.seriesChartTypes && this.seriesChartTypes.length > 0;
-        const customCombo = this.chartDataModel.chartType === 'customCombo' || seriesChartTypesExist;
+    private initComboCharts(suppliedSeriesChartTypes: boolean) {
+        const customCombo = this.chartDataModel.chartType === 'customCombo' || suppliedSeriesChartTypes;
         if (customCombo) {
             // it is not necessary to supply a chart type for combo charts when `seriesChartTypes` is supplied
             this.chartDataModel.chartType = 'customCombo';
 
             // cache supplied `seriesChartTypes` to allow switching between different chart types in the settings panel
-            this.savedCustomSeriesChartTypes = this.seriesChartTypes || [];
+            this.savedCustomSeriesChartTypes = this.seriesChartTypes;
         }
     }
 

--- a/testing/behavioural/src/charts/combo-chart-type.test.ts
+++ b/testing/behavioural/src/charts/combo-chart-type.test.ts
@@ -1,0 +1,143 @@
+import { AgChartsEnterpriseModule } from 'ag-charts-enterprise';
+
+import type { ChartType, GridApi, SeriesChartType } from 'ag-grid-community';
+import { ClientSideRowModelModule, setupAgTestIds } from 'ag-grid-community';
+import { CellSelectionModule, IntegratedChartsModule, RowGroupingModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, canvasPolyfill } from '../test-utils';
+
+describe('combo chart type', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [
+            ClientSideRowModelModule,
+            CellSelectionModule,
+            RowGroupingModule,
+            IntegratedChartsModule.with(AgChartsEnterpriseModule),
+        ],
+    });
+
+    const rowData = [
+        { period: 'Q1', recurring: 10, individual: 4 },
+        { period: 'Q2', recurring: 12, individual: 6 },
+    ];
+
+    beforeAll(async () => {
+        setupAgTestIds();
+        await canvasPolyfill.init();
+    });
+    afterAll(() => canvasPolyfill.reset());
+    afterEach(() => gridsManager.reset());
+
+    async function createComboChartedGrid(chartType: ChartType, seriesChartTypes?: SeriesChartType[]) {
+        const api = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                { field: 'period', chartDataType: 'category' },
+                { field: 'recurring', chartDataType: 'series' },
+                { field: 'individual', chartDataType: 'series' },
+            ],
+            rowData,
+            cellSelection: true,
+        });
+        const chartContainer = document.body.appendChild(document.createElement('div'));
+        const chartRef = api.createRangeChart({
+            chartContainer,
+            cellRange: { columns: ['period', 'recurring', 'individual'] },
+            chartType,
+            seriesChartTypes,
+        })!;
+        return { api, chartId: chartRef.chartId };
+    }
+
+    function chartState(api: GridApi) {
+        const [chartModel] = api.getChartModels()!;
+        return { chartType: chartModel.chartType, seriesChartTypes: chartModel.seriesChartTypes };
+    }
+
+    describe('a built-in combo stays built-in across reactive chart updates', () => {
+        const COLUMN_LINE_SERIES: SeriesChartType[] = [
+            { colId: 'recurring', chartType: 'groupedColumn', secondaryAxis: false },
+            { colId: 'individual', chartType: 'line', secondaryAxis: false },
+        ];
+        const AREA_COLUMN_SERIES: SeriesChartType[] = [
+            { colId: 'recurring', chartType: 'stackedArea', secondaryAxis: false },
+            { colId: 'individual', chartType: 'groupedColumn', secondaryAxis: false },
+        ];
+
+        test.each([
+            { chartType: 'columnLineCombo' as ChartType, expectedSeries: COLUMN_LINE_SERIES },
+            { chartType: 'areaColumnCombo' as ChartType, expectedSeries: AREA_COLUMN_SERIES },
+        ])('$chartType survives a chartThemes change', async ({ chartType, expectedSeries }) => {
+            const { api } = await createComboChartedGrid(chartType);
+            expect(chartState(api)).toEqual({ chartType, seriesChartTypes: expectedSeries });
+
+            api.setGridOption('chartThemes', ['ag-material', 'ag-default']);
+
+            expect(chartState(api)).toEqual({ chartType, seriesChartTypes: expectedSeries });
+        });
+
+        test('columnLineCombo survives a rangeChartUpdate that omits seriesChartTypes', async () => {
+            const { api, chartId } = await createComboChartedGrid('columnLineCombo');
+
+            api.updateChart({ type: 'rangeChartUpdate', chartId });
+
+            expect(chartState(api)).toEqual({
+                chartType: 'columnLineCombo',
+                seriesChartTypes: COLUMN_LINE_SERIES,
+            });
+        });
+
+        test('switching between the built-in combos recomposes the series', async () => {
+            const { api, chartId } = await createComboChartedGrid('columnLineCombo');
+
+            api.updateChart({ type: 'rangeChartUpdate', chartId, chartType: 'areaColumnCombo' });
+            expect(chartState(api)).toEqual({
+                chartType: 'areaColumnCombo',
+                seriesChartTypes: AREA_COLUMN_SERIES,
+            });
+
+            api.updateChart({ type: 'rangeChartUpdate', chartId, chartType: 'columnLineCombo' });
+            expect(chartState(api)).toEqual({
+                chartType: 'columnLineCombo',
+                seriesChartTypes: COLUMN_LINE_SERIES,
+            });
+        });
+    });
+
+    describe('a custom combo remains custom', () => {
+        const CUSTOM_SERIES: SeriesChartType[] = [
+            { colId: 'recurring', chartType: 'stackedColumn', secondaryAxis: false },
+            { colId: 'individual', chartType: 'line', secondaryAxis: true },
+        ];
+
+        test('supplied seriesChartTypes make the chart a customCombo', async () => {
+            const { api } = await createComboChartedGrid('customCombo', CUSTOM_SERIES);
+
+            expect(chartState(api)).toEqual({ chartType: 'customCombo', seriesChartTypes: CUSTOM_SERIES });
+        });
+
+        test('supplied seriesChartTypes without a combo chart type still make the chart a customCombo', async () => {
+            const { api } = await createComboChartedGrid('groupedColumn', CUSTOM_SERIES);
+
+            expect(chartState(api)).toEqual({ chartType: 'customCombo', seriesChartTypes: CUSTOM_SERIES });
+        });
+
+        test('customCombo survives a chartThemes change', async () => {
+            const { api } = await createComboChartedGrid('customCombo', CUSTOM_SERIES);
+
+            api.setGridOption('chartThemes', ['ag-material', 'ag-default']);
+
+            expect(chartState(api)).toEqual({ chartType: 'customCombo', seriesChartTypes: CUSTOM_SERIES });
+        });
+
+        test('supplying seriesChartTypes to a built-in combo converts it to a customCombo', async () => {
+            const { api, chartId } = await createComboChartedGrid('columnLineCombo');
+
+            api.updateChart({ type: 'rangeChartUpdate', chartId, seriesChartTypes: CUSTOM_SERIES });
+            expect(chartState(api)).toEqual({ chartType: 'customCombo', seriesChartTypes: CUSTOM_SERIES });
+
+            // the conversion is sticky: a later reactive update must not revert to the built-in type
+            api.setGridOption('chartThemes', ['ag-material', 'ag-default']);
+            expect(chartState(api)).toEqual({ chartType: 'customCombo', seriesChartTypes: CUSTOM_SERIES });
+        });
+    });
+});


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/RTI-3410

FIX RTI-3410

A built-in `columnLineCombo` / `areaColumnCombo` chart became a `customCombo`, so the settings panel's Combination group grew a third item and showed it as selected.

## Cause

Two independent defects, both reproducible in every framework:

- `ComboChartModel.initComboCharts` treated the per-series types a built-in combo derives for *itself* (`updateChartSeriesTypesForBuiltInCombos`) as evidence of user-supplied types. `updateModel` calls `comboChartModel.update()` for any combo chart, so any reactive update — a `chartThemes` change via `gridChartComp.reactivePropertyUpdate`, or any `rangeChartUpdate` — converted the chart. `customComboExists()` then went true and `miniChartsContainer` stopped filtering `customCombo` out of the group.
- `SeriesChartTypePanel.refreshComps` set its select/checkbox values non-silently while reflecting model state, re-entering `chartController.updateSeriesChartType`, which reports a user edit and forces `customCombo`. This is why the chart-types example's Column Line / Area Column buttons also broke.

The React/Angular-only symptom in the ticket is docs-harness timing, not framework code: the injected dark-mode block calls `setGridOption('chartThemes', …)` after chart creation there, but before it in vanilla/TS/Vue. Neither defect is new in 36.1.0.

## Fix

- `comboChartModel.ts` — only types supplied by the current update (or an already-`customCombo` chart) identify a custom combo.
- `seriesChartTypePanel.ts` — refresh the comps silently.

## Tests

New `testing/behavioural/src/charts/combo-chart-type.test.ts`: built-in combos survive a `chartThemes` change and a bare `rangeChartUpdate`, switching between built-ins recomposes the series, and the four cases where a chart legitimately is and stays a `customCombo`. Four of the eight fail without the fix.

`integrated-charts-chart-types/_examples/combo/example.spec.ts` now asserts `chartType`; it previously documented this bug as expected framework variance. All six framework variants failed before the fix.

The chart tool panel's content does not mount under jsdom (`chartCreated` fires but the menu panel content wrapper stays empty), so the second defect has e2e coverage only — a behavioural test there passes vacuously.

The `label-formatting` example declared `columnLineCombo` while supplying custom per-series types, so the declared type was silently overridden; aligned with its sibling combination examples.