### PR TITLE
Fix(tests): use ControlOrMeta in example specs so they pass on macOS

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/formula-editor-component/_examples/formula-editor-component/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/formula-editor-component/_examples/formula-editor-component/example.spec.ts
@@ -21,7 +21,8 @@ test.agExample(import.meta, () => {
 
         const editable = page.locator('.ag-cell-inline-editing [contenteditable]').first();
         await editable.click();
-        await page.keyboard.press('Control+a');
+        // Select-all is Meta+A on macOS, so Control+A leaves the existing formula in place.
+        await page.keyboard.press('ControlOrMeta+A');
         await page.keyboard.type('=3+4');
         await page.keyboard.press('Enter');
 

--- a/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/multi-column/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/row-sorting/_examples/multi-column/example.spec.ts
@@ -51,7 +51,9 @@ test.agExample(import.meta, () => {
         await expect(agIdFor.headerCell('age').locator('.ag-sort-ascending-icon')).toBeVisible();
 
         // multiSortKey: 'ctrl' means Ctrl+click adds gold as a secondary sort rather than replacing.
-        await agIdFor.headerCell('gold').click({ modifiers: ['Control'] });
+        // ControlOrMeta sends Meta on macOS, where Ctrl+click is a context-menu gesture; the grid
+        // accepts either modifier for the 'ctrl' multi-sort key.
+        await agIdFor.headerCell('gold').click({ modifiers: ['ControlOrMeta'] });
         await waitForRowAnimations(page);
         await expect(agIdFor.headerCell('gold').locator('.ag-sort-ascending-icon')).toBeVisible();
         await expect(agIdFor.headerCell('age').locator('.ag-sort-ascending-icon')).toBeVisible();


### PR DESCRIPTION
Two example specs hard-code `Control`, which does not do the intended thing on macOS:

- `row-sorting/multi-column` — Ctrl+click is a context-menu gesture on macOS, so the secondary sort was never applied. `sortService.ts:45` accepts `ctrlKey || metaKey` for `multiSortKey: 'ctrl'`.
- `formula-editor-component` — select-all is Meta+A, so `Control+a` left the existing formula in place and the typed formula appended.

Both now use `ControlOrMeta`, matching existing usage in `row-selection-multi-row` and `deep-dive` specs. Verified green locally across all six frameworks.