### PR TITLE
AG-17862 Capture the remaining API reference links in the markdown docs

### DIFF
--- a/documentation/ag-grid-docs/src/utils/markdoc/buildApiReferenceTable.test.ts
+++ b/documentation/ag-grid-docs/src/utils/markdoc/buildApiReferenceTable.test.ts
@@ -125,6 +125,197 @@ describe('buildApiReferenceSection', () => {
         expect(bodyRows(output)[0][4]).toContain('[`RowSelectionModule`]');
     });
 
+    it('links the type to its reference page, as the page does', () => {
+        const output = buildApiReferenceSection(
+            {
+                config: {},
+                properties: {
+                    chartContainer: {
+                        definition: { description: 'Provide to display the chart outside the grid.' },
+                        propertyType: 'HTMLElement',
+                        gridOpProp: { type: { returnType: 'HTMLElement' } },
+                    },
+                    chartThemeOverrides: {
+                        definition: { description: 'Allows chart options to be overridden.' },
+                        propertyType: 'AgChartThemeOverrides',
+                        gridOpProp: { type: { returnType: 'AgChartThemeOverrides' } },
+                    },
+                    columnDefs: {
+                        definition: { type: 'ColDef', description: 'Column definitions.' },
+                        propertyType: 'ColDef',
+                    },
+                    chartType: {
+                        definition: { description: 'The type of chart to create.' },
+                        propertyType: 'ChartType',
+                        gridOpProp: { type: { returnType: 'ChartType' } },
+                    },
+                },
+            },
+            links
+        );
+
+        const [chartContainer, chartThemeOverrides, columnDefs, chartType] = bodyRows(output);
+        // An external type link is left as-is rather than prefixed with the site root.
+        expect(chartContainer[1]).toBe('[`HTMLElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement)');
+        expect(chartThemeOverrides[1]).toBe(
+            '[`AgChartThemeOverrides`](https://www.ag-grid.com/charts/themes-api/#reference-AgChartTheme-overrides)'
+        );
+        expect(columnDefs[1]).toBe('[`ColDef`](https://www.ag-grid.com/javascript-data-grid/column-properties/)');
+        // ChartType has no entry in the type link map, so the page does not link it either.
+        expect(chartType[1]).toBe('`ChartType`');
+    });
+
+    it('escapes the pipe inside a linked union type', () => {
+        const output = buildApiReferenceSection(
+            {
+                config: {},
+                properties: {
+                    aggFunc: {
+                        definition: { description: 'The aggregation function to apply.' },
+                        propertyType: 'string | IAggFunc',
+                        gridOpProp: { type: { returnType: 'string | IAggFunc' } },
+                    },
+                },
+            },
+            links
+        );
+
+        expect(output).toContain(
+            '[`string \\| IAggFunc`](https://www.ag-grid.com/javascript-data-grid/aggregation-custom-functions/)'
+        );
+    });
+
+    it('leaves the type unlinked where the page has no link to give it', () => {
+        const output = buildApiReferenceSection(
+            {
+                config: {},
+                properties: {
+                    createRangeChart: {
+                        definition: {},
+                        propertyType: 'Function',
+                        gridOpProp: { type: { arguments: {}, returnType: 'void' }, meta: { comment: 'Create it.' } },
+                    },
+                    defaultColDef: {
+                        // No description of its own, so this is a parent object — the page
+                        // links its type to an in-page anchor the markdown does not have.
+                        definition: { type: 'ColDef', meta: { description: 'Default column definition.' } },
+                        propertyType: 'ColDef',
+                    },
+                    columnDefs: {
+                        // A union where more than one member is linkable is ambiguous, so
+                        // the page links neither.
+                        definition: { type: 'ColDef | ColGroupDef', description: 'Column definitions.' },
+                        propertyType: 'ColDef | ColGroupDef',
+                    },
+                },
+            },
+            links
+        );
+
+        const [createRangeChart, defaultColDef] = bodyRows(output);
+        expect(createRangeChart[1]).toBe('`Function`');
+        expect(defaultColDef[1]).toBe('`ColDef`');
+        expect(output).not.toContain('#reference-');
+        // bodyRows splits on the pipe, so assert the union against the whole output.
+        expect(output).toContain('| `columnDefs` | `ColDef \\| ColGroupDef` |');
+    });
+
+    it("keeps the property's see-also link, its options and its initial badge", () => {
+        const output = buildApiReferenceSection(
+            {
+                config: {},
+                properties: {
+                    unlinkChart: {
+                        definition: {
+                            default: false,
+                            description: 'When enabled the chart will be unlinked from the grid after creation.',
+                            more: {
+                                name: 'Unlinking Charts',
+                                url: './integrated-charts-menu/#default-chart-menu-items',
+                            },
+                        },
+                        propertyType: 'boolean',
+                        gridOpProp: {
+                            meta: {
+                                tags: [
+                                    { name: 'initial' },
+                                    {
+                                        name: 'agModule',
+                                        comment: '`IntegratedChartsModule`',
+                                        modules: [{ name: 'IntegratedChartsModule', isEnterprise: true }],
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                    chartThemeName: {
+                        definition: {
+                            description: 'The default theme to use for the created chart.',
+                            options: ['ag-default', 'ag-vivid'],
+                        },
+                        propertyType: 'string',
+                    },
+                },
+            },
+            links
+        );
+
+        const [unlinkChart, chartThemeName] = bodyRows(output);
+        // Asserted whole, as the order the page shows these in is part of the behaviour.
+        expect(unlinkChart[4]).toBe(
+            'When enabled the chart will be unlinked from the grid after creation. ' +
+                'See [Unlinking Charts](https://www.ag-grid.com/javascript-data-grid/integrated-charts-menu/#default-chart-menu-items) for more information. ' +
+                'Module: [`IntegratedChartsModule`](https://www.ag-grid.com/javascript-data-grid/modules/). ' +
+                '[Initial](https://www.ag-grid.com/javascript-data-grid/grid-interface/#initial-grid-options).'
+        );
+        expect(chartThemeName[4]).toBe(
+            "The default theme to use for the created chart. Options: `'ag-default'`, `'ag-vivid'`."
+        );
+    });
+
+    it('takes the initial link from the config when the tag overrides it', () => {
+        const output = buildApiReferenceSection(
+            {
+                config: { initialLink: './column-interface/#initial-column-options' },
+                properties: {
+                    sortable: {
+                        definition: { description: 'Set to true to allow sorting.' },
+                        propertyType: 'boolean',
+                        gridOpProp: { meta: { tags: [{ name: 'initial' }] } },
+                    },
+                },
+            },
+            links
+        );
+
+        expect(bodyRows(output)[0][4]).toContain(
+            '[Initial](https://www.ag-grid.com/javascript-data-grid/column-interface/#initial-column-options).'
+        );
+    });
+
+    it('omits the see-also link when the page hides it or it has no target', () => {
+        const properties = {
+            unlinkChart: {
+                definition: {
+                    description: 'Unlink the chart.',
+                    more: { name: 'Unlinking Charts', url: './integrated-charts-menu/' },
+                },
+                propertyType: 'boolean',
+            },
+            chartThemeOverrides: {
+                definition: { description: 'Override the theme.', more: { name: 'Overriding Existing Themes' } },
+                propertyType: 'string',
+            },
+        };
+
+        const hidden = buildApiReferenceSection({ config: { hideMore: true }, properties }, links);
+        expect(hidden).not.toContain('Unlinking Charts');
+
+        const shown = buildApiReferenceSection({ config: {}, properties }, links);
+        expect(shown).toContain('See [Unlinking Charts]');
+        expect(shown).not.toContain('Overriding Existing Themes');
+    });
+
     it('leads with the section copy the page shows, not a fabricated heading', () => {
         const output = buildApiReferenceSection(
             {

--- a/documentation/ag-grid-docs/src/utils/markdoc/buildApiReferenceTable.ts
+++ b/documentation/ag-grid-docs/src/utils/markdoc/buildApiReferenceTable.ts
@@ -1,7 +1,8 @@
 import type { Framework } from '@ag-grid-types';
 import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
 import { AG_MODULE_TAG_NAME } from '@components/reference-documentation/constants';
-import { getInterfaceName } from '@components/reference-documentation/utils/interface-helpers';
+import { getTypeUrl } from '@components/reference-documentation/utils/documentation-helpers';
+import { formatJson, getInterfaceName } from '@components/reference-documentation/utils/interface-helpers';
 import { urlWithPrefix } from '@utils/urlWithPrefix';
 
 /** One section of a reference model — the same shape the site's `Section` component renders. */
@@ -21,6 +22,7 @@ export interface LinkContext {
 interface PropertyRow {
     name: string;
     type: string;
+    typeUrl?: string;
     isRequired: boolean;
     defaultValue: string;
     description: string;
@@ -28,6 +30,9 @@ interface PropertyRow {
 
 /** Docs page listing every module — where the on-page `@agModule` badges link to. */
 const MODULES_URL = './modules';
+
+/** Where the on-page `Initial` badge links to, unless the tag overrides it. */
+const INITIAL_URL = './grid-interface/#initial-grid-options';
 
 /**
  * Render one reference section as the section copy the page leads with followed by a
@@ -39,7 +44,7 @@ export function buildApiReferenceSection(
     { title, meta, config, properties }: ApiReferenceSection,
     links: LinkContext
 ): string {
-    const rows = buildRows(properties, links);
+    const rows = buildRows(properties, config, links);
     if (rows.length === 0) {
         return '';
     }
@@ -70,7 +75,7 @@ function buildSectionHeader({ title, meta, config }: Omit<ApiReferenceSection, '
     return parts.join('\n\n');
 }
 
-function buildRows(properties: Record<string, any>, links: LinkContext): PropertyRow[] {
+function buildRows(properties: Record<string, any>, config: Record<string, any>, links: LinkContext): PropertyRow[] {
     const rows: PropertyRow[] = [];
     const names = Object.keys(properties ?? {});
     for (let i = 0, len = names.length; i < len; ++i) {
@@ -80,24 +85,69 @@ function buildRows(properties: Record<string, any>, links: LinkContext): Propert
             continue;
         }
         const definition = prop.definition ?? {};
+        const { gridOpProp, propertyType } = prop;
+        const comment = gridOpProp?.meta?.comment;
         const definitionType = typeof definition.type === 'string' ? definition.type : undefined;
-        const type = prop.propertyType || definitionType || getInterfaceName(name);
+        const type = propertyType || definitionType || getInterfaceName(name);
         // Mirror the site's getDescription fallback: explicit description, then the
         // resolved code comment, then the parent object's meta description.
-        const rawDescription = definition.description || prop.gridOpProp?.meta?.comment || definition.meta?.description;
-        const tags = prop.gridOpProp?.meta?.tags ?? definition.tags ?? [];
-        // The property's modules are badges in the page's description column, so keep
-        // them with the description rather than giving them a column of their own.
-        const modules = buildModuleLinks(tags, links);
+        const rawDescription = definition.description || comment || definition.meta?.description;
+        // Also getDescription's isObject: a property with no prose of its own is the
+        // parent of a child object, whose type the page links to an in-page anchor the
+        // markdown has no equivalent for — so leave those types unlinked.
+        const isObject = !definition.description && !comment;
+        const tags = gridOpProp?.meta?.tags ?? definition.tags ?? [];
         rows.push({
             name,
             type: String(type ?? ''),
+            typeUrl: isObject ? undefined : buildTypeUrl(definition, gridOpProp, propertyType, links),
             isRequired: Boolean(definition.isRequired),
             defaultValue: buildDefaultValue(definition, tags),
-            description: [toCellText(rawDescription, links), modules].filter(Boolean).join(' '),
+            // The page shows the options, "see also" link, module badges and `Initial`
+            // badge alongside the description, so keep them in that column in that order
+            // rather than giving each one a column of its own.
+            description: [
+                toCellText(rawDescription, links),
+                buildOptions(definition),
+                buildMoreLink(definition, config, links),
+                buildModuleLinks(tags, links),
+                buildInitialLink(tags, config, links),
+            ]
+                .filter(Boolean)
+                .join(' '),
         });
     }
     return rows;
+}
+
+/**
+ * The type badge's link, mirroring Property's getDefinitionTypeUrl: the docs config type
+ * wins over the type resolved from source, and `Function` types are never linked.
+ * getTypeUrl already framework-prefixes the URL, so only the absolute step is left. An
+ * inferred type (the page's last resort) is always a primitive, so there is nothing to
+ * gain from falling back to it here.
+ */
+function buildTypeUrl(
+    definition: Record<string, any>,
+    gridOpProp: Record<string, any> | undefined,
+    propertyType: string | undefined,
+    { framework, siteRoot }: LinkContext
+): string | undefined {
+    if (propertyType === 'Function') {
+        return undefined;
+    }
+    const type = definition.type ?? gridOpProp?.type;
+    if (!type) {
+        return undefined;
+    }
+    try {
+        const typeUrl = getTypeUrl(type, framework);
+        return typeUrl ? toAbsoluteUrl(typeUrl, siteRoot) : undefined;
+    } catch {
+        // Not a doc-relative type link — leave the type unlinked rather than emit a URL
+        // the reader cannot follow.
+        return undefined;
+    }
 }
 
 /** Mirrors Property's getTagsData: an explicit default wins over the `@default` JSDoc tag. */
@@ -111,6 +161,40 @@ function buildDefaultValue(definition: Record<string, any>, tags: { name: string
         ? `[${defaultValue.map((value) => `"${value}"`).join(', ')}]`
         : String(defaultValue);
     return `\`${escapeCell(formatted)}\``;
+}
+
+/** The values the page lists under the description when a property is a fixed set. */
+function buildOptions(definition: Record<string, any>): string {
+    const options = definition.options;
+    if (!Array.isArray(options) || options.length === 0) {
+        return '';
+    }
+    const formatted = options.map((option) => `\`${escapeCell(formatJson(option))}\``).join(', ');
+    return `Options: ${formatted}.`;
+}
+
+/**
+ * The property's "see also" doc link, which the page renders under the description.
+ * `hideMore` mirrors the page suppressing it when a tag picks properties by name, as
+ * those pages are usually the link target themselves.
+ */
+function buildMoreLink(definition: Record<string, any>, config: Record<string, any>, links: LinkContext): string {
+    const more = definition.more;
+    if (!more?.url || !more.name || config.hideMore) {
+        return '';
+    }
+    return `See [${escapeCell(String(more.name))}](${resolveDocUrl(more.url, links)}) for more information.`;
+}
+
+/**
+ * The `@initial` badge as a link to the page explaining initial-only options, matching
+ * the badge the page shows next to the type.
+ */
+function buildInitialLink(tags: Record<string, any>[], config: Record<string, any>, links: LinkContext): string {
+    if (!tags.some((tag) => tag.name === 'initial')) {
+        return '';
+    }
+    return `[Initial](${resolveDocUrl(config.initialLink ?? INITIAL_URL, links)}).`;
 }
 
 /**
@@ -140,10 +224,12 @@ function buildModuleLinks(tags: Record<string, any>[], links: LinkContext): stri
 function buildTable(rows: PropertyRow[]): string {
     const lines = ['| Property | Type | Required | Default | Description |', '| --- | --- | --- | --- | --- |'];
     for (let i = 0, len = rows.length; i < len; ++i) {
-        const { name, type, isRequired, defaultValue, description } = rows[i];
-        lines.push(
-            `| \`${name}\` | \`${escapeCell(type)}\` | ${isRequired ? 'Yes' : ''} | ${defaultValue} | ${description} |`
-        );
+        const { name, type, typeUrl, isRequired, defaultValue, description } = rows[i];
+        // The page makes the type badge itself the link, so keep the code span inside
+        // the label rather than trailing the cell with a separate link.
+        const typeText = `\`${escapeCell(type)}\``;
+        const typeCell = typeUrl ? `[${typeText}](${typeUrl})` : typeText;
+        lines.push(`| \`${name}\` | ${typeCell} | ${isRequired ? 'Yes' : ''} | ${defaultValue} | ${description} |`);
     }
     return lines.join('\n');
 }


### PR DESCRIPTION
Follow-up to the TC1–TC3 pass (#14693) from [a review comment on AG-17862](https://ag-grid.atlassian.net/browse/AG-17862?focusedCommentId=129551): extend the "keep links inside descriptions" work to the remaining places where the HTML reference row shows a link that the `.md` twin drops.

Taking [integrated-charts-api-range-chart](https://www.ag-grid.com/archive/36.1.0/react-data-grid/integrated-charts-api-range-chart) as the example, four things were missing.

### 1. The property's "see also" link

`more: { name, url }` renders on the page as a link under the description but was dropped entirely — this is the `Overriding Existing Themes` and `Unlinking Charts` case in the comment. 618 entries across 20 reference JSON files, so it lands well beyond that one page (grid-options alone has 298, column-properties 71).

`hideMore` is honoured exactly as the page honours it, so a table that selects properties by name (and is usually the link target itself) still suppresses it.

### 2. The type badge's link

The page wraps the type in a link via `getTypeUrl`; the markdown emitted a bare code span. Reusing `getTypeUrl` means the two renderings cannot disagree about which types are linkable:

| | |
| --- | --- |
| Before | `` `AgChartThemeOverrides` `` |
| After | ``[`AgChartThemeOverrides`](https://www.ag-grid.com/charts/themes-api/#reference-AgChartTheme-overrides)`` |

Union types work the way the page's do — `string \| IAggFunc` links to `IAggFunc` because that is the only member with a target, and the escaped pipe survives inside the link label.

Object properties deliberately keep an unlinked type. The page points those at an in-page `#reference-<id>.<name>` anchor, which the markdown has no equivalent for, so linking them would only produce a dangling anchor.

### 3. The `Initial` badge link

Worth having for a reader who needs to know an option cannot be updated after the grid is created. `config.initialLink` is respected, so column properties link to `#initial-column-options` rather than `#initial-grid-options`.

### 4. The `Options:` value list

Properties restricted to a fixed set (e.g. `chartThemeName`) listed their allowed values on the page only.

All four go in the description column in the order the page shows them, rather than each earning a column of its own.

## Result

`chartThemeOverrides` and `unlinkChart` on the range chart page:

```
| `chartThemeOverrides` | [`AgChartThemeOverrides`](https://www.ag-grid.com/charts/themes-api/#reference-AgChartTheme-overrides) |  |  | Allows specific chart options in the current theme to be overridden. See [Overriding Existing Themes](…/integrated-charts-customisation/#overriding-themes) for more information. |
| `unlinkChart` | `boolean` |  | `false` | When enabled the chart will be unlinked from the grid after creation… See [Unlinking Charts](…/integrated-charts-menu/#default-chart-menu-items) for more information. |
```

## Testing

Serialization stays in `buildApiReferenceTable` so it remains pure and unit-tested — 6 new tests covering the linked/unlinked type cases, the escaped union pipe, cell ordering, `hideMore`, `initialLink` and the options list.

Verified against the dev server on `integrated-charts-api-range-chart`, `column-properties` (80 see-also and 17 `Initial` links — the volume case), `excel-export-api`, `row-object` and `integrated-charts-api-pivot-chart`: 447 generated table rows, no cell-count mismatches, so the escaped pipes do not break GFM.