### PR TITLE
AG-17862 Render the licence setup tool as markdown and extract more homepage content

### DIFF
--- a/documentation/ag-grid-docs/src/components/license-setup/components/LicenseSetup.tsx
+++ b/documentation/ag-grid-docs/src/components/license-setup/components/LicenseSetup.tsx
@@ -13,6 +13,7 @@ import classnames from 'classnames';
 import { useMemo } from 'react';
 import type { FunctionComponent } from 'react';
 
+import { LICENSE_SETUP_COPY, LICENSE_SETUP_HEADINGS } from '../licenseSetupContent';
 import { getBootstrapSnippet, getDependenciesSnippet, getNpmInstallSnippet } from '../utils/getSnippets';
 import { hasValue } from '../utils/hasValue';
 import { useLicenseData } from '../utils/useLicenseData';
@@ -93,14 +94,13 @@ export const LicenseSetup: FunctionComponent<Props> = ({ library, framework, pat
             }),
         [seedRepos, framework]
     );
-    const productName = 'AG Grid';
 
     return (
         <>
             <form className={styles.form}>
-                <h2 id="validate-your-license">
-                    Validate Your Licence
-                    <LinkIcon href="#validate-your-license" />
+                <h2 id={LICENSE_SETUP_HEADINGS.validate.id}>
+                    {LICENSE_SETUP_HEADINGS.validate.text}
+                    <LinkIcon href={`#${LICENSE_SETUP_HEADINGS.validate.id}`} />
                 </h2>
 
                 <div className={styles.licenceWrapper}>
@@ -147,9 +147,9 @@ export const LicenseSetup: FunctionComponent<Props> = ({ library, framework, pat
                     )}
 
                     <div>
-                        <h3 id="configure-your-application">
-                            Configure Your Application
-                            <LinkIcon href="#configure-your-application" />
+                        <h3 id={LICENSE_SETUP_HEADINGS.configure.id}>
+                            {LICENSE_SETUP_HEADINGS.configure.text}
+                            <LinkIcon href={`#${LICENSE_SETUP_HEADINGS.configure.id}`} />
                         </h3>
 
                         <div className={styles.configureItems}>
@@ -192,9 +192,9 @@ export const LicenseSetup: FunctionComponent<Props> = ({ library, framework, pat
                 </div>
 
                 <div className={styles.results}>
-                    <h3 id="add-your-dependencies">
-                        Add Your Dependencies
-                        <LinkIcon href="#add-your-dependencies" />
+                    <h3 id={LICENSE_SETUP_HEADINGS.dependencies.id}>
+                        {LICENSE_SETUP_HEADINGS.dependencies.text}
+                        <LinkIcon href={`#${LICENSE_SETUP_HEADINGS.dependencies.id}`} />
                     </h3>
 
                     {licenseState.chartsNoGridEnterpriseError && (
@@ -209,14 +209,16 @@ export const LicenseSetup: FunctionComponent<Props> = ({ library, framework, pat
                     )}
 
                     <p>
-                        Copy the following dependencies into your <code>package.json</code>:
+                        {LICENSE_SETUP_COPY.dependenciesLead.before}{' '}
+                        <code>{LICENSE_SETUP_COPY.dependenciesLead.code}</code>
+                        {LICENSE_SETUP_COPY.dependenciesLead.after}
                     </p>
 
                     {dependenciesSnippet && (
                         <Snippet framework="javascript" language="json" content={dependenciesSnippet} copyToClipboard />
                     )}
 
-                    <p>Or install using npm:</p>
+                    <p>{LICENSE_SETUP_COPY.npmLead}</p>
 
                     {npmInstallSnippet && (
                         <Snippet framework={framework} content={npmInstallSnippet} language="bash" copyToClipboard />
@@ -224,9 +226,9 @@ export const LicenseSetup: FunctionComponent<Props> = ({ library, framework, pat
 
                     <br />
 
-                    <h3 id="set-up-your-application">
-                        Set Up Your Application
-                        <LinkIcon href="#set-up-your-application" />
+                    <h3 id={LICENSE_SETUP_HEADINGS.bootstrap.id}>
+                        {LICENSE_SETUP_HEADINGS.bootstrap.text}
+                        <LinkIcon href={`#${LICENSE_SETUP_HEADINGS.bootstrap.id}`} />
                     </h3>
 
                     {licenseState.chartsNoGridEnterpriseError && (
@@ -240,7 +242,7 @@ export const LicenseSetup: FunctionComponent<Props> = ({ library, framework, pat
                         </Warning>
                     )}
 
-                    <p>An example of how to set up your {productName} Enterprise License Key:</p>
+                    <p>{LICENSE_SETUP_COPY.bootstrapLead}</p>
 
                     {licenseState.minimalModulesInfo && <Note>{licenseState.minimalModulesInfo}</Note>}
 
@@ -251,44 +253,44 @@ export const LicenseSetup: FunctionComponent<Props> = ({ library, framework, pat
                     />
 
                     <Note>
-                        To minimise bundle size, only register the modules you want to use. See the{' '}
+                        {LICENSE_SETUP_COPY.selectingModulesNote.before}{' '}
                         <a
                             href={urlWithPrefix({
                                 framework,
-                                url: './modules/#selecting-modules',
+                                url: LICENSE_SETUP_COPY.selectingModulesNote.link.url,
                             })}
                         >
-                            Selecting Modules
+                            {LICENSE_SETUP_COPY.selectingModulesNote.link.text}
                         </a>{' '}
-                        docs for more information.{' '}
-                        {framework === 'javascript'
-                            ? `If you're using the UMD bundle, you do not need to import or
-                                register the modules.`
-                            : ``}
-                        .
+                        {LICENSE_SETUP_COPY.selectingModulesNote.after}
+                        {framework === 'javascript' ? ` ${LICENSE_SETUP_COPY.selectingModulesNote.javascriptOnly}` : ''}
                     </Note>
 
                     <Note>
-                        If you are using an AG Grid version before 33.0.0, please see the documentation for your{' '}
-                        <a href={urlWithBaseUrl('/documentation-archive')}>version</a> for help on installing your
-                        license key.
+                        {LICENSE_SETUP_COPY.olderVersionNote.before}{' '}
+                        <a href={urlWithBaseUrl(LICENSE_SETUP_COPY.olderVersionNote.link.url)}>
+                            {LICENSE_SETUP_COPY.olderVersionNote.link.text}
+                        </a>{' '}
+                        {LICENSE_SETUP_COPY.olderVersionNote.after}
                     </Note>
 
-                    <h2 id="seed-repos">
-                        Seed Repositories
-                        <LinkIcon href="#seed-repos" />
+                    <h2 id={LICENSE_SETUP_HEADINGS.seedRepos.id}>
+                        {LICENSE_SETUP_HEADINGS.seedRepos.text}
+                        <LinkIcon href={`#${LICENSE_SETUP_HEADINGS.seedRepos.id}`} />
                     </h2>
 
                     {selectedSeedRepos.length ? (
                         <>
-                            <p>Here are some seed code repositories to get you started:</p>
+                            <p>{LICENSE_SETUP_COPY.seedReposLead}</p>
 
                             <table className={styles.reposTable} role="grid">
                                 <thead>
                                     <tr>
-                                        <th scope="col">GitHub Repo</th>
-                                        <th scope="col">Framework</th>
-                                        <th scope="col">Development Environment</th>
+                                        {LICENSE_SETUP_COPY.seedReposHeaders.map((header) => (
+                                            <th key={header} scope="col">
+                                                {header}
+                                            </th>
+                                        ))}
                                     </tr>
                                 </thead>
                                 <tbody>

--- a/documentation/ag-grid-docs/src/components/license-setup/licenseSetupContent.ts
+++ b/documentation/ag-grid-docs/src/components/license-setup/licenseSetupContent.ts
@@ -1,0 +1,36 @@
+// Static copy for the licence setup tool, shared by the interactive page component and the
+// markdown twin of /license-install (see utils/markdoc/renderLicenseSetup.ts) so the two
+// cannot drift. Sentences carrying inline markup are stored as parts, and links as paths, so
+// each renderer builds its own markup and resolves URLs for its own environment.
+
+export const LICENSE_SETUP_HEADINGS = {
+    validate: { id: 'validate-your-license', text: 'Validate Your Licence' },
+    configure: { id: 'configure-your-application', text: 'Configure Your Application' },
+    dependencies: { id: 'add-your-dependencies', text: 'Add Your Dependencies' },
+    bootstrap: { id: 'set-up-your-application', text: 'Set Up Your Application' },
+    seedRepos: { id: 'seed-repos', text: 'Seed Repositories' },
+};
+
+export const LICENSE_SETUP_COPY = {
+    dependenciesLead: {
+        before: 'Copy the following dependencies into your',
+        code: 'package.json',
+        after: ':',
+    },
+    npmLead: 'Or install using npm:',
+    bootstrapLead: 'An example of how to set up your AG Grid Enterprise License Key:',
+    selectingModulesNote: {
+        before: 'To minimise bundle size, only register the modules you want to use. See the',
+        link: { text: 'Selecting Modules', url: './modules/#selecting-modules' },
+        after: 'docs for more information.',
+        // JavaScript only — the UMD bundle registers the modules for you.
+        javascriptOnly: "If you're using the UMD bundle, you do not need to import or register the modules.",
+    },
+    olderVersionNote: {
+        before: 'If you are using an AG Grid version before 33.0.0, please see the documentation for your',
+        link: { text: 'version', url: '/documentation-archive' },
+        after: 'for help on installing your license key.',
+    },
+    seedReposLead: 'Here are some seed code repositories to get you started:',
+    seedReposHeaders: ['GitHub Repo', 'Framework', 'Development Environment'],
+};

--- a/documentation/ag-grid-docs/src/components/quotes/Quotes.tsx
+++ b/documentation/ag-grid-docs/src/components/quotes/Quotes.tsx
@@ -4,17 +4,7 @@ import classNames from 'classnames';
 
 import styles from './Quotes.module.scss';
 import type { QuotesData, QuotesDataItem } from './quotesData';
-
-function filterAndSortByKey(data: QuotesData, sortKey: keyof QuotesDataItem) {
-    return Object.values(data)
-        .filter((d) => {
-            const value = d[sortKey];
-            return value !== undefined && (value as number) >= 0;
-        })
-        .sort((a: any, b: any) => {
-            return a[sortKey]! - b[sortKey]!;
-        });
-}
+import { getOrderedQuotes, statsData } from './quotesData';
 
 const QuoteItems = ({ quotes }: { quotes: QuotesDataItem[] }) => {
     return (
@@ -44,28 +34,17 @@ const QuoteItems = ({ quotes }: { quotes: QuotesDataItem[] }) => {
 };
 
 export const Quotes = ({ data }: { data: QuotesData }) => {
-    const quotes = filterAndSortByKey(data, 'order');
+    const quotes = getOrderedQuotes(data);
 
     return (
         <div>
             <div className={styles.statsOuter}>
-                <div className={styles.stat}>
-                    <h4 className="text-2xl"> 90%</h4>
-                    <p>Of the Fortune 500 use AG Grid</p>
-                </div>
-
-                <div className={styles.stat}>
-                    <h4 className="text-2xl"> 5M+</h4>
-                    <p>Weekly NPM downloads</p>
-                </div>
-                <div className={styles.stat}>
-                    <h4 className="text-2xl">13k+</h4>
-                    <p>GitHub Stars</p>
-                </div>
-                <div className={styles.stat}>
-                    <h4 className="text-2xl">40K+</h4>
-                    <p>Commits</p>
-                </div>
+                {statsData.map(({ value, label }) => (
+                    <div className={styles.stat} key={label}>
+                        <h4 className="text-2xl">{value}</h4>
+                        <p>{label}</p>
+                    </div>
+                ))}
             </div>
 
             <ul className={classNames(styles.container, 'list-style-none')}>

--- a/documentation/ag-grid-docs/src/components/quotes/quotesData.ts
+++ b/documentation/ag-grid-docs/src/components/quotes/quotesData.ts
@@ -14,6 +14,22 @@ export interface QuotesDataItem {
 
 export type QuotesData = Record<string, QuotesDataItem>;
 
+export interface StatsDataItem {
+    value: string;
+    label: string;
+}
+
+/**
+ * Headline metrics shown above the developer quotes. Shared with the markdown twin of the
+ * homepage (see utils/markdown-pages/buildHomepageMarkdown.ts) so the two cannot drift.
+ */
+export const statsData: StatsDataItem[] = [
+    { value: '90%', label: 'Of the Fortune 500 use AG Grid' },
+    { value: '5M+', label: 'Weekly NPM downloads' },
+    { value: '13k+', label: 'GitHub Stars' },
+    { value: '40K+', label: 'Commits' },
+];
+
 export const quotesData: QuotesData = {
     tannerLinsley: {
         name: 'Tanner Linsley',
@@ -43,3 +59,10 @@ export const quotesData: QuotesData = {
         order: 30,
     },
 };
+
+/** The quotes to show, in display order — an entry with no `order` is not shown. */
+export function getOrderedQuotes(data: QuotesData): QuotesDataItem[] {
+    return Object.values(data)
+        .filter((quote) => quote.order !== undefined && quote.order >= 0)
+        .sort((a, b) => a.order! - b.order!);
+}

--- a/documentation/ag-grid-docs/src/utils/markdoc/renderLicenseSetup.test.ts
+++ b/documentation/ag-grid-docs/src/utils/markdoc/renderLicenseSetup.test.ts
@@ -1,0 +1,136 @@
+import type { MarkdownFramework } from '@ag-website-shared/markdoc/renderMarkdocToMarkdown';
+import { describe, expect, it } from 'vitest';
+
+import { buildLicenseSetupMarkdown } from './renderLicenseSetup';
+
+const SITE_ROOT = 'https://www.ag-grid.com/';
+
+function build(framework: MarkdownFramework = 'javascript'): string {
+    return buildLicenseSetupMarkdown({ framework, siteRoot: SITE_ROOT });
+}
+
+/** Fenced blocks in document order, as `[language, code]`. */
+function fences(output: string): [string, string][] {
+    return [...output.matchAll(/^(`{3,})(\S*)\n([\s\S]*?)^\1$/gm)].map(([, , language, code]) => [
+        language,
+        code.trimEnd(),
+    ]);
+}
+
+describe('buildLicenseSetupMarkdown', () => {
+    it('renders the tool headings in page order and at the page depths', () => {
+        const headings = build()
+            .split('\n')
+            .filter((line) => line.startsWith('#'));
+
+        expect(headings).toEqual([
+            '## Validate Your Licence',
+            '### Configure Your Application',
+            '### Add Your Dependencies',
+            '### Set Up Your Application',
+            '## Seed Repositories',
+        ]);
+    });
+
+    it('links the interactive-only steps back to the tool on the page', () => {
+        const output = build('react');
+
+        expect(output).toContain(
+            '[Validate your licence key](https://www.ag-grid.com/react-data-grid/license-install/) using the tool on this page.'
+        );
+        expect(output).toContain(
+            '[Use the tool on this page](https://www.ag-grid.com/react-data-grid/license-install/) to include Integrated Charts.'
+        );
+    });
+
+    it('keeps the prose that introduces each snippet', () => {
+        const output = build();
+
+        expect(output).toContain('Copy the following dependencies into your `package.json`:');
+        expect(output).toContain('Or install using npm:');
+        expect(output).toContain('An example of how to set up your AG Grid Enterprise License Key:');
+    });
+
+    it('renders the selecting-modules note as a callout linking to the modules docs', () => {
+        expect(build('react')).toContain(
+            [
+                '> **Note**',
+                '>',
+                '> To minimise bundle size, only register the modules you want to use. See the' +
+                    ' [Selecting Modules](https://www.ag-grid.com/react-data-grid/modules/#selecting-modules)' +
+                    ' docs for more information.',
+            ].join('\n')
+        );
+    });
+
+    // The UMD-bundle sentence is JavaScript-only on the page.
+    it('adds the UMD bundle sentence for javascript only', () => {
+        expect(build('javascript')).toContain(
+            "docs for more information. If you're using the UMD bundle, you do not need to import or register the modules."
+        );
+        expect(build('react')).not.toContain('UMD bundle');
+    });
+
+    it('renders the older-version note as a callout linking to the archive', () => {
+        expect(build()).toContain(
+            [
+                '> **Note**',
+                '>',
+                '> If you are using an AG Grid version before 33.0.0, please see the documentation for your' +
+                    ' [version](https://www.ag-grid.com/documentation-archive) for help on installing your license key.',
+            ].join('\n')
+        );
+    });
+
+    it('emits the dependencies and npm install snippets in page order', () => {
+        const [dependencies, npmInstall] = fences(build('react'));
+
+        // The page pins the dependencies snippet to json, whatever the framework.
+        expect(dependencies[0]).toBe('json');
+        expect(dependencies[1]).toContain('dependencies: {');
+        expect(npmInstall).toEqual(['bash', 'npm install ag-grid-react ag-grid-enterprise']);
+    });
+
+    it.each([
+        ['react', 'jsx', 'ag-grid-react'],
+        ['angular', 'ts', 'ag-grid-angular'],
+        ['vue', 'ts', 'ag-grid-vue3'],
+    ] as const)('resolves the %s packages and fence language', (framework, language, wrapperPackage) => {
+        const [dependencies, npmInstall, bootstrap] = fences(build(framework));
+
+        expect(dependencies[1]).toContain(`"${wrapperPackage}"`);
+        expect(npmInstall[1]).toBe(`npm install ${wrapperPackage} ag-grid-enterprise`);
+        expect(bootstrap[0]).toBe(language);
+        expect(bootstrap[1]).toContain(`YOUR_LICENSE_KEY`);
+    });
+
+    // The JavaScript page installs no framework wrapper, and bootstraps via createGrid.
+    it('resolves the javascript packages', () => {
+        const [dependencies, npmInstall, bootstrap] = fences(build('javascript'));
+
+        expect(dependencies[1]).not.toContain('ag-grid-react');
+        expect(npmInstall[1]).toBe('npm install ag-grid-enterprise');
+        expect(bootstrap[0]).toBe('js');
+        expect(bootstrap[1]).toContain('createGrid(<dom element>, gridOptions);');
+    });
+
+    // Integrated Charts is a page toggle, off by default, so the charts packages stay out.
+    it('omits the Integrated Charts dependencies', () => {
+        const output = build('react');
+
+        expect(output).not.toContain('ag-charts-enterprise');
+        expect(output).not.toContain('IntegratedChartsModule');
+    });
+
+    it('lists only the seed repositories for the framework', () => {
+        const output = build('angular');
+        const rows = output.split('\n').filter((line) => line.startsWith('| ['));
+
+        expect(output).toContain('| GitHub Repo | Framework | Development Environment |');
+        expect(rows.length).toBeGreaterThan(0);
+        expect(rows.every((row) => row.includes('| angular |'))).toBe(true);
+        expect(rows[0]).toContain(
+            '[Angular CLI](https://github.com/ag-grid/ag-grid-seed/tree/main/enterprise/packages/angular-cli)'
+        );
+    });
+});

--- a/documentation/ag-grid-docs/src/utils/markdoc/renderLicenseSetup.ts
+++ b/documentation/ag-grid-docs/src/utils/markdoc/renderLicenseSetup.ts
@@ -1,0 +1,131 @@
+import type { Framework } from '@ag-grid-types';
+import { markdownTable } from '@ag-website-shared/markdoc/markdownTable';
+import { type MarkdownFramework, fencedCodeBlock } from '@ag-website-shared/markdoc/renderMarkdocToMarkdown';
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+import { LICENSE_SETUP_COPY, LICENSE_SETUP_HEADINGS } from '@components/license-setup/licenseSetupContent';
+import {
+    getBootstrapSnippet,
+    getDependenciesSnippet,
+    getNpmInstallSnippet,
+} from '@components/license-setup/utils/getSnippets';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
+import { urlWithPrefix } from '@utils/urlWithPrefix';
+
+import seedProjects from '../../content/seed-projects/grid-seed-projects.json';
+
+// Placeholder the page shows until a key is pasted, so the snippet reads the same in both.
+const LICENSE_PLACEHOLDER = 'YOUR_LICENSE_KEY';
+
+// The page's Integrated Charts toggle starts off, so the snippets below are the plain
+// Enterprise ones; the toggle itself needs the page.
+const IS_INTEGRATED_CHARTS = false;
+
+// Fence language per framework, matching the languages the on-page Snippet component picks
+// (see external/ag-website-shared/src/components/snippet/Snippet.tsx).
+const FENCE_LANGUAGE: Record<MarkdownFramework, string> = {
+    react: 'jsx',
+    javascript: 'js',
+    angular: 'ts',
+    vue: 'ts',
+};
+
+interface SeedProject {
+    name: string;
+    framework: string;
+    devEnvironment: string;
+    url: string;
+}
+
+/**
+ * Build the `licenseSetup` tag as markdown. The tag renders an interactive licence-key tool,
+ * but only the paste-a-key field, its validation messages and the Integrated Charts toggle
+ * need a browser: the headings, prose, all three snippets and the seed repositories are static
+ * once the key is a placeholder, so they are rendered here from the same content module, snippet
+ * builders and seed-project data the page uses. The interactive parts link back to the page.
+ */
+export function buildLicenseSetupMarkdown({
+    framework,
+    siteRoot,
+}: {
+    framework: MarkdownFramework;
+    siteRoot?: string;
+}): string {
+    const language = FENCE_LANGUAGE[framework];
+    const snippetArgs = { library: 'grid', framework, isIntegratedCharts: IS_INTEGRATED_CHARTS } as const;
+
+    const pageUrl = toAbsoluteUrl(
+        urlWithPrefix({ url: './license-install/', framework: framework as Framework }),
+        siteRoot
+    );
+    const { dependenciesLead, npmLead, bootstrapLead, selectingModulesNote, olderVersionNote } = LICENSE_SETUP_COPY;
+
+    const sections = [
+        `## ${LICENSE_SETUP_HEADINGS.validate.text}`,
+        `[Validate your licence key](${pageUrl}) using the tool on this page.`,
+        `### ${LICENSE_SETUP_HEADINGS.configure.text}`,
+        `The snippets below are for AG Grid Enterprise without Integrated Charts.` +
+            ` [Use the tool on this page](${pageUrl}) to include Integrated Charts.`,
+        `### ${LICENSE_SETUP_HEADINGS.dependencies.text}`,
+        `${dependenciesLead.before} \`${dependenciesLead.code}\`${dependenciesLead.after}`,
+    ];
+
+    const dependenciesSnippet = getDependenciesSnippet(snippetArgs);
+    if (dependenciesSnippet) {
+        // The page pins this snippet to `json` rather than taking the framework's language.
+        sections.push(fencedCodeBlock(dependenciesSnippet, 'json'));
+    }
+
+    sections.push(npmLead);
+
+    const npmInstallSnippet = getNpmInstallSnippet(snippetArgs);
+    if (npmInstallSnippet) {
+        sections.push(fencedCodeBlock(npmInstallSnippet, 'bash'));
+    }
+
+    sections.push(`### ${LICENSE_SETUP_HEADINGS.bootstrap.text}`, bootstrapLead);
+
+    const { grid: bootstrapSnippet } = getBootstrapSnippet({
+        framework: framework as Framework,
+        license: LICENSE_PLACEHOLDER,
+        isIntegratedCharts: IS_INTEGRATED_CHARTS,
+    });
+    if (bootstrapSnippet) {
+        sections.push(fencedCodeBlock(bootstrapSnippet, language));
+    }
+
+    const modulesUrl = toAbsoluteUrl(
+        urlWithPrefix({ url: selectingModulesNote.link.url, framework: framework as Framework }),
+        siteRoot
+    );
+    const umdSentence = framework === 'javascript' ? ` ${selectingModulesNote.javascriptOnly}` : '';
+    const archiveUrl = toAbsoluteUrl(urlWithBaseUrl(olderVersionNote.link.url), siteRoot);
+
+    sections.push(
+        note(
+            `${selectingModulesNote.before} [${selectingModulesNote.link.text}](${modulesUrl})` +
+                ` ${selectingModulesNote.after}${umdSentence}`
+        ),
+        note(`${olderVersionNote.before} [${olderVersionNote.link.text}](${archiveUrl}) ${olderVersionNote.after}`)
+    );
+
+    // The page hides the lead and table together when a framework has no seed repositories.
+    const seedRepos = seedReposTable(framework);
+    if (seedRepos) {
+        sections.push(`## ${LICENSE_SETUP_HEADINGS.seedRepos.text}`, LICENSE_SETUP_COPY.seedReposLead, seedRepos);
+    }
+
+    return sections.join('\n\n');
+}
+
+/** The seed repositories for this framework, as the page's table (it filters by framework too). */
+function seedReposTable(framework: MarkdownFramework): string {
+    const rows = (seedProjects as SeedProject[])
+        .filter((project) => project.framework === framework)
+        .map((project) => [`[${project.name}](${project.url})`, project.framework, project.devEnvironment]);
+    return markdownTable(LICENSE_SETUP_COPY.seedReposHeaders, rows);
+}
+
+// Matches how the serializer renders an mdoc `{% note %}` block.
+function note(text: string): string {
+    return `> **Note**\n>\n> ${text}`;
+}

--- a/documentation/ag-grid-docs/src/utils/markdoc/renderMarkdocTag.ts
+++ b/documentation/ag-grid-docs/src/utils/markdoc/renderMarkdocTag.ts
@@ -21,6 +21,7 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
 import gridSeedProjects from '../../content/seed-projects/grid-seed-projects.json';
+import { buildLicenseSetupMarkdown } from './renderLicenseSetup';
 import { buildMatrixTable } from './renderMatrixTable';
 import { type ModuleNode, buildModuleMappingsTable } from './renderModuleMappings';
 
@@ -72,7 +73,7 @@ export async function renderMarkdocTag(params: RenderMarkdocTagParams): Promise<
             case 'gettingStarted':
                 return renderGettingStarted(attributes, framework, siteRoot);
             case 'licenseSetup':
-                return renderLicenseSetup(framework, siteRoot);
+                return buildLicenseSetupMarkdown({ framework, siteRoot });
             case 'trialLicenceForm':
                 return renderTrialLicenceForm(siteRoot);
             default:
@@ -258,15 +259,6 @@ function renderGettingStarted(
             return `- [${feature.title}](${url}) — ${feature.description}`;
         })
         .join('\n');
-}
-
-// Interactive licence-key setup tool; link to the page that hosts it instead.
-function renderLicenseSetup(framework: MarkdownFramework, siteRoot?: string): string {
-    const url = toAbsoluteUrl(
-        urlWithPrefix({ url: './license-install/', framework: framework as Framework }),
-        siteRoot
-    );
-    return `[Set up your licence key](${url})`;
 }
 
 // Interactive trial-licence request form; link to the licensing page instead.

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/buildHomepageMarkdown.test.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/buildHomepageMarkdown.test.ts
@@ -30,6 +30,27 @@ describe('buildHomepageMarkdown', () => {
         expect(output).toContain('[Create a Custom Theme](https://www.ag-grid.com/theme-builder/)');
     });
 
+    it('renders each section eyebrow headline as a kicker above its heading', () => {
+        expect(output).toContain('*Unbeatable Speed & Performance*\n\n## The Fastest Data Grid In The World');
+        expect(output).toContain('*JavaScript Data Grid FAQs*\n\n## Frequently Asked Questions');
+    });
+
+    it('lists the headline metrics', () => {
+        expect(output).toContain('- **90%** — Of the Fortune 500 use AG Grid');
+        expect(output).toContain('- **5M+** — Weekly NPM downloads');
+        expect(output).toContain('- **13k+** — GitHub Stars');
+        expect(output).toContain('- **40K+** — Commits');
+    });
+
+    it('renders the developer quotes as attributed blockquotes, in display order', () => {
+        expect(output).toContain(
+            '> There are a lot of component-based table libraries out there, but I believe AG Grid is the gold standard'
+        );
+        expect(output).toContain('> — **Tanner Linsley**, Creator TanStack');
+        expect(output).toContain('> — **Brian Love**, Expert at Google Developers');
+        expect(output.indexOf('Tanner Linsley')).toBeLessThan(output.indexOf('Ryan Carniato'));
+    });
+
     it('includes a What is New version highlight and an FAQ question', () => {
         expect(output).toContain('### 36.0.0');
         expect(output).toContain('- Calculated Columns');

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/buildHomepageMarkdown.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/buildHomepageMarkdown.ts
@@ -1,5 +1,6 @@
 import { htmlInlineToMarkdown } from '@ag-website-shared/markdoc/htmlInlineToMarkdown';
 import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+import { getOrderedQuotes, quotesData, statsData } from '@components/quotes/quotesData';
 import { urlWithPrefix } from '@utils/urlWithPrefix';
 
 import faqData from '../../content/faqs/homepage.json';
@@ -65,13 +66,27 @@ function faqSection(): string {
     return (faqData as FaqItem[]).map((item) => `### ${item.question}\n\n${item.answer}`).join('\n\n');
 }
 
+/** The headline metrics shown above the quotes, as a list. */
+function statsBlock(): string {
+    return statsData.map((stat) => `- **${stat.value}** — ${stat.label}`).join('\n');
+}
+
+/** The developer quotes, each as a blockquote with its attribution. */
+function quotesBlock(): string {
+    return getOrderedQuotes(quotesData)
+        .map((quote) => `> ${quote.text}\n>\n> — **${quote.name}**, ${quote.orgRole} ${quote.orgName}`)
+        .join('\n\n');
+}
+
 function sectionBlock(section: HomepageSection, siteRoot?: string): string {
     const heading = section.headingHtml ? htmlInlineToMarkdown(section.headingHtml, siteRoot) : section.heading;
     const subHeading = section.subHeadingHtml
         ? htmlInlineToMarkdown(section.subHeadingHtml, siteRoot)
         : section.subHeading;
 
-    const parts = [`## ${heading}`];
+    // The eyebrow headline labels the section above its heading on the page. Kept as an
+    // emphasised kicker line so it keeps that reading order without adding a heading level.
+    const parts = section.tag ? [`*${section.tag}*`, `## ${heading}`] : [`## ${heading}`];
     if (subHeading) {
         parts.push(subHeading);
     }
@@ -113,6 +128,10 @@ export function buildHomepageMarkdown({ siteRoot }: { siteRoot?: string } = {}):
         `# ${hero.headingPrefix} ${hero.headingSuffix}`,
         hero.subHeading,
         heroLinks,
+        // The customer-logos strip below the hero carries no heading on the page, so its
+        // metrics and quotes follow the hero directly, in page order.
+        statsBlock(),
+        quotesBlock(),
         ...(sections as HomepageSection[]).map((section) => sectionBlock(section, siteRoot)),
     ].join('\n\n');
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17862

Two markdown-twin gaps, branched off `b36.1.0`.

## Render the licence setup tool as markdown

Ports [ag-charts#7675](https://github.com/ag-grid/ag-charts/pull/7675).

The `licenseSetup` tag rendered as a bare link to the page hosting it, so `/license-install.md` lost every heading, snippet and note from that tag onwards — TC5 on the ticket. Only pasting a key and toggling Integrated Charts need a browser, so the headings, prose, all three snippets and the seed repositories are now rendered from the same content module, snippet builders and seed-project data the page uses, and the interactive parts link back to the page (as the module selector already does).

- `licenseSetupContent.ts` — the tool's static headings and copy, shared by the page component and the twin so they cannot drift. Inline-markup sentences are stored as parts and links as paths, so each renderer builds its own markup and resolves URLs for its own environment.
- `renderLicenseSetup.ts` (+ 13 unit tests) — builds the tag as markdown.

Grid needs more than charts did: the Configure Your Application heading, the Selecting Modules note with its JavaScript-only UMD sentence, grid's differently worded older-version note, and the framework-filtered Seed Repositories table.

Incidental: the Selecting Modules note ended in a stray lone full stop on non-JavaScript frameworks, from a dangling conditional the shared copy replaces.

## Extract more homepage content

Confirmed as wanted in [comment 129189](https://ag-grid.atlassian.net/browse/AG-17862?focusedCommentId=129189): the key metrics, testimonials and eyebrow headlines were all missing from `/index.md`.

The metrics were hardcoded in `Quotes.tsx`; they move to `quotesData.ts` alongside the quotes, and the quote filter/sort moves with them, so the page and the twin share the content and the display order. The metrics render as a list and the quotes as attributed blockquotes, placed after the hero in page order — the customer-logos strip that hosts them has no heading on the page, so none is invented. Each section's eyebrow headline becomes an emphasised kicker above its `##` heading.

## Testing

- `./behave.sh --project ag-grid-docs` — 568 passed, including 13 new licence-setup tests and 3 new homepage tests.
- `yarn nx lint ag-grid-docs` clean; `yarn nx format` run.
- `playwright test --project=page-verification` — 16 passed.
- Checked the rendered output on the dev server for `/index.md`, `/react-data-grid/license-install.md` and `/javascript-data-grid/license-install.md`, and confirmed both HTML pages and the five `license-install` heading anchors are unchanged.

Note: `yarn nx build-tsc ag-grid-docs` reports 5137 errors both with and without these changes, so the changed files were type-checked via the language server instead.