### PR TITLE
Fix PDF export docs examples and context menu PDF Export item

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/context-menu/_examples/default-context-menu/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/context-menu/_examples/default-context-menu/example.spec.ts
@@ -16,6 +16,12 @@ test.agExample(import.meta, () => {
         await expect(page.locator('.ag-menu-option-text', { hasText: 'Copy' }).first()).toBeVisible();
         await expect(page.locator('.ag-menu-option-text', { hasText: 'Export' }).first()).toBeVisible();
 
+        // the Export sub menu offers every registered export module
+        await page.locator('.ag-menu-option-text', { hasText: 'Export' }).first().hover();
+        for (const exportItem of ['CSV Export', 'Excel Export', 'PDF Export']) {
+            await expect(page.locator('.ag-menu-option-text', { hasText: exportItem }).first()).toBeVisible();
+        }
+
         await page.keyboard.press('Escape');
         await expect(agIdFor.menu()).toHaveCount(0);
     });

--- a/documentation/ag-grid-docs/src/content/docs/context-menu/_examples/default-context-menu/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/context-menu/_examples/default-context-menu/main.ts
@@ -9,6 +9,7 @@ import {
     ContextMenuModule,
     ExcelExportModule,
     IntegratedChartsModule,
+    PdfExportModule,
 } from 'ag-grid-enterprise';
 
 if (process.env.NODE_ENV !== 'production') {
@@ -24,6 +25,7 @@ ModuleRegistry.registerModules([
     ContextMenuModule,
     CellSelectionModule,
     IntegratedChartsModule.with(AgChartsEnterpriseModule),
+    PdfExportModule,
 ]);
 
 let gridApi: GridApi<IOlympicData>;

--- a/documentation/ag-grid-docs/src/content/docs/context-menu/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/context-menu/index.mdoc
@@ -3,7 +3,7 @@ title: "Context Menu"
 enterprise: true
 ---
 
-The user can bring up the context menu by right clicking on a cell. By default, the context menu shows [Clipboard](./clipboard/), [CSV Export](./csv-export/), [Excel Export](./excel-export/), PDF Export and [Integrated Charts](./integrated-charts/) menu items (if the relevant [Modules](./modules/) are loaded).
+The user can bring up the context menu by right clicking on a cell. By default, the context menu shows [Clipboard](./clipboard/), [CSV Export](./csv-export/), [Excel Export](./excel-export/), [PDF Export](./pdf-export/) and [Integrated Charts](./integrated-charts/) menu items (if the relevant [Modules](./modules/) are loaded).
 
 {% gridExampleRunner title="Default Context Menu" name="default-context-menu" /%}
 
@@ -44,7 +44,7 @@ The following is a list of all the default built in menu items with the rules ab
 - `paste`: Paste the clipboard value into the selected cell (see note below). Shown by default.
 - `note`: Notes actions for the current cell. Expands to `Add Note`, `Edit Note`, `View Note` and `Remove Note` depending on the current cell state. Shown when [Notes](./notes/) is enabled.
 - `resetColumns`: Reset all columns. Not shown by default.
-- `export`: Export sub menu (containing csvExport and excelExport). Shown by default.
+- `export`: Export sub menu (containing `csvExport`, `excelExport` and `pdfExport`). Shown by default.
 - `csvExport`: Export to CSV using all default export values. Shown by default.
 - `excelExport`: Export to Excel (.xlsx) using all default export values. Shown by default.
 - `pdfExport`: Export to PDF using all default export values. Shown by default.

--- a/documentation/ag-grid-docs/src/content/docs/context-menu/index.mdoc
+++ b/documentation/ag-grid-docs/src/content/docs/context-menu/index.mdoc
@@ -34,6 +34,8 @@ If you want to turn off the context menu completely, set the grid property `supp
 
 The following is a list of all the default built in menu items with the rules about when they are shown.
 
+Menu items also require the relevant [Module](./modules/) to be loaded in order to be displayed.
+
 - `autoSizeAll`: Auto-size all columns. Not shown by default.
 - `expandAll`: When set, it's only shown if grouping by at least one column. Not shown by default.
 - `contractAll`: Collapse all groups. When set, it's only shown if grouping by at least one column. Not shown by default.
@@ -54,8 +56,6 @@ The following is a list of all the default built in menu items with the rules ab
 - `pinTop`: Pin a row to the top of the grid. Shown when [Row Pinning](./row-pinning) is enabled.
 - `pinBottom`: Pin a row to the botom of the grid. Shown when [Row Pinning](./row-pinning) is enabled.
 - `unpinRow`: Unpin a row from the top or bottom of the grid. Shown for pinned rows when [Row Pinning](./row-pinning) is enabled.
-
-Menu items also require the relevant [Module](./modules/) to be loaded in order to be displayed.
 
 {% note %}
 The 'paste' operation in the context menu uses the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API). This means

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-columns/_examples/pdf-export-columns/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-columns/_examples/pdf-export-columns/main.ts
@@ -100,19 +100,11 @@ function getPdfExportParams(): PdfExportParams {
     return params;
 }
 
-function updateDefaultPdfExportParams() {
-    gridApi.setGridOption('defaultPdfExportParams', getPdfExportParams());
-}
-
 function onBtExport() {
-    updateDefaultPdfExportParams();
+    gridApi.setGridOption('defaultPdfExportParams', getPdfExportParams());
     gridApi.exportDataAsPdf();
 }
 
 document.addEventListener('DOMContentLoaded', () => {
     gridApi = createGrid(document.querySelector<HTMLElement>('#myGrid')!, gridOptions);
-    updateDefaultPdfExportParams();
-    for (const id of ['columnSet', 'skipColumnGroupHeaders', 'skipColumnHeaders', 'exportRowNumbers']) {
-        document.querySelector(`#${id}`)!.addEventListener('change', updateDefaultPdfExportParams);
-    }
 });

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-columns/_examples/pdf-widths-autosizing/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-columns/_examples/pdf-widths-autosizing/example.spec.ts
@@ -1,26 +1,68 @@
 import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 import { readFile } from 'node:fs/promises';
 
+/** Width of the header cell rectangle drawn immediately before the given header label. */
+function headerWidth(pdfContent: string, headerText: string): number {
+    const cells = [...pdfContent.matchAll(/([\d.]+) ([\d.]+) ([\d.]+) [\d.]+ re f/g)];
+    const label = pdfContent.indexOf(`(${headerText}) Tj`);
+    if (label < 0) {
+        throw new Error(`No header cell found for "${headerText}".`);
+    }
+    // The cell rectangle is the last one drawn before its label.
+    const cell = cells.filter((match) => match.index < label).pop();
+    return Number(cell![3]);
+}
+
+function headerWidths(pdfContent: string): number[] {
+    return ['Sku', 'Product', 'Description', 'Units', 'Unit Price'].map((header) => headerWidth(pdfContent, header));
+}
+
 test.agExample(import.meta, () => {
     test.eachFramework('exports configured column widths', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await page.locator('#widthMode').selectOption('custom');
 
-        const [download] = await Promise.all([
-            page.waitForEvent('download'),
-            page.getByRole('button', { name: 'Export to PDF' }).click(),
-        ]);
-        const downloadPath = await download.path();
-
-        expect(downloadPath).toBeTruthy();
-        if (!downloadPath) {
-            throw new Error('Expected PDF export to create a downloadable file.');
+        async function exportWithWidthMode(widthMode: string): Promise<string> {
+            await page.locator('#widthMode').selectOption(widthMode);
+            const [download] = await Promise.all([
+                page.waitForEvent('download'),
+                page.getByRole('button', { name: 'Export to PDF' }).click(),
+            ]);
+            const downloadPath = await download.path();
+            if (!downloadPath) {
+                throw new Error(`Expected the ${widthMode} export to create a downloadable file.`);
+            }
+            return readFile(downloadPath, 'latin1');
         }
 
-        const pdfContent = await readFile(downloadPath, 'latin1');
-        expect(pdfContent.startsWith('%PDF-1.4')).toBe(true);
-        expect(pdfContent).toContain('(Mechanical Keyboard) Tj');
-        expect(pdfContent.trimEnd().endsWith('%%EOF')).toBe(true);
+        // A4 landscape less the default 36pt margins.
+        const printableWidth = 841.89 - 72;
+
+        const autoPdf = await exportWithWidthMode('auto');
+        expect(autoPdf.startsWith('%PDF-1.4')).toBe(true);
+        expect(autoPdf).toContain('(Mechanical Keyboard) Tj');
+        // Auto sizes each column to its content, so the long description is not truncated...
+        expect(autoPdf).toContain(
+            '(Low-profile wireless keyboard with hot-swappable switches and multi-device pairing.) Tj'
+        );
+        expect(headerWidth(autoPdf, 'Description')).toBeGreaterThan(300);
+        // ...and the table only takes the width it needs.
+        const autoTotal = headerWidths(autoPdf).reduce((total, width) => total + width, 0);
+        expect(autoTotal).toBeLessThan(printableWidth);
+
+        // Grid widths are scaled to fill the page, matching the on-screen proportions.
+        const gridPdf = await exportWithWidthMode('grid');
+        const gridWidths = headerWidths(gridPdf);
+        const gridTotal = gridWidths.reduce((total, width) => total + width, 0);
+        expect(gridTotal).toBeGreaterThan(printableWidth - 60);
+        expect(gridWidths).not.toEqual(headerWidths(autoPdf));
+
+        // Per-column widths come from the columnWidth callback; unlisted columns still auto-size.
+        const customPdf = await exportWithWidthMode('custom');
+        expect(headerWidth(customPdf, 'Sku')).toBe(70);
+        expect(headerWidth(customPdf, 'Description')).toBe(220);
+        expect(headerWidth(customPdf, 'Units')).toBe(70);
+        expect(headerWidth(customPdf, 'Product')).toBe(headerWidth(autoPdf, 'Product'));
+        expect(customPdf.trimEnd().endsWith('%%EOF')).toBe(true);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-columns/_examples/pdf-widths-autosizing/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-columns/_examples/pdf-widths-autosizing/main.ts
@@ -87,17 +87,11 @@ function getPdfExportParams(): PdfExportParams {
     return params;
 }
 
-function updateDefaultPdfExportParams() {
-    gridApi.setGridOption('defaultPdfExportParams', getPdfExportParams());
-}
-
 function onBtExport() {
-    updateDefaultPdfExportParams();
+    gridApi.setGridOption('defaultPdfExportParams', getPdfExportParams());
     gridApi.exportDataAsPdf();
 }
 
 document.addEventListener('DOMContentLoaded', () => {
     gridApi = createGrid(document.querySelector<HTMLElement>('#myGrid')!, gridOptions);
-    updateDefaultPdfExportParams();
-    document.querySelector('#widthMode')!.addEventListener('change', updateDefaultPdfExportParams);
 });

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-images/_examples/pdf-page-header-image/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-images/_examples/pdf-page-header-image/main.ts
@@ -30,9 +30,7 @@ const gridOptions: GridOptions = {
 
 function getHeaderLogo() {
     // exported page colours follow the grid theme, so pick the logo variant that stays visible.
-    const gridBackground = getComputedStyle(
-        document.querySelector<HTMLElement>('#myGrid .ag-root-wrapper')!
-    ).backgroundColor;
+    const gridBackground = getComputedStyle(document.querySelector<HTMLElement>('.ag-root-wrapper')!).backgroundColor;
     const [red = 255, green = 255, blue = 255] = gridBackground.match(/\d+(\.\d+)?/g)?.map(Number) ?? [];
     const isDarkTheme = red * 0.299 + green * 0.587 + blue * 0.114 < 128;
 

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-languages/_examples/pdf-international-characters/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-languages/_examples/pdf-international-characters/example.spec.ts
@@ -7,7 +7,7 @@ test.agExample(import.meta, () => {
         await waitForGridContent(page);
 
         await expect(agIdFor.cell('0', 'text')).toContainText('praça');
-        await expect(agIdFor.cell('2', 'text')).toContainText('東京');
+        await expect(agIdFor.cell('3', 'text')).toContainText('広場');
 
         const [download] = await Promise.all([
             page.waitForEvent('download'),

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-languages/_examples/pdf-international-characters/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-languages/_examples/pdf-international-characters/main.ts
@@ -104,7 +104,10 @@ function getDefaultPdfExportParams(fonts: PdfFontFamilyDefinition[]): PdfExportP
 }
 
 function onBtExport() {
-    gridApi.exportDataAsPdf();
+    loadFonts().then((fonts) => {
+        gridApi.setGridOption('defaultPdfExportParams', getDefaultPdfExportParams(fonts));
+        gridApi.exportDataAsPdf();
+    });
 }
 
 async function loadFonts(): Promise<PdfFontFamilyDefinition[]> {
@@ -157,8 +160,6 @@ async function loadFont(fileName: string): Promise<ArrayBuffer> {
     return response.arrayBuffer();
 }
 
-document.addEventListener('DOMContentLoaded', async () => {
-    const fonts = await loadFonts();
-    gridOptions.defaultPdfExportParams = getDefaultPdfExportParams(fonts);
+document.addEventListener('DOMContentLoaded', () => {
     gridApi = createGrid(document.querySelector<HTMLElement>('#myGrid')!, gridOptions);
 });

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-languages/_examples/pdf-non-latin-language/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-languages/_examples/pdf-non-latin-language/main.ts
@@ -15,6 +15,8 @@ interface LanguageSample {
 
 let gridApi: GridApi<LanguageSample>;
 
+const fontFamily = 'IBM Plex Sans JP';
+
 const gridOptions: GridOptions<LanguageSample> = {
     columnDefs: [{ field: 'text', headerName: 'Japanese Text', flex: 1 }],
     rowData: [
@@ -25,7 +27,14 @@ const gridOptions: GridOptions<LanguageSample> = {
 };
 
 function onBtExport() {
-    gridApi.exportDataAsPdf();
+    loadFont('IBMPlexSansJP-Regular.ttf').then((data) => {
+        gridApi.setGridOption('defaultPdfExportParams', {
+            fonts: [{ family: fontFamily, faces: [{ data, weight: 400 }] }],
+            defaultCellStyle: { fontFamily },
+            language: 'ja',
+        });
+        gridApi.exportDataAsPdf();
+    });
 }
 
 async function loadFont(fileName: string): Promise<ArrayBuffer> {
@@ -36,20 +45,6 @@ async function loadFont(fileName: string): Promise<ArrayBuffer> {
     return response.arrayBuffer();
 }
 
-document.addEventListener('DOMContentLoaded', async () => {
-    const japaneseRegular = await loadFont('IBMPlexSansJP-Regular.ttf');
-    const fontFamily = 'IBM Plex Sans JP';
-
-    gridOptions.defaultPdfExportParams = {
-        fonts: [
-            {
-                family: fontFamily,
-                faces: [{ data: japaneseRegular, weight: 400 }],
-            },
-        ],
-        defaultCellStyle: { fontFamily },
-        language: 'ja',
-    };
-
+document.addEventListener('DOMContentLoaded', () => {
     gridApi = createGrid(document.querySelector<HTMLElement>('#myGrid')!, gridOptions);
 });

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-languages/_examples/pdf-rtl-languages/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-languages/_examples/pdf-rtl-languages/main.ts
@@ -93,7 +93,10 @@ function getDefaultPdfExportParams(fonts: PdfFontFamilyDefinition[]): PdfExportP
 }
 
 function onBtExport() {
-    gridApi.exportDataAsPdf();
+    loadFonts().then((fonts) => {
+        gridApi.setGridOption('defaultPdfExportParams', getDefaultPdfExportParams(fonts));
+        gridApi.exportDataAsPdf();
+    });
 }
 
 async function loadFonts(): Promise<PdfFontFamilyDefinition[]> {
@@ -130,8 +133,6 @@ async function loadFont(fileName: string): Promise<ArrayBuffer> {
     return response.arrayBuffer();
 }
 
-document.addEventListener('DOMContentLoaded', async () => {
-    const fonts = await loadFonts();
-    gridOptions.defaultPdfExportParams = getDefaultPdfExportParams(fonts);
+document.addEventListener('DOMContentLoaded', () => {
     gridApi = createGrid(document.querySelector<HTMLElement>('#myGrid')!, gridOptions);
 });

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-page-setup/_examples/pdf-export-page-setup/example.spec.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-page-setup/_examples/pdf-export-page-setup/example.spec.ts
@@ -1,30 +1,72 @@
 import { ensureGridReady, expect, test, waitForGridContent } from '@utils/grid/test-utils';
 import { readFile } from 'node:fs/promises';
 
+const PAGE_OBJECT = '/Type /Page /Parent';
+
+function countOccurrences(pdfContent: string, text: string): number {
+    return pdfContent.split(text).length - 1;
+}
+
+/** X origin of the first header cell rectangle, which sits on the page's left margin. */
+function leftMargin(pdfContent: string): number {
+    const label = pdfContent.indexOf('(Item) Tj');
+    if (label < 0) {
+        throw new Error('No header cell found.');
+    }
+    const cells = [...pdfContent.matchAll(/([\d.]+) [\d.]+ [\d.]+ [\d.]+ re f/g)];
+    // The header cell rectangle is the last one drawn before its label.
+    const cell = cells.filter((match) => match.index < label).pop();
+    return Number(cell![1]);
+}
+
 test.agExample(import.meta, () => {
     test.eachFramework('exports the configured page and repeats table headers', async ({ page }) => {
         await ensureGridReady(page);
         await waitForGridContent(page);
-        await page.locator('#pageSize').selectOption('custom');
 
-        const [download] = await Promise.all([
-            page.waitForEvent('download'),
-            page.getByRole('button', { name: 'Export to PDF' }).click(),
-        ]);
-        const downloadPath = await download.path();
+        async function exportWithPageSetup(
+            pageSize: string,
+            orientation: string,
+            margin: string,
+            repeatHeader: boolean
+        ): Promise<string> {
+            await page.locator('#pageSize').selectOption(pageSize);
+            await page.locator('#orientation').selectOption(orientation);
+            await page.locator('#margin').selectOption(margin);
+            await page.locator('#repeatHeader').setChecked(repeatHeader);
 
-        expect(downloadPath).toBeTruthy();
-        if (!downloadPath) {
-            throw new Error('Expected PDF export to create a downloadable file.');
+            const [download] = await Promise.all([
+                page.waitForEvent('download'),
+                page.getByRole('button', { name: 'Export to PDF' }).click(),
+            ]);
+            const downloadPath = await download.path();
+            if (!downloadPath) {
+                throw new Error(`Expected the ${pageSize} export to create a downloadable file.`);
+            }
+            return readFile(downloadPath, 'latin1');
         }
 
-        const pdfContent = await readFile(downloadPath, 'latin1');
-        const itemHeaderCount = pdfContent.split('(Item) Tj').length - 1;
+        const a4Pdf = await exportWithPageSetup('A4', 'landscape', 'standard', true);
+        expect(a4Pdf.startsWith('%PDF-1.4')).toBe(true);
+        expect(a4Pdf).toContain('(Quarterly Inventory) Tj');
+        expect(a4Pdf).toContain('(Item 40) Tj');
+        expect(a4Pdf).toContain('/MediaBox [0 0 841.89 595.28]');
+        expect(leftMargin(a4Pdf)).toBe(36);
+        // repeatHeader draws the table header once per page.
+        expect(countOccurrences(a4Pdf, '(Item) Tj')).toBe(countOccurrences(a4Pdf, PAGE_OBJECT));
 
-        expect(pdfContent.startsWith('%PDF-1.4')).toBe(true);
-        expect(pdfContent).toContain('(Quarterly Inventory) Tj');
-        expect(pdfContent).toContain('(Item 40) Tj');
-        expect(itemHeaderCount).toBeGreaterThan(1);
-        expect(pdfContent.trimEnd().endsWith('%%EOF')).toBe(true);
+        // Letter, rotated to portrait, with wide margins.
+        const letterPdf = await exportWithPageSetup('Letter', 'portrait', 'wide', true);
+        expect(letterPdf).toContain('/MediaBox [0 0 612 792]');
+        expect(leftMargin(letterPdf)).toBe(54);
+
+        // A custom page size also honours the portrait orientation, so 420x300 is emitted rotated.
+        const customPdf = await exportWithPageSetup('custom', 'portrait', 'compact', false);
+        expect(customPdf).toContain('/MediaBox [0 0 300 420]');
+        expect(leftMargin(customPdf)).toBe(18);
+        // The smaller page needs more sheets, but the header is no longer repeated on each one.
+        expect(countOccurrences(customPdf, PAGE_OBJECT)).toBeGreaterThan(countOccurrences(a4Pdf, PAGE_OBJECT));
+        expect(countOccurrences(customPdf, '(Item) Tj')).toBe(1);
+        expect(customPdf.trimEnd().endsWith('%%EOF')).toBe(true);
     });
 });

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-page-setup/_examples/pdf-export-page-setup/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-page-setup/_examples/pdf-export-page-setup/main.ts
@@ -92,19 +92,11 @@ function getPdfExportParams(): PdfExportParams {
     };
 }
 
-function updateDefaultPdfExportParams() {
-    gridApi.setGridOption('defaultPdfExportParams', getPdfExportParams());
-}
-
 function onBtExport() {
-    updateDefaultPdfExportParams();
+    gridApi.setGridOption('defaultPdfExportParams', getPdfExportParams());
     gridApi.exportDataAsPdf();
 }
 
 document.addEventListener('DOMContentLoaded', () => {
     gridApi = createGrid(document.querySelector<HTMLElement>('#myGrid')!, gridOptions);
-    updateDefaultPdfExportParams();
-    for (const id of ['pageSize', 'orientation', 'margin', 'repeatHeader']) {
-        document.querySelector(`#${id}`)!.addEventListener('change', updateDefaultPdfExportParams);
-    }
 });

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-rows/_examples/pdf-export-rows/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-rows/_examples/pdf-export-rows/main.ts
@@ -101,19 +101,11 @@ function getPdfExportParams(): PdfExportParams {
     };
 }
 
-function updateDefaultPdfExportParams() {
-    gridApi.setGridOption('defaultPdfExportParams', getPdfExportParams());
-}
-
 function onBtExport() {
-    updateDefaultPdfExportParams();
+    gridApi.setGridOption('defaultPdfExportParams', getPdfExportParams());
     gridApi.exportDataAsPdf();
 }
 
 document.addEventListener('DOMContentLoaded', () => {
     gridApi = createGrid(document.querySelector<HTMLElement>('#myGrid')!, gridOptions);
-    updateDefaultPdfExportParams();
-    for (const id of ['onlySelected', 'allRows', 'skipPinnedTop', 'skipPinnedBottom']) {
-        document.querySelector(`#${id}`)!.addEventListener('change', updateDefaultPdfExportParams);
-    }
 });

--- a/documentation/ag-grid-docs/src/content/docs/pdf-export-rows/_examples/pdf-wrapping-grouping-pinning/main.ts
+++ b/documentation/ag-grid-docs/src/content/docs/pdf-export-rows/_examples/pdf-wrapping-grouping-pinning/main.ts
@@ -129,19 +129,11 @@ function getPdfExportParams(): PdfExportParams {
     };
 }
 
-function updateDefaultPdfExportParams() {
-    gridApi.setGridOption('defaultPdfExportParams', getPdfExportParams());
-}
-
 function onBtExport() {
-    updateDefaultPdfExportParams();
+    gridApi.setGridOption('defaultPdfExportParams', getPdfExportParams());
     gridApi.exportDataAsPdf();
 }
 
 document.addEventListener('DOMContentLoaded', () => {
     gridApi = createGrid(document.querySelector<HTMLElement>('#myGrid')!, gridOptions);
-    updateDefaultPdfExportParams();
-    for (const id of ['includeTop', 'includeBottom', 'limitLines']) {
-        document.querySelector(`#${id}`)!.addEventListener('change', updateDefaultPdfExportParams);
-    }
 });

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/react-utils.test.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/react-utils.test.ts
@@ -68,6 +68,27 @@ describe('convertTemplate', () => {
         expect(converted).toBe('<input type="checkbox" defaultChecked />');
     });
 
+    it('ensures a valued checked attribute becomes uncontrolled', () => {
+        const template = '<input type="checkbox" checked="checked">';
+        const converted = convertTemplate(template);
+
+        expect(converted).toBe('<input type="checkbox" defaultChecked />');
+    });
+
+    it('does not rewrite attributes that merely end in checked', () => {
+        const template = '<input type="checkbox" aria-checked="true" data-checked="">';
+        const converted = convertTemplate(template);
+
+        expect(converted).toBe('<input type="checkbox" aria-checked="true" data-checked="" />');
+    });
+
+    it('does not rewrite checked appearing in an attribute value', () => {
+        const template = '<input type="text" title="checked">';
+        const converted = convertTemplate(template);
+
+        expect(converted).toBe('<input type="text" title="checked" />');
+    });
+
     it('does not change value attributes for other elements', () => {
         const template = '<option value="bob">';
         const converted = convertTemplate(template);

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/react-utils.test.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/react-utils.test.ts
@@ -61,6 +61,13 @@ describe('convertTemplate', () => {
         expect(converted).toBe('<input type="text" defaultValue="foo" maxLength="20" />');
     });
 
+    it('ensures the checked attribute becomes uncontrolled', () => {
+        const template = '<input type="checkbox" checked="">';
+        const converted = convertTemplate(template);
+
+        expect(converted).toBe('<input type="checkbox" defaultChecked />');
+    });
+
     it('does not change value attributes for other elements', () => {
         const template = '<option value="bob">';
         const converted = convertTemplate(template);

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/react-utils.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/react-utils.ts
@@ -44,6 +44,7 @@ export function convertTemplate(template: string) {
         .replace(/,\s+event([),])/g, '$1')
         .replace(/<input (.+?[^=])>/g, '<input $1 />')
         .replace(/<input (.*)value=/g, '<input $1defaultValue=')
+        .replace(/<input ([^>]*?)\bchecked\b(?:="")?/g, '<input $1defaultChecked')
         .replace(/ class=/g, ' className=')
         .replace(/ for=/g, ' htmlFor=')
         .replace(/ <option (.*)selected=""/g, '<option $1selected={true}');
@@ -84,6 +85,7 @@ export function convertFunctionalTemplate(template: string) {
         .replace(/,\s+event([),])/g, '$1')
         .replace(/<input (.+?[^=])>/g, '<input $1 />')
         .replace(/<input (.*)value=/g, '<input $1defaultValue=')
+        .replace(/<input ([^>]*?)\bchecked\b(?:="")?/g, '<input $1defaultChecked')
         .replace(/ class=/g, ' className=')
         .replace(/ for=/g, ' htmlFor=')
         .replace(/ <option (.*)selected=""/g, '<option $1selected={true}');

--- a/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/react-utils.ts
+++ b/plugins/ag-grid-generate-example-files/src/executors/generate/generator/transformation-scripts/react-utils.ts
@@ -44,7 +44,7 @@ export function convertTemplate(template: string) {
         .replace(/,\s+event([),])/g, '$1')
         .replace(/<input (.+?[^=])>/g, '<input $1 />')
         .replace(/<input (.*)value=/g, '<input $1defaultValue=')
-        .replace(/<input ([^>]*?)\bchecked\b(?:="")?/g, '<input $1defaultChecked')
+        .replace(/(<input [^>]*?\s)checked(?:="[^"]*")?(?=[\s/>])/g, '$1defaultChecked')
         .replace(/ class=/g, ' className=')
         .replace(/ for=/g, ' htmlFor=')
         .replace(/ <option (.*)selected=""/g, '<option $1selected={true}');
@@ -85,7 +85,7 @@ export function convertFunctionalTemplate(template: string) {
         .replace(/,\s+event([),])/g, '$1')
         .replace(/<input (.+?[^=])>/g, '<input $1 />')
         .replace(/<input (.*)value=/g, '<input $1defaultValue=')
-        .replace(/<input ([^>]*?)\bchecked\b(?:="")?/g, '<input $1defaultChecked')
+        .replace(/(<input [^>]*?\s)checked(?:="[^"]*")?(?=[\s/>])/g, '$1defaultChecked')
         .replace(/ class=/g, ' className=')
         .replace(/ for=/g, ' htmlFor=')
         .replace(/ <option (.*)selected=""/g, '<option $1selected={true}');


### PR DESCRIPTION
`./docs-e2e.sh pdf` had 29 stable failures, almost all confined to the Angular, React and Vue variants of the PDF export examples. Four causes:

- **Helpers referencing `gridApi` were not template-bound.** The generator only lifts template-bound handlers into the component class, so `updateDefaultPdfExportParams` stayed at module scope still referencing the vanilla `let gridApi` binding — `ReferenceError` on export. Inlined into the export handlers, which makes the `DOMContentLoaded` listener wiring redundant (the framework variants never had it anyway).
- **`pdf-page-header-image` scoped its theme probe to `#myGrid`**, an id that only exists in the vanilla variant, so `getComputedStyle(null)` threw.
- **The language examples loaded fonts in `DOMContentLoaded`**, a block the generator discards, so `defaultPdfExportParams` never received the embedded fonts and the PDFs fell back to Helvetica. Fonts are now loaded from the export handler. Two generator constraints shaped this: an `async` template handler generates as `async function onBtExport()` *inside* the Angular class (invalid), and a module-level `const x = loadFont(...)` hits a TDZ error in React because `function` declarations are rewritten as `const` arrows placed after their call site.
- **The React generator dropped the `checked` attribute** (`checked=""` is falsy in JSX), so controls the exports read had the wrong initial state. Added a `checked` -> `defaultChecked` rewrite alongside the existing `value` -> `defaultValue` rule, anchored to an attribute boundary so prefixed attributes (`aria-checked`, `data-checked`) and quoted values are left alone. This also silently corrects ~10 other examples (overlays, row-selection, aligned-grids) that had the same wrong initial state but no assertion covering it.

Separately, the context menu page lists PDF Export among the default menu items but its example never registered `PdfExportModule`, so the item did not appear. Registered it, linked the PDF Export reference, and corrected the `export` sub menu description, which still claimed it contained only `csvExport` and `excelExport`.

Two PDF specs selected options but asserted nothing that depended on them, so a dead control would have gone unnoticed. Both now export several times and assert on values only the selected option can produce — column widths read from the PDF content stream for `pdf-widths-autosizing`, and `/MediaBox`, margin origin and per-page header counts for `pdf-export-page-setup`. Verified by hardcoding the controls in the examples and confirming both specs fail; the same check was applied to the new context menu assertion. `pdf-international-characters` also asserted on text absent from the example data; corrected to a row that exists.

**Not addressed:** the generator not lifting `gridApi`-referencing helpers into the component class is a real limitation that will keep catching new examples. Worked around per-example here rather than changing the generator, since that has a much wider blast radius — worth a ticket.

Verification: `./docs-e2e.sh pdf` 115/115; `default-context-menu` 10/10; `overlays|row-selection|aligned-grids` 319/320 (the one failure, `removing-selection-checkboxes › typescript`, passes in isolation and its variant is untouched by the generator change); `yarn nx test ag-grid-generate-example-files` 71/71; `./checks.sh` passed.