### PR TITLE
RTI-3429: hide the docs button once the sidebar is pinned open

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/page-verification.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/page-verification.spec.ts
@@ -196,6 +196,29 @@ test.describe('Page Verification', () => {
         expect(cspViolations, 'CSP violations').toEqual([]);
     });
 
+    // The header's Docs button only toggles the left docs nav, so it must be gone at every
+    // width where DocsNav pins that nav permanently open — from $breakpoint-docs-nav-medium
+    // (1100px). Widths straddle that threshold, plus one well above it.
+    test('docs button and left docs nav are never both visible', async ({ page }) => {
+        const cspViolations = await setupPage(page);
+
+        const docsButton = page.locator('#top-bar-docs-button');
+        const docsNav = page.locator('#docs-mobile-nav-collapser');
+
+        for (const { width, expectButton } of [
+            { width: 1099, expectButton: true },
+            { width: 1100, expectButton: false },
+            { width: 1250, expectButton: false },
+        ]) {
+            await page.setViewportSize({ width, height: 900 });
+            await page.goto('/react-data-grid/getting-started/');
+            await expect(docsButton, `docs button at ${width}px`).toBeVisible({ visible: expectButton });
+            await expect(docsNav, `docs nav at ${width}px`).toBeVisible({ visible: !expectButton });
+        }
+
+        expect(cspViolations, 'CSP violations').toEqual([]);
+    });
+
     // Sense-check the standalone example runner across frameworks by loading a couple of
     // examples directly at their framework-specific URLs and asserting the grid renders. This
     // exercises each framework's example compiler head-on — in particular the vanilla

--- a/external/ag-website-shared/src/components/site-header/SiteHeader.module.scss
+++ b/external/ag-website-shared/src/components/site-header/SiteHeader.module.scss
@@ -5,8 +5,8 @@
 // See ./_breakpoints.scss for the single source of truth on what each named threshold
 // controls and why.
 //
-// Exception: .header's own sticky behaviour stays @media — a container cannot query
-// its own size.
+// Exceptions, both @media: .header's own sticky behaviour (a container cannot query its
+// own size) and .mobileNavButton's hide threshold (must match DocsNav's @media query).
 .header {
     display: flex;
     align-items: center;
@@ -146,7 +146,9 @@ button.mobileNavButton {
         max-width: 120px;
     }
 
-    @container site-header (min-width: #{$docs-search-inline}) {
+    // @media, not @container: this must agree to the pixel with DocsNav's own @media
+    // query, and a container query here would measure the viewport minus the scrollbar.
+    @media screen and (min-width: $docs-button-hide-at) {
         display: none;
     }
 

--- a/external/ag-website-shared/src/components/site-header/_breakpoints.scss
+++ b/external/ag-website-shared/src/components/site-header/_breakpoints.scss
@@ -13,4 +13,5 @@
 
 $docs-search-stack: $breakpoint-site-header-extra-small; // docs button + search wrap
 $sticky-at: $breakpoint-docs-nav-medium; // @media, not @container — can't query own size
+$docs-button-hide-at: $breakpoint-docs-nav-medium; // @media — DocsNav pins the nav open here
 $switcher-show: $nav-collapse; // switcher needs room exactly when the nav does


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/RTI-3429

The header's Docs button and the left docs nav were driven by two different thresholds, so between 1100px and ~1315px the button showed while the nav was already pinned open — clicking it did nothing. Ties the button's hide threshold to the same token DocsNav uses.

Fix [RTI-3429](https://ag-grid.atlassian.net/browse/RTI-3429)