### PR TITLE
Fix(tests): stop webkit example specs racing chart creation and row virtualisation

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/excel-export-tables/_examples/excel-export-table-stripes/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/excel-export-tables/_examples/excel-export-table-stripes/example.spec.ts
@@ -1,4 +1,12 @@
-import { ensureGridReady, expect, test, waitForGridContent, waitForRowAnimations } from '@utils/grid/test-utils';
+import {
+    clickHeaderToSort,
+    ensureGridReady,
+    expect,
+    expectRowIdAtIndex,
+    test,
+    waitForGridContent,
+    waitForRowAnimations,
+} from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     test.eachFramework('Flat columns and data render', async ({ agIdFor, page }) => {
@@ -17,15 +25,16 @@ test.agExample(import.meta, () => {
         await waitForGridContent(page);
 
         // Dara Torres holds the unique maximum age (33) at data index 7.
-        const daraRow = agIdFor.rowNode('7').first();
-        await expect(daraRow).not.toHaveAttribute('row-index', '0');
+        await expectRowIdAtIndex(page, 0, '7', { not: true });
 
-        await agIdFor.headerCell('age').click();
+        // Ascending by age sorts Dara last, so her row virtualises out of the viewport — assert
+        // on the always-rendered first row rather than on her row's own element.
+        await clickHeaderToSort(agIdFor.headerCell('age'));
         await waitForRowAnimations(page);
-        await expect(daraRow).not.toHaveAttribute('row-index', '0');
+        await expectRowIdAtIndex(page, 0, '7', { not: true });
 
-        await agIdFor.headerCell('age').click();
+        await clickHeaderToSort(agIdFor.headerCell('age'));
         await waitForRowAnimations(page);
-        await expect(daraRow).toHaveAttribute('row-index', '0');
+        await expectRowIdAtIndex(page, 0, '7');
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-customisation/_examples/common-overrides/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-customisation/_examples/common-overrides/example.spec.ts
@@ -1,4 +1,4 @@
-import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForChartModels, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     // This example customises the chart via `chartThemeOverrides.common` (title, subtitle,
@@ -17,10 +17,9 @@ test.agExample(import.meta, () => {
         await expect(page.locator('.ag-cell', { hasText: 'Ireland' }).first()).toBeVisible();
 
         // A grouped-column range chart is auto-created over the category + three series columns.
-        const models = await remoteGrid(page).getChartModels();
-        expect(models).toHaveLength(1);
-        expect(models![0].chartType).toBe('groupedColumn');
-        expect(models![0].cellRange.columns).toEqual(['country', 'gold', 'silver', 'bronze']);
+        const models = await waitForChartModels(remoteGrid(page));
+        expect(models[0].chartType).toBe('groupedColumn');
+        expect(models[0].cellRange.columns).toEqual(['country', 'gold', 'silver', 'bronze']);
 
         // The chart canvas is rendered (theme overrides themselves are canvas-only).
         await expect(page.locator('.ag-chart-canvas-wrapper canvas').first()).toBeVisible();

--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-customisation/_examples/custom-chart-theme/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-customisation/_examples/custom-chart-theme/example.spec.ts
@@ -1,4 +1,4 @@
-import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForChartModels, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     // This example supplies two `customChartThemes` (light/dark) via `chartThemes`. The custom
@@ -14,11 +14,10 @@ test.agExample(import.meta, () => {
         await expect(page.locator('.ag-cell', { hasText: 'Ireland' }).first()).toBeVisible();
 
         // A grouped-bar range chart is auto-created and uses the first supplied custom theme.
-        const models = await remoteGrid(page).getChartModels();
-        expect(models).toHaveLength(1);
-        expect(models![0].chartType).toBe('groupedBar');
-        expect(models![0].chartThemeName).toBe('my-custom-theme-light');
-        expect(models![0].cellRange.columns).toEqual(['country', 'gold', 'silver', 'bronze']);
+        const models = await waitForChartModels(remoteGrid(page));
+        expect(models[0].chartType).toBe('groupedBar');
+        expect(models[0].chartThemeName).toBe('my-custom-theme-light');
+        expect(models[0].cellRange.columns).toEqual(['country', 'gold', 'silver', 'bronze']);
 
         await expect(page.locator('.ag-chart-canvas-wrapper canvas').first()).toBeVisible();
     });

--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-customisation/_examples/formatter-context/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-customisation/_examples/formatter-context/example.spec.ts
@@ -1,4 +1,4 @@
-import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForChartModels, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     // This example uses a global chart `formatter` that reaches back into the grid context to
@@ -21,10 +21,9 @@ test.agExample(import.meta, () => {
         await expect(page.locator('.ag-cell', { hasText: '$237438' }).first()).toBeVisible();
 
         // A grouped-column range chart is created over the three columns.
-        const models = await remoteGrid(page).getChartModels();
-        expect(models).toHaveLength(1);
-        expect(models![0].chartType).toBe('groupedColumn');
-        expect(models![0].cellRange.columns).toEqual(['period', 'recurring', 'individual']);
+        const models = await waitForChartModels(remoteGrid(page));
+        expect(models[0].chartType).toBe('groupedColumn');
+        expect(models[0].cellRange.columns).toEqual(['period', 'recurring', 'individual']);
 
         await expect(page.locator('.ag-chart-canvas-wrapper canvas').first()).toBeVisible();
     });

--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-customisation/_examples/global-label-formatter/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-customisation/_examples/global-label-formatter/example.spec.ts
@@ -1,4 +1,4 @@
-import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForChartModels, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     // This example uses a single global `formatter` that prefixes every number label on the chart
@@ -15,10 +15,9 @@ test.agExample(import.meta, () => {
         await expect(page.getByRole('columnheader', { name: 'Individual Sales' })).toBeVisible();
         await expect(page.locator('.ag-cell', { hasText: 'Q1 2021' }).first()).toBeVisible();
 
-        const models = await remoteGrid(page).getChartModels();
-        expect(models).toHaveLength(1);
-        expect(models![0].chartType).toBe('groupedColumn');
-        expect(models![0].cellRange.columns).toEqual(['period', 'recurring', 'individual']);
+        const models = await waitForChartModels(remoteGrid(page));
+        expect(models[0].chartType).toBe('groupedColumn');
+        expect(models[0].cellRange.columns).toEqual(['period', 'recurring', 'individual']);
 
         await expect(page.locator('.ag-chart-canvas-wrapper canvas').first()).toBeVisible();
     });

--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-customisation/_examples/label-formatting/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-customisation/_examples/label-formatting/example.spec.ts
@@ -1,4 +1,4 @@
-import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForChartModels, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     // This example applies axis label + title formatters (SI units on the primary axis, "%" on
@@ -16,14 +16,13 @@ test.agExample(import.meta, () => {
         await expect(page.getByRole('columnheader', { name: 'Efficiency' })).toBeVisible();
         await expect(page.locator('.ag-cell', { hasText: '2016' }).first()).toBeVisible();
 
-        const models = await remoteGrid(page).getChartModels();
-        expect(models).toHaveLength(1);
+        const models = await waitForChartModels(remoteGrid(page));
         // Mixed per-series chart types are stored as a custom combo.
-        expect(models![0].chartType).toBe('customCombo');
-        expect(models![0].cellRange.columns).toEqual(['year', 'generated', 'consumed', 'surplus', 'efficiency']);
+        expect(models[0].chartType).toBe('customCombo');
+        expect(models[0].cellRange.columns).toEqual(['year', 'generated', 'consumed', 'surplus', 'efficiency']);
 
         // Efficiency is charted as a line on a secondary axis; the other series are grouped columns.
-        const seriesTypes = models![0].seriesChartTypes ?? [];
+        const seriesTypes = models[0].seriesChartTypes ?? [];
         const efficiency = seriesTypes.find((s) => s.colId === 'efficiency');
         expect(efficiency?.chartType).toBe('line');
         expect(efficiency?.secondaryAxis).toBe(true);

--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-time-series/_examples/time-axis-config/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-time-series/_examples/time-axis-config/example.spec.ts
@@ -1,4 +1,4 @@
-import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForChartModels, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     // The example demonstrates configuring numeric timestamps to use a time axis by setting
@@ -15,9 +15,8 @@ test.agExample(import.meta, () => {
 
         // An area chart is created over the timestamp + cpuUsage range (the timestamp column is
         // configured with chartDataType: 'time' so the horizontal axis is a time axis).
-        const models = await gridApi.getChartModels();
-        expect(models).toHaveLength(1);
-        expect(models![0].chartType).toBe('area');
+        const models = await waitForChartModels(gridApi);
+        expect(models[0].chartType).toBe('area');
 
         // The chart canvas renders inside the example's #myChart container.
         await expect(page.locator('#myChart canvas').first()).toBeVisible();

--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-time-series/_examples/time-combination-chart/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-time-series/_examples/time-combination-chart/example.spec.ts
@@ -1,4 +1,4 @@
-import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForChartModels, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     // The example demonstrates a time-axis combination chart: rain as grouped columns and
@@ -17,12 +17,11 @@ test.agExample(import.meta, () => {
 
         // A combination chart is created over the date + rain + pressure + temp range, with the
         // date column (chartDataType: 'time') providing the time axis.
-        const models = await gridApi.getChartModels();
-        expect(models).toHaveLength(1);
-        expect(models![0].chartType).toBe('customCombo');
+        const models = await waitForChartModels(gridApi);
+        expect(models[0].chartType).toBe('customCombo');
 
         // Rain is a grouped column while pressure and temp are lines.
-        const seriesChartTypes = models![0].seriesChartTypes ?? [];
+        const seriesChartTypes = models[0].seriesChartTypes ?? [];
         const typeByColId = Object.fromEntries(seriesChartTypes.map((s) => [s.colId, s.chartType]));
         expect(typeByColId).toMatchObject({
             rain: 'groupedColumn',

--- a/documentation/ag-grid-docs/src/content/docs/integrated-charts-time-series/_examples/time-vs-category/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/integrated-charts-time-series/_examples/time-vs-category/example.spec.ts
@@ -1,4 +1,4 @@
-import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
+import { ensureGridReady, expect, test, waitForChartModels, waitForGridContent } from '@utils/grid/test-utils';
 
 test.agExample(import.meta, () => {
     // The example charts average daily temperatures on a line chart with a time axis, and
@@ -14,9 +14,8 @@ test.agExample(import.meta, () => {
         await expect(agIdFor.cell('0', 'avgTemp')).toContainText('8.27');
 
         // A line chart is created over the date + avgTemp range.
-        const models = await gridApi.getChartModels();
-        expect(models).toHaveLength(1);
-        expect(models![0].chartType).toBe('line');
+        const models = await waitForChartModels(gridApi);
+        expect(models[0].chartType).toBe('line');
 
         // The chart canvas renders inside the example's #myChart container.
         await expect(page.locator('#myChart canvas').first()).toBeVisible();

--- a/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
@@ -782,3 +782,4 @@ export { ensureGridReady, waitForGridContent } from './test/remoteGridapi';
 export { orderedValues } from './test/orderedValues';
 export { repeat } from './test/repeat';
 export { scrollGridRelative } from './test/scrollGridRelative';
+export { waitForChartModels } from './test/waitForChartModels';

--- a/documentation/ag-grid-docs/src/utils/grid/test/waitForChartModels.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test/waitForChartModels.ts
@@ -1,0 +1,22 @@
+import { expect } from 'playwright/test';
+
+import type { ChartModel } from 'ag-grid-community';
+
+import type { AsyncGridApi } from './remoteGridapi';
+
+/**
+ * Read the grid's chart models once `count` of them exist.
+ *
+ * Integrated-chart examples create their chart from `firstDataRendered`, which fires only after
+ * the example's asynchronous data load. `waitForGridContent` returns as soon as the first cell
+ * paints, so a single `getChartModels()` read can land before the chart has been created and see
+ * an empty array. Retrying the read rides that gap out.
+ */
+export async function waitForChartModels(gridApi: AsyncGridApi, count: number = 1): Promise<ChartModel[]> {
+    let models: ChartModel[] = [];
+    await expect(async () => {
+        models = (await gridApi.getChartModels()) ?? [];
+        expect(models).toHaveLength(count);
+    }).toPass();
+    return models;
+}


### PR DESCRIPTION
Fixes the three webkit test failures in [Documentation Tests run 30889740060](https://github.com/ag-grid/ag-grid/actions/runs/30889740060).

- `excel-export-table-stripes` asserted `row-index` on Dara Torres' own row element; ascending age sort moves her last, so the row virtualises out of webkit's viewport. Switched to `expectRowIdAtIndex`.
- Integrated-chart specs read `getChartModels()` once right after `waitForGridContent`, which returns before `onFirstDataRendered` creates the chart. Added `waitForChartModels` and applied it to all specs with that shape.

The 203 angular failures in the same run are `403 Forbidden` from www.ag-grid.com rate-limiting the runner, not a test bug.