### PR TITLE
filter-extra-latest-test

### DIFF
--- a/.rulesync/rules/testing.md
+++ b/.rulesync/rules/testing.md
@@ -33,13 +33,21 @@ The skill covers the traps that make a `waitFor` unfalsifiable or a sleep load-b
 
 A bug rarely has one trigger. Enumerate the reproduction paths named in the ticket and add a test for each — a programmatic API call, a panel drag and a tool-panel drop are three tests, not one. Test the plural case, not just N=1, and assert the observable end state for every path.
 
+**Prefer red before green: write the failing test first.** That is the default, because it forces the discriminating input to be chosen before the fix exists to bias it. The invariant it serves is weaker — see the test fail for the reason you expect, at least once — so when the fix already exists (ported, cherry-picked, or you simply wrote it first), applying the test before the patch or reverting the patch to confirm red is a legitimate route to the same place. A test that fails for the wrong reason — typo'd selector, unregistered module, a `waitFor` already true — is as uninformative as one that never fails.
+
+Pick the input that *separates* the two behaviours. A test that passes against both the fixed and the unfixed code proves nothing, however green it is — this is the check that catches a guard which stops a crash by skipping the work the function existed to do.
+
+**Then refactor, on green.** The third step is not optional and it is where tidying belongs: simplifying the fix, extracting a harness, merging same-setup tests, adding the `GridRows`/`GridColumns`/`FilterDom` snapshots. The test suite is what makes that safe, so it must stay green *and unchanged* throughout — if an assertion has to be edited to keep passing, that is a behaviour change wearing a refactor's clothes, and it needs its own red step.
+
 ## Commands
 
 - `./behave.sh` — the whole unit suite (package + behavioural) via the Vitest workspace.
 - `./benches.sh` — behavioural benchmarks in headless Chromium.
 - `./docs-e2e.sh` — Playwright E2E against the docs site. The Nx target is `test:e2e`; there is **no** `e2e` target.
 
-All three take `--help` and resolve only from the repo root — prefix with `cd "$(git rev-parse --show-toplevel)" &&` if the shell may have moved. `./behave.sh` does not type-check; run `yarn nx run ag-behavioural-testing:build:test` before committing. Some suites take minutes — allow a five-minute timeout and collect the exit status rather than treating silence as success.
+**Run with `--bail 1` by habit.** `./behave.sh --bail 1 <path>` stops at the first failing test — what you want in a fix-one-error-at-a-time loop, and it skips the rest of the reporting too. `--no-diff` reports names and messages with no diffs, for when a suite fails wholesale. A red run can take minutes where the green one takes seconds: vitest's diff serialisation of grid objects is effectively unbounded. The skill explains why, plus the `--stack-trace-len` trap and how `--bail` reads in a JSON report.
+
+All three take `--help` and resolve only from the repo root — from elsewhere call them by path (`../../behave.sh`), not via `cd "$(git rev-parse --show-toplevel)" &&`, which agent harnesses gate on. `./behave.sh` does not type-check; run `yarn nx run ag-behavioural-testing:build:test` before committing. Some suites take minutes — allow a five-minute timeout and collect the exit status rather than treating silence as success.
 
 ## Key practices
 

--- a/.rulesync/skills/testing/SKILL.md
+++ b/.rulesync/skills/testing/SKILL.md
@@ -40,6 +40,54 @@ When writing regression tests for a bug fix:
 
 Before finishing, re-read the ticket's "Steps to reproduce" and confirm each distinct trigger has a corresponding test. A fix verified through only one of several documented triggers is not fully verified.
 
+### See the test fail, for the reason you expect
+
+**Prefer red before green: write the failing test first, then make it pass, then refactor with the test holding
+the behaviour still.** Generically this is the better route, because it forces the discriminating input to be
+chosen while the fix does not yet exist to bias the choice — and the refactor step is where harness and snapshot
+tidying belongs, once there is a passing test to protect it.
+
+The invariant it serves is weaker than the ritual: *the test must be observed to fail for the expected reason at
+least once*. So when the fix already exists — ported, cherry-picked, or simply written before the test — reach
+red the other way round: apply the *test* before the patch and watch it fail, or revert the patch, confirm red,
+restore. An adopted fix arrives already-green, which removes the red step precisely when it is most needed.
+
+Either way it belongs **while choosing the fix**, not as a closing gate once everything is green: it is what
+tells you the fix is the right one, rather than merely that the suite passes. And watch *why* it fails — a test
+red for the wrong reason (typo'd selector, unregistered module, a `waitFor` that was already true) is as
+uninformative as one that never fails, and it will go green off the back of the wrong change.
+
+The trap either way is a test whose assertion holds for both the fixed and the unfixed code. It is green, it
+looks like a regression guard, and it proves nothing. Choose the input that *separates* the two behaviours.
+
+**Then refactor, on green — the third step is not optional.** Once a discriminating test passes, that is the
+moment to simplify the fix, extract or extend a harness, merge tests that share a setup, and add the
+`GridRows` / `GridColumns` / `FilterDom` snapshots. Doing any of it earlier means changing code with nothing
+holding the behaviour still; skipping it leaves the first thing that worked.
+
+The rule that keeps this honest: **the tests stay green and unchanged across a refactor.** If an assertion has
+to be edited for the suite to keep passing, that is a behaviour change wearing a refactor's clothes, and it owes
+its own red step. Two ways that bites in this suite specifically:
+
+- Merging tests onto one grid can silently weaken what they prove — state leaks between what were independent
+  cases. Run each merge; if a case only passes from a fresh grid, that is a finding about the code, and it keeps
+  its own grid with the reason in a comment.
+- Snapshot bodies are generated (`./behave.sh --update-grid-rows`), never hand-written. A hand-written snapshot
+  is an assertion invented from memory, and updating a *stale* one to match new output is the same mistake with
+  better camouflage: check the diff is the change you intended before accepting it.
+
+A worked example. `AbstractHeaderCellCtrl.shouldStopEventPropagation` crashed on an unguarded
+`focusSvc.focusedHeader!`. An early `return false` stops the crash — and also skips
+`suppressHeaderKeyboardEvent`, which is the only reason the method exists, so a column that wants to suppress
+silently cannot. The test shipped with it configured `suppressHeaderKeyboardEvent: () => false`, so the
+callback's `false` and the guard's early `false` were indistinguishable and it could never have failed. A
+callback returning `true` is the discriminating input, and it exposes both the missing behaviour and the
+correct fix: fall back to the cell's own `column` / `rowCtrl.rowIndex`, which is exactly what the focus service
+would have stored.
+
+Generalise from it: for any early return, name what the function does *after* that point that a caller depends
+on. If the skipped work is the function's purpose, the guard is the bug.
+
 ## Test Structure
 
 ### Directory Layout
@@ -91,9 +139,36 @@ packages/ag-grid-community/src/
 ./behave.sh --watch
 ```
 
+#### Bounding the output: `--bail 1` and `--no-diff`
+
+**`--bail 1` is the default for a fix-one-thing-at-a-time loop.** You only care about the first error, and stopping
+there skips the remaining tests *and* their reporting — seconds instead of a minute. Reach for it by habit, not only
+when a suite is badly broken.
+
+**`--no-diff` is for a suite that fails wholesale**, when you only need *which* tests fail. A red run reports for far
+longer than it runs — printing a grid DOM node has no practical bound, so a 10s suite takes minutes. Get the list
+first, then re-run one file with diffs on.
+
+```bash
+./behave.sh --bail 1 <path>           # stop at the first failure — the everyday default (--bail N for N)
+./behave.sh --no-diff <path>          # names + messages only (AG_NO_DIFF)
+./behave.sh --diff-lines 10 <path>    # cap each diff (AG_DIFF_LINES, default 80, 0 = unlimited)
+./behave.sh --stack-trace-len 20      # shorter stacks (AG_STACK_TRACE_LEN, default 40)
+```
+
+`--bail` combines with any reporter. With `--reporter=json --outputFile=…` the file is still written and valid, and
+the tests that never ran are reported as **`pending`** rather than omitted — so read `success`, not `numPassedTests`,
+which is only "as far as we got".
+
+> Keep `--stack-trace-len` at 20 or above: vitest finds a `toMatchInlineSnapshot` by walking the stack, so anything
+> shorter turns every inline snapshot into a false "Couldn't infer stack frame" failure.
+
+Colour (off for an agent or a pipe, on for a terminal and CI) and `DEBUG_PRINT_LIMIT` (1000, not testing-library's
+7000, so a failed query prints a slice rather than the whole grid) are set for you by `behave.sh`.
+
 > `./behave.sh` does not type-check (Vitest strips types via esbuild). Before committing, run `yarn nx run ag-behavioural-testing:build:test` to type-check.
 >
-> `./behave.sh` and `./benches.sh` resolve only from the repository root, so an agent whose shell has changed directory — earlier in the same command, or carried over from a previous one — will not find them. Prefix with `cd "$(git rev-parse --show-toplevel)" &&` rather than hardcoding a machine-specific path.
+> `./behave.sh` and `./benches.sh` resolve only from the repository root. From anywhere else call them by path (`../../behave.sh`) — not via `cd "$(git rev-parse --show-toplevel)" &&`, which every agent harness gates on the `cd`, the `&&` and the `$(…)`.
 >
 > Some suites take several minutes; `testing/behavioural/src/charts/format-panel-options.test.ts` alone runs ~2.5 minutes. Allow a timeout of at least five minutes, and wait for the run to finish and report its exit status — if the runner detaches the command, collect the result rather than treating silence as success.
 >

--- a/behave.sh
+++ b/behave.sh
@@ -14,6 +14,12 @@
 #   ./behave.sh -w | --watch              # Run in watch mode
 #   ./behave.sh --update                  # Update vitest snapshots
 #   ./behave.sh --update-grid-rows[=dry]  # Update GridRows inline snapshots (dry = preview only)
+#
+# Output-volume controls, for when a suite fails wholesale and the diffs dwarf the results:
+#   ./behave.sh --bail 1                  # Stop at the first failing test
+#   ./behave.sh --no-diff                 # Report which tests fail; no assertion diff, snapshots cut to a line
+#   ./behave.sh --diff-lines 10           # Cap each diff at 10 lines (0 = unlimited)
+#   ./behave.sh --stack-trace-len 20      # Shorten captured stacks; default 40, keep >= 20
 
 set -euo pipefail
 
@@ -25,6 +31,22 @@ UNIT_PROJECTS=(ag-stack ag-grid-community ag-grid-enterprise locale behavioural)
 args=()
 userChoseProjects=false # caller passed --project <name> → run theirs instead of the defaults
 runAllProjects=false    # caller passed `--project all` → no filter, every workspace project
+
+# Reads a non-negative integer for `--opt N` or `--opt=N`, so neither spelling skips validation.
+argValue=''
+countArgValue() {
+    local arg="$1" expected="$2"
+    if [[ "$arg" == *=* ]]; then
+        argValue="${arg#*=}"
+    else
+        argValue="${argv[i + 1]:-}"
+        skipNext=true
+    fi
+    if [[ ! "$argValue" =~ ^[0-9]+$ ]]; then
+        echo "Missing or invalid value for ${arg%%=*} (expected $expected)" >&2
+        exit 1
+    fi
+}
 
 argv=("$@")
 skipNext=false
@@ -44,6 +66,22 @@ for ((i = 0; i < ${#argv[@]}; i++)); do
         --update-grid-rows=*)
             echo "Unknown value: $arg (expected --update-grid-rows or --update-grid-rows=dry)" >&2
             exit 1
+            ;;
+        --no-diff)
+            export AG_NO_DIFF=1
+            ;;
+        --diff-lines | --diff-lines=*)
+            countArgValue "$arg" "a line count, 0 = unlimited"
+            export AG_DIFF_LINES="$argValue"
+            ;;
+        --stack-trace-len | --stack-trace-len=*)
+            countArgValue "$arg" "a frame count, e.g. 20"
+            # Below ~20 every inline snapshot fails "Couldn't infer stack frame". Allowed, but not silently.
+            # `10#` or bash reads a leading zero as octal and errors on `08`.
+            if ((10#$argValue < 20)); then
+                echo "behave.sh: --stack-trace-len $argValue may break inline snapshots (keep >= 20)" >&2
+            fi
+            export AG_STACK_TRACE_LEN="$argValue"
             ;;
         --project=all)
             runAllProjects=true
@@ -73,6 +111,14 @@ done
 
 # Run from the repo root so Vitest picks up vitest.workspace.ts.
 cd "$SCRIPT_DIR"
+
+# Colour is for humans: an interactive terminal or CI (whose log viewer renders ANSI). An AI agent or a
+# pipe reads the escapes as noise, and vitest emits them regardless of isTTY, so say so explicitly.
+if [[ -z "${NO_COLOR:-}" && -z "${FORCE_COLOR:-}" ]]; then
+    if [[ -n "${CLAUDECODE:-}${AI_AGENT:-}" ]] || { [[ -z "${CI:-}" ]] && [[ ! -t 1 ]]; }; then
+        export NO_COLOR=1
+    fi
+fi
 
 projectArgs=()
 if ! $runAllProjects && ! $userChoseProjects; then

--- a/packages/ag-grid-community/src/headerRendering/cells/abstractCell/abstractHeaderCellCtrl.ts
+++ b/packages/ag-grid-community/src/headerRendering/cells/abstractCell/abstractHeaderCellCtrl.ts
@@ -110,7 +110,10 @@ export abstract class AbstractHeaderCellCtrl<
     ): void;
 
     protected shouldStopEventPropagation(event: KeyboardEvent): boolean {
-        const { headerRowIndex, column } = this.beans.focusSvc.focusedHeader!;
+        const { headerRowIndex, column } = this.beans.focusSvc.focusedHeader ?? {
+            headerRowIndex: this.rowCtrl.rowIndex,
+            column: this.column,
+        };
 
         const colDef = column.getDefinition();
         const colDefFunc = colDef?.suppressHeaderKeyboardEvent;

--- a/testing/behavioural/src/filters/advanced-filter-regression/af-autocomplete.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-regression/af-autocomplete.test.ts
@@ -56,6 +56,22 @@ describe('Advanced Filter — autocomplete completion & editing', () => {
     afterAll(() => uninstallFilterLayoutMock());
     afterEach(() => gridsManager.reset());
 
+    test('a column hidden after the list was first built leaves the suggestions', async () => {
+        const api = await gridsManager.createGridAndWait('grid1', OPTS);
+        const af = AdvancedFilterHarness.get(api);
+
+        await af.type('[A');
+        expect(af.autocompleteEntries()).toEqual(['Age', 'Athlete']);
+        await af.pressKey('Escape');
+
+        api.setColumnsVisible(['athlete'], false);
+        await asyncSetTimeout(0);
+
+        await af.type('[');
+        await af.type('[A');
+        expect(af.autocompleteEntries()).toEqual(['Age']);
+    });
+
     test('the suggestion list is position-aware: column, operator, then filtered operators', async () => {
         const api = await gridsManager.createGridAndWait('grid1', OPTS);
         const af = AdvancedFilterHarness.get(api);
@@ -130,40 +146,34 @@ describe('Advanced Filter — autocomplete completion & editing', () => {
         expect(af.autocompleteEntries()).toEqual(['equals']);
     });
 
-    test('Tab completes a partial column name and appends a space', async () => {
+    // Each case retypes the whole expression, so they share one grid without carrying state between them.
+    test('Tab completes a partial column, a partial operator, and an empty operator slot', async () => {
         const api = await gridsManager.createGridAndWait('grid1', OPTS);
         const af = AdvancedFilterHarness.get(api);
 
-        await af.type('[Ath');
-        await asyncSetTimeout(0);
-        await af.tabComplete();
-        await asyncSetTimeout(0);
+        for (const [typed, completed] of [
+            ['[Ath', '[Athlete] '],
+            ['[Athlete] con', '[Athlete] contains "'],
+            // An empty slot takes the first operator, which is the same one `con` narrows to.
+            ['[Athlete] ', '[Athlete] contains "'],
+        ]) {
+            await af.type(typed);
+            await asyncSetTimeout(0);
+            await af.tabComplete();
+            await asyncSetTimeout(0);
 
-        expect(af.value).toBe('[Athlete] ');
-    });
+            expect(af.value).toBe(completed);
+        }
 
-    test('Tab completes a partial operator and opens the operand quote', async () => {
-        const api = await gridsManager.createGridAndWait('grid1', OPTS);
-        const af = AdvancedFilterHarness.get(api);
-
-        await af.type('[Athlete] con');
-        await asyncSetTimeout(0);
-        await af.tabComplete();
-        await asyncSetTimeout(0);
-
-        expect(af.value).toBe('[Athlete] contains "');
-    });
-
-    test('Tab at an empty operator slot selects the first operator', async () => {
-        const api = await gridsManager.createGridAndWait('grid1', OPTS);
-        const af = AdvancedFilterHarness.get(api);
-
-        await af.type('[Athlete] ');
-        await asyncSetTimeout(0);
-        await af.tabComplete();
-        await asyncSetTimeout(0);
-
-        expect(af.value).toBe('[Athlete] contains "');
+        // A completed operator with an open operand quote is not yet an expression to apply.
+        await new FilterDom(api, 'tab-completed operand quote').checkFilterDom(`
+            ADVANCED FILTER
+            input: "[Athlete] contains ""
+            valid: false — Expression has an error. Value is missing an end quote - ".
+            buttons: Apply ⊘ | Builder
+            model: null
+        `);
+        await new GridRows(api, 'tab completion applies nothing on its own').check(UNFILTERED);
     });
 
     test('an expression built entirely through completion applies', async () => {
@@ -251,22 +261,23 @@ describe('Advanced Filter — join autocomplete & multi-condition completion', (
     afterAll(() => uninstallFilterLayoutMock());
     afterEach(() => gridsManager.reset());
 
-    test('after a complete condition the suggestion list offers the join operators', async () => {
+    // Both cases retype from the same empty state, so one grid serves them.
+    test('after a complete condition the join slot offers both joins, and a partial narrows it', async () => {
         const api = await gridsManager.createGridAndWait('grid1', OPTS);
         const af = AdvancedFilterHarness.get(api);
 
         await af.type('[Age] > 20 ');
         expect(af.autocompleteEntries()).toEqual(['AND', 'OR']);
-    });
-
-    test('a partial join operator narrows to the matching join', async () => {
-        const api = await gridsManager.createGridAndWait('grid1', OPTS);
-        const af = AdvancedFilterHarness.get(api);
 
         await af.type('[Age] > 20 A');
         expect(af.autocompleteEntries()).toEqual(['AND']);
+
+        // Neither was applied, so the grid is still showing every row.
+        await new GridRows(api, 'join suggestions apply nothing').check(UNFILTERED);
     });
 
+    // Needs its own grid: typing this expression into an input that has already offered a join slot
+    // leaves OR on the list, so the restriction only shows on a first parse.
     test('once a join is chosen, a further operator slot only offers the same join', async () => {
         const api = await gridsManager.createGridAndWait('grid1', OPTS);
         const af = AdvancedFilterHarness.get(api);

--- a/testing/behavioural/src/filters/advanced-filter-regression/af-builder-drag.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-regression/af-builder-drag.test.ts
@@ -4,6 +4,7 @@ import { AdvancedFilterModule } from 'ag-grid-enterprise';
 
 import {
     AdvancedFilterBuilderHarness,
+    FilterDom,
     GridRows,
     TestGridsManager,
     asyncSetTimeout,
@@ -84,9 +85,51 @@ describe('Advanced Filter — builder drag-and-drop reorder', () => {
         const builder = await AdvancedFilterBuilderHarness.open(api);
         await builder.forceReRender();
         const conditions = await builder.conditionItems();
+        await new FilterDom(api, 'builder before drag down', { mode: 'builder' }).checkFilterDom(`
+            BUILDER
+            AND
+              Athlete contains "B"
+              Age > 26
+              + add
+            buttons: Apply ⊘ | Cancel
+            model:
+              filterType: "join"
+              type: "AND"
+              conditions:
+                - filterType: "text"
+                  colId: "athlete"
+                  type: "contains"
+                  filter: "B"
+                - filterType: "number"
+                  colId: "age"
+                  type: "greaterThan"
+                  filter: 26
+        `);
 
         // List rows: [join(0), athlete(1), age(2)]; drop the first condition onto row 2 (after age).
         await builder.dragToRow(conditions[0], 2);
+        // The tree is reordered before Apply, which is what the drag itself has to prove.
+        await new FilterDom(api, 'builder after drag down, before apply', { mode: 'builder' }).checkFilterDom(`
+            BUILDER
+            AND
+              Age > 26
+              Athlete contains "B"
+              + add
+            buttons: Apply | Cancel
+            model:
+              filterType: "join"
+              type: "AND"
+              conditions:
+                - filterType: "text"
+                  colId: "athlete"
+                  type: "contains"
+                  filter: "B"
+                - filterType: "number"
+                  colId: "age"
+                  type: "greaterThan"
+                  filter: 26
+        `);
+
         await builder.apply();
         await asyncSetTimeout(0);
 
@@ -102,9 +145,50 @@ describe('Advanced Filter — builder drag-and-drop reorder', () => {
         const builder = await AdvancedFilterBuilderHarness.open(api);
         await builder.forceReRender();
         const conditions = await builder.conditionItems();
+        await new FilterDom(api, 'builder before drag up', { mode: 'builder' }).checkFilterDom(`
+            BUILDER
+            AND
+              Athlete contains "B"
+              Age > 26
+              + add
+            buttons: Apply ⊘ | Cancel
+            model:
+              filterType: "join"
+              type: "AND"
+              conditions:
+                - filterType: "text"
+                  colId: "athlete"
+                  type: "contains"
+                  filter: "B"
+                - filterType: "number"
+                  colId: "age"
+                  type: "greaterThan"
+                  filter: 26
+        `);
 
         // Drop the second condition (age) onto the group's join row (0) so it lands first.
         await builder.dragToRow(conditions[1], 0);
+        await new FilterDom(api, 'builder after drag up, before apply', { mode: 'builder' }).checkFilterDom(`
+            BUILDER
+            AND
+              Age > 26
+              Athlete contains "B"
+              + add
+            buttons: Apply | Cancel
+            model:
+              filterType: "join"
+              type: "AND"
+              conditions:
+                - filterType: "text"
+                  colId: "athlete"
+                  type: "contains"
+                  filter: "B"
+                - filterType: "number"
+                  colId: "age"
+                  type: "greaterThan"
+                  filter: 26
+        `);
+
         await builder.apply();
         await asyncSetTimeout(0);
 

--- a/testing/behavioural/src/filters/advanced-filter-regression/af-builder-keyboard-nav.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-regression/af-builder-keyboard-nav.test.ts
@@ -6,6 +6,7 @@ import { AdvancedFilterModule } from 'ag-grid-enterprise';
 
 import {
     AdvancedFilterBuilderHarness,
+    FilterDom,
     GridRows,
     TestGridsManager,
     asyncSetTimeout,
@@ -59,15 +60,6 @@ function focusWrapper(item: HTMLElement): HTMLElement {
     return wrapper;
 }
 
-/** Display text of a condition row's column pill. */
-function columnPill(item: HTMLElement): string {
-    return (
-        item
-            .querySelector('.ag-advanced-filter-builder-column-pill .ag-advanced-filter-builder-pill-display')
-            ?.textContent?.trim() ?? ''
-    );
-}
-
 const HIGHLIGHT = 'ag-advanced-filter-builder-virtual-list-item-highlight';
 
 describe('Advanced Filter — builder keyboard navigation & reorder', () => {
@@ -119,11 +111,50 @@ describe('Advanced Filter — builder keyboard navigation & reorder', () => {
 
         const builder = await AdvancedFilterBuilderHarness.open(api);
         const conditions = await builder.conditionItems();
-        expect(columnPill(conditions[0])).toBe('Athlete');
-        expect(columnPill(conditions[1])).toBe('Age');
+        await new FilterDom(api, 'builder before keyboard move down', { mode: 'builder' }).checkFilterDom(`
+            BUILDER
+            AND
+              Athlete contains "B"
+              Age > 26
+              + add
+            buttons: Apply | Cancel
+            model:
+              filterType: "join"
+              type: "AND"
+              conditions:
+                - filterType: "text"
+                  colId: "athlete"
+                  type: "contains"
+                  filter: "B"
+                - filterType: "number"
+                  colId: "age"
+                  type: "greaterThan"
+                  filter: 26
+        `);
 
         // Move the first (Athlete) condition down via the keyboard, then commit.
         await builder.moveWithKeyboard(conditions[0], 'down');
+        await new FilterDom(api, 'builder after keyboard move down, before apply', { mode: 'builder' }).checkFilterDom(`
+            BUILDER
+            AND
+              Age > 26
+              Athlete contains "B"
+              + add
+            buttons: Apply | Cancel
+            model:
+              filterType: "join"
+              type: "AND"
+              conditions:
+                - filterType: "text"
+                  colId: "athlete"
+                  type: "contains"
+                  filter: "B"
+                - filterType: "number"
+                  colId: "age"
+                  type: "greaterThan"
+                  filter: 26
+        `);
+
         await builder.apply();
 
         // Order flips in the persisted model; AND is commutative so the rows are unchanged.
@@ -151,9 +182,50 @@ describe('Advanced Filter — builder keyboard navigation & reorder', () => {
 
         const builder = await AdvancedFilterBuilderHarness.open(api);
         const conditions = await builder.conditionItems();
+        await new FilterDom(api, 'builder before click move up', { mode: 'builder' }).checkFilterDom(`
+            BUILDER
+            AND
+              Athlete contains "B"
+              Age > 26
+              + add
+            buttons: Apply | Cancel
+            model:
+              filterType: "join"
+              type: "AND"
+              conditions:
+                - filterType: "text"
+                  colId: "athlete"
+                  type: "contains"
+                  filter: "B"
+                - filterType: "number"
+                  colId: "age"
+                  type: "greaterThan"
+                  filter: 26
+        `);
 
         // Move the second (Age) condition up above the first.
         await builder.move(conditions[1], 'up');
+        await new FilterDom(api, 'builder after click move up, before apply', { mode: 'builder' }).checkFilterDom(`
+            BUILDER
+            AND
+              Age > 26
+              Athlete contains "B"
+              + add
+            buttons: Apply | Cancel
+            model:
+              filterType: "join"
+              type: "AND"
+              conditions:
+                - filterType: "text"
+                  colId: "athlete"
+                  type: "contains"
+                  filter: "B"
+                - filterType: "number"
+                  colId: "age"
+                  type: "greaterThan"
+                  filter: 26
+        `);
+
         await builder.apply();
 
         await waitFor(() =>

--- a/testing/behavioural/src/filters/advanced-filter-regression/af-column-reuse.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-regression/af-column-reuse.test.ts
@@ -49,7 +49,7 @@ describe('Simple Filter — In Range (2-input) reuse surface', () => {
             input [1]: "35"
             AND
             operator: "Equals"
-            input: ""
+            input: "" ⟨Filter...⟩
             model:
               filterType: "number"
               type: "inRange"
@@ -77,7 +77,7 @@ describe('Simple Filter — In Range (2-input) reuse surface', () => {
             COLUMN FILTER
             operator: "Between"
             input [0]: "20"
-            input [1]: ""
+            input [1]: "" ⟨To⟩
             model: null
         `);
         await new GridRows(api, 'number inRange incomplete rows').check(`
@@ -104,7 +104,7 @@ describe('Simple Filter — In Range (2-input) reuse surface', () => {
             COLUMN FILTER
             operator: "Between"
             input [0]: "35"
-            input [1]: "20"
+            input [1]: "20" ✗ "Must be greater than 35"
             model: null
         `);
         await new GridRows(api, 'number inRange reversed rows').check(`
@@ -141,7 +141,7 @@ describe('Simple Filter — In Range (2-input) reuse surface', () => {
             input [1]: "2024-06-30"
             AND
             operator: "Equals"
-            input: ""
+            input: "" ⟨yyyy-mm-dd⟩
             model:
               dateFrom: "2024-03-15"
               dateTo: "2024-06-30"

--- a/testing/behavioural/src/filters/advanced-filter-regression/af-options.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-regression/af-options.test.ts
@@ -140,6 +140,39 @@ describe('Advanced Filter — grid options', () => {
                 └── LEAF id:1 athlete:"Ng" age:40
             `);
         });
+
+        test('turning the option on reaches an expression parsed while it was off', async () => {
+            const api = await gridsManager.createGridAndWait('grid1', {
+                columnDefs: [
+                    { field: 'athlete', filter: true },
+                    { field: 'age', filter: true, hide: true },
+                ],
+                rowData: ROW_DATA,
+                enableAdvancedFilter: true,
+            });
+
+            // Parsing this is what builds the offered columns, so the option is read before it changes.
+            await AdvancedFilterHarness.get(api).applyExpression('[Age] > 30');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toBeNull();
+
+            api.setGridOption('includeHiddenColumnsInAdvancedFilter', true);
+            await asyncSetTimeout(0);
+
+            // A different bound, so the expression is re-parsed rather than recognised as the text already there.
+            await AdvancedFilterHarness.get(api).applyExpression('[Age] > 39');
+            await asyncSetTimeout(0);
+            expect(api.getAdvancedFilterModel()).toEqual({
+                filterType: 'number',
+                colId: 'age',
+                type: 'greaterThan',
+                filter: 39,
+            });
+            await new GridRows(api, 'hidden column included after the option was turned on').check(`
+                ROOT id:ROOT_NODE_ID
+                └── LEAF id:1 athlete:"Ng" age:40
+            `);
+        });
     });
 
     describe('suppressAdvancedFilterEval (deprecated no-op since v34)', () => {

--- a/testing/behavioural/src/filters/advanced-filter-regression/af-validation.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter-regression/af-validation.test.ts
@@ -326,7 +326,7 @@ describe('Custom filterOptions (0/1/2-input) reuse surface', () => {
             operator: "Is even"
             AND
             operator: "Equals"
-            input: ""
+            input: "" ⟨Filter...⟩
             model:
               filterType: "number"
               type: "even"
@@ -356,7 +356,7 @@ describe('Custom filterOptions (0/1/2-input) reuse surface', () => {
             input: "10"
             AND
             operator: "Equals"
-            input: ""
+            input: "" ⟨Filter...⟩
             model:
               filterType: "number"
               type: "multipleOf"
@@ -389,7 +389,7 @@ describe('Custom filterOptions (0/1/2-input) reuse surface', () => {
             input [1]: "30"
             AND
             operator: "Equals"
-            input: ""
+            input: "" ⟨Filter...⟩
             model:
               filterType: "number"
               type: "strictlyBetween"

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-bigint-custom-parser.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-bigint-custom-parser.test.ts
@@ -4,6 +4,7 @@ import { AdvancedFilterModule } from 'ag-grid-enterprise';
 
 import {
     AdvancedFilterBuilderHarness,
+    FilterDom,
     GridRows,
     TestGridsManager,
     asyncSetTimeout,
@@ -133,6 +134,17 @@ describe('Advanced Filter - bigint custom parser and formatter', () => {
         api.setAdvancedFilterModel(api.getAdvancedFilterModel());
         const svc = getService(api);
         expect(svc.getExpressionDisplayValue()).toBe('[Value] = 0xFF');
+        await new FilterDom(api, 'hex round-trips through the formatter', { mode: 'advanced-filter' }).checkFilterDom(`
+            ADVANCED FILTER
+            input: "[Value] = 0xFF"
+            valid: true
+            buttons: Apply ⊘ | Builder
+            model:
+              filterType: "bigint"
+              colId: "value"
+              type: "equals"
+              filter: "255"
+        `);
     });
 
     test('no formatter falls back to decimal display and still matches', async () => {
@@ -161,6 +173,17 @@ describe('Advanced Filter - bigint custom parser and formatter', () => {
         `);
         api.setAdvancedFilterModel(api.getAdvancedFilterModel());
         expect(getService(api).getExpressionDisplayValue()).toBe('[Value] = 255');
+        await new FilterDom(api, 'no formatter falls back to decimal', { mode: 'advanced-filter' }).checkFilterDom(`
+            ADVANCED FILTER
+            input: "[Value] = 255"
+            valid: true
+            buttons: Apply ⊘ | Builder
+            model:
+              filterType: "bigint"
+              colId: "value"
+              type: "equals"
+              filter: "255"
+        `);
     });
 
     test('builder value pill formats the stored operand and parses custom bigint input', async () => {
@@ -178,6 +201,18 @@ describe('Advanced Filter - bigint custom parser and formatter', () => {
 
         // The stored decimal model value is displayed through the column's bigintFormatter.
         expect(valuePillText(condition)).toBe('0xFF');
+        await new FilterDom(api, 'builder pill shows the formatted operand', { mode: 'builder' }).checkFilterDom(`
+            BUILDER
+            AND
+              Value = 0xFF
+              + add
+            buttons: Apply | Cancel
+            model:
+              filterType: "bigint"
+              colId: "value"
+              type: "equals"
+              filter: "255"
+        `);
 
         // `1000n` is only understood by the column's bigintParser (native BigInt rejects the suffix),
         // so a canonical decimal in the model proves the builder ran the edit through that parser.
@@ -282,6 +317,18 @@ describe('Advanced Filter - bigint custom parser and formatter', () => {
         const [condition] = await builder.conditionItems();
         expect(valuePillText(condition)).toBe('0xff');
         expect((await builder.openValueEditor(condition)).value).toBe('0xff');
+        await new FilterDom(api, 'builder keeps the typed operand syntax', { mode: 'builder' }).checkFilterDom(`
+            BUILDER
+            AND
+              Value = 0xff
+              + add
+            buttons: Apply | Cancel
+            model:
+              filterType: "bigint"
+              colId: "value"
+              type: "equals"
+              filter: "255"
+        `);
 
         // Applying from the builder round-trips the operand through the expression text, so the
         // typed syntax must survive a re-open too - and must still filter on the parsed value.
@@ -325,5 +372,17 @@ describe('Advanced Filter - bigint custom parser and formatter', () => {
         const [condition] = await builder.conditionItems();
         expect(valuePillText(condition)).toBe('1000');
         expect((await builder.openValueEditor(condition)).value).toBe('1000');
+        await new FilterDom(api, 'builder decimal operand with no formatter', { mode: 'builder' }).checkFilterDom(`
+            BUILDER
+            AND
+              Value = 1000
+              + add
+            buttons: Apply | Cancel
+            model:
+              filterType: "bigint"
+              colId: "value"
+              type: "equals"
+              filter: "1000"
+        `);
     });
 });

--- a/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
+++ b/testing/behavioural/src/filters/advanced-filter/advanced-filter-column-filter-parity.test.ts
@@ -1,0 +1,135 @@
+import type { AdvancedFilterModel, ColumnAdvancedFilterModel, GridApi, GridOptions } from 'ag-grid-community';
+import { ClientSideRowModelModule, DateFilterModule, NumberFilterModule, TextFilterModule } from 'ag-grid-community';
+import { AdvancedFilterModule } from 'ag-grid-enterprise';
+
+import { TestGridsManager, asyncSetTimeout } from '../../test-utils';
+
+interface TestRow {
+    id: number;
+    athlete: string | null;
+    age: number | null;
+    date: string | null;
+}
+
+const ROW_DATA: TestRow[] = [
+    { id: 0, athlete: 'Alpha', age: 1, date: '2008-08-24' },
+    { id: 1, athlete: 'alpha beta', age: 2, date: '   ' },
+    { id: 2, athlete: '', age: 3, date: null },
+    { id: 3, athlete: '   ', age: null, date: '2020-07-23' },
+    { id: 4, athlete: null, age: 0, date: 'not a date' },
+    { id: 5, athlete: 'Beta', age: -2, date: '2012-08-05' },
+];
+
+const COLUMN_DEFS: GridOptions<TestRow>['columnDefs'] = [
+    { field: 'athlete', filter: 'agTextColumnFilter' },
+    { field: 'age', filter: 'agNumberColumnFilter', filterParams: { includeBlanksInNotEqual: true } },
+    { field: 'date', cellDataType: 'dateString', filter: 'agDateColumnFilter' },
+];
+
+function getDisplayedIds(api: GridApi<TestRow>): number[] {
+    const result: number[] = [];
+    for (let i = 0; i < api.getDisplayedRowCount(); i++) {
+        result.push(api.getDisplayedRowAtIndex(i)!.data!.id);
+    }
+    return result;
+}
+
+describe('Advanced Filter matches the column filter', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [
+            TextFilterModule,
+            NumberFilterModule,
+            DateFilterModule,
+            AdvancedFilterModule,
+            ClientSideRowModelModule,
+        ],
+    });
+
+    afterEach(() => gridsManager.reset());
+
+    /** The rows a column filter shows for `model`, applied to a grid with no Advanced Filter. */
+    async function withColumnFilter(colId: string, model: object): Promise<number[]> {
+        const api = gridsManager.createGrid('columnFilterGrid', { columnDefs: COLUMN_DEFS, rowData: ROW_DATA });
+        await asyncSetTimeout(0);
+        await api.setColumnFilterModel(colId, model);
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+        const ids = getDisplayedIds(api);
+        api.destroy();
+        return ids;
+    }
+
+    /** The rows the Advanced Filter shows for the equivalent condition. */
+    async function withAdvancedFilter(model: AdvancedFilterModel): Promise<number[]> {
+        const api = gridsManager.createGrid('advancedFilterGrid', {
+            columnDefs: COLUMN_DEFS,
+            rowData: ROW_DATA,
+            enableAdvancedFilter: true,
+        });
+        await asyncSetTimeout(0);
+        api.setAdvancedFilterModel(model);
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+        const ids = getDisplayedIds(api);
+        api.destroy();
+        return ids;
+    }
+
+    /** Anchors the comparison: were either side to stop filtering, both would return every row and agree. */
+    function expectFiltered(ids: number[]): void {
+        expect(ids.length).toBeGreaterThan(0);
+        expect(ids.length).toBeLessThan(ROW_DATA.length);
+    }
+
+    /**
+     * The harness that keeps the two filters honest: every built-in option, evaluated by both against the same
+     * rows. A future change that makes one of them mean something different fails here.
+     */
+    describe.each([
+        { colId: 'athlete', filterType: 'text' as const, filter: 'alpha' },
+        { colId: 'age', filterType: 'number' as const, filter: 2 },
+    ])('$colId', ({ colId, filterType, filter }) => {
+        // A number column's `notEqual` is not at parity: the Advanced Filter admits blanks to it by
+        // `includeBlanksInEquals`, where the column filter reads `includeBlanksInNotEqual`.
+        const valuedOptions =
+            filterType === 'text'
+                ? ['contains', 'notContains', 'equals', 'notEqual', 'startsWith', 'endsWith']
+                : ['equals', 'greaterThan', 'greaterThanOrEqual', 'lessThan', 'lessThanOrEqual'];
+
+        test.each(valuedOptions)('`%s` filters the same rows', async (type) => {
+            const columnFilterIds = await withColumnFilter(colId, { filterType, type, filter });
+            const advancedFilterIds = await withAdvancedFilter({
+                filterType,
+                colId,
+                type,
+                filter,
+            } as ColumnAdvancedFilterModel);
+
+            expectFiltered(columnFilterIds);
+            expect(advancedFilterIds).toEqual(columnFilterIds);
+        });
+
+        test.each(['blank', 'notBlank'])('`%s` filters the same rows', async (type) => {
+            const columnFilterIds = await withColumnFilter(colId, { filterType, type });
+            const advancedFilterIds = await withAdvancedFilter({
+                filterType,
+                colId,
+                type,
+            } as ColumnAdvancedFilterModel);
+
+            expectFiltered(columnFilterIds);
+            expect(advancedFilterIds).toEqual(columnFilterIds);
+        });
+    });
+
+    // A whitespace date is rejected as an invalid date before either filter asks whether it is blank, so
+    // `isBlank`'s treatment of whitespace never reaches it. Pinned because it is the surprise.
+    test('a whitespace `dateString` is not blank to either', async () => {
+        const columnFilterIds = await withColumnFilter('date', { filterType: 'date', type: 'blank' });
+
+        expect(columnFilterIds).toEqual([2]);
+        expect(await withAdvancedFilter({ filterType: 'dateString', colId: 'date', type: 'blank' })).toEqual(
+            columnFilterIds
+        );
+    });
+});

--- a/testing/behavioural/src/filters/bigint-filter-range-validation.test.ts
+++ b/testing/behavioural/src/filters/bigint-filter-range-validation.test.ts
@@ -3,6 +3,7 @@ import { BigIntFilterModule, ClientSideRowModelModule, setupAgTestIds } from 'ag
 
 import {
     ColumnFilterHarness,
+    FilterDom,
     GridRows,
     TestGridsManager,
     asyncSetTimeout,
@@ -42,7 +43,7 @@ describe('BigInt Range Filter', () => {
     }
 
     test('an inverted range names the bound each input must respect', async () => {
-        const { filter } = await openRangeFilter('grid1');
+        const { api, filter } = await openRangeFilter('grid1');
 
         await filter.setText('255', 0);
         await filter.setText('16', 1);
@@ -51,6 +52,14 @@ describe('BigInt Range Filter', () => {
         expect(filter.input('text', 1).validity.valid).toBe(false);
         expect(filter.input('text', 1).validationMessage).toBe('Must be greater than 255');
         expect(filter.input('text', 0).validationMessage).toBe('');
+        await new FilterDom(api, 'inverted range, to touched last', { mode: 'column-filter', colId: 'val' })
+            .checkFilterDom(`
+                COLUMN FILTER
+                operator: "Between"
+                input [0]: "255"
+                input [1]: "16" ✗ "Must be greater than 255"
+                model: null
+            `);
 
         // Touching `from` moves the message across, mirrored to name the opposite bound.
         await filter.setText('256', 0);
@@ -58,6 +67,14 @@ describe('BigInt Range Filter', () => {
         expect(filter.input('text', 0).validity.valid).toBe(false);
         expect(filter.input('text', 0).validationMessage).toBe('Must be less than 16');
         expect(filter.input('text', 1).validationMessage).toBe('');
+        await new FilterDom(api, 'inverted range, from touched last', { mode: 'column-filter', colId: 'val' })
+            .checkFilterDom(`
+                COLUMN FILTER
+                operator: "Between"
+                input [0]: "256" ✗ "Must be less than 16"
+                input [1]: "16"
+                model: null
+            `);
     });
 
     test('a from value equal to the to value is invalid', async () => {
@@ -78,7 +95,7 @@ describe('BigInt Range Filter', () => {
     });
 
     test('an unparseable value is reported as invalid rather than compared', async () => {
-        const { filter } = await openRangeFilter('grid1');
+        const { api, filter } = await openRangeFilter('grid1');
 
         await filter.setText('16', 0);
         await filter.setText('12.5', 1);
@@ -86,6 +103,13 @@ describe('BigInt Range Filter', () => {
         // A non-integer is not a BigInt, so the type error is reported instead of a range message.
         expect(filter.input('text', 1).validity.valid).toBe(false);
         expect(filter.input('text', 1).validationMessage).toBe('Invalid BigInt');
+        await new FilterDom(api, 'unparseable to value', { mode: 'column-filter', colId: 'val' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Between"
+            input [0]: "16"
+            input [1]: "12.5" ✗ "Invalid BigInt"
+            model: null
+        `);
     });
 
     test('a valid range clears the validation and filters the rows', async () => {

--- a/testing/behavioural/src/filters/filter-behaviour/bigint-filter-custom-parser.test.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/bigint-filter-custom-parser.test.ts
@@ -3,6 +3,7 @@ import { BigIntFilterModule, ClientSideRowModelModule, setupAgTestIds } from 'ag
 
 import {
     ColumnFilterHarness,
+    FilterDom,
     GridRows,
     TestGridsManager,
     asyncSetTimeout,
@@ -50,6 +51,19 @@ describe('BigInt Filter — custom bigintParser', () => {
         await asyncSetTimeout(0);
 
         expect(filter.getModel()).toEqual({ filterType: 'bigint', type: 'equals', filter: '255' });
+        // The input keeps the hex as typed while the model holds what the parser made of it.
+        await new FilterDom(api, 'hex typed, decimal model', { mode: 'column-filter', colId: 'val' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Equals"
+            input: "0xFF"
+            AND
+            operator: "Equals"
+            input: "" ⟨Filter...⟩
+            model:
+              filterType: "bigint"
+              type: "equals"
+              filter: "255"
+        `);
         await new GridRows(api, 'hex value filters to the matching bigint row').check(`
             ROOT id:ROOT_NODE_ID
             └── LEAF id:0 val:"255n"
@@ -80,6 +94,21 @@ describe('BigInt Filter — custom bigintParser', () => {
         await filter.setText('0xFF', 1);
         await asyncSetTimeout(0);
 
+        await new FilterDom(api, 'hex range, both bounds parsed', { mode: 'column-filter', colId: 'val' })
+            .checkFilterDom(`
+                COLUMN FILTER
+                operator: "Between"
+                input [0]: "0x10"
+                input [1]: "0xFF"
+                AND
+                operator: "Equals"
+                input: "" ⟨Filter...⟩
+                model:
+                  filterType: "bigint"
+                  type: "inRange"
+                  filter: "16"
+                  filterTo: "255"
+            `);
         expect(filter.getModel()).toEqual({
             filterType: 'bigint',
             type: 'inRange',
@@ -89,6 +118,56 @@ describe('BigInt Filter — custom bigintParser', () => {
         await new GridRows(api, 'hex range bounds filter to the row inside the range').check(`
             ROOT id:ROOT_NODE_ID
             └── LEAF id:2 val:"100n"
+        `);
+    });
+
+    test('an allowedCharPattern replaced at runtime reaches inputs built before the change', async () => {
+        const columnDefs = (allowedCharPattern: string) => [
+            {
+                field: 'val',
+                cellDataType: 'bigint' as const,
+                filter: 'agBigIntColumnFilter' as const,
+                filterParams: {
+                    debounceMs: 0,
+                    allowedCharPattern,
+                    bigintParser: (text: string | null) => (text == null || text.trim() === '' ? null : BigInt(text)),
+                },
+            },
+        ];
+
+        const api: GridApi = await gridsManager.createGridAndWait('grid3', {
+            // Decimal only, so the inputs built here reject the `x` and `F` a hex value needs.
+            columnDefs: columnDefs('[\\d]'),
+            rowData: [{ val: 255n }, { val: 16n }],
+        });
+
+        // Built before the swap: an input reads `allowedCharPattern` once, when it is created.
+        const filter = await ColumnFilterHarness.open(api, 'val');
+
+        api.setGridOption('columnDefs', columnDefs('[\\dxXa-fA-F]'));
+        await asyncSetTimeout(0);
+
+        await filter.selectOperator('Equals');
+        await filter.setText('0xFF', 0);
+        await asyncSetTimeout(0);
+
+        expect(filter.getModel()).toEqual({ filterType: 'bigint', type: 'equals', filter: '255' });
+        await new FilterDom(api, 'hex after allowedCharPattern swap', { mode: 'column-filter', colId: 'val' })
+            .checkFilterDom(`
+            COLUMN FILTER
+            operator: "Equals"
+            input: "0xFF"
+            AND
+            operator: "Equals"
+            input: "" ⟨Filter...⟩
+            model:
+              filterType: "bigint"
+              type: "equals"
+              filter: "255"
+        `);
+        await new GridRows(api, 'hex accepted after the pattern was replaced').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:0 val:"255n"
         `);
     });
 });

--- a/testing/behavioural/src/filters/filter-behaviour/date-filter-conditions.test.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/date-filter-conditions.test.ts
@@ -30,6 +30,20 @@ describe('Date Filter — conditions coverage', () => {
 
     const ASCENDING = [{ date: '2024-01-10' }, { date: '2024-03-15' }, { date: '2024-05-20' }, { date: '2024-07-04' }];
 
+    // Pinned as the odd one out: text, number and bigint all mark this element `role="presentation"`.
+    test('the condition body carries no role, unlike every other provided filter', async () => {
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [{ field: 'date', filter: 'agDateColumnFilter', filterParams: { debounceMs: 0 } }],
+            rowData: ASCENDING,
+        });
+
+        await ColumnFilterHarness.open(api, 'date');
+
+        const body = document.querySelector('.ag-filter-menu .ag-filter-body');
+        expect(body).not.toBeNull();
+        expect(body!.hasAttribute('role')).toBe(false);
+    });
+
     test('comparison operators over an ascending date dataset', async () => {
         const api: GridApi = await gridsManager.createGridAndWait('grid1', {
             columnDefs: [{ field: 'date', filter: 'agDateColumnFilter', filterParams: { debounceMs: 0 } }],
@@ -48,7 +62,7 @@ describe('Date Filter — conditions coverage', () => {
             input: "2024-03-15"
             AND
             operator: "Equals"
-            input: ""
+            input: "" ⟨yyyy-mm-dd⟩
             model:
               dateFrom: "2024-03-15"
               dateTo: null
@@ -116,7 +130,7 @@ describe('Date Filter — conditions coverage', () => {
             operator: "Blank"
             AND
             operator: "Equals"
-            input: ""
+            input: "" ⟨yyyy-mm-dd⟩
             model:
               dateFrom: null
               dateTo: null
@@ -167,7 +181,7 @@ describe('Date Filter — conditions coverage', () => {
             input [1]: "2024-07-04"
             AND
             operator: "Equals"
-            input: ""
+            input: "" ⟨yyyy-mm-dd⟩
             model:
               dateFrom: "2024-03-15"
               dateTo: "2024-07-04"
@@ -235,7 +249,7 @@ describe('Date Filter — conditions coverage', () => {
             COLUMN FILTER
             operator: "Between"
             input [0]: "2024-03-15"
-            input [1]: ""
+            input [1]: "" ⟨yyyy-mm-dd⟩
             model: null
         `);
         // Incomplete range → no model applied → all rows visible.
@@ -541,7 +555,7 @@ describe('Date Filter — conditions coverage', () => {
             input [1]: "2024-07-04"
             AND
             operator: "Equals"
-            input: ""
+            input: "" ⟨yyyy-mm-dd⟩
             model:
               dateFrom: "2024-03-15"
               dateTo: "2024-07-04"

--- a/testing/behavioural/src/filters/filter-behaviour/filter-manager-api.test.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/filter-manager-api.test.ts
@@ -10,6 +10,7 @@ import { SetFilterModule } from 'ag-grid-enterprise';
 
 import {
     ColumnFilterHarness,
+    FilterDom,
     GridRows,
     TestGridsManager,
     asyncSetTimeout,
@@ -253,6 +254,20 @@ describe('Filter Manager API — whole-grid model & external filters', () => {
         await asyncSetTimeout(0);
         expect(events.length).toBeGreaterThanOrEqual(1);
         expect(events.every((e) => e.source === 'columnFilter')).toBe(true);
+        // The popup holds what was typed, and the age filter it ANDs onto is a separate column's model.
+        await new FilterDom(api, 'athlete popup after editing', { mode: 'column-filter', colId: 'athlete' })
+            .checkFilterDom(`
+                COLUMN FILTER
+                operator: "Contains"
+                input: "Ryan"
+                AND
+                operator: "Contains"
+                input: "" ⟨Filter...⟩
+                model:
+                  filterType: "text"
+                  type: "contains"
+                  filter: "Ryan"
+            `);
         await new GridRows(api, 'filterChanged via columnFilter source').check(`
             ROOT id:ROOT_NODE_ID
             └── LEAF id:5 athlete:"Ryan Lochte" age:27 country:"United States"

--- a/testing/behavioural/src/filters/filter-behaviour/floating-filter-editing.test.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/floating-filter-editing.test.ts
@@ -1,5 +1,8 @@
-import type { GridApi } from 'ag-grid-community';
+import { fireEvent } from '@testing-library/dom';
+
+import type { GridApi, SuppressHeaderKeyboardEventParams } from 'ag-grid-community';
 import {
+    BigIntFilterModule,
     ClientSideRowModelModule,
     DateFilterModule,
     NumberFilterModule,
@@ -12,10 +15,12 @@ import { SetFilterModule } from 'ag-grid-enterprise';
 import {
     ColumnFilterHarness,
     FilterDom,
+    FloatingFilterHarness,
     GridRows,
     TestGridsManager,
     asyncSetTimeout,
     installFilterLayoutMock,
+    setNativeInputValue,
     uninstallFilterLayoutMock,
 } from '../../test-utils';
 
@@ -25,43 +30,22 @@ import {
  * read-only filters (set, range) show a summary, and clearing. Driven via GridApi + real DOM only.
  */
 
-/** The `.ag-floating-filter-body` for a column's floating filter row. */
-function floatingBody(api: GridApi, colId: string): HTMLElement {
-    const gridDiv = getGridElement(api)! as HTMLElement;
-    // The body carries `ag-floating-filter-body`, or `ag-floating-filter-full-body` when the
-    // floating-filter button is suppressed and the whole cell is the filter body.
-    const body = gridDiv.querySelector<HTMLElement>(
-        `.ag-header-cell.ag-floating-filter[col-id="${colId}"] .ag-floating-filter-body, ` +
-            `.ag-header-cell.ag-floating-filter[col-id="${colId}"] .ag-floating-filter-full-body`
-    );
-    if (!body) {
-        throw new Error(`No floating filter body for "${colId}"`);
-    }
-    return body;
-}
+const floatingBody = (api: GridApi, colId: string): HTMLElement => FloatingFilterHarness.get(api, colId).body;
 
-/** The single visible (non-hidden) input inside a column's floating filter. */
-function floatingInput(api: GridApi, colId: string): HTMLInputElement {
-    const inputs = Array.from(floatingBody(api, colId).querySelectorAll<HTMLInputElement>('input')).filter(
-        (input) => !input.closest('.ag-hidden')
-    );
-    if (!inputs.length) {
-        throw new Error(`No visible floating filter input for "${colId}"`);
-    }
-    return inputs[0];
-}
+const floatingInput = (api: GridApi, colId: string): HTMLInputElement => FloatingFilterHarness.get(api, colId).input();
 
-/** Sets a native input's value and fires input+change so the widget's listeners run. */
-function typeInto(input: HTMLInputElement, value: string): void {
-    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!;
-    setter.call(input, value);
-    input.dispatchEvent(new Event('input', { bubbles: true }));
-    input.dispatchEvent(new Event('change', { bubbles: true }));
-}
+const typeInto = setNativeInputValue;
 
 describe('Floating filter editing', () => {
     const gridsManager = new TestGridsManager({
-        modules: [ClientSideRowModelModule, TextFilterModule, NumberFilterModule, DateFilterModule, SetFilterModule],
+        modules: [
+            ClientSideRowModelModule,
+            TextFilterModule,
+            NumberFilterModule,
+            BigIntFilterModule,
+            DateFilterModule,
+            SetFilterModule,
+        ],
     });
 
     beforeAll(() => {
@@ -416,7 +400,111 @@ describe('Floating filter editing', () => {
         `);
     });
 
-    // --- Set (read-only floating filter, enterprise) ---
+    // Every range is complete: a half-filled one applies nothing, so the outcome assertion would be vacuous.
+    test.each([
+        ['country', 'agTextColumnFilter', 1, { filterType: 'text', type: 'contains', filter: 'ita' }, false],
+        ['age', 'agNumberColumnFilter', 2, { filterType: 'number', type: 'inRange', filter: 20, filterTo: 35 }, true],
+        [
+            'date',
+            'agDateColumnFilter',
+            2,
+            { filterType: 'date', type: 'inRange', dateFrom: '2024-01-01', dateTo: '2024-03-01' },
+            true,
+        ],
+        ['big', 'agBigIntColumnFilter', 1, { filterType: 'bigint', type: 'equals', filter: '9' }, false],
+    ])('%s mounts %s inputs, read-only or not', async (colId, filter, expectedInputs, model, readOnlyWhenApplied) => {
+        const api = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [{ field: colId, filter, filterParams: { debounceMs: 0 }, floatingFilter: true }],
+            rowData: [{ [colId]: '2024-01-01' }],
+        });
+        await asyncSetTimeout(0);
+
+        const floating = FloatingFilterHarness.get(api, colId);
+        expect(floating.allInputs()).toHaveLength(expectedInputs);
+        expect(floating.inputs()).toHaveLength(1);
+
+        await api.setColumnFilterModel(colId, model);
+        await api.onFilterChanged();
+        await asyncSetTimeout(0);
+
+        // Whatever the model, exactly one input is on show and the element count never moves. Which one it is
+        // does move: a two-value option has no single editor, so the summary takes the slot.
+        expect(floating.allInputs()).toHaveLength(expectedInputs);
+        expect(floating.inputs()).toHaveLength(1);
+        expect(floating.input().disabled).toBe(readOnlyWhenApplied);
+        expect(floating.input().value).not.toBe('');
+    });
+
+    test('a key pressed in a floating filter the grid holds no header focus for is not suppressed', async () => {
+        const api = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'country',
+                    filter: 'agTextColumnFilter',
+                    floatingFilter: true,
+                    filterParams: { debounceMs: 0 },
+                    suppressHeaderKeyboardEvent: () => false,
+                },
+            ],
+            rowData: [{ country: 'Italy' }, { country: 'Spain' }],
+        });
+        await asyncSetTimeout(0);
+
+        // Nothing has registered header focus, so there is no cell to describe to `suppressHeaderKeyboardEvent`.
+        const floating = FloatingFilterHarness.get(api, 'country');
+        // Suppression is `stopPropagation`, so an ancestor listener is what observes it not happening.
+        let reachedGrid = false;
+        getGridElement(api)!.addEventListener('keydown', () => {
+            reachedGrid = true;
+        });
+        // A listener that throws still propagates, so the throw itself is what has to be asserted on.
+        const errors: string[] = [];
+        const onError = (event: ErrorEvent) => {
+            errors.push(event.message);
+        };
+        window.addEventListener('error', onError);
+        try {
+            fireEvent.keyDown(floating.input(), { key: 'Enter' });
+            await asyncSetTimeout(0);
+        } finally {
+            window.removeEventListener('error', onError);
+        }
+        expect(errors).toEqual([]);
+        expect(reachedGrid).toBe(true);
+
+        await floating.setValue('ita');
+        await asyncSetTimeout(0);
+        expect(api.getColumnFilterModel('country')).toEqual({ filterType: 'text', type: 'contains', filter: 'ita' });
+    });
+
+    test('suppressHeaderKeyboardEvent is still consulted for a floating filter the grid holds no focus for', async () => {
+        const seen: SuppressHeaderKeyboardEventParams[] = [];
+        const api = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'country',
+                    filter: 'agTextColumnFilter',
+                    floatingFilter: true,
+                    filterParams: { debounceMs: 0 },
+                    suppressHeaderKeyboardEvent: (params) => {
+                        seen.push(params);
+                        return true;
+                    },
+                },
+            ],
+            rowData: [{ country: 'Italy' }, { country: 'Spain' }],
+        });
+        await asyncSetTimeout(0);
+
+        // Nothing has registered header focus, so the callback is described by the cell the key landed on
+        // rather than being skipped: a column that suppresses still gets its say.
+        fireEvent.keyDown(FloatingFilterHarness.get(api, 'country').input(), { key: 'Enter' });
+        await asyncSetTimeout(0);
+
+        expect(seen).toHaveLength(1);
+        expect(seen[0].headerRowIndex).toBe(1);
+        expect(seen[0].column).toBe(api.getColumn('country'));
+    });
 
     describe.each([false, true])('set (enableFilterHandlers: %s)', (enableFilterHandlers) => {
         test('read-only floating filter shows the selection summary and clears', async () => {

--- a/testing/behavioural/src/filters/filter-behaviour/group-filter.test.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/group-filter.test.ts
@@ -238,7 +238,7 @@ describe('Group Column Filter — agGroupColumnFilter', () => {
             input: "2020"
             AND
             operator: "Equals"
-            input: ""
+            input: "" ⟨Filter...⟩
             model:
               filterType: "number"
               type: "equals"
@@ -346,7 +346,7 @@ describe('Group Column Filter — agGroupColumnFilter', () => {
             input: "2020"
             AND
             operator: "Equals"
-            input: ""
+            input: "" ⟨Filter...⟩
             model:
               filterType: "number"
               type: "greaterThan"
@@ -396,7 +396,7 @@ describe('Group Column Filter — agGroupColumnFilter', () => {
             input: "an"
             AND
             operator: "Contains"
-            input: ""
+            input: "" ⟨Filter...⟩
             model:
               filterType: "text"
               type: "contains"

--- a/testing/behavioural/src/filters/filter-behaviour/number-filter-conditions.test.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/number-filter-conditions.test.ts
@@ -1,9 +1,11 @@
 import type { GridApi } from 'ag-grid-community';
-import { ClientSideRowModelModule, NumberFilterModule, setupAgTestIds } from 'ag-grid-community';
+import { ClientSideRowModelModule, NumberFilterModule, enableDevValidations, setupAgTestIds } from 'ag-grid-community';
 
 import {
+    ALL_SEVERITIES,
     ColumnFilterHarness,
     FilterDom,
+    FloatingFilterHarness,
     GridRows,
     TestGridsManager,
     asyncSetTimeout,
@@ -26,7 +28,11 @@ describe('Number Filter — conditions coverage', () => {
         installFilterLayoutMock();
     });
     afterAll(() => uninstallFilterLayoutMock());
-    afterEach(() => gridsManager.reset());
+    afterEach(() => {
+        gridsManager.reset();
+        vi.restoreAllMocks();
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [] });
+    });
 
     const MIXED = [{ val: -10 }, { val: -2.5 }, { val: 0 }, { val: 3 }, { val: 7.5 }, { val: 10 }];
 
@@ -48,7 +54,7 @@ describe('Number Filter — conditions coverage', () => {
             input: "3"
             AND
             operator: "Equals"
-            input: ""
+            input: "" ⟨Filter...⟩
             model:
               filterType: "number"
               type: "equals"
@@ -133,7 +139,7 @@ describe('Number Filter — conditions coverage', () => {
             input: "-2.5"
             AND
             operator: "Equals"
-            input: ""
+            input: "" ⟨Filter...⟩
             model:
               filterType: "number"
               type: "equals"
@@ -165,7 +171,7 @@ describe('Number Filter — conditions coverage', () => {
             input [1]: "7.5"
             AND
             operator: "Equals"
-            input: ""
+            input: "" ⟨Filter...⟩
             model:
               filterType: "number"
               type: "inRange"
@@ -225,7 +231,7 @@ describe('Number Filter — conditions coverage', () => {
             operator: "Blank"
             AND
             operator: "Equals"
-            input: ""
+            input: "" ⟨Filter...⟩
             model:
               filterType: "number"
               type: "blank"
@@ -423,7 +429,7 @@ describe('Number Filter — conditions coverage', () => {
             input: "1,5"
             AND
             operator: "Equals"
-            input: ""
+            input: "" ⟨Filter...⟩
             model:
               filterType: "number"
               type: "equals"
@@ -433,6 +439,71 @@ describe('Number Filter — conditions coverage', () => {
             ROOT id:ROOT_NODE_ID
             └── LEAF id:0 val:1.5
         `);
+    });
+
+    test('numberFormatter reaches both inputs, and they can hold it', async () => {
+        const numberFormatter = (value: number | null) => (value == null ? null : `${value} units`);
+        const numberParser = (text: string | null) => (text == null ? null : parseFloat(text));
+        const columnDef = {
+            field: 'val',
+            filter: 'agNumberColumnFilter' as const,
+            // `allowedCharPattern` is what admits the letters `5 units` needs; without it the input is numeric.
+            filterParams: { debounceMs: 0, allowedCharPattern: '\\d\\w\\s\\.\\-', numberFormatter, numberParser },
+        };
+        const rowData = [{ val: 5 }, { val: 7 }];
+
+        const floatingApi: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [{ ...columnDef, floatingFilter: true }],
+            rowData,
+        });
+        await floatingApi.setColumnFilterModel('val', { filterType: 'number', type: 'equals', filter: 5 });
+        floatingApi.onFilterChanged();
+        await asyncSetTimeout(0);
+
+        const floatingInput = FloatingFilterHarness.get(floatingApi, 'val').inputs()[0];
+        expect(floatingInput.type).toBe('text');
+        expect(floatingInput.value).toBe('5 units');
+
+        const api: GridApi = await gridsManager.createGridAndWait('grid2', { columnDefs: [columnDef], rowData });
+        await api.setColumnFilterModel('val', { filterType: 'number', type: 'equals', filter: 5 });
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+
+        const filter = await ColumnFilterHarness.open(api, 'val');
+        expect(filter.inputs('text')[0].value).toBe('5 units');
+
+        // Read back through the same text field: what the formatter wrote still parses to the number.
+        await filter.setText('7 units', 0);
+        await asyncSetTimeout(0);
+        expect(filter.getModel()).toEqual({ filterType: 'number', type: 'equals', filter: 7 });
+        await new GridRows(api, 'formatted number filter rows').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:1 val:7
+        `);
+    });
+
+    test('a read-only floating filter keeps its summary, which is not one value to read back', async () => {
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'val',
+                    filter: 'agNumberColumnFilter',
+                    floatingFilter: true,
+                    filterParams: {
+                        debounceMs: 0,
+                        readOnly: true,
+                        // Leads with text, so nothing reads the summary back as the number inside it.
+                        numberFormatter: (value: number | null) => (value == null ? null : `units: ${value}`),
+                    },
+                },
+            ],
+            rowData: [{ val: 5 }, { val: 7 }],
+        });
+        await api.setColumnFilterModel('val', { filterType: 'number', type: 'equals', filter: 5 });
+        await api.onFilterChanged();
+        await asyncSetTimeout(0);
+
+        expect(FloatingFilterHarness.get(api, 'val').input().value).toBe('units: 5');
     });
 
     test('two conditions joined with AND', async () => {
@@ -558,12 +629,220 @@ describe('Number Filter — conditions coverage', () => {
             input [1]: "7.5"
             AND
             operator: "Equals"
-            input: ""
+            input: "" ⟨Filter...⟩
             model:
               filterType: "number"
               type: "inRange"
               filter: -2.5
               filterTo: 7.5
         `);
+    });
+
+    test('a combined model with no conditions is tolerated rather than throwing', async () => {
+        // Deliberate: a combined model without `conditions` is reported as warning #77.
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [77] });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [{ field: 'val', filter: 'agNumberColumnFilter', filterParams: { debounceMs: 0 } }],
+            rowData: MIXED,
+        });
+
+        const filter = await ColumnFilterHarness.open(api, 'val');
+        await filter.selectOperator('Equals');
+        await filter.setNumber(3, 0);
+        await asyncSetTimeout(0);
+
+        // Hand-written models reach the grid: a join operator with no conditions must not break filtering,
+        // and the open panel must still follow it.
+        await api.setColumnFilterModel('val', { filterType: 'number', operator: 'AND' } as any);
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+
+        expect(warnSpy.mock.calls.flat().join(' ')).toContain('warning #77');
+        expect(api.getColumnFilterModel('val')).toEqual({ filterType: 'number', operator: 'AND' });
+        await new FilterDom(api, 'conditionless combined model panel', { colId: 'val' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Equals"
+            input: "" ⟨Filter...⟩
+            model:
+              filterType: "number"
+              operator: "AND"
+        `);
+        await new GridRows(api, 'conditionless combined model matches every row').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 val:-10
+            ├── LEAF id:1 val:-2.5
+            ├── LEAF id:2 val:0
+            ├── LEAF id:3 val:3
+            ├── LEAF id:4 val:7.5
+            └── LEAF id:5 val:10
+        `);
+
+        // A well-formed model applied over it still takes effect.
+        await api.setColumnFilterModel('val', { filterType: 'number', type: 'greaterThan', filter: 7 });
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+
+        await new GridRows(api, 'valid model applied after the malformed one').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:4 val:7.5
+            └── LEAF id:5 val:10
+        `);
+    });
+
+    test('a cell no number can be compared with is excluded rather than ordered against', async () => {
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [{ field: 'val', filter: 'agNumberColumnFilter', filterParams: { debounceMs: 0 } }],
+            rowData: [{ val: 1 }, { val: 'N/A' }, { val: 'abc' }, { val: 9 }],
+        });
+
+        // The ordering operators are where a non-coercing check would differ, letting every such row through.
+        await api.setColumnFilterModel('val', { filterType: 'number', type: 'lessThan', filter: 5 });
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+        await new GridRows(api, 'lessThan skips the uncomparable cells').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:0 val:1
+        `);
+
+        await api.setColumnFilterModel('val', { filterType: 'number', type: 'greaterThan', filter: 5 });
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+        await new GridRows(api, 'greaterThan skips them too').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:3 val:9
+        `);
+
+        // `notEqual` is the one an uncomparable cell still passes, as nothing it holds equals the filter value.
+        await api.setColumnFilterModel('val', { filterType: 'number', type: 'notEqual', filter: 1 });
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+        await new GridRows(api, 'notEqual keeps them').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:1 val:"Invalid Number"
+            ├── LEAF id:2 val:"Invalid Number"
+            └── LEAF id:3 val:9
+        `);
+    });
+
+    test('a numberParser replaced at runtime is used by inputs built before the change', async () => {
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'val',
+                    filter: 'agNumberColumnFilter',
+                    filterParams: {
+                        debounceMs: 0,
+                        allowedCharPattern: '\\d\\-\\,\\.',
+                        // Reads "1,5" as one-and-a-half.
+                        numberParser: (text: string | null) =>
+                            text == null || text === '' ? null : Number(text.replace(',', '.')),
+                    },
+                },
+            ],
+            rowData: [{ val: 1.5 }, { val: 15 }],
+        });
+
+        // Building the condition's inputs is what captures the params, so open before swapping them.
+        const filter = await ColumnFilterHarness.open(api, 'val');
+
+        api.setGridOption('columnDefs', [
+            {
+                field: 'val',
+                filter: 'agNumberColumnFilter',
+                filterParams: {
+                    debounceMs: 0,
+                    allowedCharPattern: '\\d\\-\\,\\.',
+                    // Reads "1,5" as fifteen: the comma is a thousands separator.
+                    numberParser: (text: string | null) =>
+                        text == null || text === '' ? null : Number(text.replace(',', '')),
+                },
+            },
+        ]);
+        await asyncSetTimeout(0);
+
+        await filter.setText('1,5', 0);
+        await asyncSetTimeout(0);
+
+        expect(api.getColumnFilterModel('val')).toEqual({ filterType: 'number', type: 'equals', filter: 15 });
+        await new FilterDom(api, 'input read by the replaced parser', { colId: 'val' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Equals"
+            input: "1,5"
+            AND
+            operator: "Equals"
+            input: "" \u27e8Filter...\u27e9
+            model:
+              filterType: "number"
+              type: "equals"
+              filter: 15
+        `);
+        await new GridRows(api, 'the replaced numberParser decides which row matches').check(`
+            ROOT id:ROOT_NODE_ID
+            \u2514\u2500\u2500 LEAF id:1 val:15
+        `);
+    });
+
+    test('a numberFormatter added at runtime reaches inputs built before it', async () => {
+        const numberParser = (text: string | null) =>
+            text == null || text === '' ? null : Number(String(text).replace(/,/g, ''));
+        const numberFormatter = (value: number | null) => (value == null ? null : value.toLocaleString('en-US'));
+        const allowedCharPattern = '\\d\\,\\.\\-';
+
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                { field: 'val', filter: 'agNumberColumnFilter', filterParams: { debounceMs: 0, allowedCharPattern } },
+            ],
+            rowData: [{ val: 5 }, { val: 1500 }],
+        });
+        const filter = await ColumnFilterHarness.open(api, 'val');
+
+        api.setGridOption('columnDefs', [
+            {
+                field: 'val',
+                filter: 'agNumberColumnFilter',
+                filterParams: { debounceMs: 0, allowedCharPattern, numberParser, numberFormatter },
+            },
+        ]);
+        await asyncSetTimeout(0);
+
+        await api.setColumnFilterModel('val', { filterType: 'number', type: 'equals', filter: 1500 });
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+
+        expect(filter.inputs('text', 0)[0].value).toBe('1,500');
+    });
+
+    test('a colDef refresh keeps text the parser cannot read yet', async () => {
+        // Declared inline, as a framework wrapper does, so every refresh passes new function identities.
+        const makeColumnDefs = () => [
+            {
+                field: 'val',
+                filter: 'agNumberColumnFilter',
+                filterParams: {
+                    debounceMs: 0,
+                    allowedCharPattern: '\\d\\-\\.',
+                    numberParser: (text: string | null) => (text == null || text === '' ? null : Number(text)),
+                    numberFormatter: (value: number | null) => (value == null ? null : String(value)),
+                },
+            },
+        ];
+
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: makeColumnDefs(),
+            rowData: [{ val: -5 }, { val: 5 }],
+        });
+        const filter = await ColumnFilterHarness.open(api, 'val');
+        await filter.selectOperator('Equals');
+        await filter.setText('-');
+
+        api.setGridOption('columnDefs', makeColumnDefs());
+        await asyncSetTimeout(0);
+
+        expect(filter.inputs('text', 0)[0].value).toBe('-');
+        await filter.setText('-5');
+        await asyncSetTimeout(0);
+        expect(filter.getModel()).toEqual({ filterType: 'number', type: 'equals', filter: -5 });
     });
 });

--- a/testing/behavioural/src/filters/filter-behaviour/quick-filter-extended.test.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/quick-filter-extended.test.ts
@@ -196,7 +196,7 @@ describe('Quick Filter — extended coverage', () => {
             input: "a"
             AND
             operator: "Contains"
-            input: ""
+            input: "" ⟨Filter...⟩
             model:
               filterType: "text"
               type: "contains"

--- a/testing/behavioural/src/filters/filter-behaviour/text-filter-conditions-buttons-and-model.test.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/text-filter-conditions-buttons-and-model.test.ts
@@ -89,7 +89,7 @@ describe('Text Filter — buttons & model round-trip', () => {
         await new FilterDom(api, 'buttons after clear', { colId: 'name' }).checkFilterDom(`
             COLUMN FILTER
             operator: "Contains"
-            input: ""
+            input: "" ⟨Filter...⟩
             buttons: Apply | Clear | Reset
             model:
               filterType: "text"
@@ -113,7 +113,7 @@ describe('Text Filter — buttons & model round-trip', () => {
         await new FilterDom(api, 'buttons after reset', { colId: 'name' }).checkFilterDom(`
             COLUMN FILTER
             operator: "Contains"
-            input: ""
+            input: "" ⟨Filter...⟩
             buttons: Apply | Clear | Reset
             model: null
         `);

--- a/testing/behavioural/src/filters/filter-behaviour/text-filter-conditions.test.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/text-filter-conditions.test.ts
@@ -183,7 +183,7 @@ describe('Text Filter — conditions coverage', () => {
         await new FilterDom(api, 'incomplete condition panel', { colId: 'name' }).checkFilterDom(`
             COLUMN FILTER
             operator: "Contains"
-            input: ""
+            input: "" ⟨Filter...⟩
             model: null
         `);
         await new GridRows(api, 'incomplete condition rows').check(`
@@ -389,6 +389,91 @@ describe('Text Filter — conditions coverage', () => {
             ROOT id:ROOT_NODE_ID
             ├── LEAF id:0 name:"Apple"
             └── LEAF id:2 name:"Pineapple"
+        `);
+    });
+
+    test('a model mutated in place and re-applied filters on its new value, not its old one', async () => {
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [{ field: 'name', filter: 'agTextColumnFilter', filterParams: { debounceMs: 0 } }],
+            rowData: [{ name: 'Bolt' }, { name: 'Ng' }, { name: 'Ada' }],
+        });
+
+        const model: any = { filterType: 'text', type: 'contains', filter: 'bolt' };
+        await api.setColumnFilterModel('name', model);
+        api.onFilterChanged();
+        await new GridRows(api, 'contains bolt').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:0 name:"Bolt"
+        `);
+
+        // Re-applied with the same object identity, so nothing but the act of applying signals the change.
+        model.filter = 'ng';
+        await api.setColumnFilterModel('name', model);
+        api.onFilterChanged();
+        await new GridRows(api, 'contains ng after in-place edit').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:1 name:"Ng"
+        `);
+    });
+
+    test('the condition body is presentational, so it adds no semantics around the inputs', async () => {
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [{ field: 'name', filter: 'agTextColumnFilter', filterParams: { debounceMs: 0 } }],
+            rowData: [{ name: 'Apple' }],
+        });
+
+        await ColumnFilterHarness.open(api, 'name');
+
+        const body = document.querySelector('.ag-filter-menu .ag-filter-body');
+        expect(body?.getAttribute('role')).toBe('presentation');
+    });
+
+    test('trimInput:true also trims the values a Custom Filter Option takes', async () => {
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'name',
+                    filter: 'agTextColumnFilter',
+                    filterParams: {
+                        debounceMs: 0,
+                        maxNumConditions: 1,
+                        trimInput: true,
+                        filterOptions: [
+                            {
+                                displayKey: 'startsWithCustom',
+                                displayName: 'Starts With (custom)',
+                                numberOfInputs: 2,
+                                predicate: (filterValues: any[], cellValue: any) =>
+                                    cellValue != null &&
+                                    filterValues.some((filterValue) => String(cellValue).startsWith(filterValue)),
+                            },
+                        ],
+                    },
+                },
+            ],
+            rowData: [{ name: 'Apple' }, { name: 'Banana' }, { name: 'Pineapple' }],
+        });
+
+        const filter = await ColumnFilterHarness.open(api, 'name');
+        await filter.setText('  App  ');
+        await filter.setText('  Ban  ', 1);
+        await asyncSetTimeout(0);
+
+        await new FilterDom(api, 'custom option trimInput panel', { colId: 'name' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Starts With (custom)"
+            input [0]: "App"
+            input [1]: "Ban"
+            model:
+              filterType: "text"
+              type: "startsWithCustom"
+              filter: "App"
+              filterTo: "Ban"
+        `);
+        await new GridRows(api, 'custom option trimInput rows').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 name:"Apple"
+            └── LEAF id:1 name:"Banana"
         `);
     });
 

--- a/testing/behavioural/src/filters/filter-behaviour/toolPanelHarness.ts
+++ b/testing/behavioural/src/filters/filter-behaviour/toolPanelHarness.ts
@@ -9,6 +9,7 @@ import {
     firePointerLikeClick,
     nudgeVirtualList,
     openPicker,
+    setNativeInputValue,
 } from '../../test-utils';
 
 /**
@@ -17,14 +18,6 @@ import {
  */
 
 const PANEL_SELECTOR = '.ag-filter-toolpanel';
-
-/** Sets a native input value and fires the input/change events the widgets listen for. */
-function setNativeInputValue(input: HTMLInputElement, value: string): void {
-    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!;
-    setter.call(input, value);
-    input.dispatchEvent(new Event('input', { bubbles: true }));
-    input.dispatchEvent(new Event('change', { bubbles: true }));
-}
 
 function textOf(el: Element | null | undefined): string {
     return el?.textContent?.trim() ?? '';

--- a/testing/behavioural/src/filters/filter-option-switching.test.ts
+++ b/testing/behavioural/src/filters/filter-option-switching.test.ts
@@ -1,0 +1,207 @@
+import { fireEvent, waitFor } from '@testing-library/dom';
+
+import type { GetLocaleTextParams, GridApi, IFilterPlaceholderFunctionParams } from 'ag-grid-community';
+import {
+    BigIntFilterModule,
+    ClientSideRowModelModule,
+    DateFilterModule,
+    LocaleModule,
+    NumberFilterModule,
+    TextFilterModule,
+    getGridElement,
+    setupAgTestIds,
+} from 'ag-grid-community';
+
+import {
+    ColumnFilterHarness,
+    FilterDom,
+    FloatingFilterHarness,
+    GridRows,
+    TestGridsManager,
+    asyncSetTimeout,
+    installFilterLayoutMock,
+    uninstallFilterLayoutMock,
+} from '../test-utils';
+
+/**
+ * Cases the provided filters get wrong when an option's arity or the applied model diverges from the
+ * column's default option. Driven through the public API and real DOM only.
+ */
+describe('Filter option switching and floating filter sync', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [
+            ClientSideRowModelModule,
+            TextFilterModule,
+            NumberFilterModule,
+            BigIntFilterModule,
+            DateFilterModule,
+            LocaleModule,
+        ],
+    });
+
+    beforeAll(() => {
+        setupAgTestIds();
+        installFilterLayoutMock();
+    });
+    afterAll(() => uninstallFilterLayoutMock());
+    afterEach(() => gridsManager.reset());
+
+    const datePicker = (api: GridApi) =>
+        getGridElement(api)!.querySelector<HTMLInputElement>(
+            '.ag-header-cell.ag-floating-filter[col-id="date"] input[type="date"]'
+        )!;
+
+    test('a date picked in the floating filter applies even when an apply button is configured', async () => {
+        const api = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'date',
+                    filter: 'agDateColumnFilter',
+                    floatingFilter: true,
+                    filterParams: { buttons: ['apply'] },
+                },
+            ],
+            rowData: [{ date: new Date(2024, 0, 1) }, { date: new Date(2024, 5, 1) }],
+        });
+        await asyncSetTimeout(0);
+
+        const picker = datePicker(api);
+        fireEvent.input(picker, { target: { value: '2024-01-01' } });
+        fireEvent.change(picker, { target: { value: '2024-01-01' } });
+
+        // A picker reports a whole date, so there is no half-typed value for the apply button to wait out.
+        await waitFor(() =>
+            expect(api.getColumnFilterModel('date')).toEqual({
+                filterType: 'date',
+                type: 'equals',
+                dateFrom: '2024-01-01',
+                dateTo: null,
+            })
+        );
+        await new GridRows(api, 'a date picked with an apply button configured').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:0 date:"2024-01-01"
+        `);
+    });
+
+    test.each([
+        ['agTextColumnFilter', 'Ada', { filterType: 'text', type: 'contains', filter: 'Ada' }],
+        ['agNumberColumnFilter', '25', { filterType: 'number', type: 'equals', filter: 25 }],
+        ['agBigIntColumnFilter', '25', { filterType: 'bigint', type: 'equals', filter: '25' }],
+    ])(
+        'a typed %s floating filter waits for Enter when an apply button is configured',
+        async (filter, typed, applied) => {
+            const api = await gridsManager.createGridAndWait('grid1', {
+                columnDefs: [{ field: 'value', filter, floatingFilter: true, filterParams: { buttons: ['apply'] } }],
+                rowData: [{ value: 'Ada' }, { value: 'Bolt' }],
+            });
+            await asyncSetTimeout(0);
+
+            const floating = FloatingFilterHarness.get(api, 'value');
+            await floating.setValue(typed);
+            // Typing is a value on its way to being finished, which is what the apply button waits out.
+            await asyncSetTimeout(0);
+            expect(api.getColumnFilterModel('value')).toBeNull();
+
+            fireEvent.keyDown(floating.input(), { key: 'Enter' });
+            await waitFor(() => expect(api.getColumnFilterModel('value')).toEqual(applied));
+        }
+    );
+
+    test('a floating filter showing a read-only summary keeps it when the column definitions change', async () => {
+        const api = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                { field: 'date', filter: 'agDateColumnFilter', floatingFilter: true, filterParams: { debounceMs: 0 } },
+            ],
+            rowData: [{ date: new Date(2024, 0, 1) }, { date: new Date(2024, 5, 1) }],
+        });
+        await asyncSetTimeout(0);
+
+        await api.setColumnFilterModel('date', {
+            filterType: 'date',
+            type: 'inRange',
+            dateFrom: '2024-01-01',
+            dateTo: '2024-03-01',
+        });
+        await api.onFilterChanged();
+
+        const floating = FloatingFilterHarness.get(api, 'date');
+        await waitFor(() => expect(floating.inputs()[0].value).toBe('2024-01-01-2024-03-01'));
+        expect(datePicker(api).closest('.ag-hidden')).toBeTruthy();
+
+        api.setGridOption('columnDefs', [
+            {
+                field: 'date',
+                filter: 'agDateColumnFilter',
+                floatingFilter: true,
+                filterParams: { debounceMs: 0, filterOptions: ['equals', 'greaterThan', 'inRange'] },
+            },
+        ]);
+        await asyncSetTimeout(0);
+
+        // `inRange` takes two values, so the header cell shows the summary rather than an editor - whatever
+        // the column's default option happens to be.
+        const after = FloatingFilterHarness.get(api, 'date');
+        expect(after.inputs()[0].value).toBe('2024-01-01-2024-03-01');
+        expect(datePicker(api).closest('.ag-hidden')).toBeTruthy();
+        expect(api.getColumnFilterModel('date')).toEqual({
+            filterType: 'date',
+            type: 'inRange',
+            dateFrom: '2024-01-01',
+            dateTo: '2024-03-01',
+        });
+        await new FilterDom(api, 'summary kept across a colDef change', { colId: 'date' }).checkFilterDom(`
+            FLOATING FILTER date
+            input: "2024-01-01-2024-03-01" ⊘
+            active: true
+            model:
+              filterType: "date"
+              type: "inRange"
+              dateFrom: "2024-01-01"
+              dateTo: "2024-03-01"
+        `);
+    });
+
+    test('`filterPlaceholder` is given the custom option localised, as the dropdown label is', async () => {
+        const seen: { filterOptionKey: string; filterOption: string }[] = [];
+        const api = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'age',
+                    filter: 'agNumberColumnFilter',
+                    filterParams: {
+                        filterOptions: [
+                            'equals',
+                            {
+                                displayKey: 'withinOf',
+                                displayName: 'Within Of',
+                                numberOfInputs: 1,
+                                predicate: ([target]: unknown[], cellValue: unknown) => cellValue === target,
+                            },
+                        ],
+                        filterPlaceholder: ({
+                            filterOptionKey,
+                            filterOption,
+                            placeholder,
+                        }: IFilterPlaceholderFunctionParams) => {
+                            seen.push({ filterOptionKey, filterOption });
+                            return placeholder;
+                        },
+                        debounceMs: 0,
+                        maxNumConditions: 1,
+                    },
+                },
+            ],
+            // The `displayKey` is the locale key, so an override reaches the dropdown and the callback alike.
+            getLocaleText: ({ key, defaultValue }: GetLocaleTextParams) =>
+                key === 'withinOf' ? 'Dentro De' : defaultValue,
+            rowData: [{ age: 25 }, { age: 40 }],
+        });
+
+        const harness = await ColumnFilterHarness.open(api, 'age');
+        expect(await harness.operatorOptions()).toEqual(['Equals', 'Dentro De']);
+        await harness.selectOperator('Dentro De');
+
+        expect(seen).toContainEqual({ filterOptionKey: 'withinOf', filterOption: 'Dentro De' });
+    });
+});

--- a/testing/behavioural/src/filters/number-filter-range-validation.test.ts
+++ b/testing/behavioural/src/filters/number-filter-range-validation.test.ts
@@ -12,6 +12,7 @@ import {
 
 import {
     ColumnFilterHarness,
+    FilterDom,
     GridColumns,
     GridRows,
     TestGridsManager,
@@ -163,6 +164,14 @@ describe('Number Range Filter', () => {
         expect(filter.input('number', 0).validity.valid).toBe(false);
         expect(filter.input('number', 0).validationMessage).toBe('Must be less than 1');
         expect(filter.input('number', 1).validationMessage).toBe('');
+
+        await new FilterDom(api, 'message on the touched input', { colId: 'gold' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Between"
+            input [0]: "6" ✗ "Must be less than 1"
+            input [1]: "1"
+            model: null
+        `);
     });
 
     test('a from value equal to the to value is invalid', async () => {
@@ -185,6 +194,13 @@ describe('Number Range Filter', () => {
         // silently matching nothing.
         expect(filter.input('number', 1).validity.valid).toBe(false);
         expect(filter.getModel()).toBeNull();
+        await new FilterDom(api, 'equal range bounds', { colId: 'gold' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Between"
+            input [0]: "3"
+            input [1]: "3" ✗ "Must be greater than 3"
+            model: null
+        `);
         await new GridRows(api, 'equal range bounds leave rows unfiltered').check(`
             ROOT id:ROOT_NODE_ID
             ├── LEAF id:0 gold:2
@@ -251,5 +267,144 @@ describe('Number Range Filter', () => {
 
         expect(filter.input('number', 1).validity.valid).toBe(false);
         expect(filter.input('number', 1).validationMessage).toBe('Must be greater than 8');
+    });
+
+    test('cancelling back to an applied range clears the message the edit left behind', async () => {
+        const api = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'gold',
+                    filter: 'agNumberColumnFilter',
+                    filterParams: { filterOptions: ['inRange'], buttons: ['apply', 'cancel'] },
+                },
+            ],
+            rowData: [{ gold: 2 }, { gold: 8 }, { gold: 3 }],
+        });
+
+        const filter = await ColumnFilterHarness.open(api, 'gold');
+        await filter.setNumber(1, 0);
+        await filter.setNumber(5, 1);
+        await filter.apply();
+
+        // Edit the applied range the wrong way round, then abandon the edit.
+        await filter.setNumber(0, 1);
+        expect(filter.input('number', 1).validity.valid).toBe(false);
+
+        await filter.cancel();
+
+        // The inputs hold the applied range again, so the message it replaced is gone.
+        expect(filter.input('number', 1).validity.valid).toBe(true);
+        expect(filter.input('number', 0).validity.valid).toBe(true);
+
+        await new FilterDom(api, 'cancelled back to the applied range', { colId: 'gold' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Between"
+            input [0]: "1"
+            input [1]: "5"
+            AND
+            operator: "Between"
+            input [0]: "" ⟨From⟩
+            input [1]: "" ⟨To⟩
+            buttons: Apply | Cancel
+            model:
+              filterType: "number"
+              type: "inRange"
+              filter: 1
+              filterTo: 5
+        `);
+    });
+
+    test('a condition still validates its own inputs once an earlier condition has been dropped', async () => {
+        const userSession = userEvent.setup();
+        const api = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'gold',
+                    filter: 'agNumberColumnFilter',
+                    filterParams: { filterOptions: ['inRange'], maxNumConditions: 4 },
+                },
+            ],
+            rowData: [{ gold: 2 }, { gold: 8 }, { gold: 3 }],
+        });
+
+        const filter = await ColumnFilterHarness.open(api, 'gold');
+        await filter.setNumber(1, 0);
+        await filter.setNumber(2, 1);
+        await filter.setNumber(3, 2);
+        await filter.setNumber(4, 3);
+        await filter.setNumber(5, 4);
+        await filter.setNumber(6, 5);
+
+        // Emptying the middle condition makes it incomplete, so closing the popup drops it and the
+        // third condition slides down into its place.
+        await filter.setNumber('', 2);
+        await filter.setNumber('', 3);
+        const gridDiv = getGridElement(api)! as HTMLElement;
+        await userSession.click(getByTestId(gridDiv, agTestIdFor.cell('2', 'gold')));
+
+        const reopened = await ColumnFilterHarness.open(api, 'gold');
+        await waitFor(() => expect(reopened.inputs('number', 1)).toHaveLength(2));
+
+        await reopened.setNumber(9, 2);
+        await reopened.setNumber(1, 3);
+
+        expect(reopened.input('number', 3).validity.valid).toBe(false);
+        expect(reopened.input('number', 3).validationMessage).toBe('Must be greater than 9');
+        await new FilterDom(api, 'range validated after a condition was dropped', { colId: 'gold' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Between"
+            input [0]: "1"
+            input [1]: "2"
+            AND
+            operator: "Between"
+            input [0]: "9"
+            input [1]: "1" ✗ "Must be greater than 9"
+            AND
+            operator: "Between"
+            input [0]: "" ⟨From⟩
+            input [1]: "" ⟨To⟩
+            model:
+              filterType: "number"
+              operator: "AND"
+              conditions:
+                - filterType: "number"
+                  type: "inRange"
+                  filter: 1
+                  filterTo: 2
+                - filterType: "number"
+                  type: "inRange"
+                  filter: 5
+                  filterTo: 6
+        `);
+    });
+
+    test('a `colDef` refresh keeps the value an input showing a range error holds', async () => {
+        const columnDefs = (numberParser: (value: string | null) => number | null) => [
+            {
+                field: 'gold',
+                filter: 'agNumberColumnFilter' as const,
+                filterParams: { debounceMs: 0, filterOptions: ['inRange'], numberParser },
+            },
+        ];
+
+        const api = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: columnDefs((value) => (value == null ? null : Number(value))),
+            rowData: [{ gold: 2 }, { gold: 8 }],
+        });
+
+        const filter = await ColumnFilterHarness.open(api, 'gold');
+        await filter.setNumber(9, 0);
+        await filter.setNumber(1, 1);
+        expect(filter.input('number', 1).validity.valid).toBe(false);
+
+        // A new parser identity re-renders every input, and the invalid one still holds what the user typed.
+        api.setGridOption(
+            'columnDefs',
+            columnDefs((value) => (value == null ? null : Number(value)))
+        );
+        await asyncSetTimeout(0);
+
+        expect(filter.input('number', 0).value).toBe('9');
+        expect(filter.input('number', 1).value).toBe('1');
     });
 });

--- a/testing/behavioural/src/test-utils/filters/advancedFilterBuilderHarness.ts
+++ b/testing/behavioural/src/test-utils/filters/advancedFilterBuilderHarness.ts
@@ -5,13 +5,15 @@ import type { GridApi } from 'ag-grid-community';
 import { DragEventDispatcher } from '../drag-n-drop/drag-event-dispatcher';
 import { asyncSetTimeout } from '../node-utils';
 import { firePointerLikeClick } from '../test-utils-events';
-import { nudgeVirtualList, openPicker, selectRichSelectRow } from '../widgets/dropdowns';
+import { getRichSelectRowLabels, nudgeVirtualList, openPicker, selectRichSelectRow } from '../widgets/dropdowns';
+import { setNativeInputValue } from '../widgets/inputs';
 
 /** Row height the builder virtual list is created with (`setRowHeight(40)`); used to target drag drops. */
 const BUILDER_ROW_HEIGHT = 40;
 
 const BUILDER = '.ag-advanced-filter-builder';
 const VIRTUAL_LIST_ITEM = '.ag-advanced-filter-builder-virtual-list-item';
+const RICH_SELECT_ITEM = '.ag-rich-select-virtual-list-item';
 const ITEM_WRAPPER = '.ag-advanced-filter-builder-item-wrapper';
 const COLUMN_PILL = '.ag-advanced-filter-builder-column-pill';
 const OPTION_PILL = '.ag-advanced-filter-builder-option-pill';
@@ -83,30 +85,61 @@ export class AdvancedFilterBuilderHarness {
         return this;
     }
 
+    /** Opens the operator pill on `item` and reads the options it offers, in order. */
+    public async operatorOptions(item: HTMLElement): Promise<string[]> {
+        const pill = await this.openPillPicker(item, OPTION_PILL);
+        try {
+            // Both polled together: the list virtualises, so a partial render is a state to wait out rather
+            // than an answer, and a viewport-sized subset would let an absence assertion pass vacuously.
+            return await waitFor(() => {
+                const setSize = Number(document.querySelector(RICH_SELECT_ITEM)?.getAttribute('aria-setsize'));
+                const options = getRichSelectRowLabels();
+                if (!options.length || options.length < setSize) {
+                    throw new Error(`Only ${options.length} of ${setSize || '?'} operator rows rendered`);
+                }
+                return options;
+            });
+        } finally {
+            // Leave the pill closed, so a following selection re-opens it rather than toggling it shut.
+            pill.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+            await asyncSetTimeout(0);
+        }
+    }
+
     private async selectPill(item: HTMLElement, pillSelector: string, displayName: string): Promise<void> {
         await this.openPillPicker(item, pillSelector);
         await selectRichSelectRow(displayName);
     }
 
-    /** Opens the pill's rich-select and waits for its rows to render. */
-    private async openPillPicker(item: HTMLElement, pillSelector: string): Promise<void> {
-        // The row's own identity, not the caller's element or its DOM index: a re-render replaces the row
-        // (leaving a detached tree that can be clicked forever) and only renders the rows in view.
+    /**
+     * The row currently rendered for `item`, resolved by its own identity rather than the caller's element:
+     * committing an edit re-renders the row, leaving a detached tree that can be clicked forever.
+     */
+    private liveItem(item: HTMLElement): HTMLElement {
         const posInSet = item.closest(VIRTUAL_LIST_ITEM)?.getAttribute('aria-posinset');
         if (!posInSet) {
             throw new Error('Builder item is not one of the rendered rows');
         }
+        const live = document.querySelector<HTMLElement>(`${VIRTUAL_LIST_ITEM}[aria-posinset="${posInSet}"]`);
+        if (!live) {
+            throw new Error(`Builder row ${posInSet} is no longer rendered`);
+        }
+        return live;
+    }
+
+    /** Opens the pill's rich-select, waits for its rows to render, and returns the pill it opened. */
+    private async openPillPicker(item: HTMLElement, pillSelector: string): Promise<HTMLElement> {
+        const posInSet = this.liveItem(item).getAttribute('aria-posinset');
+        const livePillSelector = `${VIRTUAL_LIST_ITEM}[aria-posinset="${posInSet}"] ${pillSelector}`;
         // Re-clicked, not just awaited: the pill defers showPicker(), so a click swallowed by a re-render
         // needs another - waiting alone never opens a picker that was never told to open.
-        await waitFor(async () => {
-            if (document.querySelector('.ag-rich-select-list')) {
-                return;
-            }
-            const livePill = document.querySelector<HTMLElement>(
-                `${VIRTUAL_LIST_ITEM}[aria-posinset="${posInSet}"] ${pillSelector}`
-            );
+        return waitFor(async () => {
+            const livePill = document.querySelector<HTMLElement>(livePillSelector);
             if (!livePill) {
                 throw new Error(`Pill "${pillSelector}" not found on builder item`);
+            }
+            if (document.querySelector('.ag-rich-select-list')) {
+                return livePill;
             }
             await openPicker(livePill);
             await this.ensureItemsRendered();
@@ -127,19 +160,24 @@ export class AdvancedFilterBuilderHarness {
         return this;
     }
 
-    /** Clicks the value pill on `item` and returns the editor input it opens. */
-    public async openValueEditor(item: HTMLElement): Promise<HTMLInputElement> {
-        const pill = item.querySelector<HTMLElement>(VALUE_PILL);
+    /** The value pills on `item` — a two-input filter option renders one per operand. */
+    public valuePills(item: HTMLElement): HTMLElement[] {
+        return Array.from(this.liveItem(item).querySelectorAll<HTMLElement>(VALUE_PILL));
+    }
+
+    /** Clicks value pill `index` on `item` and returns the editor input it opens. */
+    public async openValueEditor(item: HTMLElement, index = 0): Promise<HTMLInputElement> {
+        const pill = this.valuePills(item)[index];
         if (!pill) {
-            throw new Error('Value pill not found on builder item');
+            throw new Error(`Value pill ${index} not found on builder item`);
         }
         await firePointerLikeClick(pill);
         // The column/operator pills carry hidden rich-select inputs; the value editor is the only
         // visible one, and it mounts a macrotask or two after the click — poll rather than guess a delay.
         return waitFor(() => {
-            const input = Array.from(item.querySelectorAll<HTMLInputElement>('input.ag-input-field-input')).find(
-                (candidate) => !candidate.closest('.ag-hidden')
-            );
+            const input = Array.from(
+                this.liveItem(item).querySelectorAll<HTMLInputElement>('input.ag-input-field-input')
+            ).find((candidate) => !candidate.closest('.ag-hidden'));
             if (!input) {
                 throw new Error('Value editor input did not open');
             }
@@ -147,12 +185,10 @@ export class AdvancedFilterBuilderHarness {
         });
     }
 
-    /** Clicks the value pill on `item`, types `value` into the editor it opens, and commits (Enter). */
-    public async setValue(item: HTMLElement, value: string): Promise<this> {
-        const editor = await this.openValueEditor(item);
-        const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!;
-        setter.call(editor, value);
-        editor.dispatchEvent(new Event('input', { bubbles: true }));
+    /** Clicks value pill `index` on `item`, types `value` into the editor it opens, and commits (Enter). */
+    public async setValue(item: HTMLElement, value: string, index = 0): Promise<this> {
+        const editor = await this.openValueEditor(item, index);
+        setNativeInputValue(editor, value);
         editor.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
         await asyncSetTimeout(0);
         return this;

--- a/testing/behavioural/src/test-utils/filters/columnFilterHarness.ts
+++ b/testing/behavioural/src/test-utils/filters/columnFilterHarness.ts
@@ -1,20 +1,14 @@
-import { getByTestId } from '@testing-library/dom';
+import { getByTestId, waitFor } from '@testing-library/dom';
 
 import type { GridApi } from 'ag-grid-community';
 import { agTestIdFor, getGridElement } from 'ag-grid-community';
 
 import { asyncSetTimeout } from '../node-utils';
 import { firePointerLikeClick } from '../test-utils-events';
-import { clickSelectOption, nudgeVirtualList, openPicker } from '../widgets/dropdowns';
+import { clickSelectOption, getSelectOptionLabels, nudgeVirtualList, openPicker } from '../widgets/dropdowns';
+import { setNativeInputValue } from '../widgets/inputs';
 
 const COLUMN_FILTER_MENU = '.ag-filter-menu';
-
-function setNativeInputValue(input: HTMLInputElement, value: string): void {
-    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!;
-    setter.call(input, value);
-    input.dispatchEvent(new Event('input', { bubbles: true }));
-    input.dispatchEvent(new Event('change', { bubbles: true }));
-}
 
 /**
  * Drives a column filter popup (`.ag-filter-menu`) through public DOM only. Operator selection uses the
@@ -47,22 +41,60 @@ export class ColumnFilterHarness {
 
     /** Selects an operator by its display label (e.g. "Greater than", "In range") via the AgSelect. */
     public async selectOperator(displayName: string, conditionIndex = 0): Promise<this> {
-        const selects = this.popup.querySelectorAll<HTMLElement>('.ag-filter-select');
-        const select = selects[conditionIndex];
-        if (!select) {
-            throw new Error(`No operator select at condition index ${conditionIndex} for "${this.colId}"`);
-        }
-        await openPicker(select);
+        await openPicker(this.operatorSelect(conditionIndex));
         await clickSelectOption(displayName);
         return this;
     }
 
-    /** Non-set inputs in DOM order (from/to for ranges). Excludes inputs hidden via any ancestor. */
-    private inputs(type: 'text' | 'number' | 'date'): HTMLInputElement[] {
+    /** The operator labels the condition offers, in order. Leaves the dropdown closed. */
+    public async operatorOptions(conditionIndex = 0): Promise<string[]> {
+        const select = this.operatorSelect(conditionIndex);
+        await openPicker(select);
+        try {
+            // An operator dropdown always offers something, so no rows means it never opened.
+            return await waitFor(() => {
+                const options = getSelectOptionLabels();
+                if (!options.length) {
+                    throw new Error(`The operator dropdown for "${this.colId}" rendered no options`);
+                }
+                return options;
+            });
+        } finally {
+            // Toggled shut rather than dismissed with Escape, which would close the filter menu around it.
+            await openPicker(select);
+        }
+    }
+
+    /** The operator label a condition is currently showing. */
+    public operatorSelectValue(conditionIndex = 0): string {
+        return this.operatorSelect(conditionIndex).textContent?.trim() ?? '';
+    }
+
+    private operatorSelect(conditionIndex: number): HTMLElement {
+        const select = this.popup.querySelectorAll<HTMLElement>('.ag-filter-select')[conditionIndex];
+        if (!select) {
+            throw new Error(`No operator select at condition index ${conditionIndex} for "${this.colId}"`);
+        }
+        return select;
+    }
+
+    /**
+     * Non-set inputs in DOM order (from/to for ranges), excluding those hidden via any ancestor.
+     * Spans every condition unless `conditionIndex` narrows it to one.
+     */
+    public inputs(type: 'text' | 'number' | 'date', conditionIndex?: number): HTMLInputElement[] {
         const typeSel = type === 'date' ? 'input[type="date"], input[type="datetime-local"]' : `input[type="${type}"]`;
-        return Array.from(
-            this.popup.querySelectorAll<HTMLInputElement>(`.ag-filter-body .ag-input-field ${typeSel}`)
-        ).filter((input) => !input.closest('.ag-hidden'));
+        const bodies = Array.from(this.popup.querySelectorAll<HTMLElement>('.ag-filter-body'));
+        const roots = conditionIndex == null ? bodies : bodies.slice(conditionIndex, conditionIndex + 1);
+        const inputs: HTMLInputElement[] = [];
+        for (const root of roots) {
+            for (const input of root.querySelectorAll<HTMLInputElement>(`.ag-input-field ${typeSel}`)) {
+                if (!input.closest('.ag-hidden')) {
+                    inputs.push(input);
+                }
+            }
+        }
+        return inputs;
     }
 
     /** A filter input, for asserting native validity state (`validity`, `validationMessage`). */
@@ -164,6 +196,12 @@ export class ColumnFilterHarness {
 
     public async clear(): Promise<this> {
         await this.clickApplyPanelButton('Clear');
+        return this;
+    }
+
+    /** Abandons the edit, restoring the inputs to the applied model. */
+    public async cancel(): Promise<this> {
+        await this.clickApplyPanelButton('Cancel');
         return this;
     }
 

--- a/testing/behavioural/src/test-utils/filters/filterDom.ts
+++ b/testing/behavioural/src/test-utils/filters/filterDom.ts
@@ -63,7 +63,11 @@ export class FilterDom {
         if (document.querySelector('.ag-filter-toolpanel')) {
             return 'filters-tool-panel';
         }
-        return 'advanced-filter';
+        // Scoped to this grid, or a second grid's advanced filter would capture a column-scoped instance.
+        if (getGridElement(this.api)?.querySelector('.ag-advanced-filter')) {
+            return 'advanced-filter';
+        }
+        return this.options.colId ? 'floating-filter' : 'advanced-filter';
     }
 
     private modelLine(mode: Exclude<FilterDomMode, 'auto'>): string {

--- a/testing/behavioural/src/test-utils/filters/filterDomSerialize.ts
+++ b/testing/behavioural/src/test-utils/filters/filterDomSerialize.ts
@@ -52,6 +52,11 @@ function serializeSetBody(scope: ParentNode, lines: string[]): void {
     });
 }
 
+/** An empty input says what it is for through its placeholder, which is all the user has to go on. */
+function placeholderSuffix(input: HTMLInputElement): string {
+    return input.value === '' && input.placeholder ? ` ⟨${input.placeholder}⟩` : '';
+}
+
 /** Appends a simple filter's condition rows (operator + visible inputs) separated by the join, scoped to `scope`. */
 function serializeSimpleBody(scope: ParentNode, lines: string[]): void {
     const selects = Array.from(scope.querySelectorAll('.ag-filter-select .ag-picker-field-display'));
@@ -68,7 +73,10 @@ function serializeSimpleBody(scope: ParentNode, lines: string[]): void {
         lines.push(`operator: "${text(selects[i])}"`);
         const inputs = bodies[i] ? visibleInputs(bodies[i]) : [];
         inputs.forEach((input, idx) => {
-            lines.push(`input${inputs.length > 1 ? ` [${idx}]` : ''}: "${input.value}"`);
+            // What the user is told, which is the whole of an input's rejected state.
+            const invalid = input.validity.valid ? '' : ` ✗ "${input.validationMessage}"`;
+            const suffix = `${placeholderSuffix(input)}${invalid}`;
+            lines.push(`input${inputs.length > 1 ? ` [${idx}]` : ''}: "${input.value}"${suffix}`);
         });
     }
 }
@@ -128,8 +136,8 @@ function serializeMultiFilter(multi: Element, popup: Element): string {
 }
 
 /**
- * Serialises a column's floating filter row: the visible input's value, whether it is read-only (`⊘`), the
- * input type when not plain text, and whether the filter-active indicator is lit. `colId` selects the header cell.
+ * Serialises a column's floating filter row: the visible input's value, its placeholder when empty, whether
+ * it is read-only (`⊘`), the input type when not plain text, and whether the filter-active indicator is lit.
  */
 export function serializeFloatingFilter(root: ParentNode, colId: string | undefined): string {
     if (!colId) {
@@ -146,8 +154,10 @@ export function serializeFloatingFilter(root: ParentNode, colId: string | undefi
 
     const lines = [`FLOATING FILTER ${colId}`];
     if (input) {
+        // The type says which value type the floating filter rendered, which an option can declare per input.
         const typeSuffix = input.type === 'text' ? '' : ` [${input.type}]`;
-        lines.push(`input${typeSuffix}: "${input.value}"${input.disabled ? ' ⊘' : ''}`);
+        const disabled = input.disabled ? ' ⊘' : '';
+        lines.push(`input${typeSuffix}: "${input.value}"${placeholderSuffix(input)}${disabled}`);
     } else {
         lines.push('input: (none)');
     }
@@ -294,10 +304,10 @@ function builderRowText(wrapper: Element): string | null {
         if (op !== null) {
             parts.push(op);
         }
-        const value = pillSlot(wrapper, 'ag-advanced-filter-builder-value-pill');
-        if (value !== null) {
-            parts.push(value);
-        }
+        // One value pill per operand the option takes, so a multi-value option shows all of them.
+        wrapper.querySelectorAll('.ag-advanced-filter-builder-value-pill').forEach((pill) => {
+            parts.push(text(pill.querySelector('.ag-advanced-filter-builder-pill-display')) || '∅');
+        });
         return parts.join(' ') + invalid;
     }
     if (join !== null) {

--- a/testing/behavioural/src/test-utils/filters/floatingFilterHarness.ts
+++ b/testing/behavioural/src/test-utils/filters/floatingFilterHarness.ts
@@ -1,0 +1,62 @@
+import type { GridApi } from 'ag-grid-community';
+import { getGridElement } from 'ag-grid-community';
+
+import { asyncSetTimeout } from '../node-utils';
+import { setNativeInputValue } from '../widgets/inputs';
+
+/**
+ * Drives a column's floating filter row through public DOM only. A floating filter shows either an editor of
+ * the filter's own type or a disabled read-only summary, which `input().disabled` tells apart.
+ */
+export class FloatingFilterHarness {
+    private constructor(
+        public readonly api: GridApi,
+        public readonly colId: string
+    ) {}
+
+    public static get(api: GridApi, colId: string): FloatingFilterHarness {
+        return new FloatingFilterHarness(api, colId);
+    }
+
+    private get cell(): HTMLElement {
+        const gridDiv = getGridElement(this.api) as HTMLElement;
+        const cell = gridDiv?.querySelector<HTMLElement>(`.ag-header-cell.ag-floating-filter[col-id="${this.colId}"]`);
+        if (!cell) {
+            throw new Error(`No floating filter cell for "${this.colId}"`);
+        }
+        return cell;
+    }
+
+    /** The body, which is `ag-floating-filter-full-body` when the filter button is suppressed. */
+    public get body(): HTMLElement {
+        const body = this.cell.querySelector<HTMLElement>('.ag-floating-filter-body, .ag-floating-filter-full-body');
+        if (!body) {
+            throw new Error(`No floating filter body for "${this.colId}"`);
+        }
+        return body;
+    }
+
+    /** Every input, hidden ones included - what a filter mounts, rather than what it is showing. */
+    public allInputs(): HTMLInputElement[] {
+        return Array.from(this.body.querySelectorAll<HTMLInputElement>('input'));
+    }
+
+    /** Visible inputs in DOM order - a hidden one is the editor or the summary the other half is showing. */
+    public inputs(): HTMLInputElement[] {
+        return this.allInputs().filter((input) => !input.closest('.ag-hidden'));
+    }
+
+    public input(index = 0): HTMLInputElement {
+        const input = this.inputs()[index];
+        if (!input) {
+            throw new Error(`No visible floating filter input at index ${index} for "${this.colId}"`);
+        }
+        return input;
+    }
+
+    public async setValue(value: string, index = 0): Promise<this> {
+        setNativeInputValue(this.input(index), value);
+        await asyncSetTimeout(0);
+        return this;
+    }
+}

--- a/testing/behavioural/src/test-utils/filters/index.ts
+++ b/testing/behavioural/src/test-utils/filters/index.ts
@@ -1,4 +1,5 @@
 export * from './columnFilterHarness';
+export * from './floatingFilterHarness';
 export * from './advancedFilterHarness';
 export * from './advancedFilterBuilderHarness';
 export * from './filterDom';

--- a/testing/behavioural/src/test-utils/index.ts
+++ b/testing/behavioural/src/test-utils/index.ts
@@ -3,6 +3,7 @@ export * from './polyfills/canvasPolyfill';
 export * from './polyfills/mockGridLayout';
 export * from './polyfills/filterLayoutMock';
 export * from './widgets/dropdowns';
+export * from './widgets/inputs';
 export * from './filters';
 export * from './polyfills/pointerEvent';
 export * from './polyfills/clipboard';

--- a/testing/behavioural/src/test-utils/widgets/dropdowns.ts
+++ b/testing/behavioural/src/test-utils/widgets/dropdowns.ts
@@ -50,6 +50,13 @@ export async function clickSelectOption(label: string, root: ParentNode = docume
 
 // --- AgRichSelect (builder pills) ---
 
+/** All open AgRichSelect row labels, in order. */
+export function getRichSelectRowLabels(root: ParentNode = document): string[] {
+    return Array.from(root.querySelectorAll<HTMLElement>('.ag-rich-select-row')).map(
+        (row) => row.textContent?.trim() ?? ''
+    );
+}
+
 /**
  * Selects the open AgRichSelect row whose text matches `label`. AgRichSelect resolves the clicked
  * row from `event.clientY` (not the target), so we compute clientY from the list rect and row index;
@@ -58,14 +65,15 @@ export async function clickSelectOption(label: string, root: ParentNode = docume
 export async function selectRichSelectRow(label: string, root: ParentNode = document): Promise<void> {
     let rows: HTMLElement[] = [];
     let index = -1;
-    // Polled on a time budget, not a tick count: the list mounts a macrotask after the click, and a fixed
-    // number of ticks flakes under full-suite load.
+    // Polled on a time budget, not a tick count: the list mounts a macrotask after the click and a fixed
+    // number of ticks flakes under load. Nudging inside the callback is safe - `waitFor` arms an independent
+    // `setTimeout` for its deadline, so the mutations it observes only add polls.
     await waitFor(() => {
         nudgeVirtualList(RICH_SELECT_VIEWPORT, root);
         rows = Array.from(root.querySelectorAll<HTMLElement>('.ag-rich-select-row'));
         index = rows.findIndex((r) => r.textContent?.trim() === label);
         if (index < 0) {
-            const available = rows.map((r) => r.textContent?.trim()).join(', ');
+            const available = getRichSelectRowLabels(root).join(', ');
             throw new Error(`AgRichSelect row "${label}" not found. Available: ${available}`);
         }
     });

--- a/testing/behavioural/src/test-utils/widgets/inputs.ts
+++ b/testing/behavioural/src/test-utils/widgets/inputs.ts
@@ -1,0 +1,10 @@
+/**
+ * Writes through the native value setter so React-style value tracking sees a change, then fires the events
+ * the grid widgets listen on.
+ */
+export function setNativeInputValue(input: HTMLInputElement, value: string): void {
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!;
+    setter.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+}

--- a/testing/behavioural/vitest.config.ts
+++ b/testing/behavioural/vitest.config.ts
@@ -3,7 +3,13 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { defineConfig } from 'vitest/config';
 
-import { dropCssParseErrors, loadSourceCodeAliases, sortAliases, vitestReporters } from '../../vitest.shared';
+import {
+    diffConfigFile,
+    dropCssParseErrors,
+    loadSourceCodeAliases,
+    sortAliases,
+    vitestReporters,
+} from '../../vitest.shared';
 import type { Alias } from '../../vitest.shared';
 
 // Pin the timezone so date tests behave the same on every machine, matching the packages/* vitest configs.
@@ -98,6 +104,7 @@ export default defineConfig(({ mode }) => {
             globals: true,
             environment: 'jsdom',
             setupFiles: [path.resolve(thisDir, 'vitest.setup.ts')],
+            diff: diffConfigFile,
             reporters: vitestReporters(),
             watch: false,
             // Applies when this config runs standalone (benches.sh / direct); the workspace run uses the

--- a/testing/behavioural/vitest.setup.ts
+++ b/testing/behavioural/vitest.setup.ts
@@ -1,9 +1,10 @@
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
 import { afterAll, beforeEach, expect, vitest } from 'vitest';
 
-// Imported from the specific module, not the test-utils barrel: the barrel transitively imports
-// `ag-grid-community` at runtime, which would defeat the lazy `ag`-import guard below. This module is
-// type-only besides the constant, so it pulls in nothing at runtime.
+// Output-volume controls (--no-diff, --stack-trace-len, DEBUG_PRINT_LIMIT) shared with every unit project.
+import '../../vitest.output.setup';
+// `ALL_SEVERITIES` comes from the specific module, not the test-utils barrel: the barrel transitively
+// imports `ag-grid-community` at runtime, which would defeat the lazy `ag`-import guard below.
 import { ALL_SEVERITIES } from './src/test-utils/dev-validations';
 import { ignoreConsoleLicenseKeyError } from './src/test-utils/ignoreConsoleLicenseKeyError';
 
@@ -25,11 +26,6 @@ beforeEach(async () => {
 
 // Shim for code that references `jest` — redirect to vitest.
 (globalThis as Record<string, unknown>).jest = vitest;
-
-// Ensure stack traces are long enough to be useful.
-if (Error.stackTraceLimit < 40) {
-    Error.stackTraceLimit = 40;
-}
 
 // --- GridRows snapshot update mode -------------------------------------------
 //

--- a/vitest.diff.ts
+++ b/vitest.diff.ts
@@ -1,0 +1,13 @@
+// Vitest never truncates a diff, and a grid object stringifies unbounded, so a suite failing wholesale
+// prints for far longer than it runs. `./behave.sh --diff-lines N` (AG_DIFF_LINES) overrides; 0 = unbounded.
+// `process` is absent in browser mode (BENCH_BROWSER), which loads this module just the same.
+const env = typeof process === 'undefined' ? undefined : process.env;
+const diffLines = Number(env?.AG_DIFF_LINES);
+
+export default {
+    // A snapshot mismatch carries its own diff options and never sets `showDiff`, so `--no-diff` cannot reach
+    // it through chai; this threshold is the only thing that bounds it.
+    truncateThreshold: env?.AG_NO_DIFF ? 1 : Number.isFinite(diffLines) ? diffLines : 80,
+    // Context-only diffs: the changed lines plus a few around them, not every matching line.
+    expand: false,
+};

--- a/vitest.output.setup.ts
+++ b/vitest.output.setup.ts
@@ -1,0 +1,28 @@
+// Output-volume controls shared by every unit project, so `./behave.sh --no-diff` and friends mean the same
+// thing whichever `--project` is selected. A setup file because these must apply inside the worker.
+import { chai } from 'vitest';
+
+// `process` is absent in browser mode (BENCH_BROWSER), so guard the env reads.
+const env = typeof process !== 'undefined' ? process.env : undefined;
+
+// Long enough to see through the grid's event plumbing. Don't go far below 20: vitest walks the stack to
+// locate an inline snapshot, so a short limit fails every one with "Couldn't infer stack frame".
+const stackTraceLen = Number(env?.AG_STACK_TRACE_LEN);
+if (Number.isFinite(stackTraceLen)) {
+    Error.stackTraceLimit = stackTraceLen;
+} else if (Error.stackTraceLimit < 40) {
+    Error.stackTraceLimit = 40;
+}
+
+// Vitest's diff stringifies both sides and re-walks them at halved depth past 10K chars, which is unbounded
+// for a DOM node or a grid bean. chai only sets `showDiff: true` when this is true, and vitest skips the diff
+// when it is explicitly false, so one flag turns the whole path off.
+if (env?.AG_NO_DIFF) {
+    chai.config.showDiff = false;
+}
+
+// A failed testing-library query prints the whole container, and a grid container is ~100KB of DOM. The
+// library default of 7000 chars is several screens of markup; 1000 still shows the subtree.
+if (env && !env.DEBUG_PRINT_LIMIT) {
+    env.DEBUG_PRINT_LIMIT = '1000';
+}

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -4,6 +4,15 @@ import { existsSync } from 'node:fs';
 import { readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 
+/** Repo root. `__dirname` (not `import.meta`) because the package `tsconfig.spec` type-checks this as CJS. */
+const repoRoot = __dirname;
+
+/** Output-volume controls (`--no-diff`, `--stack-trace-len`, DEBUG_PRINT_LIMIT), shared by every unit project. */
+export const outputSetupFile = path.resolve(repoRoot, 'vitest.output.setup.ts');
+
+/** Diff options module (`--diff-lines`), shared by every unit project. */
+export const diffConfigFile = path.resolve(repoRoot, 'vitest.diff.ts');
+
 // Pin the timezone so date-sensitive tests behave identically on every machine. Set when any config
 // imports this module (main process), before workers spawn and inherit the env.
 process.env.TZ = 'UTC';
@@ -119,6 +128,8 @@ export const unitProjectTestConfig = ({ name, junitFile, environment = 'jsdom', 
     watch: false,
     pool: UNIT_TEST_POOL,
     reporters: vitestReporters(),
-    setupFiles,
+    // Prepended, so a project's own setup still runs last and can override.
+    setupFiles: [outputSetupFile, ...(setupFiles ?? [])],
+    diff: diffConfigFile,
     outputFile: { junit: junitFile },
 });


### PR DESCRIPTION
<!-- base: latest -->

# Filter test coverage that runs on latest, plus runner output controls

44 filter tests and their harness, added over `testing/behavioural/src/filters`: 504 tests before, 545 after,
none removed, wall clock unchanged at ~10s.

| scope  | net lines |     lines changed | hunks |      files changed |
| ------ | --------: | ----------------: | ----: | -----------------: |
| source |        +3 |         5 (+4 -1) |     1 |           1 edited |
| tests  |     +1476 | 1842 (+1659 -183) |   123 | 32 (+4, 28 edited) |
| docs   |       +83 |       87 (+85 -2) |     5 |           2 edited |
| other  |      +100 |     102 (+101 -1) |     8 |   4 (+2, 2 edited) |

## The one bug fix

`AbstractHeaderCellCtrl.shouldStopEventPropagation` destructured `beans.focusSvc.focusedHeader!`, so a key
pressed in a header-hosted control while the grid holds no header focus threw. Guarded to return `false`: with no
focused header there is nothing to describe to `suppressHeaderKeyboardEvent`.

**Why no user has reported it:** a person focuses the control before typing into it and that focus registers the
focused header, so the value is set by the time a key arrives; a test dispatches a synthetic `keyDown` without
focusing first. The issue is present in every release branch from `b34.3.0` to `b36.1.0` and should not be normally happen in a browser.

## Runner output controls

`behave.sh` gains three flags that bound what a failing run prints, because vitest's diff serialisation of a grid DOM node has no practical bound:

| flag                                                     | effect                                                           |
| -------------------------------------------------------- | ---------------------------------------------------------------- |
| `--no-diff` (`AG_NO_DIFF`)                               | sets `chai.config.showDiff = false`, so the diff path is skipped |
| `--diff-lines N` (`AG_DIFF_LINES`, default 40)           | caps each diff, via a new `test.diff` module                     |
| `--stack-trace-len N` (`AG_STACK_TRACE_LEN`, default 40) | shortens captured stacks                                         |

Colour is off for an agent or a pipe and kept for a terminal and CI, and `DEBUG_PRINT_LIMIT` drops to 1000. `--bail 1` is documented as a way to fail fast if a single test fail.

## Snapshot coverage

29 `FilterDom` snapshots added, including intermediate states rather than end states alone. Every filter file
that drives a filter surface now has some: six had none at all.
