### PR TITLE
chore: gitignore /.ag-dev-prompts/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ documentation/ag-grid-docs/test-results/.last-run.json
 **/modular-mcp.json
 !.rulesync/.aiignore
 /.junie/
+
+# AI Workflow: the pipeline stub npm-installs @ag-grid/dev-prompts here.
+/.ag-dev-prompts/


### PR DESCRIPTION
One line, from the 2026-08-06 AI Workflow watchdog sweep. The pipeline-side half is in [ag-dev-prompts](https://github.com/ag-grid/ag-dev-prompts); ag-charts has a companion PR carrying this plus an e2e fix that only affects that repo.

The AI Workflow pipeline clones its own prompt content into the workspace at `/.ag-dev-prompts/`, which is ignored in **neither** consumer repo. So it shows up as untracked in the agent's `git status` — and, more consequentially, is a candidate for the rescue commit's `git add -A` on a run that dies mid-flight, meaning harness files can end up committed to a `ghabot-*` branch.

The pipeline PR fixes the load-bearing half (a rescue-path denylist, plus a `.git/info/exclude` entry written at setup). This is the cheap local belt-and-braces: a local exclude does nothing for a path that is already tracked, and a repo-level ignore is what makes the state unambiguous for humans working in the tree too.

No effect on the build — the directory only exists during a pipeline run.
