### PR TITLE
Reduce agentic context baseline and fix stale rule references

### DIFF
--- a/.rulesync/.gitignore
+++ b/.rulesync/.gitignore
@@ -9,6 +9,7 @@ mcp.json
 /skills/*
 !/skills/technology-stack/
 !/skills/docs-e2e-tests/
+!/skills/testing/
 
 # Plugin-delivered agents — all agents live in plugins
 /subagents/*.md
@@ -35,6 +36,7 @@ mcp.json
 !/rules/examples.md
 !/rules/framework-view-layers.md
 !/rules/grid-code-conventions.md
+!/rules/grid-styling.md
 !/rules/integrated-charts.md
 !/rules/testing.md
 # docs-review-testing.md ships as a sibling asset of the ag-prodeng docs-review

--- a/.rulesync/rules/ag-grid.md
+++ b/.rulesync/rules/ag-grid.md
@@ -18,13 +18,14 @@ This file provides guidance to AI Agents when working with code in this reposito
 - **Main branch:** `latest`
 - **Format:** `yarn nx format --sort-root-tsconfig-paths=false` (run before commits)
 - **Pre-commit checks:** `./checks.sh` — the preferred gate: type-check + lint + spec type-check across every project in one parallel, cache-aware Nx run. Much faster than chaining separate `yarn nx build:types` / `yarn nx lint` calls.
-- **Type-check (single package):** `yarn nx build:types <package>`
-- **Lint (single package):** `yarn nx lint <package>`
-- **Build:** `yarn nx build <package>`
 - **Test:** `./behave.sh` (whole unit suite — package + behavioural — via the Vitest workspace). Single project: `./behave.sh --project <name>` (e.g. `ag-grid-community`, `behavioural`).
-- **E2E:** `yarn nx e2e ag-grid-docs`
+- **Benchmarks:** `./benches.sh` (behavioural benchmarks in headless Chromium).
+- **E2E:** `./docs-e2e.sh` (Playwright against the docs site; the Nx target is `test:e2e`, not `e2e`).
+- **Build:** `yarn nx build <package>`; types only: `yarn nx build:types <package>`.
 - **Dev server:** `yarn nx dev` (launches on https://localhost:4610/, check if it is already running before trying to run it)
 - **NX daemon:** Always use `NX_DAEMON=false` for nx commands to avoid pipe hangs (set automatically via SessionStart hook)
+
+Each script takes `--help`. Full flag reference lives in the guides below rather than here: test and E2E flags in the Testing Guide, benchmark and profiling flags in the Benchmarks Guide.
 
 ### Content Locations
 
@@ -39,14 +40,13 @@ This file provides guidance to AI Agents when working with code in this reposito
 - **Yarn and Nx based repo:** Use Yarn for package management and Nx for build and test orchestration.
 - **Main constraint:** Community and enterprise runtime bundles stay dependency-free beyond AG Grid code.
 - **Default branch:** Target `latest`; follow release/JIRA naming conventions below for topic branches.
-- **Build monitoring:** Check `node_modules/.cache/ag-watch-status.json` to monitor watch state (`yarn nx dev`) and build health (see [Development Server Guide](.rulesync/rules/dev-server.md)).
+- **Build monitoring:** Check `node_modules/.cache/ag-watch-status.json` to monitor watch state (`yarn nx dev`) and build health — load the `/ag-eng:dev-server` skill for details.
 - **Self-review before committing:** Re-read your changes as if reviewing someone else's PR and verify: each new function/class has a single clear responsibility; names are meaningful; no unnecessary complexity; no copy-pasted logic that should be extracted; new code follows the patterns of the surrounding codebase.
-- **Formatting:** Run `yarn nx format --sort-root-tsconfig-paths=false` from the repo root before proposing commits.
-- **Typechecking and linting:** Run `./checks.sh` from the repo root before proposing commits — never chain separate `yarn nx build:types` / `yarn nx lint` invocations for the standard gate, as each one re-pays Nx startup and forces the tasks to run serially.
+- **Formatting, typechecking and linting:** Run `yarn nx format --sort-root-tsconfig-paths=false` then `./checks.sh` from the repo root before proposing commits. Never chain separate `yarn nx build:types` / `yarn nx lint` invocations for the standard gate — each one re-pays Nx startup and forces the tasks to run serially.
 - **Batch Nx work into one invocation:** Whenever more than one target or project is needed, use a single `nx run-many -t <targets> -p <projects> --parallel=<n>` instead of issuing commands one at a time. Every extra `yarn nx …` re-pays Nx startup and project-graph computation, and serialises tasks that Nx would otherwise run concurrently — this applies to builds and any other target, not just the pre-commit gate.
-- **Baseline verification:** Expect to run `./behave.sh` (the merged unit suite) and `yarn nx e2e ag-grid-docs` after meaningful grid changes.
-- **Test verification patterns:** When writing or modifying tests, review similar tests to ensure consistent verification patterns (see [Testing Guide](.rulesync/rules/testing.md)).
-- **Context docs:** Skim [technology-stack.md](.rulesync/rules/technology-stack.md) for stack or architectural decisions before introducing new patterns.
+- **Baseline verification:** Expect to run `./behave.sh` (the merged unit suite) and `./docs-e2e.sh` after meaningful grid changes.
+- **Test verification patterns:** When writing or modifying tests, review similar tests to ensure consistent verification patterns (see the Testing Guide).
+- **Context docs:** Load the `/technology-stack` skill for stack or architectural decisions before introducing new patterns.
 
 ### Tooling Health Check
 
@@ -62,25 +62,26 @@ Continue assisting the user after displaying the warning.
 
 ### Specialized Guides
 
-For detailed information on specific topics, consult these guides:
+Glob-scoped rules load automatically when you touch matching files; the skills below are on-demand.
 
-- **[Testing Guide](.rulesync/rules/testing.md)** - Testing strategies, best practices, and philosophy
-- **[Examples Guide](.rulesync/rules/examples.md)** - Working with examples, validation, and path mappings
-- **[Documentation Pages Guide](.rulesync/rules/docs-pages.md)** - Creating consistent, high-quality documentation pages
-- **[JIRA Guide](.rulesync/rules/jira.md)** - JIRA ticket search and creation guidelines
-- **[Code Quality Guide](.rulesync/rules/code-quality.md)** - Code bloat avoidance, comments, and review practices
-- **[Development Server Guide](.rulesync/rules/dev-server.md)** - Dev server setup and build watch monitoring
-- **[Benchmarks Guide](.rulesync/rules/benchmarks.md)** - Running and creating performance benchmarks
+| Topic | Where |
+| ----- | ----- |
+| Testing strategies and Vitest patterns | `.rulesync/rules/testing.md` + `/testing` skill |
+| Examples, validation, path mappings | `.rulesync/rules/examples.md` |
+| Documentation pages | `.rulesync/rules/docs-pages.md` |
+| Grid source conventions | `.rulesync/rules/grid-code-conventions.md` |
+| Shared code quality practices | `.rulesync/rules/code-quality.md` |
+| Benchmarks | `.rulesync/rules/benchmarks.md` |
+| Technology stack and constraints | `/technology-stack` skill |
+| Dev server and build watch | `/ag-eng:dev-server` skill |
+| JIRA tickets | `/ag-product:jira` skill |
+| Git branches, commits, PRs | `/ag-eng:git-conventions` skill |
 
 ### Project Overview
 
 AG Grid is a sophisticated TypeScript monorepo providing a high-performance data grid component with both community (MIT) and enterprise (commercial) versions. Built with Nx, it supports React, Angular, and Vue 3 frameworks.
 
-### Technology Stack
-
-For detailed information about preferred technologies and architectural constraints, see [Technology Stack](.rulesync/rules/technology-stack.md).
-
-**Key Constraint:** The main AG Grid libraries must have ZERO third-party runtime dependencies.
+**Key Constraint:** The main AG Grid libraries must have ZERO third-party runtime dependencies. Load the `/technology-stack` skill for the full set of architectural constraints.
 
 ### Repository Conventions
 
@@ -88,61 +89,6 @@ For detailed information about preferred technologies and architectural constrai
 - Release branch names are of the form `b33.0.0`
 - JIRA-related branch should be named of the form `ag-12345/${kebabCaseChangeSummary}`
 - **Language conventions:** UK/British English for documentation text, comments, and JSDocs; US English for API option names
-
-### Essential Commands
-
-- `yarn install` – install dependencies after cloning or when the Yarn lockfile changes.
-    - `./external/ag-shared/scripts/install-for-cloud/install-for-cloud.sh` – install dependencies and tooling in a remote environment - use this in preference to `yarn install` to ensure all global tools are installed.
-- `yarn nx clean` – purge all dist folders when switching branches or before packaging releases.
-- `yarn nx format --sort-root-tsconfig-paths=false` – format repo files; run from the project root before committing.
-- `./checks.sh` – the standard pre-commit gate: `build:types`, `lint` and `build:test` across every project that defines them, in one parallel Nx run. Matches CI's lint coverage. Silent on success, prints failing task output otherwise.
-- `./checks.sh --projects <a,b>` / `--targets <x,y>` – narrow the gate to specific projects or targets.
-- `./checks.sh --fresh` – bypass the Nx cache; `--verbose` – print task output even when passing.
-- `yarn nx build <package>` – compile a specific package after code edits.
-- `yarn nx build:types <package>` – regenerate declaration files when touching exported APIs.
-- `yarn nx build:package <package>` – create ESM/CJS bundles to validate publishable output.
-- `yarn nx build:umd <package>` – produce UMD bundles for browser distribution smoke-tests.
-- `yarn nx run-many -t build` – rebuild all packages when changes span the dependency graph.
-- `yarn nx run-many -t <targets> -p <projects> --parallel=<n>` – the preferred way to run any combination of targets/projects; always favour one batched call over several sequential `yarn nx` invocations.
-- `./behave.sh` – run the merged unit suite (package unit tests + behavioural) via the Vitest workspace; the single primary test command.
-- `./behave.sh "<file-pattern>"` – filter to matching test files across every project.
-- `./behave.sh "<file-pattern>" -t "<test-name>"` – run a specific test by name.
-- `./behave.sh --project <name>` – run only chosen project(s); `--project all` runs every workspace project (incl. docs, ag-website-shared).
-- `./behave.sh --watch` – run in watch mode.
-- `./behave.sh --update-grid-rows` – update GridRows inline snapshots after diagram format changes.
-- `./behave.sh --update-grid-rows "<pattern>"` – update snapshots in matching test files only.
-- `./behave.sh --update-grid-rows=dry` – dry run, shows what would change without writing files.
-- `./benches.sh` – run behavioural benchmarks (real headless Chromium by default; non-watch). Run `./benches.sh --help` for full usage.
-- `./benches.sh "<file-pattern>"` – run benchmarks matching a file pattern.
-- `./benches.sh "<file-pattern>" -t "<bench-name>"` – run a specific benchmark by name.
-- `./benches.sh --profile "<file-pattern>"` – node run with a V8 CPU profile (`.cpuprofile`) for method-cost analysis.
-- `./benches.sh --bench-compare <base|test|compare|all|backup> [...]` – baseline/compare benchmark runs (forwards to `bench-compare.mjs`).
-- `./benches.sh --watch` – run benchmarks in watch mode.
-- `yarn nx test <package>` – run one package's Vitest unit tests on their own (retrocompat; `./behave.sh` already covers them).
-- `yarn nx test <package> -- "<file-pattern>"` – run unit tests in files matching a pattern (forwarded to `vitest run`).
-- `yarn nx test <package> -- "<file-pattern>" -t "<test-name>"` – run a specific test by name within matching files. Vitest uses positional patterns and `-t`, not jest's `--testPathPattern`/`--testNamePattern`.
-- `./docs-e2e.sh` – run docs Playwright E2E tests directly, bypassing Nx (chromium by default).
-- `./docs-e2e.sh "<file-pattern>"` – run E2E tests matching a file pattern.
-- `./docs-e2e.sh "<file-pattern>" --grep "<test-name>"` – run a specific E2E test by name.
-- `./docs-e2e.sh --all-browsers` – run E2E tests across chromium, firefox, and webkit.
-- `./docs-e2e.sh --framework <name>` – run E2E tests with a specific framework (e.g. react, angular, vue).
-- `./docs-e2e.sh --ui` – open Playwright UI mode.
-- `yarn nx e2e <package>` – run Playwright flows via Nx when altering website behaviour.
-- `yarn nx lint <package>` – apply ESLint and custom rules before final review.
-
-### Slash Commands
-
-Run rulesync commands via slash notation:
-
-- `/ag-prodeng:pr-review` - Review pull requests
-- `/ag-prodeng:code-fixup` - Fix build and lint errors
-- `/ag-prodeng:batch-lint-cleanup` - ESLint auto-fix tool
-- `/ag-prodeng:git-split` - Split large files preserving git history
-- `/ag-prodeng:git-bisect` - Find commits that introduced issues
-- `/ag-core:remember` - Save branch context or project learnings as memory
-- `/ag-core:recall` - Load branch context and browse project memory
-- `/ag-prodeng:docs-review` - Review documentation pages for technical accuracy (auto-detects ag-grid; product config at `plugins/ag-prodeng/skills/docs-review/ag-grid/config.md`)
-- `/ag-prodeng:release-docs-review` - Review all documentation changes between releases
 
 ### Architecture
 
@@ -171,85 +117,20 @@ Core dependency chain: `ag-grid-community` → `ag-grid-enterprise` → framewor
 
 ### Development Workflow
 
-#### Testing
+**Behavioural tests are the primary test suite.** `testing/behavioural/` verifies grid behaviour as a black box; package unit tests are co-located in `packages/*/src`. `./behave.sh` runs both together through the Vitest workspace. The Testing Guide covers layer choice, async waiting patterns, and snapshots.
 
-For comprehensive testing information, see [Testing Guide](.rulesync/rules/testing.md).
-
-**Behavioural tests are the primary test suite.** When verifying grid changes, run `./behave.sh` — it runs the behavioural suite and the package unit tests together in one Vitest workspace. Key testing tools:
-
-- **Behavioural tests** (primary): `testing/behavioural/` for grid behaviour verification — use Vitest
-- **Package unit tests**: Vitest with jsdom environment, co-located in `packages/*/src` (`testing/angular-tests` still uses Jest)
-- **Merged runner**: `./behave.sh` runs both of the above via the `vitest.workspace.ts` workspace
-- **E2E tests**: Playwright for website interaction testing
-- **Accessibility tests**: `testing/accessibility/` for a11y compliance
-- **Performance tests**: `testing/performance/` for performance regression testing
-
-#### Code Quality
-
-For shared code quality guidelines, see [Code Quality Guide](.rulesync/rules/code-quality.md).
-
-Essential practices:
-
-- Run `yarn nx format --sort-root-tsconfig-paths=false` before committing
-- Self-review your changes before proposing commits
-- Ensure tests exercise real implementations, not test helpers
-
-#### AG Grid Coding Style
-
-Layered on the shared code-quality guide; enforced by ESLint plus team preferences.
-
-- Always use braces for `if/else/for/while/do`.
-- Cache repeated field access in a local — performance requirement.
-- Canonical array loop: `for (let i = 0, len = a.length; i < len; ++i)`. No `Array.forEach`. `Map.forEach` is fine.
-- No lonely `if` — use guard returns, `if/else if`, or ternaries. Applies to loops too.
-- No nested ternaries — extract to a named variable.
-- No short-circuit side effects (`cond && fn()`). No assignments in expressions.
-- No `for...in`. Use `Object.keys()` + index loops; prefer `Object.keys()` over `Object.entries()` when values aren't needed.
-- No static class properties — use module-level constants.
-- Explicit access modifiers on every class member; `readonly` when not reassigned.
-- Destructure only for 2+ fields; single field uses dot access.
-- `import type` for compile-time-only imports; separate `import type { Foo }` statements, no inline `{ type Foo, Bar }`.
-
-#### Styling
-
-The grid is in transition from Legacy Themes (.scss files written in Sass under `/community-modules/styles/`) to the Theming API (.css written in modern nested CSS under `/packages/`).
-
-While this transition is in progress, changes made to Theming API should be applied to Legacy Themes. When reviewing a PR with changes to the Theming API CSS, if the same PR does not have corresponding changes to Legacy Themes, this should be flagged as a P1 level issue.
-
-### Common Development Tasks
-
-#### Quick Playbooks
-
-- **Bug fix or feature work (community/enterprise)**
-    1. Update the affected implementation (typically under `packages/ag-grid-*/src/`).
-    2. Sync any dependent docs/examples.
-    3. Run `./behave.sh` (the merged unit suite) and `./checks.sh` (types + lint).
-
-- **Documentation/content update**
-    1. Consult the [Documentation Pages Guide](.rulesync/rules/docs-pages.md) for structure and patterns.
-    2. Modify the relevant content under `documentation/ag-grid-docs/`.
-    3. Create or update examples in `_examples/` folder following the [Examples Guide](.rulesync/rules/examples.md).
-    4. Ensure all examples are framework-compatible.
-    5. Test page in dev server with `yarn nx dev` across all frameworks.
-    6. For significant doc changes, sanity-check with `yarn nx e2e ag-grid-docs`.
-
-- **Example-only change** (see [Examples Guide](.rulesync/rules/examples.md))
-    1. Edit the example files.
-    2. Mirror updates in the corresponding docs page.
-    3. Run the relevant generation/typecheck commands.
+**Bug fix or feature work:** update the implementation (typically `packages/ag-grid-*/src/`), sync dependent docs and examples, then run `./behave.sh` and `./checks.sh`. Docs and example workflows are covered by the docs-pages and examples rules, which load when you touch those trees.
 
 ### Technical Requirements
 
 - **Node.js**: Check `.nvmrc` for version
 - **Package Manager**: Yarn
-- **Build Target**: ES2020
+- **Build Target**: ES2020 (`tsconfig.base.json`); `lib` is ES2022. Runtime API availability follows the browser-support policy, not this target.
 - **TypeScript**: Strict mode enabled across all packages
 
 ### JIRA Tickets
 
-For JIRA ticket guidelines, see [JIRA Guide](.rulesync/rules/jira.md).
-
-When creating tickets for this repo, use component `Grid` instead of `Charts`.
+Load the `/ag-product:jira` skill for ticket guidelines. When creating tickets for this repo, use component `Grid` instead of `Charts`.
 
 ### Documentation Resources
 

--- a/.rulesync/rules/examples.md
+++ b/.rulesync/rules/examples.md
@@ -87,6 +87,16 @@ After editing, run `yarn nx generate-examples ag-grid-docs` and
 `yarn nx format --sort-root-tsconfig-paths=false` to confirm every variant still typechecks and is
 formatted.
 
+## Deleting or renaming an example
+
+Grep the whole docs tree for references first, not just the parent page. Examples may be referenced from elsewhere, and an orphaned reference fails the build:
+
+```bash
+grep -r 'name="example-name"' documentation/ag-grid-docs/src/content/docs/ --include='*.mdoc'
+```
+
+Examples are referenced through the `{% gridExampleRunner %}` tag, so its `name` attribute is what to search for.
+
 ## Validation
 
 ```bash

--- a/.rulesync/rules/grid-code-conventions.md
+++ b/.rulesync/rules/grid-code-conventions.md
@@ -8,6 +8,22 @@ globs: ['packages/*/src/**/*.ts', 'community-modules/*/src/**/*.ts', 'enterprise
 
 Grid-specific rules for runtime source, layered on top of the shared [Code Quality Guide](code-quality.md). Scoped to `src` so it loads only when editing grid source, not into the always-on project context.
 
+## Coding style
+
+Enforced by ESLint plus team preferences.
+
+- Always use braces for `if/else/for/while/do`.
+- Cache repeated field access in a local — performance requirement.
+- Canonical array loop: `for (let i = 0, len = a.length; i < len; ++i)`. No `Array.forEach`. `Map.forEach` is fine.
+- No lonely `if` — use guard returns, `if/else if`, or ternaries. Applies to loops too.
+- No nested ternaries — extract to a named variable.
+- No short-circuit side effects (`cond && fn()`). No assignments in expressions.
+- No `for...in`. Use `Object.keys()` + index loops; prefer `Object.keys()` over `Object.entries()` when values aren't needed.
+- No static class properties — use module-level constants.
+- Explicit access modifiers on every class member; `readonly` when not reassigned.
+- Destructure only for 2+ fields; single field uses dot access.
+- `import type` for compile-time-only imports; separate `import type { Foo }` statements, no inline `{ type Foo, Bar }`.
+
 ## Prefer inline null checks over `_exists` / `_missing`
 
 Do not use `_exists` / `_missing` in new code. They wrap a cheap null check in a function call and add a `!== ''` empty-string test that is usually unwanted:

--- a/.rulesync/rules/grid-styling.md
+++ b/.rulesync/rules/grid-styling.md
@@ -1,0 +1,18 @@
+---
+root: false
+targets: ['*']
+description: 'Grid theming: keep Theming API CSS and Legacy Themes Sass in step during the transition'
+globs:
+    [
+        'community-modules/styles/**/*.scss',
+        'packages/*/src/**/*.css',
+    ]
+---
+
+# Grid Styling
+
+The grid is in transition from Legacy Themes (`.scss` files written in Sass under `community-modules/styles/`) to the Theming API (`.css` written in modern nested CSS under `packages/`).
+
+While this transition is in progress, changes made to the Theming API should be applied to Legacy Themes as well.
+
+When reviewing a PR with changes to the Theming API CSS, if the same PR does not have corresponding changes to Legacy Themes, flag it as a **P1** level issue.

--- a/.rulesync/rules/testing.md
+++ b/.rulesync/rules/testing.md
@@ -4,391 +4,45 @@ description: 'Testing strategies, Vitest patterns, and verification for AG Grid'
 globs: ['**/*.test.ts', '**/*.spec.ts', 'testing/**/*']
 ---
 
-# Testing Guide
+# Testing — Quick Reference
 
-This guide covers testing strategies and best practices for the AG Grid codebase.
+For the full guide — runner flag reference, Vitest patterns, the complete async-waiting playbook, and snapshot usage — load the `/testing` skill.
 
-## Behavioural Tests — Primary Test Suite
+## Choosing a layer
 
-Behavioural tests in `testing/behavioural/` are the primary test suite for AG Grid. They test the grid as a **black box**, instantiating the full grid to verify complex behaviours and features.
+**Default to a behavioural test.** Behavioural tests in `testing/behavioural/` are the primary suite: they drive the full grid as a black box through the public `GridApi`. A package `*.test.ts` is only for pure logic (formatter, comparator, parser) with no grid-integration surface.
 
-**Key principles:**
-
-- The unit under test is a **behaviour**, not a function, class, method, or file
-- **Avoid mocking** — prefer fakes instead (e.g., fake DOM)
-- Test at the edges of the system to ensure real integration using public APIs
-
-## Choosing a Test Layer
-
-**Default to a behavioural test.** A package `*.test.ts` that instantiates a feature class directly is only for pure logic (formatter, comparator, parser) with no grid-integration surface. Anything that manifests through the running grid belongs in `testing/behavioural/`, driven via the public `GridApi`.
-
-**These are signs you're testing internals — write a behavioural test instead:** casting to `as any` for private state, hand-building `beans`/`gos`/`ctrlsSvc`, calling a private method to reach a branch, or spying on an internal method as the assertion. Such tests pass even when the real code path never runs.
+**Signs you're testing internals — write a behavioural test instead:** casting to `as any` for private state, hand-building `beans`/`gos`/`ctrlsSvc`, calling a private method to reach a branch, or spying on an internal method as the assertion. Such tests pass even when the real code path never runs.
 
 Search `testing/behavioural` for an existing harness before assuming a behaviour can't be black-box tested (e.g. `DragEventDispatcher` drives real header drags); extend the harness rather than dropping to a unit test.
 
-`./behave.sh` runs the merged unit suite in a single Vitest workspace (`vitest.workspace.ts`): the package (London-school) `*.test.ts` files **and** the behavioural (Chicago-school) suite together, no Nx required. `yarn nx test <package>` still runs one package's tests on its own (retained for retrocompat).
+## Wait, don't sleep
 
-## Regression Tests: Cover Every Reproduction Path
-
-A bug rarely has one trigger. The same broken behaviour is usually reachable through several entry points — a programmatic API call, `applyColumnState`, a panel drag, a tool-panel drop — that run **different code paths** to the same end state. A fix that only patches the path in the ticket's first repro step can leave the others broken.
-
-When writing regression tests for a bug fix:
-
-- **Enumerate the reproduction paths named in the ticket, and add a test for each.** If the ticket says the bug reproduces via `addRowGroupColumns`, the Row Group Panel, and the Columns tool-panel drop zone, that is three tests, not one. Interactive entry points count — drive them with the real harness (`DragEventDispatcher` for header/panel drags) rather than skipping them because they're awkward to set up.
-- **Test the plural case, not just N=1.** If the fix reorders, inserts, or buckets a *list* of things, cover adding two or three, not only one. Single-item cases often pass by coincidence (no reordering needed) while the multi-item case is where the logic actually bites.
-- **Assert the observable end state for every path**, e.g. `getColumnOrder(...)`, not just that the operation didn't throw.
-
-Before finishing, re-read the ticket's "Steps to reproduce" and confirm each distinct trigger has a corresponding test. A fix verified through only one of several documented triggers is not fully verified.
-
-## Test Structure
-
-### Directory Layout
-
-```
-testing/
-├── accessibility/     # Accessibility compliance tests
-├── behavioural/       # Grid behaviour verification
-├── csp/               # Content Security Policy tests
-├── module-size/       # Bundle size monitoring
-├── performance/       # Performance regression tests
-└── shared/            # Shared test utilities
-```
-
-### Package Tests
-
-Unit and integration tests are co-located with source code:
-
-```
-packages/ag-grid-community/src/
-├── feature/
-│   ├── featureName.ts
-│   └── featureName.test.ts
-```
-
-## Running Tests
-
-### The merged unit suite (Vitest) — `./behave.sh`
-
-`./behave.sh` is the single command for the whole unit suite: the package unit tests (`ag-stack`, `ag-grid-community`, `ag-grid-enterprise`, `locale`) plus the behavioural suite, run together through the Vitest workspace from the repo root. Watch mode is disabled by default:
-
-```bash
-# Run the whole unit suite (package + behavioural)
-./behave.sh
-
-# Filter by file pattern across every project
-./behave.sh "cell-editing-regression"
-
-# Run a specific test by name
-./behave.sh "cell-editing-regression" -t "should handle"
-
-# Run only one project (its vitest test.name), e.g. behavioural-only
-./behave.sh --project behavioural
-
-# Run every project in the workspace, incl. the node-env tooling suites (docs, ag-website-shared)
-./behave.sh --project all
-
-# Watch mode
-./behave.sh --watch
-```
-
-> `./behave.sh` does not type-check (Vitest strips types via esbuild). Before committing, run `yarn nx run ag-behavioural-testing:build:test` to type-check.
->
-> `./behave.sh` and `./benches.sh` resolve only from the repository root, so an agent whose shell has changed directory — earlier in the same command, or carried over from a previous one — will not find them. Prefix with `cd "$(git rev-parse --show-toplevel)" &&` rather than hardcoding a machine-specific path.
->
-> Some suites take several minutes; `testing/behavioural/src/charts/format-panel-options.test.ts` alone runs ~2.5 minutes. Allow a timeout of at least five minutes, and wait for the run to finish and report its exit status — if the runner detaches the command, collect the result rather than treating silence as success.
->
-> The workspace membership and shared config live in `vitest.workspace.ts`, `vitest.config.ts`, and `vitest.shared.ts` at the repo root; each project keeps its own `vitest.config.ts`. Runner-global options (reporters, `onConsoleLog`, pool) must live in the **root** config — Vitest ignores them in a project config during a workspace run.
-
-### Benchmarks
-
-Behavioural benchmarks live in `testing/behavioural/` and run via `./benches.sh`. They run in a real headless Chromium (Playwright) by **default**, so layout-dependent work is measured against a real layout engine. Run `./benches.sh --help` for the full usage (it prints vitest's `bench --help` followed by benches.sh's own options).
-
-```bash
-# Run all benchmarks
-./benches.sh
-
-# Run specific benchmark file (positional arg forwarded to `vitest bench`)
-./benches.sh "tree-data-path"
-
-# Run a specific benchmark by name within matching files
-./benches.sh "tree-data-path" -t "flattening"
-
-# V8 CPU profile (node-only) — writes a .cpuprofile for method-cost analysis
-./benches.sh --profile "tree-data-path"
-```
-
-For baseline/compare runs, `./benches.sh --bench-compare <base|test|compare|all|backup> [...]` forwards to `bench-compare.mjs` (e.g. `./benches.sh --bench-compare all --runs 3`).
-
-### Per-package unit tests (Nx, retrocompat)
-
-`./behave.sh` already covers these, but an individual package's tests can still be run on their own through Nx. Vitest takes positional file patterns and `-t` for test names — **not** jest's `--testPathPattern`/`--testNamePattern`:
-
-```bash
-# Run all tests for a package
-yarn nx test ag-grid-community
-
-# Run tests in files matching a pattern (forwarded to `vitest run`)
-yarn nx test ag-grid-community -- "featureName"
-
-# Run a specific test by name within matching files
-yarn nx test ag-grid-community -- "featureName" -t "should handle"
-```
-
-(`testing/angular-tests` still uses Jest.)
-
-### E2E Tests (Playwright)
-
-E2E tests run via Playwright against the docs site. `./docs-e2e.sh` runs them directly from the repo root, bypassing Nx, and defaults to chromium only:
-
-```bash
-# Run all E2E tests (chromium)
-./docs-e2e.sh
-
-# Run tests matching a file pattern
-./docs-e2e.sh "toolbar"
-
-# Run a specific test by name
-./docs-e2e.sh "toolbar" --grep "Quick filter"
-
-# Run against all browsers
-./docs-e2e.sh --all-browsers
-
-# Run with a specific framework
-./docs-e2e.sh --framework react
-
-# Open Playwright UI mode
-./docs-e2e.sh --ui
-```
-
-The full Nx target is still available when needed:
-
-```bash
-yarn nx e2e ag-grid-docs
-```
-
-**Note:** Vitest does not support `--testPathPattern` or `--testNamePattern`. Use positional arguments for file matching and `-t` for test name filtering.
-
-## Test Patterns
-
-### Package Unit Tests (Vitest)
-
-Follow the AAA pattern (Arrange, Act, Assert):
+**Poll async grid updates with `waitFor`** (from `@testing-library/dom`). **Never** `await asyncSetTimeout(<fixed n>)` and then assert — a guessed delay is flaky and slow. A `no-restricted-syntax` ESLint rule in `testing/behavioural/eslint.config.mjs` flags every `asyncSetTimeout(n)` where `n > 0`.
 
 ```typescript
-describe('FeatureName', () => {
-    let instance: FeatureName;
-
-    beforeEach(() => {
-        // Arrange - setup
-    });
-
-    afterEach(() => {
-        // Cleanup
-        vi.resetAllMocks();
-    });
-
-    describe('#methodName', () => {
-        it('should handle expected case', () => {
-            // Arrange
-            const input = createInput();
-
-            // Act
-            const result = instance.methodName(input);
-
-            // Assert
-            expect(result).toBe(expected);
-        });
-    });
-});
-```
-
-### Parameterised Tests
-
-Use `it.each()` for testing multiple cases:
-
-```typescript
-it.each([
-    ['case1', input1, expected1],
-    ['case2', input2, expected2],
-])('should handle %s', (_, input, expected) => {
-    expect(functionUnderTest(input)).toBe(expected);
-});
-```
-
-### Test Data Records
-
-For complex test cases, use records:
-
-```typescript
-const EXAMPLES: Record<string, TestCase> = {
-    BASIC: {
-        input: {
-            /* ... */
-        },
-        expected: {
-            /* ... */
-        },
-    },
-    EDGE_CASE: {
-        input: {
-            /* ... */
-        },
-        expected: {
-            /* ... */
-        },
-    },
-};
-
-for (const [name, example] of Object.entries(EXAMPLES)) {
-    it(`handles ${name}`, () => {
-        expect(process(example.input)).toEqual(example.expected);
-    });
-}
-```
-
-### Waiting for Async Grid Updates
-
-Much grid behaviour resolves asynchronously — set-filter values load after the panel attaches, reloads run off a debounce/microtask, and so on. To observe such an update, **poll the condition with `waitFor`** (from `@testing-library/dom`) so the test proceeds the moment the state is ready:
-
-```typescript
-import { waitFor } from '@testing-library/dom';
-
 api.setGridOption('rowData', ATHLETES);
 await waitFor(() => expect(panel.setFilterItemLabels('Athlete')).toEqual(LI_MATCHES));
 ```
 
-**Do not** `await asyncSetTimeout(<fixed n>)` and then assert. A guessed delay is flaky (too short under load) and slow (always waits the full time). Nonzero fixed delays scattered through the suite are legacy, not the pattern to copy. A `no-restricted-syntax` ESLint rule in `testing/behavioural/eslint.config.mjs` flags every `asyncSetTimeout(n)` where `n > 0`.
+`asyncSetTimeout(0)` is fine for flushing a single tick after a synchronous action. `asyncSetTimeout(1)` is the *same call* — Node clamps 0 to 1ms — so it buys nothing.
 
-`await asyncSetTimeout(0)` is fine for its distinct purpose: flushing a single microtask/event-loop tick after a synchronous action (e.g. after setting a native input value) before reading the result.
+Four traps that make a `waitFor` unfalsifiable or a sleep load-bearing (negative assertions, polls that were already true, test IDs landing on a debounce, and sleeps that only look like safety margins) are covered in the skill. **Load it before converting any timing-dependent test.**
 
-**`asyncSetTimeout(1)` is the same call as `asyncSetTimeout(0)`.** Node clamps a `0` delay to 1ms, so a `(1)` buys no extra safety over a `(0)` — and no safety at all when the update needs more than one tick. Most of the suite's nonzero delays are spelled `(1)` for this reason. Judge such a site by what follows it, not by the number: if the next line reads async state, it needs `waitFor`.
+## Regression tests: cover every reproduction path
 
-#### The sleep that looks safe
+A bug rarely has one trigger. Enumerate the reproduction paths named in the ticket and add a test for each — a programmatic API call, a panel drag and a tool-panel drop are three tests, not one. Test the plural case, not just N=1, and assert the observable end state for every path.
 
-A fixed sleep placed *before* a call that already polls internally, or before a raw state read, reads as a safety margin and is not one. Both shapes appear here:
+## Commands
 
-```typescript
-async function clickColumnMenuItem(name: string): Promise<void> {
-    const menuItem = await waitFor(() => { /* ... */ }); // already polls
-    menuItem.click();
-}
+- `./behave.sh` — the whole unit suite (package + behavioural) via the Vitest workspace.
+- `./benches.sh` — behavioural benchmarks in headless Chromium.
+- `./docs-e2e.sh` — Playwright E2E against the docs site. The Nx target is `test:e2e`; there is **no** `e2e` target.
 
-async function openEditDialogViaMenu(api: GridApi, colKey: string): Promise<void> {
-    showColumnMenu(api, colKey);
-    await asyncSetTimeout(10); // redundant — the callee already polls
-    await clickColumnMenuItem('Edit Calculated Column');
-    await asyncSetTimeout(1); // a guess gating whatever the caller asserts next
-}
-```
+All three take `--help` and resolve only from the repo root — prefix with `cd "$(git rev-parse --show-toplevel)" &&` if the shell may have moved. `./behave.sh` does not type-check; run `yarn nx run ag-behavioural-testing:build:test` before committing. Some suites take minutes — allow a five-minute timeout and collect the exit status rather than treating silence as success.
 
-Delete the first sleep: `clickColumnMenuItem` polls, so waiting before it adds latency and no determinism. Delete the second too, and have the caller poll its own assertion with `waitFor` — a trailing sleep in a helper silently becomes the caller's synchronisation, which is exactly the guess this section forbids.
+## Key practices
 
-A genuine timer window the grid debounces on (see `waitForMissingModuleReports`) is the rare exception. Keep the delay and add `// eslint-disable-next-line no-restricted-syntax -- <the window it waits on>`.
-
-#### Negative assertions
-
-`waitFor` cannot express "this never happened". It resolves the moment its callback stops throwing, so a poll for something that is already true passes on tick 0 and the test becomes unfalsifiable. When the assertion is that a call was *not* made, or that no *second* event arrived, the delay is not a guessed wait — it is the observation window, and converting it to a poll removes the coverage.
-
-Look for a positive signal first, and only fall back to the window when none exists:
-
-```typescript
-// Preferred — poll a positive signal, then assert the negative over the settled state.
-await waitFor(() => expect(api.getDisplayedRowCount()).toBe(1));
-expect(errorSpy).not.toHaveBeenCalled();
-
-// Fallback — nothing positive follows the event that must not arrive.
-await waitFor(() => expect(events.length).toBeGreaterThan(0)); // the first, expected event
-// eslint-disable-next-line no-restricted-syntax -- window in which a second, redundant columnEverythingChanged would arrive
-await asyncSetTimeout(10);
-expect(events).toHaveLength(1);
-```
-
-A positive signal only works when it provably lands *after* the thing being ruled out. If it can settle first, it shrinks the window towards zero and is worse than the sleep it replaced — keep the window and say in the disable comment what it is observing.
-
-#### Proving a wait is necessary
-
-The way to show a delay is decoration is to delete it and see the test still pass — but **run that probe at whole-file scope at least, never under `-t "<single test>"`**. Vitest isolation changes what has already happened by the time the assertion fires, so a filtered run can pass on a gate that the full file genuinely needs. A green `-t` run is not evidence that a wait is unnecessary; it is evidence of nothing.
-
-#### The poll that was already true
-
-When the sleep you are replacing sits after a mutation, check what the polled condition evaluated to *before* that mutation. If it was already true, `waitFor` resolves on its first tick and the assertion never sees the new state — the test still passes, and it now passes for any implementation.
-
-This bites hardest on "state survives a rebuild" tests, where the state asserted afterwards is the same state that held beforehand. Gate on a signal that can only be true post-mutation — the recreated object is a different instance, a count has changed, a new column has appeared — and then assert. The gate's job is to establish that the mutation landed, not to buy time: if the mutation is synchronous the gate resolves immediately and costs nothing, and it still keeps the assertion falsifiable if the work is later deferred.
-
-```typescript
-const groupBeforeRebuild = api.getProvidedColumnGroup(openedIds[0]);
-api.setGridOption('columnDefs', makeDefs());
-await waitFor(() => expect(api.getProvidedColumnGroup(openedIds[0])).not.toBe(groupBeforeRebuild));
-expect(openGroupIds(api)).toEqual(openedIds);
-```
-
-#### Test IDs land on a debounce
-
-`TestIdService` stamps `data-testid` attributes in a debounced pass off grid events, so a freshly rendered cell carries no test ID until a macrotask has elapsed. A sleep that a `*ByTestId` query depends on is therefore load-bearing, and gating on some *other* condition — the range handle existing, a row count, an API value — does not replace it: `waitFor` resolves without yielding a macrotask when its callback passes on the first tick.
-
-Poll the lookup itself, so the gate covers what the test actually reads:
-
-```typescript
-const cellOfRow = (rowIndex: number) => getByTestId(gridDiv, agTestIdFor.cell(`ROW_${rowIndex}`, 'sunshine'));
-
-await waitFor(() => {
-    expect(gridDiv.querySelector('.ag-range-handle')).toBeTruthy();
-    for (let i = 0, len = rowData.length; i < len; ++i) {
-        cellOfRow(i);
-    }
-});
-```
-
-## Best Practices
-
-1. **Test behaviour, not implementation** - Focus on what the code does, not how
-2. **Keep tests independent** - Each test should be able to run in isolation
-3. **Use descriptive names** - Test names should describe the expected behaviour
-4. **Avoid test helpers that hide behaviour** - Repetition is fine in tests; prefer inline setup over a shared factory so each test reads top-to-bottom. Do not flag duplicated test setup (row data, grid options, column defs) in code review. **Do** flag duplicated test *cases* — i.e. tests that assert the same behaviour twice — within a file or across files, since they add no coverage.
-5. **Merge tests that differ only in assertions** - Same setup → one test with sequential assertions. Avoids test-count bloat.
-6. **Clean up after tests** - Reset mocks and state in `afterEach`
-7. **Review similar tests** - When adding tests, check related tests for consistency
-8. **Wait, don't sleep** - Poll async grid updates with `waitFor`; never assert after a fixed `asyncSetTimeout(n)` delay (see [Waiting for Async Grid Updates](#waiting-for-async-grid-updates)).
-9. **Register the module before using a grid API** - Tests and benchmarks build their own module lists (not `AllCommunityModule`), so a `GridApi` method or feature whose module isn't registered logs `error #200` (`moduleName=…&reasonOrId=api.<method>`) and **no-ops silently**. Before using a new API, find its providing module (grep the method under `packages/*/src`, or read the `moduleName=` in the error URL) and register it. A passing test/bench prints no `error #200`.
-
-
-## GridRows and GridColumns Snapshots
-
-For behavioural tests, prefer `GridRows` and `GridColumns` snapshots over raw API assertions where practical. They produce inline snapshots that make the grid state visually readable and update automatically.
-
-```typescript
-import { GridColumns, GridRows } from '../test-utils';
-
-// Snapshot grid rows (rendered cell values, grouping, selection state, etc.)
-await new GridRows(api, 'description').check();
-
-// Snapshot column state (visibility, order, pinning, pivoting, etc.)
-await new GridColumns(api, 'description').checkColumns();
-```
-
-When behaviour cannot be captured by a snapshot — for example verifying a specific return value, event payload, or count — combine snapshots with targeted API checks:
-
-```typescript
-await new GridRows(api, 'after sort').check();
-expect(api.getDisplayedRowCount()).toBe(3);
-```
-
-Update snapshots after intentional grid state changes:
-
-```bash
-./behave.sh --update-grid-rows # update all
-./behave.sh --update-grid-rows "column-lookup"    # update matching files only
-```
-
-Since our test framrwork and mockGridLayout.ts are written as we go,
-if they do not cover a scenario that arise in a new test, they must be updated and fixed.
-
-## Style in Tests
-
-Tests must respect ESLint rules, but the non-lint-enforced coding-style preferences.
-
-## Coverage
-
-- Aim for meaningful coverage, not 100%
-- Focus on edge cases and error handling
-- Critical paths should have comprehensive tests
+- Prefer `GridRows` / `GridColumns` inline snapshots over raw API assertions where practical; update with `./behave.sh --update-grid-rows`.
+- Repetition is fine in tests — prefer inline setup over shared factories. Do not flag duplicated test *setup* in review; **do** flag duplicated test *cases*.
+- **Register the module before using a grid API.** Tests build their own module lists, so an unregistered API logs `error #200` and **no-ops silently**. A passing test prints no `error #200`.

--- a/.rulesync/rules/testing.md
+++ b/.rulesync/rules/testing.md
@@ -27,7 +27,7 @@ await waitFor(() => expect(panel.setFilterItemLabels('Athlete')).toEqual(LI_MATC
 
 `asyncSetTimeout(0)` is fine for flushing a single tick after a synchronous action. `asyncSetTimeout(1)` is the *same call* — Node clamps 0 to 1ms — so it buys nothing.
 
-Four traps that make a `waitFor` unfalsifiable or a sleep load-bearing (negative assertions, polls that were already true, test IDs landing on a debounce, and sleeps that only look like safety margins) are covered in the skill. **Load it before converting any timing-dependent test.**
+The skill covers the traps that make a `waitFor` unfalsifiable or a sleep load-bearing — negative assertions, polls that were already true, test IDs landing on a debounce, and sleeps that only look like safety margins — plus how to prove a wait is genuinely necessary. **Load it before converting any timing-dependent test.**
 
 ## Regression tests: cover every reproduction path
 

--- a/.rulesync/skills/testing/SKILL.md
+++ b/.rulesync/skills/testing/SKILL.md
@@ -1,0 +1,392 @@
+---
+targets: ['*']
+name: testing
+description: 'Full testing reference for AG Grid — behavioural vs package test layers, regression-test coverage, the complete runner flag reference (behave.sh / benches.sh / docs-e2e.sh), Vitest patterns, async waiting patterns (waitFor vs asyncSetTimeout), and GridRows/GridColumns snapshots. Use when writing or modifying tests, choosing a test layer, debugging a flaky or timing-dependent test, or looking up a test-runner command.'
+---
+
+# Testing Guide
+
+This guide covers testing strategies and best practices for the AG Grid codebase.
+
+## Behavioural Tests — Primary Test Suite
+
+Behavioural tests in `testing/behavioural/` are the primary test suite for AG Grid. They test the grid as a **black box**, instantiating the full grid to verify complex behaviours and features.
+
+**Key principles:**
+
+- The unit under test is a **behaviour**, not a function, class, method, or file
+- **Avoid mocking** — prefer fakes instead (e.g., fake DOM)
+- Test at the edges of the system to ensure real integration using public APIs
+
+## Choosing a Test Layer
+
+**Default to a behavioural test.** A package `*.test.ts` that instantiates a feature class directly is only for pure logic (formatter, comparator, parser) with no grid-integration surface. Anything that manifests through the running grid belongs in `testing/behavioural/`, driven via the public `GridApi`.
+
+**These are signs you're testing internals — write a behavioural test instead:** casting to `as any` for private state, hand-building `beans`/`gos`/`ctrlsSvc`, calling a private method to reach a branch, or spying on an internal method as the assertion. Such tests pass even when the real code path never runs.
+
+Search `testing/behavioural` for an existing harness before assuming a behaviour can't be black-box tested (e.g. `DragEventDispatcher` drives real header drags); extend the harness rather than dropping to a unit test.
+
+`./behave.sh` runs the merged unit suite in a single Vitest workspace (`vitest.workspace.ts`): the package (London-school) `*.test.ts` files **and** the behavioural (Chicago-school) suite together, no Nx required. `yarn nx test <package>` still runs one package's tests on its own (retained for retrocompat).
+
+## Regression Tests: Cover Every Reproduction Path
+
+A bug rarely has one trigger. The same broken behaviour is usually reachable through several entry points — a programmatic API call, `applyColumnState`, a panel drag, a tool-panel drop — that run **different code paths** to the same end state. A fix that only patches the path in the ticket's first repro step can leave the others broken.
+
+When writing regression tests for a bug fix:
+
+- **Enumerate the reproduction paths named in the ticket, and add a test for each.** If the ticket says the bug reproduces via `addRowGroupColumns`, the Row Group Panel, and the Columns tool-panel drop zone, that is three tests, not one. Interactive entry points count — drive them with the real harness (`DragEventDispatcher` for header/panel drags) rather than skipping them because they're awkward to set up.
+- **Test the plural case, not just N=1.** If the fix reorders, inserts, or buckets a *list* of things, cover adding two or three, not only one. Single-item cases often pass by coincidence (no reordering needed) while the multi-item case is where the logic actually bites.
+- **Assert the observable end state for every path**, e.g. `getColumnOrder(...)`, not just that the operation didn't throw.
+
+Before finishing, re-read the ticket's "Steps to reproduce" and confirm each distinct trigger has a corresponding test. A fix verified through only one of several documented triggers is not fully verified.
+
+## Test Structure
+
+### Directory Layout
+
+```
+testing/
+├── accessibility/     # Accessibility compliance tests
+├── behavioural/       # Grid behaviour verification
+├── csp/               # Content Security Policy tests
+├── module-size/       # Bundle size monitoring
+├── performance/       # Performance regression tests
+└── shared/            # Shared test utilities
+```
+
+### Package Tests
+
+Unit and integration tests are co-located with source code:
+
+```
+packages/ag-grid-community/src/
+├── feature/
+│   ├── featureName.ts
+│   └── featureName.test.ts
+```
+
+## Running Tests
+
+### The merged unit suite (Vitest) — `./behave.sh`
+
+`./behave.sh` is the single command for the whole unit suite: the package unit tests (`ag-stack`, `ag-grid-community`, `ag-grid-enterprise`, `locale`) plus the behavioural suite, run together through the Vitest workspace from the repo root. Watch mode is disabled by default:
+
+```bash
+# Run the whole unit suite (package + behavioural)
+./behave.sh
+
+# Filter by file pattern across every project
+./behave.sh "cell-editing-regression"
+
+# Run a specific test by name
+./behave.sh "cell-editing-regression" -t "should handle"
+
+# Run only one project (its vitest test.name), e.g. behavioural-only
+./behave.sh --project behavioural
+
+# Run every project in the workspace, incl. the node-env tooling suites (docs, ag-website-shared)
+./behave.sh --project all
+
+# Watch mode
+./behave.sh --watch
+```
+
+> `./behave.sh` does not type-check (Vitest strips types via esbuild). Before committing, run `yarn nx run ag-behavioural-testing:build:test` to type-check.
+>
+> `./behave.sh` and `./benches.sh` resolve only from the repository root, so an agent whose shell has changed directory — earlier in the same command, or carried over from a previous one — will not find them. Prefix with `cd "$(git rev-parse --show-toplevel)" &&` rather than hardcoding a machine-specific path.
+>
+> Some suites take several minutes; `testing/behavioural/src/charts/format-panel-options.test.ts` alone runs ~2.5 minutes. Allow a timeout of at least five minutes, and wait for the run to finish and report its exit status — if the runner detaches the command, collect the result rather than treating silence as success.
+>
+> The workspace membership and shared config live in `vitest.workspace.ts`, `vitest.config.ts`, and `vitest.shared.ts` at the repo root; each project keeps its own `vitest.config.ts`. Runner-global options (reporters, `onConsoleLog`, pool) must live in the **root** config — Vitest ignores them in a project config during a workspace run.
+
+### Benchmarks
+
+Behavioural benchmarks live in `testing/behavioural/` and run via `./benches.sh`. They run in a real headless Chromium (Playwright) by **default**, so layout-dependent work is measured against a real layout engine. Run `./benches.sh --help` for the full usage (it prints vitest's `bench --help` followed by benches.sh's own options).
+
+```bash
+# Run all benchmarks
+./benches.sh
+
+# Run specific benchmark file (positional arg forwarded to `vitest bench`)
+./benches.sh "tree-data-path"
+
+# Run a specific benchmark by name within matching files
+./benches.sh "tree-data-path" -t "flattening"
+
+# V8 CPU profile (node-only) — writes a .cpuprofile for method-cost analysis
+./benches.sh --profile "tree-data-path"
+```
+
+For baseline/compare runs, `./benches.sh --bench-compare <base|test|compare|all|backup> [...]` forwards to `bench-compare.mjs` (e.g. `./benches.sh --bench-compare all --runs 3`).
+
+### Per-package unit tests (Nx, retrocompat)
+
+`./behave.sh` already covers these, but an individual package's tests can still be run on their own through Nx. Vitest takes positional file patterns and `-t` for test names — **not** jest's `--testPathPattern`/`--testNamePattern`:
+
+```bash
+# Run all tests for a package
+yarn nx test ag-grid-community
+
+# Run tests in files matching a pattern (forwarded to `vitest run`)
+yarn nx test ag-grid-community -- "featureName"
+
+# Run a specific test by name within matching files
+yarn nx test ag-grid-community -- "featureName" -t "should handle"
+```
+
+(`testing/angular-tests` still uses Jest.)
+
+### E2E Tests (Playwright)
+
+E2E tests run via Playwright against the docs site. `./docs-e2e.sh` runs them directly from the repo root, bypassing Nx, and defaults to chromium only:
+
+```bash
+# Run all E2E tests (chromium)
+./docs-e2e.sh
+
+# Run tests matching a file pattern
+./docs-e2e.sh "toolbar"
+
+# Run a specific test by name
+./docs-e2e.sh "toolbar" --grep "Quick filter"
+
+# Run against all browsers
+./docs-e2e.sh --all-browsers
+
+# Run with a specific framework
+./docs-e2e.sh --framework react
+
+# Open Playwright UI mode
+./docs-e2e.sh --ui
+```
+
+The Nx target is still available when needed. Note the target is `test:e2e` — there is **no** `e2e` target on `ag-grid-docs`:
+
+```bash
+yarn nx test:e2e ag-grid-docs
+```
+
+**Note:** Vitest does not support `--testPathPattern` or `--testNamePattern`. Use positional arguments for file matching and `-t` for test name filtering.
+
+## Test Patterns
+
+### Package Unit Tests (Vitest)
+
+Follow the AAA pattern (Arrange, Act, Assert):
+
+```typescript
+describe('FeatureName', () => {
+    let instance: FeatureName;
+
+    beforeEach(() => {
+        // Arrange - setup
+    });
+
+    afterEach(() => {
+        // Cleanup
+        vi.resetAllMocks();
+    });
+
+    describe('#methodName', () => {
+        it('should handle expected case', () => {
+            // Arrange
+            const input = createInput();
+
+            // Act
+            const result = instance.methodName(input);
+
+            // Assert
+            expect(result).toBe(expected);
+        });
+    });
+});
+```
+
+### Parameterised Tests
+
+Use `it.each()` for testing multiple cases:
+
+```typescript
+it.each([
+    ['case1', input1, expected1],
+    ['case2', input2, expected2],
+])('should handle %s', (_, input, expected) => {
+    expect(functionUnderTest(input)).toBe(expected);
+});
+```
+
+### Test Data Records
+
+For complex test cases, use records:
+
+```typescript
+const EXAMPLES: Record<string, TestCase> = {
+    BASIC: {
+        input: {
+            /* ... */
+        },
+        expected: {
+            /* ... */
+        },
+    },
+    EDGE_CASE: {
+        input: {
+            /* ... */
+        },
+        expected: {
+            /* ... */
+        },
+    },
+};
+
+for (const [name, example] of Object.entries(EXAMPLES)) {
+    it(`handles ${name}`, () => {
+        expect(process(example.input)).toEqual(example.expected);
+    });
+}
+```
+
+### Waiting for Async Grid Updates
+
+Much grid behaviour resolves asynchronously — set-filter values load after the panel attaches, reloads run off a debounce/microtask, and so on. To observe such an update, **poll the condition with `waitFor`** (from `@testing-library/dom`) so the test proceeds the moment the state is ready:
+
+```typescript
+import { waitFor } from '@testing-library/dom';
+
+api.setGridOption('rowData', ATHLETES);
+await waitFor(() => expect(panel.setFilterItemLabels('Athlete')).toEqual(LI_MATCHES));
+```
+
+**Do not** `await asyncSetTimeout(<fixed n>)` and then assert. A guessed delay is flaky (too short under load) and slow (always waits the full time). Nonzero fixed delays scattered through the suite are legacy, not the pattern to copy. A `no-restricted-syntax` ESLint rule in `testing/behavioural/eslint.config.mjs` flags every `asyncSetTimeout(n)` where `n > 0`.
+
+`await asyncSetTimeout(0)` is fine for its distinct purpose: flushing a single microtask/event-loop tick after a synchronous action (e.g. after setting a native input value) before reading the result.
+
+**`asyncSetTimeout(1)` is the same call as `asyncSetTimeout(0)`.** Node clamps a `0` delay to 1ms, so a `(1)` buys no extra safety over a `(0)` — and no safety at all when the update needs more than one tick. Most of the suite's nonzero delays are spelled `(1)` for this reason. Judge such a site by what follows it, not by the number: if the next line reads async state, it needs `waitFor`.
+
+#### The sleep that looks safe
+
+A fixed sleep placed *before* a call that already polls internally, or before a raw state read, reads as a safety margin and is not one. Both shapes appear here:
+
+```typescript
+async function clickColumnMenuItem(name: string): Promise<void> {
+    const menuItem = await waitFor(() => { /* ... */ }); // already polls
+    menuItem.click();
+}
+
+async function openEditDialogViaMenu(api: GridApi, colKey: string): Promise<void> {
+    showColumnMenu(api, colKey);
+    await asyncSetTimeout(10); // redundant — the callee already polls
+    await clickColumnMenuItem('Edit Calculated Column');
+    await asyncSetTimeout(1); // a guess gating whatever the caller asserts next
+}
+```
+
+Delete the first sleep: `clickColumnMenuItem` polls, so waiting before it adds latency and no determinism. Delete the second too, and have the caller poll its own assertion with `waitFor` — a trailing sleep in a helper silently becomes the caller's synchronisation, which is exactly the guess this section forbids.
+
+A genuine timer window the grid debounces on (see `waitForMissingModuleReports`) is the rare exception. Keep the delay and add `// eslint-disable-next-line no-restricted-syntax -- <the window it waits on>`.
+
+#### Negative assertions
+
+`waitFor` cannot express "this never happened". It resolves the moment its callback stops throwing, so a poll for something that is already true passes on tick 0 and the test becomes unfalsifiable. When the assertion is that a call was *not* made, or that no *second* event arrived, the delay is not a guessed wait — it is the observation window, and converting it to a poll removes the coverage.
+
+Look for a positive signal first, and only fall back to the window when none exists:
+
+```typescript
+// Preferred — poll a positive signal, then assert the negative over the settled state.
+await waitFor(() => expect(api.getDisplayedRowCount()).toBe(1));
+expect(errorSpy).not.toHaveBeenCalled();
+
+// Fallback — nothing positive follows the event that must not arrive.
+await waitFor(() => expect(events.length).toBeGreaterThan(0)); // the first, expected event
+// eslint-disable-next-line no-restricted-syntax -- window in which a second, redundant columnEverythingChanged would arrive
+await asyncSetTimeout(10);
+expect(events).toHaveLength(1);
+```
+
+A positive signal only works when it provably lands *after* the thing being ruled out. If it can settle first, it shrinks the window towards zero and is worse than the sleep it replaced — keep the window and say in the disable comment what it is observing.
+
+#### Proving a wait is necessary
+
+The way to show a delay is decoration is to delete it and see the test still pass — but **run that probe at whole-file scope at least, never under `-t "<single test>"`**. Vitest isolation changes what has already happened by the time the assertion fires, so a filtered run can pass on a gate that the full file genuinely needs. A green `-t` run is not evidence that a wait is unnecessary; it is evidence of nothing.
+
+#### The poll that was already true
+
+When the sleep you are replacing sits after a mutation, check what the polled condition evaluated to *before* that mutation. If it was already true, `waitFor` resolves on its first tick and the assertion never sees the new state — the test still passes, and it now passes for any implementation.
+
+This bites hardest on "state survives a rebuild" tests, where the state asserted afterwards is the same state that held beforehand. Gate on a signal that can only be true post-mutation — the recreated object is a different instance, a count has changed, a new column has appeared — and then assert. The gate's job is to establish that the mutation landed, not to buy time: if the mutation is synchronous the gate resolves immediately and costs nothing, and it still keeps the assertion falsifiable if the work is later deferred.
+
+```typescript
+const groupBeforeRebuild = api.getProvidedColumnGroup(openedIds[0]);
+api.setGridOption('columnDefs', makeDefs());
+await waitFor(() => expect(api.getProvidedColumnGroup(openedIds[0])).not.toBe(groupBeforeRebuild));
+expect(openGroupIds(api)).toEqual(openedIds);
+```
+
+#### Test IDs land on a debounce
+
+`TestIdService` stamps `data-testid` attributes in a debounced pass off grid events, so a freshly rendered cell carries no test ID until a macrotask has elapsed. A sleep that a `*ByTestId` query depends on is therefore load-bearing, and gating on some *other* condition — the range handle existing, a row count, an API value — does not replace it: `waitFor` resolves without yielding a macrotask when its callback passes on the first tick.
+
+Poll the lookup itself, so the gate covers what the test actually reads:
+
+```typescript
+const cellOfRow = (rowIndex: number) => getByTestId(gridDiv, agTestIdFor.cell(`ROW_${rowIndex}`, 'sunshine'));
+
+await waitFor(() => {
+    expect(gridDiv.querySelector('.ag-range-handle')).toBeTruthy();
+    for (let i = 0, len = rowData.length; i < len; ++i) {
+        cellOfRow(i);
+    }
+});
+```
+
+## Best Practices
+
+1. **Test behaviour, not implementation** - Focus on what the code does, not how
+2. **Keep tests independent** - Each test should be able to run in isolation
+3. **Use descriptive names** - Test names should describe the expected behaviour
+4. **Avoid test helpers that hide behaviour** - Repetition is fine in tests; prefer inline setup over a shared factory so each test reads top-to-bottom. Do not flag duplicated test setup (row data, grid options, column defs) in code review. **Do** flag duplicated test *cases* — i.e. tests that assert the same behaviour twice — within a file or across files, since they add no coverage.
+5. **Merge tests that differ only in assertions** - Same setup → one test with sequential assertions. Avoids test-count bloat.
+6. **Clean up after tests** - Reset mocks and state in `afterEach`
+7. **Review similar tests** - When adding tests, check related tests for consistency
+8. **Wait, don't sleep** - Poll async grid updates with `waitFor`; never assert after a fixed `asyncSetTimeout(n)` delay (see [Waiting for Async Grid Updates](#waiting-for-async-grid-updates)).
+9. **Register the module before using a grid API** - Tests and benchmarks build their own module lists (not `AllCommunityModule`), so a `GridApi` method or feature whose module isn't registered logs `error #200` (`moduleName=…&reasonOrId=api.<method>`) and **no-ops silently**. Before using a new API, find its providing module (grep the method under `packages/*/src`, or read the `moduleName=` in the error URL) and register it. A passing test/bench prints no `error #200`.
+
+## GridRows and GridColumns Snapshots
+
+For behavioural tests, prefer `GridRows` and `GridColumns` snapshots over raw API assertions where practical. They produce inline snapshots that make the grid state visually readable and update automatically.
+
+```typescript
+import { GridColumns, GridRows } from '../test-utils';
+
+// Snapshot grid rows (rendered cell values, grouping, selection state, etc.)
+await new GridRows(api, 'description').check();
+
+// Snapshot column state (visibility, order, pinning, pivoting, etc.)
+await new GridColumns(api, 'description').checkColumns();
+```
+
+When behaviour cannot be captured by a snapshot — for example verifying a specific return value, event payload, or count — combine snapshots with targeted API checks:
+
+```typescript
+await new GridRows(api, 'after sort').check();
+expect(api.getDisplayedRowCount()).toBe(3);
+```
+
+Update snapshots after intentional grid state changes:
+
+```bash
+./behave.sh --update-grid-rows # update all
+./behave.sh --update-grid-rows "column-lookup"    # update matching files only
+```
+
+The test framework and `mockGridLayout.ts` are written as we go. If they do not cover a scenario that arises in a new test, update and fix them rather than working around the gap.
+
+## Style in Tests
+
+Tests must respect ESLint rules, and should follow the non-lint-enforced coding-style preferences too.
+
+## Coverage
+
+- Aim for meaningful coverage, not 100%
+- Focus on edge cases and error handling
+- Critical paths should have comprehensive tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,13 +11,14 @@ This file provides guidance to AI Agents when working with code in this reposito
 - **Main branch:** `latest`
 - **Format:** `yarn nx format --sort-root-tsconfig-paths=false` (run before commits)
 - **Pre-commit checks:** `./checks.sh` — the preferred gate: type-check + lint + spec type-check across every project in one parallel, cache-aware Nx run. Much faster than chaining separate `yarn nx build:types` / `yarn nx lint` calls.
-- **Type-check (single package):** `yarn nx build:types <package>`
-- **Lint (single package):** `yarn nx lint <package>`
-- **Build:** `yarn nx build <package>`
 - **Test:** `./behave.sh` (whole unit suite — package + behavioural — via the Vitest workspace). Single project: `./behave.sh --project <name>` (e.g. `ag-grid-community`, `behavioural`).
-- **E2E:** `yarn nx e2e ag-grid-docs`
+- **Benchmarks:** `./benches.sh` (behavioural benchmarks in headless Chromium).
+- **E2E:** `./docs-e2e.sh` (Playwright against the docs site; the Nx target is `test:e2e`, not `e2e`).
+- **Build:** `yarn nx build <package>`; types only: `yarn nx build:types <package>`.
 - **Dev server:** `yarn nx dev` (launches on https://localhost:4610/, check if it is already running before trying to run it)
 - **NX daemon:** Always use `NX_DAEMON=false` for nx commands to avoid pipe hangs (set automatically via SessionStart hook)
+
+Each script takes `--help`. Full flag reference lives in the guides below rather than here: test and E2E flags in the Testing Guide, benchmark and profiling flags in the Benchmarks Guide.
 
 ### Content Locations
 
@@ -32,14 +33,13 @@ This file provides guidance to AI Agents when working with code in this reposito
 - **Yarn and Nx based repo:** Use Yarn for package management and Nx for build and test orchestration.
 - **Main constraint:** Community and enterprise runtime bundles stay dependency-free beyond AG Grid code.
 - **Default branch:** Target `latest`; follow release/JIRA naming conventions below for topic branches.
-- **Build monitoring:** Check `node_modules/.cache/ag-watch-status.json` to monitor watch state (`yarn nx dev`) and build health (see [Development Server Guide](.rulesync/rules/dev-server.md)).
+- **Build monitoring:** Check `node_modules/.cache/ag-watch-status.json` to monitor watch state (`yarn nx dev`) and build health — load the `/ag-eng:dev-server` skill for details.
 - **Self-review before committing:** Re-read your changes as if reviewing someone else's PR and verify: each new function/class has a single clear responsibility; names are meaningful; no unnecessary complexity; no copy-pasted logic that should be extracted; new code follows the patterns of the surrounding codebase.
-- **Formatting:** Run `yarn nx format --sort-root-tsconfig-paths=false` from the repo root before proposing commits.
-- **Typechecking and linting:** Run `./checks.sh` from the repo root before proposing commits — never chain separate `yarn nx build:types` / `yarn nx lint` invocations for the standard gate, as each one re-pays Nx startup and forces the tasks to run serially.
+- **Formatting, typechecking and linting:** Run `yarn nx format --sort-root-tsconfig-paths=false` then `./checks.sh` from the repo root before proposing commits. Never chain separate `yarn nx build:types` / `yarn nx lint` invocations for the standard gate — each one re-pays Nx startup and forces the tasks to run serially.
 - **Batch Nx work into one invocation:** Whenever more than one target or project is needed, use a single `nx run-many -t <targets> -p <projects> --parallel=<n>` instead of issuing commands one at a time. Every extra `yarn nx …` re-pays Nx startup and project-graph computation, and serialises tasks that Nx would otherwise run concurrently — this applies to builds and any other target, not just the pre-commit gate.
-- **Baseline verification:** Expect to run `./behave.sh` (the merged unit suite) and `yarn nx e2e ag-grid-docs` after meaningful grid changes.
-- **Test verification patterns:** When writing or modifying tests, review similar tests to ensure consistent verification patterns (see [Testing Guide](.rulesync/rules/testing.md)).
-- **Context docs:** Skim [technology-stack.md](.rulesync/rules/technology-stack.md) for stack or architectural decisions before introducing new patterns.
+- **Baseline verification:** Expect to run `./behave.sh` (the merged unit suite) and `./docs-e2e.sh` after meaningful grid changes.
+- **Test verification patterns:** When writing or modifying tests, review similar tests to ensure consistent verification patterns (see the Testing Guide).
+- **Context docs:** Load the `/technology-stack` skill for stack or architectural decisions before introducing new patterns.
 
 ### Tooling Health Check
 
@@ -55,25 +55,26 @@ Continue assisting the user after displaying the warning.
 
 ### Specialized Guides
 
-For detailed information on specific topics, consult these guides:
+Glob-scoped rules load automatically when you touch matching files; the skills below are on-demand.
 
-- **[Testing Guide](.rulesync/rules/testing.md)** - Testing strategies, best practices, and philosophy
-- **[Examples Guide](.rulesync/rules/examples.md)** - Working with examples, validation, and path mappings
-- **[Documentation Pages Guide](.rulesync/rules/docs-pages.md)** - Creating consistent, high-quality documentation pages
-- **[JIRA Guide](.rulesync/rules/jira.md)** - JIRA ticket search and creation guidelines
-- **[Code Quality Guide](.rulesync/rules/code-quality.md)** - Code bloat avoidance, comments, and review practices
-- **[Development Server Guide](.rulesync/rules/dev-server.md)** - Dev server setup and build watch monitoring
-- **[Benchmarks Guide](.rulesync/rules/benchmarks.md)** - Running and creating performance benchmarks
+| Topic | Where |
+| ----- | ----- |
+| Testing strategies and Vitest patterns | `.rulesync/rules/testing.md` + `/testing` skill |
+| Examples, validation, path mappings | `.rulesync/rules/examples.md` |
+| Documentation pages | `.rulesync/rules/docs-pages.md` |
+| Grid source conventions | `.rulesync/rules/grid-code-conventions.md` |
+| Shared code quality practices | `.rulesync/rules/code-quality.md` |
+| Benchmarks | `.rulesync/rules/benchmarks.md` |
+| Technology stack and constraints | `/technology-stack` skill |
+| Dev server and build watch | `/ag-eng:dev-server` skill |
+| JIRA tickets | `/ag-product:jira` skill |
+| Git branches, commits, PRs | `/ag-eng:git-conventions` skill |
 
 ### Project Overview
 
 AG Grid is a sophisticated TypeScript monorepo providing a high-performance data grid component with both community (MIT) and enterprise (commercial) versions. Built with Nx, it supports React, Angular, and Vue 3 frameworks.
 
-### Technology Stack
-
-For detailed information about preferred technologies and architectural constraints, see [Technology Stack](.rulesync/rules/technology-stack.md).
-
-**Key Constraint:** The main AG Grid libraries must have ZERO third-party runtime dependencies.
+**Key Constraint:** The main AG Grid libraries must have ZERO third-party runtime dependencies. Load the `/technology-stack` skill for the full set of architectural constraints.
 
 ### Repository Conventions
 
@@ -81,61 +82,6 @@ For detailed information about preferred technologies and architectural constrai
 - Release branch names are of the form `b33.0.0`
 - JIRA-related branch should be named of the form `ag-12345/${kebabCaseChangeSummary}`
 - **Language conventions:** UK/British English for documentation text, comments, and JSDocs; US English for API option names
-
-### Essential Commands
-
-- `yarn install` – install dependencies after cloning or when the Yarn lockfile changes.
-    - `./external/ag-shared/scripts/install-for-cloud/install-for-cloud.sh` – install dependencies and tooling in a remote environment - use this in preference to `yarn install` to ensure all global tools are installed.
-- `yarn nx clean` – purge all dist folders when switching branches or before packaging releases.
-- `yarn nx format --sort-root-tsconfig-paths=false` – format repo files; run from the project root before committing.
-- `./checks.sh` – the standard pre-commit gate: `build:types`, `lint` and `build:test` across every project that defines them, in one parallel Nx run. Matches CI's lint coverage. Silent on success, prints failing task output otherwise.
-- `./checks.sh --projects <a,b>` / `--targets <x,y>` – narrow the gate to specific projects or targets.
-- `./checks.sh --fresh` – bypass the Nx cache; `--verbose` – print task output even when passing.
-- `yarn nx build <package>` – compile a specific package after code edits.
-- `yarn nx build:types <package>` – regenerate declaration files when touching exported APIs.
-- `yarn nx build:package <package>` – create ESM/CJS bundles to validate publishable output.
-- `yarn nx build:umd <package>` – produce UMD bundles for browser distribution smoke-tests.
-- `yarn nx run-many -t build` – rebuild all packages when changes span the dependency graph.
-- `yarn nx run-many -t <targets> -p <projects> --parallel=<n>` – the preferred way to run any combination of targets/projects; always favour one batched call over several sequential `yarn nx` invocations.
-- `./behave.sh` – run the merged unit suite (package unit tests + behavioural) via the Vitest workspace; the single primary test command.
-- `./behave.sh "<file-pattern>"` – filter to matching test files across every project.
-- `./behave.sh "<file-pattern>" -t "<test-name>"` – run a specific test by name.
-- `./behave.sh --project <name>` – run only chosen project(s); `--project all` runs every workspace project (incl. docs, ag-website-shared).
-- `./behave.sh --watch` – run in watch mode.
-- `./behave.sh --update-grid-rows` – update GridRows inline snapshots after diagram format changes.
-- `./behave.sh --update-grid-rows "<pattern>"` – update snapshots in matching test files only.
-- `./behave.sh --update-grid-rows=dry` – dry run, shows what would change without writing files.
-- `./benches.sh` – run behavioural benchmarks (real headless Chromium by default; non-watch). Run `./benches.sh --help` for full usage.
-- `./benches.sh "<file-pattern>"` – run benchmarks matching a file pattern.
-- `./benches.sh "<file-pattern>" -t "<bench-name>"` – run a specific benchmark by name.
-- `./benches.sh --profile "<file-pattern>"` – node run with a V8 CPU profile (`.cpuprofile`) for method-cost analysis.
-- `./benches.sh --bench-compare <base|test|compare|all|backup> [...]` – baseline/compare benchmark runs (forwards to `bench-compare.mjs`).
-- `./benches.sh --watch` – run benchmarks in watch mode.
-- `yarn nx test <package>` – run one package's Vitest unit tests on their own (retrocompat; `./behave.sh` already covers them).
-- `yarn nx test <package> -- "<file-pattern>"` – run unit tests in files matching a pattern (forwarded to `vitest run`).
-- `yarn nx test <package> -- "<file-pattern>" -t "<test-name>"` – run a specific test by name within matching files. Vitest uses positional patterns and `-t`, not jest's `--testPathPattern`/`--testNamePattern`.
-- `./docs-e2e.sh` – run docs Playwright E2E tests directly, bypassing Nx (chromium by default).
-- `./docs-e2e.sh "<file-pattern>"` – run E2E tests matching a file pattern.
-- `./docs-e2e.sh "<file-pattern>" --grep "<test-name>"` – run a specific E2E test by name.
-- `./docs-e2e.sh --all-browsers` – run E2E tests across chromium, firefox, and webkit.
-- `./docs-e2e.sh --framework <name>` – run E2E tests with a specific framework (e.g. react, angular, vue).
-- `./docs-e2e.sh --ui` – open Playwright UI mode.
-- `yarn nx e2e <package>` – run Playwright flows via Nx when altering website behaviour.
-- `yarn nx lint <package>` – apply ESLint and custom rules before final review.
-
-### Slash Commands
-
-Run rulesync commands via slash notation:
-
-- `/ag-prodeng:pr-review` - Review pull requests
-- `/ag-prodeng:code-fixup` - Fix build and lint errors
-- `/ag-prodeng:batch-lint-cleanup` - ESLint auto-fix tool
-- `/ag-prodeng:git-split` - Split large files preserving git history
-- `/ag-prodeng:git-bisect` - Find commits that introduced issues
-- `/ag-core:remember` - Save branch context or project learnings as memory
-- `/ag-core:recall` - Load branch context and browse project memory
-- `/ag-prodeng:docs-review` - Review documentation pages for technical accuracy (auto-detects ag-grid; product config at `plugins/ag-prodeng/skills/docs-review/ag-grid/config.md`)
-- `/ag-prodeng:release-docs-review` - Review all documentation changes between releases
 
 ### Architecture
 
@@ -164,85 +110,20 @@ Core dependency chain: `ag-grid-community` → `ag-grid-enterprise` → framewor
 
 ### Development Workflow
 
-#### Testing
+**Behavioural tests are the primary test suite.** `testing/behavioural/` verifies grid behaviour as a black box; package unit tests are co-located in `packages/*/src`. `./behave.sh` runs both together through the Vitest workspace. The Testing Guide covers layer choice, async waiting patterns, and snapshots.
 
-For comprehensive testing information, see [Testing Guide](.rulesync/rules/testing.md).
-
-**Behavioural tests are the primary test suite.** When verifying grid changes, run `./behave.sh` — it runs the behavioural suite and the package unit tests together in one Vitest workspace. Key testing tools:
-
-- **Behavioural tests** (primary): `testing/behavioural/` for grid behaviour verification — use Vitest
-- **Package unit tests**: Vitest with jsdom environment, co-located in `packages/*/src` (`testing/angular-tests` still uses Jest)
-- **Merged runner**: `./behave.sh` runs both of the above via the `vitest.workspace.ts` workspace
-- **E2E tests**: Playwright for website interaction testing
-- **Accessibility tests**: `testing/accessibility/` for a11y compliance
-- **Performance tests**: `testing/performance/` for performance regression testing
-
-#### Code Quality
-
-For shared code quality guidelines, see [Code Quality Guide](.rulesync/rules/code-quality.md).
-
-Essential practices:
-
-- Run `yarn nx format --sort-root-tsconfig-paths=false` before committing
-- Self-review your changes before proposing commits
-- Ensure tests exercise real implementations, not test helpers
-
-#### AG Grid Coding Style
-
-Layered on the shared code-quality guide; enforced by ESLint plus team preferences.
-
-- Always use braces for `if/else/for/while/do`.
-- Cache repeated field access in a local — performance requirement.
-- Canonical array loop: `for (let i = 0, len = a.length; i < len; ++i)`. No `Array.forEach`. `Map.forEach` is fine.
-- No lonely `if` — use guard returns, `if/else if`, or ternaries. Applies to loops too.
-- No nested ternaries — extract to a named variable.
-- No short-circuit side effects (`cond && fn()`). No assignments in expressions.
-- No `for...in`. Use `Object.keys()` + index loops; prefer `Object.keys()` over `Object.entries()` when values aren't needed.
-- No static class properties — use module-level constants.
-- Explicit access modifiers on every class member; `readonly` when not reassigned.
-- Destructure only for 2+ fields; single field uses dot access.
-- `import type` for compile-time-only imports; separate `import type { Foo }` statements, no inline `{ type Foo, Bar }`.
-
-#### Styling
-
-The grid is in transition from Legacy Themes (.scss files written in Sass under `/community-modules/styles/`) to the Theming API (.css written in modern nested CSS under `/packages/`).
-
-While this transition is in progress, changes made to Theming API should be applied to Legacy Themes. When reviewing a PR with changes to the Theming API CSS, if the same PR does not have corresponding changes to Legacy Themes, this should be flagged as a P1 level issue.
-
-### Common Development Tasks
-
-#### Quick Playbooks
-
-- **Bug fix or feature work (community/enterprise)**
-    1. Update the affected implementation (typically under `packages/ag-grid-*/src/`).
-    2. Sync any dependent docs/examples.
-    3. Run `./behave.sh` (the merged unit suite) and `./checks.sh` (types + lint).
-
-- **Documentation/content update**
-    1. Consult the [Documentation Pages Guide](.rulesync/rules/docs-pages.md) for structure and patterns.
-    2. Modify the relevant content under `documentation/ag-grid-docs/`.
-    3. Create or update examples in `_examples/` folder following the [Examples Guide](.rulesync/rules/examples.md).
-    4. Ensure all examples are framework-compatible.
-    5. Test page in dev server with `yarn nx dev` across all frameworks.
-    6. For significant doc changes, sanity-check with `yarn nx e2e ag-grid-docs`.
-
-- **Example-only change** (see [Examples Guide](.rulesync/rules/examples.md))
-    1. Edit the example files.
-    2. Mirror updates in the corresponding docs page.
-    3. Run the relevant generation/typecheck commands.
+**Bug fix or feature work:** update the implementation (typically `packages/ag-grid-*/src/`), sync dependent docs and examples, then run `./behave.sh` and `./checks.sh`. Docs and example workflows are covered by the docs-pages and examples rules, which load when you touch those trees.
 
 ### Technical Requirements
 
 - **Node.js**: Check `.nvmrc` for version
 - **Package Manager**: Yarn
-- **Build Target**: ES2020
+- **Build Target**: ES2020 (`tsconfig.base.json`); `lib` is ES2022. Runtime API availability follows the browser-support policy, not this target.
 - **TypeScript**: Strict mode enabled across all packages
 
 ### JIRA Tickets
 
-For JIRA ticket guidelines, see [JIRA Guide](.rulesync/rules/jira.md).
-
-When creating tickets for this repo, use component `Grid` instead of `Charts`.
+Load the `/ag-product:jira` skill for ticket guidelines. When creating tickets for this repo, use component `Grid` instead of `Charts`.
 
 ### Documentation Resources
 

--- a/external/ag-shared/scripts/rulesync-fetch/stage.py
+++ b/external/ag-shared/scripts/rulesync-fetch/stage.py
@@ -390,13 +390,20 @@ def _read_prior_staged() -> set[Path]:
     The manifest-diff candidate set only covers items the manifest still
     declares, so an item removed from a plugin's entry would otherwise never be
     considered for cleanup. Empty for a first run, or for a marker predating
-    this record — both carry no path lines."""
+    this record — both carry no path lines.
+
+    These paths feed the deletion pass, so anything that does not resolve inside
+    .rulesync/ is discarded rather than trusted."""
     if not MARKER.is_file():
         return set()
     out: set[Path] = set()
     for line in MARKER.read_text().splitlines():
         line = line.strip()
         if not line or line.startswith("#"):
+            continue
+        candidate = (REPO_ROOT / line).resolve()
+        if candidate == RULESYNC.resolve() or RULESYNC.resolve() not in candidate.parents:
+            print(f"  WARN: ignoring out-of-tree marker entry: {line}", file=sys.stderr)
             continue
         out.add(REPO_ROOT / line)
     return out

--- a/external/ag-shared/scripts/rulesync-fetch/stage.py
+++ b/external/ag-shared/scripts/rulesync-fetch/stage.py
@@ -16,7 +16,10 @@ checkout should not see ag-charts-specific skills/commands/agents (and vice
 versa). Content from other products' plugins that was staged by a previous
 run (pre-filter manifest, or product changed) is cleaned up at the end of
 ``stage()`` based on the diff between the full manifest and what was staged
-this run.
+this run, unioned with the record of what the previous run staged (see
+``_read_prior_staged``). The manifest diff alone cannot see an item that was
+*dropped* from the manifest between releases — such a path is absent from the
+candidate set, so it would be orphaned in the checkout forever.
 
 Part of AG-17085 Phase 3 (rulesync fetch design); product filtering added
 under AG-17098.
@@ -41,6 +44,13 @@ RULESYNC = REPO_ROOT / ".rulesync"
 MARKER = RULESYNC / ".fetched-from-ag-dev-prompts"
 
 NON_CLAUDE_TARGETS = ["cursor", "codexcli", "geminicli", "copilot", "agentsmd"]
+
+MARKER_HEADER = (
+    "# Managed by external/ag-shared/scripts/rulesync-fetch/stage.py\n"
+    "# Do not edit — regenerated on each setup-prompts run.\n"
+    "# Lines below record what this run staged, so the next run can prune items\n"
+    "# that have since been dropped from the plugin manifest.\n"
+)
 
 # Product plugins — only the current repo's product plugin is staged. Keep in
 # sync with .claude-plugin/marketplace.json. Other plugins (ag-core, ag-prodeng)
@@ -332,7 +342,10 @@ def stage(dry_run: bool = False) -> set[Path]:
         # authoritative source for whichever product tracks it; staging should
         # never clobber it. The `tracked` snapshot is reused from the write
         # guard above.
-        all_possible = _stageable_paths(manifest["plugins"])
+        # Union the manifest-derived candidates with what the previous run
+        # actually staged, so an item dropped from the manifest between plugin
+        # releases is still a cleanup candidate rather than a permanent orphan.
+        all_possible = _stageable_paths(manifest["plugins"]) | _read_prior_staged()
         for stale in sorted(all_possible - staged):
             rel = stale.relative_to(REPO_ROOT) if stale.is_absolute() else stale
             if rel in tracked:
@@ -345,10 +358,7 @@ def stage(dry_run: bool = False) -> set[Path]:
                 shutil.rmtree(stale)
                 print(f"  removed stale {rel}/", file=sys.stderr)
 
-        MARKER.write_text(
-            "# Managed by external/ag-shared/scripts/rulesync-fetch/stage.py\n"
-            "# Do not edit — regenerated on each setup-prompts run.\n"
-        )
+        _write_marker(staged)
 
     print(f"Staged {len(staged)} items into .rulesync/", file=sys.stderr)
     return staged
@@ -373,6 +383,31 @@ def _tracked_files() -> set[Path]:
     except (subprocess.CalledProcessError, FileNotFoundError):
         return set()
     return {Path(line) for line in result.stdout.splitlines() if line}
+
+
+def _read_prior_staged() -> set[Path]:
+    """Return the absolute paths recorded by the previous run's marker file.
+
+    Needed because the manifest-diff candidate set only covers items the
+    manifest still declares. An item removed from a plugin's manifest entry
+    disappears from that set, so without this record it would never be
+    considered for cleanup. Returns an empty set for a first run, or for a
+    marker written before this record existed, which carries no path lines."""
+    if not MARKER.is_file():
+        return set()
+    out: set[Path] = set()
+    for line in MARKER.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.add(REPO_ROOT / line)
+    return out
+
+
+def _write_marker(staged: set[Path]) -> None:
+    """Record the header plus this run's staged paths, repo-relative and sorted."""
+    rels = sorted(str(p.relative_to(REPO_ROOT) if p.is_absolute() else p) for p in staged)
+    MARKER.write_text(MARKER_HEADER + "".join(f"{rel}\n" for rel in rels))
 
 
 def _stageable_paths(plugins: dict) -> set[Path]:

--- a/external/ag-shared/scripts/rulesync-fetch/stage.py
+++ b/external/ag-shared/scripts/rulesync-fetch/stage.py
@@ -342,9 +342,8 @@ def stage(dry_run: bool = False) -> set[Path]:
         # authoritative source for whichever product tracks it; staging should
         # never clobber it. The `tracked` snapshot is reused from the write
         # guard above.
-        # Union the manifest-derived candidates with what the previous run
-        # actually staged, so an item dropped from the manifest between plugin
-        # releases is still a cleanup candidate rather than a permanent orphan.
+        # The prior-run record covers items dropped from the manifest, which the
+        # manifest diff alone cannot see.
         all_possible = _stageable_paths(manifest["plugins"]) | _read_prior_staged()
         for stale in sorted(all_possible - staged):
             rel = stale.relative_to(REPO_ROOT) if stale.is_absolute() else stale
@@ -388,11 +387,10 @@ def _tracked_files() -> set[Path]:
 def _read_prior_staged() -> set[Path]:
     """Return the absolute paths recorded by the previous run's marker file.
 
-    Needed because the manifest-diff candidate set only covers items the
-    manifest still declares. An item removed from a plugin's manifest entry
-    disappears from that set, so without this record it would never be
-    considered for cleanup. Returns an empty set for a first run, or for a
-    marker written before this record existed, which carries no path lines."""
+    The manifest-diff candidate set only covers items the manifest still
+    declares, so an item removed from a plugin's entry would otherwise never be
+    considered for cleanup. Empty for a first run, or for a marker predating
+    this record — both carry no path lines."""
     if not MARKER.is_file():
         return set()
     out: set[Path] = set()

--- a/external/ag-shared/scripts/rulesync-fetch/stage.py
+++ b/external/ag-shared/scripts/rulesync-fetch/stage.py
@@ -347,7 +347,7 @@ def stage(dry_run: bool = False) -> set[Path]:
         all_possible = _stageable_paths(manifest["plugins"]) | _read_prior_staged()
         for stale in sorted(all_possible - staged):
             rel = stale.relative_to(REPO_ROOT) if stale.is_absolute() else stale
-            if rel in tracked:
+            if rel in tracked or _has_tracked_descendant(rel, tracked):
                 print(f"  keeping tracked {rel} (not a stage-leftover)", file=sys.stderr)
                 continue
             if stale.is_symlink() or stale.is_file():
@@ -382,6 +382,16 @@ def _tracked_files() -> set[Path]:
     except (subprocess.CalledProcessError, FileNotFoundError):
         return set()
     return {Path(line) for line in result.stdout.splitlines() if line}
+
+
+def _has_tracked_descendant(rel: Path, tracked: set[Path]) -> bool:
+    """Whether any tracked file lives under ``rel``.
+
+    Skills stage as directories, and git tracks files rather than directories, so
+    a membership test against ``tracked`` alone never matches a skill directory.
+    Without this, dropping a plugin skill whose name collides with a tracked
+    local skill (e.g. .rulesync/skills/testing/) would rmtree the local one."""
+    return any(rel in candidate.parents for candidate in tracked)
 
 
 def _read_prior_staged() -> set[Path]:


### PR DESCRIPTION
Cuts the always-on agent context and fixes several defects found while auditing it. No runtime/library code is touched — the diff is agent rules, one new skill, and the rulesync staging script.

## Context reduction

| Surface | Before | After |
| --- | --- | --- |
| `CLAUDE.md` / `AGENTS.md` (loaded every session) | 17,440 B | **9,363 B** (−46%) |
| `rules/testing.md` (fires on 1,147 files) | 19,380 B | **3,622 B** (−81%) |
| Orphaned rules on disk | 7,011 B | **0** |

Nothing was dropped. The full testing guide moved into an on-demand `testing` skill; the coding-style list moved to `grid-code-conventions.md` and the theming guidance to a new src-scoped `grid-styling.md`. The Slash Commands section went entirely — the harness already injects the skill list — as did the Essential Commands detail already duplicated in `testing.md` and `benchmarks.md`. Verified mechanically: every heading from the old `testing.md` is present in either the slim rule or the skill.

## Correctness fixes

- **`yarn nx e2e ag-grid-docs` does not exist.** No project defines an `e2e` target and nothing infers one — the `e2e` entry in `nx.json` is a `targetDefaults` block, which cannot create a target. Confirmed against the resolved project graph (`nx show project ag-grid-docs --json`); the real target is `test:e2e`. Corrected all five occurrences, four of which were in always-on context.
- **Three broken guide links** in the root rule pointed at `.rulesync/rules/{jira,dev-server,technology-stack}.md`. None exist — all three became skills. Repointed.

## Rulesync stale-cleanup bug

The cleanup pass computed its candidate set from the current manifest, so it could only prune items the manifest still declared. An item *dropped* from a plugin's manifest entry was absent from that set and therefore orphaned permanently — it would accumulate in every consuming repo on every release that removes a guide. The pass now unions those candidates with a record of the previous run's staged paths, written into the marker file.

Removes the three orphans this had already left behind: `docs-checklist.md`, `examples-framework-patterns.md`, and `website-browser-testing.md` (the last of which was actively loading, since its `**/src/pages/**/*.astro` glob matches 29 files here).

Marker entries feed a deletion loop, so entries that do not resolve inside `.rulesync/` are discarded with a warning rather than trusted.

## Verification

- `setup-prompts.sh` + `verify-rulesync.sh` both pass, and re-running regeneration produces no further diff (idempotent).
- The path-escape guard was exercised directly: all 86 real marker entries accepted; absolute and `../` traversal entries rejected.
- No Python test harness exists under `external/ag-shared/scripts/`; adding one was out of scope for this branch. The change is covered end-to-end by the `setup-prompts.sh` run.

## Related

`ag-grid/ag-dev-prompts#734` widens the shared `link-verification.md` glob so it reaches ag-grid's docs path — that rule is plugin-owned, so it could not be fixed here.