### PR TITLE
[AG-18137] Fix(pagination): show page 0 of 0 when the grid has no rows

### DIFF
--- a/packages/ag-grid-community/src/pagination/pageSummaryComp.ts
+++ b/packages/ag-grid-community/src/pagination/pageSummaryComp.ts
@@ -96,7 +96,7 @@ export class PageSummaryComp extends Component {
                         this.commitPageInput();
                         break;
                     case KeyCode.ESCAPE:
-                        lbCurrentInput.setValue(String(current + 1), true); // needs to happen before blur below
+                        lbCurrentInput.setValue(String(this.getDisplayPageNumber()), true); // needs to happen before blur below
                         eInput.blur();
                         break;
                     case KeyCode.UP:
@@ -145,10 +145,9 @@ export class PageSummaryComp extends Component {
 
     private commitPageInput(): void {
         const { pagination, lbCurrentInput } = this;
-        const currentPage = pagination.getCurrentPage() + 1;
         const rawValue = lbCurrentInput.getValue(true);
         if (!rawValue?.trim()) {
-            lbCurrentInput.setValue(String(currentPage), true);
+            lbCurrentInput.setValue(String(this.getDisplayPageNumber()), true);
             return;
         }
         const rawValueNum = Number(rawValue);
@@ -156,10 +155,23 @@ export class PageSummaryComp extends Component {
         const isValid =
             Number.isFinite(rawValueNum) && Number.isInteger(rawValueNum) && rawValueNum >= 1 && rawValueNum <= total;
         if (!isValid) {
-            lbCurrentInput.setValue(String(currentPage), true);
+            lbCurrentInput.setValue(String(this.getDisplayPageNumber()), true);
             return;
         }
         pagination.goToPage(rawValueNum - 1);
+    }
+
+    /**
+     * The 1-based page number shown to the user. With no pages at all this is 0, so an empty grid reads
+     * `Page 0 of 0` alongside its `0 to 0 of 0` row summary. While the last row index is still unknown
+     * (data loading, or infinite scroll) it stays at 1, as page 1 is yet to arrive.
+     */
+    private getDisplayPageNumber(): number {
+        const { rowModel, pagination } = this;
+        if (pagination.getTotalPages() > 0) {
+            return pagination.getCurrentPage() + 1;
+        }
+        return rowModel.isLastRowIndexKnown() ? 0 : 1;
     }
 
     public refresh(): void {
@@ -195,7 +207,6 @@ export class PageSummaryComp extends Component {
         const { rowModel, pagination, lbCurrentInput, lbCurrentStatic, lbTotal } = this;
         const lastPageFound = rowModel.isLastRowIndexKnown();
         const totalPages = pagination.getTotalPages();
-        const currentPage = pagination.getCurrentPage();
         const localeTextFunc = this.getLocaleTextFunc();
 
         let lbTotalStr: string;
@@ -206,19 +217,18 @@ export class PageSummaryComp extends Component {
         }
         lbTotal.textContent = lbTotalStr;
 
-        const pagesExist = totalPages > 0;
-        const lbCurrentValue = pagesExist ? currentPage + 1 : 1;
+        const lbCurrentValue = this.getDisplayPageNumber();
         const lbCurrent = this.formatNumber(lbCurrentValue);
         if (this.suppressPageInput) {
             lbCurrentStatic.textContent = lbCurrent;
         } else {
-            // Before data loads totalPages is 0; clamp to 1 to avoid an invalid input while data loads
-            const pageCount = Math.max(1, totalPages);
-            lbCurrentInput.setMin(1);
-            lbCurrentInput.setMax(pageCount);
+            // With no pages the only page number the input can hold is 0; while data loads it is 1
+            const maxPage = Math.max(lbCurrentValue, totalPages);
+            lbCurrentInput.setMin(Math.min(1, lbCurrentValue));
+            lbCurrentInput.setMax(maxPage);
             // log10 returns number of digits (as an integer part + fraction) - 1,
             // bump that to 1 + 1x2 each side pad + 0.5 for borders and css oddities
-            lbCurrentInput.getInputElement().style.width = `${Math.floor(Math.log10(pageCount)) + 3.5}ch`;
+            lbCurrentInput.getInputElement().style.width = `${Math.floor(Math.log10(Math.max(1, maxPage))) + 3.5}ch`;
             lbCurrentInput.setValue(lbCurrentValue.toString());
             const eInput = lbCurrentInput.getInputElement();
             _setAriaLabel(
@@ -226,8 +236,8 @@ export class PageSummaryComp extends Component {
                 `${localeTextFunc('page', 'Page')} ${localeTextFunc('number', 'number')}, ${lbCurrentValue} ${localeTextFunc('of', 'of')} ${lbTotalStr}`
             );
             eInput.setAttribute('aria-valuenow', String(lbCurrentValue));
-            eInput.setAttribute('aria-valuemin', '1');
-            eInput.setAttribute('aria-valuemax', String(pageCount));
+            eInput.setAttribute('aria-valuemin', String(Math.min(1, lbCurrentValue)));
+            eInput.setAttribute('aria-valuemax', String(maxPage));
         }
 
         const strPage = localeTextFunc('page', 'Page');

--- a/testing/behavioural/src/pagination/pagination-page-summary.test.ts
+++ b/testing/behavioural/src/pagination/pagination-page-summary.test.ts
@@ -1,0 +1,144 @@
+import { userEvent } from '@testing-library/user-event';
+
+import type { GridApi, GridOptions } from 'ag-grid-community';
+import { ClientSideRowModelModule, PaginationModule, getGridElement } from 'ag-grid-community';
+
+import { TestGridsManager } from '../test-utils';
+
+const COLUMN_DEFS = [{ field: 'name' }];
+
+function createGrid(gridsManager: TestGridsManager, options: Partial<GridOptions> = {}) {
+    return gridsManager.createGrid('myGrid', {
+        columnDefs: COLUMN_DEFS,
+        pagination: true,
+        paginationPageSize: 10,
+        paginationPageSizeSelector: false,
+        ...options,
+    });
+}
+
+function makeRowData(count: number) {
+    return Array.from({ length: count }, (_, i) => ({ name: `Row ${i + 1}` }));
+}
+
+function getPageInput(api: GridApi): HTMLInputElement {
+    return getGridElement(api)!.querySelector<HTMLInputElement>('.ag-paging-page-summary-panel input')!;
+}
+
+function getTotalPagesText(api: GridApi): string | null {
+    const [, lbTotal] = getGridElement(api)!.querySelectorAll('.ag-paging-page-summary-panel .ag-paging-number');
+    return lbTotal.textContent;
+}
+
+describe('pagination page summary', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [ClientSideRowModelModule, PaginationModule],
+    });
+
+    beforeEach(() => {
+        gridsManager.reset();
+    });
+
+    afterEach(() => {
+        gridsManager.reset();
+    });
+
+    describe('no rows', () => {
+        test('shows page 0 of 0', () => {
+            const api = createGrid(gridsManager, { rowData: [] });
+
+            expect(getPageInput(api).value).toBe('0');
+            expect(getTotalPagesText(api)).toBe('0');
+        });
+
+        test('page input allows 0 as its minimum', () => {
+            const api = createGrid(gridsManager, { rowData: [] });
+            const input = getPageInput(api);
+
+            expect(input.min).toBe('0');
+            expect(input.max).toBe('0');
+            expect(input.getAttribute('aria-valuenow')).toBe('0');
+            expect(input.getAttribute('aria-valuemin')).toBe('0');
+            expect(input.getAttribute('aria-valuemax')).toBe('0');
+        });
+
+        test('an invalid page entry reverts to 0 rather than 1', async () => {
+            const api = createGrid(gridsManager, { rowData: [] });
+            const input = getPageInput(api);
+
+            await userEvent.clear(input);
+            await userEvent.type(input, '1{enter}');
+
+            expect(input.value).toBe('0');
+            expect(api.paginationGetCurrentPage()).toBe(0);
+        });
+
+        test('clearing the page input reverts to 0', async () => {
+            const api = createGrid(gridsManager, { rowData: [] });
+            const input = getPageInput(api);
+
+            await userEvent.clear(input);
+            await userEvent.type(input, '{enter}');
+
+            expect(input.value).toBe('0');
+        });
+
+        test('page number returns to 1 once rows arrive', () => {
+            const api = createGrid(gridsManager, { rowData: [] });
+            expect(getPageInput(api).value).toBe('0');
+
+            api.setGridOption('rowData', makeRowData(25));
+
+            expect(getPageInput(api).value).toBe('1');
+            expect(getTotalPagesText(api)).toBe('3');
+        });
+
+        test('page number returns to 0 once the rows are removed again', () => {
+            const api = createGrid(gridsManager, { rowData: makeRowData(25) });
+            api.paginationGoToLastPage();
+            expect(getPageInput(api).value).toBe('3');
+
+            api.setGridOption('rowData', []);
+
+            expect(getPageInput(api).value).toBe('0');
+            expect(getTotalPagesText(api)).toBe('0');
+        });
+    });
+
+    describe('with rows', () => {
+        test('an out-of-range page entry reverts to the current page', async () => {
+            const api = createGrid(gridsManager, { rowData: makeRowData(25) });
+            api.paginationGoToPage(1);
+            const input = getPageInput(api);
+            expect(input.value).toBe('2');
+
+            await userEvent.clear(input);
+            await userEvent.type(input, '99{enter}');
+
+            expect(input.value).toBe('2');
+            expect(api.paginationGetCurrentPage()).toBe(1);
+        });
+
+        test('a non-integer page entry reverts to the current page', async () => {
+            const api = createGrid(gridsManager, { rowData: makeRowData(25) });
+            const input = getPageInput(api);
+
+            await userEvent.clear(input);
+            await userEvent.type(input, '2.5{enter}');
+
+            expect(input.value).toBe('1');
+            expect(api.paginationGetCurrentPage()).toBe(0);
+        });
+
+        test('a valid page entry navigates', async () => {
+            const api = createGrid(gridsManager, { rowData: makeRowData(25) });
+            const input = getPageInput(api);
+
+            await userEvent.clear(input);
+            await userEvent.type(input, '3{enter}');
+
+            expect(input.value).toBe('3');
+            expect(api.paginationGetCurrentPage()).toBe(2);
+        });
+    });
+});


### PR DESCRIPTION
Fixes [AG-18137](https://ag-grid.atlassian.net/browse/AG-18137). Regression from 35.3.1: an empty grid read `Page 1 of 0`.

`PageSummaryComp` clamped the displayed page to 1 whenever `totalPages` was 0, to keep the new page-number input within its `min=1` range while data loads. That also swallowed the genuinely-zero-pages case. The displayed page is now 0 when the last row index is known and there are no pages, and stays 1 only while the row count is still unknown; the input's min/max and aria values follow it, and an invalid or cleared entry reverts to the displayed page rather than to 1.

Repro: https://plnkr.co/edit/JheHNYbhbWDbkVjK?preview

Tests: `testing/behavioural/src/pagination/pagination-page-summary.test.ts` — empty grid, invalid/out-of-range/cleared input, and transitions in and out of the empty state.
