### PR TITLE
AG-17862 Add markdown twins for the remaining sitemap pages (b36.1.0)

### DIFF
--- a/documentation/ag-grid-docs/plugins/agDevMarkdownNegotiation.ts
+++ b/documentation/ag-grid-docs/plugins/agDevMarkdownNegotiation.ts
@@ -1,29 +1,19 @@
 import type { Plugin } from 'vite';
 
 import agDevMarkdownNegotiation from '../../../external/ag-website-shared/plugins/agDevMarkdownNegotiation';
-import { DISABLE_MARKDOWN_DOCS, FRAMEWORKS } from '../src/constants';
+import { DISABLE_MARKDOWN_DOCS } from '../src/constants';
+import { markdownPathPatterns } from '../src/utils/markdownPages';
 
-// A single docs page path, e.g. `/react-data-grid/cell-editing/`. The final
-// segment excludes dots so the `.md` variant itself never matches (no rewrite
-// loop) and the framework landing page (`/react-data-grid/`, which has no `.md`)
-// is left alone.
-const DOCS_PAGE_PATH = new RegExp(`/(?:${FRAMEWORKS.join('|')})-data-grid/[^/.]+/?$`);
-
-// Top-level (non-docs) pages that also ship a `.md` twin. Kept in sync with the same page
-// list in the SE-80 htaccess negotiation rule (see htaccessRules.ts).
-const TOP_LEVEL_MD_PATH = /^\/(?:license-pricing|changelog|pipeline|about|documentation-archive|example)\/?$/;
-
-// The /community landing page and its subpages, each with a `.md` twin.
-const COMMUNITY_MD_PATH = /^\/community(?:\/(?:events|showcase|tools-extensions|media|beyond-the-prompt))?\/?$/;
-
-// SE-80: content-negotiate grid docs pages to their markdown variant in the dev
-// server. Grid supplies its URL shapes; the shared factory holds the mechanism
+// SE-80: content-negotiate grid pages to their markdown variant in the dev server.
+// Grid supplies its URL shapes; the shared factory holds the mechanism
 // (see external/ag-website-shared/plugins/agDevMarkdownNegotiation for the full rationale).
+// The page list comes from GRID_MARKDOWN_PAGE_GROUPS, the same registry the production
+// htaccess rules derive from, so dev and prod cannot disagree about what is negotiable.
 // The homepage twin is handled by the factory: grid is a root site, so the default
 // base (`/`) maps `/` to `/index.md`.
 export default function agDevGridMarkdownNegotiation(): Plugin {
     return agDevMarkdownNegotiation({
-        pathPatterns: [DOCS_PAGE_PATH, TOP_LEVEL_MD_PATH, COMMUNITY_MD_PATH],
+        pathPatterns: markdownPathPatterns(),
         disabled: DISABLE_MARKDOWN_DOCS,
     });
 }

--- a/documentation/ag-grid-docs/src/content/about/niall.json
+++ b/documentation/ag-grid-docs/src/content/about/niall.json
@@ -1,0 +1,30 @@
+{
+    "meta": {
+        "title": "Niall Crosby: Our Amazing Founder",
+        "description": "The story and legacy of Niall Crosby, founder of AG Grid."
+    },
+    "eyebrow": "In memory of Niall Crosby",
+    "heading": "Our Amazing Founder",
+    "intro": "AG Grid would not be where we are today without our founder Niall Crosby - a truly inspiring and unique individual who left his indelible mark on the world, as well as on his friends and colleagues at AG Grid. Niall was different to other founders from the start - the company was a reflection of his personality. Excessive noise and overheads were removed leaving a singular focus on building the best grid. That clarity of vision was essential in our early days and the spirit of this lives on today. Niall had the ability to break things down to the absolute fundamentals, bringing sharp focus to everything we do and great clarity to our mission.",
+    "photos": [
+        {
+            "src": "images/ag-grid-founder-niall-crosby.webp",
+            "alt": "AG Grid founder Niall Crosby",
+            "caption": "Niall Crosby 1977-2024"
+        },
+        {
+            "src": "images/niall-crosby-finjs-2022.webp",
+            "alt": "Niall Crosby speaking at Fin.js 2022 conference"
+        }
+    ],
+    "sections": [
+        [
+            "Those of us present for the early days also fondly remember Niall’s wicked sense of humour and the genuine joy he took from seeing the success of the company as we achieved remarkable things. Having tried his hand at a few startups, Niall knew just how thin the line between failure and success could be. He was deeply humble and never took our wins for granted, always retaining a refreshing incredulity of the astounding success his company achieved. As the company grew and our client base with it, Niall built our culture of delivering high quality output whilst surrounding himself with likeminded people to share in the success. He was also brave, and even under pressure he stuck firmly to his principles – and those principles still shape AG Grid today.",
+            "A lover of tech, travel and adventure, Niall was a fiercely independent thinker. He had been coding from a young age and delighted in seeing patterns, trends and solutions that others could not. He had an enormous curiosity for how things worked and an incredible technical mind, which led him to the world of software development. His career blossomed with his talent quickly coming to the fore as he developed enterprise applications. Niall also had an entrepreneurial streak, always on the lookout for an opportunity to start his own business. While working as a freelance developer, Niall felt a deep frustration with the quality of JavaScript datagrids so he decided to build his own. This was the origin of AG Grid. Other developers shared his frustration and the project quickly gained traction."
+        ],
+        [
+            "Niall sadly lost his life in a tragic accident in July 2024 in his native Ireland. His legacy lives on in the ambition, creativity and care he instilled in everyone at AG Grid. It is evident in the inspiration and support he provided to countless young developers and startups throughout his career. It lives on in the memories of his friends, colleagues and his young family who were central to his life.",
+            "At AG Grid we are proud to carry that legacy forward. Many of us have been part of this journey with Niall from the beginning. As Niall's friends and work family we are more committed than ever to pushing the boundaries, constantly developing new features and products, and showing the world what is possible."
+        ]
+    ]
+}

--- a/documentation/ag-grid-docs/src/content/demos/demos.json
+++ b/documentation/ag-grid-docs/src/content/demos/demos.json
@@ -1,0 +1,26 @@
+{
+    "finance": {
+        "heading": "Finance",
+        "metaTitle": "Demo - Finance",
+        "metaDescription": "Financial data example featuring live updates and sparklines.",
+        "bodyText": "Financial data example featuring live updates and sparklines.",
+        "githubUrl": "https://github.com/ag-grid/ag-grid-demos/tree/main/finance",
+        "activeTab": "finance"
+    },
+    "hr": {
+        "heading": "HR",
+        "metaTitle": "Demo - HR Management",
+        "metaDescription": "HR data example showing hierarchical employee data.",
+        "bodyText": "Example showing HR hierarchical employee data.",
+        "githubUrl": "https://github.com/ag-grid/ag-grid-demos/tree/main/hr",
+        "activeTab": "crm"
+    },
+    "inventory": {
+        "heading": "Inventory",
+        "metaTitle": "Demo - Inventory Management",
+        "metaDescription": "Inventory data example to view and manage products.",
+        "bodyText": "Inventory data example to view and manage products.",
+        "githubUrl": "https://github.com/ag-grid/ag-grid-demos/tree/main/inventory",
+        "activeTab": "inventory"
+    }
+}

--- a/documentation/ag-grid-docs/src/pages/campaigns/[bryntumProduct].astro
+++ b/documentation/ag-grid-docs/src/pages/campaigns/[bryntumProduct].astro
@@ -2,6 +2,7 @@
 import BryntumCampaign from '@components/campaigns-components/BryntumCampaign.astro';
 import type { BryntumCampaignContent } from '@components/campaigns-components/bryntum/types';
 import Layout from '@layouts/Layout.astro';
+import { campaignMeta } from '@utils/markdown-pages/buildCampaignMarkdown';
 
 export async function getStaticPaths() {
     // Match the rewritten `{slug}.json` content files; the original
@@ -34,8 +35,8 @@ interface Props {
 }
 
 const { content } = Astro.props;
-const pageTitle = content.meta?.og_title ?? content.title;
-const pageDescription = content.meta?.description ?? '';
+// Shared with the /campaigns/<slug>.md twin so both describe the page identically.
+const { title: pageTitle, description: pageDescription } = campaignMeta(content);
 
 // Per-product Open Graph images; Scheduler and Scheduler Pro deliberately share one image.
 const ogImageBasePath = '/images/campaigns/bryntum-products/opengraph-images';

--- a/documentation/ag-grid-docs/src/pages/campaigns/[bryntumProduct].md.ts
+++ b/documentation/ag-grid-docs/src/pages/campaigns/[bryntumProduct].md.ts
@@ -1,0 +1,39 @@
+import type { BryntumCampaignContent } from '@components/campaigns-components/bryntum/types';
+import { DISABLE_MARKDOWN_DOCS } from '@constants';
+import { buildCampaignMarkdown } from '@utils/markdown-pages/buildCampaignMarkdown';
+
+// Served at /campaigns/bryntum-<product>.md — the markdown twin of each partner campaign page,
+// built from the same campaign JSON the page renders. Mirrors the page's own getStaticPaths
+// (including its slug aliases) so the two URL sets line up 1:1. Content-negotiates from the HTML
+// URL on Accept: text/markdown (see the SE-80 rules in htaccessRules.ts).
+export async function getStaticPaths() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return [];
+    }
+    // Match the rewritten `{slug}.json` content files; the original `{slug}-original.json` files
+    // are kept for reference but no longer rendered.
+    const contentModules = import.meta.glob<BryntumCampaignContent>(
+        [
+            '../../content/campaigns/bryntum-products/*.json',
+            '!../../content/campaigns/bryntum-products/*-original.json',
+        ],
+        { eager: true, import: 'default' }
+    );
+
+    const slugAliases: Record<string, string> = {
+        schedulerpro: 'scheduler-pro',
+        taskboard: 'task-board',
+    };
+
+    return Object.values(contentModules).map((content) => ({
+        params: { bryntumProduct: `bryntum-${slugAliases[content.slug] ?? content.slug}` },
+        props: { content },
+    }));
+}
+
+export function GET({ props }: { props: { content: BryntumCampaignContent } }) {
+    return new Response(buildCampaignMarkdown({ content: props.content }), {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/documentation/ag-grid-docs/src/pages/contact.md.ts
+++ b/documentation/ag-grid-docs/src/pages/contact.md.ts
@@ -1,0 +1,22 @@
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+import { buildContactMarkdown } from '@ag-website-shared/markdown-pages/buildContactMarkdown';
+import { DISABLE_MARKDOWN_DOCS, LIBRARY, SITE_URL } from '@constants';
+
+// Served at /contact.md — the markdown twin of the /contact page, built from the same shared copy
+// and links the page renders. Content-negotiates from the HTML URL on Accept: text/markdown
+// (see the SE-80 rules in htaccessRules.ts).
+export function GET() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+
+    const output = buildContactMarkdown({
+        library: LIBRARY,
+        contactUrl: toAbsoluteUrl('/contact/', SITE_URL),
+    });
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/documentation/ag-grid-docs/src/pages/cookies.md.ts
+++ b/documentation/ag-grid-docs/src/pages/cookies.md.ts
@@ -1,0 +1,6 @@
+import { policyMarkdownResponse } from '@utils/markdown-pages/policyMarkdownResponse';
+
+// Served at /cookies.md — the markdown twin of the page, rendered from the same shared
+// preamble and the same policies/cookies.mdoc body the page renders. Content-negotiates
+// from the HTML URL on Accept: text/markdown (see the SE-80 rules in htaccessRules.ts).
+export const GET = () => policyMarkdownResponse('cookies');

--- a/documentation/ag-grid-docs/src/pages/example-finance.astro
+++ b/documentation/ag-grid-docs/src/pages/example-finance.astro
@@ -6,19 +6,18 @@ import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { Finance } from 'src/components/demos/examples/finance';
 import LogoMark from '@components/logo/LogoMark';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
+import { demoContent } from '@utils/markdown-pages/buildDemoMarkdown';
+
+// Copy is shared with the /example-finance.md twin so the two cannot drift.
+const content = demoContent('finance');
 ---
 
-<DemosLayout title="Demo - Finance" description="Financial data example featuring live updates and sparklines.">
+<DemosLayout title={content.metaTitle} description={content.metaDescription}>
     <div class={styles.topHeader}>
         <div>
             <div class={styles.headerTitle}>
-                <h1 class={styles.headerHeading}>Finance</h1>
-                <a
-                    class="button-secondary"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href="https://github.com/ag-grid/ag-grid-demos/tree/main/finance"
-                >
+                <h1 class={styles.headerHeading}>{content.heading}</h1>
+                <a class="button-secondary" target="_blank" rel="noopener noreferrer" href={content.githubUrl}>
                     <Icon name="github" svgClasses={styles.githubIcon} />
                     <span>See On GitHub</span>
                 </a>
@@ -27,10 +26,10 @@ import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
                 </a>
             </div>
 
-            <p>Financial data example featuring live updates and sparklines.</p>
+            <p>{content.bodyText}</p>
         </div>
 
-        <DemoTabs activeTab="finance" />
+        <DemoTabs activeTab={content.activeTab} />
     </div>
 
     <div class={styles.layout}>

--- a/documentation/ag-grid-docs/src/pages/example-finance.md.ts
+++ b/documentation/ag-grid-docs/src/pages/example-finance.md.ts
@@ -1,0 +1,15 @@
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { buildDemoMarkdown } from '@utils/markdown-pages/buildDemoMarkdown';
+
+// Served at /example-finance.md — a markdown twin of the finance demo page, built from the same
+// shared copy the page renders. Content-negotiates from the HTML URL on Accept: text/markdown
+// (see the SE-80 rules in htaccessRules.ts).
+export function GET() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+    return new Response(buildDemoMarkdown({ demo: 'finance', siteRoot: SITE_URL }), {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/documentation/ag-grid-docs/src/pages/example-hr.astro
+++ b/documentation/ag-grid-docs/src/pages/example-hr.astro
@@ -6,19 +6,18 @@ import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { HR } from '@components/demos/examples/hr';
 import LogoMark from '@components/logo/LogoMark';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
+import { demoContent } from '@utils/markdown-pages/buildDemoMarkdown';
+
+// Copy is shared with the /example-hr.md twin so the two cannot drift.
+const content = demoContent('hr');
 ---
 
-<DemosLayout title="Demo - HR Management" description="HR data example showing hierarchical employee data.">
+<DemosLayout title={content.metaTitle} description={content.metaDescription}>
     <div class={styles.topHeader}>
         <div>
             <div class={styles.headerTitle}>
-                <h1 class={styles.headerHeading}>HR</h1>
-                <a
-                    class="button-secondary"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href="https://github.com/ag-grid/ag-grid-demos/tree/main/hr"
-                >
+                <h1 class={styles.headerHeading}>{content.heading}</h1>
+                <a class="button-secondary" target="_blank" rel="noopener noreferrer" href={content.githubUrl}>
                     <Icon name="github" svgClasses={styles.githubIcon} />
                     <span>See On GitHub</span>
                 </a>
@@ -26,10 +25,10 @@ import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
                     <span>Contact Us</span>
                 </a>
             </div>
-            <p>Example showing HR hierarchical employee data.</p>
+            <p>{content.bodyText}</p>
         </div>
 
-        <DemoTabs activeTab="crm" />
+        <DemoTabs activeTab={content.activeTab} />
     </div>
 
     <div class={styles.layout}>

--- a/documentation/ag-grid-docs/src/pages/example-hr.md.ts
+++ b/documentation/ag-grid-docs/src/pages/example-hr.md.ts
@@ -1,0 +1,15 @@
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { buildDemoMarkdown } from '@utils/markdown-pages/buildDemoMarkdown';
+
+// Served at /example-hr.md — a markdown twin of the hr demo page, built from the same
+// shared copy the page renders. Content-negotiates from the HTML URL on Accept: text/markdown
+// (see the SE-80 rules in htaccessRules.ts).
+export function GET() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+    return new Response(buildDemoMarkdown({ demo: 'hr', siteRoot: SITE_URL }), {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/documentation/ag-grid-docs/src/pages/example-inventory.astro
+++ b/documentation/ag-grid-docs/src/pages/example-inventory.astro
@@ -6,19 +6,18 @@ import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { Inventory } from '@components/demos/examples/inventory';
 import LogoMark from '@components/logo/LogoMark';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
+import { demoContent } from '@utils/markdown-pages/buildDemoMarkdown';
+
+// Copy is shared with the /example-inventory.md twin so the two cannot drift.
+const content = demoContent('inventory');
 ---
 
-<DemosLayout title="Demo - Inventory Management" description="Inventory data example to view and manage products.">
+<DemosLayout title={content.metaTitle} description={content.metaDescription}>
     <div class={styles.topHeader}>
         <div>
             <div class={styles.headerTitle}>
-                <h1 class={styles.headerHeading}>Inventory</h1>
-                <a
-                    class="button-secondary"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href="https://github.com/ag-grid/ag-grid-demos/tree/main/inventory"
-                >
+                <h1 class={styles.headerHeading}>{content.heading}</h1>
+                <a class="button-secondary" target="_blank" rel="noopener noreferrer" href={content.githubUrl}>
                     <Icon name="github" svgClasses={styles.githubIcon} />
                     <span>See On GitHub</span>
                 </a>
@@ -26,10 +25,10 @@ import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
                     <span>Contact Us</span>
                 </a>
             </div>
-            <p>Inventory data example to view and manage products.</p>
+            <p>{content.bodyText}</p>
         </div>
 
-        <DemoTabs activeTab="inventory" />
+        <DemoTabs activeTab={content.activeTab} />
     </div>
     <div class={styles.layout}>
         <div class={styles.layoutWrapper}>

--- a/documentation/ag-grid-docs/src/pages/example-inventory.md.ts
+++ b/documentation/ag-grid-docs/src/pages/example-inventory.md.ts
@@ -1,0 +1,15 @@
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { buildDemoMarkdown } from '@utils/markdown-pages/buildDemoMarkdown';
+
+// Served at /example-inventory.md — a markdown twin of the inventory demo page, built from the same
+// shared copy the page renders. Content-negotiates from the HTML URL on Accept: text/markdown
+// (see the SE-80 rules in htaccessRules.ts).
+export function GET() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+    return new Response(buildDemoMarkdown({ demo: 'inventory', siteRoot: SITE_URL }), {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/documentation/ag-grid-docs/src/pages/landing-pages/angular-data-grid.md.ts
+++ b/documentation/ag-grid-docs/src/pages/landing-pages/angular-data-grid.md.ts
@@ -1,0 +1,6 @@
+import { landingPageMarkdownResponse } from '@utils/markdown-pages/landingPageMarkdownResponse';
+
+// Served at /landing-pages/angular-data-grid.md — the markdown twin of the page, built from the
+// same landing-pages/angular-data-grid.json the page renders. Content-negotiates from the HTML
+// URL on Accept: text/markdown (see the SE-80 rules in htaccessRules.ts).
+export const GET = () => landingPageMarkdownResponse('angular-data-grid');

--- a/documentation/ag-grid-docs/src/pages/landing-pages/enterprise-data-grid.md.ts
+++ b/documentation/ag-grid-docs/src/pages/landing-pages/enterprise-data-grid.md.ts
@@ -1,0 +1,6 @@
+import { landingPageMarkdownResponse } from '@utils/markdown-pages/landingPageMarkdownResponse';
+
+// Served at /landing-pages/enterprise-data-grid.md — the markdown twin of the page, built from the
+// same landing-pages/enterprise-data-grid.json the page renders. Content-negotiates from the HTML
+// URL on Accept: text/markdown (see the SE-80 rules in htaccessRules.ts).
+export const GET = () => landingPageMarkdownResponse('enterprise-data-grid');

--- a/documentation/ag-grid-docs/src/pages/landing-pages/javascript-data-grid.md.ts
+++ b/documentation/ag-grid-docs/src/pages/landing-pages/javascript-data-grid.md.ts
@@ -1,0 +1,6 @@
+import { landingPageMarkdownResponse } from '@utils/markdown-pages/landingPageMarkdownResponse';
+
+// Served at /landing-pages/javascript-data-grid.md — the markdown twin of the page, built from the
+// same landing-pages/javascript-data-grid.json the page renders. Content-negotiates from the HTML
+// URL on Accept: text/markdown (see the SE-80 rules in htaccessRules.ts).
+export const GET = () => landingPageMarkdownResponse('javascript-data-grid');

--- a/documentation/ag-grid-docs/src/pages/landing-pages/react-data-grid.md.ts
+++ b/documentation/ag-grid-docs/src/pages/landing-pages/react-data-grid.md.ts
@@ -1,0 +1,6 @@
+import { landingPageMarkdownResponse } from '@utils/markdown-pages/landingPageMarkdownResponse';
+
+// Served at /landing-pages/react-data-grid.md — the markdown twin of the page, built from the
+// same landing-pages/react-data-grid.json the page renders. Content-negotiates from the HTML
+// URL on Accept: text/markdown (see the SE-80 rules in htaccessRules.ts).
+export const GET = () => landingPageMarkdownResponse('react-data-grid');

--- a/documentation/ag-grid-docs/src/pages/landing-pages/vue-data-grid.md.ts
+++ b/documentation/ag-grid-docs/src/pages/landing-pages/vue-data-grid.md.ts
@@ -1,0 +1,6 @@
+import { landingPageMarkdownResponse } from '@utils/markdown-pages/landingPageMarkdownResponse';
+
+// Served at /landing-pages/vue-data-grid.md — the markdown twin of the page, built from the
+// same landing-pages/vue-data-grid.json the page renders. Content-negotiates from the HTML
+// URL on Accept: text/markdown (see the SE-80 rules in htaccessRules.ts).
+export const GET = () => landingPageMarkdownResponse('vue-data-grid');

--- a/documentation/ag-grid-docs/src/pages/licensing.astro
+++ b/documentation/ag-grid-docs/src/pages/licensing.astro
@@ -1,16 +1,14 @@
 ---
 import Layout from '@layouts/Layout.astro';
-import { LICENSE_INSTALL_REDIRECT_PAGE } from '@components/docs/constants';
 import FrameworkRedirectPage from '@ag-website-shared/components/framework-redirect-page/FrameworkRedirectPage.astro';
+import { STATIC_PAGE_CONTENT } from '@utils/markdown-pages/staticPageContent';
+
+// Metadata is shared with the /licensing.md twin so the two cannot drift.
+const content = STATIC_PAGE_CONTENT.licensing;
 ---
 
-<Layout
-    title="AG Grid: Licensing"
-    description={'Installing Your Licence Key'}
-    showSearchBar={false}
-    showDocsNav={false}
->
-    <FrameworkRedirectPage redirectPageName={LICENSE_INSTALL_REDIRECT_PAGE}>
+<Layout title={content.title} description={content.description} showSearchBar={false} showDocsNav={false}>
+    <FrameworkRedirectPage redirectPageName={content.redirectPageName}>
         <h1>Redirecting to AG Grid Install License page...</h1>
     </FrameworkRedirectPage>
 </Layout>

--- a/documentation/ag-grid-docs/src/pages/licensing.md.ts
+++ b/documentation/ag-grid-docs/src/pages/licensing.md.ts
@@ -1,0 +1,32 @@
+import { buildFrameworkRedirectMarkdown } from '@ag-website-shared/markdown-pages/buildFrameworkRedirectMarkdown';
+import { getFrameworkPath } from '@components/docs/utils/urlPaths';
+import { DISABLE_MARKDOWN_DOCS, FRAMEWORKS, FRAMEWORK_DISPLAY_TEXT, SITE_URL } from '@constants';
+import { STATIC_PAGE_CONTENT } from '@utils/markdown-pages/staticPageContent';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
+
+// Served at /licensing.md — the markdown twin of the /licensing redirect stub. The page bounces
+// the visitor to their remembered framework, which a non-browser reader cannot do, so the twin
+// lists every framework destination instead. Content-negotiates from the HTML URL on
+// Accept: text/markdown (see the SE-80 rules in htaccessRules.ts).
+export function GET() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+
+    const content = STATIC_PAGE_CONTENT.licensing;
+    const output = buildFrameworkRedirectMarkdown({
+        title: content.title,
+        description: content.description,
+        heading: content.heading,
+        destinations: FRAMEWORKS.map((framework) => ({
+            label: FRAMEWORK_DISPLAY_TEXT[framework],
+            url: urlWithBaseUrl(`/${getFrameworkPath(framework)}/${content.redirectPageName}/`),
+        })),
+        siteRoot: SITE_URL,
+    });
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/documentation/ag-grid-docs/src/pages/modern-slavery.md.ts
+++ b/documentation/ag-grid-docs/src/pages/modern-slavery.md.ts
@@ -1,0 +1,6 @@
+import { policyMarkdownResponse } from '@utils/markdown-pages/policyMarkdownResponse';
+
+// Served at /modern-slavery.md — the markdown twin of the page, rendered from the same shared
+// preamble and the same policies/modern-slavery.mdoc body the page renders. Content-negotiates
+// from the HTML URL on Accept: text/markdown (see the SE-80 rules in htaccessRules.ts).
+export const GET = () => policyMarkdownResponse('modern-slavery');

--- a/documentation/ag-grid-docs/src/pages/niall.astro
+++ b/documentation/ag-grid-docs/src/pages/niall.astro
@@ -2,94 +2,45 @@
 import Layout from '../layouts/Layout.astro';
 import styles from '../pages-styles/about.module.scss';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
+import niallData from '../content/about/niall.json';
+
+// Prose is shared with the /niall.md twin so the two cannot drift. Photos are interleaved
+// between the prose sections, in the order they appear in the content.
+const { meta, eyebrow, heading, intro, photos, sections } = niallData;
 ---
 
-<Layout
-    title="Niall Crosby: Our Amazing Founder"
-    description="The story and legacy of Niall Crosby, founder of AG Grid."
-    showSearchBar={true}
-    showDocsNav={false}
->
+<Layout title={meta.title} description={meta.description} showSearchBar={true} showDocsNav={false}>
     <div class="layout-max-width-small">
         <section class={styles.introSection}>
-            <span class={styles.eyebrow}>In memory of Niall Crosby</span>
-            <h2>Our Amazing Founder</h2>
+            <span class={styles.eyebrow}>{eyebrow}</span>
+            <h2>{heading}</h2>
 
-            <p>
-                AG Grid would not be where we are today without our founder Niall Crosby - a truly inspiring and unique
-                individual who left his indelible mark on the world, as well as on his friends and colleagues at AG
-                Grid. Niall was different to other founders from the start - the company was a reflection of his
-                personality. Excessive noise and overheads were removed leaving a singular focus on building the best
-                grid. That clarity of vision was essential in our early days and the spirit of this lives on today.
-                Niall had the ability to break things down to the absolute fundamentals, bringing sharp focus to
-                everything we do and great clarity to our mission.
-            </p>
+            <p>{intro}</p>
         </section>
 
-        <div class={styles.photoSection}>
-            <img
-                src={urlWithBaseUrl('images/ag-grid-founder-niall-crosby.webp')}
-                alt="AG Grid founder Niall Crosby"
-                class={styles.niallHeaderImage}
-            />
-            <span>Niall Crosby 1977-2024</span>
-        </div>
-
-        <section class={styles.contentSection}>
-            <div class={styles.niallSectionContent}>
-                <div class={styles.niallTextBlock}>
-                    <p>
-                        Those of us present for the early days also fondly remember Niall’s wicked sense of humour and
-                        the genuine joy he took from seeing the success of the company as we achieved remarkable things.
-                        Having tried his hand at a few startups, Niall knew just how thin the line between failure and
-                        success could be. He was deeply humble and never took our wins for granted, always retaining a
-                        refreshing incredulity of the astounding success his company achieved. As the company grew and
-                        our client base with it, Niall built our culture of delivering high quality output whilst
-                        surrounding himself with likeminded people to share in the success. He was also brave, and even
-                        under pressure he stuck firmly to his principles – and those principles still shape AG Grid
-                        today.
-                    </p>
-                    <p>
-                        A lover of tech, travel and adventure, Niall was a fiercely independent thinker. He had been
-                        coding from a young age and delighted in seeing patterns, trends and solutions that others could
-                        not. He had an enormous curiosity for how things worked and an incredible technical mind, which
-                        led him to the world of software development. His career blossomed with his talent quickly
-                        coming to the fore as he developed enterprise applications. Niall also had an entrepreneurial
-                        streak, always on the lookout for an opportunity to start his own business. While working as a
-                        freelance developer, Niall felt a deep frustration with the quality of JavaScript datagrids so
-                        he decided to build his own. This was the origin of AG Grid. Other developers shared his
-                        frustration and the project quickly gained traction.
-                    </p>
-                </div>
-            </div>
-        </section>
-
-        <div class={`${styles.photoSection} ${styles.photoSectionTwo}`}>
-            <img
-                src={urlWithBaseUrl('images/niall-crosby-finjs-2022.webp')}
-                alt="Niall Crosby speaking at Fin.js 2022 conference"
-                class={styles.niallHeaderImage}
-            />
-        </div>
-
-        <section class={styles.contentSection}>
-            <div class={styles.niallSectionContent}>
-                <div class={styles.niallTextBlock}>
-                    <p>
-                        Niall sadly lost his life in a tragic accident in July 2024 in his native Ireland. His legacy
-                        lives on in the ambition, creativity and care he instilled in everyone at AG Grid. It is evident
-                        in the inspiration and support he provided to countless young developers and startups throughout
-                        his career. It lives on in the memories of his friends, colleagues and his young family who were
-                        central to his life.
-                    </p>
-                    <p>
-                        At AG Grid we are proud to carry that legacy forward. Many of us have been part of this journey
-                        with Niall from the beginning. As Niall's friends and work family we are more committed than
-                        ever to pushing the boundaries, constantly developing new features and products, and showing the
-                        world what is possible.
-                    </p>
-                </div>
-            </div>
-        </section>
+        {
+            sections.map((paragraphs, index) => {
+                const photo = photos[index];
+                return (
+                    <>
+                        {photo && (
+                            <div class:list={[styles.photoSection, index > 0 && styles.photoSectionTwo]}>
+                                <img src={urlWithBaseUrl(photo.src)} alt={photo.alt} class={styles.niallHeaderImage} />
+                                {photo.caption && <span>{photo.caption}</span>}
+                            </div>
+                        )}
+                        <section class={styles.contentSection}>
+                            <div class={styles.niallSectionContent}>
+                                <div class={styles.niallTextBlock}>
+                                    {paragraphs.map((paragraph) => (
+                                        <p>{paragraph}</p>
+                                    ))}
+                                </div>
+                            </div>
+                        </section>
+                    </>
+                );
+            })
+        }
     </div>
 </Layout>

--- a/documentation/ag-grid-docs/src/pages/niall.md.ts
+++ b/documentation/ag-grid-docs/src/pages/niall.md.ts
@@ -1,0 +1,15 @@
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { buildNiallMarkdown } from '@utils/markdown-pages/buildNiallMarkdown';
+
+// Served at /niall.md — a markdown twin of the /niall memorial page, built from the same
+// niall.json the page renders. Content-negotiates from the HTML URL on Accept: text/markdown
+// (see the SE-80 rules in htaccessRules.ts).
+export function GET() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+    return new Response(buildNiallMarkdown({ siteRoot: SITE_URL }), {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/documentation/ag-grid-docs/src/pages/privacy.md.ts
+++ b/documentation/ag-grid-docs/src/pages/privacy.md.ts
@@ -1,0 +1,6 @@
+import { policyMarkdownResponse } from '@utils/markdown-pages/policyMarkdownResponse';
+
+// Served at /privacy.md — the markdown twin of the page, rendered from the same shared
+// preamble and the same policies/privacy.mdoc body the page renders. Content-negotiates
+// from the HTML URL on Accept: text/markdown (see the SE-80 rules in htaccessRules.ts).
+export const GET = () => policyMarkdownResponse('privacy');

--- a/documentation/ag-grid-docs/src/pages/react-table.md.ts
+++ b/documentation/ag-grid-docs/src/pages/react-table.md.ts
@@ -1,0 +1,6 @@
+import { landingPageMarkdownResponse } from '@utils/markdown-pages/landingPageMarkdownResponse';
+
+// Served at /react-table.md — the markdown twin of the page, built from the same
+// landing-pages/react-table.json the page renders. Content-negotiates from the HTML
+// URL on Accept: text/markdown (see the SE-80 rules in htaccessRules.ts).
+export const GET = () => landingPageMarkdownResponse('react-table');

--- a/documentation/ag-grid-docs/src/pages/reference.astro
+++ b/documentation/ag-grid-docs/src/pages/reference.astro
@@ -1,15 +1,14 @@
 ---
 import Layout from '@layouts/Layout.astro';
 import FrameworkRedirectPage from '@ag-website-shared/components/framework-redirect-page/FrameworkRedirectPage.astro';
+import { STATIC_PAGE_CONTENT } from '@utils/markdown-pages/staticPageContent';
+
+// Metadata is shared with the /reference.md twin so the two cannot drift.
+const content = STATIC_PAGE_CONTENT.reference;
 ---
 
-<Layout
-    title="AG Grid: API Reference"
-    description={'View the AG Grid API Reference Documentation - a feature-rich datagrid for major JavaScript frameworks, offering filtering, grouping, pivoting, and more.'}
-    showSearchBar={false}
-    showDocsNav={false}
->
-    <FrameworkRedirectPage redirectPageName="reference">
+<Layout title={content.title} description={content.description} showSearchBar={false} showDocsNav={false}>
+    <FrameworkRedirectPage redirectPageName={content.redirectPageName}>
         <h1>Redirecting to AG Grid API Reference...</h1>
     </FrameworkRedirectPage>
 </Layout>

--- a/documentation/ag-grid-docs/src/pages/reference.md.ts
+++ b/documentation/ag-grid-docs/src/pages/reference.md.ts
@@ -1,0 +1,32 @@
+import { buildFrameworkRedirectMarkdown } from '@ag-website-shared/markdown-pages/buildFrameworkRedirectMarkdown';
+import { getFrameworkPath } from '@components/docs/utils/urlPaths';
+import { DISABLE_MARKDOWN_DOCS, FRAMEWORKS, FRAMEWORK_DISPLAY_TEXT, SITE_URL } from '@constants';
+import { STATIC_PAGE_CONTENT } from '@utils/markdown-pages/staticPageContent';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
+
+// Served at /reference.md — the markdown twin of the /reference redirect stub. The page bounces
+// the visitor to their remembered framework, which a non-browser reader cannot do, so the twin
+// lists every framework destination instead. Content-negotiates from the HTML URL on
+// Accept: text/markdown (see the SE-80 rules in htaccessRules.ts).
+export function GET() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+
+    const content = STATIC_PAGE_CONTENT.reference;
+    const output = buildFrameworkRedirectMarkdown({
+        title: content.title,
+        description: content.description,
+        heading: content.heading,
+        destinations: FRAMEWORKS.map((framework) => ({
+            label: FRAMEWORK_DISPLAY_TEXT[framework],
+            url: urlWithBaseUrl(`/${getFrameworkPath(framework)}/${content.redirectPageName}/`),
+        })),
+        siteRoot: SITE_URL,
+    });
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/documentation/ag-grid-docs/src/pages/roadmap.md.ts
+++ b/documentation/ag-grid-docs/src/pages/roadmap.md.ts
@@ -1,0 +1,30 @@
+import { buildRoadmapMarkdown } from '@ag-website-shared/markdown-pages/buildRoadmapMarkdown';
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { urlWithPrefix } from '@utils/urlWithPrefix';
+
+import roadmapData from '../../public/roadmap/roadmap.json';
+
+// Served at /roadmap.md — a markdown twin of the /roadmap page for LLMs, built from the same
+// roadmap.json the page renders. Content-negotiates from the HTML URL on Accept: text/markdown
+// (see the SE-80 rules in htaccessRules.ts).
+export function GET() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+
+    const output = buildRoadmapMarkdown({
+        roadmapData,
+        siteRoot: SITE_URL,
+        // The page is framework-agnostic; resolve its framework-prefixed links against a single
+        // framework, matching the other markdown twins (homepage, license-pricing).
+        resolveUrl: (url) => urlWithPrefix({ framework: 'javascript', url }),
+        // The page labels quarters with the current year; the build stamps it here so the
+        // generated markdown is deterministic within a build.
+        year: new Date().getFullYear(),
+    });
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/documentation/ag-grid-docs/src/pages/roadmap.md.ts
+++ b/documentation/ag-grid-docs/src/pages/roadmap.md.ts
@@ -14,6 +14,7 @@ export function GET() {
 
     const output = buildRoadmapMarkdown({
         roadmapData,
+        productName: 'AG Grid',
         siteRoot: SITE_URL,
         // The page is framework-agnostic; resolve its framework-prefixed links against a single
         // framework, matching the other markdown twins (homepage, license-pricing).

--- a/documentation/ag-grid-docs/src/pages/session/[slug].astro
+++ b/documentation/ag-grid-docs/src/pages/session/[slug].astro
@@ -2,6 +2,7 @@
 import Layout from '../../layouts/Layout.astro';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 import { SESSIONS, sessionSlug, youtubeId } from '@utils/beyondThePromptSessions';
+import { sessionDescription } from '@utils/markdown-pages/buildSessionMarkdown';
 import styles from '../../pages-styles/session.module.scss';
 
 // One real, crawlable page per recorded session. On the Beyond the Prompt page
@@ -16,8 +17,8 @@ export function getStaticPaths() {
 
 const { session } = Astro.props;
 const videoId = session.youtubeUrl ? youtubeId(session.youtubeUrl) : null;
-const description =
-    session.description ?? `Watch "${session.title}" from Beyond the Prompt, the AG Grid and Bryntum conference.`;
+// Shared with the /session/<slug>.md twin so both describe the page identically.
+const description = sessionDescription(session);
 ---
 
 <Layout

--- a/documentation/ag-grid-docs/src/pages/session/[slug].md.ts
+++ b/documentation/ag-grid-docs/src/pages/session/[slug].md.ts
@@ -1,0 +1,24 @@
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { SESSIONS, type Session, sessionSlug } from '@utils/beyondThePromptSessions';
+import { buildSessionMarkdown } from '@utils/markdown-pages/buildSessionMarkdown';
+
+// Served at /session/<slug>.md — the markdown twin of each recorded session page, built from
+// the same SESSIONS entry the page renders. Mirrors the page's own getStaticPaths so the two
+// URL sets line up 1:1. Content-negotiates from the HTML URL on Accept: text/markdown
+// (see the SE-80 rules in htaccessRules.ts).
+export function getStaticPaths() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return [];
+    }
+    return SESSIONS.filter((session) => session.youtubeUrl).map((session) => ({
+        params: { slug: sessionSlug(session.title) },
+        props: { session },
+    }));
+}
+
+export function GET({ props }: { props: { session: Session } }) {
+    return new Response(buildSessionMarkdown({ session: props.session, siteRoot: SITE_URL }), {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/documentation/ag-grid-docs/src/pages/sitemap.astro
+++ b/documentation/ag-grid-docs/src/pages/sitemap.astro
@@ -5,6 +5,7 @@ import { getSitemapXml } from '@ag-website-shared/utils/getSitemapXml';
 import Layout from '../layouts/Layout.astro';
 import { LIVE_SITEMAP_URL, PRODUCTION_GRID_SITE_URL } from '@constants';
 import { SITEMAP_CACHE_DIR } from '@ag-website-shared/constants';
+import { STATIC_PAGE_CONTENT } from '@utils/markdown-pages/staticPageContent';
 
 const sitemapUrl = LIVE_SITEMAP_URL || `${PRODUCTION_GRID_SITE_URL}/sitemap-0.xml`;
 const xmlSitemap = await getSitemapXml({
@@ -12,14 +13,12 @@ const xmlSitemap = await getSitemapXml({
     sitemapUrl,
 });
 const parsedSitemap = parseSitemap(xmlSitemap);
+
+// Metadata is shared with the /sitemap.md twin so the two cannot drift.
+const content = STATIC_PAGE_CONTENT.sitemap;
 ---
 
-<Layout
-    title={'Sitemap | AG Grid'}
-    description={'The AG Grid sitemap. Contains links to every page on the site, including docs.'}
-    showDocsNav={false}
-    showSearchBar={true}
->
+<Layout title={content.title} description={content.description} showDocsNav={false} showSearchBar={true}>
     <div class:list={['contentViewport layout-grid']}>
         <Sitemap client:load sitemap={parsedSitemap} site={'Grid'} />
     </div>

--- a/documentation/ag-grid-docs/src/pages/sitemap.md.ts
+++ b/documentation/ag-grid-docs/src/pages/sitemap.md.ts
@@ -32,7 +32,7 @@ export async function GET() {
             ].join('\n'),
             `# ${content.heading}`,
             content.description,
-            'Every page listed here also has a markdown version: append `.md` to its URL.',
+            `Every page listed here also has a markdown version: append \`.md\` to its URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${PRODUCTION_GRID_SITE_URL}/index.md.`,
             ...sections,
         ].join('\n\n') + '\n';
 

--- a/documentation/ag-grid-docs/src/pages/sitemap.md.ts
+++ b/documentation/ag-grid-docs/src/pages/sitemap.md.ts
@@ -1,0 +1,43 @@
+import parseSitemap from '@ag-website-shared/components/sitemap/utils/sitemaputils';
+import { SITEMAP_CACHE_DIR } from '@ag-website-shared/constants';
+import { getSitemapXml } from '@ag-website-shared/utils/getSitemapXml';
+import { DISABLE_MARKDOWN_DOCS, LIVE_SITEMAP_URL, PRODUCTION_GRID_SITE_URL } from '@constants';
+import { STATIC_PAGE_CONTENT } from '@utils/markdown-pages/staticPageContent';
+
+// Served at /sitemap.md — the markdown twin of the HTML sitemap page, built from the same parsed
+// sitemap XML the page renders, so the two list the same pages under the same categories.
+// Content-negotiates from the HTML URL on Accept: text/markdown (see htaccessRules.ts).
+export async function GET() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+
+    const sitemapUrl = LIVE_SITEMAP_URL || `${PRODUCTION_GRID_SITE_URL}/sitemap-0.xml`;
+    const xmlSitemap = await getSitemapXml({ cacheDir: SITEMAP_CACHE_DIR, sitemapUrl });
+    const parsedSitemap = parseSitemap(xmlSitemap);
+
+    const content = STATIC_PAGE_CONTENT.sitemap;
+    const sections = Object.entries(parsedSitemap).map(([category, pages]) => {
+        const links = pages.map(({ url, pageName }) => `- [${pageName}](${url})`).join('\n');
+        return `## ${category}\n\n${links}`;
+    });
+
+    const output =
+        [
+            [
+                '---',
+                `title: ${JSON.stringify(content.title)}`,
+                `description: ${JSON.stringify(content.description)}`,
+                '---',
+            ].join('\n'),
+            `# ${content.heading}`,
+            content.description,
+            'Every page listed here also has a markdown version: append `.md` to its URL.',
+            ...sections,
+        ].join('\n\n') + '\n';
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/documentation/ag-grid-docs/src/pages/theme-builder.astro
+++ b/documentation/ag-grid-docs/src/pages/theme-builder.astro
@@ -6,20 +6,18 @@ import { ThemeBuilder } from '@ag-website-shared/components/theme-builder-grid/T
 
 import { getDocsPages } from '../components/docs/utils/pageData';
 import Layout from '../layouts/Layout.astro';
+import { STATIC_PAGE_CONTENT } from '@utils/markdown-pages/staticPageContent';
 
 export async function getStaticPaths() {
     const pages = await getCollection('docs');
     return getDocsPages(pages);
 }
+
+// Metadata is shared with the /theme-builder.md twin so the two cannot drift.
+const content = STATIC_PAGE_CONTENT['theme-builder'];
 ---
 
-<Layout
-    title="AG Grid Theme Builder"
-    description={'Easily build and customise themes for AG Grid with our interactive tool. Use our templates or create your own style from scratch. Export styles to AG Grid compatible themes.'}
-    showDocsNav={false}
-    showSearchBar={true}
-    hideFooter
->
+<Layout title={content.title} description={content.description} showDocsNav={false} showSearchBar={true} hideFooter>
     <div class:list={['contentViewport layout-grid']}>
         <ThemeBuilder client:only="react" />
         <EmptyState />

--- a/documentation/ag-grid-docs/src/pages/theme-builder.md.ts
+++ b/documentation/ag-grid-docs/src/pages/theme-builder.md.ts
@@ -1,0 +1,42 @@
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { STATIC_PAGE_CONTENT } from '@utils/markdown-pages/staticPageContent';
+import { urlWithPrefix } from '@utils/urlWithPrefix';
+
+// Served at /theme-builder.md — the markdown twin of the Theme Builder page. The page IS the
+// tool, so there is no prose to mirror; the twin explains what the tool does and points at the
+// theming docs, which is what an agent asked about theming actually needs. Content-negotiates
+// from the HTML URL on Accept: text/markdown (see the SE-80 rules in htaccessRules.ts).
+export function GET() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+
+    const content = STATIC_PAGE_CONTENT['theme-builder'];
+    const docsUrl = (path: string) => toAbsoluteUrl(urlWithPrefix({ framework: 'javascript', url: path }), SITE_URL);
+
+    const output =
+        [
+            [
+                '---',
+                `title: ${JSON.stringify(content.title)}`,
+                `description: ${JSON.stringify(content.description)}`,
+                '---',
+            ].join('\n'),
+            `# ${content.heading}`,
+            content.description,
+            'Theme Builder is an interactive tool, so it has no text version. It runs in the browser at ' +
+                `[${content.heading}](${toAbsoluteUrl('/theme-builder/', SITE_URL)}).`,
+            'To build a theme in code instead, see the theming documentation:',
+            [
+                `- [Theming](${docsUrl('./theming/')})`,
+                `- [Theming API](${docsUrl('./theming-api/')})`,
+                `- [Applying Themes](${docsUrl('./theming-applying-themes/')})`,
+            ].join('\n'),
+        ].join('\n\n') + '\n';
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/documentation/ag-grid-docs/src/pages/whats-new.md.ts
+++ b/documentation/ag-grid-docs/src/pages/whats-new.md.ts
@@ -1,0 +1,29 @@
+import { buildWhatsNewMarkdown } from '@ag-website-shared/markdown-pages/buildWhatsNewMarkdown';
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { urlWithPrefix } from '@utils/urlWithPrefix';
+import { type CollectionEntry, getEntry } from 'astro:content';
+
+// Served at /whats-new.md — a markdown twin of the /whats-new page for LLMs, built from the same
+// versions collection and shared product metadata the page renders. Content-negotiates from the
+// HTML URL on Accept: text/markdown (see the SE-80 rules in htaccessRules.ts).
+export async function GET() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+
+    const { data: versionsData } = (await getEntry('versions', 'ag-grid-versions')) as CollectionEntry<'versions'>;
+
+    const output = buildWhatsNewMarkdown({
+        site: 'grid',
+        versionsData,
+        siteRoot: SITE_URL,
+        // Highlight and release-note paths are framework-relative; the page resolves them against
+        // the reader's remembered framework, so the twin picks the framework-agnostic core.
+        resolveUrl: (url) => urlWithPrefix({ framework: 'javascript', url }),
+    });
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/documentation/ag-grid-docs/src/utils/agentReadinessFiles.test.ts
+++ b/documentation/ag-grid-docs/src/utils/agentReadinessFiles.test.ts
@@ -26,12 +26,13 @@ describe('buildLlmsTxt', () => {
         expect(txt).toContain('(https://www.ag-grid.com/sitemap-index.xml)');
     });
 
-    test('advertises the per-page markdown (.md) convention and the top-level .md pages', () => {
+    test('advertises the markdown (.md) convention as a site-wide rule, not a page list', () => {
         expect(txt).toContain('.md');
         expect(txt).toContain('https://www.ag-grid.com/javascript-data-grid/getting-started.md');
-        expect(txt).toContain(
-            'The Home, About, Community, Documentation Archive, Example, Pricing, Changelog and Pipeline pages also have `.md` versions'
-        );
+        // Every page in the sitemap has a twin, so llms.txt states the rule. Enumerating
+        // pages here would drift the moment one is added (see markdownPages.test.ts).
+        expect(txt).toContain('append `.md` to any page URL listed in the sitemap');
+        expect(txt).toContain('Accept: text/markdown');
     });
 
     test('lists the pipeline page', () => {
@@ -65,14 +66,13 @@ describe('buildAgentsMd', () => {
         expect(md).toContain('https://www.ag-grid.com/llms.txt');
     });
 
-    test('advertises the markdown (.md) versions', () => {
+    test('advertises the markdown (.md) versions as a site-wide rule', () => {
         expect(md).toContain('Markdown for LLMs');
         expect(md).toContain('https://www.ag-grid.com/javascript-data-grid/getting-started.md');
-        expect(md).toContain('https://www.ag-grid.com/pipeline/');
-        // The new page twins are advertised with links.
-        expect(md).toContain('[About](https://www.ag-grid.com/about/)');
-        expect(md).toContain('[Community](https://www.ag-grid.com/community/)');
-        expect(md).toContain('[Documentation Archive](https://www.ag-grid.com/documentation-archive/)');
+        // Every page in the sitemap has a twin, so point at the sitemap rather than
+        // listing pages that would drift (see markdownPages.test.ts for the guarantee).
+        expect(md).toContain('append `.md` to any page URL listed in the');
+        expect(md).toContain('[sitemap](https://www.ag-grid.com/sitemap-index.xml)');
     });
 
     test('omits the markdown affordance when markdown docs are disabled', () => {

--- a/documentation/ag-grid-docs/src/utils/agentReadinessFiles.test.ts
+++ b/documentation/ag-grid-docs/src/utils/agentReadinessFiles.test.ts
@@ -35,6 +35,10 @@ describe('buildLlmsTxt', () => {
         expect(txt).toContain('Accept: text/markdown');
     });
 
+    test('points at index.md for the homepage, whose twin is not a `.md` suffix', () => {
+        expect(txt).toContain('https://www.ag-grid.com/index.md');
+    });
+
     test('lists the pipeline page', () => {
         expect(txt).toContain('(https://www.ag-grid.com/pipeline/)');
     });
@@ -73,6 +77,10 @@ describe('buildAgentsMd', () => {
         // listing pages that would drift (see markdownPages.test.ts for the guarantee).
         expect(md).toContain('append `.md` to any page URL listed in the');
         expect(md).toContain('[sitemap](https://www.ag-grid.com/sitemap-index.xml)');
+    });
+
+    test('points at index.md for the homepage, whose twin is not a `.md` suffix', () => {
+        expect(md).toContain('https://www.ag-grid.com/index.md');
     });
 
     test('omits the markdown affordance when markdown docs are disabled', () => {

--- a/documentation/ag-grid-docs/src/utils/agentReadinessFiles.ts
+++ b/documentation/ag-grid-docs/src/utils/agentReadinessFiles.ts
@@ -29,7 +29,6 @@ interface AgentReadinessInput {
 }
 
 interface AgentReadinessLinks {
-    home: string;
     dataGrid: string;
     charts: string;
     studio: string;
@@ -38,9 +37,6 @@ interface AgentReadinessLinks {
     chartsDocs: string;
     examples: string;
     mcpServer: string;
-    about: string;
-    community: string;
-    documentationArchive: string;
     pricing: string;
     changelog: string;
     pipeline: string;
@@ -51,7 +47,6 @@ interface AgentReadinessLinks {
 function buildLinks({ siteRoot, gridDocsPrefix }: AgentReadinessInput): AgentReadinessLinks {
     const grid = `${siteRoot}${gridDocsPrefix}/`;
     return {
-        home: siteRoot,
         dataGrid: grid,
         charts: `${siteRoot}charts/`,
         studio: `${siteRoot}studio/`,
@@ -60,9 +55,6 @@ function buildLinks({ siteRoot, gridDocsPrefix }: AgentReadinessInput): AgentRea
         chartsDocs: `${siteRoot}charts/javascript/quick-start/`,
         examples: `${siteRoot}example/`,
         mcpServer: `${grid}mcp-server/`,
-        about: `${siteRoot}about/`,
-        community: `${siteRoot}community/`,
-        documentationArchive: `${siteRoot}documentation-archive/`,
         pricing: `${siteRoot}license-pricing/`,
         changelog: `${siteRoot}changelog/`,
         pipeline: `${siteRoot}pipeline/`,
@@ -77,11 +69,13 @@ function buildLinks({ siteRoot, gridDocsPrefix }: AgentReadinessInput): AgentRea
  */
 export function buildLlmsTxt(input: AgentReadinessInput): string {
     const l = buildLinks(input);
-    // Only advertise the `.md` convention when those routes are actually built.
+    // Only advertise the `.md` convention when those routes are actually built. Every page
+    // in the sitemap has a twin (enforced by the post-build check in markdownPages.test.ts),
+    // so this states the rule rather than enumerating pages that would drift out of date.
     const markdownLine =
         input.includeMarkdownDocs === false
             ? ''
-            : `\n- Markdown versions: append \`.md\` to any Data Grid docs page URL for a clean, framework-specific Markdown copy (e.g. ${l.dataGridDocs.replace(/\/$/, '')}.md), or send \`Accept: text/markdown\`. The Home, About, Community, Documentation Archive, Example, Pricing, Changelog and Pipeline pages also have \`.md\` versions.`;
+            : `\n- Markdown versions: append \`.md\` to any page URL listed in the sitemap for a clean Markdown copy (e.g. ${l.dataGridDocs.replace(/\/$/, '')}.md), or send \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL.`;
     return `# AG Grid
 > High-performance JavaScript Data Grid, plus AG Charts and AG Studio. Framework-agnostic, with React, Angular and Vue support. Free Community and paid Enterprise editions. Current major version: v${input.majorVersion}.
 
@@ -112,10 +106,11 @@ export function buildLlmsTxt(input: AgentReadinessInput): string {
 export function buildAgentsMd(input: AgentReadinessInput): string {
     const l = buildLinks(input);
     // Advertise the markdown twins only when they are built (see includeMarkdownDocs).
+    // Every page in the sitemap has one, so state the rule rather than listing pages.
     const markdownBullet =
         input.includeMarkdownDocs === false
             ? ''
-            : `\n- **Markdown for LLMs:** append \`.md\` to any Data Grid docs page URL (e.g. ${l.dataGridDocs.replace(/\/$/, '')}.md), or request the page with \`Accept: text/markdown\`. The [Home](${l.home}), [About](${l.about}), [Community](${l.community}), [Documentation Archive](${l.documentationArchive}), [Example](${l.examples}), [Pricing](${l.pricing}), [Changelog](${l.changelog}) and [Pipeline](${l.pipeline}) pages also have \`.md\` versions.`;
+            : `\n- **Markdown for LLMs:** append \`.md\` to any page URL listed in the [sitemap](${l.sitemap}) (e.g. ${l.dataGridDocs.replace(/\/$/, '')}.md), or request the page with \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL.`;
     return `# AG Grid - guide for AI coding assistants
 
 - **What it is:** JavaScript Data Grid, plus [AG Charts](${l.charts}) and [AG Studio](${l.studio}). Framework-agnostic, with React, Angular and Vue wrappers. Community (free) and Enterprise (licensed) editions.

--- a/documentation/ag-grid-docs/src/utils/agentReadinessFiles.ts
+++ b/documentation/ag-grid-docs/src/utils/agentReadinessFiles.ts
@@ -42,6 +42,8 @@ interface AgentReadinessLinks {
     pipeline: string;
     sitemap: string;
     llmsTxt: string;
+    /** The homepage twin, which is `index.md` rather than a `.md` suffix on the site root. */
+    homepageMarkdown: string;
 }
 
 function buildLinks({ siteRoot, gridDocsPrefix }: AgentReadinessInput): AgentReadinessLinks {
@@ -60,6 +62,7 @@ function buildLinks({ siteRoot, gridDocsPrefix }: AgentReadinessInput): AgentRea
         pipeline: `${siteRoot}pipeline/`,
         sitemap: `${siteRoot}sitemap-index.xml`,
         llmsTxt: `${siteRoot}llms.txt`,
+        homepageMarkdown: `${siteRoot}index.md`,
     };
 }
 
@@ -75,7 +78,7 @@ export function buildLlmsTxt(input: AgentReadinessInput): string {
     const markdownLine =
         input.includeMarkdownDocs === false
             ? ''
-            : `\n- Markdown versions: append \`.md\` to any page URL listed in the sitemap for a clean Markdown copy (e.g. ${l.dataGridDocs.replace(/\/$/, '')}.md), or send \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL.`;
+            : `\n- Markdown versions: append \`.md\` to any page URL listed in the sitemap for a clean Markdown copy (e.g. ${l.dataGridDocs.replace(/\/$/, '')}.md), or send \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${l.homepageMarkdown}.`;
     return `# AG Grid
 > High-performance JavaScript Data Grid, plus AG Charts and AG Studio. Framework-agnostic, with React, Angular and Vue support. Free Community and paid Enterprise editions. Current major version: v${input.majorVersion}.
 
@@ -110,7 +113,7 @@ export function buildAgentsMd(input: AgentReadinessInput): string {
     const markdownBullet =
         input.includeMarkdownDocs === false
             ? ''
-            : `\n- **Markdown for LLMs:** append \`.md\` to any page URL listed in the [sitemap](${l.sitemap}) (e.g. ${l.dataGridDocs.replace(/\/$/, '')}.md), or request the page with \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL.`;
+            : `\n- **Markdown for LLMs:** append \`.md\` to any page URL listed in the [sitemap](${l.sitemap}) (e.g. ${l.dataGridDocs.replace(/\/$/, '')}.md), or request the page with \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${l.homepageMarkdown}.`;
     return `# AG Grid - guide for AI coding assistants
 
 - **What it is:** JavaScript Data Grid, plus [AG Charts](${l.charts}) and [AG Studio](${l.studio}). Framework-agnostic, with React, Angular and Vue wrappers. Community (free) and Enterprise (licensed) editions.

--- a/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/documentation/ag-grid-docs/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -357,7 +357,7 @@ AddCharset utf-8 .md
     # is left untouched. Placed after host/https canonicalization but before the
     # trailing-slash 301 so the canonical (slashed) docs URL negotiates in one hop.
     RewriteCond %{HTTP_ACCEPT} text/markdown
-    RewriteCond %{REQUEST_URI} ^/((?:(?:react|angular|vue|javascript)-data-grid/[^/]+?)|license-pricing|changelog|pipeline|about|community(?:/(?:events|showcase|tools-extensions|media|beyond-the-prompt))?|documentation-archive|example)/?$
+    RewriteCond %{REQUEST_URI} ^/((?:react|angular|vue|javascript)-data-grid/[^/.]+|about|changelog|documentation-archive|example|license-pricing|pipeline|roadmap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|campaigns/bryntum-[^/.]+|landing-pages/[^/.]+|react-table|cookies|modern-slavery|privacy|example-(?:finance|hr|inventory)|contact|niall|licensing|reference|sitemap|theme-builder)/?$
     RewriteCond %{DOCUMENT_ROOT}/%1.md -f
     RewriteRule ^ /%1.md [L]
 
@@ -2741,9 +2741,9 @@ AddCharset utf-8 .md
 Header always set Referrer-Policy "strict-origin-when-cross-origin"
 Header always set Permissions-Policy "geolocation=(), microphone=(), camera=()"
 
-# SE-80: docs pages content-negotiate on Accept (see the markdown rewrite), so shared
+# SE-80: negotiated pages content-negotiate on Accept (see the markdown rewrite), so shared
 # caches must key on it. Scoped to the negotiated paths so the rest of the site keeps its default.
-<If "%{REQUEST_URI} =~ m#^/(?:(?:react|angular|vue|javascript)-data-grid/[^/]+|license-pricing|changelog|pipeline|about|community(?:/(?:events|showcase|tools-extensions|media|beyond-the-prompt))?|documentation-archive|example)/?$# || %{REQUEST_URI} == '/'">
+<If "%{REQUEST_URI} =~ m#^/(?:(?:react|angular|vue|javascript)-data-grid/[^/.]+|about|changelog|documentation-archive|example|license-pricing|pipeline|roadmap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|campaigns/bryntum-[^/.]+|landing-pages/[^/.]+|react-table|cookies|modern-slavery|privacy|example-(?:finance|hr|inventory)|contact|niall|licensing|reference|sitemap|theme-builder)/?$# || %{REQUEST_URI} == '/'">
     Header append Vary Accept
 </If>
 
@@ -2816,7 +2816,7 @@ AddCharset utf-8 .md
 
     # SE-80: content-negotiate docs pages to their markdown variant on Accept: text/markdown.
     RewriteCond %{HTTP_ACCEPT} text/markdown
-    RewriteCond %{REQUEST_URI} ^/((?:(?:react|angular|vue|javascript)-data-grid/[^/]+?)|license-pricing|changelog|pipeline|about|community(?:/(?:events|showcase|tools-extensions|media|beyond-the-prompt))?|documentation-archive|example)/?$
+    RewriteCond %{REQUEST_URI} ^/((?:react|angular|vue|javascript)-data-grid/[^/.]+|about|changelog|documentation-archive|example|license-pricing|pipeline|roadmap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|campaigns/bryntum-[^/.]+|landing-pages/[^/.]+|react-table|cookies|modern-slavery|privacy|example-(?:finance|hr|inventory)|contact|niall|licensing|reference|sitemap|theme-builder)/?$
     RewriteCond %{DOCUMENT_ROOT}/%1.md -f
     RewriteRule ^ /%1.md [L]
 
@@ -2828,9 +2828,9 @@ AddCharset utf-8 .md
     RewriteRule ^ /index.md [L]
 </IfModule>
 
-# SE-80: docs pages content-negotiate on Accept (see the markdown rewrite), so shared
+# SE-80: negotiated pages content-negotiate on Accept (see the markdown rewrite), so shared
 # caches must key on it. Scoped to the negotiated paths so the rest of the site keeps its default.
-<If "%{REQUEST_URI} =~ m#^/(?:(?:react|angular|vue|javascript)-data-grid/[^/]+|license-pricing|changelog|pipeline|about|community(?:/(?:events|showcase|tools-extensions|media|beyond-the-prompt))?|documentation-archive|example)/?$# || %{REQUEST_URI} == '/'">
+<If "%{REQUEST_URI} =~ m#^/(?:(?:react|angular|vue|javascript)-data-grid/[^/.]+|about|changelog|documentation-archive|example|license-pricing|pipeline|roadmap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|campaigns/bryntum-[^/.]+|landing-pages/[^/.]+|react-table|cookies|modern-slavery|privacy|example-(?:finance|hr|inventory)|contact|niall|licensing|reference|sitemap|theme-builder)/?$# || %{REQUEST_URI} == '/'">
     Header append Vary Accept
 </If>
 

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.test.ts
@@ -556,34 +556,87 @@ describe('htaccessRules', () => {
     });
 
     describe('SE-80: Accept: text/markdown content negotiation', () => {
-        const negotiationRules = [
-            'RewriteCond %{HTTP_ACCEPT} text/markdown',
-            // Captures a docs path or a top-level md page, reused (%1) in the -f test and rewrite target.
-            'RewriteCond %{REQUEST_URI} ^/((?:(?:react|angular|vue|javascript)-data-grid/[^/]+?)|license-pricing|changelog|pipeline|about|community(?:/(?:events|showcase|tools-extensions|media|beyond-the-prompt))?|documentation-archive|example)/?$',
-            'RewriteCond %{DOCUMENT_ROOT}/%1.md -f',
-            'RewriteRule ^ /%1.md [L]',
+        // The negotiated path list is derived from GRID_MARKDOWN_PAGE_GROUPS, so asserting the
+        // literal regex here would just restate the registry. Instead, pull the generated
+        // pattern back out and check which URLs it actually matches — that catches a broken
+        // pattern, which a string comparison against a hand-copied regex never would.
+        const extractNegotiationPattern = (content: string) => {
+            const match = content.match(/RewriteCond %\{REQUEST_URI\} \^\/\((.+)\)\/\?\$/);
+            expect(match).not.toBeNull();
+            return new RegExp(`^/(${match![1]})/?$`);
+        };
+
+        const extractVaryPattern = (content: string) => {
+            const match = content.match(/<If "%\{REQUEST_URI\} =~ m#\^\/\(\?:(.+)\)\/\?\$#/);
+            expect(match).not.toBeNull();
+            return new RegExp(`^/(?:${match![1]})/?$`);
+        };
+
+        // One representative URL per group in the registry. Every URL in the sitemap must
+        // negotiate, so a group added without a matching pattern shows up here.
+        const negotiablePaths = [
+            '/react-data-grid/cell-editing/',
+            '/javascript-data-grid/getting-started/',
+            '/about/',
+            '/changelog/',
+            '/documentation-archive/',
+            '/example/',
+            '/license-pricing/',
+            '/pipeline/',
+            '/roadmap/',
+            '/whats-new/',
+            '/community/',
+            '/community/events/',
+            '/community/beyond-the-prompt/',
+            '/session/opening-keynote/',
+            '/campaigns/bryntum-gantt/',
+            '/landing-pages/react-data-grid/',
+            '/react-table/',
+            '/cookies/',
+            '/modern-slavery/',
+            '/privacy/',
+            '/example-finance/',
+            '/example-hr/',
+            '/example-inventory/',
+            '/contact/',
+            '/niall/',
+            '/licensing/',
+            '/reference/',
+            '/sitemap/',
+            '/theme-builder/',
         ];
 
-        // The homepage twin is a separate stanza: the root URL has no path segment to capture.
-        const homepageNegotiationRules = [
-            'RewriteCond %{REQUEST_URI} ^/$',
-            'RewriteCond %{DOCUMENT_ROOT}/index.md -f',
-            'RewriteRule ^ /index.md [L]',
+        // Paths that must NOT negotiate: they have no `.md` twin, and rewriting them would
+        // either 404 or (for the `.md` itself) loop into `.md.md`.
+        const nonNegotiablePaths = [
+            '/react-data-grid/cell-editing.md', // the twin itself — final segments exclude dots
+            '/react-data-grid/', // framework landing page, redirect stub
+            '/react-data-grid/errors/123/', // sitemap-excluded
+            '/data-grid/cell-editing/', // framework-agnostic redirect stub
+            '/contact/success/', // form result, sitemap-excluded
+            '/privacy/your-choice/', // opt-out confirmation, robots-disallowed and sitemap-excluded
+            '/examples/cell-editing/component-editor/reactFunctionalTs/',
+            '/debug/files/',
+            '/sitemap-0.xml',
+            '/sitemap-index.xml',
         ];
 
         it('serves the per-page .md variant when Accept: text/markdown, gated by an on-disk check', () => {
-            for (const rule of negotiationRules) {
-                expect(productionContent).toContain(rule);
-            }
+            expect(productionContent).toContain('RewriteCond %{HTTP_ACCEPT} text/markdown');
+            expect(productionContent).toContain('RewriteCond %{DOCUMENT_ROOT}/%1.md -f');
+            expect(productionContent).toContain('RewriteRule ^ /%1.md [L]');
         });
 
         it('applies the same negotiation rules on staging, in its own mod_rewrite block', () => {
             // Staging has no redirect rewrites, so negotiation gets a dedicated block.
             expect(stagingContent).toContain('mod_rewrite.c');
             expect(stagingContent).toContain('RewriteEngine On');
-            for (const rule of negotiationRules) {
-                expect(stagingContent).toContain(rule);
-            }
+            expect(stagingContent).toContain('RewriteCond %{HTTP_ACCEPT} text/markdown');
+            expect(stagingContent).toContain('RewriteRule ^ /%1.md [L]');
+            // Both envs must negotiate exactly the same set of paths.
+            expect(extractNegotiationPattern(stagingContent).source).toBe(
+                extractNegotiationPattern(productionContent).source
+            );
         });
 
         it('runs the negotiation before the trailing-slash 301 so the canonical URL negotiates in one hop', () => {
@@ -594,33 +647,52 @@ describe('htaccessRules', () => {
             expect(negotiationIndex).toBeLessThan(trailingSlashIndex);
         });
 
-        it('adds Vary: Accept for negotiated paths (both envs) so shared caches key on the negotiated representation', () => {
+        it('negotiates every page group in the registry, with and without a trailing slash', () => {
+            const pattern = extractNegotiationPattern(productionContent);
+            for (const path of negotiablePaths) {
+                expect(pattern.test(path), `${path} should negotiate`).toBe(true);
+                expect(pattern.test(path.replace(/\/$/, '')), `${path} (no trailing slash)`).toBe(true);
+            }
+        });
+
+        it('leaves pages without a .md twin untouched', () => {
+            const pattern = extractNegotiationPattern(productionContent);
+            for (const path of nonNegotiablePaths) {
+                expect(pattern.test(path), `${path} should not negotiate`).toBe(false);
+            }
+        });
+
+        it('captures the page path in %1 so the -f guard and rewrite target resolve to /<page>.md', () => {
+            const pattern = extractNegotiationPattern(productionContent);
+            // %1 is the first capture group, reused as `%1.md` in both the guard and the target.
+            expect('/community/events/'.match(pattern)?.[1]).toBe('community/events');
+            expect('/react-data-grid/cell-editing/'.match(pattern)?.[1]).toBe('react-data-grid/cell-editing');
+            expect('/license-pricing'.match(pattern)?.[1]).toBe('license-pricing');
+        });
+
+        it('adds Vary: Accept for exactly the negotiated paths (both envs) so shared caches key on the negotiated representation', () => {
             for (const content of [productionContent, stagingContent]) {
-                expect(content).toContain(
-                    `<If "%{REQUEST_URI} =~ m#^/(?:(?:react|angular|vue|javascript)-data-grid/[^/]+|license-pricing|changelog|pipeline|about|community(?:/(?:events|showcase|tools-extensions|media|beyond-the-prompt))?|documentation-archive|example)/?$# || %{REQUEST_URI} == '/'">`
-                );
                 expect(content).toContain('Header append Vary Accept');
-            }
-        });
-
-        it('negotiates the top-level standalone pages to their .md', () => {
-            // %1 captures each page name, so the -f guard and rewrite target resolve to /<page>.md.
-            for (const content of [productionContent, stagingContent]) {
-                expect(content).toContain('|license-pricing|changelog|pipeline|about|community');
-                expect(content).toContain('|documentation-archive|example)/?$');
-            }
-        });
-
-        it('negotiates the community subpages to their .md', () => {
-            // e.g. /community/events -> %1 = community/events -> /community/events.md
-            for (const content of [productionContent, stagingContent]) {
-                expect(content).toContain(
-                    'community(?:/(?:events|showcase|tools-extensions|media|beyond-the-prompt))?'
-                );
+                // The Vary scope must cover the negotiated set exactly — narrower and a cache
+                // could serve markdown to a browser; wider and unrelated pages lose cache keying.
+                const varyPattern = extractVaryPattern(content);
+                for (const path of negotiablePaths) {
+                    expect(varyPattern.test(path), `${path} should carry Vary: Accept`).toBe(true);
+                }
+                for (const path of nonNegotiablePaths) {
+                    expect(varyPattern.test(path), `${path} should not carry Vary: Accept`).toBe(false);
+                }
+                expect(content).toContain(`%{REQUEST_URI} == '/'`);
             }
         });
 
         it('negotiates the homepage (/) to /index.md via a dedicated stanza in both envs', () => {
+            // The homepage twin is a separate stanza: the root URL has no path segment to capture.
+            const homepageNegotiationRules = [
+                'RewriteCond %{REQUEST_URI} ^/$',
+                'RewriteCond %{DOCUMENT_ROOT}/index.md -f',
+                'RewriteRule ^ /index.md [L]',
+            ];
             for (const content of [productionContent, stagingContent]) {
                 for (const rule of homepageNegotiationRules) {
                     expect(content).toContain(rule);

--- a/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
+++ b/documentation/ag-grid-docs/src/utils/htaccess/htaccessRules.ts
@@ -1,3 +1,6 @@
+// Relative rather than aliased: this module is pulled in by the agHtaccessGen integration, which
+// astro.config.mjs bundles without tsconfig path resolution (as with plugins/agDevMarkdownNegotiation).
+import { markdownPathAlternation } from '../markdownPages';
 import { urlWithBaseUrl } from '../urlWithBaseUrl';
 import type { CspEnv } from './cspRules';
 import {
@@ -83,10 +86,13 @@ const modDeflateRules = `
 // on `Accept: text/markdown`, shared by the production and staging .htaccess so the
 // rule can't drift between them. Indented 4 spaces for use inside a mod_rewrite block.
 // The negotiation is an internal rewrite (no redirect, URL unchanged), gated by an
-// on-disk check so a path without a .md is left untouched. %1 is the docs path
+// on-disk check so a path without a .md is left untouched. %1 is the page path
 // captured below, reused in both the -f test and the rewrite target.
+//
+// The path alternation is derived from GRID_MARKDOWN_PAGE_GROUPS — the same registry the
+// dev-server plugin uses — so the two can't disagree about what is negotiable.
 const markdownNegotiationRules = `    RewriteCond %{HTTP_ACCEPT} text/markdown
-    RewriteCond %{REQUEST_URI} ^/((?:(?:react|angular|vue|javascript)-data-grid/[^/]+?)|license-pricing|changelog|pipeline|about|community(?:/(?:events|showcase|tools-extensions|media|beyond-the-prompt))?|documentation-archive|example)/?$
+    RewriteCond %{REQUEST_URI} ^/(${markdownPathAlternation()})/?$
     RewriteCond %{DOCUMENT_ROOT}/%1.md -f
     RewriteRule ^ /%1.md [L]
 
@@ -106,13 +112,14 @@ const markdownNegotiationBlock = `<IfModule mod_rewrite.c>
 ${markdownNegotiationRules}
 </IfModule>`;
 
-// SE-80: docs pages content-negotiate on the Accept header (see the markdown rewrite
+// SE-80: negotiated pages content-negotiate on the Accept header (see the markdown rewrite
 // above), so shared caches must key on it — otherwise they could serve the markdown
-// variant to a browser, or HTML to an agent. Scoped to the docs paths so the rest of
-// the site keeps its default (URL-only) cache key.
-const markdownVaryHeader = `# SE-80: docs pages content-negotiate on Accept (see the markdown rewrite), so shared
+// variant to a browser, or HTML to an agent. Scoped to the negotiated paths so the rest of
+// the site keeps its default (URL-only) cache key. Derived from the same registry as the
+// rewrite rule, so the two stay in lockstep.
+const markdownVaryHeader = `# SE-80: negotiated pages content-negotiate on Accept (see the markdown rewrite), so shared
 # caches must key on it. Scoped to the negotiated paths so the rest of the site keeps its default.
-<If "%{REQUEST_URI} =~ m#^/(?:(?:react|angular|vue|javascript)-data-grid/[^/]+|license-pricing|changelog|pipeline|about|community(?:/(?:events|showcase|tools-extensions|media|beyond-the-prompt))?|documentation-archive|example)/?$# || %{REQUEST_URI} == '/'">
+<If "%{REQUEST_URI} =~ m#^/(?:${markdownPathAlternation()})/?$# || %{REQUEST_URI} == '/'">
     Header append Vary Accept
 </If>`;
 

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/buildCampaignMarkdown.test.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/buildCampaignMarkdown.test.ts
@@ -1,0 +1,72 @@
+import type { BryntumCampaignContent } from '@components/campaigns-components/bryntum/types';
+import { describe, expect, it } from 'vitest';
+
+import calendar from '../../content/campaigns/bryntum-products/calendar.json';
+import complete from '../../content/campaigns/bryntum-products/complete.json';
+import gantt from '../../content/campaigns/bryntum-products/gantt.json';
+import scheduler from '../../content/campaigns/bryntum-products/scheduler.json';
+import schedulerpro from '../../content/campaigns/bryntum-products/schedulerpro.json';
+import taskboard from '../../content/campaigns/bryntum-products/taskboard.json';
+import { buildCampaignMarkdown, campaignMeta } from './buildCampaignMarkdown';
+
+const CAMPAIGNS: Record<string, unknown> = { calendar, complete, gantt, scheduler, schedulerpro, taskboard };
+
+const build = (content: unknown) => buildCampaignMarkdown({ content: content as BryntumCampaignContent });
+
+describe('buildCampaignMarkdown', () => {
+    describe.each(Object.entries(CAMPAIGNS))('%s', (_slug, raw) => {
+        const content = raw as BryntumCampaignContent;
+        const output = build(raw);
+
+        it('opens with frontmatter from the same meta the page uses, then the hero as H1', () => {
+            const { title, description } = campaignMeta(content);
+            expect(output.startsWith('---\n')).toBe(true);
+            expect(output).toContain(`title: ${JSON.stringify(title)}`);
+            expect(output).toContain(`description: ${JSON.stringify(description)}`);
+            expect(output.match(/^# /gm)?.length).toBe(1);
+        });
+
+        it('renders a heading for every section that has one, in page order', () => {
+            const headings = content.sections
+                .slice(1)
+                .map((section) => section.heading)
+                .filter((heading): heading is string => Boolean(heading));
+            let cursor = 0;
+            for (const heading of headings) {
+                const index = output.indexOf(`## ${heading}`, cursor);
+                expect(index, `section "${heading}" missing or out of order`).toBeGreaterThan(-1);
+                cursor = index;
+            }
+        });
+
+        it('leaves no raw HTML behind and resolves every link to an absolute URL', () => {
+            expect(output).not.toMatch(/<\/?(?:p|a|ul|li|span|strong|code|h[1-6])\b/);
+            const relative = [...output.matchAll(/\[[^\]]*\]\(([^)]+)\)/g)]
+                .map((match) => match[1])
+                .filter((href) => !href.startsWith('http') && !href.startsWith('mailto:') && href !== '#');
+            expect(relative).toEqual([]);
+        });
+
+        it('ends with a single trailing newline', () => {
+            expect(output.endsWith('\n')).toBe(true);
+            expect(output.endsWith('\n\n')).toBe(false);
+        });
+    });
+
+    it('resolves campaign links to bryntum.com, since the copy is written for that site', () => {
+        const output = build(gantt);
+        expect(output).toContain('https://bryntum.com/products/gantt/examples');
+    });
+
+    it('converts body_html lists and emphasis rather than flattening them', () => {
+        const output = build(gantt);
+        expect(output).toMatch(/^- /m);
+        expect(output).toContain('**');
+    });
+
+    it('keeps the hero copy under the H1', () => {
+        const output = build(gantt);
+        expect(output).toContain('# The Quickest JS Gantt Chart');
+        expect(output).toContain('Bryntum Gantt is a speed-tuned');
+    });
+});

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/buildCampaignMarkdown.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/buildCampaignMarkdown.ts
@@ -1,0 +1,112 @@
+import { htmlBlockToMarkdown } from '@ag-website-shared/markdoc/htmlInlineToMarkdown';
+import type {
+    BryntumCampaignContent,
+    BryntumCta,
+    BryntumSection,
+} from '@components/campaigns-components/bryntum/types';
+import { decorateBryntumHtml, resolveBryntumHref } from '@utils/bryntumCampaignAssets';
+
+/** The page's title/description fallbacks, shared so the twin's frontmatter matches its meta. */
+export function campaignMeta(content: BryntumCampaignContent) {
+    return {
+        title: content.meta?.og_title ?? content.title,
+        description: content.meta?.description ?? '',
+    };
+}
+
+function ctaList(ctas: BryntumCta[] | undefined): string | undefined {
+    if (!ctas?.length) {
+        return undefined;
+    }
+    return ctas.map((cta) => `[${cta.text}](${resolveBryntumHref(cta.href)})`).join(' | ');
+}
+
+/**
+ * Body copy for a section. `body_html` is preferred over the plain-text `body_text` twin the
+ * content ships, because it carries the links and emphasis; hrefs are resolved through the same
+ * `decorateBryntumHtml` the page uses, so they land on bryntum.com with the campaign's UTM tags.
+ */
+function bodyMarkdown(section: BryntumSection): string | undefined {
+    const html = 'body_html' in section ? section.body_html : undefined;
+    if (html) {
+        return htmlBlockToMarkdown(decorateBryntumHtml(html));
+    }
+    return 'body_text' in section ? section.body_text : undefined;
+}
+
+function itemsMarkdown(section: BryntumSection): string | undefined {
+    if (!('items' in section) || !section.items?.length) {
+        return undefined;
+    }
+    const items = section.items.map((item) => {
+        const label = ('heading' in item ? item.heading : undefined) ?? ('label' in item ? item.label : undefined);
+        const text = label ? (item.href ? `[${label}](${resolveBryntumHref(item.href)})` : label) : undefined;
+        const detail =
+            ('body_text' in item ? item.body_text : undefined) ??
+            ('description' in item ? item.description : undefined);
+        if (!text) {
+            return undefined;
+        }
+        return detail ? `- **${text}** — ${detail}` : `- ${text}`;
+    });
+    const rendered = items.filter(Boolean);
+    return rendered.length ? rendered.join('\n') : undefined;
+}
+
+function sectionMarkdown(section: BryntumSection): string[] {
+    const parts: string[] = [];
+    if (section.eyebrow) {
+        // The small label above the heading on the page; kept as an emphasised kicker so it
+        // holds that reading order without adding a heading level.
+        parts.push(`*${section.eyebrow}*`);
+    }
+    if (section.heading) {
+        parts.push(`## ${section.heading}`);
+    }
+    const body = bodyMarkdown(section);
+    if (body) {
+        parts.push(body);
+    }
+    const items = itemsMarkdown(section);
+    if (items) {
+        parts.push(items);
+    }
+    const ctas = ctaList('ctas' in section ? section.ctas : undefined);
+    if (ctas) {
+        parts.push(ctas);
+    }
+    // `section.links` is deliberately not rendered: the page never renders it either, and its
+    // entries are a flattened copy of the anchors already inside `body_html`.
+    return parts;
+}
+
+/**
+ * Build the markdown twin of a `/campaigns/bryntum-<product>` page. Reads the same campaign JSON
+ * `BryntumCampaign.astro` renders and walks its sections in page order. The embedded live demos,
+ * videos and logo walls have no markdown representation, so those sections contribute their
+ * heading and supporting copy only.
+ */
+export function buildCampaignMarkdown({ content }: { content: BryntumCampaignContent }): string {
+    const { title, description } = campaignMeta(content);
+    // The hero is the page title; every other section keeps page order below it.
+    const [hero, ...rest] = content.sections;
+
+    const document: string[] = [
+        ['---', `title: ${JSON.stringify(title)}`, `description: ${JSON.stringify(description)}`, '---'].join('\n'),
+        `# ${hero?.heading ?? content.title}`,
+    ];
+
+    if (hero) {
+        const body = bodyMarkdown(hero);
+        if (body) {
+            document.push(body);
+        }
+        const ctas = ctaList('ctas' in hero ? hero.ctas : undefined);
+        if (ctas) {
+            document.push(ctas);
+        }
+    }
+    document.push(...rest.flatMap(sectionMarkdown));
+
+    return `${document.join('\n\n').trimEnd()}\n`;
+}

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/buildDemoMarkdown.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/buildDemoMarkdown.ts
@@ -1,0 +1,40 @@
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
+
+import demosData from '../../content/demos/demos.json';
+
+export type DemoName = keyof typeof demosData;
+
+/** The demo's page copy — shared with the `.astro` page so the two cannot drift. */
+export function demoContent(demo: DemoName) {
+    return demosData[demo];
+}
+
+/**
+ * Build the markdown twin of a standalone demo page (`/example-finance`, `/example-hr`,
+ * `/example-inventory`). The demo itself is a live React grid with no markdown representation, so
+ * the twin carries the page's copy and its links, and points at the source on GitHub — which is
+ * the useful thing for an agent asked how the demo is built.
+ */
+export function buildDemoMarkdown({ demo, siteRoot }: { demo: DemoName; siteRoot?: string }): string {
+    const content = demoContent(demo);
+
+    const document = [
+        [
+            '---',
+            `title: ${JSON.stringify(content.metaTitle)}`,
+            `description: ${JSON.stringify(content.metaDescription)}`,
+            '---',
+        ].join('\n'),
+        `# ${content.heading}`,
+        content.bodyText,
+        'This page hosts a live, interactive AG Grid demo. The full source is on GitHub.',
+        [
+            `[See on GitHub](${content.githubUrl})`,
+            `[View the demo](${toAbsoluteUrl(urlWithBaseUrl(`/example-${demo}/`), siteRoot)})`,
+            `[Contact us](${toAbsoluteUrl(urlWithBaseUrl('/contact/'), siteRoot)})`,
+        ].join(' | '),
+    ];
+
+    return `${document.join('\n\n').trimEnd()}\n`;
+}

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/buildDemoNiallMarkdown.test.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/buildDemoNiallMarkdown.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import niallData from '../../content/about/niall.json';
+import demosData from '../../content/demos/demos.json';
+import { type DemoName, buildDemoMarkdown, demoContent } from './buildDemoMarkdown';
+import { buildNiallMarkdown } from './buildNiallMarkdown';
+
+const SITE_ROOT = 'https://www.ag-grid.com/';
+
+describe('buildDemoMarkdown', () => {
+    describe.each(Object.keys(demosData) as DemoName[])('%s', (demo) => {
+        const output = buildDemoMarkdown({ demo, siteRoot: SITE_ROOT });
+        const content = demoContent(demo);
+
+        it('emits frontmatter and copy from the same content the page renders', () => {
+            expect(output).toContain(`title: ${JSON.stringify(content.metaTitle)}`);
+            expect(output).toContain(`description: ${JSON.stringify(content.metaDescription)}`);
+            expect(output).toContain(`# ${content.heading}`);
+            expect(output).toContain(content.bodyText);
+        });
+
+        it('points at the demo source and the live page', () => {
+            expect(output).toContain(`[See on GitHub](${content.githubUrl})`);
+            expect(output).toContain(`https://www.ag-grid.com/example-${demo}/`);
+            expect(output).toContain('https://www.ag-grid.com/contact/');
+        });
+
+        it('ends with a single trailing newline', () => {
+            expect(output.endsWith('\n')).toBe(true);
+            expect(output.endsWith('\n\n')).toBe(false);
+        });
+    });
+});
+
+describe('buildNiallMarkdown', () => {
+    const output = buildNiallMarkdown({ siteRoot: SITE_ROOT });
+
+    it('emits frontmatter and the page heading with its eyebrow', () => {
+        expect(output).toContain(`title: ${JSON.stringify(niallData.meta.title)}`);
+        expect(output).toContain(`# ${niallData.heading}`);
+        expect(output).toContain(`*${niallData.eyebrow}*`);
+    });
+
+    it('carries every paragraph of the tribute, in page order', () => {
+        let cursor = output.indexOf(niallData.intro);
+        expect(cursor).toBeGreaterThan(-1);
+        for (const paragraph of niallData.sections.flat()) {
+            const index = output.indexOf(paragraph, cursor);
+            expect(index, `paragraph missing or out of order: ${paragraph.slice(0, 40)}…`).toBeGreaterThan(-1);
+            cursor = index;
+        }
+    });
+
+    it('renders the photographs with alt text, captions and absolute sources', () => {
+        for (const photo of niallData.photos) {
+            expect(output).toContain(`![${photo.alt}](https://www.ag-grid.com/${photo.src})`);
+        }
+        expect(output).toContain('*Niall Crosby 1977-2024*');
+    });
+
+    it('ends with a single trailing newline', () => {
+        expect(output.endsWith('\n')).toBe(true);
+        expect(output.endsWith('\n\n')).toBe(false);
+    });
+});

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/buildGridLandingPageMarkdown.test.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/buildGridLandingPageMarkdown.test.ts
@@ -1,0 +1,107 @@
+import type { LandingPageContent } from '@ag-website-shared/components/landing-pages/types';
+import { describe, expect, it } from 'vitest';
+
+import angularDataGrid from '../../content/landing-pages/angular-data-grid.json';
+import enterpriseDataGrid from '../../content/landing-pages/enterprise-data-grid.json';
+import javascriptDataGrid from '../../content/landing-pages/javascript-data-grid.json';
+import reactDataGrid from '../../content/landing-pages/react-data-grid.json';
+import reactTable from '../../content/landing-pages/react-table.json';
+import vueDataGrid from '../../content/landing-pages/vue-data-grid.json';
+import versions from '../../content/versions/ag-grid-versions.json';
+import { buildGridLandingPageMarkdown } from './buildGridLandingPageMarkdown';
+
+const SITE_ROOT = 'https://www.ag-grid.com/';
+
+// Every landing page in the collection, so a new one (or a new section type in an existing
+// one) is covered here without editing the test.
+const PAGES: Record<string, unknown> = {
+    'angular-data-grid': angularDataGrid,
+    'enterprise-data-grid': enterpriseDataGrid,
+    'javascript-data-grid': javascriptDataGrid,
+    'react-data-grid': reactDataGrid,
+    'react-table': reactTable,
+    'vue-data-grid': vueDataGrid,
+};
+
+const build = (content: unknown) =>
+    buildGridLandingPageMarkdown({
+        content: content as LandingPageContent,
+        versions,
+        siteRoot: SITE_ROOT,
+    });
+
+describe('buildGridLandingPageMarkdown', () => {
+    describe.each(Object.entries(PAGES))('%s', (_slug, content) => {
+        const output = build(content);
+        const page = content as LandingPageContent;
+
+        it('opens with frontmatter carrying the page meta, then the hero as H1', () => {
+            expect(output.startsWith('---\n')).toBe(true);
+            expect(output).toContain(`title: ${JSON.stringify(page.meta.title)}`);
+            expect(output).toContain(`description: ${JSON.stringify(page.meta.description)}`);
+            const hero = page.sections.find((section) => section.type === 'hero');
+            expect(output).toContain(`\n# ${hero!.heading}`);
+        });
+
+        it('renders a heading for every non-hero section, in page order', () => {
+            const headings = page.sections
+                .filter((section) => section.type !== 'hero')
+                .map((section) => ('heading' in section ? section.heading : undefined))
+                .filter((heading): heading is string => heading != null);
+            let cursor = 0;
+            for (const heading of headings) {
+                const index = output.indexOf(`## ${heading}`, cursor);
+                expect(index, `section "${heading}" missing or out of order`).toBeGreaterThan(-1);
+                cursor = index;
+            }
+        });
+
+        it('resolves every link to an absolute URL, leaving no raw HTML behind', () => {
+            const relative = [...output.matchAll(/\[[^\]]*\]\(([^)]+)\)/g)]
+                .map((match) => match[1])
+                .filter((href) => !href.startsWith('https://') && !href.startsWith('#') && !href.startsWith('mailto:'));
+            expect(relative).toEqual([]);
+            expect(output).not.toContain('<a href');
+            expect(output).not.toContain('<b>');
+            expect(output).not.toContain('<br');
+        });
+
+        it('ends with a single trailing newline', () => {
+            expect(output.endsWith('\n')).toBe(true);
+            expect(output.endsWith('\n\n')).toBe(false);
+        });
+    });
+
+    it('resolves framework-relative FAQ links against the page framework, not the base URL', () => {
+        // FAQ answers are Markdoc rendered per-framework, so './ai-toolkit/' must become
+        // /react-data-grid/ai-toolkit/ on the React page — not /ai-toolkit/.
+        const output = build(reactDataGrid);
+        expect(output).toContain('https://www.ag-grid.com/react-data-grid/');
+        expect(output).not.toMatch(/\]\(https:\/\/www\.ag-grid\.com\/getting-started\//);
+    });
+
+    it('resolves base-relative feature and example links without re-prefixing the framework', () => {
+        // These already carry the framework segment, so they must not become
+        // /react-data-grid/react-data-grid/...
+        const output = build(reactDataGrid);
+        expect(output).not.toContain('/react-data-grid/react-data-grid/');
+    });
+
+    it('renders the enterprise pricing cards with price, note, features and CTA', () => {
+        const output = build(enterpriseDataGrid);
+        expect(output).toContain('### Community — Free');
+        expect(output).toContain('*forever*');
+        expect(output).toContain('- MIT licensed');
+        expect(output).toContain('[Get Started](https://www.ag-grid.com/data-grid/getting-started/)');
+    });
+
+    it('marks enterprise feature groups so an agent can tell them from community ones', () => {
+        expect(build(enterpriseDataGrid)).toContain('### Grouping & Aggregation (Enterprise)');
+    });
+
+    it('includes the install command and version badge from the shared content', () => {
+        const output = build(reactDataGrid);
+        expect(output).toContain('Install: `npm install ag-grid-react`');
+        expect(output).toContain('**Latest version:** v');
+    });
+});

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/buildGridLandingPageMarkdown.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/buildGridLandingPageMarkdown.ts
@@ -1,0 +1,38 @@
+import type {
+    BuildLandingPageMarkdownOptions,
+    LandingPageVersion,
+} from '@ag-website-shared/markdown-pages/landing-pages/buildLandingPageMarkdown';
+import { buildLandingPageMarkdown } from '@ag-website-shared/markdown-pages/landing-pages/buildLandingPageMarkdown';
+import { getFrameworkFromInternalFramework } from '@utils/framework';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
+import { urlWithPrefix } from '@utils/urlWithPrefix';
+
+/**
+ * Bind the shared landing-page markdown builder to AG Grid's URL helpers. Kept separate from the
+ * endpoint so it is free of `astro:content` and therefore unit-testable against the real
+ * landing-page JSON (see buildGridLandingPageMarkdown.test.ts).
+ */
+export function buildGridLandingPageMarkdown({
+    content,
+    versions,
+    siteRoot,
+}: {
+    content: BuildLandingPageMarkdownOptions['content'];
+    versions?: LandingPageVersion[];
+    siteRoot?: string;
+}): string {
+    const framework = getFrameworkFromInternalFramework(content.internalFramework);
+
+    return buildLandingPageMarkdown({
+        content,
+        versions,
+        siteRoot,
+        // Section CTAs, feature links and example links store './'-prefixed paths that already
+        // carry the framework segment, so resolve them the way the page does — with the base-URL
+        // helper, not urlWithPrefix.
+        resolveUrl: urlWithBaseUrl,
+        // FAQ answers are Markdoc rendered per-framework by renderFAQAnswers, so their './' links
+        // are framework-relative and need the prefixing helper to land on the right docs page.
+        resolveFaqUrl: (url) => urlWithPrefix({ framework, url }),
+    });
+}

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/buildNiallMarkdown.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/buildNiallMarkdown.ts
@@ -1,0 +1,34 @@
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
+
+import niallData from '../../content/about/niall.json';
+
+/**
+ * Build the markdown twin of the /niall memorial page. Reads the same niall.json the page renders,
+ * so the tribute cannot drift between the two. The photographs are represented by their captions
+ * and alt text, which is all a text rendering can carry.
+ */
+export function buildNiallMarkdown({ siteRoot }: { siteRoot?: string } = {}): string {
+    const { meta, eyebrow, heading, intro, photos, sections } = niallData;
+
+    const document: string[] = [
+        ['---', `title: ${JSON.stringify(meta.title)}`, `description: ${JSON.stringify(meta.description)}`, '---'].join(
+            '\n'
+        ),
+        `# ${heading}`,
+        `*${eyebrow}*`,
+        intro,
+    ];
+
+    // Photos are interleaved between the prose sections, matching the page's ordering.
+    sections.forEach((paragraphs, index) => {
+        const photo = photos[index];
+        if (photo) {
+            const src = toAbsoluteUrl(urlWithBaseUrl(photo.src), siteRoot);
+            document.push(`![${photo.alt}](${src})${photo.caption ? `\n\n*${photo.caption}*` : ''}`);
+        }
+        document.push(...paragraphs);
+    });
+
+    return `${document.join('\n\n').trimEnd()}\n`;
+}

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/buildPolicyMarkdown.test.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/buildPolicyMarkdown.test.ts
@@ -1,0 +1,70 @@
+import type { PolicyName } from '@ag-website-shared/components/policies/policyContent';
+import { POLICY_CONTENT } from '@ag-website-shared/components/policies/policyContent';
+import cookiesBody from '@ag-website-shared/content/policies/cookies.mdoc?raw';
+import modernSlaveryBody from '@ag-website-shared/content/policies/modern-slavery.mdoc?raw';
+import privacyBody from '@ag-website-shared/content/policies/privacy.mdoc?raw';
+import { buildPolicyMarkdown } from '@ag-website-shared/markdown-pages/policies/buildPolicyMarkdown';
+import { describe, expect, it } from 'vitest';
+
+import markdocConfig from '../../../markdoc.config';
+
+const SITE_ROOT = 'https://www.ag-grid.com/';
+
+const BODIES: Record<PolicyName, string> = {
+    privacy: privacyBody,
+    cookies: cookiesBody,
+    'modern-slavery': modernSlaveryBody,
+};
+
+const build = (policy: PolicyName) =>
+    buildPolicyMarkdown({ policy, name: 'AG Grid', body: BODIES[policy], markdocConfig, siteRoot: SITE_ROOT });
+
+describe('buildPolicyMarkdown', () => {
+    describe.each(Object.keys(BODIES) as PolicyName[])('%s', (policy) => {
+        it('emits frontmatter, then exactly one H1 matching the page heading', async () => {
+            const output = await build(policy);
+            expect(output.startsWith('---\n')).toBe(true);
+            expect(output).toContain(`title: ${JSON.stringify(`AG Grid: ${POLICY_CONTENT[policy].metaTitle}`)}`);
+            // The renderer emits its own frontmatter for the body; it must be stripped so the
+            // page's own heading is the only H1 and there is a single frontmatter block.
+            // (`---` also appears mid-document as a thematic break, so match the block itself.)
+            expect(output.match(/^# /gm)?.length).toBe(1);
+            expect(output.match(/^---\n(?:.*\n)*?---\n/)).not.toBeNull();
+            expect(output).not.toContain('\ntitle: ""');
+        });
+
+        it('renders the shared meta and intro copy as markdown, not raw HTML', async () => {
+            const output = await build(policy);
+            expect(output).not.toContain('<strong>');
+            expect(output).not.toContain('<a href');
+            expect(output.endsWith('\n')).toBe(true);
+            expect(output.endsWith('\n\n')).toBe(false);
+        });
+    });
+
+    it('renders the numbered policy body from the .mdoc, including its section headings', async () => {
+        const output = await build('privacy');
+        expect(output).toContain('# AG Grid Privacy Policy');
+        expect(output).toContain('Effective Date: 6 July 2022');
+        expect(output).toContain('**Your privacy is important to us.**');
+        expect(output).toContain('Introduction');
+        expect(output).toContain('Marketing Communications');
+    });
+
+    it('renders the cookie inventory the page shows below the policy body (AG-18105)', async () => {
+        const output = await build('cookies');
+        expect(output).toContain('## Cookies We Use');
+        expect(output).toContain('The cookies listed below were last reviewed on 7 August 2026.');
+        // One table per category, from the same JSON the CookiesTable component reads.
+        expect(output).toContain('### Strictly Necessary Cookies');
+        expect(output).toContain('| Cookie Subgroup | Cookies | Cookies used |');
+        expect(output).toContain('agGridFramework');
+    });
+
+    it('carries the modern slavery statement’s financial year and version block', async () => {
+        const output = await build('modern-slavery');
+        expect(output).toContain('**For the Financial Year Ending 31 December 2026**');
+        expect(output).toContain('**Effective Date:** 01 January 2026');
+        expect(output).toContain('Organisation Structure and Supply Chain');
+    });
+});

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/buildRoadmapWhatsNewMarkdown.test.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/buildRoadmapWhatsNewMarkdown.test.ts
@@ -1,0 +1,81 @@
+import { buildRoadmapMarkdown } from '@ag-website-shared/markdown-pages/buildRoadmapMarkdown';
+import { buildWhatsNewMarkdown, whatsNewMeta } from '@ag-website-shared/markdown-pages/buildWhatsNewMarkdown';
+import { urlWithPrefix } from '@utils/urlWithPrefix';
+import { describe, expect, it } from 'vitest';
+
+import roadmapData from '../../../public/roadmap/roadmap.json';
+import versionsData from '../../content/versions/ag-grid-versions.json';
+
+const SITE_ROOT = 'https://www.ag-grid.com/';
+const resolveUrl = (url: string) => urlWithPrefix({ framework: 'javascript', url });
+
+describe('buildRoadmapMarkdown', () => {
+    const output = buildRoadmapMarkdown({ roadmapData, siteRoot: SITE_ROOT, resolveUrl, year: 2026 });
+
+    it('emits frontmatter and the page H1, then the intro from roadmap.json', () => {
+        expect(output.startsWith('---\n')).toBe(true);
+        expect(output).toContain("# What we're building next");
+        expect(output).toContain(`## ${roadmapData.introTitle}`);
+        expect(output).toContain(roadmapData.introText);
+    });
+
+    it('formats the last-updated date the way the page does', () => {
+        expect(output).toContain('Last updated: August 5, 2026');
+    });
+
+    it('groups every item under its quarter heading, carrying status, description and rationale', () => {
+        for (const quarter of new Set(roadmapData.items.map((item) => item.q))) {
+            expect(output).toContain(`## Q${quarter} 2026`);
+        }
+        for (const item of roadmapData.items) {
+            expect(output, `missing item "${item.title}"`).toContain(item.title);
+            expect(output).toContain(item.desc);
+            expect(output).toContain(`**Why:** ${item.why}`);
+        }
+    });
+
+    it('marks each item with its status, so an agent can tell shipped from planned', () => {
+        expect(output).toContain('(shipped)');
+        expect(output).toContain('(in progress)');
+        expect(output).toContain('(planned)');
+    });
+
+    it('resolves item links into the framework docs', () => {
+        const linked = roadmapData.items.find((item) => item.link);
+        expect(linked).toBeDefined();
+        expect(output).toContain(`(${SITE_ROOT.replace(/\/$/, '')}${resolveUrl(linked!.link!)})`);
+    });
+});
+
+describe('buildWhatsNewMarkdown', () => {
+    const output = buildWhatsNewMarkdown({ site: 'grid', versionsData, siteRoot: SITE_ROOT, resolveUrl });
+
+    it('emits frontmatter matching the page meta, then the page H1', () => {
+        const { title, description } = whatsNewMeta('grid');
+        expect(output).toContain(`title: ${JSON.stringify(title)}`);
+        expect(output).toContain(`description: ${JSON.stringify(description)}`);
+        expect(output).toContain("# What's New in AG Grid");
+    });
+
+    it('lists at most the 12 versions with highlights that the page shows, newest first', () => {
+        const expected = versionsData.filter((version) => version.highlights).slice(0, 12);
+        const headings = [...output.matchAll(/^## (\S+)/gm)].map((match) => match[1]);
+        expect(headings).toEqual(expected.map((version) => version.version));
+        expect(headings.length).toBeLessThanOrEqual(12);
+        expect(output).toContain(`## ${expected[0].version} (latest)`);
+    });
+
+    it('links highlights into the docs and derives the release blog URL as the page does', () => {
+        expect(output).toContain('https://www.ag-grid.com/javascript-data-grid/column-headers/#editable-header-name');
+        expect(output).toContain('https://blog.ag-grid.com/whats-new-in-ag-grid-36-1/');
+    });
+
+    it('labels the release-notes link by release kind, as the page does', () => {
+        expect(output).toMatch(/\[See (release notes|migration guide)\]/);
+    });
+
+    it('ends with a single trailing newline', () => {
+        expect(output.endsWith('\n')).toBe(true);
+        expect(output.endsWith('\n\n')).toBe(false);
+    });
+});

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/buildRoadmapWhatsNewMarkdown.test.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/buildRoadmapWhatsNewMarkdown.test.ts
@@ -10,7 +10,13 @@ const SITE_ROOT = 'https://www.ag-grid.com/';
 const resolveUrl = (url: string) => urlWithPrefix({ framework: 'javascript', url });
 
 describe('buildRoadmapMarkdown', () => {
-    const output = buildRoadmapMarkdown({ roadmapData, siteRoot: SITE_ROOT, resolveUrl, year: 2026 });
+    const output = buildRoadmapMarkdown({
+        roadmapData,
+        productName: 'AG Grid',
+        siteRoot: SITE_ROOT,
+        resolveUrl,
+        year: 2026,
+    });
 
     it('emits frontmatter and the page H1, then the intro from roadmap.json', () => {
         expect(output.startsWith('---\n')).toBe(true);

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/buildSessionMarkdown.test.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/buildSessionMarkdown.test.ts
@@ -1,0 +1,50 @@
+import { SESSIONS, sessionSlug } from '@utils/beyondThePromptSessions';
+import { describe, expect, it } from 'vitest';
+
+import { buildSessionMarkdown, sessionDescription } from './buildSessionMarkdown';
+
+const SITE_ROOT = 'https://www.ag-grid.com/';
+
+// The same filter the page's getStaticPaths applies: only recorded sessions get a page.
+const RECORDED = SESSIONS.filter((session) => session.youtubeUrl);
+
+describe('buildSessionMarkdown', () => {
+    it('covers every recorded session', () => {
+        expect(RECORDED.length).toBeGreaterThan(0);
+        expect(new Set(RECORDED.map((session) => sessionSlug(session.title))).size).toBe(RECORDED.length);
+    });
+
+    describe.each(RECORDED.map((session) => [sessionSlug(session.title), session] as const))('%s', (_slug, session) => {
+        const output = buildSessionMarkdown({ session, siteRoot: SITE_ROOT });
+
+        it('emits frontmatter matching the page title and description, then the session as H1', () => {
+            expect(output).toContain(`title: ${JSON.stringify(`${session.title} | Beyond the Prompt`)}`);
+            expect(output).toContain(`description: ${JSON.stringify(sessionDescription(session))}`);
+            expect(output).toContain(`# ${session.title}`);
+        });
+
+        it('links the recording and the parent Beyond the Prompt page', () => {
+            expect(output).toContain(`[Watch the recording](${session.youtubeUrl})`);
+            expect(output).toContain('https://www.ag-grid.com/community/beyond-the-prompt/');
+        });
+
+        it('ends with a single trailing newline', () => {
+            expect(output.endsWith('\n')).toBe(true);
+            expect(output.endsWith('\n\n')).toBe(false);
+        });
+    });
+
+    it('lists the speakers with their roles, as the page does', () => {
+        const withSpeakers = RECORDED.find((session) => session.speakers?.length);
+        expect(withSpeakers).toBeDefined();
+        const output = buildSessionMarkdown({ session: withSpeakers!, siteRoot: SITE_ROOT });
+        const speaker = withSpeakers!.speakers![0];
+        expect(output).toContain(`${speaker.name} (${speaker.role})`);
+    });
+
+    it('falls back to a generated description when the session has none', () => {
+        expect(sessionDescription({ title: 'A Talk' })).toBe(
+            'Watch "A Talk" from Beyond the Prompt, the AG Grid and Bryntum conference.'
+        );
+    });
+});

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/buildSessionMarkdown.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/buildSessionMarkdown.ts
@@ -1,0 +1,49 @@
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+import type { Session } from '@utils/beyondThePromptSessions';
+import { sessionDurationMins } from '@utils/beyondThePromptSessions';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
+
+/** The page's description fallback, shared so the twin's frontmatter matches the page's meta. */
+export function sessionDescription(session: Session): string {
+    return (
+        session.description ?? `Watch "${session.title}" from Beyond the Prompt, the AG Grid and Bryntum conference.`
+    );
+}
+
+/**
+ * Build the markdown twin of a `/session/<slug>` recording page. Reads the same `SESSIONS` entry
+ * the page renders, so title, speakers, description and recording link cannot drift. The page's
+ * embedded YouTube player becomes a plain link to the recording — the closest markdown can get.
+ */
+export function buildSessionMarkdown({ session, siteRoot }: { session: Session; siteRoot?: string }): string {
+    const description = sessionDescription(session);
+    const durationMins = sessionDurationMins(session);
+
+    const document: string[] = [
+        [
+            '---',
+            `title: ${JSON.stringify(`${session.title} | Beyond the Prompt`)}`,
+            `description: ${JSON.stringify(description)}`,
+            '---',
+        ].join('\n'),
+        `# ${session.title}`,
+    ];
+
+    if (session.speakers?.length) {
+        document.push(session.speakers.map((speaker) => `${speaker.name} (${speaker.role})`).join(', '));
+    }
+    if (durationMins != null) {
+        document.push(`Duration: ${durationMins} minutes`);
+    }
+    if (session.youtubeUrl) {
+        document.push(`[Watch the recording](${session.youtubeUrl})`);
+    }
+    if (session.description) {
+        document.push(session.description);
+    }
+    document.push(
+        `[← Back to Beyond the Prompt](${toAbsoluteUrl(urlWithBaseUrl('/community/beyond-the-prompt/'), siteRoot)})`
+    );
+
+    return `${document.join('\n\n').trimEnd()}\n`;
+}

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/landingPageMarkdownResponse.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/landingPageMarkdownResponse.ts
@@ -1,0 +1,32 @@
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { getEntry } from 'astro:content';
+
+import { buildGridLandingPageMarkdown } from './buildGridLandingPageMarkdown';
+
+/**
+ * Shared body of the landing-page `.md` endpoints. Every landing page renders through the same
+ * `LandingPage.astro` template from its `landingPages` collection entry, so its markdown twin is
+ * the same builder over the same entry — only the slug differs.
+ */
+export async function landingPageMarkdownResponse(slug: string): Promise<Response> {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+
+    const contentEntry = await getEntry('landingPages', slug);
+    if (!contentEntry) {
+        return new Response(null, { status: 404 });
+    }
+    const versionsEntry = await getEntry('versions', 'ag-grid-versions');
+
+    const markdown = buildGridLandingPageMarkdown({
+        content: contentEntry.data,
+        versions: versionsEntry?.data,
+        siteRoot: SITE_URL,
+    });
+
+    return new Response(markdown, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/policyMarkdownResponse.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/policyMarkdownResponse.ts
@@ -1,0 +1,42 @@
+import type { PolicyName } from '@ag-website-shared/components/policies/policyContent';
+// Raw Markdoc source for the policy bodies. The pages import the same files as compiled Astro
+// components; `?raw` gives the twins the source to re-render as markdown.
+import cookiesBody from '@ag-website-shared/content/policies/cookies.mdoc?raw';
+import modernSlaveryBody from '@ag-website-shared/content/policies/modern-slavery.mdoc?raw';
+import privacyBody from '@ag-website-shared/content/policies/privacy.mdoc?raw';
+import { buildPolicyMarkdown } from '@ag-website-shared/markdown-pages/policies/buildPolicyMarkdown';
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { createGridMarkdownResolvers } from '@utils/markdoc/renderMarkdocResolvers';
+
+import markdocConfig from '../../../markdoc.config';
+
+/** The raw `.mdoc` body each policy renders from. */
+const POLICY_BODIES: Record<PolicyName, string> = {
+    privacy: privacyBody,
+    cookies: cookiesBody,
+    'modern-slavery': modernSlaveryBody,
+};
+
+/**
+ * Shared body of the policy `.md` endpoints. Each renders the same shared preamble and the same
+ * `.mdoc` body its page renders, so only the policy name differs between endpoints.
+ */
+export async function policyMarkdownResponse(policy: PolicyName): Promise<Response> {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+
+    const markdown = await buildPolicyMarkdown({
+        policy,
+        name: 'AG Grid',
+        body: POLICY_BODIES[policy],
+        markdocConfig,
+        resolvers: createGridMarkdownResolvers({ siteRoot: SITE_URL }),
+        siteRoot: SITE_URL,
+    });
+
+    return new Response(markdown, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/documentation/ag-grid-docs/src/utils/markdown-pages/staticPageContent.ts
+++ b/documentation/ag-grid-docs/src/utils/markdown-pages/staticPageContent.ts
@@ -1,0 +1,36 @@
+import { LICENSE_INSTALL_REDIRECT_PAGE } from '@components/docs/constants';
+
+/**
+ * Page metadata for the small pages whose copy would otherwise live only inside their `.astro`
+ * files — the two framework-redirect stubs, the theme builder and the HTML sitemap.
+ *
+ * Shared with their markdown twins (`/reference.md`, `/licensing.md`, `/theme-builder.md`,
+ * `/sitemap.md`) so the title and description cannot drift between the two renderings.
+ */
+export const STATIC_PAGE_CONTENT = {
+    reference: {
+        title: 'AG Grid: API Reference',
+        description:
+            'View the AG Grid API Reference Documentation - a feature-rich datagrid for major JavaScript frameworks, offering filtering, grouping, pivoting, and more.',
+        heading: 'AG Grid API Reference',
+        /** Docs page each framework variant redirects to. */
+        redirectPageName: 'reference',
+    },
+    licensing: {
+        title: 'AG Grid: Licensing',
+        description: 'Installing Your Licence Key',
+        heading: 'AG Grid Licensing',
+        redirectPageName: LICENSE_INSTALL_REDIRECT_PAGE,
+    },
+    'theme-builder': {
+        title: 'AG Grid Theme Builder',
+        description:
+            'Easily build and customise themes for AG Grid with our interactive tool. Use our templates or create your own style from scratch. Export styles to AG Grid compatible themes.',
+        heading: 'AG Grid Theme Builder',
+    },
+    sitemap: {
+        title: 'Sitemap | AG Grid',
+        description: 'The AG Grid sitemap. Contains links to every page on the site, including docs.',
+        heading: 'Sitemap',
+    },
+} as const;

--- a/documentation/ag-grid-docs/src/utils/markdownPages.test.ts
+++ b/documentation/ag-grid-docs/src/utils/markdownPages.test.ts
@@ -1,0 +1,102 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { GRID_MARKDOWN_PAGE_GROUPS, markdownPathAlternation, markdownPathPatterns } from './markdownPages';
+
+const DIST = join(__dirname, '../../dist');
+const SITEMAP = join(DIST, 'sitemap-0.xml');
+
+const patterns = markdownPathPatterns();
+const isNegotiable = (pathname: string) => patterns.some((pattern) => pattern.test(pathname));
+
+describe('GRID_MARKDOWN_PAGE_GROUPS', () => {
+    it('produces patterns valid in both JavaScript and Apache PCRE', () => {
+        // The alternation is embedded in a RewriteCond and an <If> expression, so it must avoid
+        // constructs PCRE lacks or that would break the `m#...#` delimiters.
+        const alternation = markdownPathAlternation();
+        expect(() => new RegExp(`^/(${alternation})/?$`)).not.toThrow();
+        expect(alternation).not.toContain('#');
+        expect(alternation).not.toMatch(/\(\?<[=!]/); // lookbehind
+        expect(alternation).not.toMatch(/\(\?<[A-Za-z]/); // named groups
+    });
+
+    it('never matches a .md URL, so negotiation cannot loop into .md.md', () => {
+        expect(isNegotiable('/react-data-grid/cell-editing.md')).toBe(false);
+        expect(isNegotiable('/about.md')).toBe(false);
+        expect(isNegotiable('/session/opening-keynote.md')).toBe(false);
+    });
+
+    it('documents every group, so the registry reads as the list it is', () => {
+        for (const group of GRID_MARKDOWN_PAGE_GROUPS) {
+            expect(group.describes, JSON.stringify(group)).toBeTruthy();
+        }
+    });
+});
+
+/**
+ * The only pages in a built sitemap that deliberately have no twin. All three are `noindex`, so
+ * `agSitemapFilterNoindex` drops them from the *production* sitemap — but that integration runs on
+ * production hosts only, so a local build still lists them. They are unlisted marketing pages, not
+ * documentation, so they are out of scope.
+ *
+ * Anything else missing a twin is a bug: add the page to GRID_MARKDOWN_PAGE_GROUPS and give it a
+ * `.md.ts` endpoint rather than adding it here.
+ */
+const PAGES_WITHOUT_TWINS = [
+    '/campaigns/power-of-ag-charts/',
+    '/campaigns/return-to-support/',
+    '/community/lets-cook/',
+];
+
+function builtSitemapPaths(): string[] {
+    if (!existsSync(SITEMAP)) {
+        return [];
+    }
+    return [...readFileSync(SITEMAP, 'utf8').matchAll(/<loc>([^<]+)<\/loc>/g)].map(
+        (match) => new URL(match[1]).pathname
+    );
+}
+
+// Gate on a *complete* build: an absent dist (a plain unit run) or a half-written one (a build in
+// flight) skips rather than fails, since neither says anything about page coverage. The site has
+// ~1500 pages, so this threshold cannot be met by a partial build of the non-docs pages alone.
+const sitemapPaths = builtSitemapPaths();
+const hasCompleteBuild = sitemapPaths.length > 1000;
+
+// The invariant this whole feature rests on: an agent can append `.md` to any URL in the sitemap.
+// Requires a build (`nx build ag-grid-docs`); skipped otherwise so unit runs stay fast.
+describe.runIf(hasCompleteBuild)('every sitemap URL has a .md twin in dist', () => {
+    // Guard against a vacuous pass: if filtering ever empties the set, the assertions below would
+    // hold trivially and the check would silently stop protecting anything.
+    it('checks a full sitemap', () => {
+        expect(sitemapPaths.length).toBeGreaterThan(1000);
+    });
+
+    it('emits a .md file next to every page', () => {
+        const missing = sitemapPaths.filter((pathname) => {
+            const trimmed = pathname.replace(/\/$/, '');
+            // The homepage twin is index.md — the root URL has no segment to suffix.
+            const twin = trimmed === '' ? 'index.md' : `${trimmed.slice(1)}.md`;
+            return !existsSync(join(DIST, twin));
+        });
+        expect(missing, `${missing.length} sitemap URLs have no .md twin`).toEqual(PAGES_WITHOUT_TWINS);
+    });
+
+    it('routes every page with a twin through the negotiation patterns', () => {
+        // A twin that exists on disk but is not in the registry would never be served on
+        // `Accept: text/markdown`, so the two must agree.
+        const unroutable = sitemapPaths.filter(
+            (pathname) => pathname !== '/' && !PAGES_WITHOUT_TWINS.includes(pathname) && !isNegotiable(pathname)
+        );
+        expect(unroutable, `${unroutable.length} pages have a twin but no negotiation rule`).toEqual([]);
+    });
+
+    it('keeps the no-twin exclusion list free of stale entries', () => {
+        // If one of these pages is removed or gains a twin, the entry must go — otherwise the
+        // list quietly grows into a place where real gaps can hide.
+        for (const pathname of PAGES_WITHOUT_TWINS) {
+            expect(sitemapPaths, `${pathname} is no longer in the sitemap`).toContain(pathname);
+        }
+    });
+});

--- a/documentation/ag-grid-docs/src/utils/markdownPages.ts
+++ b/documentation/ag-grid-docs/src/utils/markdownPages.ts
@@ -1,0 +1,91 @@
+// Type-only import: erased at runtime, so this module stays loadable under plain node (the
+// htaccess test harness runs it through `tsx`, where the shared subrepo resolves as CJS).
+import type { MarkdownPageGroup } from '../../../../external/ag-website-shared/src/markdown-pages/markdownPageRegistry';
+import { FRAMEWORKS } from '../constants';
+
+/**
+ * SE-80: every AG Grid page that ships a markdown (`.md`) twin, declared once.
+ *
+ * Derives the dev-server negotiation patterns, the Apache rewrite rule and the Apache
+ * `Vary: Accept` scope — see `@ag-website-shared/markdown-pages/markdownPageRegistry` for
+ * the pattern-syntax constraints (the patterns are compiled by both JavaScript and PCRE).
+ *
+ * The invariant this list serves: **every URL in the sitemap has a `.md` twin**. That is
+ * enforced by the post-build check in `markdownPages.test.ts`, so a new page added without
+ * a twin fails the build rather than silently 404ing for agents. Pages excluded from the
+ * sitemap (example runners, `debug/*`, redirect stubs' framework variants, `contact/success`)
+ * are correspondingly absent here.
+ *
+ * Imported by the dev-server Vite plugin, which is bundled with `astro.config.mjs` and so
+ * resolves without tsconfig path aliases — hence the relative import above.
+ */
+export const GRID_MARKDOWN_PAGE_GROUPS: MarkdownPageGroup[] = [
+    {
+        describes: 'The homepage. Negotiated by a dedicated rule: its twin is index.md, not <path>.md.',
+    },
+    {
+        describes: 'Every docs page, once per framework — the bulk of the twins (~365 pages x 4).',
+        pattern: `(?:${FRAMEWORKS.join('|')})-data-grid/[^/.]+`,
+    },
+    {
+        describes: 'Top-level content pages.',
+        pattern: 'about|changelog|documentation-archive|example|license-pricing|pipeline|roadmap|whats-new',
+    },
+    {
+        describes: 'The community landing page and its subpages.',
+        pattern: 'community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?',
+    },
+    {
+        describes: 'Beyond the Prompt conference session recordings.',
+        pattern: 'session/[^/.]+',
+    },
+    {
+        describes: 'Bryntum partner campaign pages.',
+        pattern: 'campaigns/bryntum-[^/.]+',
+    },
+    {
+        describes: 'SEO landing pages, all rendered from the landingPages collection.',
+        pattern: 'landing-pages/[^/.]+|react-table',
+    },
+    {
+        // /privacy/your-choice is deliberately absent: it is a post-submission confirmation page,
+        // disallowed in robots.txt and excluded from the sitemap, like the /contact result pages.
+        describes: 'Legal and policy pages.',
+        pattern: 'cookies|modern-slavery|privacy',
+    },
+    {
+        describes: 'Standalone demo applications.',
+        pattern: 'example-(?:finance|hr|inventory)',
+    },
+    {
+        describes: 'Company pages.',
+        pattern: 'contact|niall',
+    },
+    {
+        describes: 'Framework redirect stubs and interactive tools.',
+        pattern: 'licensing|reference|sitemap|theme-builder',
+    },
+];
+
+function patternedGroups(): string[] {
+    return GRID_MARKDOWN_PAGE_GROUPS.map((group) => group.pattern).filter(
+        (pattern): pattern is string => pattern != null && pattern.length > 0
+    );
+}
+
+/**
+ * Alternation fragment for embedding in an anchored Apache regex, e.g. `^/(<alternation>)/?$`.
+ * Returned without an enclosing group so the caller controls whether the match is captured
+ * (`RewriteCond` needs `%1`; the `Vary` `<If>` does not).
+ */
+export function markdownPathAlternation(): string {
+    return patternedGroups().join('|');
+}
+
+/**
+ * Anchored JavaScript regexes, one per group, for the dev-server negotiation plugin. A trailing
+ * slash is optional so both `/about` and `/about/` negotiate.
+ */
+export function markdownPathPatterns(): RegExp[] {
+    return patternedGroups().map((pattern) => new RegExp(`^/(?:${pattern})/?$`));
+}

--- a/documentation/ag-grid-docs/src/utils/sitemap.ts
+++ b/documentation/ag-grid-docs/src/utils/sitemap.ts
@@ -49,9 +49,12 @@ const isNonPublicContent = (page: string) => {
     return (
         page.includes('pdf-export') ||
         page.endsWith('/style-guide/') ||
-        // Contact form result pages
+        // Post-submission confirmation pages. These are already disallowed in robots.txt (see
+        // getSitemapIgnorePaths), so listing them in the sitemap contradicts it and Search Console
+        // reports them as "submitted URL blocked by robots.txt".
         page.endsWith('/contact/failure/') ||
-        page.endsWith('/contact/success/')
+        page.endsWith('/contact/success/') ||
+        page.endsWith('/privacy/your-choice/')
     );
 };
 

--- a/external/ag-website-shared/src/components/contact-us/ContactPage.astro
+++ b/external/ag-website-shared/src/components/contact-us/ContactPage.astro
@@ -6,30 +6,32 @@ import PageHero from '@ag-website-shared/components/page-hero/PageHero.astro';
 import { getEntry, type CollectionEntry } from 'astro:content';
 import { buildContactPage } from '@ag-website-shared/utils/structuredData';
 import { LIBRARY } from '@constants';
+import { CONTACT_CONTENT, contactGithubUrl } from './contactContent';
 import styles from './ContactPage.module.scss';
 
-const githubUrl = LIBRARY === 'charts' ? 'https://github.com/ag-grid/ag-charts' : 'https://github.com/ag-grid/ag-grid';
+// Copy and links are shared with the /contact.md twin so the two cannot drift.
+const githubUrl = contactGithubUrl(LIBRARY);
 
 const { data: metadata } = (await getEntry('metadata', 'metadata')) as CollectionEntry<'metadata'>;
 const contactPageStructuredData = buildContactPage({
     canonicalUrlBase: metadata.canonicalUrlBase,
     pageUrl: new URL(Astro.url.pathname, metadata.canonicalUrlBase).href,
-    name: 'Contact AG Grid',
+    name: CONTACT_CONTENT.structuredDataName,
 });
 ---
 
 <Layout
-    title="Contact AG Grid: Get in Touch with Our Team"
-    description="Have questions or need assistance? Contact the AG Grid team for support, licensing, or any other inquiries."
+    title={CONTACT_CONTENT.title}
+    description={CONTACT_CONTENT.description}
     showSearchBar={true}
     showDocsNav={false}
     pageStructuredData={[contactPageStructuredData]}
 >
     <div class={styles.contactPage}>
         <PageHero
-            eyebrow="Get in touch"
-            headline="Contact Us"
-            subhead="Get help with pricing, explore use cases, understand how our products can help you, and more."
+            eyebrow={CONTACT_CONTENT.eyebrow}
+            headline={CONTACT_CONTENT.headline}
+            subhead={CONTACT_CONTENT.subhead}
         />
         <div class="layout-max-width-small">
             <section id="contact-section" class={styles.contactSection}>

--- a/external/ag-website-shared/src/components/contact-us/ContactPage.astro
+++ b/external/ag-website-shared/src/components/contact-us/ContactPage.astro
@@ -6,11 +6,11 @@ import PageHero from '@ag-website-shared/components/page-hero/PageHero.astro';
 import { getEntry, type CollectionEntry } from 'astro:content';
 import { buildContactPage } from '@ag-website-shared/utils/structuredData';
 import { LIBRARY } from '@constants';
-import { CONTACT_CONTENT, contactGithubUrl } from './contactContent';
+import { CONTACT_CONTENT, contactSocialLinks } from './contactContent';
 import styles from './ContactPage.module.scss';
 
 // Copy and links are shared with the /contact.md twin so the two cannot drift.
-const githubUrl = contactGithubUrl(LIBRARY);
+const socialLinks = contactSocialLinks(LIBRARY);
 
 const { data: metadata } = (await getEntry('metadata', 'metadata')) as CollectionEntry<'metadata'>;
 const contactPageStructuredData = buildContactPage({
@@ -40,46 +40,20 @@ const contactPageStructuredData = buildContactPage({
                 </div>
 
                 <div class={styles.socialLinks}>
-                    <a
-                        href={githubUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label="GitHub"
-                        class={styles.socialLinkRow}
-                    >
-                        <Icon name="github" />
-                        <span>GitHub</span>
-                    </a>
-                    <a
-                        href="https://x.com/ag_grid"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label="X (Twitter)"
-                        class={styles.socialLinkRow}
-                    >
-                        <Icon name="xLogo" />
-                        <span>X</span>
-                    </a>
-                    <a
-                        href="https://youtube.com/c/aggrid"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label="YouTube"
-                        class={styles.socialLinkRow}
-                    >
-                        <Icon name="youtube" />
-                        <span>YouTube</span>
-                    </a>
-                    <a
-                        href="https://linkedin.com/company/ag-grid"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label="LinkedIn"
-                        class={styles.socialLinkRow}
-                    >
-                        <Icon name="linkedin" />
-                        <span>LinkedIn</span>
-                    </a>
+                    {
+                        socialLinks.map(({ label, ariaLabel, icon, url }) => (
+                            <a
+                                href={url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                aria-label={ariaLabel ?? label}
+                                class={styles.socialLinkRow}
+                            >
+                                <Icon name={icon} />
+                                <span>{label}</span>
+                            </a>
+                        ))
+                    }
                 </div>
             </section>
         </div>

--- a/external/ag-website-shared/src/components/contact-us/contactContent.ts
+++ b/external/ag-website-shared/src/components/contact-us/contactContent.ts
@@ -1,3 +1,5 @@
+import type { IconName } from '@ag-website-shared/components/icon/Icon';
+
 /**
  * Copy and links for the contact page, shared between `ContactPage.astro` and its markdown twin
  * (`@ag-website-shared/markdown-pages/buildContactMarkdown`) so the two cannot drift.
@@ -13,12 +15,19 @@ export const CONTACT_CONTENT = {
     structuredDataName: 'Contact AG Grid',
 } as const;
 
-/** Social links shown beside the contact form. GitHub differs per product. */
-export const CONTACT_SOCIAL_LINKS = [
-    { label: 'X', icon: 'xLogo', url: 'https://x.com/ag_grid' },
+export interface ContactSocialLink {
+    label: string;
+    /** Falls back to the label; only needed where the label alone is not self-describing. */
+    ariaLabel?: string;
+    icon: IconName;
+    url: string;
+}
+
+const CONTACT_SOCIAL_LINKS: ContactSocialLink[] = [
+    { label: 'X', ariaLabel: 'X (Twitter)', icon: 'xLogo', url: 'https://x.com/ag_grid' },
     { label: 'YouTube', icon: 'youtube', url: 'https://youtube.com/c/aggrid' },
     { label: 'LinkedIn', icon: 'linkedin', url: 'https://linkedin.com/company/ag-grid' },
-] as const;
+];
 
 export const GITHUB_URL_BY_LIBRARY = {
     charts: 'https://github.com/ag-grid/ag-charts',
@@ -27,4 +36,9 @@ export const GITHUB_URL_BY_LIBRARY = {
 
 export function contactGithubUrl(library: string): string {
     return library === 'charts' ? GITHUB_URL_BY_LIBRARY.charts : GITHUB_URL_BY_LIBRARY.grid;
+}
+
+/** Social links shown beside the contact form, in display order. GitHub differs per product. */
+export function contactSocialLinks(library: string): ContactSocialLink[] {
+    return [{ label: 'GitHub', icon: 'github', url: contactGithubUrl(library) }, ...CONTACT_SOCIAL_LINKS];
 }

--- a/external/ag-website-shared/src/components/contact-us/contactContent.ts
+++ b/external/ag-website-shared/src/components/contact-us/contactContent.ts
@@ -1,0 +1,30 @@
+/**
+ * Copy and links for the contact page, shared between `ContactPage.astro` and its markdown twin
+ * (`@ag-website-shared/markdown-pages/buildContactMarkdown`) so the two cannot drift.
+ */
+export const CONTACT_CONTENT = {
+    title: 'Contact AG Grid: Get in Touch with Our Team',
+    description:
+        'Have questions or need assistance? Contact the AG Grid team for support, licensing, or any other inquiries.',
+    eyebrow: 'Get in touch',
+    headline: 'Contact Us',
+    subhead: 'Get help with pricing, explore use cases, understand how our products can help you, and more.',
+    /** Structured-data name for the page. */
+    structuredDataName: 'Contact AG Grid',
+} as const;
+
+/** Social links shown beside the contact form. GitHub differs per product. */
+export const CONTACT_SOCIAL_LINKS = [
+    { label: 'X', icon: 'xLogo', url: 'https://x.com/ag_grid' },
+    { label: 'YouTube', icon: 'youtube', url: 'https://youtube.com/c/aggrid' },
+    { label: 'LinkedIn', icon: 'linkedin', url: 'https://linkedin.com/company/ag-grid' },
+] as const;
+
+export const GITHUB_URL_BY_LIBRARY = {
+    charts: 'https://github.com/ag-grid/ag-charts',
+    grid: 'https://github.com/ag-grid/ag-grid',
+} as const;
+
+export function contactGithubUrl(library: string): string {
+    return library === 'charts' ? GITHUB_URL_BY_LIBRARY.charts : GITHUB_URL_BY_LIBRARY.grid;
+}

--- a/external/ag-website-shared/src/components/policies/pages/cookies.astro
+++ b/external/ag-website-shared/src/components/policies/pages/cookies.astro
@@ -2,6 +2,7 @@
 import Layout from '@layouts/Layout.astro';
 import { Content as CookiesPolicies } from '@ag-website-shared/content/policies/cookies.mdoc';
 import CookiesTable from '../components/CookiesTable.astro';
+import { POLICY_CONTENT, policyHeading } from '../policyContent';
 import styles from '../policyPage.module.scss';
 
 interface Props {
@@ -9,22 +10,24 @@ interface Props {
 }
 
 const { name } = Astro.props;
+// Heading and effective date are shared with the /cookies.md twin so the two cannot drift.
+const content = POLICY_CONTENT.cookies;
 ---
 
 <Layout
-    title={`${name}: Cookies Policy`}
-    description="This page outlines our policy in relation to the cookies that we collect on our website."
+    title={`${name}: ${content.metaTitle}`}
+    description={content.description}
     showSearchBar={true}
     showDocsNav={false}
 >
     <div class:list={styles.policyPage}>
         <div class="layout-max-width-small">
-            <h1>Cookies Policy</h1>
+            <h1>{policyHeading('cookies', name)}</h1>
             <hr />
 
             <header>
                 <div id="introduction" class={styles.introduction}>
-                    <h4>Effective Date: May 17, 2018</h4>
+                    {content.meta.map((line) => <h4 set:html={line} />)}
                 </div>
 
                 <nav>
@@ -53,9 +56,9 @@ const { name } = Astro.props;
             </div>
 
             <section>
-                <h3 id="cookies-we-use">Cookies We Use</h3>
+                <h3 id={content.cookiesSection.id}>{content.cookiesSection.heading}</h3>
                 <hr />
-                <p>The cookies listed below were last reviewed on 7 August 2026.</p>
+                <p>{content.cookiesSection.note}</p>
                 <CookiesTable />
             </section>
         </div>

--- a/external/ag-website-shared/src/components/policies/pages/modern-slavery.astro
+++ b/external/ag-website-shared/src/components/policies/pages/modern-slavery.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '@layouts/Layout.astro';
 import { Content as ModernSlaveryPolicies } from '@ag-website-shared/content/policies/modern-slavery.mdoc';
+import { POLICY_CONTENT, policyHeading } from '../policyContent';
 import styles from '../policyPage.module.scss';
 
 interface Props {
@@ -8,25 +9,25 @@ interface Props {
 }
 
 const { name } = Astro.props;
+// Heading and the financial-year/version/effective-date block are shared with the
+// /modern-slavery.md twin so the two cannot drift.
+const content = POLICY_CONTENT['modern-slavery'];
 ---
 
 <Layout
-    title={`${name}: Modern Slavery and
-Human Trafficking Statement`}
-    description="AG Grid Ltd has a zero-tolerance approach to modern slavery. We are committed to acting ethically and with integrity in all our business dealings and relationships and to implementing and enforcing effective systems and controls to ensure modern slavery is not taking place anywhere in our own business or in any of our supply chains."
+    title={`${name}: ${content.metaTitle}`}
+    description={content.description}
     showSearchBar={true}
     showDocsNav={false}
 >
     <div class:list={styles.policyPage}>
         <div class="layout-max-width-small">
-            <h1>AG Grid Modern Slavery and Human Trafficking Statement</h1>
+            <h1>{policyHeading('modern-slavery', name)}</h1>
             <hr />
 
             <header>
                 <div id="meta" class={styles.introduction}>
-                    <p><strong>For the Financial Year Ending 31 December 2026</strong></p>
-                    <p><strong>Version:</strong> 1.0</p>
-                    <p><strong>Effective Date:</strong> 01 January 2026</p>
+                    {content.meta.map((line) => <p set:html={line} />)}
                 </div>
 
                 <nav>

--- a/external/ag-website-shared/src/components/policies/pages/privacy.astro
+++ b/external/ag-website-shared/src/components/policies/pages/privacy.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '@layouts/Layout.astro';
 import { Content as PrivacyPolicies } from '@ag-website-shared/content/policies/privacy.mdoc';
+import { POLICY_CONTENT, policyHeading } from '../policyContent';
 import styles from '../policyPage.module.scss';
 
 interface Props {
@@ -8,40 +9,26 @@ interface Props {
 }
 
 const { name } = Astro.props;
+// Heading, effective date and intro copy are shared with the /privacy.md twin so the two
+// cannot drift; the numbered policy body below comes from the same .mdoc the twin renders.
+const content = POLICY_CONTENT.privacy;
 ---
 
 <Layout
-    title={`${name}: Privacy Policy`}
-    description="We take your privacy very seriously at AG Grid. This page outlines our privacy policy which we have updated in light of GDPR."
+    title={`${name}: ${content.metaTitle}`}
+    description={content.description}
     showSearchBar={true}
     showDocsNav={false}
 >
     <div class:list={styles.policyPage}>
         <div class="layout-max-width-small">
-            <h1>AG Grid Privacy Policy</h1>
+            <h1>{policyHeading('privacy', name)}</h1>
             <hr />
 
             <header>
                 <div id="introduction" class={styles.introduction}>
-                    <h4>Effective Date: 6 July 2022</h4>
-                    <p>Welcome to AG Grid's Privacy Policy.</p>
-                    <p>
-                        <strong>Your privacy is important to us.</strong>
-                    </p>
-                    <p>
-                        At ag-grid, we are fully committed to protecting your personal data and complying with all data
-                        privacy laws.{' '}
-                    </p>
-                    <p>
-                        This policy serves as a guide and reference point for how we may collect and use personal
-                        information, and the rights and choices available to all our visitors and customers.
-                    </p>
-                    <p>
-                        We strongly recommend you read our policy and understand what we collect, how we collect it,
-                        what we do with it, how we protect it, and your rights regarding information, <strong
-                            >before</strong
-                        > you use or access any of our services.
-                    </p>
+                    {content.meta.map((line) => <h4 set:html={line} />)}
+                    {content.intro.map((line) => <p set:html={line} />)}
                 </div>
 
                 <nav>

--- a/external/ag-website-shared/src/components/policies/policyContent.ts
+++ b/external/ag-website-shared/src/components/policies/policyContent.ts
@@ -1,0 +1,82 @@
+/**
+ * Prose for the legal/policy pages that lives outside their `.mdoc` bodies — the page heading,
+ * the effective-date block and the introductory paragraphs above the numbered sections.
+ *
+ * Kept here rather than inline in the `.astro` wrappers so the pages and their markdown twins
+ * (see `@ag-website-shared/markdown-pages/policies/buildPolicyMarkdown`) render the same copy and
+ * cannot drift. The numbered body of each policy stays in `@ag-website-shared/content/policies/*.mdoc`.
+ *
+ * `{name}` in a heading or description is replaced with the product name the page is rendered for
+ * ("AG Grid", "AG Charts"), so one definition serves every site.
+ */
+export interface PolicyContent {
+    /** Page `<h1>`, also the markdown twin's H1. */
+    heading: string;
+    /** `<title>` suffix — the Layout renders `<product>: <metaTitle>`. */
+    metaTitle: string;
+    /** Meta description, shared with the twin's frontmatter. */
+    description: string;
+    /** The dated preamble above the intro paragraphs, e.g. `Effective Date: 6 July 2022`. */
+    meta: string[];
+    /** Introductory paragraphs, as inline HTML (`<strong>` only). */
+    intro: string[];
+    /** Framing for a data-driven section rendered below the policy body (the cookie inventory). */
+    cookiesSection?: {
+        id: string;
+        heading: string;
+        note: string;
+    };
+}
+
+export const POLICY_CONTENT = {
+    privacy: {
+        heading: '{name} Privacy Policy',
+        metaTitle: 'Privacy Policy',
+        description:
+            'We take your privacy very seriously at AG Grid. This page outlines our privacy policy which we have updated in light of GDPR.',
+        meta: ['Effective Date: 6 July 2022'],
+        intro: [
+            "Welcome to AG Grid's Privacy Policy.",
+            '<strong>Your privacy is important to us.</strong>',
+            'At ag-grid, we are fully committed to protecting your personal data and complying with all data privacy laws.',
+            'This policy serves as a guide and reference point for how we may collect and use personal information, and the rights and choices available to all our visitors and customers.',
+            'We strongly recommend you read our policy and understand what we collect, how we collect it, what we do with it, how we protect it, and your rights regarding information, <strong>before</strong> you use or access any of our services.',
+        ],
+    },
+    cookies: {
+        heading: 'Cookies Policy',
+        metaTitle: 'Cookies Policy',
+        description: 'This page outlines our policy in relation to the cookies that we collect on our website.',
+        meta: ['Effective Date: May 17, 2018'],
+        intro: [],
+        /**
+         * The cookie inventory rendered below the policy body, from
+         * `@ag-website-shared/content/policies/cookies-data-*.json` (AG-18105). Shared so the
+         * `CookiesTable` section on the page and the `/cookies.md` twin carry the same framing.
+         */
+        cookiesSection: {
+            id: 'cookies-we-use',
+            heading: 'Cookies We Use',
+            note: 'The cookies listed below were last reviewed on 7 August 2026.',
+        },
+    },
+    'modern-slavery': {
+        heading: '{name} Modern Slavery and Human Trafficking Statement',
+        metaTitle: 'Modern Slavery and Human Trafficking Statement',
+        description:
+            'AG Grid Ltd has a zero-tolerance approach to modern slavery. We are committed to acting ethically and with integrity in all our business dealings and relationships and to implementing and enforcing effective systems and controls to ensure modern slavery is not taking place anywhere in our own business or in any of our supply chains.',
+        meta: [
+            '<strong>For the Financial Year Ending 31 December 2026</strong>',
+            '<strong>Version:</strong> 1.0',
+            '<strong>Effective Date:</strong> 01 January 2026',
+        ],
+        intro: [],
+    },
+} as const satisfies Record<string, PolicyContent>;
+
+export type PolicyName = keyof typeof POLICY_CONTENT;
+
+/** Resolve `{name}` placeholders against the product the page is rendered for. */
+export function policyHeading(policy: PolicyName, name: string): string {
+    return POLICY_CONTENT[policy].heading.replace('{name}', name);
+}

--- a/external/ag-website-shared/src/markdoc/htmlInlineToMarkdown.test.ts
+++ b/external/ag-website-shared/src/markdoc/htmlInlineToMarkdown.test.ts
@@ -50,6 +50,25 @@ describe('htmlBlockToMarkdown', () => {
         expect(htmlBlockToMarkdown('<ul><li>One</li><li>Two</li><li>Three</li></ul>')).toBe('- One\n- Two\n- Three');
     });
 
+    it('numbers an ordered list, so the sequence the copy relies on survives', () => {
+        expect(htmlBlockToMarkdown('<ol><li>One</li><li>Two</li><li>Three</li></ol>')).toBe('1. One\n2. Two\n3. Three');
+    });
+
+    it('numbers each ordered list from 1, independently of the ones before it', () => {
+        const html = '<ol><li>A</li><li>B</li></ol><ol><li>C</li></ol>';
+        expect(htmlBlockToMarkdown(html)).toBe('1. A\n2. B\n\n1. C');
+    });
+
+    it('keeps ordered and unordered markers apart in the same fragment', () => {
+        const html = '<ol><li>First</li></ol><ul><li>Bullet</li></ul>';
+        expect(htmlBlockToMarkdown(html)).toBe('1. First\n\n- Bullet');
+    });
+
+    it('converts links and emphasis inside ordered list items', () => {
+        const html = '<ol><li><a href="/about/">about</a></li><li><b>bold</b></li></ol>';
+        expect(htmlBlockToMarkdown(html, SITE_ROOT)).toBe('1. [about](https://www.ag-grid.com/about/)\n2. **bold**');
+    });
+
     it('keeps a paragraph, a list and a heading as separate blocks in source order', () => {
         const html = '<p>Intro.</p><h6>Section</h6><ul><li>A</li><li>B</li></ul><p>Outro.</p>';
         expect(htmlBlockToMarkdown(html)).toBe('Intro.\n\n###### Section\n\n- A\n- B\n\nOutro.');

--- a/external/ag-website-shared/src/markdoc/htmlInlineToMarkdown.test.ts
+++ b/external/ag-website-shared/src/markdoc/htmlInlineToMarkdown.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { htmlBlockToMarkdown, htmlInlineToMarkdown } from './htmlInlineToMarkdown';
+
+const SITE_ROOT = 'https://www.ag-grid.com/';
+
+describe('htmlInlineToMarkdown', () => {
+    it('converts anchors, resolving site-relative hrefs against the site root', () => {
+        expect(htmlInlineToMarkdown('See <a href="/about/">about us</a>.', SITE_ROOT)).toBe(
+            'See [about us](https://www.ag-grid.com/about/).'
+        );
+    });
+
+    it('leaves external, mailto and anchor hrefs untouched', () => {
+        expect(htmlInlineToMarkdown('<a href="https://x.com/ag_grid">X</a>', SITE_ROOT)).toBe(
+            '[X](https://x.com/ag_grid)'
+        );
+        expect(htmlInlineToMarkdown('<a href="mailto:a@b.com">mail</a>', SITE_ROOT)).toBe('[mail](mailto:a@b.com)');
+        expect(htmlInlineToMarkdown('<a href="#top">top</a>', SITE_ROOT)).toBe('[top](#top)');
+    });
+
+    it('keeps emphasis rather than flattening it', () => {
+        expect(htmlInlineToMarkdown('Add <b>fast</b> and <strong>rich</strong> grids')).toBe(
+            'Add **fast** and **rich** grids'
+        );
+        expect(htmlInlineToMarkdown('an <em>idea</em> and an <i>aside</i>')).toBe('an *idea* and an *aside*');
+        expect(htmlInlineToMarkdown('call <code>setGridOption()</code>')).toBe('call `setGridOption()`');
+    });
+
+    it('moves whitespace outside the emphasis delimiters, which CommonMark requires', () => {
+        // `** foo **` is not emphasis; the spaces have to sit outside the markers.
+        expect(htmlInlineToMarkdown('over<b> 90% </b>of the Fortune 500')).toBe('over **90%** of the Fortune 500');
+    });
+
+    it('drops empty emphasis rather than emitting stray markers', () => {
+        expect(htmlInlineToMarkdown('a<b></b>b')).toBe('ab');
+    });
+
+    it('strips remaining tags and collapses whitespace', () => {
+        expect(htmlInlineToMarkdown('one<br />two   <span>three</span>')).toBe('onetwo three');
+    });
+});
+
+describe('htmlBlockToMarkdown', () => {
+    it('separates paragraphs into markdown blocks', () => {
+        expect(htmlBlockToMarkdown('<p>First para.</p><p>Second para.</p>')).toBe('First para.\n\nSecond para.');
+    });
+
+    it('renders a list as a single markdown list, not one block per item', () => {
+        expect(htmlBlockToMarkdown('<ul><li>One</li><li>Two</li><li>Three</li></ul>')).toBe('- One\n- Two\n- Three');
+    });
+
+    it('keeps a paragraph, a list and a heading as separate blocks in source order', () => {
+        const html = '<p>Intro.</p><h6>Section</h6><ul><li>A</li><li>B</li></ul><p>Outro.</p>';
+        expect(htmlBlockToMarkdown(html)).toBe('Intro.\n\n###### Section\n\n- A\n- B\n\nOutro.');
+    });
+
+    it('converts links and emphasis inside blocks', () => {
+        const html = '<p>Read the <a href="https://bryntum.com/docs">docs</a> for <b>Gantt</b>.</p>';
+        expect(htmlBlockToMarkdown(html)).toBe('Read the [docs](https://bryntum.com/docs) for **Gantt**.');
+    });
+
+    it('converts links inside list items', () => {
+        const html = '<ul><li><a href="https://bryntum.com/a">A</a></li><li>plain</li></ul>';
+        expect(htmlBlockToMarkdown(html)).toBe('- [A](https://bryntum.com/a)\n- plain');
+    });
+
+    it('handles bare text outside any block', () => {
+        expect(htmlBlockToMarkdown('Just text, no tags.')).toBe('Just text, no tags.');
+    });
+
+    it('returns an empty string for markup with no text content', () => {
+        expect(htmlBlockToMarkdown('<p></p><ul></ul>')).toBe('');
+    });
+
+    it('leaves no sentinel characters in the output', () => {
+        // Checked with includes() rather than a regex: control characters in a regex literal
+        // trip eslint's no-control-regex.
+        const output = htmlBlockToMarkdown('<p>a</p><ul><li>b</li></ul><p>c</p>');
+        expect(output.includes(String.fromCharCode(0)), 'block sentinel leaked').toBe(false);
+        expect(output.includes(String.fromCharCode(1)), 'line sentinel leaked').toBe(false);
+    });
+});

--- a/external/ag-website-shared/src/markdoc/htmlInlineToMarkdown.ts
+++ b/external/ag-website-shared/src/markdoc/htmlInlineToMarkdown.ts
@@ -13,17 +13,88 @@ export function resolveContentLink(href: string, siteRoot?: string): string {
 }
 
 /**
- * Convert an inline HTML fragment (as stored in landing-page/about content) to markdown:
- * `<a>` links become markdown links with their href resolved, and any remaining tags are
+ * Convert an inline HTML fragment (as stored in landing-page/about/policy content) to markdown:
+ * `<a>` links become markdown links with their href resolved, `<strong>`/`<b>` and `<em>`/`<i>`
+ * become their markdown emphasis, `<code>` becomes a code span, and any remaining tags are
  * dropped. Handles single- or double-quoted attributes and extra attributes on the anchor.
  */
 export function htmlInlineToMarkdown(html: string, siteRoot?: string): string {
-    return html
+    return (
+        html
+            .replace(
+                /<a\s+[^>]*?href=['"]([^'"]+)['"][^>]*>([\s\S]*?)<\/a>/gi,
+                (_match, href, text) =>
+                    `[${text.replace(/<[^>]+>/g, '').trim()}](${resolveContentLink(href, siteRoot)})`
+            )
+            // Emphasis carries meaning in the source copy, so keep it rather than flattening it.
+            .replace(/<(strong|b)>([\s\S]*?)<\/\1>/gi, (_match, _tag, text) => emphasise(text, '**'))
+            .replace(/<(em|i)>([\s\S]*?)<\/\1>/gi, (_match, _tag, text) => emphasise(text, '*'))
+            .replace(/<code>([\s\S]*?)<\/code>/gi, (_match, text) => `\`${text.replace(/<[^>]+>/g, '').trim()}\``)
+            .replace(/<[^>]+>/g, '')
+            .replace(/\s+/g, ' ')
+            .trim()
+    );
+}
+
+/**
+ * Whitespace inside an emphasis tag is moved outside the delimiters, since `** foo **` is not
+ * emphasis in CommonMark. An empty tag collapses to nothing rather than to a stray `**`.
+ */
+function emphasise(text: string, delimiter: string): string {
+    const inner = text.replace(/<[^>]+>/g, '');
+    const trimmed = inner.trim();
+    if (!trimmed) {
+        return '';
+    }
+    const leading = inner.startsWith(' ') ? ' ' : '';
+    const trailing = inner.endsWith(' ') ? ' ' : '';
+    return `${leading}${delimiter}${trimmed}${delimiter}${trailing}`;
+}
+
+// Sentinels marking block and line boundaries, so they survive the inline pass (which collapses
+// runs of whitespace). Control characters, so they cannot occur in the source copy.
+const BLOCK_SEPARATOR = '\u0000';
+const LINE_SEPARATOR = '\u0001';
+
+/**
+ * Convert a block-level HTML fragment (paragraphs, lists and headings, as stored in the Bryntum
+ * campaign content) to markdown. Block structure becomes markdown blocks; the text inside each is
+ * converted with {@link htmlInlineToMarkdown}, so links and emphasis survive.
+ *
+ * Anchors are expected to be absolute already — resolve product-relative hrefs before calling
+ * (the campaign pages do this with `decorateBryntumHtml`).
+ */
+export function htmlBlockToMarkdown(html: string, siteRoot?: string): string {
+    // Innermost blocks first, so a list item's own markup is consumed before its <ul> wrapper.
+    // List items are line-joined into a single markdown list; other blocks are block-separated.
+    const marked = html
         .replace(
-            /<a\s+[^>]*?href=['"]([^'"]+)['"][^>]*>([\s\S]*?)<\/a>/gi,
-            (_match, href, text) => `[${text.replace(/<[^>]+>/g, '').trim()}](${resolveContentLink(href, siteRoot)})`
+            /<li\b[^>]*>([\s\S]*?)<\/li>/gi,
+            (_match, text) => `${LINE_SEPARATOR}- ${htmlInlineToMarkdown(text, siteRoot)}`
         )
-        .replace(/<[^>]+>/g, '')
-        .replace(/\s+/g, ' ')
+        .replace(/<\/(?:ul|ol)>/gi, BLOCK_SEPARATOR)
+        .replace(
+            /<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi,
+            (_match, level: string, text) =>
+                `${BLOCK_SEPARATOR}${'#'.repeat(Number(level))} ${htmlInlineToMarkdown(text, siteRoot)}${BLOCK_SEPARATOR}`
+        )
+        .replace(
+            /<p\b[^>]*>([\s\S]*?)<\/p>/gi,
+            (_match, text) => `${BLOCK_SEPARATOR}${htmlInlineToMarkdown(text, siteRoot)}${BLOCK_SEPARATOR}`
+        );
+
+    return marked
+        .split(BLOCK_SEPARATOR)
+        .map((block) =>
+            block
+                .split(LINE_SEPARATOR)
+                // List items are already converted; anything left outside a block (bare text,
+                // stray <span>s) is inline copy and still needs converting.
+                .map((line) => (line.startsWith('- ') ? line.trim() : htmlInlineToMarkdown(line, siteRoot)))
+                .filter(Boolean)
+                .join('\n')
+        )
+        .filter(Boolean)
+        .join('\n\n')
         .trim();
 }

--- a/external/ag-website-shared/src/markdoc/htmlInlineToMarkdown.ts
+++ b/external/ag-website-shared/src/markdoc/htmlInlineToMarkdown.ts
@@ -56,6 +56,9 @@ function emphasise(text: string, delimiter: string): string {
 const BLOCK_SEPARATOR = '\u0000';
 const LINE_SEPARATOR = '\u0001';
 
+/** Markers emitted for list items, so an already-converted item is not re-run as inline copy. */
+const LIST_MARKER = /^(?:- |\d+\. )/;
+
 /**
  * Convert a block-level HTML fragment (paragraphs, lists and headings, as stored in the Bryntum
  * campaign content) to markdown. Block structure becomes markdown blocks; the text inside each is
@@ -68,11 +71,17 @@ export function htmlBlockToMarkdown(html: string, siteRoot?: string): string {
     // Innermost blocks first, so a list item's own markup is consumed before its <ul> wrapper.
     // List items are line-joined into a single markdown list; other blocks are block-separated.
     const marked = html
+        // <ol> is consumed whole so its items can be numbered; what reaches the <li> pass below is
+        // therefore unordered, and takes the bullet marker.
+        .replace(
+            /<ol\b[^>]*>([\s\S]*?)<\/ol>/gi,
+            (_match, items) => `${numberedListItems(items, siteRoot)}${BLOCK_SEPARATOR}`
+        )
         .replace(
             /<li\b[^>]*>([\s\S]*?)<\/li>/gi,
             (_match, text) => `${LINE_SEPARATOR}- ${htmlInlineToMarkdown(text, siteRoot)}`
         )
-        .replace(/<\/(?:ul|ol)>/gi, BLOCK_SEPARATOR)
+        .replace(/<\/ul>/gi, BLOCK_SEPARATOR)
         .replace(
             /<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi,
             (_match, level: string, text) =>
@@ -90,11 +99,20 @@ export function htmlBlockToMarkdown(html: string, siteRoot?: string): string {
                 .split(LINE_SEPARATOR)
                 // List items are already converted; anything left outside a block (bare text,
                 // stray <span>s) is inline copy and still needs converting.
-                .map((line) => (line.startsWith('- ') ? line.trim() : htmlInlineToMarkdown(line, siteRoot)))
+                .map((line) => (LIST_MARKER.test(line) ? line.trim() : htmlInlineToMarkdown(line, siteRoot)))
                 .filter(Boolean)
                 .join('\n')
         )
         .filter(Boolean)
         .join('\n\n')
         .trim();
+}
+
+/** Numbered from 1: `<ol start>` does not appear in the source copy. */
+function numberedListItems(items: string, siteRoot?: string): string {
+    let position = 0;
+    return items.replace(/<li\b[^>]*>([\s\S]*?)<\/li>/gi, (_match, text) => {
+        position += 1;
+        return `${LINE_SEPARATOR}${position}. ${htmlInlineToMarkdown(text, siteRoot)}`;
+    });
 }

--- a/external/ag-website-shared/src/markdown-pages/buildContactMarkdown.ts
+++ b/external/ag-website-shared/src/markdown-pages/buildContactMarkdown.ts
@@ -1,8 +1,4 @@
-import {
-    CONTACT_CONTENT,
-    CONTACT_SOCIAL_LINKS,
-    contactGithubUrl,
-} from '@ag-website-shared/components/contact-us/contactContent';
+import { CONTACT_CONTENT, contactSocialLinks } from '@ag-website-shared/components/contact-us/contactContent';
 
 /**
  * Build the markdown twin of the contact page. The page's substance is an interactive form, which
@@ -13,11 +9,6 @@ import {
  * `library` they pass (which selects the GitHub repository).
  */
 export function buildContactMarkdown({ library, contactUrl }: { library: string; contactUrl: string }): string {
-    const socialLinks = [
-        { label: 'GitHub', url: contactGithubUrl(library) },
-        ...CONTACT_SOCIAL_LINKS.map(({ label, url }) => ({ label, url })),
-    ];
-
     const document = [
         [
             '---',
@@ -30,7 +21,9 @@ export function buildContactMarkdown({ library, contactUrl }: { library: string;
         CONTACT_CONTENT.subhead,
         `The contact form is on the page itself: [${CONTACT_CONTENT.headline}](${contactUrl}).`,
         '## Elsewhere',
-        socialLinks.map(({ label, url }) => `- [${label}](${url})`).join('\n'),
+        contactSocialLinks(library)
+            .map(({ label, url }) => `- [${label}](${url})`)
+            .join('\n'),
     ];
 
     return `${document.join('\n\n').trimEnd()}\n`;

--- a/external/ag-website-shared/src/markdown-pages/buildContactMarkdown.ts
+++ b/external/ag-website-shared/src/markdown-pages/buildContactMarkdown.ts
@@ -1,0 +1,37 @@
+import {
+    CONTACT_CONTENT,
+    CONTACT_SOCIAL_LINKS,
+    contactGithubUrl,
+} from '@ag-website-shared/components/contact-us/contactContent';
+
+/**
+ * Build the markdown twin of the contact page. The page's substance is an interactive form, which
+ * markdown cannot carry — so the twin renders the same headline and standfirst, then points at the
+ * form and the support channels that ARE reachable without a browser.
+ *
+ * Product-agnostic: AG Grid, AG Charts and AG Studio share this module and differ only in the
+ * `library` they pass (which selects the GitHub repository).
+ */
+export function buildContactMarkdown({ library, contactUrl }: { library: string; contactUrl: string }): string {
+    const socialLinks = [
+        { label: 'GitHub', url: contactGithubUrl(library) },
+        ...CONTACT_SOCIAL_LINKS.map(({ label, url }) => ({ label, url })),
+    ];
+
+    const document = [
+        [
+            '---',
+            `title: ${JSON.stringify(CONTACT_CONTENT.title)}`,
+            `description: ${JSON.stringify(CONTACT_CONTENT.description)}`,
+            '---',
+        ].join('\n'),
+        `# ${CONTACT_CONTENT.headline}`,
+        `*${CONTACT_CONTENT.eyebrow}*`,
+        CONTACT_CONTENT.subhead,
+        `The contact form is on the page itself: [${CONTACT_CONTENT.headline}](${contactUrl}).`,
+        '## Elsewhere',
+        socialLinks.map(({ label, url }) => `- [${label}](${url})`).join('\n'),
+    ];
+
+    return `${document.join('\n\n').trimEnd()}\n`;
+}

--- a/external/ag-website-shared/src/markdown-pages/buildFrameworkRedirectMarkdown.ts
+++ b/external/ag-website-shared/src/markdown-pages/buildFrameworkRedirectMarkdown.ts
@@ -1,0 +1,38 @@
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+
+export interface BuildFrameworkRedirectMarkdownOptions {
+    title: string;
+    description: string;
+    /** H1 for the twin — the page's own heading is redirect chrome ("Redirecting to…"). */
+    heading: string;
+    /** One entry per framework: its display name and the URL the page would redirect to. */
+    destinations: Array<{ label: string; url: string }>;
+    siteRoot?: string;
+}
+
+/**
+ * Build the markdown twin of a framework-redirect stub (`/reference`, `/licensing`). These pages
+ * carry no content of their own: they bounce the visitor to the docs page for the framework held
+ * in their local storage. A reader with no local storage — an LLM — needs the destinations spelled
+ * out, so the twin lists one link per framework instead of the redirect notice.
+ *
+ * Product-agnostic: the caller supplies the destinations, so AG Grid, AG Charts and AG Studio
+ * share this module.
+ */
+export function buildFrameworkRedirectMarkdown({
+    title,
+    description,
+    heading,
+    destinations,
+    siteRoot,
+}: BuildFrameworkRedirectMarkdownOptions): string {
+    const document = [
+        ['---', `title: ${JSON.stringify(title)}`, `description: ${JSON.stringify(description)}`, '---'].join('\n'),
+        `# ${heading}`,
+        description,
+        'This page redirects to the version for your framework. Pick one:',
+        destinations.map(({ label, url }) => `- [${label}](${toAbsoluteUrl(url, siteRoot)})`).join('\n'),
+    ];
+
+    return `${document.join('\n\n').trimEnd()}\n`;
+}

--- a/external/ag-website-shared/src/markdown-pages/buildRoadmapMarkdown.ts
+++ b/external/ag-website-shared/src/markdown-pages/buildRoadmapMarkdown.ts
@@ -17,6 +17,8 @@ export interface RoadmapData {
 
 export interface BuildRoadmapMarkdownOptions {
     roadmapData: RoadmapData;
+    /** Product display name for the page metadata, e.g. `AG Charts`. */
+    productName: string;
     siteRoot?: string;
     /** Resolve an item's `./`-prefixed docs link — the site's `urlWithPrefix` bound to a framework. */
     resolveUrl: (url: string) => string;
@@ -37,15 +39,21 @@ function formatLastUpdated(dateStr: string): string {
  * groups items by quarter exactly as `RoadmapBoard` does. The page's status filter is interactive;
  * here each item carries its status inline instead.
  *
- * Product-agnostic: the caller injects `resolveUrl` and the year, so AG Grid, AG Charts and
- * AG Studio share this module.
+ * Product-agnostic: the caller injects `productName`, `resolveUrl` and the year, so AG Grid,
+ * AG Charts and AG Studio share this module.
  */
-export function buildRoadmapMarkdown({ roadmapData, siteRoot, resolveUrl, year }: BuildRoadmapMarkdownOptions): string {
+export function buildRoadmapMarkdown({
+    roadmapData,
+    productName,
+    siteRoot,
+    resolveUrl,
+    year,
+}: BuildRoadmapMarkdownOptions): string {
     const document: string[] = [
         [
             '---',
-            'title: "Roadmap | AG Grid"',
-            'description: "AG Grid Roadmap - see what we are building next, including planned features, items in progress, and recently shipped work."',
+            `title: ${JSON.stringify(`Roadmap | ${productName}`)}`,
+            `description: ${JSON.stringify(`${productName} Roadmap - see what we are building next, including planned features, items in progress, and recently shipped work.`)}`,
             '---',
         ].join('\n'),
         "# What we're building next",

--- a/external/ag-website-shared/src/markdown-pages/buildRoadmapMarkdown.ts
+++ b/external/ag-website-shared/src/markdown-pages/buildRoadmapMarkdown.ts
@@ -1,0 +1,88 @@
+import type { RoadmapItem } from '@ag-website-shared/components/roadmap/types';
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+
+/**
+ * A roadmap item as this builder needs it. `status` is widened from `RoadmapItem`'s union to
+ * `string` so the raw JSON import type-checks — the twin only prints the status as a label,
+ * whereas the page's filter buttons depend on the exact values.
+ */
+type RoadmapMarkdownItem = Omit<RoadmapItem, 'status'> & { status: string };
+
+export interface RoadmapData {
+    introTitle?: string;
+    introText?: string;
+    items: RoadmapMarkdownItem[];
+    lastUpdated: string;
+}
+
+export interface BuildRoadmapMarkdownOptions {
+    roadmapData: RoadmapData;
+    siteRoot?: string;
+    /** Resolve an item's `./`-prefixed docs link — the site's `urlWithPrefix` bound to a framework. */
+    resolveUrl: (url: string) => string;
+    /**
+     * Year the quarter headings are labelled with. The page uses the current year via
+     * `new Date()`; passed in here so the generated markdown is deterministic for the build.
+     */
+    year: number;
+}
+
+/** Matches the page's `formatLastUpdated`, so both render the date identically. */
+function formatLastUpdated(dateStr: string): string {
+    return new Intl.DateTimeFormat('en', { year: 'numeric', month: 'long', day: 'numeric' }).format(new Date(dateStr));
+}
+
+/**
+ * Build the markdown twin of the roadmap page. Reads the same `roadmap.json` the page renders and
+ * groups items by quarter exactly as `RoadmapBoard` does. The page's status filter is interactive;
+ * here each item carries its status inline instead.
+ *
+ * Product-agnostic: the caller injects `resolveUrl` and the year, so AG Grid, AG Charts and
+ * AG Studio share this module.
+ */
+export function buildRoadmapMarkdown({ roadmapData, siteRoot, resolveUrl, year }: BuildRoadmapMarkdownOptions): string {
+    const document: string[] = [
+        [
+            '---',
+            'title: "Roadmap | AG Grid"',
+            'description: "AG Grid Roadmap - see what we are building next, including planned features, items in progress, and recently shipped work."',
+            '---',
+        ].join('\n'),
+        "# What we're building next",
+    ];
+
+    if (roadmapData.lastUpdated) {
+        document.push(`Last updated: ${formatLastUpdated(roadmapData.lastUpdated)}`);
+    }
+    if (roadmapData.introTitle) {
+        document.push(`## ${roadmapData.introTitle}`);
+    }
+    if (roadmapData.introText) {
+        document.push(roadmapData.introText);
+    }
+
+    // Same grouping as RoadmapBoard: one section per quarter, in the order the items appear.
+    const byQuarter = new Map<number, RoadmapMarkdownItem[]>();
+    for (const item of roadmapData.items) {
+        const quarterItems = byQuarter.get(item.q) ?? [];
+        quarterItems.push(item);
+        byQuarter.set(item.q, quarterItems);
+    }
+
+    for (const [quarter, items] of byQuarter) {
+        document.push(`## Q${quarter} ${year}`);
+        for (const item of items) {
+            const title = item.link ? `[${item.title}](${toAbsoluteUrl(resolveUrl(item.link), siteRoot)})` : item.title;
+            // Status reads as a label because the page conveys it with a coloured pill.
+            document.push(`### ${title} (${item.status.replace(/-/g, ' ')})`);
+            if (item.desc) {
+                document.push(item.desc);
+            }
+            if (item.why) {
+                document.push(`**Why:** ${item.why}`);
+            }
+        }
+    }
+
+    return `${document.join('\n\n').trimEnd()}\n`;
+}

--- a/external/ag-website-shared/src/markdown-pages/buildWhatsNewMarkdown.ts
+++ b/external/ag-website-shared/src/markdown-pages/buildWhatsNewMarkdown.ts
@@ -1,0 +1,112 @@
+import whatsNewData from '@ag-website-shared/content/whats-new/data.json';
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+import { parseVersion } from '@ag-website-shared/utils/parseVersion';
+
+/** How many versions the page lists; the twin matches it so the two show the same releases. */
+const MAX_VERSIONS = 12;
+
+export interface WhatsNewVersion {
+    version: string;
+    date?: string;
+    /** Mirrors the page's `Highlight` component: an absolute `url`, a product-docs `path`, or a charts-docs `chartsPath`. */
+    highlights?: Array<{ text: string; url?: string; path?: string; chartsPath?: string }>;
+    notesPath?: string;
+    hideBlogPostLink?: boolean;
+}
+
+export interface BuildWhatsNewMarkdownOptions {
+    /** Product key into the shared whats-new data (`grid`, `charts`, `studio`). */
+    site: keyof typeof whatsNewData;
+    /** The `versions` collection, as the page receives it. */
+    versionsData: WhatsNewVersion[];
+    siteRoot?: string;
+    /**
+     * Resolve a highlight's `./`-prefixed docs path — the site's `urlWithPrefix` bound to a
+     * framework. Highlights link into framework docs, so a product without a framework dimension
+     * can pass its plain base-URL helper instead.
+     */
+    resolveUrl: (url: string) => string;
+    /** Resolve a highlight's `chartsPath` into the charts docs, as the page's `Highlight` does. */
+    resolveChartsUrl?: (url: string) => string;
+}
+
+/** The page title and description, shared so the twin's frontmatter matches the page's meta. */
+export function whatsNewMeta(site: BuildWhatsNewMarkdownOptions['site']) {
+    const { name } = whatsNewData[site];
+    return {
+        title: `${name} What's new`,
+        description: `See what's new in recent ${name} versions. View feature highlights, browse release notes or read our release blogs. Includes major and minor releases.`,
+    };
+}
+
+/**
+ * Build the markdown twin of the What's New page. Reads the same `versions` data and shared
+ * product metadata the page renders, applies the same "has highlights" filter and the same
+ * 12-version cap, and derives blog URLs the same way — so the two cannot drift.
+ *
+ * Product-agnostic: AG Grid, AG Charts and AG Studio share this module.
+ */
+export function buildWhatsNewMarkdown({
+    site,
+    versionsData,
+    siteRoot,
+    resolveUrl,
+    resolveChartsUrl,
+}: BuildWhatsNewMarkdownOptions): string {
+    const { name, blogPrefix } = whatsNewData[site];
+    const { title, description } = whatsNewMeta(site);
+
+    const versions = versionsData.filter((version) => version.highlights).slice(0, MAX_VERSIONS);
+
+    const document: string[] = [
+        ['---', `title: ${JSON.stringify(title)}`, `description: ${JSON.stringify(description)}`, '---'].join('\n'),
+        `# What's New in ${name}`,
+        `See what's new in recent ${name} versions.`,
+    ];
+
+    for (const [index, versionInfo] of versions.entries()) {
+        const { major, minor, isMajor } = parseVersion(versionInfo.version);
+        const blogUrl = `${minor ? `${blogPrefix}${major}-${minor}` : `${blogPrefix}${major}`}/`;
+
+        const heading = [
+            `## ${versionInfo.version}`,
+            index === 0 ? '(latest)' : '',
+            versionInfo.date ? `— ${versionInfo.date}` : '',
+        ]
+            .filter(Boolean)
+            .join(' ');
+        document.push(heading);
+        document.push('Feature Highlights');
+
+        // Same precedence as the page's `Highlight` component: absolute url, then product docs
+        // path, then charts docs path, else plain text.
+        const highlights = (versionInfo.highlights ?? []).map(({ text, url, path, chartsPath }) => {
+            if (url) {
+                return `- [${text}](${url})`;
+            }
+            if (path) {
+                return `- [${text}](${toAbsoluteUrl(resolveUrl(path), siteRoot)})`;
+            }
+            if (chartsPath && resolveChartsUrl) {
+                return `- [${text}](${toAbsoluteUrl(resolveChartsUrl(chartsPath), siteRoot)})`;
+            }
+            return `- ${text}`;
+        });
+        if (highlights.length) {
+            document.push(highlights.join('\n'));
+        }
+
+        const links = [
+            // The page labels this button by release kind; keep the same wording.
+            versionInfo.notesPath
+                ? `[${isMajor ? 'See migration guide' : 'See release notes'}](${toAbsoluteUrl(resolveUrl(versionInfo.notesPath), siteRoot)})`
+                : undefined,
+            versionInfo.hideBlogPostLink ? undefined : `[Read more](${blogUrl})`,
+        ].filter(Boolean);
+        if (links.length) {
+            document.push(links.join(' | '));
+        }
+    }
+
+    return `${document.join('\n\n').trimEnd()}\n`;
+}

--- a/external/ag-website-shared/src/markdown-pages/landing-pages/buildLandingPageMarkdown.ts
+++ b/external/ag-website-shared/src/markdown-pages/landing-pages/buildLandingPageMarkdown.ts
@@ -33,9 +33,9 @@ export interface BuildLandingPageMarkdownOptions {
     resolveFaqUrl?: (url: string) => string;
 }
 
-type Resolve = (url: string) => string;
+export type Resolve = (url: string) => string;
 
-function link(text: string, url: string, resolve: Resolve, siteRoot?: string): string {
+export function link(text: string, url: string, resolve: Resolve, siteRoot?: string): string {
     return `[${text}](${url.startsWith('http') ? url : toAbsoluteUrl(resolve(url), siteRoot)})`;
 }
 
@@ -43,7 +43,7 @@ function link(text: string, url: string, resolve: Resolve, siteRoot?: string): s
  * Rewrite the targets of markdown links already present in authored copy (FAQ answers are
  * Markdoc, so they arrive as markdown rather than as a URL field to resolve).
  */
-function resolveMarkdownLinks(markdown: string, resolve: Resolve, siteRoot?: string): string {
+export function resolveMarkdownLinks(markdown: string, resolve: Resolve, siteRoot?: string): string {
     return markdown.replace(/\[([^\]]*)\]\(([^)\s]+)\)/g, (match, text: string, target: string) => {
         if (target.startsWith('http') || target.startsWith('mailto') || target.startsWith('#')) {
             return match;
@@ -57,7 +57,7 @@ function resolveMarkdownLinks(markdown: string, resolve: Resolve, siteRoot?: str
  * emphasised kicker so it holds that reading order without adding a heading level —
  * matching how the homepage twin renders its section tags.
  */
-function sectionHeader(
+export function sectionHeader(
     section: { tag?: string; heading?: string; headingHtml?: string; subHeading?: string; subHeadingHtml?: string },
     siteRoot?: string
 ): string[] {
@@ -114,7 +114,7 @@ function pricingBody(section: ExtractSection<'pricing'>, resolve: Resolve, siteR
 }
 
 /** Section body beyond the shared tag/heading/subheading header. */
-function sectionBody(
+export function sectionBody(
     section: LandingPageSectionType,
     resolve: Resolve,
     resolveFaq: Resolve,

--- a/external/ag-website-shared/src/markdown-pages/landing-pages/buildLandingPageMarkdown.ts
+++ b/external/ag-website-shared/src/markdown-pages/landing-pages/buildLandingPageMarkdown.ts
@@ -1,0 +1,200 @@
+import type {
+    ExtractSection,
+    LandingPageContent,
+    LandingPageSectionType,
+} from '@ag-website-shared/components/landing-pages/types';
+import { htmlInlineToMarkdown } from '@ag-website-shared/markdoc/htmlInlineToMarkdown';
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+
+export interface LandingPageVersion {
+    version: string;
+    landingPageHighlight?: string;
+}
+
+export interface BuildLandingPageMarkdownOptions {
+    /** The same `landingPages` collection entry `LandingPage.astro` renders. */
+    content: LandingPageContent;
+    /** The `versions` collection, for the hero's version badge. */
+    versions?: LandingPageVersion[];
+    /** Canonical origin, so links survive being read out of context. */
+    siteRoot?: string;
+    /**
+     * Resolve a content URL to a site-relative path — the site's `urlWithBaseUrl`. Section CTAs,
+     * feature links and example links store `./`-prefixed paths that ALREADY include the framework
+     * segment (`./react-data-grid/getting-started`), so this must be the base-URL helper.
+     */
+    resolveUrl: (url: string) => string;
+    /**
+     * Resolve a link inside an FAQ answer — the site's `urlWithPrefix` bound to the page's
+     * framework. FAQ answers are Markdoc, rendered by `renderFAQAnswers` with the page framework,
+     * so their `./` links are framework-RELATIVE (`./getting-started/`) and need the prefixing
+     * helper instead. Defaults to `resolveUrl` for sites without a framework dimension.
+     */
+    resolveFaqUrl?: (url: string) => string;
+}
+
+type Resolve = (url: string) => string;
+
+function link(text: string, url: string, resolve: Resolve, siteRoot?: string): string {
+    return `[${text}](${url.startsWith('http') ? url : toAbsoluteUrl(resolve(url), siteRoot)})`;
+}
+
+/**
+ * Rewrite the targets of markdown links already present in authored copy (FAQ answers are
+ * Markdoc, so they arrive as markdown rather than as a URL field to resolve).
+ */
+function resolveMarkdownLinks(markdown: string, resolve: Resolve, siteRoot?: string): string {
+    return markdown.replace(/\[([^\]]*)\]\(([^)\s]+)\)/g, (match, text: string, target: string) => {
+        if (target.startsWith('http') || target.startsWith('mailto') || target.startsWith('#')) {
+            return match;
+        }
+        return `[${text}](${toAbsoluteUrl(resolve(target), siteRoot)})`;
+    });
+}
+
+/**
+ * The eyebrow headline that labels a section above its heading on the page. Kept as an
+ * emphasised kicker so it holds that reading order without adding a heading level —
+ * matching how the homepage twin renders its section tags.
+ */
+function sectionHeader(
+    section: { tag?: string; heading?: string; headingHtml?: string; subHeading?: string; subHeadingHtml?: string },
+    siteRoot?: string
+): string[] {
+    const heading = section.headingHtml ? htmlInlineToMarkdown(section.headingHtml, siteRoot) : section.heading;
+    const subHeading = section.subHeadingHtml
+        ? htmlInlineToMarkdown(section.subHeadingHtml, siteRoot)
+        : section.subHeading;
+
+    const parts: string[] = [];
+    if (section.tag) {
+        parts.push(`*${section.tag}*`);
+    }
+    if (heading) {
+        parts.push(`## ${heading}`);
+    }
+    if (subHeading) {
+        parts.push(subHeading);
+    }
+    return parts;
+}
+
+function featuresBody(section: ExtractSection<'features'>, resolve: Resolve, siteRoot?: string): string[] {
+    return section.items.map((item) => {
+        const title = item.isEnterprise ? `### ${item.title} (Enterprise)` : `### ${item.title}`;
+        const bullets = item.features.map((feature) => {
+            const heading = feature.link
+                ? `**${link(feature.heading, feature.link, resolve, siteRoot)}**`
+                : `**${feature.heading}**`;
+            return `- ${heading} — ${feature.detail}`;
+        });
+        const more = item.docsLink ? `\n\n${link(`More on ${item.title}`, item.docsLink, resolve, siteRoot)}` : '';
+        return `${title}\n\n${bullets.join('\n')}${more}`;
+    });
+}
+
+function examplesBody(section: ExtractSection<'examples'>, resolve: Resolve, siteRoot?: string): string[] {
+    const items = section.items.map((item) => {
+        const demo = item.demo ? ` (${link('live demo', item.demo, resolve, siteRoot)})` : '';
+        return `- **${link(item.title, item.docs, resolve, siteRoot)}** — ${item.content}${demo}`;
+    });
+    return [items.join('\n')];
+}
+
+function pricingBody(section: ExtractSection<'pricing'>, resolve: Resolve, siteRoot?: string): string[] {
+    return section.cards.map((card) => {
+        const features = card.features.map((feature) => `- ${feature}`).join('\n');
+        return [
+            `### ${card.title} — ${card.price}`,
+            `*${card.priceNote}*`,
+            features,
+            link(card.ctaText, card.ctaUrl, resolve, siteRoot),
+        ].join('\n\n');
+    });
+}
+
+/** Section body beyond the shared tag/heading/subheading header. */
+function sectionBody(
+    section: LandingPageSectionType,
+    resolve: Resolve,
+    resolveFaq: Resolve,
+    siteRoot?: string
+): string[] {
+    switch (section.type) {
+        case 'features':
+            return featuresBody(section, resolve, siteRoot);
+        case 'examples':
+            return examplesBody(section, resolve, siteRoot);
+        case 'faq':
+            return section.items.map(
+                (item) => `### ${item.question}\n\n${resolveMarkdownLinks(item.answer, resolveFaq, siteRoot)}`
+            );
+        case 'contact':
+            return [section.features.map((feature) => `- ${feature}`).join('\n')];
+        case 'pricing':
+            return pricingBody(section, resolve, siteRoot);
+        // The remaining sections are interactive on the page (a showcase carousel, the customer
+        // logo wall, the automated integrated-charts demo, the comparison table, the theme
+        // builder video). They carry no further prose, so their heading and subheading are the
+        // whole of their content here.
+        case 'hero':
+        case 'showcase':
+        case 'customers':
+        case 'integrated-charts':
+        case 'theme-builder':
+        case 'comparison':
+            return [];
+    }
+}
+
+/**
+ * Build the markdown twin of a content-driven landing page. Reads the same `landingPages`
+ * collection entry `LandingPage.astro` renders and walks the same `sections` discriminated
+ * union in the same order, so the two cannot drift.
+ *
+ * Product-agnostic: the caller injects `resolveUrl` (its site's `urlWithBaseUrl`), so AG Grid,
+ * AG Charts and AG Studio share this module and differ only in how they resolve content URLs.
+ */
+export function buildLandingPageMarkdown({
+    content,
+    versions,
+    siteRoot,
+    resolveUrl,
+    resolveFaqUrl = resolveUrl,
+}: BuildLandingPageMarkdownOptions): string {
+    const hero = content.sections.find((section) => section.type === 'hero');
+    const latestVersion = versions?.find((version) => version.landingPageHighlight);
+
+    const frontmatter = [
+        '---',
+        `title: ${JSON.stringify(content.meta.title)}`,
+        `description: ${JSON.stringify(content.meta.description)}`,
+        '---',
+    ].join('\n');
+
+    const intro: string[] = [];
+    if (hero) {
+        const heading = hero.headingHtml ? htmlInlineToMarkdown(hero.headingHtml, siteRoot) : hero.heading;
+        intro.push(`# ${heading}`);
+        intro.push(hero.subHeadingHtml ? htmlInlineToMarkdown(hero.subHeadingHtml, siteRoot) : hero.subHeading);
+        if (hero.showVersionBadge && latestVersion) {
+            intro.push(`**Latest version:** v${latestVersion.version} — ${latestVersion.landingPageHighlight}`);
+        }
+        if (content.packageName) {
+            intro.push(`Install: \`npm install ${content.packageName}\``);
+        }
+        if (hero.secondaryCta?.url) {
+            intro.push(link(hero.secondaryCta.text, hero.secondaryCta.url, resolveUrl, siteRoot));
+        }
+    }
+
+    // The hero is rendered above as the page title; every other section keeps page order.
+    const body = content.sections
+        .filter((section) => section.type !== 'hero')
+        .flatMap((section) => [
+            ...sectionHeader(section, siteRoot),
+            ...sectionBody(section, resolveUrl, resolveFaqUrl, siteRoot),
+        ]);
+
+    return `${[frontmatter, ...intro, ...body].join('\n\n').trimEnd()}\n`;
+}

--- a/external/ag-website-shared/src/markdown-pages/markdownPageRegistry.ts
+++ b/external/ag-website-shared/src/markdown-pages/markdownPageRegistry.ts
@@ -1,0 +1,35 @@
+/**
+ * SE-80: the contract for declaring which pages ship a markdown (`.md`) twin.
+ *
+ * The set of twinned pages is consumed in three places that must agree exactly — the dev-server
+ * negotiation plugin, the Apache rewrite rule, and the Apache `Vary: Accept` scope. Previously
+ * each held its own hand-maintained copy of the list, so adding a twin was a multi-file edit with
+ * nothing to catch an omission. Each product now declares its pages once as `MarkdownPageGroup`s
+ * and derives all three from that single list.
+ *
+ * Only the type lives here. The derivation (see AG Grid's `markdownPages.ts`) is three lines, and
+ * keeping it product-side avoids a runtime import across this package boundary: this subrepo has
+ * no `"type": "module"`, so a consumer running under plain node — as the htaccess test harness does
+ * via `tsx` — would load it as CJS and see no named exports.
+ */
+export interface MarkdownPageGroup {
+    /**
+     * URL path pattern with no leading or trailing slash, e.g. `license-pricing` or
+     * `session/[^/.]+`. Consumers anchor it as `^/(<pattern>)/?$`.
+     *
+     * Must be valid in BOTH the JavaScript RegExp engine (dev-server plugin) and Apache's PCRE
+     * (`RewriteCond`, and `<If>` expressions using `m#...#` delimiters). Keep to the common subset:
+     * `(?:…)`, `|`, `?`, and negated character classes. No named groups, no lookbehind, no `#`.
+     *
+     * Match final path segments with `[^/.]+` rather than `[^/]+` so a request for the twin itself
+     * (`/react-data-grid/cell-editing.md`) never matches and re-negotiates into `….md.md`. No page
+     * slug on any of the sites contains a dot.
+     *
+     * Omit for a page negotiated by a dedicated rule rather than the shared alternation — currently
+     * only the site root, whose twin is `index.md` because it has no path segment to suffix. Such a
+     * group documents the page without contributing to the patterns.
+     */
+    pattern?: string;
+    /** What this group covers, for readers of the registry. Not emitted anywhere. */
+    describes: string;
+}

--- a/external/ag-website-shared/src/markdown-pages/policies/buildPolicyMarkdown.ts
+++ b/external/ag-website-shared/src/markdown-pages/policies/buildPolicyMarkdown.ts
@@ -1,0 +1,88 @@
+import type { PolicyContent, PolicyName } from '@ag-website-shared/components/policies/policyContent';
+import { POLICY_CONTENT, policyHeading } from '@ag-website-shared/components/policies/policyContent';
+import cookiesData from '@ag-website-shared/content/policies/cookies-data-07-08-26.json';
+import { htmlInlineToMarkdown } from '@ag-website-shared/markdoc/htmlInlineToMarkdown';
+import { markdownTable } from '@ag-website-shared/markdoc/markdownTable';
+import type { MarkdocConfigLike, MarkdownResolvers } from '@ag-website-shared/markdoc/renderMarkdocToMarkdown';
+import { renderMarkdocToMarkdown } from '@ag-website-shared/markdoc/renderMarkdocToMarkdown';
+
+export interface BuildPolicyMarkdownOptions {
+    policy: PolicyName;
+    /** Product name substituted into the heading, e.g. `AG Grid`. */
+    name: string;
+    /** Raw `.mdoc` source for the policy body. Import it with Vite's `?raw` suffix. */
+    body: string;
+    /** The product's Markdoc config, so tags and functions resolve exactly as on the page. */
+    markdocConfig: MarkdocConfigLike;
+    resolvers?: MarkdownResolvers;
+    siteRoot?: string;
+}
+
+/**
+ * Build the markdown twin of a legal/policy page: the shared heading, effective-date block and
+ * intro paragraphs from `POLICY_CONTENT`, followed by the policy body rendered from the same
+ * `.mdoc` the page renders. The page's in-page table of contents is omitted — it is navigation
+ * chrome, and the headings it links to are present in the markdown already.
+ *
+ * Product-agnostic: AG Grid, AG Charts and AG Studio share this module and differ only in the
+ * `name` they render and the Markdoc config they pass.
+ */
+export async function buildPolicyMarkdown({
+    policy,
+    name,
+    body,
+    markdocConfig,
+    resolvers,
+    siteRoot,
+}: BuildPolicyMarkdownOptions): Promise<string> {
+    const content = POLICY_CONTENT[policy];
+    const heading = policyHeading(policy, name);
+
+    // The policy body carries its own numbered `###` headings, so render it without a frontmatter
+    // title and prepend the shared preamble here — otherwise the twin would have two H1s.
+    const renderedBody = await renderMarkdocToMarkdown({
+        body,
+        framework: 'javascript',
+        pageName: policy,
+        markdocConfig,
+        resolvers,
+    });
+    // Strip the frontmatter block the renderer emits; this page supplies its own below.
+    const policyBody = renderedBody.replace(/^---\n[\s\S]*?\n---\n+/, '').trim();
+
+    const document = [
+        [
+            '---',
+            `title: ${JSON.stringify(`${name}: ${content.metaTitle}`)}`,
+            `description: ${JSON.stringify(content.description)}`,
+            '---',
+        ].join('\n'),
+        `# ${heading}`,
+        ...content.meta.map((line) => htmlInlineToMarkdown(line, siteRoot)),
+        ...content.intro.map((line) => htmlInlineToMarkdown(line, siteRoot)),
+        policyBody,
+        ...cookiesInventory(content.cookiesSection),
+    ].filter(Boolean);
+
+    return `${document.join('\n\n').trimEnd()}\n`;
+}
+
+/**
+ * The cookie inventory the page renders below the policy body via `CookiesTable` (AG-18105), as one
+ * markdown table per category. Reads the same JSON the component does, so the two cannot drift.
+ * Returns nothing for policies with no such section.
+ */
+function cookiesInventory(section: PolicyContent['cookiesSection']): string[] {
+    if (!section) {
+        return [];
+    }
+    const categories = cookiesData.categories.flatMap(({ name, description, cookies }) => {
+        // Mirrors the component: a few entries cover a whole domain rather than a named cookie.
+        const rows = cookies.map(({ name: cookieName, subgroup, party, moreInfo }) => {
+            const label = cookieName ?? '—';
+            return [subgroup, moreInfo ? `[${label}](${moreInfo})` : label, party];
+        });
+        return [`### ${name}`, description, markdownTable(['Cookie Subgroup', 'Cookies', 'Cookies used'], rows)];
+    });
+    return [`## ${section.heading}`, section.note, ...categories].filter(Boolean);
+}


### PR DESCRIPTION
Release-branch counterpart of #14769 and #14788, cherry-picked onto `b36.1.0` in that order.
Both applied without conflict, and every ported file is byte-identical to `latest`.

## What lands

**#14769 — markdown twins for the remaining sitemap pages.** Probing production
`sitemap-0.xml` for `.md` siblings found 38 non-docs pages with no twin; 37 gain one here and
`/privacy/your-choice/` is dropped from the sitemap instead (it is in `getSitemapIgnorePaths()`,
so robots.txt already disallowed it — the site was submitting a URL it simultaneously blocks).

The set of twinned pages was hardcoded in four places that all had to agree — the dev-server
negotiation plugin, the Apache rewrite rule, the `Vary: Accept` scope, and the `/llms.txt` /
`/AGENTS.md` prose. They now derive from a single `GRID_MARKDOWN_PAGE_GROUPS`.

Two fidelity fixes ride along: `htmlInlineToMarkdown` was silently dropping `<strong>` / `<b>` /
`<em>` / `<code>`, so **existing** About, homepage and community twins lost inline emphasis; and
the campaign twin was rendering `section.links`, which the page never renders.

**#14788 — the review fixes ported from Charts.** Ordered lists lost their numbering
(`<ol>` items emitted `-`); the contact page's "shared" social links were not actually shared, so
the list and the rendered markup could drift; and the site-wide "append `.md` to any sitemap URL"
rule was false for the homepage, whose twin is `/index.md`. Plus two shared-API changes Grid has
to take — `buildRoadmapMarkdown` now takes `productName`, and `buildLandingPageMarkdown` exports
its section helpers.

## Verification

Run in a fresh worktree off `b36.1.0`, with a baseline run on the pristine base commit for
comparison:

| Check | Base `b36.1.0` | This branch |
| --- | --- | --- |
| `nx test ag-grid-docs` | 31 files, 584 pass | **38 files, 718 pass** |
| `nx test ag-website-shared` | 14 files, 150 pass | **15 files, 168 pass** |
| `nx lint` (both projects) | 0 errors | **0 errors** (11 pre-existing warnings) |
| `nx build ag-grid-docs` | — | **PASSED** (1042 tasks) |

The docs suite was run twice: once before the site build, where the four `markdownPages.test.ts`
cases that read `dist/` skip themselves, and once after, where they execute — hence 718 rather
than 714. The post-build run is the one that actually asserts every sitemap URL has a `.md`
sibling in `dist`, and the new twins are present on disk (`/roadmap.md`, `/licensing.md`,
`/privacy.md`, `/reference.md`, `/sitemap.md`, `/whats-new.md`, `/theme-builder.md`,
`/react-table.md`, `/niall.md`, …).

New coverage includes `htmlInlineToMarkdown` (18 tests, incl. the ordered-list cases),
`buildGridLandingPageMarkdown` (29), `buildSessionMarkdown` (36), `buildCampaignMarkdown` (27),
`buildDemoNiallMarkdown` (13) and `buildPolicyMarkdown` (9). The htaccess suites still pass
unchanged at 74 + 35.

`ag-grid-docs:build-tsc` is **not** run: it fails identically on the pristine base commit
(~5900 errors, mostly `packages/ag-grid-community/src` and `public/example-runner/` boilerplate).
It is not a CI gate on either branch — `ci.yml` runs `lint`, `test` and `build`, and `checks.sh`
on `latest` uses `build:types`, which `ag-grid-docs` does not define.

## One difference from `latest` worth knowing

`external/ag-website-shared` on `b36.1.0` sits on subrepo commit `4563a27`, whereas `latest` is on
`e914cbd`. The cherry-picks deliberately do not move `.gitrepo`, so the release branch takes the
new markdown-page modules on top of its existing shared baseline rather than pulling the whole
subrepo forward. The shared source files touched by these two PRs are byte-identical to `latest`,
and nothing they import is missing at the older baseline (checked file-by-file, and confirmed by
the shared and docs suites plus the site build).
