### PR TITLE
Faster stabler e2e tests

### DIFF
--- a/docs-e2e.sh
+++ b/docs-e2e.sh
@@ -34,6 +34,8 @@ Options:
   --framework <name>      Set FRAMEWORK env var. Valid: typescript, vanilla,
                           reactFunctionalTs, reactFunctionalTs_Dev, angular, vue3
   --url <url>             Set BASE_URL env var (default: https://localhost:4610)
+  --all-variants          Also run the production React variant (or ALL_FRAMEWORK_VARIANTS=true).
+                          CI runs both; locally only the development one runs.
   --help                  Show this help message
 
 Playwright options (forwarded as-is):
@@ -90,6 +92,10 @@ while [[ $# -gt 0 ]]; do
         --url)
             export BASE_URL="$2"
             shift 2
+            ;;
+        --all-variants)
+            export ALL_FRAMEWORK_VARIANTS=true
+            shift
             ;;
         *)
             args+=("$1")

--- a/documentation/ag-grid-docs/package.json
+++ b/documentation/ag-grid-docs/package.json
@@ -95,6 +95,7 @@
     "vue": "^3.5.13"
   },
   "devDependencies": {
+    "@fontsource/ibm-plex-sans": "^5.3.0",
     "@playwright/test": "^1.59.1",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@types/he": "^1.2.3",

--- a/documentation/ag-grid-docs/playwright.config.ts
+++ b/documentation/ag-grid-docs/playwright.config.ts
@@ -88,6 +88,11 @@ export default defineConfig({
         /* Base URL to use in actions like `await page.goto('/')`. */
         baseURL,
 
+        // The dev server's certificate is self-signed. Chromium waives that for localhost but Node does not,
+        // so route handlers that re-request a URL fail without this. Left on for a deployed run, whose
+        // certificate is real and should still be checked.
+        ignoreHTTPSErrors: isLocalRun(baseURL),
+
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         // Keep this off for CI runs that upload reports: a trace records request headers, so it would
         // capture the WAF bypass credential in an artefact that GitHub's log masking does not cover.

--- a/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/provided/reactFunctionalTs/useFetchJson.tsx
+++ b/documentation/ag-grid-docs/src/content/docs/grid-state/_examples/grid-state/provided/reactFunctionalTs/useFetchJson.tsx
@@ -8,6 +8,8 @@ export const useFetchJson = <T,>(url: string, limit?: number) => {
     const [data, setData] = useState<T[]>();
     const [loading, setLoading] = useState(true);
     useEffect(() => {
+        // StrictMode runs this effect twice: drop the superseded run's response rather than applying both.
+        let cancelled = false;
         const fetchData = async () => {
             setLoading(true);
 
@@ -15,10 +17,16 @@ export const useFetchJson = <T,>(url: string, limit?: number) => {
             const response = await fetch(url);
             const json = await response.json();
             const data = limit ? json.slice(0, limit) : json;
+            if (cancelled) {
+                return;
+            }
             setData(data);
             setLoading(false);
         };
         fetchData();
+        return () => {
+            cancelled = true;
+        };
     }, [url, limit]);
     return { data, loading };
 };

--- a/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test-utils.ts
@@ -6,6 +6,7 @@ import { type AgModuleName, wrapAgTestIdFor } from 'ag-grid-community';
 
 import { applyCpuThrottle, clearCpuThrottle } from './test/applyCpuThrottle';
 import { routeExampleAssetsFromDisk, routeExternalThroughMirror, warnOnNetworkAccess } from './test/localSources';
+import { routeExampleModulesTranspiled } from './test/localTranspile';
 import { type AsyncGridApi, type EventLog, createRemoteGridApiProxy } from './test/remoteGridapi';
 import { shouldBeAsyncGuard } from './test/shouldBeAsyncGuard';
 import { WAF_BYPASS_HEADER, wafBypassSecret } from './test/wafBypass';
@@ -60,6 +61,15 @@ const ALL_FRAMEWORKS = [
 ] as const;
 type AgFramework = (typeof ALL_FRAMEWORKS)[number];
 
+/**
+ * React is the only framework declared twice - once on the production build, once forcing the development
+ * one - so this only ever drops a React variant. That is a sixth of the suite, and locally the development
+ * build is the one worth the wall clock, so CI runs both and a local run does not.
+ */
+const runAllFrameworkVariants = !!process.env.CI || process.env.ALL_FRAMEWORK_VARIANTS === 'true';
+
+const PROD_VARIANT_FRAMEWORK = 'reactFunctionalTs';
+
 // Filter frameworks based on FRAMEWORK environment variable
 function getFilteredFrameworks(): readonly AgFramework[] {
     const frameworkFilter = process.env.FRAMEWORK;
@@ -73,10 +83,23 @@ function getFilteredFrameworks(): readonly AgFramework[] {
             );
         }
     }
+    if (!runAllFrameworkVariants) {
+        return ALL_FRAMEWORKS.filter((framework) => framework !== PROD_VARIANT_FRAMEWORK);
+    }
     return ALL_FRAMEWORKS;
 }
 
 const FILTERED_FRAMEWORKS = getFilteredFrameworks();
+
+// One worker, so a run says once what it is doing rather than once per worker.
+if (process.env.TEST_WORKER_INDEX === '0' && !process.env.FRAMEWORK) {
+    // eslint-disable-next-line no-console
+    console.log(
+        runAllFrameworkVariants
+            ? `Running all framework variants: ${FILTERED_FRAMEWORKS.join(', ')}`
+            : `Skipping the ${PROD_VARIANT_FRAMEWORK} variant - set ALL_FRAMEWORK_VARIANTS=true to include it`
+    );
+}
 
 const licenseTexts = [
     '****************************************************************************************************************************',
@@ -178,7 +201,9 @@ async function loadPage(
         enableTestIds: 'true',
     };
 
-    if (loadPageOptions?.prod) {
+    // Stated rather than left to the boilerplate, whose default is the development build - so the two React
+    // variants both loaded it and the production build was never actually exercised.
+    if (loadPageOptions?.prod || (loadPageOptions?.prod === undefined && agFramework === PROD_VARIANT_FRAMEWORK)) {
         queryOptions.prod = 'true';
     } else if (loadPageOptions?.prod === false || agFramework === reactFunctionalTsDev) {
         queryOptions.prod = 'false';
@@ -260,6 +285,7 @@ export const extended = base.extend<TestFixtures>({
             // served `/example-assets/`.
             await routeExternalThroughMirror(page, siteOrigin);
             await routeExampleAssetsFromDisk(page);
+            await routeExampleModulesTranspiled(page, siteOrigin);
             await use();
         },
         { auto: true },
@@ -412,13 +438,13 @@ async function checkForErrorsAndTearDownExample(errors: string[], page: Page) {
         errors = [];
     }
 
-    let exampleRemoved = false;
-    await page.evaluate(() => {
+    const exampleRemoved = await page.evaluate(() => {
         const win: any = window;
-        if (win.tearDownExample) {
-            win.tearDownExample();
-            exampleRemoved = true;
+        if (!win.tearDownExample) {
+            return false;
         }
+        win.tearDownExample();
+        return true;
     });
     if (exampleRemoved) {
         const root = page.locator('.ag-root-wrapper');

--- a/documentation/ag-grid-docs/src/utils/grid/test/localFonts.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test/localFonts.ts
@@ -1,0 +1,52 @@
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+
+export const GOOGLE_FONTS_CSS = 'https://fonts.googleapis.com/css2';
+
+/** Only families examples measure text in are worth installing; every other one still goes to the mirror. */
+const FONT_PACKAGES: Record<string, string> = {
+    'IBM Plex Sans': '@fontsource/ibm-plex-sans',
+};
+
+/** Fontsource writes one `src` per face, woff2 first, then a woff fallback that goes with it. */
+const FONTSOURCE_SRC = /src:\s*url\(\.\/(files\/\S+\.woff2)\)[^;]*;/g;
+
+const resolveFrom = createRequire(import.meta.url).resolve;
+
+/**
+ * Examples auto-size columns the first time data renders and those widths stick, so a grid that measures
+ * before its webfont arrives keeps fallback widths for ever. Inlining the faces leaves nothing to race -
+ * they are usable as the stylesheet parses, before any script mounts a grid. Neither half of that is
+ * available from the CDN: the face is a second request the grid can beat, and even `display=block` lays
+ * text out with the fallback's metrics until it lands.
+ */
+async function buildStylesheet(url: string): Promise<string | undefined> {
+    const [family, weights] = (new URL(url).searchParams.get('family') ?? '').split(':wght@');
+    const pkg = FONT_PACKAGES[family];
+    if (!pkg) {
+        return undefined;
+    }
+    const sheets = await Promise.all(
+        weights.split(';').map((weight) => readFile(resolveFrom(`${pkg}/${weight}.css`), 'utf8'))
+    );
+    const css = sheets.join('');
+    const files = Array.from(new Set(Array.from(css.matchAll(FONTSOURCE_SRC), (match) => match[1])));
+    const bodies = await Promise.all(files.map((file) => readFile(resolveFrom(`${pkg}/${file}`))));
+    const base64 = new Map(files.map((file, i) => [file, bodies[i].toString('base64')]));
+    return css
+        .replace(FONTSOURCE_SRC, (_, file) => `src: url(data:font/woff2;base64,${base64.get(file)});`)
+        .replace(/font-display:\s*swap;/g, 'font-display: block;');
+}
+
+/** The same stylesheet serves every test in the worker, and building it base64s a few hundred KB. */
+const stylesheets = new Map<string, Promise<string | undefined>>();
+
+/** Undefined for anything the installed packages cannot cover - an unknown family, or a weight not shipped. */
+export function localFontStylesheet(url: string): Promise<string | undefined> {
+    let pending = stylesheets.get(url);
+    if (!pending) {
+        pending = buildStylesheet(url).catch(() => undefined);
+        stylesheets.set(url, pending);
+    }
+    return pending;
+}

--- a/documentation/ag-grid-docs/src/utils/grid/test/localFonts.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test/localFonts.ts
@@ -13,29 +13,50 @@ const FONTSOURCE_SRC = /src:\s*url\(\.\/(files\/\S+\.woff2)\)[^;]*;/g;
 
 const resolveFrom = createRequire(import.meta.url).resolve;
 
+/** Relative to its own package, so the faces have to be read before another family's are appended. */
+async function inlineFaces(pkg: string, css: string): Promise<string> {
+    const files = Array.from(new Set(Array.from(css.matchAll(FONTSOURCE_SRC), (match) => match[1])));
+    const bodies = await Promise.all(files.map((file) => readFile(resolveFrom(`${pkg}/${file}`))));
+    const base64 = new Map(files.map((file, i) => [file, bodies[i].toString('base64')]));
+    return css.replace(FONTSOURCE_SRC, (_, file) => `src: url(data:font/woff2;base64,${base64.get(file)});`);
+}
+
+/**
+ * A weight list is what names the fontsource files, so a bare family or a `300..700` range is not something
+ * the installed package can answer - those belong to the mirror.
+ */
+async function familyStylesheet(entry: string): Promise<string | undefined> {
+    const [family, weights] = entry.split(':wght@');
+    const pkg = FONT_PACKAGES[family];
+    if (!pkg || !weights || weights.includes('..')) {
+        return undefined;
+    }
+    const sheets = await Promise.all(
+        weights.split(';').map((weight) => readFile(resolveFrom(`${pkg}/${weight}.css`), 'utf8'))
+    );
+    return inlineFaces(pkg, sheets.join(''));
+}
+
 /**
  * Examples auto-size columns the first time data renders and those widths stick, so a grid that measures
  * before its webfont arrives keeps fallback widths for ever. Inlining the faces leaves nothing to race -
  * they are usable as the stylesheet parses, before any script mounts a grid. Neither half of that is
  * available from the CDN: the face is a second request the grid can beat, and even `display=block` lays
  * text out with the fallback's metrics until it lands.
+ *
+ * All or nothing across the `family` parameters: one request is one stylesheet, so answering it with the
+ * faces of only the families installed would silently drop the others.
  */
 async function buildStylesheet(url: string): Promise<string | undefined> {
-    const [family, weights] = (new URL(url).searchParams.get('family') ?? '').split(':wght@');
-    const pkg = FONT_PACKAGES[family];
-    if (!pkg) {
+    const requested = new URL(url).searchParams.getAll('family');
+    if (requested.length === 0) {
         return undefined;
     }
-    const sheets = await Promise.all(
-        weights.split(';').map((weight) => readFile(resolveFrom(`${pkg}/${weight}.css`), 'utf8'))
-    );
-    const css = sheets.join('');
-    const files = Array.from(new Set(Array.from(css.matchAll(FONTSOURCE_SRC), (match) => match[1])));
-    const bodies = await Promise.all(files.map((file) => readFile(resolveFrom(`${pkg}/${file}`))));
-    const base64 = new Map(files.map((file, i) => [file, bodies[i].toString('base64')]));
-    return css
-        .replace(FONTSOURCE_SRC, (_, file) => `src: url(data:font/woff2;base64,${base64.get(file)});`)
-        .replace(/font-display:\s*swap;/g, 'font-display: block;');
+    const families = await Promise.all(requested.map(familyStylesheet));
+    if (families.some((css) => css === undefined)) {
+        return undefined;
+    }
+    return families.join('').replace(/font-display:\s*swap;/g, 'font-display: block;');
 }
 
 /** The same stylesheet serves every test in the worker, and building it base64s a few hundred KB. */

--- a/documentation/ag-grid-docs/src/utils/grid/test/localSources.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test/localSources.ts
@@ -4,6 +4,9 @@ import { appendFile, mkdir, readFile, readdir, rename, rm, stat, utimes, writeFi
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { GOOGLE_FONTS_CSS, localFontStylesheet } from './localFonts';
+import { systemRegisterFor } from './localTranspile';
+
 const EXAMPLE_ASSETS_URL_PREFIX = '/example-assets/';
 const EXAMPLE_ASSETS_DIR = fileURLToPath(new URL('../../../../public/example-assets/', import.meta.url));
 
@@ -18,8 +21,8 @@ const isFile = (path: string): Promise<boolean> =>
 const TEXT_MEASURABLE_RESOURCE_TYPES = ['fetch', 'xhr'];
 
 /**
- * Examples auto-size columns the first time data renders and those widths stick, so serving data from disk
- * made it beat the webfont and measure text in the fallback.
+ * Inlined faces cover the families examples measure, but not every one they can ask for, so serving data
+ * from disk can still let it beat a font that is still arriving and be measured in the fallback.
  */
 async function waitForTextMeasurable(page: Page): Promise<void> {
     await page
@@ -55,26 +58,71 @@ export async function routeExampleAssetsFromDisk(page: Page): Promise<void> {
     });
 }
 
-/**
- * Everything off the site's own origin is mirrored. An allowlist of known CDNs leaves every host nobody
- * thought of reaching the public internet - `flags.fmcdn.net` and `cdn.cookielaw.org` already needed their
- * own per-spec stubs - so the default is "mirror it" and only the build under test is exempt.
- */
-const isExternalTo =
-    (siteOrigin: string) =>
-    (url: URL): boolean =>
-        url.origin !== siteOrigin && (url.protocol === 'https:' || url.protocol === 'http:');
-
 const MIRROR_DIR = fileURLToPath(new URL('../../../../.playwright-network-mirror/', import.meta.url));
-const MIRROR_META_SEPARATOR = 0x0a;
+
+/** One file per entry so a single rename publishes it whole; the first newline ends the metadata. */
+const META_SEPARATOR = 0x0a;
+
+type MirrorMeta = { status: number; headers: Record<string, string>; bytes: number; fetchedAt: number };
+type MirrorEntry = { body: Buffer; meta: MirrorMeta };
+
+/** What identifies an entry to this run, and where it lives. */
+type MirrorId = { key: string; path: string };
+
+/**
+ * Keyed by user agent as well as URL, so a host that negotiates cannot answer the wrong browser: Google
+ * Fonts serves `font-stretch: 100%` to one and `normal` to another. A browser upgrade earns a fresh key.
+ * The digest keeps paths unique; the readable stem is so an entry can be identified and deleted by hand.
+ */
+function mirrorIdFor(url: string, userAgent: string): MirrorId {
+    const key = `${userAgent}\n${url}`;
+    const { hostname, pathname } = new URL(url);
+    const stem = `${hostname}${pathname}`.replace(/[^a-zA-Z0-9._-]+/g, '-').slice(0, 100);
+    const digest = createHash('sha1').update(key).digest('hex').slice(0, 12);
+    return { key, path: join(MIRROR_DIR, `${stem}-${digest}`) };
+}
+
+/** Any read failure - absent, truncated, mid-write - just means "not mirrored yet". */
+async function readEntry(path: string): Promise<MirrorEntry | undefined> {
+    try {
+        const file = await readFile(path);
+        const split = file.indexOf(META_SEPARATOR);
+        if (split < 0) {
+            return undefined;
+        }
+        const meta: MirrorMeta = JSON.parse(file.subarray(0, split).toString('utf8'));
+        const body = file.subarray(split + 1);
+        // The rename publishes a whole entry, so a short body means the file was damaged afterwards -
+        // serving it would fail as a corrupt bundle rather than as a cache miss.
+        if (body.length !== meta.bytes) {
+            return undefined;
+        }
+        // Marks the entry as still in use so the sweep only reclaims what nothing asks for any more.
+        const now = new Date();
+        void utimes(path, now, now).catch(() => undefined);
+        return { meta, body };
+    } catch {
+        return undefined;
+    }
+}
+
+/** Written to a pid-suffixed name first: two workers renaming at once must not interleave one entry. */
+async function writeEntry(path: string, { body, meta }: MirrorEntry): Promise<void> {
+    const tmp = `${path}.${process.pid}.tmp`;
+    await mkdir(MIRROR_DIR, { recursive: true });
+    await writeFile(tmp, `${JSON.stringify(meta)}\n`, 'utf8');
+    await appendFile(tmp, body);
+    await rename(tmp, path);
+}
 
 /**
  * Housekeeping, not invalidation: a read renews the entry, so anything still wanted never ages out and this
  * only reclaims what nothing asks for any more - the superseded URL after a version bump, say.
  */
 const MIRROR_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
 /** A temporary file lives for milliseconds, so anything this old was orphaned by a worker that was killed. */
-const MIRROR_TMP_MAX_AGE_MS = 60 * 60 * 1000;
+const TMP_MAX_AGE_MS = 60 * 60 * 1000;
 
 let mirrorSweep: Promise<void> | undefined;
 
@@ -86,7 +134,7 @@ function sweepMirror(): Promise<void> {
         await Promise.all(
             names.map(async (name) => {
                 const path = join(MIRROR_DIR, name);
-                const maxAge = name.endsWith('.tmp') ? MIRROR_TMP_MAX_AGE_MS : MIRROR_MAX_AGE_MS;
+                const maxAge = name.endsWith('.tmp') ? TMP_MAX_AGE_MS : MIRROR_MAX_AGE_MS;
                 const info = await stat(path).catch(() => undefined);
                 if (info && now - info.mtimeMs > maxAge) {
                     await rm(path, { force: true }).catch(() => undefined);
@@ -96,8 +144,6 @@ function sweepMirror(): Promise<void> {
     })();
     return mirrorSweep;
 }
-
-type MirrorMeta = { status: number; headers: Record<string, string>; bytes: number; fetchedAt: number };
 
 const IMMUTABLE = /\bimmutable\b/;
 const NO_REUSE = /\bno-(store|cache)\b/;
@@ -128,59 +174,6 @@ function freshnessMs(meta: MirrorMeta): number {
  * a run never re-checks something it has already answered, however long it runs.
  */
 const isFresh = (meta: MirrorMeta): boolean => Date.now() - meta.fetchedAt < freshnessMs(meta);
-type MirrorEntry = { body: Buffer; meta: MirrorMeta };
-
-/** Bodies are multi-MB (`typescript.min.js` alone is ~6MB) and every test wants them, so resolve each once. */
-const mirrorEntries = new Map<string, Promise<MirrorEntry | undefined>>();
-
-/**
- * Keyed by user agent as well as URL, so a host that negotiates cannot answer the wrong browser: Google
- * Fonts serves `font-stretch: 100%` to one and `normal` to another. A browser upgrade earns a fresh key.
- */
-const mirrorKeyFor = (url: string, userAgent: string): string => `${userAgent}\n${url}`;
-
-/** The digest keeps entries unique; the readable stem is so one can be identified and deleted by hand. */
-function mirrorPathFor(url: string, key: string): string {
-    const { hostname, pathname } = new URL(url);
-    const stem = `${hostname}${pathname}`.replace(/[^a-zA-Z0-9._-]+/g, '-').slice(0, 100);
-    return join(MIRROR_DIR, `${stem}-${createHash('sha1').update(key).digest('hex').slice(0, 12)}`);
-}
-
-/** Any read failure - absent, truncated, mid-write - just means "not mirrored yet". */
-async function readMirrorEntry(path: string): Promise<MirrorEntry | undefined> {
-    try {
-        const file = await readFile(path);
-        const split = file.indexOf(MIRROR_META_SEPARATOR);
-        if (split < 0) {
-            return undefined;
-        }
-        const meta: MirrorMeta = JSON.parse(file.subarray(0, split).toString('utf8'));
-        const body = file.subarray(split + 1);
-        // The rename publishes a whole entry, so a short body means the file was damaged afterwards -
-        // serving it would fail as a corrupt bundle rather than as a cache miss.
-        if (body.length !== meta.bytes) {
-            return undefined;
-        }
-        // Marks the entry as still in use so the sweep only reclaims what nothing asks for any more.
-        const now = new Date();
-        void utimes(path, now, now).catch(() => undefined);
-        return { meta, body };
-    } catch {
-        return undefined;
-    }
-}
-
-/**
- * Metadata and body share one file so a single rename publishes the entry whole. Written to a pid-suffixed
- * name first: with a file each, two workers renaming at once can pair one's body with the other's status.
- */
-async function writeMirrorEntry(path: string, { body, meta }: MirrorEntry): Promise<void> {
-    const tmp = `${path}.${process.pid}.tmp`;
-    await mkdir(MIRROR_DIR, { recursive: true });
-    await writeFile(tmp, `${JSON.stringify(meta)}\n`, 'utf8');
-    await appendFile(tmp, body);
-    await rename(tmp, path);
-}
 
 function withoutHeaders(headers: Record<string, string>, drop: string[]): Record<string, string> {
     const kept = { ...headers };
@@ -218,14 +211,15 @@ const settledFailures = new Set<string>();
  */
 async function fetchIntoMirror(
     route: Route,
-    key: string,
-    path: string,
+    url: string,
+    id: MirrorId,
     stored: MirrorEntry | undefined
 ): Promise<MirrorEntry | undefined> {
     let entry: MirrorEntry;
     try {
         const sent = withoutHeaders(route.request().headers(), CONDITIONAL_HEADERS);
         const response = await route.fetch({
+            url,
             headers: stored ? { ...sent, ...validatorsFor(stored.meta.headers) } : sent,
         });
         const status = response.status();
@@ -234,7 +228,7 @@ async function fetchIntoMirror(
         } else if (status < 200 || status >= 300) {
             // `route.fetch` has already followed any redirect, so nothing here carries the bytes.
             if (status >= 400 && status < 500 && !stored) {
-                settledFailures.add(key);
+                settledFailures.add(id.key);
             }
             return stored;
         } else {
@@ -253,30 +247,33 @@ async function fetchIntoMirror(
         return stored;
     }
     // Persisting is best effort - a full or read-only disk should not cost us a response already in hand.
-    await writeMirrorEntry(path, entry).catch(() => undefined);
+    await writeEntry(id.path, entry).catch(() => undefined);
     return entry;
 }
+
+/** Bodies are multi-MB (`typescript.min.js` alone is ~6MB) and every test wants them, so resolve each once. */
+const mirrorEntries = new Map<string, Promise<MirrorEntry | undefined>>();
 
 /**
  * Single-flight per worker, and the reason a run never re-checks a URL: the first request resolves it and
  * every later one awaits the same promise, so freshness is judged once however long the run lasts.
  */
-async function loadMirrorEntry(route: Route, key: string, path: string): Promise<MirrorEntry | undefined> {
-    if (settledFailures.has(key)) {
+async function loadMirrorEntry(route: Route, url: string, id: MirrorId): Promise<MirrorEntry | undefined> {
+    if (settledFailures.has(id.key)) {
         return undefined;
     }
-    const inFlight = mirrorEntries.get(key);
+    const inFlight = mirrorEntries.get(id.key);
     if (inFlight) {
         return inFlight;
     }
-    const pending = readMirrorEntry(path).then((stored) =>
-        stored && isFresh(stored.meta) ? stored : fetchIntoMirror(route, key, path, stored)
+    const pending = readEntry(id.path).then((stored) =>
+        stored && isFresh(stored.meta) ? stored : fetchIntoMirror(route, url, id, stored)
     );
-    mirrorEntries.set(key, pending);
+    mirrorEntries.set(id.key, pending);
     const entry = await pending;
     // Never memoize a transient failure, or one bad fetch is replayed by every later test in this worker.
     if (!entry) {
-        mirrorEntries.delete(key);
+        mirrorEntries.delete(id.key);
     }
     return entry;
 }
@@ -301,12 +298,6 @@ async function claimMissReport(url: string): Promise<boolean> {
         return true;
     } catch {
         return false;
-    }
-}
-
-async function recordNetworkMiss(url: string, requestedBy: string): Promise<void> {
-    if (await claimMissReport(url)) {
-        unreportedMisses.push(`${url}\n   requested by ${requestedBy}`);
     }
 }
 
@@ -345,6 +336,16 @@ function userAgentFor(page: Page): Promise<string> {
 }
 
 /**
+ * Everything off the site's own origin is mirrored. An allowlist of known CDNs leaves every host nobody
+ * thought of reaching the public internet - `flags.fmcdn.net` and `cdn.cookielaw.org` already needed their
+ * own per-spec stubs - so the default is "mirror it" and only the build under test is exempt.
+ */
+const isExternalTo =
+    (siteOrigin: string) =>
+    (url: URL): boolean =>
+        url.origin !== siteOrigin && (url.protocol === 'https:' || url.protocol === 'http:');
+
+/**
  * Mirrors off-origin responses to disk, shared by every worker. Without this a cold run re-fetches the same
  * multi-MB bundles for every test, and under parallel load those requests time tests out.
  */
@@ -352,15 +353,23 @@ export async function routeExternalThroughMirror(page: Page, siteOrigin: string)
     void sweepMirror();
     await page.route(isExternalTo(siteOrigin), async (route) => {
         const url = route.request().url();
-        const key = mirrorKeyFor(url, await userAgentFor(page));
-        const entry = await loadMirrorEntry(route, key, mirrorPathFor(url, key));
+        const fontCss = url.startsWith(GOOGLE_FONTS_CSS) ? await localFontStylesheet(url) : undefined;
+        if (fontCss) {
+            await route.fulfill({ contentType: 'text/css', body: fontCss });
+            return;
+        }
+        const id = mirrorIdFor(url, await userAgentFor(page));
+        const entry = await loadMirrorEntry(route, url, id);
         if (!entry) {
             // The example page, not the spec: every framework variant shares one spec, so only the URL
             // identifies which example asked for it.
-            await recordNetworkMiss(url, page.url());
+            if (await claimMissReport(url)) {
+                unreportedMisses.push(`${url}\n   requested by ${page.url()}`);
+            }
             await route.fallback();
             return;
         }
-        await route.fulfill({ status: entry.meta.status, headers: entry.meta.headers, body: entry.body });
+        const body = (await systemRegisterFor(url, id.path, entry.body)) ?? entry.body;
+        await route.fulfill({ status: entry.meta.status, headers: entry.meta.headers, body });
     });
 }

--- a/documentation/ag-grid-docs/src/utils/grid/test/localTranspile.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test/localTranspile.ts
@@ -1,0 +1,149 @@
+import type { Page } from '@playwright/test';
+import { createHash } from 'node:crypto';
+import { readFile, rename, writeFile } from 'node:fs/promises';
+import ts from 'typescript';
+
+/**
+ * The example runner transpiles TypeScript in the browser, which costs every test a 3.3MB download of
+ * `typescript.min.js` plus the compile itself - the same work, repeated once per test, in the slowest
+ * place to do it. Emitting `System.register` here instead gives SystemJS a format it loads natively, so
+ * it never asks for the compiler. This is a test-harness shortcut only: the shipped site is unchanged
+ * and still demonstrates the in-browser path.
+ */
+const TRANSPILED_MODULE = /\.(ts|tsx|jsx)$/;
+
+const EXAMPLES_PREFIX = '/examples/';
+
+/**
+ * Mirrors the `typescriptOptions` each boilerplate passes to plugin-typescript, so output matches - down to
+ * the source map, which that plugin defaults on. Inlined because the map is served from a route rather than
+ * a file the browser could fetch alongside it, and with sources so a failure still points at the example's
+ * own TypeScript.
+ */
+function compilerOptionsFor(framework: string): ts.CompilerOptions {
+    const base: ts.CompilerOptions = {
+        module: ts.ModuleKind.System,
+        target: ts.ScriptTarget.ES2020,
+        inlineSourceMap: true,
+        inlineSources: true,
+    };
+    if (framework === 'angular') {
+        return { ...base, experimentalDecorators: true, emitDecoratorMetadata: true };
+    }
+    if (framework.startsWith('reactFunctional')) {
+        return { ...base, jsx: ts.JsxEmit.React };
+    }
+    return base;
+}
+
+/** Framework decides the compiler options, and it is the segment before the file name. */
+function frameworkFor(pathname: string): string {
+    const segments = pathname.split('/');
+    return segments[segments.length - 2] ?? '';
+}
+
+/**
+ * The test-id block the generator injects imports the enterprise bundle to resolve names from `?modules=`,
+ * and nothing else uses it. Without that parameter the branch is dead, so a community example was parsing
+ * 2.6MB of unminified enterprise for nothing. An example that is genuinely enterprise imports it itself and
+ * is unaffected.
+ */
+const INJECTED_ENTERPRISE_IMPORT = /^import \* as agGridEnterprise from 'ag-grid-enterprise';$\n/m;
+
+function withoutUnusedEnterprise(source: string): string {
+    return source.replace(INJECTED_ENTERPRISE_IMPORT, '').replace('agGridEnterprise[name]', 'undefined');
+}
+
+/** Keyed on the source itself, so an edit mid-run recompiles rather than serving the previous build. */
+const transpiled = new Map<string, string>();
+
+function transpile(source: string, fileName: string, framework: string): string {
+    const key = createHash('sha1').update(framework).update(source).digest('hex');
+    let output = transpiled.get(key);
+    if (output === undefined) {
+        output = ts.transpileModule(source, { fileName, compilerOptions: compilerOptionsFor(framework) }).outputText;
+        transpiled.set(key, output);
+    }
+    return output;
+}
+
+/**
+ * SystemJS 0.19 predates ES modules, so it hands any it meets to the same in-browser compiler. Angular and
+ * Vue ship as ESM, which is why those examples still fetched it once their own sources arrived compiled.
+ */
+const ESM_BUNDLE = /\/fesm20\d\d\/|\.esm-browser\.js$|\.mjs$/;
+
+/** ESNext because only the module wrapper needs changing - downlevelling a framework build would not. */
+const ESM_TO_SYSTEM: ts.CompilerOptions = { module: ts.ModuleKind.System, target: ts.ScriptTarget.ESNext };
+
+const transpileEsm = (source: string): string =>
+    ts.transpileModule(source, { compilerOptions: ESM_TO_SYSTEM }).outputText;
+
+/** Bumped when the emit changes, so cached bundles from an older converter are not reused. */
+const CONVERTER = 'v1';
+
+/** Every test reloads the same framework bundles, so a worker resolves each one once and reuses it. */
+const converted = new Map<string, Promise<Buffer>>();
+
+/**
+ * Megabyte bundles cost a few hundred milliseconds each to convert, so the result lives beside its mirror
+ * entry: the sweep that ages out the entry reclaims this too, and only the first run of all pays for it.
+ */
+async function convertBundle(path: string, body: Buffer): Promise<Buffer> {
+    const cached = await readFile(path).catch(() => undefined);
+    if (cached) {
+        return cached;
+    }
+    const output = Buffer.from(transpileEsm(body.toString('utf8')));
+    // Same publish-by-rename as the mirror: workers convert concurrently and must not read a partial file.
+    const tmp = `${path}.${process.pid}.tmp`;
+    await writeFile(tmp, output)
+        .then(() => rename(tmp, path))
+        .catch(() => undefined);
+    return output;
+}
+
+export function systemRegisterFor(url: string, mirrorPath: string, body: Buffer): Promise<Buffer> | undefined {
+    if (!ESM_BUNDLE.test(new URL(url).pathname)) {
+        return undefined;
+    }
+    const path = `${mirrorPath}.${CONVERTER}.system`;
+    let pending = converted.get(path);
+    if (!pending) {
+        pending = convertBundle(path, body);
+        converted.set(path, pending);
+    }
+    return pending;
+}
+
+/**
+ * Compiles what the browser would otherwise compile: the example's own modules, and the framework wrappers
+ * the site serves from its own origin. `ag-grid-angular` ships as fesm2022, and that one file was enough to
+ * pull in the whole compiler - the mirror's conversion only covers third-party bundles.
+ */
+export async function routeExampleModulesTranspiled(page: Page, siteOrigin: string): Promise<void> {
+    const isExampleModule = (pathname: string): boolean =>
+        pathname.startsWith(EXAMPLES_PREFIX) && TRANSPILED_MODULE.test(pathname);
+
+    await page.route(
+        (url) => url.origin === siteOrigin && (isExampleModule(url.pathname) || ESM_BUNDLE.test(url.pathname)),
+        async (route) => {
+            const { pathname } = new URL(route.request().url());
+            const response = await route.fetch();
+            if (!response.ok()) {
+                await route.fulfill({ response });
+                return;
+            }
+            const raw = await response.text();
+            if (!isExampleModule(pathname)) {
+                await route.fulfill({ contentType: 'application/javascript', body: transpileEsm(raw) });
+                return;
+            }
+            // The page has already navigated, so its query says whether the enterprise import will be used.
+            const needsEnterprise = new URL(page.url()).searchParams.has('modules');
+            const source = needsEnterprise ? raw : withoutUnusedEnterprise(raw);
+            const body = transpile(source, pathname.split('/').pop()!, frameworkFor(pathname));
+            await route.fulfill({ contentType: 'application/javascript', body });
+        }
+    );
+}

--- a/documentation/ag-grid-docs/src/utils/grid/test/localTranspile.ts
+++ b/documentation/ag-grid-docs/src/utils/grid/test/localTranspile.ts
@@ -58,7 +58,7 @@ function withoutUnusedEnterprise(source: string): string {
 const transpiled = new Map<string, string>();
 
 function transpile(source: string, fileName: string, framework: string): string {
-    const key = createHash('sha1').update(framework).update(source).digest('hex');
+    const key = createHash('sha1').update(framework).update(fileName).update(source).digest('hex');
     let output = transpiled.get(key);
     if (output === undefined) {
         output = ts.transpileModule(source, { fileName, compilerOptions: compilerOptionsFor(framework) }).outputText;
@@ -76,8 +76,18 @@ const ESM_BUNDLE = /\/fesm20\d\d\/|\.esm-browser\.js$|\.mjs$/;
 /** ESNext because only the module wrapper needs changing - downlevelling a framework build would not. */
 const ESM_TO_SYSTEM: ts.CompilerOptions = { module: ts.ModuleKind.System, target: ts.ScriptTarget.ESNext };
 
-const transpileEsm = (source: string): string =>
-    ts.transpileModule(source, { compilerOptions: ESM_TO_SYSTEM }).outputText;
+/** Content-addressed, and shared with the same-origin route: those bundles are asked for by every test. */
+const convertedEsm = new Map<string, string>();
+
+function transpileEsm(source: string): string {
+    const key = createHash('sha1').update(source).digest('hex');
+    let output = convertedEsm.get(key);
+    if (output === undefined) {
+        output = ts.transpileModule(source, { compilerOptions: ESM_TO_SYSTEM }).outputText;
+        convertedEsm.set(key, output);
+    }
+    return output;
+}
 
 /** Bumped when the emit changes, so cached bundles from an older converter are not reused. */
 const CONVERTER = 'v1';
@@ -107,7 +117,8 @@ export function systemRegisterFor(url: string, mirrorPath: string, body: Buffer)
     if (!ESM_BUNDLE.test(new URL(url).pathname)) {
         return undefined;
     }
-    const path = `${mirrorPath}.${CONVERTER}.system`;
+    const digest = createHash('sha1').update(body).digest('hex').slice(0, 12);
+    const path = `${mirrorPath}.${CONVERTER}.${digest}.system`;
     let pending = converted.get(path);
     if (!pending) {
         pending = convertBundle(path, body);

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/getOtherScriptFiles.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/utils/getOtherScriptFiles.ts
@@ -201,17 +201,25 @@ export const useFetchJson = (url, limit) => {
     const [data, setData] = useState();
     const [loading, setLoading] = useState(true);
     useEffect(() => {
+        // StrictMode runs this effect twice: drop the superseded run's response rather than applying both.
+        let cancelled = false;
         const fetchData = async () => {
             setLoading(true);
-            
+
             // Note error handling is omitted here for brevity
-            const response = await fetch(url);                
+            const response = await fetch(url);
             const json = await response.json();
             const data = limit ? json.slice(0, limit) : json;
+            if (cancelled) {
+                return;
+            }
             setData(data);
             setLoading(false);
         };
         fetchData();
+        return () => {
+            cancelled = true;
+        };
     }, [url, limit]);
     return { data, loading };
 };`;
@@ -226,6 +234,8 @@ export const useFetchJson = <T,>(url:string, limit?: number) => {
     const [data, setData] = useState<T[]>();
     const [loading, setLoading] = useState(true);
     useEffect(() => {
+        // StrictMode runs this effect twice: drop the superseded run's response rather than applying both.
+        let cancelled = false;
         const fetchData = async () => {
             setLoading(true);
 
@@ -233,10 +243,16 @@ export const useFetchJson = <T,>(url:string, limit?: number) => {
             const response = await fetch(url);
             const json = await response.json();
             const data = limit ? json.slice(0, limit) : json;
+            if (cancelled) {
+                return;
+            }
             setData(data);
             setLoading(false);
         };
         fetchData();
+        return () => {
+            cancelled = true;
+        };
     }, [url, limit]);
     return { data, loading };
 };`;

--- a/testing/behavioural/src/columnHeaderEdit/editable-group-header-name-react.test.tsx
+++ b/testing/behavioural/src/columnHeaderEdit/editable-group-header-name-react.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, waitFor } from '@testing-library/react';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import type { ColDef, ColGroupDef, GridApi, GridReadyEvent } from 'ag-grid-community';
@@ -45,11 +45,13 @@ describe('editable group header name (react)', () => {
         const groupText = () => document.querySelector('.ag-header-group-text')?.textContent;
         await waitFor(() => expect(groupText()).toBe('Group'));
 
-        gridApi!.setState({
-            columnGroup: {
-                openColumnGroupIds: [],
-                headerNames: [{ groupId: 'athleteGroup', headerName: 'Renamed' }],
-            },
+        act(() => {
+            gridApi!.setState({
+                columnGroup: {
+                    openColumnGroupIds: [],
+                    headerNames: [{ groupId: 'athleteGroup', headerName: 'Renamed' }],
+                },
+            });
         });
 
         await waitFor(() => expect(groupText()).toBe('Renamed'));

--- a/testing/behavioural/src/formulas/calculated-columns-state.test.ts
+++ b/testing/behavioural/src/formulas/calculated-columns-state.test.ts
@@ -1,4 +1,5 @@
 import { waitFor } from '@testing-library/dom';
+import { vi } from 'vitest';
 
 import type { GridApi, GridOptions, GridState, Module, UserColumnProperty } from 'ag-grid-community';
 import {
@@ -1193,6 +1194,8 @@ describe('calculated columns - grid state persistence', () => {
         // does when the developer ignores that: identity falls back to the build's positional ids, which
         // the layer cannot match, so nothing the user does through the dialog takes effect.
         enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [319] });
+        // Suppression stops the throw but not the log, by design, so hold the console and assert #319 fires.
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
         const anonymousColumnDefs = (): GridOptions['columnDefs'] => [
             { field: 'a' },
             { field: 'b' },
@@ -1208,6 +1211,8 @@ describe('calculated columns - grid state persistence', () => {
         });
         // With neither colId nor field to key on, both calc cols land on positional ids.
         await waitFor(() => expect(order(source)).toEqual(['a', 'b', '0', '1']));
+        expect(warn.mock.calls.flat().join(' ')).toContain('#319');
+        warn.mockRestore();
 
         await editViaDialog(source, '0', { title: 'Renamed Sum' });
         // The rename is dropped by the rebuild the edit triggers: the entry it wrote is keyed by the

--- a/testing/behavioural/src/selection/row-selection.test.ts
+++ b/testing/behavioural/src/selection/row-selection.test.ts
@@ -99,6 +99,36 @@ describe('Row Selection Grid Options', () => {
     });
 
     describe('deselection when rows leave the model', () => {
+        test('a second delivery of equal rowData discards selection unless getRowId identifies the rows', () => {
+            const olympics = (): any[] => [
+                { id: '1', sport: 'football' },
+                { id: '2', sport: 'rugby' },
+                { id: '3', sport: 'tennis' },
+            ];
+
+            const anonymous = gridMgr.createGrid('anonymousGrid', {
+                columnDefs,
+                rowSelection: { mode: 'multiRow' },
+                rowData: olympics(),
+            });
+            anonymous.setNodesSelected({ nodes: [anonymous.getDisplayedRowAtIndex(1)!], newValue: true });
+            expect(anonymous.getSelectedNodes()).toHaveLength(1);
+            anonymous.setGridOption('rowData', olympics());
+
+            const identified = gridMgr.createGrid('identifiedGrid', {
+                columnDefs,
+                rowSelection: { mode: 'multiRow' },
+                getRowId: (p) => p.data.id,
+                rowData: olympics(),
+            });
+            identified.setNodesSelected({ nodes: [identified.getDisplayedRowAtIndex(1)!], newValue: true });
+            expect(identified.getSelectedNodes()).toHaveLength(1);
+            identified.setGridOption('rowData', olympics());
+
+            expect(anonymous.getSelectedNodes()).toHaveLength(0);
+            expect(identified.getSelectedNodes().map((node) => node.id)).toEqual(['2']);
+        });
+
         // Immutable rowData removal destroys the dropped node (deleteUnusedNodes); it must leave the
         // selection, while the surviving selected row stays selected.
         test('selected row dropped from selection on immutable rowData removal', async () => {

--- a/testing/behavioural/vitest.setup.ts
+++ b/testing/behavioural/vitest.setup.ts
@@ -5,6 +5,7 @@ import { afterAll, beforeEach, expect, vitest } from 'vitest';
 // `ag-grid-community` at runtime, which would defeat the lazy `ag`-import guard below. This module is
 // type-only besides the constant, so it pulls in nothing at runtime.
 import { ALL_SEVERITIES } from './src/test-utils/dev-validations';
+import { ignoreConsoleLicenseKeyError } from './src/test-utils/ignoreConsoleLicenseKeyError';
 
 // Register all jest-dom matchers globally.
 expect.extend(jestDomMatchers);
@@ -19,6 +20,7 @@ expect.extend(jestDomMatchers);
 beforeEach(async () => {
     const { enableDevValidations } = await import('ag-grid-community');
     enableDevValidations({ throwOn: ALL_SEVERITIES });
+    ignoreConsoleLicenseKeyError();
 });
 
 // Shim for code that references `jest` — redirect to vitest.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3246,6 +3246,11 @@
   resolved "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz#a269e055e40e2f45873bae9d1a2fdccbd314ea3f"
   integrity sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==
 
+"@fontsource/ibm-plex-sans@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@fontsource/ibm-plex-sans/-/ibm-plex-sans-5.3.0.tgz#8099950b404e625f65e7bd833bcb84ffe6bcd40c"
+  integrity sha512-CbE4CbbEEZJX860XyUiRpsksXIQR8Rp2XDva2VO53NJox9tVNtusrysd2x5YkUEY3ErQ66W1IiiQL8/wihhw5w==
+
 "@gar/promise-retry@^1.0.0", "@gar/promise-retry@^1.0.2":
   version "1.0.3"
   resolved "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz#65e726428e794bc4453948e0a41e6de4215ce8b0"


### PR DESCRIPTION
# Faster and stabler docs E2E

SystemJS predates ES modules, so every example page fetched `typescript.min.js` (3.35MB) and compiled itself **once per test**. Compiling in Node and serving `System.register` instead means the compiler is never requested — 1 or 2 requests per test become zero, across all five frameworks.

## Numbers

231 tests, alternating A/B, two rounds. Only test-only files swapped; same dev server both arms.

|      | latest         | branch |
| ---- | -------------- | ------ |
| warm | 48s            | 30s    |
| cold | 77s, 12 failed | 32s    |

Median per test:

| framework             | latest | branch | change |
| --------------------- | ------ | ------ | ------ |
| angular               | 3530ms | 1614ms | -54%   |
| vue3                  | 2033ms | 1052ms | -48%   |
| typescript            | 1610ms | 938ms  | -42%   |
| reactFunctionalTs_Dev | 1930ms | 1284ms | -34%   |
| reactFunctionalTs     | 1914ms | 1280ms | -33%   |
| vanilla               | 1165ms | 914ms  | -22%   |

`vanilla` has no TypeScript and no ESM — it gains only because the others stopped competing for cores. The 12 cold failures on latest were `column-menu` examples timing out waiting for their data across all six frameworks; not diagnosed, and not seen on the branch in any run. A local run is a further ~17% faster on top of the above, from skipping one React variant (below).

## Speed

New `src/utils/grid/test/localTranspile.ts`, an auto fixture beside the existing mirror.

- **Example modules compiled in Node.** `ts.transpileModule` with `module: System`, per-framework options mirrored from each boilerplate — including `emitDecoratorMetadata`, which 616 Angular examples need for `constructor(private http: HttpClient)`. Source maps inlined, as plugin-typescript defaulted them on.
- **ESM framework bundles converted too**, or SystemJS hands them to the same compiler. Third-party ones cached beside their mirror entry. `ag-grid-angular` ships fesm2022 from the site's own origin, and that one file dragged in the whole 3MB — most of Angular's -54%.
- **Injected test-id block no longer imports enterprise.** It only resolves `?modules=` names, which 6 specs use; every other community example parsed 2.66MB of unminified enterprise for a dead branch.
- **One React variant locally.** `ALL_FRAMEWORK_VARIANTS=true` or `./docs-e2e.sh --all-variants` opts in; CI always runs both. A run prints which it is doing.

## Stability

- **Fonts inlined from disk instead of fetched from Google.** Examples auto-size columns on first render and those widths stick, so a grid that measures before its webfont lands keeps fallback widths for ever. `display=block` on the CDN request does not fix it: layout uses the invisible fallback's metrics until the font arrives. `@fontsource/ibm-plex-sans` (devDependency) is base64-inlined, so faces are usable as the stylesheet parses — 18 faces, 345KB, zero network. Latest's `waitForTextMeasurable` is kept for the families not inlined.
- **React's two variants tested the same build.** The boilerplate reads `prod: urlParams.get('prod') === 'false' ? false : (urlParams.get('prod') ?? false)`, so absent and `prod=false` both resolve to the development build — `reactFunctionalTs` and `reactFunctionalTs_Dev` were exact duplicates and the production build was never exercised. `loadPage` now states `prod=true` for the former.
- **Teardown verifies destruction.** `exampleRemoved` was assigned inside `page.evaluate`, so it only made a browser global; the detach wait never ran, in all 10,583 tests.
- **`ignoreHTTPSErrors` on local runs only** — Chromium waives the dev server's self-signed cert, Node doesn't, so route handlers that re-request a URL failed.
- **`useFetchJson` cancels its superseded run**, so React StrictMode's double effect no longer delivers rows twice and discards a selection made in between. New behavioural test in `row-selection.test.ts`.

## Behavioural test output hygiene

A green run now prints nothing: 521 files, 7858 tests, zero stderr.

- `ignoreConsoleLicenseKeyError()` moved into `vitest.setup.ts`. `testGridsManager` installed it per grid, so tests rendering the grid themselves — the React ones, via `@testing-library/react` — printed the licence box, and which of them printed it depended on worker ordering.
- `editable-group-header-name-react` wraps its `setState` in `act()`; it was emitting React act warnings.
- `calculated-columns-state` asserts warning #319 rather than letting it print. Suppression stops the throw, not the log, by design.
