### PR TITLE
AG-17860 - Track markdown actions dropdown events in Plausible (36.1.0)

### DIFF
--- a/documentation/ag-grid-docs/src/components/docs/components/Header.tsx
+++ b/documentation/ag-grid-docs/src/components/docs/components/Header.tsx
@@ -56,7 +56,7 @@ export const Header: FunctionComponent<Props> = ({
                     {version && <span className={styles.version}>{`Version ${version}`}</span>}
 
                     <div className={styles.headerActions}>
-                        {markdownHref && <MarkdownActions markdownHref={markdownHref} />}
+                        {markdownHref && <MarkdownActions markdownHref={markdownHref} framework={framework} />}
                         <div className={styles.frameworkSelectorSlot}>
                             <FrameworkSelectorInsideDocs
                                 path={path}

--- a/documentation/ag-grid-docs/src/utils/analytics.ts
+++ b/documentation/ag-grid-docs/src/utils/analytics.ts
@@ -9,6 +9,7 @@ const EVENT_NAME = {
     infoEmail: 'Info Email',
     buyButton: 'Buy Button',
     downloadDS: 'Download Figma Design System',
+    markdownActions: 'Markdown Actions',
     page404: '404',
     // React Landing Page Goals
     reactLandingPageGetStarted: 'React Landing Page - Get Started',
@@ -141,6 +142,13 @@ const trackDownloadDS = (props: object) => {
 };
 
 export const trackOnceDownloadDS = createTrackPlausibleOnce(EVENT_NAME.downloadDS, trackDownloadDS);
+
+export const trackMarkdownActions = (props: object) => {
+    trackPlausible({
+        eventName: EVENT_NAME.markdownActions,
+        props,
+    });
+};
 
 export const trackTrialLicenseFormSuccess = (props: object) => {
     trackPlausible({

--- a/external/ag-website-shared/src/components/markdown-actions/MarkdownActions.tsx
+++ b/external/ag-website-shared/src/components/markdown-actions/MarkdownActions.tsx
@@ -1,4 +1,5 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import { trackMarkdownActions } from '@utils/analytics';
 import { ChevronDown } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { FunctionComponent } from 'react';
@@ -7,6 +8,7 @@ import styles from './MarkdownActions.module.scss';
 
 interface Props {
     markdownHref: string;
+    framework?: string;
 }
 
 type CopyState = 'idle' | 'copied' | 'failed';
@@ -18,6 +20,8 @@ const COPY_LABELS: Record<CopyState, string> = {
 };
 
 const COPY_LABEL_RESET_MS = 2000;
+
+const VIEW_AS_MARKDOWN_LABEL = 'View as Markdown';
 
 // The chat apps fetch the .md themselves, so they need an absolute, publicly
 // reachable URL — on localhost the page will open but the fetch won't resolve.
@@ -39,13 +43,22 @@ const CHAT_APPS = [
  * copies it, and the chevron reveals the remaining markdown/LLM actions. Consumers
  * pass the page's `.md` URL and place it wherever the page header has room.
  */
-export const MarkdownActions: FunctionComponent<Props> = ({ markdownHref }) => {
+export const MarkdownActions: FunctionComponent<Props> = ({ markdownHref, framework }) => {
     const [copyState, setCopyState] = useState<CopyState>('idle');
     const resetTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
 
     useEffect(() => {
         return () => clearTimeout(resetTimeoutRef.current);
     }, []);
+
+    // Plausible records the page URL against every custom event, so only the
+    // action and the framework need to be sent as properties.
+    const trackAction = useCallback(
+        (action: string) => {
+            trackMarkdownActions({ action, framework });
+        },
+        [framework]
+    );
 
     const flashCopyState = useCallback((state: CopyState) => {
         setCopyState(state);
@@ -54,6 +67,7 @@ export const MarkdownActions: FunctionComponent<Props> = ({ markdownHref }) => {
     }, []);
 
     const copyMarkdown = useCallback(async () => {
+        trackAction(COPY_LABELS.idle);
         try {
             const response = await fetch(markdownHref);
             if (!response.ok) {
@@ -65,14 +79,15 @@ export const MarkdownActions: FunctionComponent<Props> = ({ markdownHref }) => {
             console.error('Could not copy the markdown version of this page', error);
             flashCopyState('failed');
         }
-    }, [markdownHref, flashCopyState]);
+    }, [markdownHref, flashCopyState, trackAction]);
 
     const openChatApp = useCallback(
-        (buildUrl: (prompt: string) => string) => {
+        (label: string, buildUrl: (prompt: string) => string) => {
+            trackAction(label);
             const markdownUrl = new URL(markdownHref, window.location.href).toString();
             window.open(buildUrl(buildChatPrompt(markdownUrl)), '_blank', 'noopener,noreferrer');
         },
-        [markdownHref]
+        [markdownHref, trackAction]
     );
 
     return (
@@ -96,8 +111,12 @@ export const MarkdownActions: FunctionComponent<Props> = ({ markdownHref }) => {
                 <DropdownMenu.Portal>
                     <DropdownMenu.Content className={styles.content} align="end" sideOffset={0}>
                         <DropdownMenu.Item className={styles.item} asChild>
-                            <a href={markdownHref} data-markdown-link>
-                                View as Markdown
+                            <a
+                                href={markdownHref}
+                                data-markdown-link
+                                onClick={() => trackAction(VIEW_AS_MARKDOWN_LABEL)}
+                            >
+                                {VIEW_AS_MARKDOWN_LABEL}
                             </a>
                         </DropdownMenu.Item>
 
@@ -105,7 +124,7 @@ export const MarkdownActions: FunctionComponent<Props> = ({ markdownHref }) => {
                             <DropdownMenu.Item
                                 key={label}
                                 className={styles.item}
-                                onSelect={() => openChatApp(buildUrl)}
+                                onSelect={() => openChatApp(label, buildUrl)}
                             >
                                 {label}
                             </DropdownMenu.Item>


### PR DESCRIPTION
Release-branch port of the `Markdown Actions` Plausible event for the in-flight 36.1.0 release.

Companion to the `latest` PR: https://github.com/ag-grid/ag-grid/pull/14728

## What

Adds a `Markdown Actions` Plausible event covering every option in the docs header split button — `Copy as Markdown`, `View as Markdown`, `Open in Claude`, `Open in ChatGPT` — sending `action` and `framework` as properties. The page is not sent, as Plausible already records the page URL against every custom event.

## Why this branch

`b36.1.0` is the only release branch that contains the markdown actions component at all — it shipped on 2026-07-28 (AG-17860), after `b36.0.2` and every earlier release branch was cut.

`MarkdownActions` is shared with the charts and studio sites, so those repos have matching PRs on both `latest` and their newest release branch.

## Testing

The three touched files were byte-identical between `origin/latest` and `origin/b36.1.0` before this change, and this is a clean cherry-pick of the `latest` commit, so the resulting file contents are byte-identical to the version linted on that PR (`yarn nx lint ag-grid-docs`, passing).

Lint was not re-run in this worktree — it has no `node_modules` — but given identical inputs and identical outputs it would be the same run.