### PR TITLE
AG-17860 - Track markdown actions dropdown events in Plausible

### DIFF
--- a/documentation/ag-grid-docs/src/components/docs/components/Header.tsx
+++ b/documentation/ag-grid-docs/src/components/docs/components/Header.tsx
@@ -56,7 +56,7 @@ export const Header: FunctionComponent<Props> = ({
                     {version && <span className={styles.version}>{`Version ${version}`}</span>}
 
                     <div className={styles.headerActions}>
-                        {markdownHref && <MarkdownActions markdownHref={markdownHref} />}
+                        {markdownHref && <MarkdownActions markdownHref={markdownHref} framework={framework} />}
                         <div className={styles.frameworkSelectorSlot}>
                             <FrameworkSelectorInsideDocs
                                 path={path}

--- a/documentation/ag-grid-docs/src/utils/analytics.ts
+++ b/documentation/ag-grid-docs/src/utils/analytics.ts
@@ -9,6 +9,7 @@ const EVENT_NAME = {
     infoEmail: 'Info Email',
     buyButton: 'Buy Button',
     downloadDS: 'Download Figma Design System',
+    markdownActions: 'Markdown Actions',
     page404: '404',
     // React Landing Page Goals
     reactLandingPageGetStarted: 'React Landing Page - Get Started',
@@ -141,6 +142,13 @@ const trackDownloadDS = (props: object) => {
 };
 
 export const trackOnceDownloadDS = createTrackPlausibleOnce(EVENT_NAME.downloadDS, trackDownloadDS);
+
+export const trackMarkdownActions = (props: object) => {
+    trackPlausible({
+        eventName: EVENT_NAME.markdownActions,
+        props,
+    });
+};
 
 export const trackTrialLicenseFormSuccess = (props: object) => {
     trackPlausible({

--- a/external/ag-website-shared/src/components/markdown-actions/MarkdownActions.tsx
+++ b/external/ag-website-shared/src/components/markdown-actions/MarkdownActions.tsx
@@ -1,4 +1,5 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import { trackMarkdownActions } from '@utils/analytics';
 import { ChevronDown } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { FunctionComponent } from 'react';
@@ -7,6 +8,7 @@ import styles from './MarkdownActions.module.scss';
 
 interface Props {
     markdownHref: string;
+    framework?: string;
 }
 
 type CopyState = 'idle' | 'copied' | 'failed';
@@ -18,6 +20,8 @@ const COPY_LABELS: Record<CopyState, string> = {
 };
 
 const COPY_LABEL_RESET_MS = 2000;
+
+const VIEW_AS_MARKDOWN_LABEL = 'View as Markdown';
 
 // The chat apps fetch the .md themselves, so they need an absolute, publicly
 // reachable URL — on localhost the page will open but the fetch won't resolve.
@@ -39,13 +43,22 @@ const CHAT_APPS = [
  * copies it, and the chevron reveals the remaining markdown/LLM actions. Consumers
  * pass the page's `.md` URL and place it wherever the page header has room.
  */
-export const MarkdownActions: FunctionComponent<Props> = ({ markdownHref }) => {
+export const MarkdownActions: FunctionComponent<Props> = ({ markdownHref, framework }) => {
     const [copyState, setCopyState] = useState<CopyState>('idle');
     const resetTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
 
     useEffect(() => {
         return () => clearTimeout(resetTimeoutRef.current);
     }, []);
+
+    // Plausible records the page URL against every custom event, so only the
+    // action and the framework need to be sent as properties.
+    const trackAction = useCallback(
+        (action: string) => {
+            trackMarkdownActions({ action, framework });
+        },
+        [framework]
+    );
 
     const flashCopyState = useCallback((state: CopyState) => {
         setCopyState(state);
@@ -54,6 +67,7 @@ export const MarkdownActions: FunctionComponent<Props> = ({ markdownHref }) => {
     }, []);
 
     const copyMarkdown = useCallback(async () => {
+        trackAction(COPY_LABELS.idle);
         try {
             const response = await fetch(markdownHref);
             if (!response.ok) {
@@ -65,14 +79,15 @@ export const MarkdownActions: FunctionComponent<Props> = ({ markdownHref }) => {
             console.error('Could not copy the markdown version of this page', error);
             flashCopyState('failed');
         }
-    }, [markdownHref, flashCopyState]);
+    }, [markdownHref, flashCopyState, trackAction]);
 
     const openChatApp = useCallback(
-        (buildUrl: (prompt: string) => string) => {
+        (label: string, buildUrl: (prompt: string) => string) => {
+            trackAction(label);
             const markdownUrl = new URL(markdownHref, window.location.href).toString();
             window.open(buildUrl(buildChatPrompt(markdownUrl)), '_blank', 'noopener,noreferrer');
         },
-        [markdownHref]
+        [markdownHref, trackAction]
     );
 
     return (
@@ -96,8 +111,12 @@ export const MarkdownActions: FunctionComponent<Props> = ({ markdownHref }) => {
                 <DropdownMenu.Portal>
                     <DropdownMenu.Content className={styles.content} align="end" sideOffset={0}>
                         <DropdownMenu.Item className={styles.item} asChild>
-                            <a href={markdownHref} data-markdown-link>
-                                View as Markdown
+                            <a
+                                href={markdownHref}
+                                data-markdown-link
+                                onClick={() => trackAction(VIEW_AS_MARKDOWN_LABEL)}
+                            >
+                                {VIEW_AS_MARKDOWN_LABEL}
                             </a>
                         </DropdownMenu.Item>
 
@@ -105,7 +124,7 @@ export const MarkdownActions: FunctionComponent<Props> = ({ markdownHref }) => {
                             <DropdownMenu.Item
                                 key={label}
                                 className={styles.item}
-                                onSelect={() => openChatApp(buildUrl)}
+                                onSelect={() => openChatApp(label, buildUrl)}
                             >
                                 {label}
                             </DropdownMenu.Item>


### PR DESCRIPTION
## What

Adds a `Markdown Actions` Plausible event covering every option in the docs header split button:

| Action | Tracked as |
| --- | --- |
| Primary button | `Copy as Markdown` |
| Dropdown | `View as Markdown` |
| Dropdown | `Open in Claude` |
| Dropdown | `Open in ChatGPT` |

Properties sent: `action` and `framework`.

The page is deliberately **not** sent as a property — Plausible already records the page URL against every custom event, so it can be broken down by page without spending a custom property slot. `framework` is sent explicitly because although it is derivable from the docs URL prefix, a property gives a one-click breakdown.

## Why the shared component changed

`MarkdownActions` lives in `external/ag-website-shared` and is rendered by the grid, charts and studio docs headers. It now imports `@utils/analytics`, which each site resolves to its own file — so all three sites need a matching `trackMarkdownActions` export or their build breaks. Companion PRs:

- ag-charts `latest` + `b14.1.0`
- ag-studio `latest` + `b2.1.0`
- ag-grid `b36.1.0`

This follows the existing precedent of `TrialLicenceForm.tsx`, which already imports `@utils/analytics` from the shared package.

## Notes

- No `trackOnce` variant: repeat clicks are genuine usage here, not noise.
- Action strings reuse the existing UI labels (`COPY_LABELS`, `CHAT_APPS`) so the Plausible breakdown reads directly and the labels cannot drift from what users see.

## Testing

- `yarn nx format --sort-root-tsconfig-paths=false`
- `yarn nx lint ag-grid-docs` — passes
- Not verified in a browser that events reach Plausible.