### PR TITLE
Fix the broken star history chart in the README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,9 +444,9 @@ AG Grid is used by 100,000's of developers across the world, from almost every i
 Founded in 2016, AG Grid has seen a steady rise in popularity and is now the market leader for Data Grids:
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date&theme=dark"/>
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date"/>
-  <img width="100%" alt="The AG Grid star history chart" src="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date"/>
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date&theme=dark"/>
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date"/>
+  <img width="100%" alt="The AG Grid star history chart" src="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date"/>
 </picture>
 
 ## 🤝 Support

--- a/community-modules/locale/README.md
+++ b/community-modules/locale/README.md
@@ -444,9 +444,9 @@ AG Grid is used by 100,000's of developers across the world, from almost every i
 Founded in 2016, AG Grid has seen a steady rise in popularity and is now the market leader for Data Grids:
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date&theme=dark"/>
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date"/>
-  <img width="100%" alt="The AG Grid star history chart" src="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date"/>
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date&theme=dark"/>
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date"/>
+  <img width="100%" alt="The AG Grid star history chart" src="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date"/>
 </picture>
 
 ## 🤝 Support

--- a/community-modules/styles/README.md
+++ b/community-modules/styles/README.md
@@ -444,9 +444,9 @@ AG Grid is used by 100,000's of developers across the world, from almost every i
 Founded in 2016, AG Grid has seen a steady rise in popularity and is now the market leader for Data Grids:
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date&theme=dark"/>
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date"/>
-  <img width="100%" alt="The AG Grid star history chart" src="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date"/>
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date&theme=dark"/>
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date"/>
+  <img width="100%" alt="The AG Grid star history chart" src="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date"/>
 </picture>
 
 ## 🤝 Support

--- a/packages/ag-grid-angular/README.md
+++ b/packages/ag-grid-angular/README.md
@@ -464,9 +464,9 @@ AG Grid is used by 100,000's of developers across the world, from almost every i
 Founded in 2016, AG Grid has seen a steady rise in popularity and is now the market leader for Data Grids:
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date&theme=dark"/>
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date"/>
-  <img width="100%" alt="The AG Grid star history chart" src="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date"/>
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date&theme=dark"/>
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date"/>
+  <img width="100%" alt="The AG Grid star history chart" src="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date"/>
 </picture>
 
 ## 🤝 Support

--- a/packages/ag-grid-angular/projects/ag-grid-angular/README.md
+++ b/packages/ag-grid-angular/projects/ag-grid-angular/README.md
@@ -464,9 +464,9 @@ AG Grid is used by 100,000's of developers across the world, from almost every i
 Founded in 2016, AG Grid has seen a steady rise in popularity and is now the market leader for Data Grids:
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date&theme=dark"/>
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date"/>
-  <img width="100%" alt="The AG Grid star history chart" src="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date"/>
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date&theme=dark"/>
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date"/>
+  <img width="100%" alt="The AG Grid star history chart" src="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date"/>
 </picture>
 
 ## 🤝 Support

--- a/packages/ag-grid-community/README.md
+++ b/packages/ag-grid-community/README.md
@@ -444,9 +444,9 @@ AG Grid is used by 100,000's of developers across the world, from almost every i
 Founded in 2016, AG Grid has seen a steady rise in popularity and is now the market leader for Data Grids:
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date&theme=dark"/>
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date"/>
-  <img width="100%" alt="The AG Grid star history chart" src="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date"/>
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date&theme=dark"/>
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date"/>
+  <img width="100%" alt="The AG Grid star history chart" src="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date"/>
 </picture>
 
 ## 🤝 Support

--- a/packages/ag-grid-react/README.md
+++ b/packages/ag-grid-react/README.md
@@ -453,9 +453,9 @@ AG Grid is used by 100,000's of developers across the world, from almost every i
 Founded in 2016, AG Grid has seen a steady rise in popularity and is now the market leader for Data Grids:
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date&theme=dark"/>
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date"/>
-  <img width="100%" alt="The AG Grid star history chart" src="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date"/>
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date&theme=dark"/>
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date"/>
+  <img width="100%" alt="The AG Grid star history chart" src="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date"/>
 </picture>
 
 ## 🤝 Support

--- a/packages/ag-grid-vue3/README.md
+++ b/packages/ag-grid-vue3/README.md
@@ -473,9 +473,9 @@ AG Grid is used by 100,000's of developers across the world, from almost every i
 Founded in 2016, AG Grid has seen a steady rise in popularity and is now the market leader for Data Grids:
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date&theme=dark"/>
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date"/>
-  <img width="100%" alt="The AG Grid star history chart" src="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date"/>
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date&theme=dark"/>
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date"/>
+  <img width="100%" alt="The AG Grid star history chart" src="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date"/>
 </picture>
 
 ## 🤝 Support

--- a/packages/ag-stack/README.md
+++ b/packages/ag-stack/README.md
@@ -444,9 +444,9 @@ AG Grid is used by 100,000's of developers across the world, from almost every i
 Founded in 2016, AG Grid has seen a steady rise in popularity and is now the market leader for Data Grids:
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date&theme=dark"/>
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date"/>
-  <img width="100%" alt="The AG Grid star history chart" src="https://api.star-history.com/svg?repos=ag-grid/ag-grid&type=Date"/>
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date&theme=dark"/>
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date"/>
+  <img width="100%" alt="The AG Grid star history chart" src="https://star-history.dera.page/svg?repos=ag-grid/ag-grid&type=Date"/>
 </picture>
 
 ## 🤝 Support


### PR DESCRIPTION
The star history chart shown in the README files is currently broken, so the stargazers section renders nothing. This change updates the chart image source in the README files (including the framework package READMEs) so the AG Grid star history displays correctly again.

This is a Docs/Docs-Marketing change and touches README files only.