### PR TITLE
AG-17862 Port the markdown-page review fixes from Charts and realign the shared subrepo

### DIFF
--- a/documentation/ag-grid-docs/src/pages/roadmap.md.ts
+++ b/documentation/ag-grid-docs/src/pages/roadmap.md.ts
@@ -14,6 +14,7 @@ export function GET() {
 
     const output = buildRoadmapMarkdown({
         roadmapData,
+        productName: 'AG Grid',
         siteRoot: SITE_URL,
         // The page is framework-agnostic; resolve its framework-prefixed links against a single
         // framework, matching the other markdown twins (homepage, license-pricing).

--- a/documentation/ag-grid-docs/src/pages/sitemap.md.ts
+++ b/documentation/ag-grid-docs/src/pages/sitemap.md.ts
@@ -32,7 +32,7 @@ export async function GET() {
             ].join('\n'),
             `# ${content.heading}`,
             content.description,
-            'Every page listed here also has a markdown version: append `.md` to its URL.',
+            `Every page listed here also has a markdown version: append \`.md\` to its URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${PRODUCTION_GRID_SITE_URL}/index.md.`,
             ...sections,
         ].join('\n\n') + '\n';
 

--- a/documentation/ag-grid-docs/src/utils/agentReadinessFiles.test.ts
+++ b/documentation/ag-grid-docs/src/utils/agentReadinessFiles.test.ts
@@ -35,6 +35,10 @@ describe('buildLlmsTxt', () => {
         expect(txt).toContain('Accept: text/markdown');
     });
 
+    test('points at index.md for the homepage, whose twin is not a `.md` suffix', () => {
+        expect(txt).toContain('https://www.ag-grid.com/index.md');
+    });
+
     test('lists the pipeline page', () => {
         expect(txt).toContain('(https://www.ag-grid.com/pipeline/)');
     });
@@ -73,6 +77,10 @@ describe('buildAgentsMd', () => {
         // listing pages that would drift (see markdownPages.test.ts for the guarantee).
         expect(md).toContain('append `.md` to any page URL listed in the');
         expect(md).toContain('[sitemap](https://www.ag-grid.com/sitemap-index.xml)');
+    });
+
+    test('points at index.md for the homepage, whose twin is not a `.md` suffix', () => {
+        expect(md).toContain('https://www.ag-grid.com/index.md');
     });
 
     test('omits the markdown affordance when markdown docs are disabled', () => {

--- a/documentation/ag-grid-docs/src/utils/agentReadinessFiles.ts
+++ b/documentation/ag-grid-docs/src/utils/agentReadinessFiles.ts
@@ -42,6 +42,8 @@ interface AgentReadinessLinks {
     pipeline: string;
     sitemap: string;
     llmsTxt: string;
+    /** The homepage twin, which is `index.md` rather than a `.md` suffix on the site root. */
+    homepageMarkdown: string;
 }
 
 function buildLinks({ siteRoot, gridDocsPrefix }: AgentReadinessInput): AgentReadinessLinks {
@@ -60,6 +62,7 @@ function buildLinks({ siteRoot, gridDocsPrefix }: AgentReadinessInput): AgentRea
         pipeline: `${siteRoot}pipeline/`,
         sitemap: `${siteRoot}sitemap-index.xml`,
         llmsTxt: `${siteRoot}llms.txt`,
+        homepageMarkdown: `${siteRoot}index.md`,
     };
 }
 
@@ -75,7 +78,7 @@ export function buildLlmsTxt(input: AgentReadinessInput): string {
     const markdownLine =
         input.includeMarkdownDocs === false
             ? ''
-            : `\n- Markdown versions: append \`.md\` to any page URL listed in the sitemap for a clean Markdown copy (e.g. ${l.dataGridDocs.replace(/\/$/, '')}.md), or send \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL.`;
+            : `\n- Markdown versions: append \`.md\` to any page URL listed in the sitemap for a clean Markdown copy (e.g. ${l.dataGridDocs.replace(/\/$/, '')}.md), or send \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${l.homepageMarkdown}.`;
     return `# AG Grid
 > High-performance JavaScript Data Grid, plus AG Charts and AG Studio. Framework-agnostic, with React, Angular and Vue support. Free Community and paid Enterprise editions. Current major version: v${input.majorVersion}.
 
@@ -110,7 +113,7 @@ export function buildAgentsMd(input: AgentReadinessInput): string {
     const markdownBullet =
         input.includeMarkdownDocs === false
             ? ''
-            : `\n- **Markdown for LLMs:** append \`.md\` to any page URL listed in the [sitemap](${l.sitemap}) (e.g. ${l.dataGridDocs.replace(/\/$/, '')}.md), or request the page with \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL.`;
+            : `\n- **Markdown for LLMs:** append \`.md\` to any page URL listed in the [sitemap](${l.sitemap}) (e.g. ${l.dataGridDocs.replace(/\/$/, '')}.md), or request the page with \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${l.homepageMarkdown}.`;
     return `# AG Grid - guide for AI coding assistants
 
 - **What it is:** JavaScript Data Grid, plus [AG Charts](${l.charts}) and [AG Studio](${l.studio}). Framework-agnostic, with React, Angular and Vue wrappers. Community (free) and Enterprise (licensed) editions.

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/buildRoadmapWhatsNewMarkdown.test.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/buildRoadmapWhatsNewMarkdown.test.ts
@@ -10,7 +10,13 @@ const SITE_ROOT = 'https://www.ag-grid.com/';
 const resolveUrl = (url: string) => urlWithPrefix({ framework: 'javascript', url });
 
 describe('buildRoadmapMarkdown', () => {
-    const output = buildRoadmapMarkdown({ roadmapData, siteRoot: SITE_ROOT, resolveUrl, year: 2026 });
+    const output = buildRoadmapMarkdown({
+        roadmapData,
+        productName: 'AG Grid',
+        siteRoot: SITE_ROOT,
+        resolveUrl,
+        year: 2026,
+    });
 
     it('emits frontmatter and the page H1, then the intro from roadmap.json', () => {
         expect(output.startsWith('---\n')).toBe(true);

--- a/external/ag-website-shared/src/components/contact-us/ContactPage.astro
+++ b/external/ag-website-shared/src/components/contact-us/ContactPage.astro
@@ -6,11 +6,11 @@ import PageHero from '@ag-website-shared/components/page-hero/PageHero.astro';
 import { getEntry, type CollectionEntry } from 'astro:content';
 import { buildContactPage } from '@ag-website-shared/utils/structuredData';
 import { LIBRARY } from '@constants';
-import { CONTACT_CONTENT, contactGithubUrl } from './contactContent';
+import { CONTACT_CONTENT, contactSocialLinks } from './contactContent';
 import styles from './ContactPage.module.scss';
 
 // Copy and links are shared with the /contact.md twin so the two cannot drift.
-const githubUrl = contactGithubUrl(LIBRARY);
+const socialLinks = contactSocialLinks(LIBRARY);
 
 const { data: metadata } = (await getEntry('metadata', 'metadata')) as CollectionEntry<'metadata'>;
 const contactPageStructuredData = buildContactPage({
@@ -40,46 +40,20 @@ const contactPageStructuredData = buildContactPage({
                 </div>
 
                 <div class={styles.socialLinks}>
-                    <a
-                        href={githubUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label="GitHub"
-                        class={styles.socialLinkRow}
-                    >
-                        <Icon name="github" />
-                        <span>GitHub</span>
-                    </a>
-                    <a
-                        href="https://x.com/ag_grid"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label="X (Twitter)"
-                        class={styles.socialLinkRow}
-                    >
-                        <Icon name="xLogo" />
-                        <span>X</span>
-                    </a>
-                    <a
-                        href="https://youtube.com/c/aggrid"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label="YouTube"
-                        class={styles.socialLinkRow}
-                    >
-                        <Icon name="youtube" />
-                        <span>YouTube</span>
-                    </a>
-                    <a
-                        href="https://linkedin.com/company/ag-grid"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label="LinkedIn"
-                        class={styles.socialLinkRow}
-                    >
-                        <Icon name="linkedin" />
-                        <span>LinkedIn</span>
-                    </a>
+                    {
+                        socialLinks.map(({ label, ariaLabel, icon, url }) => (
+                            <a
+                                href={url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                aria-label={ariaLabel ?? label}
+                                class={styles.socialLinkRow}
+                            >
+                                <Icon name={icon} />
+                                <span>{label}</span>
+                            </a>
+                        ))
+                    }
                 </div>
             </section>
         </div>

--- a/external/ag-website-shared/src/components/contact-us/contactContent.ts
+++ b/external/ag-website-shared/src/components/contact-us/contactContent.ts
@@ -1,3 +1,5 @@
+import type { IconName } from '@ag-website-shared/components/icon/Icon';
+
 /**
  * Copy and links for the contact page, shared between `ContactPage.astro` and its markdown twin
  * (`@ag-website-shared/markdown-pages/buildContactMarkdown`) so the two cannot drift.
@@ -13,12 +15,19 @@ export const CONTACT_CONTENT = {
     structuredDataName: 'Contact AG Grid',
 } as const;
 
-/** Social links shown beside the contact form. GitHub differs per product. */
-export const CONTACT_SOCIAL_LINKS = [
-    { label: 'X', icon: 'xLogo', url: 'https://x.com/ag_grid' },
+export interface ContactSocialLink {
+    label: string;
+    /** Falls back to the label; only needed where the label alone is not self-describing. */
+    ariaLabel?: string;
+    icon: IconName;
+    url: string;
+}
+
+const CONTACT_SOCIAL_LINKS: ContactSocialLink[] = [
+    { label: 'X', ariaLabel: 'X (Twitter)', icon: 'xLogo', url: 'https://x.com/ag_grid' },
     { label: 'YouTube', icon: 'youtube', url: 'https://youtube.com/c/aggrid' },
     { label: 'LinkedIn', icon: 'linkedin', url: 'https://linkedin.com/company/ag-grid' },
-] as const;
+];
 
 export const GITHUB_URL_BY_LIBRARY = {
     charts: 'https://github.com/ag-grid/ag-charts',
@@ -27,4 +36,9 @@ export const GITHUB_URL_BY_LIBRARY = {
 
 export function contactGithubUrl(library: string): string {
     return library === 'charts' ? GITHUB_URL_BY_LIBRARY.charts : GITHUB_URL_BY_LIBRARY.grid;
+}
+
+/** Social links shown beside the contact form, in display order. GitHub differs per product. */
+export function contactSocialLinks(library: string): ContactSocialLink[] {
+    return [{ label: 'GitHub', icon: 'github', url: contactGithubUrl(library) }, ...CONTACT_SOCIAL_LINKS];
 }

--- a/external/ag-website-shared/src/markdoc/htmlInlineToMarkdown.test.ts
+++ b/external/ag-website-shared/src/markdoc/htmlInlineToMarkdown.test.ts
@@ -50,6 +50,25 @@ describe('htmlBlockToMarkdown', () => {
         expect(htmlBlockToMarkdown('<ul><li>One</li><li>Two</li><li>Three</li></ul>')).toBe('- One\n- Two\n- Three');
     });
 
+    it('numbers an ordered list, so the sequence the copy relies on survives', () => {
+        expect(htmlBlockToMarkdown('<ol><li>One</li><li>Two</li><li>Three</li></ol>')).toBe('1. One\n2. Two\n3. Three');
+    });
+
+    it('numbers each ordered list from 1, independently of the ones before it', () => {
+        const html = '<ol><li>A</li><li>B</li></ol><ol><li>C</li></ol>';
+        expect(htmlBlockToMarkdown(html)).toBe('1. A\n2. B\n\n1. C');
+    });
+
+    it('keeps ordered and unordered markers apart in the same fragment', () => {
+        const html = '<ol><li>First</li></ol><ul><li>Bullet</li></ul>';
+        expect(htmlBlockToMarkdown(html)).toBe('1. First\n\n- Bullet');
+    });
+
+    it('converts links and emphasis inside ordered list items', () => {
+        const html = '<ol><li><a href="/about/">about</a></li><li><b>bold</b></li></ol>';
+        expect(htmlBlockToMarkdown(html, SITE_ROOT)).toBe('1. [about](https://www.ag-grid.com/about/)\n2. **bold**');
+    });
+
     it('keeps a paragraph, a list and a heading as separate blocks in source order', () => {
         const html = '<p>Intro.</p><h6>Section</h6><ul><li>A</li><li>B</li></ul><p>Outro.</p>';
         expect(htmlBlockToMarkdown(html)).toBe('Intro.\n\n###### Section\n\n- A\n- B\n\nOutro.');

--- a/external/ag-website-shared/src/markdoc/htmlInlineToMarkdown.ts
+++ b/external/ag-website-shared/src/markdoc/htmlInlineToMarkdown.ts
@@ -56,6 +56,9 @@ function emphasise(text: string, delimiter: string): string {
 const BLOCK_SEPARATOR = '\u0000';
 const LINE_SEPARATOR = '\u0001';
 
+/** Markers emitted for list items, so an already-converted item is not re-run as inline copy. */
+const LIST_MARKER = /^(?:- |\d+\. )/;
+
 /**
  * Convert a block-level HTML fragment (paragraphs, lists and headings, as stored in the Bryntum
  * campaign content) to markdown. Block structure becomes markdown blocks; the text inside each is
@@ -68,11 +71,17 @@ export function htmlBlockToMarkdown(html: string, siteRoot?: string): string {
     // Innermost blocks first, so a list item's own markup is consumed before its <ul> wrapper.
     // List items are line-joined into a single markdown list; other blocks are block-separated.
     const marked = html
+        // <ol> is consumed whole so its items can be numbered; what reaches the <li> pass below is
+        // therefore unordered, and takes the bullet marker.
+        .replace(
+            /<ol\b[^>]*>([\s\S]*?)<\/ol>/gi,
+            (_match, items) => `${numberedListItems(items, siteRoot)}${BLOCK_SEPARATOR}`
+        )
         .replace(
             /<li\b[^>]*>([\s\S]*?)<\/li>/gi,
             (_match, text) => `${LINE_SEPARATOR}- ${htmlInlineToMarkdown(text, siteRoot)}`
         )
-        .replace(/<\/(?:ul|ol)>/gi, BLOCK_SEPARATOR)
+        .replace(/<\/ul>/gi, BLOCK_SEPARATOR)
         .replace(
             /<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi,
             (_match, level: string, text) =>
@@ -90,11 +99,20 @@ export function htmlBlockToMarkdown(html: string, siteRoot?: string): string {
                 .split(LINE_SEPARATOR)
                 // List items are already converted; anything left outside a block (bare text,
                 // stray <span>s) is inline copy and still needs converting.
-                .map((line) => (line.startsWith('- ') ? line.trim() : htmlInlineToMarkdown(line, siteRoot)))
+                .map((line) => (LIST_MARKER.test(line) ? line.trim() : htmlInlineToMarkdown(line, siteRoot)))
                 .filter(Boolean)
                 .join('\n')
         )
         .filter(Boolean)
         .join('\n\n')
         .trim();
+}
+
+/** Numbered from 1: `<ol start>` does not appear in the source copy. */
+function numberedListItems(items: string, siteRoot?: string): string {
+    let position = 0;
+    return items.replace(/<li\b[^>]*>([\s\S]*?)<\/li>/gi, (_match, text) => {
+        position += 1;
+        return `${LINE_SEPARATOR}${position}. ${htmlInlineToMarkdown(text, siteRoot)}`;
+    });
 }

--- a/external/ag-website-shared/src/markdown-pages/buildContactMarkdown.ts
+++ b/external/ag-website-shared/src/markdown-pages/buildContactMarkdown.ts
@@ -1,8 +1,4 @@
-import {
-    CONTACT_CONTENT,
-    CONTACT_SOCIAL_LINKS,
-    contactGithubUrl,
-} from '@ag-website-shared/components/contact-us/contactContent';
+import { CONTACT_CONTENT, contactSocialLinks } from '@ag-website-shared/components/contact-us/contactContent';
 
 /**
  * Build the markdown twin of the contact page. The page's substance is an interactive form, which
@@ -13,11 +9,6 @@ import {
  * `library` they pass (which selects the GitHub repository).
  */
 export function buildContactMarkdown({ library, contactUrl }: { library: string; contactUrl: string }): string {
-    const socialLinks = [
-        { label: 'GitHub', url: contactGithubUrl(library) },
-        ...CONTACT_SOCIAL_LINKS.map(({ label, url }) => ({ label, url })),
-    ];
-
     const document = [
         [
             '---',
@@ -30,7 +21,9 @@ export function buildContactMarkdown({ library, contactUrl }: { library: string;
         CONTACT_CONTENT.subhead,
         `The contact form is on the page itself: [${CONTACT_CONTENT.headline}](${contactUrl}).`,
         '## Elsewhere',
-        socialLinks.map(({ label, url }) => `- [${label}](${url})`).join('\n'),
+        contactSocialLinks(library)
+            .map(({ label, url }) => `- [${label}](${url})`)
+            .join('\n'),
     ];
 
     return `${document.join('\n\n').trimEnd()}\n`;

--- a/external/ag-website-shared/src/markdown-pages/buildRoadmapMarkdown.ts
+++ b/external/ag-website-shared/src/markdown-pages/buildRoadmapMarkdown.ts
@@ -17,6 +17,8 @@ export interface RoadmapData {
 
 export interface BuildRoadmapMarkdownOptions {
     roadmapData: RoadmapData;
+    /** Product display name for the page metadata, e.g. `AG Charts`. */
+    productName: string;
     siteRoot?: string;
     /** Resolve an item's `./`-prefixed docs link — the site's `urlWithPrefix` bound to a framework. */
     resolveUrl: (url: string) => string;
@@ -37,15 +39,21 @@ function formatLastUpdated(dateStr: string): string {
  * groups items by quarter exactly as `RoadmapBoard` does. The page's status filter is interactive;
  * here each item carries its status inline instead.
  *
- * Product-agnostic: the caller injects `resolveUrl` and the year, so AG Grid, AG Charts and
- * AG Studio share this module.
+ * Product-agnostic: the caller injects `productName`, `resolveUrl` and the year, so AG Grid,
+ * AG Charts and AG Studio share this module.
  */
-export function buildRoadmapMarkdown({ roadmapData, siteRoot, resolveUrl, year }: BuildRoadmapMarkdownOptions): string {
+export function buildRoadmapMarkdown({
+    roadmapData,
+    productName,
+    siteRoot,
+    resolveUrl,
+    year,
+}: BuildRoadmapMarkdownOptions): string {
     const document: string[] = [
         [
             '---',
-            'title: "Roadmap | AG Grid"',
-            'description: "AG Grid Roadmap - see what we are building next, including planned features, items in progress, and recently shipped work."',
+            `title: ${JSON.stringify(`Roadmap | ${productName}`)}`,
+            `description: ${JSON.stringify(`${productName} Roadmap - see what we are building next, including planned features, items in progress, and recently shipped work.`)}`,
             '---',
         ].join('\n'),
         "# What we're building next",

--- a/external/ag-website-shared/src/markdown-pages/landing-pages/buildLandingPageMarkdown.ts
+++ b/external/ag-website-shared/src/markdown-pages/landing-pages/buildLandingPageMarkdown.ts
@@ -33,9 +33,9 @@ export interface BuildLandingPageMarkdownOptions {
     resolveFaqUrl?: (url: string) => string;
 }
 
-type Resolve = (url: string) => string;
+export type Resolve = (url: string) => string;
 
-function link(text: string, url: string, resolve: Resolve, siteRoot?: string): string {
+export function link(text: string, url: string, resolve: Resolve, siteRoot?: string): string {
     return `[${text}](${url.startsWith('http') ? url : toAbsoluteUrl(resolve(url), siteRoot)})`;
 }
 
@@ -43,7 +43,7 @@ function link(text: string, url: string, resolve: Resolve, siteRoot?: string): s
  * Rewrite the targets of markdown links already present in authored copy (FAQ answers are
  * Markdoc, so they arrive as markdown rather than as a URL field to resolve).
  */
-function resolveMarkdownLinks(markdown: string, resolve: Resolve, siteRoot?: string): string {
+export function resolveMarkdownLinks(markdown: string, resolve: Resolve, siteRoot?: string): string {
     return markdown.replace(/\[([^\]]*)\]\(([^)\s]+)\)/g, (match, text: string, target: string) => {
         if (target.startsWith('http') || target.startsWith('mailto') || target.startsWith('#')) {
             return match;
@@ -57,7 +57,7 @@ function resolveMarkdownLinks(markdown: string, resolve: Resolve, siteRoot?: str
  * emphasised kicker so it holds that reading order without adding a heading level —
  * matching how the homepage twin renders its section tags.
  */
-function sectionHeader(
+export function sectionHeader(
     section: { tag?: string; heading?: string; headingHtml?: string; subHeading?: string; subHeadingHtml?: string },
     siteRoot?: string
 ): string[] {
@@ -114,7 +114,7 @@ function pricingBody(section: ExtractSection<'pricing'>, resolve: Resolve, siteR
 }
 
 /** Section body beyond the shared tag/heading/subheading header. */
-function sectionBody(
+export function sectionBody(
     section: LandingPageSectionType,
     resolve: Resolve,
     resolveFaq: Resolve,


### PR DESCRIPTION
## What

Ports the review fixes from the Charts counterpart of this work ([ag-charts#7761](https://github.com/ag-grid/ag-charts/pull/7761)) into Grid, and realigns the `ag-website-shared` subrepo so the two repos hold the same shared code again. Both repos sit on subrepo commit `e914cbd1b9`, and PR #14769 left the shared markdown-page modules diverging once Charts generalised them.

Three of the five are the same defects the Charts review found, present here for the same reason; two are shared-API changes Grid has to take.

## The fixes

**Ordered lists lost their numbering** — `htmlBlockToMarkdown` accepted both `<ul>` and `<ol>` wrappers but emitted `-` for every `<li>`, so ordered copy silently became a bullet list. `<ol>` is now consumed whole by a pass that numbers its items, restarting per list, so only `<ul>` items take the bullet.

Grid is the **only** consumer of this function — `buildCampaignMarkdown.ts`, for the Bryntum campaign twins. The six campaign JSON files currently contain 30 `<ul>` and no `<ol>`, so nothing renders wrongly today; the fix closes the trap before campaign content gains an ordered list.

**Contact social links were not actually shared** — `contactContent.ts` exported a `CONTACT_SOCIAL_LINKS` list that only the markdown twin read, while `ContactPage.astro` rendered its four links independently. Editing the "shared" list would have drifted the two apart. `contactSocialLinks(library)` now returns GitHub (per-product) plus the three socials in display order, and the page maps over it. Rendered markup is byte-identical: `icon` is typed `IconName`, and the `X (Twitter)` aria-label is preserved through an optional `ariaLabel` field.

**The site-wide `.md` rule was false for the homepage** — `/sitemap.md` claimed *every* page listed has a `.md` version, and `llms.txt` / `AGENTS.md` said `.md` can be appended to any sitemap URL. The site root is special-cased in `markdownPages.ts` — its twin is `/index.md`, not `/.md` — so an agent following that instruction for the homepage got a 404. All three now name the exception and point at `/index.md`.

## The two shared-API changes

**`buildRoadmapMarkdown` takes `productName`** — its frontmatter hardcoded `Roadmap | AG Grid`, which is wrong for the other two products. The caller now injects the name. **This one is load-bearing:** the option is required, so without this commit Grid fails to typecheck on the next `git subrepo pull`. Grid's output is unchanged — it passes `'AG Grid'`, producing the same title and description as before.

**`buildLandingPageMarkdown` exports its section helpers** — `Resolve`, `link`, `resolveMarkdownLinks`, `sectionHeader` and `sectionBody` change from module-private to exported so the Charts landing-page builder can reuse them. Visibility only; no behaviour change and no Grid caller affected.

## Verification

- `./checks.sh --projects ag-grid-docs,ag-website-shared --fresh` — **PASSED**
- `yarn nx test ag-website-shared` — 18 files, 192 tests pass, including 4 new ordered-list cases
- `yarn nx test ag-grid-docs` — `agentReadinessFiles.test.ts` 13/13 and `buildRoadmapWhatsNewMarkdown.test.ts` 10/10 pass
- `ContactPage.astro` — no `astro check` target exists, so the Astro compiler was run over the file directly: 0 diagnostics, and the emitted render carries href / aria-label / class / `Icon name` / label span exactly as the hand-written version did

Two failures on this branch are pre-existing and reproduce on `latest` with the changes stashed:

- `markdownPages.test.ts > emits a .md file next to every page` — reads `dist/`, which is a stale build with no twins in it (712 pass without these changes, 714 with)
- `ag-grid-community:lint` — eslint parse errors on stale nested `packages/ag-grid-community/packages/ag-grid-community/dist/` artefacts, which is why `./checks.sh` was scoped to the two projects this PR touches

## Note on the subrepo

The shared files here are byte-identical to the Charts branch, so a later `git subrepo push` / `pull` should reconcile cleanly. ag-charts#7761 is still open, though — if it changes further under review, the shared side will need another pass.
