### PR TITLE
RTI-3428: only stick the site header once the nav is inline

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/page-verification.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/page-verification.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
 const isCspIssue = (msg: string) => /Content-Security-Policy|Refused to (load|execute|connect)/i.test(msg);
 // An actual enforced block, as opposed to a report-only policy that's merely being
@@ -215,6 +215,58 @@ test.describe('Page Verification', () => {
             await expect(docsButton, `docs button at ${width}px`).toBeVisible({ visible: expectButton });
             await expect(docsNav, `docs nav at ${width}px`).toBeVisible({ visible: !expectButton });
         }
+
+        expect(cspViolations, 'CSP violations').toEqual([]);
+    });
+
+    // A sticky header that is still showing the hamburger is a trap: the open menu is roughly as
+    // tall as the page, so it could never scroll out of view. 1110px is below $nav-collapse, so
+    // the hamburger is shown; 1250px is above it, where the nav is inline and must still stick.
+    test('header only sticks once the nav is inline, not while the hamburger is shown', async ({ page }) => {
+        const cspViolations = await setupPage(page);
+
+        const header = page.locator('.site-header');
+        const menuButton = page.getByRole('button', { name: 'Toggle navigation' });
+        const boxOf = async (locator: Locator) => {
+            const box = await locator.boundingBox();
+            if (!box) {
+                throw new Error(`no layout box for ${locator}`);
+            }
+            return box;
+        };
+
+        await page.setViewportSize({ width: 1110, height: 900 });
+        await page.goto('/react-data-grid/getting-started/');
+        await expect(menuButton).toBeVisible();
+
+        await page.evaluate(() => window.scrollTo(0, 1200));
+        const closed = await boxOf(header);
+        expect(closed.y + closed.height, 'collapsed header scrolls away with the page').toBeLessThanOrEqual(0);
+        // Nothing is pinned above the left docs nav, so it has nothing to offset itself for.
+        const docsNav = await boxOf(page.locator('#docs-nav-scroll'));
+        expect(docsNav.y, 'left docs nav pinned to the top of the viewport').toBe(0);
+
+        // The header nav is a hydrated island, so a click can land before it is interactive.
+        // Retry, clicking only while the button reports closed so a late click can't undo it.
+        await page.evaluate(() => window.scrollTo(0, 0));
+        await expect(async () => {
+            if ((await menuButton.getAttribute('aria-expanded')) !== 'true') {
+                await menuButton.click();
+            }
+            await expect(menuButton).toHaveAttribute('aria-expanded', 'true');
+        }).toPass();
+        await expect(page.locator('#mobile-docs-nav')).toBeVisible();
+
+        await page.evaluate(() => window.scrollTo(0, 1200));
+        const open = await boxOf(header);
+        expect(open.y + open.height, 'open nav scrolls away with the page').toBeLessThanOrEqual(0);
+
+        // Reload rather than just resize: the open nav leaves inline heights on the collapsible.
+        await page.setViewportSize({ width: 1250, height: 900 });
+        await page.goto('/react-data-grid/getting-started/');
+        await expect(menuButton).toBeHidden();
+        await page.evaluate(() => window.scrollTo(0, 1200));
+        expect((await boxOf(header)).y, 'inline header stays pinned to the top').toBe(0);
 
         expect(cspViolations, 'CSP violations').toEqual([]);
     });

--- a/external/ag-website-shared/src/components/docs-navigation/DocsNav.module.scss
+++ b/external/ag-website-shared/src/components/docs-navigation/DocsNav.module.scss
@@ -1,4 +1,6 @@
 @use 'design-system' as *;
+// $sticky-at: where the site header pins itself, and so where this nav must leave room for it.
+@use '../site-header/breakpoints' as site-header;
 
 @media screen and (min-width: $breakpoint-docs-nav-medium) {
     :global(#docs-mobile-nav-collapser) {
@@ -38,12 +40,21 @@
 
     position: sticky;
     width: 100%;
-    top: var(--layout-site-header-height);
+    // Below $sticky-at the header scrolls away with the page, leaving nothing to offset for.
+    top: 0;
     overflow-x: hidden;
     overflow-y: auto;
 
     @media screen and (min-width: $breakpoint-docs-nav-medium) {
-        height: calc(100vh - var(--layout-site-header-height));
+        height: 100vh;
+
+        @media screen and (min-width: site-header.$sticky-at) {
+            height: calc(100vh - var(--layout-site-header-height));
+        }
+    }
+
+    @media screen and (min-width: site-header.$sticky-at) {
+        top: var(--layout-site-header-height);
     }
 
     #{$selector-darkmode} & {

--- a/external/ag-website-shared/src/components/site-header/SiteHeader.module.scss
+++ b/external/ag-website-shared/src/components/site-header/SiteHeader.module.scss
@@ -6,7 +6,8 @@
 // controls and why.
 //
 // Exceptions, both @media: .header's own sticky behaviour (a container cannot query its
-// own size) and .mobileNavButton's hide threshold (must match DocsNav's @media query).
+// own size, so $sticky-at can only approximate $nav-collapse) and .mobileNavButton's hide
+// threshold (must match DocsNav's @media query).
 .header {
     display: flex;
     align-items: center;
@@ -21,6 +22,13 @@
         top: 0;
         width: 100%;
         z-index: 10002; // needed in order to prevent grid z-indexes overlapping on small height
+
+        // In the scrollbar-width sliver where $sticky-at has landed but the hamburger is still
+        // shown, a sticky open menu — roughly as tall as the page — could never scroll out of
+        // view. `relative`, not `static`: .mobileMenuButton anchors to this box.
+        &:has(.mobileMenuButton[aria-expanded='true']) {
+            position: relative;
+        }
     }
 
     #{$selector-darkmode}:has([data-is-homepage='false']) &,

--- a/external/ag-website-shared/src/components/site-header/_breakpoints.scss
+++ b/external/ag-website-shared/src/components/site-header/_breakpoints.scss
@@ -12,6 +12,9 @@
 // AnnouncementBanner — why it's owned there rather than aliased like these three.
 
 $docs-search-stack: $breakpoint-site-header-extra-small; // docs button + search wrap
-$sticky-at: $breakpoint-docs-nav-medium; // @media, not @container — can't query own size
+// Sticky is @media (a container cannot query its own size), so this lands a scrollbar's width
+// later than $nav-collapse's container query — see SiteHeader.module.scss's .header for why the
+// header must not stick while the hamburger is shown, and what covers the overlap.
+$sticky-at: $nav-collapse;
 $docs-button-hide-at: $breakpoint-docs-nav-medium; // @media — DocsNav pins the nav open here
 $switcher-show: $nav-collapse; // switcher needs room exactly when the nav does


### PR DESCRIPTION
The hamburger's open menu is roughly as tall as the page, and a sticky box that tall can never scroll out of view — it sat over the page content instead of the content being pushed down below it.

`$sticky-at` was `$breakpoint-docs-nav-medium` (1100px), where DocsNav pins the left nav open, but the header stays collapsed to the hamburger until `$nav-collapse` (1120px). Between the two the header was in its mobile layout and sticky at the same time — the breakpoint mismatch behind the report.

- Tie `$sticky-at` to `$nav-collapse`, so the header only sticks once the nav is actually inline. The sticky rule has to stay `@media` (a container cannot query its own size), so it can still land a scrollbar's width late; the `:has()` rule on `.header` keeps the open menu out of the content in that sliver.
- DocsNav offset itself by a header's height unconditionally, which stranded it that far down the viewport once the header scrolled away. It now reserves that space only from `$sticky-at`.

Covered by a new `page-verification` e2e test — verified failing against the pre-fix build and passing here.