### PR TITLE
AG-16738-filter-options-validation-and-typing

### DIFF
--- a/documentation/ag-grid-docs/src/content/docs/component-filter/_examples/use-grid-handlers/year-filter.component_angular.ts
+++ b/documentation/ag-grid-docs/src/content/docs/component-filter/_examples/use-grid-handlers/year-filter.component_angular.ts
@@ -4,9 +4,9 @@ import { FormsModule } from '@angular/forms';
 import type { IFilterDisplayAngularComp } from 'ag-grid-angular';
 import type {
     FilterDisplayParams,
+    FilterOptionKey,
     FilterWrapperParams,
     IAfterGuiAttachedParams,
-    ISimpleFilterModelType,
     NumberFilterModel,
 } from 'ag-grid-community';
 
@@ -59,7 +59,7 @@ export class YearFilter implements IFilterDisplayAngularComp<any, any, NumberFil
     // e.g. if filter is on multiple columns and open simultaneously in filter tool panel
     name = `year${id++}`;
     params!: FilterDisplayParams<any, any, NumberFilterModel> & FilterWrapperParams;
-    year: ISimpleFilterModelType | 'All' = 'All';
+    year: FilterOptionKey | 'All' = 'All';
 
     agInit(params: FilterDisplayParams<any, any, NumberFilterModel> & FilterWrapperParams): void {
         this.refresh(params);

--- a/packages/ag-grid-community/src/filter/floating/provided/simpleFloatingFilter.ts
+++ b/packages/ag-grid-community/src/filter/floating/provided/simpleFloatingFilter.ts
@@ -3,10 +3,10 @@ import type { FilterChangedEvent } from '../../../events';
 import { Component } from '../../../widgets/component';
 import type { IProvidedFilterParams, ProvidedFilterModel } from '../../provided/iProvidedFilter';
 import type {
+    FilterOptionKey,
     ICombinedSimpleModel,
     ISimpleFilter,
     ISimpleFilterModel,
-    ISimpleFilterModelType,
     ISimpleFilterParams,
 } from '../../provided/iSimpleFilter';
 import { OptionsFactory } from '../../provided/optionsFactory';
@@ -166,7 +166,7 @@ export abstract class SimpleFloatingFilter<TParams extends IFloatingFilterParams
     }
 
     private isTypeEditable(type?: string | null): boolean {
-        return !!type && !this.readOnly && getNumberOfInputs(type as ISimpleFilterModelType, this.optionsFactory) === 1;
+        return !!type && !this.readOnly && getNumberOfInputs(type as FilterOptionKey, this.optionsFactory) === 1;
     }
 
     protected getAriaLabel(column: AgColumn): string {

--- a/packages/ag-grid-community/src/filter/floating/provided/textInputFloatingFilter.ts
+++ b/packages/ag-grid-community/src/filter/floating/provided/textInputFloatingFilter.ts
@@ -3,7 +3,7 @@ import { KeyCode, RefPlaceholder, _clearElement, _debounce } from 'ag-stack';
 import type { AgColumn } from '../../../entities/agColumn';
 import type { ElementParams } from '../../../utils/element';
 import type { BigIntFilterModel } from '../../provided/bigInt/iBigIntFilter';
-import type { ISimpleFilterModelType, ISimpleFilterParams } from '../../provided/iSimpleFilter';
+import type { FilterOptionKey, ISimpleFilterParams } from '../../provided/iSimpleFilter';
 import type { NumberFilterModel } from '../../provided/number/iNumberFilter';
 import { _isUseApplyButton, getDebounceMs, getPlaceholderText } from '../../provided/providedFilterUtils';
 import type {
@@ -71,11 +71,11 @@ export abstract class TextInputFloatingFilter<
         const { inputSvc, defaultDebounceMs, readOnly } = this;
         const { filterPlaceholder, column, browserAutoComplete, filterParams } = params;
 
-        const filterOptionKey = (this.lastType ?? this.optionsFactory.defaultOption!) as ISimpleFilterModelType;
+        const filterOptionKey = (this.lastType ?? this.optionsFactory.defaultOption!) as FilterOptionKey;
         const parentFilterPlaceholder = (params.filterParams as ISimpleFilterParams).filterPlaceholder;
         const placeholder =
             filterPlaceholder === true
-                ? getPlaceholderText(this, parentFilterPlaceholder, 'filterOoo', filterOptionKey)
+                ? getPlaceholderText(this, parentFilterPlaceholder, 'filterOoo', filterOptionKey, this.optionsFactory)
                 : filterPlaceholder || undefined;
 
         inputSvc.setParams({

--- a/packages/ag-grid-community/src/filter/provided/bigInt/iBigIntFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/bigInt/iBigIntFilter.ts
@@ -1,9 +1,16 @@
 import type { IFilterParams } from '../../../interfaces/iFilter';
 import type { IScalarFilterParams } from '../iScalarFilter';
-import type { ISimpleFilterModel } from '../iSimpleFilter';
+import type {
+    CustomFilterOptionKey,
+    IFilterOptionDef,
+    ISimpleFilterModel,
+    ScalarFilterOptionKey,
+} from '../iSimpleFilter';
 import type { ITextInputFloatingFilterParams } from '../text/iTextFilter';
 
 export interface BigIntFilterModel extends ISimpleFilterModel {
+    /** One of the BigInt Filter's options, or a Custom Filter Option's `displayKey`. */
+    type?: ScalarFilterOptionKey | CustomFilterOptionKey | null;
     /** Filter type is always `'bigint'` */
     filterType?: 'bigint';
     /**
@@ -28,6 +35,10 @@ export type BigIntFilterParams<TData = any> = IBigIntFilterParams & IFilterParam
  * Parameters used in `colDef.filterParams` to configure a BigInt Filter (`agBigIntColumnFilter`).
  */
 export interface IBigIntFilterParams extends IScalarFilterParams {
+    /** Array of filter options to present to the user. A key the filter cannot evaluate is reported when used. */
+    filterOptions?: (IFilterOptionDef | ScalarFilterOptionKey | CustomFilterOptionKey)[];
+    /** The default filter option to be selected. Must be one of the offered options. */
+    defaultOption?: ScalarFilterOptionKey | CustomFilterOptionKey;
     /**
      * When specified, the input field will be of type `text`, and this will be used as a regex of all the characters that are allowed to be typed.
      * This will be compared against any typed character and prevent the character from appearing in the input if it does not match.

--- a/packages/ag-grid-community/src/filter/provided/date/iDateFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/date/iDateFilter.ts
@@ -1,11 +1,19 @@
 import type { IFilterParams } from '../../../interfaces/iFilter';
 import type { IScalarFilterParams } from '../iScalarFilter';
-import type { ISimpleFilterModel, ISimpleFilterModelPresetType } from '../iSimpleFilter';
+import type {
+    CustomFilterOptionKey,
+    DateFilterOptionKey,
+    IFilterOptionDef,
+    ISimpleFilterModel,
+    ISimpleFilterModelPresetType,
+} from '../iSimpleFilter';
 
 // The date filter model takes strings, although the filter actually works with dates. This is because a Date object
 // won't convert easily to JSON. When the model is used for doing the filtering, it's converted to a Date object.
 
 export interface DateFilterModel extends ISimpleFilterModel {
+    /** One of the Date Filter's options, or a Custom Filter Option's `displayKey`. */
+    type?: DateFilterOptionKey | CustomFilterOptionKey | null;
     /** Filter type is always `'date'` */
     filterType?: 'date';
     /**
@@ -52,6 +60,10 @@ export type DateFilterParams<TData = any> = IDateFilterParams & IFilterParams<TD
  */
 
 export interface IDateFilterParams extends IScalarFilterParams {
+    /** Array of filter options to present to the user. A key the filter cannot evaluate is reported when used. */
+    filterOptions?: (IFilterOptionDef | DateFilterOptionKey | CustomFilterOptionKey)[];
+    /** The default filter option to be selected. Must be one of the offered options. */
+    defaultOption?: DateFilterOptionKey | CustomFilterOptionKey;
     /**
      * Required if the data for the column are not native JS `Date` objects.
      * If cell values can contain invalid dates, should also implement `isValidDate`.

--- a/packages/ag-grid-community/src/filter/provided/iSimpleFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/iSimpleFilter.ts
@@ -23,9 +23,9 @@ export interface ISimpleFilter extends IProvidedFilter, IFloatingFilterParent {
 
 export interface IFilterPlaceholderFunctionParams {
     /**
-     * The filter option key
+     * The filter option key. A Custom Filter Option reports its `displayKey`.
      */
-    filterOptionKey: ISimpleFilterModelType;
+    filterOptionKey: FilterOptionKey;
     /**
      * The filter option name as localised text
      */
@@ -49,10 +49,11 @@ export type SimpleFilterParams<TData = any> = ISimpleFilterParams & IFilterParam
 export interface ISimpleFilterParams extends IProvidedFilterParams {
     /**
      * Array of filter options to present to the user.
+     * A key the filter cannot evaluate is reported when a value is tested against it under the built-in matching.
      */
-    filterOptions?: (IFilterOptionDef | ISimpleFilterModelType)[];
-    /** The default filter option to be selected. */
-    defaultOption?: string;
+    filterOptions?: (IFilterOptionDef | ISimpleFilterModelType | CustomFilterOptionKey)[];
+    /** The default filter option to be selected. Must be one of the offered options. */
+    defaultOption?: ISimpleFilterModelType | CustomFilterOptionKey;
     /**
      * By default, the two conditions are combined using `AND`.
      * You can change this default by setting this property.
@@ -105,26 +106,48 @@ export type ISimpleFilterModelPresetType =
     | 'last12Months'
     | 'last24Months';
 
-export type ISimpleFilterModelType =
-    | 'empty'
+/**
+ * The `displayKey` of a Custom Filter Option. Plain `string` would swallow the literals it is unioned with and leave
+ * nothing to suggest; the intersection accepts any string without collapsing them. Spelt this way because static
+ * analysis rejects the equivalent `{}` as a type with no members.
+ */
+export type CustomFilterOptionKey = string & Record<never, never>;
+
+/** A built-in filter option key, or the `displayKey` of a Custom Filter Option. */
+export type FilterOptionKey = ISimpleFilterModelType | CustomFilterOptionKey;
+
+/** Valid on every simple filter: `'empty'` selects no condition, `'blank'`/`'notBlank'` test presence, not a value. */
+export type CommonFilterOptionKey = 'empty' | 'blank' | 'notBlank';
+
+/** The built-in option keys valid on a Text Filter. */
+export type TextFilterOptionKey =
+    | CommonFilterOptionKey
+    | 'equals'
+    | 'notEqual'
+    | 'contains'
+    | 'notContains'
+    | 'startsWith'
+    | 'endsWith';
+
+/** The built-in option keys valid on the ordered filters, which compare values. */
+export type ScalarFilterOptionKey =
+    | CommonFilterOptionKey
     | 'equals'
     | 'notEqual'
     | 'lessThan'
     | 'lessThanOrEqual'
     | 'greaterThan'
     | 'greaterThanOrEqual'
-    | 'inRange'
-    | 'contains'
-    | 'notContains'
-    | 'startsWith'
-    | 'endsWith'
-    | 'blank'
-    | 'notBlank'
-    | ISimpleFilterModelPresetType;
+    | 'inRange';
+
+/** The ordered filter keys, plus the relative ranges only a date can express. */
+export type DateFilterOptionKey = ScalarFilterOptionKey | ISimpleFilterModelPresetType;
+
+export type ISimpleFilterModelType = TextFilterOptionKey | DateFilterOptionKey;
 
 export interface ISimpleFilterModel extends ProvidedFilterModel {
-    /** One of the filter options, e.g. `'equals'` */
-    type?: ISimpleFilterModelType | null;
+    /** One of the filter options, e.g. `'equals'`, or a Custom Filter Option's `displayKey`. */
+    type?: FilterOptionKey | null;
 }
 
 export interface ICombinedSimpleModel<M extends ISimpleFilterModel> extends ProvidedFilterModel {

--- a/packages/ag-grid-community/src/filter/provided/number/iNumberFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/number/iNumberFilter.ts
@@ -1,9 +1,16 @@
 import type { IFilterParams } from '../../../interfaces/iFilter';
 import type { IScalarFilterParams } from '../iScalarFilter';
-import type { ISimpleFilterModel } from '../iSimpleFilter';
+import type {
+    CustomFilterOptionKey,
+    IFilterOptionDef,
+    ISimpleFilterModel,
+    ScalarFilterOptionKey,
+} from '../iSimpleFilter';
 import type { ITextInputFloatingFilterParams } from '../text/iTextFilter';
 
 export interface NumberFilterModel extends ISimpleFilterModel {
+    /** One of the Number Filter's options, or a Custom Filter Option's `displayKey`. */
+    type?: ScalarFilterOptionKey | CustomFilterOptionKey | null;
     /** Filter type is always `'number'` */
     filterType?: 'number';
     /**
@@ -28,6 +35,10 @@ export type NumberFilterParams<TData = any> = INumberFilterParams & IFilterParam
  */
 
 export interface INumberFilterParams extends IScalarFilterParams {
+    /** Array of filter options to present to the user. A key the filter cannot evaluate is reported when used. */
+    filterOptions?: (IFilterOptionDef | ScalarFilterOptionKey | CustomFilterOptionKey)[];
+    /** The default filter option to be selected. Must be one of the offered options. */
+    defaultOption?: ScalarFilterOptionKey | CustomFilterOptionKey;
     /**
      * When specified, the input field will be of type `text`, and this will be used as a regex of all the characters that are allowed to be typed.
      * This will be compared against any typed character and prevent the character from appearing in the input if it does not match.

--- a/packages/ag-grid-community/src/filter/provided/optionsFactory.ts
+++ b/packages/ag-grid-community/src/filter/provided/optionsFactory.ts
@@ -1,81 +1,90 @@
 import type { LogService } from '../../validation/logService';
 import type { IFilterOptionDef, ISimpleFilterParams } from './iSimpleFilter';
 
+/** An entry missing any of these cannot be offered; they are listed so the warning can name the missing one. */
+const REQUIRED_OPTION_PROPERTIES: (keyof IFilterOptionDef)[] = ['displayKey', 'displayName', 'predicate'];
+
 /* Common logic for options, used by both filters and floating filters. */
 export class OptionsFactory {
-    protected customFilterOptions: { [name: string]: IFilterOptionDef } = {};
+    private customFilterOptions: Map<string, IFilterOptionDef>;
+    /** As configured, so a refresh compares what it was given rather than what it kept. */
+    private configuredOptions: (IFilterOptionDef | string)[];
+    /** What the dropdown offers: the configured list minus its malformed entries, or the built-ins if none survive. */
     public filterOptions: (IFilterOptionDef | string)[];
+    private offeredOptions: Map<string, IFilterOptionDef | string>;
     public defaultOption?: string;
 
     public init(log: LogService, params: ISimpleFilterParams, defaultOptions: string[]): void {
-        this.filterOptions = params.filterOptions ?? defaultOptions;
-        this.mapCustomOptions(log);
+        this.configuredOptions = params.filterOptions ?? defaultOptions;
+        this.buildOptions(log, defaultOptions);
         this.defaultOption = this.getDefaultItem(log, params.defaultOption);
     }
 
     public refresh(log: LogService, params: ISimpleFilterParams, defaultOptions: string[]): void {
         const filterOptions = params.filterOptions ?? defaultOptions;
-        if (this.filterOptions !== filterOptions) {
-            this.filterOptions = filterOptions;
-            this.customFilterOptions = {};
-            this.mapCustomOptions(log);
+        if (this.configuredOptions !== filterOptions) {
+            this.configuredOptions = filterOptions;
+            this.buildOptions(log, defaultOptions);
         }
         this.defaultOption = this.getDefaultItem(log, params.defaultOption);
     }
 
-    private mapCustomOptions(log: LogService): void {
-        const { filterOptions } = this;
-        if (!filterOptions) {
-            return;
+    /** Rebuilt wholesale, so a `predicate` the previous list carried cannot survive into this one. */
+    private buildOptions(log: LogService, defaultOptions: string[]): void {
+        this.collectUsableOptions(log, this.configuredOptions);
+        // A column with nothing to offer cannot open its filter at all, so a list that keeps none falls back.
+        if (!this.filterOptions.length) {
+            log.warn(74);
+            this.collectUsableOptions(log, defaultOptions);
         }
+    }
 
-        for (const filterOption of filterOptions) {
-            if (typeof filterOption === 'string') {
-                continue;
-            }
-
-            const requiredProperties = [['displayKey'], ['displayName'], ['predicate', 'test']];
-            const propertyCheck = (keys: [keyof IFilterOptionDef]) => {
-                if (!keys.some((key) => filterOption[key] != null)) {
-                    log.warn(72, { keys });
-                    return false;
+    private collectUsableOptions(log: LogService, configuredOptions: (IFilterOptionDef | string)[]): void {
+        // A `Map` holds a key at the position it was first set in, so it dedupes without reordering the dropdown.
+        const offered = new Map<string, IFilterOptionDef | string>();
+        const customOptions = new Map<string, IFilterOptionDef>();
+        for (let i = 0, len = configuredOptions.length; i < len; ++i) {
+            const option = configuredOptions[i];
+            if (option == null) {
+                continue; // `typeof null` is `'object'`, so a hole would read as an option with no properties
+            } else if (typeof option === 'string') {
+                offered.set(option, offered.get(option) ?? option); // a definition already stored outranks a bare key
+            } else {
+                const missing = REQUIRED_OPTION_PROPERTIES.filter((name) => option[name] == null);
+                if (missing.length) {
+                    log.warn(72, { keys: missing });
+                    continue;
                 }
-
-                return true;
-            };
-
-            if (!requiredProperties.every(propertyCheck)) {
-                this.filterOptions = filterOptions.filter((v) => v === filterOption) || [];
-                continue;
+                const key = option.displayKey;
+                offered.set(key, option);
+                customOptions.set(key, option);
             }
-
-            this.customFilterOptions[filterOption.displayKey] = filterOption;
         }
+        this.offeredOptions = offered;
+        this.filterOptions = [...offered.values()];
+        this.customFilterOptions = customOptions;
     }
 
     private getDefaultItem(log: LogService, defaultOption?: string): string | undefined {
-        const { filterOptions } = this;
-        if (defaultOption) {
-            return defaultOption;
-        } else if (filterOptions.length >= 1) {
-            const firstFilterOption = filterOptions[0];
-
-            if (typeof firstFilterOption === 'string') {
-                return firstFilterOption;
-            } else if (firstFilterOption.displayKey) {
-                return firstFilterOption.displayKey;
-            } else {
-                // invalid FilterOptionDef supplied as it doesn't contain a 'displayKey
-                log.warn(73);
-            }
-        } else {
-            //no filter options for filter
-            log.warn(74);
+        const firstFilterOption = this.filterOptions[0];
+        if (firstFilterOption == null) {
+            return undefined;
         }
-        return undefined;
+        // Only an option the dropdown lists can be selected into it.
+        if (defaultOption != null) {
+            if (this.hasOption(defaultOption)) {
+                return defaultOption;
+            }
+            log.warn(326, { defaultOption });
+        }
+        return typeof firstFilterOption === 'string' ? firstFilterOption : firstFilterOption.displayKey;
+    }
+
+    public hasOption(key?: string | null): boolean {
+        return key != null && this.offeredOptions.has(key);
     }
 
     public getCustomOption(name?: string | null): IFilterOptionDef | undefined {
-        return this.customFilterOptions[name!];
+        return name == null ? undefined : this.customFilterOptions.get(name);
     }
 }

--- a/packages/ag-grid-community/src/filter/provided/providedFilterUtils.ts
+++ b/packages/ag-grid-community/src/filter/provided/providedFilterUtils.ts
@@ -5,7 +5,8 @@ import type { LogService } from '../../validation/logService';
 import type { FilterLocaleTextKey } from '../filterLocaleText';
 import { translateForFilter } from '../filterLocaleText';
 import type { IProvidedFilterParams } from './iProvidedFilter';
-import type { FilterPlaceholderFunction, ISimpleFilterModelType } from './iSimpleFilter';
+import type { FilterOptionKey, FilterPlaceholderFunction } from './iSimpleFilter';
+import type { OptionsFactory } from './optionsFactory';
 
 export function getDebounceMs(log: LogService, params: IProvidedFilterParams, debounceDefault: number): number {
     const { debounceMs } = params;
@@ -25,15 +26,28 @@ export function _isUseApplyButton(params: FilterWrapperParams): boolean {
     return (params.buttons?.indexOf('apply') ?? -1) >= 0;
 }
 
+/** A Custom Filter Option has no built-in locale entry, so its own `displayKey`/`displayName` are the lookup. */
+export function translateFilterOption(
+    bean: { getLocaleTextFunc(): LocaleTextFunc },
+    optionsFactory: OptionsFactory,
+    filterOptionKey: FilterOptionKey
+): string {
+    const customOption = optionsFactory.getCustomOption(filterOptionKey);
+    return customOption
+        ? bean.getLocaleTextFunc()(customOption.displayKey, customOption.displayName)
+        : translateForFilter(bean, filterOptionKey as FilterLocaleTextKey);
+}
+
 export function getPlaceholderText(
     bean: { getLocaleTextFunc(): LocaleTextFunc },
     filterPlaceholder: string | FilterPlaceholderFunction | undefined,
     defaultPlaceholder: FilterLocaleTextKey,
-    filterOptionKey: ISimpleFilterModelType
+    filterOptionKey: FilterOptionKey,
+    optionsFactory: OptionsFactory
 ): string {
     let placeholder = translateForFilter(bean, defaultPlaceholder);
     if (typeof filterPlaceholder === 'function') {
-        const filterOption = translateForFilter(bean, filterOptionKey);
+        const filterOption = translateFilterOption(bean, optionsFactory, filterOptionKey);
         placeholder = filterPlaceholder({
             filterOptionKey,
             filterOption,

--- a/packages/ag-grid-community/src/filter/provided/scalarFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/scalarFilterHandler.ts
@@ -1,5 +1,5 @@
 import type { Comparator, IScalarFilterParams } from './iScalarFilter';
-import type { ISimpleFilterModel, ISimpleFilterModelType, Tuple } from './iSimpleFilter';
+import type { FilterOptionKey, ISimpleFilterModel, Tuple } from './iSimpleFilter';
 import { SimpleFilterHandler } from './simpleFilterHandler';
 import { isBlank } from './simpleFilterUtils';
 
@@ -12,7 +12,7 @@ export abstract class ScalarFilterHandler<
 
     protected abstract isValid(value: TValue): boolean;
 
-    protected evaluateNullValue(filterType?: ISimpleFilterModelType | null) {
+    protected evaluateNullValue(filterType?: FilterOptionKey | null) {
         const {
             includeBlanksInEquals,
             includeBlanksInNotEqual,
@@ -101,7 +101,7 @@ export abstract class ScalarFilterHandler<
                 return !isBlank(cellValue);
 
             default:
-                this.warn(76, { filterModelType: type });
+                this.warnUnexpectedFilterType(type);
                 return true;
         }
     }

--- a/packages/ag-grid-community/src/filter/provided/simpleFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/simpleFilter.ts
@@ -20,11 +20,11 @@ import type { Component, ComponentSelector } from '../../widgets/component';
 import type { GridInputTextField, GridRadioButton, GridSelect } from '../../widgets/gridWidgetTypes';
 import type { FilterLocaleTextKey } from '../filterLocaleText';
 import type {
+    FilterOptionKey,
     ICombinedSimpleModel,
     IFilterOptionDef,
     ISimpleFilter,
     ISimpleFilterModel,
-    ISimpleFilterModelType,
     ISimpleFilterParams,
     JoinOperator,
     MapValuesFromSimpleFilterModel,
@@ -33,7 +33,7 @@ import type {
 } from './iSimpleFilter';
 import { OptionsFactory } from './optionsFactory';
 import { ProvidedFilter } from './providedFilter';
-import { getPlaceholderText } from './providedFilterUtils';
+import { getPlaceholderText, translateFilterOption } from './providedFilterUtils';
 import {
     getDefaultJoinOperator,
     getNumberOfInputs,
@@ -173,12 +173,12 @@ export abstract class SimpleFilter<
         return conditions[0];
     }
 
-    protected getConditionTypes(): (ISimpleFilterModelType | null)[] {
-        return this.eTypes.map((eType) => eType.getValue() as ISimpleFilterModelType);
+    protected getConditionTypes(): (FilterOptionKey | null)[] {
+        return this.eTypes.map((eType) => eType.getValue() as FilterOptionKey);
     }
 
-    protected getConditionType(position: number): ISimpleFilterModelType | null {
-        return this.eTypes[position].getValue() as ISimpleFilterModelType;
+    protected getConditionType(position: number): FilterOptionKey | null {
+        return this.eTypes[position].getValue() as FilterOptionKey;
     }
 
     protected getJoinOperator(): JoinOperator {
@@ -375,19 +375,14 @@ export abstract class SimpleFilter<
         eType.setDisabled(filterListOptions.length <= 1);
     }
 
+    /** `translate` is overridden per filter, so a built-in key must go through it rather than the shared lookup. */
     private createBoilerplateListOption(option: string): ListOption {
         return { value: option, text: this.translate(option as FilterLocaleTextKey) };
     }
 
     private createCustomListOption(option: IFilterOptionDef): ListOption {
-        const { displayKey } = option;
-        const customOption = this.optionsFactory.getCustomOption(option.displayKey);
-        return {
-            value: displayKey,
-            text: customOption
-                ? this.getLocaleTextFunc()(customOption.displayKey, customOption.displayName)
-                : this.translate(displayKey as FilterLocaleTextKey),
-        };
+        const displayKey = option.displayKey;
+        return { value: displayKey, text: translateFilterOption(this, this.optionsFactory, displayKey) };
     }
 
     protected createBodyTemplate(): ElementParams | null {
@@ -620,8 +615,14 @@ export abstract class SimpleFilter<
                       ? globalTranslate('ariaFilterValue', 'Filter Value')
                       : globalTranslate('ariaFilterToValue', 'Filter to Value');
 
-            const filterOptionKey = eTypes[position].getValue() as ISimpleFilterModelType;
-            const placeholderText = getPlaceholderText(this, filterPlaceholder, placeholderKey, filterOptionKey);
+            const filterOptionKey = eTypes[position].getValue() as FilterOptionKey;
+            const placeholderText = getPlaceholderText(
+                this,
+                filterPlaceholder,
+                placeholderKey,
+                filterOptionKey,
+                this.optionsFactory
+            );
 
             element.setInputPlaceholder(placeholderText);
             element.setInputAriaLabel(ariaLabel);
@@ -669,7 +670,7 @@ export abstract class SimpleFilter<
 
     private forEachPositionTypeInput(
         position: number,
-        type: ISimpleFilterModelType | null,
+        type: FilterOptionKey | null,
         cb: (element: E, index: number, position: number, numberOfInputs: number) => void
     ): void {
         const numberOfInputs = getNumberOfInputs(type, this.optionsFactory);

--- a/packages/ag-grid-community/src/filter/provided/simpleFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/simpleFilterHandler.ts
@@ -6,9 +6,9 @@ import type {
     IDoesFilterPassParams,
 } from '../../interfaces/iFilter';
 import type {
+    FilterOptionKey,
     ICombinedSimpleModel,
     ISimpleFilterModel,
-    ISimpleFilterModelType,
     ISimpleFilterParams,
     MapValuesFromSimpleFilterModel,
     Tuple,
@@ -37,6 +37,7 @@ export abstract class SimpleFilterHandler<
     protected params: FilterHandlerParams<any, any, TModel | ICombinedSimpleModel<TModel>, TParams>;
     private optionsFactory: OptionsFactory;
     private filterModelFormatter: SimpleFilterModelFormatter<ISimpleFilterParams>;
+    private readonly warnedKeys = new Set<FilterOptionKey | null | undefined>();
 
     constructor(
         private readonly mapValuesFromModel: MapValuesFromSimpleFilterModel<TModel, TValue>,
@@ -45,7 +46,19 @@ export abstract class SimpleFilterHandler<
         super();
     }
 
-    protected abstract evaluateNullValue(filterType?: ISimpleFilterModelType | null): boolean;
+    protected abstract evaluateNullValue(filterType?: FilterOptionKey | null): boolean;
+
+    /**
+     * Once per key, never per row: a log call formats its message and doc URL before the once-per-message guard
+     * discards the duplicate. A Custom Filter Option owns its key, so a skipped predicate is a missing value.
+     */
+    protected warnUnexpectedFilterType(type?: FilterOptionKey | null): void {
+        if (this.optionsFactory.getCustomOption(type) || this.warnedKeys.has(type)) {
+            return;
+        }
+        this.warnedKeys.add(type);
+        this.warn(76, { filterModelType: type });
+    }
 
     protected abstract evaluateNonNullValue(
         range: Tuple<TValue>,
@@ -125,7 +138,7 @@ export abstract class SimpleFilterHandler<
     ): void {
         const {
             model,
-            filterParams: { filterOptions, maxNumConditions },
+            filterParams: { maxNumConditions },
         } = params;
 
         if (model == null) {
@@ -136,16 +149,11 @@ export abstract class SimpleFilterHandler<
 
         let conditions: TModel[] | null = isCombined ? model.conditions : [model];
 
-        // Invalid when one of the existing condition options is not in new options list
-        const newOptionsList =
-            filterOptions?.map((option) => (typeof option === 'string' ? option : option.displayKey)) ??
-            this.defaultOptions;
+        // Checked against the list the dropdown is built from, so a malformed option does not count as offered.
+        const allConditionsAreOffered =
+            !conditions || conditions.every((condition) => this.optionsFactory.hasOption(condition.type));
 
-        const allConditionsExistInNewOptionsList =
-            !conditions ||
-            conditions.every((condition) => newOptionsList.find((option) => option === condition.type) !== undefined);
-
-        if (!allConditionsExistInNewOptionsList) {
+        if (!allConditionsAreOffered) {
             this.params = {
                 ...params,
                 model: null,

--- a/packages/ag-grid-community/src/filter/provided/simpleFilterModelFormatter.ts
+++ b/packages/ag-grid-community/src/filter/provided/simpleFilterModelFormatter.ts
@@ -2,12 +2,7 @@ import { BeanStub } from '../../context/beanStub';
 import type { FilterLocaleTextKey } from '../filterLocaleText';
 import { translateForFilter } from '../filterLocaleText';
 import type { ProvidedFilterModel } from './iProvidedFilter';
-import type {
-    ICombinedSimpleModel,
-    ISimpleFilterModel,
-    ISimpleFilterModelType,
-    ISimpleFilterParams,
-} from './iSimpleFilter';
+import type { FilterOptionKey, ICombinedSimpleModel, ISimpleFilterModel, ISimpleFilterParams } from './iSimpleFilter';
 import type { OptionsFactory } from './optionsFactory';
 
 export const SCALAR_FILTER_TYPE_KEYS = {
@@ -103,7 +98,7 @@ export abstract class SimpleFilterModelFormatter<
     }
 
     protected conditionForToolPanel(
-        type: ISimpleFilterModelType | null | undefined,
+        type: FilterOptionKey | null | undefined,
         isRange: boolean,
         getFilter: () => string,
         getFilterTo: () => string,
@@ -129,7 +124,7 @@ export abstract class SimpleFilterModelFormatter<
         return null;
     }
 
-    protected getTypeKey(type: ISimpleFilterModelType | null | undefined): FilterLocaleTextKey | null {
+    protected getTypeKey(type: FilterOptionKey | null | undefined): FilterLocaleTextKey | null {
         const suffix = this.filterTypeKeys[type as keyof FilterTypeKeys];
         return suffix ? `filterSummary${suffix}` : null;
     }

--- a/packages/ag-grid-community/src/filter/provided/simpleFilterUtils.ts
+++ b/packages/ag-grid-community/src/filter/provided/simpleFilterUtils.ts
@@ -1,5 +1,5 @@
 import type { LogService } from '../../validation/logService';
-import type { IFilterOptionDef, ISimpleFilterModelType, JoinOperator, Tuple } from './iSimpleFilter';
+import type { FilterOptionKey, IFilterOptionDef, ISimpleFilterModelType, JoinOperator, Tuple } from './iSimpleFilter';
 import type { OptionsFactory } from './optionsFactory';
 
 export function removeItems<T>(items: T[], startPosition: number, deleteCount?: number): T[] {
@@ -43,7 +43,7 @@ export function validateAndUpdateConditions<M>(log: LogService, conditions: M[],
     return numConditions;
 }
 
-const zeroInputTypes: Set<ISimpleFilterModelType> = new Set([
+const zeroInputTypes: ReadonlySet<string> = new Set<ISimpleFilterModelType>([
     'empty',
     'notBlank',
     'blank',
@@ -71,10 +71,7 @@ const zeroInputTypes: Set<ISimpleFilterModelType> = new Set([
     'last24Months',
 ]);
 
-export function getNumberOfInputs(
-    type: ISimpleFilterModelType | null | undefined,
-    optionsFactory: OptionsFactory
-): number {
+export function getNumberOfInputs(type: FilterOptionKey | null | undefined, optionsFactory: OptionsFactory): number {
     const customOpts = optionsFactory.getCustomOption(type);
     if (customOpts) {
         const { numberOfInputs } = customOpts;

--- a/packages/ag-grid-community/src/filter/provided/text/iTextFilter.ts
+++ b/packages/ag-grid-community/src/filter/provided/text/iTextFilter.ts
@@ -1,11 +1,19 @@
 import type { BaseColDefParams } from '../../../entities/colDef';
 import type { IFilterParams } from '../../../interfaces/iFilter';
 import type { IFloatingFilterParams } from '../../floating/floatingFilter';
-import type { ISimpleFilterModel, ISimpleFilterParams } from '../iSimpleFilter';
+import type {
+    CustomFilterOptionKey,
+    IFilterOptionDef,
+    ISimpleFilterModel,
+    ISimpleFilterParams,
+    TextFilterOptionKey,
+} from '../iSimpleFilter';
 import type { NumberFilter } from '../number/numberFilter';
 import type { TextFilter } from './textFilter';
 
 export interface TextFilterModel extends ISimpleFilterModel {
+    /** One of the Text Filter's options, or a Custom Filter Option's `displayKey`. */
+    type?: TextFilterOptionKey | CustomFilterOptionKey | null;
     /** Filter type is always `'text'` */
     filterType?: 'text';
     /**
@@ -58,6 +66,10 @@ export type TextFilterParams<TData = any> = ITextFilterParams & IFilterParams<TD
  */
 
 export interface ITextFilterParams extends ISimpleFilterParams {
+    /** Array of filter options to present to the user. A key the filter cannot evaluate is reported when used. */
+    filterOptions?: (IFilterOptionDef | TextFilterOptionKey | CustomFilterOptionKey)[];
+    /** The default filter option to be selected. Must be one of the offered options. */
+    defaultOption?: TextFilterOptionKey | CustomFilterOptionKey;
     /**
      * Used to override how to filter based on the user input.
      * Returns `true` if the value passes the filter, otherwise `false`.

--- a/packages/ag-grid-community/src/filter/provided/text/textFilterHandler.ts
+++ b/packages/ag-grid-community/src/filter/provided/text/textFilterHandler.ts
@@ -1,5 +1,5 @@
 import type { FilterHandlerParams, IDoesFilterPassParams } from '../../../interfaces/iFilter';
-import type { ICombinedSimpleModel, ISimpleFilterModelType, Tuple } from '../iSimpleFilter';
+import type { FilterOptionKey, ICombinedSimpleModel, TextFilterOptionKey, Tuple } from '../iSimpleFilter';
 import { isCombinedFilterModel } from '../iSimpleFilter';
 import { SimpleFilterHandler } from '../simpleFilterHandler';
 import { isBlank } from '../simpleFilterUtils';
@@ -7,6 +7,16 @@ import type { ITextFilterParams, TextFilterModel, TextFormatter, TextMatcher } f
 import { DEFAULT_TEXT_FILTER_OPTIONS } from './textFilterConstants';
 import { TextFilterModelFormatter } from './textFilterModelFormatter';
 import { mapValuesFromTextFilterModel, trimInputForFilter } from './textFilterUtils';
+
+/** Every key `defaultMatcher` answers; anything else needs a `textMatcher` to mean something. */
+const DEFAULT_MATCHER_KEYS: ReadonlySet<string> = new Set<TextFilterOptionKey>([
+    'contains',
+    'notContains',
+    'equals',
+    'notEqual',
+    'startsWith',
+    'endsWith',
+]);
 
 const defaultMatcher: TextMatcher = ({ filterOption, value, filterText }) => {
     if (filterText == null) {
@@ -65,10 +75,18 @@ export class TextFilterHandler extends SimpleFilterHandler<TextFilterModel, stri
             filterParams.textFormatter ?? (filterParams.caseSensitive ? defaultFormatter : defaultLowercaseFormatter);
     }
 
-    protected override evaluateNullValue(filterType: ISimpleFilterModelType | null) {
-        const filterTypesAllowNulls: ISimpleFilterModelType[] = ['notEqual', 'notContains', 'blank'];
+    /** The key is checked rather than the matcher's answer, which cannot distinguish "no match" from "unknown". */
+    private isUnmatchable(type?: FilterOptionKey | null): boolean {
+        return this.matcher === defaultMatcher && (type == null || !DEFAULT_MATCHER_KEYS.has(type));
+    }
 
-        return filterType ? filterTypesAllowNulls.indexOf(filterType) >= 0 : false;
+    protected override evaluateNullValue(filterType: FilterOptionKey | null) {
+        // Presence is decided without the matcher, so an unusable key is reported for a blank column too.
+        if (filterType !== 'blank' && filterType !== 'notBlank' && this.isUnmatchable(filterType)) {
+            this.warnUnexpectedFilterType(filterType);
+            return false;
+        }
+        return filterType === 'notEqual' || filterType === 'notContains' || filterType === 'blank';
     }
 
     protected override evaluateNonNullValue(
@@ -87,12 +105,19 @@ export class TextFilterHandler extends SimpleFilterHandler<TextFilterModel, stri
             filterParams: { textFormatter },
         } = this.params;
 
-        if (filterModel.type === 'blank') {
+        const type = filterModel.type;
+        if (type === 'blank') {
             return isBlank(cellValue);
-        } else if (filterModel.type === 'notBlank') {
+        } else if (type === 'notBlank') {
             return !isBlank(cellValue);
         }
 
+        if (this.isUnmatchable(type)) {
+            this.warnUnexpectedFilterType(type);
+            return false;
+        }
+
+        const matcher = this.matcher;
         const matcherParams = {
             api,
             colDef,
@@ -100,12 +125,12 @@ export class TextFilterHandler extends SimpleFilterHandler<TextFilterModel, stri
             context,
             node: params.node,
             data: params.data,
-            filterOption: filterModel.type,
+            filterOption: type,
             value: cellValueFormatted,
             textFormatter,
         };
 
-        return formattedValues.some((v) => this.matcher({ ...matcherParams, filterText: v }));
+        return formattedValues.some((v) => matcher({ ...matcherParams, filterText: v }));
     }
 
     public processModelToApply(

--- a/packages/ag-grid-community/src/main.ts
+++ b/packages/ag-grid-community/src/main.ts
@@ -237,16 +237,23 @@ export type {
 export type { IScalarFilterParams, ScalarFilterParams } from './filter/provided/iScalarFilter';
 export { isCombinedFilterModel } from './filter/provided/iSimpleFilter';
 export type {
+    CommonFilterOptionKey,
+    CustomFilterOptionKey,
+    DateFilterOptionKey,
+    FilterOptionKey,
     FilterPlaceholderFunction,
     ICombinedSimpleModel,
     IFilterOptionDef,
     IFilterPlaceholderFunctionParams,
     ISimpleFilter,
     ISimpleFilterModel,
+    ISimpleFilterModelPresetType,
     ISimpleFilterModelType,
     ISimpleFilterParams,
     JoinOperator,
+    ScalarFilterOptionKey,
     SimpleFilterParams,
+    TextFilterOptionKey,
 } from './filter/provided/iSimpleFilter';
 export type {
     INumberFilterParams,

--- a/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
+++ b/packages/ag-grid-community/src/validation/errorMessages/errorText.ts
@@ -369,8 +369,7 @@ export const AG_GRID_ERRORS = {
     70: ({ newFilter }: { newFilter: any }) =>
         `Grid option \`quickFilterText\` only supports string inputs, received: ${typeof newFilter}` as const,
     71: () => '`debounceMs` is ignored when apply button is present' as const,
-    72: ({ keys }: { keys: string[] }) => [`ignoring \`FilterOptionDef\` as it doesn't contain one of `, keys] as const,
-    73: () => `invalid \`FilterOptionDef\` supplied as it doesn't contain a \`displayKey\`` as const,
+    72: ({ keys }: { keys: string[] }) => [`ignoring \`FilterOptionDef\` as it is missing `, keys] as const,
     74: () => 'no filter options for filter' as const,
     75: () => 'Unknown button type specified' as const,
     76: ({ filterModelType }: { filterModelType: any }) =>
@@ -947,6 +946,8 @@ export const AG_GRID_ERRORS = {
     },
     325: ({ property, value }: { property: string; value?: unknown }) =>
         `\`${property}\` must be an array with at least one element, currently it is \`[${String(value)}]\``,
+    326: ({ defaultOption }: { defaultOption: string }) =>
+        `ignoring \`defaultOption\` \`${defaultOption}\` as it is not one of the filter's \`filterOptions\`` as const,
 };
 
 export type ErrorMap = typeof AG_GRID_ERRORS;

--- a/testing/behavioural/src/filters/filter-options-validation.test.ts
+++ b/testing/behavioural/src/filters/filter-options-validation.test.ts
@@ -1,0 +1,1330 @@
+import { waitFor } from '@testing-library/dom';
+
+import type { ColDef, GridApi, GridOptions, IFilterOptionDef, ITextFilterParams } from 'ag-grid-community';
+import {
+    BigIntFilterModule,
+    ClientSideRowModelModule,
+    DateFilterModule,
+    NumberFilterModule,
+    TextFilterModule,
+    enableDevValidations,
+    setupAgTestIds,
+} from 'ag-grid-community';
+import { ColumnMenuModule } from 'ag-grid-enterprise';
+
+import {
+    ALL_SEVERITIES,
+    ColumnFilterHarness,
+    FilterDom,
+    GridRows,
+    TestGridsManager,
+    asyncSetTimeout,
+    installFilterLayoutMock,
+    uninstallFilterLayoutMock,
+} from '../test-utils';
+
+/**
+ * What a `filterOptions` list offers, and what is reported when it cannot: a malformed entry, a `defaultOption`
+ * the list does not contain, a key one filter cannot evaluate, and a `displayKey` colliding with a built-in one.
+ */
+interface AgeRow {
+    age: number;
+}
+
+const MULTIPLE_OF_AGE: IFilterOptionDef = {
+    displayKey: 'multipleOf',
+    displayName: 'Multiple of',
+    numberOfInputs: 1,
+    predicate: ([value], cellValue) => cellValue != null && cellValue % value === 0,
+};
+
+/** No `predicate` and no `test`, so the grid cannot evaluate it. */
+const NO_PREDICATE_OPTION = {
+    displayKey: 'noPredicate',
+    displayName: 'No Predicate',
+    numberOfInputs: 1,
+} as IFilterOptionDef;
+
+describe('Column filter — a model naming an option the column does not offer', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [NumberFilterModule, ColumnMenuModule, ClientSideRowModelModule],
+    });
+
+    beforeAll(() => {
+        setupAgTestIds();
+        installFilterLayoutMock();
+    });
+    afterAll(() => uninstallFilterLayoutMock());
+    afterEach(() => gridsManager.reset());
+
+    const restrictedOpts: GridOptions<AgeRow> = {
+        columnDefs: [
+            {
+                field: 'age',
+                filter: 'agNumberColumnFilter',
+                filterParams: {
+                    filterOptions: ['equals', MULTIPLE_OF_AGE],
+                    debounceMs: 0,
+                    maxNumConditions: 1,
+                },
+            },
+        ],
+        rowData: [{ age: 25 }, { age: 40 }, { age: 28 }, { age: 33 }],
+    };
+
+    test('a built-in option left out of `filterOptions` is cleared, not applied', async () => {
+        const api: GridApi<AgeRow> = await gridsManager.createGridAndWait('grid1', restrictedOpts);
+
+        await api.setColumnFilterModel('age', { filterType: 'number', type: 'greaterThan', filter: 30 });
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+
+        expect(api.getColumnFilterModel('age')).toBeNull();
+        await new GridRows(api, 'unfiltered - the option is not offered').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 age:25
+            ├── LEAF id:1 age:40
+            ├── LEAF id:2 age:28
+            └── LEAF id:3 age:33
+        `);
+        await new FilterDom(api, 'a built-in option left out of the list', { colId: 'age' }).checkFilterDom(`
+            FLOATING FILTER age: (not present)
+            model: null
+        `);
+    });
+
+    test('an option the list does offer is applied untouched', async () => {
+        const api: GridApi<AgeRow> = await gridsManager.createGridAndWait('grid1', restrictedOpts);
+
+        await api.setColumnFilterModel('age', { filterType: 'number', type: 'multipleOf', filter: 5 });
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+
+        expect(api.getColumnFilterModel('age')).toEqual({ filterType: 'number', type: 'multipleOf', filter: 5 });
+        await new GridRows(api, 'offered option applies').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 age:25
+            └── LEAF id:1 age:40
+        `);
+        await new FilterDom(api, 'an offered option applied untouched', { colId: 'age' }).checkFilterDom(`
+            FLOATING FILTER age: (not present)
+            model:
+              filterType: "number"
+              type: "multipleOf"
+              filter: 5
+        `);
+    });
+});
+
+describe('Column filter — an invalid custom option', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [NumberFilterModule, ColumnMenuModule, ClientSideRowModelModule],
+    });
+
+    beforeAll(() => {
+        setupAgTestIds();
+        installFilterLayoutMock();
+    });
+    afterAll(() => uninstallFilterLayoutMock());
+    afterEach(() => {
+        gridsManager.reset();
+        vi.restoreAllMocks();
+        enableDevValidations({ throwOn: ALL_SEVERITIES });
+    });
+
+    test('is dropped, leaving every other option usable', async () => {
+        // Deliberate: the option is missing `predicate`/`test`, which triggers warning #72.
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [72] });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const api: GridApi<AgeRow> = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'age',
+                    filter: 'agNumberColumnFilter',
+                    filterParams: {
+                        filterOptions: ['equals', NO_PREDICATE_OPTION, MULTIPLE_OF_AGE],
+                        debounceMs: 0,
+                        maxNumConditions: 1,
+                    },
+                },
+            ],
+            rowData: [{ age: 25 }, { age: 40 }, { age: 28 }, { age: 33 }],
+        });
+
+        // The unusable option goes; the ones the user can actually filter with stay.
+        const filter = await ColumnFilterHarness.open(api, 'age');
+        expect(warnSpy.mock.calls.flat().join(' ')).toContain('warning #72');
+        expect(await filter.operatorOptions()).toEqual(['Equals', 'Multiple of']);
+
+        await filter.selectOperator('Multiple of');
+        await filter.setNumber(5, 0);
+        await asyncSetTimeout(0);
+        await new GridRows(api, 'valid option still filters').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 age:25
+            └── LEAF id:1 age:40
+        `);
+        await new FilterDom(api, 'an invalid option dropped from the list', { colId: 'age' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Multiple of"
+            input: "5"
+            model:
+              filterType: "number"
+              type: "multipleOf"
+              filter: 5
+        `);
+    });
+
+    test('is not defaulted to when it is listed first, as the dropdown never offers it', async () => {
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [72] });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const api: GridApi<AgeRow> = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'age',
+                    filter: 'agNumberColumnFilter',
+                    filterParams: {
+                        filterOptions: [NO_PREDICATE_OPTION, 'equals', MULTIPLE_OF_AGE],
+                        debounceMs: 0,
+                        maxNumConditions: 1,
+                    },
+                },
+            ],
+            rowData: [{ age: 25 }, { age: 40 }, { age: 28 }, { age: 33 }],
+        });
+
+        const filter = await ColumnFilterHarness.open(api, 'age');
+        expect(warnSpy.mock.calls.flat().join(' ')).toContain('warning #72');
+        expect(await filter.operatorOptions()).toEqual(['Equals', 'Multiple of']);
+        // The first option the user can actually pick is what the condition starts on.
+        expect(filter.operatorSelectValue()).toBe('Equals');
+
+        await filter.setNumber(40, 0);
+        await asyncSetTimeout(0);
+        await new GridRows(api, 'the defaulted option filters').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:1 age:40
+        `);
+        await new FilterDom(api, 'an invalid option listed first', { colId: 'age' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Equals"
+            input: "40"
+            model:
+              filterType: "number"
+              type: "equals"
+              filter: 40
+        `);
+    });
+
+    test('is not defaulted to by `defaultOption` either, which names an option the dropdown lacks', async () => {
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [72, 326] });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const api: GridApi<AgeRow> = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'age',
+                    filter: 'agNumberColumnFilter',
+                    filterParams: {
+                        filterOptions: ['equals', NO_PREDICATE_OPTION, MULTIPLE_OF_AGE],
+                        defaultOption: 'noPredicate',
+                        debounceMs: 0,
+                        maxNumConditions: 1,
+                    },
+                },
+            ],
+            rowData: [{ age: 25 }, { age: 40 }, { age: 28 }, { age: 33 }],
+        });
+
+        const filter = await ColumnFilterHarness.open(api, 'age');
+        expect(await filter.operatorOptions()).toEqual(['Equals', 'Multiple of']);
+        expect(filter.operatorSelectValue()).toBe('Equals');
+
+        // Both faults are the user's to fix: the option is malformed, and the default names one not offered.
+        const warnings = warnSpy.mock.calls.flat().join(' ');
+        expect(warnings).toContain('warning #72');
+        expect(warnings).toContain('warning #326');
+        expect(warnings).toContain('noPredicate');
+
+        await filter.setNumber(40, 0);
+        await asyncSetTimeout(0);
+        await new GridRows(api, 'the fallback option filters').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:1 age:40
+        `);
+        await new FilterDom(api, 'a `defaultOption` naming an option the list lacks', { colId: 'age' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Equals"
+            input: "40"
+            model:
+              filterType: "number"
+              type: "equals"
+              filter: 40
+        `);
+    });
+
+    test('a model naming it is cleared, as nothing can show or evaluate that condition', async () => {
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [72] });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const api: GridApi<AgeRow> = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'age',
+                    filter: 'agNumberColumnFilter',
+                    filterParams: { filterOptions: ['equals', NO_PREDICATE_OPTION], debounceMs: 0 },
+                },
+            ],
+            rowData: [{ age: 25 }, { age: 40 }, { age: null as any }],
+        });
+
+        await api.setColumnFilterModel('age', { filterType: 'number', type: 'noPredicate', filter: 5 });
+        api.onFilterChanged();
+        await asyncSetTimeout(0);
+
+        expect(warnSpy.mock.calls.flat().join(' ')).toContain('warning #72');
+        expect(api.getColumnFilterModel('age')).toBeNull();
+        // The blank row proves the condition is gone: an option that cannot be evaluated hides blanks while it survives.
+        await new GridRows(api, 'unfiltered - the option was dropped').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 age:25
+            ├── LEAF id:1 age:40
+            └── LEAF id:2 age:null
+        `);
+        await new FilterDom(api, 'a model naming an invalid option', { colId: 'age' }).checkFilterDom(`
+            FLOATING FILTER age: (not present)
+            model: null
+        `);
+    });
+});
+
+const EDGE_KEY_ROWS: AgeRow[] = [{ age: 25 }, { age: 40 }, { age: 28 }];
+
+/** `toString` and `constructor` both resolve on any prototype-bearing lookup table. */
+const TO_STRING_OPTION: IFilterOptionDef = {
+    displayKey: 'toString',
+    displayName: 'Even Numbers',
+    numberOfInputs: 0,
+    predicate: (_values, cellValue) => cellValue != null && cellValue % 2 === 0,
+};
+
+const CONSTRUCTOR_OPTION: IFilterOptionDef = {
+    displayKey: 'constructor',
+    displayName: 'Over',
+    numberOfInputs: 1,
+    predicate: ([value], cellValue) => cellValue != null && cellValue > value,
+};
+
+const EDGE_KEY_OPTS: GridOptions<AgeRow> = {
+    columnDefs: [
+        {
+            field: 'age',
+            filter: 'agNumberColumnFilter',
+            filterParams: {
+                filterOptions: ['equals', TO_STRING_OPTION, CONSTRUCTOR_OPTION],
+                debounceMs: 0,
+                maxNumConditions: 1,
+            },
+        },
+    ],
+    rowData: EDGE_KEY_ROWS,
+};
+
+describe('Column filter — a built-in option the filter cannot evaluate', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [TextFilterModule, NumberFilterModule, ColumnMenuModule, ClientSideRowModelModule],
+    });
+
+    beforeAll(() => {
+        setupAgTestIds();
+        installFilterLayoutMock();
+    });
+    afterAll(() => uninstallFilterLayoutMock());
+    afterEach(() => {
+        gridsManager.reset();
+        vi.restoreAllMocks();
+        enableDevValidations({ throwOn: ALL_SEVERITIES });
+    });
+
+    const createGrid = (filterOptions: (string | IFilterOptionDef)[]) =>
+        gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'athlete',
+                    filter: 'agTextColumnFilter',
+                    filterParams: { filterOptions, debounceMs: 0, maxNumConditions: 1 },
+                },
+            ],
+            rowData: [{ athlete: 'Bolt' }, { athlete: 'Ng' }],
+        } as GridOptions);
+
+    // The reported case: a key that is not a filter option at all, rather than one belonging elsewhere.
+    test('a key no filter defines is offered under its own name, and reported when it is evaluated', async () => {
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [76] });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const api: GridApi = await createGrid(['equals', 'notEqual', 'wrong']);
+        const filter = await ColumnFilterHarness.open(api, 'athlete');
+        // Nothing localises it, so the key stands in for the label it has no translation for.
+        expect(await filter.operatorOptions()).toEqual(['Equals', 'Does not equal', 'wrong']);
+        expect(warnSpy).not.toHaveBeenCalled();
+
+        await filter.selectOperator('wrong');
+        await filter.setText('Bolt', 0);
+        await asyncSetTimeout(0);
+
+        expect(api.getColumnFilterModel('athlete')).toEqual({
+            filterType: 'text',
+            type: 'wrong',
+            filter: 'Bolt',
+        });
+        // `Bolt` is in the data, so a key that matched anything would leave a row behind.
+        await new GridRows(api, 'a key no filter defines').check(`
+            ROOT id:ROOT_NODE_ID
+        `);
+        const warnings = warnSpy.mock.calls.flat().join(' ');
+        expect(warnings).toContain('warning #76');
+        expect(warnings).toContain('wrong');
+        await new FilterDom(api, 'a key no filter defines', { colId: 'athlete' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "wrong"
+            input: "Bolt"
+            model:
+              filterType: "text"
+              type: "wrong"
+              filter: "Bolt"
+        `);
+    });
+
+    // The option is offered as configured: only a `textMatcher` or a `predicate` can say what it means,
+    // and either may supply one, so it is the evaluation with neither that reports.
+    test('an option belonging to another filter type is offered, and reported when it is evaluated', async () => {
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [76] });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const api: GridApi = await createGrid(['contains', 'inRange']);
+        const filter = await ColumnFilterHarness.open(api, 'athlete');
+        expect(await filter.operatorOptions()).toEqual(['Contains', 'Between']);
+        expect(warnSpy).not.toHaveBeenCalled();
+
+        await filter.selectOperator('Between');
+        await filter.setText('A', 0);
+        await filter.setText('Z', 1);
+        await asyncSetTimeout(0);
+
+        expect(api.getColumnFilterModel('athlete')).toEqual({
+            filterType: 'text',
+            type: 'inRange',
+            filter: 'A',
+            filterTo: 'Z',
+        });
+        await new GridRows(api, 'a text `inRange` the matcher cannot answer').check(`
+            ROOT id:ROOT_NODE_ID
+        `);
+        const warnings = warnSpy.mock.calls.flat().join(' ');
+        expect(warnings).toContain('warning #76');
+        expect(warnings).toContain('inRange');
+        await new FilterDom(api, 'an option belonging to another filter type', { colId: 'athlete' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Between"
+            input [0]: "A"
+            input [1]: "Z"
+            model:
+              filterType: "text"
+              type: "inRange"
+              filter: "A"
+              filterTo: "Z"
+        `);
+    });
+
+    test('a relative date range on a text filter is offered with no inputs, and reported the same way', async () => {
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [76] });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const api: GridApi = await createGrid(['contains', 'lastYear']);
+        const filter = await ColumnFilterHarness.open(api, 'athlete');
+
+        await filter.selectOperator('Last Year');
+        await asyncSetTimeout(0);
+
+        expect(filter.inputs('text')).toEqual([]);
+        expect(api.getColumnFilterModel('athlete')).toEqual({ filterType: 'text', type: 'lastYear' });
+        await new GridRows(api, 'a text `lastYear` the matcher cannot answer').check(`
+            ROOT id:ROOT_NODE_ID
+        `);
+        const warnings = warnSpy.mock.calls.flat().join(' ');
+        expect(warnings).toContain('warning #76');
+        expect(warnings).toContain('lastYear');
+        await new FilterDom(api, 'a relative date range on a text filter', { colId: 'athlete' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Last Year"
+            model:
+              filterType: "text"
+              type: "lastYear"
+        `);
+    });
+
+    // Both filters report `#76`; the scalar filters admit the row they cannot judge, the text filter excludes it.
+    test('a number filter shows every row for the option it cannot evaluate', async () => {
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [76] });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'age',
+                    filter: 'agNumberColumnFilter',
+                    filterParams: { filterOptions: ['equals', 'contains'], debounceMs: 0 },
+                },
+            ],
+            rowData: [{ age: 25 }, { age: 40 }],
+        } as GridOptions);
+
+        const filter = await ColumnFilterHarness.open(api, 'age');
+        await filter.selectOperator('Contains');
+        await filter.setNumber(25, 0);
+        await asyncSetTimeout(0);
+
+        // The scalar filters admit the row they cannot judge; the text filter excludes it.
+        await new GridRows(api, 'a number `contains` the comparison cannot answer').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 age:25
+            └── LEAF id:1 age:40
+        `);
+        const warnings = warnSpy.mock.calls.flat().join(' ');
+        expect(warnings).toContain('warning #76');
+        expect(warnings).toContain('contains');
+        await new FilterDom(api, 'a number filter shows every row', { colId: 'age' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Contains"
+            input: "25"
+            AND
+            operator: "Equals"
+            input: "" ⟨Filter...⟩
+            model:
+              filterType: "number"
+              type: "contains"
+              filter: 25
+        `);
+    });
+
+    // Presence is decided without the matcher, so a column that never reaches it must still report.
+    test('a column of blank values still reports the key it cannot evaluate', async () => {
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [76] });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'athlete',
+                    filter: 'agTextColumnFilter',
+                    filterParams: { filterOptions: ['contains', 'inRange'], debounceMs: 0, maxNumConditions: 1 },
+                },
+            ],
+            rowData: [{ athlete: null }, { athlete: null }],
+        } as GridOptions);
+
+        await api.setColumnFilterModel('athlete', {
+            filterType: 'text',
+            type: 'inRange',
+            filter: 'A',
+            filterTo: 'Z',
+        });
+        await api.onFilterChanged();
+
+        const warnings = warnSpy.mock.calls.flat().join(' ');
+        expect(warnings).toContain('warning #76');
+        expect(warnings).toContain('inRange');
+        await new GridRows(api, 'a blank column with an unusable key').check(`
+            ROOT id:ROOT_NODE_ID
+        `);
+    });
+
+    // The option is configured correctly and only its value is missing, so the key is not what went wrong.
+    test('a Custom Filter Option waiting for its value is not reported as a key the filter cannot evaluate', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const api: GridApi = await createGrid([
+            'contains',
+            {
+                displayKey: 'soundsLike',
+                displayName: 'Sounds Like',
+                numberOfInputs: 1,
+                predicate: ([t]: unknown[], cellValue: unknown) => cellValue === t,
+            },
+        ]);
+
+        await api.setColumnFilterModel('athlete', { filterType: 'text', type: 'soundsLike', filter: null });
+        await api.onFilterChanged();
+
+        expect(warnSpy).not.toHaveBeenCalled();
+        await new GridRows(api, 'a custom option with no value matches nothing').check(`
+            ROOT id:ROOT_NODE_ID
+        `);
+    });
+
+    test('a `textMatcher` answering the key is what makes it usable, and nothing is reported', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const filterParams: ITextFilterParams = {
+            filterOptions: ['contains', 'lessThan'],
+            textMatcher: ({ filterOption, value, filterText }) =>
+                filterOption === 'lessThan' ? value < filterText! : value.includes(filterText!),
+            debounceMs: 0,
+            maxNumConditions: 1,
+        };
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [{ field: 'athlete', filter: 'agTextColumnFilter', filterParams }],
+            rowData: [{ athlete: 'Bolt' }, { athlete: 'Ng' }],
+        } as GridOptions);
+
+        const filter = await ColumnFilterHarness.open(api, 'athlete');
+        await filter.selectOperator('Less than');
+        await filter.setText('c', 0);
+        await asyncSetTimeout(0);
+
+        await new GridRows(api, 'a text `lessThan` the matcher does answer').check(`
+            ROOT id:ROOT_NODE_ID
+            └── LEAF id:0 athlete:"Bolt"
+        `);
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    test('a Custom Filter Option supplying the same key defines the evaluation', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const api: GridApi = await createGrid([
+            'contains',
+            {
+                displayKey: 'inRange',
+                displayName: 'Between',
+                numberOfInputs: 2,
+                predicate: ([from, to], cellValue) => cellValue > from && cellValue < to,
+            },
+        ]);
+
+        expect(warnSpy).not.toHaveBeenCalled();
+        const filter = await ColumnFilterHarness.open(api, 'athlete');
+        expect(await filter.operatorOptions()).toEqual(['Contains', 'Between']);
+    });
+});
+
+describe('Column filter — a custom option whose `displayKey` is a built-in key', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [NumberFilterModule, ColumnMenuModule, ClientSideRowModelModule],
+    });
+
+    beforeAll(() => {
+        setupAgTestIds();
+        installFilterLayoutMock();
+    });
+    afterAll(() => uninstallFilterLayoutMock());
+    afterEach(() => gridsManager.reset());
+
+    /** `equals` redefined for this column: the built-in of the same key is replaced, not offered beside it. */
+    const EQUALS_TENS: IFilterOptionDef = {
+        displayKey: 'equals',
+        displayName: 'Equals (tens)',
+        numberOfInputs: 1,
+        predicate: ([value], cellValue) => cellValue != null && Math.floor(cellValue / 10) === value,
+    };
+
+    const createGrid = (filterOptions: (string | IFilterOptionDef)[]) =>
+        gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'age',
+                    filter: 'agNumberColumnFilter',
+                    filterParams: { filterOptions, debounceMs: 0, maxNumConditions: 1 },
+                },
+            ],
+            rowData: [{ age: 25 }, { age: 40 }, { age: 28 }, { age: 33 }],
+        } as GridOptions);
+
+    test('replaces it in the dropdown rather than appearing twice', async () => {
+        const api: GridApi = await createGrid(['equals', EQUALS_TENS, 'greaterThan']);
+
+        const filter = await ColumnFilterHarness.open(api, 'age');
+        expect(await filter.operatorOptions()).toEqual(['Equals (tens)', 'Greater than']);
+        await new FilterDom(api, 'a `displayKey` replacing a built-in key', { colId: 'age' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Equals (tens)"
+            input: "" ⟨Filter...⟩
+            model: null
+        `);
+    });
+
+    test('a built-in key listed twice is offered once', async () => {
+        const api: GridApi = await createGrid(['equals', 'greaterThan', 'equals']);
+
+        const filter = await ColumnFilterHarness.open(api, 'age');
+        expect(await filter.operatorOptions()).toEqual(['Equals', 'Greater than']);
+    });
+
+    test('keeps the place the key was first listed in, whichever form declared it', async () => {
+        const api: GridApi = await createGrid(['greaterThan', EQUALS_TENS, 'equals']);
+
+        const filter = await ColumnFilterHarness.open(api, 'age');
+        expect(await filter.operatorOptions()).toEqual(['Greater than', 'Equals (tens)']);
+        await new FilterDom(api, 'the key keeps the place it was first listed in', { colId: 'age' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Greater than"
+            input: "" ⟨Filter...⟩
+            model: null
+        `);
+    });
+
+    test('is the one that evaluates, so the built-in behaviour is gone', async () => {
+        const api: GridApi = await createGrid(['equals', EQUALS_TENS]);
+
+        const filter = await ColumnFilterHarness.open(api, 'age');
+        await filter.setNumber(2, 0);
+        await asyncSetTimeout(0);
+
+        // The built-in `equals` would match nothing; the replacement matches every age in the twenties.
+        await new FilterDom(api, 'the replacing option is the one selected', { colId: 'age' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Equals (tens)"
+            input: "2"
+            model:
+              filterType: "number"
+              type: "equals"
+              filter: 2
+        `);
+        await new GridRows(api, 'the custom predicate decides').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 age:25
+            └── LEAF id:2 age:28
+        `);
+    });
+});
+
+describe('Column filter — a `defaultOption` the dropdown does not offer', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [NumberFilterModule, ColumnMenuModule, ClientSideRowModelModule],
+    });
+
+    beforeAll(() => {
+        setupAgTestIds();
+        installFilterLayoutMock();
+    });
+    afterAll(() => uninstallFilterLayoutMock());
+    afterEach(() => {
+        gridsManager.reset();
+        vi.restoreAllMocks();
+        enableDevValidations({ throwOn: ALL_SEVERITIES });
+    });
+
+    test('falls back to the first offered option, and reports the one it could not select', async () => {
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [326] });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'age',
+                    filter: 'agNumberColumnFilter',
+                    filterParams: {
+                        filterOptions: ['greaterThan', 'equals'],
+                        defaultOption: 'lessThan',
+                        debounceMs: 0,
+                    },
+                },
+            ],
+            rowData: [{ age: 25 }, { age: 40 }],
+        } as GridOptions);
+
+        const filter = await ColumnFilterHarness.open(api, 'age');
+        expect(filter.operatorSelectValue()).toBe('Greater than');
+
+        const warnings = warnSpy.mock.calls.flat().join(' ');
+        expect(warnings).toContain('warning #326');
+        expect(warnings).toContain('lessThan');
+        await new FilterDom(api, 'fallen back to the first offered option', { colId: 'age' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Greater than"
+            input: "" ⟨Filter...⟩
+            model: null
+        `);
+    });
+});
+
+describe('Column filter — a malformed `filterOptions` list', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [TextFilterModule, NumberFilterModule, ColumnMenuModule, ClientSideRowModelModule],
+    });
+
+    beforeAll(() => {
+        setupAgTestIds();
+        installFilterLayoutMock();
+    });
+    afterAll(() => uninstallFilterLayoutMock());
+    afterEach(() => {
+        gridsManager.reset();
+        vi.restoreAllMocks();
+        enableDevValidations({ throwOn: ALL_SEVERITIES });
+    });
+
+    const ANY_OF_TWO: IFilterOptionDef = {
+        displayKey: 'anyOfTwo',
+        displayName: 'Any Of Two',
+        numberOfInputs: 2,
+        predicate: (values, cellValue) => values.includes(cellValue),
+    };
+
+    // A column that offers nothing cannot open its filter at all, which is worse than the bad configuration.
+    test('that keeps no option at all falls back to the built-in list, so the filter still opens', async () => {
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [72, 74] });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'age',
+                    filter: 'agNumberColumnFilter',
+                    filterParams: {
+                        filterOptions: [{ displayKey: 'x', displayName: 'X' } as IFilterOptionDef],
+                        debounceMs: 0,
+                    },
+                },
+            ],
+            rowData: [{ age: 25 }, { age: 40 }],
+        } as GridOptions);
+
+        const filter = await ColumnFilterHarness.open(api, 'age');
+        expect(await filter.operatorOptions()).toContain('Equals');
+        await filter.selectOperator('Equals');
+        await filter.setNumber(25, 0);
+        await waitFor(() =>
+            expect(api.getColumnFilterModel('age')).toEqual({ filterType: 'number', type: 'equals', filter: 25 })
+        );
+
+        const warnings = warnSpy.mock.calls.flat().join(' ');
+        expect(warnings).toContain('warning #72');
+        expect(warnings).toContain('warning #74');
+        await new FilterDom(api, 'a list that keeps no option', { colId: 'age' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Equals"
+            input: "25"
+            AND
+            operator: "Equals"
+            input: "" ⟨Filter...⟩
+            model:
+              filterType: "number"
+              type: "equals"
+              filter: 25
+        `);
+    });
+
+    // An empty list reaches the same fallback with the loop never running, so nothing is malformed to report.
+    test('that is empty falls back to the built-in list, reporting only that it kept nothing', async () => {
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [74] });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'age',
+                    filter: 'agNumberColumnFilter',
+                    filterParams: { filterOptions: [], debounceMs: 0 },
+                },
+            ],
+            rowData: [{ age: 25 }, { age: 40 }],
+        } as GridOptions);
+
+        const filter = await ColumnFilterHarness.open(api, 'age');
+        expect(await filter.operatorOptions()).toContain('Equals');
+        const warnings = warnSpy.mock.calls.flat().join(' ');
+        expect(warnings).toContain('warning #74');
+        expect(warnings).not.toContain('warning #72');
+        await new FilterDom(api, 'an empty list', { colId: 'age' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Equals"
+            input: "" ⟨Filter...⟩
+            model: null
+        `);
+    });
+
+    test('a numeric string `numberOfInputs` counts, and a hole in the list is skipped', async () => {
+        const api: GridApi<AgeRow> = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'age',
+                    filter: 'agNumberColumnFilter',
+                    filterParams: {
+                        // A JS caller gets no type check, so a list can hold both.
+                        filterOptions: [null, { ...ANY_OF_TWO, numberOfInputs: '2' }] as any,
+                        debounceMs: 0,
+                    },
+                },
+            ],
+            rowData: [{ age: 25 }, { age: 40 }, { age: 28 }, { age: 33 }],
+        });
+
+        const filter = await ColumnFilterHarness.open(api, 'age');
+        expect(filter.operatorSelectValue()).toBe('Any Of Two');
+        expect(filter.inputs('number')).toHaveLength(2);
+
+        await filter.setNumber(25, 0);
+        await filter.setNumber(40, 1);
+        expect(filter.getModel()).toEqual({ filterType: 'number', type: 'anyOfTwo', filter: 25, filterTo: 40 });
+        await new FilterDom(api, 'a numeric string `numberOfInputs`', { colId: 'age' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Any Of Two"
+            input [0]: "25"
+            input [1]: "40"
+            AND
+            operator: "Any Of Two"
+            input [0]: "" ⟨From⟩
+            input [1]: "" ⟨To⟩
+            model:
+              filterType: "number"
+              type: "anyOfTwo"
+              filter: 25
+              filterTo: 40
+        `);
+    });
+
+    test('`filterPlaceholder` is given the custom option, not an unresolved key', async () => {
+        const seen: { filterOptionKey: string; filterOption: string }[] = [];
+        const api = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'age',
+                    filter: 'agNumberColumnFilter',
+                    filterParams: {
+                        filterOptions: [
+                            'equals',
+                            {
+                                displayKey: 'withinOf',
+                                displayName: 'Within Of',
+                                numberOfInputs: 2,
+                                predicate: ([target, tolerance]: any[], cellValue: any) =>
+                                    Math.abs(cellValue - target) <= tolerance,
+                            },
+                        ],
+                        filterPlaceholder: ({ filterOptionKey, filterOption, placeholder }: any) => {
+                            seen.push({ filterOptionKey, filterOption });
+                            return placeholder;
+                        },
+                        debounceMs: 0,
+                        maxNumConditions: 1,
+                    },
+                },
+            ],
+            rowData: [{ age: 25 }, { age: 40 }],
+        });
+
+        const harness = await ColumnFilterHarness.open(api, 'age');
+        await harness.selectOperator('Within Of');
+
+        // A custom option has no built-in locale text, so its `displayName` is what the callback must see.
+        expect(seen).toContainEqual({ filterOptionKey: 'withinOf', filterOption: 'Within Of' });
+    });
+
+    test('a custom option declared with only the removed `test` is rejected rather than offered', async () => {
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [72] });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const api = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'country',
+                    filter: 'agTextColumnFilter',
+                    filterParams: {
+                        filterOptions: [
+                            'contains',
+                            'equals',
+                            {
+                                displayKey: 'startsWithA',
+                                displayName: 'Starts with A',
+                                test: (_filterValue: string, cellValue: string) => cellValue?.startsWith('A'),
+                            },
+                        ],
+                    },
+                },
+            ],
+            rowData: [{ country: 'Argentina' }, { country: 'Brazil' }, { country: 'Australia' }],
+        });
+        await asyncSetTimeout(0);
+
+        const harness = await ColumnFilterHarness.open(api, 'country');
+        expect(await harness.operatorOptions()).toEqual(['Contains', 'Equals']);
+
+        // Nothing runs `test`, so an option carrying only it is reported rather than left to match nothing.
+        const warnings = warnSpy.mock.calls.flat().join(' ');
+        expect(warnings).toContain('warning #72');
+        expect(warnings).toContain('predicate');
+
+        await api.setColumnFilterModel('country', { filterType: 'text', type: 'startsWithA', filter: 'x' });
+        await api.onFilterChanged();
+        // A model naming an option the column does not offer filters nothing, as any other unknown one does.
+        await waitFor(() => expect(api.getDisplayedRowCount()).toBe(3));
+        await new FilterDom(api, 'a `test`-only option is not offered', { colId: 'country' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Contains"
+            input: "x"
+            AND
+            operator: "Contains"
+            input: "" ⟨Filter...⟩
+            model: null
+        `);
+    });
+});
+
+describe('Custom filter option — a `displayKey` shadowing `Object.prototype`', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [NumberFilterModule, ColumnMenuModule, ClientSideRowModelModule],
+    });
+
+    beforeAll(() => {
+        setupAgTestIds();
+        installFilterLayoutMock();
+    });
+    afterAll(() => uninstallFilterLayoutMock());
+    afterEach(() => {
+        gridsManager.reset();
+        vi.restoreAllMocks();
+        enableDevValidations({ throwOn: ALL_SEVERITIES });
+    });
+
+    test('the column filter offers it and filters with it', async () => {
+        const api: GridApi<AgeRow> = await gridsManager.createGridAndWait('grid1', EDGE_KEY_OPTS);
+
+        const filter = await ColumnFilterHarness.open(api, 'age');
+        expect(await filter.operatorOptions()).toEqual(['Equals', 'Even Numbers', 'Over']);
+
+        await filter.selectOperator('Even Numbers');
+        await asyncSetTimeout(0);
+        await new GridRows(api, 'even ages via a `toString` key').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:1 age:40
+            └── LEAF id:2 age:28
+        `);
+        expect(api.getColumnFilterModel('age')).toEqual({ filterType: 'number', type: 'toString' });
+
+        await filter.selectOperator('Over');
+        await filter.setNumber(26, 0);
+        await waitFor(() =>
+            expect(api.getColumnFilterModel('age')).toEqual({
+                filterType: 'number',
+                type: 'constructor',
+                filter: 26,
+            })
+        );
+        await new FilterDom(api, 'a `displayKey` shadowing `Object.prototype`', { colId: 'age' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Over"
+            input: "26"
+            model:
+              filterType: "number"
+              type: "constructor"
+              filter: 26
+        `);
+    });
+});
+
+describe('Column filter — the offered list survives a colDef refresh', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [NumberFilterModule, ColumnMenuModule, ClientSideRowModelModule],
+    });
+
+    beforeAll(() => {
+        setupAgTestIds();
+        installFilterLayoutMock();
+    });
+    afterAll(() => uninstallFilterLayoutMock());
+    afterEach(() => {
+        gridsManager.reset();
+        vi.restoreAllMocks();
+        enableDevValidations({ throwOn: ALL_SEVERITIES });
+    });
+
+    const EVEN: IFilterOptionDef = {
+        displayKey: 'even',
+        displayName: 'Even',
+        numberOfInputs: 0,
+        predicate: (_values, cellValue: number) => cellValue % 2 === 0,
+    };
+
+    const colDef = (filterOptions: (string | IFilterOptionDef)[]): ColDef<AgeRow>[] => [
+        { field: 'age', filter: 'agNumberColumnFilter', filterParams: { filterOptions, debounceMs: 0 } },
+    ];
+
+    const AGES = [{ age: 25 }, { age: 40 }, { age: 28 }];
+
+    test('the same list re-declared leaves the offered options and the applied model alone', async () => {
+        const options = ['equals', EVEN];
+        const api: GridApi<AgeRow> = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: colDef(options),
+            rowData: AGES,
+        } as GridOptions);
+
+        await api.setColumnFilterModel('age', { filterType: 'number', type: 'even' });
+        await api.onFilterChanged();
+
+        api.setGridOption('columnDefs', colDef(options));
+        await asyncSetTimeout(0);
+
+        const filter = await ColumnFilterHarness.open(api, 'age');
+        expect(await filter.operatorOptions()).toEqual(['Equals', 'Even']);
+        await new FilterDom(api, 'same list re-declared', { colId: 'age' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Even"
+            AND
+            operator: "Equals"
+            input: "" ⟨Filter...⟩
+            model:
+              filterType: "number"
+              type: "even"
+        `);
+        await new GridRows(api, 'same list re-declared').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:1 age:40
+            └── LEAF id:2 age:28
+        `);
+    });
+
+    // A `colDef` is replaced, never edited, so editing the list it was given is not a change the grid acts on:
+    // the applied model survives an option disappearing from under it.
+    test('a list mutated in place is not a refresh at all', async () => {
+        const options: (string | IFilterOptionDef)[] = ['equals', EVEN];
+        const api: GridApi<AgeRow> = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: colDef(options),
+            rowData: AGES,
+        } as GridOptions);
+
+        await api.setColumnFilterModel('age', { filterType: 'number', type: 'even' });
+        await api.onFilterChanged();
+
+        options.splice(1, 1);
+        api.setGridOption('columnDefs', colDef(options));
+        await asyncSetTimeout(0);
+
+        expect(api.getColumnFilterModel('age')).toEqual({ filterType: 'number', type: 'even' });
+        await new GridRows(api, 'a list mutated in place').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:1 age:40
+            └── LEAF id:2 age:28
+        `);
+    });
+
+    // The handler keeps its own factory, so an applied model is re-judged against the list the refresh installed.
+    test('an applied model is cleared when the refresh stops offering its option', async () => {
+        const api: GridApi<AgeRow> = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: colDef(['equals', EVEN]),
+            rowData: AGES,
+        } as GridOptions);
+
+        await api.setColumnFilterModel('age', { filterType: 'number', type: 'even' });
+        await api.onFilterChanged();
+        await new GridRows(api, 'the custom option filters before the refresh').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:1 age:40
+            └── LEAF id:2 age:28
+        `);
+
+        api.setGridOption('columnDefs', colDef(['equals', 'greaterThan']));
+        await asyncSetTimeout(0);
+
+        expect(api.getColumnFilterModel('age')).toBeNull();
+        await new GridRows(api, 'the model goes with the option it named').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 age:25
+            ├── LEAF id:1 age:40
+            └── LEAF id:2 age:28
+        `);
+    });
+
+    test('a malformed entry arriving on the refresh is dropped, as it is on init', async () => {
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [72] });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const api: GridApi<AgeRow> = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: colDef(['equals', EVEN]),
+            rowData: AGES,
+        } as GridOptions);
+        expect(warnSpy).not.toHaveBeenCalled();
+
+        api.setGridOption(
+            'columnDefs',
+            colDef(['equals', 'greaterThan', { displayKey: 'odd', displayName: 'Odd' } as any])
+        );
+        await asyncSetTimeout(0);
+
+        const filter = await ColumnFilterHarness.open(api, 'age');
+        expect(await filter.operatorOptions()).toEqual(['Equals', 'Greater than']);
+        const warnings = warnSpy.mock.calls.flat().join(' ');
+        expect(warnings).toContain('warning #72');
+        expect(warnings).toContain('predicate');
+        await new FilterDom(api, 'a malformed entry arriving on the refresh', { colId: 'age' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Equals"
+            input: "" ⟨Filter...⟩
+            model: null
+        `);
+    });
+});
+
+describe('Column filter — a combined model naming an option the column does not offer', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [NumberFilterModule, ColumnMenuModule, ClientSideRowModelModule],
+    });
+
+    beforeAll(() => setupAgTestIds());
+    afterEach(() => gridsManager.reset());
+
+    test('is cleared whole, rather than filtering on the condition that is offered', async () => {
+        const api: GridApi<AgeRow> = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'age',
+                    filter: 'agNumberColumnFilter',
+                    filterParams: { filterOptions: ['equals', 'greaterThan'], debounceMs: 0 },
+                },
+            ],
+            rowData: [{ age: 25 }, { age: 40 }, { age: 28 }],
+        } as GridOptions);
+
+        await api.setColumnFilterModel('age', {
+            filterType: 'number',
+            operator: 'OR',
+            conditions: [
+                { filterType: 'number', type: 'equals', filter: 25 },
+                { filterType: 'number', type: 'lessThan', filter: 30 },
+            ],
+        });
+        await api.onFilterChanged();
+
+        // One unoffered condition invalidates the model, so the offered one does not filter on its own.
+        expect(api.getColumnFilterModel('age')).toBeNull();
+        await new GridRows(api, 'combined model with an unoffered condition').check(`
+            ROOT id:ROOT_NODE_ID
+            ├── LEAF id:0 age:25
+            ├── LEAF id:1 age:40
+            └── LEAF id:2 age:28
+        `);
+    });
+});
+
+describe('Column filter — validation is the same for every filter type', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [DateFilterModule, BigIntFilterModule, ColumnMenuModule, ClientSideRowModelModule],
+    });
+
+    beforeAll(() => {
+        setupAgTestIds();
+        installFilterLayoutMock();
+    });
+    afterAll(() => uninstallFilterLayoutMock());
+    afterEach(() => {
+        gridsManager.reset();
+        vi.restoreAllMocks();
+        enableDevValidations({ throwOn: ALL_SEVERITIES });
+    });
+
+    // `OptionsFactory` is shared, so a fourth data type must not have its own answer.
+    const withMalformedOption = (filter: string, rowData: unknown[]) =>
+        gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'value',
+                    filter,
+                    filterParams: {
+                        filterOptions: ['equals', 'notEqual', { displayKey: 'bad', displayName: 'Bad' }],
+                        debounceMs: 0,
+                    },
+                },
+            ],
+            rowData,
+        } as GridOptions);
+
+    const expectDropped = async (api: GridApi, warnSpy: ReturnType<typeof vi.spyOn>) => {
+        const harness = await ColumnFilterHarness.open(api, 'value');
+        expect(await harness.operatorOptions()).toEqual(['Equals', 'Does not equal']);
+        const warnings = warnSpy.mock.calls.flat().join(' ');
+        expect(warnings).toContain('warning #72');
+    };
+
+    test('a malformed entry on a date column is dropped and reported', async () => {
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [72] });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const api: GridApi = await withMalformedOption('agDateColumnFilter', [{ value: new Date(2024, 0, 1) }]);
+        await expectDropped(api, warnSpy);
+        await new FilterDom(api, 'a malformed entry on a date column', { colId: 'value' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Equals"
+            input: "" ⟨yyyy-mm-dd⟩
+            model: null
+        `);
+    });
+
+    test('a malformed entry on a bigint column is dropped and reported', async () => {
+        enableDevValidations({ throwOn: ALL_SEVERITIES, suppress: [72] });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const api: GridApi = await withMalformedOption('agBigIntColumnFilter', [{ value: 25n }]);
+        await expectDropped(api, warnSpy);
+        await new FilterDom(api, 'a malformed entry on a bigint column', { colId: 'value' }).checkFilterDom(`
+            COLUMN FILTER
+            operator: "Equals"
+            input: "" ⟨Filter...⟩
+            model: null
+        `);
+    });
+});
+
+describe('Column filter — `filterPlaceholder` on the floating filter', () => {
+    const gridsManager = new TestGridsManager({
+        modules: [TextFilterModule, ColumnMenuModule, ClientSideRowModelModule],
+    });
+
+    beforeAll(() => setupAgTestIds());
+    afterEach(() => gridsManager.reset());
+
+    // The other caller of `getPlaceholderText`, resolving the option through the same options factory.
+    test('is given the custom option, not an unresolved key', async () => {
+        const seen: { filterOptionKey: string; filterOption: string }[] = [];
+        const api: GridApi = await gridsManager.createGridAndWait('grid1', {
+            columnDefs: [
+                {
+                    field: 'athlete',
+                    filter: 'agTextColumnFilter',
+                    floatingFilter: true,
+                    // The callback is only consulted when the floating filter asks for a placeholder.
+                    floatingFilterComponentParams: { filterPlaceholder: true },
+                    filterParams: {
+                        filterOptions: [
+                            {
+                                displayKey: 'soundsLike',
+                                displayName: 'Sounds Like',
+                                numberOfInputs: 1,
+                                predicate: ([t]: unknown[], cellValue: unknown) => cellValue === t,
+                            },
+                        ],
+                        filterPlaceholder: ({ filterOptionKey, filterOption, placeholder }: any) => {
+                            seen.push({ filterOptionKey, filterOption });
+                            return placeholder;
+                        },
+                        debounceMs: 0,
+                    },
+                },
+            ],
+            rowData: [{ athlete: 'Bolt' }],
+        } as GridOptions);
+        await asyncSetTimeout(0);
+
+        expect(seen.length).toBeGreaterThan(0);
+        expect(seen.every((s) => s.filterOptionKey === 'soundsLike')).toBe(true);
+        expect(seen.every((s) => s.filterOption === 'Sounds Like')).toBe(true);
+        await new FilterDom(api, 'floating filter placeholder', { colId: 'athlete' }).checkFilterDom(`
+            FLOATING FILTER athlete
+            input: "" ⟨Filter...⟩
+            active: false
+            model: null
+        `);
+    });
+});


### PR DESCRIPTION
<!-- base: latest -->

# AG-16738: validate `filterOptions`, and type it per filter

FIX [AG-16738](https://ag-grid.atlassian.net/browse/AG-16738)

A `filterOptions` entry the filter cannot use is accepted in silence, and the declared type suggests options
the filter never evaluates.

| scope  | net lines |   lines changed | hunks | files changed |
| ------ | --------: | --------------: | ----: | ------------: |
| source |      +126 | 392 (+259 -133) |    84 |     17 edited |
| tests  |     +1330 |      1330 added |     1 |         1 new |
| docs   |        +0 |       4 (+2 -2) |     3 |      1 edited |

## Breaking bug fixes

No breaking changes. Two fixes are visible to code that depended on the defect.

**1. Every `type` and `filterOptionKey` field admits a Custom Filter Option's `displayKey`**, so a narrower
annotation stops compiling. This covers `ISimpleFilterModel['type']`, the four concrete models, and
`IFilterPlaceholderFunctionParams['filterOptionKey']`. The old type was wrong, not merely tight: the grid already
writes a custom `displayKey` into those fields, at five sites where the narrow type compiles only by casting. The
cost is that a mistyped built-in key is no longer a compile error on a model, because one field cannot be both open
to custom keys and closed to typos; the runtime reports it instead, under `76`. Annotate with the exported
`FilterOptionKey`, or drop the annotation. Runtime is unchanged.

**2. A `FilterOptionDef` carrying only the removed `test` alias is rejected**, with warning `72` naming the
missing property. Nothing calls `test`, so the option was offered and matched no rows. It is not on
`IFilterOptionDef`, so only JS callers see it disappear.

Error `73` is removed, unobservably: an option with no `displayKey` is now dropped before the lookup that raised
it. Warning `72` reads `is missing` rather than `doesn't contain one of`, which described the alias group it no
longer has. Warning `74` changes meaning, from "this column has no filter options" to "your list left none, so the
built-in ones are in use"; its text is unchanged.

## TC1: a malformed or unusable entry is reported

`OptionsFactory` gains a single build pass over the configured list, replacing a loop that mutated the list it
was iterating. Five defects fall out of it, two of them crashes:

| defect                                                                          | before                                                                                     |
| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| a rejected entry emptied the list                                               | `filterOptions.filter((v) => v === filterOption)` kept only the malformed entry            |
| `displayKey: 'toString'` crashed                                                | custom options were an object literal, so the lookup returned an `Object.prototype` member |
| a hole in the list crashed                                                      | `typeof null` is `'object'`, so `null` passed the string guard                             |
| `defaultOption` was returned unchecked                                          | the dropdown could sit on a value it does not list; now warning `326`                      |
| a built-in key and a `FilterOptionDef` sharing a `displayKey` were both offered | two dropdown rows for one key                                                              |

A list that keeps no option falls back to the built-in one under warning `74`, a column offering nothing being
unable to open its filter at all. `validateModel` checks conditions against the offered list rather than raw
`filterParams.filterOptions`, so a model naming a dropped entry is cleared instead of evaluated, and an O(n·m)
scan becomes a map lookup.

The Text Filter reports warning `76` for a key its matching cannot answer, as the scalar filters already do,
though the two answer it differently: the scalar filters admit the row they cannot judge, the Text Filter
excludes it. It fires at evaluation, blank values included, and only under the default matcher, so a
`textMatcher` supplying its own keys stays trusted, and never for a Custom Filter Option, whose predicate is
skipped for a missing value rather than a bad key. Both report once per key rather than once per row, the
logger formatting its message and
documentation URL before the once-per-message guard discards the duplicate: 593 ms against 32 ms on a
50 000-row pass.

## TC2: per-filter option keys

`ISimpleFilterModelType` splits into `TextFilterOptionKey`, `ScalarFilterOptionKey` and `DateFilterOptionKey`
over a shared `CommonFilterOptionKey`. Each filter's params and model then declare `filterOptions`, `defaultOption`
and `type` in terms of its own union, so a Date preset is no longer suggested on a Text Filter or a
`TextFilterModel`. `ISimpleFilterModelPresetType` is exported, `DateFilterOptionKey` being defined in terms of it.

Those four declarations are restated per filter rather than inherited from one generic
`ISimpleFilterParams<TOptionKey>`, which is what this started as. The generic reads better and is 40 lines shorter,
but it costs the reference documentation: `generate-doc-references` substitutes a parent's type parameter only when
the child is generic too, so `interface ITextFilterParams extends ISimpleFilterParams<TextFilterOptionKey>` renders
`filterOptions` as `(IFilterOptionDef | TOptionKey | CustomFilterOptionKey)[]` on the Text, Number, Date and BigInt
Filter pages, where today it reads `(IFilterOptionDef | ISimpleFilterModelType)[]`. The parameter also buys no
safety to offset that: because `CustomFilterOptionKey` widens both sides to `string`, a child restating
`filterOptions` with another filter's keys compiles clean. Restating is the same information a reader can see.

A custom `displayKey` can be any string, so every one of those unions has to admit one. Writing `| string` would
work and destroy the suggestions: TypeScript reduces `'equals' | 'contains' | string` to plain `string`, and the
editor then offers nothing. Intersecting with an empty object type stops that reduction — `string & Record<never,
never>` is still just `string` to assignability, but it is not *identical* to `string`, so the literals survive
beside it and stay in autocomplete. That is what `CustomFilterOptionKey` is.

`filterPlaceholder` resolves a custom option through its `displayKey`, as the dropdown label does, rather than
handing the callback an unresolved key; the three sites doing that share one `translateFilterOption`.

## Verification

33 behavioural tests in `testing/behavioural/src/filters/filter-options-validation.test.ts`, 24 of them
`FilterDom` snapshots, spanning `OptionsFactory`, `validateModel`, all four handlers and placeholder resolution
on both the popup and the floating filter. A new suite because no existing one owns `filterOptions` validation.

**22 fail with the source reverted and the tests left in place**; the rest are regression cover, including the
`refresh` path and combined AND/OR models. The ticket's own repro,
`filterOptions: ['equals', 'notEqual', 'wrong']`, fails there with `expected '' to contain 'warning #76'`.
